### PR TITLE
Bumped pypollencom to 1.1.2

### DIFF
--- a/homeassistant/components/sensor/pollen.py
+++ b/homeassistant/components/sensor/pollen.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle, slugify
 
-REQUIREMENTS = ['pypollencom==1.1.1']
+REQUIREMENTS = ['pypollencom==1.1.2']
 _LOGGER = logging.getLogger(__name__)
 
 ATTR_ALLERGEN_GENUS = 'primary_allergen_genus'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -889,7 +889,7 @@ pyotp==2.2.6
 pyowm==2.8.0
 
 # homeassistant.components.sensor.pollen
-pypollencom==1.1.1
+pypollencom==1.1.2
 
 # homeassistant.components.qwikswitch
 pyqwikswitch==0.71


### PR DESCRIPTION
## Description:
Bumped pypollencom to 1.1.2, which addresses some new API changes.

**Related issue (if applicable):** fixes #13896 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: pollen
    zip_code: "123456"
    monitored_conditions:
      - allergy_average_forecasted
      - allergy_average_historical
      - allergy_index_today
      - allergy_index_tomorrow
      - allergy_index_yesterday
      - disease_average_forecasted
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - ~[ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)~

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - ~[ ] New dependencies are only imported inside functions that use them ([example][ex-import]).~
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - ~[ ] New files were added to `.coveragerc`.~

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
