### PR TITLE
Add Docker Compose yml file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+
+services:
+  home-assistant:
+    image: homeassistant/home-assistant
+    container_name: home-assistant
+    ports:
+      - 8123:8123
+    volumes:
+      - ~/.homeassistant:/config

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,10 @@ services:
   home-assistant:
     image: homeassistant/home-assistant
     container_name: home-assistant
+    network_mode: host
     ports:
       - 8123:8123
     volumes:
       - ~/.homeassistant:/config
+      - /etc/localtime:/etc/localtime:ro
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,4 +9,3 @@ services:
     volumes:
       - ~/.homeassistant:/config
       - /etc/localtime:/etc/localtime:ro
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
   home-assistant:
     image: homeassistant/home-assistant
     container_name: home-assistant
+    restart: unless-stopped
     network_mode: host
     ports:
       - 8123:8123

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,6 @@ services:
     container_name: home-assistant
     restart: unless-stopped
     network_mode: host
-    ports:
-      - 8123:8123
     volumes:
       - ~/.homeassistant:/config
       - /etc/localtime:/etc/localtime:ro


### PR DESCRIPTION
## Description:
Adds a Docker Compose yml file which uses the user's `~/.homeassistant` directory for the `/config` dir.
Makes it easier to run `docker-compose up -d` for new users.

## Checklist:
  - [x] The code change is tested and works locally.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
