### PR TITLE
Waze Travel Time: optional inclusive/exclusive filters

### DIFF
--- a/homeassistant/components/sensor/waze_travel_time.py
+++ b/homeassistant/components/sensor/waze_travel_time.py
@@ -26,7 +26,7 @@ ATTR_ROUTE = 'route'
 CONF_ATTRIBUTION = "Data provided by the Waze.com"
 CONF_DESTINATION = 'destination'
 CONF_ORIGIN = 'origin'
-CONF_INCL_FILTER = 'incL_filter'
+CONF_INCL_FILTER = 'incl_filter'
 CONF_EXCL_FILTER = 'excl_filter'
 
 DEFAULT_NAME = 'Waze Travel Time'

--- a/homeassistant/components/sensor/waze_travel_time.py
+++ b/homeassistant/components/sensor/waze_travel_time.py
@@ -26,7 +26,7 @@ ATTR_ROUTE = 'route'
 CONF_ATTRIBUTION = "Data provided by the Waze.com"
 CONF_DESTINATION = 'destination'
 CONF_ORIGIN = 'origin'
-CONF_INC_FILTER = 'inc_filter'
+CONF_INCL_FILTER = 'incL_filter'
 CONF_EXCL_FILTER = 'excl_filter'
 
 DEFAULT_NAME = 'Waze Travel Time'
@@ -42,7 +42,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_DESTINATION): cv.string,
     vol.Required(CONF_REGION): vol.In(REGIONS),
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional(CONF_INC_FILTER): cv.string,
+    vol.Optional(CONF_INCL_FILTER): cv.string,
     vol.Optional(CONF_EXCL_FILTER): cv.string,
 })
 
@@ -53,12 +53,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     name = config.get(CONF_NAME)
     origin = config.get(CONF_ORIGIN)
     region = config.get(CONF_REGION)
-    inc_filter = config.get(CONF_INC_FILTER)
+    incl_filter = config.get(CONF_INCL_FILTER)
     excl_filter = config.get(CONF_EXCL_FILTER)
 
     try:
-        waze_data = WazeRouteData(origin, destination, region,
-                                  inc_filter, excl_filter)
+        waze_data = WazeRouteData(
+            origin, destination, region, incl_filter, excl_filter)
     except requests.exceptions.HTTPError as error:
         _LOGGER.error("%s", error)
         return
@@ -116,12 +116,12 @@ class WazeTravelTime(Entity):
 class WazeRouteData(object):
     """Get data from Waze."""
 
-    def __init__(self, origin, destination, region, inc_filter, excl_filter):
+    def __init__(self, origin, destination, region, incl_filter, excl_filter):
         """Initialize the data object."""
         self._destination = destination
         self._origin = origin
         self._region = region
-        self._inc_filter = inc_filter
+        self._incl_filter = incl_filter
         self._excl_filter = excl_filter
         self.data = {}
 
@@ -134,7 +134,7 @@ class WazeRouteData(object):
             params = WazeRouteCalculator.WazeRouteCalculator(
                 self._origin, self._destination, self._region, None)
             results = params.calc_all_routes_info()
-            if self._inc_filter is not None:
+            if self._incl_filter is not None:
                 results = {k: v for k, v in results.items() if
                            self._inc_filter.lower() in k.lower()}
             if self._excl_filter is not None:

--- a/homeassistant/components/sensor/waze_travel_time.py
+++ b/homeassistant/components/sensor/waze_travel_time.py
@@ -136,7 +136,7 @@ class WazeRouteData(object):
             results = params.calc_all_routes_info()
             if self._incl_filter is not None:
                 results = {k: v for k, v in results.items() if
-                           self._inc_filter.lower() in k.lower()}
+                           self._incl_filter.lower() in k.lower()}
             if self._excl_filter is not None:
                 results = {k: v for k, v in results.items() if
                            self._excl_filter.lower() not in k.lower()}

--- a/homeassistant/components/sensor/waze_travel_time.py
+++ b/homeassistant/components/sensor/waze_travel_time.py
@@ -57,7 +57,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     excl_filter = config.get(CONF_EXCL_FILTER)
 
     try:
-        waze_data = WazeRouteData(origin, destination, region, inc_filter, excl_filter)
+        waze_data = WazeRouteData(origin, destination, region, 
+            inc_filter, excl_filter)
     except requests.exceptions.HTTPError as error:
         _LOGGER.error("%s", error)
         return
@@ -134,9 +135,11 @@ class WazeRouteData(object):
                 self._origin, self._destination, self._region, None)
             results = params.calc_all_routes_info()
             if self._inc_filter is not None:
-                results = {k: v for k, v in results.items() if self._inc_filter.lower() in k.lower()}
+                results = {k: v for k, v in results.items() if 
+                    self._inc_filter.lower() in k.lower()}
             if self._excl_filter is not None:
-                results = {k: v for k, v in results.items() if self._excl_filter.lower() not in k.lower()}
+                results = {k: v for k, v in results.items() if 
+                    self._excl_filter.lower() not in k.lower()}
             best_route = next(iter(results))
             (duration, distance) = results[best_route]
             best_route_str = bytes(best_route, 'ISO-8859-1').decode('UTF-8')

--- a/homeassistant/components/sensor/waze_travel_time.py
+++ b/homeassistant/components/sensor/waze_travel_time.py
@@ -26,6 +26,8 @@ ATTR_ROUTE = 'route'
 CONF_ATTRIBUTION = "Data provided by the Waze.com"
 CONF_DESTINATION = 'destination'
 CONF_ORIGIN = 'origin'
+CONF_INC_FILTER = 'inc_filter'
+CONF_EXCL_FILTER = 'excl_filter'
 
 DEFAULT_NAME = 'Waze Travel Time'
 
@@ -40,6 +42,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_DESTINATION): cv.string,
     vol.Required(CONF_REGION): vol.In(REGIONS),
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_INC_FILTER): cv.string,
+    vol.Optional(CONF_EXCL_FILTER): cv.string,
 })
 
 
@@ -49,9 +53,11 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     name = config.get(CONF_NAME)
     origin = config.get(CONF_ORIGIN)
     region = config.get(CONF_REGION)
+    inc_filter = config.get(CONF_INC_FILTER)
+    excl_filter = config.get(CONF_EXCL_FILTER)
 
     try:
-        waze_data = WazeRouteData(origin, destination, region)
+        waze_data = WazeRouteData(origin, destination, region, inc_filter, excl_filter)
     except requests.exceptions.HTTPError as error:
         _LOGGER.error("%s", error)
         return
@@ -109,11 +115,13 @@ class WazeTravelTime(Entity):
 class WazeRouteData(object):
     """Get data from Waze."""
 
-    def __init__(self, origin, destination, region):
+    def __init__(self, origin, destination, region, inc_filter, excl_filter):
         """Initialize the data object."""
         self._destination = destination
         self._origin = origin
         self._region = region
+        self._inc_filter = inc_filter
+        self._excl_filter = excl_filter
         self.data = {}
 
     @Throttle(SCAN_INTERVAL)
@@ -125,6 +133,10 @@ class WazeRouteData(object):
             params = WazeRouteCalculator.WazeRouteCalculator(
                 self._origin, self._destination, self._region, None)
             results = params.calc_all_routes_info()
+            if self._inc_filter is not None:
+                results = {k: v for k, v in results.items() if self._inc_filter.lower() in k.lower()}
+            if self._excl_filter is not None:
+                results = {k: v for k, v in results.items() if self._excl_filter.lower() not in k.lower()}
             best_route = next(iter(results))
             (duration, distance) = results[best_route]
             best_route_str = bytes(best_route, 'ISO-8859-1').decode('UTF-8')

--- a/homeassistant/components/sensor/waze_travel_time.py
+++ b/homeassistant/components/sensor/waze_travel_time.py
@@ -57,8 +57,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     excl_filter = config.get(CONF_EXCL_FILTER)
 
     try:
-        waze_data = WazeRouteData(origin, destination, region, 
-            inc_filter, excl_filter)
+        waze_data = WazeRouteData(origin, destination, region,
+                                  inc_filter, excl_filter)
     except requests.exceptions.HTTPError as error:
         _LOGGER.error("%s", error)
         return
@@ -135,11 +135,11 @@ class WazeRouteData(object):
                 self._origin, self._destination, self._region, None)
             results = params.calc_all_routes_info()
             if self._inc_filter is not None:
-                results = {k: v for k, v in results.items() if 
-                    self._inc_filter.lower() in k.lower()}
+                results = {k: v for k, v in results.items() if
+                           self._inc_filter.lower() in k.lower()}
             if self._excl_filter is not None:
-                results = {k: v for k, v in results.items() if 
-                    self._excl_filter.lower() not in k.lower()}
+                results = {k: v for k, v in results.items() if
+                           self._excl_filter.lower() not in k.lower()}
             best_route = next(iter(results))
             (duration, distance) = results[best_route]
             best_route_str = bytes(best_route, 'ISO-8859-1').decode('UTF-8')


### PR DESCRIPTION
Added optional `inc_filter` and `excl_filter' params that allow to refine the reported routes: the first is not always the best/desired. A simple case-insensitive filtering (no regular expression) is used.

## Description:

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5208

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: waze_travel_time
    origin: Montréal, QC
    destination: Québec, QC
    region: 'US'
    inc_filter: 'High'
    excl_filter: 'local'
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
