### PR TITLE
Add a component for Sisyphus Kinetic Art Tables

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -251,6 +251,9 @@ omit =
     homeassistant/components/scsgate.py
     homeassistant/components/*/scsgate.py
 
+    homeassistant/components/sisyphus.py
+    homeassistant/components/*/sisyphus.py
+
     homeassistant/components/skybell.py
     homeassistant/components/*/skybell.py
 

--- a/homeassistant/components/light/sisyphus.py
+++ b/homeassistant/components/light/sisyphus.py
@@ -14,6 +14,8 @@ _LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = ['sisyphus']
 
+SUPPORTED_FEATURES = SUPPORT_BRIGHTNESS
+
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up a single Sisyphus table."""
@@ -39,7 +41,7 @@ class SisyphusLight(Light):
     async def async_added_to_hass(self):
         """Add listeners after this object has been initialized."""
         self._table.add_listener(
-            lambda: self.schedule_update_ha_state(False))
+            lambda: self.async_schedule_update_ha_state(False))
 
     @property
     def name(self):
@@ -59,7 +61,7 @@ class SisyphusLight(Light):
     @property
     def supported_features(self):
         """Return the features supported by the table; i.e. brightness."""
-        return SUPPORT_BRIGHTNESS
+        return SUPPORTED_FEATURES
 
     async def async_turn_off(self, **kwargs):
         """Put the table to sleep."""

--- a/homeassistant/components/light/sisyphus.py
+++ b/homeassistant/components/light/sisyphus.py
@@ -37,6 +37,7 @@ class SisyphusLight(Light):
         self._table = table
 
     async def async_added_to_hass(self):
+        """Add listeners after this object has been initialized."""
         self._table.add_listener(
             lambda: self.schedule_update_ha_state(False))
 
@@ -52,12 +53,12 @@ class SisyphusLight(Light):
 
     @property
     def brightness(self):
-        """Return the urrent brightness of the table's ring light."""
+        """Return the current brightness of the table's ring light."""
         return self._table.brightness * 255
 
     @property
     def supported_features(self):
-        """Return the eatures supported by the table; i.e. brightness."""
+        """Return the features supported by the table; i.e. brightness."""
         return SUPPORT_BRIGHTNESS
 
     async def async_turn_off(self, **kwargs):

--- a/homeassistant/components/light/sisyphus.py
+++ b/homeassistant/components/light/sisyphus.py
@@ -6,7 +6,7 @@ table light brightness.
 import logging
 
 from homeassistant.const import CONF_NAME
-from homeassistant.components.light import ATTR_BRIGHTNESS, SUPPORT_BRIGHTNESS, Light
+from homeassistant.components.light import SUPPORT_BRIGHTNESS, Light
 from homeassistant.components.sisyphus import DATA_SISYPHUS
 
 _LOGGER = logging.getLogger(__name__)
@@ -18,7 +18,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     name = discovery_info[CONF_NAME]
     add_devices(
         [SisyphusSwitch(name, hass.data[DATA_SISYPHUS][name])],
-        update_before_add = True)
+        update_before_add=True)
 
 
 class SisyphusSwitch(Light):

--- a/homeassistant/components/light/sisyphus.py
+++ b/homeassistant/components/light/sisyphus.py
@@ -1,8 +1,8 @@
 """
-Exposes a Sisyphus Kinetic Art Table as a light.
+Support for the light on the Sisyphus Kinetic Art Table.
 
-Turning the switch off will sleep the table; turning it on will wake it up.
-Brightness controls the table light brightness.
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/light.sisyphus/
 """
 import logging
 
@@ -35,18 +35,10 @@ class SisyphusLight(Light):
         """
         self._name = name
         self._table = table
-        self._initialized = False
 
-    def update(self):
-        """Lazily initializes the table."""
-        if not self._initialized:
-            # We wait until update before adding the listener because
-            # otherwise there's a race condition by which this entity
-            # might not have had its hass field set, and thus
-            # the schedule_update_ha_state call will fail
-            self._table.add_listener(
-                lambda: self.schedule_update_ha_state(False))
-            self._initialized = True
+    async def async_added_to_hass(self):
+        self._table.add_listener(
+            lambda: self.schedule_update_ha_state(False))
 
     @property
     def name(self):

--- a/homeassistant/components/light/sisyphus.py
+++ b/homeassistant/components/light/sisyphus.py
@@ -1,0 +1,66 @@
+"""
+Exposes a Sisyphus Kinetic Art Table as a light. Turning the switch off
+will sleep the table; turning it on will wake it up. Brightness controls the
+table light brightness.
+"""
+import logging
+
+from homeassistant.const import CONF_NAME
+from homeassistant.components.light import ATTR_BRIGHTNESS, SUPPORT_BRIGHTNESS, Light
+from homeassistant.components.sisyphus import DATA_SISYPHUS
+
+_LOGGER = logging.getLogger(__name__)
+
+DEPENDENCIES = ['sisyphus']
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    name = discovery_info[CONF_NAME]
+    add_devices(
+        [SisyphusSwitch(name, hass.data[DATA_SISYPHUS][name])],
+        update_before_add = True)
+
+
+class SisyphusSwitch(Light):
+    def __init__(self, name, table):
+        self._name = name
+        self._table = table
+        self._initialized = False
+
+    def update(self):
+        if not self._initialized:
+            # We wait until update before adding the listener because
+            # otherwise there's a race condition by which this entity
+            # might not have had its hass field set, and thus
+            # the schedule_update_ha_state call will fail
+            self._table.add_listener(
+                lambda: self.schedule_update_ha_state(False))
+            self._initialized = True
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def is_on(self):
+        return not self._table.is_sleeping
+
+    @property
+    def brightness(self):
+        return self._table.brightness * 255
+
+    @property
+    def supported_features(self):
+        return SUPPORT_BRIGHTNESS
+
+    async def async_turn_off(self, **kwargs):
+        await self._table.sleep()
+        _LOGGER.debug("Sisyphus table %s: sleep")
+
+    async def async_turn_on(self, **kwargs):
+        if not self.is_on:
+            await self._table.wakeup()
+            _LOGGER.debug("Sisyphus table %s: wakeup")
+
+        if "brightness" in kwargs:
+            await self._table.set_brightness(kwargs["brightness"] / 255.0)

--- a/homeassistant/components/light/sisyphus.py
+++ b/homeassistant/components/light/sisyphus.py
@@ -1,7 +1,8 @@
 """
-Exposes a Sisyphus Kinetic Art Table as a light. Turning the switch off
-will sleep the table; turning it on will wake it up. Brightness controls the
-table light brightness.
+Exposes a Sisyphus Kinetic Art Table as a light.
+
+Turning the switch off will sleep the table; turning it on will wake it up.
+Brightness controls the table light brightness.
 """
 import logging
 
@@ -15,19 +16,29 @@ DEPENDENCIES = ['sisyphus']
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up a single Sisyphus table."""
     name = discovery_info[CONF_NAME]
     add_devices(
-        [SisyphusSwitch(name, hass.data[DATA_SISYPHUS][name])],
+        [SisyphusLight(name, hass.data[DATA_SISYPHUS][name])],
         update_before_add=True)
 
 
-class SisyphusSwitch(Light):
+class SisyphusLight(Light):
+    """Represents a Sisyphus table as a light."""
+
     def __init__(self, name, table):
+        """
+        Constructor.
+
+        :param name: name of the table
+        :param table: sisyphus-control Table object
+        """
         self._name = name
         self._table = table
         self._initialized = False
 
     def update(self):
+        """Lazily initializes the table."""
         if not self._initialized:
             # We wait until update before adding the listener because
             # otherwise there's a race condition by which this entity
@@ -39,25 +50,31 @@ class SisyphusSwitch(Light):
 
     @property
     def name(self):
+        """Return the ame of the table."""
         return self._name
 
     @property
     def is_on(self):
+        """Return True if the table is on."""
         return not self._table.is_sleeping
 
     @property
     def brightness(self):
+        """Return the urrent brightness of the table's ring light."""
         return self._table.brightness * 255
 
     @property
     def supported_features(self):
+        """Return the eatures supported by the table; i.e. brightness."""
         return SUPPORT_BRIGHTNESS
 
     async def async_turn_off(self, **kwargs):
+        """Put the table to sleep."""
         await self._table.sleep()
         _LOGGER.debug("Sisyphus table %s: sleep")
 
     async def async_turn_on(self, **kwargs):
+        """Wake up the table if necessary, optionally changes brightness."""
         if not self.is_on:
             await self._table.wakeup()
             _LOGGER.debug("Sisyphus table %s: wakeup")

--- a/homeassistant/components/media_player/sisyphus.py
+++ b/homeassistant/components/media_player/sisyphus.py
@@ -27,6 +27,16 @@ DEPENDENCIES = ['sisyphus']
 
 MEDIA_TYPE_TRACK = "sisyphus_track"
 
+SUPPORTED_FEATURES = SUPPORT_VOLUME_MUTE \
+    | SUPPORT_VOLUME_SET \
+    | SUPPORT_TURN_OFF \
+    | SUPPORT_TURN_ON \
+    | SUPPORT_PAUSE \
+    | SUPPORT_SHUFFLE_SET \
+    | SUPPORT_PREVIOUS_TRACK \
+    | SUPPORT_NEXT_TRACK \
+    | SUPPORT_PLAY
+
 
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -52,18 +62,11 @@ class SisyphusPlayer(MediaPlayerDevice):
         self._name = name
         self._host = host
         self._table = table
-        self._initialized = False
 
-    def update(self):
-        """Lazily initializes the table."""
-        if not self._initialized:
-            # We wait until update before adding the listener because
-            # otherwise there's a race condition by which this entity
-            # might not have had its hass field set, and thus
-            # the schedule_update_ha_state call will fail
-            self._table.add_listener(
-                lambda: self.schedule_update_ha_state(False))
-            self._initialized = True
+    async def async_added_to_hass(self):
+        """Add listeners after this object has been initialized."""
+        self._table.add_listener(
+            lambda: self.async_schedule_update_ha_state(False))
 
     @property
     def name(self):
@@ -132,15 +135,7 @@ class SisyphusPlayer(MediaPlayerDevice):
     @property
     def supported_features(self):
         """Return the features supported by this table."""
-        return SUPPORT_VOLUME_MUTE \
-            | SUPPORT_VOLUME_SET \
-            | SUPPORT_TURN_OFF \
-            | SUPPORT_TURN_ON \
-            | SUPPORT_PAUSE \
-            | SUPPORT_SHUFFLE_SET \
-            | SUPPORT_PREVIOUS_TRACK \
-            | SUPPORT_NEXT_TRACK \
-            | SUPPORT_PLAY
+        return SUPPORTED_FEATURES
 
     @property
     def media_image_url(self):

--- a/homeassistant/components/media_player/sisyphus.py
+++ b/homeassistant/components/media_player/sisyphus.py
@@ -78,12 +78,12 @@ class SisyphusPlayer(MediaPlayerDevice):
         """Return the current state of the table; sleeping maps to off."""
         if self._table.state in ["homing", "playing"]:
             return STATE_PLAYING
-        elif self._table.state == "paused":
+        if self._table.state == "paused":
             if self._table.is_sleeping:
                 return STATE_OFF
 
             return STATE_PAUSED
-        elif self._table.state == "waiting":
+        if self._table.state == "waiting":
             return STATE_IDLE
 
         return None

--- a/homeassistant/components/media_player/sisyphus.py
+++ b/homeassistant/components/media_player/sisyphus.py
@@ -1,0 +1,176 @@
+"""
+Exposes the Sisyphus Kinetic Art Table as a media player. Media controls
+work as one would expect. Volume controls table speed.
+"""
+import logging
+
+from homeassistant.components.media_player import (
+    SUPPORT_NEXT_TRACK,
+    SUPPORT_PAUSE,
+    SUPPORT_PLAY,
+    SUPPORT_PREVIOUS_TRACK,
+    SUPPORT_SHUFFLE_SET,
+    SUPPORT_TURN_OFF,
+    SUPPORT_TURN_ON,
+    SUPPORT_VOLUME_MUTE,
+    SUPPORT_VOLUME_SET,
+    MediaPlayerDevice)
+from homeassistant.components.sisyphus import DATA_SISYPHUS
+from homeassistant.const import CONF_HOST, CONF_NAME, STATE_PLAYING, \
+    STATE_PAUSED, STATE_IDLE, STATE_OFF
+
+_LOGGER = logging.getLogger(__name__)
+
+DEPENDENCIES = ['sisyphus']
+
+MEDIA_TYPE_TRACK = "sisyphus_track"
+
+# Features that are always available, regardless of the state of the table
+ALWAYS_FEATURES = \
+    SUPPORT_VOLUME_MUTE \
+    | SUPPORT_VOLUME_SET \
+    | SUPPORT_TURN_OFF \
+    | SUPPORT_TURN_ON
+
+
+# pylint: disable=unused-argument
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    name = discovery_info[CONF_NAME]
+    host = discovery_info[CONF_HOST]
+    add_devices(
+        [SisyphusPlayer(name, host, hass.data[DATA_SISYPHUS][name])],
+        update_before_add=True)
+
+
+class SisyphusPlayer(MediaPlayerDevice):
+    def __init__(self, name, host, table):
+        self._name = name
+        self._host = host
+        self._table = table
+        self._initialized = False
+
+    def update(self):
+        if not self._initialized:
+            # We wait until update before adding the listener because
+            # otherwise there's a race condition by which this entity
+            # might not have had its hass field set, and thus
+            # the schedule_update_ha_state call will fail
+            self._table.add_listener(
+                lambda: self.schedule_update_ha_state(False))
+            self._initialized = True
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def state(self):
+        if self._table.state in ["homing", "playing"]:
+            return STATE_PLAYING
+        elif self._table.state == "paused":
+            if self._table.is_sleeping:
+                return STATE_OFF
+            else:
+                return STATE_PAUSED
+        elif self._table.state == "waiting":
+            return STATE_IDLE
+        raise Exception("Unknown state: {0}".format(self._table.state))
+
+    @property
+    def volume_level(self):
+        return self._table.speed
+
+    @property
+    def shuffle(self):
+        return self._table.is_shuffle
+
+    async def async_set_shuffle(self, shuffle):
+        await self._table.set_shuffle(shuffle)
+
+    @property
+    def media_playlist(self):
+        return self._table.active_playlist.name \
+            if self._table.active_playlist \
+            else None
+
+    @property
+    def media_title(self):
+        return self._table.active_track.name \
+            if self._table.active_track \
+            else None
+
+    @property
+    def media_content_type(self):
+        return MEDIA_TYPE_TRACK
+
+    @property
+    def media_content_id(self):
+        return self._table.active_track.id \
+            if self._table.active_track \
+            else None
+
+    @property
+    def supported_features(self):
+        if self.state == STATE_PLAYING:
+            features = ALWAYS_FEATURES | SUPPORT_PAUSE
+
+            if self._table.active_playlist:
+                features |= SUPPORT_SHUFFLE_SET
+                current_track_index = self._get_current_track_index()
+                if current_track_index > 0:
+                    features |= SUPPORT_PREVIOUS_TRACK
+                if current_track_index < len(self._table.tracks) - 1:
+                    features |= SUPPORT_NEXT_TRACK
+
+            return features
+        else:
+            return ALWAYS_FEATURES | SUPPORT_PLAY
+
+    @property
+    def media_image_url(self):
+        from sisyphus.control import Track
+        if self._table.active_track:
+            return self._table.active_track.get_thumbnail_url(
+                Track.ThumbnailSize.LARGE)
+        else:
+            return super.media_image_url()
+
+    async def async_turn_on(self):
+        await self._table.wakeup()
+
+    async def async_turn_off(self):
+        await self._table.sleep()
+
+    async def async_volume_down(self):
+        await self._table.set_speed(max(0, self._table.speed - 0.1))
+
+    async def async_volume_up(self):
+        await self._table.set_speed(min(1.0, self._table.speed + 0.1))
+
+    async def async_set_volume_level(self, volume):
+        await self._table.set_speed(volume)
+
+    async def async_media_play(self):
+        await self._table.play()
+
+    async def async_media_pause(self):
+        await self._table.pause()
+
+    async def async_media_next_track(self):
+        cur_track_index = self._get_current_track_index()
+
+        await self._table.active_playlist.play(
+            self._table.active_playlist.tracks[cur_track_index + 1])
+
+    async def async_media_previous_track(self):
+        cur_track_index = self._get_current_track_index()
+
+        await self._table.active_playlist.play(
+            self._table.active_playlist.tracks[cur_track_index - 1])
+
+    def _get_current_track_index(self):
+        for index, track in enumerate(self._table.active_playlist.tracks):
+            if track.id == self._table.active_track.id:
+                return index
+
+        return -1

--- a/homeassistant/components/media_player/sisyphus.py
+++ b/homeassistant/components/media_player/sisyphus.py
@@ -72,7 +72,7 @@ class SisyphusPlayer(MediaPlayerDevice):
 
     @property
     def state(self):
-        """Return the urrent state of the table; sleeping maps to off."""
+        """Return the current state of the table; sleeping maps to off."""
         if self._table.state in ["homing", "playing"]:
             return STATE_PLAYING
         elif self._table.state == "paused":
@@ -82,7 +82,8 @@ class SisyphusPlayer(MediaPlayerDevice):
             return STATE_PAUSED
         elif self._table.state == "waiting":
             return STATE_IDLE
-        raise Exception("Unknown state: {0}".format(self._table.state))
+
+        return None
 
     @property
     def volume_level(self):

--- a/homeassistant/components/media_player/sisyphus.py
+++ b/homeassistant/components/media_player/sisyphus.py
@@ -1,7 +1,8 @@
 """
-Exposes the Sisyphus Kinetic Art Table as a media player.
+Support for track controls on the Sisyphus Kinetic Art Table.
 
-Media controls work as one would expect. Volume controls table speed.
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/media_player.sisyphus/
 """
 import logging
 
@@ -25,13 +26,6 @@ _LOGGER = logging.getLogger(__name__)
 DEPENDENCIES = ['sisyphus']
 
 MEDIA_TYPE_TRACK = "sisyphus_track"
-
-# Features that are always available, regardless of the state of the table
-ALWAYS_FEATURES = \
-    SUPPORT_VOLUME_MUTE \
-    | SUPPORT_VOLUME_SET \
-    | SUPPORT_TURN_OFF \
-    | SUPPORT_TURN_ON
 
 
 # pylint: disable=unused-argument
@@ -136,21 +130,16 @@ class SisyphusPlayer(MediaPlayerDevice):
 
     @property
     def supported_features(self):
-        """Return the features supported by this table in its current state."""
-        if self.state == STATE_PLAYING:
-            features = ALWAYS_FEATURES | SUPPORT_PAUSE
-
-            if self._table.active_playlist:
-                features |= SUPPORT_SHUFFLE_SET
-                current_track_index = self._get_current_track_index()
-                if current_track_index > 0:
-                    features |= SUPPORT_PREVIOUS_TRACK
-                if current_track_index < len(self._table.tracks) - 1:
-                    features |= SUPPORT_NEXT_TRACK
-
-            return features
-
-        return ALWAYS_FEATURES | SUPPORT_PLAY
+        """Return the features supported by this table."""
+        return SUPPORT_VOLUME_MUTE \
+            | SUPPORT_VOLUME_SET \
+            | SUPPORT_TURN_OFF \
+            | SUPPORT_TURN_ON \
+            | SUPPORT_PAUSE \
+            | SUPPORT_SHUFFLE_SET \
+            | SUPPORT_PREVIOUS_TRACK \
+            | SUPPORT_NEXT_TRACK \
+            | SUPPORT_PLAY
 
     @property
     def media_image_url(self):

--- a/homeassistant/components/media_player/sisyphus.py
+++ b/homeassistant/components/media_player/sisyphus.py
@@ -84,8 +84,8 @@ class SisyphusPlayer(MediaPlayerDevice):
         elif self._table.state == "paused":
             if self._table.is_sleeping:
                 return STATE_OFF
-            else:
-                return STATE_PAUSED
+
+            return STATE_PAUSED
         elif self._table.state == "waiting":
             return STATE_IDLE
         raise Exception("Unknown state: {0}".format(self._table.state))
@@ -149,18 +149,18 @@ class SisyphusPlayer(MediaPlayerDevice):
                     features |= SUPPORT_NEXT_TRACK
 
             return features
-        else:
-            return ALWAYS_FEATURES | SUPPORT_PLAY
+
+        return ALWAYS_FEATURES | SUPPORT_PLAY
 
     @property
     def media_image_url(self):
         """Return the URL for a thumbnail image of the current track."""
-        from sisyphus.control import Track
+        from sisyphus_control import Track
         if self._table.active_track:
             return self._table.active_track.get_thumbnail_url(
                 Track.ThumbnailSize.LARGE)
-        else:
-            return super.media_image_url()
+
+        return super.media_image_url()
 
     async def async_turn_on(self):
         """Wake up a sleeping table."""

--- a/homeassistant/components/sisyphus.py
+++ b/homeassistant/components/sisyphus.py
@@ -75,8 +75,3 @@ async def async_setup(hass, config):
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, close_tables)
 
     return True
-
-
-
-
-

--- a/homeassistant/components/sisyphus.py
+++ b/homeassistant/components/sisyphus.py
@@ -1,0 +1,82 @@
+"""
+Enables control of Sisyphus Kinetic Art Tables. Each table is exposed as
+a light and a media player.
+"""
+import logging
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_NAME,
+    EVENT_HOMEASSISTANT_STOP
+)
+from homeassistant.helpers.discovery import async_load_platform
+
+REQUIREMENTS = ['sisyphus-control==1.1.1']
+
+_LOGGER = logging.getLogger(__name__)
+
+DATA_SISYPHUS = 'sisyphus'
+DOMAIN = 'sisyphus'
+
+AUTODETECT_SCHEMA = vol.Schema({
+    DOMAIN: {},
+}, extra=vol.ALLOW_EXTRA)
+
+TABLES_SCHEMA = vol.Schema({
+    DOMAIN: [
+        {
+            vol.Required(CONF_NAME): cv.string,
+            vol.Required(CONF_HOST): cv.string,
+        },
+    ],
+}, extra=vol.ALLOW_EXTRA)
+
+CONFIG_SCHEMA = vol.Any(AUTODETECT_SCHEMA, TABLES_SCHEMA)
+
+
+async def async_setup(hass, config):
+    import sisyphus.control
+    tables = hass.data.setdefault(DATA_SISYPHUS, {})
+    table_configs = config.get(DOMAIN)
+
+    async def add_table(host, name=None):
+        table = await sisyphus.control.Table.connect(host)
+        if name is None:
+            name = table.name
+        tables[name] = table
+        _LOGGER.debug("Connected to %s at %s", name, host)
+
+        hass.async_add_job(async_load_platform(
+            hass, 'light', 'sisyphus', {
+                CONF_NAME: name,
+            }, config
+        ))
+        hass.async_add_job(async_load_platform(
+            hass, 'media_player', 'sisyphus', {
+                CONF_NAME: name,
+                CONF_HOST: host,
+            }, config
+        ))
+
+    if isinstance(table_configs, dict):  # AUTODETECT_SCHEMA
+        for ip in await sisyphus.control.Table.find_table_ips():
+            await add_table(ip)
+    else:  # TABLES_SCHEMA
+        for conf in table_configs:
+            if conf.get(CONF_HOST) is not None:
+                await add_table(conf.get(CONF_HOST), conf.get(CONF_NAME))
+
+    async def close_tables(*args):
+        for table in tables.values():
+            await table.close()
+
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, close_tables)
+
+    return True
+
+
+
+
+

--- a/homeassistant/components/sisyphus.py
+++ b/homeassistant/components/sisyphus.py
@@ -44,7 +44,7 @@ async def async_setup(hass, config):
     table_configs = config.get(DOMAIN)
 
     async def add_table(host, name=None):
-        """Adds platforms for a single table with the given hostname"""
+        """Add platforms for a single table with the given hostname."""
         table = await Table.connect(host)
         if name is None:
             name = table.name
@@ -72,7 +72,7 @@ async def async_setup(hass, config):
                 await add_table(conf.get(CONF_HOST), conf.get(CONF_NAME))
 
     async def close_tables(*args):
-        """Closes all table objects"""
+        """Close all table objects."""
         for table in tables.values():
             await table.close()
 

--- a/homeassistant/components/sisyphus.py
+++ b/homeassistant/components/sisyphus.py
@@ -1,6 +1,7 @@
 """
-Enables control of Sisyphus Kinetic Art Tables. Each table is exposed as
-a light and a media player.
+Enables control of Sisyphus Kinetic Art Tables.
+
+Each table is exposed as a light and a media player.
 """
 import logging
 import voluptuous as vol
@@ -37,6 +38,7 @@ CONFIG_SCHEMA = vol.Any(AUTODETECT_SCHEMA, TABLES_SCHEMA)
 
 
 async def async_setup(hass, config):
+    """Set up the sisyphus component."""
     import sisyphus.control
     tables = hass.data.setdefault(DATA_SISYPHUS, {})
     table_configs = config.get(DOMAIN)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1244,7 +1244,7 @@ simplepush==1.1.4
 simplisafe-python==1.0.5
 
 # homeassistant.components.sisyphus
-sisyphus-control==1.1.1
+sisyphus-control==2.0.0
 
 # homeassistant.components.skybell
 skybellpy==0.1.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1244,7 +1244,7 @@ simplepush==1.1.4
 simplisafe-python==1.0.5
 
 # homeassistant.components.sisyphus
-sisyphus-control==2.0.0
+sisyphus-control==2.1
 
 # homeassistant.components.skybell
 skybellpy==0.1.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1243,6 +1243,9 @@ simplepush==1.1.4
 # homeassistant.components.alarm_control_panel.simplisafe
 simplisafe-python==1.0.5
 
+# homeassistant.components.sisyphus
+sisyphus-control==1.1.1
+
 # homeassistant.components.skybell
 skybellpy==0.1.2
 


### PR DESCRIPTION
## Description:

The [Sisyphus Kinetic Art Table](https://sisyphus-industries.com/) uses a steel ball to draw intricate patterns in sand, thrown into sharp relief by a ring of LED lights around the outside.

This component enables basic control of these tables through Home Assistant.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5369

## Example entry for `configuration.yaml` (if applicable):
```yaml
sisyphus:

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
