### PR TITLE
Bump pycmus version

### DIFF
--- a/homeassistant/components/media_player/cmus.py
+++ b/homeassistant/components/media_player/cmus.py
@@ -19,7 +19,7 @@ from homeassistant.const import (
     CONF_PASSWORD)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['pycmus==0.1.0']
+REQUIREMENTS = ['pycmus==0.1.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -729,7 +729,7 @@ pychannels==1.0.0
 pychromecast==2.1.0
 
 # homeassistant.components.media_player.cmus
-pycmus==0.1.0
+pycmus==0.1.1
 
 # homeassistant.components.comfoconnect
 pycomfoconnect==0.3


### PR DESCRIPTION
This commit bumps the pycmus version used by the cmus component. There
was a bug in the previous version used, 1.0.0, when running in local
mode. This was caused by a mtreinish/pycmus#1 and also was reported in
the home-assistant forums (but not as an issue):

https://community.home-assistant.io/t/cant-install-cmus-component/7961

Version 0.1.1 of pycmus fixes this issue so it should work properly for
users running cmus and home-assistant on the same machine.

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
