### PR TITLE
Re-enable eliqonline requirement

### DIFF
--- a/homeassistant/components/sensor/eliqonline.py
+++ b/homeassistant/components/sensor/eliqonline.py
@@ -14,8 +14,7 @@ from homeassistant.const import (CONF_ACCESS_TOKEN, CONF_NAME, STATE_UNKNOWN)
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 
-# pylint: disable=import-error, no-member
-REQUIREMENTS = []  # ['eliqonline==1.0.13'] - package disappeared
+REQUIREMENTS = ['eliqonline==1.0.14']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -276,6 +276,9 @@ dsmr_parser==0.11
 # homeassistant.components.sensor.dweet
 dweepy==0.3.0
 
+# homeassistant.components.sensor.eliqonline
+eliqonline==1.0.14
+
 # homeassistant.components.enocean
 enocean==0.40
 


### PR DESCRIPTION
## Description:
Re-enable the eliqonline requirement.
The pip package was de-published by the package author for personal reasons. I have now accepted maintainership and the package is re-published.

**Related issue (if applicable):**
See https://github.com/home-assistant/home-assistant/pull/14156
