### PR TITLE
Do not sync entities with an empty name

### DIFF
--- a/homeassistant/components/google_assistant/smart_home.py
+++ b/homeassistant/components/google_assistant/smart_home.py
@@ -102,18 +102,23 @@ class _GoogleEntity:
         if state.state == STATE_UNAVAILABLE:
             return None
 
+        entity_config = self.config.entity_config.get(state.entity_id, {})
+        name = (entity_config.get(CONF_NAME) or state.name).strip()
+
+        # If an empty string
+        if not name:
+            return None
+
         traits = self.traits()
 
         # Found no supported traits for this entity
         if not traits:
             return None
 
-        entity_config = self.config.entity_config.get(state.entity_id, {})
-
         device = {
             'id': state.entity_id,
             'name': {
-                'name': entity_config.get(CONF_NAME) or state.name
+                'name': name
             },
             'attributes': {},
             'traits': [trait.name for trait in traits],

--- a/tests/components/google_assistant/test_smart_home.py
+++ b/tests/components/google_assistant/test_smart_home.py
@@ -286,3 +286,29 @@ async def test_unavailable_state_doesnt_sync(hass):
             'devices': []
         }
     }
+
+
+async def test_empty_name_doesnt_sync(hass):
+    """Test that an entity with empty name does not sync over."""
+    light = DemoLight(
+        None, ' ',
+        state=False,
+    )
+    light.hass = hass
+    light.entity_id = 'light.demo_light'
+    await light.async_update_ha_state()
+
+    result = await sh.async_handle_message(hass, BASIC_CONFIG, {
+        "requestId": REQ_ID,
+        "inputs": [{
+            "intent": "action.devices.SYNC"
+        }]
+    })
+
+    assert result == {
+        'requestId': REQ_ID,
+        'payload': {
+            'agentUserId': 'test-agent',
+            'devices': []
+        }
+    }


### PR DESCRIPTION
## Description:
Do not sync over entities to Google Assistant if they have an empty name. This is not allowed by Google.

## Example entry for `configuration.yaml` (if applicable):
```yaml
cloud:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
