### PR TITLE
Adds useful attributes to RainMachine programs and zones

### DIFF
--- a/homeassistant/components/rainmachine.py
+++ b/homeassistant/components/rainmachine.py
@@ -93,14 +93,15 @@ class RainMachineEntity(Entity):
     """Define a generic RainMachine entity."""
 
     def __init__(self,
-                 device_mac,
                  rainmachine_type,
                  rainmachine_entity_id,
                  icon=DEFAULT_ICON):
         """Initialize."""
+        self._client = self.hass.data[DATA_RAINMACHINE]
+
         self._attrs = {ATTR_ATTRIBUTION: DEFAULT_ATTRIBUTION}
         self._icon = icon
-        self._device_mac = device_mac
+        self._device_mac = self._client.provision.wifi()['macAddress']
         self._rainmachine_type = rainmachine_type
         self._rainmachine_entity_id = rainmachine_entity_id
 

--- a/homeassistant/components/rainmachine.py
+++ b/homeassistant/components/rainmachine.py
@@ -130,3 +130,4 @@ class RainMachineEntity(Entity):
             self.rainmachine.device_mac.replace(
                 ':', ''), self._rainmachine_type,
             self._rainmachine_entity_id)
+

--- a/homeassistant/components/rainmachine.py
+++ b/homeassistant/components/rainmachine.py
@@ -130,4 +130,3 @@ class RainMachineEntity(Entity):
             self.rainmachine.device_mac.replace(
                 ':', ''), self._rainmachine_type,
             self._rainmachine_entity_id)
-

--- a/homeassistant/components/rainmachine.py
+++ b/homeassistant/components/rainmachine.py
@@ -5,13 +5,14 @@ For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/rainmachine/
 """
 import logging
-from datetime import timedelta
 
 import voluptuous as vol
 
-from homeassistant.helpers import config_validation as cv, discovery
 from homeassistant.const import (
-    CONF_IP_ADDRESS, CONF_PASSWORD, CONF_PORT, CONF_SSL, CONF_SWITCHES)
+    ATTR_ATTRIBUTION, CONF_IP_ADDRESS, CONF_PASSWORD, CONF_PORT, CONF_SSL,
+    CONF_SWITCHES)
+from homeassistant.helpers import config_validation as cv, discovery
+from homeassistant.helpers.entity import Entity
 
 REQUIREMENTS = ['regenmaschine==0.4.1']
 
@@ -26,11 +27,11 @@ NOTIFICATION_TITLE = 'RainMachine Component Setup'
 CONF_ZONE_RUN_TIME = 'zone_run_time'
 
 DEFAULT_ATTRIBUTION = 'Data provided by Green Electronics LLC'
+DEFAULT_ICON = 'mdi:water'
 DEFAULT_PORT = 8080
 DEFAULT_SSL = True
 
-MIN_SCAN_TIME = timedelta(seconds=1)
-MIN_SCAN_TIME_FORCED = timedelta(milliseconds=100)
+PROGRAM_UPDATE_TOPIC = '{0}_program_update'.format(DOMAIN)
 
 SWITCH_SCHEMA = vol.Schema({
     vol.Optional(CONF_ZONE_RUN_TIME):
@@ -68,8 +69,7 @@ def setup(hass, config):
         auth = Authenticator.create_local(
             ip_address, password, port=port, https=ssl)
         client = Client(auth)
-        mac = client.provision.wifi()['macAddress']
-        hass.data[DATA_RAINMACHINE] = (client, mac)
+        hass.data[DATA_RAINMACHINE] = client
     except (HTTPError, ConnectTimeout, UnboundLocalError) as exc_info:
         _LOGGER.error('An error occurred: %s', str(exc_info))
         hass.components.persistent_notification.create(
@@ -87,3 +87,36 @@ def setup(hass, config):
     _LOGGER.debug('Setup complete')
 
     return True
+
+
+class RainMachineEntity(Entity):
+    """Define a generic RainMachine entity."""
+
+    def __init__(self,
+                 device_mac,
+                 rainmachine_type,
+                 rainmachine_entity_id,
+                 icon=DEFAULT_ICON):
+        """Initialize."""
+        self._attrs = {ATTR_ATTRIBUTION: DEFAULT_ATTRIBUTION}
+        self._icon = icon
+        self._device_mac = device_mac
+        self._rainmachine_type = rainmachine_type
+        self._rainmachine_entity_id = rainmachine_entity_id
+
+    @property
+    def device_state_attributes(self) -> dict:
+        """Return the state attributes."""
+        return self._attrs
+
+    @property
+    def icon(self) -> str:
+        """Return the icon."""
+        return self._icon
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique, HASS-friendly identifier for this entity."""
+        return '{0}_{1}_{2}'.format(
+            self._device_mac.replace(':', ''), self._rainmachine_type,
+            self._rainmachine_entity_id)

--- a/homeassistant/components/switch/rainmachine.py
+++ b/homeassistant/components/switch/rainmachine.py
@@ -248,7 +248,7 @@ class RainMachineZone(RainMachineSwitch):
     @callback
     def _program_updated(self):
         """Update state, trigger updates."""
-        self.schedule_update_ha_state(True)
+        self.async_schedule_update_ha_state(True)
 
     async def async_added_to_hass(self):
         """Register callbacks."""

--- a/homeassistant/components/switch/rainmachine.py
+++ b/homeassistant/components/switch/rainmachine.py
@@ -22,44 +22,20 @@ _LOGGER = getLogger(__name__)
 ATTR_AREA = 'area'
 ATTR_CS_ON = 'cs_on'
 ATTR_CURRENT_CYCLE = 'current_cycle'
-ATTR_CURRENT_FIELD_CAPACITY = 'current_field_capacity'
 ATTR_CYCLES = 'cycles'
 ATTR_DELAY = 'delay'
 ATTR_DELAY_ON = 'delay_on'
-ATTR_EFFICIENCY = 'sprinkler_head_efficiency'
 ATTR_FIELD_CAPACITY = 'field_capacity'
-ATTR_FLOW_RATE = 'flow_rate'
-ATTR_FREQUENCY = 'frequency'
-ATTR_IGNORE_WEATHER = 'ignoring_weather_data'
-ATTR_INTAKE_RATE = 'soil_intake_rate'
-ATTR_MACHINE_DURATION = 'machine_duration'
-ATTR_MASTER_VALVE = 'master_valve'
-ATTR_MAX_DEPLETION = 'max_allowed_depletion'
-ATTR_NEXT_RUN = 'next_run'
 ATTR_NO_CYCLES = 'number_of_cycles'
-ATTR_PERM_WILTING = 'permanent_wilting_point'
 ATTR_PRECIP_RATE = 'sprinkler_head_precipitation_rate'
-ATTR_REFERENCE_TIME = 'suggested_summer_watering_seconds'
 ATTR_RESTRICTIONS = 'restrictions'
-ATTR_ROOT_DEPTH = 'average_root_depth'
-ATTR_SAVINGS = 'savings'
-ATTR_SECONDS_REMAINING = 'seconds_remaining'
-ATTR_SIMULATION_EXPIRED = 'simulation_expired'
 ATTR_SLOPE = 'slope'
 ATTR_SOAK = 'soak'
 ATTR_SOIL_TYPE = 'soil_type'
 ATTR_SPRINKLER_TYPE = 'sprinkler_head_type'
-ATTR_START_TIME = 'start_time'
 ATTR_STATUS = 'status'
 ATTR_SUN_EXPOSURE = 'sun_exposure'
-ATTR_SURFACE_ACCUM = 'soil_surface_accumulation'
-ATTR_TALL = 'is_tall'
-ATTR_TOTAL_DURATION = 'total_duration'
-ATTR_USER_DURATION = 'user_duration'
-ATTR_USE_WATERSENSE = 'using_watersense'
 ATTR_VEGETATION_TYPE = 'vegetation_type'
-ATTR_WATER_SKIP = 'watering_percentage_skip_amount'
-ATTR_YEARLY_RECURRING = 'yearly_recurring'
 ATTR_ZONES = 'zones'
 
 DEFAULT_ZONE_RUN = 60 * 10
@@ -201,27 +177,6 @@ class RainMachineProgram(RainMachineSwitch):
         """Return a list of active zones associated with this program."""
         return [z for z in self._obj['wateringTimes'] if z['active']]
 
-    def _calculate_running_days(self) -> str:
-        """Calculate running days from an RM string ("0010001100")."""
-        freq_type = self._obj['frequency']['type']
-        freq_param = self._obj['frequency']['param']
-        if freq_type == 0:
-            return 'Daily'
-
-        if freq_type == 1:
-            return 'Every {0} Days'.format(freq_param)
-
-        if freq_type == 2:
-            return ', '.join([
-                DAYS[idx] for idx, val in enumerate(freq_param[2:-1][::-1])
-                if val == '1'
-            ])
-
-        if freq_type == 4:
-            return '{0} Days'.format('Odd' if freq_param == '1' else 'Even')
-
-        return None
-
     def turn_off(self, **kwargs) -> None:
         """Turn the program off."""
         from regenmaschine.exceptions import HTTPError
@@ -257,20 +212,9 @@ class RainMachineProgram(RainMachineSwitch):
                 ATTR_CYCLES: self._obj.get('cycles'),
                 ATTR_DELAY: self._obj.get('delay'),
                 ATTR_DELAY_ON: self._obj.get('delay_on'),
-                ATTR_FREQUENCY: self._calculate_running_days(),
-                ATTR_IGNORE_WEATHER:
-                    self._obj.get('ignoreInternetWeather'),
-                ATTR_NEXT_RUN: self._obj.get('nextRun'),
-                ATTR_SIMULATION_EXPIRED:
-                    self._obj.get('simulationExpired'),
                 ATTR_SOAK: self._obj.get('soak'),
-                ATTR_START_TIME: self._obj.get('startTime'),
                 ATTR_STATUS:
                     PROGRAM_STATUS_MAP[self._obj.get('status')],
-                ATTR_USE_WATERSENSE: self._obj.get('useWaterSense'),
-                ATTR_WATER_SKIP: self._obj.get('freq_modified'),
-                ATTR_YEARLY_RECURRING:
-                    self._obj.get('yearlyRecurring'),
                 ATTR_ZONES: ', '.join(z['name'] for z in self.zones)
             })
         except HTTPError as exc_info:
@@ -344,40 +288,14 @@ class RainMachineZone(RainMachineSwitch):
             self._attrs.update({
                 ATTR_AREA: self._properties_json.get('waterSense').get('area'),
                 ATTR_CURRENT_CYCLE: self._obj.get('cycle'),
-                ATTR_CURRENT_FIELD_CAPACITY:
-                    self._properties_json.get(
-                        'waterSense').get('currentFieldCapacity'),
-                ATTR_EFFICIENCY:
-                    self._properties_json.get(
-                        'waterSense').get('appEfficiency'),
                 ATTR_FIELD_CAPACITY:
                     self._properties_json.get(
                         'waterSense').get('fieldCapacity'),
-                ATTR_FLOW_RATE:
-                    self._properties_json.get('waterSense').get('flowRate'),
-                ATTR_INTAKE_RATE:
-                    self._properties_json.get(
-                        'waterSense').get('soilIntakeRate'),
-                ATTR_MACHINE_DURATION:
-                    self._obj.get('machineDuration'),
-                ATTR_MASTER_VALVE: self._obj.get('master'),
-                ATTR_MAX_DEPLETION:
-                    self._properties_json.get(
-                        'waterSense').get('maxAllowedDepletion'),
                 ATTR_NO_CYCLES: self._obj.get('noOfCycles'),
-                ATTR_PERM_WILTING:
-                    self._properties_json.get('waterSense').get('permWilting'),
                 ATTR_PRECIP_RATE:
                     self._properties_json.get(
                         'waterSense').get('precipitationRate'),
-                ATTR_REFERENCE_TIME:
-                    self._properties_json.get(
-                        'waterSense').get('referenceTime'),
                 ATTR_RESTRICTIONS: self._obj.get('restriction'),
-                ATTR_ROOT_DEPTH:
-                    self._properties_json.get('waterSense').get('rootDepth'),
-                ATTR_SAVINGS: self._properties_json.get('savings'),
-                ATTR_SECONDS_REMAINING: self._obj.get('remaining'),
                 ATTR_SLOPE: SLOPE_TYPE_MAP[self._properties_json.get('slope')],
                 ATTR_SOIL_TYPE:
                     SOIL_TYPE_MAP[self._properties_json.get('sun')],
@@ -385,12 +303,6 @@ class RainMachineZone(RainMachineSwitch):
                     SPRINKLER_TYPE_MAP[self._properties_json.get('group_id')],
                 ATTR_SUN_EXPOSURE:
                     SUN_EXPOSURE_MAP[self._properties_json.get('sun')],
-                ATTR_SURFACE_ACCUM:
-                    self._properties_json.get(
-                        'waterSense').get('allowedSurfaceAcc'),
-                ATTR_TALL:
-                    self._properties_json.get('waterSense').get('isTallPlant'),
-                ATTR_USER_DURATION: self._obj.get('userDuration'),
                 ATTR_VEGETATION_TYPE:
                     VEGETATION_MAP[self._obj.get('type')],
             })

--- a/homeassistant/components/switch/rainmachine.py
+++ b/homeassistant/components/switch/rainmachine.py
@@ -143,7 +143,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     zone_run_time = discovery_info.get(CONF_ZONE_RUN_TIME, DEFAULT_ZONE_RUN)
 
-    client = hass.data.get(DATA_RAINMACHINE)
+    client = hass.data[DATA_RAINMACHINE]
 
     entities = []
     for program in client.programs.all().get('programs', {}):
@@ -151,14 +151,14 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             continue
 
         _LOGGER.debug('Adding program: %s', program)
-        entities.append(RainMachineProgram(client, program))
+        entities.append(RainMachineProgram(program))
 
     for zone in client.zones.all().get('zones', {}):
         if not zone.get('active'):
             continue
 
         _LOGGER.debug('Adding zone: %s', zone)
-        entities.append(RainMachineZone(client, zone, zone_run_time))
+        entities.append(RainMachineZone(zone, zone_run_time))
 
     add_devices(entities, True)
 
@@ -166,14 +166,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class RainMachineSwitch(RainMachineEntity, SwitchDevice):
     """A class to represent a generic RainMachine entity."""
 
-    def __init__(self, client, rainmachine_type, entity_attrs):
+    def __init__(self, rainmachine_type, entity_attrs):
         """Initialize a generic RainMachine entity."""
-        self._client = client
         self._entity_attrs = entity_attrs
         self._type = rainmachine_type
 
-        super().__init__(self._client.provision.wifi()['macAddress'],
-                         rainmachine_type, entity_attrs.get('uid'))
+        super().__init__(rainmachine_type, entity_attrs.get('uid'))
 
     @property
     def is_enabled(self) -> bool:
@@ -184,9 +182,9 @@ class RainMachineSwitch(RainMachineEntity, SwitchDevice):
 class RainMachineProgram(RainMachineSwitch):
     """A RainMachine program."""
 
-    def __init__(self, client, program_json):
+    def __init__(self, program_json):
         """Initialize."""
-        super().__init__(client, 'program', program_json)
+        super().__init__('program', program_json)
 
     @property
     def is_on(self) -> bool:
@@ -284,9 +282,9 @@ class RainMachineProgram(RainMachineSwitch):
 class RainMachineZone(RainMachineSwitch):
     """A RainMachine zone."""
 
-    def __init__(self, client, zone_json, zone_run_time):
+    def __init__(self, zone_json, zone_run_time):
         """Initialize a RainMachine zone."""
-        super().__init__(client, 'zone', zone_json)
+        super().__init__('zone', zone_json)
 
         self._properties_json = {}
         self._run_time = zone_run_time

--- a/homeassistant/components/switch/rainmachine.py
+++ b/homeassistant/components/switch/rainmachine.py
@@ -10,6 +10,7 @@ from logging import getLogger
 from homeassistant.components.rainmachine import (
     CONF_ZONE_RUN_TIME, DATA_RAINMACHINE, PROGRAM_UPDATE_TOPIC,
     RainMachineEntity)
+from homeassistant.const import ATTR_ID
 from homeassistant.components.switch import SwitchDevice
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import (
@@ -208,6 +209,7 @@ class RainMachineProgram(RainMachineSwitch):
                 self._rainmachine_entity_id)
 
             self._attrs.update({
+                ATTR_ID: self._obj['uid'],
                 ATTR_CS_ON: self._obj.get('cs_on'),
                 ATTR_CYCLES: self._obj.get('cycles'),
                 ATTR_DELAY: self._obj.get('delay'),
@@ -286,6 +288,7 @@ class RainMachineZone(RainMachineSwitch):
                 self._rainmachine_entity_id, properties=True)
 
             self._attrs.update({
+                ATTR_ID: self._obj['uid'],
                 ATTR_AREA: self._properties_json.get('waterSense').get('area'),
                 ATTR_CURRENT_CYCLE: self._obj.get('cycle'),
                 ATTR_FIELD_CAPACITY:

--- a/homeassistant/components/switch/rainmachine.py
+++ b/homeassistant/components/switch/rainmachine.py
@@ -135,7 +135,7 @@ VEGETATION_MAP = {
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Set this component up under its platform."""
+    """Set up the RainMachine Switch platform."""
     if discovery_info is None:
         return
 


### PR DESCRIPTION
## Description:
This PR adds several useful attributes to RainMachine programs and zones, including:

- Restrictions
- Cycles
- Capacities
- Sun Type
- Soil Type
- Vegetation Type

Additionally, under the hood, the process of migrating common RainMachine data/logic into the component created by #14225 starts.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
rainmachine:
  ip_address: 192.168.1.100
  password: abc123
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  ~- [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)~

If the code communicates with devices, web services, or third-party tools:
  ~- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).~
  ~- [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).~
  ~- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.~
  ~- [ ] New files were added to `.coveragerc`.~

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54