### PR TITLE
Remove universal wheel setting

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[wheel]
-universal = 1
-
 [tool:pytest]
 testpaths = tests
 norecursedirs = .git testing_config


### PR DESCRIPTION
## Description:
* Home assistant should not build a universal wheel since we don't support Python 2. See https://packaging.python.org/tutorials/distributing-packages/#universal-wheels.

## Checklist:
  - [x] The code change is tested and works locally.