### PR TITLE
Refine more 'generic' Modbus Climate

### DIFF
--- a/homeassistant/components/climate/modbus.py
+++ b/homeassistant/components/climate/modbus.py
@@ -284,6 +284,7 @@ class ModbusClimate(ClimateDevice):
         return self.get_value(CONF_IS_ON)
 
     def try_reconnect(self):
+        """Retry connect to modbus."""
         from pymodbus.client.sync import ModbusTcpClient as ModbusClient
         from pymodbus.transaction import ModbusRtuFramer as ModbusFramer
         client = ModbusClient(host=modbus.HUB._client.host,
@@ -306,24 +307,24 @@ class ModbusClimate(ClimateDevice):
                 result = modbus.HUB.read_coils(slave, register, count)
                 try:
                     value = bool(result.bits[0])
-                except:
+                except BaseException:
                     _LOGGER.error("No response from %s %s", self._name, prop)
                     self.try_reconnect()
                     return
             else:
                 try:
                     if register_type == REGISTER_TYPE_INPUT:
-                        result = modbus.HUB.read_input_registers(slave,
-                                                             register, count)
+                        result = modbus.HUB.read_input_registers(
+                            slave, register, count)
                     else:
-                        result = modbus.HUB.read_holding_registers(slave,
-                                                               register, count)
+                        result = modbus.HUB.read_holding_registers(
+                            slave, register, count)
 
                     val = 0
                     registers = result.registers
                     if mod.get(CONF_REVERSE_ORDER):
                         registers.reverse()
-                except:
+                except BaseException:
                     _LOGGER.error("No response from %s %s", self._name, prop)
                     self.try_reconnect()
                     return

--- a/homeassistant/components/climate/modbus.py
+++ b/homeassistant/components/climate/modbus.py
@@ -1,105 +1,181 @@
 """
 Platform for a Generic Modbus Thermostat.
 
-This uses a setpoint and process
-value within the controller, so both the current temperature register and the
-target temperature register need to be configured.
-
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/climate.modbus/
 """
+
 import logging
 import struct
 
 import voluptuous as vol
 
-from homeassistant.const import (
-    CONF_NAME, CONF_SLAVE, ATTR_TEMPERATURE)
 from homeassistant.components.climate import (
-    ClimateDevice, PLATFORM_SCHEMA, SUPPORT_TARGET_TEMPERATURE)
-
+    ClimateDevice, SUPPORT_TARGET_TEMPERATURE, SUPPORT_TARGET_HUMIDITY,
+    SUPPORT_OPERATION_MODE, SUPPORT_FAN_MODE, SUPPORT_SWING_MODE,
+    SUPPORT_HOLD_MODE, SUPPORT_AWAY_MODE, SUPPORT_AUX_HEAT, SUPPORT_ON_OFF,
+    SUPPORT_TARGET_HUMIDITY_HIGH, SUPPORT_TARGET_HUMIDITY_LOW,
+    PLATFORM_SCHEMA)
+from homeassistant.const import (
+    CONF_NAME, CONF_SLAVE, CONF_OFFSET, CONF_STRUCTURE, ATTR_TEMPERATURE)
+from homeassistant.helpers.event import async_call_later
 import homeassistant.components.modbus as modbus
 import homeassistant.helpers.config_validation as cv
 
+_LOGGER = logging.getLogger(__name__)
+
 DEPENDENCIES = ['modbus']
 
-# Parameters not defined by homeassistant.const
-CONF_TARGET_TEMP = 'target_temp_register'
-CONF_CURRENT_TEMP = 'current_temp_register'
+CONF_TEMPERATURE = 'temperature'
+CONF_TARGET_TEMPERATURE = 'target_temperature'
+CONF_HUMIDITY = 'humidity'
+CONF_TARGET_HUMIDITY = 'target_humidity'
+CONF_OPERATION = 'operation'
+CONF_FAN = 'fan'
+CONF_SWING = 'swing'
+CONF_HOLD = 'hold'
+CONF_AWAY = 'away'
+CONF_AUX = 'aux'
+CONF_IS_ON = 'is_on'
+
+CONF_OPERATION_LIST = 'operation_list'
+CONF_FAN_LIST = 'fan_list'
+CONF_SWING_LIST = 'swing_list'
+
+CONF_COUNT = 'count'
 CONF_DATA_TYPE = 'data_type'
-CONF_COUNT = 'data_count'
-CONF_PRECISION = 'precision'
+CONF_REGISTER = 'register'
+CONF_REGISTER_TYPE = 'register_type'
+CONF_REGISTERS = 'registers'
+CONF_REVERSE_ORDER = 'reverse_order'
+CONF_SCALE = 'scale'
+
+REGISTER_TYPE_HOLDING = 'holding'
+REGISTER_TYPE_INPUT = 'input'
 
 DATA_TYPE_INT = 'int'
 DATA_TYPE_UINT = 'uint'
 DATA_TYPE_FLOAT = 'float'
+DATA_TYPE_CUSTOM = 'custom'
+
+SUPPORTED_FEATURES = {
+    CONF_TEMPERATURE: 0,
+    CONF_TARGET_TEMPERATURE: SUPPORT_TARGET_TEMPERATURE,
+    CONF_HUMIDITY: 0,
+    CONF_TARGET_HUMIDITY: SUPPORT_TARGET_HUMIDITY |
+                          SUPPORT_TARGET_HUMIDITY_LOW |
+                          SUPPORT_TARGET_HUMIDITY_HIGH,
+    CONF_OPERATION: SUPPORT_OPERATION_MODE,
+    CONF_FAN: SUPPORT_FAN_MODE,
+    CONF_SWING: SUPPORT_SWING_MODE,
+    CONF_HOLD: SUPPORT_HOLD_MODE,
+    CONF_AWAY: SUPPORT_AWAY_MODE,
+    CONF_AUX: SUPPORT_AUX_HEAT,
+    CONF_IS_ON: SUPPORT_ON_OFF
+    }
+
+DEFAULT_NAME = 'Modbus'
+DEFAULT_OPERATION_LIST = ['heat', 'cool', 'auto', 'off']
+DEFAULT_FAN_LIST = ['On Low', 'On High', 'Auto Low', 'Auto High', 'Off']
+DEFAULT_SWING_LIST = ['Auto', '1', '2', '3', 'Off']
+
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_NAME): cv.string,
-    vol.Required(CONF_SLAVE): cv.positive_int,
-    vol.Required(CONF_TARGET_TEMP): cv.positive_int,
-    vol.Required(CONF_CURRENT_TEMP): cv.positive_int,
-    vol.Optional(CONF_DATA_TYPE, default=DATA_TYPE_FLOAT):
-        vol.In([DATA_TYPE_INT, DATA_TYPE_UINT, DATA_TYPE_FLOAT]),
-    vol.Optional(CONF_COUNT, default=2): cv.positive_int,
-    vol.Optional(CONF_PRECISION, default=1): cv.positive_int
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_OPERATION_LIST, default=DEFAULT_OPERATION_LIST):
+        vol.All(cv.ensure_list, vol.Length(min=2)),
+    vol.Optional(CONF_FAN_LIST, default=DEFAULT_FAN_LIST):
+        vol.All(cv.ensure_list, vol.Length(min=2)),
+    vol.Optional(CONF_SWING_LIST, default=DEFAULT_SWING_LIST):
+        vol.All(cv.ensure_list, vol.Length(min=2)),
 })
-
-_LOGGER = logging.getLogger(__name__)
-
-SUPPORT_FLAGS = SUPPORT_TARGET_TEMPERATURE
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Set up the Modbus Thermostat Platform."""
+    """Set up the Modbus climate devices."""
     name = config.get(CONF_NAME)
-    modbus_slave = config.get(CONF_SLAVE)
-    target_temp_register = config.get(CONF_TARGET_TEMP)
-    current_temp_register = config.get(CONF_CURRENT_TEMP)
-    data_type = config.get(CONF_DATA_TYPE)
-    count = config.get(CONF_COUNT)
-    precision = config.get(CONF_PRECISION)
+    operation_list = config.get(CONF_OPERATION_LIST)
+    fan_list = config.get(CONF_FAN_LIST)
+    swing_list = config.get(CONF_SWING_LIST)
 
-    add_devices([ModbusThermostat(name, modbus_slave,
-                                  target_temp_register, current_temp_register,
-                                  data_type, count, precision)], True)
+    data_types = {DATA_TYPE_INT: {1: 'h', 2: 'i', 4: 'q'}}
+    data_types[DATA_TYPE_UINT] = {1: 'H', 2: 'I', 4: 'Q'}
+    data_types[DATA_TYPE_FLOAT] = {1: 'e', 2: 'f', 4: 'd'}
+
+    mods = {}
+    for prop in SUPPORTED_FEATURES:
+        mod = config.get(prop)
+        if not mod:
+            continue
+
+        count = mod[CONF_COUNT] if CONF_COUNT in mod else 1
+        data_type = mod.get(CONF_DATA_TYPE)
+        if data_type != DATA_TYPE_CUSTOM:
+            try:
+                mod[CONF_STRUCTURE] = '>{}'.format(data_types[
+                    DATA_TYPE_INT if data_type is None else data_type][count])
+            except KeyError:
+                _LOGGER.error("Unable to detect data type for %s", prop)
+                continue
+
+        try:
+            size = struct.calcsize(mod[CONF_STRUCTURE])
+        except struct.error as err:
+            _LOGGER.error(
+                "Error in sensor %s structure: %s", prop, err)
+            continue
+
+        if count * 2 != size:
+            _LOGGER.error(
+                "Structure size (%d bytes) mismatch registers count "
+                "(%d words)", size, count)
+            continue
+
+        mods[prop] = mod
+
+    if not mods:
+        _LOGGER.error("Invalid config %s: no modbus items", name)
+        return
+
+    def has_valid_register(mods, index):
+        """Check valid register."""
+        for prop in mods:
+            registers = mods[prop].get(CONF_REGISTERS)
+            if not registers or index >= len(registers):
+                return False
+        return True
+
+    devices = []
+    for index in range(100):
+        if not has_valid_register(mods, index):
+            break
+        devices.append(ModbusClimate(name, operation_list, fan_list,
+                                     swing_list, mods, index))
+
+    if not devices:
+        for prop in mods:
+            if CONF_REGISTER not in mod:
+                _LOGGER.error("Invalid config %s/%s: no register", name, prop)
+                return
+        devices.append(ModbusClimate(name, operation_list, fan_list,
+                                     swing_list, mods))
+
+    add_devices(devices, True)
 
 
-class ModbusThermostat(ClimateDevice):
-    """Representation of a Modbus Thermostat."""
+class ModbusClimate(ClimateDevice):
+    """Representation of a Modbus climate device."""
 
-    def __init__(self, name, modbus_slave, target_temp_register,
-                 current_temp_register, data_type, count, precision):
-        """Initialize the unit."""
-        self._name = name
-        self._slave = modbus_slave
-        self._target_temperature_register = target_temp_register
-        self._current_temperature_register = current_temp_register
-        self._target_temperature = None
-        self._current_temperature = None
-        self._data_type = data_type
-        self._count = int(count)
-        self._precision = precision
-        self._structure = '>f'
-
-        data_types = {DATA_TYPE_INT: {1: 'h', 2: 'i', 4: 'q'},
-                      DATA_TYPE_UINT: {1: 'H', 2: 'I', 4: 'Q'},
-                      DATA_TYPE_FLOAT: {1: 'e', 2: 'f', 4: 'd'}}
-
-        self._structure = '>{}'.format(data_types[self._data_type]
-                                       [self._count])
-
-    @property
-    def supported_features(self):
-        """Return the list of supported features."""
-        return SUPPORT_FLAGS
-
-    def update(self):
-        """Update Target & Current Temperature."""
-        self._target_temperature = self.read_register(
-            self._target_temperature_register)
-        self._current_temperature = self.read_register(
-            self._current_temperature_register)
+    def __init__(self, name, operation_list,
+                 fan_list, swing_list, mods, index=-1):
+        """Initialize the climate device."""
+        self._name = name + str(index + 1) if index != -1 else name
+        self._index = index
+        self._mods = mods
+        self._operation_list = operation_list
+        self._fan_list = fan_list
+        self._swing_list = swing_list
+        self._values = {}
 
     @property
     def name(self):
@@ -107,42 +183,228 @@ class ModbusThermostat(ClimateDevice):
         return self._name
 
     @property
+    def supported_features(self):
+        """Return the list of supported features."""
+        features = 0
+        for prop in self._mods:
+            features |= SUPPORTED_FEATURES[prop]
+        return features
+
+    @property
+    def temperature_unit(self):
+        """Return the unit of measurement."""
+        return self.unit_of_measurement
+
+    @property
+    def target_temperature_step(self):
+        """Return the supported step of target temperature."""
+        return 1
+
+    @property
     def current_temperature(self):
         """Return the current temperature."""
-        return self._current_temperature
+        return self.get_value(CONF_TEMPERATURE)
 
     @property
     def target_temperature(self):
         """Return the temperature we try to reach."""
-        return self._target_temperature
+        return self.get_value(CONF_TARGET_TEMPERATURE)
+
+    @property
+    def current_humidity(self):
+        """Return the current humidity."""
+        return self.get_value(CONF_HUMIDITY)
+
+    @property
+    def target_humidity(self):
+        """Return the humidity we try to reach."""
+        return self.get_value(CONF_TARGET_HUMIDITY)
+
+    @property
+    def current_operation(self):
+        """Return current operation ie. heat, cool, idle."""
+        operation = self.get_value(CONF_OPERATION)
+        if operation is not None and operation < len(self._operation_list):
+            return self._operation_list[operation]
+        return None
+
+    @property
+    def operation_list(self):
+        """Return the list of available operation modes."""
+        return self._operation_list
+
+    @property
+    def current_fan_mode(self):
+        """Return the fan setting."""
+        fan = self.get_value(CONF_FAN)
+        if fan is not None and fan < len(self._fan_list):
+            return self._fan_list[fan]
+        return None
+
+    @property
+    def fan_list(self):
+        """Return the list of available fan modes."""
+        return self._fan_list
+
+    @property
+    def current_swing_mode(self):
+        """Return the swing setting."""
+        swing = self.get_value(CONF_SWING)
+        if swing is not None and swing < len(self._swing_list):
+            return self._swing_list[swing]
+        return None
+
+    @property
+    def swing_list(self):
+        """List of available swing modes."""
+        return self._swing_list
+
+    @property
+    def current_hold_mode(self):
+        """Return hold mode setting."""
+        return self.get_value(CONF_HOLD)
+
+    @property
+    def is_away_mode_on(self):
+        """Return if away mode is on."""
+        return self.get_value(CONF_AWAY)
+
+    @property
+    def is_aux_heat_on(self):
+        """Return true if aux heat is on."""
+        return self.get_value(CONF_AUX)
+
+    @property
+    def is_on(self):
+        """Return true if the device is on."""
+        return self.get_value(CONF_IS_ON)
+
+    def update(self):
+        """Update state."""
+        for prop in self._mods:
+            mod = self._mods[prop]
+            register_type, slave, register, count, scale, offset = \
+                self.register_info(mod)
+
+            if register_type == 'coil':
+                result = modbus.HUB.read_coils(slave, register, count)
+                value = bool(result.bits[0])
+            else:
+                if register_type == REGISTER_TYPE_INPUT:
+                    result = modbus.HUB.read_input_registers(slave,
+                                                             register, count)
+                else:
+                    result = modbus.HUB.read_holding_registers(slave,
+                                                               register, count)
+
+                val = 0
+                try:
+                    registers = result.registers
+                    if mod.get(CONF_REVERSE_ORDER):
+                        registers.reverse()
+                except AttributeError:
+                    _LOGGER.error("No response from modbus %s", prop)
+                    return
+
+                byte_string = b''.join(
+                    [x.to_bytes(2, byteorder='big') for x in registers]
+                )
+                val = struct.unpack(mod[CONF_STRUCTURE], byte_string)[0]
+                value = scale * val + offset
+
+            _LOGGER.info("Read %s: %s = %f", self.name, prop, value)
+            self._values[prop] = value
 
     def set_temperature(self, **kwargs):
-        """Set new target temperature."""
-        target_temperature = kwargs.get(ATTR_TEMPERATURE)
-        if target_temperature is None:
-            return
-        byte_string = struct.pack(self._structure, target_temperature)
-        register_value = struct.unpack('>h', byte_string[0:2])[0]
+        """Set new target temperatures."""
+        temperature = kwargs.get(ATTR_TEMPERATURE)
+        if temperature is not None:
+            self.set_value(CONF_TARGET_TEMPERATURE, temperature)
 
+    def set_humidity(self, humidity):
+        """Set new target humidity."""
+        self.set_value(CONF_TARGET_HUMIDITY, humidity)
+
+    def set_operation_mode(self, operation_mode):
+        """Set new operation mode."""
         try:
-            self.write_register(self._target_temperature_register,
-                                register_value)
-        except AttributeError as ex:
-            _LOGGER.error(ex)
+            index = self._operation_list.index(operation_mode)
+            self.set_value(CONF_OPERATION, index)
+        except ValueError:
+            _LOGGER.error("Invalid operation_mode: %s", operation_mode)
 
-    def read_register(self, register):
-        """Read holding register using the modbus hub slave."""
+    def set_fan_mode(self, fan_mode):
+        """Set new fan mode."""
         try:
-            result = modbus.HUB.read_holding_registers(self._slave, register,
-                                                       self._count)
-        except AttributeError as ex:
-            _LOGGER.error(ex)
-        byte_string = b''.join(
-            [x.to_bytes(2, byteorder='big') for x in result.registers])
-        val = struct.unpack(self._structure, byte_string)[0]
-        register_value = format(val, '.{}f'.format(self._precision))
-        return register_value
+            index = self._fan_list.index(fan_mode)
+            self.set_value(CONF_FAN, index)
+        except ValueError:
+            _LOGGER.error("Invalid fan_mode: %s", fan_mode)
 
-    def write_register(self, register, value):
-        """Write register using the modbus hub slave."""
-        modbus.HUB.write_registers(self._slave, register, [value, 0])
+    def set_swing_mode(self, swing_mode):
+        """Set new swing mode."""
+        try:
+            index = self._swing_list.index(swing_mode)
+            self.set_value(CONF_SWING, index)
+        except ValueError:
+            _LOGGER.error("Invalid swing_mode: %s", swing_mode)
+
+    def set_hold_mode(self, hold_mode):
+        """Set new hold mode."""
+        self.set_value(CONF_HOLD, hold_mode)
+
+    def turn_away_mode_on(self):
+        """Turn away mode on."""
+        self.set_value(CONF_AWAY, True)
+
+    def turn_away_mode_off(self):
+        """Turn away mode off."""
+        self.set_value(CONF_AWAY, False)
+
+    def turn_aux_heat_on(self):
+        """Turn auxiliary heater on."""
+        self.set_value(CONF_AUX, True)
+
+    def turn_aux_heat_off(self):
+        """Turn auxiliary heater off."""
+        self.set_value(CONF_AUX, False)
+
+    def turn_on(self):
+        """Turn on."""
+        self.set_value(CONF_IS_ON, True)
+
+    def turn_off(self):
+        """Turn off."""
+        self.set_value(CONF_IS_ON, False)
+
+    def register_info(self, mod):
+        """Get register info."""
+        register_type = mod.get(CONF_REGISTER_TYPE)
+        register = mod[CONF_REGISTER] \
+            if self._index == -1 else mod[CONF_REGISTERS][self._index]
+        slave = mod[CONF_SLAVE] if CONF_SLAVE in mod else 1
+        count = mod[CONF_COUNT] if CONF_COUNT in mod else 1
+        scale = mod[CONF_SCALE] if CONF_SCALE in mod else 1
+        offset = mod[CONF_OFFSET] if CONF_OFFSET in mod else 0
+        return (register_type, slave, register, count, scale, offset)
+
+    def get_value(self, prop):
+        """Get property value."""
+        return self._values.get(prop)
+
+    def set_value(self, prop, value):
+        """Set property value."""
+        mod = self._mods[prop]
+        register_type, slave, register, count, scale, offset = \
+            self.register_info(mod)
+        _LOGGER.info("Write %s: %s = %f", self.name, prop, value)
+
+        if register_type == 'coil':
+            modbus.HUB.write_coil(slave, register, bool(value))
+        else:
+            val = (value - offset) / scale
+            modbus.HUB.write_register(slave, register, int(val))
+
+        self._values[prop] = value
+
+        async_call_later(self.hass, 2, self.async_schedule_update_ha_state)

--- a/homeassistant/components/climate/modbus.py
+++ b/homeassistant/components/climate/modbus.py
@@ -224,6 +224,9 @@ class ModbusClimate(ClimateDevice):
     @property
     def current_operation(self):
         """Return current operation ie. heat, cool, idle."""
+        if not self.is_on:
+            return 'off'
+
         operation = self.get_value(CONF_OPERATION)
         if operation is not None and operation < len(self._operation_list):
             return self._operation_list[operation]
@@ -279,6 +282,17 @@ class ModbusClimate(ClimateDevice):
     def is_on(self):
         """Return true if the device is on."""
         return self.get_value(CONF_IS_ON)
+        
+    def try_reconnect(self):
+        from pymodbus.client.sync import ModbusTcpClient as ModbusClient
+        from pymodbus.transaction import ModbusRtuFramer as ModbusFramer
+        client = ModbusClient(host=modbus.HUB._client.host,
+                              port=modbus.HUB._client.port,
+                              framer=ModbusFramer,
+                              timeout=modbus.HUB._client.timeout)
+        _LOGGER.error("Reconnect: %s", client)
+        modbus.HUB._client = client
+        modbus.HUB._client.connect()
 
     def update(self):
         """Update state."""
@@ -290,22 +304,28 @@ class ModbusClimate(ClimateDevice):
 
             if register_type == REGISTER_TYPE_COIL:
                 result = modbus.HUB.read_coils(slave, register, count)
-                value = bool(result.bits[0])
+                try:
+                	value = bool(result.bits[0])
+                except:
+                    _LOGGER.error("No response from %s %s", self._name, prop)
+                    self.try_reconnect()
+                    return
             else:
-                if register_type == REGISTER_TYPE_INPUT:
-                    result = modbus.HUB.read_input_registers(slave,
+                try:
+                    if register_type == REGISTER_TYPE_INPUT:
+                        result = modbus.HUB.read_input_registers(slave,
                                                              register, count)
-                else:
-                    result = modbus.HUB.read_holding_registers(slave,
+                    else:
+                        result = modbus.HUB.read_holding_registers(slave,
                                                                register, count)
 
-                val = 0
-                try:
+                    val = 0
                     registers = result.registers
                     if mod.get(CONF_REVERSE_ORDER):
                         registers.reverse()
-                except AttributeError:
-                    _LOGGER.error("No response from modbus %s", prop)
+                except:
+                    _LOGGER.error("No response from %s %s", self._name, prop)
+                    self.try_reconnect()
                     return
 
                 byte_string = b''.join(
@@ -330,8 +350,16 @@ class ModbusClimate(ClimateDevice):
     def set_operation_mode(self, operation_mode):
         """Set new operation mode."""
         try:
-            index = self._operation_list.index(operation_mode)
-            self.set_value(CONF_OPERATION, index)
+            is_on = operation_mode != 'off'
+            self.set_value(CONF_IS_ON, is_on)
+            if is_on:
+                if operation_mode == 'auto':
+                    current = self.current_temperature
+                    target = self.target_temperature
+                    operation_mode = 'heat' \
+                        if current and target and current < target else 'cool'
+                index = self._operation_list.index(operation_mode)
+                self.set_value(CONF_OPERATION, index)
         except ValueError:
             _LOGGER.error("Invalid operation_mode: %s", operation_mode)
 

--- a/homeassistant/components/climate/modbus.py
+++ b/homeassistant/components/climate/modbus.py
@@ -282,7 +282,7 @@ class ModbusClimate(ClimateDevice):
     def is_on(self):
         """Return true if the device is on."""
         return self.get_value(CONF_IS_ON)
-        
+
     def try_reconnect(self):
         from pymodbus.client.sync import ModbusTcpClient as ModbusClient
         from pymodbus.transaction import ModbusRtuFramer as ModbusFramer
@@ -305,7 +305,7 @@ class ModbusClimate(ClimateDevice):
             if register_type == REGISTER_TYPE_COIL:
                 result = modbus.HUB.read_coils(slave, register, count)
                 try:
-                	value = bool(result.bits[0])
+                    value = bool(result.bits[0])
                 except:
                     _LOGGER.error("No response from %s %s", self._name, prop)
                     self.try_reconnect()

--- a/homeassistant/components/climate/modbus.py
+++ b/homeassistant/components/climate/modbus.py
@@ -155,7 +155,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     if not devices:
         for prop in mods:
-            if CONF_REGISTER not in mod:
+            if CONF_REGISTER not in mods[prop]:
                 _LOGGER.error("Invalid config %s/%s: no register", name, prop)
                 return
         devices.append(ModbusClimate(name, operation_list, fan_list,


### PR DESCRIPTION
## Description:

Hi, awesome people,

I just propose a new Modbus climate component with more 'generic' Climate feature support.

 1. Based on climate.demo generic climate, plus with Modbus implementation;
 2. All configuration sub-fields is similar with https://www.home-assistant.io/components/sensor.modbus/, plus with optional multi-registers support (to simplify config file).

But I known there is a big different with the original climate.modbus. I'm not sure you can accept it. If someone agree with me to replace this component, I'll add corresponding document and keep on maintaining this component.

Or, any advice is welcome, your help will be highly appreciated. @Kirchoff @MartinHjelmare @pvizeli 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>COMING SOON

## Example entry for `configuration.yaml` (if applicable):
```yaml
   - platform: modbus
     name: Daikin
     temperature: {register: 3, register_type: input, scale: 0.1}
     target_temperature: {register:4}
     operation: {register: 5}
     fan: {register: 6}
     is_on: {register: 1, register_type: coil}
```

## Another example shows all supported features:
```yaml
   - platform: modbus
     name: Daikin
     temperature: {registers: [3,7,11], register_type: input, scale: 0.1}
     target_temperature: {registers:[4,8,12]}
     operation: {registers: [5,9,13]}
     fan: {registers: [6,10,14]}
     is_on: {registers[: [1,2,3], register_type: coil}
     humidity: {registers: [30,31,32], register_type: input, scale: 0.1}
     target_humidity: {registers:[40,41,42]}
     swing: {registers:[50,51,52]}
     hold: {registers:[60,61,62]}
     away: {registers:[70,71,72]}
     aux: {registers:[80,81,82]}
```
This will create 3 Modbus climate with different registers and same other configs.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
