### PR TITLE
Modify weather components for "new" frontend card

### DIFF
--- a/homeassistant/components/weather/buienradar.py
+++ b/homeassistant/components/weather/buienradar.py
@@ -122,15 +122,6 @@ class BrWeather(WeatherEntity):
                     return conditions.get(ccode)
 
     @property
-    def entity_picture(self):
-        """Return the entity picture to use in the frontend, if any."""
-        from buienradar.buienradar import (IMAGE)
-
-        if self._data and self._data.condition:
-            return self._data.condition.get(IMAGE, None)
-        return None
-
-    @property
     def temperature(self):
         """Return the current temperature."""
         return self._data.temperature

--- a/homeassistant/components/weather/darksky.py
+++ b/homeassistant/components/weather/darksky.py
@@ -25,9 +25,6 @@ _LOGGER = logging.getLogger(__name__)
 
 ATTRIBUTION = "Powered by Dark Sky"
 
-ATTR_DAILY_FORECAST_SUMMARY = 'daily_forecast_summary'
-ATTR_HOURLY_FORECAST_SUMMARY = 'hourly_forecast_summary'
-
 CONF_UNITS = 'units'
 
 DEFAULT_NAME = 'Dark Sky'
@@ -121,25 +118,6 @@ class DarkSkyWeather(WeatherEntity):
                 datetime.fromtimestamp(entry.d.get('time')).isoformat(),
             ATTR_FORECAST_TEMP: entry.d.get('temperature')}
                 for entry in self._ds_hourly.data]
-
-    @property
-    def hourly_forecast_summary(self):
-        """Return a summary of the hourly forecast."""
-        return self._ds_hourly.summary
-
-    @property
-    def daily_forecast_summary(self):
-        """Return a summary of the daily forecast."""
-        return self._ds_daily.summary
-
-    @property
-    def device_state_attributes(self):
-        """Return the state attributes."""
-        attrs = {
-            ATTR_DAILY_FORECAST_SUMMARY: self.daily_forecast_summary,
-            ATTR_HOURLY_FORECAST_SUMMARY: self.hourly_forecast_summary
-        }
-        return attrs
 
     def update(self):
         """Get the latest data from Dark Sky."""

--- a/homeassistant/components/weather/openweathermap.py
+++ b/homeassistant/components/weather/openweathermap.py
@@ -28,7 +28,6 @@ DEFAULT_NAME = 'OpenWeatherMap'
 
 MIN_TIME_BETWEEN_FORECAST_UPDATES = timedelta(minutes=30)
 MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=10)
-MIN_OFFSET_BETWEEN_FORECAST_CONDITIONS = 3
 
 CONDITION_CLASSES = {
     'cloudy': [804],
@@ -144,12 +143,11 @@ class OpenWeatherMapWeather(WeatherEntity):
             data.append({
                 ATTR_FORECAST_TIME: entry.get_reference_time('unix') * 1000,
                 ATTR_FORECAST_TEMP:
-                    entry.get_temperature('celsius').get('temp')
-            })
-            if (len(data) - 1) % MIN_OFFSET_BETWEEN_FORECAST_CONDITIONS == 0:
-                data[len(data) - 1][ATTR_FORECAST_CONDITION] = \
+                    entry.get_temperature('celsius').get('temp'),
+                ATTR_FORECAST_CONDITION:
                     [k for k, v in CONDITION_CLASSES.items()
                      if entry.get_weather_code() in v][0]
+            })
         return data
 
     def update(self):

--- a/tests/components/weather/test_darksky.py
+++ b/tests/components/weather/test_darksky.py
@@ -49,6 +49,3 @@ class TestDarkSky(unittest.TestCase):
 
         state = self.hass.states.get('weather.test')
         self.assertEqual(state.state, 'Clear')
-        self.assertEqual(state.attributes['daily_forecast_summary'],
-                         'No precipitation throughout the week, with '
-                         'temperatures falling to 66°F on Thursday.')


### PR DESCRIPTION
## Description:

-removed unused attributes
-hack to remove forecast summaeries removed

Frontend PR: https://github.com/home-assistant/home-assistant-polymer/pull/1117

## Example entry for `configuration.yaml` (if applicable):
```yaml
weather:
  - platform: bom
    station: IDD60801.94229
  - platform: buienradar
    forecast: true
  - platform: darksky
    api_key: XX
  - platform: metoffice
    api_key: XX
  - platform: openweathermap
    api_key: XX
  - platform: yweather
  - platform: zamg
    station_id: 11101
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**