### PR TITLE
Add aqara lock support

### DIFF
--- a/homeassistant/components/lock/xiaomi_aqara.py
+++ b/homeassistant/components/lock/xiaomi_aqara.py
@@ -4,13 +4,13 @@ Support for Xiaomi Aqara Lock.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/lock.xiaomi_aqara/
 """
-import asyncio
 import logging
 from homeassistant.components.xiaomi_aqara import (PY_XIAOMI_GATEWAY,
                                                    XiaomiDevice)
 from homeassistant.components.lock import LockDevice
 from homeassistant.const import (STATE_LOCKED, STATE_UNLOCKED)
 from homeassistant.helpers.event import async_call_later
+from homeassistant.core import callback
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -66,7 +66,7 @@ class XiaomiAqaraLock(LockDevice, XiaomiDevice):
         }
         return attributes
 
-    @asyncio.coroutine
+    @callback
     def clear_unlock_state(self, _):
         """Clear unlock state automatically."""
         self._state = STATE_LOCKED

--- a/homeassistant/components/lock/xiaomi_aqara.py
+++ b/homeassistant/components/lock/xiaomi_aqara.py
@@ -1,0 +1,70 @@
+"""Support for Xiaomi Gateway Lock."""
+import logging
+from homeassistant.components.xiaomi_aqara import (PY_XIAOMI_GATEWAY,
+                                                   XiaomiDevice)
+from homeassistant.components.lock import LockDevice
+
+_LOGGER = logging.getLogger(__name__)
+
+FINGER_KEY = 'fing_verified'
+PASSWORD_KEY = 'psw_verified'
+CARD_KEY = 'card_verified'
+VERIFIED_WRONG_KEY = 'verified_wrong'
+
+ATTR_VERIFIED_WRONG_TIMES = 'verified_wrong_times'
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Perform the setup for Xiaomi devices."""
+    devices = []
+
+    for (_, gateway) in hass.data[PY_XIAOMI_GATEWAY].gateways.items():
+        for device in gateway.devices['lock']:
+            model = device['model']
+            if model == 'lock.aq1':
+                devices.append(XiaomiGatewayLock(device, 'Lock', gateway))
+    add_devices(devices)
+
+
+class XiaomiGatewayLock(LockDevice, XiaomiDevice):
+    """Representation of a XiaomiGatewayLock."""
+
+    def __init__(self, device, name, xiaomi_hub):
+        """Initialize the XiaomiGatewayLock."""
+        self._changed_by = 0
+        self._verified_wrong_times = 0
+
+        XiaomiDevice.__init__(self, device, name, xiaomi_hub)
+
+    @property
+    def is_locked(self) -> bool:
+        """Return true if lock is locked."""
+        return True
+
+    @property
+    def changed_by(self) -> int:
+        """Last change triggered by."""
+        return self._changed_by
+
+    @property
+    def device_state_attributes(self) -> dict:
+        """Return the state attributes."""
+        attributes = {}
+        attributes[ATTR_VERIFIED_WRONG_TIMES] = self._verified_wrong_times
+        return attributes
+
+    def parse_data(self, data, raw_data):
+        """Parse data sent by gateway."""
+        value = data.get(VERIFIED_WRONG_KEY)
+        if value is not None:
+            self._verified_wrong_times = int(value)
+            return True
+
+        for key in (FINGER_KEY, PASSWORD_KEY, CARD_KEY):
+            value = data.get(key)
+            if value is not None:
+                self._changed_by = int(value)
+                self._verified_wrong_times = 0
+                return True
+
+        return False

--- a/homeassistant/components/lock/xiaomi_aqara.py
+++ b/homeassistant/components/lock/xiaomi_aqara.py
@@ -1,5 +1,5 @@
 """
-Support for Xiaomi Gateway Lock.
+Support for Xiaomi Aqara Lock.
 
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/lock.xiaomi_aqara/
@@ -27,15 +27,15 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         for device in gateway.devices['lock']:
             model = device['model']
             if model == 'lock.aq1':
-                devices.append(XiaomiGatewayLock(device, 'Lock', gateway))
+                devices.append(XiaomiAqaraLock(device, 'Lock', gateway))
     add_devices(devices)
 
 
-class XiaomiGatewayLock(LockDevice, XiaomiDevice):
-    """Representation of a XiaomiGatewayLock."""
+class XiaomiAqaraLock(LockDevice, XiaomiDevice):
+    """Representation of a XiaomiAqaraLock."""
 
     def __init__(self, device, name, xiaomi_hub):
-        """Initialize the XiaomiGatewayLock."""
+        """Initialize the XiaomiAqaraLock."""
         self._changed_by = 0
         self._verified_wrong_times = 0
 

--- a/homeassistant/components/lock/xiaomi_aqara.py
+++ b/homeassistant/components/lock/xiaomi_aqara.py
@@ -1,4 +1,9 @@
-"""Support for Xiaomi Gateway Lock."""
+"""
+Support for Xiaomi Gateway Lock.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/lock.xiaomi_aqara/
+"""
 import logging
 from homeassistant.components.xiaomi_aqara import (PY_XIAOMI_GATEWAY,
                                                    XiaomiDevice)
@@ -18,7 +23,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Perform the setup for Xiaomi devices."""
     devices = []
 
-    for (_, gateway) in hass.data[PY_XIAOMI_GATEWAY].gateways.items():
+    for gateway in hass.data[PY_XIAOMI_GATEWAY].gateways.values():
         for device in gateway.devices['lock']:
             model = device['model']
             if model == 'lock.aq1':
@@ -34,7 +39,7 @@ class XiaomiGatewayLock(LockDevice, XiaomiDevice):
         self._changed_by = 0
         self._verified_wrong_times = 0
 
-        XiaomiDevice.__init__(self, device, name, xiaomi_hub)
+        super().__init__(device, name, xiaomi_hub)
 
     @property
     def is_locked(self) -> bool:
@@ -49,8 +54,9 @@ class XiaomiGatewayLock(LockDevice, XiaomiDevice):
     @property
     def device_state_attributes(self) -> dict:
         """Return the state attributes."""
-        attributes = {}
-        attributes[ATTR_VERIFIED_WRONG_TIMES] = self._verified_wrong_times
+        attributes = {
+            ATTR_VERIFIED_WRONG_TIMES: self._verified_wrong_times,
+        }
         return attributes
 
     def parse_data(self, data, raw_data):

--- a/homeassistant/components/lock/xiaomi_aqara.py
+++ b/homeassistant/components/lock/xiaomi_aqara.py
@@ -24,7 +24,8 @@ ATTR_VERIFIED_WRONG_TIMES = 'verified_wrong_times'
 UNLOCK_MAINTAIN_TIME = 5
 
 
-def setup_platform(hass, config, add_devices, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_devices,
+                               discovery_info=None):
     """Perform the setup for Xiaomi devices."""
     devices = []
 
@@ -33,7 +34,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             model = device['model']
             if model == 'lock.aq1':
                 devices.append(XiaomiAqaraLock(device, 'Lock', gateway))
-    add_devices(devices)
+    async_add_devices(devices)
 
 
 class XiaomiAqaraLock(LockDevice, XiaomiDevice):

--- a/homeassistant/components/lock/xiaomi_aqara.py
+++ b/homeassistant/components/lock/xiaomi_aqara.py
@@ -21,7 +21,7 @@ VERIFIED_WRONG_KEY = 'verified_wrong'
 
 ATTR_VERIFIED_WRONG_TIMES = 'verified_wrong_times'
 
-UNLOCK_MAINTAIN_TIME_S = 5
+UNLOCK_MAINTAIN_TIME = 5
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -84,7 +84,7 @@ class XiaomiAqaraLock(LockDevice, XiaomiDevice):
                 self._changed_by = int(value)
                 self._verified_wrong_times = 0
                 self._state = STATE_UNLOCKED
-                async_call_later(self.hass, UNLOCK_MAINTAIN_TIME_S,
+                async_call_later(self.hass, UNLOCK_MAINTAIN_TIME,
                                  self.clear_unlock_state)
                 return True
 

--- a/homeassistant/components/xiaomi_aqara.py
+++ b/homeassistant/components/xiaomi_aqara.py
@@ -137,7 +137,8 @@ def setup(hass, config):
     xiaomi.listen()
     _LOGGER.debug("Gateways discovered. Listening for broadcasts")
 
-    for component in ['binary_sensor', 'sensor', 'switch', 'light', 'cover']:
+    for component in ['binary_sensor', 'sensor', 'switch', 'light', 'cover',
+                      'lock']:
         discovery.load_platform(hass, component, DOMAIN, {}, config)
 
     def stop_xiaomi(event):


### PR DESCRIPTION
Signed-off-by: SchumyHao <schumyhaojl@126.com>

## Description:
Add aqara lock support

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
