### PR TITLE
Upgraded miflora library to version 0.4.0

### DIFF
--- a/homeassistant/components/sensor/miflora.py
+++ b/homeassistant/components/sensor/miflora.py
@@ -16,7 +16,7 @@ from homeassistant.const import (
 )
 
 
-REQUIREMENTS = ['miflora==0.3.0']
+REQUIREMENTS = ['miflora==0.4.0']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -63,10 +63,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     from miflora import miflora_poller
     try:
         import bluepy.btle  # noqa: F401 # pylint: disable=unused-variable
-        from miflora.backends.bluepy import BluepyBackend
+        from btlewrap import BluepyBackend
         backend = BluepyBackend
     except ImportError:
-        from miflora.backends.gatttool import GatttoolBackend
+        from btlewrap import GatttoolBackend
         backend = GatttoolBackend
     _LOGGER.debug('Miflora is using %s backend.', backend.__name__)
 
@@ -138,7 +138,7 @@ class MiFloraSensor(Entity):
 
         This uses a rolling median over 3 values to filter out outliers.
         """
-        from miflora.backends import BluetoothBackendException
+        from btlewrap import BluetoothBackendException
         try:
             _LOGGER.debug("Polling data for %s", self.name)
             data = self.poller.parameter_value(self.parameter)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -525,7 +525,7 @@ messagebird==1.2.0
 mficlient==0.3.0
 
 # homeassistant.components.sensor.miflora
-miflora==0.3.0
+miflora==0.4.0
 
 # homeassistant.components.sensor.mopar
 motorparts==1.0.2


### PR DESCRIPTION
## Description:
As there is a new version 0.4.0 with some fixes and improvements, we should also upgrade HASS to use this version:
https://github.com/open-homeautomation/miflora/releases/tag/v0.4

As miflora and https://github.com/home-assistant/home-assistant/pull/13955 are using the same bluetooth library, locking the Bluetooth device between those two components should work now as well. Thus there should not be any concurrency issues there.

**Related issue (if applicable):** fixes https://github.com/open-homeautomation/miflora/issues/93

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
no changes

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
