### PR TITLE
Disable ebox requirement

### DIFF
--- a/homeassistant/components/sensor/ebox.py
+++ b/homeassistant/components/sensor/ebox.py
@@ -19,6 +19,7 @@ from homeassistant.const import (
     CONF_NAME, CONF_MONITORED_VARIABLES)
 from homeassistant.helpers.entity import Entity
 
+# pylint: disable=import-error
 REQUIREMENTS = []  # ['pyebox==0.1.0'] - disabled because it breaks pip10
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/sensor/ebox.py
+++ b/homeassistant/components/sensor/ebox.py
@@ -19,7 +19,7 @@ from homeassistant.const import (
     CONF_NAME, CONF_MONITORED_VARIABLES)
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['pyebox==0.1.0']
+REQUIREMENTS = []  # ['pyebox==0.1.0'] - disabled because it breaks pip10
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -747,9 +747,6 @@ pydispatcher==2.0.5
 # homeassistant.components.android_ip_webcam
 pydroid-ipcam==0.8
 
-# homeassistant.components.sensor.ebox
-pyebox==0.1.0
-
 # homeassistant.components.climate.econet
 pyeconet==0.0.5
 


### PR DESCRIPTION
## Description:
The requirement of the ebox platform is breaking installation of Home Assistant using pip10. It has been fixed in 1.1.1 but the package has been rewritten since then and 1.1.1 has not been published to PyPi.

Breaking change: if you want to use the ebox sensor, you'll have to manually install the dependecy using `python3 -m pip install ebox==0.1.0`.

CC @titilambert
