### PR TITLE
Add stdout and stderr to debug output for shell_command

### DIFF
--- a/homeassistant/components/shell_command.py
+++ b/homeassistant/components/shell_command.py
@@ -68,8 +68,9 @@ def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
                 cmd,
                 loop=hass.loop,
                 stdin=None,
-                stdout=asyncio.subprocess.DEVNULL,
-                stderr=asyncio.subprocess.DEVNULL)
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                )
         else:
             # Template used. Break into list and use create_subprocess_exec
             # (which uses shell=False) for security
@@ -80,12 +81,19 @@ def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
                 *shlexed_cmd,
                 loop=hass.loop,
                 stdin=None,
-                stdout=asyncio.subprocess.DEVNULL,
-                stderr=asyncio.subprocess.DEVNULL)
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                )
 
         process = yield from create_process
-        yield from process.communicate()
+        stdout_data, stderr_data = yield from process.communicate()
 
+        if stdout_data:
+            _LOGGER.debug("Stdout of command: `%s`, return code: %s:\n%s",
+                          cmd, process.returncode, stdout_data)
+        if stderr_data:
+            _LOGGER.debug("Stderr of command: `%s`, return code: %s:\n%s",
+                          cmd, process.returncode, stderr_data)
         if process.returncode != 0:
             _LOGGER.exception("Error running command: `%s`, return code: %s",
                               cmd, process.returncode)

--- a/tests/components/test_shell_command.py
+++ b/tests/components/test_shell_command.py
@@ -149,3 +149,41 @@ class TestShellCommand(unittest.TestCase):
             self.assertEqual(1, mock_call.call_count)
             self.assertEqual(1, mock_error.call_count)
             self.assertFalse(os.path.isfile(path))
+
+    @patch('homeassistant.components.shell_command._LOGGER.debug')
+    def test_stdout_captured(self, mock_output):
+        """Test subprocess that has stdout."""
+        test_phrase = "I have output"
+        self.assertTrue(
+                setup_component(self.hass, shell_command.DOMAIN, {
+                    shell_command.DOMAIN: {
+                        'test_service': "echo {}".format(test_phrase)
+                        }
+                    }))
+
+        self.hass.services.call('shell_command', 'test_service',
+                                blocking=True)
+
+        self.hass.block_till_done()
+        self.assertEqual(1, mock_output.call_count)
+        self.assertEqual(test_phrase.encode() + b'\n',
+                         mock_output.call_args_list[0][0][-1])
+
+    @patch('homeassistant.components.shell_command._LOGGER.debug')
+    def test_stderr_captured(self, mock_output):
+        """Test subprocess that has stderr."""
+        test_phrase = "I have error"
+        self.assertTrue(
+                setup_component(self.hass, shell_command.DOMAIN, {
+                    shell_command.DOMAIN: {
+                        'test_service': ">&2 echo {}".format(test_phrase)
+                        }
+                    }))
+
+        self.hass.services.call('shell_command', 'test_service',
+                                blocking=True)
+
+        self.hass.block_till_done()
+        self.assertEqual(1, mock_output.call_count)
+        self.assertEqual(test_phrase.encode() + b'\n',
+                         mock_output.call_args_list[0][0][-1])


### PR DESCRIPTION
## Description:

`shell_command` is much easier to debug if its stdout and stderr are captured and made available in the log. As implemented in this PR, they will only been shown when `shell_command` logging verbosity is set to `debug`, allowing users to use that information when needed, but should not clutter the logs by default.

**Related issue (if applicable):**

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
