### PR TITLE
Light mqtt_json: Add HS color support

### DIFF
--- a/homeassistant/components/light/mqtt_json.py
+++ b/homeassistant/components/light/mqtt_json.py
@@ -44,12 +44,14 @@ DEFAULT_OPTIMISTIC = False
 DEFAULT_RGB = False
 DEFAULT_WHITE_VALUE = False
 DEFAULT_XY = False
+DEFAULT_HS = False
 DEFAULT_BRIGHTNESS_SCALE = 255
 
 CONF_EFFECT_LIST = 'effect_list'
 
 CONF_FLASH_TIME_LONG = 'flash_time_long'
 CONF_FLASH_TIME_SHORT = 'flash_time_short'
+CONF_HS = 'hs'
 
 # Stealing some of these from the base MQTT configs.
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -72,6 +74,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_STATE_TOPIC): mqtt.valid_subscribe_topic,
     vol.Optional(CONF_WHITE_VALUE, default=DEFAULT_WHITE_VALUE): cv.boolean,
     vol.Optional(CONF_XY, default=DEFAULT_XY): cv.boolean,
+    vol.Optional(CONF_HS, default=DEFAULT_HS): cv.boolean,
     vol.Required(CONF_COMMAND_TOPIC): mqtt.valid_publish_topic,
 }).extend(mqtt.MQTT_AVAILABILITY_SCHEMA.schema)
 
@@ -99,6 +102,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         config.get(CONF_RGB),
         config.get(CONF_WHITE_VALUE),
         config.get(CONF_XY),
+        config.get(CONF_HS),
         {
             key: config.get(key) for key in (
                 CONF_FLASH_TIME_SHORT,
@@ -116,7 +120,7 @@ class MqttJson(MqttAvailability, Light):
     """Representation of a MQTT JSON light."""
 
     def __init__(self, name, effect_list, topic, qos, retain, optimistic,
-                 brightness, color_temp, effect, rgb, white_value, xy,
+                 brightness, color_temp, effect, rgb, white_value, xy, hs,
                  flash_times, availability_topic, payload_available,
                  payload_not_available, brightness_scale):
         """Initialize MQTT JSON light."""
@@ -131,6 +135,7 @@ class MqttJson(MqttAvailability, Light):
         self._state = False
         self._rgb = rgb
         self._xy = xy
+        self._hs_support = hs
         if brightness:
             self._brightness = 255
         else:
@@ -146,7 +151,7 @@ class MqttJson(MqttAvailability, Light):
         else:
             self._effect = None
 
-        if rgb or xy:
+        if hs or rgb or xy:
             self._hs = [0, 0]
         else:
             self._hs = None
@@ -166,6 +171,7 @@ class MqttJson(MqttAvailability, Light):
         self._supported_features |= (effect and SUPPORT_EFFECT)
         self._supported_features |= (white_value and SUPPORT_WHITE_VALUE)
         self._supported_features |= (xy and SUPPORT_COLOR)
+        self._supported_features |= (hs and SUPPORT_COLOR)
 
     @asyncio.coroutine
     def async_added_to_hass(self):
@@ -193,6 +199,7 @@ class MqttJson(MqttAvailability, Light):
                     pass
                 except ValueError:
                     _LOGGER.warning("Invalid RGB color value received")
+
                 try:
                     x_color = float(values['color']['x'])
                     y_color = float(values['color']['y'])
@@ -202,6 +209,14 @@ class MqttJson(MqttAvailability, Light):
                     pass
                 except ValueError:
                     _LOGGER.warning("Invalid XY color value received")
+
+                try:
+                    hue = float(values['color']['h'])
+                    saturation = float(values['color']['s'])
+
+                    self._hs = (hue, saturation)
+                except KeyError:
+                    pass
 
             if self._brightness is not None:
                 try:
@@ -309,7 +324,7 @@ class MqttJson(MqttAvailability, Light):
 
         message = {'state': 'ON'}
 
-        if ATTR_HS_COLOR in kwargs and (self._rgb or self._xy):
+        if ATTR_HS_COLOR in kwargs and (self._hs_support or self._rgb or self._xy):
             hs_color = kwargs[ATTR_HS_COLOR]
             message['color'] = {}
             if self._rgb:
@@ -325,6 +340,9 @@ class MqttJson(MqttAvailability, Light):
                 xy_color = color_util.color_hs_to_xy(*kwargs[ATTR_HS_COLOR])
                 message['color']['x'] = xy_color[0]
                 message['color']['y'] = xy_color[1]
+            if self._hs_support:
+                message['color']['h'] = hs_color[0]
+                message['color']['s'] = hs_color[1]
 
             if self._optimistic:
                 self._hs = kwargs[ATTR_HS_COLOR]

--- a/homeassistant/components/light/mqtt_json.py
+++ b/homeassistant/components/light/mqtt_json.py
@@ -217,6 +217,8 @@ class MqttJson(MqttAvailability, Light):
                     self._hs = (hue, saturation)
                 except KeyError:
                     pass
+                except ValueError:
+                    _LOGGER.warning("Invalid HS color value received")
 
             if self._brightness is not None:
                 try:

--- a/homeassistant/components/light/mqtt_json.py
+++ b/homeassistant/components/light/mqtt_json.py
@@ -324,7 +324,8 @@ class MqttJson(MqttAvailability, Light):
 
         message = {'state': 'ON'}
 
-        if ATTR_HS_COLOR in kwargs and (self._hs_support or self._rgb or self._xy):
+        if ATTR_HS_COLOR in kwargs and (self._hs_support
+                                        or self._rgb or self._xy):
             hs_color = kwargs[ATTR_HS_COLOR]
             message['color'] = {}
             if self._rgb:


### PR DESCRIPTION
## Description:

Add Hue/Saturation color support for the `mqtt_json` platform. Using the HSV color wheel for colors can help with making color transitions a lot nicer, since rotating on the hue color wheel doesn't have weird intermediary color values.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5214

## Example entry for `configuration.yaml` (if applicable):
```yaml
light:
  - platform: mqtt_json
    command_topic: "home/rgb1/set"
    hs: True
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
