### PR TITLE
deluge-components-update

### DIFF
--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -243,7 +243,7 @@ defusedxml==0.5.0
 
 # homeassistant.components.sensor.deluge
 # homeassistant.components.switch.deluge
-deluge-client==1.0.5
+deluge-client==1.4.0
 
 # homeassistant.components.media_player.denonavr
 denonavr==0.6.1


### PR DESCRIPTION
I apologize for the previous PRs for this component as i am new with github. I have unified my PRs into one and hopefully this will not have any issues.

## Description:
- `setup_platform()` will try to connect to deluge daemon and raise PlatformNotReady if the connection fails.
- Sensors and switch will become unavailable if the connection is lost.
- I have talked to the developer of the deluge_client and discussed adding a new [reconnect()](https://github.com/JohnDoee/deluge-client/commit/f9163a5df0dd169d5e4ddcb22c1ffd229efc9c0d) function that is called within the `call` function. Now with version 1.4.0 the deluge_client will attempt to reconnect if the connection was previously lost. This will be done during the `update()` when the `call` function will be executed.
- Use different function call for starting and stopping torrents (switch component) as the previous call is not working properly with the latest deluge v 1.3.13

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
