### PR TITLE
Ignore more loading errors

### DIFF
--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -105,7 +105,16 @@ def get_component(hass, comp_or_platform) -> Optional[ModuleType]:
         except ImportError as err:
             # This error happens if for example custom_components/switch
             # exists and we try to load switch.demo.
-            if str(err) != "No module named '{}'".format(path):
+            # Ignore errors for custom_components, custom_components.switch
+            # and custom_components.switch.demo.
+            white_listed_errors = []
+            parts = []
+            for part in path.split('.'):
+                parts.append(part)
+                white_listed_errors.append(
+                    "No module named '{}'".format('.'.join(parts)))
+
+            if str(err) not in white_listed_errors:
                 _LOGGER.exception(
                     ("Error loading %s. Make sure all "
                      "dependencies are installed"), path)


### PR DESCRIPTION
## Description:
Realized I did not restore some part of error avoiding logic in #14327. Adding it back.

Fixes:

```
2018-05-07 10:28:15 ERROR (MainThread) [homeassistant.loader] Error loading custom_components.automation.state. Make sure all dependencies are installed
Traceback (most recent call last):
  File "/Users/paulus.schoutsen/dev/hass/home-assistant/homeassistant/loader.py", line 86, in get_component
    module = importlib.import_module(path)
  File "/usr/local/Cellar/python/3.6.5/Frameworks/Python.framework/Versions/3.6/lib/python3.6/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 994, in _gcd_import
  File "<frozen importlib._bootstrap>", line 971, in _find_and_load
  File "<frozen importlib._bootstrap>", line 941, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 994, in _gcd_import
  File "<frozen importlib._bootstrap>", line 971, in _find_and_load
  File "<frozen importlib._bootstrap>", line 953, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'custom_components.automation'
```
