### PR TITLE
Move RainMachine to component/hub model

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -208,6 +208,9 @@ omit =
     homeassistant/components/raincloud.py
     homeassistant/components/*/raincloud.py
 
+    homeassistant/components/rainmachine.py
+    homeassistant/components/*/rainmachine.py
+
     homeassistant/components/raspihats.py
     homeassistant/components/*/raspihats.py
 
@@ -711,7 +714,6 @@ omit =
     homeassistant/components/switch/orvibo.py
     homeassistant/components/switch/pulseaudio_loopback.py
     homeassistant/components/switch/rainbird.py
-    homeassistant/components/switch/rainmachine.py
     homeassistant/components/switch/rest.py
     homeassistant/components/switch/rpi_rf.py
     homeassistant/components/switch/snmp.py

--- a/homeassistant/components/rainmachine.py
+++ b/homeassistant/components/rainmachine.py
@@ -1,0 +1,112 @@
+"""
+This component provides support for RainMachine sprinkler controllers.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/rainmachine/
+"""
+import logging
+from datetime import timedelta
+
+import voluptuous as vol
+from requests.exceptions import HTTPError, ConnectTimeout
+
+from homeassistant.helpers import config_validation as cv
+from homeassistant.const import (
+    CONF_EMAIL, CONF_IP_ADDRESS, CONF_PASSWORD, CONF_PORT, CONF_SSL)
+from homeassistant.util import Throttle
+
+REQUIREMENTS = ['regenmaschine==0.4.1']
+
+_LOGGER = logging.getLogger(__name__)
+
+DATA_RAINMACHINE = 'data_rainmachine'
+DOMAIN = 'rainmachine'
+
+NOTIFICATION_ID = 'rainmachine_notification'
+NOTIFICATION_TITLE = 'RainMachine Component Setup'
+
+CONF_ATTRIBUTION = 'Data provided by Green Electronics LLC'
+
+DEFAULT_PORT = 8080
+DEFAULT_SSL = True
+
+MIN_SCAN_TIME_LOCAL = timedelta(seconds=1)
+MIN_SCAN_TIME_REMOTE = timedelta(seconds=1)
+MIN_SCAN_TIME_FORCED = timedelta(milliseconds=100)
+
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema(
+        vol.All(
+            cv.has_at_least_one_key(CONF_IP_ADDRESS, CONF_EMAIL),
+            {
+                vol.Exclusive(CONF_IP_ADDRESS, 'auth'): cv.string,
+                vol.Exclusive(CONF_EMAIL, 'auth'):
+                    vol.Email(),  # pylint: disable=no-value-for-parameter
+                vol.Required(CONF_PASSWORD): cv.string,
+                vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+                vol.Optional(CONF_SSL, default=DEFAULT_SSL): cv.boolean,
+            }))
+    }, extra=vol.ALLOW_EXTRA)
+
+
+def setup(hass, config):
+    """Set up an Arlo component."""
+    import regenmaschine as rm
+
+    _LOGGER.debug('Config data: %s', config)
+
+    conf = config[DOMAIN]
+    ip_address = conf.get(CONF_IP_ADDRESS, None)
+    email_address = conf.get(CONF_EMAIL, None)
+    password = conf[CONF_PASSWORD]
+
+    try:
+        if ip_address:
+            port = conf[CONF_PORT]
+            ssl = conf[CONF_SSL]
+            auth = rm.Authenticator.create_local(
+                ip_address,
+                password,
+                port=port,
+                https=ssl)
+            _LOGGER.debug('Configuring local API: %s', auth)
+        elif email_address:
+            auth = rm.Authenticator.create_remote(email_address, password)
+            _LOGGER.debug('Configuring remote API: %s', auth)
+
+        client = rm.Client(auth)
+        hass.data[DATA_RAINMACHINE] = client
+    except (rm.exceptions.HTTPError, UnboundLocalError) as exc_info:
+        _LOGGER.error('An error occurred: %s', str(exc_info))
+        hass.components.persistent_notification.create(
+            'Error: {0}<br />'
+            'You will need to restart hass after fixing.'
+            ''.format(exc_info),
+            title=NOTIFICATION_TITLE,
+            notification_id=NOTIFICATION_ID)
+        return False
+    return True
+
+
+def aware_throttle(api_type):
+    """Create an API type-aware throttler."""
+    _decorator = None
+    if api_type == 'local':
+
+        @Throttle(MIN_SCAN_TIME_LOCAL, MIN_SCAN_TIME_FORCED)
+        def decorator(function):
+            """Create a local API throttler."""
+            return function
+
+        _decorator = decorator
+    else:
+
+        @Throttle(MIN_SCAN_TIME_REMOTE, MIN_SCAN_TIME_FORCED)
+        def decorator(function):
+            """Create a remote API throttler."""
+            return function
+
+        _decorator = decorator
+
+    return _decorator

--- a/homeassistant/components/rainmachine.py
+++ b/homeassistant/components/rainmachine.py
@@ -52,8 +52,8 @@ def setup(hass, config):
     from regenmaschine.exceptions import HTTPError
 
     conf = config[DOMAIN]
-    ip_address = conf.get(CONF_IP_ADDRESS, None)
-    email_address = conf.get(CONF_EMAIL, None)
+    ip_address = conf.get(CONF_IP_ADDRESS)
+    email_address = conf.get(CONF_EMAIL)
     password = conf[CONF_PASSWORD]
 
     try:

--- a/homeassistant/components/rainmachine.py
+++ b/homeassistant/components/rainmachine.py
@@ -36,24 +36,18 @@ MIN_SCAN_TIME_FORCED = timedelta(milliseconds=100)
 
 CONFIG_SCHEMA = vol.Schema(
     {
-        DOMAIN:
-        vol.Schema(
-            vol.All(
-                cv.has_at_least_one_key(CONF_IP_ADDRESS, CONF_EMAIL),
-                {
-                    vol.Exclusive(CONF_IP_ADDRESS, 'auth'): cv.string,
-                    vol.Exclusive(CONF_EMAIL, 'auth'):
-                        vol.Email(),  # pylint: disable=no-value-for-parameter
-                    vol.Required(CONF_PASSWORD): cv.string,
-                    vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
-                    vol.Optional(CONF_SSL, default=DEFAULT_SSL): cv.boolean,
-                }))
+        DOMAIN: vol.Schema({
+            vol.Required(CONF_IP_ADDRESS): cv.string,
+            vol.Required(CONF_PASSWORD): cv.string,
+            vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+            vol.Optional(CONF_SSL, default=DEFAULT_SSL): cv.boolean,
+        })
     },
     extra=vol.ALLOW_EXTRA)
 
 
 def setup(hass, config):
-    """Set up an Arlo component."""
+    """Set up the RainMachine component."""
     from regenmaschine import Authenticator, Client
     from regenmaschine.exceptions import HTTPError
 

--- a/homeassistant/components/rainmachine.py
+++ b/homeassistant/components/rainmachine.py
@@ -24,8 +24,7 @@ DOMAIN = 'rainmachine'
 NOTIFICATION_ID = 'rainmachine_notification'
 NOTIFICATION_TITLE = 'RainMachine Component Setup'
 
-CONF_ATTRIBUTION = 'Data provided by Green Electronics LLC'
-
+DEFAULT_ATTRIBUTION = 'Data provided by Green Electronics LLC'
 DEFAULT_PORT = 8080
 DEFAULT_SSL = True
 

--- a/homeassistant/components/rainmachine.py
+++ b/homeassistant/components/rainmachine.py
@@ -34,28 +34,28 @@ MIN_SCAN_TIME_LOCAL = timedelta(seconds=1)
 MIN_SCAN_TIME_REMOTE = timedelta(seconds=1)
 MIN_SCAN_TIME_FORCED = timedelta(milliseconds=100)
 
-
-CONFIG_SCHEMA = vol.Schema({
-    DOMAIN: vol.Schema(
-        vol.All(
-            cv.has_at_least_one_key(CONF_IP_ADDRESS, CONF_EMAIL),
-            {
-                vol.Exclusive(CONF_IP_ADDRESS, 'auth'): cv.string,
-                vol.Exclusive(CONF_EMAIL, 'auth'):
-                    vol.Email(),  # pylint: disable=no-value-for-parameter
-                vol.Required(CONF_PASSWORD): cv.string,
-                vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
-                vol.Optional(CONF_SSL, default=DEFAULT_SSL): cv.boolean,
-            }))
-}, extra=vol.ALLOW_EXTRA)
+CONFIG_SCHEMA = vol.Schema(
+    {
+        DOMAIN:
+        vol.Schema(
+            vol.All(
+                cv.has_at_least_one_key(CONF_IP_ADDRESS, CONF_EMAIL),
+                {
+                    vol.Exclusive(CONF_IP_ADDRESS, 'auth'): cv.string,
+                    vol.Exclusive(CONF_EMAIL, 'auth'):
+                        vol.Email(),  # pylint: disable=no-value-for-parameter
+                    vol.Required(CONF_PASSWORD): cv.string,
+                    vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+                    vol.Optional(CONF_SSL, default=DEFAULT_SSL): cv.boolean,
+                }))
+    },
+    extra=vol.ALLOW_EXTRA)
 
 
 def setup(hass, config):
     """Set up an Arlo component."""
     from regenmaschine import Authenticator, Client
     from regenmaschine.exceptions import HTTPError
-
-    _LOGGER.debug('Config data: %s', config)
 
     conf = config[DOMAIN]
     ip_address = conf.get(CONF_IP_ADDRESS, None)
@@ -67,14 +67,11 @@ def setup(hass, config):
             port = conf[CONF_PORT]
             ssl = conf[CONF_SSL]
             auth = Authenticator.create_local(
-                ip_address,
-                password,
-                port=port,
-                https=ssl)
-            _LOGGER.debug('Configuring local API: %s', auth)
+                ip_address, password, port=port, https=ssl)
+            _LOGGER.debug('Configuring local API: %s', ip_address)
         elif email_address:
             auth = Authenticator.create_remote(email_address, password)
-            _LOGGER.debug('Configuring remote API: %s', auth)
+            _LOGGER.debug('Configuring remote API')
 
         client = Client(auth)
         hass.data[DATA_RAINMACHINE] = client

--- a/homeassistant/components/switch/rainmachine.py
+++ b/homeassistant/components/switch/rainmachine.py
@@ -6,7 +6,7 @@ import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.rainmachine import (
-    DATA_RAINMACHINE, MIN_SCAN_TIME, MIN_SCAN_TIME_FORCED)
+    DATA_RAINMACHINE, DEFAULT_ATTRIBUTION, MIN_SCAN_TIME, MIN_SCAN_TIME_FORCED)
 from homeassistant.components.switch import PLATFORM_SCHEMA, SwitchDevice
 from homeassistant.const import ATTR_ATTRIBUTION, ATTR_DEVICE_CLASS
 from homeassistant.util import Throttle
@@ -71,7 +71,7 @@ class RainMachineEntity(SwitchDevice):
         self.device_name = device_name
 
         self._attrs = {
-            ATTR_ATTRIBUTION: '© RainMachine',
+            ATTR_ATTRIBUTION: DEFAULT_ATTRIBUTION,
             ATTR_DEVICE_CLASS: self.device_name
         }
 

--- a/homeassistant/components/switch/rainmachine.py
+++ b/homeassistant/components/switch/rainmachine.py
@@ -43,11 +43,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
         _LOGGER.debug('Adding program: %s', program)
         entities.append(
-            RainMachineProgram(
-                client,
-                device_name,
-                device_mac,
-                program))
+            RainMachineProgram(client, device_name, device_mac, program))
 
     for zone in client.zones.all().get('zones', {}):
         if not zone.get('active'):
@@ -55,12 +51,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
         _LOGGER.debug('Adding zone: %s', zone)
         entities.append(
-            RainMachineZone(
-                client,
-                device_name,
-                device_mac,
-                zone,
-                zone_run_time))
+            RainMachineZone(client, device_name, device_mac, zone,
+                            zone_run_time))
 
     add_devices(entities, True)
 
@@ -189,8 +181,10 @@ class RainMachineZone(RainMachineEntity):
         super().__init__(client, device_name, device_mac, zone_json)
         self._run_time = zone_run_time
         self._attrs.update({
-            ATTR_CYCLES: self._entity_json.get('noOfCycles'),
-            ATTR_TOTAL_DURATION: self._entity_json.get('userDuration')
+            ATTR_CYCLES:
+            self._entity_json.get('noOfCycles'),
+            ATTR_TOTAL_DURATION:
+            self._entity_json.get('userDuration')
         })
 
     @property

--- a/homeassistant/components/switch/rainmachine.py
+++ b/homeassistant/components/switch/rainmachine.py
@@ -127,7 +127,7 @@ class RainMachineProgram(RainMachineEntity):
     @property
     def name(self) -> str:
         """Return the name of the program."""
-        return 'Program: {}'.format(self._entity_json.get('name'))
+        return 'Program: {0}'.format(self._entity_json.get('name'))
 
     @property
     def unique_id(self) -> str:
@@ -181,10 +181,8 @@ class RainMachineZone(RainMachineEntity):
         super().__init__(client, device_name, device_mac, zone_json)
         self._run_time = zone_run_time
         self._attrs.update({
-            ATTR_CYCLES:
-            self._entity_json.get('noOfCycles'),
-            ATTR_TOTAL_DURATION:
-            self._entity_json.get('userDuration')
+            ATTR_CYCLES: self._entity_json.get('noOfCycles'),
+            ATTR_TOTAL_DURATION: self._entity_json.get('userDuration')
         })
 
     @property
@@ -195,7 +193,7 @@ class RainMachineZone(RainMachineEntity):
     @property
     def name(self) -> str:
         """Return the name of the zone."""
-        return 'Zone: {}'.format(self._entity_json.get('name'))
+        return 'Zone: {0}'.format(self._entity_json.get('name'))
 
     @property
     def unique_id(self) -> str:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1113,7 +1113,7 @@ raincloudy==0.0.4
 # homeassistant.components.raspihats
 # raspihats==2.2.3
 
-# homeassistant.components.switch.rainmachine
+# homeassistant.components.rainmachine
 regenmaschine==0.4.1
 
 # homeassistant.components.python_script


### PR DESCRIPTION
## Description:
This is the first of several PRs designed to add more functionality to the RainMachine integration. The first is this, which moves the integration from existing fully in a switch platform to being a combo component + switch platform (a la Arlo, et. al.). No functionality changes, per se, in this PR.

This will be the master PR; fine to merge once it passes tests and review, but others will be held back until this is merged.

**BREAKING CHANGE 1:** with the migration to the component/hub model, existing configuration files will break. The new format (below) should be used.

**BREAKING CHANGE 2:** after intense amounts of fiddling, it's clear to me that the RainMachine remote API is broken, clunky, etc. After some investigation, I haven't found a single user who's using it, so using this PR as a time to remove it and references to it.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** https://github.com/home-assistant/home-assistant.github.io/pull/5251

## Example entry for `configuration.yaml` (if applicable):
```yaml
rainmachine:
  ip_address: 192.168.1.100
  password: abc123

switch:
  - platform: rainmachine
    zone_run_time: 300
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
