### PR TITLE
Add "framerate" parameter to generic camera

### DIFF
--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -256,6 +256,11 @@ class Camera(Entity):
         """Return the camera model."""
         return None
 
+    @property
+    def frame_interval(self):
+        """Return the interval between frames of the mjpeg stream"""
+        return 0.5
+
     def camera_image(self):
         """Return bytes of camera image."""
         raise NotImplementedError()
@@ -272,10 +277,6 @@ class Camera(Entity):
 
         This method must be run in the event loop.
         """
-        if interval < MIN_STREAM_INTERVAL:
-            raise ValueError("Stream interval must be be > {}"
-                             .format(MIN_STREAM_INTERVAL))
-
         response = web.StreamResponse()
         response.content_type = ('multipart/x-mixed-replace; '
                                  'boundary=--frameboundary')
@@ -325,8 +326,7 @@ class Camera(Entity):
         a direct stream from the camera.
         This method must be run in the event loop.
         """
-        await self.handle_async_still_stream(request,
-                                             FALLBACK_STREAM_INTERVAL)
+        await self.handle_async_still_stream(request, self.frame_interval)
 
     @property
     def state(self):
@@ -448,6 +448,9 @@ class CameraMjpegStream(CameraView):
         try:
             # Compose camera stream from stills
             interval = float(request.query.get('interval'))
+            if interval < MIN_STREAM_INTERVAL:
+                raise ValueError("Stream interval must be be > {}"
+                                 .format(MIN_STREAM_INTERVAL))
             await camera.handle_async_still_stream(request, interval)
             return
         except ValueError:

--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -258,7 +258,7 @@ class Camera(Entity):
 
     @property
     def frame_interval(self):
-        """Return the interval between frames of the mjpeg stream"""
+        """Return the interval between frames of the mjpeg stream."""
         return 0.5
 
     def camera_image(self):

--- a/homeassistant/components/camera/generic.py
+++ b/homeassistant/components/camera/generic.py
@@ -28,6 +28,7 @@ _LOGGER = logging.getLogger(__name__)
 CONF_CONTENT_TYPE = 'content_type'
 CONF_LIMIT_REFETCH_TO_URL_CHANGE = 'limit_refetch_to_url_change'
 CONF_STILL_IMAGE_URL = 'still_image_url'
+CONF_FRAMERATE = 'framerate'
 
 DEFAULT_NAME = 'Generic Camera'
 
@@ -40,6 +41,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_PASSWORD): cv.string,
     vol.Optional(CONF_USERNAME): cv.string,
     vol.Optional(CONF_CONTENT_TYPE, default=DEFAULT_CONTENT_TYPE): cv.string,
+    vol.Optional(CONF_FRAMERATE, default=2): cv.positive_int,
 })
 
 
@@ -62,6 +64,7 @@ class GenericCamera(Camera):
         self._still_image_url = device_info[CONF_STILL_IMAGE_URL]
         self._still_image_url.hass = hass
         self._limit_refetch = device_info[CONF_LIMIT_REFETCH_TO_URL_CHANGE]
+        self._frame_interval = 1 / device_info[CONF_FRAMERATE]
         self.content_type = device_info[CONF_CONTENT_TYPE]
 
         username = device_info.get(CONF_USERNAME)
@@ -77,6 +80,11 @@ class GenericCamera(Camera):
 
         self._last_url = None
         self._last_image = None
+
+    @property
+    def frame_interval(self):
+        """Return the interval between frames of the mjpeg stream"""
+        return self._frame_interval
 
     def camera_image(self):
         """Return bytes of camera image."""

--- a/homeassistant/components/camera/generic.py
+++ b/homeassistant/components/camera/generic.py
@@ -83,7 +83,7 @@ class GenericCamera(Camera):
 
     @property
     def frame_interval(self):
-        """Return the interval between frames of the mjpeg stream"""
+        """Return the interval between frames of the mjpeg stream."""
         return self._frame_interval
 
     def camera_image(self):


### PR DESCRIPTION
## Description:
Add a "framerate" parameter to generic camera, to allow specifying the FPS to stream, instead of using the default 2 FPS.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5245

## Example entry for `configuration.yaml` (if applicable):
```yaml
camera:
  - name: Bedroom
    platform: generic
    still_image_url: http://192.168.1.2/tmpfs/auto.jpg
    framerate: 10
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)
