### PR TITLE
Fix binary_sensor async_update

### DIFF
--- a/homeassistant/components/binary_sensor/zha.py
+++ b/homeassistant/components/binary_sensor/zha.py
@@ -133,7 +133,8 @@ class BinarySensor(zha.Entity, BinarySensorDevice):
         from bellows.types.basic import uint16_t
 
         result = await zha.safe_read(self._endpoint.ias_zone,
-                                     ['zone_status'])
+                                     ['zone_status'],
+                                     allow_cache=False)
         state = result.get('zone_status', self._state)
         if isinstance(state, (int, uint16_t)):
             self._state = result.get('zone_status', self._state) & 3

--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -410,7 +410,7 @@ def get_discovery_info(hass, discovery_info):
     return all_discovery_info.get(discovery_key, None)
 
 
-async def safe_read(cluster, attributes):
+async def safe_read(cluster, attributes, allow_cache=True):
     """Swallow all exceptions from network read.
 
     If we throw during initialization, setup fails. Rather have an entity that
@@ -420,7 +420,7 @@ async def safe_read(cluster, attributes):
     try:
         result, _ = await cluster.read_attributes(
             attributes,
-            allow_cache=True,
+            allow_cache=allow_cache,
         )
         return result
     except Exception:  # pylint: disable=broad-except


### PR DESCRIPTION
## Description:

Do not read zone_status attribute from cache, as it is not updated by regular IAS Zone Status Change Notifications. 

## Checklist:
  - [x] The code change is tested and works locally.