### PR TITLE
Converts RainMachine to hub model (part 2)

### DIFF
--- a/homeassistant/components/rainmachine.py
+++ b/homeassistant/components/rainmachine.py
@@ -23,14 +23,14 @@ DOMAIN = 'rainmachine'
 NOTIFICATION_ID = 'rainmachine_notification'
 NOTIFICATION_TITLE = 'RainMachine Component Setup'
 
+CONF_ZONE_RUN_TIME = 'zone_run_time'
+
 DEFAULT_ATTRIBUTION = 'Data provided by Green Electronics LLC'
 DEFAULT_PORT = 8080
 DEFAULT_SSL = True
 
 MIN_SCAN_TIME = timedelta(seconds=1)
 MIN_SCAN_TIME_FORCED = timedelta(milliseconds=100)
-
-CONF_ZONE_RUN_TIME = 'zone_run_time'
 
 SWITCH_SCHEMA = vol.Schema({
     vol.Optional(CONF_ZONE_RUN_TIME):

--- a/homeassistant/components/rainmachine.py
+++ b/homeassistant/components/rainmachine.py
@@ -62,7 +62,7 @@ def setup(hass, config):
     port = conf[CONF_PORT]
     ssl = conf[CONF_SSL]
 
-    _LOGGER.debug('Setting up client')
+    _LOGGER.debug('Setting up RainMachine client')
 
     try:
         auth = Authenticator.create_local(

--- a/homeassistant/components/rainmachine.py
+++ b/homeassistant/components/rainmachine.py
@@ -68,7 +68,8 @@ def setup(hass, config):
         auth = Authenticator.create_local(
             ip_address, password, port=port, https=ssl)
         client = Client(auth)
-        hass.data[DATA_RAINMACHINE] = client
+        mac = client.provision.wifi()['macAddress']
+        hass.data[DATA_RAINMACHINE] = (client, mac)
     except (HTTPError, ConnectTimeout, UnboundLocalError) as exc_info:
         _LOGGER.error('An error occurred: %s', str(exc_info))
         hass.components.persistent_notification.create(

--- a/homeassistant/components/rainmachine.py
+++ b/homeassistant/components/rainmachine.py
@@ -8,11 +8,10 @@ import logging
 from datetime import timedelta
 
 import voluptuous as vol
-from requests.exceptions import ConnectTimeout
 
-from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import config_validation as cv, discovery
 from homeassistant.const import (
-    CONF_IP_ADDRESS, CONF_PASSWORD, CONF_PORT, CONF_SSL)
+    CONF_IP_ADDRESS, CONF_PASSWORD, CONF_PORT, CONF_SSL, CONF_SWITCHES)
 
 REQUIREMENTS = ['regenmaschine==0.4.1']
 
@@ -31,6 +30,13 @@ DEFAULT_SSL = True
 MIN_SCAN_TIME = timedelta(seconds=1)
 MIN_SCAN_TIME_FORCED = timedelta(milliseconds=100)
 
+CONF_ZONE_RUN_TIME = 'zone_run_time'
+
+SWITCH_SCHEMA = vol.Schema({
+    vol.Optional(CONF_ZONE_RUN_TIME):
+        cv.positive_int
+})
+
 CONFIG_SCHEMA = vol.Schema(
     {
         DOMAIN: vol.Schema({
@@ -38,6 +44,7 @@ CONFIG_SCHEMA = vol.Schema(
             vol.Required(CONF_PASSWORD): cv.string,
             vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
             vol.Optional(CONF_SSL, default=DEFAULT_SSL): cv.boolean,
+            vol.Optional(CONF_SWITCHES): SWITCH_SCHEMA,
         })
     },
     extra=vol.ALLOW_EXTRA)
@@ -47,12 +54,15 @@ def setup(hass, config):
     """Set up the RainMachine component."""
     from regenmaschine import Authenticator, Client
     from regenmaschine.exceptions import HTTPError
+    from requests.exceptions import ConnectTimeout
 
     conf = config[DOMAIN]
     ip_address = conf[CONF_IP_ADDRESS]
     password = conf[CONF_PASSWORD]
     port = conf[CONF_PORT]
     ssl = conf[CONF_SSL]
+
+    _LOGGER.debug('Setting up client')
 
     try:
         auth = Authenticator.create_local(
@@ -68,4 +78,11 @@ def setup(hass, config):
             title=NOTIFICATION_TITLE,
             notification_id=NOTIFICATION_ID)
         return False
+
+    _LOGGER.debug('Setting up switch platform')
+    switch_config = conf.get(CONF_SWITCHES, {})
+    discovery.load_platform(hass, 'switch', DOMAIN, switch_config, config)
+
+    _LOGGER.debug('Setup complete')
+
     return True

--- a/homeassistant/components/switch/rainmachine.py
+++ b/homeassistant/components/switch/rainmachine.py
@@ -4,38 +4,34 @@ from logging import getLogger
 
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.components.rainmachine import (
-    DATA_RAINMACHINE, DEFAULT_ATTRIBUTION, MIN_SCAN_TIME, MIN_SCAN_TIME_FORCED)
-from homeassistant.components.switch import PLATFORM_SCHEMA, SwitchDevice
+    CONF_ZONE_RUN_TIME, DATA_RAINMACHINE, DEFAULT_ATTRIBUTION, MIN_SCAN_TIME,
+    MIN_SCAN_TIME_FORCED)
+from homeassistant.components.switch import SwitchDevice
 from homeassistant.const import ATTR_ATTRIBUTION, ATTR_DEVICE_CLASS
 from homeassistant.util import Throttle
 
 _LOGGER = getLogger(__name__)
 DEPENDENCIES = ['rainmachine']
 
+DEFAULT_ZONE_RUN = 60 * 10
+
 ATTR_CYCLES = 'cycles'
 ATTR_TOTAL_DURATION = 'total_duration'
-
-CONF_ZONE_RUN_TIME = 'zone_run_time'
-
-DEFAULT_ZONE_RUN_SECONDS = 60 * 10
-
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Optional(CONF_ZONE_RUN_TIME, default=DEFAULT_ZONE_RUN_SECONDS):
-        cv.positive_int
-})
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set this component up under its platform."""
+    if discovery_info is None:
+        return
+
     client = hass.data.get(DATA_RAINMACHINE)
     device_name = client.provision.device_name()['name']
     device_mac = client.provision.wifi()['macAddress']
 
-    _LOGGER.debug('Config received: %s', config)
+    _LOGGER.debug('Config received: %s', discovery_info)
 
-    zone_run_time = config[CONF_ZONE_RUN_TIME]
+    zone_run_time = discovery_info.get(CONF_ZONE_RUN_TIME, DEFAULT_ZONE_RUN)
 
     entities = []
     for program in client.programs.all().get('programs', {}):

--- a/homeassistant/components/switch/rainmachine.py
+++ b/homeassistant/components/switch/rainmachine.py
@@ -8,7 +8,7 @@ from homeassistant.components.rainmachine import (
     CONF_ZONE_RUN_TIME, DATA_RAINMACHINE, DEFAULT_ATTRIBUTION, MIN_SCAN_TIME,
     MIN_SCAN_TIME_FORCED)
 from homeassistant.components.switch import SwitchDevice
-from homeassistant.const import ATTR_ATTRIBUTION, ATTR_DEVICE_CLASS
+from homeassistant.const import ATTR_ATTRIBUTION
 from homeassistant.util import Throttle
 
 DEPENDENCIES = ['rainmachine']

--- a/homeassistant/components/switch/rainmachine.py
+++ b/homeassistant/components/switch/rainmachine.py
@@ -11,13 +11,14 @@ from homeassistant.components.switch import SwitchDevice
 from homeassistant.const import ATTR_ATTRIBUTION, ATTR_DEVICE_CLASS
 from homeassistant.util import Throttle
 
-_LOGGER = getLogger(__name__)
 DEPENDENCIES = ['rainmachine']
 
-DEFAULT_ZONE_RUN = 60 * 10
+_LOGGER = getLogger(__name__)
 
 ATTR_CYCLES = 'cycles'
 ATTR_TOTAL_DURATION = 'total_duration'
+
+DEFAULT_ZONE_RUN = 60 * 10
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -25,13 +26,13 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     if discovery_info is None:
         return
 
-    client = hass.data.get(DATA_RAINMACHINE)
-    device_name = client.provision.device_name()['name']
-    device_mac = client.provision.wifi()['macAddress']
-
     _LOGGER.debug('Config received: %s', discovery_info)
 
     zone_run_time = discovery_info.get(CONF_ZONE_RUN_TIME, DEFAULT_ZONE_RUN)
+
+    client = hass.data.get(DATA_RAINMACHINE)
+    device_name = client.provision.device_name()['name']
+    device_mac = client.provision.wifi()['macAddress']
 
     entities = []
     for program in client.programs.all().get('programs', {}):

--- a/homeassistant/components/switch/rainmachine.py
+++ b/homeassistant/components/switch/rainmachine.py
@@ -2,8 +2,6 @@
 
 from logging import getLogger
 
-import voluptuous as vol
-
 from homeassistant.components.rainmachine import (
     CONF_ZONE_RUN_TIME, DATA_RAINMACHINE, DEFAULT_ATTRIBUTION, MIN_SCAN_TIME,
     MIN_SCAN_TIME_FORCED)


### PR DESCRIPTION
## Description:
#14085 was the first cut at moving RainMachine to a hub/component model (for future functionality). After discussion with @balloob, I want to tweak things so that the `rainmachine` component forwards discovery of entities to the platforms (which will make configuration easier, as shown below).

**BREAKING CHANGE:** #14085 (already merged) broke the existing format; this will do so again. If we can merge this before #14085 is released, we will limit to one breaking change (ideal) and can use the message described in that PR.

CC: @MartinHjelmare 

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** https://github.com/home-assistant/home-assistant.github.io/pull/5251 (although this related to #14085 originally, since it hasn't been merged, going to hustle and use it for this PR, as well)

## Example entry for `configuration.yaml` (if applicable):
```yaml
# Bare Configuration:
rainmachine:
  ip_address: 192.168.1.100
  password: abc123

# Configuration of Existing Switch Parameter:
rainmachine:
  ip_address: 192.168.1.100
  password: abc123
  switches:
    zone_run_time: 240
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  ~- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).~
  ~- [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).~
  ~- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.~
  ~- [ ] New files were added to `.coveragerc`.~

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
