### PR TITLE
Add more math functions to templates

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -452,6 +452,38 @@ def logarithm(value, base=math.e):
         return value
 
 
+def sine(value):
+    """Filter to get sine of the value."""
+    try:
+        return math.sin(float(value))
+    except (ValueError, TypeError):
+        return value
+
+
+def cosine(value):
+    """Filter to get cosine of the value."""
+    try:
+        return math.cos(float(value))
+    except (ValueError, TypeError):
+        return value
+
+
+def tangent(value):
+    """Filter to get tangent of the value."""
+    try:
+        return math.tan(float(value))
+    except (ValueError, TypeError):
+        return value
+
+
+def square_root(value):
+    """Filter to get square root of the value."""
+    try:
+        return math.sqrt(float(value))
+    except (ValueError, TypeError):
+        return value
+
+
 def timestamp_custom(value, date_format=DATE_STR_FORMAT, local=True):
     """Filter to convert given timestamp to format."""
     try:
@@ -571,6 +603,10 @@ ENV = TemplateEnvironment()
 ENV.filters['round'] = forgiving_round
 ENV.filters['multiply'] = multiply
 ENV.filters['log'] = logarithm
+ENV.filters['sin'] = sine
+ENV.filters['cos'] = cosine
+ENV.filters['tan'] = tangent
+ENV.filters['sqrt'] = square_root
 ENV.filters['timestamp_custom'] = timestamp_custom
 ENV.filters['timestamp_local'] = timestamp_local
 ENV.filters['timestamp_utc'] = timestamp_utc
@@ -583,6 +619,13 @@ ENV.filters['regex_replace'] = regex_replace
 ENV.filters['regex_search'] = regex_search
 ENV.filters['regex_findall_index'] = regex_findall_index
 ENV.globals['log'] = logarithm
+ENV.globals['sin'] = sine
+ENV.globals['cos'] = cosine
+ENV.globals['tan'] = tangent
+ENV.globals['sqrt'] = square_root
+ENV.globals['pi'] = math.pi
+ENV.globals['tau'] = math.pi * 2
+ENV.globals['e'] = math.e
 ENV.globals['float'] = forgiving_float
 ENV.globals['now'] = dt_util.now
 ENV.globals['utcnow'] = dt_util.utcnow

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -149,6 +149,74 @@ class TestHelpersTemplate(unittest.TestCase):
                     '{{ log(%s, %s) | round(1) }}' % (value, base),
                     self.hass).render())
 
+    def test_sine(self):
+        """Test sine."""
+        tests = [
+            (0, '0.0'),
+            (math.pi / 2, '1.0'),
+            (math.pi, '0.0'),
+            (math.pi * 1.5, '-1.0'),
+            (math.pi / 10, '0.309')
+        ]
+
+        for value, expected in tests:
+            self.assertEqual(
+                expected,
+                template.Template(
+                    '{{ %s | sin | round(3) }}' % value,
+                    self.hass).render())
+
+    def test_cos(self):
+        """Test cosine."""
+        tests = [
+            (0, '1.0'),
+            (math.pi / 2, '0.0'),
+            (math.pi, '-1.0'),
+            (math.pi * 1.5, '-0.0'),
+            (math.pi / 10, '0.951')
+        ]
+
+        for value, expected in tests:
+            self.assertEqual(
+                expected,
+                template.Template(
+                    '{{ %s | cos | round(3) }}' % value,
+                    self.hass).render())
+
+    def test_tan(self):
+        """Test tangent."""
+        tests = [
+            (0, '0.0'),
+            (math.pi, '-0.0'),
+            (math.pi / 180 * 45, '1.0'),
+            (math.pi / 180 * 90, '1.633123935319537e+16'),
+            (math.pi / 180 * 135, '-1.0')
+        ]
+
+        for value, expected in tests:
+            self.assertEqual(
+                expected,
+                template.Template(
+                    '{{ %s | tan | round(3) }}' % value,
+                    self.hass).render())
+
+    def test_sqrt(self):
+        """Test square root."""
+        tests = [
+            (0, '0.0'),
+            (1, '1.0'),
+            (2, '1.414'),
+            (10, '3.162'),
+            (100, '10.0'),
+        ]
+
+        for value, expected in tests:
+            self.assertEqual(
+                expected,
+                template.Template(
+                    '{{ %s | sqrt | round(3) }}' % value,
+                    self.hass).render())
+
     def test_strptime(self):
         """Test the parse timestamp method."""
         tests = [


### PR DESCRIPTION
## Description:

We make `sin`, `cos`, `tan`, and `sqrt` functions, and the `pi`, `tau`,
and `e` constants available in templates.

**Related issue (if applicable):**

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5186

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
