### PR TITLE
Revert cast platform polling mode

### DIFF
--- a/tests/components/media_player/test_cast.py
+++ b/tests/components/media_player/test_cast.py
@@ -1,7 +1,6 @@
 """The tests for the Cast Media player platform."""
 # pylint: disable=protected-access
 import asyncio
-import datetime as dt
 from typing import Optional
 from unittest.mock import patch, MagicMock, Mock
 from uuid import UUID
@@ -15,8 +14,7 @@ from homeassistant.components.media_player.cast import ChromecastInfo
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.helpers.dispatcher import async_dispatcher_connect, \
     async_dispatcher_send
-from homeassistant.components.media_player import cast, \
-    ATTR_MEDIA_POSITION, ATTR_MEDIA_POSITION_UPDATED_AT
+from homeassistant.components.media_player import cast
 from homeassistant.setup import async_setup_component
 
 
@@ -288,8 +286,6 @@ async def test_entity_media_states(hass: HomeAssistantType):
     assert entity.unique_id == full_info.uuid
 
     media_status = MagicMock(images=None)
-    media_status.current_time = 0
-    media_status.playback_rate = 1
     media_status.player_is_playing = True
     entity.new_media_status(media_status)
     await hass.async_block_till_done()
@@ -322,85 +318,6 @@ async def test_entity_media_states(hass: HomeAssistantType):
     await hass.async_block_till_done()
     state = hass.states.get('media_player.speaker')
     assert state.state == 'unknown'
-
-
-async def test_entity_media_position(hass: HomeAssistantType):
-    """Test various entity media states."""
-    info = get_fake_chromecast_info()
-    full_info = attr.evolve(info, model_name='google home',
-                            friendly_name='Speaker', uuid=FakeUUID)
-
-    with patch('pychromecast.dial.get_device_status',
-               return_value=full_info):
-        chromecast, entity = await async_setup_media_player_cast(hass, info)
-
-    media_status = MagicMock(images=None)
-    media_status.current_time = 10
-    media_status.playback_rate = 1
-    media_status.player_is_playing = True
-    media_status.player_is_paused = False
-    media_status.player_is_idle = False
-    now = dt.datetime.now(dt.timezone.utc)
-    with patch('homeassistant.util.dt.utcnow', return_value=now):
-        entity.new_media_status(media_status)
-        await hass.async_block_till_done()
-    state = hass.states.get('media_player.speaker')
-    assert state.attributes[ATTR_MEDIA_POSITION] == 10
-    assert state.attributes[ATTR_MEDIA_POSITION_UPDATED_AT] == now
-
-    media_status.current_time = 15
-    now_plus_5 = now + dt.timedelta(seconds=5)
-    with patch('homeassistant.util.dt.utcnow', return_value=now_plus_5):
-        entity.new_media_status(media_status)
-        await hass.async_block_till_done()
-    state = hass.states.get('media_player.speaker')
-    assert state.attributes[ATTR_MEDIA_POSITION] == 10
-    assert state.attributes[ATTR_MEDIA_POSITION_UPDATED_AT] == now
-
-    media_status.current_time = 20
-    with patch('homeassistant.util.dt.utcnow', return_value=now_plus_5):
-        entity.new_media_status(media_status)
-        await hass.async_block_till_done()
-    state = hass.states.get('media_player.speaker')
-    assert state.attributes[ATTR_MEDIA_POSITION] == 20
-    assert state.attributes[ATTR_MEDIA_POSITION_UPDATED_AT] == now_plus_5
-
-    media_status.current_time = 25
-    now_plus_10 = now + dt.timedelta(seconds=10)
-    media_status.player_is_playing = False
-    media_status.player_is_paused = True
-    with patch('homeassistant.util.dt.utcnow', return_value=now_plus_10):
-        entity.new_media_status(media_status)
-        await hass.async_block_till_done()
-    state = hass.states.get('media_player.speaker')
-    assert state.attributes[ATTR_MEDIA_POSITION] == 25
-    assert state.attributes[ATTR_MEDIA_POSITION_UPDATED_AT] == now_plus_10
-
-    now_plus_15 = now + dt.timedelta(seconds=15)
-    with patch('homeassistant.util.dt.utcnow', return_value=now_plus_15):
-        entity.new_media_status(media_status)
-        await hass.async_block_till_done()
-    state = hass.states.get('media_player.speaker')
-    assert state.attributes[ATTR_MEDIA_POSITION] == 25
-    assert state.attributes[ATTR_MEDIA_POSITION_UPDATED_AT] == now_plus_10
-
-    media_status.current_time = 30
-    now_plus_20 = now + dt.timedelta(seconds=20)
-    with patch('homeassistant.util.dt.utcnow', return_value=now_plus_20):
-        entity.new_media_status(media_status)
-        await hass.async_block_till_done()
-    state = hass.states.get('media_player.speaker')
-    assert state.attributes[ATTR_MEDIA_POSITION] == 30
-    assert state.attributes[ATTR_MEDIA_POSITION_UPDATED_AT] == now_plus_20
-
-    media_status.player_is_paused = False
-    media_status.player_is_idle = True
-    with patch('homeassistant.util.dt.utcnow', return_value=now_plus_20):
-        entity.new_media_status(media_status)
-        await hass.async_block_till_done()
-    state = hass.states.get('media_player.speaker')
-    assert ATTR_MEDIA_POSITION not in state.attributes
-    assert ATTR_MEDIA_POSITION_UPDATED_AT not in state.attributes
 
 
 async def test_switched_host(hass: HomeAssistantType):


### PR DESCRIPTION
## Description:

We used to rely on the cast device notifying us of all media status changed via callbacks. However, some apps like Netflix sometimes didn't send those callbacks even though the state had changed. In #13275, I introduced a semi-polling mode for the cast platform: we would still respond to all callbacks, but in addition we would poll the chromecast device every 30 seconds for the current state to resolve the Netflix media status issue.

However, it turned out that some other apps on the other hand don't like the polling mode at all :(. When polled for the current state via a `GET_STATUS` request, they responded with the media status of the most recent *callback* media status, not the actual media status (but only for a *some* apps 🤬). As there's no information in the `MEDIA_STATUS` messages to which timestamp the `currentTime` attribute corresponds, there's no good way to solve this IMHO.

This PR reverts #13770 and partially reverts #13275 to go back to the old callback-only method. It has its own issues, but is a lot better than the issues mentioned in #13770.

I must say, the cast protocol is extremely weird with lots of these things. I seriously would have expected a better quality out of one of google's products.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>


## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  - platform: cast
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
