### PR TITLE
Cleanup on exit

### DIFF
--- a/homeassistant/components/media_player/mediaroom.py
+++ b/homeassistant/components/media_player/mediaroom.py
@@ -130,7 +130,7 @@ class MediaroomDevice(MediaPlayerDevice):
         self._channel = None
         self._optimistic = optimistic
         self._state = STATE_PLAYING if optimistic else STATE_STANDBY
-        self._name = 'Mediaroom {}'.format(device_id)
+        self._name = 'Mediaroom {}'.format(device_id if device_id else host)
         self._available = True
         if device_id:
             self._unique_id = device_id

--- a/homeassistant/components/media_player/mediaroom.py
+++ b/homeassistant/components/media_player/mediaroom.py
@@ -91,7 +91,8 @@ async def async_setup_platform(hass, config, async_add_devices,
                 _LOGGER.debug("Stopping internal pymediaroom discovery.")
                 hass.data[DISCOVERY_MEDIAROOM].close()
 
-            hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, stop_discovery)
+            hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP,
+                                       stop_discovery)
 
             _LOGGER.debug("Auto discovery installed")
 

--- a/homeassistant/components/media_player/mediaroom.py
+++ b/homeassistant/components/media_player/mediaroom.py
@@ -8,6 +8,7 @@ import logging
 
 import voluptuous as vol
 
+from homeassistant.core import callback
 from homeassistant.components.media_player import (
     MEDIA_TYPE_CHANNEL, SUPPORT_PAUSE, SUPPORT_PLAY_MEDIA, SUPPORT_TURN_OFF,
     SUPPORT_TURN_ON, SUPPORT_STOP, PLATFORM_SCHEMA, SUPPORT_NEXT_TRACK,
@@ -86,7 +87,8 @@ async def async_setup_platform(hass, config, async_add_devices,
             hass.data[DISCOVERY_MEDIAROOM] = await install_mediaroom_protocol(
                 responses_callback=callback_notify)
 
-            async def stop_discovery(event):
+            @callback
+            def stop_discovery(event):
                 """Stop discovery of new mediaroom STB's."""
                 _LOGGER.debug("Stopping internal pymediaroom discovery.")
                 hass.data[DISCOVERY_MEDIAROOM].close()

--- a/homeassistant/components/media_player/mediaroom.py
+++ b/homeassistant/components/media_player/mediaroom.py
@@ -24,7 +24,7 @@ from homeassistant.const import (
 )
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['pymediaroom==0.6']
+REQUIREMENTS = ['pymediaroom==0.6.3']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -832,7 +832,7 @@ pylutron==0.1.0
 pymailgunner==1.4
 
 # homeassistant.components.media_player.mediaroom
-pymediaroom==0.6
+pymediaroom==0.6.3
 
 # homeassistant.components.media_player.xiaomi_tv
 pymitv==1.0.0


### PR DESCRIPTION
## Description:

This pull request adds a cleanup callback and respective supporting library version bump.

The version bump to the supporting library actually fixes an issue with environments using uvloop (BUG FIX)

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  - platform: mediarooom
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable.
  - [x] New dependencies are only imported inside functions that use them.
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.


