### PR TITLE
Fixed Capsman data not being used

### DIFF
--- a/homeassistant/components/device_tracker/mikrotik.py
+++ b/homeassistant/components/device_tracker/mikrotik.py
@@ -176,7 +176,7 @@ class MikrotikScanner(DeviceScanner):
                      for device in device_names
                      if device.get('mac-address')}
 
-        if self.wireless_exist:
+        if self.wireless_exist or self.capsman_exist:
             self.last_results = {
                 device.get('mac-address'):
                     mac_names.get(device.get('mac-address'))


### PR DESCRIPTION
## Description:
**Fixes the components function to use the wlan registration-table when available.**

Without this patch the component will use the fallback option to use the dhcp leases. This will list the devices as "At Home" until the dhcp lease time has run out.
With this patch only the devices with a active connection will be listed as "At Home"

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**