### PR TITLE
Updated list of AWS regions for Amazon Polly

### DIFF
--- a/homeassistant/components/tts/amazon_polly.py
+++ b/homeassistant/components/tts/amazon_polly.py
@@ -20,7 +20,11 @@ CONF_PROFILE_NAME = 'profile_name'
 ATTR_CREDENTIALS = 'credentials'
 
 DEFAULT_REGION = 'us-east-1'
-SUPPORTED_REGIONS = ['us-east-1', 'us-east-2', 'us-west-2', 'eu-west-1']
+SUPPORTED_REGIONS = ['us-east-1', 'us-east-2', 'us-west-1', 'us-west-2',
+                     'ca-central-1', 'eu-west-1', 'eu-central-1', 'eu-west-2',
+                     'eu-west-3', 'ap-southeast-1', 'ap-southeast-2',
+                     'ap-northeast-2', 'ap-northeast-1', 'ap-south-1',
+                     'sa-east-1']
 
 CONF_VOICE = 'voice'
 CONF_OUTPUT_FORMAT = 'output_format'


### PR DESCRIPTION
Updated the list of AWS regions for the Amazon Polly service.

## Description:


**Related issue:** fixes #14052 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation:** home-assistant/home-assistant.github.io#5247

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
