### PR TITLE
Adds update file_path service to local_file camera

### DIFF
--- a/homeassistant/components/camera/local_file.py
+++ b/homeassistant/components/camera/local_file.py
@@ -19,7 +19,7 @@ _LOGGER = logging.getLogger(__name__)
 
 CONF_FILE_PATH = 'file_path'
 DEFAULT_NAME = 'Local File'
-SERVICE_UPDATE_FILE_PATH = 'update_file_path'
+SERVICE_UPDATE_FILE_PATH = 'local_file_update_file_path'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_FILE_PATH): cv.string,
@@ -95,8 +95,10 @@ class LocalFile(Camera):
     @property
     def device_state_attributes(self):
         """Return the camera state attributes."""
-        attr = {
-            'access_token': self.access_tokens[-1],
-            'file_path': self._file_path
-        }
-        return attr
+        attr = super(LocalFile, self).device_state_attributes
+        if attr is None:
+            attr = {}
+        return {
+            'file_path': self._file_path,
+            **attr
+            }

--- a/homeassistant/components/camera/local_file.py
+++ b/homeassistant/components/camera/local_file.py
@@ -42,7 +42,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         camera.update_file_path(file_path)
         return True
 
-    hass.services.async_register(
+    hass.services.register(
         DOMAIN,
         SERVICE_UPDATE_FILE_PATH,
         update_file_path_service,

--- a/homeassistant/components/camera/local_file.py
+++ b/homeassistant/components/camera/local_file.py
@@ -75,6 +75,13 @@ class LocalFile(Camera):
         """Update the camera file path."""
         if os.path.isfile(file_path):
             self._file_path = file_path
+            self.hass.bus.fire(
+                DOMAIN, {
+                    'entity_id': self.entity_id,
+                    "event_type": "update_file_path",
+                    'name': self._name,
+                    "file_path": file_path,
+                    })
         else:
             _LOGGER.warning("Invalid file_path: %s", file_path)
 

--- a/homeassistant/components/camera/local_file.py
+++ b/homeassistant/components/camera/local_file.py
@@ -4,6 +4,7 @@ Camera that loads a picture from a local file.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/camera.local_file/
 """
+import asyncio
 import logging
 import mimetypes
 import os
@@ -48,7 +49,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         camera.update_file_path(file_path)
         return True
 
-    hass.services.register(
+    hass.services.async_register(
         DOMAIN,
         SERVICE_UPDATE_FILE_PATH,
         update_file_path_service,

--- a/homeassistant/components/camera/local_file.py
+++ b/homeassistant/components/camera/local_file.py
@@ -49,10 +49,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         return True
 
     hass.services.register(
-            DOMAIN,
-            SERVICE_UPDATE_FILE_PATH,
-            update_file_path_service,
-            schema=CAMERA_SERVICE_UPDATE_FILE_PATH)
+        DOMAIN,
+        SERVICE_UPDATE_FILE_PATH,
+        update_file_path_service,
+        schema=CAMERA_SERVICE_UPDATE_FILE_PATH)
 
     add_devices([camera])
 

--- a/homeassistant/components/camera/local_file.py
+++ b/homeassistant/components/camera/local_file.py
@@ -4,7 +4,6 @@ Camera that loads a picture from a local file.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/camera.local_file/
 """
-import asyncio
 import logging
 import mimetypes
 import os

--- a/homeassistant/components/camera/local_file.py
+++ b/homeassistant/components/camera/local_file.py
@@ -91,3 +91,12 @@ class LocalFile(Camera):
     def name(self):
         """Return the name of this camera."""
         return self._name
+
+    @property
+    def device_state_attributes(self):
+        """Return the camera state attributes."""
+        attr = {
+            'access_token': self.access_tokens[-1],
+            'file_path': self._file_path
+        }
+        return attr

--- a/homeassistant/components/camera/local_file.py
+++ b/homeassistant/components/camera/local_file.py
@@ -95,10 +95,6 @@ class LocalFile(Camera):
     @property
     def device_state_attributes(self):
         """Return the camera state attributes."""
-        attr = super(LocalFile, self).device_state_attributes
-        if attr is None:
-            attr = {}
         return {
             'file_path': self._file_path,
-            **attr
-            }
+        }

--- a/homeassistant/components/camera/local_file.py
+++ b/homeassistant/components/camera/local_file.py
@@ -84,6 +84,7 @@ class LocalFile(Camera):
         """Update the local_file camera file path."""
         if os.path.isfile(file_path):
             self._file_path = file_path
+            self.schedule_update_ha_state()
         else:
             _LOGGER.warning("Invalid file_path: %s", file_path)
 

--- a/homeassistant/components/camera/services.yaml
+++ b/homeassistant/components/camera/services.yaml
@@ -24,7 +24,7 @@ snapshot:
       description: Template of a Filename. Variable is entity_id.
       example: '/tmp/snapshot_{{ entity_id }}'
 
-update_file_path:
+local_file_update_file_path:
   description: Update the file_path for a local_file camera.
   fields:
     entity_id:

--- a/homeassistant/components/camera/services.yaml
+++ b/homeassistant/components/camera/services.yaml
@@ -24,6 +24,16 @@ snapshot:
       description: Template of a Filename. Variable is entity_id.
       example: '/tmp/snapshot_{{ entity_id }}'
 
+update_file_path:
+  description: Update the file_path for a local_file camera.
+  fields:
+    entity_id:
+      description: Name(s) of entities to update.
+      example: 'camera.local_file'
+    file_path:
+      description: Path to the new image file.
+      example: '/images/newimage.jpg'
+
 onvif_ptz:
   description: Pan/Tilt/Zoom service for ONVIF camera.
   fields:
@@ -39,4 +49,3 @@ onvif_ptz:
     zoom:
       description: "Zoom. Allowed values: ZOOM_IN, ZOOM_OUT"
       example: "ZOOM_IN"
-

--- a/tests/components/camera/test_local_file.py
+++ b/tests/components/camera/test_local_file.py
@@ -120,8 +120,7 @@ def test_camera_content_type(hass, aiohttp_client):
     assert body == image
 
 
-@asyncio.coroutine
-def test_update_file_path(hass):
+async def test_update_file_path(hass):
     """Test update_file_path service."""
     # Setup platform
 
@@ -129,7 +128,7 @@ def test_update_file_path(hass):
 
     with mock.patch('os.path.isfile', mock.Mock(return_value=True)), \
             mock.patch('os.access', mock.Mock(return_value=True)):
-        yield from async_setup_component(hass, 'camera', {
+        await async_setup_component(hass, 'camera', {
             'camera': {
                 'platform': 'local_file',
                 'file_path': 'mock/path.jpg'
@@ -146,10 +145,10 @@ def test_update_file_path(hass):
             "file_path": 'new/path.jpg'
         }
 
-        yield from hass.services.async_call(DOMAIN,
-                                            SERVICE_UPDATE_FILE_PATH,
-                                            service_data)
-        yield from hass.async_block_till_done()
+        await hass.services.async_call(DOMAIN,
+                                       SERVICE_UPDATE_FILE_PATH,
+                                       service_data)
+        await hass.async_block_till_done()
 
         state = hass.states.get('camera.local_file')
         assert state.attributes.get('file_path') == 'new/path.jpg'

--- a/tests/components/camera/test_local_file.py
+++ b/tests/components/camera/test_local_file.py
@@ -6,6 +6,7 @@ from unittest import mock
 # https://bugs.python.org/issue23004
 from mock_open import MockOpen
 
+from homeassistant.components.camera.local_file import LocalFile as camera
 from homeassistant.setup import async_setup_component
 
 from tests.common import mock_registry
@@ -131,7 +132,12 @@ def test_update_file_path_service(hass):
                 'file_path': 'mock.file',
             }})
 
-        hass.components.camera.update_file_path('/img/test.jpg')
+    with mock.patch(
+            'homeassistant.components.camera.open', mopen, create=True), \
+            mock.patch.object(
+                    hass.config, 'is_allowed_path', return_value=True):
+
+        camera.update_file_path(hass, '/img/test.jpg')
         yield from hass.async_block_till_done()
 
         mock_write = mopen().write

--- a/tests/components/camera/test_local_file.py
+++ b/tests/components/camera/test_local_file.py
@@ -122,6 +122,7 @@ def test_camera_content_type(hass, aiohttp_client):
 def test_update_file_path_service(hass):
     """Test update_file_path service."""
     mopen = mock.mock_open()
+    mock_registry(hass)
 
     with mock.patch('os.path.isfile', mock.Mock(return_value=True)), \
             mock.patch('os.access', mock.Mock(return_value=True)):

--- a/tests/components/camera/test_local_file.py
+++ b/tests/components/camera/test_local_file.py
@@ -136,12 +136,15 @@ def test_update_file_path(hass):
     assert state.attributes.get('friendly_name') == 'Local File'
     assert state.attributes.get('file_path') == 'mock/path.jpg'
 
-    # Call service to update file_path
-    service_data = {
-        "entity_id": 'camera.local_file',
-        "file_path": 'new/path.jpg'
-    }
-    hass.services.call(
-            camera.DOMAIN, SERVICE_UPDATE_FILE_PATH, service_data)
-    yield from hass.async_block_till_done()
-    assert state.attributes.get('file_path') == 'new/path.jpg'
+    # THE FOLLOWING FAILS, I DON'T UNDERSTAND WHY
+
+#    service_data = {
+#        "entity_id": 'camera.local_file',
+#        "file_path": 'new/path.jpg'
+#    }
+#    hass.services.call(
+#        camera.DOMAIN, SERVICE_UPDATE_FILE_PATH, service_data)
+#    yield from hass.async_block_till_done()
+
+#    state = hass.states.get('camera.local_file')
+#    assert state.attributes.get('file_path') == 'new/path.jpg'

--- a/tests/components/camera/test_local_file.py
+++ b/tests/components/camera/test_local_file.py
@@ -6,7 +6,7 @@ from unittest import mock
 # https://bugs.python.org/issue23004
 from mock_open import MockOpen
 
-from homeassistant.components.camera.local_file import LocalFile as camera
+import homeassistant.components.camera as camera
 from homeassistant.setup import async_setup_component
 
 from tests.common import mock_registry
@@ -142,7 +142,7 @@ def test_update_file_path_service(hass):
         data = {'entity_id': 'camera.local_file',
                 'file_path': '/img/test.jpg'}
         hass.services.call(
-                camera, 'update_file_path', data)
+                camera.DOMAIN, 'update_file_path', data)
         yield from hass.async_block_till_done()
 
         mock_write = mopen().write

--- a/tests/components/camera/test_local_file.py
+++ b/tests/components/camera/test_local_file.py
@@ -7,6 +7,8 @@ from unittest import mock
 from mock_open import MockOpen
 
 from homeassistant.components import camera
+from homeassistant.components.camera.local_file import (
+    SERVICE_UPDATE_FILE_PATH)
 from homeassistant.setup import async_setup_component
 
 from tests.common import mock_registry
@@ -135,6 +137,11 @@ def test_update_file_path(hass):
     assert state.attributes.get('file_path') == 'mock/path.jpg'
 
     # Call service to update file_path
-    camera.update_file_path(hass, 'new/path.jpg')
+    service_data = {
+        "entity_id": 'camera.local_file',
+        "file_path": 'new/path.jpg'
+    }
+    hass.services.call(
+            camera.DOMAIN, SERVICE_UPDATE_FILE_PATH, service_data)
     yield from hass.async_block_till_done()
     assert state.attributes.get('file_path') == 'new/path.jpg'

--- a/tests/components/camera/test_local_file.py
+++ b/tests/components/camera/test_local_file.py
@@ -2,27 +2,14 @@
 import asyncio
 from unittest import mock
 
-import pytest
-
 # Using third party package because of a bug reading binary data in Python 3.4
 # https://bugs.python.org/issue23004
 from mock_open import MockOpen
 
-import homeassistant.components.camera as camera
+import homeassistant.components.camera.local_file as camera
 from homeassistant.setup import async_setup_component
 
 from tests.common import mock_registry
-
-
-@pytest.fixture
-def mock_camera(hass):
-    """Initialize a demo camera platform."""
-    assert hass.loop.run_until_complete(async_setup_component(hass, 'camera', {
-        camera.DOMAIN: {
-            'platform': 'local_file',
-            'file_path': 'mock.file',
-        }
-    }))
 
 
 @asyncio.coroutine
@@ -132,16 +119,20 @@ def test_camera_content_type(hass, aiohttp_client):
 
 
 @asyncio.coroutine
-def test_snapshot_service(hass, mock_camera):
+def test_snapshot_service(hass):
     """Test snapshot service."""
     mopen = mock.mock_open()
 
-    with mock.patch(
-            'homeassistant.components.camera.open', mopen, create=True), \
-            mock.patch.object(
-                    hass.config, 'is_allowed_path', return_value=True):
+    with mock.patch('os.path.isfile', mock.Mock(return_value=True)), \
+            mock.patch('os.access', mock.Mock(return_value=False)):
+        yield from async_setup_component(hass, 'camera', {
+            'camera': {
+                'name': 'config_test',
+                'platform': 'local_file',
+                'file_path': 'mock.file',
+            }})
 
-        hass.components.camera.local_file.update_file_path('/img/test.jpg')
+        camera.update_file_path('/img/test.jpg')
         yield from hass.async_block_till_done()
 
         mock_write = mopen().write

--- a/tests/components/camera/test_local_file.py
+++ b/tests/components/camera/test_local_file.py
@@ -6,7 +6,7 @@ from unittest import mock
 # https://bugs.python.org/issue23004
 from mock_open import MockOpen
 
-from homeassistant.components import camera
+from homeassistant.components.camera import DOMAIN
 from homeassistant.components.camera.local_file import (
     SERVICE_UPDATE_FILE_PATH)
 from homeassistant.setup import async_setup_component
@@ -146,7 +146,7 @@ def test_update_file_path(hass):
             "file_path": 'new/path.jpg'
         }
 
-        yield from hass.services.async_call(camera.DOMAIN,
+        yield from hass.services.async_call(DOMAIN,
                                             SERVICE_UPDATE_FILE_PATH,
                                             service_data)
         yield from hass.async_block_till_done()

--- a/tests/components/camera/test_local_file.py
+++ b/tests/components/camera/test_local_file.py
@@ -134,8 +134,7 @@ def test_update_file_path_service(hass):
 
     with mock.patch(
             'homeassistant.components.camera.open', mopen, create=True), \
-            mock.patch.object(
-                    hass.config, 'is_allowed_path', return_value=True):
+            mock.patch('os.path.isfile', mock.Mock(return_value=True)):
 
         camera.update_file_path(hass, '/img/test.jpg')
         yield from hass.async_block_till_done()

--- a/tests/components/camera/test_local_file.py
+++ b/tests/components/camera/test_local_file.py
@@ -124,7 +124,7 @@ def test_update_file_path_service(hass):
     mopen = mock.mock_open()
 
     with mock.patch('os.path.isfile', mock.Mock(return_value=True)), \
-            mock.patch('os.access', mock.Mock(return_value=False)):
+            mock.patch('os.access', mock.Mock(return_value=True)):
         yield from async_setup_component(hass, 'camera', {
             'camera': {
                 'name': 'config_test',
@@ -132,8 +132,10 @@ def test_update_file_path_service(hass):
                 'file_path': 'mock.file',
             }})
 
+    m_open = MockOpen(read_data=b'hello')
     with mock.patch(
-            'homeassistant.components.camera.open', mopen, create=True), \
+            'homeassistant.components.camera.local_file.open',
+            m_open, create=True), \
             mock.patch('os.path.isfile', mock.Mock(return_value=True)):
 
         camera.update_file_path(hass, '/img/test.jpg')

--- a/tests/components/camera/test_local_file.py
+++ b/tests/components/camera/test_local_file.py
@@ -138,13 +138,13 @@ def test_update_file_path(hass):
 
     # THE FOLLOWING FAILS, I DON'T UNDERSTAND WHY
 
-#    service_data = {
-#        "entity_id": 'camera.local_file',
-#        "file_path": 'new/path.jpg'
-#    }
-#    hass.services.call(
-#        camera.DOMAIN, SERVICE_UPDATE_FILE_PATH, service_data)
-#    yield from hass.async_block_till_done()
+    service_data = {
+        "entity_id": 'camera.local_file',
+        "file_path": 'new/path.jpg'
+    }
+    hass.services.call(
+        camera.DOMAIN, SERVICE_UPDATE_FILE_PATH, service_data)
+    yield from hass.async_block_till_done()
 
-#    state = hass.states.get('camera.local_file')
-#    assert state.attributes.get('file_path') == 'new/path.jpg'
+    state = hass.states.get('camera.local_file')
+    assert state.attributes.get('file_path') == 'new/path.jpg'

--- a/tests/components/camera/test_local_file.py
+++ b/tests/components/camera/test_local_file.py
@@ -143,7 +143,7 @@ def test_update_file_path_service(hass):
 
         data = {'entity_id': 'camera.local_file',
                 'file_path': '/img/test.jpg'}
-        hass.services.call(
+        hass.services.async_call(
                 camera.DOMAIN, SERVICE_UPDATE_FILE_PATH, data)
         yield from hass.async_block_till_done()
 

--- a/tests/components/camera/test_local_file.py
+++ b/tests/components/camera/test_local_file.py
@@ -7,6 +7,8 @@ from unittest import mock
 from mock_open import MockOpen
 
 import homeassistant.components.camera as camera
+from homeassistant.components.camera.local_file import (
+    SERVICE_UPDATE_FILE_PATH)
 from homeassistant.setup import async_setup_component
 
 from tests.common import mock_registry
@@ -142,7 +144,7 @@ def test_update_file_path_service(hass):
         data = {'entity_id': 'camera.local_file',
                 'file_path': '/img/test.jpg'}
         hass.services.call(
-                camera.DOMAIN, 'update_file_path', data)
+                camera.DOMAIN, SERVICE_UPDATE_FILE_PATH, data)
         yield from hass.async_block_till_done()
 
         mock_write = mopen().write

--- a/tests/components/camera/test_local_file.py
+++ b/tests/components/camera/test_local_file.py
@@ -147,8 +147,8 @@ def test_update_file_path(hass):
         }
 
         yield from hass.services.async_call(camera.DOMAIN,
-                                     SERVICE_UPDATE_FILE_PATH,
-                                     service_data)
+                                            SERVICE_UPDATE_FILE_PATH,
+                                            service_data)
         yield from hass.async_block_till_done()
 
         state = hass.states.get('camera.local_file')

--- a/tests/components/camera/test_local_file.py
+++ b/tests/components/camera/test_local_file.py
@@ -6,6 +6,7 @@ from unittest import mock
 # https://bugs.python.org/issue23004
 from mock_open import MockOpen
 
+from homeassistant.components import camera
 from homeassistant.setup import async_setup_component
 
 from tests.common import mock_registry
@@ -134,4 +135,6 @@ def test_update_file_path(hass):
     assert state.attributes.get('file_path') == 'mock/path.jpg'
 
     # Call service to update file_path
-#    camera.enable_motion_detection(hass, 'camera.demo_camera')
+    camera.update_file_path(hass, 'new/path.jpg')
+    yield from hass.async_block_till_done()
+    assert state.attributes.get('file_path') == 'new/path.jpg'

--- a/tests/components/camera/test_local_file.py
+++ b/tests/components/camera/test_local_file.py
@@ -6,7 +6,6 @@ from unittest import mock
 # https://bugs.python.org/issue23004
 from mock_open import MockOpen
 
-import homeassistant.components.camera.local_file as camera
 from homeassistant.setup import async_setup_component
 
 from tests.common import mock_registry
@@ -119,8 +118,8 @@ def test_camera_content_type(hass, aiohttp_client):
 
 
 @asyncio.coroutine
-def test_snapshot_service(hass):
-    """Test snapshot service."""
+def test_update_file_path_service(hass):
+    """Test update_file_path service."""
     mopen = mock.mock_open()
 
     with mock.patch('os.path.isfile', mock.Mock(return_value=True)), \
@@ -132,7 +131,7 @@ def test_snapshot_service(hass):
                 'file_path': 'mock.file',
             }})
 
-        camera.update_file_path('/img/test.jpg')
+        hass.components.camera.update_file_path('/img/test.jpg')
         yield from hass.async_block_till_done()
 
         mock_write = mopen().write

--- a/tests/components/camera/test_local_file.py
+++ b/tests/components/camera/test_local_file.py
@@ -139,7 +139,10 @@ def test_update_file_path_service(hass):
             m_open, create=True), \
             mock.patch('os.path.isfile', mock.Mock(return_value=True)):
 
-        camera.update_file_path(hass, '/img/test.jpg')
+        data = {'entity_id': 'camera.local_file',
+                'file_path': '/img/test.jpg'}
+        hass.services.call(
+                camera, 'update_file_path', data)
         yield from hass.async_block_till_done()
 
         mock_write = mopen().write


### PR DESCRIPTION
## Description:
Currently the [local_file](https://www.home-assistant.io/components/camera.local_file/) camera is limited to displaying whatever image it was configured with. This PR adds the service `camera.local_file_update_file_path` to update the file that is displayed, and also adds the `file_path` as an attribute. The service can be called the `SERVICES` tool with:
```
{
  "entity_id": "camera.local_file",
  "file_path":"/Users/robincole/Pictures/me.jpg"
}
```

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io/pull/5228) with documentation (if applicable):** home-assistant/home-assistant.github.io#<5228>

## Example entry for `configuration.yaml` (if applicable):
NO CHANGES TO THE CONFIG

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)