### PR TITLE
Fix key error upon missing node

### DIFF
--- a/homeassistant/components/mysensors.py
+++ b/homeassistant/components/mysensors.py
@@ -495,8 +495,9 @@ def gw_callback_factory(hass):
         _LOGGER.debug(
             "Node update: node %s child %s", msg.node_id, msg.child_id)
 
-        child = msg.gateway.sensors[msg.node_id].children.get(msg.child_id)
-        if child is None:
+        try:
+            child = msg.gateway.sensors[msg.node_id].children[msg.child_id]
+        except KeyError:
             _LOGGER.debug("Not a child update for node %s", msg.node_id)
             return
 


### PR DESCRIPTION
## Description:
* This is needed after gateway ready message generates an update while persistence is off, or while the gateway node hasn't been presented yet.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**