### PR TITLE
Add interval to feedreader.py

### DIFF
--- a/homeassistant/components/feedreader.py
+++ b/homeassistant/components/feedreader.py
@@ -1,5 +1,3 @@
-
-
 """
 Support for RSS/Atom feeds.
 
@@ -160,8 +158,7 @@ class StoredData(object):
                 with self._lock, open(self._data_file, 'rb') as myfile:
                     self._data = pickle.load(myfile) or {}
                     self._cache_outdated = False
-            # pylint: disable=bare-except
-            except:
+            except:  # noqa: E722  # pylint: disable=bare-except
                 _LOGGER.error("Error loading data from pickled file %s",
                               self._data_file)
 
@@ -179,8 +176,7 @@ class StoredData(object):
                           url, self._data_file)
             try:
                 pickle.dump(self._data, myfile)
-            # pylint: disable=bare-except
-            except:
+            except:  # noqa: E722  # pylint: disable=bare-except
                 _LOGGER.error(
                     "Error saving pickled data to %s", self._data_file)
         self._cache_outdated = True


### PR DESCRIPTION
Add configurable time interval to feedreader.py, in configuration.yaml add interval: time in seconds, default = 300 secs = 5 minutes

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
