### PR TITLE
Upgrade colorlog to 3.1.4

### DIFF
--- a/homeassistant/scripts/check_config.py
+++ b/homeassistant/scripts/check_config.py
@@ -21,7 +21,7 @@ from homeassistant.config import (
 import homeassistant.util.yaml as yaml
 from homeassistant.exceptions import HomeAssistantError
 
-REQUIREMENTS = ('colorlog==3.1.2',)
+REQUIREMENTS = ('colorlog==3.1.4',)
 if system() == 'Windows':  # Ensure colorama installed for colorlog on Windows
     REQUIREMENTS += ('colorama<=1',)
 
@@ -58,7 +58,7 @@ def color(the_color, *args, reset=None):
 def run(script_args: List) -> int:
     """Handle ensure config commandline script."""
     parser = argparse.ArgumentParser(
-        description=("Check Home Assistant configuration."))
+        description="Check Home Assistant configuration.")
     parser.add_argument(
         '--script', choices=['check_config'])
     parser.add_argument(

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -202,7 +202,7 @@ coinbase==2.1.0
 coinmarketcap==4.2.1
 
 # homeassistant.scripts.check_config
-colorlog==3.1.2
+colorlog==3.1.4
 
 # homeassistant.components.alarm_control_panel.concord232
 # homeassistant.components.binary_sensor.concord232


### PR DESCRIPTION
## Description:
Changelog: https://github.com/borntyping/python-colorlog/commits/master

## Example entry for `configuration.yaml` (if applicable):
```bash
$ hass --script check_config
INFO:homeassistant.util.package:Attempting install of colorlog==3.1.4
Testing configuration at /home/fab/.homeassistant
Failed config
  General Errors: 
    - Component not found: not_a_component

Successful config (partial)
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
 

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
