### PR TITLE
Updated foobot_async package version

### DIFF
--- a/homeassistant/components/sensor/foobot.py
+++ b/homeassistant/components/sensor/foobot.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 
 
-REQUIREMENTS = ['foobot_async==0.3.0']
+REQUIREMENTS = ['foobot_async==0.3.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -311,7 +311,7 @@ fixerio==0.1.1
 flux_led==0.21
 
 # homeassistant.components.sensor.foobot
-foobot_async==0.3.0
+foobot_async==0.3.1
 
 # homeassistant.components.notify.free_mobile
 freesms==0.1.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -63,7 +63,7 @@ evohomeclient==0.2.5
 feedparser==5.2.1
 
 # homeassistant.components.sensor.foobot
-foobot_async==0.3.0
+foobot_async==0.3.1
 
 # homeassistant.components.tts.google
 gTTS-token==1.1.1


### PR DESCRIPTION
Fix #13886

## Description:

Updated foobot_async package version with the aiohttp package version pinning removed.

**Related issue (if applicable):** fixes #13886

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**