### PR TITLE
Fix new Matrix notifier

### DIFF
--- a/homeassistant/components/matrix.py
+++ b/homeassistant/components/matrix.py
@@ -114,9 +114,6 @@ class MatrixBot(object):
 
         self._listening_rooms = listening_rooms
 
-        # Logging in is deferred b/c it does I/O
-        self._setup_done = False
-
         # We have to fetch the aliases for every room to make sure we don't
         # join it twice by accident. However, fetching aliases is costly,
         # so we only do it once per room.
@@ -343,9 +340,5 @@ class MatrixBot(object):
 
     def handle_send_message(self, service):
         """Handle the send_message service."""
-        if not self._setup_done:
-            _LOGGER.warning("Could not send message: setup is not done!")
-            return
-
         self._send_message(service.data[ATTR_MESSAGE],
                            service.data[ATTR_TARGET])


### PR DESCRIPTION
## Description:

In #13355 I seem to have messed up incorporating one of the last reviews: When I moved around the deferred setup stuff, it looks like I haven't properly removed the "wait for setup to be done" logic. This results in the matrix notifier not working, since it waits for a setup that never happens.

This PR fixes that.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
