### PR TITLE
Remove typing dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,6 @@ REQUIRES = [
     'pip>=8.0.3',
     'jinja2>=2.10',
     'voluptuous==0.11.1',
-    'typing>=3,<4',
     'aiohttp==3.1.3',
     'async_timeout==2.0.1',
     'astral==1.6.1',


### PR DESCRIPTION
## Description:

The typing module in already included in Python 3.5, as 3.5 is now the minimum version this can be removed.

It is already patched out by [Arch Linux](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=home-assistant#n57) and [meta-homeassistant](https://github.com/bachp/meta-homeassistant/blob/master/recipes-homeassistant/homeassistant/files/0001-remove-typing-it-is-already-included-in-python-3.5.patch)

**Related issue (if applicable):** fixes #13238

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
