### PR TITLE
[RFC] [WIP] New platform eLan

### DIFF
--- a/homeassistant/components/elan.py
+++ b/homeassistant/components/elan.py
@@ -1,5 +1,6 @@
 """
-Support for elan devices manual discovery.
+Support for elan devices via manual discovery.
+
 For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/elan/
 

--- a/homeassistant/components/elan.py
+++ b/homeassistant/components/elan.py
@@ -17,17 +17,12 @@ elan:
 import asyncio
 import logging
 
-import async_timeout
 import voluptuous as vol
 
-SERVICE_ELAN = 'elan'
-
 from homeassistant.helpers import discovery
-from homeassistant.helpers.discovery import load_platform
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers import config_validation as cv
 
-from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+SERVICE_ELAN = 'elan'
 
 DOMAIN = 'elan'
 
@@ -55,16 +50,16 @@ def async_setup(hass, config):
     """Setup elan component."""
     conf = config.get(DOMAIN, {})
     url = conf.get('url')
-    _LOGGER.info('elan platform setup ' + url)
+    _LOGGER.info('elan platform setup %s', url)
     offsets = conf.get('offsets')
-    _LOGGER.info('elan platform offsets ' + str(offsets))
+    _LOGGER.info('elan platform offsets %f', offsets)
 
     @asyncio.coroutine
     def elan_discovered(service, info):
         """Run when a gateway is discovered."""
         url = info['url']
         offsets = info['offsets']
-        _LOGGER.info('elan discovered ' + url)
+        _LOGGER.info('elan discovered %s', url)
         yield from _setup_elan(hass, config, url, offsets)
 
     discovery.async_listen(hass, SERVICE_ELAN, elan_discovered)

--- a/homeassistant/components/elan.py
+++ b/homeassistant/components/elan.py
@@ -15,6 +15,7 @@ SERVICE_ELAN = 'elan'
 
 from homeassistant.helpers import discovery
 from homeassistant.helpers.discovery import load_platform
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers import config_validation as cv
 
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
@@ -28,12 +29,17 @@ _LOGGER = logging.getLogger(__name__)
 
 CONF_STATIC = 'static'
 
-CONFIG_SCHEMA = vol.Schema({
-    DOMAIN: vol.Schema({
-        vol.Required('url'): cv.string,
-        vol.Optional('offsets'): {cv.string : vol.Coerce(float)},
-    }),
-}, extra=vol.ALLOW_EXTRA)
+CONFIG_SCHEMA = vol.Schema(
+    {
+        DOMAIN:
+        vol.Schema({
+            vol.Required('url'): cv.string,
+            vol.Optional('offsets'): {
+                cv.string: vol.Coerce(float)
+            },
+        }),
+    },
+    extra=vol.ALLOW_EXTRA)
 
 
 @asyncio.coroutine
@@ -55,15 +61,20 @@ def async_setup(hass, config):
 
     discovery.async_listen(hass, SERVICE_ELAN, elan_discovered)
 
-    yield from elan_discovered(None,{'url': url, 'offsets':offsets})
+    yield from elan_discovered(None, {'url': url, 'offsets': offsets})
 
     return True
+
 
 @asyncio.coroutine
 def _setup_elan(hass, hass_config, url, offsets):
     """Call platform discovery for devices on particular elan."""
-    hass.async_add_job(discovery.async_load_platform(
-        hass, 'light', DOMAIN, {'url': url}, hass_config))
-    hass.async_add_job(discovery.async_load_platform(
-        hass, 'sensor', DOMAIN, {'url': url, 'offsets':offsets}, hass_config))
+    hass.async_add_job(
+        discovery.async_load_platform(hass, 'light', DOMAIN, {'url': url},
+                                      hass_config))
+    hass.async_add_job(
+        discovery.async_load_platform(hass, 'sensor', DOMAIN, {
+            'url': url,
+            'offsets': offsets
+        }, hass_config))
     return True

--- a/homeassistant/components/elan.py
+++ b/homeassistant/components/elan.py
@@ -2,6 +2,16 @@
 Support for elan devices manual discovery.
 For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/elan/
+
+Setup:
+ - Add INELS RF devices in eLAN web interface (follow eLAN manual)
+ - Add platfrom url into Home Assistant configuration
+
+Sample configuration:
+
+elan:
+  url:  "http://192.168.168.123"
+
 """
 
 import asyncio
@@ -10,7 +20,6 @@ import logging
 import async_timeout
 import voluptuous as vol
 
-#from homeassistant.components.discovery import SERVICE_elan
 SERVICE_ELAN = 'elan'
 
 from homeassistant.helpers import discovery
@@ -22,7 +31,6 @@ from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 
 DOMAIN = 'elan'
 
-#SUBSCRIPTION_REGISTRY = None # do budoucna zde bude ws link k elanu abychom meli upozorneni na zmeny stavu
 KNOWN_DEVICES = []
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/elan.py
+++ b/homeassistant/components/elan.py
@@ -1,0 +1,69 @@
+"""
+Support for elan devices manual discovery.
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/elan/
+"""
+
+import asyncio
+import logging
+
+import async_timeout
+import voluptuous as vol
+
+#from homeassistant.components.discovery import SERVICE_elan
+SERVICE_ELAN = 'elan'
+
+from homeassistant.helpers import discovery
+from homeassistant.helpers.discovery import load_platform
+from homeassistant.helpers import config_validation as cv
+
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+
+DOMAIN = 'elan'
+
+#SUBSCRIPTION_REGISTRY = None # do budoucna zde bude ws link k elanu abychom meli upozorneni na zmeny stavu
+KNOWN_DEVICES = []
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_STATIC = 'static'
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required('url'): cv.string,
+        vol.Optional('offsets'): {cv.string : vol.Coerce(float)},
+    }),
+}, extra=vol.ALLOW_EXTRA)
+
+
+@asyncio.coroutine
+def async_setup(hass, config):
+    """Setup elan component."""
+    conf = config.get(DOMAIN, {})
+    url = conf.get('url')
+    _LOGGER.info('elan platform setup ' + url)
+    offsets = conf.get('offsets')
+    _LOGGER.info('elan platform offsets ' + str(offsets))
+
+    @asyncio.coroutine
+    def elan_discovered(service, info):
+        """Run when a gateway is discovered."""
+        url = info['url']
+        offsets = info['offsets']
+        _LOGGER.info('elan discovered ' + url)
+        yield from _setup_elan(hass, config, url, offsets)
+
+    discovery.async_listen(hass, SERVICE_ELAN, elan_discovered)
+
+    yield from elan_discovered(None,{'url': url, 'offsets':offsets})
+
+    return True
+
+@asyncio.coroutine
+def _setup_elan(hass, hass_config, url, offsets):
+    """Call platform discovery for devices on particular elan."""
+    hass.async_add_job(discovery.async_load_platform(
+        hass, 'light', DOMAIN, {'url': url}, hass_config))
+    hass.async_add_job(discovery.async_load_platform(
+        hass, 'sensor', DOMAIN, {'url': url, 'offsets':offsets}, hass_config))
+    return True

--- a/homeassistant/components/elan.py
+++ b/homeassistant/components/elan.py
@@ -52,7 +52,7 @@ def async_setup(hass, config):
     url = conf.get('url')
     _LOGGER.info('elan platform setup %s', url)
     offsets = conf.get('offsets')
-    _LOGGER.info('elan platform offsets %f', offsets)
+    _LOGGER.info('elan platform offsets %s', str(offsets))
 
     @asyncio.coroutine
     def elan_discovered(service, info):

--- a/homeassistant/components/light/elan.py
+++ b/homeassistant/components/light/elan.py
@@ -85,7 +85,6 @@ class ElanLight(Light):
     @asyncio.coroutine
     def async_added_to_hass(self):
         """Start thread when added to hass."""
-        #self._async_start_observe()
 
     @property
     def available(self):
@@ -94,7 +93,7 @@ class ElanLight(Light):
 
     @property
     def should_poll(self):
-        """WS notification not implemented yet - polling is needed"""
+        """WS notification not implemented yet - polling is needed."""
         return True
 
     @property
@@ -125,6 +124,7 @@ class ElanLight(Light):
     @asyncio.coroutine
     def update(self):
         """Fetch new state data for this light.
+
         This is the only method that should fetch new data for Home Assistant.
         """
         _LOGGER.info('elan Light update')
@@ -157,9 +157,7 @@ class ElanLight(Light):
 
     @asyncio.coroutine
     def async_turn_on(self, **kwargs):
-        """
-        Instruct the light to turn on.
-        """
+        """Instruct the light to turn on."""
         _LOGGER.info('Turning on elan light')
         _LOGGER.info(self._light)
         if ATTR_BRIGHTNESS in kwargs:

--- a/homeassistant/components/light/elan.py
+++ b/homeassistant/components/light/elan.py
@@ -43,10 +43,10 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         if info['device info']['type'] == 'light':
             _LOGGER.info("elan Light to add")
             _LOGGER.info(device)
-            async_add_devices([elanLight(device_list[device]['url'], info)])
+            async_add_devices([ElanLight(device_list[device]['url'], info)])
 
 
-class elanLight(Light):
+class ElanLight(Light):
     """The platform class required by Home Assistant."""
 
     def __init__(self, light, info):

--- a/homeassistant/components/light/elan.py
+++ b/homeassistant/components/light/elan.py
@@ -4,25 +4,16 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/xxxx/
 """
 import asyncio
-import aiohttp
 import logging
 import voluptuous as vol
 
-from homeassistant.core import callback
-from homeassistant.const import ATTR_BATTERY_LEVEL
 from homeassistant.components.light import (
-    ATTR_BRIGHTNESS, ATTR_HS_COLOR, SUPPORT_BRIGHTNESS, SUPPORT_COLOR, Light)
+    ATTR_BRIGHTNESS, SUPPORT_BRIGHTNESS, Light)
 from homeassistant.components.light import PLATFORM_SCHEMA
-from homeassistant.util import color as color_util
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-#REQUIREMENTS = ['pyelan']
-
 _LOGGER = logging.getLogger(__name__)
-
-#MIN_TIME_BETWEEN_SCANS = timedelta(seconds=10)
-#MIN_TIME_BETWEEN_FORCED_SCANS = timedelta(milliseconds=100)
 
 # Validation of the user's configuration
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({

--- a/homeassistant/components/light/elan.py
+++ b/homeassistant/components/light/elan.py
@@ -1,0 +1,183 @@
+"""
+Support for the elan.
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/xxxx/
+"""
+import asyncio
+import aiohttp
+import logging
+import voluptuous as vol
+
+from homeassistant.core import callback
+from homeassistant.const import ATTR_BATTERY_LEVEL
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS, ATTR_HS_COLOR,
+    SUPPORT_BRIGHTNESS, SUPPORT_COLOR, Light)
+from homeassistant.components.light import  PLATFORM_SCHEMA
+from homeassistant.util import color as color_util
+from homeassistant.helpers import config_validation as cv
+
+#REQUIREMENTS = ['pyelan']
+
+_LOGGER = logging.getLogger(__name__)
+
+#MIN_TIME_BETWEEN_SCANS = timedelta(seconds=10)
+#MIN_TIME_BETWEEN_FORCED_SCANS = timedelta(milliseconds=100)
+
+# Validation of the user's configuration
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required('url'): cv.string,
+})
+
+
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+    """Set up the elan Light platform."""
+    if discovery_info is None:
+        return
+
+    url = discovery_info['url']
+
+    session = aiohttp.ClientSession()
+    resp = yield from session.get(url+'/api/devices', timeout=3)
+    device_list = yield from resp.json()
+    _LOGGER.info("elan devices")
+    _LOGGER.info(device_list)
+
+    for device in device_list:
+        resp =  yield from session.get(device_list[device]['url'], timeout=3)
+        info =  yield from resp.json()
+        _LOGGER.info("elan device")
+        _LOGGER.info(device)
+        if info['device info']['type'] == 'light':
+            _LOGGER.info("elan Light to add")
+            _LOGGER.info(device)
+            async_add_devices([elanLight(device_list[device]['url'], info)])
+
+class elanLight(Light):
+    """The platform class required by Home Assistant."""
+
+    def __init__(self, light, info):
+        """Initialize a Light."""
+        _LOGGER.info("elan light initialisation")
+        _LOGGER.info(info)
+        self._light = light
+        self._info = info
+        self._name = info['device info']['label']
+        self._state = None
+        self._brightness = None
+
+        self._last_brightness = 100
+        self._dimmer = False
+        self._available = True
+        self._features = None
+        self._rgb_color = None
+
+        self._features = 0
+
+        if info['primary actions'][0] == 'brightness':
+            self._features = SUPPORT_BRIGHTNESS
+            self._dimmer = True
+
+    @property
+    def device_state_attributes(self):
+        """Return the devices' state attributes."""
+        attrs = {}
+        return attrs
+
+    @asyncio.coroutine
+    def async_added_to_hass(self):
+        """Start thread when added to hass."""
+        #self._async_start_observe()
+
+    @property
+    def available(self):
+        """Return True if entity is available."""
+        return self._available
+
+    @property
+    def should_poll(self):
+        """WS notification not implemented yet - polling is needed"""
+        return True
+
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+        return self._features
+
+    @property
+    def name(self):
+        """Return the display name of this light."""
+        return self._name
+
+    @property
+    def is_on(self):
+        """Return true if light is on."""
+        return self._state
+
+    @property
+    def brightness(self):
+        """Return the brightness of the light."""
+        return self._brightness
+
+    @property
+    def rgb_color(self):
+        """RGB color of the light."""
+        return self._rgb_color
+
+
+    @asyncio.coroutine
+    def update(self):
+        """Fetch new state data for this light.
+
+        This is the only method that should fetch new data for Home Assistant.
+        """
+        _LOGGER.info('elan Light update')
+        _LOGGER.info(self._light + '/state')
+        session = aiohttp.ClientSession()
+        resp = yield from session.get(self._light + '/state', timeout=3)
+        state = yield from resp.json()
+        _LOGGER.info(state)
+        tmp = False
+        if 'on' in state:
+            tmp = state['on']
+        if 'brightness' in state:
+            self._brightness = state['brightness']
+            if state['brightness'] > 0:
+                tmp = True
+        self._state = tmp
+
+    @asyncio.coroutine
+    def async_turn_off(self, **kwargs):
+        """Instruct the light to turn off."""
+        _LOGGER.info('Turning off elan light')
+        _LOGGER.info(self._light)
+        session = aiohttp.ClientSession()
+        if self._dimmer:
+            resp = yield from session.put(self._light, json={'brightness':0})
+        else:
+            resp = yield from session.put(self._light, json={'on':False})
+        info = yield from resp.text()
+        _LOGGER.info(info)
+
+    @asyncio.coroutine
+    def async_turn_on(self, **kwargs):
+        """
+        Instruct the light to turn on.
+        """
+        _LOGGER.info('Turning on elan light')
+        _LOGGER.info(self._light)
+        if ATTR_BRIGHTNESS in kwargs:
+            if kwargs[ATTR_BRIGHTNESS] > 0:
+                self._last_brightness = kwargs[ATTR_BRIGHTNESS]
+
+        session = aiohttp.ClientSession()
+        if self._dimmer:
+            if self._last_brightness is 0:
+                self._last_brightness = 100
+            resp = yield from session.put(self._light, json={'brightness': self._last_brightness})
+        else:
+            resp =yield from session.put(self._light, json={'on': True})
+
+        info = yield from resp.text()
+        _LOGGER.info(info)

--- a/homeassistant/components/light/elan.py
+++ b/homeassistant/components/light/elan.py
@@ -11,11 +11,11 @@ import voluptuous as vol
 from homeassistant.core import callback
 from homeassistant.const import ATTR_BATTERY_LEVEL
 from homeassistant.components.light import (
-    ATTR_BRIGHTNESS, ATTR_HS_COLOR,
-    SUPPORT_BRIGHTNESS, SUPPORT_COLOR, Light)
-from homeassistant.components.light import  PLATFORM_SCHEMA
+    ATTR_BRIGHTNESS, ATTR_HS_COLOR, SUPPORT_BRIGHTNESS, SUPPORT_COLOR, Light)
+from homeassistant.components.light import PLATFORM_SCHEMA
 from homeassistant.util import color as color_util
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 #REQUIREMENTS = ['pyelan']
 
@@ -38,21 +38,22 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 
     url = discovery_info['url']
 
-    session = aiohttp.ClientSession()
-    resp = yield from session.get(url+'/api/devices', timeout=3)
+    session = async_get_clientsession(hass)
+    resp = yield from session.get(url + '/api/devices', timeout=3)
     device_list = yield from resp.json()
     _LOGGER.info("elan devices")
     _LOGGER.info(device_list)
 
     for device in device_list:
-        resp =  yield from session.get(device_list[device]['url'], timeout=3)
-        info =  yield from resp.json()
+        resp = yield from session.get(device_list[device]['url'], timeout=3)
+        info = yield from resp.json()
         _LOGGER.info("elan device")
         _LOGGER.info(device)
         if info['device info']['type'] == 'light':
             _LOGGER.info("elan Light to add")
             _LOGGER.info(device)
             async_add_devices([elanLight(device_list[device]['url'], info)])
+
 
 class elanLight(Light):
     """The platform class required by Home Assistant."""
@@ -125,7 +126,6 @@ class elanLight(Light):
         """RGB color of the light."""
         return self._rgb_color
 
-
     @asyncio.coroutine
     def update(self):
         """Fetch new state data for this light.
@@ -134,7 +134,7 @@ class elanLight(Light):
         """
         _LOGGER.info('elan Light update')
         _LOGGER.info(self._light + '/state')
-        session = aiohttp.ClientSession()
+        session = async_get_clientsession(self.hass)
         resp = yield from session.get(self._light + '/state', timeout=3)
         state = yield from resp.json()
         _LOGGER.info(state)
@@ -152,11 +152,11 @@ class elanLight(Light):
         """Instruct the light to turn off."""
         _LOGGER.info('Turning off elan light')
         _LOGGER.info(self._light)
-        session = aiohttp.ClientSession()
+        session = async_get_clientsession(self.hass)
         if self._dimmer:
-            resp = yield from session.put(self._light, json={'brightness':0})
+            resp = yield from session.put(self._light, json={'brightness': 0})
         else:
-            resp = yield from session.put(self._light, json={'on':False})
+            resp = yield from session.put(self._light, json={'on': False})
         info = yield from resp.text()
         _LOGGER.info(info)
 
@@ -171,13 +171,14 @@ class elanLight(Light):
             if kwargs[ATTR_BRIGHTNESS] > 0:
                 self._last_brightness = kwargs[ATTR_BRIGHTNESS]
 
-        session = aiohttp.ClientSession()
+        session = async_get_clientsession(self.hass)
         if self._dimmer:
             if self._last_brightness is 0:
                 self._last_brightness = 100
-            resp = yield from session.put(self._light, json={'brightness': self._last_brightness})
+            resp = yield from session.put(
+                self._light, json={'brightness': self._last_brightness})
         else:
-            resp =yield from session.put(self._light, json={'on': True})
+            resp = yield from session.put(self._light, json={'on': True})
 
         info = yield from resp.text()
         _LOGGER.info(info)

--- a/homeassistant/components/sensor/elan.py
+++ b/homeassistant/components/sensor/elan.py
@@ -1,4 +1,4 @@
-_temperature_out"""
+"""
 Support for the elan.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/xxxx/

--- a/homeassistant/components/sensor/elan.py
+++ b/homeassistant/components/sensor/elan.py
@@ -1,0 +1,187 @@
+"""
+Support for the elan.
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/xxxx/
+"""
+import asyncio
+import aiohttp
+import logging
+import voluptuous as vol
+
+from homeassistant.core import callback
+from homeassistant.const import TEMP_CELSIUS
+from homeassistant.helpers.entity import Entity
+from homeassistant.components.sensor import  PLATFORM_SCHEMA
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.entity import Entity, async_generate_entity_id
+from homeassistant.helpers.event import async_track_state_change
+from homeassistant.exceptions import TemplateError
+
+DOMAIN = 'elan'
+
+#REQUIREMENTS = ['pyelan']
+
+_LOGGER = logging.getLogger(__name__)
+
+#MIN_TIME_BETWEEN_SCANS = timedelta(seconds=10)
+#MIN_TIME_BETWEEN_FORCED_SCANS = timedelta(milliseconds=100)
+
+# Validation of the user's configuration
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required('url'): cv.string,
+    vol.Optional('offsets'): {cv.string : vol.Coerce(float)},
+})
+
+
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+    """Set up the elan thermostat platform."""
+    if discovery_info is None:
+        return
+
+    url = discovery_info['url']
+
+    session = aiohttp.ClientSession()
+    resp = yield from session.get(url+'/api/devices', timeout=3)
+    device_list = yield from resp.json()
+    _LOGGER.info("elan devices")
+    _LOGGER.info(device_list)
+    _LOGGER.info(str(config))
+
+    temperature_offsets = {}
+
+    if 'offsets' in config:
+        if isinstance(config['offsets'], dict):
+            temperature_offsets = config['offsets']
+            _LOGGER.info(temperature_offsets)
+
+    if 'offsets' in discovery_info:
+        if isinstance(discovery_info['offsets'], dict):
+            temperature_offsets = discovery_info['offsets']
+            _LOGGER.info(temperature_offsets)
+
+    for device in device_list:
+        resp =  yield from session.get(device_list[device]['url'], timeout=3)
+        info =  yield from resp.json()
+        _LOGGER.info("elan device")
+        _LOGGER.info(device)
+        if info['device info']['type'] == 'heating':
+            _LOGGER.info("elan Thermostat to add")
+            _LOGGER.info(device)
+            async_add_devices([elanThermostat(device_list[device]['url'], info, 'temperature',temperature_offsets.get(device_list[device]['url'],0))])
+            async_add_devices([elanThermostat(device_list[device]['url'], info, 'on')])
+#    session.close()
+
+class elanThermostat(Entity):
+    """The platform class required by Home Assistant."""
+
+    def __init__(self, thermostat, info, var, offset = 0):
+        """Initialize a thermostat."""
+        _LOGGER.info("elan thermostat initialisation")
+        _LOGGER.info(info)
+        self._thermostat = thermostat
+        self._var = 'temperature'
+        self._info = info
+        self._state = None
+        self._name = info['device info']['label']
+        self._temperatureIN = None
+        self._temperatureOUT = None
+        self._temperatureOffset = offset
+        self._on = None
+        self._locked = None
+        self._units = None
+        if var is 'temperature':
+            self._name = info['device info']['label'] + '-T'
+            self._var = var
+            self._units = TEMP_CELSIUS
+
+        if var is 'temperature OUT':
+            self._name = info['device info']['label'] + '-T OUT'
+            self._var = var
+            self._units = TEMP_CELSIUS
+
+        if var is 'temperature IN':
+            self._name = info['device info']['label'] + '-T IN'
+            self._var = var
+            self._units = TEMP_CELSIUS
+
+        if var is 'on':
+            self._name = info['device info']['label'] + '-ON'
+            self._var = var
+
+        self._temperatureOffset = offset
+
+        self._available = True
+
+
+    @asyncio.coroutine
+    def async_added_to_hass(self):
+        """Start thread when added to hass."""
+        #self._async_start_observe()
+
+    @property
+    def available(self):
+        """Return True if entity is available."""
+        return self._available
+
+    @property
+    def should_poll(self):
+        """WS notification not implemented yet - polling is needed"""
+        return True
+
+    @property
+    def name(self):
+        """Return the display name of this thermostat."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement."""
+        return self._units
+
+    @asyncio.coroutine
+    def update(self):
+        """Fetch new state data for this thermostat.
+
+        This is the only method that should fetch new data for Home Assistant.
+        """
+        _LOGGER.info('elan thermostat update')
+        _LOGGER.info(self._thermostat + '/state')
+        session = aiohttp.ClientSession()
+        resp = yield from session.get(self._thermostat + '/state', timeout=3)
+        state = yield from resp.json()
+        _LOGGER.info(state)
+        if 'temperature IN' in state:
+            self._temperatureIN = state['temperature IN']
+
+        if 'temperature OUT' in state:
+            self._temperatureOUT = state['temperature OUT']
+
+        if 'on' in state:
+            self._on = state['on']
+        if 'locked' in state:
+            self._locked = state['locked']
+
+        if self._var is 'temperature':
+            if self._temperatureIN and (self._temperatureIN>-99):
+                self._state = self._temperatureIN + self._temperatureOffset
+            if self._temperatureOUT and (self._temperatureOUT>-99):
+                self._state = self._temperatureOUT + self._temperatureOffset
+
+        if self._var is 'temperature OUT':
+            if self._temperatureOUT and (self._temperatureOUT>-99):
+                self._state = self._temperatureOUT + self._temperatureOffset
+
+        if self._var is 'temperature IN':
+            if self._temperatureIN and (self._temperatureIN>-99):
+                self._state = self._temperatureIN + self._temperatureOffset
+
+        if self._var is 'on':
+            self._state = self._on
+
+        _LOGGER.info(self._state)

--- a/homeassistant/components/sensor/elan.py
+++ b/homeassistant/components/sensor/elan.py
@@ -76,9 +76,8 @@ class ElanThermostat(Entity):
 
     def __init__(self, session, thermostat, info, var, offset=0):
         """Initialize a thermostat."""
-        _LOGGER.info("elan thermostat %s initialisation",
-                     info['device info']['label'])
-        _LOGGER.info(info)
+        _LOGGER.info("elan thermostat %s initialisation (%s, %d)",
+                     info['device info']['label'], var, offset)
         self._thermostat = thermostat
         self._var = 'temperature'
         self._info = info

--- a/homeassistant/components/sensor/elan.py
+++ b/homeassistant/components/sensor/elan.py
@@ -58,11 +58,9 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     for device in device_list:
         resp = yield from session.get(device_list[device]['url'], timeout=3)
         info = yield from resp.json()
-        _LOGGER.info("elan device")
-        _LOGGER.info(device)
         if info['device info']['type'] == 'heating':
-            _LOGGER.info("elan Thermostat to add")
-            _LOGGER.info(device)
+            _LOGGER.info("Adding elan Thermostat %s",
+                         device_list[device]['url'])
             async_add_devices([
                 ElanThermostat(
                     session, device_list[device]['url'], info, 'temperature',
@@ -78,7 +76,8 @@ class ElanThermostat(Entity):
 
     def __init__(self, session, thermostat, info, var, offset=0):
         """Initialize a thermostat."""
-        _LOGGER.info("elan thermostat initialisation")
+        _LOGGER.info("elan thermostat %s initialisation",
+                     info['device info']['label'])
         _LOGGER.info(info)
         self._thermostat = thermostat
         self._var = 'temperature'
@@ -151,12 +150,11 @@ class ElanThermostat(Entity):
 
         This is the only method that should fetch new data for Home Assistant.
         """
-        _LOGGER.info('elan thermostat update')
         stateurl = self._thermostat + '/state'
-        _LOGGER.info(stateurl)
+        _LOGGER.debug('Getting elan thermostat %s update', stateurl)
         resp = yield from self._session.get(stateurl, timeout=3)
         state = yield from resp.json()
-        _LOGGER.info(state)
+        _LOGGER.debug(state)
         if 'temperature IN' in state:
             self._temperature_in = state['temperature IN']
 
@@ -185,4 +183,4 @@ class ElanThermostat(Entity):
         if self._var is 'on':
             self._state = self._on
 
-        _LOGGER.info(self._state)
+        _LOGGER.debug(self._state)

--- a/homeassistant/components/sensor/elan.py
+++ b/homeassistant/components/sensor/elan.py
@@ -4,28 +4,19 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/xxxx/
 """
 import asyncio
-import aiohttp
 import logging
 import voluptuous as vol
 
 from homeassistant.core import callback
 from homeassistant.const import TEMP_CELSIUS
-from homeassistant.helpers.entity import Entity
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.entity import Entity, async_generate_entity_id
-from homeassistant.helpers.event import async_track_state_change
-from homeassistant.exceptions import TemplateError
+from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 DOMAIN = 'elan'
 
-#REQUIREMENTS = ['pyelan']
-
 _LOGGER = logging.getLogger(__name__)
-
-#MIN_TIME_BETWEEN_SCANS = timedelta(seconds=10)
-#MIN_TIME_BETWEEN_FORCED_SCANS = timedelta(milliseconds=100)
 
 # Validation of the user's configuration
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({

--- a/homeassistant/components/sensor/elan.py
+++ b/homeassistant/components/sensor/elan.py
@@ -90,22 +90,22 @@ class ElanThermostat(Entity):
         self._on = None
         self._locked = None
         self._units = None
-        if var is 'temperature':
+        if var == 'temperature':
             self._name = info['device info']['label'] + '-T'
             self._var = var
             self._units = TEMP_CELSIUS
 
-        if var is 'temperature OUT':
+        if var == 'temperature OUT':
             self._name = info['device info']['label'] + '-T OUT'
             self._var = var
             self._units = TEMP_CELSIUS
 
-        if var is 'temperature IN':
+        if var == 'temperature IN':
             self._name = info['device info']['label'] + '-T IN'
             self._var = var
             self._units = TEMP_CELSIUS
 
-        if var is 'on':
+        if var == 'on':
             self._name = info['device info']['label'] + '-ON'
             self._var = var
 
@@ -166,21 +166,21 @@ class ElanThermostat(Entity):
         if 'locked' in state:
             self._locked = state['locked']
 
-        if self._var is 'temperature':
+        if self._var == 'temperature':
             if self._temperature_in and (self._temperature_in > -99):
                 self._state = self._temperature_in + self._temperature_offset
             if self._temperature_out and (self._temperature_out > -99):
                 self._state = self._temperature_out + self._temperature_offset
 
-        if self._var is 'temperature OUT':
+        if self._var == 'temperature OUT':
             if self._temperature_out and (self._temperature_out > -99):
                 self._state = self._temperature_out + self._temperature_offset
 
-        if self._var is 'temperature IN':
+        if self._var == 'temperature IN':
             if self._temperature_in and (self._temperature_in > -99):
                 self._state = self._temperature_in + self._temperature_offset
 
-        if self._var is 'on':
+        if self._var == 'on':
             self._state = self._on
 
         _LOGGER.debug(self._state)

--- a/homeassistant/components/sensor/elan.py
+++ b/homeassistant/components/sensor/elan.py
@@ -119,7 +119,6 @@ class ElanThermostat(Entity):
     @asyncio.coroutine
     def async_added_to_hass(self):
         """Start thread when added to hass."""
-        #self._async_start_observe()
 
     @property
     def available(self):
@@ -128,7 +127,7 @@ class ElanThermostat(Entity):
 
     @property
     def should_poll(self):
-        """WS notification not implemented yet - polling is needed"""
+        """WS notification not implemented yet - polling is needed."""
         return True
 
     @property


### PR DESCRIPTION
## Description:

This is attempt to add INELS RF system support via eLAN gateway (https://www.elkoep.com/smart-rf-box-elan-rf-003) into Home Assistant.

At this moment support for lights is implemented and temperature sensor (thermostat readings).

The code is working however is probably not in state for the merge (at least documentation is missing). 

Comments are welcome

## Example entry for `configuration.yaml` :
```yaml
elan:
  url:  "http://192.168.33.5"

```
