### PR TITLE
Improve handling of offline Sonos devices

### DIFF
--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -682,11 +682,15 @@ class SonosDevice(MediaPlayerDevice):
             if group:
                 # New group information is pushed
                 coordinator_uid, *slave_uids = group.split(',')
-            else:
+            elif self.soco.group:
                 # Use SoCo cache for existing topology
                 coordinator_uid = self.soco.group.coordinator.uid
                 slave_uids = [p.uid for p in self.soco.group.members
                               if p.uid != coordinator_uid]
+            else:
+                # Not yet in the cache, this can happen when a speaker boots
+                coordinator_uid = self.unique_id
+                slave_uids = []
 
             if self.unique_id == coordinator_uid:
                 sonos_group = []


### PR DESCRIPTION
## Description:

SoCo maintains a cache of all players so a just booted player can appear to not exist. In this case the player forms of group that contains only itself.

**Related issue (if applicable):** fixes #14344

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.
