### PR TITLE
Add unique_id for BMW ConnectedDrive

### DIFF
--- a/homeassistant/components/binary_sensor/bmw_connected_drive.py
+++ b/homeassistant/components/binary_sensor/bmw_connected_drive.py
@@ -46,6 +46,7 @@ class BMWConnectedDriveSensor(BinarySensorDevice):
         self._vehicle = vehicle
         self._attribute = attribute
         self._name = '{} {}'.format(self._vehicle.name, self._attribute)
+        self._unique_id = '{}-{}'.format(self._vehicle.vin, self._attribute)
         self._sensor_name = sensor_name
         self._device_class = device_class
         self._state = None
@@ -54,6 +55,11 @@ class BMWConnectedDriveSensor(BinarySensorDevice):
     def should_poll(self) -> bool:
         """Data update is triggered from BMWConnectedDriveEntity."""
         return False
+
+    @property
+    def unique_id(self):
+        """Return the unique ID of the binary sensor."""
+        return self._unique_id
 
     @property
     def name(self):

--- a/homeassistant/components/lock/bmw_connected_drive.py
+++ b/homeassistant/components/lock/bmw_connected_drive.py
@@ -38,6 +38,7 @@ class BMWLock(LockDevice):
         self._vehicle = vehicle
         self._attribute = attribute
         self._name = '{} {}'.format(self._vehicle.name, self._attribute)
+        self._unique_id = '{}-{}'.format(self._vehicle.vin, self._attribute)
         self._sensor_name = sensor_name
         self._state = None
 
@@ -48,6 +49,11 @@ class BMWLock(LockDevice):
         Updates are triggered from BMWConnectedDriveAccount.
         """
         return False
+
+    @property
+    def unique_id(self):
+        """Return the unique ID of the binary sensor."""
+        return self._unique_id
 
     @property
     def name(self):

--- a/homeassistant/components/lock/bmw_connected_drive.py
+++ b/homeassistant/components/lock/bmw_connected_drive.py
@@ -52,7 +52,7 @@ class BMWLock(LockDevice):
 
     @property
     def unique_id(self):
-        """Return the unique ID of the binary sensor."""
+        """Return the unique ID of the lock."""
         return self._unique_id
 
     @property

--- a/homeassistant/components/sensor/bmw_connected_drive.py
+++ b/homeassistant/components/sensor/bmw_connected_drive.py
@@ -52,6 +52,7 @@ class BMWConnectedDriveSensor(Entity):
         self._state = None
         self._unit_of_measurement = None
         self._name = '{} {}'.format(self._vehicle.name, self._attribute)
+        self._unique_id = '{}-{}'.format(self._vehicle.vin, self._attribute)
         self._sensor_name = sensor_name
         self._icon = icon
 
@@ -59,6 +60,11 @@ class BMWConnectedDriveSensor(Entity):
     def should_poll(self) -> bool:
         """Data update is triggered from BMWConnectedDriveEntity."""
         return False
+
+    @property
+    def unique_id(self):
+        """Return the unique ID of the binary sensor."""
+        return self._unique_id
 
     @property
     def name(self) -> str:

--- a/homeassistant/components/sensor/bmw_connected_drive.py
+++ b/homeassistant/components/sensor/bmw_connected_drive.py
@@ -63,7 +63,7 @@ class BMWConnectedDriveSensor(Entity):
 
     @property
     def unique_id(self):
-        """Return the unique ID of the binary sensor."""
+        """Return the unique ID of the sensor."""
         return self._unique_id
 
     @property
@@ -92,7 +92,7 @@ class BMWConnectedDriveSensor(Entity):
 
     @property
     def device_state_attributes(self):
-        """Return the state attributes of the binary sensor."""
+        """Return the state attributes of the sensor."""
         return {
             'car': self._vehicle.name
         }


### PR DESCRIPTION
## Description:
Add `unique_id` for the following BMW ConnectedDrive components:
- binary sensors
- lock
- sensors

The `unique_id` is defined as the vin_number plus sensor type as discussed [here](https://github.com/home-assistant/home-assistant/pull/12591#issuecomment-374784447) with @MartinHjelmare.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
