### PR TITLE
Don't add a url to built-in panels

### DIFF
--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -167,6 +167,7 @@ class BuiltInPanel(AbstractPanel):
             'icon': self.sidebar_icon,
             'title': self.sidebar_title,
             'config': self.config,
+            'url_path': self.frontend_url_path,
         }
 
 

--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -147,21 +147,6 @@ class AbstractPanel:
             'get', '/{}/{{extra:.+}}'.format(self.frontend_url_path),
             index_view.get)
 
-    def to_response(self, hass, request):
-        """Panel as dictionary."""
-        result = {
-            'component_name': self.component_name,
-            'icon': self.sidebar_icon,
-            'title': self.sidebar_title,
-            'url_path': self.frontend_url_path,
-            'config': self.config,
-        }
-        if _is_latest(hass.data[DATA_JS_VERSION], request):
-            result['url'] = self.webcomponent_url_latest
-        else:
-            result['url'] = self.webcomponent_url_es5
-        return result
-
 
 class BuiltInPanel(AbstractPanel):
     """Panel that is part of hass_frontend."""
@@ -175,30 +160,14 @@ class BuiltInPanel(AbstractPanel):
         self.frontend_url_path = frontend_url_path or component_name
         self.config = config
 
-    @asyncio.coroutine
-    def async_finalize(self, hass, frontend_repository_path):
-        """Finalize this panel for usage.
-
-        If frontend_repository_path is set, will be prepended to path of
-        built-in components.
-        """
-        if frontend_repository_path is None:
-            import hass_frontend
-            import hass_frontend_es5
-
-            self.webcomponent_url_latest = \
-                '/frontend_latest/panels/ha-panel-{}-{}.html'.format(
-                    self.component_name,
-                    hass_frontend.FINGERPRINTS[self.component_name])
-            self.webcomponent_url_es5 = \
-                '/frontend_es5/panels/ha-panel-{}-{}.html'.format(
-                    self.component_name,
-                    hass_frontend_es5.FINGERPRINTS[self.component_name])
-        else:
-            # Dev mode
-            self.webcomponent_url_es5 = self.webcomponent_url_latest = \
-                '/home-assistant-polymer/panels/{}/ha-panel-{}.html'.format(
-                    self.component_name, self.component_name)
+    def to_response(self, hass, request):
+        """Panel as dictionary."""
+        return {
+            'component_name': self.component_name,
+            'icon': self.sidebar_icon,
+            'title': self.sidebar_title,
+            'config': self.config,
+        }
 
 
 class ExternalPanel(AbstractPanel):
@@ -243,6 +212,21 @@ class ExternalPanel(AbstractPanel):
                 # if path is None, we're in prod mode, so cache static assets
                 frontend_repository_path is None)
             self.REGISTERED_COMPONENTS.add(self.component_name)
+
+    def to_response(self, hass, request):
+        """Panel as dictionary."""
+        result = {
+            'component_name': self.component_name,
+            'icon': self.sidebar_icon,
+            'title': self.sidebar_title,
+            'url_path': self.frontend_url_path,
+            'config': self.config,
+        }
+        if _is_latest(hass.data[DATA_JS_VERSION], request):
+            result['url'] = self.webcomponent_url_latest
+        else:
+            result['url'] = self.webcomponent_url_es5
+        return result
 
 
 @bind_hass
@@ -365,10 +349,10 @@ def async_setup(hass, config):
     index_view = IndexView(repo_path, js_version, client)
     hass.http.register_view(index_view)
 
-    @asyncio.coroutine
-    def finalize_panel(panel):
+    async def finalize_panel(panel):
         """Finalize setup of a panel."""
-        yield from panel.async_finalize(hass, repo_path)
+        if hasattr(panel, 'async_finalize'):
+            await panel.async_finalize(hass, repo_path)
         panel.async_register_index_routes(hass.http.app.router, index_view)
 
     yield from asyncio.wait([

--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -25,7 +25,7 @@ from homeassistant.core import callback
 from homeassistant.helpers.translation import async_get_translations
 from homeassistant.loader import bind_hass
 
-REQUIREMENTS = ['home-assistant-frontend==20180510.1']
+REQUIREMENTS = ['home-assistant-frontend==20180515.0']
 
 DOMAIN = 'frontend'
 DEPENDENCIES = ['api', 'websocket_api', 'http', 'system_log']

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -386,7 +386,7 @@ hipnotify==1.0.8
 holidays==0.9.5
 
 # homeassistant.components.frontend
-home-assistant-frontend==20180510.1
+home-assistant-frontend==20180515.0
 
 # homeassistant.components.homekit_controller
 # homekit==0.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -81,7 +81,7 @@ hbmqtt==0.9.2
 holidays==0.9.5
 
 # homeassistant.components.frontend
-home-assistant-frontend==20180510.1
+home-assistant-frontend==20180515.0
 
 # homeassistant.components.influxdb
 # homeassistant.components.sensor.influxdb

--- a/tests/components/test_frontend.py
+++ b/tests/components/test_frontend.py
@@ -57,7 +57,7 @@ def test_frontend_and_static(mock_http_client):
 
     # Test we can retrieve frontend.js
     frontendjs = re.search(
-        r'(?P<app>\/frontend_es5\/frontend-[A-Za-z0-9]{32}.html)', text)
+        r'(?P<app>\/frontend_es5\/app-[A-Za-z0-9]{32}.js)', text)
 
     assert frontendjs is not None
     resp = yield from mock_http_client.get(frontendjs.groups(0)[0])
@@ -210,6 +210,6 @@ async def test_get_panels(hass, hass_ws_client):
     assert msg['type'] == wapi.TYPE_RESULT
     assert msg['success']
     assert msg['result']['map']['component_name'] == 'map'
+    assert msg['result']['map']['url_path'] == 'map'
     assert msg['result']['map']['icon'] == 'mdi:account-location'
     assert msg['result']['map']['title'] == 'Map'
-    assert 'url_path' not in msg['result']['map']

--- a/tests/components/test_frontend.py
+++ b/tests/components/test_frontend.py
@@ -210,6 +210,6 @@ async def test_get_panels(hass, hass_ws_client):
     assert msg['type'] == wapi.TYPE_RESULT
     assert msg['success']
     assert msg['result']['map']['component_name'] == 'map'
-    assert msg['result']['map']['url_path'] == 'map'
     assert msg['result']['map']['icon'] == 'mdi:account-location'
     assert msg['result']['map']['title'] == 'Map'
+    assert 'url_path' not in msg['result']['map']

--- a/tests/components/test_panel_iframe.py
+++ b/tests/components/test_panel_iframe.py
@@ -1,6 +1,5 @@
 """The tests for the panel_iframe component."""
 import unittest
-from unittest.mock import patch
 
 from homeassistant import setup
 from homeassistant.components import frontend

--- a/tests/components/test_panel_iframe.py
+++ b/tests/components/test_panel_iframe.py
@@ -33,8 +33,6 @@ class TestPanelIframe(unittest.TestCase):
                     'panel_iframe': conf
                 })
 
-    @patch.dict('hass_frontend_es5.FINGERPRINTS',
-                {'iframe': 'md5md5'})
     def test_correct_config(self):
         """Test correct config."""
         assert setup.setup_component(
@@ -70,7 +68,6 @@ class TestPanelIframe(unittest.TestCase):
             'config': {'url': 'http://192.168.1.1'},
             'icon': 'mdi:network-wireless',
             'title': 'Router',
-            'url': '/frontend_es5/panels/ha-panel-iframe-md5md5.html',
             'url_path': 'router'
         }
 
@@ -79,7 +76,6 @@ class TestPanelIframe(unittest.TestCase):
             'config': {'url': 'https://www.wunderground.com/us/ca/san-diego'},
             'icon': 'mdi:weather',
             'title': 'Weather',
-            'url': '/frontend_es5/panels/ha-panel-iframe-md5md5.html',
             'url_path': 'weather',
         }
 
@@ -88,7 +84,6 @@ class TestPanelIframe(unittest.TestCase):
             'config': {'url': '/api'},
             'icon': 'mdi:weather',
             'title': 'Api',
-            'url': '/frontend_es5/panels/ha-panel-iframe-md5md5.html',
             'url_path': 'api',
         }
 
@@ -97,6 +92,5 @@ class TestPanelIframe(unittest.TestCase):
             'config': {'url': 'ftp://some/ftp'},
             'icon': 'mdi:weather',
             'title': 'FTP',
-            'url': '/frontend_es5/panels/ha-panel-iframe-md5md5.html',
             'url_path': 'ftp',
         }


### PR DESCRIPTION
## Description:
This is a change to support the Polymer 3 conversion of the frontend happening at https://github.com/home-assistant/home-assistant-polymer/pull/1154

## Example entry for `configuration.yaml` (if applicable):
```yaml
frontend:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
