### PR TITLE
Expose the condition code on condition sensors

### DIFF
--- a/homeassistant/components/sensor/yweather.py
+++ b/homeassistant/components/sensor/yweather.py
@@ -131,9 +131,12 @@ class YahooWeatherSensor(Entity):
     @property
     def device_state_attributes(self):
         """Return the state attributes."""
-        return {
-            ATTR_ATTRIBUTION: CONF_ATTRIBUTION,
-        }
+        attrs = { ATTR_ATTRIBUTION: CONF_ATTRIBUTION }
+
+        if self._code is None or "weather" in self._type:
+            attrs['condition_code'] = self._code
+
+        return attrs
 
     def update(self):
         """Get the latest data from Yahoo! and updates the states."""

--- a/homeassistant/components/sensor/yweather.py
+++ b/homeassistant/components/sensor/yweather.py
@@ -131,7 +131,7 @@ class YahooWeatherSensor(Entity):
     @property
     def device_state_attributes(self):
         """Return the state attributes."""
-        attrs = { ATTR_ATTRIBUTION: CONF_ATTRIBUTION }
+        attrs = {ATTR_ATTRIBUTION: CONF_ATTRIBUTION}
 
         if self._code is None or "weather" in self._type:
             attrs['condition_code'] = self._code

--- a/homeassistant/components/sensor/yweather.py
+++ b/homeassistant/components/sensor/yweather.py
@@ -133,7 +133,7 @@ class YahooWeatherSensor(Entity):
         """Return the state attributes."""
         attrs = {ATTR_ATTRIBUTION: CONF_ATTRIBUTION}
 
-        if self._code is None or "weather" in self._type:
+        if self._code is not None and "weather" in self._type:
             attrs['condition_code'] = self._code
 
         return attrs

--- a/tests/components/sensor/test_yweather.py
+++ b/tests/components/sensor/test_yweather.py
@@ -162,6 +162,8 @@ class TestWeather(unittest.TestCase):
         state = self.hass.states.get('sensor.yweather_condition')
         assert state is not None
         self.assertEqual(state.state, 'Mostly Cloudy')
+        self.assertEqual(state.attributes.get('condition_code'),
+                         28)
         self.assertEqual(state.attributes.get('friendly_name'),
                          'Yweather Condition')
 

--- a/tests/components/sensor/test_yweather.py
+++ b/tests/components/sensor/test_yweather.py
@@ -163,7 +163,7 @@ class TestWeather(unittest.TestCase):
         assert state is not None
         self.assertEqual(state.state, 'Mostly Cloudy')
         self.assertEqual(state.attributes.get('condition_code'),
-                         28)
+                         '28')
         self.assertEqual(state.attributes.get('friendly_name'),
                          'Yweather Condition')
 


### PR DESCRIPTION
## Description:

This exposes the `condition_code` on the condition YWeather sensor. The Yahoo Weather condition codes have long been used to map to icons like [these great weather icons](http://erikflowers.github.io/weather-icons/) and [these](http://adamwhitcroft.com/climacons/).

Exposing the codes lets other projects like dashboards utilize the codes to use iconography to show conditions with custom icons.
