### PR TITLE
Minor Wink fixes

### DIFF
--- a/homeassistant/components/climate/wink.py
+++ b/homeassistant/components/climate/wink.py
@@ -190,7 +190,7 @@ class WinkThermostat(WinkDevice, ClimateDevice):
     @property
     def cool_on(self):
         """Return whether or not the heat is actually heating."""
-        return self.wink.heat_on()
+        return self.wink.cool_on()
 
     @property
     def current_operation(self):

--- a/homeassistant/components/light/wink.py
+++ b/homeassistant/components/light/wink.py
@@ -16,8 +16,6 @@ from homeassistant.util.color import \
 
 DEPENDENCIES = ['wink']
 
-SUPPORT_WINK = SUPPORT_BRIGHTNESS | SUPPORT_COLOR_TEMP | SUPPORT_COLOR
-
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Wink lights."""
@@ -78,7 +76,14 @@ class WinkLight(WinkDevice, Light):
     @property
     def supported_features(self):
         """Flag supported features."""
-        return SUPPORT_WINK
+        supports = SUPPORT_BRIGHTNESS
+        if self.wink.supports_temperature():
+            supports = supports | SUPPORT_COLOR_TEMP
+        if self.wink.supports_xy_color():
+            supports = supports | SUPPORT_COLOR
+        elif self.wink.supports_hue_saturation():
+            supports = supports | SUPPORT_COLOR
+        return supports
 
     def turn_on(self, **kwargs):
         """Turn the switch on."""


### PR DESCRIPTION
## Description:
Don't show the color picker or the temperature slider for a light unless the light actually supports it.

This also fixes the issue blow, copy and paste typo.

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/14255


## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
