### PR TITLE
Add priority and cycles to LaMetric

### DIFF
--- a/homeassistant/components/notify/lametric.py
+++ b/homeassistant/components/notify/lametric.py
@@ -92,8 +92,8 @@ class LaMetricNotificationService(BaseNotificationService):
                 if data['priority'] in AVAILABLE_PRIORITIES:
                     priority = data['priority']
                 else:
-                    _LOGGER.warning("Priority %s invalid, using default %s" %
-                                    (data['priority'], priority))
+                    _LOGGER.warning("Priority %s invalid, using default %s",
+                                    data['priority'], priority)
 
         text_frame = SimpleFrame(icon, message)
         _LOGGER.debug("Icon/Message/Cycles/Lifetime: %s, %s, %d, %d",

--- a/homeassistant/components/notify/lametric.py
+++ b/homeassistant/components/notify/lametric.py
@@ -25,11 +25,14 @@ CONF_LIFETIME = "lifetime"
 CONF_CYCLES = "cycles"
 CONF_PRIORITY = "priority"
 
+AVAILABLE_PRIORITIES = ["info", "warning", "critical"]
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_ICON, default="i555"): cv.string,
     vol.Optional(CONF_LIFETIME, default=10): cv.positive_int,
     vol.Optional(CONF_CYCLES, default=1): cv.positive_int,
-    vol.Optional(CONF_PRIORITY, default="warning"): cv.string,
+    vol.Optional(CONF_PRIORITY, default="warning"):
+        vol.In(AVAILABLE_PRIORITIES)
 })
 
 
@@ -86,11 +89,11 @@ class LaMetricNotificationService(BaseNotificationService):
             if "cycles" in data:
                 cycles = data['cycles']
             if "priority" in data:
-                if data['priority'] in ["info", "warning", "critical"]:
+                if data['priority'] in AVAILABLE_PRIORITIES:
                     priority = data['priority']
                 else:
-                    _LOGGER.warning("Priority '%s' invalid, using default "
-                                    "'%s'" % (data['priority'], priority))
+                    _LOGGER.warning("Priority %s invalid, using default %s" %
+                                    (data['priority'], priority))
 
         text_frame = SimpleFrame(icon, message)
         _LOGGER.debug("Icon/Message/Cycles/Lifetime: %s, %s, %d, %d",

--- a/homeassistant/components/notify/lametric.py
+++ b/homeassistant/components/notify/lametric.py
@@ -23,11 +23,13 @@ _LOGGER = logging.getLogger(__name__)
 
 CONF_LIFETIME = "lifetime"
 CONF_CYCLES = "cycles"
+CONF_PRIORITY = "priority"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_ICON, default="i555"): cv.string,
     vol.Optional(CONF_LIFETIME, default=10): cv.positive_int,
     vol.Optional(CONF_CYCLES, default=1): cv.positive_int,
+    vol.Optional(CONF_PRIORITY, default="warning"): cv.string,
 })
 
 
@@ -38,18 +40,20 @@ def get_service(hass, config, discovery_info=None):
     return LaMetricNotificationService(hlmn,
                                        config[CONF_ICON],
                                        config[CONF_LIFETIME] * 1000,
-                                       config[CONF_CYCLES])
+                                       config[CONF_CYCLES],
+                                       config[CONF_PRIORITY])
 
 
 class LaMetricNotificationService(BaseNotificationService):
     """Implement the notification service for LaMetric."""
 
-    def __init__(self, hasslametricmanager, icon, lifetime, cycles):
+    def __init__(self, hasslametricmanager, icon, lifetime, cycles, priority):
         """Initialize the service."""
         self.hasslametricmanager = hasslametricmanager
         self._icon = icon
         self._lifetime = lifetime
         self._cycles = cycles
+        self._priority = priority
         self._devices = []
 
     # pylint: disable=broad-except
@@ -64,6 +68,7 @@ class LaMetricNotificationService(BaseNotificationService):
         icon = self._icon
         cycles = self._cycles
         sound = None
+        priority = self._priority
 
         # Additional data?
         if data is not None:
@@ -78,6 +83,14 @@ class LaMetricNotificationService(BaseNotificationService):
                 except AssertionError:
                     _LOGGER.error("Sound ID %s unknown, ignoring",
                                   data["sound"])
+            if "cycles" in data:
+                cycles = data['cycles']
+            if "priority" in data:
+                if data['priority'] in ["info", "warning", "critical"]:
+                    priority = data['priority']
+                else:
+                    _LOGGER.warning("Priority '%s' invalid, using default "
+                                    "'%s'" % (data['priority'], priority))
 
         text_frame = SimpleFrame(icon, message)
         _LOGGER.debug("Icon/Message/Cycles/Lifetime: %s, %s, %d, %d",
@@ -100,7 +113,8 @@ class LaMetricNotificationService(BaseNotificationService):
             if targets is None or dev["name"] in targets:
                 try:
                     lmn.set_device(dev)
-                    lmn.send_notification(model, lifetime=self._lifetime)
+                    lmn.send_notification(model, lifetime=self._lifetime,
+                                          priority=priority)
                     _LOGGER.debug("Sent notification to LaMetric %s",
                                   dev["name"])
                 except OSError:


### PR DESCRIPTION
## Description:
Priority can be "info", "warning" (default), or "critical" and cycles is the number of times the message is displayed. If cycles is set to 0 we get a persistent notification that has to be dismissed manually.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5358

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
