### PR TITLE
Support control of away mode and hold mode in Venstar component. Correctly detect humidifiers.

### DIFF
--- a/homeassistant/components/climate/venstar.py
+++ b/homeassistant/components/climate/venstar.py
@@ -293,7 +293,7 @@ class VenstarThermostat(ClimateDevice):
         elif hold_mode == HOLD_MODE_OFF:
             success = self._client.set_schedule(1)
         else:
-            _LOGGER.error("Unknown hold mode \"%s\"", hold_mode)
+            _LOGGER.error("Unknown hold mode: %s", hold_mode)
             success = False
 
         if not success:

--- a/homeassistant/components/climate/venstar.py
+++ b/homeassistant/components/climate/venstar.py
@@ -12,6 +12,7 @@ from homeassistant.components.climate import (
     ATTR_OPERATION_MODE, ATTR_TARGET_TEMP_HIGH, ATTR_TARGET_TEMP_LOW,
     PLATFORM_SCHEMA, STATE_AUTO, STATE_COOL, STATE_HEAT, SUPPORT_FAN_MODE,
     SUPPORT_OPERATION_MODE, SUPPORT_TARGET_HUMIDITY, SUPPORT_AWAY_MODE,
+    SUPPORT_TARGET_HUMIDITY_HIGH, SUPPORT_TARGET_HUMIDITY_LOW,
     SUPPORT_HOLD_MODE, SUPPORT_TARGET_TEMPERATURE,
     SUPPORT_TARGET_TEMPERATURE_HIGH, SUPPORT_TARGET_TEMPERATURE_LOW,
     ClimateDevice)
@@ -92,8 +93,10 @@ class VenstarThermostat(ClimateDevice):
             features |= (SUPPORT_TARGET_TEMPERATURE_HIGH |
                          SUPPORT_TARGET_TEMPERATURE_LOW)
 
-        if self._client.hum_active == 1:
-            features |= SUPPORT_TARGET_HUMIDITY
+        if hasattr(self._client,'hum_active'):
+            features |= (SUPPORT_TARGET_HUMIDITY |
+                         SUPPORT_TARGET_HUMIDITY_HIGH |
+                         SUPPORT_TARGET_HUMIDITY_LOW)
 
         return features
 

--- a/homeassistant/components/climate/venstar.py
+++ b/homeassistant/components/climate/venstar.py
@@ -99,7 +99,7 @@ class VenstarThermostat(ClimateDevice):
                          SUPPORT_TARGET_TEMPERATURE_LOW)
 
         if (self._humidifier and
-                hasattr(self._client,'hum_active')):
+                hasattr(self._client, 'hum_active')):
             features |= (SUPPORT_TARGET_HUMIDITY |
                          SUPPORT_TARGET_HUMIDITY_HIGH |
                          SUPPORT_TARGET_HUMIDITY_LOW)
@@ -221,8 +221,7 @@ class VenstarThermostat(ClimateDevice):
         """Return the status of hold mode."""
         if self._client.schedule == 0:
             return HOLD_MODE_TEMPERATURE
-        else:
-            return HOLD_MODE_OFF
+        return HOLD_MODE_OFF
 
     def _set_operation_mode(self, operation_mode):
         """Change the operation mode (internal)."""
@@ -287,14 +286,14 @@ class VenstarThermostat(ClimateDevice):
         if not success:
             _LOGGER.error("Failed to change the target humidity level")
 
-    def set_hold_mode(self, hold):
+    def set_hold_mode(self, hold_mode):
         """Set the hold mode."""
-        if hold == HOLD_MODE_TEMPERATURE:
+        if hold_mode == HOLD_MODE_TEMPERATURE:
             success = self._client.set_schedule(0)
-        elif hold == HOLD_MODE_OFF:
+        elif hold_mode == HOLD_MODE_OFF:
             success = self._client.set_schedule(1)
         else:
-            _LOGGER.error("Unknown hold mode \"%s\"" % hold)
+            _LOGGER.error("Unknown hold mode \"%s\"", hold_mode)
             success = False
 
         if not success:


### PR DESCRIPTION
## Description:
This PR implements the following changes for the Venstar climate component:
- Adds support for controlling the state of away mode.
- Adds support for setting the hold mode.
- Resolves an issue where humidifiers were not detected unless the humidifier was actively running (as opposed to merely present) when this component was initialized.
- Adds a configuration option to allow the user to choose if humidification control is enabled.



**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5298


## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

