### PR TITLE
Make alert name (message) optional

### DIFF
--- a/homeassistant/components/alert.py
+++ b/homeassistant/components/alert.py
@@ -33,7 +33,7 @@ DEFAULT_CAN_ACK = True
 DEFAULT_SKIP_FIRST = False
 
 ALERT_SCHEMA = vol.Schema({
-    vol.Required(CONF_NAME): cv.string,
+    vol.Optional(CONF_NAME): cv.string,
     vol.Optional(CONF_DONE_MESSAGE): cv.string,
     vol.Required(CONF_ENTITY_ID): cv.entity_id,
     vol.Required(CONF_STATE, default=STATE_ON): cv.string,
@@ -246,11 +246,12 @@ class Alert(ToggleEntity):
             return
 
         if not self._ack:
-            _LOGGER.info("Alerting: %s", self._name)
             self._send_done_message = True
-            for target in self._notifiers:
-                yield from self.hass.services.async_call(
-                    'notify', target, {'message': self._name})
+            if self._name:
+                _LOGGER.info("Alerting: %s", self._name)
+                for target in self._notifiers:
+                    yield from self.hass.services.async_call(
+                        'notify', target, {'message': self._name})
         yield from self._schedule_notify()
 
     @asyncio.coroutine

--- a/tests/components/test_alert.py
+++ b/tests/components/test_alert.py
@@ -146,6 +146,31 @@ class TestAlert(unittest.TestCase):
         self.hass.block_till_done()
         self.assertEqual(1, len(events))
 
+    def test_notification_name(self):
+        """Test notifications."""
+        events = []
+        config = deepcopy(TEST_CONFIG)
+        del(config[alert.DOMAIN][NAME][alert.CONF_NAME])
+
+        @callback
+        def record_event(event):
+            """Add recorded event to set."""
+            events.append(event)
+
+        self.hass.services.register(
+            notify.DOMAIN, NOTIFIER, record_event)
+
+        assert setup_component(self.hass, alert.DOMAIN, config)
+        self.assertEqual(0, len(events))
+
+        self.hass.states.set("sensor.test", STATE_ON)
+        self.hass.block_till_done()
+        self.assertEqual(1, len(events))
+
+        self.hass.states.set("sensor.test", STATE_OFF)
+        self.hass.block_till_done()
+        self.assertEqual(1, len(events))
+
     def test_notification(self):
         """Test notifications."""
         events = []


### PR DESCRIPTION
Solves #14116

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>
fixes #14116

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>
home-assistant/home-assistant.github.io#5277

## Example entry for `configuration.yaml` (if applicable):
```yaml
alert:
  garage_door:
    name: Garage is open
    done_message: Garage is closed
    entity_id: input_boolean.garage_door
    state: 'on'
    repeat: 30
    can_acknowledge: True
    skip_first: True
    notifiers:
      - ryans_phone
      - kristens_phone
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
