### PR TITLE
Fix Hue color state for missing xy

### DIFF
--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -245,7 +245,7 @@ class HueLight(Light):
         mode = self._color_mode
         source = self.light.action if self.is_group else self.light.state
 
-        if mode in ('xy', 'hs'):
+        if mode in ('xy', 'hs') and 'xy' in source:
             return color.color_xy_to_hs(*source['xy'])
 
         return None

--- a/tests/components/light/test_hue.py
+++ b/tests/components/light/test_hue.py
@@ -652,6 +652,19 @@ def test_hs_color():
 
     light = hue_light.HueLight(
         light=Mock(state={
+            'colormode': 'hs',
+            'hue': 1234,
+            'sat': 123,
+        }),
+        request_bridge_update=None,
+        bridge=Mock(),
+        is_group=False,
+    )
+
+    assert light.hs_color is None
+
+    light = hue_light.HueLight(
+        light=Mock(state={
             'colormode': 'xy',
             'hue': 1234,
             'sat': 123,


### PR DESCRIPTION
## Description:

I made a mistake with my revert in #14154, I missed that the original code used `get()` to handle non-existent keys. Sorry 😢.

**Related issue (if applicable):** reported in https://github.com/home-assistant/home-assistant/pull/14113#issuecomment-385778613

## Checklist:
  - [ ] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.
