### PR TITLE
WIP: add model and serial to caseta devices

### DIFF
--- a/homeassistant/components/lutron_caseta.py
+++ b/homeassistant/components/lutron_caseta.py
@@ -82,7 +82,6 @@ class LutronCasetaDevice(Entity):
         self._device_type = device["type"]
         self._device_name = device["name"]
         self._device_zone = device["zone"]
-        self._device_model = device["model"]
         self._device_serial = device["serial"]
         self._state = None
         self._smartbridge = bridge
@@ -97,11 +96,6 @@ class LutronCasetaDevice(Entity):
     def name(self):
         """Return the name of the device."""
         return self._device_name
-
-    @property
-    def model(self):
-        """Return the model number of the device."""
-        return self._device_model
 
     @property
     def serial(self):

--- a/homeassistant/components/lutron_caseta.py
+++ b/homeassistant/components/lutron_caseta.py
@@ -14,7 +14,7 @@ from homeassistant.const import CONF_HOST
 from homeassistant.helpers import discovery
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['pylutron-caseta==0.5.0']
+REQUIREMENTS = ['pylutron-caseta==0.5.1']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -82,6 +82,8 @@ class LutronCasetaDevice(Entity):
         self._device_type = device["type"]
         self._device_name = device["name"]
         self._device_zone = device["zone"]
+        self._device_model = device["model"]
+        self._device_serial = device["serial"]
         self._state = None
         self._smartbridge = bridge
 
@@ -95,6 +97,21 @@ class LutronCasetaDevice(Entity):
     def name(self):
         """Return the name of the device."""
         return self._device_name
+
+    @property
+    def model(self):
+        """Return the model number of the device."""
+        return self._device_model
+
+    @property
+    def serial(self):
+        """Return the serial number of the device."""
+        return self._device_serial
+
+    @property
+    def unique_id(self):
+        """Return the unique ID of the device (model + serial)."""
+        return "{}.{}".format(self._device_model, self._device_serial)
 
     @property
     def device_state_attributes(self):

--- a/homeassistant/components/lutron_caseta.py
+++ b/homeassistant/components/lutron_caseta.py
@@ -110,8 +110,8 @@ class LutronCasetaDevice(Entity):
 
     @property
     def unique_id(self):
-        """Return the unique ID of the device (model + serial)."""
-        return "{}.{}".format(self._device_model, self._device_serial)
+        """Return the unique ID of the device (serial)."""
+        return str(self._device_serial)
 
     @property
     def device_state_attributes(self):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -833,7 +833,7 @@ pylitejet==0.1
 pyloopenergy==0.0.18
 
 # homeassistant.components.lutron_caseta
-pylutron-caseta==0.5.0
+pylutron-caseta==0.5.1
 
 # homeassistant.components.lutron
 pylutron==0.1.0


### PR DESCRIPTION
## Description:

This depends on gurumitts/pylutron-caseta#25 which has not been merged yet, and I have not actually tested it on my environment yet.

This should add model numbers and serial numbers to lutron_caseta devices and enable the entity registry.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable): N/A

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
