### PR TITLE
Give unknown zwave nodes a better name

### DIFF
--- a/homeassistant/components/zwave/util.py
+++ b/homeassistant/components/zwave/util.py
@@ -68,8 +68,10 @@ def check_value_schema(value, schema):
 
 def node_name(node):
     """Return the name of the node."""
-    return node.name or '{} {}'.format(
-        node.manufacturer_name, node.product_name)
+    if is_node_parsed(node):
+        return node.name or '{} {}'.format(
+            node.manufacturer_name, node.product_name)
+    return 'Unknown Node {}'.format(node.node_id)
 
 
 async def check_has_unique_id(entity, ready_callback, timeout_callback, loop):
@@ -89,4 +91,4 @@ async def check_has_unique_id(entity, ready_callback, timeout_callback, loop):
 
 def is_node_parsed(node):
     """Check whether the node has been parsed or still waiting to be parsed."""
-    return node.manufacturer_name and node.product_name
+    return (node.manufacturer_name and node.product_name) or node.name

--- a/homeassistant/components/zwave/util.py
+++ b/homeassistant/components/zwave/util.py
@@ -91,4 +91,4 @@ async def check_has_unique_id(entity, ready_callback, timeout_callback, loop):
 
 def is_node_parsed(node):
     """Check whether the node has been parsed or still waiting to be parsed."""
-    return (node.manufacturer_name and node.product_name) or node.name
+    return bool((node.manufacturer_name and node.product_name) or node.name)

--- a/tests/components/zwave/test_init.py
+++ b/tests/components/zwave/test_init.py
@@ -237,7 +237,8 @@ async def test_unparsed_node_discovery(hass, mock_openzwave):
 
     assert len(mock_receivers) == 1
 
-    node = MockNode(node_id=14, manufacturer_name=None, is_ready=False)
+    node = MockNode(
+        node_id=14, manufacturer_name=None, name=None, is_ready=False)
 
     sleeps = []
 
@@ -262,7 +263,7 @@ async def test_unparsed_node_discovery(hass, mock_openzwave):
                 assert len(mock_logger.warning.mock_calls) == 1
                 assert mock_logger.warning.mock_calls[0][1][1:] == \
                     (14, const.NODE_READY_WAIT_SECS)
-    assert hass.states.get('zwave.mock_node').state is 'unknown'
+    assert hass.states.get('zwave.unknown_node_14').state is 'unknown'
 
 
 @asyncio.coroutine

--- a/tests/components/zwave/test_node_entity.py
+++ b/tests/components/zwave/test_node_entity.py
@@ -363,6 +363,7 @@ class TestZWaveNodeEntity(unittest.TestCase):
     def test_unique_id_missing_data(self):
         """Test unique_id."""
         self.node.manufacturer_name = None
+        self.node.name = None
         entity = node_entity.ZWaveNodeEntity(self.node, self.zwave_network)
 
         self.assertIsNone(entity.unique_id)


### PR DESCRIPTION
## Description:

If zwave node couldn't be parsed for manufacturer/product and also wasn't given a saved-in-zwave `name` it would get a `" "` name and `"_"` ID.

This PR would result in `"Unknown Node <node_id>"` name instead.

This is a **breaking change** as such node won't be in the entity registry and thus the entity_id would change.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
