### PR TITLE
device_tracker.ubus: catch ConnectionError

### DIFF
--- a/homeassistant/components/device_tracker/ubus.py
+++ b/homeassistant/components/device_tracker/ubus.py
@@ -207,7 +207,7 @@ def _req_json_rpc(url, session_id, rpcmethod, subsystem, method, **params):
     try:
         res = requests.post(url, data=data, timeout=5)
 
-    except requests.exceptions.Timeout:
+    except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
         return
 
     if res.status_code == 200:


### PR DESCRIPTION
When an OpenWrt device monitored via ubus is offline, this causes the
log to be flooded with several exceptions. Avoid this by catching
requests.exceptions.ConnectionError in addition to
requests.exceptions.Timeout.

Signed-off-by: Stijn Tintel <stijn@linux-ipv6.be>

## Description:

Log showing the problem:
```
2018-04-21 11:47:38 WARNING (MainThread) [homeassistant.components.device_tracker] Updating device list from ubus took longer than the scheduled scan interval 0:00:12
2018-04-21 11:47:38 ERROR (MainThread) [homeassistant.core] Error doing job: Task exception was never retrieved
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/urllib3/connection.py", line 141, in _new_conn
    (self.host, self.port), self.timeout, **extra_kw)
  File "/usr/local/lib/python3.6/site-packages/urllib3/util/connection.py", line 83, in create_connection
    raise err
  File "/usr/local/lib/python3.6/site-packages/urllib3/util/connection.py", line 73, in create_connection
    sock.connect(sa)
OSError: [Errno 113] No route to host

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/urllib3/connectionpool.py", line 601, in urlopen
    chunked=chunked)
  File "/usr/local/lib/python3.6/site-packages/urllib3/connectionpool.py", line 357, in _make_request
    conn.request(method, url, **httplib_request_kw)
  File "/usr/local/lib/python3.6/http/client.py", line 1239, in request
    self._send_request(method, url, body, headers, encode_chunked)
  File "/usr/local/lib/python3.6/http/client.py", line 1285, in _send_request
    self.endheaders(body, encode_chunked=encode_chunked)
  File "/usr/local/lib/python3.6/http/client.py", line 1234, in endheaders
    self._send_output(message_body, encode_chunked=encode_chunked)
  File "/usr/local/lib/python3.6/http/client.py", line 1026, in _send_output
    self.send(msg)
  File "/usr/local/lib/python3.6/http/client.py", line 964, in send
    self.connect()
  File "/usr/local/lib/python3.6/site-packages/urllib3/connection.py", line 166, in connect
    conn = self._new_conn()
  File "/usr/local/lib/python3.6/site-packages/urllib3/connection.py", line 150, in _new_conn
    self, "Failed to establish a new connection: %s" % e)
urllib3.exceptions.NewConnectionError: <urllib3.connection.HTTPConnection object at 0x7f3318043400>: Failed to establish a new connection: [Errno 113] No route to host

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/requests/adapters.py", line 440, in send
    timeout=timeout
  File "/usr/local/lib/python3.6/site-packages/urllib3/connectionpool.py", line 639, in urlopen
    _stacktrace=sys.exc_info()[2])
  File "/usr/local/lib/python3.6/site-packages/urllib3/util/retry.py", line 388, in increment
    raise MaxRetryError(_pool, url, error or ResponseError(cause))
urllib3.exceptions.MaxRetryError: HTTPConnectionPool(host='192.168.54.250', port=80): Max retries exceeded with url: /ubus (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7f3318043400>: Failed to establish a new connection: [Errno 113] No route to host',))

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/src/app/homeassistant/components/device_tracker/__init__.py", line 684, in async_device_tracker_scan
    found_devices = yield from scanner.async_scan_devices()
  File "/usr/local/lib/python3.6/concurrent/futures/thread.py", line 56, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/src/app/homeassistant/components/device_tracker/ubus.py", line 94, in scan_devices
    self._update_info()
  File "/usr/src/app/homeassistant/components/device_tracker/ubus.py", line 57, in decorator
    return func(self, *args, **kwargs)
  File "/usr/src/app/homeassistant/components/device_tracker/ubus.py", line 130, in _update_info
    self.url, self.session_id, 'call', hostapd, 'get_clients')
  File "/usr/src/app/homeassistant/components/device_tracker/ubus.py", line 205, in _req_json_rpc
    res = requests.post(url, data=data, timeout=5)
  File "/usr/local/lib/python3.6/site-packages/requests/api.py", line 112, in post
    return request('post', url, data=data, json=json, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/requests/api.py", line 58, in request
    return session.request(method=method, url=url, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/requests/sessions.py", line 508, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/local/lib/python3.6/site-packages/requests/sessions.py", line 618, in send
    r = adapter.send(request, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/requests/adapters.py", line 508, in send
    raise ConnectionError(e, request=request)
requests.exceptions.ConnectionError: HTTPConnectionPool(host='192.168.54.250', port=80): Max retries exceeded with url: /ubus (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7f3318043400>: Failed to establish a new connection: [Errno 113] No route to host',))
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`.

(I do run into the problem described at https://community.home-assistant.io/t/having-trouble-setting-up-a-development-environment/17753 when running tox)