### PR TITLE
Adds unique ID to Roku for entity registry inclusion

### DIFF
--- a/homeassistant/components/media_player/roku.py
+++ b/homeassistant/components/media_player/roku.py
@@ -147,6 +147,11 @@ class RokuDevice(MediaPlayerDevice):
         return SUPPORT_ROKU
 
     @property
+    def unique_id(self):
+        """Return a unique, HASS-friendly identifier for this entity."""
+        return "roku_{}".format(self.device_info.sernum)
+
+    @property
     def media_content_type(self):
         """Content type of current playing media."""
         if self.current_app is None:

--- a/homeassistant/components/media_player/roku.py
+++ b/homeassistant/components/media_player/roku.py
@@ -149,7 +149,7 @@ class RokuDevice(MediaPlayerDevice):
     @property
     def unique_id(self):
         """Return a unique, HASS-friendly identifier for this entity."""
-        return "roku_{}".format(self.device_info.sernum)
+        return self.device_info.sernum
 
     @property
     def media_content_type(self):


### PR DESCRIPTION
## Description:
Adds a unique ID to the Roku media player so it can be included in the entity registry – so long, `media_player.roku_yp012n976523`!

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  - platform: roku
    host: 192.168.1.100
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  ~- [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)~

If the code communicates with devices, web services, or third-party tools:
  ~- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).~
  ~- [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).~
  ~- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.~
  ~- [ ] New files were added to `.coveragerc`.~

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
