### PR TITLE
Add homematicip cloud climate platform

### DIFF
--- a/homeassistant/components/climate/homematicip_cloud.py
+++ b/homeassistant/components/climate/homematicip_cloud.py
@@ -82,7 +82,7 @@ class HomematicipHeatingGroup(HomematicipGenericDevice, ClimateDevice):
     def current_operation(self):
         """Return current operation ie. automatic or manual."""
         return HMIP_STATE_TO_HA.get(self._device.controlMode)
-        
+
     @property
     def min_temp(self):
         """Return the minimum temperature."""

--- a/homeassistant/components/climate/homematicip_cloud.py
+++ b/homeassistant/components/climate/homematicip_cloud.py
@@ -48,7 +48,7 @@ class HomematicipHeatingGroup(HomematicipGenericDevice, ClimateDevice):
     @property
     def icon(self):
         """Return the icon."""
-        return 'mdi:nest-thermostat'
+        return 'mdi:thermostat'
 
     @property
     def temperature_unit(self):

--- a/homeassistant/components/climate/homematicip_cloud.py
+++ b/homeassistant/components/climate/homematicip_cloud.py
@@ -1,0 +1,125 @@
+"""
+Support for HomematicIP climate.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/climate.homematicip_cloud/
+"""
+
+import logging
+
+from homeassistant.components.climate import (
+    ClimateDevice, SUPPORT_TARGET_TEMPERATURE, SUPPORT_OPERATION_MODE)
+from homeassistant.const import TEMP_CELSIUS, ATTR_TEMPERATURE
+from homeassistant.components.homematicip_cloud import (
+    HomematicipGenericDevice, DOMAIN as HOMEMATICIP_CLOUD_DOMAIN,
+    ATTR_HOME_ID)
+
+_LOGGER = logging.getLogger(__name__)
+
+STATE_BOOST = 'Boost'
+
+
+async def async_setup_platform(hass, config, async_add_devices,
+                               discovery_info=None):
+    """Set up the HomematicIP climate devices."""
+    from homematicip.group import HeatingGroup
+
+    if discovery_info is None:
+        return
+    home = hass.data[HOMEMATICIP_CLOUD_DOMAIN][discovery_info[ATTR_HOME_ID]]
+
+    devices = []
+    for device in home.groups:
+        if isinstance(device, HeatingGroup):
+            devices.append(HomematicipHeatingGroup(hass, home, device))
+
+    if devices:
+        async_add_devices(devices)
+
+
+class HomematicipHeatingGroup(HomematicipGenericDevice, ClimateDevice):
+    """Representation of a MomematicIP heating group."""
+
+    def __init__(self, hass, home, device):
+        """Initialize heating group."""
+        device.modelType = 'Group'
+        super().__init__(home, device)
+
+    @property
+    def icon(self):
+        """Return the icon."""
+        return 'mdi:nest-thermostat'
+
+    @property
+    def temperature_unit(self):
+        """Return the unit of measurement."""
+        return TEMP_CELSIUS
+
+    @property
+    def supported_features(self):
+        """Return the list of supported features."""
+        return SUPPORT_TARGET_TEMPERATURE | SUPPORT_OPERATION_MODE
+
+    @property
+    def target_temperature(self):
+        """Return the temperature we try to reach."""
+        return self._device.setPointTemperature
+
+    @property
+    def current_temperature(self):
+        """Return the current temperature."""
+        return self._device.actualTemperature
+
+    @property
+    def current_humidity(self):
+        """Return the current humidity."""
+        return self._device.humidity
+
+    @property
+    def min_temp(self):
+        """Return the minimum temperature."""
+        return self._device.minTemperature
+
+    @property
+    def max_temp(self):
+        """Return the maximum temperature."""
+        return self._device.maxTemperature
+
+    async def async_set_temperature(self, **kwargs):
+        """Set new target temperature."""
+        temperature = kwargs.get(ATTR_TEMPERATURE)
+        if temperature is None:
+            return
+        await self._device.set_point_temperature(temperature)
+
+    @property
+    def current_operation(self):
+        """Return current operation (auto, manual, boost, vacation)."""
+        if self._device.boostMode:
+            return STATE_BOOST
+        elif self._device.controlMode == 'AUTOMATIC':
+            return self._device.activeProfile.name
+        return self._device.controlMode
+
+    @property
+    def operation_list(self):
+        """Return the list of available operation modes."""
+        modes = []
+        for profile in self._device.profiles:
+            if profile.name != '' and profile.enabled and profile.visible:
+                modes.append(profile.name)
+        modes.append(STATE_BOOST)
+        return modes
+
+    async def async_set_operation_mode(self, operation_mode):
+        """Set operation mode."""
+        if operation_mode == 'Boost':
+            await self._device.set_boost()
+        else:
+            await self._device.set_boost(False)
+            index = 0
+            for profile in self._device.profiles:
+                if profile.name == operation_mode:
+                    await self._device.set_active_profile(index)
+                    return
+                index = index + 1

--- a/homeassistant/components/climate/homematicip_cloud.py
+++ b/homeassistant/components/climate/homematicip_cloud.py
@@ -9,7 +9,7 @@ import logging
 
 from homeassistant.components.climate import (
     ClimateDevice, SUPPORT_TARGET_TEMPERATURE, ATTR_TEMPERATURE,
-    STATE_AUTO, STATE_MANUAL, STATE_PERFORMANCE)
+    STATE_AUTO, STATE_MANUAL)
 from homeassistant.const import TEMP_CELSIUS
 from homeassistant.components.homematicip_cloud import (
     HomematicipGenericDevice, DOMAIN as HOMEMATICIP_CLOUD_DOMAIN,

--- a/homeassistant/components/climate/homematicip_cloud.py
+++ b/homeassistant/components/climate/homematicip_cloud.py
@@ -8,7 +8,8 @@ https://home-assistant.io/components/climate.homematicip_cloud/
 import logging
 
 from homeassistant.components.climate import (
-    ClimateDevice, SUPPORT_TARGET_TEMPERATURE)
+    ClimateDevice, SUPPORT_TARGET_TEMPERATURE, ATTR_TEMPERATURE,
+    STATE_AUTO, STATE_MANUAL, STATE_PERFORMANCE)
 from homeassistant.const import TEMP_CELSIUS
 from homeassistant.components.homematicip_cloud import (
     HomematicipGenericDevice, DOMAIN as HOMEMATICIP_CLOUD_DOMAIN,
@@ -17,6 +18,13 @@ from homeassistant.components.homematicip_cloud import (
 _LOGGER = logging.getLogger(__name__)
 
 STATE_BOOST = 'Boost'
+
+HA_STATE_TO_HMIP = {
+    STATE_AUTO: 'AUTOMATIC',
+    STATE_MANUAL: 'MANUAL',
+}
+
+HMIP_STATE_TO_HA = {value: key for key, value in HA_STATE_TO_HMIP.items()}
 
 
 async def async_setup_platform(hass, config, async_add_devices,
@@ -42,7 +50,7 @@ class HomematicipHeatingGroup(HomematicipGenericDevice, ClimateDevice):
 
     def __init__(self, home, device):
         """Initialize heating group."""
-        device.modelType = 'HeatingGroup'
+        device.modelType = 'Group-Heating'
         super().__init__(home, device)
 
     @property
@@ -70,6 +78,11 @@ class HomematicipHeatingGroup(HomematicipGenericDevice, ClimateDevice):
         """Return the current humidity."""
         return self._device.humidity
 
+    @property
+    def current_operation(self):
+        """Return current operation ie. automatic or manual."""
+        return HMIP_STATE_TO_HA.get(self._device.controlMode)
+        
     @property
     def min_temp(self):
         """Return the minimum temperature."""

--- a/homeassistant/components/homematicip_cloud.py
+++ b/homeassistant/components/homematicip_cloud.py
@@ -17,7 +17,7 @@ from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.entity import Entity
 from homeassistant.core import callback
 
-REQUIREMENTS = ['homematicip==0.9.2.4']
+REQUIREMENTS = ['homematicip==0.9.3.3']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -27,7 +27,8 @@ COMPONENTS = [
     'sensor',
     'binary_sensor',
     'switch',
-    'light'
+    'light',
+    'climate',
 ]
 
 CONF_NAME = 'name'

--- a/homeassistant/components/homematicip_cloud.py
+++ b/homeassistant/components/homematicip_cloud.py
@@ -17,7 +17,7 @@ from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.entity import Entity
 from homeassistant.core import callback
 
-REQUIREMENTS = ['homematicip==0.9.3.3']
+REQUIREMENTS = ['homematicip==0.9.4']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -392,7 +392,7 @@ home-assistant-frontend==20180510.1
 # homekit==0.6
 
 # homeassistant.components.homematicip_cloud
-homematicip==0.9.3.3
+homematicip==0.9.4
 
 # homeassistant.components.camera.onvif
 http://github.com/tgaugry/suds-passworddigest-py3/archive/86fc50e39b4d2b8997481967d6a7fe1c57118999.zip#suds-passworddigest-py3==0.1.2a

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -392,7 +392,7 @@ home-assistant-frontend==20180510.1
 # homekit==0.6
 
 # homeassistant.components.homematicip_cloud
-homematicip==0.9.2.4
+homematicip==0.9.3.3
 
 # homeassistant.components.camera.onvif
 http://github.com/tgaugry/suds-passworddigest-py3/archive/86fc50e39b4d2b8997481967d6a7fe1c57118999.zip#suds-passworddigest-py3==0.1.2a


### PR DESCRIPTION
## Description:

- Add support for HomematicIP climate devices.
- Update to latest homematicip-rest-api lib

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):**
https://github.com/home-assistant/home-assistant.github.io/pull/5396

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54