### PR TITLE
Add alarmdotcom sensor status

### DIFF
--- a/homeassistant/components/alarm_control_panel/alarmdotcom.py
+++ b/homeassistant/components/alarm_control_panel/alarmdotcom.py
@@ -93,6 +93,13 @@ class AlarmDotCom(alarm.AlarmControlPanel):
             return STATE_ALARM_ARMED_AWAY
         return STATE_UNKNOWN
 
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        return {
+            'sensor_status': self._alarm.sensor_status
+        }
+
     @asyncio.coroutine
     def async_alarm_disarm(self, code=None):
         """Send disarm command."""

--- a/homeassistant/components/alarm_control_panel/alarmdotcom.py
+++ b/homeassistant/components/alarm_control_panel/alarmdotcom.py
@@ -17,7 +17,7 @@ from homeassistant.const import (
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['pyalarmdotcom==0.3.1']
+REQUIREMENTS = ['pyalarmdotcom==0.3.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -695,7 +695,7 @@ pyads==2.2.6
 pyairvisual==1.0.0
 
 # homeassistant.components.alarm_control_panel.alarmdotcom
-pyalarmdotcom==0.3.1
+pyalarmdotcom==0.3.2
 
 # homeassistant.components.arlo
 pyarlo==0.1.2


### PR DESCRIPTION
## Description:

This PR adds an `sensor_status` attribute to alarm.com alarm control panels as described in https://github.com/Xorso/pyalarmdotcom/pull/5.

![image](https://user-images.githubusercontent.com/47/39555554-b1cc1ff4-4e3f-11e8-80e8-865b11aad97b.png)


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**