### PR TITLE
Add room hint support to Google Assistant cloud

### DIFF
--- a/homeassistant/components/cloud/__init__.py
+++ b/homeassistant/components/cloud/__init__.py
@@ -21,6 +21,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.util import dt as dt_util
 from homeassistant.components.alexa import smart_home as alexa_sh
 from homeassistant.components.google_assistant import helpers as ga_h
+from homeassistant.components.google_assistant import const as ga_c
 
 from . import http_api, iot
 from .const import CONFIG_DIR, DOMAIN, SERVERS
@@ -52,7 +53,8 @@ ALEXA_ENTITY_SCHEMA = vol.Schema({
 
 GOOGLE_ENTITY_SCHEMA = vol.Schema({
     vol.Optional(CONF_NAME): cv.string,
-    vol.Optional(CONF_ALIASES): vol.All(cv.ensure_list, [cv.string])
+    vol.Optional(CONF_ALIASES): vol.All(cv.ensure_list, [cv.string]),
+    vol.Optional(ga_c.CONF_ROOM_HINT): cv.string,
 })
 
 ASSISTANT_SCHEMA = vol.Schema({

--- a/tests/components/cloud/test_iot.py
+++ b/tests/components/cloud/test_iot.py
@@ -318,7 +318,8 @@ def test_handler_google_actions(hass):
                     'entity_config': {
                         'switch.test': {
                             'name': 'Config name',
-                            'aliases': 'Config alias'
+                            'aliases': 'Config alias',
+                            'room': 'living room'
                         }
                     }
                 }
@@ -347,6 +348,7 @@ def test_handler_google_actions(hass):
     assert device['name']['name'] == 'Config name'
     assert device['name']['nicknames'] == ['Config alias']
     assert device['type'] == 'action.devices.types.SWITCH'
+    assert device['roomHint'] == 'living room'
 
 
 async def test_refresh_token_expired(hass):


### PR DESCRIPTION
## Description:
Allow configuring room hints for Google Assistant entities.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** https://github.com/home-assistant/home-assistant.github.io/pull/5274

## Example entry for `configuration.yaml` (if applicable):
```yaml
cloud:
  google_actions:
    entity_config:
      switch.test:
        room: living room
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
