### PR TITLE
[WIP] Config Validation Time with Units

### DIFF
--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -13,7 +13,7 @@ from homeassistant.components.google import (
     CONF_OFFSET, CONF_DEVICE_ID, CONF_NAME)
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.helpers.config_validation import PLATFORM_SCHEMA  # noqa
-from homeassistant.helpers.config_validation import time_period_str
+from homeassistant.helpers.config_validation import time_period_str_colon
 from homeassistant.helpers.entity import Entity, generate_entity_id
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.template import DATE_STR_FORMAT
@@ -168,7 +168,7 @@ class CalendarEventDevice(Entity):
                 else:
                     time = '0:{}'.format(time)
 
-            offset_time = time_period_str(time)
+            offset_time = time_period_str_colon(time)
             summary = (summary[:search.start()] + summary[search.end():]) \
                 .strip()
         else:

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -275,7 +275,9 @@ def time_period_str_unit(value: Any) -> timedelta:
 
     unit_to_kwarg = {
         'ms': 'milliseconds',
-        's': 'seconds', 'sec': 'seconds', '': 'seconds',
+        's': 'seconds',
+        'sec': 'seconds',
+        '': 'seconds',
         'min': 'minutes',
         'h': 'hours',
         'd': 'days',

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -231,7 +231,7 @@ def date(value) -> date_sys:
     return date_val
 
 
-def time_period_str(value: str) -> timedelta:
+def time_period_str_colon(value: str) -> timedelta:
     """Validate and transform time offset."""
     if isinstance(value, int):
         raise vol.Invalid('Make sure you wrap time values in quotes')
@@ -266,15 +266,36 @@ def time_period_str(value: str) -> timedelta:
     return offset
 
 
-def time_period_seconds(value: Union[int, str]) -> timedelta:
-    """Validate and transform seconds to a time offset."""
-    try:
-        return timedelta(seconds=int(value))
-    except (ValueError, TypeError):
-        raise vol.Invalid('Expected seconds, got {}'.format(value))
+def time_period_str_unit(value: str) -> timedelta:
+    value = string(value)
+
+    if value.endswith('ms'):
+        try:
+            return timedelta(milliseconds=float(value[:-2].rstrip()))
+        except ValueError:
+            raise vol.Invalid("Expected milliseconds, got {}".format(value))
+    elif value.endswith('min'):
+        try:
+            return timedelta(minutes=float(value[:-3].rstrip()))
+        except ValueError:
+            raise vol.Invalid("Expected minutes, got {}".format(value))
+    elif value.endswith('h'):
+        try:
+            return timedelta(hours=float(value[:-1].rstrip()))
+        except ValueError:
+            raise vol.Invalid("Expected hours, got {}".format(value))
+    else:
+        # Default to seconds
+        if value.endswith('s'):
+            value = value[-1].rstrip()
+
+        try:
+            return timedelta(seconds=float(value))
+        except ValueError:
+            raise vol.Invalid("Expected seconds, got {}".format(value))
 
 
-time_period = vol.Any(time_period_str, time_period_seconds, timedelta,
+time_period = vol.Any(time_period_str_colon, time_period_str_unit, timedelta,
                       time_period_dict)
 
 

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -309,6 +309,36 @@ def test_time_period():
     assert -1 * timedelta(hours=1, minutes=15) == schema('-1:15')
 
 
+def test_time_period_with_unit():
+    """Test time_period_str_unit validation."""
+    # Test with time_period to see if it plays nicely with other formats
+    schema = vol.Schema(cv.time_period)
+
+    assert timedelta(seconds=70) == schema('70')
+    assert timedelta(seconds=0) == schema('0')
+    assert timedelta(seconds=70) == schema(70)
+    assert timedelta(seconds=0) == schema(0)
+    assert timedelta(seconds=70) == schema('70s')
+    assert timedelta(seconds=70) == schema('70 s')
+    assert timedelta(seconds=70) == schema('70\ts')
+    assert timedelta(seconds=70) == schema('70  s')
+    assert timedelta(seconds=10) == schema('10 sec')
+    assert timedelta(minutes=50) == schema('50 min')
+    assert timedelta(milliseconds=15) == schema('15ms')
+    assert timedelta(seconds=-15) == schema('-15')
+    assert timedelta(hours=-3) == schema('-3h')
+    assert timedelta(hours=3) == schema('+3h')
+    assert timedelta(days=14) == schema('14d')
+
+    for value in ['3.5', '-4.5h', '3m', '70u', '4,6h', '']:
+        with pytest.raises(vol.Invalid):
+            schema(value)
+
+    # Check time_period_str_unit doesn't match time_period_dict
+    with pytest.raises(vol.Invalid):
+        cv.time_period_str_unit({'minutes': 30})
+
+
 def test_service():
     """Test service validation."""
     schema = vol.Schema(cv.service)

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -314,23 +314,23 @@ def test_time_period_with_unit():
     # Test with time_period to see if it plays nicely with other formats
     schema = vol.Schema(cv.time_period)
 
-    assert timedelta(seconds=70) == schema('70')
-    assert timedelta(seconds=0) == schema('0')
-    assert timedelta(seconds=70) == schema(70)
-    assert timedelta(seconds=0) == schema(0)
-    assert timedelta(seconds=70) == schema('70s')
-    assert timedelta(seconds=70) == schema('70 s')
-    assert timedelta(seconds=70) == schema('70\ts')
-    assert timedelta(seconds=70) == schema('70  s')
-    assert timedelta(seconds=10) == schema('10 sec')
-    assert timedelta(minutes=50) == schema('50 min')
-    assert timedelta(milliseconds=15) == schema('15ms')
-    assert timedelta(seconds=-15) == schema('-15')
-    assert timedelta(hours=-3) == schema('-3h')
-    assert timedelta(hours=3) == schema('+3h')
-    assert timedelta(days=14) == schema('14d')
+    assert schema('70') == timedelta(seconds=70)
+    assert schema('0') == timedelta(seconds=0)
+    assert schema(70) == timedelta(seconds=70)
+    assert schema(0) == timedelta(seconds=0)
+    assert schema('70s') == timedelta(seconds=70)
+    assert schema('70 s') == timedelta(seconds=70)
+    assert schema('70\ts') == timedelta(seconds=70)
+    assert schema('70  s') == timedelta(seconds=70)
+    assert schema('10 sec') == timedelta(seconds=10)
+    assert schema('50 min') == timedelta(minutes=50)
+    assert schema('15ms') == timedelta(milliseconds=15)
+    assert schema('-15') == timedelta(seconds=-15)
+    assert schema('-3h') == timedelta(hours=-3)
+    assert schema('+3h') == timedelta(hours=3)
+    assert schema('14d') == timedelta(days=14)
 
-    for value in ['3.5', '-4.5h', '3m', '70u', '4,6h', '']:
+    for value in ['3.5', '-4.5h', '3m', '70u', '4,6h', '', 3.5]:
         with pytest.raises(vol.Invalid):
             schema(value)
 


### PR DESCRIPTION
## Description:

**TL;DR** Allow setting time like this `some_time_option: 15s`

In Home Assistant, there are currently two main ways to set time periods in the configuration. For example: when using the [`numeric_state`](https://www.home-assistant.io/docs/automation/trigger/#numeric-state-trigger) trigger, we can set a `for` time of 1 minute 10 seconds in these two ways:

```yaml
for: 00:01:10

for:
  minutes: 1
  seconds: 10

# New format (in this PR):
for: 70s
```

In my opinion, both are not too user-friendly:

 * When using the first one (`HH:MM`, `HH:MM:SS`), I always have to go back to the Home Assistant docs and double check what the values separated by the colons represent. For example, when I wanted to set a time of 30 seconds, I accidentally typed `0:30` (30 minutes) numerous times already.

 * The second one (using a dictionary) is IMO much user-friendlier, but I also have two problems with it.

    1. Writing the time as a dictionary value is unnecessarily long. Writing time periods should ideally not take multiple lines. (Not a big problem)
    2. With this format, I find myself looking up the configuration sometimes too. Is the key called `second` or `seconds`, or even `s`? As you might already think, I'm very bad at remembering stuff :P

This PR allows users to write time periods like this: `some_time_option: 10s` for 10 seconds (taken from my [esphomeyaml](https://github.com/OttoWinter/esphomeyaml/blob/7915e420f47c1c3bf9b079051fe53eb54acf89e1/esphomeyaml/config_validation.py#L202-L211) project). In my humble opinion, this format is much easier to remember as this time period representation is often used in physics and mathematics. At least I often like to write time values like this.

Some examples:

 * `10s`: 10 seconds
 * `10 s`: 10 seconds
 * `5min`: 5 minutes
 * `-5min`: -5 minutes
 * `3h`: 3 hours
 * `3.5h`: 3 and a half hours
 * `15ms`: 15 milliseconds
 * `15`: 15 seconds (as before)

There are a couple of open questions:

 * First, do you agree that this should be added?
 * Should float values be allowed, like `3.5h`.
 * What time units should be supported? Right now it's `ms`, `s`, `min`, `h`. Do we need `d` for days?
 * Should users be allowed to write something like this `5min 30s` (combining time periods)? Then we would probably need to remove the option the space between value and unit part, so `1 h` would not work.

I will add tests and write documentation if others agree that this is a feature that should be added.


**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#TBD

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
