### PR TITLE
Allow independent control of white level on flux_led component

### DIFF
--- a/homeassistant/components/light/flux_led.py
+++ b/homeassistant/components/light/flux_led.py
@@ -191,7 +191,6 @@ class FluxLight(Light):
     @property
     def supported_features(self):
         """Flag supported features."""
-
         if self._mode is MODE_RGBW:
             return SUPPORT_FLUX_LED | SUPPORT_WHITE_VALUE
 

--- a/homeassistant/components/light/flux_led.py
+++ b/homeassistant/components/light/flux_led.py
@@ -28,7 +28,7 @@ ATTR_MODE = 'mode'
 DOMAIN = 'flux_led'
 
 SUPPORT_FLUX_LED = (SUPPORT_BRIGHTNESS | SUPPORT_EFFECT |
-                    SUPPORT_COLOR | SUPPORT_WHITE_VALUE)
+                    SUPPORT_COLOR)
 
 MODE_RGB = 'rgb'
 MODE_RGBW = 'rgbw'
@@ -191,6 +191,10 @@ class FluxLight(Light):
     @property
     def supported_features(self):
         """Flag supported features."""
+
+        if(self._mode is MODE_RGBW):
+            return (SUPPORT_FLUX_LED | SUPPORT_WHITE_VALUE)
+
         return SUPPORT_FLUX_LED
 
     @property

--- a/homeassistant/components/light/flux_led.py
+++ b/homeassistant/components/light/flux_led.py
@@ -192,8 +192,8 @@ class FluxLight(Light):
     def supported_features(self):
         """Flag supported features."""
 
-        if(self._mode is MODE_RGBW):
-            return (SUPPORT_FLUX_LED | SUPPORT_WHITE_VALUE)
+        if self._mode is MODE_RGBW:
+            return SUPPORT_FLUX_LED | SUPPORT_WHITE_VALUE
 
         return SUPPORT_FLUX_LED
 

--- a/homeassistant/components/light/flux_led.py
+++ b/homeassistant/components/light/flux_led.py
@@ -12,8 +12,8 @@ import voluptuous as vol
 
 from homeassistant.const import CONF_DEVICES, CONF_NAME, CONF_PROTOCOL
 from homeassistant.components.light import (
-    ATTR_BRIGHTNESS, ATTR_HS_COLOR, ATTR_EFFECT, ATTR_WHITE_VALUE, EFFECT_COLORLOOP,
-    EFFECT_RANDOM, SUPPORT_BRIGHTNESS, SUPPORT_EFFECT,
+    ATTR_BRIGHTNESS, ATTR_HS_COLOR, ATTR_EFFECT, ATTR_WHITE_VALUE,
+    EFFECT_COLORLOOP, EFFECT_RANDOM, SUPPORT_BRIGHTNESS, SUPPORT_EFFECT,
     SUPPORT_COLOR, SUPPORT_WHITE_VALUE, Light, PLATFORM_SCHEMA)
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.color as color_util
@@ -227,7 +227,7 @@ class FluxLight(Light):
         if rgb is not None:
             self._bulb.setRgb(*tuple(rgb), brightness=self.brightness)
 
-        #brightness change only
+        # brightness change only
         elif brightness is not None:
             (red, green, blue) = self._bulb.getRgb()
             self._bulb.setRgb(red, green, blue, brightness=brightness)
@@ -238,7 +238,7 @@ class FluxLight(Light):
                               random.randint(0, 255),
                               random.randint(0, 255))
 
-        #effect selection
+        # effect selection
         elif effect in EFFECT_MAP:
             self._bulb.setPresetPattern(EFFECT_MAP[effect], 50)
 


### PR DESCRIPTION
## Description:
Allows independent control of white level on flux_led lights in RGBW mode.  Also preserve brightness on color change.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**