### PR TITLE
Fix TypeError on round(self.humidity) (fixes #13116)

### DIFF
--- a/homeassistant/components/weather/__init__.py
+++ b/homeassistant/components/weather/__init__.py
@@ -110,9 +110,11 @@ class WeatherEntity(Entity):
             ATTR_WEATHER_TEMPERATURE: show_temp(
                 self.hass, self.temperature, self.temperature_unit,
                 self.precision),
-            ATTR_WEATHER_HUMIDITY: (round(self.humidity) if self.humidity
-                                    else None)
         }
+
+        humidity = self.humidity
+        if humidity is not None:
+            data[ATTR_WEATHER_HUMIDITY] = round(humidity)
 
         ozone = self.ozone
         if ozone is not None:

--- a/homeassistant/components/weather/__init__.py
+++ b/homeassistant/components/weather/__init__.py
@@ -110,7 +110,8 @@ class WeatherEntity(Entity):
             ATTR_WEATHER_TEMPERATURE: show_temp(
                 self.hass, self.temperature, self.temperature_unit,
                 self.precision),
-            ATTR_WEATHER_HUMIDITY: round(self.humidity)
+            ATTR_WEATHER_HUMIDITY: (round(self.humidity) if self.humidity
+                                    else None)
         }
 
         ozone = self.ozone


### PR DESCRIPTION
During init, some (most?) platforms postpone the first update for a while. This produces errors in the log as home assistant is trying to round() uninitialised variables. This commit fixes that

## Description:
fixes #13116

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`.