### PR TITLE
zha: Clean up listener registration and button state

### DIFF
--- a/homeassistant/components/binary_sensor/zha.py
+++ b/homeassistant/components/binary_sensor/zha.py
@@ -164,7 +164,6 @@ class Switch(zha.Entity, BinarySensorDevice):
             """Handle attribute updates on this cluster."""
             if attrid == 0:
                 self._entity.set_state(value)
-                self._entity.schedule_update_ha_state()
 
         def zdo_command(self, *args, **kwargs):
             """Handle ZDO commands on this cluster."""
@@ -202,6 +201,7 @@ class Switch(zha.Entity, BinarySensorDevice):
 
     def __init__(self, **kwargs):
         """Initialize Switch."""
+        super().__init__(**kwargs)
         self._state = True
         self._level = 255
         from zigpy.zcl.clusters import general
@@ -209,7 +209,6 @@ class Switch(zha.Entity, BinarySensorDevice):
             general.OnOff.cluster_id: self.OnOffListener(self),
             general.LevelControl.cluster_id: self.LevelListener(self),
         }
-        super().__init__(**kwargs)
 
     @property
     def is_on(self) -> bool:
@@ -227,20 +226,20 @@ class Switch(zha.Entity, BinarySensorDevice):
             self._level = 0
         self._level = min(255, max(0, self._level + change))
         self._state = bool(self._level)
-        self.schedule_update_ha_state()
+        self.async_schedule_update_ha_state()
 
     def set_level(self, level):
         """Set the level, setting state if appropriate."""
         self._level = level
         self._state = bool(self._level)
-        self.schedule_update_ha_state()
+        self.async_schedule_update_ha_state()
 
     def set_state(self, state):
         """Set the state."""
         self._state = state
         if self._level == 0:
             self._level = 255
-        self.schedule_update_ha_state()
+        self.async_schedule_update_ha_state()
 
     async def async_update(self):
         """Retrieve latest state."""

--- a/homeassistant/components/sensor/zha.py
+++ b/homeassistant/components/sensor/zha.py
@@ -71,7 +71,7 @@ class Sensor(zha.Entity):
         _LOGGER.debug("Attribute updated: %s %s %s", self, attribute, value)
         if attribute == self.value_attribute:
             self._state = value
-            self.schedule_update_ha_state()
+            self.async_schedule_update_ha_state()
 
 
 class TemperatureSensor(Sensor):


### PR DESCRIPTION
 - Instead of registering listeners in the entity __init__, do it in
   async_added_to_hass to avoid errors updating an entity which isn't fully
   set up yet
 - schedule_update_ha_state -> async_schedule_update_ha_state

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
