### PR TITLE
Upgrade netdisco to 1.4.0

### DIFF
--- a/homeassistant/components/discovery.py
+++ b/homeassistant/components/discovery.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.event import async_track_point_in_utc_time
 from homeassistant.helpers.discovery import async_load_platform, async_discover
 import homeassistant.util.dt as dt_util
 
-REQUIREMENTS = ['netdisco==1.3.1']
+REQUIREMENTS = ['netdisco==1.4.0']
 
 DOMAIN = 'discovery'
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -553,7 +553,7 @@ nad_receiver==0.0.9
 nanoleaf==0.4.1
 
 # homeassistant.components.discovery
-netdisco==1.3.1
+netdisco==1.4.0
 
 # homeassistant.components.sensor.neurio_energy
 neurio==0.3.1


### PR DESCRIPTION
## Description:
- Better Yeelight device identification
- Canon printer
- AVM Fritz
- HP Printers

## Example entry for `configuration.yaml` (if applicable):
```yaml
discovery:
```

Output:

```bash
2018-04-28 22:07:22 INFO (MainThread) [homeassistant.core] Bus:Handling <Event platform_discovered[L]: service=load_platform.sensor, platform=syncthru, discovered=host=192.168.0.25, port=5200, ssdp_description=http://192.168.0.25:5200/Printer.xml, name=Samsung C410 Series (192.168.0.25), model_name=SEC001599EC0D55, model_number=1.0, serial=ZET5B8GD7A01QNL, manufacturer=Samsung Electronics, udn=uuid:16a65700-007c-1000-bb49-001599ec0d55>
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
