### PR TITLE
Adds facebox

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -422,7 +422,6 @@ omit =
     homeassistant/components/ifttt.py
     homeassistant/components/image_processing/dlib_face_detect.py
     homeassistant/components/image_processing/dlib_face_identify.py
-    homeassistant/components/image_processing/facebox.py
     homeassistant/components/image_processing/seven_segments.py
     homeassistant/components/keyboard_remote.py
     homeassistant/components/keyboard.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -422,6 +422,7 @@ omit =
     homeassistant/components/ifttt.py
     homeassistant/components/image_processing/dlib_face_detect.py
     homeassistant/components/image_processing/dlib_face_identify.py
+    homeassistant/components/image_processing/facebox.py
     homeassistant/components/image_processing/seven_segments.py
     homeassistant/components/keyboard_remote.py
     homeassistant/components/keyboard.py

--- a/homeassistant/components/image_processing/facebox.py
+++ b/homeassistant/components/image_processing/facebox.py
@@ -1,0 +1,110 @@
+"""
+Component that will perform facial detection and identification via facebox.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/image_processing.facebox
+"""
+import base64
+import logging
+
+import requests
+import voluptuous as vol
+
+from homeassistant.core import split_entity_id
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.image_processing import (
+    PLATFORM_SCHEMA, ImageProcessingFaceEntity, CONF_SOURCE, CONF_ENTITY_ID,
+    CONF_NAME)
+from homeassistant.const import (CONF_IP_ADDRESS, CONF_PORT)
+
+_LOGGER = logging.getLogger(__name__)
+
+CLASSIFIER = 'facebox'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_IP_ADDRESS): cv.string,
+    vol.Required(CONF_PORT): cv.port,
+})
+
+
+def encode_image(image):
+    """base64 encode an image stream."""
+    base64_img = base64.b64encode(image).decode('ascii')
+    return {"base64": base64_img}
+
+
+def get_matched_faces(faces):
+    """Return the name and rounded confidence of matched faces."""
+    return {face['name']: round(face['confidence'], 2)
+            for face in faces if face['matched']}
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the classifier."""
+    entities = []
+    for camera in config[CONF_SOURCE]:
+        entities.append(FaceClassifyEntity(
+            config[CONF_IP_ADDRESS],
+            config[CONF_PORT],
+            camera[CONF_ENTITY_ID],
+            camera.get(CONF_NAME)
+        ))
+    add_devices(entities)
+
+
+class FaceClassifyEntity(ImageProcessingFaceEntity):
+    """Perform a face classification."""
+
+    def __init__(self, ip, port, camera_entity, name=None):
+        """Init with the API key and model id."""
+        super().__init__()
+        self._url = "http://{}:{}/{}/check".format(ip, port, CLASSIFIER)
+        self._camera = camera_entity
+        if name:
+            self._name = name
+        else:
+            camera_name = split_entity_id(camera_entity)[1]
+            self._name = "{} {}".format(
+                CLASSIFIER, camera_name)
+        self._matched = {}
+
+    def process_image(self, image):
+        """Process an image."""
+        response = {}
+        try:
+            response = requests.post(
+                self._url,
+                json=encode_image(image),
+                timeout=9
+                ).json()
+        except requests.exceptions.ConnectionError:
+            _LOGGER.error("ConnectionError: Is %s running?", CLASSIFIER)
+            response['success'] = False
+
+        if response['success']:
+            faces = response['faces']
+            total = response['facesCount']
+            self.process_faces(faces, total)
+            self._matched = get_matched_faces(faces)
+
+        else:
+            self.total_faces = None
+            self.faces = []
+            self._matched = {}
+
+    @property
+    def camera_entity(self):
+        """Return camera entity id from process pictures."""
+        return self._camera
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def device_state_attributes(self):
+        """Return the classifier attributes."""
+        return {
+            'matched_faces': self._matched,
+            }

--- a/tests/components/image_processing/test_facebox.py
+++ b/tests/components/image_processing/test_facebox.py
@@ -1,0 +1,73 @@
+"""The tests for the facebox component."""
+from unittest.mock import patch
+
+import pytest
+import requests_mock
+
+from homeassistant.const import (
+    ATTR_ENTITY_ID, CONF_IP_ADDRESS, CONF_PORT)
+from homeassistant.setup import async_setup_component
+import homeassistant.components.image_processing as ip
+
+MOCK_IP = '192.168.0.1'
+MOCK_PORT = '8080'
+
+MOCK_JSON = {"facesCount": 1,
+             "success": True,
+             "faces": [{'confidence': 0.5812028911604818,
+                        'id': 'john.jpg',
+                        'matched': True,
+                        'name': 'John Lennon',
+                        'rect': {'height': 75,
+                                 'left': 63,
+                                 'top': 262,
+                                 'width': 74}
+                        }]
+             }
+
+VALID_ENTITY_ID = 'image_processing.facebox_demo_camera'
+VALID_CONFIG = {
+    ip.DOMAIN: {
+        'platform': 'facebox',
+        CONF_IP_ADDRESS: MOCK_IP,
+        CONF_PORT: MOCK_PORT,
+        ip.CONF_SOURCE: {
+            ip.CONF_ENTITY_ID: 'camera.demo_camera'}
+        },
+    'camera': {
+        'platform': 'demo'
+        }
+    }
+
+
+@pytest.fixture
+def mock_image():
+    """Return a mock camera image."""
+    with patch('homeassistant.components.camera.demo.DemoCamera.camera_image',
+               return_value=b'Test') as image:
+        yield image
+
+
+async def test_setup_platform(hass):
+    """Setup platform with one entity."""
+    await async_setup_component(hass, ip.DOMAIN, VALID_CONFIG)
+    assert hass.states.get(VALID_ENTITY_ID)
+
+
+async def test_process_image(hass, mock_image):
+    """Test processing of an image."""
+    await async_setup_component(hass, ip.DOMAIN, VALID_CONFIG)
+    assert hass.states.get(VALID_ENTITY_ID)
+
+    with requests_mock.Mocker() as mock_req:
+        url = "http://{}:{}/facebox/check".format(MOCK_IP, MOCK_PORT)
+        mock_req.post(url, json=MOCK_JSON)
+        data = {ATTR_ENTITY_ID: VALID_ENTITY_ID}
+        await hass.services.async_call(ip.DOMAIN,
+                                       ip.SERVICE_SCAN,
+                                       service_data=data)
+        await hass.async_block_till_done()
+
+    state = hass.states.get(VALID_ENTITY_ID)
+    assert state.state == '1'
+    assert state.attributes.get('matched_faces') == {'John Lennon': 0.58}

--- a/tests/components/image_processing/test_facebox.py
+++ b/tests/components/image_processing/test_facebox.py
@@ -6,9 +6,10 @@ import requests_mock
 
 from homeassistant.core import callback
 from homeassistant.const import (
-    ATTR_ENTITY_ID, CONF_IP_ADDRESS, CONF_PORT)
+    ATTR_ENTITY_ID, CONF_FRIENDLY_NAME, CONF_IP_ADDRESS, CONF_PORT)
 from homeassistant.setup import async_setup_component
 import homeassistant.components.image_processing as ip
+import homeassistant.components.image_processing.facebox as fb
 
 MOCK_IP = '192.168.0.1'
 MOCK_PORT = '8080'
@@ -38,6 +39,16 @@ VALID_CONFIG = {
         'platform': 'demo'
         }
     }
+
+
+def test_encode_image():
+    """Test that binary data is encoded correctly."""
+    assert fb.encode_image(b'test')["base64"] == 'dGVzdA=='
+
+
+def test_get_matched_faces():
+    """Test that matched faces are parsed correctly."""
+    assert fb.get_matched_faces([MOCK_FACES]) == {MOCK_FACES['name']: 0.58}
 
 
 @pytest.fixture
@@ -83,6 +94,7 @@ async def test_process_image(hass, mock_image):
 
     MOCK_FACES[ATTR_ENTITY_ID] = VALID_ENTITY_ID  # Update.
     assert state.attributes.get('faces') == [MOCK_FACES]
+    assert state.attributes.get(CONF_FRIENDLY_NAME) == 'facebox demo_camera'
 
     assert len(face_events) == 1
     assert face_events[0].data['name'] == MOCK_FACES['name']

--- a/tests/components/image_processing/test_facebox.py
+++ b/tests/components/image_processing/test_facebox.py
@@ -7,7 +7,8 @@ import requests_mock
 
 from homeassistant.core import callback
 from homeassistant.const import (
-    ATTR_ENTITY_ID, CONF_FRIENDLY_NAME, CONF_IP_ADDRESS, CONF_PORT)
+    ATTR_ENTITY_ID, CONF_FRIENDLY_NAME,
+    CONF_IP_ADDRESS, CONF_PORT, STATE_UNKNOWN)
 from homeassistant.setup import async_setup_component
 import homeassistant.components.image_processing as ip
 import homeassistant.components.image_processing.facebox as fb
@@ -104,7 +105,7 @@ async def test_process_image(hass, mock_image):
 
 
 async def test_connection_error(hass, mock_image):
-    """Test processing of an image."""
+    """Test connection error."""
     await async_setup_component(hass, ip.DOMAIN, VALID_CONFIG)
     assert hass.states.get(VALID_ENTITY_ID)
 
@@ -119,7 +120,7 @@ async def test_connection_error(hass, mock_image):
         await hass.async_block_till_done()
 
     state = hass.states.get(VALID_ENTITY_ID)
-    assert state.state == 'unknown'
+    assert state.state == STATE_UNKNOWN
     assert state.attributes.get('faces') == []
     assert state.attributes.get('matched_faces') == {}
 

--- a/tests/components/image_processing/test_facebox.py
+++ b/tests/components/image_processing/test_facebox.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 import pytest
 import requests_mock
 
+from homeassistant.core import callback
 from homeassistant.const import (
     ATTR_ENTITY_ID, CONF_IP_ADDRESS, CONF_PORT)
 from homeassistant.setup import async_setup_component
@@ -58,6 +59,15 @@ async def test_process_image(hass, mock_image):
     await async_setup_component(hass, ip.DOMAIN, VALID_CONFIG)
     assert hass.states.get(VALID_ENTITY_ID)
 
+    face_events = []
+
+    @callback
+    def mock_face_event(event):
+        """Mock event."""
+        face_events.append(event)
+
+    hass.bus.async_listen('image_processing.detect_face', mock_face_event)
+
     with requests_mock.Mocker() as mock_req:
         url = "http://{}:{}/facebox/check".format(MOCK_IP, MOCK_PORT)
         mock_req.post(url, json=MOCK_JSON)
@@ -69,7 +79,12 @@ async def test_process_image(hass, mock_image):
 
     state = hass.states.get(VALID_ENTITY_ID)
     assert state.state == '1'
-    assert state.attributes.get('matched_faces') == {'John Lennon': 0.58}
+    assert state.attributes.get('matched_faces') == {MOCK_FACES['name']: 0.58}
 
     MOCK_FACES[ATTR_ENTITY_ID] = VALID_ENTITY_ID  # Update.
     assert state.attributes.get('faces') == [MOCK_FACES]
+
+    assert len(face_events) == 1
+    assert face_events[0].data['name'] == MOCK_FACES['name']
+    assert face_events[0].data['confidence'] == MOCK_FACES['confidence']
+    assert face_events[0].data['entity_id'] == VALID_ENTITY_ID

--- a/tests/components/image_processing/test_facebox.py
+++ b/tests/components/image_processing/test_facebox.py
@@ -12,17 +12,16 @@ import homeassistant.components.image_processing as ip
 MOCK_IP = '192.168.0.1'
 MOCK_PORT = '8080'
 
+MOCK_FACES = {'confidence': 0.5812028911604818,
+              'id': 'john.jpg',
+              'matched': True,
+              'name': 'John Lennon',
+              'rect': {'height': 75, 'left': 63, 'top': 262, 'width': 74}
+              }
+
 MOCK_JSON = {"facesCount": 1,
              "success": True,
-             "faces": [{'confidence': 0.5812028911604818,
-                        'id': 'john.jpg',
-                        'matched': True,
-                        'name': 'John Lennon',
-                        'rect': {'height': 75,
-                                 'left': 63,
-                                 'top': 262,
-                                 'width': 74}
-                        }]
+             "faces": [MOCK_FACES]
              }
 
 VALID_ENTITY_ID = 'image_processing.facebox_demo_camera'
@@ -71,3 +70,6 @@ async def test_process_image(hass, mock_image):
     state = hass.states.get(VALID_ENTITY_ID)
     assert state.state == '1'
     assert state.attributes.get('matched_faces') == {'John Lennon': 0.58}
+
+    MOCK_FACES[ATTR_ENTITY_ID] = VALID_ENTITY_ID  # Update.
+    assert state.attributes.get('faces') == [MOCK_FACES]

--- a/tests/components/image_processing/test_facebox.py
+++ b/tests/components/image_processing/test_facebox.py
@@ -15,16 +15,16 @@ import homeassistant.components.image_processing.facebox as fb
 MOCK_IP = '192.168.0.1'
 MOCK_PORT = '8080'
 
-MOCK_FACES = {'confidence': 0.5812028911604818,
-              'id': 'john.jpg',
-              'matched': True,
-              'name': 'John Lennon',
-              'rect': {'height': 75, 'left': 63, 'top': 262, 'width': 74}
-              }
+MOCK_FACE = {'confidence': 0.5812028911604818,
+             'id': 'john.jpg',
+             'matched': True,
+             'name': 'John Lennon',
+             'rect': {'height': 75, 'left': 63, 'top': 262, 'width': 74}
+             }
 
 MOCK_JSON = {"facesCount": 1,
              "success": True,
-             "faces": [MOCK_FACES]
+             "faces": [MOCK_FACE]
              }
 
 VALID_ENTITY_ID = 'image_processing.facebox_demo_camera'
@@ -49,7 +49,7 @@ def test_encode_image():
 
 def test_get_matched_faces():
     """Test that matched faces are parsed correctly."""
-    assert fb.get_matched_faces([MOCK_FACES]) == {MOCK_FACES['name']: 0.58}
+    assert fb.get_matched_faces([MOCK_FACE]) == {MOCK_FACE['name']: 0.58}
 
 
 @pytest.fixture
@@ -91,15 +91,15 @@ async def test_process_image(hass, mock_image):
 
     state = hass.states.get(VALID_ENTITY_ID)
     assert state.state == '1'
-    assert state.attributes.get('matched_faces') == {MOCK_FACES['name']: 0.58}
+    assert state.attributes.get('matched_faces') == {MOCK_FACE['name']: 0.58}
 
-    MOCK_FACES[ATTR_ENTITY_ID] = VALID_ENTITY_ID  # Update.
-    assert state.attributes.get('faces') == [MOCK_FACES]
+    MOCK_FACE[ATTR_ENTITY_ID] = VALID_ENTITY_ID  # Update.
+    assert state.attributes.get('faces') == [MOCK_FACE]
     assert state.attributes.get(CONF_FRIENDLY_NAME) == 'facebox demo_camera'
 
     assert len(face_events) == 1
-    assert face_events[0].data['name'] == MOCK_FACES['name']
-    assert face_events[0].data['confidence'] == MOCK_FACES['confidence']
+    assert face_events[0].data['name'] == MOCK_FACE['name']
+    assert face_events[0].data['confidence'] == MOCK_FACE['confidence']
     assert face_events[0].data['entity_id'] == VALID_ENTITY_ID
 
 


### PR DESCRIPTION
Replaces https://github.com/home-assistant/home-assistant/pull/14307

## Description:
Adds component for face detection (number of faces) and identification (recognition of taught faces) using [facebox](https://machineboxio.com/docs/facebox/teaching-facebox). Run facebox with:
```
MB_KEY="INSERT-YOUR-KEY-HERE"

docker run -p 8080:8080 -e "MB_KEY=$MB_KEY" machinebox/facebox
```

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io/) with documentation (if applicable):**
https://github.com/home-assistant/home-assistant.github.io/pull/5300
## Example entry for `configuration.yaml` (if applicable):
```yaml
image_processing:
  - platform: facebox
    ip_address: 192.168.0.1
    port: 8080
    source:
      - entity_id: camera.local_file
        name: my_name
      - entity_id: camera.demo_camera
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io/)
