### PR TITLE
Upgrade pylutron-caseta to 0.5.0 to reestablish connections

### DIFF
--- a/homeassistant/components/lutron_caseta.py
+++ b/homeassistant/components/lutron_caseta.py
@@ -14,7 +14,7 @@ from homeassistant.const import CONF_HOST
 from homeassistant.helpers import discovery
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['pylutron-caseta==0.3.0']
+REQUIREMENTS = ['pylutron-caseta==0.5.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -833,7 +833,7 @@ pylitejet==0.1
 pyloopenergy==0.0.18
 
 # homeassistant.components.lutron_caseta
-pylutron-caseta==0.3.0
+pylutron-caseta==0.5.0
 
 # homeassistant.components.lutron
 pylutron==0.1.0


### PR DESCRIPTION
## Description:

Something changed on the lutron end of things and pylutron_caseta was unable to connect to the caseta bridge. This was fixed upstream in (see links below) but the library was not upgraded in home assistant.

 - https://github.com/gurumitts/pylutron-caseta/issues/22
 - https://github.com/gurumitts/pylutron-caseta/pull/23

No configuration changes were needed in home assistant to make this work.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
