### PR TITLE
Remove extra quotes from docstrings

### DIFF
--- a/homeassistant/components/folder_watcher.py
+++ b/homeassistant/components/folder_watcher.py
@@ -43,7 +43,7 @@ def setup(hass, config):
 
 
 def create_event_handler(patterns, hass):
-    """"Return the Watchdog EventHandler object."""
+    """Return the Watchdog EventHandler object."""
     from watchdog.events import PatternMatchingEventHandler
 
     class EventHandler(PatternMatchingEventHandler):

--- a/homeassistant/components/sensor/sigfox.py
+++ b/homeassistant/components/sensor/sigfox.py
@@ -66,7 +66,7 @@ class SigfoxAPI(object):
             self._devices = self.get_devices(device_types)
 
     def check_credentials(self):
-        """"Check API credentials are valid."""
+        """Check API credentials are valid."""
         url = urljoin(API_URL, 'devicetypes')
         response = requests.get(url, auth=self._auth, timeout=10)
         if response.status_code != 200:

--- a/homeassistant/components/sensor/simulated.py
+++ b/homeassistant/components/sensor/simulated.py
@@ -87,7 +87,7 @@ class SimulatedSensor(Entity):
         self._state = None
 
     def time_delta(self):
-        """"Return the time delta."""
+        """Return the time delta."""
         dt0 = self._start_time
         dt1 = dt_util.utcnow()
         return dt1 - dt0

--- a/tests/components/automation/test_event.py
+++ b/tests/components/automation/test_event.py
@@ -26,7 +26,7 @@ class TestAutomationEvent(unittest.TestCase):
         self.hass.services.register('test', 'automation', record_call)
 
     def tearDown(self):
-        """"Stop everything that was started."""
+        """Stop everything that was started."""
         self.hass.stop()
 
     def test_if_fires_on_event(self):

--- a/tests/components/automation/test_numeric_state.py
+++ b/tests/components/automation/test_numeric_state.py
@@ -35,7 +35,7 @@ class TestAutomationNumericState(unittest.TestCase):
         self.hass.stop()
 
     def test_if_fires_on_entity_change_below(self):
-        """"Test the firing with changed entity."""
+        """Test the firing with changed entity."""
         assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
@@ -62,7 +62,7 @@ class TestAutomationNumericState(unittest.TestCase):
         self.assertEqual(1, len(self.calls))
 
     def test_if_fires_on_entity_change_over_to_below(self):
-        """"Test the firing with changed entity."""
+        """Test the firing with changed entity."""
         self.hass.states.set('test.entity', 11)
         self.hass.block_till_done()
 
@@ -85,7 +85,7 @@ class TestAutomationNumericState(unittest.TestCase):
         self.assertEqual(1, len(self.calls))
 
     def test_if_fires_on_entities_change_over_to_below(self):
-        """"Test the firing with changed entities."""
+        """Test the firing with changed entities."""
         self.hass.states.set('test.entity_1', 11)
         self.hass.states.set('test.entity_2', 11)
         self.hass.block_till_done()
@@ -115,7 +115,7 @@ class TestAutomationNumericState(unittest.TestCase):
         self.assertEqual(2, len(self.calls))
 
     def test_if_not_fires_on_entity_change_below_to_below(self):
-        """"Test the firing with changed entity."""
+        """Test the firing with changed entity."""
         self.hass.states.set('test.entity', 11)
         self.hass.block_till_done()
 
@@ -148,7 +148,7 @@ class TestAutomationNumericState(unittest.TestCase):
         self.assertEqual(1, len(self.calls))
 
     def test_if_not_below_fires_on_entity_change_to_equal(self):
-        """"Test the firing with changed entity."""
+        """Test the firing with changed entity."""
         self.hass.states.set('test.entity', 11)
         self.hass.block_till_done()
 
@@ -171,7 +171,7 @@ class TestAutomationNumericState(unittest.TestCase):
         self.assertEqual(0, len(self.calls))
 
     def test_if_fires_on_initial_entity_below(self):
-        """"Test the firing when starting with a match."""
+        """Test the firing when starting with a match."""
         self.hass.states.set('test.entity', 9)
         self.hass.block_till_done()
 
@@ -194,7 +194,7 @@ class TestAutomationNumericState(unittest.TestCase):
         self.assertEqual(1, len(self.calls))
 
     def test_if_fires_on_initial_entity_above(self):
-        """"Test the firing when starting with a match."""
+        """Test the firing when starting with a match."""
         self.hass.states.set('test.entity', 11)
         self.hass.block_till_done()
 
@@ -217,7 +217,7 @@ class TestAutomationNumericState(unittest.TestCase):
         self.assertEqual(1, len(self.calls))
 
     def test_if_fires_on_entity_change_above(self):
-        """"Test the firing with changed entity."""
+        """Test the firing with changed entity."""
         assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
@@ -236,7 +236,7 @@ class TestAutomationNumericState(unittest.TestCase):
         self.assertEqual(1, len(self.calls))
 
     def test_if_fires_on_entity_change_below_to_above(self):
-        """"Test the firing with changed entity."""
+        """Test the firing with changed entity."""
         # set initial state
         self.hass.states.set('test.entity', 9)
         self.hass.block_till_done()
@@ -260,7 +260,7 @@ class TestAutomationNumericState(unittest.TestCase):
         self.assertEqual(1, len(self.calls))
 
     def test_if_not_fires_on_entity_change_above_to_above(self):
-        """"Test the firing with changed entity."""
+        """Test the firing with changed entity."""
         # set initial state
         self.hass.states.set('test.entity', 9)
         self.hass.block_till_done()
@@ -289,7 +289,7 @@ class TestAutomationNumericState(unittest.TestCase):
         self.assertEqual(1, len(self.calls))
 
     def test_if_not_above_fires_on_entity_change_to_equal(self):
-        """"Test the firing with changed entity."""
+        """Test the firing with changed entity."""
         # set initial state
         self.hass.states.set('test.entity', 9)
         self.hass.block_till_done()
@@ -313,7 +313,7 @@ class TestAutomationNumericState(unittest.TestCase):
         self.assertEqual(0, len(self.calls))
 
     def test_if_fires_on_entity_change_below_range(self):
-        """"Test the firing with changed entity."""
+        """Test the firing with changed entity."""
         assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
@@ -333,7 +333,7 @@ class TestAutomationNumericState(unittest.TestCase):
         self.assertEqual(1, len(self.calls))
 
     def test_if_fires_on_entity_change_below_above_range(self):
-        """"Test the firing with changed entity."""
+        """Test the firing with changed entity."""
         assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
@@ -353,7 +353,7 @@ class TestAutomationNumericState(unittest.TestCase):
         self.assertEqual(0, len(self.calls))
 
     def test_if_fires_on_entity_change_over_to_below_range(self):
-        """"Test the firing with changed entity."""
+        """Test the firing with changed entity."""
         self.hass.states.set('test.entity', 11)
         self.hass.block_till_done()
 
@@ -377,7 +377,7 @@ class TestAutomationNumericState(unittest.TestCase):
         self.assertEqual(1, len(self.calls))
 
     def test_if_fires_on_entity_change_over_to_below_above_range(self):
-        """"Test the firing with changed entity."""
+        """Test the firing with changed entity."""
         self.hass.states.set('test.entity', 11)
         self.hass.block_till_done()
 
@@ -401,7 +401,7 @@ class TestAutomationNumericState(unittest.TestCase):
         self.assertEqual(0, len(self.calls))
 
     def test_if_not_fires_if_entity_not_match(self):
-        """"Test if not fired with non matching entity."""
+        """Test if not fired with non matching entity."""
         assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
@@ -420,7 +420,7 @@ class TestAutomationNumericState(unittest.TestCase):
         self.assertEqual(0, len(self.calls))
 
     def test_if_fires_on_entity_change_below_with_attribute(self):
-        """"Test attributes change."""
+        """Test attributes change."""
         assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
@@ -439,7 +439,7 @@ class TestAutomationNumericState(unittest.TestCase):
         self.assertEqual(1, len(self.calls))
 
     def test_if_not_fires_on_entity_change_not_below_with_attribute(self):
-        """"Test attributes."""
+        """Test attributes."""
         assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
@@ -458,7 +458,7 @@ class TestAutomationNumericState(unittest.TestCase):
         self.assertEqual(0, len(self.calls))
 
     def test_if_fires_on_attribute_change_with_attribute_below(self):
-        """"Test attributes change."""
+        """Test attributes change."""
         assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
@@ -478,7 +478,7 @@ class TestAutomationNumericState(unittest.TestCase):
         self.assertEqual(1, len(self.calls))
 
     def test_if_not_fires_on_attribute_change_with_attribute_not_below(self):
-        """"Test attributes change."""
+        """Test attributes change."""
         assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
@@ -498,7 +498,7 @@ class TestAutomationNumericState(unittest.TestCase):
         self.assertEqual(0, len(self.calls))
 
     def test_if_not_fires_on_entity_change_with_attribute_below(self):
-        """"Test attributes change."""
+        """Test attributes change."""
         assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
@@ -518,7 +518,7 @@ class TestAutomationNumericState(unittest.TestCase):
         self.assertEqual(0, len(self.calls))
 
     def test_if_not_fires_on_entity_change_with_not_attribute_below(self):
-        """"Test attributes change."""
+        """Test attributes change."""
         assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
@@ -538,7 +538,7 @@ class TestAutomationNumericState(unittest.TestCase):
         self.assertEqual(0, len(self.calls))
 
     def test_fires_on_attr_change_with_attribute_below_and_multiple_attr(self):
-        """"Test attributes change."""
+        """Test attributes change."""
         assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
@@ -559,7 +559,7 @@ class TestAutomationNumericState(unittest.TestCase):
         self.assertEqual(1, len(self.calls))
 
     def test_template_list(self):
-        """"Test template list."""
+        """Test template list."""
         assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
@@ -581,7 +581,7 @@ class TestAutomationNumericState(unittest.TestCase):
         self.assertEqual(1, len(self.calls))
 
     def test_template_string(self):
-        """"Test template string."""
+        """Test template string."""
         assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
@@ -614,7 +614,7 @@ class TestAutomationNumericState(unittest.TestCase):
             self.calls[0].data['some'])
 
     def test_not_fires_on_attr_change_with_attr_not_below_multiple_attr(self):
-        """"Test if not fired changed attributes."""
+        """Test if not fired changed attributes."""
         assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
                 'trigger': {
@@ -635,7 +635,7 @@ class TestAutomationNumericState(unittest.TestCase):
         self.assertEqual(0, len(self.calls))
 
     def test_if_action(self):
-        """"Test if action."""
+        """Test if action."""
         entity_id = 'domain.test_entity'
         assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {

--- a/tests/components/binary_sensor/test_nx584.py
+++ b/tests/components/binary_sensor/test_nx584.py
@@ -113,7 +113,7 @@ class TestNX584SensorSetup(unittest.TestCase):
         self._test_assert_graceful_fail({})
 
     def test_setup_version_too_old(self):
-        """"Test if version is too old."""
+        """Test if version is too old."""
         nx584_client.Client.return_value.get_version.return_value = '1.0'
         self._test_assert_graceful_fail({})
 

--- a/tests/components/binary_sensor/test_template.py
+++ b/tests/components/binary_sensor/test_template.py
@@ -31,7 +31,7 @@ class TestBinarySensorTemplate(unittest.TestCase):
         self.hass.stop()
 
     def test_setup(self):
-        """"Test the setup."""
+        """Test the setup."""
         config = {
             'binary_sensor': {
                 'platform': 'template',
@@ -49,7 +49,7 @@ class TestBinarySensorTemplate(unittest.TestCase):
                 self.hass, 'binary_sensor', config)
 
     def test_setup_no_sensors(self):
-        """"Test setup with no sensors."""
+        """Test setup with no sensors."""
         with assert_setup_component(0):
             assert setup.setup_component(self.hass, 'binary_sensor', {
                 'binary_sensor': {
@@ -58,7 +58,7 @@ class TestBinarySensorTemplate(unittest.TestCase):
             })
 
     def test_setup_invalid_device(self):
-        """"Test the setup with invalid devices."""
+        """Test the setup with invalid devices."""
         with assert_setup_component(0):
             assert setup.setup_component(self.hass, 'binary_sensor', {
                 'binary_sensor': {
@@ -70,7 +70,7 @@ class TestBinarySensorTemplate(unittest.TestCase):
             })
 
     def test_setup_invalid_device_class(self):
-        """"Test setup with invalid sensor class."""
+        """Test setup with invalid sensor class."""
         with assert_setup_component(0):
             assert setup.setup_component(self.hass, 'binary_sensor', {
                 'binary_sensor': {
@@ -85,7 +85,7 @@ class TestBinarySensorTemplate(unittest.TestCase):
             })
 
     def test_setup_invalid_missing_template(self):
-        """"Test setup with invalid and missing template."""
+        """Test setup with invalid and missing template."""
         with assert_setup_component(0):
             assert setup.setup_component(self.hass, 'binary_sensor', {
                 'binary_sensor': {
@@ -161,7 +161,7 @@ class TestBinarySensorTemplate(unittest.TestCase):
         assert state.attributes['entity_picture'] == '/local/sensor.png'
 
     def test_attributes(self):
-        """"Test the attributes."""
+        """Test the attributes."""
         vs = run_callback_threadsafe(
             self.hass.loop, template.BinarySensorTemplate,
             self.hass, 'parent', 'Parent', 'motion',
@@ -182,7 +182,7 @@ class TestBinarySensorTemplate(unittest.TestCase):
         self.assertTrue(vs.is_on)
 
     def test_event(self):
-        """"Test the event."""
+        """Test the event."""
         config = {
             'binary_sensor': {
                 'platform': 'template',
@@ -214,7 +214,7 @@ class TestBinarySensorTemplate(unittest.TestCase):
 
     @mock.patch('homeassistant.helpers.template.Template.render')
     def test_update_template_error(self, mock_render):
-        """"Test the template update error."""
+        """Test the template update error."""
         vs = run_callback_threadsafe(
             self.hass.loop, template.BinarySensorTemplate,
             self.hass, 'parent', 'Parent', 'motion',

--- a/tests/components/camera/test_uvc.py
+++ b/tests/components/camera/test_uvc.py
@@ -26,7 +26,7 @@ class TestUVCSetup(unittest.TestCase):
     @mock.patch('uvcclient.nvr.UVCRemote')
     @mock.patch.object(uvc, 'UnifiVideoCamera')
     def test_setup_full_config(self, mock_uvc, mock_remote):
-        """"Test the setup with full configuration."""
+        """Test the setup with full configuration."""
         config = {
             'platform': 'uvc',
             'nvr': 'foo',
@@ -41,7 +41,7 @@ class TestUVCSetup(unittest.TestCase):
         ]
 
         def fake_get_camera(uuid):
-            """"Create a fake camera."""
+            """Create a fake camera."""
             if uuid == 'id3':
                 return {'model': 'airCam'}
             else:
@@ -65,7 +65,7 @@ class TestUVCSetup(unittest.TestCase):
     @mock.patch('uvcclient.nvr.UVCRemote')
     @mock.patch.object(uvc, 'UnifiVideoCamera')
     def test_setup_partial_config(self, mock_uvc, mock_remote):
-        """"Test the setup with partial configuration."""
+        """Test the setup with partial configuration."""
         config = {
             'platform': 'uvc',
             'nvr': 'foo',
@@ -152,7 +152,7 @@ class TestUVC(unittest.TestCase):
     """Test class for UVC."""
 
     def setup_method(self, method):
-        """"Setup the mock camera."""
+        """Setup the mock camera."""
         self.nvr = mock.MagicMock()
         self.uuid = 'uuid'
         self.name = 'name'
@@ -171,7 +171,7 @@ class TestUVC(unittest.TestCase):
         self.nvr.server_version = (3, 2, 0)
 
     def test_properties(self):
-        """"Test the properties."""
+        """Test the properties."""
         self.assertEqual(self.name, self.uvc.name)
         self.assertTrue(self.uvc.is_recording)
         self.assertEqual('Ubiquiti', self.uvc.brand)
@@ -180,7 +180,7 @@ class TestUVC(unittest.TestCase):
     @mock.patch('uvcclient.store.get_info_store')
     @mock.patch('uvcclient.camera.UVCCameraClientV320')
     def test_login(self, mock_camera, mock_store):
-        """"Test the login."""
+        """Test the login."""
         self.uvc._login()
         self.assertEqual(mock_camera.call_count, 1)
         self.assertEqual(
@@ -205,7 +205,7 @@ class TestUVC(unittest.TestCase):
     @mock.patch('uvcclient.store.get_info_store')
     @mock.patch('uvcclient.camera.UVCCameraClientV320')
     def test_login_tries_both_addrs_and_caches(self, mock_camera, mock_store):
-        """"Test the login tries."""
+        """Test the login tries."""
         responses = [0]
 
         def fake_login(*a):
@@ -234,13 +234,13 @@ class TestUVC(unittest.TestCase):
     @mock.patch('uvcclient.store.get_info_store')
     @mock.patch('uvcclient.camera.UVCCameraClientV320')
     def test_login_fails_both_properly(self, mock_camera, mock_store):
-        """"Test if login fails properly."""
+        """Test if login fails properly."""
         mock_camera.return_value.login.side_effect = socket.error
         self.assertEqual(None, self.uvc._login())
         self.assertEqual(None, self.uvc._connect_addr)
 
     def test_camera_image_tries_login_bails_on_failure(self):
-        """"Test retrieving failure."""
+        """Test retrieving failure."""
         with mock.patch.object(self.uvc, '_login') as mock_login:
             mock_login.return_value = False
             self.assertEqual(None, self.uvc.camera_image())
@@ -248,19 +248,19 @@ class TestUVC(unittest.TestCase):
             self.assertEqual(mock_login.call_args, mock.call())
 
     def test_camera_image_logged_in(self):
-        """"Test the login state."""
+        """Test the login state."""
         self.uvc._camera = mock.MagicMock()
         self.assertEqual(self.uvc._camera.get_snapshot.return_value,
                          self.uvc.camera_image())
 
     def test_camera_image_error(self):
-        """"Test the camera image error."""
+        """Test the camera image error."""
         self.uvc._camera = mock.MagicMock()
         self.uvc._camera.get_snapshot.side_effect = camera.CameraConnectError
         self.assertEqual(None, self.uvc.camera_image())
 
     def test_camera_image_reauths(self):
-        """"Test the re-authentication."""
+        """Test the re-authentication."""
         responses = [0]
 
         def fake_snapshot():
@@ -281,7 +281,7 @@ class TestUVC(unittest.TestCase):
             self.assertEqual([], responses)
 
     def test_camera_image_reauths_only_once(self):
-        """"Test if the re-authentication only happens once."""
+        """Test if the re-authentication only happens once."""
         self.uvc._camera = mock.MagicMock()
         self.uvc._camera.get_snapshot.side_effect = camera.CameraAuthError
         with mock.patch.object(self.uvc, '_login') as mock_login:

--- a/tests/components/device_tracker/test_unifi_direct.py
+++ b/tests/components/device_tracker/test_unifi_direct.py
@@ -71,7 +71,7 @@ class TestComponentsDeviceTrackerUnifiDirect(unittest.TestCase):
 
     @patch('pexpect.pxssh.pxssh')
     def test_get_device_name(self, mock_ssh):
-        """"Testing MAC matching."""
+        """Testing MAC matching."""
         conf_dict = {
             DOMAIN: {
                 CONF_PLATFORM: 'unifi_direct',
@@ -95,7 +95,7 @@ class TestComponentsDeviceTrackerUnifiDirect(unittest.TestCase):
     @patch('pexpect.pxssh.pxssh.logout')
     @patch('pexpect.pxssh.pxssh.login')
     def test_failed_to_log_in(self, mock_login, mock_logout):
-        """"Testing exception at login results in False."""
+        """Testing exception at login results in False."""
         from pexpect import exceptions
 
         conf_dict = {
@@ -120,7 +120,7 @@ class TestComponentsDeviceTrackerUnifiDirect(unittest.TestCase):
     @patch('pexpect.pxssh.pxssh.sendline')
     def test_to_get_update(self, mock_sendline, mock_prompt, mock_login,
                            mock_logout):
-        """"Testing exception in get_update matching."""
+        """Testing exception in get_update matching."""
         conf_dict = {
             DOMAIN: {
                 CONF_PLATFORM: 'unifi_direct',

--- a/tests/components/device_tracker/test_xiaomi.py
+++ b/tests/components/device_tracker/test_xiaomi.py
@@ -210,7 +210,7 @@ class TestXiaomiDeviceScanner(unittest.TestCase):
     @patch('requests.get', side_effect=mocked_requests)
     @patch('requests.post', side_effect=mocked_requests)
     def test_invalid_credential(self, mock_get, mock_post):
-        """"Testing invalid credential handling."""
+        """Testing invalid credential handling."""
         config = {
             DOMAIN: xiaomi.PLATFORM_SCHEMA({
                 CONF_PLATFORM: xiaomi.DOMAIN,
@@ -224,7 +224,7 @@ class TestXiaomiDeviceScanner(unittest.TestCase):
     @patch('requests.get', side_effect=mocked_requests)
     @patch('requests.post', side_effect=mocked_requests)
     def test_valid_credential(self, mock_get, mock_post):
-        """"Testing valid refresh."""
+        """Testing valid refresh."""
         config = {
             DOMAIN: xiaomi.PLATFORM_SCHEMA({
                 CONF_PLATFORM: xiaomi.DOMAIN,
@@ -244,7 +244,7 @@ class TestXiaomiDeviceScanner(unittest.TestCase):
     @patch('requests.get', side_effect=mocked_requests)
     @patch('requests.post', side_effect=mocked_requests)
     def test_token_timed_out(self, mock_get, mock_post):
-        """"Testing refresh with a timed out token.
+        """Testing refresh with a timed out token.
 
         New token is requested and list is downloaded a second time.
         """

--- a/tests/components/fan/test_mqtt.py
+++ b/tests/components/fan/test_mqtt.py
@@ -18,7 +18,7 @@ class TestMqttFan(unittest.TestCase):
         self.mock_publish = mock_mqtt_component(self.hass)
 
     def tearDown(self):  # pylint: disable=invalid-name
-        """"Stop everything that was started."""
+        """Stop everything that was started."""
         self.hass.stop()
 
     def test_default_availability_payload(self):

--- a/tests/components/light/test_template.py
+++ b/tests/components/light/test_template.py
@@ -36,7 +36,7 @@ class TestTemplateLight:
         self.hass.stop()
 
     def test_template_state_text(self):
-        """"Test the state text of a template."""
+        """Test the state text of a template."""
         with assert_setup_component(1, 'light'):
             assert setup.setup_component(self.hass, 'light', {
                 'light': {

--- a/tests/components/notify/test_demo.py
+++ b/tests/components/notify/test_demo.py
@@ -33,7 +33,7 @@ class TestNotifyDemo(unittest.TestCase):
         self.hass.bus.listen(demo.EVENT_NOTIFY, record_event)
 
     def tearDown(self):  # pylint: disable=invalid-name
-        """"Stop down everything that was started."""
+        """Stop down everything that was started."""
         self.hass.stop()
 
     def _setup_notify(self):

--- a/tests/components/notify/test_file.py
+++ b/tests/components/notify/test_file.py
@@ -20,7 +20,7 @@ class TestNotifyFile(unittest.TestCase):
         self.hass = get_test_home_assistant()
 
     def tearDown(self):  # pylint: disable=invalid-name
-        """"Stop down everything that was started."""
+        """Stop down everything that was started."""
         self.hass.stop()
 
     def test_bad_config(self):

--- a/tests/components/notify/test_group.py
+++ b/tests/components/notify/test_group.py
@@ -53,7 +53,7 @@ class TestNotifyGroup(unittest.TestCase):
         assert self.service is not None
 
     def tearDown(self):  # pylint: disable=invalid-name
-        """"Stop everything that was started."""
+        """Stop everything that was started."""
         self.hass.stop()
 
     def test_send_message_with_data(self):

--- a/tests/components/notify/test_smtp.py
+++ b/tests/components/notify/test_smtp.py
@@ -27,7 +27,7 @@ class TestNotifySmtp(unittest.TestCase):
                                'HomeAssistant', 0)
 
     def tearDown(self):  # pylint: disable=invalid-name
-        """"Stop down everything that was started."""
+        """Stop down everything that was started."""
         self.hass.stop()
 
     @patch('email.utils.make_msgid', return_value='<mock@mock>')

--- a/tests/components/sensor/test_template.py
+++ b/tests/components/sensor/test_template.py
@@ -269,7 +269,7 @@ class TestTemplateSensor:
         assert self.hass.states.all() == []
 
     def test_setup_invalid_device_class(self):
-        """"Test setup with invalid device_class."""
+        """Test setup with invalid device_class."""
         with assert_setup_component(0):
             assert setup_component(self.hass, 'sensor', {
                 'sensor': {
@@ -284,7 +284,7 @@ class TestTemplateSensor:
             })
 
     def test_setup_valid_device_class(self):
-        """"Test setup with valid device_class."""
+        """Test setup with valid device_class."""
         with assert_setup_component(1):
             assert setup_component(self.hass, 'sensor', {
                 'sensor': {

--- a/tests/components/switch/test_mqtt.py
+++ b/tests/components/switch/test_mqtt.py
@@ -20,7 +20,7 @@ class TestSwitchMQTT(unittest.TestCase):
         self.mock_publish = mock_mqtt_component(self.hass)
 
     def tearDown(self):  # pylint: disable=invalid-name
-        """"Stop everything that was started."""
+        """Stop everything that was started."""
         self.hass.stop()
 
     def test_controlling_state_via_topic(self):

--- a/tests/components/switch/test_template.py
+++ b/tests/components/switch/test_template.py
@@ -32,7 +32,7 @@ class TestTemplateSwitch:
         self.hass.stop()
 
     def test_template_state_text(self):
-        """"Test the state text of a template."""
+        """Test the state text of a template."""
         with assert_setup_component(1, 'switch'):
             assert setup.setup_component(self.hass, 'switch', {
                 'switch': {

--- a/tests/components/test_mqtt_eventstream.py
+++ b/tests/components/test_mqtt_eventstream.py
@@ -44,11 +44,11 @@ class TestMqttEventStream(object):
             eventstream.DOMAIN: config})
 
     def test_setup_succeeds(self):
-        """"Test the success of the setup."""
+        """Test the success of the setup."""
         assert self.add_eventstream()
 
     def test_setup_with_pub(self):
-        """"Test the setup with subscription."""
+        """Test the setup with subscription."""
         # Should start off with no listeners for all events
         assert self.hass.bus.listeners.get('*') is None
 
@@ -60,7 +60,7 @@ class TestMqttEventStream(object):
 
     @patch('homeassistant.components.mqtt.async_subscribe')
     def test_subscribe(self, mock_sub):
-        """"Test the subscription."""
+        """Test the subscription."""
         sub_topic = 'foo'
         assert self.add_eventstream(sub_topic=sub_topic)
         self.hass.block_till_done()
@@ -71,7 +71,7 @@ class TestMqttEventStream(object):
     @patch('homeassistant.components.mqtt.async_publish')
     @patch('homeassistant.core.dt_util.utcnow')
     def test_state_changed_event_sends_message(self, mock_utcnow, mock_pub):
-        """"Test the sending of a new message if event changed."""
+        """Test the sending of a new message if event changed."""
         now = dt_util.as_utc(dt_util.now())
         e_id = 'fake.entity'
         pub_topic = 'bar'
@@ -113,7 +113,7 @@ class TestMqttEventStream(object):
 
     @patch('homeassistant.components.mqtt.async_publish')
     def test_time_event_does_not_send_message(self, mock_pub):
-        """"Test the sending of a new message if time event."""
+        """Test the sending of a new message if time event."""
         assert self.add_eventstream(pub_topic='bar')
         self.hass.block_till_done()
 
@@ -125,7 +125,7 @@ class TestMqttEventStream(object):
         assert not mock_pub.called
 
     def test_receiving_remote_event_fires_hass_event(self):
-        """"Test the receiving of the remotely fired event."""
+        """Test the receiving of the remotely fired event."""
         sub_topic = 'foo'
         assert self.add_eventstream(sub_topic=sub_topic)
         self.hass.block_till_done()
@@ -150,7 +150,7 @@ class TestMqttEventStream(object):
 
     @patch('homeassistant.components.mqtt.async_publish')
     def test_ignored_event_doesnt_send_over_stream(self, mock_pub):
-        """"Test the ignoring of sending events if defined."""
+        """Test the ignoring of sending events if defined."""
         assert self.add_eventstream(pub_topic='bar',
                                     ignore_event=['state_changed'])
         self.hass.block_till_done()
@@ -177,7 +177,7 @@ class TestMqttEventStream(object):
 
     @patch('homeassistant.components.mqtt.async_publish')
     def test_wrong_ignored_event_sends_over_stream(self, mock_pub):
-        """"Test the ignoring of sending events if defined."""
+        """Test the ignoring of sending events if defined."""
         assert self.add_eventstream(pub_topic='bar',
                                     ignore_event=['statee_changed'])
         self.hass.block_till_done()

--- a/tests/components/test_mqtt_statestream.py
+++ b/tests/components/test_mqtt_statestream.py
@@ -47,17 +47,17 @@ class TestMqttStateStream(object):
         assert self.add_statestream() is False
 
     def test_setup_succeeds_without_attributes(self):
-        """"Test the success of the setup with a valid base_topic."""
+        """Test the success of the setup with a valid base_topic."""
         assert self.add_statestream(base_topic='pub')
 
     def test_setup_succeeds_with_attributes(self):
-        """"Test setup with a valid base_topic and publish_attributes."""
+        """Test setup with a valid base_topic and publish_attributes."""
         assert self.add_statestream(base_topic='pub', publish_attributes=True)
 
     @patch('homeassistant.components.mqtt.async_publish')
     @patch('homeassistant.core.dt_util.utcnow')
     def test_state_changed_event_sends_message(self, mock_utcnow, mock_pub):
-        """"Test the sending of a new message if event changed."""
+        """Test the sending of a new message if event changed."""
         e_id = 'fake.entity'
         base_topic = 'pub'
 
@@ -84,7 +84,7 @@ class TestMqttStateStream(object):
             self,
             mock_utcnow,
             mock_pub):
-        """"Test the sending of a message and timestamps if event changed."""
+        """Test the sending of a message and timestamps if event changed."""
         e_id = 'another.entity'
         base_topic = 'pub'
 
@@ -118,7 +118,7 @@ class TestMqttStateStream(object):
     @patch('homeassistant.components.mqtt.async_publish')
     @patch('homeassistant.core.dt_util.utcnow')
     def test_state_changed_attr_sends_message(self, mock_utcnow, mock_pub):
-        """"Test the sending of a new message if attribute changed."""
+        """Test the sending of a new message if attribute changed."""
         e_id = 'fake.entity'
         base_topic = 'pub'
 
@@ -160,7 +160,7 @@ class TestMqttStateStream(object):
     @patch('homeassistant.components.mqtt.async_publish')
     @patch('homeassistant.core.dt_util.utcnow')
     def test_state_changed_event_include_domain(self, mock_utcnow, mock_pub):
-        """"Test that filtering on included domain works as expected."""
+        """Test that filtering on included domain works as expected."""
         base_topic = 'pub'
 
         incl = {
@@ -198,7 +198,7 @@ class TestMqttStateStream(object):
     @patch('homeassistant.components.mqtt.async_publish')
     @patch('homeassistant.core.dt_util.utcnow')
     def test_state_changed_event_include_entity(self, mock_utcnow, mock_pub):
-        """"Test that filtering on included entity works as expected."""
+        """Test that filtering on included entity works as expected."""
         base_topic = 'pub'
 
         incl = {
@@ -236,7 +236,7 @@ class TestMqttStateStream(object):
     @patch('homeassistant.components.mqtt.async_publish')
     @patch('homeassistant.core.dt_util.utcnow')
     def test_state_changed_event_exclude_domain(self, mock_utcnow, mock_pub):
-        """"Test that filtering on excluded domain works as expected."""
+        """Test that filtering on excluded domain works as expected."""
         base_topic = 'pub'
 
         incl = {}
@@ -274,7 +274,7 @@ class TestMqttStateStream(object):
     @patch('homeassistant.components.mqtt.async_publish')
     @patch('homeassistant.core.dt_util.utcnow')
     def test_state_changed_event_exclude_entity(self, mock_utcnow, mock_pub):
-        """"Test that filtering on excluded entity works as expected."""
+        """Test that filtering on excluded entity works as expected."""
         base_topic = 'pub'
 
         incl = {}
@@ -313,7 +313,7 @@ class TestMqttStateStream(object):
     @patch('homeassistant.core.dt_util.utcnow')
     def test_state_changed_event_exclude_domain_include_entity(
             self, mock_utcnow, mock_pub):
-        """"Test filtering with excluded domain and included entity."""
+        """Test filtering with excluded domain and included entity."""
         base_topic = 'pub'
 
         incl = {
@@ -354,7 +354,7 @@ class TestMqttStateStream(object):
     @patch('homeassistant.core.dt_util.utcnow')
     def test_state_changed_event_include_domain_exclude_entity(
             self, mock_utcnow, mock_pub):
-        """"Test filtering with included domain and excluded entity."""
+        """Test filtering with included domain and excluded entity."""
         base_topic = 'pub'
 
         incl = {


### PR DESCRIPTION
## Description:

Found while testing update of flake8-docstrings and pydocstyle (which I'll submit soon).

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**