### PR TITLE
Add timed_state_infer binary sensor

### DIFF
--- a/homeassistant/components/binary_sensor/timed_state_infer.py
+++ b/homeassistant/components/binary_sensor/timed_state_infer.py
@@ -121,11 +121,11 @@ class TimedStateInferBinarySensor(BinarySensorDevice):
         if self._pending:
             time_pending = dt_util.utcnow() - self._pending_since
             if self._is_on:
-                time_remaining = time_pending - self._time_off
+                time_remaining = self._time_off - time_pending
             else:
-                time_remaining = time_pending - self._time_on
+                time_remaining = self._time_on - time_pending
 
-            if time_remaining.seconds <= 0:
+            if time_remaining.total_seconds() <= 0:
                 self._is_on = not self._is_on
                 self._pending = False
                 self.schedule_update_ha_state()

--- a/homeassistant/components/binary_sensor/timed_state_infer.py
+++ b/homeassistant/components/binary_sensor/timed_state_infer.py
@@ -11,8 +11,8 @@ from homeassistant.const import CONF_ENTITY_ID, STATE_UNKNOWN, CONF_NAME
 import homeassistant.helpers.config_validation as cv
 from homeassistant.core import callback
 from homeassistant.helpers.config_validation import PLATFORM_SCHEMA
-from homeassistant.helpers.event import track_point_in_time, track_state_change, \
-    async_track_state_change, async_track_point_in_time
+from homeassistant.helpers.event import async_track_state_change,\
+    async_track_point_in_time
 from homeassistant.util import dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
@@ -31,6 +31,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_VALUE_ON): vol.Coerce(float),
     vol.Required(CONF_VALUE_OFF): vol.Coerce(float)
 })
+
 
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):

--- a/homeassistant/components/binary_sensor/timed_state_infer.py
+++ b/homeassistant/components/binary_sensor/timed_state_infer.py
@@ -86,6 +86,9 @@ class TimedStateInferBinarySensor(BinarySensorDevice):
         async_track_state_change(self._hass, self._observed_entity_id,
                                  async_sensor_state_listener)
 
+        # update the sensor when added to hass
+        yield from self.async_pending_expired(dt_util.utcnow())
+
     @asyncio.coroutine
     def async_pending_expired(self, time):
         device_state = self.hass.states.get(self._observed_entity_id)
@@ -107,11 +110,11 @@ class TimedStateInferBinarySensor(BinarySensorDevice):
 
         """If we are already in the correct state, no need to do anything"""
         if self._is_on:
-            if obs_value >= self._value_on:
+            if obs_value > self._value_off:
                 self._pending = False
                 return
         else:
-            if obs_value <= self._value_off:
+            if obs_value < self._value_on:
                 self._pending = False
                 return
 

--- a/homeassistant/components/binary_sensor/timed_state_infer.py
+++ b/homeassistant/components/binary_sensor/timed_state_infer.py
@@ -1,6 +1,4 @@
-# """
-# Infers its state from the current state and duration of other sensors.
-# """
+"""Infers its state from the current state and duration of other sensors."""
 import asyncio
 import logging
 from datetime import timedelta
@@ -35,6 +33,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+    """Set up the Timed State Infer Binary sensor."""
     async_add_devices([TimedStateInferBinarySensor(hass, config[CONF_NAME],
                                                    config[CONF_ENTITY_ID],
                                                    config[CONF_TIME_ON],
@@ -48,6 +47,7 @@ class TimedStateInferBinarySensor(BinarySensorDevice):
 
     def __init__(self, hass, name, observed_entity_id, time_on, time_off,
                  value_on, value_off):
+        """Initialization of the Binary Sensor."""
         self._hass = hass
         self._name = name
         self._observed_entity_id = observed_entity_id
@@ -77,7 +77,6 @@ class TimedStateInferBinarySensor(BinarySensorDevice):
     @asyncio.coroutine
     def async_added_to_hass(self):
         """Call when entity about to be added."""
-
         @callback
         def async_sensor_state_listener(entity, old_state, new_state):
             """Handle sensor state changes."""
@@ -91,6 +90,7 @@ class TimedStateInferBinarySensor(BinarySensorDevice):
 
     @asyncio.coroutine
     def async_pending_expired(self, time):
+        """Called after the pending time has elapsed."""
         device_state = self.hass.states.get(self._observed_entity_id)
         if device_state is None:
             return
@@ -98,6 +98,7 @@ class TimedStateInferBinarySensor(BinarySensorDevice):
         self.update_state(device_state.state)
 
     def update_state(self, observed_entity_state):
+        """Update the sensor state based on the observed entity state."""
         if observed_entity_state == STATE_UNKNOWN:
             return
 
@@ -108,7 +109,7 @@ class TimedStateInferBinarySensor(BinarySensorDevice):
                             observed_entity_state)
             return
 
-        """If we are already in the correct state, no need to do anything"""
+        # if we are already in the correct state, no need to do anything
         if self._is_on:
             if obs_value > self._value_off:
                 self._pending = False

--- a/homeassistant/components/binary_sensor/timed_state_infer.py
+++ b/homeassistant/components/binary_sensor/timed_state_infer.py
@@ -1,0 +1,137 @@
+# """
+# Infers its state from the current state and duration of other sensors.
+# """
+import asyncio
+import logging
+from datetime import timedelta
+import voluptuous as vol
+
+from homeassistant.components.binary_sensor import BinarySensorDevice
+from homeassistant.const import CONF_ENTITY_ID, STATE_UNKNOWN, CONF_NAME
+import homeassistant.helpers.config_validation as cv
+from homeassistant.core import callback
+from homeassistant.helpers.config_validation import PLATFORM_SCHEMA
+from homeassistant.helpers.event import track_point_in_time, track_state_change, \
+    async_track_state_change, async_track_point_in_time
+from homeassistant.util import dt as dt_util
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_TIME_ON = 'seconds_on'
+CONF_TIME_OFF = 'seconds_off'
+CONF_VALUE_ON = 'value_on'
+CONF_VALUE_OFF = 'value_off'
+DEFAULT_NAME = "Timed State Infer Binary Sensor"
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Required(CONF_ENTITY_ID): cv.entity_id,
+    vol.Required(CONF_TIME_ON): cv.positive_int,
+    vol.Required(CONF_TIME_OFF): cv.positive_int,
+    vol.Required(CONF_VALUE_ON): vol.Coerce(float),
+    vol.Required(CONF_VALUE_OFF): vol.Coerce(float)
+})
+
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+    async_add_devices([TimedStateInferBinarySensor(hass, config[CONF_NAME],
+                                                   config[CONF_ENTITY_ID],
+                                                   config[CONF_TIME_ON],
+                                                   config[CONF_TIME_OFF],
+                                                   config[CONF_VALUE_ON],
+                                                   config[CONF_VALUE_OFF])])
+
+
+class TimedStateInferBinarySensor(BinarySensorDevice):
+    """Representation of a sensor."""
+
+    def __init__(self, hass, name, observed_entity_id, time_on, time_off,
+                 value_on, value_off):
+        self._hass = hass
+        self._name = name
+        self._observed_entity_id = observed_entity_id
+        self._time_on = timedelta(seconds=time_on)
+        self._time_off = timedelta(seconds=time_off)
+        self._value_on = value_on
+        self._value_off = value_off
+        self._is_on = False
+        self._pending = False
+        self._pending_since = None
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def should_poll(self):
+        """No polling needed."""
+        return False
+
+    @property
+    def is_on(self):
+        """Return true if sensor is on."""
+        return self._is_on
+
+    @asyncio.coroutine
+    def async_added_to_hass(self):
+        """Call when entity about to be added."""
+
+        @callback
+        def async_sensor_state_listener(entity, old_state, new_state):
+            """Handle sensor state changes."""
+            self.update_state(new_state.state)
+
+        async_track_state_change(self._hass, self._observed_entity_id,
+                                 async_sensor_state_listener)
+
+    @asyncio.coroutine
+    def async_pending_expired(self, time):
+        device_state = self.hass.states.get(self._observed_entity_id)
+        if device_state is None:
+            return
+
+        self.update_state(device_state.state)
+
+    def update_state(self, observed_entity_state):
+        if observed_entity_state == STATE_UNKNOWN:
+            return
+
+        try:
+            obs_value = float(observed_entity_state)
+        except ValueError:
+            _LOGGER.warning("Value cannot be processed as a number: %s",
+                            observed_entity_state)
+            return
+
+        """If we are already in the correct state, no need to do anything"""
+        if self._is_on:
+            if obs_value >= self._value_on:
+                self._pending = False
+                return
+        else:
+            if obs_value <= self._value_off:
+                self._pending = False
+                return
+
+        if self._pending:
+            time_pending = dt_util.utcnow() - self._pending_since
+            if self._is_on:
+                time_remaining = time_pending - self._time_off
+            else:
+                time_remaining = time_pending - self._time_on
+
+            if time_remaining.seconds <= 0:
+                self._is_on = not self._is_on
+                self._pending = False
+                self.schedule_update_ha_state()
+        else:
+            # enter pending mode (start counting time to change state)
+            self._pending_since = dt_util.utcnow()
+            self._pending = True
+
+            time_to_expire = dt_util.utcnow() + (
+                self._time_off if self._is_on else self._time_on)
+
+            async_track_point_in_time(self._hass, self.async_pending_expired,
+                                      time_to_expire)

--- a/tests/components/binary_sensor/test_timed_state_infer.py
+++ b/tests/components/binary_sensor/test_timed_state_infer.py
@@ -1,0 +1,70 @@
+"""The test for the timed state infer binary sensor platform."""
+import unittest
+from unittest.mock import patch
+from datetime import timedelta
+
+from homeassistant.setup import setup_component
+import homeassistant.util.dt as dt_util
+
+from tests.common import get_test_home_assistant, fire_time_changed
+
+
+class TestTimedStateInferBinarySensor(unittest.TestCase):
+    """Test the timed state infer binary sensor."""
+
+    def setup_method(self, method):
+        """Set up things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+
+    def teardown_method(self, method):
+        """Stop everything that was started."""
+        self.hass.stop()
+
+    def test_sensor_state(self):
+        """Test sensor on observed sensor state changes."""
+        config = {
+            'binary_sensor': {
+                'name': 'Test_Sensor',
+                'platform': 'timed_state_infer',
+                'entity_id': 'input_number.test_monitored',
+                'seconds_on': 5,
+                'seconds_off': 10,
+                'value_on': 5,
+                'value_off': 1,
+            }
+        }
+
+        assert setup_component(self.hass, 'binary_sensor', config)
+
+        self.hass.states.set('input_number.test_monitored', 5)
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('binary_sensor.test_sensor')
+        assert state.state == 'off'
+
+        # advance the required time for the state to change
+        utc_now = dt_util.utcnow() + timedelta(seconds=5)
+        with patch('homeassistant.helpers.condition.dt_util.utcnow',
+                   return_value=utc_now):
+            fire_time_changed(self.hass, dt_util.utcnow())
+            self.hass.block_till_done()
+            state = self.hass.states.get('binary_sensor.test_sensor')
+            assert state.state == 'on'
+
+            self.hass.states.set('input_number.test_monitored', 0)
+            self.hass.block_till_done()
+            assert state.state == 'on'
+
+        utc_now = utc_now + timedelta(seconds=10)
+        with patch('homeassistant.helpers.condition.dt_util.utcnow',
+                   return_value=utc_now):
+            fire_time_changed(self.hass, dt_util.utcnow())
+            self.hass.block_till_done()
+            state = self.hass.states.get('binary_sensor.test_sensor')
+            assert state.state == 'off'
+
+        utc_now = utc_now + timedelta(seconds=10)
+        with patch('homeassistant.helpers.condition.dt_util.utcnow',
+                   return_value=utc_now):
+            fire_time_changed(self.hass, dt_util.utcnow())
+            assert state.state == 'off'


### PR DESCRIPTION
## Description:
This binary sensor can be used to infer the state of a device based on its state over a time period. This is useful for determining if a machine (like a Dishwasher) is doing a cycle, based on its power usage, for example.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
binary_sensor:
  - platform: timed_state_infer
    name: 'Washing Machine'
    entity_id: sensor.power_washing_machine
    seconds_on: 60
    seconds_off: 300
    value_on: 10
    value_off: 0
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.