### PR TITLE
Removes mistaken double underscore from new Bluetooth addresses in `known_devices.yaml`. Correcting `known_devices.yaml` is strongly advised. 

### DIFF
--- a/homeassistant/components/device_tracker/bluetooth_tracker.py
+++ b/homeassistant/components/device_tracker/bluetooth_tracker.py
@@ -40,7 +40,7 @@ def setup_scanner(hass, config, see, discovery_info=None):
         attributes = {}
         if rssi is not None:
             attributes['rssi'] = rssi
-        see(mac="{}_{}".format(BT_PREFIX, mac), host_name=name,
+        see(mac="{}{}".format(BT_PREFIX, mac), host_name=name,
             attributes=attributes, source_type=SOURCE_TYPE_BLUETOOTH)
 
     def discover_devices():


### PR DESCRIPTION
## Description:

Fixes an issue where an additional `_` was being added to bluetooth addresses (during each reboot/scan) causing the `bluetooth` `device_tracker` to have problems.

Due to a previous update, it is strongly recommended to remove Bluetooth addresses in the `known_devices.yaml` file that may contain double underscores (`__`) before the mac address. This step should be performed only after updating. This will remove invalid Bluetooth address issues from the log.
 
**Related issue (if applicable):** fixes #13846 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
