### PR TITLE
Zone - Hass configuration name is optional

### DIFF
--- a/homeassistant/components/zone/__init__.py
+++ b/homeassistant/components/zone/__init__.py
@@ -57,10 +57,12 @@ async def async_setup(hass, config):
             zone.entity_id = async_generate_entity_id(
                 ENTITY_ID_FORMAT, entry[CONF_NAME], None, hass)
             hass.async_add_job(zone.async_update_ha_state())
-            hass.data[DOMAIN][name] = zone
+            hass.data[DOMAIN][slugify(name)] = zone
 
     if HOME_ZONE not in hass.data[DOMAIN] and HOME_ZONE not in zone_entries:
         name = hass.config.location_name
+        if not name:
+            name = HOME_ZONE
         zone = Zone(hass, name, hass.config.latitude, hass.config.longitude,
                     DEFAULT_RADIUS, ICON_HOME, False)
         zone.entity_id = ENTITY_ID_HOME

--- a/homeassistant/components/zone/__init__.py
+++ b/homeassistant/components/zone/__init__.py
@@ -61,7 +61,7 @@ async def async_setup(hass, config):
 
     if HOME_ZONE not in hass.data[DOMAIN] and HOME_ZONE not in zone_entries:
         name = hass.config.location_name
-        if not name:
+        if name is None:
             name = HOME_ZONE
         zone = Zone(hass, name, hass.config.latitude, hass.config.longitude,
                     DEFAULT_RADIUS, ICON_HOME, False)

--- a/homeassistant/components/zone/__init__.py
+++ b/homeassistant/components/zone/__init__.py
@@ -45,29 +45,25 @@ PLATFORM_SCHEMA = vol.Schema({
 
 async def async_setup(hass, config):
     """Setup configured zones as well as home assistant zone if necessary."""
-    if DOMAIN not in hass.data:
-        hass.data[DOMAIN] = {}
+    hass.data[DOMAIN] = {}
+    entities = set()
     zone_entries = configured_zones(hass)
     for _, entry in config_per_platform(config, DOMAIN):
-        name = slugify(entry[CONF_NAME])
-        if name not in zone_entries:
+        if slugify(entry[CONF_NAME]) not in zone_entries:
             zone = Zone(hass, entry[CONF_NAME], entry[CONF_LATITUDE],
                         entry[CONF_LONGITUDE], entry.get(CONF_RADIUS),
                         entry.get(CONF_ICON), entry.get(CONF_PASSIVE))
             zone.entity_id = async_generate_entity_id(
-                ENTITY_ID_FORMAT, entry[CONF_NAME], None, hass)
+                ENTITY_ID_FORMAT, entry[CONF_NAME], entities)
             hass.async_add_job(zone.async_update_ha_state())
-            hass.data[DOMAIN][slugify(name)] = zone
+            entities.add(zone.entity_id)
 
-    if HOME_ZONE not in hass.data[DOMAIN] and HOME_ZONE not in zone_entries:
-        name = hass.config.location_name
-        if name is None:
-            name = HOME_ZONE
-        zone = Zone(hass, name, hass.config.latitude, hass.config.longitude,
+    if ENTITY_ID_HOME not in entities and HOME_ZONE not in zone_entries:
+        zone = Zone(hass, hass.config.location_name,
+                    hass.config.latitude, hass.config.longitude,
                     DEFAULT_RADIUS, ICON_HOME, False)
         zone.entity_id = ENTITY_ID_HOME
         hass.async_add_job(zone.async_update_ha_state())
-        hass.data[DOMAIN][slugify(name)] = zone
 
     return True
 

--- a/tests/components/zone/test_init.py
+++ b/tests/components/zone/test_init.py
@@ -59,7 +59,6 @@ class TestComponentZone(unittest.TestCase):
         assert self.hass.config.latitude == state.attributes['latitude']
         assert self.hass.config.longitude == state.attributes['longitude']
         assert not state.attributes.get('passive', False)
-        assert 'test_home' in self.hass.data[zone.DOMAIN]
 
     def test_setup(self):
         """Test a successful setup."""
@@ -79,8 +78,6 @@ class TestComponentZone(unittest.TestCase):
         assert info['longitude'] == state.attributes['longitude']
         assert info['radius'] == state.attributes['radius']
         assert info['passive'] == state.attributes['passive']
-        assert 'test_zone' in self.hass.data[zone.DOMAIN]
-        assert 'test_home' in self.hass.data[zone.DOMAIN]
 
     def test_setup_zone_skips_home_zone(self):
         """Test that zone named Home should override hass home zone."""
@@ -94,8 +91,6 @@ class TestComponentZone(unittest.TestCase):
         assert len(self.hass.states.entity_ids('zone')) == 1
         state = self.hass.states.get('zone.home')
         assert info['name'] == state.name
-        assert 'home' in self.hass.data[zone.DOMAIN]
-        assert 'test_home' not in self.hass.data[zone.DOMAIN]
 
     def test_setup_registered_zone_skips_home_zone(self):
         """Test that config entry named home should override hass home zone."""
@@ -105,7 +100,6 @@ class TestComponentZone(unittest.TestCase):
         entry.add_to_hass(self.hass)
         assert setup.setup_component(self.hass, zone.DOMAIN, {'zone': None})
         assert len(self.hass.states.entity_ids('zone')) == 0
-        assert not self.hass.data[zone.DOMAIN]
 
     def test_setup_registered_zone_skips_configured_zone(self):
         """Test if config entry will override configured zone."""
@@ -123,8 +117,6 @@ class TestComponentZone(unittest.TestCase):
         assert len(self.hass.states.entity_ids('zone')) == 1
         state = self.hass.states.get('zone.test_zone')
         assert not state
-        assert 'test_zone' not in self.hass.data[zone.DOMAIN]
-        assert 'test_home' in self.hass.data[zone.DOMAIN]
 
     def test_active_zone_skips_passive_zones(self):
         """Test active and passive zones."""

--- a/tests/components/zone/test_init.py
+++ b/tests/components/zone/test_init.py
@@ -92,6 +92,16 @@ class TestComponentZone(unittest.TestCase):
         state = self.hass.states.get('zone.home')
         assert info['name'] == state.name
 
+    def test_setup_name_can_be_same_on_multiple_zones(self):
+        """Test that zone named Home should override hass home zone."""
+        info = {
+            'name': 'Test Zone',
+            'latitude': 1.1,
+            'longitude': -2.2,
+        }
+        assert setup.setup_component(self.hass, zone.DOMAIN, {'zone': [info, info]})
+        assert len(self.hass.states.entity_ids('zone')) == 3
+
     def test_setup_registered_zone_skips_home_zone(self):
         """Test that config entry named home should override hass home zone."""
         entry = MockConfigEntry(domain=zone.DOMAIN, data={

--- a/tests/components/zone/test_init.py
+++ b/tests/components/zone/test_init.py
@@ -99,7 +99,8 @@ class TestComponentZone(unittest.TestCase):
             'latitude': 1.1,
             'longitude': -2.2,
         }
-        assert setup.setup_component(self.hass, zone.DOMAIN, {'zone': [info, info]})
+        assert setup.setup_component(
+            self.hass, zone.DOMAIN, {'zone': [info, info]})
         assert len(self.hass.states.entity_ids('zone')) == 3
 
     def test_setup_registered_zone_skips_home_zone(self):


### PR DESCRIPTION
## Description:
Hass configuration option name is optional, make sure there is a name for the home zone

**Related issue (if applicable):** fixes #14396

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
