### PR TITLE
Fix name of tox pylint env

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35, py36, lint, requirements, typing
+envlist = py35, py36, lint, pylint, typing
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
## Description:
The env list was not updated when envs changed names in #10670.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**