### PR TITLE
Changed device_class requirements - HomeKit

### DIFF
--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -129,8 +129,8 @@ def get_accessory(hass, state, aid, config):
         elif device_class == DEVICE_CLASS_CO2 \
                 or DEVICE_CLASS_CO2 in state.entity_id:
             a_type = 'CarbonDioxideSensor'
-        elif device_class == DEVICE_CLASS_LIGHT or \
-                unit in ('lm', 'lux', 'lx'):
+        elif device_class == DEVICE_CLASS_LIGHT or unit == 'lm' or \
+                unit == 'lux' or unit == 'lx':
             a_type = 'LightSensor'
 
     elif state.domain in ('switch', 'remote', 'input_boolean', 'script'):

--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -118,7 +118,7 @@ def get_accessory(hass, state, aid, config):
         unit = state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
         device_class = state.attributes.get(ATTR_DEVICE_CLASS)
 
-        if device_class == DEVICE_CLASS_TEMPERATURE and \
+        if device_class == DEVICE_CLASS_TEMPERATURE or \
                 unit in (TEMP_CELSIUS, TEMP_FAHRENHEIT):
             a_type = 'TemperatureSensor'
         elif device_class == DEVICE_CLASS_HUMIDITY and unit == '%':
@@ -129,7 +129,7 @@ def get_accessory(hass, state, aid, config):
         elif device_class == DEVICE_CLASS_CO2 \
                 or DEVICE_CLASS_CO2 in state.entity_id:
             a_type = 'CarbonDioxideSensor'
-        elif device_class == DEVICE_CLASS_LIGHT and \
+        elif device_class == DEVICE_CLASS_LIGHT or \
                 unit in ('lm', 'lux', 'lx'):
             a_type = 'LightSensor'
 

--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -118,10 +118,10 @@ def get_accessory(hass, state, aid, config):
         unit = state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
         device_class = state.attributes.get(ATTR_DEVICE_CLASS)
 
-        if device_class == DEVICE_CLASS_TEMPERATURE or unit == TEMP_CELSIUS \
-                or unit == TEMP_FAHRENHEIT:
+        if device_class == DEVICE_CLASS_TEMPERATURE and (
+                unit == TEMP_CELSIUS or unit == TEMP_FAHRENHEIT):
             a_type = 'TemperatureSensor'
-        elif device_class == DEVICE_CLASS_HUMIDITY or unit == '%':
+        elif device_class == DEVICE_CLASS_HUMIDITY and unit == '%':
             a_type = 'HumiditySensor'
         elif device_class == DEVICE_CLASS_PM25 \
                 or DEVICE_CLASS_PM25 in state.entity_id:
@@ -129,8 +129,8 @@ def get_accessory(hass, state, aid, config):
         elif device_class == DEVICE_CLASS_CO2 \
                 or DEVICE_CLASS_CO2 in state.entity_id:
             a_type = 'CarbonDioxideSensor'
-        elif device_class == DEVICE_CLASS_LIGHT or unit == 'lm' or \
-                unit == 'lux' or unit == 'lx':
+        elif device_class == DEVICE_CLASS_LIGHT and (
+                unit == 'lm' or unit == 'lux' or unit == 'lx'):
             a_type = 'LightSensor'
 
     elif state.domain == 'switch' or state.domain == 'remote' \

--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -118,8 +118,8 @@ def get_accessory(hass, state, aid, config):
         unit = state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
         device_class = state.attributes.get(ATTR_DEVICE_CLASS)
 
-        if device_class == DEVICE_CLASS_TEMPERATURE and (
-                unit == TEMP_CELSIUS or unit == TEMP_FAHRENHEIT):
+        if device_class == DEVICE_CLASS_TEMPERATURE and \
+                unit in (TEMP_CELSIUS, TEMP_FAHRENHEIT):
             a_type = 'TemperatureSensor'
         elif device_class == DEVICE_CLASS_HUMIDITY and unit == '%':
             a_type = 'HumiditySensor'
@@ -129,12 +129,11 @@ def get_accessory(hass, state, aid, config):
         elif device_class == DEVICE_CLASS_CO2 \
                 or DEVICE_CLASS_CO2 in state.entity_id:
             a_type = 'CarbonDioxideSensor'
-        elif device_class == DEVICE_CLASS_LIGHT and (
-                unit == 'lm' or unit == 'lux' or unit == 'lx'):
+        elif device_class == DEVICE_CLASS_LIGHT and \
+                unit in ('lm', 'lux', 'lx'):
             a_type = 'LightSensor'
 
-    elif state.domain == 'switch' or state.domain == 'remote' \
-            or state.domain == 'input_boolean' or state.domain == 'script':
+    elif state.domain in ('switch', 'remote', 'input_boolean', 'script'):
         a_type = 'Switch'
 
     if a_type is None:

--- a/tests/components/homekit/test_get_accessories.py
+++ b/tests/components/homekit/test_get_accessories.py
@@ -43,39 +43,28 @@ class TestGetAccessories(unittest.TestCase):
         """Test if mock type was called."""
         self.assertTrue(self.mock_type.called)
 
-    def test_sensor_temperature(self):
-        """Test temperature sensor with device class temperature."""
-        with patch.dict(TYPES, {'TemperatureSensor': self.mock_type}):
-            state = State('sensor.temperature', '23',
-                          {ATTR_DEVICE_CLASS: 'temperature'})
-            get_accessory(None, state, 2, {})
-
     def test_sensor_temperature_celsius(self):
         """Test temperature sensor with Celsius as unit."""
         with patch.dict(TYPES, {'TemperatureSensor': self.mock_type}):
             state = State('sensor.temperature', '23',
-                          {ATTR_UNIT_OF_MEASUREMENT: TEMP_CELSIUS})
+                          {ATTR_DEVICE_CLASS: 'temperature',
+                           ATTR_UNIT_OF_MEASUREMENT: TEMP_CELSIUS})
             get_accessory(None, state, 2, {})
 
     def test_sensor_temperature_fahrenheit(self):
         """Test temperature sensor with Fahrenheit as unit."""
         with patch.dict(TYPES, {'TemperatureSensor': self.mock_type}):
             state = State('sensor.temperature', '74',
-                          {ATTR_UNIT_OF_MEASUREMENT: TEMP_FAHRENHEIT})
+                          {ATTR_DEVICE_CLASS: 'temperature',
+                           ATTR_UNIT_OF_MEASUREMENT: TEMP_FAHRENHEIT})
             get_accessory(None, state, 2, {})
 
     def test_sensor_humidity(self):
         """Test humidity sensor with device class humidity."""
         with patch.dict(TYPES, {'HumiditySensor': self.mock_type}):
             state = State('sensor.humidity', '20',
-                          {ATTR_DEVICE_CLASS: 'humidity'})
-            get_accessory(None, state, 2, {})
-
-    def test_sensor_humidity_unit(self):
-        """Test humidity sensor with % as unit."""
-        with patch.dict(TYPES, {'HumiditySensor': self.mock_type}):
-            state = State('sensor.humidity', '20',
-                          {ATTR_UNIT_OF_MEASUREMENT: '%'})
+                          {ATTR_DEVICE_CLASS: 'humidity',
+                           ATTR_UNIT_OF_MEASUREMENT: '%'})
             get_accessory(None, state, 2, {})
 
     def test_air_quality_sensor(self):
@@ -104,32 +93,28 @@ class TestGetAccessories(unittest.TestCase):
             state = State('sensor.airmeter_co2', '500', {})
             get_accessory(None, state, 2, {})
 
-    def test_light_sensor(self):
-        """Test light sensor with device class lux."""
-        with patch.dict(TYPES, {'LightSensor': self.mock_type}):
-            state = State('sensor.light', '900',
-                          {ATTR_DEVICE_CLASS: 'light'})
-            get_accessory(None, state, 2, {})
-
     def test_light_sensor_unit_lm(self):
         """Test light sensor with lm as unit."""
         with patch.dict(TYPES, {'LightSensor': self.mock_type}):
             state = State('sensor.light', '900',
-                          {ATTR_UNIT_OF_MEASUREMENT: 'lm'})
+                          {ATTR_DEVICE_CLASS: 'light',
+                           ATTR_UNIT_OF_MEASUREMENT: 'lm'})
             get_accessory(None, state, 2, {})
 
     def test_light_sensor_unit_lux(self):
         """Test light sensor with lux as unit."""
         with patch.dict(TYPES, {'LightSensor': self.mock_type}):
             state = State('sensor.light', '900',
-                          {ATTR_UNIT_OF_MEASUREMENT: 'lux'})
+                          {ATTR_DEVICE_CLASS: 'light',
+                           ATTR_UNIT_OF_MEASUREMENT: 'lux'})
             get_accessory(None, state, 2, {})
 
     def test_light_sensor_unit_lx(self):
         """Test light sensor with lx as unit."""
         with patch.dict(TYPES, {'LightSensor': self.mock_type}):
             state = State('sensor.light', '900',
-                          {ATTR_UNIT_OF_MEASUREMENT: 'lx'})
+                          {ATTR_DEVICE_CLASS: 'light',
+                           ATTR_UNIT_OF_MEASUREMENT: 'lx'})
             get_accessory(None, state, 2, {})
 
     def test_binary_sensor(self):

--- a/tests/components/homekit/test_get_accessories.py
+++ b/tests/components/homekit/test_get_accessories.py
@@ -43,20 +43,25 @@ class TestGetAccessories(unittest.TestCase):
         """Test if mock type was called."""
         self.assertTrue(self.mock_type.called)
 
+    def test_sensor_temperature(self):
+        """Test temperature sensor with device class temperature."""
+        with patch.dict(TYPES, {'TemperatureSensor': self.mock_type}):
+            state = State('sensor.temperature', '23',
+                          {ATTR_DEVICE_CLASS: 'temperature'})
+            get_accessory(None, state, 2, {})
+
     def test_sensor_temperature_celsius(self):
         """Test temperature sensor with Celsius as unit."""
         with patch.dict(TYPES, {'TemperatureSensor': self.mock_type}):
             state = State('sensor.temperature', '23',
-                          {ATTR_DEVICE_CLASS: 'temperature',
-                           ATTR_UNIT_OF_MEASUREMENT: TEMP_CELSIUS})
+                          {ATTR_UNIT_OF_MEASUREMENT: TEMP_CELSIUS})
             get_accessory(None, state, 2, {})
 
     def test_sensor_temperature_fahrenheit(self):
         """Test temperature sensor with Fahrenheit as unit."""
         with patch.dict(TYPES, {'TemperatureSensor': self.mock_type}):
             state = State('sensor.temperature', '74',
-                          {ATTR_DEVICE_CLASS: 'temperature',
-                           ATTR_UNIT_OF_MEASUREMENT: TEMP_FAHRENHEIT})
+                          {ATTR_UNIT_OF_MEASUREMENT: TEMP_FAHRENHEIT})
             get_accessory(None, state, 2, {})
 
     def test_sensor_humidity(self):
@@ -93,28 +98,32 @@ class TestGetAccessories(unittest.TestCase):
             state = State('sensor.airmeter_co2', '500', {})
             get_accessory(None, state, 2, {})
 
+    def test_light_sensor(self):
+        """Test light sensor with device class lux."""
+        with patch.dict(TYPES, {'LightSensor': self.mock_type}):
+            state = State('sensor.light', '900',
+                          {ATTR_DEVICE_CLASS: 'light'})
+            get_accessory(None, state, 2, {})
+
     def test_light_sensor_unit_lm(self):
         """Test light sensor with lm as unit."""
         with patch.dict(TYPES, {'LightSensor': self.mock_type}):
             state = State('sensor.light', '900',
-                          {ATTR_DEVICE_CLASS: 'light',
-                           ATTR_UNIT_OF_MEASUREMENT: 'lm'})
+                          {ATTR_UNIT_OF_MEASUREMENT: 'lm'})
             get_accessory(None, state, 2, {})
 
     def test_light_sensor_unit_lux(self):
         """Test light sensor with lux as unit."""
         with patch.dict(TYPES, {'LightSensor': self.mock_type}):
             state = State('sensor.light', '900',
-                          {ATTR_DEVICE_CLASS: 'light',
-                           ATTR_UNIT_OF_MEASUREMENT: 'lux'})
+                          {ATTR_UNIT_OF_MEASUREMENT: 'lux'})
             get_accessory(None, state, 2, {})
 
     def test_light_sensor_unit_lx(self):
         """Test light sensor with lx as unit."""
         with patch.dict(TYPES, {'LightSensor': self.mock_type}):
             state = State('sensor.light', '900',
-                          {ATTR_DEVICE_CLASS: 'light',
-                           ATTR_UNIT_OF_MEASUREMENT: 'lx'})
+                          {ATTR_UNIT_OF_MEASUREMENT: 'lx'})
             get_accessory(None, state, 2, {})
 
     def test_binary_sensor(self):


### PR DESCRIPTION
## Description:
The device_class parameter is now required for ~~`temperature`~~, `humidity`, ~~`light`~~ sensors.

This should have been done that way right from the beginning. However, since `sensors` didn't had `device_class` support yet, it was added only unofficially. In addition it created issues like the one below for `Humidity Sensors`.
This is a breaking change since not every `sensor` platforms supports `device_classes` yet. Therefore the user must manually specify the `device_class` in the `customize` section or the sensor won't be added.

**Related issue (if applicable):** fixes [Community](https://community.home-assistant.io/t/homekit-and-how-entities-are-are-represented-in-home-app/51427)

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5304

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)
  - [x] Tests have been added to verify that the new code works.

---

### Breaking Changes
Humidity sensors now require the `device_class: 'humidity'` attribute to be added as a HomeKit sensor. The sensor platform should handle that for you. However since not every one supports that yet, you might need to add it manually to the `customize` section for the entity.