### PR TITLE
Ignore NaN values for influxdb

### DIFF
--- a/homeassistant/components/influxdb.py
+++ b/homeassistant/components/influxdb.py
@@ -222,10 +222,11 @@ def setup(hass, config):
                             RE_DECIMAL.sub('', new_value))
 
                 # Infinity and NaN are not valid floats in InfluxDB
-                if key in json['fields']:
-                    converted = json['fields'][key]
-                    if math.isinf(converted) or math.isnan(converted):
+                try:
+                    if not math.isfinite(json['fields'][key]):
                         del json['fields'][key]
+                except (KeyError, TypeError):
+                    pass
 
         json['tags'].update(tags)
 

--- a/homeassistant/components/influxdb.py
+++ b/homeassistant/components/influxdb.py
@@ -9,6 +9,7 @@ import re
 import queue
 import threading
 import time
+import math
 
 import requests.exceptions
 import voluptuous as vol
@@ -220,9 +221,11 @@ def setup(hass, config):
                         json['fields'][key] = float(
                             RE_DECIMAL.sub('', new_value))
 
-                # Infinity is not a valid float in InfluxDB
-                if (key, float("inf")) in json['fields'].items():
-                    del json['fields'][key]
+                # Infinity and NaN are not valid floats in InfluxDB
+                if key in json['fields']:
+                    converted = json['fields'][key]
+                    if math.isinf(converted) or math.isnan(converted):
+                        del json['fields'][key]
 
         json['tags'].update(tags)
 

--- a/tests/components/test_influxdb.py
+++ b/tests/components/test_influxdb.py
@@ -217,7 +217,7 @@ class TestInfluxDB(unittest.TestCase):
         """Test the event listener for missing units."""
         self._setup()
 
-        attrs = {'bignumstring':  "9" * 999}
+        attrs = {'bignumstring':  '9' * 999, 'nonumstring': 'nan'}
         state = mock.MagicMock(
             state=8, domain='fake', entity_id='fake.entity-id',
             object_id='entity', attributes=attrs)


### PR DESCRIPTION
## Description:

This extends the InfluxDB invalid-value filter to also handle "nan" values.

**Related issue (if applicable):** [reported in forum](https://community.home-assistant.io/t/error-writing-to-influxdb/43887/16)

## Checklist:
  - [ ] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.
