### PR TITLE
Show a notification when a config entry is discovered

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -382,7 +382,7 @@ class ConfigEntries:
             await async_setup_component(
                 self.hass, entry.domain, self._hass_config)
 
-        # remove notification if 0 flows with discovery source in progress
+        # Return Entry if they not from a discovery request
         if result['source'] not in DISCOVERY_SOURCES:
             return entry
 

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -145,23 +145,6 @@ DISCOVERY_NOTIFICATION_ID = 'config_entry_discovery'
 DISCOVERY_SOURCES = (data_entry_flow.SOURCE_DISCOVERY,)
 
 
-@callback
-def async_create_discovery_notification(hass):
-    """Notify user of a discovered config entry."""
-    hass.components.persistent_notification.async_create(
-        title='New devices discovered',
-        message=("We have discovered new devices on your network. "
-                 "[Check it out](/config/integrations)"),
-        notification_id=DISCOVERY_NOTIFICATION_ID
-    )
-
-
-def async_dismiss_discovery_notification(hass):
-    """Dismiss discovery notification."""
-    hass.components.persistent_notification.async_dismiss(
-        DISCOVERY_NOTIFICATION_ID)
-
-
 class ConfigEntry:
     """Hold a configuration entry."""
 
@@ -389,7 +372,8 @@ class ConfigEntries:
         # If no discovery config entries in progress, remove notification.
         if not any(ent['source'] in DISCOVERY_SOURCES for ent
                    in self.hass.config_entries.flow.async_progress()):
-            async_dismiss_discovery_notification(self.hass)
+            hass.components.persistent_notification.async_dismiss(
+                DISCOVERY_NOTIFICATION_ID)
 
         return entry
 
@@ -410,7 +394,12 @@ class ConfigEntries:
 
         # Create notification.
         if source in DISCOVERY_SOURCES:
-            async_create_discovery_notification(self.hass)
+            hass.components.persistent_notification.async_create(
+                title='New devices discovered',
+                message=("We have discovered new devices on your network. "
+                        "[Check it out](/config/integrations)"),
+                notification_id=DISCOVERY_NOTIFICATION_ID
+            )
 
         return handler()
 

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -372,7 +372,7 @@ class ConfigEntries:
         # If no discovery config entries in progress, remove notification.
         if not any(ent['source'] in DISCOVERY_SOURCES for ent
                    in self.hass.config_entries.flow.async_progress()):
-            hass.components.persistent_notification.async_dismiss(
+            self.hass.components.persistent_notification.async_dismiss(
                 DISCOVERY_NOTIFICATION_ID)
 
         return entry
@@ -394,10 +394,10 @@ class ConfigEntries:
 
         # Create notification.
         if source in DISCOVERY_SOURCES:
-            hass.components.persistent_notification.async_create(
+            self.hass.components.persistent_notification.async_create(
                 title='New devices discovered',
                 message=("We have discovered new devices on your network. "
-                        "[Check it out](/config/integrations)"),
+                         "[Check it out](/config/integrations)"),
                 notification_id=DISCOVERY_NOTIFICATION_ID
             )
 

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -52,7 +52,7 @@ class FlowManager:
 
     async def async_init(self, handler, *, source=SOURCE_USER, data=None):
         """Start a configuration flow."""
-        flow = await self._async_create_flow(handler)
+        flow = await self._async_create_flow(handler, source=source, data=data)
         flow.hass = self.hass
         flow.handler = handler
         flow.flow_id = uuid.uuid4().hex

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ if os.environ.get('UVLOOP') == '1':
     import uvloop
     asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
 
-logging.basicConfig()
+logging.basicConfig(level=logging.INFO)
 logging.getLogger('sqlalchemy.engine').setLevel(logging.INFO)
 
 

--- a/tests/test_data_entry_flow.py
+++ b/tests/test_data_entry_flow.py
@@ -12,7 +12,7 @@ def manager():
     handlers = Registry()
     entries = []
 
-    async def async_create_flow(handler_name):
+    async def async_create_flow(handler_name, *, source, data):
         handler = handlers.get(handler_name)
 
         if handler is None:


### PR DESCRIPTION
## Description:
When we migrated Hue to use config entries for discovery, the user was no longer notified when we discovered it. This will reinstate that behavior with a generic notification for any config flow that is initiated by discovery. We will also automatically dismiss the notification when all discovered flows are finished.

## Example entry for `configuration.yaml` (if applicable):
```yaml
discovery:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
