### PR TITLE
Fix BOM weather '-' value

### DIFF
--- a/homeassistant/components/weather/bom.py
+++ b/homeassistant/components/weather/bom.py
@@ -48,7 +48,7 @@ class BOMWeather(WeatherEntity):
     def __init__(self, bom_data, stationname=None):
         """Initialise the platform with a data instance and station name."""
         self.bom_data = bom_data
-        self.stationname = stationname or self.bom_data.data.get('name')
+        self.stationname = stationname or self.bom_data.latest_data.get('name')
 
     def update(self):
         """Update current conditions."""
@@ -62,14 +62,14 @@ class BOMWeather(WeatherEntity):
     @property
     def condition(self):
         """Return the current condition."""
-        return self.bom_data.data.get('weather')
+        return self.bom_data.get_reading('weather')
 
     # Now implement the WeatherEntity interface
 
     @property
     def temperature(self):
         """Return the platform temperature."""
-        return self.bom_data.data.get('air_temp')
+        return self.bom_data.get_reading('air_temp')
 
     @property
     def temperature_unit(self):
@@ -79,17 +79,17 @@ class BOMWeather(WeatherEntity):
     @property
     def pressure(self):
         """Return the mean sea-level pressure."""
-        return self.bom_data.data.get('press_msl')
+        return self.bom_data.get_reading('press_msl')
 
     @property
     def humidity(self):
         """Return the relative humidity."""
-        return self.bom_data.data.get('rel_hum')
+        return self.bom_data.get_reading('rel_hum')
 
     @property
     def wind_speed(self):
         """Return the wind speed."""
-        return self.bom_data.data.get('wind_spd_kmh')
+        return self.bom_data.get_reading('wind_spd_kmh')
 
     @property
     def wind_bearing(self):
@@ -99,7 +99,7 @@ class BOMWeather(WeatherEntity):
                       'S', 'SSW', 'SW', 'WSW',
                       'W', 'WNW', 'NW', 'NNW']
         wind = {name: idx * 360 / 16 for idx, name in enumerate(directions)}
-        return wind.get(self.bom_data.data.get('wind_dir'))
+        return wind.get(self.bom_data.get_reading('wind_dir'))
 
     @property
     def attribution(self):

--- a/tests/components/sensor/test_bom.py
+++ b/tests/components/sensor/test_bom.py
@@ -1,0 +1,97 @@
+"""The tests for the BOM Weather sensor platform."""
+import re
+import unittest
+import json
+import requests
+from unittest.mock import patch
+from urllib.parse import urlparse
+
+from homeassistant.setup import setup_component
+from homeassistant.components import sensor
+
+from tests.common import (
+    get_test_home_assistant, assert_setup_component, load_fixture)
+
+VALID_CONFIG = {
+    'platform': 'bom',
+    'station': 'IDN60901.94767',
+    'name': 'Fake',
+    'monitored_conditions': [
+        'apparent_t',
+        'press',
+        'weather'
+    ]
+}
+
+
+def mocked_requests(*args, **kwargs):
+    """Mock requests.get invocations."""
+    class MockResponse:
+        """Class to represent a mocked response."""
+
+        def __init__(self, json_data, status_code):
+            """Initialize the mock response class."""
+            self.json_data = json_data
+            self.status_code = status_code
+
+        def json(self):
+            """Return the json of the response."""
+            return self.json_data
+
+        @property
+        def content(self):
+            """Return the content of the response."""
+            return self.json()
+
+        def raise_for_status(self):
+            """Raise an HTTPError if status is not 200."""
+            if self.status_code != 200:
+                raise requests.HTTPError(self.status_code)
+
+    url = urlparse(args[0])
+    if re.match(r'^/fwo/[\w]+/[\w.]+\.json', url.path):
+        return MockResponse(json.loads(load_fixture('bom_weather.json')), 200)
+
+    raise NotImplementedError('Unknown route {}'.format(url.path))
+
+
+class TestBOMWeatherSensor(unittest.TestCase):
+    """Test the BOM Weather sensor."""
+
+    def setUp(self):
+        """Set up things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+        self.config = VALID_CONFIG
+
+    def tearDown(self):
+        """Stop everything that was started."""
+        self.hass.stop()
+
+    @patch('requests.get', side_effect=mocked_requests)
+    def test_setup(self, mock_get):
+        """Test the setup with custom settings."""
+        with assert_setup_component(1, sensor.DOMAIN):
+            self.assertTrue(setup_component(self.hass, sensor.DOMAIN, {
+                'sensor': VALID_CONFIG}))
+
+        fake_entities = [
+            'bom_fake_feels_like_c',
+            'bom_fake_pressure_mb',
+            'bom_fake_weather']
+
+        for entity_id in fake_entities:
+            state = self.hass.states.get('sensor.{}'.format(entity_id))
+            self.assertIsNotNone(state)
+
+    @patch('requests.get', side_effect=mocked_requests)
+    def test_sensor_values(self, mock_get):
+        """Test retrieval of sensor values."""
+        self.assertTrue(setup_component(
+            self.hass, sensor.DOMAIN, {'sensor': VALID_CONFIG}))
+
+        self.assertEqual('Fine', self.hass.states.get(
+            'sensor.bom_fake_weather').state)
+        self.assertEqual('1021.7', self.hass.states.get(
+            'sensor.bom_fake_pressure_mb').state)
+        self.assertEqual('25.0', self.hass.states.get(
+            'sensor.bom_fake_feels_like_c').state)

--- a/tests/fixtures/bom_weather.json
+++ b/tests/fixtures/bom_weather.json
@@ -1,0 +1,42 @@
+{
+  "observations": {
+    "data": [
+      {
+        "wmo": 94767,
+        "name": "Fake",
+        "history_product": "IDN00000",
+        "local_date_time_full": "20180422130000",
+        "apparent_t": 25.0,
+        "press": 1021.7,
+        "weather": "-"
+      },
+      {
+        "wmo": 94767,
+        "name": "Fake",
+        "history_product": "IDN00000",
+        "local_date_time_full": "20180422130000",
+        "apparent_t": 22.0,
+        "press": 1019.7,
+        "weather": "-"
+      },
+      {
+        "wmo": 94767,
+        "name": "Fake",
+        "history_product": "IDN00000",
+        "local_date_time_full": "20180422130000",
+        "apparent_t": 20.0,
+        "press": 1011.7,
+        "weather": "Fine"
+      },
+      {
+        "wmo": 94767,
+        "name": "Fake",
+        "history_product": "IDN00000",
+        "local_date_time_full": "20180422130000",
+        "apparent_t": 18.0,
+        "press": 1010.0,
+        "weather": "-"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Description:

BOM weather only provide forecast data every few updates, so the state usually looks like the following:

![image](https://user-images.githubusercontent.com/1289759/39092305-4ef3dfdc-464e-11e8-9385-eda7efc9a7fc.png)

With occasional data along the way

![image](https://user-images.githubusercontent.com/1289759/39092307-53a30b48-464e-11e8-9d93-347faa0add8f.png)

This PR uses the historical data to show the last, non `-` value for the `weather` sensor to fix this issue for `weather` only.  


## Example entry for `configuration.yaml` (if applicable):
```yaml
weather:
  - platform: bom
    station: IDN60901.94767
sensor:
  - platform: bom
    station: IDN60901.94767
    name: Sydney
    monitored_conditions:
      - apparent_t
      - cloud
      - cloud_base_m
      - cloud_oktas
      - cloud_type_id
      - cloud_type
      - delta_t
      - gust_kmh
      - gust_kt
      - air_temp
      - dewpt
      - press
      - press_qnh
      - press_msl
      - press_tend
      - rain_trace
      - rel_hum
      - sea_state
      - swell_dir_worded
      - swell_height
      - swell_period
      - vis_km
      - weather
      - wind_dir
      - wind_spd_kmh
      - wind_spd_kt

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**


If the code communicates with devices, web services, or third-party tools:
  - [ ] ~New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).~
  - [ ] ~New dependencies are only imported inside functions that use them ([example][ex-import]).~
  - [ ] ~New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.~
  - [ ] ~New files were added to `.coveragerc`.~

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
