### PR TITLE
Update to waze_travel_time

### DIFF
--- a/homeassistant/components/sensor/waze_travel_time.py
+++ b/homeassistant/components/sensor/waze_travel_time.py
@@ -7,7 +7,6 @@ https://home-assistant.io/components/sensor.waze_travel_time/
 from datetime import timedelta
 import logging
 
-import requests
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
@@ -61,6 +60,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         add_devices([sensor])
 
     hass.bus.listen_once(EVENT_HOMEASSISTANT_START, run_setup)
+
 
 class WazeTravelTime(Entity):
     """Representation of a Waze travel time sensor."""

--- a/homeassistant/components/sensor/waze_travel_time.py
+++ b/homeassistant/components/sensor/waze_travel_time.py
@@ -59,7 +59,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
         sensor = WazeTravelTime(hass, name, origin, destination, region)
         add_devices([sensor])
-        
+
     hass.bus.listen_once(EVENT_HOMEASSISTANT_START, run_setup)
 
 class WazeTravelTime(Entity):
@@ -163,7 +163,7 @@ class WazeTravelTime(Entity):
                 return self._get_location_from_attributes(entity)
 
         return friendly_name
-        
+
     @Throttle(SCAN_INTERVAL)
     def update(self):
         """Fetch new state data for the sensor."""

--- a/homeassistant/components/sensor/waze_travel_time.py
+++ b/homeassistant/components/sensor/waze_travel_time.py
@@ -11,7 +11,9 @@ import requests
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import ATTR_ATTRIBUTION, CONF_NAME, CONF_REGION, EVENT_HOMEASSISTANT_START, ATTR_LATITUDE, ATTR_LONGITUDE
+from homeassistant.const import (
+    ATTR_ATTRIBUTION, CONF_NAME, CONF_REGION, EVENT_HOMEASSISTANT_START, 
+    ATTR_LATITUDE, ATTR_LONGITUDE)
 import homeassistant.helpers.config_validation as cv
 import homeassistant.helpers.location as location
 from homeassistant.helpers.entity import Entity
@@ -68,12 +70,12 @@ class WazeTravelTime(Entity):
         self._name = name
         self._region = region
         self._state = None
-        
+
         if origin.split('.', 1)[0] in TRACKABLE_DOMAINS:
             self._origin_entity_id = origin
         else:
             self._origin = origin
-            
+
         if destination.split('.', 1)[0] in TRACKABLE_DOMAINS:
             self._destination_entity_id = destination
         else:
@@ -89,7 +91,7 @@ class WazeTravelTime(Entity):
         """Return the state of the sensor."""
         if self._state is None:
             return None
-            
+
         if 'duration' in self._state:
             return round(self._state['duration'])
         return None
@@ -109,7 +111,7 @@ class WazeTravelTime(Entity):
         """Return the state attributes of the last update."""
         if self._state is None:
             return None
-        
+
         res = {ATTR_ATTRIBUTION:CONF_ATTRIBUTION}
         if 'duration' in self._state:
             res[ATTR_DURATION] = self._state['duration']
@@ -118,7 +120,7 @@ class WazeTravelTime(Entity):
         if 'route' in self._state:
             res[ATTR_ROUTE] = self._state['route']            
         return res
-        
+
     def _get_location_from_entity(self, entity_id):
         """Get the location from the entity state or attributes."""
         entity = self._hass.states.get(entity_id)
@@ -146,7 +148,7 @@ class WazeTravelTime(Entity):
 
         # When everything fails just return nothing
         return None
-        
+
     @staticmethod
     def _get_location_from_attributes(entity):
         """Get the lat/long string from an entities attributes."""
@@ -165,20 +167,20 @@ class WazeTravelTime(Entity):
     def update(self):
         """Fetch new state data for the sensor."""
         import WazeRouteCalculator
-        
+
         if hasattr(self, '_origin_entity_id'):
             self._origin = self._get_location_from_entity(
                 self._origin_entity_id
             )
-            
+
         if hasattr(self, '_destination_entity_id'):
             self._destination = self._get_location_from_entity(
                 self._destination_entity_id
             )
-        
+
         self._destination = self._resolve_zone(self._destination)
         self._origin = self._resolve_zone(self._origin)
-            
+
         if self._destination is not None and self._origin is not None:
             try:
                 params = WazeRouteCalculator.WazeRouteCalculator(

--- a/homeassistant/components/sensor/waze_travel_time.py
+++ b/homeassistant/components/sensor/waze_travel_time.py
@@ -11,8 +11,9 @@ import requests
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import ATTR_ATTRIBUTION, CONF_NAME, CONF_REGION
+from homeassistant.const import ATTR_ATTRIBUTION, CONF_NAME, CONF_REGION, EVENT_HOMEASSISTANT_START, ATTR_LATITUDE, ATTR_LONGITUDE
 import homeassistant.helpers.config_validation as cv
+import homeassistant.helpers.location as location
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 
@@ -20,6 +21,7 @@ REQUIREMENTS = ['WazeRouteCalculator==0.5']
 
 _LOGGER = logging.getLogger(__name__)
 
+ATTR_DURATION = 'duration'
 ATTR_DISTANCE = 'distance'
 ATTR_ROUTE = 'route'
 
@@ -42,31 +44,40 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 })
 
+TRACKABLE_DOMAINS = ['device_tracker', 'sensor', 'zone']
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Waze travel time sensor platform."""
-    destination = config.get(CONF_DESTINATION)
-    name = config.get(CONF_NAME)
-    origin = config.get(CONF_ORIGIN)
-    region = config.get(CONF_REGION)
-
-    try:
-        waze_data = WazeRouteData(origin, destination, region)
-    except requests.exceptions.HTTPError as error:
-        _LOGGER.error("%s", error)
-        return
-
-    add_devices([WazeTravelTime(waze_data, name)], True)
-
+    def run_setup(event):
+        destination = config.get(CONF_DESTINATION)
+        name = config.get(CONF_NAME)
+        origin = config.get(CONF_ORIGIN)
+        region = config.get(CONF_REGION)
+        
+        sensor = WazeTravelTime(hass, name, origin, destination, region)
+        add_devices([sensor])
+        
+    hass.bus.listen_once(EVENT_HOMEASSISTANT_START, run_setup)
 
 class WazeTravelTime(Entity):
     """Representation of a Waze travel time sensor."""
 
-    def __init__(self, waze_data, name):
+    def __init__(self, hass, name, origin, destination, region):
         """Initialize the Waze travel time sensor."""
+        self._hass = hass
         self._name = name
+        self._region = region
         self._state = None
-        self.waze_data = waze_data
+        
+        if origin.split('.', 1)[0] in TRACKABLE_DOMAINS:
+            self._origin_entity_id = origin
+        else:
+            self._origin = origin
+            
+        if destination.split('.', 1)[0] in TRACKABLE_DOMAINS:
+            self._destination_entity_id = destination
+        else:
+            self._destination = destination
 
     @property
     def name(self):
@@ -76,7 +87,12 @@ class WazeTravelTime(Entity):
     @property
     def state(self):
         """Return the state of the sensor."""
-        return round(self._state['duration'])
+        if self._state is None:
+            return None
+            
+        if 'duration' in self._state:
+            return round(self._state['duration'])
+        return None
 
     @property
     def unit_of_measurement(self):
@@ -91,46 +107,93 @@ class WazeTravelTime(Entity):
     @property
     def device_state_attributes(self):
         """Return the state attributes of the last update."""
-        return {
-            ATTR_ATTRIBUTION: CONF_ATTRIBUTION,
-            ATTR_DISTANCE: round(self._state['distance']),
-            ATTR_ROUTE: self._state['route'],
-        }
+        if self._state is None:
+            return None
+        
+        res = {ATTR_ATTRIBUTION:CONF_ATTRIBUTION}
+        if 'duration' in self._state:
+            res[ATTR_DURATION] = self._state['duration']
+        if 'distance' in self._state:
+            res[ATTR_DISTANCE] = self._state['distance']
+        if 'route' in self._state:
+            res[ATTR_ROUTE] = self._state['route']            
+        return res
+        
+    def _get_location_from_entity(self, entity_id):
+        """Get the location from the entity state or attributes."""
+        entity = self._hass.states.get(entity_id)
 
-    def update(self):
-        """Fetch new state data for the sensor."""
-        try:
-            self.waze_data.update()
-            self._state = self.waze_data.data
-        except KeyError:
-            _LOGGER.error("Error retrieving data from server")
+        if entity is None:
+            _LOGGER.error("Unable to find entity %s", entity_id)
+            return None
 
+        # Check if the entity has location attributes (zone)
+        if location.has_location(entity):
+            return self._get_location_from_attributes(entity)
 
-class WazeRouteData(object):
-    """Get data from Waze."""
+        # Check if device is in a zone (device_tracker)
+        zone_entity = self._hass.states.get("zone.%s" % entity.state)
+        if location.has_location(zone_entity):
+            _LOGGER.debug(
+                "%s is in %s, getting zone location",
+                entity_id, zone_entity.entity_id
+            )
+            return self._get_location_from_attributes(zone_entity)
 
-    def __init__(self, origin, destination, region):
-        """Initialize the data object."""
-        self._destination = destination
-        self._origin = origin
-        self._region = region
-        self.data = {}
+        # If zone was not found in state then use the state as the location
+        if entity_id.startswith("sensor."):
+            return entity.state
 
+        # When everything fails just return nothing
+        return None
+        
+    @staticmethod
+    def _get_location_from_attributes(entity):
+        """Get the lat/long string from an entities attributes."""
+        attr = entity.attributes
+        return "%s,%s" % (attr.get(ATTR_LATITUDE), attr.get(ATTR_LONGITUDE))
+
+    def _resolve_zone(self, friendly_name):
+        entities = self._hass.states.all()
+        for entity in entities:
+            if entity.domain == 'zone' and entity.name == friendly_name:
+                return self._get_location_from_attributes(entity)
+
+        return friendly_name
+        
     @Throttle(SCAN_INTERVAL)
     def update(self):
-        """Fetch latest data from Waze."""
+        """Fetch new state data for the sensor."""
         import WazeRouteCalculator
-        _LOGGER.debug("Update in progress...")
-        try:
-            params = WazeRouteCalculator.WazeRouteCalculator(
-                self._origin, self._destination, self._region, None)
-            results = params.calc_all_routes_info()
-            best_route = next(iter(results))
-            (duration, distance) = results[best_route]
-            best_route_str = bytes(best_route, 'ISO-8859-1').decode('UTF-8')
-            self.data['duration'] = duration
-            self.data['distance'] = distance
-            self.data['route'] = best_route_str
-        except WazeRouteCalculator.WRCError as exp:
-            _LOGGER.error("Error on retrieving data: %s", exp)
-            return
+        
+        if hasattr(self, '_origin_entity_id'):
+            self._origin = self._get_location_from_entity(
+                self._origin_entity_id
+            )
+            
+        if hasattr(self, '_destination_entity_id'):
+            self._destination = self._get_location_from_entity(
+                self._destination_entity_id
+            )
+        
+        self._destination = self._resolve_zone(self._destination)
+        self._origin = self._resolve_zone(self._origin)
+            
+        if self._destination is not None and self._origin is not None:
+            try:
+                params = WazeRouteCalculator.WazeRouteCalculator(
+                    self._origin, self._destination, self._region)
+                routes = params.calc_all_routes_info()
+                route = next(iter(routes))
+                duration, distance = routes[route]
+                route = bytes(route, 'ISO-8859-1').decode('UTF-8')
+                self._state = {
+                    'duration': duration,
+                    'distance': distance,
+                    'route': route}
+            except WazeRouteCalculator.WRCError as exp:
+                _LOGGER.error("Error on retrieving data: %s", exp)
+                return
+            except KeyError:
+                _LOGGER.error("Error retrieving data from server")
+                return

--- a/homeassistant/components/sensor/waze_travel_time.py
+++ b/homeassistant/components/sensor/waze_travel_time.py
@@ -119,7 +119,7 @@ class WazeTravelTime(Entity):
         if 'distance' in self._state:
             res[ATTR_DISTANCE] = self._state['distance']
         if 'route' in self._state:
-            res[ATTR_ROUTE] = self._state['route']            
+            res[ATTR_ROUTE] = self._state['route']
         return res
 
     def _get_location_from_entity(self, entity_id):

--- a/homeassistant/components/sensor/waze_travel_time.py
+++ b/homeassistant/components/sensor/waze_travel_time.py
@@ -48,6 +48,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 TRACKABLE_DOMAINS = ['device_tracker', 'sensor', 'zone']
 
+
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Waze travel time sensor platform."""
     def run_setup(event):

--- a/homeassistant/components/sensor/waze_travel_time.py
+++ b/homeassistant/components/sensor/waze_travel_time.py
@@ -12,7 +12,7 @@ import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
-    ATTR_ATTRIBUTION, CONF_NAME, CONF_REGION, EVENT_HOMEASSISTANT_START, 
+    ATTR_ATTRIBUTION, CONF_NAME, CONF_REGION, EVENT_HOMEASSISTANT_START,
     ATTR_LATITUDE, ATTR_LONGITUDE)
 import homeassistant.helpers.config_validation as cv
 import homeassistant.helpers.location as location
@@ -56,7 +56,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         name = config.get(CONF_NAME)
         origin = config.get(CONF_ORIGIN)
         region = config.get(CONF_REGION)
-        
+
         sensor = WazeTravelTime(hass, name, origin, destination, region)
         add_devices([sensor])
         
@@ -113,7 +113,7 @@ class WazeTravelTime(Entity):
         if self._state is None:
             return None
 
-        res = {ATTR_ATTRIBUTION:CONF_ATTRIBUTION}
+        res = {ATTR_ATTRIBUTION: CONF_ATTRIBUTION}
         if 'duration' in self._state:
             res[ATTR_DURATION] = self._state['duration']
         if 'distance' in self._state:


### PR DESCRIPTION
Current version only supports latitude and longitude or an address for the origin and destination fields.  This update allows those fields to use entity IDs of `device_tracker`, `zone`, and `sensor`.

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
