### PR TITLE
Add script to run monkeytype typing on test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,6 @@ desktop.ini
 
 # Secrets
 .lokalise_token
+
+# monkeytype
+monkeytype.sqlite3

--- a/script/monkeytype
+++ b/script/monkeytype
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Run monkeytype on test suite or optionally on a test module or directory.
+
+# Stop on errors
+set -e
+
+cd "$(dirname "$0")/.."
+
+command -v pytest >/dev/null 2>&1 || {
+  echo >&2 "This script requires pytest but it's not installed." \
+    "Aborting. Try: pip install pytest"; exit 1; }
+
+command -v monkeytype >/dev/null 2>&1 || {
+  echo >&2 "This script requires monkeytype but it's not installed." \
+    "Aborting. Try: pip install monkeytype"; exit 1; }
+
+if [ $# -eq 0 ]
+  then
+    echo "Run monkeytype on test suite"
+    monkeytype run "`command -v pytest`"
+    exit
+fi
+
+echo "Run monkeytype on tests in $1"
+monkeytype run "`command -v pytest`" "$1"


### PR DESCRIPTION
## Description:
* The monkeytype script takes an optional argument to specify a test module or directory to run. Otherwise the whole test suite will run.
* Add monkeytype sqlite db to gitignore.

See [this instagram blog post](https://instagram-engineering.com/let-your-code-type-hint-itself-introducing-open-source-monkeytype-a855c7284881) for a description of the workflow involved to use the monkeytype program.

**Basic workflow:**
1. Run `script/monkeytype tests/path/to/your_test_module.py`.
2. Run `monkeytype stub homeassistant.your_actual_module`.
3. Look at output from the monkeytyped typing stub. If not totally bad, apply the stub to your module. You most likely will need to manually edit the typing in the last step.
4. Run `monkeytype apply homeassistant.your_actual_module`.
5. Check the diff and manually correct the typing if needed. Commit, push the branch and make a PR.

**Note:**
Applying a monkeytyped stub to a module that has existing typing annotations might error and not work. This tool is most useful for totally untyped modules.

https://developers.home-assistant.io/docs/en/development_typing.html

**Related issue (if applicable):**
https://github.com/home-assistant/home-assistant/pull/14410#issuecomment-388550769

## Checklist:
  - [x] The code change is tested and works locally.