### PR TITLE
add power state  support on off

### DIFF
--- a/tests/components/homekit/test_type_thermostats.py
+++ b/tests/components/homekit/test_type_thermostats.py
@@ -7,7 +7,7 @@ from homeassistant.components.climate import (
     ATTR_TARGET_TEMP_LOW, ATTR_TARGET_TEMP_HIGH, ATTR_OPERATION_MODE,
     ATTR_OPERATION_LIST, STATE_COOL, STATE_HEAT, STATE_AUTO)
 from homeassistant.const import (
-    ATTR_SERVICE, ATTR_SERVICE_DATA, ATTR_SUPPORTED_FEATURES,
+    ATTR_ENTITY_ID, ATTR_SERVICE, ATTR_SERVICE_DATA, ATTR_SUPPORTED_FEATURES,
     ATTR_UNIT_OF_MEASUREMENT, EVENT_CALL_SERVICE,
     STATE_OFF, TEMP_CELSIUS, TEMP_FAHRENHEIT)
 
@@ -260,6 +260,65 @@ class TestHomekitThermostats(unittest.TestCase):
             self.events[1].data[ATTR_SERVICE_DATA][ATTR_TARGET_TEMP_HIGH],
             25.0)
         self.assertEqual(acc.char_cooling_thresh_temp.value, 25.0)
+
+    def test_power_state(self):
+        """Test if accessory and HA are updated accordingly."""
+        climate = 'climate.test'
+
+        # SUPPORT_ON_OFF = True
+        self.hass.states.set(climate, STATE_HEAT,
+                             {ATTR_SUPPORTED_FEATURES: 4096,
+                              ATTR_OPERATION_MODE: STATE_HEAT,
+                              ATTR_TEMPERATURE: 23.0,
+                              ATTR_CURRENT_TEMPERATURE: 18.0})
+        self.hass.block_till_done()
+        acc = self.thermostat_cls(self.hass, 'Climate', climate,
+                                  2, config=None)
+        acc.run()
+        self.assertTrue(acc.support_power_state)
+
+        self.assertEqual(acc.char_current_heat_cool.value, 1)
+        self.assertEqual(acc.char_target_heat_cool.value, 1)
+
+        self.hass.states.set(climate, STATE_OFF,
+                             {ATTR_OPERATION_MODE: STATE_HEAT,
+                              ATTR_TEMPERATURE: 23.0,
+                              ATTR_CURRENT_TEMPERATURE: 18.0})
+        self.hass.block_till_done()
+        self.assertEqual(acc.char_current_heat_cool.value, 0)
+        self.assertEqual(acc.char_target_heat_cool.value, 0)
+
+        self.hass.states.set(climate, STATE_OFF,
+                             {ATTR_OPERATION_MODE: STATE_OFF,
+                              ATTR_TEMPERATURE: 23.0,
+                              ATTR_CURRENT_TEMPERATURE: 18.0})
+        self.hass.block_till_done()
+        self.assertEqual(acc.char_current_heat_cool.value, 0)
+        self.assertEqual(acc.char_target_heat_cool.value, 0)
+
+        # Set from HomeKit
+        acc.char_target_heat_cool.client_update_value(1)
+        self.hass.block_till_done()
+        self.assertEqual(
+            self.events[0].data[ATTR_SERVICE], 'turn_on')
+        self.assertEqual(
+            self.events[0].data[ATTR_SERVICE_DATA][ATTR_ENTITY_ID],
+            climate)
+        self.assertEqual(
+            self.events[1].data[ATTR_SERVICE], 'set_operation_mode')
+        self.assertEqual(
+            self.events[1].data[ATTR_SERVICE_DATA][ATTR_OPERATION_MODE],
+            STATE_HEAT)
+        self.assertEqual(acc.char_target_heat_cool.value, 1)
+
+        acc.char_target_heat_cool.client_update_value(0)
+        self.hass.block_till_done()
+        self.assertEqual(
+            self.events[2].data[ATTR_SERVICE], 'turn_off')
+        self.assertEqual(
+            self.events[2].data[ATTR_SERVICE_DATA][ATTR_ENTITY_ID],
+            climate)
+        self.assertEqual(acc.char_target_heat_cool.value, 0)
 
     def test_thermostat_fahrenheit(self):
         """Test if accessory and HA are updated accordingly."""


### PR DESCRIPTION
add power state  support on off

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
