### PR TITLE
Add more homematicip cloud components

### DIFF
--- a/homeassistant/components/binary_sensor/homematicip_cloud.py
+++ b/homeassistant/components/binary_sensor/homematicip_cloud.py
@@ -23,8 +23,6 @@ ATTR_ILLUMINATION = 'illumination'
 
 HMIP_OPEN = 'open'
 
-STATE_SABOTAGE = 'sabotage'
-
 
 async def async_setup_platform(hass, config, async_add_devices,
                                discovery_info=None):
@@ -53,23 +51,18 @@ class HomematicipShutterContact(HomematicipGenericDevice, BinarySensorDevice):
         super().__init__(home, device)
 
     @property
-    def icon(self):
-        """Return the icon."""
-        if self._device.sabotage:
-            return 'mdi:alert'
-        if self._device.windowState is None:
-            return
-        if self._device.windowState.lower() == HMIP_OPEN:
-            return 'mdi:checkbox-marked-circle-outline'
+    def device_class(self):
+        """Return the class of this sensor."""
+        return 'door'
 
     @property
-    def state(self):
-        """Return the state."""
+    def is_on(self):
+        """Return true if the shutter contact is on/open."""
         if self._device.sabotage:
-            return STATE_SABOTAGE
+            return True
         if self._device.windowState is None:
-            return
-        return self._device.windowState.lower()
+            return None
+        return self._device.windowState.lower() == HMIP_OPEN
 
 
 class HomematicipMotionDetector(HomematicipGenericDevice, BinarySensorDevice):
@@ -80,16 +73,13 @@ class HomematicipMotionDetector(HomematicipGenericDevice, BinarySensorDevice):
         super().__init__(home, device)
 
     @property
-    def icon(self):
-        """Return the icon."""
-        if self._device.sabotage:
-            return 'mdi:alert'
-        if self._device.motionDetected:
-            return 'mdi:run-fast'
+    def device_class(self):
+        """Return the class of this sensor."""
+        return 'motion'
 
     @property
-    def state(self):
-        """Return the state."""
+    def is_on(self):
+        """Return true if motion is detected."""
         if self._device.sabotage:
-            return STATE_SABOTAGE
+            return True
         return self._device.motionDetected

--- a/homeassistant/components/binary_sensor/homematicip_cloud.py
+++ b/homeassistant/components/binary_sensor/homematicip_cloud.py
@@ -1,0 +1,95 @@
+"""
+Support for HomematicIP binary sensor.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/binary_sensor.homematicip_cloud/
+"""
+
+import logging
+
+from homeassistant.components.binary_sensor import BinarySensorDevice
+from homeassistant.components.homematicip_cloud import (
+    HomematicipGenericDevice, DOMAIN as HOMEMATICIP_CLOUD_DOMAIN,
+    ATTR_HOME_ID)
+
+DEPENDENCIES = ['homematicip_cloud']
+
+_LOGGER = logging.getLogger(__name__)
+
+ATTR_WINDOW_STATE = 'window_state'
+ATTR_EVENT_DELAY = 'event_delay'
+ATTR_MOTION_DETECTED = 'motion_detected'
+ATTR_ILLUMINATION = 'illumination'
+
+HMIP_OPEN = 'open'
+
+STATE_SABOTAGE = 'sabotage'
+
+
+async def async_setup_platform(hass, config, async_add_devices,
+                               discovery_info=None):
+    """Set up the HomematicIP binary sensor devices."""
+    from homematicip.device import (ShutterContact, MotionDetectorIndoor)
+
+    if discovery_info is None:
+        return
+    home = hass.data[HOMEMATICIP_CLOUD_DOMAIN][discovery_info[ATTR_HOME_ID]]
+    devices = []
+    for device in home.devices:
+        if isinstance(device, ShutterContact):
+            devices.append(HomematicipShutterContact(home, device))
+        elif isinstance(device, MotionDetectorIndoor):
+            devices.append(HomematicipMotionDetector(home, device))
+
+    if devices:
+        async_add_devices(devices)
+
+
+class HomematicipShutterContact(HomematicipGenericDevice, BinarySensorDevice):
+    """HomematicIP shutter contact."""
+
+    def __init__(self, home, device):
+        """Initialize the shutter contact."""
+        super().__init__(home, device)
+
+    @property
+    def icon(self):
+        """Return the icon."""
+        if self._device.sabotage:
+            return 'mdi:alert'
+        if self._device.windowState is None:
+            return
+        if self._device.windowState.lower() == HMIP_OPEN:
+            return 'mdi:checkbox-marked-circle-outline'
+
+    @property
+    def state(self):
+        """Return the state."""
+        if self._device.sabotage:
+            return STATE_SABOTAGE
+        if self._device.windowState is None:
+            return
+        return self._device.windowState.lower()
+
+
+class HomematicipMotionDetector(HomematicipGenericDevice, BinarySensorDevice):
+    """MomematicIP motion detector."""
+
+    def __init__(self, home, device):
+        """Initialize the shutter contact."""
+        super().__init__(home, device)
+
+    @property
+    def icon(self):
+        """Return the icon."""
+        if self._device.sabotage:
+            return 'mdi:alert'
+        if self._device.motionDetected:
+            return 'mdi:run-fast'
+
+    @property
+    def state(self):
+        """Return the state."""
+        if self._device.sabotage:
+            return STATE_SABOTAGE
+        return self._device.motionDetected

--- a/homeassistant/components/homematicip_cloud.py
+++ b/homeassistant/components/homematicip_cloud.py
@@ -24,6 +24,7 @@ DOMAIN = 'homematicip_cloud'
 COMPONENTS = [
     'sensor',
     'binary_sensor',
+    'switch',
 ]
 
 CONF_NAME = 'name'

--- a/homeassistant/components/homematicip_cloud.py
+++ b/homeassistant/components/homematicip_cloud.py
@@ -25,6 +25,7 @@ COMPONENTS = [
     'sensor',
     'binary_sensor',
     'switch',
+    'light'
 ]
 
 CONF_NAME = 'name'

--- a/homeassistant/components/homematicip_cloud.py
+++ b/homeassistant/components/homematicip_cloud.py
@@ -22,7 +22,8 @@ _LOGGER = logging.getLogger(__name__)
 DOMAIN = 'homematicip_cloud'
 
 COMPONENTS = [
-    'sensor'
+    'sensor',
+    'binary_sensor',
 ]
 
 CONF_NAME = 'name'

--- a/homeassistant/components/light/homematicip_cloud.py
+++ b/homeassistant/components/light/homematicip_cloud.py
@@ -33,7 +33,7 @@ async def async_setup_platform(hass, config, async_add_devices,
     devices = []
     for device in home.devices:
         if isinstance(device, BrandSwitchMeasuring):
-            devices.append(HomematicipMeasuringLight(home, device))
+            devices.append(HomematicipLightMeasuring(home, device))
 
     if devices:
         async_add_devices(devices)
@@ -60,7 +60,7 @@ class HomematicipLight(HomematicipGenericDevice, Light):
         await self._device.turn_off()
 
 
-class HomematicipMeasuringLight(HomematicipLight):
+class HomematicipLightMeasuring(HomematicipLight):
     """MomematicIP measuring light device."""
 
     @property

--- a/homeassistant/components/light/homematicip_cloud.py
+++ b/homeassistant/components/light/homematicip_cloud.py
@@ -1,0 +1,76 @@
+"""
+Support for HomematicIP light.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/light.homematicip_cloud/
+"""
+
+import logging
+
+from homeassistant.components.light import Light
+from homeassistant.components.homematicip_cloud import (
+    HomematicipGenericDevice, DOMAIN as HOMEMATICIP_CLOUD_DOMAIN,
+    ATTR_HOME_ID)
+
+DEPENDENCIES = ['homematicip_cloud']
+
+_LOGGER = logging.getLogger(__name__)
+
+ATTR_POWER_CONSUMPTION = 'power_consumption'
+ATTR_ENERGIE_COUNTER = 'energie_counter'
+ATTR_PROFILE_MODE = 'profile_mode'
+
+
+async def async_setup_platform(hass, config, async_add_devices,
+                               discovery_info=None):
+    """Set up the HomematicIP light devices."""
+    from homematicip.device import (
+        BrandSwitchMeasuring)
+
+    if discovery_info is None:
+        return
+    home = hass.data[HOMEMATICIP_CLOUD_DOMAIN][discovery_info[ATTR_HOME_ID]]
+    devices = []
+    for device in home.devices:
+        if isinstance(device, BrandSwitchMeasuring):
+            devices.append(HomematicipMeasuringLight(home, device))
+
+    if devices:
+        async_add_devices(devices)
+
+
+class HomematicipLight(HomematicipGenericDevice, Light):
+    """MomematicIP light device."""
+
+    def __init__(self, home, device):
+        """Initialize the light device."""
+        super().__init__(home, device)
+
+    @property
+    def is_on(self):
+        """Return true if device is on."""
+        return self._device.on
+
+    async def async_turn_on(self, **kwargs):
+        """Turn the device on."""
+        await self._device.turn_on()
+
+    async def async_turn_off(self, **kwargs):
+        """Turn the device off."""
+        await self._device.turn_off()
+
+
+class HomematicipMeasuringLight(HomematicipLight):
+    """MomematicIP measuring light device."""
+
+    @property
+    def current_power_w(self):
+        """Return the current power usage in W."""
+        return self._device.currentPowerConsumption
+
+    @property
+    def today_energy_kwh(self):
+        """Return the today total energy usage in kWh."""
+        if self._device.energyCounter is None:
+            return 0
+        return round(self._device.energyCounter)

--- a/homeassistant/components/switch/homematicip_cloud.py
+++ b/homeassistant/components/switch/homematicip_cloud.py
@@ -34,9 +34,10 @@ async def async_setup_platform(hass, config, async_add_devices,
     devices = []
     for device in home.devices:
         if isinstance(device, BrandSwitchMeasuring):
+            # BrandSwitch is implemented in the light platform
             pass
         elif isinstance(device, PlugableSwitchMeasuring):
-            devices.append(HomematicipMeasuringSwitch(home, device))
+            devices.append(HomematicipSwitchMeasuring(home, device))
         elif isinstance(device, PlugableSwitch):
             devices.append(HomematicipSwitch(home, device))
 
@@ -65,7 +66,7 @@ class HomematicipSwitch(HomematicipGenericDevice, SwitchDevice):
         await self._device.turn_off()
 
 
-class HomematicipMeasuringSwitch(HomematicipSwitch):
+class HomematicipSwitchMeasuring(HomematicipSwitch):
     """MomematicIP measuring switch device."""
 
     @property

--- a/homeassistant/components/switch/homematicip_cloud.py
+++ b/homeassistant/components/switch/homematicip_cloud.py
@@ -34,7 +34,9 @@ async def async_setup_platform(hass, config, async_add_devices,
     devices = []
     for device in home.devices:
         if isinstance(device, BrandSwitchMeasuring):
-            # BrandSwitch is implemented in the light platform
+            # BrandSwitchMeasuring inherits PlugableSwitchMeasuring
+            # This device is implemented in the light platform and will
+            # not be added in the switch platform
             pass
         elif isinstance(device, PlugableSwitchMeasuring):
             devices.append(HomematicipSwitchMeasuring(home, device))

--- a/homeassistant/components/switch/homematicip_cloud.py
+++ b/homeassistant/components/switch/homematicip_cloud.py
@@ -1,0 +1,81 @@
+"""
+Support for HomematicIP switch.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/switch.homematicip_cloud/
+"""
+
+import logging
+
+from homeassistant.components.switch import SwitchDevice
+from homeassistant.components.homematicip_cloud import (
+    HomematicipGenericDevice, DOMAIN as HOMEMATICIP_CLOUD_DOMAIN,
+    ATTR_HOME_ID)
+
+DEPENDENCIES = ['homematicip_cloud']
+
+_LOGGER = logging.getLogger(__name__)
+
+ATTR_POWER_CONSUMPTION = 'power_consumption'
+ATTR_ENERGIE_COUNTER = 'energie_counter'
+ATTR_PROFILE_MODE = 'profile_mode'
+
+
+async def async_setup_platform(hass, config, async_add_devices,
+                               discovery_info=None):
+    """Set up the HomematicIP switch devices."""
+    from homematicip.device import (
+        PlugableSwitch, PlugableSwitchMeasuring,
+        BrandSwitchMeasuring)
+
+    if discovery_info is None:
+        return
+    home = hass.data[HOMEMATICIP_CLOUD_DOMAIN][discovery_info[ATTR_HOME_ID]]
+    devices = []
+    for device in home.devices:
+        if isinstance(device, BrandSwitchMeasuring):
+            pass
+        elif isinstance(device, PlugableSwitchMeasuring):
+            devices.append(HomematicipMeasuringSwitch(home, device))
+        elif isinstance(device, PlugableSwitch):
+            devices.append(HomematicipSwitch(home, device))
+
+    if devices:
+        async_add_devices(devices)
+
+
+class HomematicipSwitch(HomematicipGenericDevice, SwitchDevice):
+    """MomematicIP switch device."""
+
+    def __init__(self, home, device):
+        """Initialize the switch device."""
+        super().__init__(home, device)
+
+    @property
+    def is_on(self):
+        """Return true if device is on."""
+        return self._device.on
+
+    async def async_turn_on(self, **kwargs):
+        """Turn the device on."""
+        await self._device.turn_on()
+
+    async def async_turn_off(self, **kwargs):
+        """Turn the device off."""
+        await self._device.turn_off()
+
+
+class HomematicipMeasuringSwitch(HomematicipSwitch):
+    """MomematicIP measuring switch device."""
+
+    @property
+    def current_power_w(self):
+        """Return the current power usage in W."""
+        return self._device.currentPowerConsumption
+
+    @property
+    def today_energy_kwh(self):
+        """Return the today total energy usage in kWh."""
+        if self._device.energyCounter is None:
+            return 0
+        return round(self._device.energyCounter)


### PR DESCRIPTION
## Description:

Add components to `homematicip_cloud`:
- binary_sensor: shutter contact, motion detector
- switch: power switch and measuring power switch
- light: measuring light switch
 
**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5248

## Example entry for `configuration.yaml` (if applicable):
```yaml
homematicip_cloud:
  - accesspoint: !secret homematicip_accesspoint
    authtoken: !secret homematicip_authtoken
  - name: loc2
    accesspoint: !secret homematicip_accesspoint-loc2
    authtoken: !secret homematicip_authtoken-loc2
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54