### PR TITLE
Allow easy extension of websocket API

### DIFF
--- a/homeassistant/components/websocket_api.py
+++ b/homeassistant/components/websocket_api.py
@@ -456,7 +456,8 @@ def handle_get_services(connection, msg):
     async def get_services_helper(msg):
         """Get available services and fire complete message."""
         descriptions = await async_get_all_descriptions(connection.hass)
-        connection.send_message_outside(result_message(msg['id'], descriptions))
+        connection.send_message_outside(result_message(msg['id'],
+                                        descriptions))
 
     connection.hass.async_add_job(get_services_helper(msg))
 

--- a/homeassistant/components/websocket_api.py
+++ b/homeassistant/components/websocket_api.py
@@ -493,8 +493,8 @@ def handle_get_services(hass, connection, msg):
     async def get_services_helper(msg):
         """Get available services and fire complete message."""
         descriptions = await async_get_all_descriptions(hass)
-        connection.send_message_outside(result_message(msg['id'],
-                                        descriptions))
+        connection.send_message_outside(
+            result_message(msg['id'], descriptions))
 
     hass.async_add_job(get_services_helper(msg))
 

--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -1,0 +1,21 @@
+import pytest
+
+from homeassistant.setup import async_setup_component
+from homeassistant.components import websocket_api as wapi
+
+
+@pytest.fixture
+def websocket_client(loop, hass, aiohttp_client):
+    """Websocket client fixture connected to websocket server."""
+    assert loop.run_until_complete(
+        async_setup_component(hass, 'websocket_api'))
+
+    client = loop.run_until_complete(aiohttp_client(hass.http.app))
+    ws = loop.run_until_complete(client.ws_connect(wapi.URL))
+    auth_ok = loop.run_until_complete(ws.receive_json())
+    assert auth_ok['type'] == wapi.TYPE_AUTH_OK
+
+    yield ws
+
+    if not ws.closed:
+        loop.run_until_complete(ws.close())

--- a/tests/components/test_frontend.py
+++ b/tests/components/test_frontend.py
@@ -8,7 +8,7 @@ import pytest
 from homeassistant.setup import async_setup_component
 from homeassistant.components.frontend import (
     DOMAIN, CONF_JS_VERSION, CONF_THEMES, CONF_EXTRA_HTML_URL,
-    CONF_EXTRA_HTML_URL_ES5, DATA_PANELS, DATA_JS_VERSION)
+    CONF_EXTRA_HTML_URL_ES5, DATA_PANELS)
 from homeassistant.components import websocket_api as wapi
 
 
@@ -192,26 +192,24 @@ def test_panel_without_path(hass):
     assert 'test_component' not in hass.data[DATA_PANELS]
 
 
-@asyncio.coroutine
-def test_get_panels(hass, websocket_client):
+async def test_get_panels(hass, hass_ws_client):
     """Test get_panels command."""
-    yield from hass.components.frontend.async_register_built_in_panel(
+    await async_setup_component(hass, 'frontend')
+    await hass.components.frontend.async_register_built_in_panel(
         'map', 'Map', 'mdi:account-location')
-    hass.data[DATA_JS_VERSION] = 'es5'
-    yield from websocket_client.send_json({
+
+    client = await hass_ws_client(hass)
+    await client.send_json({
         'id': 5,
         'type': 'get_panels',
     })
 
-    msg = yield from websocket_client.receive_json()
+    msg = await client.receive_json()
+
     assert msg['id'] == 5
     assert msg['type'] == wapi.TYPE_RESULT
     assert msg['success']
-    assert msg['result'] == {'map': {
-        'component_name': 'map',
-        'url_path': 'map',
-        'config': None,
-        'url': None,
-        'icon': 'mdi:account-location',
-        'title': 'Map',
-    }}
+    assert msg['result']['map']['component_name'] == 'map'
+    assert msg['result']['map']['url_path'] == 'map'
+    assert msg['result']['map']['icon'] == 'mdi:account-location'
+    assert msg['result']['map']['title'] == 'Map'

--- a/tests/components/test_websocket_api.py
+++ b/tests/components/test_websocket_api.py
@@ -297,7 +297,7 @@ def test_get_panels(hass, websocket_client):
     hass.data[frontend.DATA_JS_VERSION] = 'es5'
     yield from websocket_client.send_json({
         'id': 5,
-        'type': wapi.TYPE_GET_PANELS,
+        'type': 'get_panels',
     })
 
     msg = yield from websocket_client.receive_json()
@@ -335,5 +335,17 @@ def test_pending_msg_overflow(hass, mock_low_queue, websocket_client):
             'id': idx + 1,
             'type': wapi.TYPE_PING,
         })
+    msg = yield from websocket_client.receive()
+    assert msg.type == WSMsgType.close
+
+
+@asyncio.coroutine
+def test_unknown_command(websocket_client):
+    """Test get_panels command."""
+    yield from websocket_client.send_json({
+        'id': 5,
+        'type': 'unknown_command',
+    })
+
     msg = yield from websocket_client.receive()
     assert msg.type == WSMsgType.close

--- a/tests/components/test_websocket_api.py
+++ b/tests/components/test_websocket_api.py
@@ -16,6 +16,13 @@ API_PASSWORD = 'test1234'
 
 
 @pytest.fixture
+def websocket_client(hass, hass_ws_client):
+    """Create a websocket client."""
+    client = hass.loop.run_until_complete(hass_ws_client(hass))
+    return client
+
+
+@pytest.fixture
 def no_auth_websocket_client(hass, loop, aiohttp_client):
     """Websocket connection that requires authentication."""
     assert loop.run_until_complete(

--- a/tests/components/test_websocket_api.py
+++ b/tests/components/test_websocket_api.py
@@ -7,29 +7,12 @@ from async_timeout import timeout
 import pytest
 
 from homeassistant.core import callback
-from homeassistant.components import websocket_api as wapi, frontend
+from homeassistant.components import websocket_api as wapi
 from homeassistant.setup import async_setup_component
 
 from tests.common import mock_coro
 
 API_PASSWORD = 'test1234'
-
-
-@pytest.fixture
-def websocket_client(loop, hass, aiohttp_client):
-    """Websocket client fixture connected to websocket server."""
-    assert loop.run_until_complete(
-        async_setup_component(hass, 'websocket_api'))
-
-    client = loop.run_until_complete(aiohttp_client(hass.http.app))
-    ws = loop.run_until_complete(client.ws_connect(wapi.URL))
-    auth_ok = loop.run_until_complete(ws.receive_json())
-    assert auth_ok['type'] == wapi.TYPE_AUTH_OK
-
-    yield ws
-
-    if not ws.closed:
-        loop.run_until_complete(ws.close())
 
 
 @pytest.fixture
@@ -287,31 +270,6 @@ def test_get_config(hass, websocket_client):
             set(msg['result']['whitelist_external_dirs'])
 
     assert msg['result'] == hass.config.as_dict()
-
-
-@asyncio.coroutine
-def test_get_panels(hass, websocket_client):
-    """Test get_panels command."""
-    yield from hass.components.frontend.async_register_built_in_panel(
-        'map', 'Map', 'mdi:account-location')
-    hass.data[frontend.DATA_JS_VERSION] = 'es5'
-    yield from websocket_client.send_json({
-        'id': 5,
-        'type': 'get_panels',
-    })
-
-    msg = yield from websocket_client.receive_json()
-    assert msg['id'] == 5
-    assert msg['type'] == wapi.TYPE_RESULT
-    assert msg['success']
-    assert msg['result'] == {'map': {
-        'component_name': 'map',
-        'url_path': 'map',
-        'config': None,
-        'url': None,
-        'icon': 'mdi:account-location',
-        'title': 'Map',
-    }}
 
 
 @asyncio.coroutine

--- a/tests/components/test_websocket_api.py
+++ b/tests/components/test_websocket_api.py
@@ -18,8 +18,7 @@ API_PASSWORD = 'test1234'
 @pytest.fixture
 def websocket_client(hass, hass_ws_client):
     """Create a websocket client."""
-    client = hass.loop.run_until_complete(hass_ws_client(hass))
-    return client
+    return hass.loop.run_until_complete(hass_ws_client(hass))
 
 
 @pytest.fixture


### PR DESCRIPTION
## Description:
Allow other components to easily register new command types for the websocket API.

This will allow us to keep frontend commands in the frontend component. Also means we can start adding themes and maybe translations too?

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
