### PR TITLE
Make Feedreader component more extendable

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -415,7 +415,6 @@ omit =
     homeassistant/components/emoncms_history.py
     homeassistant/components/emulated_hue/upnp.py
     homeassistant/components/fan/mqtt.py
-    homeassistant/components/feedreader.py
     homeassistant/components/folder_watcher.py
     homeassistant/components/foursquare.py
     homeassistant/components/goalfeed.py

--- a/homeassistant/components/feedreader.py
+++ b/homeassistant/components/feedreader.py
@@ -88,10 +88,7 @@ class FeedManager(object):
             elif self._feed.entries:
                 _LOGGER.debug("%s entri(es) available in feed %s",
                               len(self._feed.entries), self._url)
-                if len(self._feed.entries) > MAX_ENTRIES:
-                    _LOGGER.debug("Processing only the first %s entries "
-                                  "in feed %s", MAX_ENTRIES, self._url)
-                    self._feed.entries = self._feed.entries[0:MAX_ENTRIES]
+                self._filter_entries()
                 self._publish_new_entries()
                 if self._has_published_parsed:
                     self._storage.put_timestamp(
@@ -99,6 +96,13 @@ class FeedManager(object):
             else:
                 self._log_no_entries()
         _LOGGER.info("Fetch from feed %s completed", self._url)
+
+    def _filter_entries(self):
+        """Filter the entries provided and return the ones to keep."""
+        if len(self._feed.entries) > MAX_ENTRIES:
+            _LOGGER.debug("Processing only the first %s entries "
+                          "in feed %s", MAX_ENTRIES, self._url)
+            self._feed.entries = self._feed.entries[0:MAX_ENTRIES]
 
     def _update_and_fire_entry(self, entry):
         """Update last_entry_timestamp and fire entry."""

--- a/homeassistant/components/feedreader.py
+++ b/homeassistant/components/feedreader.py
@@ -56,6 +56,7 @@ class FeedManager(object):
         self._storage = storage
         self._last_entry_timestamp = None
         self._has_published_parsed = False
+        self._event_type = EVENT_FEEDREADER
         hass.bus.listen_once(
             EVENT_HOMEASSISTANT_START, lambda _: self._update())
         self._init_regular_updates(hass)
@@ -117,7 +118,7 @@ class FeedManager(object):
             _LOGGER.debug("No published_parsed info available for entry %s",
                           entry.title)
         entry.update({'feed_url': self._url})
-        self._hass.bus.fire(EVENT_FEEDREADER, entry)
+        self._hass.bus.fire(self._event_type, entry)
 
     def _publish_new_entries(self):
         """Publish new entries to the event bus."""

--- a/homeassistant/components/feedreader.py
+++ b/homeassistant/components/feedreader.py
@@ -58,12 +58,16 @@ class FeedManager(object):
         self._has_published_parsed = False
         hass.bus.listen_once(
             EVENT_HOMEASSISTANT_START, lambda _: self._update())
-        track_utc_time_change(
-            hass, lambda now: self._update(), minute=0, second=0)
+        self._init_regular_updates(hass)
 
     def _log_no_entries(self):
         """Send no entries log at debug level."""
         _LOGGER.debug("No new entries to be published in feed %s", self._url)
+
+    def _init_regular_updates(self, hass):
+        """Schedule regular updates at the top of the clock."""
+        track_utc_time_change(
+            hass, lambda now: self._update(), minute=0, second=0)
 
     def _update(self):
         """Update the feed and publish new entries to the event bus."""

--- a/homeassistant/components/feedreader.py
+++ b/homeassistant/components/feedreader.py
@@ -74,6 +74,7 @@ class FeedManager(object):
 
     @property
     def last_update_successful(self):
+        """Returns True if the last feed update was successful."""
         return self._last_update_successful
 
     def _update(self):

--- a/homeassistant/components/feedreader.py
+++ b/homeassistant/components/feedreader.py
@@ -74,7 +74,7 @@ class FeedManager(object):
 
     @property
     def last_update_successful(self):
-        """Returns True if the last feed update was successful."""
+        """Return True if the last feed update was successful."""
         return self._last_update_successful
 
     def _update(self):

--- a/homeassistant/components/feedreader.py
+++ b/homeassistant/components/feedreader.py
@@ -89,8 +89,12 @@ class FeedManager(object):
             _LOGGER.error("Error fetching feed data from %s", self._url)
             self._last_update_successful = False
         else:
-            # If an error is detected, output message but continue processing
-            # the feed entries.
+            # The 'bozo' flag really only indicates that there was an issue
+            # during the initial parsing of the XML, but it doesn't indicate
+            # whether this is an unrecoverable error. In this case the
+            # feedparser lib is trying a less strict parsing approach.
+            # If an error is detected here, log error message but continue
+            # processing the feed entries if present.
             if self._feed.bozo != 0:
                 _LOGGER.error("Error parsing feed %s: %s", self._url,
                               self._feed.bozo_exception)

--- a/tests/components/test_feedreader.py
+++ b/tests/components/test_feedreader.py
@@ -69,7 +69,10 @@ class TestFeedreaderComponent(unittest.TestCase):
         with patch("homeassistant.components.feedreader."
                    "track_utc_time_change") as track_method:
             manager = FeedManager(feed_data, self.hass, storage)
-            track_method.assert_called_once()
+            # Can't use 'assert_called_once' here because it's not available
+            # in Python 3.5 yet.
+            track_method.assert_called_once_with(self.hass, mock.ANY, minute=0,
+                                                 second=0)
         # Artificially trigger update.
         self.hass.bus.fire(EVENT_HOMEASSISTANT_START)
         # Collect events.

--- a/tests/components/test_feedreader.py
+++ b/tests/components/test_feedreader.py
@@ -1,0 +1,145 @@
+"""The tests for the feedreader component."""
+import time
+from datetime import datetime
+
+import unittest
+from genericpath import exists
+from logging import getLogger
+from os import remove
+from unittest import mock
+from unittest.mock import patch
+
+from homeassistant.components import feedreader
+from homeassistant.components.feedreader import CONF_URLS, FeedManager, \
+    StoredData, EVENT_FEEDREADER
+from homeassistant.const import EVENT_HOMEASSISTANT_START
+from homeassistant.core import callback
+from homeassistant.setup import setup_component
+from tests.common import get_test_home_assistant, assert_setup_component, \
+    load_fixture
+
+_LOGGER = getLogger(__name__)
+
+URL = 'http://some.rss.local/rss_feed.xml'
+VALID_CONFIG_1 = {
+    feedreader.DOMAIN: {
+        CONF_URLS: [URL]
+    }
+}
+
+
+class TestFeedreaderComponent(unittest.TestCase):
+    """Test the feedreader component."""
+
+    def setUp(self):
+        """Initialize values for this testcase class."""
+        self.hass = get_test_home_assistant()
+        # Delete any previously stored data
+        data_file = self.hass.config.path("{}.pickle".format('feedreader'))
+        if exists(data_file):
+            remove(data_file)
+
+    def tearDown(self):
+        """Stop everything that was started."""
+        self.hass.stop()
+
+    def test_setup_one_feed(self):
+        """Test the general setup of this component."""
+        with assert_setup_component(1, 'feedreader'):
+            self.assertTrue(setup_component(self.hass, feedreader.DOMAIN,
+                                            VALID_CONFIG_1))
+
+    def setup_manager(self, feed_data):
+        events = []
+
+        @callback
+        def record_event(event):
+            """Add recorded event to set."""
+            events.append(event)
+
+        self.hass.bus.listen(EVENT_FEEDREADER, record_event)
+
+        # Loading raw data from fixture and plug in to data object as URL
+        # works since the third-party feedparser library accepts a URL
+        # as well as the actual data.
+        data_file = self.hass.config.path("{}.pickle".format(
+            feedreader.DOMAIN))
+        storage = StoredData(data_file)
+        with patch("homeassistant.components.feedreader."
+                   "track_utc_time_change") as track_method:
+            manager = FeedManager(feed_data, self.hass, storage)
+            track_method.assert_called_once()
+        # Artificially trigger update.
+        self.hass.bus.fire(EVENT_HOMEASSISTANT_START)
+        # Collect events.
+        self.hass.block_till_done()
+        return manager, events
+
+    def test_feed(self):
+        """Test simple feed with valid data."""
+        feed_data = load_fixture('feedreader.xml')
+        manager, events = self.setup_manager(feed_data)
+        assert len(events) == 1
+        assert events[0].data.title == "Title 1"
+        assert events[0].data.description == "Description 1"
+        assert events[0].data.link == "http://www.example.com/link/1"
+        assert events[0].data.id == "GUID 1"
+        assert datetime.fromtimestamp(
+            time.mktime(events[0].data.published_parsed)) == \
+            datetime(2018, 4, 30, 5, 10, 0)
+        assert manager.last_update_successful == True
+
+    def test_feed_updates(self):
+        """Test feed updates."""
+        # 1. Run
+        feed_data = load_fixture('feedreader.xml')
+        manager, events = self.setup_manager(feed_data)
+        assert len(events) == 1
+        # 2. Run
+        feed_data2 = load_fixture('feedreader1.xml')
+        # Must patch 'get_timestamp' method because the timestamp is stored
+        # with the URL which in these tests is the raw XML data.
+        with patch("homeassistant.components.feedreader.StoredData."
+                   "get_timestamp", return_value=time.struct_time(
+                (2018, 4, 30, 5, 10, 0, 0, 120, 0))) as mock_get_timestamp:
+            manager2, events2 = self.setup_manager(feed_data2)
+            assert len(events2) == 1
+        # 3. Run
+        feed_data3 = load_fixture('feedreader1.xml')
+        with patch("homeassistant.components.feedreader.StoredData."
+                   "get_timestamp", return_value=time.struct_time(
+                (2018, 4, 30, 5, 11, 0, 0, 120, 0))) as mock_get_timestamp:
+            manager3, events3 = self.setup_manager(feed_data3)
+            assert len(events3) == 0
+
+    def test_feed_max_length(self):
+        """Test long feed beyond the 20 entry limit."""
+        feed_data = load_fixture('feedreader2.xml')
+        manager, events = self.setup_manager(feed_data)
+        assert len(events) == 20
+
+    def test_feed_without_publication_date(self):
+        """Test simple feed with entry without publication date."""
+        feed_data = load_fixture('feedreader3.xml')
+        manager, events = self.setup_manager(feed_data)
+        assert len(events) == 2
+
+    def test_feed_invalid_data(self):
+        """Test feed with invalid data."""
+        feed_data = "INVALID DATA"
+        manager, events = self.setup_manager(feed_data)
+        assert len(events) == 0
+        assert manager.last_update_successful == True
+
+    @mock.patch('feedparser.parse', return_value=None)
+    def test_feed_parsing_failed(self, mock_parse):
+        """Test feed where parsing fails."""
+        data_file = self.hass.config.path("{}.pickle".format(
+            feedreader.DOMAIN))
+        storage = StoredData(data_file)
+        manager = FeedManager("FEED DATA", self.hass, storage)
+        # Artificially trigger update.
+        self.hass.bus.fire(EVENT_HOMEASSISTANT_START)
+        # Collect events.
+        self.hass.block_till_done()
+        assert manager.last_update_successful == False

--- a/tests/components/test_feedreader.py
+++ b/tests/components/test_feedreader.py
@@ -50,6 +50,7 @@ class TestFeedreaderComponent(unittest.TestCase):
                                             VALID_CONFIG_1))
 
     def setup_manager(self, feed_data):
+        """Generic test setup method."""
         events = []
 
         @callback
@@ -87,7 +88,7 @@ class TestFeedreaderComponent(unittest.TestCase):
         assert datetime.fromtimestamp(
             time.mktime(events[0].data.published_parsed)) == \
             datetime(2018, 4, 30, 5, 10, 0)
-        assert manager.last_update_successful == True
+        assert manager.last_update_successful is True
 
     def test_feed_updates(self):
         """Test feed updates."""
@@ -101,14 +102,14 @@ class TestFeedreaderComponent(unittest.TestCase):
         # with the URL which in these tests is the raw XML data.
         with patch("homeassistant.components.feedreader.StoredData."
                    "get_timestamp", return_value=time.struct_time(
-                (2018, 4, 30, 5, 10, 0, 0, 120, 0))) as mock_get_timestamp:
+                (2018, 4, 30, 5, 10, 0, 0, 120, 0))):
             manager2, events2 = self.setup_manager(feed_data2)
             assert len(events2) == 1
         # 3. Run
         feed_data3 = load_fixture('feedreader1.xml')
         with patch("homeassistant.components.feedreader.StoredData."
                    "get_timestamp", return_value=time.struct_time(
-                (2018, 4, 30, 5, 11, 0, 0, 120, 0))) as mock_get_timestamp:
+                (2018, 4, 30, 5, 11, 0, 0, 120, 0))):
             manager3, events3 = self.setup_manager(feed_data3)
             assert len(events3) == 0
 
@@ -129,7 +130,7 @@ class TestFeedreaderComponent(unittest.TestCase):
         feed_data = "INVALID DATA"
         manager, events = self.setup_manager(feed_data)
         assert len(events) == 0
-        assert manager.last_update_successful == True
+        assert manager.last_update_successful is True
 
     @mock.patch('feedparser.parse', return_value=None)
     def test_feed_parsing_failed(self, mock_parse):
@@ -142,4 +143,4 @@ class TestFeedreaderComponent(unittest.TestCase):
         self.hass.bus.fire(EVENT_HOMEASSISTANT_START)
         # Collect events.
         self.hass.block_till_done()
-        assert manager.last_update_successful == False
+        assert manager.last_update_successful is False

--- a/tests/fixtures/feedreader.xml
+++ b/tests/fixtures/feedreader.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<rss version="2.0">
+    <channel>
+        <title>RSS Sample</title>
+        <description>This is an example of an RSS feed</description>
+        <link>http://www.example.com/main.html</link>
+        <lastBuildDate>Mon, 30 Apr 2018 12:00:00 +1000 </lastBuildDate>
+        <pubDate>Mon, 30 Apr 2018 15:00:00 +1000</pubDate>
+        <ttl>1800</ttl>
+
+        <item>
+            <title>Title 1</title>
+            <description>Description 1</description>
+            <link>http://www.example.com/link/1</link>
+            <guid isPermaLink="false">GUID 1</guid>
+            <pubDate>Mon, 30 Apr 2018 15:10:00 +1000</pubDate>
+        </item>
+
+    </channel>
+</rss>

--- a/tests/fixtures/feedreader1.xml
+++ b/tests/fixtures/feedreader1.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<rss version="2.0">
+    <channel>
+        <title>RSS Sample</title>
+        <description>This is an example of an RSS feed</description>
+        <link>http://www.example.com/main.html</link>
+        <lastBuildDate>Mon, 30 Apr 2018 12:00:00 +1000 </lastBuildDate>
+        <pubDate>Mon, 30 Apr 2018 15:00:00 +1000</pubDate>
+        <ttl>1800</ttl>
+
+        <item>
+            <title>Title 1</title>
+            <description>Description 1</description>
+            <link>http://www.example.com/link/1</link>
+            <guid isPermaLink="false">GUID 1</guid>
+            <pubDate>Mon, 30 Apr 2018 15:10:00 +1000</pubDate>
+        </item>
+        <item>
+            <title>Title 2</title>
+            <description>Description 2</description>
+            <link>http://www.example.com/link/2</link>
+            <guid isPermaLink="false">GUID 2</guid>
+            <pubDate>Mon, 30 Apr 2018 15:11:00 +1000</pubDate>
+        </item>
+
+    </channel>
+</rss>

--- a/tests/fixtures/feedreader2.xml
+++ b/tests/fixtures/feedreader2.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<rss version="2.0">
+    <channel>
+        <title>RSS Sample</title>
+        <description>This is an example of an RSS feed</description>
+        <link>http://www.example.com/main.html</link>
+        <lastBuildDate>Mon, 30 Apr 2018 12:00:00 +1000 </lastBuildDate>
+        <pubDate>Mon, 30 Apr 2018 15:00:00 +1000</pubDate>
+        <ttl>1800</ttl>
+
+        <item>
+            <title>Title 1</title>
+            <pubDate>Mon, 30 Apr 2018 15:00:00 +1000</pubDate>
+        </item>
+        <item>
+            <title>Title 2</title>
+            <pubDate>Mon, 30 Apr 2018 15:01:00 +1000</pubDate>
+        </item>
+        <item>
+            <title>Title 3</title>
+            <pubDate>Mon, 30 Apr 2018 15:02:00 +1000</pubDate>
+        </item>
+        <item>
+            <title>Title 4</title>
+            <pubDate>Mon, 30 Apr 2018 15:03:00 +1000</pubDate>
+        </item>
+        <item>
+            <title>Title 5</title>
+            <pubDate>Mon, 30 Apr 2018 15:04:00 +1000</pubDate>
+        </item>
+        <item>
+            <title>Title 6</title>
+            <pubDate>Mon, 30 Apr 2018 15:05:00 +1000</pubDate>
+        </item>
+        <item>
+            <title>Title 7</title>
+            <pubDate>Mon, 30 Apr 2018 15:06:00 +1000</pubDate>
+        </item>
+        <item>
+            <title>Title 8</title>
+            <pubDate>Mon, 30 Apr 2018 15:07:00 +1000</pubDate>
+        </item>
+        <item>
+            <title>Title 9</title>
+            <pubDate>Mon, 30 Apr 2018 15:08:00 +1000</pubDate>
+        </item>
+        <item>
+            <title>Title 10</title>
+            <pubDate>Mon, 30 Apr 2018 15:09:00 +1000</pubDate>
+        </item>
+        <item>
+            <title>Title 11</title>
+            <pubDate>Mon, 30 Apr 2018 15:10:00 +1000</pubDate>
+        </item>
+        <item>
+            <title>Title 12</title>
+            <pubDate>Mon, 30 Apr 2018 15:11:00 +1000</pubDate>
+        </item>
+        <item>
+            <title>Title 13</title>
+            <pubDate>Mon, 30 Apr 2018 15:12:00 +1000</pubDate>
+        </item>
+        <item>
+            <title>Title 14</title>
+            <pubDate>Mon, 30 Apr 2018 15:13:00 +1000</pubDate>
+        </item>
+        <item>
+            <title>Title 15</title>
+            <pubDate>Mon, 30 Apr 2018 15:14:00 +1000</pubDate>
+        </item>
+        <item>
+            <title>Title 16</title>
+            <pubDate>Mon, 30 Apr 2018 15:15:00 +1000</pubDate>
+        </item>
+        <item>
+            <title>Title 17</title>
+            <pubDate>Mon, 30 Apr 2018 15:16:00 +1000</pubDate>
+        </item>
+        <item>
+            <title>Title 18</title>
+            <pubDate>Mon, 30 Apr 2018 15:17:00 +1000</pubDate>
+        </item>
+        <item>
+            <title>Title 19</title>
+            <pubDate>Mon, 30 Apr 2018 15:18:00 +1000</pubDate>
+        </item>
+        <item>
+            <title>Title 20</title>
+            <pubDate>Mon, 30 Apr 2018 15:19:00 +1000</pubDate>
+        </item>
+        <item>
+            <title>Title 21</title>
+            <pubDate>Mon, 30 Apr 2018 15:20:00 +1000</pubDate>
+        </item>
+
+    </channel>
+</rss>

--- a/tests/fixtures/feedreader3.xml
+++ b/tests/fixtures/feedreader3.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<rss version="2.0">
+    <channel>
+        <title>RSS Sample</title>
+        <description>This is an example of an RSS feed</description>
+        <link>http://www.example.com/main.html</link>
+        <lastBuildDate>Mon, 30 Apr 2018 12:00:00 +1000 </lastBuildDate>
+        <pubDate>Mon, 30 Apr 2018 15:00:00 +1000</pubDate>
+        <ttl>1800</ttl>
+
+        <item>
+            <title>Title 1</title>
+            <description>Description 1</description>
+            <link>http://www.example.com/link/1</link>
+            <guid isPermaLink="false">GUID 1</guid>
+            <pubDate>Mon, 30 Apr 2018 15:10:00 +1000</pubDate>
+        </item>
+        <item>
+            <title>Title 2</title>
+            <description>Description 2</description>
+            <link>http://www.example.com/link/2</link>
+            <guid isPermaLink="false">GUID 2</guid>
+        </item>
+
+    </channel>
+</rss>


### PR DESCRIPTION
## Description:
I am proposing a few small changes to the feedreader component:
* Moved the code that regularly updates the feed into own method so that subclasses can override this behaviour. The default feedreader is still updating at the top of the clock.
* Moved the maximum entry filter into own method so that subclasses can override this behaviour and filter the feed differently. The default feedreader is still chopping off the feed after 20 entries.
* Made the previously hard-coded event type configurable so that subclasses can introduce their own event type schema. The default feedreader is still publishing as `feedreader`.
* Introduced a dedicated feed id attribute so that subclasses can introduce their own feed id schema. The default feedreader is still using the feed URL as its id.
* Breaking change: Currently, parsing the feed is considered a failure if the `bozo` flag in the underlying `feedparser` is set. The `bozo` flag is set if the initial parsing fails, however, the library then tries a less restrictive approach parsing the feed which may still succeed. This change in the feedreader component still logs a message if the `bozo` flag is set, but then tries to access the feed to see if entries are present.
* As a bonus, I added unit tests for the feedreader component which are currently missing altogether.

The background for all the changes above is a planned extension (already work in progress) to transform the geo_rss_events sensor into a component which will then be based on the feedreader component.

If preferable, I can separate the non-breaking changes from the breaking changes.

**Related issue (if applicable):** n/a

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable):
Configuration options have not changed.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
