### PR TITLE
Bugfix: IP Address option HomeKit

### DIFF
--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -3,6 +3,7 @@
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/homekit/
 """
+import ipaddress
 import logging
 from zlib import adler32
 
@@ -12,8 +13,8 @@ from homeassistant.components.cover import (
     SUPPORT_CLOSE, SUPPORT_OPEN, SUPPORT_SET_POSITION)
 from homeassistant.const import (
     ATTR_SUPPORTED_FEATURES, ATTR_UNIT_OF_MEASUREMENT,
-    ATTR_DEVICE_CLASS, CONF_PORT, TEMP_CELSIUS, TEMP_FAHRENHEIT,
-    EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP)
+    ATTR_DEVICE_CLASS, CONF_IP_ADDRESS, CONF_PORT, TEMP_CELSIUS,
+    TEMP_FAHRENHEIT, EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entityfilter import FILTER_SCHEMA
 from homeassistant.util import get_local_ip
@@ -35,6 +36,8 @@ REQUIREMENTS = ['HAP-python==1.1.9']
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.All({
         vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+        vol.Optional(CONF_IP_ADDRESS):
+            vol.All(ipaddress.ip_address, cv.string),
         vol.Optional(CONF_AUTO_START, default=DEFAULT_AUTO_START): cv.boolean,
         vol.Optional(CONF_FILTER, default={}): FILTER_SCHEMA,
         vol.Optional(CONF_ENTITY_CONFIG, default={}): validate_entity_config,
@@ -48,11 +51,12 @@ async def async_setup(hass, config):
 
     conf = config[DOMAIN]
     port = conf[CONF_PORT]
+    ip_address = conf.get(CONF_IP_ADDRESS)
     auto_start = conf[CONF_AUTO_START]
     entity_filter = conf[CONF_FILTER]
     entity_config = conf[CONF_ENTITY_CONFIG]
 
-    homekit = HomeKit(hass, port, entity_filter, entity_config)
+    homekit = HomeKit(hass, port, ip_address, entity_filter, entity_config)
     homekit.setup()
 
     if auto_start:
@@ -151,10 +155,11 @@ def generate_aid(entity_id):
 class HomeKit():
     """Class to handle all actions between HomeKit and Home Assistant."""
 
-    def __init__(self, hass, port, entity_filter, entity_config):
+    def __init__(self, hass, port, ip_address, entity_filter, entity_config):
         """Initialize a HomeKit object."""
         self.hass = hass
         self._port = port
+        self._ip_address = ip_address
         self._filter = entity_filter
         self._config = entity_config
         self.started = False
@@ -169,9 +174,10 @@ class HomeKit():
         self.hass.bus.async_listen_once(
             EVENT_HOMEASSISTANT_STOP, self.stop)
 
+        ip_addr = self._ip_address or get_local_ip()
         path = self.hass.config.path(HOMEKIT_FILE)
         self.bridge = HomeBridge(self.hass)
-        self.driver = HomeDriver(self.bridge, self._port, get_local_ip(), path)
+        self.driver = HomeDriver(self.bridge, self._port, ip_addr, path)
 
     def add_bridge_accessory(self, state):
         """Try adding accessory to bridge if configured beforehand."""

--- a/tests/components/homekit/test_homekit.py
+++ b/tests/components/homekit/test_homekit.py
@@ -11,7 +11,8 @@ from homeassistant.components.homekit.const import (
     DEFAULT_PORT, SERVICE_HOMEKIT_START)
 from homeassistant.helpers.entityfilter import generate_filter
 from homeassistant.const import (
-    CONF_PORT, EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP)
+    CONF_IP_ADDRESS, CONF_PORT,
+    EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP)
 
 from tests.common import get_test_home_assistant
 from tests.components.homekit.test_accessories import patch_debounce
@@ -59,7 +60,7 @@ class TestHomeKit(unittest.TestCase):
             self.hass, DOMAIN, {DOMAIN: {}}))
 
         self.assertEqual(mock_homekit.mock_calls, [
-            call(self.hass, DEFAULT_PORT, ANY, {}),
+            call(self.hass, DEFAULT_PORT, None, ANY, {}),
             call().setup()])
 
         # Test auto start enabled
@@ -74,7 +75,8 @@ class TestHomeKit(unittest.TestCase):
         """Test async_setup with auto start disabled and test service calls."""
         mock_homekit.return_value = homekit = Mock()
 
-        config = {DOMAIN: {CONF_AUTO_START: False, CONF_PORT: 11111}}
+        config = {DOMAIN: {CONF_AUTO_START: False, CONF_PORT: 11111,
+                           CONF_IP_ADDRESS: '172.0.0.0'}}
         self.assertTrue(setup.setup_component(
             self.hass, DOMAIN, config))
 
@@ -82,7 +84,7 @@ class TestHomeKit(unittest.TestCase):
         self.hass.block_till_done()
 
         self.assertEqual(mock_homekit.mock_calls, [
-            call(self.hass, 11111, ANY, {}),
+            call(self.hass, 11111, '172.0.0.0', ANY, {}),
             call().setup()])
 
         # Test start call with driver stopped.
@@ -101,7 +103,7 @@ class TestHomeKit(unittest.TestCase):
 
     def test_homekit_setup(self):
         """Test setup of bridge and driver."""
-        homekit = HomeKit(self.hass, DEFAULT_PORT, {}, {})
+        homekit = HomeKit(self.hass, DEFAULT_PORT, None, {}, {})
 
         with patch(PATH_HOMEKIT + '.accessories.HomeDriver') as mock_driver, \
                 patch('homeassistant.util.get_local_ip') as mock_ip:
@@ -117,9 +119,17 @@ class TestHomeKit(unittest.TestCase):
         self.assertEqual(
             self.hass.bus.listeners.get(EVENT_HOMEASSISTANT_STOP), 1)
 
+    def test_homekit_setup_ip_address(self):
+        """Test setup with given IP address."""
+        homekit = HomeKit(self.hass, DEFAULT_PORT, '172.0.0.0', {}, {})
+
+        with patch(PATH_HOMEKIT + '.accessories.HomeDriver') as mock_driver:
+            homekit.setup()
+        mock_driver.assert_called_with(ANY, DEFAULT_PORT, '172.0.0.0', ANY)
+
     def test_homekit_add_accessory(self):
         """Add accessory if config exists and get_acc returns an accessory."""
-        homekit = HomeKit(self.hass, None, lambda entity_id: True, {})
+        homekit = HomeKit(self.hass, None, None, lambda entity_id: True, {})
         homekit.bridge = HomeBridge(self.hass)
 
         with patch(PATH_HOMEKIT + '.accessories.HomeBridge.add_accessory') \
@@ -142,7 +152,7 @@ class TestHomeKit(unittest.TestCase):
     def test_homekit_entity_filter(self):
         """Test the entity filter."""
         entity_filter = generate_filter(['cover'], ['demo.test'], [], [])
-        homekit = HomeKit(self.hass, None, entity_filter, {})
+        homekit = HomeKit(self.hass, None, None, entity_filter, {})
 
         with patch(PATH_HOMEKIT + '.get_accessory') as mock_get_acc:
             mock_get_acc.return_value = None
@@ -162,7 +172,7 @@ class TestHomeKit(unittest.TestCase):
     @patch(PATH_HOMEKIT + '.HomeKit.add_bridge_accessory')
     def test_homekit_start(self, mock_add_bridge_acc, mock_show_setup_msg):
         """Test HomeKit start method."""
-        homekit = HomeKit(self.hass, None, {}, {'cover.demo': {}})
+        homekit = HomeKit(self.hass, None, None, {}, {'cover.demo': {}})
         homekit.bridge = HomeBridge(self.hass)
         homekit.driver = Mock()
 
@@ -184,7 +194,7 @@ class TestHomeKit(unittest.TestCase):
 
     def test_homekit_stop(self):
         """Test HomeKit stop method."""
-        homekit = HomeKit(None, None, None, None)
+        homekit = HomeKit(None, None, None, None, None)
         homekit.driver = Mock()
 
         # Test if started = False


### PR DESCRIPTION
## Description:
`util.get_local_ip` doesn't return the correct local ip in some cases (see issues belove). Therefore I've added the `CONF_IP_ADDRESS` option. Since `HomeKit` isn't the only component this issue applies to, I've also added a new validator for IP addresses to `config_validation`.

The regex pattern I've used works, but there might be an even better one. I'm open for suggestions.


**Related issue (if applicable):** fixes #14077
**Also related:** #14107 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5281

## Example entry for `configuration.yaml` (if applicable):
```yaml
homekit:
  ip_address: '172.0.0.1'
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)
  - [x] Tests have been added to verify that the new code works.