### PR TITLE
Add configurable option to choose unique entity ids or not.

### DIFF
--- a/homeassistant/components/binary_sensor/vera.py
+++ b/homeassistant/components/binary_sensor/vera.py
@@ -20,7 +20,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Perform the setup for Vera controller devices."""
     add_devices(
         VeraBinarySensor(device, hass.data[VERA_CONTROLLER],
-            discovery_info['unique_entities'])
+                         discovery_info['unique_entities'])
         for device in hass.data[VERA_DEVICES]['binary_sensor'])
 
 

--- a/homeassistant/components/binary_sensor/vera.py
+++ b/homeassistant/components/binary_sensor/vera.py
@@ -19,17 +19,17 @@ _LOGGER = logging.getLogger(__name__)
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Perform the setup for Vera controller devices."""
     add_devices(
-        VeraBinarySensor(device, hass.data[VERA_CONTROLLER])
+        VeraBinarySensor(device, hass.data[VERA_CONTROLLER], discovery_info['unique_entities'])
         for device in hass.data[VERA_DEVICES]['binary_sensor'])
 
 
 class VeraBinarySensor(VeraDevice, BinarySensorDevice):
     """Representation of a Vera Binary Sensor."""
 
-    def __init__(self, vera_device, controller):
+    def __init__(self, vera_device, controller, unique_entities):
         """Initialize the binary_sensor."""
         self._state = False
-        VeraDevice.__init__(self, vera_device, controller)
+        VeraDevice.__init__(self, vera_device, controller, unique_entities)
         self.entity_id = ENTITY_ID_FORMAT.format(self.vera_id)
 
     @property

--- a/homeassistant/components/binary_sensor/vera.py
+++ b/homeassistant/components/binary_sensor/vera.py
@@ -19,7 +19,8 @@ _LOGGER = logging.getLogger(__name__)
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Perform the setup for Vera controller devices."""
     add_devices(
-        VeraBinarySensor(device, hass.data[VERA_CONTROLLER], discovery_info['unique_entities'])
+        VeraBinarySensor(device, hass.data[VERA_CONTROLLER],
+            discovery_info['unique_entities'])
         for device in hass.data[VERA_DEVICES]['binary_sensor'])
 
 

--- a/homeassistant/components/climate/vera.py
+++ b/homeassistant/components/climate/vera.py
@@ -32,7 +32,8 @@ SUPPORT_FLAGS = (SUPPORT_TARGET_TEMPERATURE | SUPPORT_OPERATION_MODE |
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     """Set up of Vera thermostats."""
     add_devices_callback(
-        VeraThermostat(device, hass.data[VERA_CONTROLLER], discovery_info['unique_entities']) for
+        VeraThermostat(device, hass.data[VERA_CONTROLLER],
+            discovery_info['unique_entities']) for
         device in hass.data[VERA_DEVICES]['climate'])
 
 

--- a/homeassistant/components/climate/vera.py
+++ b/homeassistant/components/climate/vera.py
@@ -33,7 +33,7 @@ def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     """Set up of Vera thermostats."""
     add_devices_callback(
         VeraThermostat(device, hass.data[VERA_CONTROLLER],
-            discovery_info['unique_entities']) for
+                       discovery_info['unique_entities']) for
         device in hass.data[VERA_DEVICES]['climate'])
 
 

--- a/homeassistant/components/climate/vera.py
+++ b/homeassistant/components/climate/vera.py
@@ -32,16 +32,16 @@ SUPPORT_FLAGS = (SUPPORT_TARGET_TEMPERATURE | SUPPORT_OPERATION_MODE |
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     """Set up of Vera thermostats."""
     add_devices_callback(
-        VeraThermostat(device, hass.data[VERA_CONTROLLER]) for
+        VeraThermostat(device, hass.data[VERA_CONTROLLER], discovery_info['unique_entities']) for
         device in hass.data[VERA_DEVICES]['climate'])
 
 
 class VeraThermostat(VeraDevice, ClimateDevice):
     """Representation of a Vera Thermostat."""
 
-    def __init__(self, vera_device, controller):
+    def __init__(self, vera_device, controller, unique_entities):
         """Initialize the Vera device."""
-        VeraDevice.__init__(self, vera_device, controller)
+        VeraDevice.__init__(self, vera_device, controller, unique_entities)
         self.entity_id = ENTITY_ID_FORMAT.format(self.vera_id)
 
     @property

--- a/homeassistant/components/cover/vera.py
+++ b/homeassistant/components/cover/vera.py
@@ -19,7 +19,8 @@ _LOGGER = logging.getLogger(__name__)
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Vera covers."""
     add_devices(
-        VeraCover(device, hass.data[VERA_CONTROLLER], discovery_info['unique_entities']) for
+        VeraCover(device, hass.data[VERA_CONTROLLER],
+            discovery_info['unique_entities']) for
         device in hass.data[VERA_DEVICES]['cover'])
 
 

--- a/homeassistant/components/cover/vera.py
+++ b/homeassistant/components/cover/vera.py
@@ -19,16 +19,16 @@ _LOGGER = logging.getLogger(__name__)
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Vera covers."""
     add_devices(
-        VeraCover(device, hass.data[VERA_CONTROLLER]) for
+        VeraCover(device, hass.data[VERA_CONTROLLER], discovery_info['unique_entities']) for
         device in hass.data[VERA_DEVICES]['cover'])
 
 
 class VeraCover(VeraDevice, CoverDevice):
     """Representation a Vera Cover."""
 
-    def __init__(self, vera_device, controller):
+    def __init__(self, vera_device, controller, unique_entities):
         """Initialize the Vera device."""
-        VeraDevice.__init__(self, vera_device, controller)
+        VeraDevice.__init__(self, vera_device, controller, unique_entities)
         self.entity_id = ENTITY_ID_FORMAT.format(self.vera_id)
 
     @property

--- a/homeassistant/components/cover/vera.py
+++ b/homeassistant/components/cover/vera.py
@@ -20,7 +20,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Vera covers."""
     add_devices(
         VeraCover(device, hass.data[VERA_CONTROLLER],
-            discovery_info['unique_entities']) for
+                  discovery_info['unique_entities']) for
         device in hass.data[VERA_DEVICES]['cover'])
 
 

--- a/homeassistant/components/light/vera.py
+++ b/homeassistant/components/light/vera.py
@@ -22,7 +22,8 @@ DEPENDENCIES = ['vera']
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Vera lights."""
     add_devices(
-        VeraLight(device, hass.data[VERA_CONTROLLER], discovery_info['unique_entities']) for
+        VeraLight(device, hass.data[VERA_CONTROLLER],
+            discovery_info['unique_entities']) for
         device in hass.data[VERA_DEVICES]['light'])
 
 

--- a/homeassistant/components/light/vera.py
+++ b/homeassistant/components/light/vera.py
@@ -23,7 +23,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Vera lights."""
     add_devices(
         VeraLight(device, hass.data[VERA_CONTROLLER],
-            discovery_info['unique_entities']) for
+                  discovery_info['unique_entities']) for
         device in hass.data[VERA_DEVICES]['light'])
 
 

--- a/homeassistant/components/light/vera.py
+++ b/homeassistant/components/light/vera.py
@@ -22,19 +22,19 @@ DEPENDENCIES = ['vera']
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Vera lights."""
     add_devices(
-        VeraLight(device, hass.data[VERA_CONTROLLER]) for
+        VeraLight(device, hass.data[VERA_CONTROLLER], discovery_info['unique_entities']) for
         device in hass.data[VERA_DEVICES]['light'])
 
 
 class VeraLight(VeraDevice, Light):
     """Representation of a Vera Light, including dimmable."""
 
-    def __init__(self, vera_device, controller):
+    def __init__(self, vera_device, controller, unique_entities):
         """Initialize the light."""
         self._state = False
         self._color = None
         self._brightness = None
-        VeraDevice.__init__(self, vera_device, controller)
+        VeraDevice.__init__(self, vera_device, controller, unique_entities)
         self.entity_id = ENTITY_ID_FORMAT.format(self.vera_id)
 
     @property

--- a/homeassistant/components/lock/vera.py
+++ b/homeassistant/components/lock/vera.py
@@ -20,7 +20,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Find and return Vera locks."""
     add_devices(
         VeraLock(device, hass.data[VERA_CONTROLLER],
-            discovery_info['unique_entities']) for
+                 discovery_info['unique_entities']) for
         device in hass.data[VERA_DEVICES]['lock'])
 
 

--- a/homeassistant/components/lock/vera.py
+++ b/homeassistant/components/lock/vera.py
@@ -19,7 +19,8 @@ DEPENDENCIES = ['vera']
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Find and return Vera locks."""
     add_devices(
-        VeraLock(device, hass.data[VERA_CONTROLLER], discovery_info['unique_entities']) for
+        VeraLock(device, hass.data[VERA_CONTROLLER],
+            discovery_info['unique_entities']) for
         device in hass.data[VERA_DEVICES]['lock'])
 
 

--- a/homeassistant/components/lock/vera.py
+++ b/homeassistant/components/lock/vera.py
@@ -19,17 +19,17 @@ DEPENDENCIES = ['vera']
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Find and return Vera locks."""
     add_devices(
-        VeraLock(device, hass.data[VERA_CONTROLLER]) for
+        VeraLock(device, hass.data[VERA_CONTROLLER], discovery_info['unique_entities']) for
         device in hass.data[VERA_DEVICES]['lock'])
 
 
 class VeraLock(VeraDevice, LockDevice):
     """Representation of a Vera lock."""
 
-    def __init__(self, vera_device, controller):
+    def __init__(self, vera_device, controller, unique_entities):
         """Initialize the Vera device."""
         self._state = None
-        VeraDevice.__init__(self, vera_device, controller)
+        VeraDevice.__init__(self, vera_device, controller, unique_entities)
         self.entity_id = ENTITY_ID_FORMAT.format(self.vera_id)
 
     def lock(self, **kwargs):

--- a/homeassistant/components/scene/vera.py
+++ b/homeassistant/components/scene/vera.py
@@ -19,22 +19,25 @@ _LOGGER = logging.getLogger(__name__)
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Vera scenes."""
     add_devices(
-        [VeraScene(scene, hass.data[VERA_CONTROLLER])
+        [VeraScene(scene, hass.data[VERA_CONTROLLER], discovery_info['unique_entities'])
          for scene in hass.data[VERA_SCENES]], True)
 
 
 class VeraScene(Scene):
     """Representation of a Vera scene entity."""
 
-    def __init__(self, vera_scene, controller):
+    def __init__(self, vera_scene, controller, unique_entities):
         """Initialize the scene."""
         self.vera_scene = vera_scene
         self.controller = controller
 
         self._name = self.vera_scene.name
         # Append device id to prevent name clashes in HA.
-        self.vera_id = VERA_ID_FORMAT.format(
-            slugify(vera_scene.name), vera_scene.scene_id)
+        if unique_entities:
+            self.vera_id = VERA_ID_FORMAT.format(
+                slugify(vera_scene.name), vera_scene.scene_id)
+        else:
+            self.vera_id = slugify(vera_scene.name)
 
     def update(self):
         """Update the scene status."""

--- a/homeassistant/components/scene/vera.py
+++ b/homeassistant/components/scene/vera.py
@@ -19,7 +19,8 @@ _LOGGER = logging.getLogger(__name__)
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Vera scenes."""
     add_devices(
-        [VeraScene(scene, hass.data[VERA_CONTROLLER], discovery_info['unique_entities'])
+        [VeraScene(scene, hass.data[VERA_CONTROLLER],
+            discovery_info['unique_entities'])
          for scene in hass.data[VERA_SCENES]], True)
 
 

--- a/homeassistant/components/scene/vera.py
+++ b/homeassistant/components/scene/vera.py
@@ -20,7 +20,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Vera scenes."""
     add_devices(
         [VeraScene(scene, hass.data[VERA_CONTROLLER],
-            discovery_info['unique_entities'])
+                   discovery_info['unique_entities'])
          for scene in hass.data[VERA_SCENES]], True)
 
 

--- a/homeassistant/components/sensor/vera.py
+++ b/homeassistant/components/sensor/vera.py
@@ -25,7 +25,8 @@ SCAN_INTERVAL = timedelta(seconds=5)
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Vera controller devices."""
     add_devices(
-        VeraSensor(device, hass.data[VERA_CONTROLLER], discovery_info['unique_entities'])
+        VeraSensor(device, hass.data[VERA_CONTROLLER],
+            discovery_info['unique_entities'])
         for device in hass.data[VERA_DEVICES]['sensor'])
 
 

--- a/homeassistant/components/sensor/vera.py
+++ b/homeassistant/components/sensor/vera.py
@@ -25,19 +25,19 @@ SCAN_INTERVAL = timedelta(seconds=5)
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Vera controller devices."""
     add_devices(
-        VeraSensor(device, hass.data[VERA_CONTROLLER])
+        VeraSensor(device, hass.data[VERA_CONTROLLER], discovery_info['unique_entities'])
         for device in hass.data[VERA_DEVICES]['sensor'])
 
 
 class VeraSensor(VeraDevice, Entity):
     """Representation of a Vera Sensor."""
 
-    def __init__(self, vera_device, controller):
+    def __init__(self, vera_device, controller, unique_entities):
         """Initialize the sensor."""
         self.current_value = None
         self._temperature_units = None
         self.last_changed_time = None
-        VeraDevice.__init__(self, vera_device, controller)
+        VeraDevice.__init__(self, vera_device, controller, unique_entities)
         self.entity_id = ENTITY_ID_FORMAT.format(self.vera_id)
 
     @property

--- a/homeassistant/components/sensor/vera.py
+++ b/homeassistant/components/sensor/vera.py
@@ -26,7 +26,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Vera controller devices."""
     add_devices(
         VeraSensor(device, hass.data[VERA_CONTROLLER],
-            discovery_info['unique_entities'])
+                   discovery_info['unique_entities'])
         for device in hass.data[VERA_DEVICES]['sensor'])
 
 

--- a/homeassistant/components/switch/vera.py
+++ b/homeassistant/components/switch/vera.py
@@ -19,7 +19,8 @@ _LOGGER = logging.getLogger(__name__)
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Vera switches."""
     add_devices(
-        VeraSwitch(device, hass.data[VERA_CONTROLLER], discovery_info['unique_entities']) for
+        VeraSwitch(device, hass.data[VERA_CONTROLLER],
+            discovery_info['unique_entities']) for
         device in hass.data[VERA_DEVICES]['switch'])
 
 

--- a/homeassistant/components/switch/vera.py
+++ b/homeassistant/components/switch/vera.py
@@ -19,17 +19,17 @@ _LOGGER = logging.getLogger(__name__)
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Vera switches."""
     add_devices(
-        VeraSwitch(device, hass.data[VERA_CONTROLLER]) for
+        VeraSwitch(device, hass.data[VERA_CONTROLLER], discovery_info['unique_entities']) for
         device in hass.data[VERA_DEVICES]['switch'])
 
 
 class VeraSwitch(VeraDevice, SwitchDevice):
     """Representation of a Vera Switch."""
 
-    def __init__(self, vera_device, controller):
+    def __init__(self, vera_device, controller, unique_entities):
         """Initialize the Vera device."""
         self._state = False
-        VeraDevice.__init__(self, vera_device, controller)
+        VeraDevice.__init__(self, vera_device, controller, unique_entities)
         self.entity_id = ENTITY_ID_FORMAT.format(self.vera_id)
 
     def turn_on(self, **kwargs):

--- a/homeassistant/components/switch/vera.py
+++ b/homeassistant/components/switch/vera.py
@@ -20,7 +20,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Vera switches."""
     add_devices(
         VeraSwitch(device, hass.data[VERA_CONTROLLER],
-            discovery_info['unique_entities']) for
+                   discovery_info['unique_entities']) for
         device in hass.data[VERA_DEVICES]['switch'])
 
 

--- a/homeassistant/components/vera.py
+++ b/homeassistant/components/vera.py
@@ -71,7 +71,6 @@ def setup(hass, base_config):
     base_url = config.get(CONF_CONTROLLER)
     light_ids = config.get(CONF_LIGHTS)
     exclude_ids = config.get(CONF_EXCLUDE)
-    global unique_entities
     unique_entities = config.get(CONF_UNIQUE_ENTITIES)
 
     # Initialize the Vera controller.
@@ -107,7 +106,7 @@ def setup(hass, base_config):
     hass.data[VERA_SCENES] = vera_scenes
 
     for component in VERA_COMPONENTS:
-        discovery.load_platform(hass, component, DOMAIN, {}, base_config)
+        discovery.load_platform(hass, component, DOMAIN, {'unique_entities': unique_entities}, base_config)
 
     return True
 
@@ -141,7 +140,7 @@ def map_vera_device(vera_device, remap):
 class VeraDevice(Entity):
     """Representation of a Vera device entity."""
 
-    def __init__(self, vera_device, controller):
+    def __init__(self, vera_device, controller, unique_entities):
         """Initialize the device."""
         self.vera_device = vera_device
         self.controller = controller

--- a/homeassistant/components/vera.py
+++ b/homeassistant/components/vera.py
@@ -71,6 +71,7 @@ def setup(hass, base_config):
     base_url = config.get(CONF_CONTROLLER)
     light_ids = config.get(CONF_LIGHTS)
     exclude_ids = config.get(CONF_EXCLUDE)
+#    global unique_entities
     unique_entities = config.get(CONF_UNIQUE_ENTITIES)
 
     # Initialize the Vera controller.
@@ -106,7 +107,8 @@ def setup(hass, base_config):
     hass.data[VERA_SCENES] = vera_scenes
 
     for component in VERA_COMPONENTS:
-        discovery.load_platform(hass, component, DOMAIN, {'unique_entities': unique_entities}, base_config)
+        discovery.load_platform(hass, component, DOMAIN,
+                {'unique_entities': unique_entities}, base_config)
 
     return True
 

--- a/homeassistant/components/vera.py
+++ b/homeassistant/components/vera.py
@@ -108,7 +108,8 @@ def setup(hass, base_config):
 
     for component in VERA_COMPONENTS:
         discovery.load_platform(hass, component, DOMAIN,
-                                {'unique_entities': unique_entities}, base_config)
+                                {'unique_entities': unique_entities},
+                                base_config)
 
     return True
 

--- a/homeassistant/components/vera.py
+++ b/homeassistant/components/vera.py
@@ -108,7 +108,7 @@ def setup(hass, base_config):
 
     for component in VERA_COMPONENTS:
         discovery.load_platform(hass, component, DOMAIN,
-                {'unique_entities': unique_entities}, base_config)
+                                {'unique_entities': unique_entities}, base_config)
 
     return True
 


### PR DESCRIPTION
## Description:

Since unique entity ids in Vera are enforced by appending the Vera device ID, it is impossible to freely define the entity_ids. While I understand the reasoning, and that many people would prefer having their entity_ids automatically unique, I would much prefer to be able to define my entity_ids on my own, by making sure the names in Vera are unique. Vera is currently the only component I use where I can't define my entity_ids, and I repeatedly have to look up the vera id when creating automations - which is tedious.

This PR adds a boolean variable, unique_entities, to the config, with the default set to True, optionally letting people, like myself, have full control of the entity_ids.

**Related Pull Request:** https://github.com/home-assistant/home-assistant/pull/6523/

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5257

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io/pull/5257)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.



[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
