### PR TITLE
Fix #14107 - get_local_ip() returns outbound IP address when VPN is present 

### DIFF
--- a/homeassistant/components/zeroconf.py
+++ b/homeassistant/components/zeroconf.py
@@ -12,6 +12,7 @@ import voluptuous as vol
 
 from homeassistant import util
 from homeassistant.const import (EVENT_HOMEASSISTANT_STOP, __version__)
+from homeassistant.helpers import config_validation as cv
 
 REQUIREMENTS = ['zeroconf==0.20.0']
 
@@ -25,7 +26,7 @@ ZEROCONF_TYPE = '_home-assistant._tcp.local.'
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
-        vol.Optional(CONF_LOCAL_IP): ip_address,
+        vol.Optional(CONF_LOCAL_IP): vol.All(ip_address, cv.string),
     }),
 }, extra=vol.ALLOW_EXTRA)
 
@@ -48,10 +49,11 @@ def setup(hass, config):
     }
 
     host_ip = config.get(CONF_LOCAL_IP)
-    if host_ip is not None:
-        host_ip = str(host_ip)
-    else:
+    if host_ip is None:
         host_ip = util.get_local_ip()
+        _LOGGER.info(
+            "Listen IP address not specified, auto-detected address is %s",
+            host_ip)
 
     _LOGGER.debug("Using %s to annouce %s", host_ip, ZEROCONF_TYPE)
 


### PR DESCRIPTION
## Description:

This PR adds a `local_ip` configuration option in order to address #14107

**Related issue (if applicable):** fixes #14107

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
zeroconf:
  local_ip: 192.168.1.100
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)