### PR TITLE
Added option to invert aREST pin switch logic for active low relays

### DIFF
--- a/homeassistant/components/switch/arest.py
+++ b/homeassistant/components/switch/arest.py
@@ -56,7 +56,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     for pinnum, pin in pins.items():
         dev.append(ArestSwitchPin(
             resource, config.get(CONF_NAME, response.json()[CONF_NAME]),
-            pin.get(CONF_NAME), pinnum, pin.get(CONF_INVERT, False)))
+            pin.get(CONF_NAME), pinnum, pin.get(CONF_INVERT)))
 
     functions = config.get(CONF_FUNCTIONS)
     for funcname, func in functions.items():

--- a/homeassistant/components/switch/arest.py
+++ b/homeassistant/components/switch/arest.py
@@ -170,7 +170,8 @@ class ArestSwitchPin(ArestSwitchBase):
         """Turn the device on."""
         one_or_zero = 0 if self.invert else 1
         request = requests.get(
-            '{}/digital/{}/{}'.format(self._resource, self._pin, one_or_zero), timeout=10)
+            '{}/digital/{}/{}'.format(self._resource, self._pin, one_or_zero),
+            timeout=10)
         if request.status_code == 200:
             self._state = True
         else:
@@ -181,7 +182,8 @@ class ArestSwitchPin(ArestSwitchBase):
         """Turn the device off."""
         one_or_zero = 1 if self.invert else 0
         request = requests.get(
-            '{}/digital/{}/{}'.format(self._resource, self._pin, one_or_zero), timeout=10)
+            '{}/digital/{}/{}'.format(self._resource, self._pin, one_or_zero),
+            timeout=10)
         if request.status_code == 200:
             self._state = False
         else:

--- a/homeassistant/components/switch/arest.py
+++ b/homeassistant/components/switch/arest.py
@@ -18,11 +18,13 @@ _LOGGER = logging.getLogger(__name__)
 
 CONF_FUNCTIONS = 'functions'
 CONF_PINS = 'pins'
+CONF_INVERT = 'invert'
 
 DEFAULT_NAME = 'aREST switch'
 
 PIN_FUNCTION_SCHEMA = vol.Schema({
     vol.Optional(CONF_NAME): cv.string,
+    vol.Optional(CONF_INVERT): cv.boolean,
 })
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -54,7 +56,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     for pinnum, pin in pins.items():
         dev.append(ArestSwitchPin(
             resource, config.get(CONF_NAME, response.json()[CONF_NAME]),
-            pin.get(CONF_NAME), pinnum))
+            pin.get(CONF_NAME), pinnum, pin.get(CONF_INVERT, False)))
 
     functions = config.get(CONF_FUNCTIONS)
     for funcname, func in functions.items():
@@ -152,10 +154,11 @@ class ArestSwitchFunction(ArestSwitchBase):
 class ArestSwitchPin(ArestSwitchBase):
     """Representation of an aREST switch. Based on digital I/O."""
 
-    def __init__(self, resource, location, name, pin):
+    def __init__(self, resource, location, name, pin, invert):
         """Initialize the switch."""
         super().__init__(resource, location, name)
         self._pin = pin
+        self.invert = invert
 
         request = requests.get(
             '{}/mode/{}/o'.format(self._resource, self._pin), timeout=10)
@@ -165,8 +168,9 @@ class ArestSwitchPin(ArestSwitchBase):
 
     def turn_on(self, **kwargs):
         """Turn the device on."""
+        one_or_zero = 0 if self.invert else 1
         request = requests.get(
-            '{}/digital/{}/1'.format(self._resource, self._pin), timeout=10)
+            '{}/digital/{}/{}'.format(self._resource, self._pin, one_or_zero), timeout=10)
         if request.status_code == 200:
             self._state = True
         else:
@@ -175,8 +179,9 @@ class ArestSwitchPin(ArestSwitchBase):
 
     def turn_off(self, **kwargs):
         """Turn the device off."""
+        one_or_zero = 1 if self.invert else 0
         request = requests.get(
-            '{}/digital/{}/0'.format(self._resource, self._pin), timeout=10)
+            '{}/digital/{}/{}'.format(self._resource, self._pin, one_or_zero), timeout=10)
         if request.status_code == 200:
             self._state = False
         else:
@@ -188,7 +193,8 @@ class ArestSwitchPin(ArestSwitchBase):
         try:
             request = requests.get(
                 '{}/digital/{}'.format(self._resource, self._pin), timeout=10)
-            self._state = request.json()['return_value'] != 0
+            one_or_zero = 1 if self.invert else 0
+            self._state = request.json()['return_value'] != one_or_zero
             self._available = True
         except requests.exceptions.ConnectionError:
             _LOGGER.warning("No route to device %s", self._resource)

--- a/homeassistant/components/switch/arest.py
+++ b/homeassistant/components/switch/arest.py
@@ -170,7 +170,8 @@ class ArestSwitchPin(ArestSwitchBase):
         """Turn the device on."""
         turn_on_payload = int(not self.invert)
         request = requests.get(
-            '{}/digital/{}/{}'.format(self._resource, self._pin, turn_on_payload),
+            '{}/digital/{}/{}'.format(self._resource, self._pin,
+                                      turn_on_payload),
             timeout=10)
         if request.status_code == 200:
             self._state = True
@@ -182,7 +183,8 @@ class ArestSwitchPin(ArestSwitchBase):
         """Turn the device off."""
         turn_off_payload = int(self.invert)
         request = requests.get(
-            '{}/digital/{}/{}'.format(self._resource, self._pin, turn_off_payload),
+            '{}/digital/{}/{}'.format(self._resource, self._pin,
+                                      turn_off_payload),
             timeout=10)
         if request.status_code == 200:
             self._state = False

--- a/homeassistant/components/switch/arest.py
+++ b/homeassistant/components/switch/arest.py
@@ -24,7 +24,7 @@ DEFAULT_NAME = 'aREST switch'
 
 PIN_FUNCTION_SCHEMA = vol.Schema({
     vol.Optional(CONF_NAME): cv.string,
-    vol.Optional(CONF_INVERT): cv.boolean,
+    vol.Optional(CONF_INVERT, default=False): cv.boolean,
 })
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -168,9 +168,9 @@ class ArestSwitchPin(ArestSwitchBase):
 
     def turn_on(self, **kwargs):
         """Turn the device on."""
-        one_or_zero = 0 if self.invert else 1
+        turn_on_payload = int(not self.invert)
         request = requests.get(
-            '{}/digital/{}/{}'.format(self._resource, self._pin, one_or_zero),
+            '{}/digital/{}/{}'.format(self._resource, self._pin, turn_on_payload),
             timeout=10)
         if request.status_code == 200:
             self._state = True
@@ -180,9 +180,9 @@ class ArestSwitchPin(ArestSwitchBase):
 
     def turn_off(self, **kwargs):
         """Turn the device off."""
-        one_or_zero = 1 if self.invert else 0
+        turn_off_payload = int(self.invert)
         request = requests.get(
-            '{}/digital/{}/{}'.format(self._resource, self._pin, one_or_zero),
+            '{}/digital/{}/{}'.format(self._resource, self._pin, turn_off_payload),
             timeout=10)
         if request.status_code == 200:
             self._state = False
@@ -195,8 +195,8 @@ class ArestSwitchPin(ArestSwitchBase):
         try:
             request = requests.get(
                 '{}/digital/{}'.format(self._resource, self._pin), timeout=10)
-            one_or_zero = 1 if self.invert else 0
-            self._state = request.json()['return_value'] != one_or_zero
+            status_value = int(self.invert)
+            self._state = request.json()['return_value'] != status_value
             self._available = True
         except requests.exceptions.ConnectionError:
             _LOGGER.warning("No route to device %s", self._resource)


### PR DESCRIPTION
## Description:
The current aREST pin switch assumes that setting the pin HIGH will turn a switch on, however when using the widely available and super common mechanical relay module that isn't the case. These modules are active low, meaning that the relay is turned on when the pin is set LOW. This change allows the user to specify if the pin switch logic should be inverted i.e. HIGH = off and LOW = on

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5377

## Example entry for `configuration.yaml` (if applicable):
```yaml
  - platform: arest
    resource: http://192.168.X.X
    pins:
      2:
        name: Switch One
        invert: True
      3:
        name: Switch Two
        invert: True
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
