### PR TITLE
Default should_poll to False if assumed_state is True

### DIFF
--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -89,7 +89,7 @@ class Entity(object):
 
         False if entity pushes its state to HA.
         """
-        return True
+        return not self.assumed_state
 
     @property
     def unique_id(self) -> str:


### PR DESCRIPTION
## Description:
Mini PR: if an entity has `assumed_state` = True, we should default `should_poll` to False.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
