### PR TITLE
HomematicIP cloud: Add logic to check accesspoint connection state

### DIFF
--- a/homeassistant/components/homematicip_cloud.py
+++ b/homeassistant/components/homematicip_cloud.py
@@ -136,11 +136,11 @@ class HomematicipConnector:
             self._accesspoint_connected = False
             self.set_all_to_unavailable()
         elif not self._accesspoint_connected:
-                # Explicitly getting an update as device states might have
-                # changed during access point disconnect."""
+            # Explicitly getting an update as device states might have
+            # changed during access point disconnect."""
 
-                job = self._hass.async_add_job(self.get_state())
-                job.add_done_callback(self.get_state_finished)
+            job = self._hass.async_add_job(self.get_state())
+            job.add_done_callback(self.get_state_finished)
 
     async def get_state(self):
         """Update hmip state and tell hass."""

--- a/homeassistant/components/homematicip_cloud.py
+++ b/homeassistant/components/homematicip_cloud.py
@@ -15,6 +15,7 @@ from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.entity import Entity
+from homeassistant.core import callback
 
 REQUIREMENTS = ['homematicip==0.9.2.4']
 
@@ -108,7 +109,7 @@ class HomematicipConnector:
         self.home = AsyncHome(hass.loop, websession)
         self.home.set_auth_token(_authtoken)
 
-        self.home.on_update(self.update)
+        self.home.on_update(self.async_update)
         self._accesspoint_connected = True
 
         hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, self.close())
@@ -118,8 +119,9 @@ class HomematicipConnector:
         await self.home.init(self._accesspoint)
         await self.home.get_current_state()
 
-    def update(self, *args, **kwargs):
-        """Update the home device.
+    @callback
+    def async_update(self, *args, **kwargs):
+        """Async update the home device.
 
         Triggered when the hmip HOME_CHANGED event has fired.
         There are several occasions for this event to happen.
@@ -133,8 +135,7 @@ class HomematicipConnector:
                 "HMIP access point has lost connection with the cloud")
             self._accesspoint_connected = False
             self.set_all_to_unavailable()
-        else:
-            if not self._accesspoint_connected:
+        elif not self._accesspoint_connected:
                 # Explicitly getting an update as device states might have
                 # changed during access point disconnect."""
 

--- a/homeassistant/components/homematicip_cloud.py
+++ b/homeassistant/components/homematicip_cloud.py
@@ -126,7 +126,8 @@ class HomematicipConnector:
         We are only interested to check whether the access point
         is still connected. If not, device state changes cannot
         be forwarded to hass. So if access point is disconnected all devices
-        are set to unavailable."""
+        are set to unavailable.
+        """
         if not self.home.connected:
             _LOGGER.error(
                 "HMIP access point has lost connection with the cloud")
@@ -134,9 +135,8 @@ class HomematicipConnector:
             self.set_all_to_unavailable()
         else:
             if not self._accesspoint_connected:
-                """Explicitly getting an update as device states might have
-                changed during access point disconnect.
-                """
+                # Explicitly getting an update as device states might have
+                # changed during access point disconnect."""
 
                 job = self._hass.async_add_job(self.get_state())
                 job.add_done_callback(self.get_state_finished)
@@ -147,7 +147,7 @@ class HomematicipConnector:
         self.update_all()
 
     def get_state_finished(self, future):
-        """Executed when get_state coroutine has finished."""
+        """Execute when get_state coroutine has finished."""
         from homematicip.base.base_connection import HmipConnectionError
 
         try:
@@ -160,15 +160,13 @@ class HomematicipConnector:
             self._hass.async_add_job(self.home.disable_events())
 
     def set_all_to_unavailable(self):
-        """Set all devices to unavailable and tell Hass"""
-
+        """Set all devices to unavailable and tell Hass."""
         for device in self.home.devices:
             device.unreach = True
         self.update_all()
 
     def update_all(self):
         """Signal all devices to update their state."""
-
         for device in self.home.devices:
             device.fire_update_event()
 

--- a/homeassistant/components/homematicip_cloud.py
+++ b/homeassistant/components/homematicip_cloud.py
@@ -7,11 +7,12 @@ https://home-assistant.io/components/homematicip_cloud/
 
 import asyncio
 import logging
+
 import voluptuous as vol
 
+import homeassistant.helpers.config_validation as cv
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.entity import Entity
 
@@ -96,6 +97,7 @@ class HomematicipConnector:
     def __init__(self, hass, config, websession):
         """Initialize HomematicIP cloud connection."""
         from homematicip.async.home import AsyncHome
+
         self._hass = hass
         self._ws_close_requested = False
         self._retry_task = None
@@ -106,12 +108,69 @@ class HomematicipConnector:
         self.home = AsyncHome(hass.loop, websession)
         self.home.set_auth_token(_authtoken)
 
+        self.home.on_update(self.update)
+        self._accesspoint_connected = True
+
         hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, self.close())
 
     async def init(self):
         """Initialize connection."""
         await self.home.init(self._accesspoint)
         await self.home.get_current_state()
+
+    def update(self, *args, **kwargs):
+        """Update the home device.
+
+        Triggered when the hmip HOME_CHANGED event has fired.
+        There are several occasions for this event to happen.
+        We are only interested to check whether the access point
+        is still connected. If not, device state changes cannot
+        be forwarded to hass. So if access point is disconnected all devices
+        are set to unavailable."""
+        if not self.home.connected:
+            _LOGGER.error(
+                "HMIP access point has lost connection with the cloud")
+            self._accesspoint_connected = False
+            self.set_all_to_unavailable()
+        else:
+            if not self._accesspoint_connected:
+                """Explicitly getting an update as device states might have
+                changed during access point disconnect.
+                """
+
+                job = self._hass.async_add_job(self.get_state())
+                job.add_done_callback(self.get_state_finished)
+
+    async def get_state(self):
+        """Update hmip state and tell hass."""
+        await self.home.get_current_state()
+        self.update_all()
+
+    def get_state_finished(self, future):
+        """Executed when get_state coroutine has finished."""
+        from homematicip.base.base_connection import HmipConnectionError
+
+        try:
+            future.result()
+        except HmipConnectionError:
+            # Somehow connection could not recover. Will disconnect and
+            # so reconnect loop is taking over.
+            _LOGGER.error(
+                "updating state after himp access point reconnect failed.")
+            self._hass.async_add_job(self.home.disable_events())
+
+    def set_all_to_unavailable(self):
+        """Set all devices to unavailable and tell Hass"""
+
+        for device in self.home.devices:
+            device.unreach = True
+        self.update_all()
+
+    def update_all(self):
+        """Signal all devices to update their state."""
+
+        for device in self.home.devices:
+            device.fire_update_event()
 
     async def _handle_connection(self):
         """Handle websocket connection."""


### PR DESCRIPTION
## Description:

Homematic IP is a cloud based system. while hass keeps connected to the HmIP cloud the access-point might get disconnected (unplugged cable or something). This PR checks for the access-point connection and sets all connected devices to unavailable to prevent hass automations to happen based on out-of-date device states.