### PR TITLE
Introduced Iperf3 client sensor

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -619,6 +619,7 @@ omit =
     homeassistant/components/sensor/imap_email_content.py
     homeassistant/components/sensor/imap.py
     homeassistant/components/sensor/influxdb.py
+    homeassistant/components/sensor/iperf3.py
     homeassistant/components/sensor/irish_rail_transport.py
     homeassistant/components/sensor/kwb.py
     homeassistant/components/sensor/lacrosse.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ LABEL maintainer="Paulus Schoutsen <Paulus@PaulusSchoutsen.nl>"
 #ENV INSTALL_LIBCEC no
 #ENV INSTALL_PHANTOMJS no
 #ENV INSTALL_SSOCR no
+#ENV INSTALL_IPERF3 no
 
 VOLUME /config
 

--- a/homeassistant/components/sensor/iperf3.py
+++ b/homeassistant/components/sensor/iperf3.py
@@ -85,7 +85,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             sensor.update()
 
     for sensor in dev:
-        hass.services.register(DOMAIN, sensor._service_name, update)
+        hass.services.register(DOMAIN, sensor.service_name, update)
 
 
 class Iperf3Sensor(Entity):
@@ -94,11 +94,9 @@ class Iperf3Sensor(Entity):
     def __init__(self, iperf3_data, sensor_type):
         """Initialize the sensor."""
         self._name = \
-            "{} {}".format(SENSOR_TYPES[sensor_type][0], iperf3_data._server)
+            "{} {}".format(SENSOR_TYPES[sensor_type][0], iperf3_data.server)
         self._state = None
         self._sensor_type = sensor_type
-        self._service_name = \
-            slugify("{} {}".format('update_iperf3', iperf3_data._server))
         self._unit_of_measurement = SENSOR_TYPES[sensor_type][1]
         self.iperf3_client = iperf3_data
 
@@ -106,6 +104,11 @@ class Iperf3Sensor(Entity):
     def name(self):
         """Return the name of the sensor."""
         return self._name
+
+    @property
+    def service_name(self):
+        """Return the service name of the sensor."""
+        return slugify("{} {}".format('update_iperf3', self.iperf3_client.server))
 
     @property
     def state(self):
@@ -165,6 +168,10 @@ class Iperf3Data(object):
                 hass, self.update, second=config.get(CONF_SECOND),
                 minute=config.get(CONF_MINUTE), hour=config.get(CONF_HOUR),
                 day=config.get(CONF_DAY))
+    @property
+    def server(self):
+        """Return server attribute."""
+        return self._server
 
     def update(self, now):
         """Get the latest data using Iperf3."""

--- a/homeassistant/components/sensor/iperf3.py
+++ b/homeassistant/components/sensor/iperf3.py
@@ -29,7 +29,7 @@ ATTR_REMOTE_PORT = 'Remote Port'
 ATTR_TEST_STATUS = 'Test Status'
 ATTR_VERSION = 'Version'
 
-CONF_ATTRIBUTION = 'Data retrived using Iperf3'
+CONF_ATTRIBUTION = 'Data retrieved using Iperf3'
 CONF_SECOND = 'second'
 CONF_MINUTE = 'minute'
 CONF_HOUR = 'hour'

--- a/homeassistant/components/sensor/iperf3.py
+++ b/homeassistant/components/sensor/iperf3.py
@@ -66,6 +66,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         """Update service for manual updates."""
         for sensor in dev:
             sensor.update()
+            sensor.schedule_update_ha_state()
 
     for sensor in dev:
         hass.services.register(DOMAIN, sensor.service_name, update)

--- a/homeassistant/components/sensor/iperf3.py
+++ b/homeassistant/components/sensor/iperf3.py
@@ -108,7 +108,8 @@ class Iperf3Sensor(Entity):
     @property
     def service_name(self):
         """Return the service name of the sensor."""
-        return slugify("{} {}".format('update_iperf3', self.iperf3_client.server))
+        return slugify("{} {}".format(
+            'update_iperf3', self.iperf3_client.server))
 
     @property
     def state(self):
@@ -168,6 +169,7 @@ class Iperf3Data(object):
                 hass, self.update, second=config.get(CONF_SECOND),
                 minute=config.get(CONF_MINUTE), hour=config.get(CONF_HOUR),
                 day=config.get(CONF_DAY))
+
     @property
     def server(self):
         """Return server attribute."""

--- a/homeassistant/components/sensor/iperf3.py
+++ b/homeassistant/components/sensor/iperf3.py
@@ -1,0 +1,221 @@
+"""
+Support for Iperf3 network measurement tool.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.iperf3/
+"""
+import asyncio
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components.sensor import DOMAIN, PLATFORM_SCHEMA
+from homeassistant.const import (
+    ATTR_ATTRIBUTION, CONF_MONITORED_CONDITIONS, STATE_UNKNOWN)
+import homeassistant.helpers.config_validation as cv
+from homeassistant.util import slugify
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.event import track_time_change
+from homeassistant.helpers.restore_state import async_get_last_state
+import homeassistant.util.dt as dt_util
+
+REQUIREMENTS = ['iperf3==0.1.10']
+
+_LOGGER = logging.getLogger(__name__)
+
+ATTR_PROTOCOL = 'Protocol'
+ATTR_REMOTE_HOST = 'Remote Server'
+ATTR_REMOTE_PORT = 'Remote Port'
+ATTR_TEST_STATUS = 'Test Status'
+ATTR_VERSION = 'Version'
+
+CONF_ATTRIBUTION = 'Data retrived using Iperf3'
+CONF_SECOND = 'second'
+CONF_MINUTE = 'minute'
+CONF_HOUR = 'hour'
+CONF_DAY = 'day'
+CONF_MANUAL = 'manual'
+CONF_DURATION = 'duration'
+CONF_SERVER = 'server'
+CONF_PORT = 'port'
+
+DEFAULT_DURATION = 10
+DEFAULT_PORT = 5201
+
+ICON = 'mdi:speedometer'
+
+SENSOR_TYPES = {
+    'download': ['Download', 'Mbit/s'],
+    'upload': ['Upload', 'Mbit/s'],
+}
+
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_MONITORED_CONDITIONS):
+        vol.All(cv.ensure_list, [vol.In(list(SENSOR_TYPES))]),
+    vol.Required(CONF_PORT, default=DEFAULT_PORT): cv.port,
+    vol.Required(CONF_SERVER): cv.string,
+    vol.Optional(CONF_DURATION, default=DEFAULT_DURATION): vol.Range(5, 10),
+    vol.Optional(CONF_SECOND, default=[0]):
+        vol.All(cv.ensure_list, [vol.All(vol.Coerce(int), vol.Range(0, 59))]),
+    vol.Optional(CONF_MINUTE, default=[0]):
+        vol.All(cv.ensure_list, [vol.All(vol.Coerce(int), vol.Range(0, 59))]),
+    vol.Optional(CONF_HOUR):
+        vol.All(cv.ensure_list, [vol.All(vol.Coerce(int), vol.Range(0, 23))]),
+    vol.Optional(CONF_DAY):
+        vol.All(cv.ensure_list, [vol.All(vol.Coerce(int), vol.Range(1, 31))]),
+    vol.Optional(CONF_MANUAL, default=False): cv.boolean,
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the Iperf3 sensor."""
+    data = Iperf3Data(hass, config)
+
+    dev = []
+    for sensor in config[CONF_MONITORED_CONDITIONS]:
+        dev.append(Iperf3Sensor(data, sensor))
+
+    add_devices(dev)
+
+    def update(call=None):
+        """Update service for manual updates."""
+        data.update(dt_util.now())
+        for sensor in dev:
+            sensor.update()
+
+    for sensor in dev:
+        hass.services.register(DOMAIN, sensor._service_name, update)
+
+
+class Iperf3Sensor(Entity):
+    """A Iperf3 sensor implementation."""
+
+    def __init__(self, iperf3_data, sensor_type):
+        """Initialize the sensor."""
+        self._name = \
+            "{} {}".format(SENSOR_TYPES[sensor_type][0], iperf3_data._server)
+        self._state = None
+        self._sensor_type = sensor_type
+        self._service_name = \
+            slugify("{} {}".format('update_iperf3', iperf3_data._server))
+        self._unit_of_measurement = SENSOR_TYPES[sensor_type][1]
+        self.iperf3_client = iperf3_data
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the device."""
+        return self._state
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement of this entity, if any."""
+        return self._unit_of_measurement
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        if self.iperf3_client.data is not None and \
+           self.iperf3_client.attrs is not None:
+            return self.iperf3_client.attrs
+
+    def update(self):
+        """Get the latest data and update the states."""
+        data = self.iperf3_client.data
+        if data is None:
+            return
+
+        if self._sensor_type == 'download':
+            self._state = data['download']
+        elif self._sensor_type == 'upload':
+            self._state = data['upload']
+
+    @asyncio.coroutine
+    def async_added_to_hass(self):
+        """Handle entity which will be added."""
+        state = yield from async_get_last_state(self.hass, self.entity_id)
+        if not state:
+            return
+        self._state = state.state
+
+    @property
+    def icon(self):
+        """Return icon."""
+        return ICON
+
+
+class Iperf3Data(object):
+    """Iperf3 data object."""
+
+    def __init__(self, hass, config):
+        """Initialize the data object."""
+        self.data = None
+        self.attrs = None
+        self._server = config.get(CONF_SERVER)
+        self._port = config.get(CONF_PORT)
+        self._duration = config.get(CONF_DURATION)
+
+        if not config.get(CONF_MANUAL):
+            track_time_change(
+                hass, self.update, second=config.get(CONF_SECOND),
+                minute=config.get(CONF_MINUTE), hour=config.get(CONF_HOUR),
+                day=config.get(CONF_DAY))
+
+    def update(self, now):
+        """Get the latest data using Iperf3."""
+        import iperf3
+
+        _LOGGER.info("Iperf3 sensor: Connecting to %s:%s",
+                     self._server, self._port)
+
+        try:
+            client = iperf3.Client()
+            client.duration = self._duration
+            client.server_hostname = self._server
+            client.port = self._port
+            client.verbose = False
+            result = client.run()
+
+            if result:
+                if result.error is not None:
+
+                    # if fails set to STATE_UNKNOWN
+                    _LOGGER.error("Iperf3 sensor error: %s", result.error)
+
+                    self.data = {
+                        'download': STATE_UNKNOWN,
+                        'upload': STATE_UNKNOWN,
+                    }
+
+                    self.attrs = {
+                        ATTR_ATTRIBUTION: CONF_ATTRIBUTION,
+                        ATTR_PROTOCOL: STATE_UNKNOWN,
+                        ATTR_REMOTE_HOST: STATE_UNKNOWN,
+                        ATTR_REMOTE_PORT: STATE_UNKNOWN,
+                        ATTR_VERSION: STATE_UNKNOWN,
+                        ATTR_TEST_STATUS: result.error,
+                    }
+
+                else:
+
+                    self.data = {
+                        'download': result.received_Mbps,
+                        'upload': result.sent_Mbps,
+                    }
+
+                    self.attrs = {
+                        ATTR_ATTRIBUTION: CONF_ATTRIBUTION,
+                        ATTR_PROTOCOL: result.protocol,
+                        ATTR_REMOTE_HOST: result.remote_host,
+                        ATTR_REMOTE_PORT: result.remote_port,
+                        ATTR_VERSION: result.version,
+                        ATTR_TEST_STATUS: 'OK',
+                    }
+
+        except (OSError, AttributeError) as error:
+            _LOGGER.error("Iperf3 sensor error: %s", error)

--- a/homeassistant/components/sensor/iperf3.py
+++ b/homeassistant/components/sensor/iperf3.py
@@ -62,7 +62,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                              sensor))
     add_devices(dev)
 
-    def update(hass, call=None):
+    def update(call=None):
         """Update service for manual updates."""
         for sensor in dev:
             sensor.update()

--- a/homeassistant/components/sensor/iperf3.py
+++ b/homeassistant/components/sensor/iperf3.py
@@ -149,10 +149,10 @@ class Iperf3Sensor(Entity):
             return
 
         if self._sensor_type == 'download':
-            self._state = self.result.received_Mbps
+            self._state = round(self.result.received_Mbps, 2)
 
         elif self._sensor_type == 'upload':
-            self._state = self.result.sent_Mbps
+            self._state = round(self.result.sent_Mbps, 2)
 
     @asyncio.coroutine
     def async_added_to_hass(self):

--- a/homeassistant/components/sensor/iperf3.py
+++ b/homeassistant/components/sensor/iperf3.py
@@ -56,10 +56,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     dev = []
     for sensor in config[CONF_MONITORED_CONDITIONS]:
         dev.append(
-                Iperf3Sensor(config[CONF_HOST],
-                             config[CONF_PORT],
-                             config[CONF_DURATION],
-                             sensor))
+            Iperf3Sensor(config[CONF_HOST],
+                         config[CONF_PORT],
+                         config[CONF_DURATION],
+                         sensor))
     add_devices(dev)
 
     def update(call=None):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -451,6 +451,9 @@ insteonlocal==0.53
 # homeassistant.components.insteon_plm
 insteonplm==0.9.2
 
+# homeassistant.components.sensor.iperf3
+iperf3==0.1.10
+
 # homeassistant.components.verisure
 jsonpath==0.75
 

--- a/virtualization/Docker/Dockerfile.dev
+++ b/virtualization/Docker/Dockerfile.dev
@@ -13,6 +13,7 @@ LABEL maintainer="Paulus Schoutsen <Paulus@PaulusSchoutsen.nl>"
 #ENV INSTALL_PHANTOMJS no
 #ENV INSTALL_COAP no
 #ENV INSTALL_SSOCR no
+#ENV INSTALL_IPERF3 no
 
 VOLUME /config
 

--- a/virtualization/Docker/scripts/iperf3
+++ b/virtualization/Docker/scripts/iperf3
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Sets up iperf3.
+
+# Stop on errors
+set -e
+
+PACKAGES=(
+  iperf3
+)
+
+apt-get install -y --no-install-recommends ${PACKAGES[@]}

--- a/virtualization/Docker/setup_docker_prereqs
+++ b/virtualization/Docker/setup_docker_prereqs
@@ -10,6 +10,7 @@ INSTALL_FFMPEG="${INSTALL_FFMPEG:-yes}"
 INSTALL_LIBCEC="${INSTALL_LIBCEC:-yes}"
 INSTALL_PHANTOMJS="${INSTALL_PHANTOMJS:-yes}"
 INSTALL_SSOCR="${INSTALL_SSOCR:-yes}"
+INSTALL_IPERF3="${INSTALL_IPERF3:-yes}"
 
 # Required debian packages for running hass or components
 PACKAGES=(
@@ -62,6 +63,10 @@ fi
 
 if [ "$INSTALL_SSOCR" == "yes" ]; then
   virtualization/Docker/scripts/ssocr
+fi
+
+if [ "$INSTALL_IPERF3" == "yes" ]; then
+  virtualization/Docker/scripts/iperf3
 fi
 
 # Remove packages


### PR DESCRIPTION
## Description:
Introducing Iperf3 client sensor. With this sensor is possible to use [iperf3](http://software.es.net/iperf/) to test your network connection against a local or remote Iperf3 server. 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5282

**Pull request in home-assistant/hassio-build:** https://github.com/home-assistant/hassio-build/pull/77

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: iperf3
    host: 192.168.169.6
    duration: 10 
    monitored_conditions:
      - download
      - upload
```
* Download
![image](https://user-images.githubusercontent.com/809840/39462796-f1c88f98-4ce1-11e8-8e64-48f838be8de0.png)

* Upload
![image](https://user-images.githubusercontent.com/809840/39462810-1156ffa2-4ce2-11e8-858f-45dfb60c6bad.png)

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) 

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
