### PR TITLE
Fixes #14169 (Upgrade pyupnp-async to 0.1.0.2)

### DIFF
--- a/homeassistant/components/upnp.py
+++ b/homeassistant/components/upnp.py
@@ -15,7 +15,7 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import discovery
 from homeassistant.util import get_local_ip
 
-REQUIREMENTS = ['pyupnp-async==0.1.0.1']
+REQUIREMENTS = ['pyupnp-async==0.1.0.2']
 DEPENDENCIES = ['http']
 
 _LOGGER = logging.getLogger(__name__)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1069,7 +1069,7 @@ pytradfri[async]==5.4.2
 pyunifi==2.13
 
 # homeassistant.components.upnp
-pyupnp-async==0.1.0.1
+pyupnp-async==0.1.0.2
 
 # homeassistant.components.keyboard
 # pyuserinput==0.1.11

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -162,7 +162,7 @@ pythonwhois==2.4.3
 pyunifi==2.13
 
 # homeassistant.components.upnp
-pyupnp-async==0.1.0.1
+pyupnp-async==0.1.0.2
 
 # homeassistant.components.notify.html5
 pywebpush==1.6.0


### PR DESCRIPTION
## Description:

pyupnp-async version bump

**Related issue (if applicable):** fixes #14169 

## Example entry for `configuration.yaml` (if applicable):
```yaml
upnp:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.