### PR TITLE
Fix module names for custom components

### DIFF
--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -133,6 +133,11 @@ def _load_module(path, base_module, name):
     spec.loader.exec_module(module)
     # A hack, I know. Don't currently know how to work around it.
     module.__name__ = "{}.{}".format(base_module, name)
+    if module.__package__:
+        module.__package__ = "{}.{}".format(base_module, module.__package__)
+    else:
+        module.__package__ = base_module
+
     return module
 
 

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -73,13 +73,15 @@ def get_component(hass, comp_or_platform):
 
     # Try custom component
     module = _load_module(hass.config.path(PATH_CUSTOM_COMPONENTS),
-                          comp_or_platform)
+                          PATH_CUSTOM_COMPONENTS, comp_or_platform)
 
     if module is None:
         try:
             module = importlib.import_module(
                 '{}.{}'.format(PACKAGE_COMPONENTS, comp_or_platform))
+            _LOGGER.debug('Loaded %s (built-in)', comp_or_platform)
         except ImportError:
+            _LOGGER.warning('Unable to find %s', comp_or_platform)
             module = None
 
     cache = hass.data.get(DATA_KEY)
@@ -102,18 +104,20 @@ def _find_spec(path, name):
     return None
 
 
-def _load_module(path, name):
+def _load_module(path, base_module, name):
     """Load a module based on a folder and a name."""
+    mod_name = "{}.{}".format(base_module, name)
     spec = _find_spec([path], name)
 
     # Special handling if loading platforms and the folder is a namespace
     # (namespace is a folder without __init__.py)
     if spec is None and '.' in name:
-        parent_spec = _find_spec([path], name.split('.')[0])
+        mod_parent_name = name.split('.')[0]
+        parent_spec = _find_spec([path], mod_parent_name)
         if (parent_spec is None or
                 parent_spec.submodule_search_locations is None):
             return None
-        spec = _find_spec(parent_spec.submodule_search_locations, name)
+        spec = _find_spec(parent_spec.submodule_search_locations, mod_name)
 
     # Not found
     if spec is None:
@@ -123,8 +127,12 @@ def _load_module(path, name):
     if spec.loader is None:
         return None
 
+    _LOGGER.debug('Loaded %s (%s)', name, base_module)
+
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
+    # A hack, I know. Don't currently know how to work around it.
+    module.__name__ = "{}.{}".format(base_module, name)
     return module
 
 

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -132,7 +132,6 @@ def _load_module(path, base_module, name):
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     # A hack, I know. Don't currently know how to work around it.
-    print(name, module.__name__, module.__package__)
     if not module.__name__.startswith(base_module):
         module.__name__ = "{}.{}".format(base_module, name)
 

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -132,11 +132,14 @@ def _load_module(path, base_module, name):
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     # A hack, I know. Don't currently know how to work around it.
-    module.__name__ = "{}.{}".format(base_module, name)
-    if module.__package__:
-        module.__package__ = "{}.{}".format(base_module, module.__package__)
-    else:
+    print(name, module.__name__, module.__package__)
+    if not module.__name__.startswith(base_module):
+        module.__name__ = "{}.{}".format(base_module, name)
+
+    if not module.__package__:
         module.__package__ = base_module
+    elif not module.__package__.startswith(base_module):
+        module.__package__ = "{}.{}".format(base_module, name)
 
     return module
 

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -111,3 +111,12 @@ async def test_custom_component_name(hass):
     """Test the name attribte of custom components."""
     comp = loader.get_component(hass, 'test_standalone')
     assert comp.__name__ == 'custom_components.test_standalone'
+    assert comp.__package__ == 'custom_components'
+
+    comp = loader.get_component(hass, 'test_package')
+    assert comp.__name__ == 'custom_components.test_package'
+    assert comp.__package__ == 'custom_components.test_package'
+
+    comp = loader.get_component(hass, 'light.test')
+    assert comp.__name__ == 'custom_components.light.test'
+    assert comp.__package__ == 'custom_components.light'

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -30,8 +30,7 @@ class TestLoader(unittest.TestCase):
         comp = object()
         loader.set_component(self.hass, 'switch.test_set', comp)
 
-        self.assertEqual(comp,
-                         loader.get_component(self.hass, 'switch.test_set'))
+        assert loader.get_component(self.hass, 'switch.test_set') is comp
 
     def test_get_component(self):
         """Test if get_component works."""
@@ -106,3 +105,9 @@ def test_helpers_wrapper(hass):
     yield from hass.async_block_till_done()
 
     assert result == ['hello']
+
+
+async def test_custom_component_name(hass):
+    """Test the name attribte of custom components."""
+    comp = loader.get_component(hass, 'test_standalone')
+    assert comp.__name__ == 'custom_components.test_standalone'

--- a/tests/testing_config/custom_components/test_package/__init__.py
+++ b/tests/testing_config/custom_components/test_package/__init__.py
@@ -2,6 +2,6 @@
 DOMAIN = 'test_package'
 
 
-def setup(hass, config):
+async def async_setup(hass, config):
     """Mock a successful setup."""
     return True


### PR DESCRIPTION
## Description:
After #14211, the `__name__` attribute on custom components no longer had the `custom_component` prefix. This fixes it.

**Related issue (if applicable):** fixes #14304

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
