### PR TITLE
Add HomeKit firmware revision characteristic

### DIFF
--- a/homeassistant/components/homekit/accessories.py
+++ b/homeassistant/components/homekit/accessories.py
@@ -7,6 +7,7 @@ import logging
 from pyhap.accessory import Accessory, Bridge, Category
 from pyhap.accessory_driver import AccessoryDriver
 
+from homeassistant.const import __version__
 from homeassistant.core import callback as ha_callback
 from homeassistant.helpers.event import (
     async_track_state_change, track_point_in_utc_time)
@@ -14,7 +15,7 @@ from homeassistant.util import dt as dt_util
 
 from .const import (
     DEBOUNCE_TIMEOUT, BRIDGE_MODEL, BRIDGE_NAME, MANUFACTURER,
-    SERV_ACCESSORY_INFO, CHAR_MANUFACTURER,
+    SERV_ACCESSORY_INFO, CHAR_FIRMWARE_REVISION, CHAR_MANUFACTURER,
     CHAR_MODEL, CHAR_NAME, CHAR_SERIAL_NUMBER)
 from .util import (
     show_setup_message, dismiss_setup_message)
@@ -85,13 +86,15 @@ def setup_char(char_name, service, value=None, properties=None, callback=None):
 
 
 def set_accessory_info(acc, name, model, manufacturer=MANUFACTURER,
-                       serial_number='0000'):
+                       serial_number='0000', firmware_revision=__version__):
     """Set the default accessory information."""
     service = acc.get_service(SERV_ACCESSORY_INFO)
     service.get_characteristic(CHAR_NAME).set_value(name)
     service.get_characteristic(CHAR_MODEL).set_value(model)
     service.get_characteristic(CHAR_MANUFACTURER).set_value(manufacturer)
     service.get_characteristic(CHAR_SERIAL_NUMBER).set_value(serial_number)
+    (service.get_characteristic(CHAR_FIRMWARE_REVISION)
+     .set_value(firmware_revision))
 
 
 class HomeAccessory(Accessory):

--- a/homeassistant/components/homekit/const.py
+++ b/homeassistant/components/homekit/const.py
@@ -74,6 +74,7 @@ CHAR_CURRENT_POSITION = 'CurrentPosition'  # Int | [0, 100]
 CHAR_CURRENT_HUMIDITY = 'CurrentRelativeHumidity'  # percent
 CHAR_CURRENT_SECURITY_STATE = 'SecuritySystemCurrentState'
 CHAR_CURRENT_TEMPERATURE = 'CurrentTemperature'
+CHAR_FIRMWARE_REVISION = 'FirmwareRevision'
 CHAR_HEATING_THRESHOLD_TEMPERATURE = 'HeatingThresholdTemperature'
 CHAR_HUE = 'Hue'  # arcdegress | [0, 360]
 CHAR_LEAK_DETECTED = 'LeakDetected'

--- a/tests/components/homekit/test_accessories.py
+++ b/tests/components/homekit/test_accessories.py
@@ -10,7 +10,7 @@ from homeassistant.components.homekit.accessories import (
     add_preload_service, set_accessory_info,
     debounce, HomeAccessory, HomeBridge, HomeDriver)
 from homeassistant.components.homekit.const import (
-    BRIDGE_MODEL, BRIDGE_NAME, SERV_ACCESSORY_INFO,
+    BRIDGE_MODEL, BRIDGE_NAME, SERV_ACCESSORY_INFO, CHAR_FIRMWARE_REVISION,
     CHAR_MANUFACTURER, CHAR_MODEL, CHAR_NAME, CHAR_SERIAL_NUMBER)
 from homeassistant.const import ATTR_NOW, EVENT_TIME_CHANGED
 import homeassistant.util.dt as dt_util
@@ -92,7 +92,8 @@ class TestAccessories(unittest.TestCase):
         """Test setting the basic accessory information."""
         # Test HomeAccessory
         acc = HomeAccessory('HA', 'Home Accessory', 'homekit.accessory', 2, '')
-        set_accessory_info(acc, 'name', 'model', 'manufacturer', '0000')
+        set_accessory_info(acc, 'name', 'model', 'manufacturer', '0000',
+                           '1.2.3')
 
         serv = acc.get_service(SERV_ACCESSORY_INFO)
         self.assertEqual(serv.get_characteristic(CHAR_NAME).value, 'name')
@@ -101,10 +102,13 @@ class TestAccessories(unittest.TestCase):
             serv.get_characteristic(CHAR_MANUFACTURER).value, 'manufacturer')
         self.assertEqual(
             serv.get_characteristic(CHAR_SERIAL_NUMBER).value, '0000')
+        self.assertEqual(
+            serv.get_characteristic(CHAR_FIRMWARE_REVISION).value, '1.2.3')
 
         # Test HomeBridge
         acc = HomeBridge('hass')
-        set_accessory_info(acc, 'name', 'model', 'manufacturer', '0000')
+        set_accessory_info(acc, 'name', 'model', 'manufacturer', '0000',
+                           '1.2.3')
 
         serv = acc.get_service(SERV_ACCESSORY_INFO)
         self.assertEqual(serv.get_characteristic(CHAR_MODEL).value, 'model')
@@ -112,6 +116,8 @@ class TestAccessories(unittest.TestCase):
             serv.get_characteristic(CHAR_MANUFACTURER).value, 'manufacturer')
         self.assertEqual(
             serv.get_characteristic(CHAR_SERIAL_NUMBER).value, '0000')
+        self.assertEqual(
+            serv.get_characteristic(CHAR_FIRMWARE_REVISION).value, '1.2.3')
 
     def test_home_accessory(self):
         """Test HomeAccessory class."""


### PR DESCRIPTION
## Description:
Adds characteristic to accessory information service for firmware revision. By default, firmware revision is set to current Home Assistant version.

![fullsizeoutput_3de5](https://user-images.githubusercontent.com/630673/39348990-4c391c86-49c7-11e8-9b53-a7994301525c.jpeg)

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
N/A
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
