### PR TITLE
Support setting explicit mute value for Panasonic Viera TV

### DIFF
--- a/homeassistant/components/media_player/panasonic_viera.py
+++ b/homeassistant/components/media_player/panasonic_viera.py
@@ -172,20 +172,20 @@ class PanasonicVieraTVDevice(MediaPlayerDevice):
     def media_play(self):
         """Send play command."""
         self._playing = True
-        self.send_key('NRC_PLAY-ONOFF')
+        self._remote.media_play()
 
     def media_pause(self):
         """Send media pause command to media player."""
         self._playing = False
-        self.send_key('NRC_PAUSE-ONOFF')
+        self._remote.media_pause()
 
     def media_next_track(self):
         """Send next track command."""
-        self.send_key('NRC_FF-ONOFF')
+        self._remote.media_next_track()
 
     def media_previous_track(self):
         """Send the previous track command."""
-        self.send_key('NRC_REW-ONOFF')
+        self._remote.media_previous_track()
 
     def play_media(self, media_type, media_id, **kwargs):
         """Play media."""

--- a/homeassistant/components/media_player/panasonic_viera.py
+++ b/homeassistant/components/media_player/panasonic_viera.py
@@ -138,20 +138,20 @@ class PanasonicVieraTVDevice(MediaPlayerDevice):
     def turn_off(self):
         """Turn off media player."""
         if self._state != STATE_OFF:
-            self.send_key('NRC_POWER-ONOFF')
+            self._remote.turn_off()
             self._state = STATE_OFF
 
     def volume_up(self):
         """Volume up the media player."""
-        self.send_key('NRC_VOLUP-ONOFF')
+        self._remote.volume_up()
 
     def volume_down(self):
         """Volume down media player."""
-        self.send_key('NRC_VOLDOWN-ONOFF')
+        self._remote.volume_down()
 
     def mute_volume(self, mute):
         """Send mute command."""
-        self.send_key('NRC_MUTE-ONOFF')
+        self._remote.set_mute(mute)
 
     def set_volume_level(self, volume):
         """Set volume level, range 0..1."""


### PR DESCRIPTION
## Description:
Though the [Media Player docs](https://www.home-assistant.io/components/media_player/) suggest one can explicitly set a mute value via `media_player.volume_mute`, previously, this component only toggled mute, as nothing was done with the passed value. This has been fixed by using the `panasonic_viera` module's methods instead of API calls.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54