### PR TITLE
Look at registry before pulling zwave config values

### DIFF
--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -108,10 +108,9 @@ class EntityRegistry:
     def async_get_or_create(self, domain, platform, unique_id, *,
                             suggested_object_id=None):
         """Get entity. Create if it doesn't exist."""
-        for entity in self.entities.values():
-            if entity.domain == domain and entity.platform == platform and \
-               entity.unique_id == unique_id:
-                return entity
+        entity_id = self.async_get_entity_id(domain, platform, unique_id)
+        if entity_id:
+            return self.entities[entity_id]
 
         entity_id = self.async_generate_entity_id(
             domain, suggested_object_id or '{}_{}'.format(platform, unique_id))

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -84,6 +84,15 @@ class EntityRegistry:
         return entity_id in self.entities
 
     @callback
+    def async_get_entity_id(self, domain: str, platform: str, unique_id: str):
+        """Check if an entity_id is currently registered."""
+        for entity in self.entities.values():
+            if entity.domain == domain and entity.platform == platform and \
+               entity.unique_id == unique_id:
+                return entity.entity_id
+        return None
+
+    @callback
     def async_generate_entity_id(self, domain, suggested_object_id):
         """Generate an entity ID that does not conflict.
 

--- a/tests/components/zwave/test_init.py
+++ b/tests/components/zwave/test_init.py
@@ -13,6 +13,7 @@ from homeassistant.components.binary_sensor.zwave import get_device
 from homeassistant.components.zwave import (
     const, CONFIG_SCHEMA, CONF_DEVICE_CONFIG_GLOB, DATA_NETWORK)
 from homeassistant.setup import setup_component
+from tests.common import mock_registry
 
 import pytest
 
@@ -468,6 +469,7 @@ class TestZWaveDeviceEntityValues(unittest.TestCase):
         """Initialize values for this testcase class."""
         self.hass = get_test_home_assistant()
         self.hass.start()
+        self.registry = mock_registry(self.hass)
 
         setup_component(self.hass, 'zwave', {'zwave': {}})
         self.hass.block_till_done()
@@ -487,7 +489,7 @@ class TestZWaveDeviceEntityValues(unittest.TestCase):
                     const.DISC_OPTIONAL: True,
                 }}}
         self.primary = MockValue(
-            command_class='mock_primary_class', node=self.node)
+            command_class='mock_primary_class', node=self.node, value_id=1000)
         self.secondary = MockValue(
             command_class='mock_secondary_class', node=self.node)
         self.duplicate_secondary = MockValue(
@@ -521,6 +523,7 @@ class TestZWaveDeviceEntityValues(unittest.TestCase):
             primary_value=self.primary,
             zwave_config=self.zwave_config,
             device_config=self.device_config,
+            registry=self.registry
         )
 
         assert values.primary is self.primary
@@ -592,6 +595,7 @@ class TestZWaveDeviceEntityValues(unittest.TestCase):
             primary_value=self.primary,
             zwave_config=self.zwave_config,
             device_config=self.device_config,
+            registry=self.registry
         )
         self.hass.block_till_done()
 
@@ -630,6 +634,7 @@ class TestZWaveDeviceEntityValues(unittest.TestCase):
             primary_value=self.primary,
             zwave_config=self.zwave_config,
             device_config=self.device_config,
+            registry=self.registry
         )
         values._check_entity_ready()
         self.hass.block_till_done()
@@ -639,7 +644,7 @@ class TestZWaveDeviceEntityValues(unittest.TestCase):
     @patch.object(zwave, 'get_platform')
     @patch.object(zwave, 'discovery')
     def test_entity_workaround_component(self, discovery, get_platform):
-        """Test ignore workaround."""
+        """Test component workaround."""
         discovery.async_load_platform.return_value = mock_coro()
         mock_platform = MagicMock()
         get_platform.return_value = mock_platform
@@ -666,6 +671,7 @@ class TestZWaveDeviceEntityValues(unittest.TestCase):
             primary_value=self.primary,
             zwave_config=self.zwave_config,
             device_config=self.device_config,
+            registry=self.registry
         )
         values._check_entity_ready()
         self.hass.block_till_done()
@@ -697,6 +703,7 @@ class TestZWaveDeviceEntityValues(unittest.TestCase):
             primary_value=self.primary,
             zwave_config=self.zwave_config,
             device_config=self.device_config,
+            registry=self.registry
         )
         values._check_entity_ready()
         self.hass.block_till_done()
@@ -720,8 +727,38 @@ class TestZWaveDeviceEntityValues(unittest.TestCase):
             primary_value=self.primary,
             zwave_config=self.zwave_config,
             device_config=self.device_config,
+            registry=self.registry
         )
         values._check_entity_ready()
+        self.hass.block_till_done()
+
+        assert not discovery.async_load_platform.called
+
+    @patch.object(zwave, 'get_platform')
+    @patch.object(zwave, 'discovery')
+    def test_entity_config_ignore_with_registry(self, discovery, get_platform):
+        """Test ignore config.
+
+        The case when the device is in entity registry.
+        """
+        self.node.values = {
+            self.primary.value_id: self.primary,
+            self.secondary.value_id: self.secondary,
+        }
+        self.device_config = {'mock_component.registry_id': {
+            zwave.CONF_IGNORED: True
+        }}
+        self.registry.async_get_or_create(
+            'mock_component', zwave.DOMAIN, '567-1000',
+            suggested_object_id='registry_id')
+        zwave.ZWaveDeviceEntityValues(
+            hass=self.hass,
+            schema=self.mock_schema,
+            primary_value=self.primary,
+            zwave_config=self.zwave_config,
+            device_config=self.device_config,
+            registry=self.registry
+        )
         self.hass.block_till_done()
 
         assert not discovery.async_load_platform.called
@@ -743,6 +780,7 @@ class TestZWaveDeviceEntityValues(unittest.TestCase):
             primary_value=self.primary,
             zwave_config=self.zwave_config,
             device_config=self.device_config,
+            registry=self.registry
         )
         self.hass.block_till_done()
 
@@ -770,6 +808,7 @@ class TestZWaveDeviceEntityValues(unittest.TestCase):
             primary_value=self.primary,
             zwave_config=self.zwave_config,
             device_config=self.device_config,
+            registry=self.registry
         )
         values._check_entity_ready()
         self.hass.block_till_done()

--- a/tests/helpers/test_entity_registry.py
+++ b/tests/helpers/test_entity_registry.py
@@ -180,3 +180,13 @@ test.disabled_hass:
     assert entry_disabled_hass.disabled_by == entity_registry.DISABLED_HASS
     assert entry_disabled_user.disabled
     assert entry_disabled_user.disabled_by == entity_registry.DISABLED_USER
+
+
+@asyncio.coroutine
+def test_async_get_entity_id(registry):
+    """Test that entity_id is returned."""
+    entry = registry.async_get_or_create('light', 'hue', '1234')
+    assert entry.entity_id == 'light.hue_1234'
+    assert registry.async_get_entity_id(
+        'light', 'hue', '1234') == 'light.hue_1234'
+    assert registry.async_get_entity_id('light', 'hue', '123') is None

--- a/tests/mock/zwave.py
+++ b/tests/mock/zwave.py
@@ -178,6 +178,7 @@ class MockValue(MagicMock):
             MockValue._mock_value_id += 1
             value_id = MockValue._mock_value_id
         self.value_id = value_id
+        self.object_id = value_id
         for attr_name in kwargs:
             setattr(self, attr_name, kwargs[attr_name])
 


### PR DESCRIPTION
## Description:

The entity_id zwave would guess for entities for pulling config data could be different from the entity_id stored in the registry. This would cause config data to be ignored.

Now zwave peeks into the registry before building the entity_id.

While a similar problem exists with zwave node, the only data  anode could have is `'ignored'` and that is supported by the registry itself.

## Example entry for `configuration.yaml` (if applicable):
```yaml
zwave:
  device_config:
    light.zwave_light:
      polling_intensity: 10
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
