### PR TITLE
Bump locationsharinglib to 2.0.2

### DIFF
--- a/homeassistant/components/device_tracker/google_maps.py
+++ b/homeassistant/components/device_tracker/google_maps.py
@@ -19,7 +19,7 @@ from homeassistant.util import slugify
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['locationsharinglib==1.2.2']
+REQUIREMENTS = ['locationsharinglib==2.0.2']
 
 CREDENTIALS_FILE = '.google_maps_location_sharing.cookies'
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -503,7 +503,7 @@ liveboxplaytv==2.0.2
 lmnotify==0.0.4
 
 # homeassistant.components.device_tracker.google_maps
-locationsharinglib==1.2.2
+locationsharinglib==2.0.2
 
 # homeassistant.components.sensor.luftdaten
 luftdaten==0.1.3


### PR DESCRIPTION
## Description:
Bump locationsharinglib to 2.0.2 

if you get errors : 

1) disable 2 auth factor on your google account

2) clean/delete the '.google_maps_location_sharing.cookies' file at the root of the home-assitant config
and restart HA
(You need to do it when you upgrade from 0.67 => 0.68 or 0.69 ... )

3)
* secret.yaml
```
device_tracker_gmail: 'test@gmail.com'
device_tracker_gmail_password: 'password'
```
Change to : 
```
device_tracker_gmail: 'test@gmail.com'
device_tracker_gmail_password: password
```
* configuration.yaml
```
  - platform: google_maps
    username: !secret device_tracker_gmail
    password: !secret device_tracker_gmail_password
    new_device_defaults:
      track_new_devices: true
```


4) make sur that in your know_device.yaml   ``track:``is set to **true** (by default it's false)

```
google_maps_NUMBER:
  hide_if_away: false
  icon:
  mac:
  name: google maps NUMBER
  picture: https://lh3.googleusercontent.com/-[b64code]/mo/photo.jpg
  track: true
```

**Related issue (if applicable):** possible fixes https://community.home-assistant.io/t/google-maps-location-sharing/15155/279

#14177 

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
