### PR TITLE
Add debounce to move_cover

### DIFF
--- a/homeassistant/components/homekit/type_covers.py
+++ b/homeassistant/components/homekit/type_covers.py
@@ -11,7 +11,7 @@ from homeassistant.const import (
     ATTR_SUPPORTED_FEATURES)
 
 from . import TYPES
-from .accessories import HomeAccessory
+from .accessories import HomeAccessory, debounce
 from .const import (
     SERV_WINDOW_COVERING, CHAR_CURRENT_POSITION,
     CHAR_TARGET_POSITION, CHAR_POSITION_STATE,
@@ -80,6 +80,7 @@ class WindowCovering(HomeAccessory):
         self.char_target_position = serv_cover.configure_char(
             CHAR_TARGET_POSITION, value=0, setter_callback=self.move_cover)
 
+    @debounce
     def move_cover(self, value):
         """Move cover to value if call came from HomeKit."""
         _LOGGER.debug('%s: Set position to %d', self.entity_id, value)
@@ -122,6 +123,7 @@ class WindowCoveringBasic(HomeAccessory):
         self.char_position_state = serv_cover.configure_char(
             CHAR_POSITION_STATE, value=2)
 
+    @debounce
     def move_cover(self, value):
         """Move cover to value if call came from HomeKit."""
         _LOGGER.debug('%s: Set position to %d', self.entity_id, value)

--- a/homeassistant/components/homekit/type_security_systems.py
+++ b/homeassistant/components/homekit/type_security_systems.py
@@ -67,7 +67,7 @@ class SecuritySystem(HomeAccessory):
             _LOGGER.debug('%s: Updated current state to %s (%d)',
                           self.entity_id, hass_state, current_security_state)
 
-            # SecuritySystemTargetSTate does not support triggered
+            # SecuritySystemTargetState does not support triggered
             if not self.flag_target_state and \
                     hass_state != STATE_ALARM_TRIGGERED:
                 self.char_target_state.set_value(current_security_state)


### PR DESCRIPTION
## Description:
The PR adds the logic already used for the light brightness sliders in `HomeKit` to the cover position sliders.

**Related issue (if applicable):** fixes #14292 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**