### PR TITLE
Add facebook messenger webhook endpoint for actionable notifications/message based events

### DIFF
--- a/homeassistant/components/notify/facebook.py
+++ b/homeassistant/components/notify/facebook.py
@@ -8,28 +8,36 @@ import json
 import logging
 
 from aiohttp.hdrs import CONTENT_TYPE
+import asyncio
 import requests
 import voluptuous as vol
 
+from homeassistant.components.http import HomeAssistantView
 from homeassistant.components.notify import (
     ATTR_DATA, ATTR_TARGET, PLATFORM_SCHEMA, BaseNotificationService)
-from homeassistant.const import CONTENT_TYPE_JSON
+from homeassistant.const import (CONTENT_TYPE_JSON,  HTTP_BAD_REQUEST)
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
+CONF_ALLOWED_CHAT_IDS = 'allowed_chat_ids'
 CONF_PAGE_ACCESS_TOKEN = 'page_access_token'
 BASE_URL = 'https://graph.facebook.com/v2.6/me/messages'
 CREATE_BROADCAST_URL = 'https://graph.facebook.com/v2.11/me/message_creatives'
 SEND_BROADCAST_URL = 'https://graph.facebook.com/v2.11/me/broadcast_messages'
+FACEBOOK_HANDLER_URL = '/api/facebook_webhooks'
+EVENT_FACEBOOK_MESSAGE = 'facebook_message'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_PAGE_ACCESS_TOKEN): cv.string,
+    vol.Optional(CONF_ALLOWED_CHAT_IDS):
+        vol.All(cv.ensure_list, [vol.Coerce(int)]),
 })
 
 
 def get_service(hass, config, discovery_info=None):
     """Get the Facebook notification service."""
+    hass.http.register_view(FacebookReceiver(hass, config))
     return FacebookNotificationService(config[CONF_PAGE_ACCESS_TOKEN])
 
 
@@ -115,3 +123,94 @@ def log_error(response):
     _LOGGER.error(
         "Error %s : %s (Code %s)", response.status_code, error_message,
         error_code)
+
+
+class FacebookReceiver(HomeAssistantView):
+    """Handle webhooks from Facebook."""
+
+    requires_auth = False
+    url = FACEBOOK_HANDLER_URL
+    name = 'api:facebook_webhooks'
+
+    def __init__(self, hass, config):
+        """Initialize the class."""
+        self.hass = hass
+        self.token = config[CONF_PAGE_ACCESS_TOKEN]
+        self.allowed_chat_ids = config.get(CONF_ALLOWED_CHAT_IDS)
+
+    @asyncio.coroutine
+    def get(self, request):
+        """Accept the GET verification from facebook."""
+
+        data = request.query
+
+        if data.get("hub.mode") == "subscribe" and data.get("hub.challenge"):
+            if not data.get("hub.verify_token") == self.token:
+                return "token mismatch", 403
+
+        return data.get("hub.challenge"), 200
+
+    @asyncio.coroutine
+    def post(self, request):
+        """Accept the POST from facebook."""
+
+        try:
+            data = yield from request.json()
+        except ValueError:
+            return self.json_message('Invalid JSON specified',
+                                     HTTP_BAD_REQUEST)
+
+        for entry in data["entry"]:
+            for messaging_event in entry["messaging"]:
+
+                if messaging_event.get("message"):
+
+                    sender_id = messaging_event["sender"]["id"]
+                    message_text = messaging_event["message"]["text"]
+
+                    if message_text == "get my id":
+                        self.reply_with_id(sender_id)
+                        return "ok", 200
+
+                    if self.allowed_chat_ids is not None:
+                        if int(sender_id) in self.allowed_chat_ids:
+                            _LOGGER.debug("Received facebook message.")
+                            event_data = {
+                                'sender_id': sender_id,
+                                'message': message_text,
+                                'payload': None
+                            }
+
+                            if "quick_reply" in messaging_event["message"]:
+                                event_data['payload'] = messaging_event["message"]["quick_reply"]["payload"]
+
+                            self.hass.bus.async_fire(EVENT_FACEBOOK_MESSAGE, event_data)
+                        else:
+                            _LOGGER.warn("Received message on facebook webhook from sender not in allowed chat ids.")
+                    else:
+                        _LOGGER.warn("Recieved message but no allowed senders defined")
+
+        return "ok", 200
+
+    def reply_with_id(self, sender_id):
+        """Reply with the id of the sender to make configuration easier."""
+
+        message_text = "Your id is {}".format(sender_id)
+        params = {
+            "access_token": self.token
+        }
+        headers = {
+            "Content-Type": "application/json"
+        }
+        data = json.dumps({
+            "recipient": {
+                "id": sender_id
+            },
+            "message": {
+                "text": message_text
+            }
+        })
+
+        resp = requests.post(BASE_URL, params=params, headers=headers, data=data)
+        if resp.status_code != 200:
+            log_error(resp)

--- a/homeassistant/components/notify/facebook.py
+++ b/homeassistant/components/notify/facebook.py
@@ -15,7 +15,7 @@ import voluptuous as vol
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.components.notify import (
     ATTR_DATA, ATTR_TARGET, PLATFORM_SCHEMA, BaseNotificationService)
-from homeassistant.const import (CONTENT_TYPE_JSON,  HTTP_BAD_REQUEST)
+from homeassistant.const import (CONTENT_TYPE_JSON, HTTP_BAD_REQUEST)
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
@@ -182,13 +182,19 @@ class FacebookReceiver(HomeAssistantView):
                             }
 
                             if "quick_reply" in messaging_event["message"]:
-                                event_data['payload'] = messaging_event["message"]["quick_reply"]["payload"]
+                                event_data['payload'] = \
+                                    messaging_event["message"]["quick_reply"][
+                                        "payload"]
 
-                            self.hass.bus.async_fire(EVENT_FACEBOOK_MESSAGE, event_data)
+                            self.hass.bus.async_fire(EVENT_FACEBOOK_MESSAGE,
+                                                     event_data)
                         else:
-                            _LOGGER.warn("Received message on facebook webhook from sender not in allowed chat ids.")
+                            _LOGGER.warn(
+                                ("Received message on facebook webhook from "
+                                 "sender not in allowed chat ids."))
                     else:
-                        _LOGGER.warn("Recieved message but no allowed senders defined")
+                        _LOGGER.warn(
+                            "Recieved message but no allowed senders defined")
 
         return "ok", 200
 
@@ -211,6 +217,7 @@ class FacebookReceiver(HomeAssistantView):
             }
         })
 
-        resp = requests.post(BASE_URL, params=params, headers=headers, data=data)
+        resp = requests.post(BASE_URL, params=params, headers=headers,
+                             data=data)
         if resp.status_code != 200:
             log_error(resp)


### PR DESCRIPTION
## Description:
Add endpoint for facebook messenger platform webooks to make configuration easier (adds handling for 'get my id' message) and fire events for messages/quick replies like telegram

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5299

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
