### PR TITLE
Allow qwikswitch sensors as part of devices

### DIFF
--- a/homeassistant/components/qwikswitch.py
+++ b/homeassistant/components/qwikswitch.py
@@ -150,8 +150,10 @@ async def async_setup(hass, config):
     comps = {'switch': [], 'light': [], 'sensor': [], 'binary_sensor': []}
 
     try:
+        sensor_ids = []
         for sens in sensors:
             _, _type = SENSORS[sens['type']]
+            sensor_ids.append(sens['id'])
             if _type is bool:
                 comps['binary_sensor'].append(sens)
                 continue
@@ -192,7 +194,7 @@ async def async_setup(hass, config):
                     'qwikswitch.button.{}'.format(qspacket[QS_ID]), qspacket)
                 return
 
-            if qspacket[QS_ID] not in qsusb.devices:
+            if qspacket[QS_ID] in sensor_ids:
                 # Not a standard device in, component can handle packet
                 # i.e. sensors
                 _LOGGER.debug("Dispatch %s ((%s))", qspacket[QS_ID], qspacket)

--- a/homeassistant/components/qwikswitch.py
+++ b/homeassistant/components/qwikswitch.py
@@ -195,8 +195,6 @@ async def async_setup(hass, config):
                 return
 
             if qspacket[QS_ID] in sensor_ids:
-                # Not a standard device in, component can handle packet
-                # i.e. sensors
                 _LOGGER.debug("Dispatch %s ((%s))", qspacket[QS_ID], qspacket)
                 hass.helpers.dispatcher.async_dispatcher_send(
                     qspacket[QS_ID], qspacket)


### PR DESCRIPTION
## Description:
Fix `sensors` part of devices

**Related issue (if applicable):** fixes [via forum](https://community.home-assistant.io/t/qwikswitch-binary-sensors-stop-working/52222)

## Example entry for `configuration.yaml` (if applicable):
```yaml
qwikswitch:

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
