### PR TITLE
Proposal: Add sensor device classes

### DIFF
--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -8,6 +8,8 @@ https://home-assistant.io/components/sensor/
 from datetime import timedelta
 import logging
 
+import voluptuous as vol
+
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.config_validation import PLATFORM_SCHEMA  # noqa
 
@@ -18,6 +20,13 @@ DOMAIN = 'sensor'
 ENTITY_ID_FORMAT = DOMAIN + '.{}'
 
 SCAN_INTERVAL = timedelta(seconds=30)
+DEVICE_CLASSES = [
+    'battery',  # % of battery that is left
+    'humidity',  # % of humidity in the air
+    'temperature',  # temperature (C/F)
+]
+
+DEVICE_CLASSES_SCHEMA = vol.All(vol.Lower, vol.In(DEVICE_CLASSES))
 
 
 async def async_setup(hass, config):

--- a/homeassistant/components/sensor/ecobee.py
+++ b/homeassistant/components/sensor/ecobee.py
@@ -53,6 +53,13 @@ class EcobeeSensor(Entity):
         return self._name
 
     @property
+    def device_class(self):
+        """Return the device class of the sensor."""
+        if self.type in ('temperature', 'humidity'):
+            return self.type
+        return None
+
+    @property
     def state(self):
         """Return the state of the sensor."""
         return self._state

--- a/homeassistant/components/sensor/linux_battery.py
+++ b/homeassistant/components/sensor/linux_battery.py
@@ -95,6 +95,11 @@ class LinuxBatterySensor(Entity):
         return self._name
 
     @property
+    def device_class(self):
+        """Return the device class of the sensor."""
+        return 'battery'
+
+    @property
     def state(self):
         """Return the state of the sensor."""
         return self._battery_stat.capacity

--- a/homeassistant/components/sensor/nest.py
+++ b/homeassistant/components/sensor/nest.py
@@ -140,6 +140,11 @@ class NestTempSensor(NestSensor):
         """Return the state of the sensor."""
         return self._state
 
+    @property
+    def device_class(self):
+        """Return the device class of the sensor."""
+        return 'temperature'
+
     def update(self):
         """Retrieve latest state."""
         if self.device.temperature_scale == 'C':


### PR DESCRIPTION
## Description:
We should add device classes to sensors, just like we have for binary sensors.

Previously, we would try to distinguish / group sensors by unit of measurement in, for example, the history panel in the frontend. However, this can result in a graph that contains both battery levels and humidity (both %).

As an example, I've updated 3 sensors.

We will update the frontend to recognize device classes for sensors and automatically assign icons.

I think that we should be a little conservative in adding device classes. We should only add them for the ones that are common.
