### PR TITLE
script/lint: Add check for pylint files

### DIFF
--- a/script/lint
+++ b/script/lint
@@ -8,7 +8,7 @@ echo '================================================='
 echo '=                FILES CHANGED                  ='
 echo '================================================='
 if [ -z "$files" ] ; then
-  echo "No python file changed. Rather use: tox -e lint"
+  echo "No python file changed. Rather use: tox -e lint\n"
   exit
 fi
 printf "%s\n" $files
@@ -19,5 +19,10 @@ flake8 --doctests $files
 echo "================"
 echo "LINT with pylint"
 echo "================"
+pylint_files=$(echo "$files" | grep -v '^tests.*')
+if [ -z "$pylint_files" ] ; then
+  echo "Only test files changed. Skipping\n"
+  exit
+fi
 pylint $(echo "$files" | grep -v '^tests.*')
 echo

--- a/script/lint
+++ b/script/lint
@@ -24,5 +24,5 @@ if [ -z "$pylint_files" ] ; then
   echo "Only test files changed. Skipping\n"
   exit
 fi
-pylint $(echo "$files" | grep -v '^tests.*')
+pylint $pylint_files
 echo


### PR DESCRIPTION
## Description:
If `script/lint` is run when only test files have changed. The `pylint` command will return the help page.

CC: @kellerza @armills 