### PR TITLE
Bump pyvizio to 0.0.3

### DIFF
--- a/homeassistant/components/media_player/vizio.py
+++ b/homeassistant/components/media_player/vizio.py
@@ -19,7 +19,7 @@ from homeassistant.const import (
 from homeassistant.helpers import config_validation as cv
 import homeassistant.util as util
 
-REQUIREMENTS = ['pyvizio==0.0.2']
+REQUIREMENTS = ['pyvizio==0.0.3']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1084,7 +1084,7 @@ pyvera==0.2.42
 pyvesync==0.1.1
 
 # homeassistant.components.media_player.vizio
-pyvizio==0.0.2
+pyvizio==0.0.3
 
 # homeassistant.components.velux
 pyvlx==0.1.3


### PR DESCRIPTION
## Description:
Bumps pyvizio to 0.0.3 to fix connection failures after a Vizio firmware update.

**Related issue (if applicable):** fixes #13669 

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  - platform: vizio
    host: 192.168.1.123
    access_token: !secret vizio_access_token
    name: Living Room TV
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
