### PR TITLE
Update mychevy to 0.4.0

### DIFF
--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -537,7 +537,7 @@ motorparts==1.0.2
 mutagen==1.40.0
 
 # homeassistant.components.mychevy
-mychevy==0.1.1
+mychevy==0.4.0
 
 # homeassistant.components.mycroft
 mycroftapi==2.0


### PR DESCRIPTION
After 2 months of being offline, the my.chevy website seems to be
working again. Some data structures changed in the mean time. The new
library will handle multiple cars. This involves a breaking change in
slug urls for devices where these now include the car make, model, and
year in them.

Discovery has to be delayed until after the initial site login to get
the car metadata.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
