### PR TITLE
Pollen.com: Added attributes on top 3 allergens

### DIFF
--- a/homeassistant/components/sensor/pollen.py
+++ b/homeassistant/components/sensor/pollen.py
@@ -160,7 +160,7 @@ class BaseSensor(Entity):
 
     def __init__(self, data, data_params, name, icon, unique_id):
         """Initialize the sensor."""
-        self._attrs = {}
+        self._attrs = {ATTR_ATTRIBUTION: DEFAULT_ATTRIBUTION}
         self._icon = icon
         self._name = name
         self._data_params = data_params
@@ -172,7 +172,6 @@ class BaseSensor(Entity):
     @property
     def device_state_attributes(self):
         """Return the device state attributes."""
-        self._attrs.update({ATTR_ATTRIBUTION: DEFAULT_ATTRIBUTION})
         return self._attrs
 
     @property
@@ -254,10 +253,25 @@ class AllergyIndexSensor(BaseSensor):
                 i['label'] for i in RATING_MAPPING
                 if i['minimum'] <= period['Index'] <= i['maximum']
             ]
-            self._attrs[ATTR_ALLERGEN_GENUS] = period['Triggers'][0]['Genus']
-            self._attrs[ATTR_ALLERGEN_NAME] = period['Triggers'][0]['Name']
-            self._attrs[ATTR_ALLERGEN_TYPE] = period['Triggers'][0][
-                'PlantType']
+
+            for i in range(3):
+                index = i + 1
+                try:
+                    data = period['Triggers'][i]
+                    self._attrs['{0}_{1}'.format(
+                        ATTR_ALLERGEN_GENUS, index)] = data['Genus']
+                    self._attrs['{0}_{1}'.format(
+                        ATTR_ALLERGEN_NAME, index)] = data['Name']
+                    self._attrs['{0}_{1}'.format(
+                        ATTR_ALLERGEN_TYPE, index)] = data['PlantType']
+                except IndexError:
+                    self._attrs['{0}_{1}'.format(
+                        ATTR_ALLERGEN_GENUS, index)] = None
+                    self._attrs['{0}_{1}'.format(
+                        ATTR_ALLERGEN_NAME, index)] = None
+                    self._attrs['{0}_{1}'.format(
+                        ATTR_ALLERGEN_TYPE, index)] = None
+
             self._attrs[ATTR_RATING] = rating
 
         except KeyError:


### PR DESCRIPTION
## Description:
Added the ability for the Pollen.com "Allergy Index: Today" sensor to show info (via attributes) on the top 3 allergens, rather than just the top 1.

Additionally, made a small improvement to how the attribution attribute is added.

**This is a BREAKING CHANGE:** prior versions of the platform will have attributes named:

`primary_allergen_genus`
`primary_allergen_name`
`primary_allergen_type`

Now, in order to reflect that the attribute set is the first of many, the attributes are renamed:

`primary_allergen_genus_1`
`primary_allergen_name_1`
`primary_allergen_type_1`

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: pollen
    zip_code: "12345"
    monitored_conditions:
      - allergy_average_forecasted
      - allergy_average_historical
      - allergy_index_today
      - allergy_index_tomorrow
      - allergy_index_yesterday
      - disease_average_forecasted
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - ~[ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)~

If the code communicates with devices, web services, or third-party tools:
  - ~[ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).~
  - ~[ ] New dependencies are only imported inside functions that use them ([example][ex-import]).~
  - ~[ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.~
  - ~[ ] New files were added to `.coveragerc`.~

If the code does not interact with devices:
  - ~[ ] Tests have been added to verify that the new code works.~

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
