### PR TITLE
Improve chromecast disconnection logic

### DIFF
--- a/homeassistant/components/media_player/cast.py
+++ b/homeassistant/components/media_player/cast.py
@@ -306,13 +306,17 @@ class CastDevice(MediaPlayerDevice):
             _LOGGER.debug("Discovered chromecast with same UUID: %s", discover)
             self.hass.async_add_job(self.async_set_cast_info(discover))
 
+        async def stop(event):
+            await self.async_will_remove_from_hass()
+
         async_dispatcher_connect(self.hass, SIGNAL_CAST_DISCOVERED,
                                  async_cast_discovered)
+        self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, stop)
         self.hass.async_add_job(self.async_set_cast_info(self._cast_info))
 
     async def async_will_remove_from_hass(self) -> None:
         """Disconnect Chromecast object when removed."""
-        self._async_disconnect()
+        await self._async_disconnect()
         if self._cast_info.uuid is not None:
             # Remove the entity from the added casts so that it can dynamically
             # be re-added again.
@@ -328,7 +332,7 @@ class CastDevice(MediaPlayerDevice):
             if old_cast_info.host_port == cast_info.host_port:
                 # Nothing connection-related updated
                 return
-            self._async_disconnect()
+            await self._async_disconnect()
 
         # Failed connection will unfortunately never raise an exception, it
         # will instead just try connecting indefinitely.
@@ -348,15 +352,17 @@ class CastDevice(MediaPlayerDevice):
         _LOGGER.debug("Connection successful!")
         self.async_schedule_update_ha_state()
 
-    @callback
-    def _async_disconnect(self):
+    async def _async_disconnect(self):
         """Disconnect Chromecast object if it is set."""
         if self._chromecast is None:
             # Can't disconnect if not connected.
             return
-        _LOGGER.debug("Disconnecting from previous chromecast socket.")
+        _LOGGER.debug("Disconnecting from chromecast socket.")
         self._available = False
-        self._chromecast.disconnect(blocking=False)
+        self.async_schedule_update_ha_state()
+
+        await self.hass.async_add_job(self._chromecast.disconnect)
+
         # Invalidate some attributes
         self._chromecast = None
         self.cast_status = None
@@ -364,6 +370,8 @@ class CastDevice(MediaPlayerDevice):
         self.media_status_received = None
         self._status_listener.invalidate()
         self._status_listener = None
+
+        self.async_schedule_update_ha_state()
 
     # ========== Callbacks ==========
     def new_cast_status(self, cast_status):

--- a/tests/components/media_player/test_cast.py
+++ b/tests/components/media_player/test_cast.py
@@ -346,8 +346,16 @@ async def test_switched_host(hass: HomeAssistantType):
         async_dispatcher_send(hass, cast.SIGNAL_CAST_DISCOVERED, changed)
         await hass.async_block_till_done()
         assert get_chromecast.call_count == 1
-        chromecast.disconnect.assert_called_once_with(blocking=False)
+        assert chromecast.disconnect.call_count == 1
 
-        hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
-        await hass.async_block_till_done()
-        chromecast.disconnect.assert_called_once_with(blocking=False)
+
+async def test_disconnect_on_stop(hass: HomeAssistantType):
+    """Test cast device disconnects socket on stop."""
+    info = get_fake_chromecast_info()
+
+    with patch('pychromecast.dial.get_device_status', return_value=info):
+        chromecast, _ = await async_setup_media_player_cast(hass, info)
+
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
+    await hass.async_block_till_done()
+    assert chromecast.disconnect.call_count == 1


### PR DESCRIPTION
## Description:

The latest cleanup to the cast platform introduced a weird bug where disconnecting from the old leader of a cast audio group was not handled correctly.

In particular, cast group leaders don't like accepting connections as long as there are open sockets to the old leader. In the old code, we would do a non-blocking disconnect and not join the socket client thread. So we tried connecting to the new leader before the old leader was disconnected. This prevented us from connecting to cast groups on every second leader change.

Apparently, `async_will_remove_from_hass` is not called on `EVENT_HOMEASSISTANT_STOP`. With the assumption that this seems to be intended (feels weird to me), I manually added a listener to the event bus.

If there's a 68.1 release, it might be good to maybe include this PR. It's not a huge code change and I spent the last few days testing this change.

**Related issue (if applicable):** fixes #13530

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  - platform: cast
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
