### PR TITLE
Docker - Chrome for Headless Use

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ LABEL maintainer="Paulus Schoutsen <Paulus@PaulusSchoutsen.nl>"
 #ENV INSTALL_FFMPEG no
 #ENV INSTALL_LIBCEC no
 #ENV INSTALL_PHANTOMJS no
+#ENV INSTALL_CHROME no
 #ENV INSTALL_SSOCR no
 
 VOLUME /config

--- a/virtualization/Docker/scripts/chrome
+++ b/virtualization/Docker/scripts/chrome
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Sets up chrome for headless use.
+# https://gist.github.com/ziadoz/3e8ab7e944d02fe872c3454d17af31a5
+
+# Stop on errors
+set -e
+
+echo 'Starting Chrome Install\n'
+
+# Versions
+CHROME_DRIVER_VERSION=`curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE`
+SELENIUM_STANDALONE_VERSION=3.4.0
+SELENIUM_SUBDIR=$(echo "$SELENIUM_STANDALONE_VERSION" | cut -d"." -f-2)
+
+# Install Chrome.
+curl -sS -o - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
+echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list
+apt-get -y update
+apt-get -y install google-chrome-stable --no-install-recommends
+
+google-chrome --version

--- a/virtualization/Docker/scripts/chrome
+++ b/virtualization/Docker/scripts/chrome
@@ -5,12 +5,11 @@
 # Stop on errors
 set -e
 
-echo 'Starting Chrome Install\n'
+cd /usr/src/app/
+mkdir -p build && cd build
 
 # Versions
 CHROME_DRIVER_VERSION=`curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE`
-SELENIUM_STANDALONE_VERSION=3.4.0
-SELENIUM_SUBDIR=$(echo "$SELENIUM_STANDALONE_VERSION" | cut -d"." -f-2)
 
 # Install Chrome.
 curl -sS -o - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
@@ -19,3 +18,10 @@ apt-get -y update
 apt-get -y install google-chrome-stable --no-install-recommends
 
 google-chrome --version
+
+# Install ChromeDriver
+curl -sS http://chromedriver.storage.googleapis.com/$CHROME_DRIVER_VERSION/chromedriver_linux64.zip -o chromedriver_linux64.zip
+unzip chromedriver_linux64.zip -d ./
+rm chromedriver_linux64.zip
+mv -f chromedriver /usr/local/bin/chromedriver
+chmod +x /usr/local/bin/chromedriver

--- a/virtualization/Docker/setup_docker_prereqs
+++ b/virtualization/Docker/setup_docker_prereqs
@@ -33,6 +33,7 @@ PACKAGES_DEV=(
   cmake
   git
   swig
+  unzip
 )
 
 # Install packages

--- a/virtualization/Docker/setup_docker_prereqs
+++ b/virtualization/Docker/setup_docker_prereqs
@@ -9,6 +9,7 @@ INSTALL_OPENALPR="${INSTALL_OPENALPR:-yes}"
 INSTALL_FFMPEG="${INSTALL_FFMPEG:-yes}"
 INSTALL_LIBCEC="${INSTALL_LIBCEC:-yes}"
 INSTALL_PHANTOMJS="${INSTALL_PHANTOMJS:-yes}"
+INSTALL_CHROME="${INSTALL_CHROME:-yes}"
 INSTALL_SSOCR="${INSTALL_SSOCR:-yes}"
 
 # Required debian packages for running hass or components
@@ -56,6 +57,10 @@ fi
 
 if [ "$INSTALL_PHANTOMJS" == "yes" ]; then
   virtualization/Docker/scripts/phantomjs
+fi
+
+if [ "$INSTALL_CHROME" == "yes" ]; then
+  virtualization/Docker/scripts/chrome
 fi
 
 if [ "$INSTALL_SSOCR" == "yes" ]; then


### PR DESCRIPTION
The purpose of this PR is to allow people running docker images of HA to use chrome headless for scraping pages.  An example is the USPS component: https://www.home-assistant.io/components/usps/