### PR TITLE
Add more parameters for DSMR sensor

### DIFF
--- a/homeassistant/components/sensor/dsmr.py
+++ b/homeassistant/components/sensor/dsmr.py
@@ -77,12 +77,12 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         ['Power Production Phase L2', obis_ref.INSTANTANEOUS_ACTIVE_POWER_L2_NEGATIVE],
         ['Power Production Phase L3', obis_ref.INSTANTANEOUS_ACTIVE_POWER_L3_NEGATIVE],
         ['Long Power Failure Count', obis_ref.LONG_POWER_FAILURE_COUNT],
-	['Voltage Sags Phase L1', obis_ref.VOLTAGE_SAG_L1_COUNT],
-	['Voltage Sags Phase L2', obis_ref.VOLTAGE_SAG_L2_COUNT],
-	['Voltage Sags Phase L3', obis_ref.VOLTAGE_SAG_L3_COUNT],
-	['Voltage Swells Phase L1', obis_ref.VOLTAGE_SWELL_L1_COUNT],
-	['Voltage Swells Phase L2', obis_ref.VOLTAGE_SWELL_L2_COUNT],
-	['Voltage Swells Phase L3', obis_ref.VOLTAGE_SWELL_L3_COUNT],
+        ['Voltage Sags Phase L1', obis_ref.VOLTAGE_SAG_L1_COUNT],
+        ['Voltage Sags Phase L2', obis_ref.VOLTAGE_SAG_L2_COUNT],
+        ['Voltage Sags Phase L3', obis_ref.VOLTAGE_SAG_L3_COUNT],
+        ['Voltage Swells Phase L1', obis_ref.VOLTAGE_SWELL_L1_COUNT],
+        ['Voltage Swells Phase L2', obis_ref.VOLTAGE_SWELL_L2_COUNT],
+        ['Voltage Swells Phase L3', obis_ref.VOLTAGE_SWELL_L3_COUNT],
     ]
 
     # Generate device entities

--- a/homeassistant/components/sensor/dsmr.py
+++ b/homeassistant/components/sensor/dsmr.py
@@ -32,6 +32,7 @@ DOMAIN = 'dsmr'
 ICON_GAS = 'mdi:fire'
 ICON_POWER = 'mdi:flash'
 ICON_POWER_FAILURE = 'mdi:flash-off'
+ICON_SWELL_SAG = 'mdi:pulse'
 
 # Smart meter sends telegram every 10 seconds
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=10)
@@ -188,6 +189,8 @@ class DSMREntity(Entity):
     @property
     def icon(self):
         """Icon to use in the frontend, if any."""
+        if 'Sags' in self._name or 'Swells' in self.name:
+            return ICON_SWELL_SAG
         if 'Failure' in self._name:
             return ICON_POWER_FAILURE
         if 'Power' in self._name:

--- a/homeassistant/components/sensor/dsmr.py
+++ b/homeassistant/components/sensor/dsmr.py
@@ -63,26 +63,86 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 
     # Define list of name,obis mappings to generate entities
     obis_mapping = [
-        ['Power Consumption', obis_ref.CURRENT_ELECTRICITY_USAGE],
-        ['Power Production', obis_ref.CURRENT_ELECTRICITY_DELIVERY],
-        ['Power Tariff', obis_ref.ELECTRICITY_ACTIVE_TARIFF],
-        ['Power Consumption (low)', obis_ref.ELECTRICITY_USED_TARIFF_1],
-        ['Power Consumption (normal)', obis_ref.ELECTRICITY_USED_TARIFF_2],
-        ['Power Production (low)', obis_ref.ELECTRICITY_DELIVERED_TARIFF_1],
-        ['Power Production (normal)', obis_ref.ELECTRICITY_DELIVERED_TARIFF_2],
-        ['Power Consumption Phase L1', obis_ref.INSTANTANEOUS_ACTIVE_POWER_L1_POSITIVE],
-        ['Power Consumption Phase L2', obis_ref.INSTANTANEOUS_ACTIVE_POWER_L2_POSITIVE],
-        ['Power Consumption Phase L3', obis_ref.INSTANTANEOUS_ACTIVE_POWER_L3_POSITIVE],
-        ['Power Production Phase L1', obis_ref.INSTANTANEOUS_ACTIVE_POWER_L1_NEGATIVE],
-        ['Power Production Phase L2', obis_ref.INSTANTANEOUS_ACTIVE_POWER_L2_NEGATIVE],
-        ['Power Production Phase L3', obis_ref.INSTANTANEOUS_ACTIVE_POWER_L3_NEGATIVE],
-        ['Long Power Failure Count', obis_ref.LONG_POWER_FAILURE_COUNT],
-        ['Voltage Sags Phase L1', obis_ref.VOLTAGE_SAG_L1_COUNT],
-        ['Voltage Sags Phase L2', obis_ref.VOLTAGE_SAG_L2_COUNT],
-        ['Voltage Sags Phase L3', obis_ref.VOLTAGE_SAG_L3_COUNT],
-        ['Voltage Swells Phase L1', obis_ref.VOLTAGE_SWELL_L1_COUNT],
-        ['Voltage Swells Phase L2', obis_ref.VOLTAGE_SWELL_L2_COUNT],
-        ['Voltage Swells Phase L3', obis_ref.VOLTAGE_SWELL_L3_COUNT],
+        [
+            'Power Consumption',
+            obis_ref.CURRENT_ELECTRICITY_USAGE
+        ],
+        [
+            'Power Production',
+            obis_ref.CURRENT_ELECTRICITY_DELIVERY
+        ],
+        [
+            'Power Tariff',
+            obis_ref.ELECTRICITY_ACTIVE_TARIFF
+        ],
+        [
+            'Power Consumption (low)',
+            obis_ref.ELECTRICITY_USED_TARIFF_1
+        ],
+        [
+            'Power Consumption (normal)',
+            obis_ref.ELECTRICITY_USED_TARIFF_2
+        ],
+        [
+            'Power Production (low)',
+            obis_ref.ELECTRICITY_DELIVERED_TARIFF_1
+        ],
+        [
+            'Power Production (normal)',
+            obis_ref.ELECTRICITY_DELIVERED_TARIFF_2
+        ],
+        [
+            'Power Consumption Phase L1',
+            obis_ref.INSTANTANEOUS_ACTIVE_POWER_L1_POSITIVE
+        ],
+        [
+            'Power Consumption Phase L2',
+            obis_ref.INSTANTANEOUS_ACTIVE_POWER_L2_POSITIVE
+        ],
+        [
+            'Power Consumption Phase L3',
+            obis_ref.INSTANTANEOUS_ACTIVE_POWER_L3_POSITIVE
+        ],
+        [
+            'Power Production Phase L1',
+            obis_ref.INSTANTANEOUS_ACTIVE_POWER_L1_NEGATIVE
+        ],
+        [
+            'Power Production Phase L2',
+            obis_ref.INSTANTANEOUS_ACTIVE_POWER_L2_NEGATIVE
+        ],
+        [
+            'Power Production Phase L3',
+            obis_ref.INSTANTANEOUS_ACTIVE_POWER_L3_NEGATIVE
+        ],
+        [
+            'Long Power Failure Count',
+            obis_ref.LONG_POWER_FAILURE_COUNT
+        ],
+        [
+            'Voltage Sags Phase L1',
+            obis_ref.VOLTAGE_SAG_L1_COUNT
+        ],
+        [
+            'Voltage Sags Phase L2',
+            obis_ref.VOLTAGE_SAG_L2_COUNT
+        ],
+        [
+            'Voltage Sags Phase L3',
+            obis_ref.VOLTAGE_SAG_L3_COUNT
+        ],
+        [
+            'Voltage Swells Phase L1',
+            obis_ref.VOLTAGE_SWELL_L1_COUNT
+        ],
+        [
+            'Voltage Swells Phase L2',
+            obis_ref.VOLTAGE_SWELL_L2_COUNT
+        ],
+        [
+            'Voltage Swells Phase L3',
+            obis_ref.VOLTAGE_SWELL_L3_COUNT
+        ],
     ]
 
     # Generate device entities

--- a/homeassistant/components/sensor/dsmr.py
+++ b/homeassistant/components/sensor/dsmr.py
@@ -68,6 +68,19 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         ['Power Consumption (normal)', obis_ref.ELECTRICITY_USED_TARIFF_2],
         ['Power Production (low)', obis_ref.ELECTRICITY_DELIVERED_TARIFF_1],
         ['Power Production (normal)', obis_ref.ELECTRICITY_DELIVERED_TARIFF_2],
+        ['Power Consumption Phase L1', obis_ref.INSTANTANEOUS_ACTIVE_POWER_L1_POSITIVE],
+        ['Power Consumption Phase L2', obis_ref.INSTANTANEOUS_ACTIVE_POWER_L2_POSITIVE],
+        ['Power Consumption Phase L3', obis_ref.INSTANTANEOUS_ACTIVE_POWER_L3_POSITIVE],
+        ['Power Production Phase L1', obis_ref.INSTANTANEOUS_ACTIVE_POWER_L1_NEGATIVE],
+        ['Power Production Phase L2', obis_ref.INSTANTANEOUS_ACTIVE_POWER_L2_NEGATIVE],
+        ['Power Production Phase L3', obis_ref.INSTANTANEOUS_ACTIVE_POWER_L3_NEGATIVE],
+        ['Long Power Failure Count', obis_ref.LONG_POWER_FAILURE_COUNT],
+	['Voltage Sags Phase L1', obis_ref.VOLTAGE_SAG_L1_COUNT],
+	['Voltage Sags Phase L2', obis_ref.VOLTAGE_SAG_L2_COUNT],
+	['Voltage Sags Phase L3', obis_ref.VOLTAGE_SAG_L3_COUNT],
+	['Voltage Swells Phase L1', obis_ref.VOLTAGE_SWELL_L1_COUNT],
+	['Voltage Swells Phase L2', obis_ref.VOLTAGE_SWELL_L2_COUNT],
+	['Voltage Swells Phase L3', obis_ref.VOLTAGE_SWELL_L3_COUNT],
     ]
 
     # Generate device entities

--- a/homeassistant/components/sensor/dsmr.py
+++ b/homeassistant/components/sensor/dsmr.py
@@ -31,6 +31,7 @@ DOMAIN = 'dsmr'
 
 ICON_GAS = 'mdi:fire'
 ICON_POWER = 'mdi:flash'
+ICON_POWER_FAILURE = 'mdi:flash-off'
 
 # Smart meter sends telegram every 10 seconds
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=10)
@@ -187,6 +188,8 @@ class DSMREntity(Entity):
     @property
     def icon(self):
         """Icon to use in the frontend, if any."""
+        if 'Failure' in self._name:
+            return ICON_POWER_FAILURE
         if 'Power' in self._name:
             return ICON_POWER
         elif 'Gas' in self._name:


### PR DESCRIPTION
## Description:

This PR adds more parameters to the DSMR sensor component (Dutch Smart Meters), as these are supported by the dsmr_parser library. Added:

- power consumption/production per phase (L1,L2,L3)
- voltage swells & sags per phase
- total count of (long) power failures

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: dsmr
    dsmr_version: 4

group:
  meter_readings:
    name: Meter readings
    entities:
      - sensor.power_consumption_phase_l1
      - sensor.power_consumption_phase_l2
      - sensor.power_consumption_phase_l3
      - sensor.power_consumption_low
      - sensor.power_consumption_normal
      - sensor.power_production_low
      - sensor.power_production_normal
      - sensor.long_power_failure_count
      - sensor.voltage_swells_phase_l1
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass** _(Unfortunately I don't have this as a running setup, could someone give it a shot?)_

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
