### PR TITLE
Fix poorly formatted automations

### DIFF
--- a/homeassistant/components/config/automation.py
+++ b/homeassistant/components/config/automation.py
@@ -1,6 +1,7 @@
 """Provide configuration end points for Automations."""
 import asyncio
 from collections import OrderedDict
+import uuid
 
 from homeassistant.const import CONF_ID
 from homeassistant.components.config import EditIdBasedConfigView
@@ -29,7 +30,12 @@ class EditAutomationConfigView(EditIdBasedConfigView):
         """Set value."""
         index = None
         for index, cur_value in enumerate(data):
-            if cur_value[CONF_ID] == config_key:
+            # When people copy paste their automations to the config file,
+            # they sometimes forget to add IDs. Fix it here.
+            if CONF_ID not in cur_value:
+                cur_value[CONF_ID] = uuid.uuid4().hex
+
+            elif cur_value[CONF_ID] == config_key:
                 break
         else:
             cur_value = OrderedDict()


### PR DESCRIPTION
## Description:
Automation editor would be prevented from writing automations if the user had copy pasted some automations over to `automations.yaml` but forgot to add an ID (as per the instructions).

Now, if we see an automation without an ID, we'll add one.

## Example entry for `configuration.yaml` (if applicable):
```yaml
config:
automation: !include automations.yaml
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
