### PR TITLE
Publish attributes unconditionally

### DIFF
--- a/homeassistant/components/mqtt_statestream.py
+++ b/homeassistant/components/mqtt_statestream.py
@@ -88,10 +88,9 @@ def async_setup(hass, config):
 
         if publish_attributes:
             for key, val in new_state.attributes.items():
-                if val:
-                    encoded_val = json.dumps(val, cls=JSONEncoder)
-                    hass.components.mqtt.async_publish(mybase + key,
-                                                       encoded_val, 1, True)
+                encoded_val = json.dumps(val, cls=JSONEncoder)
+                hass.components.mqtt.async_publish(mybase + key,
+                                                   encoded_val, 1, True)
 
     async_track_state_change(hass, MATCH_ALL, _state_publisher)
     return True

--- a/tests/components/test_mqtt_statestream.py
+++ b/tests/components/test_mqtt_statestream.py
@@ -134,7 +134,7 @@ class TestMqttStateStream(object):
         test_attributes = {
             "testing": "YES",
             "list": ["a", "b", "c"],
-            "bool": True
+            "bool": False
         }
 
         # Set a state of an entity
@@ -150,7 +150,7 @@ class TestMqttStateStream(object):
                                1, True),
             call.async_publish(self.hass, 'pub/fake/entity/list',
                                '["a", "b", "c"]', 1, True),
-            call.async_publish(self.hass, 'pub/fake/entity/bool', "true",
+            call.async_publish(self.hass, 'pub/fake/entity/bool', "false",
                                1, True)
         ]
 


### PR DESCRIPTION
## Description:
Because the attribute publish command was previously hidden behind `if val:`, falsy values like False and 0.0 weren't being published, thereby making Statestream -- particularly in the case of booleans, where the first True would be retained indefinitely -- a completely worthless indicator of state.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54