### PR TITLE
Improve precision of Hue color state

### DIFF
--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -242,26 +242,16 @@ class HueLight(Light):
     @property
     def hs_color(self):
         """Return the hs color value."""
-        # pylint: disable=redefined-outer-name
         mode = self._color_mode
-
-        if mode not in ('hs', 'xy'):
-            return
-
         source = self.light.action if self.is_group else self.light.state
 
-        hue = source.get('hue')
-        sat = source.get('sat')
+        if mode == 'xy' and 'xy' in source:
+            return color.color_xy_to_hs(*source['xy'])
 
-        # Sometimes the state will not include valid hue/sat values.
-        # Reported as issue 13434
-        if hue is not None and sat is not None:
-            return hue / 65535 * 360, sat / 255 * 100
+        if mode == 'hs' and 'hue' in source and 'sat' in source:
+            return source['hue'] / 65535 * 360, source['sat'] / 255 * 100
 
-        if 'xy' not in source:
-            return None
-
-        return color.color_xy_to_hs(*source['xy'])
+        return None
 
     @property
     def color_temp(self):

--- a/tests/components/light/test_hue.py
+++ b/tests/components/light/test_hue.py
@@ -237,7 +237,7 @@ async def test_lights(hass, mock_bridge):
     assert lamp_1 is not None
     assert lamp_1.state == 'on'
     assert lamp_1.attributes['brightness'] == 144
-    assert lamp_1.attributes['hs_color'] == (71.896, 83.137)
+    assert lamp_1.attributes['hs_color'] == (36.067, 69.804)
 
     lamp_2 = hass.states.get('light.hue_lamp_2')
     assert lamp_2 is not None
@@ -253,7 +253,7 @@ async def test_lights_color_mode(hass, mock_bridge):
     assert lamp_1 is not None
     assert lamp_1.state == 'on'
     assert lamp_1.attributes['brightness'] == 144
-    assert lamp_1.attributes['hs_color'] == (71.896, 83.137)
+    assert lamp_1.attributes['hs_color'] == (36.067, 69.804)
     assert 'color_temp' not in lamp_1.attributes
 
     new_light1_on = LIGHT_1_ON.copy()
@@ -667,19 +667,6 @@ def test_hs_color():
         light=Mock(state={
             'colormode': 'xy',
             'hue': 1234,
-            'sat': 123,
-        }),
-        request_bridge_update=None,
-        bridge=Mock(),
-        is_group=False,
-    )
-
-    assert light.hs_color == (1234 / 65535 * 360, 123 / 255 * 100)
-
-    light = hue_light.HueLight(
-        light=Mock(state={
-            'colormode': 'xy',
-            'hue': None,
             'sat': 123,
             'xy': [0.4, 0.5]
         }),


### PR DESCRIPTION
## Description:

We are currently _setting_ colors using the xy API of Hue and _getting_ HS values, converting each as necessary.

However, xy<->HS conversions are bulb dependent so we cannot match the conversion done in-bulb.

This PR changes to read out the true xy value that was set. We will still do some conversions but the errors should cancel out because it's now all done inside HA.

The change had some testing in the linked issue though I do not have Hue bulbs myself.

(Note that this PR only makes each separate attribute consistent between write-read. Conversions are still unpredictable across color models. Setting xy, reading HS and then setting that HS will not give the original xy value.)

**Related issue (if applicable):** fixes #13944 

## Checklist:
  - [ ] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.
