### PR TITLE
Remove excessive debugging in webostv module

### DIFF
--- a/homeassistant/components/media_player/webostv.py
+++ b/homeassistant/components/media_player/webostv.py
@@ -352,33 +352,30 @@ class LgWebOSDevice(MediaPlayerDevice):
         if media_type == MEDIA_TYPE_CHANNEL:
             _LOGGER.debug("Searching channel...")
             partial_match_channel_id = None
+            perfect_match_channel_id = None
 
             for channel in self._client.get_channels():
-                _LOGGER.debug(
-                    "Checking channel number <%s>, name <%s>, id <%s>...",
-                    channel['channelNumber'],
-                    channel['channelName'],
-                    channel['channelId'])
                 if media_id == channel['channelNumber']:
-                    _LOGGER.debug(
-                        "Perfect match on channel number: switching!")
-                    self._client.set_channel(channel['channelId'])
-                    return
+                    perfect_match_channel_id = channel['channelId']
+                    continue
                 elif media_id.lower() == channel['channelName'].lower():
-                    _LOGGER.debug(
-                        "Perfect match on channel name: switching!")
-                    self._client.set_channel(channel['channelId'])
-                    return
+                    perfect_match_channel_id = channel['channelId']
+                    continue
                 elif media_id.lower() in channel['channelName'].lower():
-                    _LOGGER.debug(
-                        "Partial match on channel name: saving it...")
                     partial_match_channel_id = channel['channelId']
 
-            if partial_match_channel_id is not None:
-                _LOGGER.debug(
-                    "Using partial match on channel name: switching!")
+            if perfect_match_channel_id is not None:
+                _LOGGER.info(
+                    "Switching to channel <%s> with perfect match",
+                    perfect_match_channel_id)
+                self._client.set_channel(perfect_match_channel_id)
+            elif partial_match_channel_id is not None:
+                _LOGGER.info(
+                    "Switching to channel <%s> with partial match",
+                    partial_match_channel_id)
                 self._client.set_channel(partial_match_channel_id)
-                return
+
+            return
 
     def media_play(self):
         """Send play command."""


### PR DESCRIPTION
## Description:
As per comment in #13934

**Related issue (if applicable):** fixes #13934

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
