### PR TITLE
Order the output of the automation editor

### DIFF
--- a/homeassistant/components/config/automation.py
+++ b/homeassistant/components/config/automation.py
@@ -45,7 +45,8 @@ class EditAutomationConfigView(EditIdBasedConfigView):
             if key in new_value:
                 updated_value[key] = new_value[key]
 
-        # We cover all fields above, but just in case we start supporting more fields
+        # We cover all current fields above, but just in case we start
+        # supporting more fields in the future.
         updated_value.update(cur_value)
         updated_value.update(new_value)
         data[index] = updated_value

--- a/homeassistant/components/config/automation.py
+++ b/homeassistant/components/config/automation.py
@@ -1,6 +1,8 @@
 """Provide configuration end points for Automations."""
 import asyncio
+from collections import OrderedDict
 
+from homeassistant.const import CONF_ID
 from homeassistant.components.config import EditIdBasedConfigView
 from homeassistant.components.automation import (
     PLATFORM_SCHEMA, DOMAIN, async_reload)
@@ -13,8 +15,37 @@ CONFIG_PATH = 'automations.yaml'
 @asyncio.coroutine
 def async_setup(hass):
     """Set up the Automation config API."""
-    hass.http.register_view(EditIdBasedConfigView(
+    hass.http.register_view(EditAutomationConfigView(
         DOMAIN, 'config', CONFIG_PATH, cv.string,
         PLATFORM_SCHEMA, post_write_hook=async_reload
     ))
     return True
+
+
+class EditAutomationConfigView(EditIdBasedConfigView):
+    """Edit automation config."""
+
+    def _write_value(self, hass, data, config_key, new_value):
+        """Set value."""
+        index = None
+        for index, cur_value in enumerate(data):
+            if cur_value[CONF_ID] == config_key:
+                break
+        else:
+            cur_value = OrderedDict()
+            cur_value[CONF_ID] = config_key
+            index = len(data)
+            data.append(cur_value)
+
+        # Iterate through some keys that we want to have ordered in the output
+        updated_value = OrderedDict()
+        for key in ('id', 'alias', 'trigger', 'condition', 'action'):
+            if key in cur_value:
+                updated_value[key] = cur_value[key]
+            if key in new_value:
+                updated_value[key] = new_value[key]
+
+        # We cover all fields above, but just in case we start supporting more fields
+        updated_value.update(cur_value)
+        updated_value.update(new_value)
+        data[index] = updated_value

--- a/tests/components/config/test_automation.py
+++ b/tests/components/config/test_automation.py
@@ -1,0 +1,85 @@
+"""Test Automation config panel."""
+import asyncio
+import json
+from unittest.mock import patch, MagicMock
+
+from homeassistant.bootstrap import async_setup_component
+from homeassistant.components import config
+
+
+async def test_get_device_config(hass, aiohttp_client):
+    """Test getting device config."""
+    with patch.object(config, 'SECTIONS', ['automation']):
+        await async_setup_component(hass, 'config', {})
+
+    client = await aiohttp_client(hass.http.app)
+
+    def mock_read(path):
+        """Mock reading data."""
+        return [
+            {
+                'id': 'sun',
+            },
+            {
+                'id': 'moon',
+            }
+        ]
+
+    with patch('homeassistant.components.config._read', mock_read):
+        resp = await client.get(
+            '/api/config/automation/config/moon')
+
+    assert resp.status == 200
+    result = await resp.json()
+
+    assert result == {'id': 'moon'}
+
+
+async def test_update_device_config(hass, aiohttp_client):
+    """Test updating device config."""
+    with patch.object(config, 'SECTIONS', ['automation']):
+        await async_setup_component(hass, 'config', {})
+
+    client = await aiohttp_client(hass.http.app)
+
+    orig_data = [
+            {
+                'id': 'sun',
+            },
+            {
+                'id': 'moon',
+            }
+        ]
+
+    def mock_read(path):
+        """Mock reading data."""
+        return orig_data
+
+    written = []
+
+    def mock_write(path, data):
+        """Mock writing data."""
+        written.append(data)
+
+    with patch('homeassistant.components.config._read', mock_read), \
+            patch('homeassistant.components.config._write', mock_write):
+        resp = await client.post(
+            '/api/config/automation/config/moon', data=json.dumps({
+                'trigger': [],
+                'action': [],
+                'condition': [],
+            }))
+
+    assert resp.status == 200
+    result = await resp.json()
+    assert result == {'result': 'ok'}
+
+    assert list(orig_data[1]) == ['id', 'trigger', 'condition', 'action']
+    assert orig_data[1] == {
+        'id': 'moon',
+        'trigger': [],
+        'condition': [],
+        'action': [],
+    }
+    assert written[0] == orig_data
+

--- a/tests/components/config/test_automation.py
+++ b/tests/components/config/test_automation.py
@@ -1,7 +1,6 @@
 """Test Automation config panel."""
-import asyncio
 import json
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 from homeassistant.bootstrap import async_setup_component
 from homeassistant.components import config
@@ -82,4 +81,3 @@ async def test_update_device_config(hass, aiohttp_client):
         'action': [],
     }
     assert written[0] == orig_data
-


### PR DESCRIPTION
## Description:
The automation editor lost the ordering of the keys, making it crazy confusing for people trying to edit the YAML by hand.

## Example entry for `automation.yaml` (if applicable):
```yaml
- id: '1524244793854'
  alias: Test automation 2
  trigger:
  - entity_id: light.hue_white_lamp_1
    from: 'off'
    platform: state
    to: 'on'
  condition: []
  action:
  - event: hello
    event_data: {}

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
