### PR TITLE
[RFC] Physical Quantity Device Class Names

### DIFF
--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -21,8 +21,8 @@ ENTITY_ID_FORMAT = DOMAIN + '.{}'
 
 SCAN_INTERVAL = timedelta(seconds=30)
 DEVICE_CLASSES = [
-    'battery',  # % of battery that is left
-    'humidity',  # % of humidity in the air
+    'battery_level',  # % of battery that is left
+    'relative_humidity',  # % of humidity in the air
     'temperature',  # temperature (C/F)
 ]
 

--- a/homeassistant/components/sensor/deconz.py
+++ b/homeassistant/components/sensor/deconz.py
@@ -126,7 +126,7 @@ class DeconzBattery(Entity):
         """Register dispatcher callback for update of battery state."""
         self._device = device
         self._name = '{} {}'.format(self._device.name, 'Battery Level')
-        self._device_class = 'battery'
+        self._device_class = 'battery_level'
         self._unit_of_measurement = "%"
 
     async def async_added_to_hass(self):

--- a/homeassistant/components/sensor/demo.py
+++ b/homeassistant/components/sensor/demo.py
@@ -14,7 +14,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices([
         DemoSensor('Outside Temperature', 15.6, 'temperature',
                    TEMP_CELSIUS, 12),
-        DemoSensor('Outside Humidity', 54, 'humidity', '%', None),
+        DemoSensor('Outside Humidity', 54, 'relative_humidity', '%', None),
     ])
 
 

--- a/homeassistant/components/sensor/ecobee.py
+++ b/homeassistant/components/sensor/ecobee.py
@@ -55,7 +55,7 @@ class EcobeeSensor(Entity):
     @property
     def device_class(self):
         """Return the device class of the sensor."""
-        if self.type in ('temperature', 'humidity'):
+        if self.type in ('temperature', 'relative_humidity'):
             return self.type
         return None
 

--- a/homeassistant/components/sensor/ecobee.py
+++ b/homeassistant/components/sensor/ecobee.py
@@ -55,8 +55,10 @@ class EcobeeSensor(Entity):
     @property
     def device_class(self):
         """Return the device class of the sensor."""
-        if self.type in ('temperature', 'relative_humidity'):
-            return self.type
+        if self.type == 'temperature':
+            return 'temperature'
+        if self.type == 'humidity':
+            return 'relative_humidity'
         return None
 
     @property

--- a/homeassistant/components/sensor/linux_battery.py
+++ b/homeassistant/components/sensor/linux_battery.py
@@ -97,7 +97,7 @@ class LinuxBatterySensor(Entity):
     @property
     def device_class(self):
         """Return the device class of the sensor."""
-        return 'battery'
+        return 'battery_level'
 
     @property
     def state(self):


### PR DESCRIPTION
## Description:

Context: This PR is a result of some discussion in the discord dev channel.

Basically, the idea is to name device classes after *physical quantities* in all cases. So, ideally the question "What does this sensor measure?" should result in the device class name.

For example, a temperature sensor measures `temperature`, but a battery level sensor doesn't measure `battery`. It measures the *battery level*.

Also, device classes should ideally always use the same *type* of unit. For example, all sensors in a `humidity` device class should always measure a ratio of water to air - and not the absolute amount of water vapor in the air. The advantage of physical quantity device classes would be that this property is always complied with.
(I think a definition for this could be: If you reduce a unit to its base SI units and remove all constant factors, it should remain constant for all units within a device class.)

Of course this is very subtle and over-thinking things a lot. Therefore feel free to ignore/close this PR. IMO it could make a future unit system (https://github.com/home-assistant/architecture/issues/10) easier and would automatically lead to clearly defined device classes.

Feedback welcome :)

Changes:

 - `battery` → `battery_level`
 - `humidity` → `relative_humidity` (humidity itself is not a physical quantity and can have different dimensions, for example specific humidity)

Will update frontend/docs/dev-docs if this is wanted.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
