### PR TITLE
Support triggered state for alarm control panel in HomeKit

### DIFF
--- a/homeassistant/components/homekit/type_security_systems.py
+++ b/homeassistant/components/homekit/type_security_systems.py
@@ -66,8 +66,7 @@ class SecuritySystem(HomeAccessory):
                           self.entity_id, hass_state, current_security_state)
 
             # SecuritySystemTargetSTate does not support triggered
-            if hass_state in (STATE_ALARM_ARMED_HOME, STATE_ALARM_ARMED_AWAY,
-                              STATE_ALARM_ARMED_NIGHT, STATE_ALARM_DISARMED):
-                if not self.flag_target_state:
-                    self.char_target_state.set_value(current_security_state)
-                self.flag_target_state = False
+            if not self.flag_target_state and \
+                    hass_state != STATE_ALARM_TRIGGERED:
+                self.char_target_state.set_value(current_security_state)
+            self.flag_target_state = False

--- a/tests/components/homekit/test_type_security_systems.py
+++ b/tests/components/homekit/test_type_security_systems.py
@@ -7,7 +7,8 @@ from homeassistant.components.homekit.type_security_systems import (
 from homeassistant.const import (
     ATTR_CODE, ATTR_SERVICE, ATTR_SERVICE_DATA, EVENT_CALL_SERVICE,
     STATE_ALARM_ARMED_AWAY, STATE_ALARM_ARMED_HOME,
-    STATE_ALARM_ARMED_NIGHT, STATE_ALARM_DISARMED, STATE_UNKNOWN)
+    STATE_ALARM_ARMED_NIGHT, STATE_ALARM_DISARMED, STATE_ALARM_TRIGGERED,
+    STATE_UNKNOWN)
 
 from tests.common import get_test_home_assistant
 
@@ -65,10 +66,15 @@ class TestHomekitSecuritySystems(unittest.TestCase):
         self.assertEqual(acc.char_target_state.value, 3)
         self.assertEqual(acc.char_current_state.value, 3)
 
+        self.hass.states.set(acp, STATE_ALARM_TRIGGERED)
+        self.hass.block_till_done()
+        self.assertEqual(acc.char_target_state.value, 3)
+        self.assertEqual(acc.char_current_state.value, 4)
+
         self.hass.states.set(acp, STATE_UNKNOWN)
         self.hass.block_till_done()
         self.assertEqual(acc.char_target_state.value, 3)
-        self.assertEqual(acc.char_current_state.value, 3)
+        self.assertEqual(acc.char_current_state.value, 4)
 
         # Set from HomeKit
         acc.char_target_state.client_update_value(0)


### PR DESCRIPTION
## Description:
Extends support for alarm control panels in HomeKit to include `triggered` state.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
N/A
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
