### PR TITLE
Change the divisor for total consumption output

### DIFF
--- a/homeassistant/components/switch/fritzbox.py
+++ b/homeassistant/components/switch/fritzbox.py
@@ -87,7 +87,7 @@ class FritzboxSwitch(SwitchDevice):
 
         if self._device.has_powermeter:
             attrs[ATTR_TOTAL_CONSUMPTION] = "{:.3f}".format(
-                (self._device.energy or 0.0) / 100000)
+                (self._device.energy or 0.0) / 1000)
             attrs[ATTR_TOTAL_CONSUMPTION_UNIT] = \
                 ATTR_TOTAL_CONSUMPTION_UNIT_VALUE
         if self._device.has_temperature_sensor:


### PR DESCRIPTION
According to my observations, the "switch_energy" value displayed by Pyfritzhome is the sum of Wh over the time since start of measurement. 
As a result, the correct divisor for representing output as kWh would be 1000 instead of 10000.

![fritz](https://user-images.githubusercontent.com/7945681/38194714-879e67e2-3679-11e8-8b1f-5e75a3e45dcf.png)