### PR TITLE
PhilipsTV API 5: Added tv channel change and setting of volume level.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -640,6 +640,7 @@ omit =
     homeassistant/components/sensor/plex.py
     homeassistant/components/sensor/pocketcasts.py
     homeassistant/components/sensor/pollen.py
+    homeassistant/components/sensor/postnl.py
     homeassistant/components/sensor/pushbullet.py
     homeassistant/components/sensor/pvoutput.py
     homeassistant/components/sensor/pyload.py

--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -6,6 +6,7 @@ For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/camera/
 """
 import asyncio
+import base64
 import collections
 from contextlib import suppress
 from datetime import timedelta
@@ -13,20 +14,20 @@ import logging
 import hashlib
 from random import SystemRandom
 
-import aiohttp
+import attr
 from aiohttp import web
 import async_timeout
 import voluptuous as vol
 
 from homeassistant.core import callback
-from homeassistant.const import (ATTR_ENTITY_ID, ATTR_ENTITY_PICTURE)
+from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.loader import bind_hass
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.config_validation import PLATFORM_SCHEMA  # noqa
 from homeassistant.components.http import HomeAssistantView, KEY_AUTHENTICATED
+from homeassistant.components import websocket_api
 import homeassistant.helpers.config_validation as cv
 
 DOMAIN = 'camera'
@@ -64,6 +65,20 @@ CAMERA_SERVICE_SNAPSHOT = CAMERA_SERVICE_SCHEMA.extend({
     vol.Required(ATTR_FILENAME): cv.template
 })
 
+WS_TYPE_CAMERA_THUMBNAIL = 'camera_thumbnail'
+SCHEMA_WS_CAMERA_THUMBNAIL = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend({
+    'type': WS_TYPE_CAMERA_THUMBNAIL,
+    'entity_id': cv.entity_id
+})
+
+
+@attr.s
+class Image:
+    """Represent an image."""
+
+    content_type = attr.ib(type=str)
+    content = attr.ib(type=bytes)
+
 
 @bind_hass
 def enable_motion_detection(hass, entity_id=None):
@@ -92,43 +107,40 @@ def async_snapshot(hass, filename, entity_id=None):
 
 
 @bind_hass
-@asyncio.coroutine
-def async_get_image(hass, entity_id, timeout=10):
+async def async_get_image(hass, entity_id, timeout=10):
     """Fetch an image from a camera entity."""
-    websession = async_get_clientsession(hass)
-    state = hass.states.get(entity_id)
+    component = hass.data.get(DOMAIN)
 
-    if state is None:
-        raise HomeAssistantError(
-            "No entity '{0}' for grab an image".format(entity_id))
+    if component is None:
+        raise HomeAssistantError('Camera component not setup')
 
-    url = "{0}{1}".format(
-        hass.config.api.base_url,
-        state.attributes.get(ATTR_ENTITY_PICTURE)
-    )
+    camera = component.get_entity(entity_id)
 
-    try:
+    if camera is None:
+        raise HomeAssistantError('Camera not found')
+
+    with suppress(asyncio.CancelledError, asyncio.TimeoutError):
         with async_timeout.timeout(timeout, loop=hass.loop):
-            response = yield from websession.get(url)
+            image = await camera.async_camera_image()
 
-            if response.status != 200:
-                raise HomeAssistantError("Error {0} on {1}".format(
-                    response.status, url))
+            if image:
+                return Image(camera.content_type, image)
 
-            image = yield from response.read()
-            return image
-
-    except (asyncio.TimeoutError, aiohttp.ClientError):
-        raise HomeAssistantError("Can't connect to {0}".format(url))
+    raise HomeAssistantError('Unable to get image')
 
 
 @asyncio.coroutine
 def async_setup(hass, config):
     """Set up the camera component."""
-    component = EntityComponent(_LOGGER, DOMAIN, hass, SCAN_INTERVAL)
+    component = hass.data[DOMAIN] = \
+        EntityComponent(_LOGGER, DOMAIN, hass, SCAN_INTERVAL)
 
     hass.http.register_view(CameraImageView(component))
     hass.http.register_view(CameraMjpegStream(component))
+    hass.components.websocket_api.async_register_command(
+        WS_TYPE_CAMERA_THUMBNAIL, websocket_camera_thumbnail,
+        SCHEMA_WS_CAMERA_THUMBNAIL
+    )
 
     yield from component.async_setup(config)
 
@@ -344,20 +356,20 @@ class Camera(Entity):
     @property
     def state_attributes(self):
         """Return the camera state attributes."""
-        attr = {
+        attrs = {
             'access_token': self.access_tokens[-1],
         }
 
         if self.model:
-            attr['model_name'] = self.model
+            attrs['model_name'] = self.model
 
         if self.brand:
-            attr['brand'] = self.brand
+            attrs['brand'] = self.brand
 
         if self.motion_detection_enabled:
-            attr['motion_detection'] = self.motion_detection_enabled
+            attrs['motion_detection'] = self.motion_detection_enabled
 
-        return attr
+        return attrs
 
     @callback
     def async_update_token(self):
@@ -440,3 +452,26 @@ class CameraMjpegStream(CameraView):
             return
         except ValueError:
             return web.Response(status=400)
+
+
+@callback
+def websocket_camera_thumbnail(hass, connection, msg):
+    """Handle get camera thumbnail websocket command.
+
+    Async friendly.
+    """
+    async def send_camera_still():
+        """Send a camera still."""
+        try:
+            image = await async_get_image(hass, msg['entity_id'])
+            connection.send_message_outside(websocket_api.result_message(
+                msg['id'], {
+                    'content_type': image.content_type,
+                    'content': base64.b64encode(image.content).decode('utf-8')
+                }
+            ))
+        except HomeAssistantError:
+            connection.send_message_outside(websocket_api.error_message(
+                msg['id'], 'image_fetch_failed', 'Unable to fetch image'))
+
+    hass.async_add_job(send_camera_still())

--- a/homeassistant/components/device_tracker/netgear.py
+++ b/homeassistant/components/device_tracker/netgear.py
@@ -12,21 +12,27 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.components.device_tracker import (
     DOMAIN, PLATFORM_SCHEMA, DeviceScanner)
 from homeassistant.const import (
-    CONF_HOST, CONF_PASSWORD, CONF_USERNAME, CONF_PORT)
+    CONF_HOST, CONF_PASSWORD, CONF_USERNAME, CONF_PORT, CONF_SSL,
+    CONF_DEVICES, CONF_EXCLUDE)
 
-REQUIREMENTS = ['pynetgear==0.3.3']
+REQUIREMENTS = ['pynetgear==0.4.0']
 
 _LOGGER = logging.getLogger(__name__)
 
-DEFAULT_HOST = 'routerlogin.net'
-DEFAULT_USER = 'admin'
-DEFAULT_PORT = 5000
+CONF_APS = 'accesspoints'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
-    vol.Optional(CONF_USERNAME, default=DEFAULT_USER): cv.string,
+    vol.Optional(CONF_HOST, default=''): cv.string,
+    vol.Optional(CONF_SSL, default=False): cv.boolean,
+    vol.Optional(CONF_USERNAME, default=''): cv.string,
     vol.Required(CONF_PASSWORD): cv.string,
-    vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port
+    vol.Optional(CONF_PORT, default=None): vol.Any(None, cv.port),
+    vol.Optional(CONF_DEVICES, default=[]):
+        vol.All(cv.ensure_list, [cv.string]),
+    vol.Optional(CONF_EXCLUDE, default=[]):
+        vol.All(cv.ensure_list, [cv.string]),
+    vol.Optional(CONF_APS, default=[]):
+        vol.All(cv.ensure_list, [cv.string]),
 })
 
 
@@ -34,11 +40,16 @@ def get_scanner(hass, config):
     """Validate the configuration and returns a Netgear scanner."""
     info = config[DOMAIN]
     host = info.get(CONF_HOST)
+    ssl = info.get(CONF_SSL)
     username = info.get(CONF_USERNAME)
     password = info.get(CONF_PASSWORD)
     port = info.get(CONF_PORT)
+    devices = info.get(CONF_DEVICES)
+    excluded_devices = info.get(CONF_EXCLUDE)
+    accesspoints = info.get(CONF_APS)
 
-    scanner = NetgearDeviceScanner(host, username, password, port)
+    scanner = NetgearDeviceScanner(host, ssl, username, password, port,
+                                   devices, excluded_devices, accesspoints)
 
     return scanner if scanner.success_init else None
 
@@ -46,16 +57,21 @@ def get_scanner(hass, config):
 class NetgearDeviceScanner(DeviceScanner):
     """Queries a Netgear wireless router using the SOAP-API."""
 
-    def __init__(self, host, username, password, port):
+    def __init__(self, host, ssl, username, password, port, devices,
+                 excluded_devices, accesspoints):
         """Initialize the scanner."""
         import pynetgear
 
+        self.tracked_devices = devices
+        self.excluded_devices = excluded_devices
+        self.tracked_accesspoints = accesspoints
+
         self.last_results = []
-        self._api = pynetgear.Netgear(password, host, username, port)
+        self._api = pynetgear.Netgear(password, host, username, port, ssl)
 
         _LOGGER.info("Logging in")
 
-        results = self._api.get_attached_devices()
+        results = self.get_attached_devices()
 
         self.success_init = results is not None
 
@@ -68,15 +84,50 @@ class NetgearDeviceScanner(DeviceScanner):
         """Scan for new devices and return a list with found device IDs."""
         self._update_info()
 
-        return (device.mac for device in self.last_results)
+        devices = []
+
+        for dev in self.last_results:
+            tracked = (not self.tracked_devices or
+                       dev.mac in self.tracked_devices or
+                       dev.name in self.tracked_devices)
+            tracked = tracked and (not self.excluded_devices or not(
+                dev.mac in self.excluded_devices or
+                dev.name in self.excluded_devices))
+            if tracked:
+                devices.append(dev.mac)
+                if (self.tracked_accesspoints and
+                        dev.conn_ap_mac in self.tracked_accesspoints):
+                    devices.append(dev.mac + "_" + dev.conn_ap_mac)
+
+        return devices
 
     def get_device_name(self, device):
-        """Return the name of the given device or None if we don't know."""
-        try:
-            return next(result.name for result in self.last_results
-                        if result.mac == device)
-        except StopIteration:
-            return None
+        """Return the name of the given device or the MAC if we don't know."""
+        parts = device.split("_")
+        mac = parts[0]
+        ap_mac = None
+        if len(parts) > 1:
+            ap_mac = parts[1]
+
+        name = None
+        for dev in self.last_results:
+            if dev.mac == mac:
+                name = dev.name
+                break
+
+        if not name or name == "--":
+            name = mac
+
+        if ap_mac:
+            ap_name = "Router"
+            for dev in self.last_results:
+                if dev.mac == ap_mac:
+                    ap_name = dev.name
+                    break
+
+            return name + " on " + ap_name
+
+        return name
 
     def _update_info(self):
         """Retrieve latest information from the Netgear router.
@@ -88,9 +139,21 @@ class NetgearDeviceScanner(DeviceScanner):
 
         _LOGGER.info("Scanning")
 
-        results = self._api.get_attached_devices()
+        results = self.get_attached_devices()
 
         if results is None:
             _LOGGER.warning("Error scanning devices")
 
         self.last_results = results or []
+
+    def get_attached_devices(self):
+        """
+        List attached devices with pynetgear.
+
+        The v2 method takes more time and is more heavy on the router
+        so we only use it if we need connected AP info.
+        """
+        if self.tracked_accesspoints:
+            return self._api.get_attached_devices_2()
+
+        return self._api.get_attached_devices()

--- a/homeassistant/components/fan/template.py
+++ b/homeassistant/components/fan/template.py
@@ -1,0 +1,324 @@
+"""
+Support for Template fans.
+
+For more details about this platform, please refer to the documentation
+https://home-assistant.io/components/fan.template/
+"""
+import logging
+
+import voluptuous as vol
+
+from homeassistant.core import callback
+from homeassistant.const import (
+    CONF_FRIENDLY_NAME, CONF_VALUE_TEMPLATE, CONF_ENTITY_ID,
+    STATE_ON, STATE_OFF, MATCH_ALL, EVENT_HOMEASSISTANT_START,
+    STATE_UNKNOWN)
+
+from homeassistant.exceptions import TemplateError
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.config_validation import PLATFORM_SCHEMA
+from homeassistant.helpers.entity import ToggleEntity
+from homeassistant.components.fan import (SPEED_LOW, SPEED_MEDIUM,
+                                          SPEED_HIGH, SUPPORT_SET_SPEED,
+                                          SUPPORT_OSCILLATE, FanEntity,
+                                          ATTR_SPEED, ATTR_OSCILLATING,
+                                          ENTITY_ID_FORMAT)
+
+from homeassistant.helpers.entity import async_generate_entity_id
+from homeassistant.helpers.script import Script
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_FANS = 'fans'
+CONF_SPEED_LIST = 'speeds'
+CONF_SPEED_TEMPLATE = 'speed_template'
+CONF_OSCILLATING_TEMPLATE = 'oscillating_template'
+CONF_ON_ACTION = 'turn_on'
+CONF_OFF_ACTION = 'turn_off'
+CONF_SET_SPEED_ACTION = 'set_speed'
+CONF_SET_OSCILLATING_ACTION = 'set_oscillating'
+
+_VALID_STATES = [STATE_ON, STATE_OFF]
+_VALID_OSC = [True, False]
+
+FAN_SCHEMA = vol.Schema({
+    vol.Optional(CONF_FRIENDLY_NAME): cv.string,
+    vol.Required(CONF_VALUE_TEMPLATE): cv.template,
+    vol.Optional(CONF_SPEED_TEMPLATE): cv.template,
+    vol.Optional(CONF_OSCILLATING_TEMPLATE): cv.template,
+
+    vol.Required(CONF_ON_ACTION): cv.SCRIPT_SCHEMA,
+    vol.Required(CONF_OFF_ACTION): cv.SCRIPT_SCHEMA,
+
+    vol.Optional(CONF_SET_SPEED_ACTION): cv.SCRIPT_SCHEMA,
+    vol.Optional(CONF_SET_OSCILLATING_ACTION): cv.SCRIPT_SCHEMA,
+
+    vol.Optional(
+        CONF_SPEED_LIST,
+        default=[SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH]
+    ): cv.ensure_list,
+
+    vol.Optional(CONF_ENTITY_ID): cv.entity_ids
+})
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_FANS): vol.Schema({cv.slug: FAN_SCHEMA}),
+})
+
+
+async def async_setup_platform(
+        hass, config, async_add_devices, discovery_info=None
+):
+    """Set up the Template Fans."""
+    fans = []
+
+    for device, device_config in config[CONF_FANS].items():
+        friendly_name = device_config.get(CONF_FRIENDLY_NAME, device)
+
+        state_template = device_config[CONF_VALUE_TEMPLATE]
+        speed_template = device_config.get(CONF_SPEED_TEMPLATE)
+        oscillating_template = device_config.get(
+            CONF_OSCILLATING_TEMPLATE
+        )
+
+        on_action = device_config[CONF_ON_ACTION]
+        off_action = device_config[CONF_OFF_ACTION]
+        set_speed_action = device_config.get(CONF_SET_SPEED_ACTION)
+        set_oscillating_action = device_config.get(CONF_SET_OSCILLATING_ACTION)
+
+        speed_list = device_config[CONF_SPEED_LIST]
+
+        entity_ids = set()
+        manual_entity_ids = device_config.get(CONF_ENTITY_ID)
+
+        for template in (state_template, speed_template, oscillating_template):
+            if template is None:
+                continue
+            template.hass = hass
+
+            if entity_ids == MATCH_ALL or manual_entity_ids is not None:
+                continue
+
+            template_entity_ids = template.extract_entities()
+            if template_entity_ids == MATCH_ALL:
+                entity_ids = MATCH_ALL
+            else:
+                entity_ids |= set(template_entity_ids)
+
+        if manual_entity_ids is not None:
+            entity_ids = manual_entity_ids
+        elif entity_ids != MATCH_ALL:
+            entity_ids = list(entity_ids)
+
+        fans.append(
+            TemplateFan(
+                hass, device, friendly_name,
+                state_template, speed_template, oscillating_template,
+                on_action, off_action, set_speed_action,
+                set_oscillating_action, speed_list, entity_ids
+            )
+        )
+
+    async_add_devices(fans)
+
+
+class TemplateFan(FanEntity):
+    """A template fan component."""
+
+    def __init__(self, hass, device_id, friendly_name,
+                 state_template, speed_template, oscillating_template,
+                 on_action, off_action, set_speed_action,
+                 set_oscillating_action, speed_list, entity_ids):
+        """Initialize the fan."""
+        self.hass = hass
+        self.entity_id = async_generate_entity_id(
+            ENTITY_ID_FORMAT, device_id, hass=hass)
+        self._name = friendly_name
+
+        self._template = state_template
+        self._speed_template = speed_template
+        self._oscillating_template = oscillating_template
+        self._supported_features = 0
+
+        self._on_script = Script(hass, on_action)
+        self._off_script = Script(hass, off_action)
+
+        self._set_speed_script = None
+        if set_speed_action:
+            self._set_speed_script = Script(hass, set_speed_action)
+
+        self._set_oscillating_script = None
+        if set_oscillating_action:
+            self._set_oscillating_script = Script(hass, set_oscillating_action)
+
+        self._state = STATE_OFF
+        self._speed = None
+        self._oscillating = None
+
+        self._template.hass = self.hass
+        if self._speed_template:
+            self._speed_template.hass = self.hass
+            self._supported_features |= SUPPORT_SET_SPEED
+        if self._oscillating_template:
+            self._oscillating_template.hass = self.hass
+            self._supported_features |= SUPPORT_OSCILLATE
+
+        self._entities = entity_ids
+        # List of valid speeds
+        self._speed_list = speed_list
+
+    @property
+    def name(self):
+        """Return the display name of this fan."""
+        return self._name
+
+    @property
+    def supported_features(self) -> int:
+        """Flag supported features."""
+        return self._supported_features
+
+    @property
+    def speed_list(self: ToggleEntity) -> list:
+        """Get the list of available speeds."""
+        return self._speed_list
+
+    @property
+    def is_on(self):
+        """Return true if device is on."""
+        return self._state == STATE_ON
+
+    @property
+    def speed(self):
+        """Return the current speed."""
+        return self._speed
+
+    @property
+    def oscillating(self):
+        """Return the oscillation state."""
+        return self._oscillating
+
+    @property
+    def should_poll(self):
+        """Return the polling state."""
+        return False
+
+    # pylint: disable=arguments-differ
+    async def async_turn_on(self, speed: str = None) -> None:
+        """Turn on the fan."""
+        await self._on_script.async_run()
+        self._state = STATE_ON
+
+        if speed is not None:
+            await self.async_set_speed(speed)
+
+    # pylint: disable=arguments-differ
+    async def async_turn_off(self) -> None:
+        """Turn off the fan."""
+        await self._off_script.async_run()
+        self._state = STATE_OFF
+
+    async def async_set_speed(self, speed: str) -> None:
+        """Set the speed of the fan."""
+        if self._set_speed_script is None:
+            return
+
+        if speed in self._speed_list:
+            self._speed = speed
+            await self._set_speed_script.async_run({ATTR_SPEED: speed})
+        else:
+            _LOGGER.error(
+                'Received invalid speed: %s. ' +
+                'Expected: %s.',
+                speed, self._speed_list)
+
+    async def async_oscillate(self, oscillating: bool) -> None:
+        """Set oscillation of the fan."""
+        if self._set_oscillating_script is None:
+            return
+
+        await self._set_oscillating_script.async_run(
+            {ATTR_OSCILLATING: oscillating}
+        )
+        self._oscillating = oscillating
+
+    async def async_added_to_hass(self):
+        """Register callbacks."""
+        @callback
+        def template_fan_state_listener(entity, old_state, new_state):
+            """Handle target device state changes."""
+            self.async_schedule_update_ha_state(True)
+
+        @callback
+        def template_fan_startup(event):
+            """Update template on startup."""
+            self.hass.helpers.event.async_track_state_change(
+                self._entities, template_fan_state_listener)
+
+            self.async_schedule_update_ha_state(True)
+
+        self.hass.bus.async_listen_once(
+            EVENT_HOMEASSISTANT_START, template_fan_startup)
+
+    async def async_update(self):
+        """Update the state from the template."""
+        # Update state
+        try:
+            state = self._template.async_render()
+        except TemplateError as ex:
+            _LOGGER.error(ex)
+            state = None
+            self._state = None
+
+        # Validate state
+        if state in _VALID_STATES:
+            self._state = state
+        elif state == STATE_UNKNOWN:
+            self._state = None
+        else:
+            _LOGGER.error(
+                'Received invalid fan is_on state: %s. ' +
+                'Expected: %s.',
+                state, ', '.join(_VALID_STATES))
+            self._state = None
+
+        # Update speed if 'speed_template' is configured
+        if self._speed_template is not None:
+            try:
+                speed = self._speed_template.async_render()
+            except TemplateError as ex:
+                _LOGGER.error(ex)
+                speed = None
+                self._state = None
+
+            # Validate speed
+            if speed in self._speed_list:
+                self._speed = speed
+            elif speed == STATE_UNKNOWN:
+                self._speed = None
+            else:
+                _LOGGER.error(
+                    'Received invalid speed: %s. ' +
+                    'Expected: %s.',
+                    speed, self._speed_list)
+                self._speed = None
+
+        # Update oscillating if 'oscillating_template' is configured
+        if self._oscillating_template is not None:
+            try:
+                oscillating = self._oscillating_template.async_render()
+            except TemplateError as ex:
+                _LOGGER.error(ex)
+                self._state = None
+
+            # Validate osc
+            if oscillating == 'True' or oscillating is True:
+                self._oscillating = True
+            elif oscillating == 'False' or oscillating is False:
+                self._oscillating = False
+            elif oscillating == STATE_UNKNOWN:
+                self._oscillating = None
+            else:
+                _LOGGER.error(
+                    'Received invalid oscillating: %s. ' +
+                    'Expected: True/False.', oscillating)
+                self._oscillating = None

--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -606,6 +606,7 @@ def _is_latest(js_option, request):
     return useragent and hass_frontend.version(useragent)
 
 
+@callback
 def websocket_handle_get_panels(hass, connection, msg):
     """Handle get panels command.
 

--- a/homeassistant/components/image_processing/__init__.py
+++ b/homeassistant/components/image_processing/__init__.py
@@ -132,4 +132,4 @@ class ImageProcessingEntity(Entity):
             return
 
         # process image data
-        yield from self.async_process_image(image)
+        yield from self.async_process_image(image.content)

--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -245,7 +245,7 @@ class HueLight(Light):
         mode = self._color_mode
         source = self.light.action if self.is_group else self.light.state
 
-        if mode in ('xy', 'hs'):
+        if mode in ('xy', 'hs') and 'xy' in source:
             return color.color_xy_to_hs(*source['xy'])
 
         return None

--- a/homeassistant/components/media_player/philips_js.py
+++ b/homeassistant/components/media_player/philips_js.py
@@ -13,7 +13,8 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.components.media_player import (
     PLATFORM_SCHEMA, SUPPORT_NEXT_TRACK, SUPPORT_PREVIOUS_TRACK,
     SUPPORT_SELECT_SOURCE, SUPPORT_TURN_OFF, SUPPORT_TURN_ON,
-    SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_STEP, SUPPORT_PLAY, MediaPlayerDevice)
+    SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_SET, SUPPORT_VOLUME_STEP,
+    SUPPORT_PLAY, MediaPlayerDevice)
 from homeassistant.const import (
     CONF_HOST, CONF_NAME, CONF_API_VERSION, STATE_OFF, STATE_ON, STATE_UNKNOWN)
 from homeassistant.helpers.script import Script
@@ -27,6 +28,8 @@ MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=30)
 
 SUPPORT_PHILIPS_JS = SUPPORT_TURN_OFF | SUPPORT_VOLUME_STEP | \
                      SUPPORT_VOLUME_MUTE | SUPPORT_SELECT_SOURCE
+
+SUPPORT_PHILIPS_JS_V5 = SUPPORT_PHILIPS_JS | SUPPORT_VOLUME_SET
 
 SUPPORT_PHILIPS_JS_TV = SUPPORT_PHILIPS_JS | SUPPORT_NEXT_TRACK | \
                         SUPPORT_PREVIOUS_TRACK | SUPPORT_PLAY
@@ -98,6 +101,8 @@ class PhilipsTV(MediaPlayerDevice):
     def supported_features(self):
         """Flag media player features that are supported."""
         is_supporting_turn_on = SUPPORT_TURN_ON if self._on_script else 0
+        if self._tv._api_version == '5':
+            return SUPPORT_PHILIPS_JS_V5 | is_supporting_turn_on
         if self._watching_tv:
             return SUPPORT_PHILIPS_JS_TV | is_supporting_turn_on
         return SUPPORT_PHILIPS_JS | is_supporting_turn_on
@@ -117,14 +122,22 @@ class PhilipsTV(MediaPlayerDevice):
         """List of available input sources."""
         return self._source_list
 
+    def _select_body(self, ccid):
+        return {"channelList": {"id": "alltv"}, "channel": {"ccid": ccid}}
+
     def select_source(self, source):
         """Set the input source."""
         if source in self._source_mapping:
-            self._tv.setSource(self._source_mapping.get(source))
+            id = self._source_mapping.get(source)
+            if self._tv._api_version == '5':
+                self._tv._postReq('activities/tv', self._select_body(id))
+            else:
+                self._tv.setSource(id)
             self._source = source
             if not self._tv.on:
                 self._state = STATE_OFF
-            self._watching_tv = bool(self._tv.source_id == 'tv')
+            if self._tv._api_version != '5':
+                self._watching_tv = bool(self._tv.source_id == 'tv')
 
     @property
     def volume_level(self):
@@ -135,6 +148,26 @@ class PhilipsTV(MediaPlayerDevice):
     def is_volume_muted(self):
         """Boolean if volume is currently muted."""
         return self._muted
+
+    def set_volume_level(self, volume):
+        """Set volume level, range 0..1."""
+        if self._volume != volume:
+            self._setVolume(volume)
+            self._volume = volume
+            if not self._tv.on:
+                self._state = STATE_OFF
+
+    def _setVolume(self, level):
+        if level:
+            if self._min_volume != 0 or not self._max_volume:
+                self.getAudiodata()
+            try:
+                targetlevel = int(level * self._max_volume)
+            except ValueError:
+                _LOGGER.warning("Invalid audio level %s" % str(level))
+                return
+            body = {'current': targetlevel, 'muted': False}
+            self._tv._postReq('audio/volume', body)
 
     def turn_on(self):
         """Turn on the device."""
@@ -176,18 +209,13 @@ class PhilipsTV(MediaPlayerDevice):
     @property
     def media_title(self):
         """Title of current playing media."""
+        if self._tv._api_version == '5':
+            return self._source
         if self._watching_tv and self._channel_name:
             return '{} - {}'.format(self._source, self._channel_name)
         return self._source
 
-    @Throttle(MIN_TIME_BETWEEN_UPDATES)
-    def update(self):
-        """Get the latest data and update device state."""
-        self._tv.update()
-        self._min_volume = self._tv.min_volume
-        self._max_volume = self._tv.max_volume
-        self._volume = self._tv.volume
-        self._muted = self._tv.muted
+    def _update_sources_v1(self):
         if self._tv.source_id:
             src = self._tv.sources.get(self._tv.source_id, None)
             if src:
@@ -197,16 +225,45 @@ class PhilipsTV(MediaPlayerDevice):
                 srcname = self._tv.sources.get(srcid, dict()).get('name', None)
                 self._source_list.append(srcname)
                 self._source_mapping[srcname] = srcid
-        if self._tv.on:
-            self._state = STATE_ON
-        else:
-            self._state = STATE_OFF
-
         self._watching_tv = bool(self._tv.source_id == 'tv')
-
         self._tv.getChannelId()
         self._tv.getChannels()
         if self._tv.channels and self._tv.channel_id in self._tv.channels:
             self._channel_name = self._tv.channels[self._tv.channel_id]['name']
         else:
             self._channel_name = None
+
+    def _update_sources_v5(self):
+        r = self._tv._getReq('channeldb/tv/channelLists/alltv')
+        if r:
+            self._channels = r['Channel']
+        r = self._tv._getReq('activities/tv')
+        if r:
+            self._channel_name = r['channel']['name']
+            self._source = r['channel']['name']
+
+        if self._channels and not self._source_list:
+            for channel in self._channels:
+                srcname = channel['name']
+                self._source_list.append(srcname)
+                self._source_mapping[srcname] = channel['ccid']
+
+    @Throttle(MIN_TIME_BETWEEN_UPDATES)
+    def update(self):
+        """Get the latest data and update device state."""
+        if self._tv._api_version == '5':
+            self._tv.getName()
+            self._tv.getAudiodata()
+            self._volume = self._tv.volume / self._tv.max_volume
+            self._update_sources_v5()
+        else:
+            self._tv.update()
+            self._volume = self._tv.volume
+            self._update_sources_v1()
+        self._min_volume = self._tv.min_volume
+        self._max_volume = self._tv.max_volume
+        self._muted = self._tv.muted
+        if self._tv.on:
+            self._state = STATE_ON
+        else:
+            self._state = STATE_OFF

--- a/homeassistant/components/media_player/philips_js.py
+++ b/homeassistant/components/media_player/philips_js.py
@@ -30,8 +30,6 @@ SUPPORT_PHILIPS_JS = SUPPORT_TURN_OFF | SUPPORT_VOLUME_STEP | \
                      SUPPORT_VOLUME_SET | SUPPORT_VOLUME_MUTE | \
                      SUPPORT_SELECT_SOURCE
 
-SUPPORT_PHILIPS_JS_V5 = SUPPORT_PHILIPS_JS | SUPPORT_VOLUME_SET
-
 SUPPORT_PHILIPS_JS_TV = SUPPORT_PHILIPS_JS | SUPPORT_NEXT_TRACK | \
                         SUPPORT_PREVIOUS_TRACK | SUPPORT_PLAY
 
@@ -102,8 +100,6 @@ class PhilipsTV(MediaPlayerDevice):
     def supported_features(self):
         """Flag media player features that are supported."""
         is_supporting_turn_on = SUPPORT_TURN_ON if self._on_script else 0
-        if self._tv._api_version == '5':
-            return SUPPORT_PHILIPS_JS_V5 | is_supporting_turn_on
         if self._watching_tv:
             return SUPPORT_PHILIPS_JS_TV | is_supporting_turn_on
         return SUPPORT_PHILIPS_JS | is_supporting_turn_on
@@ -123,22 +119,14 @@ class PhilipsTV(MediaPlayerDevice):
         """List of available input sources."""
         return self._source_list
 
-    def _select_body(self, ccid):
-        return {"channelList": {"id": "alltv"}, "channel": {"ccid": ccid}}
-
     def select_source(self, source):
         """Set the input source."""
         if source in self._source_mapping:
-            id = self._source_mapping.get(source)
-            if self._tv._api_version == '5':
-                self._tv._postReq('activities/tv', self._select_body(id))
-            else:
-                self._tv.setSource(id)
+            self._tv.setSource(self._source_mapping.get(source))
             self._source = source
             if not self._tv.on:
                 self._state = STATE_OFF
-            if self._tv._api_version != '5':
-                self._watching_tv = bool(self._tv.source_id == 'tv')
+            self._watching_tv = bool(self._tv.source_id == 'tv')
 
     @property
     def volume_level(self):
@@ -149,26 +137,6 @@ class PhilipsTV(MediaPlayerDevice):
     def is_volume_muted(self):
         """Boolean if volume is currently muted."""
         return self._muted
-
-    def set_volume_level(self, volume):
-        """Set volume level, range 0..1."""
-        if self._volume != volume:
-            self._setVolume(volume)
-            self._volume = volume
-            if not self._tv.on:
-                self._state = STATE_OFF
-
-    def _setVolume(self, level):
-        if level:
-            if self._min_volume != 0 or not self._max_volume:
-                self.getAudiodata()
-            try:
-                targetlevel = int(level * self._max_volume)
-            except ValueError:
-                _LOGGER.warning("Invalid audio level %s" % str(level))
-                return
-            body = {'current': targetlevel, 'muted': False}
-            self._tv._postReq('audio/volume', body)
 
     def turn_on(self):
         """Turn on the device."""
@@ -217,13 +185,18 @@ class PhilipsTV(MediaPlayerDevice):
     @property
     def media_title(self):
         """Title of current playing media."""
-        if self._tv._api_version == '5':
-            return self._source
         if self._watching_tv and self._channel_name:
             return '{} - {}'.format(self._source, self._channel_name)
         return self._source
 
-    def _update_sources_v1(self):
+    @Throttle(MIN_TIME_BETWEEN_UPDATES)
+    def update(self):
+        """Get the latest data and update device state."""
+        self._tv.update()
+        self._min_volume = self._tv.min_volume
+        self._max_volume = self._tv.max_volume
+        self._volume = self._tv.volume
+        self._muted = self._tv.muted
         if self._tv.source_id:
             self._source = self._tv.getSourceName(self._tv.source_id)
         if self._tv.sources and not self._source_list:
@@ -231,45 +204,16 @@ class PhilipsTV(MediaPlayerDevice):
                 srcname = self._tv.getSourceName(srcid)
                 self._source_list.append(srcname)
                 self._source_mapping[srcname] = srcid
+        if self._tv.on:
+            self._state = STATE_ON
+        else:
+            self._state = STATE_OFF
+
         self._watching_tv = bool(self._tv.source_id == 'tv')
+
         self._tv.getChannelId()
         self._tv.getChannels()
         if self._tv.channels and self._tv.channel_id in self._tv.channels:
             self._channel_name = self._tv.channels[self._tv.channel_id]['name']
         else:
             self._channel_name = None
-
-    def _update_sources_v5(self):
-        r = self._tv._getReq('channeldb/tv/channelLists/alltv')
-        if r:
-            self._channels = r['Channel']
-        r = self._tv._getReq('activities/tv')
-        if r:
-            self._channel_name = r['channel']['name']
-            self._source = r['channel']['name']
-
-        if self._channels and not self._source_list:
-            for channel in self._channels:
-                srcname = channel['name']
-                self._source_list.append(srcname)
-                self._source_mapping[srcname] = channel['ccid']
-
-    @Throttle(MIN_TIME_BETWEEN_UPDATES)
-    def update(self):
-        """Get the latest data and update device state."""
-        if self._tv._api_version == '5':
-            self._tv.getName()
-            self._tv.getAudiodata()
-            self._volume = self._tv.volume / self._tv.max_volume
-            self._update_sources_v5()
-        else:
-            self._tv.update()
-            self._volume = self._tv.volume
-            self._update_sources_v1()
-        self._min_volume = self._tv.min_volume
-        self._max_volume = self._tv.max_volume
-        self._muted = self._tv.muted
-        if self._tv.on:
-            self._state = STATE_ON
-        else:
-            self._state = STATE_OFF

--- a/homeassistant/components/microsoft_face.py
+++ b/homeassistant/components/microsoft_face.py
@@ -239,7 +239,7 @@ def async_setup(hass, config):
                 'post',
                 "persongroups/{0}/persons/{1}/persistedFaces".format(
                     g_id, p_id),
-                image,
+                image.content,
                 binary=True
             )
         except HomeAssistantError as err:

--- a/homeassistant/components/sensor/demo.py
+++ b/homeassistant/components/sensor/demo.py
@@ -12,18 +12,21 @@ from homeassistant.helpers.entity import Entity
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Demo sensors."""
     add_devices([
-        DemoSensor('Outside Temperature', 15.6, TEMP_CELSIUS, 12),
-        DemoSensor('Outside Humidity', 54, '%', None),
+        DemoSensor('Outside Temperature', 15.6, 'temperature',
+                   TEMP_CELSIUS, 12),
+        DemoSensor('Outside Humidity', 54, 'humidity', '%', None),
     ])
 
 
 class DemoSensor(Entity):
     """Representation of a Demo sensor."""
 
-    def __init__(self, name, state, unit_of_measurement, battery):
+    def __init__(self, name, state, device_class,
+                 unit_of_measurement, battery):
         """Initialize the sensor."""
         self._name = name
         self._state = state
+        self._device_class = device_class
         self._unit_of_measurement = unit_of_measurement
         self._battery = battery
 
@@ -31,6 +34,11 @@ class DemoSensor(Entity):
     def should_poll(self):
         """No polling needed for a demo sensor."""
         return False
+
+    @property
+    def device_class(self):
+        """Return the device class of the sensor."""
+        return self._device_class
 
     @property
     def name(self):

--- a/homeassistant/components/sensor/eliqonline.py
+++ b/homeassistant/components/sensor/eliqonline.py
@@ -14,8 +14,7 @@ from homeassistant.const import (CONF_ACCESS_TOKEN, CONF_NAME, STATE_UNKNOWN)
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 
-# pylint: disable=import-error, no-member
-REQUIREMENTS = []  # ['eliqonline==1.0.13'] - package disappeared
+REQUIREMENTS = ['eliqonline==1.0.14']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sensor/postnl.py
+++ b/homeassistant/components/sensor/postnl.py
@@ -1,0 +1,110 @@
+"""
+Sensor for PostNL packages.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.postnl/
+"""
+from datetime import timedelta
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import (
+    ATTR_ATTRIBUTION, CONF_NAME, CONF_PASSWORD, CONF_USERNAME)
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import Entity
+from homeassistant.util import Throttle
+
+REQUIREMENTS = ['postnl_api==1.0.1']
+
+_LOGGER = logging.getLogger(__name__)
+
+ATTRIBUTION = 'Information provided by PostNL'
+
+DEFAULT_NAME = 'postnl'
+
+ICON = 'mdi:package-variant-closed'
+
+MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=30)
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_USERNAME): cv.string,
+    vol.Required(CONF_PASSWORD): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+})
+
+
+# pylint: disable=unused-argument
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the PostNL sensor platform."""
+    from postnl_api import PostNL_API, UnauthorizedException
+
+    username = config.get(CONF_USERNAME)
+    password = config.get(CONF_PASSWORD)
+    name = config.get(CONF_NAME)
+
+    try:
+        api = PostNL_API(username, password)
+
+    except UnauthorizedException:
+        _LOGGER.exception("Can't connect to the PostNL webservice")
+        return
+
+    add_devices([PostNLSensor(api, name)], True)
+
+
+class PostNLSensor(Entity):
+    """Representation of a PostNL sensor."""
+
+    def __init__(self, api, name):
+        """Initialize the PostNL sensor."""
+        self._name = name
+        self._attributes = None
+        self._state = None
+        self._api = api
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement of this entity, if any."""
+        return 'package(s)'
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        return self._attributes
+
+    @property
+    def icon(self):
+        """Icon to use in the frontend."""
+        return ICON
+
+    @Throttle(MIN_TIME_BETWEEN_UPDATES)
+    def update(self):
+        """Update device state."""
+        shipments = self._api.get_relevant_shipments()
+        status_counts = {}
+
+        for shipment in shipments:
+            status = shipment['status']['formatted']['short']
+            status = self._api.parse_datetime(status, '%d-%m-%Y', '%H:%M')
+
+            name = shipment['settings']['title']
+            status_counts[name] = status
+
+        self._attributes = {
+            ATTR_ATTRIBUTION: ATTRIBUTION,
+            **status_counts
+        }
+
+        self._state = len(status_counts)

--- a/homeassistant/components/sensor/upnp.py
+++ b/homeassistant/components/sensor/upnp.py
@@ -11,6 +11,8 @@ from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)
 
+DEPENDENCIES = ['upnp']
+
 BYTES_RECEIVED = 1
 BYTES_SENT = 2
 PACKETS_RECEIVED = 3
@@ -25,12 +27,16 @@ SENSOR_TYPES = {
 }
 
 
-async def async_setup_platform(hass, config, add_devices, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_devices,
+                               discovery_info=None):
     """Set up the IGD sensors."""
+    if discovery_info is None:
+        return
+
     device = hass.data[DATA_UPNP]
     service = device.find_first_service(CIC_SERVICE)
     unit = discovery_info['unit']
-    add_devices([
+    async_add_devices([
         IGDSensor(service, t, unit if SENSOR_TYPES[t][1] else '#')
         for t in SENSOR_TYPES], True)
 

--- a/homeassistant/components/sensor/wunderground.py
+++ b/homeassistant/components/sensor/wunderground.py
@@ -15,13 +15,13 @@ import voluptuous as vol
 
 from homeassistant.helpers.typing import HomeAssistantType, ConfigType
 from homeassistant.components import sensor
-from homeassistant.components.sensor import PLATFORM_SCHEMA, ENTITY_ID_FORMAT
+from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
     CONF_MONITORED_CONDITIONS, CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE,
     TEMP_FAHRENHEIT, TEMP_CELSIUS, LENGTH_INCHES, LENGTH_KILOMETERS,
-    LENGTH_MILES, LENGTH_FEET, ATTR_ATTRIBUTION, CONF_ENTITY_NAMESPACE)
+    LENGTH_MILES, LENGTH_FEET, ATTR_ATTRIBUTION)
 from homeassistant.exceptions import PlatformNotReady
-from homeassistant.helpers.entity import Entity, async_generate_entity_id
+from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
@@ -618,8 +618,6 @@ LANG_CODES = [
     'CY', 'SN', 'JI', 'YI',
 ]
 
-DEFAULT_ENTITY_NAMESPACE = 'pws'
-
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_API_KEY): cv.string,
     vol.Optional(CONF_PWS_ID): cv.string,
@@ -629,31 +627,30 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Inclusive(CONF_LONGITUDE, 'coordinates',
                   'Latitude and longitude must exist together'): cv.longitude,
     vol.Required(CONF_MONITORED_CONDITIONS):
-        vol.All(cv.ensure_list, vol.Length(min=1), [vol.In(SENSOR_TYPES)]),
-    vol.Optional(CONF_ENTITY_NAMESPACE,
-                 default=DEFAULT_ENTITY_NAMESPACE): cv.string,
+        vol.All(cv.ensure_list, vol.Length(min=1), [vol.In(SENSOR_TYPES)])
 })
-
-# Stores a list of entity ids we added in order to support multiple stations
-# at once.
-ADDED_ENTITY_IDS_KEY = 'wunderground_added_entity_ids'
 
 
 async def async_setup_platform(hass: HomeAssistantType, config: ConfigType,
                                async_add_devices, discovery_info=None):
     """Set up the WUnderground sensor."""
-    hass.data.setdefault(ADDED_ENTITY_IDS_KEY, set())
-
     latitude = config.get(CONF_LATITUDE, hass.config.latitude)
     longitude = config.get(CONF_LONGITUDE, hass.config.longitude)
-    namespace = config.get(CONF_ENTITY_NAMESPACE)
+    pws_id = config.get(CONF_PWS_ID)
 
     rest = WUndergroundData(
-        hass, config.get(CONF_API_KEY), config.get(CONF_PWS_ID),
+        hass, config.get(CONF_API_KEY), pws_id,
         config.get(CONF_LANG), latitude, longitude)
+
+    if pws_id is None:
+        unique_id_base = "@{:06f},{:06f}".format(longitude, latitude)
+    else:
+        # Manually specified weather station, use that for unique_id
+        unique_id_base = pws_id
     sensors = []
     for variable in config[CONF_MONITORED_CONDITIONS]:
-        sensors.append(WUndergroundSensor(hass, rest, variable, namespace))
+        sensors.append(WUndergroundSensor(hass, rest, variable,
+                                          unique_id_base))
 
     await rest.async_update()
     if not rest.data:
@@ -666,7 +663,7 @@ class WUndergroundSensor(Entity):
     """Implementing the WUnderground sensor."""
 
     def __init__(self, hass: HomeAssistantType, rest, condition,
-                 namespace: str):
+                 unique_id_base: str):
         """Initialize the sensor."""
         self.rest = rest
         self._condition = condition
@@ -678,12 +675,10 @@ class WUndergroundSensor(Entity):
         self._entity_picture = None
         self._unit_of_measurement = self._cfg_expand("unit_of_measurement")
         self.rest.request_feature(SENSOR_TYPES[condition].feature)
-        current_ids = set(hass.states.async_entity_ids(sensor.DOMAIN))
-        current_ids |= hass.data[ADDED_ENTITY_IDS_KEY]
-        self.entity_id = async_generate_entity_id(
-            ENTITY_ID_FORMAT, "{} {}".format(namespace, condition),
-            current_ids=current_ids)
-        hass.data[ADDED_ENTITY_IDS_KEY].add(self.entity_id)
+        # This is only the suggested entity id, it might get changed by
+        # the entity registry later.
+        self.entity_id = sensor.ENTITY_ID_FORMAT.format('pws_' + condition)
+        self._unique_id = "{},{}".format(unique_id_base, condition)
 
     def _cfg_expand(self, what, default=None):
         """Parse and return sensor data."""
@@ -762,6 +757,11 @@ class WUndergroundSensor(Entity):
         if isinstance(url, str):
             self._entity_picture = re.sub(r'^http://', 'https://',
                                           url, flags=re.IGNORECASE)
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique ID."""
+        return self._unique_id
 
 
 class WUndergroundData(object):

--- a/homeassistant/components/switch/mqtt.py
+++ b/homeassistant/components/switch/mqtt.py
@@ -16,9 +16,10 @@ from homeassistant.components.mqtt import (
 from homeassistant.components.switch import SwitchDevice
 from homeassistant.const import (
     CONF_NAME, CONF_OPTIMISTIC, CONF_VALUE_TEMPLATE, CONF_PAYLOAD_OFF,
-    CONF_PAYLOAD_ON, CONF_ICON)
+    CONF_PAYLOAD_ON, CONF_ICON, STATE_ON)
 import homeassistant.components.mqtt as mqtt
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.restore_state import async_get_last_state
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -111,6 +112,12 @@ class MqttSwitch(MqttAvailability, SwitchDevice):
             await mqtt.async_subscribe(
                 self.hass, self._state_topic, state_message_received,
                 self._qos)
+
+        if self._optimistic:
+            last_state = await async_get_last_state(self.hass,
+                                                    self.entity_id)
+            if last_state:
+                self._state = last_state.state == STATE_ON
 
     @property
     def should_poll(self):

--- a/homeassistant/components/upnp.py
+++ b/homeassistant/components/upnp.py
@@ -50,7 +50,7 @@ CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Optional(CONF_ENABLE_PORT_MAPPING, default=True): cv.boolean,
         vol.Optional(CONF_UNITS, default="MBytes"): vol.In(UNITS),
-        vol.Optional(CONF_LOCAL_IP): ip_address,
+        vol.Optional(CONF_LOCAL_IP): vol.All(ip_address, cv.string),
         vol.Optional(CONF_PORTS):
             vol.Schema({vol.Any(CONF_HASS, cv.positive_int): cv.positive_int})
     }),
@@ -62,9 +62,7 @@ async def async_setup(hass, config):
     config = config[DOMAIN]
     host = config.get(CONF_LOCAL_IP)
 
-    if host is not None:
-        host = str(host)
-    else:
+    if host is None:
         host = get_local_ip()
 
     if host == '127.0.0.1':
@@ -90,10 +88,8 @@ async def async_setup(hass, config):
                 service = device.find_first_service(IP_SERVICE)
             if _service['serviceType'] == CIC_SERVICE:
                 unit = config.get(CONF_UNITS)
-                discovery.load_platform(hass, 'sensor',
-                                        DOMAIN,
-                                        {'unit': unit},
-                                        config)
+                hass.async_add_job(discovery.async_load_platform(
+                    hass, 'sensor', DOMAIN, {'unit': unit}, config))
     except UpnpSoapError as error:
         _LOGGER.error(error)
         return False

--- a/homeassistant/components/websocket_api.py
+++ b/homeassistant/components/websocket_api.py
@@ -429,6 +429,7 @@ class ActiveConnection:
         return wsock
 
 
+@callback
 def handle_subscribe_events(hass, connection, msg):
     """Handle subscribe events command.
 
@@ -447,6 +448,7 @@ def handle_subscribe_events(hass, connection, msg):
     connection.to_write.put_nowait(result_message(msg['id']))
 
 
+@callback
 def handle_unsubscribe_events(hass, connection, msg):
     """Handle unsubscribe events command.
 
@@ -462,6 +464,7 @@ def handle_unsubscribe_events(hass, connection, msg):
             msg['id'], ERR_NOT_FOUND, 'Subscription not found.'))
 
 
+@callback
 def handle_call_service(hass, connection, msg):
     """Handle call service command.
 
@@ -476,6 +479,7 @@ def handle_call_service(hass, connection, msg):
     hass.async_add_job(call_service_helper(msg))
 
 
+@callback
 def handle_get_states(hass, connection, msg):
     """Handle get states command.
 
@@ -485,6 +489,7 @@ def handle_get_states(hass, connection, msg):
         msg['id'], hass.states.async_all()))
 
 
+@callback
 def handle_get_services(hass, connection, msg):
     """Handle get services command.
 
@@ -499,6 +504,7 @@ def handle_get_services(hass, connection, msg):
     hass.async_add_job(get_services_helper(msg))
 
 
+@callback
 def handle_get_config(hass, connection, msg):
     """Handle get config command.
 
@@ -508,6 +514,7 @@ def handle_get_config(hass, connection, msg):
         msg['id'], hass.config.as_dict()))
 
 
+@callback
 def handle_ping(hass, connection, msg):
     """Handle ping command.
 

--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -359,6 +359,11 @@ def setup(hass, config):
         _LOGGER.info("Z-Wave soft_reset have been initialized")
         network.controller.soft_reset()
 
+    def update_config(service):
+        """Update the config from git."""
+        _LOGGER.info("Configuration update has been initialized")
+        network.controller.update_ozw_config()
+
     def test_network(service):
         """Test the network by sending commands to all the nodes."""
         _LOGGER.info("Z-Wave test_network have been initialized")
@@ -616,6 +621,8 @@ def setup(hass, config):
         hass.services.register(DOMAIN, const.SERVICE_HEAL_NETWORK,
                                heal_network)
         hass.services.register(DOMAIN, const.SERVICE_SOFT_RESET, soft_reset)
+        hass.services.register(DOMAIN, const.SERVICE_UPDATE_CONFIG,
+                               update_config)
         hass.services.register(DOMAIN, const.SERVICE_TEST_NETWORK,
                                test_network)
         hass.services.register(DOMAIN, const.SERVICE_STOP_NETWORK,

--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -297,15 +297,46 @@ def setup(hass, config):
     def node_added(node):
         """Handle a new node on the network."""
         entity = ZWaveNodeEntity(node, network)
-        name = node_name(node)
-        generated_id = generate_entity_id(DOMAIN + '.{}', name, [])
-        node_config = device_config.get(generated_id)
-        if node_config.get(CONF_IGNORED):
-            _LOGGER.info(
-                "Ignoring node entity %s due to device settings",
-                generated_id)
+
+        def _add_node_to_component():
+            name = node_name(node)
+            generated_id = generate_entity_id(DOMAIN + '.{}', name, [])
+            node_config = device_config.get(generated_id)
+            if node_config.get(CONF_IGNORED):
+                _LOGGER.info(
+                    "Ignoring node entity %s due to device settings",
+                    generated_id)
+                return
+            component.add_entities([entity])
+
+        if entity.unique_id:
+            _add_node_to_component()
             return
-        component.add_entities([entity])
+
+        async def _check_node_ready():
+            """Wait for node to be parsed."""
+            start_time = dt_util.utcnow()
+            while True:
+                waited = int((dt_util.utcnow()-start_time).total_seconds())
+
+                if entity.unique_id:
+                    _LOGGER.info("Z-Wave node %d ready after %d seconds",
+                                 entity.node_id, waited)
+                    break
+                elif waited >= const.NODE_READY_WAIT_SECS:
+                    # Wait up to NODE_READY_WAIT_SECS seconds for the Z-Wave
+                    # node to be ready.
+                    _LOGGER.warning(
+                        "Z-Wave node %d not ready after %d seconds, "
+                        "continuing anyway",
+                        entity.node_id, waited)
+                    break
+                else:
+                    await asyncio.sleep(1, loop=hass.loop)
+
+            hass.async_add_job(_add_node_to_component)
+
+        hass.add_job(_check_node_ready)
 
     def network_ready():
         """Handle the query of all awake nodes."""

--- a/homeassistant/components/zwave/const.py
+++ b/homeassistant/components/zwave/const.py
@@ -20,6 +20,7 @@ ATTR_POLL_INTENSITY = "poll_intensity"
 ATTR_VALUE_INDEX = "value_index"
 ATTR_VALUE_INSTANCE = "value_instance"
 NETWORK_READY_WAIT_SECS = 300
+NODE_READY_WAIT_SECS = 30
 
 DISCOVERY_DEVICE = 'device'
 

--- a/homeassistant/components/zwave/const.py
+++ b/homeassistant/components/zwave/const.py
@@ -51,6 +51,7 @@ SERVICE_RENAME_VALUE = "rename_value"
 SERVICE_REFRESH_ENTITY = "refresh_entity"
 SERVICE_REFRESH_NODE = "refresh_node"
 SERVICE_RESET_NODE_METERS = "reset_node_meters"
+SERVICE_UPDATE_CONFIG = "update_config"
 
 EVENT_SCENE_ACTIVATED = "zwave.scene_activated"
 EVENT_NODE_EVENT = "zwave.node_event"

--- a/homeassistant/components/zwave/node_entity.py
+++ b/homeassistant/components/zwave/node_entity.py
@@ -81,6 +81,7 @@ class ZWaveNodeEntity(ZWaveBaseEntity):
         self._name = node_name(self.node)
         self._product_name = node.product_name
         self._manufacturer_name = node.manufacturer_name
+        self._unique_id = self._compute_unique_id()
         self._attributes = {}
         self.wakeup_interval = None
         self.location = None
@@ -94,6 +95,11 @@ class ZWaveNodeEntity(ZWaveBaseEntity):
             self.network_node_event, ZWaveNetwork.SIGNAL_NODE_EVENT)
         dispatcher.connect(
             self.network_scene_activated, ZWaveNetwork.SIGNAL_SCENE_EVENT)
+
+    @property
+    def unique_id(self):
+        """Unique ID of Z-wave node."""
+        return self._unique_id
 
     def network_node_changed(self, node=None, value=None, args=None):
         """Handle a changed node on the network."""
@@ -138,7 +144,13 @@ class ZWaveNodeEntity(ZWaveBaseEntity):
             self.wakeup_interval = None
 
         self.battery_level = self.node.get_battery_level()
+        self._product_name = self.node.product_name
+        self._manufacturer_name = self.node.manufacturer_name
+        self._name = node_name(self.node)
         self._attributes = attributes
+
+        if not self._unique_id:
+            self._unique_id = self._compute_unique_id()
 
         self.maybe_schedule_update()
 
@@ -229,3 +241,8 @@ class ZWaveNodeEntity(ZWaveBaseEntity):
             attrs[ATTR_WAKEUP] = self.wakeup_interval
 
         return attrs
+
+    def _compute_unique_id(self):
+        if self._manufacturer_name and self._product_name:
+            return 'node-{}'.format(self.node_id)
+        return None

--- a/homeassistant/components/zwave/services.yaml
+++ b/homeassistant/components/zwave/services.yaml
@@ -119,6 +119,9 @@ set_wakeup:
     value:
       description: Value of the interval to set. (integer)
 
+update_config:
+  description: Attempt to update ozw configuration files from git to support newer devices.
+
 start_network:
   description: Start the Z-Wave network. This might take a while, depending on how big your Z-Wave network is.
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -632,6 +632,9 @@ pmsensor==0.4
 # homeassistant.components.sensor.pocketcasts
 pocketcasts==0.1
 
+# homeassistant.components.sensor.postnl
+postnl_api==1.0.1
+
 # homeassistant.components.climate.proliphix
 proliphix==0.4.1
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -869,7 +869,7 @@ pymysensors==0.11.1
 pynello==1.5.1
 
 # homeassistant.components.device_tracker.netgear
-pynetgear==0.3.3
+pynetgear==0.4.0
 
 # homeassistant.components.switch.netio
 pynetio==0.1.6

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -276,6 +276,9 @@ dsmr_parser==0.11
 # homeassistant.components.sensor.dweet
 dweepy==0.3.0
 
+# homeassistant.components.sensor.eliqonline
+eliqonline==1.0.14
+
 # homeassistant.components.enocean
 enocean==0.40
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -365,7 +365,7 @@ gstreamer-player==1.1.0
 ha-ffmpeg==1.9
 
 # homeassistant.components.media_player.philips_js
-ha-philipsjs==0.0.3
+ha-philipsjs==0.0.4
 
 # homeassistant.components.sensor.geo_rss_events
 haversine==0.4.5

--- a/tests/components/fan/test_template.py
+++ b/tests/components/fan/test_template.py
@@ -1,0 +1,549 @@
+"""The tests for the Template fan platform."""
+import logging
+
+from homeassistant.core import callback
+from homeassistant import setup
+import homeassistant.components as components
+from homeassistant.const import STATE_ON, STATE_OFF
+from homeassistant.components.fan import (
+    ATTR_SPEED, ATTR_OSCILLATING, SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH)
+
+from tests.common import (
+    get_test_home_assistant, assert_setup_component)
+_LOGGER = logging.getLogger(__name__)
+
+
+_TEST_FAN = 'fan.test_fan'
+# Represent for fan's state
+_STATE_INPUT_BOOLEAN = 'input_boolean.state'
+# Represent for fan's speed
+_SPEED_INPUT_SELECT = 'input_select.speed'
+# Represent for fan's oscillating
+_OSC_INPUT = 'input_select.osc'
+
+
+class TestTemplateFan:
+    """Test the Template light."""
+
+    hass = None
+    calls = None
+    # pylint: disable=invalid-name
+
+    def setup_method(self, method):
+        """Setup."""
+        self.hass = get_test_home_assistant()
+
+        self.calls = []
+
+        @callback
+        def record_call(service):
+            """Track function calls.."""
+            self.calls.append(service)
+
+        self.hass.services.register('test', 'automation', record_call)
+
+    def teardown_method(self, method):
+        """Stop everything that was started."""
+        self.hass.stop()
+
+    # Configuration tests #
+    def test_missing_optional_config(self):
+        """Test: missing optional template is ok."""
+        with assert_setup_component(1, 'fan'):
+            assert setup.setup_component(self.hass, 'fan', {
+                'fan': {
+                    'platform': 'template',
+                    'fans': {
+                        'test_fan': {
+                            'value_template': "{{ 'on' }}",
+
+                            'turn_on': {
+                                'service': 'script.fan_on'
+                            },
+                            'turn_off': {
+                                'service': 'script.fan_off'
+                            }
+                        }
+                    }
+                }
+            })
+
+        self.hass.start()
+        self.hass.block_till_done()
+
+        self._verify(STATE_ON, None, None)
+
+    def test_missing_value_template_config(self):
+        """Test: missing 'value_template' will fail."""
+        with assert_setup_component(0, 'fan'):
+            assert setup.setup_component(self.hass, 'fan', {
+                'fan': {
+                    'platform': 'template',
+                    'fans': {
+                        'test_fan': {
+                            'turn_on': {
+                                'service': 'script.fan_on'
+                            },
+                            'turn_off': {
+                                'service': 'script.fan_off'
+                            }
+                        }
+                    }
+                }
+            })
+
+        self.hass.start()
+        self.hass.block_till_done()
+
+        assert self.hass.states.all() == []
+
+    def test_missing_turn_on_config(self):
+        """Test: missing 'turn_on' will fail."""
+        with assert_setup_component(0, 'fan'):
+            assert setup.setup_component(self.hass, 'fan', {
+                'fan': {
+                    'platform': 'template',
+                    'fans': {
+                        'test_fan': {
+                            'value_template': "{{ 'on' }}",
+                            'turn_off': {
+                                'service': 'script.fan_off'
+                            }
+                        }
+                    }
+                }
+            })
+
+        self.hass.start()
+        self.hass.block_till_done()
+
+        assert self.hass.states.all() == []
+
+    def test_missing_turn_off_config(self):
+        """Test: missing 'turn_off' will fail."""
+        with assert_setup_component(0, 'fan'):
+            assert setup.setup_component(self.hass, 'fan', {
+                'fan': {
+                    'platform': 'template',
+                    'fans': {
+                        'test_fan': {
+                            'value_template': "{{ 'on' }}",
+                            'turn_on': {
+                                'service': 'script.fan_on'
+                            }
+                        }
+                    }
+                }
+            })
+
+        self.hass.start()
+        self.hass.block_till_done()
+
+        assert self.hass.states.all() == []
+
+    def test_invalid_config(self):
+        """Test: missing 'turn_off' will fail."""
+        with assert_setup_component(0, 'fan'):
+            assert setup.setup_component(self.hass, 'fan', {
+                'platform': 'template',
+                'fans': {
+                    'test_fan': {
+                        'value_template': "{{ 'on' }}",
+                        'turn_on': {
+                            'service': 'script.fan_on'
+                        }
+                    }
+                }
+            })
+
+        self.hass.start()
+        self.hass.block_till_done()
+
+        assert self.hass.states.all() == []
+
+    # End of configuration tests #
+
+    # Template tests #
+    def test_templates_with_entities(self):
+        """Test tempalates with values from other entities."""
+        value_template = """
+            {% if is_state('input_boolean.state', 'True') %}
+                {{ 'on' }}
+            {% else %}
+                {{ 'off' }}
+            {% endif %}
+        """
+
+        with assert_setup_component(1, 'fan'):
+            assert setup.setup_component(self.hass, 'fan', {
+                'fan': {
+                    'platform': 'template',
+                    'fans': {
+                        'test_fan': {
+                            'value_template': value_template,
+                            'speed_template':
+                                "{{ states('input_select.speed') }}",
+                            'oscillating_template':
+                                "{{ states('input_select.osc') }}",
+                            'turn_on': {
+                                'service': 'script.fan_on'
+                            },
+                            'turn_off': {
+                                'service': 'script.fan_off'
+                            }
+                        }
+                    }
+                }
+            })
+
+        self.hass.start()
+        self.hass.block_till_done()
+
+        self._verify(STATE_OFF, None, None)
+
+        self.hass.states.set(_STATE_INPUT_BOOLEAN, True)
+        self.hass.states.set(_SPEED_INPUT_SELECT, SPEED_MEDIUM)
+        self.hass.states.set(_OSC_INPUT, 'True')
+        self.hass.block_till_done()
+
+        self._verify(STATE_ON, SPEED_MEDIUM, True)
+
+    def test_templates_with_valid_values(self):
+        """Test templates with valid values."""
+        with assert_setup_component(1, 'fan'):
+            assert setup.setup_component(self.hass, 'fan', {
+                'fan': {
+                    'platform': 'template',
+                    'fans': {
+                        'test_fan': {
+                            'value_template':
+                                "{{ 'on' }}",
+                            'speed_template':
+                                "{{ 'medium' }}",
+                            'oscillating_template':
+                                "{{ 1 == 1 }}",
+
+                            'turn_on': {
+                                'service': 'script.fan_on'
+                            },
+                            'turn_off': {
+                                'service': 'script.fan_off'
+                            }
+                        }
+                    }
+                }
+            })
+
+        self.hass.start()
+        self.hass.block_till_done()
+
+        self._verify(STATE_ON, SPEED_MEDIUM, True)
+
+    def test_templates_invalid_values(self):
+        """Test templates with invalid values."""
+        with assert_setup_component(1, 'fan'):
+            assert setup.setup_component(self.hass, 'fan', {
+                'fan': {
+                    'platform': 'template',
+                    'fans': {
+                        'test_fan': {
+                            'value_template':
+                                "{{ 'abc' }}",
+                            'speed_template':
+                                "{{ '0' }}",
+                            'oscillating_template':
+                                "{{ 'xyz' }}",
+
+                            'turn_on': {
+                                'service': 'script.fan_on'
+                            },
+                            'turn_off': {
+                                'service': 'script.fan_off'
+                            }
+                        }
+                    }
+                }
+            })
+
+        self.hass.start()
+        self.hass.block_till_done()
+
+        self._verify(STATE_OFF, None, None)
+
+    # End of template tests #
+
+    # Function tests #
+    def test_on_off(self):
+        """Test turn on and turn off."""
+        self._register_components()
+
+        # Turn on fan
+        components.fan.turn_on(self.hass, _TEST_FAN)
+        self.hass.block_till_done()
+
+        # verify
+        assert self.hass.states.get(_STATE_INPUT_BOOLEAN).state == STATE_ON
+        self._verify(STATE_ON, None, None)
+
+        # Turn off fan
+        components.fan.turn_off(self.hass, _TEST_FAN)
+        self.hass.block_till_done()
+
+        # verify
+        assert self.hass.states.get(_STATE_INPUT_BOOLEAN).state == STATE_OFF
+        self._verify(STATE_OFF, None, None)
+
+    def test_on_with_speed(self):
+        """Test turn on with speed."""
+        self._register_components()
+
+        # Turn on fan with high speed
+        components.fan.turn_on(self.hass, _TEST_FAN, SPEED_HIGH)
+        self.hass.block_till_done()
+
+        # verify
+        assert self.hass.states.get(_STATE_INPUT_BOOLEAN).state == STATE_ON
+        assert self.hass.states.get(_SPEED_INPUT_SELECT).state == SPEED_HIGH
+        self._verify(STATE_ON, SPEED_HIGH, None)
+
+    def test_set_speed(self):
+        """Test set valid speed."""
+        self._register_components()
+
+        # Turn on fan
+        components.fan.turn_on(self.hass, _TEST_FAN)
+        self.hass.block_till_done()
+
+        # Set fan's speed to high
+        components.fan.set_speed(self.hass, _TEST_FAN, SPEED_HIGH)
+        self.hass.block_till_done()
+
+        # verify
+        assert self.hass.states.get(_SPEED_INPUT_SELECT).state == SPEED_HIGH
+        self._verify(STATE_ON, SPEED_HIGH, None)
+
+        # Set fan's speed to medium
+        components.fan.set_speed(self.hass, _TEST_FAN, SPEED_MEDIUM)
+        self.hass.block_till_done()
+
+        # verify
+        assert self.hass.states.get(_SPEED_INPUT_SELECT).state == SPEED_MEDIUM
+        self._verify(STATE_ON, SPEED_MEDIUM, None)
+
+    def test_set_invalid_speed_from_initial_stage(self):
+        """Test set invalid speed when fan is in initial state."""
+        self._register_components()
+
+        # Turn on fan
+        components.fan.turn_on(self.hass, _TEST_FAN)
+        self.hass.block_till_done()
+
+        # Set fan's speed to 'invalid'
+        components.fan.set_speed(self.hass, _TEST_FAN, 'invalid')
+        self.hass.block_till_done()
+
+        # verify speed is unchanged
+        assert self.hass.states.get(_SPEED_INPUT_SELECT).state == ''
+        self._verify(STATE_ON, None, None)
+
+    def test_set_invalid_speed(self):
+        """Test set invalid speed when fan has valid speed."""
+        self._register_components()
+
+        # Turn on fan
+        components.fan.turn_on(self.hass, _TEST_FAN)
+        self.hass.block_till_done()
+
+        # Set fan's speed to high
+        components.fan.set_speed(self.hass, _TEST_FAN, SPEED_HIGH)
+        self.hass.block_till_done()
+
+        # verify
+        assert self.hass.states.get(_SPEED_INPUT_SELECT).state == SPEED_HIGH
+        self._verify(STATE_ON, SPEED_HIGH, None)
+
+        # Set fan's speed to 'invalid'
+        components.fan.set_speed(self.hass, _TEST_FAN, 'invalid')
+        self.hass.block_till_done()
+
+        # verify speed is unchanged
+        assert self.hass.states.get(_SPEED_INPUT_SELECT).state == SPEED_HIGH
+        self._verify(STATE_ON, SPEED_HIGH, None)
+
+    def test_custom_speed_list(self):
+        """Test set custom speed list."""
+        self._register_components(['1', '2', '3'])
+
+        # Turn on fan
+        components.fan.turn_on(self.hass, _TEST_FAN)
+        self.hass.block_till_done()
+
+        # Set fan's speed to '1'
+        components.fan.set_speed(self.hass, _TEST_FAN, '1')
+        self.hass.block_till_done()
+
+        # verify
+        assert self.hass.states.get(_SPEED_INPUT_SELECT).state == '1'
+        self._verify(STATE_ON, '1', None)
+
+        # Set fan's speed to 'medium' which is invalid
+        components.fan.set_speed(self.hass, _TEST_FAN, SPEED_MEDIUM)
+        self.hass.block_till_done()
+
+        # verify that speed is unchanged
+        assert self.hass.states.get(_SPEED_INPUT_SELECT).state == '1'
+        self._verify(STATE_ON, '1', None)
+
+    def test_set_osc(self):
+        """Test set oscillating."""
+        self._register_components()
+
+        # Turn on fan
+        components.fan.turn_on(self.hass, _TEST_FAN)
+        self.hass.block_till_done()
+
+        # Set fan's osc to True
+        components.fan.oscillate(self.hass, _TEST_FAN, True)
+        self.hass.block_till_done()
+
+        # verify
+        assert self.hass.states.get(_OSC_INPUT).state == 'True'
+        self._verify(STATE_ON, None, True)
+
+        # Set fan's osc to False
+        components.fan.oscillate(self.hass, _TEST_FAN, False)
+        self.hass.block_till_done()
+
+        # verify
+        assert self.hass.states.get(_OSC_INPUT).state == 'False'
+        self._verify(STATE_ON, None, False)
+
+    def test_set_invalid_osc_from_initial_state(self):
+        """Test set invalid oscillating when fan is in initial state."""
+        self._register_components()
+
+        # Turn on fan
+        components.fan.turn_on(self.hass, _TEST_FAN)
+        self.hass.block_till_done()
+
+        # Set fan's osc to 'invalid'
+        components.fan.oscillate(self.hass, _TEST_FAN, 'invalid')
+        self.hass.block_till_done()
+
+        # verify
+        assert self.hass.states.get(_OSC_INPUT).state == ''
+        self._verify(STATE_ON, None, None)
+
+    def test_set_invalid_osc(self):
+        """Test set invalid oscillating when fan has valid osc."""
+        self._register_components()
+
+        # Turn on fan
+        components.fan.turn_on(self.hass, _TEST_FAN)
+        self.hass.block_till_done()
+
+        # Set fan's osc to True
+        components.fan.oscillate(self.hass, _TEST_FAN, True)
+        self.hass.block_till_done()
+
+        # verify
+        assert self.hass.states.get(_OSC_INPUT).state == 'True'
+        self._verify(STATE_ON, None, True)
+
+        # Set fan's osc to False
+        components.fan.oscillate(self.hass, _TEST_FAN, None)
+        self.hass.block_till_done()
+
+        # verify osc is unchanged
+        assert self.hass.states.get(_OSC_INPUT).state == 'True'
+        self._verify(STATE_ON, None, True)
+
+    def _verify(self, expected_state, expected_speed, expected_oscillating):
+        """Verify fan's state, speed and osc."""
+        state = self.hass.states.get(_TEST_FAN)
+        attributes = state.attributes
+        assert state.state == expected_state
+        assert attributes.get(ATTR_SPEED, None) == expected_speed
+        assert attributes.get(ATTR_OSCILLATING, None) == expected_oscillating
+
+    def _register_components(self, speed_list=None):
+        """Register basic components for testing."""
+        with assert_setup_component(1, 'input_boolean'):
+            assert setup.setup_component(
+                self.hass,
+                'input_boolean',
+                {'input_boolean': {'state': None}}
+            )
+
+        with assert_setup_component(2, 'input_select'):
+            assert setup.setup_component(self.hass, 'input_select', {
+                'input_select': {
+                    'speed': {
+                        'name': 'Speed',
+                        'options': ['', SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH,
+                                    '1', '2', '3']
+                    },
+
+                    'osc': {
+                        'name': 'oscillating',
+                        'options': ['', 'True', 'False']
+                    },
+                }
+            })
+
+        with assert_setup_component(1, 'fan'):
+            value_template = """
+            {% if is_state('input_boolean.state', 'on') %}
+                {{ 'on' }}
+            {% else %}
+                {{ 'off' }}
+            {% endif %}
+            """
+
+            test_fan_config = {
+                'value_template': value_template,
+                'speed_template':
+                    "{{ states('input_select.speed') }}",
+                'oscillating_template':
+                    "{{ states('input_select.osc') }}",
+
+                'turn_on': {
+                    'service': 'input_boolean.turn_on',
+                    'entity_id': _STATE_INPUT_BOOLEAN
+                },
+                'turn_off': {
+                    'service': 'input_boolean.turn_off',
+                    'entity_id': _STATE_INPUT_BOOLEAN
+                },
+                'set_speed': {
+                    'service': 'input_select.select_option',
+
+                    'data_template': {
+                        'entity_id': _SPEED_INPUT_SELECT,
+                        'option': '{{ speed }}'
+                    }
+                },
+                'set_oscillating': {
+                    'service': 'input_select.select_option',
+
+                    'data_template': {
+                        'entity_id': _OSC_INPUT,
+                        'option': '{{ oscillating }}'
+                    }
+                }
+            }
+
+            if speed_list:
+                test_fan_config['speeds'] = speed_list
+
+            assert setup.setup_component(self.hass, 'fan', {
+                'fan': {
+                    'platform': 'template',
+                    'fans': {
+                        'test_fan': test_fan_config
+                    }
+                }
+            })
+
+        self.hass.start()
+        self.hass.block_till_done()

--- a/tests/components/homekit/test_type_thermostats.py
+++ b/tests/components/homekit/test_type_thermostats.py
@@ -7,7 +7,7 @@ from homeassistant.components.climate import (
     ATTR_TARGET_TEMP_LOW, ATTR_TARGET_TEMP_HIGH, ATTR_OPERATION_MODE,
     ATTR_OPERATION_LIST, STATE_COOL, STATE_HEAT, STATE_AUTO)
 from homeassistant.const import (
-    ATTR_SERVICE, ATTR_SERVICE_DATA, ATTR_SUPPORTED_FEATURES,
+    ATTR_ENTITY_ID, ATTR_SERVICE, ATTR_SERVICE_DATA, ATTR_SUPPORTED_FEATURES,
     ATTR_UNIT_OF_MEASUREMENT, EVENT_CALL_SERVICE,
     STATE_OFF, TEMP_CELSIUS, TEMP_FAHRENHEIT)
 
@@ -260,6 +260,65 @@ class TestHomekitThermostats(unittest.TestCase):
             self.events[1].data[ATTR_SERVICE_DATA][ATTR_TARGET_TEMP_HIGH],
             25.0)
         self.assertEqual(acc.char_cooling_thresh_temp.value, 25.0)
+
+    def test_power_state(self):
+        """Test if accessory and HA are updated accordingly."""
+        climate = 'climate.test'
+
+        # SUPPORT_ON_OFF = True
+        self.hass.states.set(climate, STATE_HEAT,
+                             {ATTR_SUPPORTED_FEATURES: 4096,
+                              ATTR_OPERATION_MODE: STATE_HEAT,
+                              ATTR_TEMPERATURE: 23.0,
+                              ATTR_CURRENT_TEMPERATURE: 18.0})
+        self.hass.block_till_done()
+        acc = self.thermostat_cls(self.hass, 'Climate', climate,
+                                  2, config=None)
+        acc.run()
+        self.assertTrue(acc.support_power_state)
+
+        self.assertEqual(acc.char_current_heat_cool.value, 1)
+        self.assertEqual(acc.char_target_heat_cool.value, 1)
+
+        self.hass.states.set(climate, STATE_OFF,
+                             {ATTR_OPERATION_MODE: STATE_HEAT,
+                              ATTR_TEMPERATURE: 23.0,
+                              ATTR_CURRENT_TEMPERATURE: 18.0})
+        self.hass.block_till_done()
+        self.assertEqual(acc.char_current_heat_cool.value, 0)
+        self.assertEqual(acc.char_target_heat_cool.value, 0)
+
+        self.hass.states.set(climate, STATE_OFF,
+                             {ATTR_OPERATION_MODE: STATE_OFF,
+                              ATTR_TEMPERATURE: 23.0,
+                              ATTR_CURRENT_TEMPERATURE: 18.0})
+        self.hass.block_till_done()
+        self.assertEqual(acc.char_current_heat_cool.value, 0)
+        self.assertEqual(acc.char_target_heat_cool.value, 0)
+
+        # Set from HomeKit
+        acc.char_target_heat_cool.client_update_value(1)
+        self.hass.block_till_done()
+        self.assertEqual(
+            self.events[0].data[ATTR_SERVICE], 'turn_on')
+        self.assertEqual(
+            self.events[0].data[ATTR_SERVICE_DATA][ATTR_ENTITY_ID],
+            climate)
+        self.assertEqual(
+            self.events[1].data[ATTR_SERVICE], 'set_operation_mode')
+        self.assertEqual(
+            self.events[1].data[ATTR_SERVICE_DATA][ATTR_OPERATION_MODE],
+            STATE_HEAT)
+        self.assertEqual(acc.char_target_heat_cool.value, 1)
+
+        acc.char_target_heat_cool.client_update_value(0)
+        self.hass.block_till_done()
+        self.assertEqual(
+            self.events[2].data[ATTR_SERVICE], 'turn_off')
+        self.assertEqual(
+            self.events[2].data[ATTR_SERVICE_DATA][ATTR_ENTITY_ID],
+            climate)
+        self.assertEqual(acc.char_target_heat_cool.value, 0)
 
     def test_thermostat_fahrenheit(self):
         """Test if accessory and HA are updated accordingly."""

--- a/tests/components/image_processing/test_openalpr_cloud.py
+++ b/tests/components/image_processing/test_openalpr_cloud.py
@@ -3,14 +3,13 @@ import asyncio
 from unittest.mock import patch, PropertyMock
 
 from homeassistant.core import callback
-from homeassistant.const import ATTR_ENTITY_PICTURE
 from homeassistant.setup import setup_component
-import homeassistant.components.image_processing as ip
+from homeassistant.components import camera, image_processing as ip
 from homeassistant.components.image_processing.openalpr_cloud import (
     OPENALPR_API_URL)
 
 from tests.common import (
-    get_test_home_assistant, assert_setup_component, load_fixture)
+    get_test_home_assistant, assert_setup_component, load_fixture, mock_coro)
 
 
 class TestOpenAlprCloudSetup(object):
@@ -131,11 +130,6 @@ class TestOpenAlprCloud(object):
                    new_callable=PropertyMock(return_value=False)):
             setup_component(self.hass, ip.DOMAIN, config)
 
-        state = self.hass.states.get('camera.demo_camera')
-        self.url = "{0}{1}".format(
-            self.hass.config.api.base_url,
-            state.attributes.get(ATTR_ENTITY_PICTURE))
-
         self.alpr_events = []
 
         @callback
@@ -158,18 +152,20 @@ class TestOpenAlprCloud(object):
 
     def test_openalpr_process_image(self, aioclient_mock):
         """Setup and scan a picture and test plates from event."""
-        aioclient_mock.get(self.url, content=b'image')
         aioclient_mock.post(
             OPENALPR_API_URL, params=self.params,
             text=load_fixture('alpr_cloud.json'), status=200
         )
 
-        ip.scan(self.hass, entity_id='image_processing.test_local')
-        self.hass.block_till_done()
+        with patch('homeassistant.components.camera.async_get_image',
+                   return_value=mock_coro(
+                       camera.Image('image/jpeg', b'image'))):
+            ip.scan(self.hass, entity_id='image_processing.test_local')
+            self.hass.block_till_done()
 
         state = self.hass.states.get('image_processing.test_local')
 
-        assert len(aioclient_mock.mock_calls) == 2
+        assert len(aioclient_mock.mock_calls) == 1
         assert len(self.alpr_events) == 5
         assert state.attributes.get('vehicles') == 1
         assert state.state == 'H786P0J'
@@ -184,28 +180,32 @@ class TestOpenAlprCloud(object):
 
     def test_openalpr_process_image_api_error(self, aioclient_mock):
         """Setup and scan a picture and test api error."""
-        aioclient_mock.get(self.url, content=b'image')
         aioclient_mock.post(
             OPENALPR_API_URL, params=self.params,
             text="{'error': 'error message'}", status=400
         )
 
-        ip.scan(self.hass, entity_id='image_processing.test_local')
-        self.hass.block_till_done()
+        with patch('homeassistant.components.camera.async_get_image',
+                   return_value=mock_coro(
+                       camera.Image('image/jpeg', b'image'))):
+            ip.scan(self.hass, entity_id='image_processing.test_local')
+            self.hass.block_till_done()
 
-        assert len(aioclient_mock.mock_calls) == 2
+        assert len(aioclient_mock.mock_calls) == 1
         assert len(self.alpr_events) == 0
 
     def test_openalpr_process_image_api_timeout(self, aioclient_mock):
         """Setup and scan a picture and test api error."""
-        aioclient_mock.get(self.url, content=b'image')
         aioclient_mock.post(
             OPENALPR_API_URL, params=self.params,
             exc=asyncio.TimeoutError()
         )
 
-        ip.scan(self.hass, entity_id='image_processing.test_local')
-        self.hass.block_till_done()
+        with patch('homeassistant.components.camera.async_get_image',
+                   return_value=mock_coro(
+                       camera.Image('image/jpeg', b'image'))):
+            ip.scan(self.hass, entity_id='image_processing.test_local')
+            self.hass.block_till_done()
 
-        assert len(aioclient_mock.mock_calls) == 2
+        assert len(aioclient_mock.mock_calls) == 1
         assert len(self.alpr_events) == 0

--- a/tests/components/light/test_hue.py
+++ b/tests/components/light/test_hue.py
@@ -652,6 +652,19 @@ def test_hs_color():
 
     light = hue_light.HueLight(
         light=Mock(state={
+            'colormode': 'hs',
+            'hue': 1234,
+            'sat': 123,
+        }),
+        request_bridge_update=None,
+        bridge=Mock(),
+        is_group=False,
+    )
+
+    assert light.hs_color is None
+
+    light = hue_light.HueLight(
+        light=Mock(state={
             'colormode': 'xy',
             'hue': 1234,
             'sat': 123,

--- a/tests/components/media_player/test_blackbird.py
+++ b/tests/components/media_player/test_blackbird.py
@@ -59,7 +59,6 @@ class TestBlackbirdSchema(unittest.TestCase):
         """Test valid schema."""
         valid_schema = {
             'platform': 'blackbird',
-            'type': 'serial',
             'port': '/dev/ttyUSB0',
             'zones': {1: {'name': 'a'},
                       2: {'name': 'a'},
@@ -87,8 +86,7 @@ class TestBlackbirdSchema(unittest.TestCase):
         """Test valid schema."""
         valid_schema = {
             'platform': 'blackbird',
-            'type': 'socket',
-            'port': '192.168.1.50',
+            'host': '192.168.1.50',
             'zones': {1: {'name': 'a'},
                       2: {'name': 'a'},
                       3: {'name': 'a'},
@@ -109,10 +107,18 @@ class TestBlackbirdSchema(unittest.TestCase):
         schemas = (
             {},  # Empty
             None,  # None
-            # Missing type
+            # Port and host used concurrently
             {
                 'platform': 'blackbird',
-                'port': 'aaa',
+                'port': '/dev/ttyUSB0',
+                'host': '192.168.1.50',
+                'name': 'Name',
+                'zones': {1: {'name': 'a'}},
+                'sources': {1: {'name': 'b'}},
+            },
+            # Port or host missing
+            {
+                'platform': 'blackbird',
                 'name': 'Name',
                 'zones': {1: {'name': 'a'}},
                 'sources': {1: {'name': 'b'}},
@@ -120,8 +126,7 @@ class TestBlackbirdSchema(unittest.TestCase):
             # Invalid zone number
             {
                 'platform': 'blackbird',
-                'type': 'serial',
-                'port': 'aaa',
+                'port': '/dev/ttyUSB0',
                 'name': 'Name',
                 'zones': {11: {'name': 'a'}},
                 'sources': {1: {'name': 'b'}},
@@ -129,8 +134,7 @@ class TestBlackbirdSchema(unittest.TestCase):
             # Invalid source number
             {
                 'platform': 'blackbird',
-                'type': 'serial',
-                'port': 'aaa',
+                'port': '/dev/ttyUSB0',
                 'name': 'Name',
                 'zones': {1: {'name': 'a'}},
                 'sources': {9: {'name': 'b'}},
@@ -138,8 +142,7 @@ class TestBlackbirdSchema(unittest.TestCase):
             # Zone missing name
             {
                 'platform': 'blackbird',
-                'type': 'serial',
-                'port': 'aaa',
+                'port': '/dev/ttyUSB0',
                 'name': 'Name',
                 'zones': {1: {}},
                 'sources': {1: {'name': 'b'}},
@@ -147,20 +150,10 @@ class TestBlackbirdSchema(unittest.TestCase):
             # Source missing name
             {
                 'platform': 'blackbird',
-                'type': 'serial',
-                'port': 'aaa',
+                'port': '/dev/ttyUSB0',
                 'name': 'Name',
                 'zones': {1: {'name': 'a'}},
                 'sources': {1: {}},
-            },
-            # Invalid type
-            {
-                'platform': 'blackbird',
-                'type': 'aaa',
-                'port': 'aaa',
-                'name': 'Name',
-                'zones': {1: {'name': 'a'}},
-                'sources': {1: {'name': 'b'}},
             },
         )
         for value in schemas:
@@ -181,7 +174,6 @@ class TestBlackbirdMediaPlayer(unittest.TestCase):
                         new=lambda *a: self.blackbird):
             setup_platform(self.hass, {
                 'platform': 'blackbird',
-                'type': 'serial',
                 'port': '/dev/ttyUSB0',
                 'zones': {3: {'name': 'Zone name'}},
                 'sources': {1: {'name': 'one'},
@@ -189,7 +181,7 @@ class TestBlackbirdMediaPlayer(unittest.TestCase):
                             2: {'name': 'two'}},
             }, lambda *args, **kwargs: None, {})
             self.hass.block_till_done()
-        self.media_player = self.hass.data[DATA_BLACKBIRD][0]
+        self.media_player = self.hass.data[DATA_BLACKBIRD]['/dev/ttyUSB0-3']
         self.media_player.hass = self.hass
         self.media_player.entity_id = 'media_player.zone_3'
 
@@ -203,7 +195,8 @@ class TestBlackbirdMediaPlayer(unittest.TestCase):
         self.assertTrue(self.hass.services.has_service(DOMAIN,
                                                        SERVICE_SETALLZONES))
         self.assertEqual(len(self.hass.data[DATA_BLACKBIRD]), 1)
-        self.assertEqual(self.hass.data[DATA_BLACKBIRD][0].name, 'Zone name')
+        self.assertEqual(self.hass.data[DATA_BLACKBIRD]['/dev/ttyUSB0-3'].name,
+                         'Zone name')
 
     def test_setallzones_service_call_with_entity_id(self):
         """Test set all zone source service call with entity id."""

--- a/tests/components/media_player/test_init.py
+++ b/tests/components/media_player/test_init.py
@@ -1,0 +1,37 @@
+"""Test the base functions of the media player."""
+import base64
+from unittest.mock import patch
+
+from homeassistant.setup import async_setup_component
+from homeassistant.components import websocket_api
+
+from tests.common import mock_coro
+
+
+async def test_get_panels(hass, hass_ws_client):
+    """Test get_panels command."""
+    await async_setup_component(hass, 'media_player', {
+        'media_player': {
+            'platform': 'demo'
+        }
+    })
+
+    client = await hass_ws_client(hass)
+
+    with patch('homeassistant.components.media_player.MediaPlayerDevice.'
+               'async_get_media_image', return_value=mock_coro(
+                   (b'image', 'image/jpeg'))):
+        await client.send_json({
+            'id': 5,
+            'type': 'media_player_thumbnail',
+            'entity_id': 'media_player.bedroom',
+        })
+
+        msg = await client.receive_json()
+
+    assert msg['id'] == 5
+    assert msg['type'] == websocket_api.TYPE_RESULT
+    assert msg['success']
+    assert msg['result']['content_type'] == 'image/jpeg'
+    assert msg['result']['content'] == \
+        base64.b64encode(b'image').decode('utf-8')

--- a/tests/components/test_microsoft_face.py
+++ b/tests/components/test_microsoft_face.py
@@ -2,7 +2,7 @@
 import asyncio
 from unittest.mock import patch
 
-import homeassistant.components.microsoft_face as mf
+from homeassistant.components import camera, microsoft_face as mf
 from homeassistant.setup import setup_component
 
 from tests.common import (
@@ -190,7 +190,7 @@ class TestMicrosoftFaceSetup(object):
         assert len(aioclient_mock.mock_calls) == 1
 
     @patch('homeassistant.components.camera.async_get_image',
-           return_value=mock_coro(b'Test'))
+           return_value=mock_coro(camera.Image('image/jpeg', b'Test')))
     def test_service_face(self, camera_mock, aioclient_mock):
         """Setup component, test person face services."""
         aioclient_mock.get(

--- a/tests/components/zwave/test_init.py
+++ b/tests/components/zwave/test_init.py
@@ -224,6 +224,47 @@ def test_node_discovery(hass, mock_openzwave):
     assert hass.states.get('zwave.mock_node').state is 'unknown'
 
 
+async def test_unparsed_node_discovery(hass, mock_openzwave):
+    """Test discovery of a node."""
+    mock_receivers = []
+
+    def mock_connect(receiver, signal, *args, **kwargs):
+        if signal == MockNetwork.SIGNAL_NODE_ADDED:
+            mock_receivers.append(receiver)
+
+    with patch('pydispatch.dispatcher.connect', new=mock_connect):
+        await async_setup_component(hass, 'zwave', {'zwave': {}})
+
+    assert len(mock_receivers) == 1
+
+    node = MockNode(node_id=14, manufacturer_name=None)
+
+    sleeps = []
+
+    def utcnow():
+        return datetime.fromtimestamp(len(sleeps))
+
+    asyncio_sleep = asyncio.sleep
+
+    async def sleep(duration, loop):
+        if duration > 0:
+            sleeps.append(duration)
+        await asyncio_sleep(0, loop=loop)
+
+    with patch('homeassistant.components.zwave.dt_util.utcnow', new=utcnow):
+        with patch('asyncio.sleep', new=sleep):
+            with patch.object(zwave, '_LOGGER') as mock_logger:
+                hass.async_add_job(mock_receivers[0], node)
+                await hass.async_block_till_done()
+
+                assert len(sleeps) == const.NODE_READY_WAIT_SECS
+                assert mock_logger.warning.called
+                assert len(mock_logger.warning.mock_calls) == 1
+                assert mock_logger.warning.mock_calls[0][1][1:] == \
+                    (14, const.NODE_READY_WAIT_SECS)
+    assert hass.states.get('zwave.mock_node').state is 'unknown'
+
+
 @asyncio.coroutine
 def test_node_ignored(hass, mock_openzwave):
     """Test discovery of a node."""

--- a/tests/components/zwave/test_node_entity.py
+++ b/tests/components/zwave/test_node_entity.py
@@ -182,8 +182,6 @@ class TestZWaveNodeEntity(unittest.TestCase):
             query_stage='Dynamic', is_awake=True, is_ready=False,
             is_failed=False, is_info_received=True, max_baud_rate=40000,
             is_zwave_plus=False, capabilities=[], neighbors=[], location=None)
-        self.node.manufacturer_name = 'Test Manufacturer'
-        self.node.product_name = 'Test Product'
         self.entity = node_entity.ZWaveNodeEntity(self.node,
                                                   self.zwave_network)
 
@@ -357,3 +355,14 @@ class TestZWaveNodeEntity(unittest.TestCase):
     def test_not_polled(self):
         """Test should_poll property."""
         self.assertFalse(self.entity.should_poll)
+
+    def test_unique_id(self):
+        """Test unique_id."""
+        self.assertEqual('node-567', self.entity.unique_id)
+
+    def test_unique_id_missing_data(self):
+        """Test unique_id."""
+        self.node.manufacturer_name = None
+        entity = node_entity.ZWaveNodeEntity(self.node, self.zwave_network)
+
+        self.assertIsNone(entity.unique_id)

--- a/tests/mock/zwave.py
+++ b/tests/mock/zwave.py
@@ -119,6 +119,8 @@ class MockNode(MagicMock):
                  product_type='678',
                  command_classes=None,
                  can_wake_up_value=True,
+                 manufacturer_name='Test Manufacturer',
+                 product_name='Test Product',
                  network=None,
                  **kwargs):
         """Initialize a Z-Wave mock node."""
@@ -128,6 +130,8 @@ class MockNode(MagicMock):
         self.manufacturer_id = manufacturer_id
         self.product_id = product_id
         self.product_type = product_type
+        self.manufacturer_name = manufacturer_name
+        self.product_name = product_name
         self.can_wake_up_value = can_wake_up_value
         self._command_classes = command_classes or []
         if network is not None:

--- a/virtualization/Docker/setup_docker_prereqs
+++ b/virtualization/Docker/setup_docker_prereqs
@@ -25,6 +25,8 @@ PACKAGES=(
   libsodium13
   # homeassistant.components.zwave
   libudev-dev
+  # homeassistant.components.homekit_controller
+  libmpc-dev libmpfr-dev libgmp-dev
 )
 
 # Required debian packages for building dependencies


### PR DESCRIPTION
## Description:
When using api_version: 5 with philips_js you can now change tv channels, but not the source like HDMI 1 etc. This is not possible with API 5. Furthermore you can set the volume to a specific value.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5288

## Example entry for `configuration.yaml`:
```yaml
media_player:
  - platform: philips_js
    host: 192.168.0.123
    name: PhilipsTV
    api_version: 5
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54