### PR TITLE
Update hitron_coda.py to fix login for Shaw modems

### DIFF
--- a/homeassistant/components/device_tracker/hitron_coda.py
+++ b/homeassistant/components/device_tracker/hitron_coda.py
@@ -14,15 +14,18 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.components.device_tracker import (
     DOMAIN, PLATFORM_SCHEMA, DeviceScanner)
 from homeassistant.const import (
-    CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+    CONF_HOST, CONF_PASSWORD, CONF_USERNAME, CONF_TYPE
 )
 
 _LOGGER = logging.getLogger(__name__)
 
+DEFAULT_TYPE = "rogers"
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
     vol.Required(CONF_USERNAME): cv.string,
-    vol.Required(CONF_PASSWORD): cv.string
+    vol.Required(CONF_PASSWORD): cv.string,
+    vol.Optional(CONF_TYPE, default=DEFAULT_TYPE): cv.string,
 })
 
 
@@ -49,6 +52,11 @@ class HitronCODADeviceScanner(DeviceScanner):
         self._username = config.get(CONF_USERNAME)
         self._password = config.get(CONF_PASSWORD)
 
+        if config.get(CONF_TYPE) == "shaw":
+            self._type = 'pwd'
+        else:
+            self.type = 'pws'
+
         self._userid = None
 
         self.success_init = self._update_info()
@@ -74,7 +82,7 @@ class HitronCODADeviceScanner(DeviceScanner):
         try:
             data = [
                 ('user', self._username),
-                ('pws', self._password),
+                (self._type, self._password),
             ]
             res = requests.post(self._loginurl, data=data, timeout=10)
         except requests.exceptions.Timeout:


### PR DESCRIPTION
I have a Hitron modem provided by Shaw communications rather than from Rogers as the Docs specify for this device_tracker but it seems like the api/code is all the same except that the login failed due to the password being passed as "pws" instead of "pwd". Making that one character change allowed HASS to read the connected device details from my Hitron modem. If this difference is actually one that stands between the Rogers-provided Hitron modems and the Shaw-provided variant, I am happy to create another device-tracker file for the Shaw modem. I just figured I would go with the simplest solution first.

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5321

## Example entry for `configuration.yaml` (if applicable):
```yaml
device_tracker:
  - platform: hitron_coda
    host: !secret router_ip
    username: !secret router_username
    password: !secret router_password
    type: rogers
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
