### PR TITLE
Further untangle data entry flow

### DIFF
--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -167,25 +167,3 @@ class FlowHandler:
             'handler': self.handler,
             'reason': reason
         }
-
-
-class SingleSchemaFlow(FlowHandler):
-    """Helper class to create a flow from a single voluptuous schema."""
-
-    def __init__(self, schema, title=None):
-        """Initialize the single flow schema."""
-        self._schema = schema
-        self._title = title
-
-    async def step_init(self, user_input=None):
-        """Handle the step of the form."""
-        if user_input is not None:
-            return self.async_create_entry(
-                title=self._title,
-                data=user_input
-            )
-
-        return self.async_show_form(
-            step_id='init',
-            data_schema=self._schema
-        )

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -34,13 +34,11 @@ class UnknownStep(FlowError):
 class FlowManager:
     """Manage all the flows that are in progress."""
 
-    def __init__(self, hass, handlers, async_missing_handler,
-                 async_save_entry):
+    def __init__(self, hass, async_create_flow, async_save_entry):
         """Initialize the flow manager."""
         self.hass = hass
-        self._handlers = handlers
         self._progress = {}
-        self._async_missing_handler = async_missing_handler
+        self._async_create_flow = async_create_flow
         self._async_save_entry = async_save_entry
 
     @callback
@@ -48,27 +46,18 @@ class FlowManager:
         """Return the flows in progress."""
         return [{
             'flow_id': flow.flow_id,
-            'domain': flow.domain,
+            'handler': flow.handler,
             'source': flow.source,
         } for flow in self._progress.values()]
 
-    async def async_init(self, domain, *, source=SOURCE_USER, data=None):
+    async def async_init(self, handler, *, source=SOURCE_USER, data=None):
         """Start a configuration flow."""
-        handler = self._handlers.get(domain)
-
-        if handler is None:
-            await self._async_missing_handler(domain)
-            handler = self._handlers.get(domain)
-
-        if handler is None:
-            raise UnknownHandler
-
-        flow_id = uuid.uuid4().hex
-        flow = self._progress[flow_id] = handler()
+        flow = await self._async_create_flow(handler)
         flow.hass = self.hass
-        flow.domain = domain
-        flow.flow_id = flow_id
+        flow.handler = handler
+        flow.flow_id = uuid.uuid4().hex
         flow.source = source
+        self._progress[flow.flow_id] = flow
 
         if source == SOURCE_USER:
             step = 'init'
@@ -137,7 +126,7 @@ class FlowHandler:
     # Set by flow manager
     flow_id = None
     hass = None
-    domain = None
+    handler = None
     source = SOURCE_USER
     cur_step = None
 
@@ -150,7 +139,7 @@ class FlowHandler:
         return {
             'type': RESULT_TYPE_FORM,
             'flow_id': self.flow_id,
-            'domain': self.domain,
+            'handler': self.handler,
             'step_id': step_id,
             'data_schema': data_schema,
             'errors': errors,
@@ -163,7 +152,7 @@ class FlowHandler:
             'version': self.VERSION,
             'type': RESULT_TYPE_CREATE_ENTRY,
             'flow_id': self.flow_id,
-            'domain': self.domain,
+            'handler': self.handler,
             'title': title,
             'data': data,
             'source': self.source,
@@ -175,6 +164,28 @@ class FlowHandler:
         return {
             'type': RESULT_TYPE_ABORT,
             'flow_id': self.flow_id,
-            'domain': self.domain,
+            'handler': self.handler,
             'reason': reason
         }
+
+
+class SingleSchemaFlow(FlowHandler):
+    """Helper class to create a flow from a single voluptuous schema."""
+
+    def __init__(self, schema, title=None):
+        """Initialize the single flow schema."""
+        self._schema = schema
+        self._title = title
+
+    async def step_init(self, user_input=None):
+        """Handle the step of the form."""
+        if user_input is not None:
+            return self.async_create_entry(
+                title=self._title,
+                data=user_input
+            )
+
+        return self.async_show_form(
+            step_id='init',
+            data_schema=self._schema
+        )

--- a/tests/components/config/test_config_entries.py
+++ b/tests/components/config/test_config_entries.py
@@ -120,7 +120,7 @@ def test_initialize_flow(hass, client):
 
     assert data == {
         'type': 'form',
-        'domain': 'test',
+        'handler': 'test',
         'step_id': 'init',
         'data_schema': [
             {
@@ -156,7 +156,7 @@ def test_abort(hass, client):
     data = yield from resp.json()
     data.pop('flow_id')
     assert data == {
-        'domain': 'test',
+        'handler': 'test',
         'reason': 'bla',
         'type': 'abort'
     }
@@ -186,7 +186,7 @@ def test_create_account(hass, client):
     data = yield from resp.json()
     data.pop('flow_id')
     assert data == {
-        'domain': 'test',
+        'handler': 'test',
         'title': 'Test Entry',
         'type': 'create_entry',
         'source': 'user',
@@ -226,7 +226,7 @@ def test_two_step_flow(hass, client):
         flow_id = data.pop('flow_id')
         assert data == {
             'type': 'form',
-            'domain': 'test',
+            'handler': 'test',
             'step_id': 'account',
             'data_schema': [
                 {
@@ -245,7 +245,7 @@ def test_two_step_flow(hass, client):
         data = yield from resp.json()
         data.pop('flow_id')
         assert data == {
-            'domain': 'test',
+            'handler': 'test',
             'type': 'create_entry',
             'title': 'user-title',
             'version': 1,
@@ -279,7 +279,7 @@ def test_get_progress_index(hass, client):
     assert data == [
         {
             'flow_id': form['flow_id'],
-            'domain': 'test',
+            'handler': 'test',
             'source': 'hassio'
         }
     ]

--- a/tests/components/test_discovery.py
+++ b/tests/components/test_discovery.py
@@ -168,7 +168,7 @@ async def test_discover_config_flow(hass):
 
     with patch.dict(discovery.CONFIG_ENTRY_HANDLERS, {
         'mock-service': 'mock-component'}), patch(
-            'homeassistant.config_entries.FlowManager.async_init') as m_init:
+            'homeassistant.data_entry_flow.FlowManager.async_init') as m_init:
         await mock_discovery(hass, discover)
 
     assert len(m_init.mock_calls) == 1


### PR DESCRIPTION
## Description:
This will further untangle the data entry flow module from config entries. We no longer assume that we can always lookup the flow class in a dictionary and instantiate from there. Instead, we need to pass in a method to instantiate a config flow.

We now refer to `handler` instead of `domain` for the type of a handler. This also requires a frontend change: https://github.com/home-assistant/home-assistant-polymer/pull/1084

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
