### PR TITLE
deCONZ allow unloading of config entry

### DIFF
--- a/homeassistant/components/binary_sensor/__init__.py
+++ b/homeassistant/components/binary_sensor/__init__.py
@@ -62,6 +62,11 @@ async def async_setup_entry(hass, entry):
     return await hass.data[DOMAIN].async_setup_entry(entry)
 
 
+async def async_unload_entry(hass, entry):
+    """Unload a config entry."""
+    return await hass.data[DOMAIN].async_unload_entry(entry)
+
+
 # pylint: disable=no-self-use
 class BinarySensorDevice(Entity):
     """Represent a binary sensor."""

--- a/homeassistant/components/deconz/__init__.py
+++ b/homeassistant/components/deconz/__init__.py
@@ -14,7 +14,8 @@ from homeassistant.util.json import load_json
 
 # Loading the config flow file will register the flow
 from .config_flow import configured_hosts
-from .const import CONFIG_FILE, DATA_DECONZ_ID, DOMAIN, _LOGGER
+from .const import (
+    CONFIG_FILE, DATA_DECONZ_EVENT, DATA_DECONZ_ID, DOMAIN, _LOGGER)
 
 REQUIREMENTS = ['pydeconz==36']
 
@@ -79,6 +80,7 @@ async def async_setup_entry(hass, config_entry):
         return False
 
     hass.data[DOMAIN] = deconz
+    hass.data[DATA_DECONZ_EVENT] = []
     hass.data[DATA_DECONZ_ID] = {}
 
     for component in ['binary_sensor', 'light', 'scene', 'sensor']:
@@ -137,6 +139,8 @@ async def async_unload_entry(hass, config_entry):
     hass.services.async_remove(DOMAIN, SERVICE_DECONZ)
     deconz.close()
     for component in ['binary_sensor', 'light', 'scene', 'sensor']:
-        hass.async_add_job(hass.config_entries.async_forward_entry_unload(
-            config_entry, component))
+        await hass.config_entries.async_forward_entry_unload(
+            config_entry, component)
+    for event in hass.data[DATA_DECONZ_EVENT]:
+        del event
     return True

--- a/homeassistant/components/deconz/__init__.py
+++ b/homeassistant/components/deconz/__init__.py
@@ -6,8 +6,9 @@ https://home-assistant.io/components/deconz/
 """
 import voluptuous as vol
 
-from homeassistant.const import (CONF_API_KEY, CONF_EVENT,
-    CONF_HOST, CONF_ID, CONF_PORT, EVENT_HOMEASSISTANT_STOP)
+from homeassistant.const import (
+    CONF_API_KEY, CONF_EVENT, CONF_HOST,
+    CONF_ID, CONF_PORT, EVENT_HOMEASSISTANT_STOP)
 from homeassistant.core import EventOrigin, callback
 from homeassistant.helpers import aiohttp_client, config_validation as cv
 from homeassistant.util import slugify
@@ -88,8 +89,9 @@ async def async_setup_entry(hass, config_entry):
         hass.async_add_job(hass.config_entries.async_forward_entry_setup(
             config_entry, component))
 
-    hass.data[DATA_DECONZ_EVENT] = [DeconzEvent(hass, sensor)
-        for sensor in deconz.sensors.values() if sensor.type in DECONZ_REMOTE]
+    hass.data[DATA_DECONZ_EVENT] = [DeconzEvent(
+        hass, sensor) for sensor in deconz.sensors.values()
+                                    if sensor.type in DECONZ_REMOTE]
 
     deconz.start()
 

--- a/homeassistant/components/deconz/__init__.py
+++ b/homeassistant/components/deconz/__init__.py
@@ -141,6 +141,6 @@ async def async_unload_entry(hass, config_entry):
     for component in ['binary_sensor', 'light', 'scene', 'sensor']:
         await hass.config_entries.async_forward_entry_unload(
             config_entry, component)
-    for event in hass.data[DATA_DECONZ_EVENT]:
-        del event
+    hass.data[DATA_DECONZ_EVENT] = []
+    hass.data[DATA_DECONZ_ID] = []
     return True

--- a/homeassistant/components/deconz/const.py
+++ b/homeassistant/components/deconz/const.py
@@ -5,4 +5,5 @@ _LOGGER = logging.getLogger('homeassistant.components.deconz')
 
 DOMAIN = 'deconz'
 CONFIG_FILE = 'deconz.conf'
+DATA_DECONZ_EVENT = 'deconz_events'
 DATA_DECONZ_ID = 'deconz_entities'

--- a/homeassistant/components/scene/__init__.py
+++ b/homeassistant/components/scene/__init__.py
@@ -95,6 +95,11 @@ async def async_setup_entry(hass, entry):
     return await hass.data[DOMAIN].async_setup_entry(entry)
 
 
+async def async_unload_entry(hass, entry):
+    """Unload a config entry."""
+    return await hass.data[DOMAIN].async_unload_entry(entry)
+
+
 class Scene(Entity):
     """A scene is a group of entities and the states we want them to be."""
 

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -41,3 +41,8 @@ async def async_setup(hass, config):
 async def async_setup_entry(hass, entry):
     """Setup a config entry."""
     return await hass.data[DOMAIN].async_setup_entry(entry)
+
+
+async def async_unload_entry(hass, entry):
+    """Unload a config entry."""
+    return await hass.data[DOMAIN].async_unload_entry(entry)

--- a/homeassistant/components/sensor/deconz.py
+++ b/homeassistant/components/sensor/deconz.py
@@ -5,10 +5,9 @@ For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/sensor.deconz/
 """
 from homeassistant.components.deconz import (
-    DOMAIN as DATA_DECONZ, DATA_DECONZ_EVENT, DATA_DECONZ_ID)
-from homeassistant.const import (
-    ATTR_BATTERY_LEVEL, ATTR_VOLTAGE, CONF_EVENT, CONF_ID)
-from homeassistant.core import EventOrigin, callback
+    DOMAIN as DATA_DECONZ, DATA_DECONZ_ID)
+from homeassistant.const import ATTR_BATTERY_LEVEL, ATTR_VOLTAGE
+from homeassistant.core import callback
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.icon import icon_for_battery_level
 from homeassistant.util import slugify
@@ -35,7 +34,6 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
     for sensor in sensors.values():
         if sensor and sensor.type in DECONZ_SENSOR:
             if sensor.type in DECONZ_REMOTE:
-                hass.data[DATA_DECONZ_EVENT].append(DeconzEvent(hass, sensor))
                 if sensor.battery:
                     entities.append(DeconzBattery(sensor))
             else:
@@ -184,26 +182,3 @@ class DeconzBattery(Entity):
             ATTR_EVENT_ID: slugify(self._device.name),
         }
         return attr
-
-
-class DeconzEvent(object):
-    """When you want signals instead of entities.
-
-    Stateless sensors such as remotes are expected to generate an event
-    instead of a sensor entity in hass.
-    """
-
-    def __init__(self, hass, device):
-        """Register callback that will be used for signals."""
-        self._hass = hass
-        self._device = device
-        self._device.register_async_callback(self.async_update_callback)
-        self._event = 'deconz_{}'.format(CONF_EVENT)
-        self._id = slugify(self._device.name)
-
-    @callback
-    def async_update_callback(self, reason):
-        """Fire the event if reason is that state is updated."""
-        if reason['state']:
-            data = {CONF_ID: self._id, CONF_EVENT: self._device.state}
-            self._hass.bus.async_fire(self._event, data, EventOrigin.remote)

--- a/homeassistant/components/sensor/deconz.py
+++ b/homeassistant/components/sensor/deconz.py
@@ -5,7 +5,7 @@ For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/sensor.deconz/
 """
 from homeassistant.components.deconz import (
-    DOMAIN as DATA_DECONZ, DATA_DECONZ_ID)
+    DOMAIN as DATA_DECONZ, DATA_DECONZ_EVENT, DATA_DECONZ_ID)
 from homeassistant.const import (
     ATTR_BATTERY_LEVEL, ATTR_VOLTAGE, CONF_EVENT, CONF_ID)
 from homeassistant.core import EventOrigin, callback
@@ -35,7 +35,7 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
     for sensor in sensors.values():
         if sensor and sensor.type in DECONZ_SENSOR:
             if sensor.type in DECONZ_REMOTE:
-                DeconzEvent(hass, sensor)
+                hass.data[DATA_DECONZ_EVENT].append(DeconzEvent(hass, sensor))
                 if sensor.battery:
                     entities.append(DeconzBattery(sensor))
             else:

--- a/tests/components/deconz/test_init.py
+++ b/tests/components/deconz/test_init.py
@@ -116,6 +116,10 @@ async def test_unload_entry(hass):
     with patch('pydeconz.DeconzSession.async_load_parameters',
                return_value=mock_coro(True)):
         assert await deconz.async_setup_entry(hass, entry) is True
-
+    assert deconz.DATA_DECONZ_EVENT in hass.data
+    hass.data[deconz.DATA_DECONZ_EVENT].append(Mock())
+    hass.data[deconz.DATA_DECONZ_ID] = {'id': 'deconzid'}
     assert await deconz.async_unload_entry(hass, entry)
     assert deconz.DOMAIN not in hass.data
+    assert len(hass.data[deconz.DATA_DECONZ_EVENT]) == 0
+    assert len(hass.data[deconz.DATA_DECONZ_ID]) == 0

--- a/tests/components/deconz/test_init.py
+++ b/tests/components/deconz/test_init.py
@@ -107,3 +107,15 @@ async def test_setup_entry_successful(hass):
         (entry, 'scene')
     assert mock_config_entries.async_forward_entry_setup.mock_calls[3][1] == \
         (entry, 'sensor')
+
+
+async def test_unload_entry(hass):
+    """Test being able to unload an entry."""
+    entry = Mock()
+    entry.data = {'host': '1.2.3.4', 'port': 80, 'api_key': '1234567890ABCDEF'}
+    with patch('pydeconz.DeconzSession.async_load_parameters',
+               return_value=mock_coro(True)):
+        assert await deconz.async_setup_entry(hass, entry) is True
+
+    assert await deconz.async_unload_entry(hass, entry)
+    assert deconz.DOMAIN not in hass.data

--- a/tests/components/sensor/test_deconz.py
+++ b/tests/components/sensor/test_deconz.py
@@ -51,6 +51,7 @@ async def setup_bridge(hass, data):
                return_value=mock_coro(data)):
         await bridge.async_load_parameters()
     hass.data[deconz.DOMAIN] = bridge
+    hass.data[deconz.DATA_DECONZ_EVENT] = []
     hass.data[deconz.DATA_DECONZ_ID] = {}
     config_entry = config_entries.ConfigEntry(
         1, deconz.DOMAIN, 'Mock Title', {'host': 'mock-host'}, 'test')


### PR DESCRIPTION
## Description:
Allow unloading deCONZ config entries and all its' entities

- [x] Unload works for binary sensor, light, scene and sensor components
- [x] Make removing DeconzEvents possible
- [x] Add new tests

## Checklist:
- [x] The code change is tested and works locally.
- [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
- [x] Tests have been added to verify that the new code works.