### PR TITLE
Allow custom types for Google Assistant entities

### DIFF
--- a/homeassistant/components/google_assistant/__init__.py
+++ b/homeassistant/components/google_assistant/__init__.py
@@ -17,7 +17,7 @@ import voluptuous as vol
 from homeassistant.core import HomeAssistant  # NOQA
 from typing import Dict, Any  # NOQA
 
-from homeassistant.const import CONF_NAME
+from homeassistant.const import (CONF_NAME, CONF_TYPE)
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.loader import bind_hass
@@ -40,6 +40,7 @@ DEFAULT_AGENT_USER_ID = 'home-assistant'
 
 ENTITY_SCHEMA = vol.Schema({
     vol.Optional(CONF_NAME): cv.string,
+    vol.Optional(CONF_TYPE): cv.string, # allows you to override the domain it uses so you can get things like `remote` to work with GA
     vol.Optional(CONF_EXPOSE): cv.boolean,
     vol.Optional(CONF_ALIASES): vol.All(cv.ensure_list, [cv.string]),
     vol.Optional(CONF_ROOM_HINT): cv.string

--- a/homeassistant/components/google_assistant/__init__.py
+++ b/homeassistant/components/google_assistant/__init__.py
@@ -40,7 +40,9 @@ DEFAULT_AGENT_USER_ID = 'home-assistant'
 
 ENTITY_SCHEMA = vol.Schema({
     vol.Optional(CONF_NAME): cv.string,
-    vol.Optional(CONF_TYPE): cv.string, # allows you to override the domain it uses so you can get things like `remote` to work with GA
+    # allows you to override the domain it uses so
+    # you can get things like `remote` to work with GA
+    vol.Optional(CONF_TYPE): cv.string,
     vol.Optional(CONF_EXPOSE): cv.boolean,
     vol.Optional(CONF_ALIASES): vol.All(cv.ensure_list, [cv.string]),
     vol.Optional(CONF_ROOM_HINT): cv.string

--- a/homeassistant/components/google_assistant/smart_home.py
+++ b/homeassistant/components/google_assistant/smart_home.py
@@ -128,8 +128,11 @@ class _GoogleEntity:
             'attributes': {},
             'traits': [trait.name for trait in traits],
             'willReportState': False,
-            # Use the overridden type if available, to allow things like `remote` to work
-            'type': DOMAIN_TO_GOOGLE_TYPES[entity_config.get(CONF_TYPE) or state.domain],
+            # Use the overridden type if available,
+            # to allow things like `remote` to work
+            'type': DOMAIN_TO_GOOGLE_TYPES[
+                entity_config.get(CONF_TYPE) or state.domain
+            ],
         }
 
         # use aliases

--- a/homeassistant/components/google_assistant/smart_home.py
+++ b/homeassistant/components/google_assistant/smart_home.py
@@ -15,7 +15,7 @@ from homeassistant.util.decorator import Registry
 
 from homeassistant.core import callback
 from homeassistant.const import (
-    CONF_NAME, STATE_UNAVAILABLE, ATTR_SUPPORTED_FEATURES)
+    CONF_NAME, CONF_TYPE, STATE_UNAVAILABLE, ATTR_SUPPORTED_FEATURES)
 from homeassistant.components import (
     climate,
     cover,
@@ -82,7 +82,12 @@ class _GoogleEntity:
     def traits(self):
         """Return traits for entity."""
         state = self.state
-        domain = state.domain
+
+        entity_config = self.config.entity_config.get(state.entity_id, {})
+        type = entity_config.get(CONF_TYPE)
+
+        # Use the overridden type if available
+        domain = type or state.domain
         features = state.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
 
         return [Trait(state) for Trait in trait.TRAITS
@@ -123,7 +128,8 @@ class _GoogleEntity:
             'attributes': {},
             'traits': [trait.name for trait in traits],
             'willReportState': False,
-            'type': DOMAIN_TO_GOOGLE_TYPES[state.domain],
+            # Use the overridden type if available, to allow things like `remote` to work
+            'type': DOMAIN_TO_GOOGLE_TYPES[entity_config.get(CONF_TYPE) or state.domain],
         }
 
         # use aliases


### PR DESCRIPTION
## Description:

Full disclosure: I am a programmer, but have very little experience with Python.

When the Google Assistant integration was first included, it was possible to define a custom "type" so that your entity behaved like something else. I used this to make my `remote` act like a `switch` so I could say stuff like, "Turn off the TV in the master bedroom" and it'd turn off the TV in the master bedroom!

But then this behavior was removed. [I tried asking around on Github](https://github.com/home-assistant/home-assistant/issues/13019#issuecomment-385222448) and Discord to find out why it was removed, but didn't get an answer.

I don't know if there was a specific reason it was removed, but this PR makes the below config work again.

~~**Related issue (if applicable):** fixes #<home-assistant issue number goes here>~~

~~**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>~~

## Example entry for `configuration.yaml` (if applicable):
```yaml
google_assistant:
  project_id: !secret google_assistant_project_id
  client_id: !secret google_assistant_client_id
  access_token: !secret google_assistant_access_token
  agent_user_id: !secret google_assistant_agent_user_id
  exposed_domains:
  entity_config:
    remote.master_bedroom:
      expose: true
      name: Master Bedroom TV
      type: switch
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] ~~New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).~~
  - [ ] ~~New dependencies are only imported inside functions that use them ([example][ex-import]).~~
  - [ ] ~~New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.~~
  - [ ] ~~New files were added to `.coveragerc`.~~

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
