### PR TITLE
Bump locationsharinglib to 1.2.2

### DIFF
--- a/homeassistant/components/device_tracker/google_maps.py
+++ b/homeassistant/components/device_tracker/google_maps.py
@@ -19,7 +19,7 @@ from homeassistant.util import slugify
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['locationsharinglib==1.2.1']
+REQUIREMENTS = ['locationsharinglib==1.2.2']
 
 CREDENTIALS_FILE = '.google_maps_location_sharing.cookies'
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -503,7 +503,7 @@ liveboxplaytv==2.0.2
 lmnotify==0.0.4
 
 # homeassistant.components.device_tracker.google_maps
-locationsharinglib==1.2.1
+locationsharinglib==1.2.2
 
 # homeassistant.components.sensor.luftdaten
 luftdaten==0.1.3


### PR DESCRIPTION
## Description:
Bump locationsharinglib to 1.2.2:
This add 2FA authentification google map device tracker

**Related issue (if applicable):** fixes #13978 #13858
And possible fix for all errors =>
https://community.home-assistant.io/t/google-maps-location-sharing/15155/297

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
