### PR TITLE
Change Eufy brightness handling

### DIFF
--- a/homeassistant/components/light/eufy.py
+++ b/homeassistant/components/light/eufy.py
@@ -61,13 +61,14 @@ class EufyLight(Light):
     def update(self):
         """Synchronise state from the bulb."""
         self._bulb.update()
-        self._brightness = self._bulb.brightness
-        self._temp = self._bulb.temperature
-        if self._bulb.colors:
-            self._colormode = True
-            self._hs = color_util.color_RGB_to_hs(*self._bulb.colors)
-        else:
-            self._colormode = False
+        if self._bulb.power:
+            self._brightness = self._bulb.brightness
+            self._temp = self._bulb.temperature
+            if self._bulb.colors:
+                self._colormode = True
+                self._hs = color_util.color_RGB_to_hs(*self._bulb.colors)
+            else:
+                self._colormode = False
         self._state = self._bulb.power
 
     @property
@@ -130,7 +131,9 @@ class EufyLight(Light):
         if brightness is not None:
             brightness = int(brightness * 100 / 255)
         else:
-            brightness = max(1, self._brightness)
+            if self._brightness is None:
+                self._brightness = 100
+            brightness = self._brightness
 
         if colortemp is not None:
             self._colormode = False


### PR DESCRIPTION
Eufy device state isn't reported if the bulb is off, so avoid stamping on
the previous values if the bulb isn't going to give us useful information.
In addition, improve handling of bulb turn on if we aren't provided with a
brightness - this should avoid the bulb tending to end up with a brightness of
1 after power cycling.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
