### PR TITLE
Add tv channel and volume level for philips js API 5

### DIFF
--- a/homeassistant/components/media_player/philips_js.py
+++ b/homeassistant/components/media_player/philips_js.py
@@ -169,10 +169,7 @@ class PhilipsTV(MediaPlayerDevice):
 
     def set_volume_level(self, volume):
         """Set volume level, range 0..1."""
-        if self._volume != volume:
-            self._tv.setVolume(volume)
-            if not self._tv.on:
-                self._state = STATE_OFF
+        self._tv.setVolume(volume)
 
     def media_previous_track(self):
         """Send rewind command."""

--- a/homeassistant/components/media_player/philips_js.py
+++ b/homeassistant/components/media_player/philips_js.py
@@ -13,20 +13,22 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.components.media_player import (
     PLATFORM_SCHEMA, SUPPORT_NEXT_TRACK, SUPPORT_PREVIOUS_TRACK,
     SUPPORT_SELECT_SOURCE, SUPPORT_TURN_OFF, SUPPORT_TURN_ON,
-    SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_STEP, SUPPORT_PLAY, MediaPlayerDevice)
+    SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_SET, SUPPORT_VOLUME_STEP,
+    SUPPORT_PLAY, MediaPlayerDevice)
 from homeassistant.const import (
     CONF_HOST, CONF_NAME, CONF_API_VERSION, STATE_OFF, STATE_ON, STATE_UNKNOWN)
 from homeassistant.helpers.script import Script
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['ha-philipsjs==0.0.3']
+REQUIREMENTS = ['ha-philipsjs==0.0.4']
 
 _LOGGER = logging.getLogger(__name__)
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=30)
 
 SUPPORT_PHILIPS_JS = SUPPORT_TURN_OFF | SUPPORT_VOLUME_STEP | \
-                     SUPPORT_VOLUME_MUTE | SUPPORT_SELECT_SOURCE
+                     SUPPORT_VOLUME_SET | SUPPORT_VOLUME_MUTE | \
+                     SUPPORT_SELECT_SOURCE
 
 SUPPORT_PHILIPS_JS_TV = SUPPORT_PHILIPS_JS | SUPPORT_NEXT_TRACK | \
                         SUPPORT_PREVIOUS_TRACK | SUPPORT_PLAY
@@ -165,6 +167,13 @@ class PhilipsTV(MediaPlayerDevice):
         if not self._tv.on:
             self._state = STATE_OFF
 
+    def set_volume_level(self, volume):
+        """Set volume level, range 0..1."""
+        if self._volume != volume:
+            self._tv.setVolume(volume)
+            if not self._tv.on:
+                self._state = STATE_OFF
+
     def media_previous_track(self):
         """Send rewind command."""
         self._tv.sendKey('Previous')
@@ -189,12 +198,10 @@ class PhilipsTV(MediaPlayerDevice):
         self._volume = self._tv.volume
         self._muted = self._tv.muted
         if self._tv.source_id:
-            src = self._tv.sources.get(self._tv.source_id, None)
-            if src:
-                self._source = src.get('name', None)
+            self._source = self._tv.getSourceName(self._tv.source_id)
         if self._tv.sources and not self._source_list:
-            for srcid in sorted(self._tv.sources):
-                srcname = self._tv.sources.get(srcid, dict()).get('name', None)
+            for srcid in self._tv.sources:
+                srcname = self._tv.getSourceName(srcid)
                 self._source_list.append(srcname)
                 self._source_mapping[srcname] = srcid
         if self._tv.on:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -365,7 +365,7 @@ gstreamer-player==1.1.0
 ha-ffmpeg==1.9
 
 # homeassistant.components.media_player.philips_js
-ha-philipsjs==0.0.3
+ha-philipsjs==0.0.4
 
 # homeassistant.components.sensor.geo_rss_events
 haversine==0.4.5


### PR DESCRIPTION
## Description:
When using api_version: 5 with philips_js you can now change tv channels, but not the source like HDMI 1 etc. This is not possible with API 5. Furthermore you can set the volume to a specific value.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5288

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  - platform: philips_js
    host: 192.168.0.123
    name: PhilipsTV
    api_version: 5
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
