### PR TITLE
Upgrade pyota to 2.0.5

### DIFF
--- a/homeassistant/components/iota.py
+++ b/homeassistant/components/iota.py
@@ -13,7 +13,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.discovery import load_platform
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['pyota==2.0.4']
+REQUIREMENTS = ['pyota==2.0.5']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sensor/iota.py
+++ b/homeassistant/components/sensor/iota.py
@@ -7,9 +7,17 @@ https://home-assistant.io/components/iota
 import logging
 from datetime import timedelta
 
-from homeassistant.components.iota import IotaDevice
+from homeassistant.components.iota import IotaDevice, CONF_WALLETS
+from homeassistant.const import CONF_NAME
 
 _LOGGER = logging.getLogger(__name__)
+
+ATTR_TESTNET = 'testnet'
+ATTR_URL = 'url'
+
+CONF_IRI = 'iri'
+CONF_SEED = 'seed'
+CONF_TESTNET = 'testnet'
 
 DEPENDENCIES = ['iota']
 
@@ -21,7 +29,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     # Add sensors for wallet balance
     iota_config = discovery_info
     sensors = [IotaBalanceSensor(wallet, iota_config)
-               for wallet in iota_config['wallets']]
+               for wallet in iota_config[CONF_WALLETS]]
 
     # Add sensor for node information
     sensors.append(IotaNodeSensor(iota_config=iota_config))
@@ -34,10 +42,9 @@ class IotaBalanceSensor(IotaDevice):
 
     def __init__(self, wallet_config, iota_config):
         """Initialize the sensor."""
-        super().__init__(name=wallet_config['name'],
-                         seed=wallet_config['seed'],
-                         iri=iota_config['iri'],
-                         is_testnet=iota_config['testnet'])
+        super().__init__(
+            name=wallet_config[CONF_NAME], seed=wallet_config[CONF_SEED],
+            iri=iota_config[CONF_IRI], is_testnet=iota_config[CONF_TESTNET])
         self._state = None
 
     @property
@@ -65,10 +72,11 @@ class IotaNodeSensor(IotaDevice):
 
     def __init__(self, iota_config):
         """Initialize the sensor."""
-        super().__init__(name='Node Info', seed=None, iri=iota_config['iri'],
-                         is_testnet=iota_config['testnet'])
+        super().__init__(
+            name='Node Info', seed=None, iri=iota_config[CONF_IRI],
+            is_testnet=iota_config[CONF_TESTNET])
         self._state = None
-        self._attr = {'url': self.iri, 'testnet': self.is_testnet}
+        self._attr = {ATTR_URL: self.iri, ATTR_TESTNET: self.is_testnet}
 
     @property
     def name(self):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -891,7 +891,7 @@ pynut2==2.1.2
 pynx584==0.4
 
 # homeassistant.components.iota
-pyota==2.0.4
+pyota==2.0.5
 
 # homeassistant.components.sensor.otp
 pyotp==2.2.6


### PR DESCRIPTION
## Description:
Changelog: https://github.com/iotaledger/iota.lib.py/releases/tag/2.0.5

## Example entry for `configuration.yaml` (if applicable):
```yaml
iota:
  iri: https://testnet140.tangle.works:443
  testnet: true
  wallets:
    - name: Default Wallet
      seed: OYYAHJDBNPHLVCKWMVBCYBYSUSSWLIDQ9AAXOMAMAMSUA9Y9PWXOCYGXIMLLBURGRHEZAZPEMUIXVIVQC
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
