### PR TITLE
Eufy colour bulb updates

### DIFF
--- a/homeassistant/components/eufy.py
+++ b/homeassistant/components/eufy.py
@@ -15,7 +15,7 @@ from homeassistant.helpers import discovery
 import homeassistant.helpers.config_validation as cv
 
 
-REQUIREMENTS = ['lakeside==0.4']
+REQUIREMENTS = ['lakeside==0.5']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/light/eufy.py
+++ b/homeassistant/components/light/eufy.py
@@ -111,7 +111,7 @@ class EufyLight(Light):
     @property
     def hs_color(self):
         """Return the color of this light."""
-        if self._colormode == False:
+        if not self._colormode:
             return None
         return self._hs
 
@@ -145,7 +145,7 @@ class EufyLight(Light):
             rgb = color_util.color_hsv_to_RGB(
                 hs[0], hs[1], brightness / 255 * 100)
             self._colormode = True
-        elif self._colormode == True:
+        elif self._colormode:
             rgb = color_util.color_hsv_to_RGB(
                 self._hs[0], self._hs[1], brightness / 255 * 100)
         else:

--- a/homeassistant/components/light/eufy.py
+++ b/homeassistant/components/light/eufy.py
@@ -48,12 +48,14 @@ class EufyLight(Light):
         self._code = device['code']
         self._type = device['type']
         self._bulb = lakeside.bulb(self._address, self._code, self._type)
+        self._colormode = False
         if self._type == "T1011":
             self._features = SUPPORT_BRIGHTNESS
         elif self._type == "T1012":
             self._features = SUPPORT_BRIGHTNESS | SUPPORT_COLOR_TEMP
         elif self._type == "T1013":
-            self._features = SUPPORT_BRIGHTNESS | SUPPORT_COLOR
+            self._features = SUPPORT_BRIGHTNESS | SUPPORT_COLOR_TEMP | \
+                             SUPPORT_COLOR
         self._bulb.connect()
 
     def update(self):
@@ -62,9 +64,10 @@ class EufyLight(Light):
         self._brightness = self._bulb.brightness
         self._temp = self._bulb.temperature
         if self._bulb.colors:
-            self._hs = color_util.color_RGB_to_hsv(*self._bulb.colors)
+            self._colormode = True
+            self._hs = color_util.color_RGB_to_hs(*self._bulb.colors)
         else:
-            self._hs = None
+            self._colormode = False
         self._state = self._bulb.power
 
     @property
@@ -108,6 +111,8 @@ class EufyLight(Light):
     @property
     def hs_color(self):
         """Return the color of this light."""
+        if self._colormode == False:
+            return None
         return self._hs
 
     @property
@@ -128,6 +133,7 @@ class EufyLight(Light):
             brightness = max(1, self._brightness)
 
         if colortemp is not None:
+            self._colormode = False
             temp_in_k = mired_to_kelvin(colortemp)
             relative_temp = temp_in_k - EUFY_MIN_KELVIN
             temp = int(relative_temp * 100 /
@@ -138,6 +144,10 @@ class EufyLight(Light):
         if hs is not None:
             rgb = color_util.color_hsv_to_RGB(
                 hs[0], hs[1], brightness / 255 * 100)
+            self._colormode = True
+        elif self._colormode == True:
+            rgb = color_util.color_hsv_to_RGB(
+                self._hs[0], self._hs[1], brightness / 255 * 100)
         else:
             rgb = None
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -458,7 +458,7 @@ keyring==12.0.0
 keyrings.alt==3.0
 
 # homeassistant.components.eufy
-lakeside==0.4
+lakeside==0.5
 
 # homeassistant.components.device_tracker.owntracks
 # homeassistant.components.device_tracker.owntracks_http


### PR DESCRIPTION
The Eufy colour bulbs behave differently to the white ones. I've been able to test one now, so here are some fixes.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
