### PR TITLE
Add Nest away binary sensor and eta sensor

### DIFF
--- a/homeassistant/components/binary_sensor/nest.py
+++ b/homeassistant/components/binary_sensor/nest.py
@@ -117,7 +117,8 @@ class NestBinarySensor(NestSensor, BinarySensorDevice):
         """Retrieve latest state."""
         value = getattr(self.device, self.variable)
         if self.variable in STRUCTURE_BINARY_TYPES:
-            self._state = bool(STRUCTURE_BINARY_STATE_MAP[self.variable][value])
+            self._state = bool(STRUCTURE_BINARY_STATE_MAP
+                               [self.variable][value])
         else:
             self._state = bool(value)
 

--- a/homeassistant/components/binary_sensor/nest.py
+++ b/homeassistant/components/binary_sensor/nest.py
@@ -29,6 +29,16 @@ CAMERA_BINARY_TYPES = [
     'person_detected',
 ]
 
+STRUCTURE_BINARY_TYPES = [
+    'away',
+    # 'security_state', # wait python-nest update
+]
+
+STRUCTURE_BINARY_STATE_MAP = {
+    'away': {'away': True, 'home': False},
+    'security_state': {'deter': True, 'ok': False},
+}
+
 _BINARY_TYPES_DEPRECATED = [
     'hvac_ac_state',
     'hvac_aux_heater_state',
@@ -41,7 +51,7 @@ _BINARY_TYPES_DEPRECATED = [
 ]
 
 _VALID_BINARY_SENSOR_TYPES = BINARY_TYPES + CLIMATE_BINARY_TYPES \
-    + CAMERA_BINARY_TYPES
+    + CAMERA_BINARY_TYPES + STRUCTURE_BINARY_TYPES
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -68,6 +78,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             _LOGGER.error(wstr)
 
     sensors = []
+    for structure in nest.structures():
+        sensors += [NestBinarySensor(structure, None, variable)
+                    for variable in conditions
+                    if variable in STRUCTURE_BINARY_TYPES]
     device_chain = chain(nest.thermostats(),
                          nest.smoke_co_alarms(),
                          nest.cameras())
@@ -88,7 +102,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                 sensors += [NestActivityZoneSensor(structure,
                                                    device,
                                                    activity_zone)]
-
     add_devices(sensors, True)
 
 
@@ -102,7 +115,11 @@ class NestBinarySensor(NestSensor, BinarySensorDevice):
 
     def update(self):
         """Retrieve latest state."""
-        self._state = bool(getattr(self.device, self.variable))
+        value = getattr(self.device, self.variable)
+        if self.variable in STRUCTURE_BINARY_TYPES:
+            self._state = bool(STRUCTURE_BINARY_STATE_MAP[self.variable][value])
+        else:
+            self._state = bool(value)
 
 
 class NestActivityZoneSensor(NestBinarySensor):

--- a/homeassistant/components/binary_sensor/nest.py
+++ b/homeassistant/components/binary_sensor/nest.py
@@ -31,7 +31,7 @@ CAMERA_BINARY_TYPES = [
 
 STRUCTURE_BINARY_TYPES = [
     'away',
-    # 'security_state', # wait python-nest update
+    # 'security_state', # wait for pending python-nest update
 ]
 
 STRUCTURE_BINARY_STATE_MAP = {

--- a/homeassistant/components/nest.py
+++ b/homeassistant/components/nest.py
@@ -201,7 +201,7 @@ class NestDevice(object):
             for structure in self.nest.structures:
                 if structure.name in self.local_structure:
                     for device in structure.smoke_co_alarms:
-                        yield(structure, device)
+                        yield (structure, device)
                 else:
                     _LOGGER.debug("Ignoring structure %s, not in %s",
                                   structure.name, self.local_structure)
@@ -215,7 +215,7 @@ class NestDevice(object):
             for structure in self.nest.structures:
                 if structure.name in self.local_structure:
                     for device in structure.cameras:
-                        yield(structure, device)
+                        yield (structure, device)
                 else:
                     _LOGGER.debug("Ignoring structure %s, not in %s",
                                   structure.name, self.local_structure)

--- a/homeassistant/components/nest.py
+++ b/homeassistant/components/nest.py
@@ -168,6 +168,19 @@ class NestDevice(object):
             self.local_structure = conf[CONF_STRUCTURE]
         _LOGGER.debug("Structures to include: %s", self.local_structure)
 
+    def structures(self):
+        """Generate a list of structures."""
+        try:
+            for structure in self.nest.structures:
+                if structure.name in self.local_structure:
+                    yield structure
+                else:
+                    _LOGGER.debug("Ignoring structure %s, not in %s",
+                                  structure.name, self.local_structure)
+        except socket.error:
+            _LOGGER.error(
+                "Connection error logging into the nest web service.")
+
     def thermostats(self):
         """Generate a list of thermostats and their location."""
         try:
@@ -190,8 +203,8 @@ class NestDevice(object):
                     for device in structure.smoke_co_alarms:
                         yield(structure, device)
                 else:
-                    _LOGGER.info("Ignoring structure %s, not in %s",
-                                 structure.name, self.local_structure)
+                    _LOGGER.debug("Ignoring structure %s, not in %s",
+                                  structure.name, self.local_structure)
         except socket.error:
             _LOGGER.error(
                 "Connection error logging into the nest web service.")
@@ -204,8 +217,8 @@ class NestDevice(object):
                     for device in structure.cameras:
                         yield(structure, device)
                 else:
-                    _LOGGER.info("Ignoring structure %s, not in %s",
-                                 structure.name, self.local_structure)
+                    _LOGGER.debug("Ignoring structure %s, not in %s",
+                                  structure.name, self.local_structure)
         except socket.error:
             _LOGGER.error(
                 "Connection error logging into the nest web service.")

--- a/homeassistant/components/sensor/nest.py
+++ b/homeassistant/components/sensor/nest.py
@@ -36,10 +36,13 @@ PROTECT_VARS_DEPRECATED = ['battery_level']
 
 SENSOR_TEMP_TYPES = ['temperature', 'target']
 
+STRUCTURE_SENSOR_TYPES = ['eta']
+
 _SENSOR_TYPES_DEPRECATED = SENSOR_TYPES_DEPRECATED \
     + list(DEPRECATED_WEATHER_VARS.keys()) + PROTECT_VARS_DEPRECATED
 
-_VALID_SENSOR_TYPES = SENSOR_TYPES + SENSOR_TEMP_TYPES + PROTECT_VARS
+_VALID_SENSOR_TYPES = SENSOR_TYPES + SENSOR_TEMP_TYPES + PROTECT_VARS  \
+    + STRUCTURE_SENSOR_TYPES
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -73,6 +76,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             _LOGGER.error(wstr)
 
     all_sensors = []
+    for structure in nest.structures():
+        all_sensors += [NestBasicSensor(structure, None, variable)
+                        for variable in conditions
+                        if variable in STRUCTURE_SENSOR_TYPES]
     for structure, device in chain(nest.thermostats(), nest.smoke_co_alarms()):
         sensors = [NestBasicSensor(structure, device, variable)
                    for variable in conditions
@@ -94,13 +101,20 @@ class NestSensor(Entity):
     def __init__(self, structure, device, variable):
         """Initialize the sensor."""
         self.structure = structure
-        self.device = device
         self.variable = variable
 
-        # device specific
-        self._location = self.device.where
-        self._name = "{} {}".format(self.device.name_long,
-                                    self.variable.replace("_", " "))
+        if device is not None:
+            # device specific
+            self.device = device
+            self._location = self.device.where
+            self._name = "{} {}".format(self.device.name_long,
+                                        self.variable.replace("_", " "))
+        else:
+            # structure only
+            self.device = structure
+            self._name = "{} {}".format(self.structure.name,
+                                        self.variable.replace("_", " "))
+
         self._state = None
         self._unit = None
 
@@ -129,6 +143,8 @@ class NestBasicSensor(NestSensor):
 
         if self.variable == 'operation_mode':
             self._state = getattr(self.device, "mode")
+        elif self.variable == 'eta':
+            self._state = getattr(self.device, 'eta_begin')
         else:
             self._state = getattr(self.device, self.variable)
 

--- a/homeassistant/components/sensor/nest.py
+++ b/homeassistant/components/sensor/nest.py
@@ -38,6 +38,8 @@ SENSOR_TEMP_TYPES = ['temperature', 'target']
 
 STRUCTURE_SENSOR_TYPES = ['eta']
 
+VARIABLE_NAME_MAPPING = {'eta': 'eta_begin', 'operation_mode': 'mode'}
+
 _SENSOR_TYPES_DEPRECATED = SENSOR_TYPES_DEPRECATED \
     + list(DEPRECATED_WEATHER_VARS.keys()) + PROTECT_VARS_DEPRECATED
 
@@ -108,12 +110,12 @@ class NestSensor(Entity):
             self.device = device
             self._location = self.device.where
             self._name = "{} {}".format(self.device.name_long,
-                                        self.variable.replace("_", " "))
+                                        self.variable.replace('_', ' '))
         else:
             # structure only
             self.device = structure
             self._name = "{} {}".format(self.structure.name,
-                                        self.variable.replace("_", " "))
+                                        self.variable.replace('_', ' '))
 
         self._state = None
         self._unit = None
@@ -141,10 +143,9 @@ class NestBasicSensor(NestSensor):
         """Retrieve latest state."""
         self._unit = SENSOR_UNITS.get(self.variable, None)
 
-        if self.variable == 'operation_mode':
-            self._state = getattr(self.device, "mode")
-        elif self.variable == 'eta':
-            self._state = getattr(self.device, 'eta_begin')
+        if self.variable in VARIABLE_NAME_MAPPING:
+            self._state = getattr(self.device,
+                                  VARIABLE_NAME_MAPPING[self.variable])
         else:
             self._state = getattr(self.device, self.variable)
 


### PR DESCRIPTION
## Description:
[away](https://developers.nest.com/documentation/cloud/api-structure#away) and [eta_begin](https://developers.nest.com/documentation/cloud/api-structure#eta_begin) are two data already in Nest structure data, but didn't exposed in HA for some reason. However, HA provide a service to change away mode, that is strange for me. So I want to expose those attribute to HA.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5352

## Example entry for `configuration.yaml` (if applicable):
Auto discover/configuration sensors, no change on configuration

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

