### PR TITLE
Invoke pytest instead of py.test per upstream recommendation, #dropthedot

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ setenv =
 whitelist_externals = /usr/bin/env
 install_command = /usr/bin/env LANG=C.UTF-8 pip install {opts} {packages}
 commands =
-     py.test --timeout=9 --duration=10 --cov --cov-report= {posargs}
+     pytest --timeout=9 --duration=10 --cov --cov-report= {posargs}
 deps =
      -r{toxinidir}/requirements_test_all.txt
      -c{toxinidir}/homeassistant/package_constraints.txt


### PR DESCRIPTION
## Description:

http://blog.pytest.org/2016/whats-new-in-pytest-30/
https://twitter.com/hashtag/dropthedot

## Checklist:
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
