### PR TITLE
New sensor domain expiry

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -574,6 +574,7 @@ omit =
     homeassistant/components/sensor/discogs.py
     homeassistant/components/sensor/dnsip.py
     homeassistant/components/sensor/dovado.py
+    homeassistant/components/sensor/domain_expiry.py
     homeassistant/components/sensor/dte_energy_bridge.py
     homeassistant/components/sensor/dublin_bus_transport.py
     homeassistant/components/sensor/dwd_weather_warnings.py

--- a/homeassistant/components/sensor/domain_expiry.py
+++ b/homeassistant/components/sensor/domain_expiry.py
@@ -1,0 +1,84 @@
+"""
+Counter for the days till domain will expire.
+
+For more details about this sensor please refer to the documentation at
+https://home-assistant.io/components/sensor.domain_expiry/
+"""
+import logging
+from datetime import datetime, timedelta
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import (CONF_NAME, CONF_HOST,
+                                 EVENT_HOMEASSISTANT_START)
+from homeassistant.helpers.entity import Entity
+
+REQUIREMENTS = ['python-whois==0.6.9']
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_NAME = 'Domain Expiry'
+
+SCAN_INTERVAL = timedelta(hours=24)
+
+TIMEOUT = 10.0
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_HOST): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up domain expiry sensor."""
+    def run_setup(event):
+        """Wait until Home Assistant is fully initialized before creating.
+
+        Delay the setup until Home Assistant is fully initialized.
+        """
+        server_name = config.get(CONF_HOST)
+        sensor_name = config.get(CONF_NAME)
+
+        add_devices([DomainExpiry(sensor_name, server_name)],
+                    True)
+
+    hass.bus.listen_once(EVENT_HOMEASSISTANT_START, run_setup)
+
+
+class DomainExpiry(Entity):
+    """Implementation of the domain expiry sensor."""
+
+    def __init__(self, sensor_name, server_name):
+        """Initialize the sensor."""
+        self.server_name = server_name
+        self._name = sensor_name
+        self._state = None
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit this state is expressed in."""
+        return 'days'
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def icon(self):
+        """Icon to use in the frontend, if any."""
+        return 'mdi:earth'
+
+    def update(self):
+        """Fetch the domain information."""
+        import whois
+        domain = whois.whois(self.server_name)
+        expiry = domain.expiration_date - datetime.today()
+        self._state = expiry.days

--- a/homeassistant/components/sensor/domain_expiry.py
+++ b/homeassistant/components/sensor/domain_expiry.py
@@ -11,7 +11,7 @@ import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import (CONF_NAME, CONF_HOST)
+from homeassistant.const import (CONF_NAME, CONF_DOMAIN)
 from homeassistant.helpers.entity import Entity
 
 REQUIREMENTS = ['python-whois==0.6.9']
@@ -23,14 +23,14 @@ DEFAULT_NAME = 'Domain Expiry'
 SCAN_INTERVAL = timedelta(hours=24)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_HOST): cv.string,
+    vol.Required(CONF_DOMAIN): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string
 })
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up domain expiry sensor."""
-    server_name = config.get(CONF_HOST)
+    server_name = config.get(CONF_DOMAIN)
     sensor_name = config.get(CONF_NAME)
 
     add_devices([DomainExpiry(sensor_name, server_name)], True)

--- a/homeassistant/components/sensor/domain_expiry.py
+++ b/homeassistant/components/sensor/domain_expiry.py
@@ -5,7 +5,7 @@ For more details about this sensor please refer to the documentation at
 https://home-assistant.io/components/sensor.domain_expiry/
 """
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import voluptuous as vol
 
@@ -19,6 +19,8 @@ REQUIREMENTS = ['python-whois==0.6.9']
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_NAME = 'Domain Expiry'
+
+SCAN_INTERVAL = timedelta(hours=24)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,

--- a/homeassistant/components/sensor/domain_expiry.py
+++ b/homeassistant/components/sensor/domain_expiry.py
@@ -72,4 +72,3 @@ class DomainExpiry(Entity):
             self._state = expiry.days
         else:
             _LOGGER.error("Cannot get expiry date for %s", self.server_name)
-

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1035,6 +1035,9 @@ python-velbus==2.0.11
 # homeassistant.components.media_player.vlc
 python-vlc==1.1.2
 
+# homeassistant.components.sensor.domain_expiry
+python-whois==0.6.9
+
 # homeassistant.components.wink
 python-wink==1.7.3
 


### PR DESCRIPTION
## Description:
Domain expiry sensor.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5242


## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: domain_expiry
    domain: google.com
    name: google
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
