### PR TITLE
Fritzbox netmonitor name

### DIFF
--- a/homeassistant/components/sensor/fritzbox_netmonitor.py
+++ b/homeassistant/components/sensor/fritzbox_netmonitor.py
@@ -10,7 +10,7 @@ from datetime import timedelta
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import (CONF_HOST, STATE_UNAVAILABLE)
+from homeassistant.const import (CONF_NAME, CONF_HOST, STATE_UNAVAILABLE)
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import Throttle

--- a/homeassistant/components/sensor/fritzbox_netmonitor.py
+++ b/homeassistant/components/sensor/fritzbox_netmonitor.py
@@ -21,6 +21,7 @@ REQUIREMENTS = ['fritzconnection==0.6.5']
 
 _LOGGER = logging.getLogger(__name__)
 
+CONF_DEFAULT_NAME = 'fritz_netmonitor'
 CONF_DEFAULT_IP = '169.254.1.1'  # This IP is valid for all FRITZ!Box routers.
 
 ATTR_BYTES_RECEIVED = 'bytes_received'
@@ -43,6 +44,7 @@ STATE_OFFLINE = 'offline'
 ICON = 'mdi:web'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_NAME, default=CONF_DEFAULT_NAME): cv.string,
     vol.Optional(CONF_HOST, default=CONF_DEFAULT_IP): cv.string,
 })
 
@@ -53,6 +55,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     import fritzconnection as fc
     from fritzconnection.fritzconnection import FritzConnectionException
 
+    name = config.get(CONF_NAME)
     host = config.get(CONF_HOST)
 
     try:
@@ -66,15 +69,15 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     else:
         _LOGGER.info("Successfully connected to FRITZ!Box")
 
-    add_devices([FritzboxMonitorSensor(fstatus)], True)
+    add_devices([FritzboxMonitorSensor(name, fstatus)], True)
 
 
 class FritzboxMonitorSensor(Entity):
     """Implementation of a fritzbox monitor sensor."""
 
-    def __init__(self, fstatus):
+    def __init__(self, name, fstatus):
         """Initialize the sensor."""
-        self._name = 'fritz_netmonitor'
+        self._name = name
         self._fstatus = fstatus
         self._state = STATE_UNAVAILABLE
         self._is_linked = self._is_connected = self._wan_access_type = None


### PR DESCRIPTION
## Description:
Add the ability to set the name for the netmonitor without the use of customize.

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: fritzbox_netmonitor
    name: FritzBox
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
