### PR TITLE
Improve handling of x-forwarded-for header (fixes #14345)

### DIFF
--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -175,7 +175,7 @@ class HomeAssistantHTTP(object):
             middlewares=[staticresource_middleware])
 
         # This order matters
-        setup_real_ip(app, use_x_forwarded_for)
+        setup_real_ip(app, use_x_forwarded_for, trusted_networks)
 
         if is_ban_enabled:
             setup_bans(hass, app, login_threshold)

--- a/homeassistant/components/http/real_ip.py
+++ b/homeassistant/components/http/real_ip.py
@@ -11,15 +11,23 @@ from .const import KEY_REAL_IP
 
 
 @callback
-def setup_real_ip(app, use_x_forwarded_for):
+def setup_real_ip(app, use_x_forwarded_for, trusted_networks):
     """Create IP Ban middleware for the app."""
     @middleware
     async def real_ip_middleware(request, handler):
         """Real IP middleware."""
         if (use_x_forwarded_for and
                 X_FORWARDED_FOR in request.headers):
-            request[KEY_REAL_IP] = ip_address(
-                request.headers.get(X_FORWARDED_FOR).split(',')[0])
+            forwarded_for = request.headers.get(X_FORWARDED_FOR).split(', ')
+            for ip_addr in forwarded_for:
+                if (any(ip_address(ip_addr) in trusted_network
+                        for trusted_network in trusted_networks)):
+                    continue
+                else:
+                    request[KEY_REAL_IP] = ip_address(ip_addr)
+                    break
+            if request.get(KEY_REAL_IP) is None:
+                request[KEY_REAL_IP] = ip_address(forwarded_for[0])
         else:
             request[KEY_REAL_IP] = \
                 ip_address(request.transport.get_extra_info('peername')[0])

--- a/tests/components/http/test_auth.py
+++ b/tests/components/http/test_auth.py
@@ -41,7 +41,7 @@ def app():
     """Fixture to setup a web.Application."""
     app = web.Application()
     app.router.add_get('/', mock_handler)
-    setup_real_ip(app, False)
+    setup_real_ip(app, False, TRUSTED_NETWORKS)
     return app
 
 

--- a/tests/components/http/test_real_ip.py
+++ b/tests/components/http/test_real_ip.py
@@ -5,6 +5,7 @@ from aiohttp.hdrs import X_FORWARDED_FOR
 from homeassistant.components.http.real_ip import setup_real_ip
 from homeassistant.components.http.const import KEY_REAL_IP
 
+from .test_auth import TRUSTED_NETWORKS
 
 async def mock_handler(request):
     """Handler that returns the real IP as text."""
@@ -15,7 +16,7 @@ async def test_ignore_x_forwarded_for(aiohttp_client):
     """Test that we get the IP from the transport."""
     app = web.Application()
     app.router.add_get('/', mock_handler)
-    setup_real_ip(app, False)
+    setup_real_ip(app, False, TRUSTED_NETWORKS)
 
     mock_api_client = await aiohttp_client(app)
 
@@ -31,7 +32,7 @@ async def test_use_x_forwarded_for(aiohttp_client):
     """Test that we get the IP from the transport."""
     app = web.Application()
     app.router.add_get('/', mock_handler)
-    setup_real_ip(app, True)
+    setup_real_ip(app, True, TRUSTED_NETWORKS)
 
     mock_api_client = await aiohttp_client(app)
 

--- a/tests/components/http/test_real_ip.py
+++ b/tests/components/http/test_real_ip.py
@@ -7,6 +7,7 @@ from homeassistant.components.http.const import KEY_REAL_IP
 
 from .test_auth import TRUSTED_NETWORKS
 
+
 async def mock_handler(request):
     """Handler that returns the real IP as text."""
     return web.Response(text=str(request[KEY_REAL_IP]))


### PR DESCRIPTION
Improved handling of x-forwarded-for header to prevent spoofing attacks when using use_x_forwarded_for and trusted_networks.
Updated tests to reflect changes in the http component.

## Description:
This PR scans the x-forwarded-for header for the first IP address which is not in one of the trusted_networks ranges and uses that as the external IP. If no untrusted IP is found it reverts to the old behaviour (first IP in the x-forwarded-for header)
This will prevent a spoofing attack as described in #14345, provided the reverse proxy is configured correctly.

**Related issue (if applicable):** fixes #14345

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.