### PR TITLE
Clean up HomeKit accessory information characteristics

### DIFF
--- a/homeassistant/components/homekit/accessories.py
+++ b/homeassistant/components/homekit/accessories.py
@@ -7,15 +7,17 @@ import logging
 from pyhap.accessory import Accessory, Bridge, Category
 from pyhap.accessory_driver import AccessoryDriver
 
+from homeassistant.const import __version__
 from homeassistant.core import callback as ha_callback
+from homeassistant.core import split_entity_id
 from homeassistant.helpers.event import (
     async_track_state_change, track_point_in_utc_time)
 from homeassistant.util import dt as dt_util
 
 from .const import (
     DEBOUNCE_TIMEOUT, BRIDGE_MODEL, BRIDGE_NAME, BRIDGE_SERIAL_NUMBER,
-    MANUFACTURER, SERV_ACCESSORY_INFO, CHAR_MANUFACTURER,
-    CHAR_MODEL, CHAR_NAME, CHAR_SERIAL_NUMBER, UNKNOWN)
+    MANUFACTURER, SERV_ACCESSORY_INFO, CHAR_FIRMWARE_REVISION,
+    CHAR_MANUFACTURER, CHAR_MODEL, CHAR_NAME, CHAR_SERIAL_NUMBER)
 from .util import (
     show_setup_message, dismiss_setup_message)
 
@@ -84,14 +86,17 @@ def setup_char(char_name, service, value=None, properties=None, callback=None):
     return char
 
 
-def set_accessory_info(acc, name, model, manufacturer=MANUFACTURER,
-                       serial_number=UNKNOWN):
+def set_accessory_info(acc, name, model, serial_number,
+                       manufacturer=MANUFACTURER,
+                       firmware_revision=__version__):
     """Set the default accessory information."""
     service = acc.get_service(SERV_ACCESSORY_INFO)
     service.get_characteristic(CHAR_NAME).set_value(name)
     service.get_characteristic(CHAR_MODEL).set_value(model)
     service.get_characteristic(CHAR_MANUFACTURER).set_value(manufacturer)
     service.get_characteristic(CHAR_SERIAL_NUMBER).set_value(serial_number)
+    service.get_characteristic(CHAR_FIRMWARE_REVISION) \
+        .set_value(firmware_revision)
 
 
 class HomeAccessory(Accessory):
@@ -100,7 +105,7 @@ class HomeAccessory(Accessory):
     def __init__(self, hass, name, entity_id, aid, category):
         """Initialize a Accessory object."""
         super().__init__(name, aid=aid)
-        domain = entity_id.split(".")[0].replace("_", " ").title()
+        domain = split_entity_id(entity_id)[0].replace("_", " ").title()
         set_accessory_info(self, name, model=domain, serial_number=entity_id)
         self.category = getattr(Category, category, Category.OTHER)
         self.entity_id = entity_id

--- a/homeassistant/components/homekit/accessories.py
+++ b/homeassistant/components/homekit/accessories.py
@@ -13,9 +13,9 @@ from homeassistant.helpers.event import (
 from homeassistant.util import dt as dt_util
 
 from .const import (
-    DEBOUNCE_TIMEOUT, BRIDGE_MODEL, BRIDGE_NAME, MANUFACTURER,
-    SERV_ACCESSORY_INFO, CHAR_MANUFACTURER,
-    CHAR_MODEL, CHAR_NAME, CHAR_SERIAL_NUMBER)
+    DEBOUNCE_TIMEOUT, BRIDGE_MODEL, BRIDGE_NAME, BRIDGE_SERIAL_NUMBER,
+    MANUFACTURER, SERV_ACCESSORY_INFO, CHAR_MANUFACTURER,
+    CHAR_MODEL, CHAR_NAME, CHAR_SERIAL_NUMBER, UNKNOWN)
 from .util import (
     show_setup_message, dismiss_setup_message)
 
@@ -85,7 +85,7 @@ def setup_char(char_name, service, value=None, properties=None, callback=None):
 
 
 def set_accessory_info(acc, name, model, manufacturer=MANUFACTURER,
-                       serial_number='0000'):
+                       serial_number=UNKNOWN):
     """Set the default accessory information."""
     service = acc.get_service(SERV_ACCESSORY_INFO)
     service.get_characteristic(CHAR_NAME).set_value(name)
@@ -100,7 +100,8 @@ class HomeAccessory(Accessory):
     def __init__(self, hass, name, entity_id, aid, category):
         """Initialize a Accessory object."""
         super().__init__(name, aid=aid)
-        set_accessory_info(self, name, model=entity_id)
+        domain = entity_id.split(".")[0].replace("_", " ").title()
+        set_accessory_info(self, name, model=domain, serial_number=entity_id)
         self.category = getattr(Category, category, Category.OTHER)
         self.entity_id = entity_id
         self.hass = hass
@@ -137,7 +138,8 @@ class HomeBridge(Bridge):
     def __init__(self, hass, name=BRIDGE_NAME):
         """Initialize a Bridge object."""
         super().__init__(name)
-        set_accessory_info(self, name, model=BRIDGE_MODEL)
+        set_accessory_info(self, name, model=BRIDGE_MODEL,
+                           serial_number=BRIDGE_SERIAL_NUMBER)
         self.hass = hass
 
     def _set_services(self):

--- a/homeassistant/components/homekit/const.py
+++ b/homeassistant/components/homekit/const.py
@@ -18,9 +18,11 @@ DEFAULT_PORT = 51827
 SERVICE_HOMEKIT_START = 'start'
 
 # #### STRING CONSTANTS ####
-BRIDGE_MODEL = 'homekit.bridge'
-BRIDGE_NAME = 'Home Assistant'
-MANUFACTURER = 'HomeAssistant'
+BRIDGE_MODEL = 'Bridge'
+BRIDGE_NAME = 'Home Assistant Bridge'
+BRIDGE_SERIAL_NUMBER = 'homekit.bridge'
+MANUFACTURER = 'Home Assistant'
+UNKNOWN = 'Unknown'
 
 # #### Categories ####
 CATEGORY_ALARM_SYSTEM = 'ALARM_SYSTEM'

--- a/homeassistant/components/homekit/const.py
+++ b/homeassistant/components/homekit/const.py
@@ -22,7 +22,6 @@ BRIDGE_MODEL = 'Bridge'
 BRIDGE_NAME = 'Home Assistant Bridge'
 BRIDGE_SERIAL_NUMBER = 'homekit.bridge'
 MANUFACTURER = 'Home Assistant'
-UNKNOWN = 'Unknown'
 
 # #### Categories ####
 CATEGORY_ALARM_SYSTEM = 'ALARM_SYSTEM'
@@ -76,6 +75,7 @@ CHAR_CURRENT_POSITION = 'CurrentPosition'  # Int | [0, 100]
 CHAR_CURRENT_HUMIDITY = 'CurrentRelativeHumidity'  # percent
 CHAR_CURRENT_SECURITY_STATE = 'SecuritySystemCurrentState'
 CHAR_CURRENT_TEMPERATURE = 'CurrentTemperature'
+CHAR_FIRMWARE_REVISION = 'FirmwareRevision'
 CHAR_HEATING_THRESHOLD_TEMPERATURE = 'HeatingThresholdTemperature'
 CHAR_HUE = 'Hue'  # arcdegress | [0, 360]
 CHAR_LEAK_DETECTED = 'LeakDetected'

--- a/tests/components/homekit/test_accessories.py
+++ b/tests/components/homekit/test_accessories.py
@@ -136,7 +136,7 @@ class TestAccessories(unittest.TestCase):
         hass.states.set('homekit.accessory', 'off')
         hass.block_till_done()
 
-        acc = HomeAccessory('hass', 'test_name', 'test_model', 2, '')
+        acc = HomeAccessory('hass', 'test_name', 'test_model.demo', 2, '')
         self.assertEqual(acc.display_name, 'test_name')
         self.assertEqual(acc.aid, 2)
         self.assertEqual(len(acc.services), 1)

--- a/tests/components/homekit/test_accessories.py
+++ b/tests/components/homekit/test_accessories.py
@@ -10,8 +10,8 @@ from homeassistant.components.homekit.accessories import (
     add_preload_service, set_accessory_info,
     debounce, HomeAccessory, HomeBridge, HomeDriver)
 from homeassistant.components.homekit.const import (
-    BRIDGE_MODEL, BRIDGE_NAME, SERV_ACCESSORY_INFO,
-    CHAR_MANUFACTURER, CHAR_MODEL, CHAR_NAME, CHAR_SERIAL_NUMBER)
+    BRIDGE_MODEL, BRIDGE_NAME, SERV_ACCESSORY_INFO, CHAR_FIRMWARE_REVISION,
+    CHAR_MANUFACTURER, CHAR_MODEL, CHAR_NAME, CHAR_SERIAL_NUMBER, MANUFACTURER)
 from homeassistant.const import ATTR_NOW, EVENT_TIME_CHANGED
 import homeassistant.util.dt as dt_util
 
@@ -92,26 +92,30 @@ class TestAccessories(unittest.TestCase):
         """Test setting the basic accessory information."""
         # Test HomeAccessory
         acc = HomeAccessory('HA', 'Home Accessory', 'homekit.accessory', 2, '')
-        set_accessory_info(acc, 'name', 'model', 'manufacturer', '0000')
+        set_accessory_info(acc, 'name', 'model', '0000', MANUFACTURER, '1.2.3')
 
         serv = acc.get_service(SERV_ACCESSORY_INFO)
         self.assertEqual(serv.get_characteristic(CHAR_NAME).value, 'name')
         self.assertEqual(serv.get_characteristic(CHAR_MODEL).value, 'model')
         self.assertEqual(
-            serv.get_characteristic(CHAR_MANUFACTURER).value, 'manufacturer')
-        self.assertEqual(
             serv.get_characteristic(CHAR_SERIAL_NUMBER).value, '0000')
+        self.assertEqual(
+            serv.get_characteristic(CHAR_MANUFACTURER).value, MANUFACTURER)
+        self.assertEqual(
+            serv.get_characteristic(CHAR_FIRMWARE_REVISION).value, '1.2.3')
 
         # Test HomeBridge
         acc = HomeBridge('hass')
-        set_accessory_info(acc, 'name', 'model', 'manufacturer', '0000')
+        set_accessory_info(acc, 'name', 'model', '0000', MANUFACTURER, '1.2.3')
 
         serv = acc.get_service(SERV_ACCESSORY_INFO)
         self.assertEqual(serv.get_characteristic(CHAR_MODEL).value, 'model')
         self.assertEqual(
-            serv.get_characteristic(CHAR_MANUFACTURER).value, 'manufacturer')
-        self.assertEqual(
             serv.get_characteristic(CHAR_SERIAL_NUMBER).value, '0000')
+        self.assertEqual(
+            serv.get_characteristic(CHAR_MANUFACTURER).value, MANUFACTURER)
+        self.assertEqual(
+            serv.get_characteristic(CHAR_FIRMWARE_REVISION).value, '1.2.3')
 
     def test_home_accessory(self):
         """Test HomeAccessory class."""
@@ -124,7 +128,7 @@ class TestAccessories(unittest.TestCase):
         self.assertEqual(len(acc.services), 1)
         serv = acc.services[0]  # SERV_ACCESSORY_INFO
         self.assertEqual(
-            serv.get_characteristic(CHAR_MODEL).value, 'homekit.accessory')
+            serv.get_characteristic(CHAR_MODEL).value, 'Homekit')
 
         hass.states.set('homekit.accessory', 'on')
         hass.block_till_done()
@@ -138,7 +142,7 @@ class TestAccessories(unittest.TestCase):
         self.assertEqual(len(acc.services), 1)
         serv = acc.services[0]  # SERV_ACCESSORY_INFO
         self.assertEqual(
-            serv.get_characteristic(CHAR_MODEL).value, 'test_model')
+            serv.get_characteristic(CHAR_MODEL).value, 'Test Model')
 
         hass.stop()
 


### PR DESCRIPTION
## Description:
Clean up HomeKit accessory information characteristics. Model is now mapped to `domain` and serial number is mapped to `entity_id`. Also added firmware revision characteristic using current Home Assistant version.

![fullsizeoutput_3dfb](https://user-images.githubusercontent.com/630673/39361015-92f309f8-49ee-11e8-86cb-65c21efe44b9.jpeg)

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
N/A
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54