### PR TITLE
Xiaomi MiIO Vacuum: Params of the send command can be a list now

### DIFF
--- a/homeassistant/components/vacuum/__init__.py
+++ b/homeassistant/components/vacuum/__init__.py
@@ -57,7 +57,7 @@ VACUUM_SET_FAN_SPEED_SERVICE_SCHEMA = VACUUM_SERVICE_SCHEMA.extend({
 
 VACUUM_SEND_COMMAND_SERVICE_SCHEMA = VACUUM_SERVICE_SCHEMA.extend({
     vol.Required(ATTR_COMMAND): cv.string,
-    vol.Optional(ATTR_PARAMS): cv.Dict,
+    vol.Optional(ATTR_PARAMS): vol.Any(cv.Dict, cv.ensure_list),
 })
 
 SERVICE_TO_METHOD = {


### PR DESCRIPTION
## Description:

A string is converted to a list now. A list remains a list and a dict remains a dict. 

```
Service call: vacuum.send_command {"command":"set_bright", params:{"bright": 21}}
Outout: DEBUG:miio.device:192.168.132.37:54321 >>: {'method': 'set_bright', 'params': {'bright': 21}, 'id': 5}

Service call: vacuum.send_command {"command":"set_bright", params:[21]}
Output: DEBUG:miio.device:192.168.132.37:54321 >>: {'method': 'set_bright', 'params': [21], 'id': 10}

Service call: vacuum.send_command {"command":"set_bright", params:21}
Output: DEBUG:miio.device:192.168.132.37:54321 >>: {'method': 'set_bright', 'params': [21], 'id': 14}
```

**Related issue (if applicable):** fixes #13879
