### PR TITLE
Updating dark sky update interval to 5 mins

### DIFF
--- a/homeassistant/components/climate/honeywell.py
+++ b/homeassistant/components/climate/honeywell.py
@@ -20,7 +20,7 @@ from homeassistant.const import (
     CONF_PASSWORD, CONF_USERNAME, TEMP_CELSIUS, TEMP_FAHRENHEIT,
     ATTR_TEMPERATURE, CONF_REGION)
 
-REQUIREMENTS = ['evohomeclient==0.2.5', 'somecomfort==0.5.0']
+REQUIREMENTS = ['evohomeclient==0.2.5', 'somecomfort==0.5.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/config/__init__.py
+++ b/homeassistant/components/config/__init__.py
@@ -18,36 +18,25 @@ SECTIONS = ('core', 'customize', 'group', 'hassbian', 'automation', 'script',
 ON_DEMAND = ('zwave',)
 
 
-@asyncio.coroutine
-def async_setup(hass, config):
+async def async_setup(hass, config):
     """Set up the config component."""
-    yield from hass.components.frontend.async_register_built_in_panel(
+    await hass.components.frontend.async_register_built_in_panel(
         'config', 'config', 'mdi:settings')
 
-    @asyncio.coroutine
-    def setup_panel(panel_name):
+    async def setup_panel(panel_name):
         """Set up a panel."""
-        panel = yield from async_prepare_setup_platform(
+        panel = await async_prepare_setup_platform(
             hass, config, DOMAIN, panel_name)
 
         if not panel:
             return
 
-        success = yield from panel.async_setup(hass)
+        success = await panel.async_setup(hass)
 
         if success:
             key = '{}.{}'.format(DOMAIN, panel_name)
             hass.bus.async_fire(EVENT_COMPONENT_LOADED, {ATTR_COMPONENT: key})
             hass.config.components.add(key)
-
-    tasks = [setup_panel(panel_name) for panel_name in SECTIONS]
-
-    for panel_name in ON_DEMAND:
-        if panel_name in hass.config.components:
-            tasks.append(setup_panel(panel_name))
-
-    if tasks:
-        yield from asyncio.wait(tasks, loop=hass.loop)
 
     @callback
     def component_loaded(event):
@@ -57,6 +46,15 @@ def async_setup(hass, config):
             hass.async_add_job(setup_panel(panel_name))
 
     hass.bus.async_listen(EVENT_COMPONENT_LOADED, component_loaded)
+
+    tasks = [setup_panel(panel_name) for panel_name in SECTIONS]
+
+    for panel_name in ON_DEMAND:
+        if panel_name in hass.config.components:
+            tasks.append(setup_panel(panel_name))
+
+    if tasks:
+        await asyncio.wait(tasks, loop=hass.loop)
 
     return True
 
@@ -86,11 +84,10 @@ class BaseEditConfigView(HomeAssistantView):
         """Set value."""
         raise NotImplementedError
 
-    @asyncio.coroutine
-    def get(self, request, config_key):
+    async def get(self, request, config_key):
         """Fetch device specific config."""
         hass = request.app['hass']
-        current = yield from self.read_config(hass)
+        current = await self.read_config(hass)
         value = self._get_value(hass, current, config_key)
 
         if value is None:
@@ -98,11 +95,10 @@ class BaseEditConfigView(HomeAssistantView):
 
         return self.json(value)
 
-    @asyncio.coroutine
-    def post(self, request, config_key):
+    async def post(self, request, config_key):
         """Validate config and return results."""
         try:
-            data = yield from request.json()
+            data = await request.json()
         except ValueError:
             return self.json_message('Invalid JSON specified', 400)
 
@@ -121,10 +117,10 @@ class BaseEditConfigView(HomeAssistantView):
         hass = request.app['hass']
         path = hass.config.path(self.path)
 
-        current = yield from self.read_config(hass)
+        current = await self.read_config(hass)
         self._write_value(hass, current, config_key, data)
 
-        yield from hass.async_add_job(_write, path, current)
+        await hass.async_add_job(_write, path, current)
 
         if self.post_write_hook is not None:
             hass.async_add_job(self.post_write_hook(hass))
@@ -133,10 +129,9 @@ class BaseEditConfigView(HomeAssistantView):
             'result': 'ok',
         })
 
-    @asyncio.coroutine
-    def read_config(self, hass):
+    async def read_config(self, hass):
         """Read the config."""
-        current = yield from hass.async_add_job(
+        current = await hass.async_add_job(
             _read, hass.config.path(self.path))
         if not current:
             current = self._empty_config()

--- a/homeassistant/components/cover/gogogate2.py
+++ b/homeassistant/components/cover/gogogate2.py
@@ -11,7 +11,7 @@ import voluptuous as vol
 from homeassistant.components.cover import (
     CoverDevice, SUPPORT_OPEN, SUPPORT_CLOSE)
 from homeassistant.const import (
-    CONF_USERNAME, CONF_PASSWORD, STATE_CLOSED, STATE_UNKNOWN,
+    CONF_USERNAME, CONF_PASSWORD, STATE_CLOSED,
     CONF_IP_ADDRESS, CONF_NAME)
 import homeassistant.helpers.config_validation as cv
 
@@ -50,7 +50,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
         add_devices(MyGogogate2Device(
             mygogogate2, door, name) for door in devices)
-        return
 
     except (TypeError, KeyError, NameError, ValueError) as ex:
         _LOGGER.error("%s", ex)
@@ -60,7 +59,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             ''.format(ex),
             title=NOTIFICATION_TITLE,
             notification_id=NOTIFICATION_ID)
-        return
 
 
 class MyGogogate2Device(CoverDevice):
@@ -72,7 +70,7 @@ class MyGogogate2Device(CoverDevice):
         self.device_id = device['door']
         self._name = name or device['name']
         self._status = device['status']
-        self.available = None
+        self._available = None
 
     @property
     def name(self):
@@ -97,24 +95,22 @@ class MyGogogate2Device(CoverDevice):
     @property
     def available(self):
         """Could the device be accessed during the last update call."""
-        return self.available
+        return self._available
 
     def close_cover(self, **kwargs):
         """Issue close command to cover."""
         self.mygogogate2.close_device(self.device_id)
-        self.schedule_update_ha_state(True)
 
     def open_cover(self, **kwargs):
         """Issue open command to cover."""
         self.mygogogate2.open_device(self.device_id)
-        self.schedule_update_ha_state(True)
 
     def update(self):
         """Update status of cover."""
         try:
             self._status = self.mygogogate2.get_status(self.device_id)
-            self.available = True
+            self._available = True
         except (TypeError, KeyError, NameError, ValueError) as ex:
             _LOGGER.error("%s", ex)
-            self._status = STATE_UNKNOWN
-            self.available = False
+            self._status = None
+            self._available = False

--- a/homeassistant/components/device_tracker/bluetooth_tracker.py
+++ b/homeassistant/components/device_tracker/bluetooth_tracker.py
@@ -40,7 +40,7 @@ def setup_scanner(hass, config, see, discovery_info=None):
         attributes = {}
         if rssi is not None:
             attributes['rssi'] = rssi
-        see(mac="{}_{}".format(BT_PREFIX, mac), host_name=name,
+        see(mac="{}{}".format(BT_PREFIX, mac), host_name=name,
             attributes=attributes, source_type=SOURCE_TYPE_BLUETOOTH)
 
     def discover_devices():

--- a/homeassistant/components/discovery.py
+++ b/homeassistant/components/discovery.py
@@ -84,7 +84,8 @@ CONF_IGNORE = 'ignore'
 CONFIG_SCHEMA = vol.Schema({
     vol.Required(DOMAIN): vol.Schema({
         vol.Optional(CONF_IGNORE, default=[]):
-            vol.All(cv.ensure_list, [vol.In(SERVICE_HANDLERS)])
+            vol.All(cv.ensure_list, [
+                vol.In(list(CONFIG_ENTRY_HANDLERS) + list(SERVICE_HANDLERS))])
     }),
 }, extra=vol.ALLOW_EXTRA)
 

--- a/homeassistant/components/fan/xiaomi_miio.py
+++ b/homeassistant/components/fan/xiaomi_miio.py
@@ -708,7 +708,7 @@ class XiaomiAirHumidifier(XiaomiGenericDevice):
 
     def __init__(self, name, device, model, unique_id):
         """Initialize the plug switch."""
-        from miio.airpurifier import OperationMode
+        from miio.airhumidifier import OperationMode
 
         super().__init__(name, device, model, unique_id)
 

--- a/homeassistant/components/fan/xiaomi_miio.py
+++ b/homeassistant/components/fan/xiaomi_miio.py
@@ -748,6 +748,7 @@ class XiaomiAirHumidifier(XiaomiGenericDevice):
             self._available = False
             _LOGGER.error("Got exception while fetching the state: %s", ex)
 
+    @property
     def speed_list(self) -> list:
         """Get the list of available speeds."""
         return self._speed_list

--- a/homeassistant/components/qwikswitch.py
+++ b/homeassistant/components/qwikswitch.py
@@ -18,7 +18,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.components.light import ATTR_BRIGHTNESS
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['pyqwikswitch==0.6']
+REQUIREMENTS = ['pyqwikswitch==0.71']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/qwikswitch.py
+++ b/homeassistant/components/qwikswitch.py
@@ -18,7 +18,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.components.light import ATTR_BRIGHTNESS
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['pyqwikswitch==0.71']
+REQUIREMENTS = ['pyqwikswitch==0.6']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sensor/darksky.py
+++ b/homeassistant/components/sensor/darksky.py
@@ -146,7 +146,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
                   'Latitude and longitude must exist together'): cv.latitude,
     vol.Inclusive(CONF_LONGITUDE, 'coordinates',
                   'Latitude and longitude must exist together'): cv.longitude,
-    vol.Optional(CONF_UPDATE_INTERVAL, default=timedelta(seconds=120)): (
+    vol.Optional(CONF_UPDATE_INTERVAL, default=timedelta(seconds=300)): (
         vol.All(cv.time_period, cv.positive_timedelta)),
     vol.Optional(CONF_FORECAST):
         vol.All(cv.ensure_list, [vol.Range(min=1, max=7)]),

--- a/homeassistant/components/sensor/fido.py
+++ b/homeassistant/components/sensor/fido.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['pyfido==2.1.0']
+REQUIREMENTS = ['pyfido==2.1.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sensor/hydroquebec.py
+++ b/homeassistant/components/sensor/hydroquebec.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['pyhydroquebec==2.2.1']
+REQUIREMENTS = ['pyhydroquebec==2.2.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sensor/pollen.py
+++ b/homeassistant/components/sensor/pollen.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle, slugify
 
-REQUIREMENTS = ['pypollencom==1.1.1']
+REQUIREMENTS = ['pypollencom==1.1.2']
 _LOGGER = logging.getLogger(__name__)
 
 ATTR_ALLERGEN_GENUS = 'primary_allergen_genus'

--- a/homeassistant/components/switch/broadlink.py
+++ b/homeassistant/components/switch/broadlink.py
@@ -19,7 +19,7 @@ from homeassistant.const import (
     CONF_COMMAND_OFF, CONF_COMMAND_ON, CONF_FRIENDLY_NAME, CONF_HOST, CONF_MAC,
     CONF_SWITCHES, CONF_TIMEOUT, CONF_TYPE)
 import homeassistant.helpers.config_validation as cv
-from homeassistant.util import Throttle
+from homeassistant.util import Throttle, slugify
 from homeassistant.util.dt import utcnow
 
 REQUIREMENTS = ['broadlink==0.8.0']
@@ -187,7 +187,7 @@ class BroadlinkRMSwitch(SwitchDevice):
 
     def __init__(self, name, friendly_name, device, command_on, command_off):
         """Initialize the switch."""
-        self.entity_id = ENTITY_ID_FORMAT.format(name)
+        self.entity_id = ENTITY_ID_FORMAT.format(slugify(name))
         self._name = friendly_name
         self._state = False
         self._command_on = b64decode(command_on) if command_on else None
@@ -257,7 +257,7 @@ class BroadlinkSP1Switch(BroadlinkRMSwitch):
 
     def __init__(self, friendly_name, device):
         """Initialize the switch."""
-        super().__init__(friendly_name, device, None, None)
+        super().__init__(friendly_name, friendly_name, device, None, None)
         self._command_on = 1
         self._command_off = 0
 
@@ -313,7 +313,7 @@ class BroadlinkMP1Slot(BroadlinkRMSwitch):
 
     def __init__(self, friendly_name, device, slot, parent_device):
         """Initialize the slot of switch."""
-        super().__init__(friendly_name, device, None, None)
+        super().__init__(friendly_name, friendly_name, device, None, None)
         self._command_on = 1
         self._command_off = 0
         self._slot = slot

--- a/homeassistant/components/switch/vesync.py
+++ b/homeassistant/components/switch/vesync.py
@@ -60,6 +60,8 @@ class VeSyncSwitchHA(SwitchDevice):
     def __init__(self, plug):
         """Initialize the VeSync switch device."""
         self.smartplug = plug
+        self._current_power_w = None
+        self._today_energy_kwh = None
 
     @property
     def unique_id(self):
@@ -74,12 +76,12 @@ class VeSyncSwitchHA(SwitchDevice):
     @property
     def current_power_w(self):
         """Return the current power usage in W."""
-        return self.smartplug.get_power()
+        return self._current_power_w
 
     @property
     def today_energy_kwh(self):
         """Return the today total energy usage in kWh."""
-        return self.smartplug.get_kwh_today()
+        return self._today_energy_kwh
 
     @property
     def available(self) -> bool:
@@ -102,3 +104,5 @@ class VeSyncSwitchHA(SwitchDevice):
     def update(self):
         """Handle data changes for node values."""
         self.smartplug.update()
+        self._current_power_w = self.smartplug.get_power()
+        self._today_energy_kwh = self.smartplug.get_kwh_today()

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -2,7 +2,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 67
-PATCH_VERSION = '0'
+PATCH_VERSION = '1'
 __short_version__ = '{}.{}'.format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = '{}.{}'.format(__short_version__, PATCH_VERSION)
 REQUIRED_PYTHON_VER = (3, 5, 3)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -885,7 +885,7 @@ pyowm==2.8.0
 pypollencom==1.1.2
 
 # homeassistant.components.qwikswitch
-pyqwikswitch==0.71
+pyqwikswitch==0.6
 
 # homeassistant.components.rainbird
 pyrainbird==0.1.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -882,7 +882,7 @@ pyotp==2.2.6
 pyowm==2.8.0
 
 # homeassistant.components.sensor.pollen
-pypollencom==1.1.1
+pypollencom==1.1.2
 
 # homeassistant.components.qwikswitch
 pyqwikswitch==0.71

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1185,7 +1185,7 @@ smappy==0.2.15
 snapcast==2.0.8
 
 # homeassistant.components.climate.honeywell
-somecomfort==0.5.0
+somecomfort==0.5.2
 
 # homeassistant.components.sensor.speedtest
 speedtest-cli==2.0.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -780,7 +780,7 @@ pyhiveapi==0.2.11
 pyhomematic==0.1.40
 
 # homeassistant.components.sensor.hydroquebec
-pyhydroquebec==2.2.1
+pyhydroquebec==2.2.2
 
 # homeassistant.components.alarm_control_panel.ialarm
 pyialarm==0.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -756,7 +756,7 @@ pyenvisalink==2.2
 pyephember==0.1.1
 
 # homeassistant.components.sensor.fido
-pyfido==2.1.0
+pyfido==2.1.1
 
 # homeassistant.components.climate.flexit
 pyflexit==0.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -885,7 +885,7 @@ pyowm==2.8.0
 pypollencom==1.1.1
 
 # homeassistant.components.qwikswitch
-pyqwikswitch==0.6
+pyqwikswitch==0.71
 
 # homeassistant.components.rainbird
 pyrainbird==0.1.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -174,7 +174,7 @@ rxv==0.5.1
 sleepyq==0.6
 
 # homeassistant.components.climate.honeywell
-somecomfort==0.5.0
+somecomfort==0.5.2
 
 # homeassistant.components.recorder
 # homeassistant.scripts.db_migrator


### PR DESCRIPTION
## Description:

With Darksky allowing only 1000 API requests per day, 2 minutes retry seems to be bit closer to running over the limit and actually it did for 5 days in my account. Hence proposing a change to 5 minutes to keep the API happy and also it doesn't hurt to check the weather for every 5 mins than 2 mins someone lives in Jupiter :-P



**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
