### PR TITLE
Fixed datetime values in SQL sensor

### DIFF
--- a/homeassistant/components/sensor/sql.py
+++ b/homeassistant/components/sensor/sql.py
@@ -5,6 +5,7 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.sql/
 """
 import decimal
+import datetime
 import logging
 
 import voluptuous as vol
@@ -145,6 +146,8 @@ class SQLSensor(Entity):
                 for key, value in res.items():
                     if isinstance(value, decimal.Decimal):
                         value = float(value)
+                    if isinstance(value, datetime.date):
+                        value = str(value)
                     self._attributes[key] = value
         except sqlalchemy.exc.SQLAlchemyError as err:
             _LOGGER.error("Error executing query %s: %s", self._query, err)


### PR DESCRIPTION
## Description of the issue:
If a value from a SQL Sensor is a datetime like, '2018-04-28 12:12:12', errors like these would occur:

```
2018-04-28 11:53:44 ERROR (Recorder) [homeassistant.components.recorder.util] Error executing query: Object of type 'date' is not JSON serializable
2018-04-28 11:53:44 INFO (MainThread) [homeassistant.core] Bus:Handling <Event system_log_event[L]: timestamp=1524934424.7096515, level=ERROR, message=Error executing query: Object of type 'date' is not JSON serializable, exception=, source=components/recorder/util.py>
2018-04-28 11:53:55 ERROR (MainThread) [homeassistant.components.websocket_api] Unable to serialize to JSON: Object of type 'date' is not JSON serializable
2018-04-28 11:53:55 INFO (MainThread) [homeassistant.core] Bus:Handling <Event system_log_event[L]: timestamp=1524934435.9548202, level=ERROR, message=Unable to serialize to JSON: Object of type 'date' is not JSON serializable
```

In addition, the web interface would not completely load.

## Additional Information:
Not sure if it matters, I'm using MariaDB for the recorder database.

## Fix:
I decided to test the value for a datetime, then cast any datetime value as a string.  That fixed the errors and also allowed the web site to load.

## Checklist:
  - [ X ] The code change is tested and works locally.
  - [ X ] Local tests pass with `tox`.

Here is the summary from the tests:

SKIPPED:  py35: InterpreterNotFound: python3.5
  py36: commands succeeded
  lint: commands succeeded
  requirements: commands succeeded