### PR TITLE
Revert Hue color state to be xy-based

### DIFF
--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -245,11 +245,8 @@ class HueLight(Light):
         mode = self._color_mode
         source = self.light.action if self.is_group else self.light.state
 
-        if mode == 'xy' and 'xy' in source:
+        if mode in ('xy', 'hs'):
             return color.color_xy_to_hs(*source['xy'])
-
-        if mode == 'hs' and 'hue' in source and 'sat' in source:
-            return source['hue'] / 65535 * 360, source['sat'] / 255 * 100
 
         return None
 

--- a/tests/components/light/test_hue.py
+++ b/tests/components/light/test_hue.py
@@ -652,19 +652,6 @@ def test_hs_color():
 
     light = hue_light.HueLight(
         light=Mock(state={
-            'colormode': 'hs',
-            'hue': 1234,
-            'sat': 123,
-        }),
-        request_bridge_update=None,
-        bridge=Mock(),
-        is_group=False,
-    )
-
-    assert light.hs_color == (1234 / 65535 * 360, 123 / 255 * 100)
-
-    light = hue_light.HueLight(
-        light=Mock(state={
             'colormode': 'xy',
             'hue': 1234,
             'sat': 123,


### PR DESCRIPTION
## Description:

Apparently, the colormode of Hue lights cannot be trusted (see #14119). This PR reverts to always use the xy attribute for colors, like we did before the hue/sat conversion.

For reference, the pre-hue/sat implementation is here: https://github.com/home-assistant/home-assistant/blob/0.65.6/homeassistant/components/light/hue.py#L250-L255

**Related issue (if applicable):** fixes #14119

## Checklist:
  - [ ] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.
