### PR TITLE
deCONZ shouldn't close HASS web session

### DIFF
--- a/homeassistant/components/deconz/__init__.py
+++ b/homeassistant/components/deconz/__init__.py
@@ -18,7 +18,7 @@ from homeassistant.helpers import discovery, aiohttp_client
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.util.json import load_json, save_json
 
-REQUIREMENTS = ['pydeconz==35']
+REQUIREMENTS = ['pydeconz==36']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -730,7 +730,7 @@ pycsspeechtts==1.0.2
 pydaikin==0.4
 
 # homeassistant.components.deconz
-pydeconz==35
+pydeconz==36
 
 # homeassistant.components.zwave
 pydispatcher==2.0.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -130,7 +130,7 @@ pushbullet.py==0.11.0
 py-canary==0.5.0
 
 # homeassistant.components.deconz
-pydeconz==35
+pydeconz==36
 
 # homeassistant.components.zwave
 pydispatcher==2.0.5


### PR DESCRIPTION
## Description:
A small refactoring in lib that moved utility methods to use HASS web session missed to remove a session.close call after generating a new API key.

**Related issue (if applicable):** fixes reported in forum

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**