### PR TITLE
Add support for light sensors with 'lx' unit to HomeKit

### DIFF
--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -126,7 +126,7 @@ def get_accessory(hass, state, aid, config):
                 or DEVICE_CLASS_CO2 in state.entity_id:
             a_type = 'CarbonDioxideSensor'
         elif device_class == DEVICE_CLASS_LIGHT or unit == 'lm' or \
-                unit == 'lux':
+                unit == 'lux' or unit == 'lx':
             a_type = 'LightSensor'
 
     elif state.domain == 'switch' or state.domain == 'remote' \

--- a/tests/components/homekit/test_get_accessories.py
+++ b/tests/components/homekit/test_get_accessories.py
@@ -125,6 +125,13 @@ class TestGetAccessories(unittest.TestCase):
                           {ATTR_UNIT_OF_MEASUREMENT: 'lux'})
             get_accessory(None, state, 2, {})
 
+    def test_light_sensor_unit_lx(self):
+        """Test light sensor with lx as unit."""
+        with patch.dict(TYPES, {'LightSensor': self.mock_type}):
+            state = State('sensor.light', '900',
+                          {ATTR_UNIT_OF_MEASUREMENT: 'lx'})
+            get_accessory(None, state, 2, {})
+
     def test_binary_sensor(self):
         """Test binary sensor with opening class."""
         with patch.dict(TYPES, {'BinarySensor': self.mock_type}):


### PR DESCRIPTION
## Description:
Adds the 'lx' unit for the light sensor (e.g Xiaomi Aquara illumination sensors).

**Related issue (if applicable):** fixes #14129

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
