### PR TITLE
Add tesla update switch to control polling

### DIFF
--- a/homeassistant/components/sensor/tesla.py
+++ b/homeassistant/components/sensor/tesla.py
@@ -23,7 +23,7 @@ SCAN_INTERVAL = timedelta(minutes=5)
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Tesla sensor platform."""
-    controller = hass.data[TESLA_DOMAIN]['devices']['controller']
+    controller = hass.data[TESLA_DOMAIN]['controller']
     devices = []
 
     for device in hass.data[TESLA_DOMAIN]['devices']['sensor']:

--- a/homeassistant/components/switch/tesla.py
+++ b/homeassistant/components/switch/tesla.py
@@ -17,11 +17,12 @@ DEPENDENCIES = ['tesla']
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Tesla switch platform."""
-    controller = hass.data[TESLA_DOMAIN]['devices']['controller']
+    controller = hass.data[TESLA_DOMAIN]['controller']
     devices = []
     for device in hass.data[TESLA_DOMAIN]['devices']['switch']:
         if device.bin_type == 0x8:
             devices.append(ChargerSwitch(device, controller))
+            devices.append(UpdateSwitch(device, controller))
         elif device.bin_type == 0x9:
             devices.append(RangeSwitch(device, controller))
     add_devices(devices, True)
@@ -88,4 +89,40 @@ class RangeSwitch(TeslaDevice, SwitchDevice):
         _LOGGER.debug("Updating state for: %s", self._name)
         self.tesla_device.update()
         self._state = STATE_ON if self.tesla_device.is_maxrange() \
+            else STATE_OFF
+
+
+class UpdateSwitch(TeslaDevice, SwitchDevice):
+    """Representation of a Tesla update switch."""
+
+    def __init__(self, tesla_device, controller):
+        """Initialise of the switch."""
+        self._state = None
+        super().__init__(tesla_device, controller)
+        self._name = self._name.replace("charger", "update")
+        self.tesla_id = self.tesla_id.replace("charger", "update")
+        self.entity_id = ENTITY_ID_FORMAT.format(self.tesla_id)
+
+    def turn_on(self, **kwargs):
+        """Send the on command."""
+        _LOGGER.debug("Enable updates: %s %s", self._name,
+                      self.tesla_device.id())
+        self.controller.set_updates(self.tesla_device.id(), True)
+
+    def turn_off(self, **kwargs):
+        """Send the off command."""
+        _LOGGER.debug("Disable updates: %s %s", self._name,
+                      self.tesla_device.id())
+        self.controller.set_updates(self.tesla_device.id(), False)
+
+    @property
+    def is_on(self):
+        """Get whether the switch is in on state."""
+        return self._state == STATE_ON
+
+    def update(self):
+        """Update the state of the switch."""
+        car_id = self.tesla_device.id()
+        _LOGGER.debug("Updating state for: %s %s", self._name, car_id)
+        self._state = STATE_ON if self.controller.get_updates(car_id) \
             else STATE_OFF


### PR DESCRIPTION
## Description:
Adding ability to disable polling of specific vehicles.  This is useful to allow the vehicles to go into deep sleep either at night or while parked at a airport.

NOTE: This should not be merged until teslajsonpy incorporates a separate [PR](https://github.com/zabuldon/teslajsonpy/pull/8) to add functionality to the library.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5177

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
