### PR TITLE
Fix fan service description

### DIFF
--- a/homeassistant/components/fan/services.yaml
+++ b/homeassistant/components/fan/services.yaml
@@ -51,8 +51,8 @@ set_direction:
       description: Name(s) of the entities to toggle
       example: 'fan.living_room'
     direction:
-      description: The direction to rotate
-      example: 'left'
+      description: The direction to rotate. Either 'forward' or 'reverse'
+      example: 'forward'
 
 dyson_set_night_mode:
   description: Set the fan in night mode.


### PR DESCRIPTION
## Description:
The direction attributes should be `forward` and `reverse`.

Issue: https://github.com/home-assistant/home-assistant-polymer/issues/1158
Frontend PR: https://github.com/home-assistant/home-assistant-polymer/pull/1159

## Checklist:
  - [x] The code change is tested and works locally.