### PR TITLE
[webostv] play_media(): improve best matching channel

### DIFF
--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -448,6 +448,9 @@ insteonlocal==0.53
 # homeassistant.components.insteon_plm
 insteonplm==0.9.1
 
+# homeassistant.components.media_player.webostv
+jellyfish==0.6.1
+
 # homeassistant.components.verisure
 jsonpath==0.75
 


### PR DESCRIPTION
## Description:
Improvement over #13934 
Selects the bast matching channel base on levenstein distance
This allows to better control by voice.
E.g. if I say "CNN", but "c n n" is recorded, it can still match the channel "CNN" (butnot "CBO")

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5312

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
