### PR TITLE
Restores switch state, case the switch is optimistic

### DIFF
--- a/homeassistant/components/switch/mqtt.py
+++ b/homeassistant/components/switch/mqtt.py
@@ -4,7 +4,6 @@ Support for MQTT switches.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/switch.mqtt/
 """
-import asyncio
 import logging
 
 import voluptuous as vol
@@ -40,8 +39,7 @@ PLATFORM_SCHEMA = mqtt.MQTT_RW_PLATFORM_SCHEMA.extend({
 }).extend(mqtt.MQTT_AVAILABILITY_SCHEMA.schema)
 
 
-@asyncio.coroutine
-def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up the MQTT switch."""
     if discovery_info is not None:
         config = PLATFORM_SCHEMA(discovery_info)
@@ -89,10 +87,9 @@ class MqttSwitch(MqttAvailability, SwitchDevice):
         self._optimistic = optimistic
         self._template = value_template
 
-    @asyncio.coroutine
-    def async_added_to_hass(self):
+    async def async_added_to_hass(self):
         """Subscribe to MQTT events."""
-        yield from super().async_added_to_hass()
+        await super().async_added_to_hass()
 
         @callback
         def state_message_received(topic, payload, qos):
@@ -111,12 +108,12 @@ class MqttSwitch(MqttAvailability, SwitchDevice):
             # Force into optimistic mode.
             self._optimistic = True
         else:
-            yield from mqtt.async_subscribe(
+            await mqtt.async_subscribe(
                 self.hass, self._state_topic, state_message_received,
                 self._qos)
 
         if self._optimistic:
-            last_state = yield from async_get_last_state(self.hass,
+            last_state = await async_get_last_state(self.hass,
                                                          self.entity_id)
             if last_state:
                 self._state = last_state.state == STATE_ON
@@ -146,8 +143,7 @@ class MqttSwitch(MqttAvailability, SwitchDevice):
         """Return the icon."""
         return self._icon
 
-    @asyncio.coroutine
-    def async_turn_on(self, **kwargs):
+    async def async_turn_on(self, **kwargs):
         """Turn the device on.
 
         This method is a coroutine.
@@ -160,8 +156,7 @@ class MqttSwitch(MqttAvailability, SwitchDevice):
             self._state = True
             self.async_schedule_update_ha_state()
 
-    @asyncio.coroutine
-    def async_turn_off(self, **kwargs):
+    async def async_turn_off(self, **kwargs):
         """Turn the device off.
 
         This method is a coroutine.

--- a/homeassistant/components/switch/mqtt.py
+++ b/homeassistant/components/switch/mqtt.py
@@ -20,6 +20,7 @@ from homeassistant.const import (
     CONF_PAYLOAD_ON, CONF_ICON)
 import homeassistant.components.mqtt as mqtt
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.restore_state import async_get_last_state
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -113,6 +114,13 @@ class MqttSwitch(MqttAvailability, SwitchDevice):
             yield from mqtt.async_subscribe(
                 self.hass, self._state_topic, state_message_received,
                 self._qos)
+
+        if self._optimistic:
+            last_state = yield from async_get_last_state(self.hass,
+                                                         self.entity_id)
+            if last_state:
+                self._state = last_state.state
+                self.async_schedule_update_ha_state()
 
     @property
     def should_poll(self):

--- a/homeassistant/components/switch/mqtt.py
+++ b/homeassistant/components/switch/mqtt.py
@@ -17,7 +17,7 @@ from homeassistant.components.mqtt import (
 from homeassistant.components.switch import SwitchDevice
 from homeassistant.const import (
     CONF_NAME, CONF_OPTIMISTIC, CONF_VALUE_TEMPLATE, CONF_PAYLOAD_OFF,
-    CONF_PAYLOAD_ON, CONF_ICON)
+    CONF_PAYLOAD_ON, CONF_ICON, STATE_ON, STATE_OFF)
 import homeassistant.components.mqtt as mqtt
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.restore_state import async_get_last_state
@@ -119,7 +119,7 @@ class MqttSwitch(MqttAvailability, SwitchDevice):
             last_state = yield from async_get_last_state(self.hass,
                                                          self.entity_id)
             if last_state:
-                self._state = last_state.state
+                self._state = last_state.state == STATE_ON
 
     @property
     def should_poll(self):

--- a/homeassistant/components/switch/mqtt.py
+++ b/homeassistant/components/switch/mqtt.py
@@ -39,7 +39,8 @@ PLATFORM_SCHEMA = mqtt.MQTT_RW_PLATFORM_SCHEMA.extend({
 }).extend(mqtt.MQTT_AVAILABILITY_SCHEMA.schema)
 
 
-async def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_devices,
+                               discovery_info=None):
     """Set up the MQTT switch."""
     if discovery_info is not None:
         config = PLATFORM_SCHEMA(discovery_info)
@@ -114,7 +115,7 @@ class MqttSwitch(MqttAvailability, SwitchDevice):
 
         if self._optimistic:
             last_state = await async_get_last_state(self.hass,
-                                                         self.entity_id)
+                                                    self.entity_id)
             if last_state:
                 self._state = last_state.state == STATE_ON
 

--- a/homeassistant/components/switch/mqtt.py
+++ b/homeassistant/components/switch/mqtt.py
@@ -17,7 +17,7 @@ from homeassistant.components.mqtt import (
 from homeassistant.components.switch import SwitchDevice
 from homeassistant.const import (
     CONF_NAME, CONF_OPTIMISTIC, CONF_VALUE_TEMPLATE, CONF_PAYLOAD_OFF,
-    CONF_PAYLOAD_ON, CONF_ICON, STATE_ON, STATE_OFF)
+    CONF_PAYLOAD_ON, CONF_ICON, STATE_ON)
 import homeassistant.components.mqtt as mqtt
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.restore_state import async_get_last_state

--- a/homeassistant/components/switch/mqtt.py
+++ b/homeassistant/components/switch/mqtt.py
@@ -120,7 +120,6 @@ class MqttSwitch(MqttAvailability, SwitchDevice):
                                                          self.entity_id)
             if last_state:
                 self._state = last_state.state
-                self.async_schedule_update_ha_state()
 
     @property
     def should_poll(self):


### PR DESCRIPTION
## Description:

When the switch works in _optimistic_ mode, HA is unaware of the current switch state and always defaults to False on restart.

This pull request restores the state of the switch to the last state, which is somehow what is expected from an optimistic switch (that he has kept the state since the last restart and not defaulted to False)

## Example entry for `configuration.yaml` (if applicable):
```yaml
switch:
  - platform: mqtt
    name: teste_switch
    command_topic: test/dummy_switch
    optimistic: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

