### PR TITLE
bump gogogate2 version

### DIFF
--- a/homeassistant/components/cover/gogogate2.py
+++ b/homeassistant/components/cover/gogogate2.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
     CONF_IP_ADDRESS, CONF_NAME)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['pygogogate2==0.0.3']
+REQUIREMENTS = ['pygogogate2==0.0.7']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -778,7 +778,7 @@ pyfritzhome==0.3.7
 pyfttt==0.3
 
 # homeassistant.components.cover.gogogate2
-pygogogate2==0.0.3
+pygogogate2==0.0.7
 
 # homeassistant.components.remote.harmony
 pyharmony==1.0.20


### PR DESCRIPTION
Description:
This PR bumps the version of the pygogogate2 component which fixes an issue with encryption for the gogogate2 api

Pull request in home-assistant.github.io with documentation (if applicable): home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

Example entry for configuration.yaml (if applicable):
Checklist:
[x] The code change is tested and works locally.
[x] Local tests pass with tox. Your PR cannot be merged unless tests pass
[] If user exposed functionality or configuration variables are added/changed:

[] Documentation added/updated in home-assistant.github.io
[] If the code communicates with devices, web services, or third-party tools:

[x] New dependencies have been added to the REQUIREMENTS variable (example).
[] New dependencies are only imported inside functions that use them (example).
[x] New dependencies have been added to requirements_all.txt by running script/gen_requirements_all.py.
[] New files were added to .coveragerc.
If the code does not interact with devices:

[] Tests have been added to verify that the new code works.