### PR TITLE
Fix Python 3.6 compatibility for HomeKit controller

### DIFF
--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -31,7 +31,7 @@ KNOWN_DEVICES = "{}-devices".format(DOMAIN)
 _LOGGER = logging.getLogger(__name__)
 
 
-def homekit_http_send(self, message_body=None):
+def homekit_http_send(self, message_body=None, encode_chunked=False):
     r"""Send the currently buffered request and clear the buffer.
 
     Appends an extra \r\n to the buffer.


### PR DESCRIPTION
Python 3.6's http client passes an additional argument to _send_output,
so add that to the function definition.


**Related issue (if applicable):** fixes #14127 

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
