### PR TITLE
Bump requirement to pydeconz v38

### DIFF
--- a/homeassistant/components/deconz/__init__.py
+++ b/homeassistant/components/deconz/__init__.py
@@ -22,7 +22,7 @@ from .const import (
     CONFIG_FILE, DATA_DECONZ_EVENT, DATA_DECONZ_ID,
     DATA_DECONZ_UNSUB, DOMAIN, _LOGGER)
 
-REQUIREMENTS = ['pydeconz==37']
+REQUIREMENTS = ['pydeconz==38']
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -745,7 +745,7 @@ pycsspeechtts==1.0.2
 pydaikin==0.4
 
 # homeassistant.components.deconz
-pydeconz==37
+pydeconz==38
 
 # homeassistant.components.zwave
 pydispatcher==2.0.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -133,7 +133,7 @@ py-canary==0.5.0
 pyblackbird==0.5
 
 # homeassistant.components.deconz
-pydeconz==37
+pydeconz==38
 
 # homeassistant.components.zwave
 pydispatcher==2.0.5


### PR DESCRIPTION
## Description:
pydeconz shouldn't do calculations on empty values

**Related issue (if applicable):**
Solves https://community.home-assistant.io/t/error-in-pydeconz-sensor-py-line-128/52965
