### PR TITLE
Use "Returns" consistently to avoid being treated as section

### DIFF
--- a/tests/components/test_shell_command.py
+++ b/tests/components/test_shell_command.py
@@ -19,8 +19,7 @@ def mock_process_creator(error: bool = False) -> asyncio.coroutine:
     def communicate() -> Tuple[bytes, bytes]:
         """Mock a coroutine that runs a process when yielded.
 
-        Returns:
-            a tuple of (stdout, stderr).
+        Returns a tuple of (stdout, stderr).
         """
         return b"I am stdout", b"I am stderr"
 


### PR DESCRIPTION
## Description:

Otherwise, by side effect, results in error D413 by recent pydocstyle.

Another low hanging fruit from my upcoming pydocstyle update.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
