### PR TITLE
Async conversion HomeKit Types

### DIFF
--- a/homeassistant/components/homekit/accessories.py
+++ b/homeassistant/components/homekit/accessories.py
@@ -84,20 +84,25 @@ class HomeAccessory(Accessory):
         async_track_state_change(
             self.hass, self.entity_id, self.update_state_callback)
 
+    @ha_callback
     def update_state_callback(self, entity_id=None, old_state=None,
                               new_state=None):
-        """Callback from state change listener."""
+        """Callback from state change listener.
+
+        Must be run from in the event loop.
+        """
         _LOGGER.debug('New_state: %s', new_state)
         if new_state is None:
             return
-        self.update_state(new_state)
+        self.hass.async_add_job(self.async_update_state, new_state)
 
-    def update_state(self, new_state):
+    @ha_callback
+    def async_update_state(self, new_state):
         """Method called on state change to update HomeKit value.
 
-        Overridden by accessory types.
+        Must be run from in the event loop.
         """
-        pass
+        raise NotImplementedError()
 
 
 class HomeBridge(Bridge):

--- a/homeassistant/components/homekit/accessories.py
+++ b/homeassistant/components/homekit/accessories.py
@@ -94,13 +94,12 @@ class HomeAccessory(Accessory):
         _LOGGER.debug('New_state: %s', new_state)
         if new_state is None:
             return
-        self.hass.async_add_job(self.async_update_state, new_state)
+        self.async_update_state(new_state)
 
-    @ha_callback
     def async_update_state(self, new_state):
         """Method called on state change to update HomeKit value.
 
-        Must be run from in the event loop.
+        Method is run in the event loop.
         """
         raise NotImplementedError()
 

--- a/homeassistant/components/homekit/type_covers.py
+++ b/homeassistant/components/homekit/type_covers.py
@@ -58,8 +58,11 @@ class GarageDoorOpener(HomeAccessory):
             await self.hass.services.async_call(
                 DOMAIN, SERVICE_CLOSE_COVER, params)
 
-    async def async_update_state(self, new_state):
-        """Update cover state after state changed. Coroutine."""
+    def async_update_state(self, new_state):
+        """Update cover state after state changed.
+
+        Method is run in the event loop.
+        """
         hass_state = new_state.state
         if hass_state in (STATE_OPEN, STATE_CLOSED):
             current_state = 0 if hass_state == STATE_OPEN else 1
@@ -104,8 +107,11 @@ class WindowCovering(HomeAccessory):
         await self.hass.services.async_call(
             DOMAIN, SERVICE_SET_COVER_POSITION, params)
 
-    async def async_update_state(self, new_state):
-        """Update cover position after state changed. Coroutine."""
+    def async_update_state(self, new_state):
+        """Update cover position after state changed.
+
+        Method is run in the event loop.
+        """
         current_position = new_state.attributes.get(ATTR_CURRENT_POSITION)
         if isinstance(current_position, int):
             self.hass.async_add_job(
@@ -170,8 +176,11 @@ class WindowCoveringBasic(HomeAccessory):
         self.hass.async_add_job(self.char_target_position.set_value, position)
         self.hass.async_add_job(self.char_position_state.set_value, 2)
 
-    async def async_update_state(self, new_state):
-        """Update cover position after state changed. Coroutine."""
+    def async_update_state(self, new_state):
+        """Update cover position after state changed.
+
+        Method is run in the event loop.
+        """
         position_mapping = {STATE_OPEN: 100, STATE_CLOSED: 0}
         hk_position = position_mapping.get(new_state.state)
         if hk_position is not None:

--- a/homeassistant/components/homekit/type_covers.py
+++ b/homeassistant/components/homekit/type_covers.py
@@ -41,24 +41,33 @@ class GarageDoorOpener(HomeAccessory):
 
     def set_state(self, value):
         """Change garage state if call came from HomeKit."""
+        self.hass.add_job(self.async_set_state, value)
+
+    async def async_set_state(self, value):
+        """Change garage state if call came from HomeKit. Coroutine."""
         _LOGGER.debug('%s: Set state to %d', self.entity_id, value)
         self.flag_target_state = True
 
+        params = {ATTR_ENTITY_ID: self.entity_id}
         if value == 0:
-            self.char_current_state.set_value(3)
-            self.hass.components.cover.open_cover(self.entity_id)
+            self.hass.async_add_job(self.char_current_state.set_value, 3)
+            await self.hass.services.async_call(
+                DOMAIN, SERVICE_OPEN_COVER, params)
         elif value == 1:
-            self.char_current_state.set_value(2)
-            self.hass.components.cover.close_cover(self.entity_id)
+            self.hass.async_add_job(self.char_current_state.set_value, 2)
+            await self.hass.services.async_call(
+                DOMAIN, SERVICE_CLOSE_COVER, params)
 
-    def update_state(self, new_state):
-        """Update cover state after state changed."""
+    async def async_update_state(self, new_state):
+        """Update cover state after state changed. Coroutine."""
         hass_state = new_state.state
         if hass_state in (STATE_OPEN, STATE_CLOSED):
             current_state = 0 if hass_state == STATE_OPEN else 1
-            self.char_current_state.set_value(current_state)
+            self.hass.async_add_job(
+                self.char_current_state.set_value, current_state)
             if not self.flag_target_state:
-                self.char_target_state.set_value(current_state)
+                self.hass.async_add_job(
+                    self.char_target_state.set_value, current_state)
             self.flag_target_state = False
 
 
@@ -83,20 +92,28 @@ class WindowCovering(HomeAccessory):
     @debounce
     def move_cover(self, value):
         """Move cover to value if call came from HomeKit."""
+        self.hass.add_job(self.async_move_cover, value)
+
+    async def async_move_cover(self, value):
+        """Move cover to value if call came from HomeKit. Coroutine."""
         _LOGGER.debug('%s: Set position to %d', self.entity_id, value)
         self.homekit_target = value
 
-        params = {ATTR_ENTITY_ID: self.entity_id, ATTR_POSITION: value}
-        self.hass.services.call(DOMAIN, SERVICE_SET_COVER_POSITION, params)
+        params = {ATTR_ENTITY_ID: self.entity_id,
+                  ATTR_POSITION: value}
+        await self.hass.services.async_call(
+            DOMAIN, SERVICE_SET_COVER_POSITION, params)
 
-    def update_state(self, new_state):
-        """Update cover position after state changed."""
+    async def async_update_state(self, new_state):
+        """Update cover position after state changed. Coroutine."""
         current_position = new_state.attributes.get(ATTR_CURRENT_POSITION)
         if isinstance(current_position, int):
-            self.char_current_position.set_value(current_position)
+            self.hass.async_add_job(
+                self.char_current_position.set_value, current_position)
             if self.homekit_target is None or \
                     abs(current_position - self.homekit_target) < 6:
-                self.char_target_position.set_value(current_position)
+                self.hass.async_add_job(
+                    self.char_target_position.set_value, current_position)
                 self.homekit_target = None
 
 
@@ -126,6 +143,10 @@ class WindowCoveringBasic(HomeAccessory):
     @debounce
     def move_cover(self, value):
         """Move cover to value if call came from HomeKit."""
+        self.hass.add_job(self.async_move_cover, value)
+
+    async def async_move_cover(self, value):
+        """Move cover to value if call came from HomeKit. Coroutine."""
         _LOGGER.debug('%s: Set position to %d', self.entity_id, value)
 
         if self.supports_stop:
@@ -141,19 +162,21 @@ class WindowCoveringBasic(HomeAccessory):
             else:
                 service, position = (SERVICE_CLOSE_COVER, 0)
 
-        self.hass.services.call(DOMAIN, service,
-                                {ATTR_ENTITY_ID: self.entity_id})
+        params = {ATTR_ENTITY_ID: self.entity_id}
+        await self.hass.services.async_call(DOMAIN, service, params)
 
         # Snap the current/target position to the expected final position.
-        self.char_current_position.set_value(position)
-        self.char_target_position.set_value(position)
-        self.char_position_state.set_value(2)
+        self.hass.async_add_job(self.char_current_position.set_value, position)
+        self.hass.async_add_job(self.char_target_position.set_value, position)
+        self.hass.async_add_job(self.char_position_state.set_value, 2)
 
-    def update_state(self, new_state):
-        """Update cover position after state changed."""
+    async def async_update_state(self, new_state):
+        """Update cover position after state changed. Coroutine."""
         position_mapping = {STATE_OPEN: 100, STATE_CLOSED: 0}
         hk_position = position_mapping.get(new_state.state)
         if hk_position is not None:
-            self.char_current_position.set_value(hk_position)
-            self.char_target_position.set_value(hk_position)
-            self.char_position_state.set_value(2)
+            self.hass.async_add_job(
+                self.char_current_position.set_value, hk_position)
+            self.hass.async_add_job(
+                self.char_target_position.set_value, hk_position)
+            self.hass.async_add_job(self.char_position_state.set_value, 2)

--- a/homeassistant/components/homekit/type_fans.py
+++ b/homeassistant/components/homekit/type_fans.py
@@ -57,6 +57,10 @@ class Fan(HomeAccessory):
 
     def set_state(self, value):
         """Set state if call came from HomeKit."""
+        self.hass.add_job(self.async_set_state, value)
+
+    async def async_set_state(self, value):
+        """Set state if call came from HomeKit. Coroutine."""
         if self._state == value:
             return
 
@@ -64,35 +68,45 @@ class Fan(HomeAccessory):
         self._flag[CHAR_ACTIVE] = True
         service = SERVICE_TURN_ON if value == 1 else SERVICE_TURN_OFF
         params = {ATTR_ENTITY_ID: self.entity_id}
-        self.hass.services.call(DOMAIN, service, params)
+        await self.hass.services.async_call(DOMAIN, service, params)
 
     def set_direction(self, value):
         """Set state if call came from HomeKit."""
+        self.hass.add_job(self.async_set_direction, value)
+
+    async def async_set_direction(self, value):
+        """Set state if call came from HomeKit. Coroutine."""
         _LOGGER.debug('%s: Set direction to %d', self.entity_id, value)
         self._flag[CHAR_ROTATION_DIRECTION] = True
         direction = DIRECTION_REVERSE if value == 1 else DIRECTION_FORWARD
         params = {ATTR_ENTITY_ID: self.entity_id,
                   ATTR_DIRECTION: direction}
-        self.hass.services.call(DOMAIN, SERVICE_SET_DIRECTION, params)
+        await self.hass.services.async_call(
+            DOMAIN, SERVICE_SET_DIRECTION, params)
 
     def set_oscillating(self, value):
         """Set state if call came from HomeKit."""
+        self.hass.add_job(self.async_set_oscillating, value)
+
+    async def async_set_oscillating(self, value):
+        """Set state if call came from HomeKit. Coroutine."""
         _LOGGER.debug('%s: Set oscillating to %d', self.entity_id, value)
         self._flag[CHAR_SWING_MODE] = True
         oscillating = True if value == 1 else False
         params = {ATTR_ENTITY_ID: self.entity_id,
                   ATTR_OSCILLATING: oscillating}
-        self.hass.services.call(DOMAIN, SERVICE_OSCILLATE, params)
+        await self.hass.services.async_call(DOMAIN, SERVICE_OSCILLATE, params)
 
-    def update_state(self, new_state):
-        """Update fan after state change."""
+    async def async_update_state(self, new_state):
+        """Update fan after state change. Coroutine."""
         # Handle State
         state = new_state.state
         if state in (STATE_ON, STATE_OFF):
             self._state = 1 if state == STATE_ON else 0
             if not self._flag[CHAR_ACTIVE] and \
                     self.char_active.value != self._state:
-                self.char_active.set_value(self._state)
+                self.hass.async_add_job(
+                    self.char_active.set_value, self._state)
             self._flag[CHAR_ACTIVE] = False
 
         # Handle Direction
@@ -102,7 +116,8 @@ class Fan(HomeAccessory):
                     direction in (DIRECTION_FORWARD, DIRECTION_REVERSE):
                 hk_direction = 1 if direction == DIRECTION_REVERSE else 0
                 if self.char_direction.value != hk_direction:
-                    self.char_direction.set_value(hk_direction)
+                    self.hass.async_add_job(
+                        self.char_direction.set_value, hk_direction)
             self._flag[CHAR_ROTATION_DIRECTION] = False
 
         # Handle Oscillating
@@ -112,5 +127,6 @@ class Fan(HomeAccessory):
                     oscillating in (True, False):
                 hk_oscillating = 1 if oscillating else 0
                 if self.char_swing.value != hk_oscillating:
-                    self.char_swing.set_value(hk_oscillating)
+                    self.hass.async_add_job(
+                        self.char_swing.set_value, hk_oscillating)
             self._flag[CHAR_SWING_MODE] = False

--- a/homeassistant/components/homekit/type_fans.py
+++ b/homeassistant/components/homekit/type_fans.py
@@ -97,8 +97,11 @@ class Fan(HomeAccessory):
                   ATTR_OSCILLATING: oscillating}
         await self.hass.services.async_call(DOMAIN, SERVICE_OSCILLATE, params)
 
-    async def async_update_state(self, new_state):
-        """Update fan after state change. Coroutine."""
+    def async_update_state(self, new_state):
+        """Update fan after state change.
+
+        Method is run in the event loop.
+        """
         # Handle State
         state = new_state.state
         if state in (STATE_ON, STATE_OFF):

--- a/homeassistant/components/homekit/type_lights.py
+++ b/homeassistant/components/homekit/type_lights.py
@@ -4,9 +4,12 @@ import logging
 from pyhap.const import CATEGORY_LIGHTBULB
 
 from homeassistant.components.light import (
-    ATTR_HS_COLOR, ATTR_COLOR_TEMP, ATTR_BRIGHTNESS, ATTR_MIN_MIREDS,
+    DOMAIN, ATTR_HS_COLOR, ATTR_COLOR_TEMP, ATTR_BRIGHTNESS,
+    ATTR_BRIGHTNESS_PCT, ATTR_MIN_MIREDS,
     ATTR_MAX_MIREDS, SUPPORT_COLOR, SUPPORT_COLOR_TEMP, SUPPORT_BRIGHTNESS)
-from homeassistant.const import ATTR_SUPPORTED_FEATURES, STATE_ON, STATE_OFF
+from homeassistant.const import (
+    ATTR_ENTITY_ID, ATTR_SUPPORTED_FEATURES,
+    SERVICE_TURN_OFF, SERVICE_TURN_ON, STATE_ON, STATE_OFF)
 
 from . import TYPES
 from .accessories import HomeAccessory, debounce
@@ -74,50 +77,78 @@ class Light(HomeAccessory):
 
     def set_state(self, value):
         """Set state if call came from HomeKit."""
+        self.hass.add_job(self.async_set_state, value)
+
+    async def async_set_state(self, value):
+        """Set state if call came from HomeKit. Coroutine."""
         if self._state == value:
             return
 
         _LOGGER.debug('%s: Set state to %d', self.entity_id, value)
         self._flag[CHAR_ON] = True
 
+        params = {ATTR_ENTITY_ID: self.entity_id}
         if value == 1:
-            self.hass.components.light.turn_on(self.entity_id)
+            await self.hass.services.async_call(
+                DOMAIN, SERVICE_TURN_ON, params)
         elif value == 0:
-            self.hass.components.light.turn_off(self.entity_id)
+            await self.hass.services.async_call(
+                DOMAIN, SERVICE_TURN_OFF, params)
 
     @debounce
     def set_brightness(self, value):
         """Set brightness if call came from HomeKit."""
+        self.hass.add_job(self.async_set_brightness, value)
+
+    async def async_set_brightness(self, value):
+        """Set brightness if call came from HomeKit. Coroutine."""
         _LOGGER.debug('%s: Set brightness to %d', self.entity_id, value)
         self._flag[CHAR_BRIGHTNESS] = True
         if value != 0:
-            self.hass.components.light.turn_on(
-                self.entity_id, brightness_pct=value)
+            params = {ATTR_ENTITY_ID: self.entity_id,
+                      ATTR_BRIGHTNESS_PCT: value}
+            await self.hass.services.async_call(
+                DOMAIN, SERVICE_TURN_ON, params)
         else:
-            self.hass.components.light.turn_off(self.entity_id)
+            params = {ATTR_ENTITY_ID: self.entity_id}
+            await self.hass.services.async_call(
+                DOMAIN, SERVICE_TURN_OFF, params)
 
     def set_color_temperature(self, value):
         """Set color temperature if call came from HomeKit."""
+        self.hass.add_job(self.async_set_color_temperature, value)
+
+    async def async_set_color_temperature(self, value):
+        """Set color temperature if call came from HomeKit. Coroutine."""
         _LOGGER.debug('%s: Set color temp to %s', self.entity_id, value)
         self._flag[CHAR_COLOR_TEMPERATURE] = True
-        self.hass.components.light.turn_on(self.entity_id, color_temp=value)
+        params = {ATTR_ENTITY_ID: self.entity_id, ATTR_COLOR_TEMP: value}
+        await self.hass.services.async_call(DOMAIN, SERVICE_TURN_ON, params)
 
     def set_saturation(self, value):
         """Set saturation if call came from HomeKit."""
+        self.hass.add_job(self.async_set_saturation, value)
+
+    async def async_set_saturation(self, value):
+        """Set saturation if call came from HomeKit. Coroutine."""
         _LOGGER.debug('%s: Set saturation to %d', self.entity_id, value)
         self._flag[CHAR_SATURATION] = True
         self._saturation = value
-        self.set_color()
+        await self.async_set_color()
 
     def set_hue(self, value):
         """Set hue if call came from HomeKit."""
+        self.hass.add_job(self.async_set_hue, value)
+
+    async def async_set_hue(self, value):
+        """Set hue if call came from HomeKit. Coroutine."""
         _LOGGER.debug('%s: Set hue to %d', self.entity_id, value)
         self._flag[CHAR_HUE] = True
         self._hue = value
-        self.set_color()
+        await self.async_set_color()
 
-    def set_color(self):
-        """Set color if call came from HomeKit."""
+    async def async_set_color(self):
+        """Set color if call came from HomeKit. Coroutine."""
         # Handle Color
         if self._features & SUPPORT_COLOR and self._flag[CHAR_HUE] and \
                 self._flag[CHAR_SATURATION]:
@@ -125,17 +156,19 @@ class Light(HomeAccessory):
             _LOGGER.debug('%s: Set hs_color to %s', self.entity_id, color)
             self._flag.update({
                 CHAR_HUE: False, CHAR_SATURATION: False, RGB_COLOR: True})
-            self.hass.components.light.turn_on(
-                self.entity_id, hs_color=color)
+            params = {ATTR_ENTITY_ID: self.entity_id,
+                      ATTR_HS_COLOR: color}
+            await self.hass.services.async_call(
+                DOMAIN, SERVICE_TURN_ON, params)
 
-    def update_state(self, new_state):
-        """Update light after state change."""
+    async def async_update_state(self, new_state):
+        """Update light after state change. Coroutine."""
         # Handle State
         state = new_state.state
         if state in (STATE_ON, STATE_OFF):
             self._state = 1 if state == STATE_ON else 0
             if not self._flag[CHAR_ON] and self.char_on.value != self._state:
-                self.char_on.set_value(self._state)
+                self.hass.async_add_job(self.char_on.set_value, self._state)
             self._flag[CHAR_ON] = False
 
         # Handle Brightness
@@ -144,7 +177,8 @@ class Light(HomeAccessory):
             if not self._flag[CHAR_BRIGHTNESS] and isinstance(brightness, int):
                 brightness = round(brightness / 255 * 100, 0)
                 if self.char_brightness.value != brightness:
-                    self.char_brightness.set_value(brightness)
+                    self.hass.async_add_job(
+                        self.char_brightness.set_value, brightness)
             self._flag[CHAR_BRIGHTNESS] = False
 
         # Handle color temperature
@@ -153,7 +187,8 @@ class Light(HomeAccessory):
             if not self._flag[CHAR_COLOR_TEMPERATURE] \
                 and isinstance(color_temperature, int) and \
                     self.char_color_temperature.value != color_temperature:
-                self.char_color_temperature.set_value(color_temperature)
+                self.hass.async_add_job(
+                    self.char_color_temperature.set_value, color_temperature)
             self._flag[CHAR_COLOR_TEMPERATURE] = False
 
         # Handle Color
@@ -164,7 +199,8 @@ class Light(HomeAccessory):
                     hue != self._hue or saturation != self._saturation) and \
                     isinstance(hue, (int, float)) and \
                     isinstance(saturation, (int, float)):
-                self.char_hue.set_value(hue)
-                self.char_saturation.set_value(saturation)
+                self.hass.async_add_job(self.char_hue.set_value, hue)
+                self.hass.async_add_job(
+                    self.char_saturation.set_value, saturation)
                 self._hue, self._saturation = (hue, saturation)
             self._flag[RGB_COLOR] = False

--- a/homeassistant/components/homekit/type_lights.py
+++ b/homeassistant/components/homekit/type_lights.py
@@ -161,8 +161,11 @@ class Light(HomeAccessory):
             await self.hass.services.async_call(
                 DOMAIN, SERVICE_TURN_ON, params)
 
-    async def async_update_state(self, new_state):
-        """Update light after state change. Coroutine."""
+    def async_update_state(self, new_state):
+        """Update light after state change.
+
+        Method is run in the event loop.
+        """
         # Handle State
         state = new_state.state
         if state in (STATE_ON, STATE_OFF):

--- a/homeassistant/components/homekit/type_locks.py
+++ b/homeassistant/components/homekit/type_locks.py
@@ -4,7 +4,7 @@ import logging
 from pyhap.const import CATEGORY_DOOR_LOCK
 
 from homeassistant.components.lock import (
-    ATTR_ENTITY_ID, STATE_LOCKED, STATE_UNLOCKED, STATE_UNKNOWN)
+    ATTR_ENTITY_ID, DOMAIN, STATE_LOCKED, STATE_UNLOCKED, STATE_UNKNOWN)
 from homeassistant.const import ATTR_CODE
 
 from . import TYPES
@@ -46,6 +46,10 @@ class Lock(HomeAccessory):
 
     def set_state(self, value):
         """Set lock state to value if call came from HomeKit."""
+        self.hass.add_job(self.async_set_state, value)
+
+    async def async_set_state(self, value):
+        """Set lock state to value if call came from HomeKit. Coroutine."""
         _LOGGER.debug("%s: Set state to %d", self.entity_id, value)
         self.flag_target_state = True
 
@@ -55,19 +59,21 @@ class Lock(HomeAccessory):
         params = {ATTR_ENTITY_ID: self.entity_id}
         if self._code:
             params[ATTR_CODE] = self._code
-        self.hass.services.call('lock', service, params)
+        await self.hass.services.async_call(DOMAIN, service, params)
 
-    def update_state(self, new_state):
-        """Update lock after state changed."""
+    async def async_update_state(self, new_state):
+        """Update lock after state changed. Coroutine."""
         hass_state = new_state.state
         if hass_state in HASS_TO_HOMEKIT:
             current_lock_state = HASS_TO_HOMEKIT[hass_state]
-            self.char_current_state.set_value(current_lock_state)
+            self.hass.async_add_job(
+                self.char_current_state.set_value, current_lock_state)
             _LOGGER.debug('%s: Updated current state to %s (%d)',
                           self.entity_id, hass_state, current_lock_state)
 
             # LockTargetState only supports locked and unlocked
             if hass_state in (STATE_LOCKED, STATE_UNLOCKED):
                 if not self.flag_target_state:
-                    self.char_target_state.set_value(current_lock_state)
+                    self.hass.async_add_job(
+                        self.char_target_state.set_value, current_lock_state)
                 self.flag_target_state = False

--- a/homeassistant/components/homekit/type_locks.py
+++ b/homeassistant/components/homekit/type_locks.py
@@ -61,8 +61,11 @@ class Lock(HomeAccessory):
             params[ATTR_CODE] = self._code
         await self.hass.services.async_call(DOMAIN, service, params)
 
-    async def async_update_state(self, new_state):
-        """Update lock after state changed. Coroutine."""
+    def async_update_state(self, new_state):
+        """Update lock after state changed.
+
+        Method is run in the event loop.
+        """
         hass_state = new_state.state
         if hass_state in HASS_TO_HOMEKIT:
             current_lock_state = HASS_TO_HOMEKIT[hass_state]

--- a/homeassistant/components/homekit/type_security_systems.py
+++ b/homeassistant/components/homekit/type_security_systems.py
@@ -3,6 +3,7 @@ import logging
 
 from pyhap.const import CATEGORY_ALARM_SYSTEM
 
+from homeassistant.components.alarm_control_panel import DOMAIN
 from homeassistant.const import (
     STATE_ALARM_ARMED_AWAY, STATE_ALARM_ARMED_HOME,
     STATE_ALARM_ARMED_NIGHT, STATE_ALARM_DISARMED,
@@ -47,6 +48,13 @@ class SecuritySystem(HomeAccessory):
 
     def set_security_state(self, value):
         """Move security state to value if call came from HomeKit."""
+        self.hass.add_job(self.async_set_security_state, value)
+
+    async def async_set_security_state(self, value):
+        """Move security state to value if call came from HomeKit.
+
+        Coroutine.
+        """
         _LOGGER.debug('%s: Set security state to %d',
                       self.entity_id, value)
         self.flag_target_state = True
@@ -56,19 +64,21 @@ class SecuritySystem(HomeAccessory):
         params = {ATTR_ENTITY_ID: self.entity_id}
         if self._alarm_code:
             params[ATTR_CODE] = self._alarm_code
-        self.hass.services.call('alarm_control_panel', service, params)
+        await self.hass.services.async_call(DOMAIN, service, params)
 
-    def update_state(self, new_state):
-        """Update security state after state changed."""
+    async def async_update_state(self, new_state):
+        """Update security state after state changed. Coroutine."""
         hass_state = new_state.state
         if hass_state in HASS_TO_HOMEKIT:
             current_security_state = HASS_TO_HOMEKIT[hass_state]
-            self.char_current_state.set_value(current_security_state)
+            self.hass.async_add_job(
+                self.char_current_state.set_value, current_security_state)
             _LOGGER.debug('%s: Updated current state to %s (%d)',
                           self.entity_id, hass_state, current_security_state)
 
             # SecuritySystemTargetState does not support triggered
             if not self.flag_target_state and \
                     hass_state != STATE_ALARM_TRIGGERED:
-                self.char_target_state.set_value(current_security_state)
+                self.hass.async_add_job(
+                    self.char_target_state.set_value, current_security_state)
             self.flag_target_state = False

--- a/homeassistant/components/homekit/type_security_systems.py
+++ b/homeassistant/components/homekit/type_security_systems.py
@@ -66,8 +66,11 @@ class SecuritySystem(HomeAccessory):
             params[ATTR_CODE] = self._alarm_code
         await self.hass.services.async_call(DOMAIN, service, params)
 
-    async def async_update_state(self, new_state):
-        """Update security state after state changed. Coroutine."""
+    def async_update_state(self, new_state):
+        """Update security state after state changed.
+
+        Method is run in the event loop.
+        """
         hass_state = new_state.state
         if hass_state in HASS_TO_HOMEKIT:
             current_security_state = HASS_TO_HOMEKIT[hass_state]

--- a/homeassistant/components/homekit/type_sensors.py
+++ b/homeassistant/components/homekit/type_sensors.py
@@ -59,8 +59,11 @@ class TemperatureSensor(HomeAccessory):
             CHAR_CURRENT_TEMPERATURE, value=0, properties=PROP_CELSIUS)
         self.unit = None
 
-    async def async_update_state(self, new_state):
-        """Update temperature after state changed. Coroutine."""
+    def async_update_state(self, new_state):
+        """Update temperature after state changed.
+
+        Method is run in the event loop.
+        """
         unit = new_state.attributes.get(ATTR_UNIT_OF_MEASUREMENT, TEMP_CELSIUS)
         temperature = convert_to_float(new_state.state)
         if temperature:
@@ -81,8 +84,11 @@ class HumiditySensor(HomeAccessory):
         self.char_humidity = serv_humidity.configure_char(
             CHAR_CURRENT_HUMIDITY, value=0)
 
-    async def async_update_state(self, new_state):
-        """Update accessory after state change. Coroutine."""
+    def async_update_state(self, new_state):
+        """Update accessory after state change.
+
+        Method is run in the event loop.
+        """
         humidity = convert_to_float(new_state.state)
         if humidity:
             self.hass.async_add_job(self.char_humidity.set_value, humidity)
@@ -104,8 +110,11 @@ class AirQualitySensor(HomeAccessory):
         self.char_density = serv_air_quality.configure_char(
             CHAR_AIR_PARTICULATE_DENSITY, value=0)
 
-    async def async_update_state(self, new_state):
-        """Update accessory after state change."""
+    def async_update_state(self, new_state):
+        """Update accessory after state change.
+
+        Method is run in the event loop.
+        """
         density = convert_to_float(new_state.state)
         if density is not None:
             self.hass.async_add_job(self.char_density.set_value, density)
@@ -131,8 +140,11 @@ class CarbonDioxideSensor(HomeAccessory):
         self.char_detected = serv_co2.configure_char(
             CHAR_CARBON_DIOXIDE_DETECTED, value=0)
 
-    async def async_update_state(self, new_state):
-        """Update accessory after state change. Coroutine."""
+    def async_update_state(self, new_state):
+        """Update accessory after state change.
+
+        Method is run in the event loop.
+        """
         co2 = convert_to_float(new_state.state)
         if co2 is not None:
             self.hass.async_add_job(self.char_co2.set_value, co2)
@@ -154,8 +166,11 @@ class LightSensor(HomeAccessory):
         self.char_light = serv_light.configure_char(
             CHAR_CURRENT_AMBIENT_LIGHT_LEVEL, value=0)
 
-    async def async_update_state(self, new_state):
-        """Update accessory after state change. Coroutine."""
+    def async_update_state(self, new_state):
+        """Update accessory after state change.
+
+        Method is run in the event loop.
+        """
         luminance = convert_to_float(new_state.state)
         if luminance is not None:
             self.hass.async_add_job(self.char_light.set_value, luminance)
@@ -178,8 +193,11 @@ class BinarySensor(HomeAccessory):
         service = self.add_preload_service(service_char[0])
         self.char_detected = service.configure_char(service_char[1], value=0)
 
-    async def async_update_state(self, new_state):
-        """Update accessory after state change. Coroutine."""
+    def async_update_state(self, new_state):
+        """Update accessory after state change.
+
+        Method is run in the event loop.
+        """
         state = new_state.state
         detected = (state == STATE_ON) or (state == STATE_HOME)
         self.hass.async_add_job(self.char_detected.set_value, detected)

--- a/homeassistant/components/homekit/type_sensors.py
+++ b/homeassistant/components/homekit/type_sensors.py
@@ -59,13 +59,13 @@ class TemperatureSensor(HomeAccessory):
             CHAR_CURRENT_TEMPERATURE, value=0, properties=PROP_CELSIUS)
         self.unit = None
 
-    def update_state(self, new_state):
-        """Update temperature after state changed."""
+    async def async_update_state(self, new_state):
+        """Update temperature after state changed. Coroutine."""
         unit = new_state.attributes.get(ATTR_UNIT_OF_MEASUREMENT, TEMP_CELSIUS)
         temperature = convert_to_float(new_state.state)
         if temperature:
             temperature = temperature_to_homekit(temperature, unit)
-            self.char_temp.set_value(temperature)
+            self.hass.async_add_job(self.char_temp.set_value, temperature)
             _LOGGER.debug('%s: Current temperature set to %d°C',
                           self.entity_id, temperature)
 
@@ -81,13 +81,12 @@ class HumiditySensor(HomeAccessory):
         self.char_humidity = serv_humidity.configure_char(
             CHAR_CURRENT_HUMIDITY, value=0)
 
-    def update_state(self, new_state):
-        """Update accessory after state change."""
+    async def async_update_state(self, new_state):
+        """Update accessory after state change. Coroutine."""
         humidity = convert_to_float(new_state.state)
         if humidity:
-            self.char_humidity.set_value(humidity)
-            _LOGGER.debug('%s: Percent set to %d%%',
-                          self.entity_id, humidity)
+            self.hass.async_add_job(self.char_humidity.set_value, humidity)
+            _LOGGER.debug('%s: Percent set to %d%%', self.entity_id, humidity)
 
 
 @TYPES.register('AirQualitySensor')
@@ -105,12 +104,13 @@ class AirQualitySensor(HomeAccessory):
         self.char_density = serv_air_quality.configure_char(
             CHAR_AIR_PARTICULATE_DENSITY, value=0)
 
-    def update_state(self, new_state):
+    async def async_update_state(self, new_state):
         """Update accessory after state change."""
         density = convert_to_float(new_state.state)
         if density is not None:
-            self.char_density.set_value(density)
-            self.char_quality.set_value(density_to_air_quality(density))
+            self.hass.async_add_job(self.char_density.set_value, density)
+            self.hass.async_add_job(
+                self.char_quality.set_value, density_to_air_quality(density))
             _LOGGER.debug('%s: Set to %d', self.entity_id, density)
 
 
@@ -131,14 +131,14 @@ class CarbonDioxideSensor(HomeAccessory):
         self.char_detected = serv_co2.configure_char(
             CHAR_CARBON_DIOXIDE_DETECTED, value=0)
 
-    def update_state(self, new_state):
-        """Update accessory after state change."""
+    async def async_update_state(self, new_state):
+        """Update accessory after state change. Coroutine."""
         co2 = convert_to_float(new_state.state)
         if co2 is not None:
-            self.char_co2.set_value(co2)
+            self.hass.async_add_job(self.char_co2.set_value, co2)
             if co2 > self.char_peak.value:
-                self.char_peak.set_value(co2)
-            self.char_detected.set_value(co2 > 1000)
+                self.hass.async_add_job(self.char_peak.set_value, co2)
+            self.hass.async_add_job(self.char_detected.set_value, co2 > 1000)
             _LOGGER.debug('%s: Set to %d', self.entity_id, co2)
 
 
@@ -154,11 +154,11 @@ class LightSensor(HomeAccessory):
         self.char_light = serv_light.configure_char(
             CHAR_CURRENT_AMBIENT_LIGHT_LEVEL, value=0)
 
-    def update_state(self, new_state):
-        """Update accessory after state change."""
+    async def async_update_state(self, new_state):
+        """Update accessory after state change. Coroutine."""
         luminance = convert_to_float(new_state.state)
         if luminance is not None:
-            self.char_light.set_value(luminance)
+            self.hass.async_add_job(self.char_light.set_value, luminance)
             _LOGGER.debug('%s: Set to %d', self.entity_id, luminance)
 
 
@@ -178,9 +178,9 @@ class BinarySensor(HomeAccessory):
         service = self.add_preload_service(service_char[0])
         self.char_detected = service.configure_char(service_char[1], value=0)
 
-    def update_state(self, new_state):
-        """Update accessory after state change."""
+    async def async_update_state(self, new_state):
+        """Update accessory after state change. Coroutine."""
         state = new_state.state
         detected = (state == STATE_ON) or (state == STATE_HOME)
-        self.char_detected.set_value(detected)
+        self.hass.async_add_job(self.char_detected.set_value, detected)
         _LOGGER.debug('%s: Set to %d', self.entity_id, detected)

--- a/homeassistant/components/homekit/type_switches.py
+++ b/homeassistant/components/homekit/type_switches.py
@@ -41,8 +41,11 @@ class Switch(HomeAccessory):
         params = {ATTR_ENTITY_ID: self.entity_id}
         await self.hass.services.async_call(self._domain, service, params)
 
-    async def async_update_state(self, new_state):
-        """Update switch state after state changed. Coroutine."""
+    def async_update_state(self, new_state):
+        """Update switch state after state changed.
+
+        Method is run in the event loop.
+        """
         current_state = (new_state.state == STATE_ON)
         if not self.flag_target_state:
             _LOGGER.debug('%s: Set current state to %s',

--- a/homeassistant/components/homekit/type_thermostats.py
+++ b/homeassistant/components/homekit/type_thermostats.py
@@ -183,8 +183,11 @@ class Thermostat(HomeAccessory):
         await self.hass.services.async_call(
             DOMAIN, SERVICE_SET_TEMPERATURE, params)
 
-    async def async_update_state(self, new_state):
-        """Update security state after state changed. Coroutine."""
+    def async_update_state(self, new_state):
+        """Update security state after state changed.
+
+        Method is run in the event loop.
+        """
         self._unit = new_state.attributes.get(ATTR_UNIT_OF_MEASUREMENT,
                                               TEMP_CELSIUS)
 

--- a/tests/components/homekit/test_accessories.py
+++ b/tests/components/homekit/test_accessories.py
@@ -5,6 +5,8 @@ This includes tests for all mock object types.
 from datetime import datetime, timedelta
 from unittest.mock import patch, Mock
 
+import pytest
+
 from homeassistant.components.homekit.accessories import (
     debounce, HomeAccessory, HomeBridge, HomeDriver)
 from homeassistant.components.homekit.const import (
@@ -76,7 +78,8 @@ async def test_home_accessory(hass):
 
     hass.states.async_set('homekit.accessory', 'on')
     await hass.async_block_till_done()
-    await hass.async_add_job(acc.run)
+    with pytest.raises(NotImplementedError):
+        await hass.async_add_job(acc.run)
     hass.states.async_set('homekit.accessory', 'off')
     await hass.async_block_till_done()
 


### PR DESCRIPTION
## Description:
This is the first PR to complete the `async` conversion for the `homekit` component. I focused on converting the `type` classes. Another PR will deal with the main `HomeKit` class.

As for the changes:
 - Setter methods are called from `HAP-python` and thus aren't executed in the same event loop. Therefore upon execution they will call `hass.add_job` on their `async` method.
 - The `async` setter methods now call `await hass.services.async_call` for service execution.
 - The `update_state` method s(callbacks for `track_change_listeners`) are now `async_update_state`. I omitted the `callback` decorator, see https://github.com/home-assistant/home-assistant/pull/14399#pullrequestreview-119609647
 - Any call to `set_value` on a characteristic in `HAP-python` is now prefixed with `hass.async_add_job` (in `async` methods only).

Since I haven't used `async` for that long, any input is welcome.


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**