### PR TITLE
Qwikswitch binary sensors

### DIFF
--- a/homeassistant/components/binary_sensor/qwikswitch.py
+++ b/homeassistant/components/binary_sensor/qwikswitch.py
@@ -38,9 +38,9 @@ class QSBinarySensor(QSEntity, BinarySensorDevice):
 
         super().__init__(sensor['id'], sensor['name'])
         self.channel = sensor['channel']
-        self.sensor_type = sensor['type']
+        sensor_type = sensor['type']
 
-        self._decode, _ = SENSORS[self.sensor_type]
+        self._decode, _ = SENSORS[sensor_type]
         self._invert = not sensor.get('invert', False)
         self._class = sensor.get('class', 'door')
 

--- a/homeassistant/components/binary_sensor/qwikswitch.py
+++ b/homeassistant/components/binary_sensor/qwikswitch.py
@@ -1,12 +1,13 @@
 """
-Support for Qwikswitch Sensors.
+Support for Qwikswitch Binary Sensors.
 
 For more details about this platform, please refer to the documentation at
-https://home-assistant.io/components/sensor.qwikswitch/
+https://home-assistant.io/components/binary_sensor.qwikswitch/
 """
 import logging
 
-from homeassistant.components.qwikswitch import DOMAIN as QWIKSWITCH, QSEntity
+from homeassistant.components.binary_sensor import BinarySensorDevice
+from homeassistant.components.qwikswitch import QSEntity, DOMAIN as QWIKSWITCH
 from homeassistant.core import callback
 
 DEPENDENCIES = [QWIKSWITCH]
@@ -15,20 +16,21 @@ _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_platform(hass, _, add_devices, discovery_info=None):
-    """Add sensor from the main Qwikswitch component."""
+    """Add binary sensor from the main Qwikswitch component."""
     if discovery_info is None:
         return
 
     qsusb = hass.data[QWIKSWITCH]
-    _LOGGER.debug("Setup qwikswitch.sensor %s, %s", qsusb, discovery_info)
-    devs = [QSSensor(sensor) for sensor in discovery_info[QWIKSWITCH]]
+    _LOGGER.debug("Setup qwikswitch.binary_sensor %s, %s",
+                  qsusb, discovery_info)
+    devs = [QSBinarySensor(sensor) for sensor in discovery_info[QWIKSWITCH]]
     add_devices(devs)
 
 
-class QSSensor(QSEntity):
+class QSBinarySensor(QSEntity, BinarySensorDevice):
     """Sensor based on a Qwikswitch relay/dimmer module."""
 
-    _val = None
+    _val = False
 
     def __init__(self, sensor):
         """Initialize the sensor."""
@@ -38,9 +40,9 @@ class QSSensor(QSEntity):
         self.channel = sensor['channel']
         self.sensor_type = sensor['type']
 
-        self._decode, self.unit = SENSORS[self.sensor_type]
-        if isinstance(self.unit, type):
-            self.unit = "{}:{}".format(self.sensor_type, self.channel)
+        self._decode, _ = SENSORS[self.sensor_type]
+        self._invert = not sensor.get('invert', False)
+        self._class = sensor.get('class', 'door')
 
     @callback
     def update_packet(self, packet):
@@ -49,13 +51,13 @@ class QSSensor(QSEntity):
         _LOGGER.debug("Update %s (%s:%s) decoded as %s: %s",
                       self.entity_id, self.qsid, self.channel, val, packet)
         if val is not None:
-            self._val = val
+            self._val = bool(val)
             self.async_schedule_update_ha_state()
 
     @property
-    def state(self):
-        """Return the value of the sensor."""
-        return str(self._val)
+    def is_on(self):
+        """Check if device is on (non-zero)."""
+        return self._val == self._invert
 
     @property
     def unique_id(self):
@@ -63,6 +65,6 @@ class QSSensor(QSEntity):
         return "qs{}:{}".format(self.qsid, self.channel)
 
     @property
-    def unit_of_measurement(self):
-        """Return the unit the value is expressed in."""
-        return self.unit
+    def device_class(self):
+        """Return the class of this sensor."""
+        return self._class

--- a/homeassistant/components/qwikswitch.py
+++ b/homeassistant/components/qwikswitch.py
@@ -19,7 +19,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.discovery import load_platform
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['pyqwikswitch==0.71']
+REQUIREMENTS = ['pyqwikswitch==0.8']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sensor/qwikswitch.py
+++ b/homeassistant/components/sensor/qwikswitch.py
@@ -36,11 +36,11 @@ class QSSensor(QSEntity):
 
         super().__init__(sensor['id'], sensor['name'])
         self.channel = sensor['channel']
-        self.sensor_type = sensor['type']
+        sensor_type = sensor['type']
 
-        self._decode, self.unit = SENSORS[self.sensor_type]
+        self._decode, self.unit = SENSORS[sensor_type]
         if isinstance(self.unit, type):
-            self.unit = "{}:{}".format(self.sensor_type, self.channel)
+            self.unit = "{}:{}".format(sensor_type, self.channel)
 
     @callback
     def update_packet(self, packet):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -892,7 +892,7 @@ pyowm==2.8.0
 pypollencom==1.1.2
 
 # homeassistant.components.qwikswitch
-pyqwikswitch==0.71
+pyqwikswitch==0.8
 
 # homeassistant.components.rainbird
 pyrainbird==0.1.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -146,7 +146,7 @@ pymonoprice==0.3
 pynx584==0.4
 
 # homeassistant.components.qwikswitch
-pyqwikswitch==0.71
+pyqwikswitch==0.8
 
 # homeassistant.components.sensor.darksky
 # homeassistant.components.weather.darksky


### PR DESCRIPTION
## Description:
* Final part of the qwikswitch sensors -> binary sensors
* Fix up asyncio.Timeout in library 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5210

## Example entry for `configuration.yaml` (if applicable):
```yaml
qwikswitch:
  url: ...
  sensors:
    - name: door_contact
      id: '@0c2991'
      channel: 1
      type: imod
      invert: True
      class: door
    - name: some_qc
      id: '@0c2992'
      channel: 1
      type: qwikcord    

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [N/A] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
