### PR TITLE
Add domain to labels and count state changes to Prometheus

### DIFF
--- a/homeassistant/components/prometheus.py
+++ b/homeassistant/components/prometheus.py
@@ -86,6 +86,13 @@ class Metrics(object):
         if hasattr(self, handler):
             getattr(self, handler)(state)
 
+        metric = self._metric(
+            'state_change',
+            self.prometheus_client.Counter,
+            'The number of state changes',
+        )
+        metric.labels(**self._labels(state)).inc()
+
     def _metric(self, metric, factory, documentation, labels=None):
         if labels is None:
             labels = ['entity', 'friendly_name', 'domain']

--- a/homeassistant/components/prometheus.py
+++ b/homeassistant/components/prometheus.py
@@ -88,7 +88,7 @@ class Metrics(object):
 
     def _metric(self, metric, factory, documentation, labels=None):
         if labels is None:
-            labels = ['entity', 'friendly_name']
+            labels = ['entity', 'friendly_name', 'domain']
 
         try:
             return self._metrics[metric]
@@ -100,6 +100,7 @@ class Metrics(object):
     def _labels(state):
         return {
             'entity': state.entity_id,
+            'domain': state.domain,
             'friendly_name': state.attributes.get('friendly_name'),
         }
 


### PR DESCRIPTION
## Description:

This PR makes the following enhancements to the Prometheus component:

* All metrics gain an additional `domain` label.
* A new `state_change` metric is incremented for each state change.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**