### PR TITLE
fix check config not working after #14211

### DIFF
--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -687,7 +687,7 @@ async def async_check_ha_config_file(hass):
     from homeassistant.scripts.check_config import check_ha_config_file
 
     res = await hass.async_add_job(
-        check_ha_config_file, hass.config.config_dir)
+        check_ha_config_file, hass)
 
     if not res.errors:
         return None


### PR DESCRIPTION
## Description:
When clicking `Check configuration` or `Restart Service` in Web UI, I got the following error log:
Seems that `config.py` didn't change to fit the new reload function.
```
2018-05-03 12:07:35 ERROR (MainThread) [aiohttp.server] Error handling request
Traceback (most recent call last):
  File "/mnt/c/Workspaces/github/home-assistant/lvenv/lib/python3.6/site-packages/aiohttp/web_protocol.py", line 381, in start
    resp = await self._request_handler(request)
  File "/mnt/c/Workspaces/github/home-assistant/lvenv/lib/python3.6/site-packages/aiohttp/web_app.py", line 322, in _handle
    resp = await handler(request)
  File "/mnt/c/Workspaces/github/home-assistant/lvenv/lib/python3.6/site-packages/aiohttp/web_middlewares.py", line 88, in impl
    return await handler(request)
  File "/mnt/c/Workspaces/github/home-assistant/homeassistant/components/http/static.py", line 68, in staticresource_middleware
    return await handler(request)
  File "/mnt/c/Workspaces/github/home-assistant/homeassistant/components/http/real_ip.py", line 27, in real_ip_middleware
    return await handler(request)
  File "/mnt/c/Workspaces/github/home-assistant/homeassistant/components/http/ban.py", line 68, in ban_middleware
    return await handler(request)
  File "/mnt/c/Workspaces/github/home-assistant/homeassistant/components/http/auth.py", line 28, in auth_middleware
    return await handler(request)
  File "/mnt/c/Workspaces/github/home-assistant/homeassistant/components/http/view.py", line 104, in handle
    result = await result
  File "/mnt/c/Workspaces/github/home-assistant/homeassistant/components/config/core.py", line 24, in post
    errors = yield from async_check_ha_config_file(request.app['hass'])
  File "/mnt/c/Workspaces/github/home-assistant/homeassistant/config.py", line 690, in async_check_ha_config_file
    check_ha_config_file, hass.config.config_dir)
  File "/usr/lib/python3.6/concurrent/futures/thread.py", line 56, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/mnt/c/Workspaces/github/home-assistant/homeassistant/scripts/check_config.py", line 288, in check_ha_config_file
    config_dir = hass.config.config_dir
AttributeError: 'str' object has no attribute 'config'
```

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
