### PR TITLE
Update QNAP lib to 0.2.6; handle null temps gracefully

### DIFF
--- a/homeassistant/components/sensor/qnap.py
+++ b/homeassistant/components/sensor/qnap.py
@@ -17,7 +17,7 @@ from homeassistant.const import (
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['qnapstats==0.2.5']
+REQUIREMENTS = ['qnapstats==0.2.6']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -352,7 +352,7 @@ class QNAPDriveSensor(QNAPSensor):
             return data['health']
 
         if self.var_id == 'drive_temp':
-            return int(data['temp_c'])
+            return int(data['temp_c']) if data['temp_c'] is not None else 0
 
     @property
     def name(self):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1099,7 +1099,7 @@ pyxeoma==1.4.0
 pyzabbix==0.7.4
 
 # homeassistant.components.sensor.qnap
-qnapstats==0.2.5
+qnapstats==0.2.6
 
 # homeassistant.components.switch.rachio
 rachiopy==0.1.2


### PR DESCRIPTION
## Description:

There's one particular QNAP model which sometimes return empty/null temperatures for certain disks. This commit ensures that this model can be integrated with HASS without causing KeyErrors or other exceptions - if this edge case is hit, the sensor will simply show `0` instead of erroring.

**Related issue (if applicable):** fixes https://github.com/colinodell/python-qnapstats/issues/16

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [x] ~~New~~ Existing dependencies have been ~~added to~~ updated in the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] ~~New~~ Existing dependencies have been ~~added to~~ manually updated in `requirements_all.txt` ~~by running `script/gen_requirements_all.py`~~.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14