### PR TITLE
More detailed error message when fetching rest data fails

### DIFF
--- a/homeassistant/components/sensor/rest.py
+++ b/homeassistant/components/sensor/rest.py
@@ -176,6 +176,7 @@ class RestData(object):
                     self._request, timeout=10, verify=self._verify_ssl)
 
             self.data = response.text
-        except requests.exceptions.RequestException:
-            _LOGGER.error("Error fetching data: %s", self._request)
+        except requests.exceptions.RequestException as ex:
+            _LOGGER.error("Error fetching data: %s from %s failed with %s",
+                          self._request, self._request.url, ex)
             self.data = None


### PR DESCRIPTION
## Description:
At the moment, if fetching rest data for a `sensor` or `binary_sensor` fails, the error message in the log only contains the following information:
```
2018-05-07 07:29:40 ERROR (SyncWorker_10) [homeassistant.components.sensor.rest] Error fetching data: <PreparedRequest [GET]>
```
This is not really helpful in tracking down which entity may be affected and what is causing the issue.

I am proposing to add the URL and the exception to the error message, so that it looks like this:
```
2018-05-11 16:12:01 ERROR (SyncWorker_16) [homeassistant.components.sensor.rest] Error fetching data: <PreparedRequest [GET]> from http://test.server:8754/monitor.json with ('Connection aborted.
', RemoteDisconnected('Remote end closed connection without response',))
```

**Related issue (if applicable):** n/a

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable): n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
