### PR TITLE
Add channel changing support to SamsungTV component

### DIFF
--- a/homeassistant/components/media_player/samsungtv.py
+++ b/homeassistant/components/media_player/samsungtv.py
@@ -273,7 +273,7 @@ class SamsungTVDevice(MediaPlayerDevice):
             return
 
         for digit in media_id:
-            self.hass.async_add_job(self.send_key, 'KEY_' + digit)
+            await self.hass.async_add_job(self.send_key, 'KEY_' + digit)
             await asyncio.sleep(KEY_PRESS_TIMEOUT, self.hass.loop)
 
     def turn_on(self):

--- a/homeassistant/components/media_player/samsungtv.py
+++ b/homeassistant/components/media_player/samsungtv.py
@@ -4,6 +4,7 @@ Support for interface with an Samsung TV.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/media_player.samsungtv/
 """
+import asyncio
 import logging
 import socket
 from datetime import timedelta
@@ -15,8 +16,9 @@ import voluptuous as vol
 
 from homeassistant.components.media_player import (
     SUPPORT_NEXT_TRACK, SUPPORT_PAUSE, SUPPORT_PREVIOUS_TRACK,
-    SUPPORT_TURN_OFF, SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_STEP,
-    SUPPORT_PLAY, MediaPlayerDevice, PLATFORM_SCHEMA, SUPPORT_TURN_ON)
+    SUPPORT_TURN_OFF, SUPPORT_TURN_ON, SUPPORT_PLAY,
+    SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_STEP, SUPPORT_PLAY_MEDIA,
+    MediaPlayerDevice, PLATFORM_SCHEMA, MEDIA_TYPE_CHANNEL)
 from homeassistant.const import (
     CONF_HOST, CONF_NAME, STATE_OFF, STATE_ON, STATE_UNKNOWN, CONF_PORT,
     CONF_MAC)
@@ -32,12 +34,13 @@ CONF_TIMEOUT = 'timeout'
 DEFAULT_NAME = 'Samsung TV Remote'
 DEFAULT_PORT = 55000
 DEFAULT_TIMEOUT = 0
+KEY_PRESS_TIMEOUT = 1.2
 
 KNOWN_DEVICES_KEY = 'samsungtv_known_devices'
 
 SUPPORT_SAMSUNGTV = SUPPORT_PAUSE | SUPPORT_VOLUME_STEP | \
     SUPPORT_VOLUME_MUTE | SUPPORT_PREVIOUS_TRACK | \
-    SUPPORT_NEXT_TRACK | SUPPORT_TURN_OFF | SUPPORT_PLAY
+    SUPPORT_NEXT_TRACK | SUPPORT_TURN_OFF | SUPPORT_PLAY | SUPPORT_PLAY_MEDIA
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
@@ -255,6 +258,23 @@ class SamsungTVDevice(MediaPlayerDevice):
     def media_previous_track(self):
         """Send the previous track command."""
         self.send_key('KEY_REWIND')
+
+    async def async_play_media(self, media_type, media_id, **kwargs):
+        """Support changing a channel."""
+        if media_type != MEDIA_TYPE_CHANNEL:
+            _LOGGER.error('Unsupported media type')
+            return
+
+        # media_id should only be a channel number
+        try:
+            cv.positive_int(media_id)
+        except vol.Invalid:
+            _LOGGER.error('Media ID must be positive integer')
+            return
+
+        for digit in media_id:
+            self.hass.async_add_job(self.send_key, 'KEY_' + digit)
+            await asyncio.sleep(KEY_PRESS_TIMEOUT, self.hass.loop)
 
     def turn_on(self):
         """Turn the media player on."""

--- a/tests/components/media_player/test_samsungtv.py
+++ b/tests/components/media_player/test_samsungtv.py
@@ -1,11 +1,16 @@
 """Tests for samsungtv Components."""
+import asyncio
 import unittest
+from unittest.mock import call, patch, MagicMock
 from subprocess import CalledProcessError
 
 from asynctest import mock
 
+import pytest
+
 import tests.common
-from homeassistant.components.media_player import SUPPORT_TURN_ON
+from homeassistant.components.media_player import SUPPORT_TURN_ON, \
+    MEDIA_TYPE_CHANNEL, MEDIA_TYPE_URL
 from homeassistant.components.media_player.samsungtv import setup_platform, \
     CONF_TIMEOUT, SamsungTVDevice, SUPPORT_SAMSUNGTV
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT, STATE_ON, \
@@ -301,3 +306,54 @@ class TestSamsungTv(unittest.TestCase):
         self.device._mac = "fake"
         self.device.turn_on()
         self.device._wol.send_magic_packet.assert_called_once_with("fake")
+
+
+@pytest.fixture
+def samsung_mock():
+    """Mock samsungctl."""
+    with patch.dict('sys.modules', {
+        'samsungctl': MagicMock(),
+    }):
+        yield
+
+
+async def test_play_media(hass, samsung_mock):
+    """Test for play_media."""
+    asyncio_sleep = asyncio.sleep
+    sleeps = []
+
+    async def sleep(duration, loop):
+        sleeps.append(duration)
+        await asyncio_sleep(0, loop=loop)
+
+    with patch('asyncio.sleep', new=sleep):
+        device = SamsungTVDevice(**WORKING_CONFIG)
+        device.hass = hass
+
+        hass.async_add_job = mock.Mock()
+        await device.async_play_media(MEDIA_TYPE_CHANNEL, "576")
+
+        send = device.send_key
+        exp = [call(send, "KEY_5"), call(send, "KEY_7"), call(send, "KEY_6")]
+        assert hass.async_add_job.call_args_list == exp
+        assert len(sleeps) == 3
+
+
+async def test_play_media_invalid_type(hass, samsung_mock):
+    """Test for play_media with invalid media type."""
+    url = "https://example.com"
+    device = SamsungTVDevice(**WORKING_CONFIG)
+    await device.async_play_media(MEDIA_TYPE_URL, url)
+
+
+async def test_play_media_channel_as_string(hass, samsung_mock):
+    """Test for play_media with invalid channel as string."""
+    url = "https://example.com"
+    device = SamsungTVDevice(**WORKING_CONFIG)
+    await device.async_play_media(MEDIA_TYPE_CHANNEL, url)
+
+
+async def test_play_media_channel_as_non_positive(hass, samsung_mock):
+    """Test for play_media with invalid channel as non positive integer."""
+    device = SamsungTVDevice(**WORKING_CONFIG)
+    await device.async_play_media(MEDIA_TYPE_CHANNEL, "-4")

--- a/tests/components/media_player/test_samsungtv.py
+++ b/tests/components/media_player/test_samsungtv.py
@@ -15,7 +15,7 @@ from homeassistant.components.media_player.samsungtv import setup_platform, \
     CONF_TIMEOUT, SamsungTVDevice, SUPPORT_SAMSUNGTV
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT, STATE_ON, \
     CONF_MAC, STATE_OFF
-from tests.common import MockDependency, mock_coro
+from tests.common import MockDependency
 from homeassistant.util import dt as dt_util
 from datetime import timedelta
 
@@ -326,15 +326,11 @@ async def test_play_media(hass, samsung_mock):
         sleeps.append(duration)
         await asyncio_sleep(0, loop=loop)
 
-    def async_add_job(target, *args):
-        return mock_coro(target(*args))
-
     with patch('asyncio.sleep', new=sleep):
         device = SamsungTVDevice(**WORKING_CONFIG)
         device.hass = hass
 
         device.send_key = mock.Mock()
-        hass.async_add_job = async_add_job
         await device.async_play_media(MEDIA_TYPE_CHANNEL, "576")
 
         exp = [call("KEY_5"), call("KEY_7"), call("KEY_6")]
@@ -346,17 +342,23 @@ async def test_play_media_invalid_type(hass, samsung_mock):
     """Test for play_media with invalid media type."""
     url = "https://example.com"
     device = SamsungTVDevice(**WORKING_CONFIG)
+    device.send_key = mock.Mock()
     await device.async_play_media(MEDIA_TYPE_URL, url)
+    assert device.send_key.call_count == 0
 
 
 async def test_play_media_channel_as_string(hass, samsung_mock):
     """Test for play_media with invalid channel as string."""
     url = "https://example.com"
     device = SamsungTVDevice(**WORKING_CONFIG)
+    device.send_key = mock.Mock()
     await device.async_play_media(MEDIA_TYPE_CHANNEL, url)
+    assert device.send_key.call_count == 0
 
 
 async def test_play_media_channel_as_non_positive(hass, samsung_mock):
     """Test for play_media with invalid channel as non positive integer."""
     device = SamsungTVDevice(**WORKING_CONFIG)
+    device.send_key = mock.Mock()
     await device.async_play_media(MEDIA_TYPE_CHANNEL, "-4")
+    assert device.send_key.call_count == 0


### PR DESCRIPTION
So I was looking for a way to change the channel for Samsung TVs and came across this comment:
https://github.com/home-assistant/home-assistant/issues/1014#issuecomment-178412227

This PR aims to allow the specific functionality of changing channels via `play_media` service.

Docs update: https://github.com/home-assistant/home-assistant.github.io/pull/5362

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) (https://github.com/home-assistant/home-assistant.github.io/pull/5362)

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.