### PR TITLE
Snips: Added slot values for siteId and probability

### DIFF
--- a/homeassistant/components/snips.py
+++ b/homeassistant/components/snips.py
@@ -131,7 +131,7 @@ async def async_setup(hass, config):
         slots = {}
         for slot in request.get('slots', []):
             slots[slot['slotName']] = {'value': resolve_slot_values(slot)}
-        slots['siteId'] = {'value': request.get('siteId')}
+        slots['site_id'] = {'value': request.get('siteId')}
         slots['probability'] = {'value': request['intent']['probability']}
 
         try:

--- a/homeassistant/components/snips.py
+++ b/homeassistant/components/snips.py
@@ -131,6 +131,8 @@ async def async_setup(hass, config):
         slots = {}
         for slot in request.get('slots', []):
             slots[slot['slotName']] = {'value': resolve_slot_values(slot)}
+        slots['siteId'] = {'value': request.get('siteId')}
+        slots['probability'] = {'value': request['intent']['probability']}
 
         try:
             intent_response = await intent.async_handle(

--- a/tests/components/test_snips.py
+++ b/tests/components/test_snips.py
@@ -120,7 +120,7 @@ async def test_snips_intent(hass, mqtt_mock):
     assert intent.intent_type == 'Lights'
     assert intent.slots == {'light_color': {'value': 'green'},
                             'probability': {'value': 1},
-                            'siteId': {'value': None}}
+                            'site_id': {'value': None}}
     assert intent.text_input == 'turn the lights green'
 
 
@@ -172,7 +172,7 @@ async def test_snips_intent_with_duration(hass, mqtt_mock):
     assert intent.platform == 'snips'
     assert intent.intent_type == 'SetTimer'
     assert intent.slots == {'probability': {'value': 1},
-                            'siteId': {'value': None},
+                            'site_id': {'value': None},
                             'timer_duration': {'value': 300}}
 
 
@@ -336,7 +336,7 @@ async def test_intent_special_slots(hass, mqtt_mock):
                     "service": "light.turn_on",
                     "data_template": {
                         "probability": "{{ probability }}",
-                        "siteId": "{{ siteId }}"
+                        "site_id": "{{ site_id }}"
                     }
                 }
             }
@@ -361,7 +361,7 @@ async def test_intent_special_slots(hass, mqtt_mock):
     assert calls[0].domain == 'light'
     assert calls[0].service == 'turn_on'
     assert calls[0].data['probability'] == '0.85'
-    assert calls[0].data['siteId'] == 'default'
+    assert calls[0].data['site_id'] == 'default'
 
 
 async def test_snips_say(hass, caplog):

--- a/tests/components/test_snips.py
+++ b/tests/components/test_snips.py
@@ -118,7 +118,9 @@ async def test_snips_intent(hass, mqtt_mock):
     intent = intents[0]
     assert intent.platform == 'snips'
     assert intent.intent_type == 'Lights'
-    assert intent.slots == {'light_color': {'value': 'green'}}
+    assert intent.slots == {'light_color': {'value': 'green'},
+                            'probability': {'value': 1},
+                            'siteId': {'value': None}}
     assert intent.text_input == 'turn the lights green'
 
 
@@ -169,7 +171,9 @@ async def test_snips_intent_with_duration(hass, mqtt_mock):
     intent = intents[0]
     assert intent.platform == 'snips'
     assert intent.intent_type == 'SetTimer'
-    assert intent.slots == {'timer_duration': {'value': 300}}
+    assert intent.slots == {'probability': {'value': 1},
+                            'siteId': {'value': None},
+                            'timer_duration': {'value': 300}}
 
 
 async def test_intent_speech_response(hass, mqtt_mock):
@@ -318,11 +322,51 @@ async def test_snips_low_probability(hass, mqtt_mock, caplog):
     assert 'Intent below probaility threshold 0.49 < 0.5' in caplog.text
 
 
+async def test_intent_special_slots(hass, mqtt_mock):
+    """Test intent special slot values via Snips."""
+    calls = async_mock_service(hass, 'light', 'turn_on')
+    result = await async_setup_component(hass, "snips", {
+        "snips": {},
+    })
+    assert result
+    result = await async_setup_component(hass, "intent_script", {
+        "intent_script": {
+            "Lights": {
+                "action": {
+                    "service": "light.turn_on",
+                    "data_template": {
+                        "probability": "{{ probability }}",
+                        "siteId": "{{ siteId }}"
+                    }
+                }
+            }
+        }
+    })
+    assert result
+    payload = """
+    {
+        "input": "turn the light on",
+        "intent": {
+            "intentName": "Lights",
+            "probability": 0.85
+        },
+        "siteId": "default",
+        "slots": []
+    }
+    """
+    async_fire_mqtt_message(hass, 'hermes/intent/Lights', payload)
+    await hass.async_block_till_done()
+
+    assert len(calls) == 1
+    assert calls[0].domain == 'light'
+    assert calls[0].service == 'turn_on'
+    assert calls[0].data['probability'] == '0.85'
+    assert calls[0].data['siteId'] == 'default'
+
+
 async def test_snips_say(hass, caplog):
     """Test snips say with invalid config."""
-    calls = async_mock_service(hass, 'snips', 'say',
-                               snips.SERVICE_SCHEMA_SAY)
-
+    calls = async_mock_service(hass, 'snips', 'say', snips.SERVICE_SCHEMA_SAY)
     data = {'text': 'Hello'}
     await hass.services.async_call('snips', 'say', data)
     await hass.async_block_till_done()


### PR DESCRIPTION
## Description:
Added slot values populated with siteId and probability.
Added test for those.

**Related issue (if applicable):** fixes #N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5315

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
