### PR TITLE
Add relative time option to simulated sensors

### DIFF
--- a/homeassistant/components/sensor/simulated.py
+++ b/homeassistant/components/sensor/simulated.py
@@ -7,6 +7,7 @@ https://home-assistant.io/components/sensor.simulated/
 import logging
 import math
 from random import Random
+from datetime import datetime
 
 import voluptuous as vol
 
@@ -25,6 +26,7 @@ CONF_PERIOD = 'period'
 CONF_PHASE = 'phase'
 CONF_SEED = 'seed'
 CONF_UNIT = 'unit'
+CONF_RELATIVE_TO_EPOCH = 'relative_to_epoch'
 
 DEFAULT_AMP = 1
 DEFAULT_FWHM = 0
@@ -34,6 +36,7 @@ DEFAULT_PERIOD = 60
 DEFAULT_PHASE = 0
 DEFAULT_SEED = 999
 DEFAULT_UNIT = 'value'
+DEFAULT_RELATIVE_TO_EPOCH = True
 
 ICON = 'mdi:chart-line'
 
@@ -46,6 +49,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_PHASE, default=DEFAULT_PHASE): vol.Coerce(float),
     vol.Optional(CONF_SEED, default=DEFAULT_SEED): cv.positive_int,
     vol.Optional(CONF_UNIT, default=DEFAULT_UNIT): cv.string,
+    vol.Optional(CONF_RELATIVE_TO_EPOCH, default=DEFAULT_RELATIVE_TO_EPOCH):
+        cv.boolean,
 })
 
 
@@ -59,15 +64,18 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     phase = config.get(CONF_PHASE)
     fwhm = config.get(CONF_FWHM)
     seed = config.get(CONF_SEED)
+    relative_to_epoch = config.get(CONF_RELATIVE_TO_EPOCH)
 
-    sensor = SimulatedSensor(name, unit, amp, mean, period, phase, fwhm, seed)
+    sensor = SimulatedSensor(name, unit, amp, mean, period, phase, fwhm, seed,
+                             relative_to_epoch)
     add_devices([sensor], True)
 
 
 class SimulatedSensor(Entity):
     """Class for simulated sensor."""
 
-    def __init__(self, name, unit, amp, mean, period, phase, fwhm, seed):
+    def __init__(self, name, unit, amp, mean, period, phase, fwhm, seed,
+                 relative_to_epoch):
         """Init the class."""
         self._name = name
         self._unit = unit
@@ -78,7 +86,11 @@ class SimulatedSensor(Entity):
         self._fwhm = fwhm
         self._seed = seed
         self._random = Random(seed)  # A local seeded Random
-        self._start_time = dt_util.utcnow()
+        self._start_time = (
+            datetime(1970, 1, 1, tzinfo=dt_util.UTC) if relative_to_epoch
+            else dt_util.utcnow()
+        )
+        self._relative_to_epoch = relative_to_epoch
         self._state = None
 
     def time_delta(self):
@@ -136,5 +148,6 @@ class SimulatedSensor(Entity):
             'phase': self._phase,
             'spread': self._fwhm,
             'seed': self._seed,
+            'relative_to_epoch': self._relative_to_epoch,
             }
         return attr

--- a/tests/components/sensor/test_simulated.py
+++ b/tests/components/sensor/test_simulated.py
@@ -5,8 +5,8 @@ from tests.common import get_test_home_assistant
 
 from homeassistant.components.sensor.simulated import (
     CONF_AMP, CONF_FWHM, CONF_MEAN, CONF_PERIOD, CONF_PHASE, CONF_SEED,
-    CONF_UNIT, DEFAULT_AMP, DEFAULT_FWHM, DEFAULT_MEAN, DEFAULT_NAME,
-    DEFAULT_PHASE, DEFAULT_SEED)
+    CONF_UNIT, CONF_RELATIVE_TO_EPOCH, DEFAULT_AMP, DEFAULT_FWHM, DEFAULT_MEAN,
+    DEFAULT_NAME, DEFAULT_PHASE, DEFAULT_SEED, DEFAULT_RELATIVE_TO_EPOCH)
 from homeassistant.const import CONF_FRIENDLY_NAME
 from homeassistant.setup import setup_component
 
@@ -42,3 +42,5 @@ class TestSimulatedSensor(unittest.TestCase):
         assert state.attributes.get(CONF_PHASE) == DEFAULT_PHASE
         assert state.attributes.get(CONF_FWHM) == DEFAULT_FWHM
         assert state.attributes.get(CONF_SEED) == DEFAULT_SEED
+        assert state.attributes.get(
+            CONF_RELATIVE_TO_EPOCH) == DEFAULT_RELATIVE_TO_EPOCH


### PR DESCRIPTION
## Description:

By default simulated sensors are relative to when they're activated,
instead we make this togglable with this new option 'relative_to_epoch',
and instead they relative to 1970-01-01 00:00:00.

**Related issue (if applicable):**

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5223

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: simulated
    name: 'one'
    unit: '%'
    amplitude: 256
    mean: 0
    spread: 0
    seed: 0
    period: 86400
    relative_to_epoch: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
