### PR TITLE
Feedreader configurable update interval and max entries

### DIFF
--- a/homeassistant/components/feedreader.py
+++ b/homeassistant/components/feedreader.py
@@ -21,6 +21,7 @@ REQUIREMENTS = ['feedparser==5.2.1']
 _LOGGER = getLogger(__name__)
 
 CONF_URLS = 'urls'
+CONF_MAX_ENTRIES = 'max_entries'
 
 DEFAULT_SCAN_INTERVAL = timedelta(hours=1)
 
@@ -35,6 +36,7 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Required(CONF_URLS): vol.All(cv.ensure_list, [cv.url]),
         vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL):
             cv.time_period,
+        vol.Optional(CONF_MAX_ENTRIES, default=MAX_ENTRIES): cv.positive_int
     }
 }, extra=vol.ALLOW_EXTRA)
 
@@ -43,19 +45,22 @@ def setup(hass, config):
     """Set up the Feedreader component."""
     urls = config.get(DOMAIN)[CONF_URLS]
     scan_interval = config.get(DOMAIN).get(CONF_SCAN_INTERVAL)
+    max_entries = config.get(DOMAIN).get(CONF_MAX_ENTRIES)
     data_file = hass.config.path("{}.pickle".format(DOMAIN))
     storage = StoredData(data_file)
-    feeds = [FeedManager(url, scan_interval, hass, storage) for url in urls]
+    feeds = [FeedManager(url, scan_interval, max_entries, hass, storage) for
+             url in urls]
     return len(feeds) > 0
 
 
 class FeedManager(object):
     """Abstraction over Feedparser module."""
 
-    def __init__(self, url, scan_interval, hass, storage):
+    def __init__(self, url, scan_interval, max_entries, hass, storage):
         """Initialize the FeedManager object, poll as per scan interval."""
         self._url = url
         self._scan_interval = scan_interval
+        self._max_entries = max_entries
         self._feed = None
         self._hass = hass
         self._firstrun = True
@@ -122,10 +127,10 @@ class FeedManager(object):
 
     def _filter_entries(self):
         """Filter the entries provided and return the ones to keep."""
-        if len(self._feed.entries) > MAX_ENTRIES:
+        if len(self._feed.entries) > self._max_entries:
             _LOGGER.debug("Processing only the first %s entries "
-                          "in feed %s", MAX_ENTRIES, self._url)
-            self._feed.entries = self._feed.entries[0:MAX_ENTRIES]
+                          "in feed %s", self._max_entries, self._url)
+            self._feed.entries = self._feed.entries[0:self._max_entries]
 
     def _update_and_fire_entry(self, entry):
         """Update last_entry_timestamp and fire entry."""

--- a/homeassistant/components/feedreader.py
+++ b/homeassistant/components/feedreader.py
@@ -23,20 +23,20 @@ _LOGGER = getLogger(__name__)
 CONF_URLS = 'urls'
 CONF_MAX_ENTRIES = 'max_entries'
 
+DEFAULT_MAX_ENTRIES = 20
 DEFAULT_SCAN_INTERVAL = timedelta(hours=1)
 
 DOMAIN = 'feedreader'
 
 EVENT_FEEDREADER = 'feedreader'
 
-MAX_ENTRIES = 20
-
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: {
         vol.Required(CONF_URLS): vol.All(cv.ensure_list, [cv.url]),
         vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL):
             cv.time_period,
-        vol.Optional(CONF_MAX_ENTRIES, default=MAX_ENTRIES): cv.positive_int
+        vol.Optional(CONF_MAX_ENTRIES, default=DEFAULT_MAX_ENTRIES):
+            cv.positive_int
     }
 }, extra=vol.ALLOW_EXTRA)
 

--- a/tests/components/test_feedreader.py
+++ b/tests/components/test_feedreader.py
@@ -177,8 +177,8 @@ class TestFeedreaderComponent(unittest.TestCase):
         data_file = self.hass.config.path("{}.pickle".format(
             feedreader.DOMAIN))
         storage = StoredData(data_file)
-        manager = FeedManager("FEED DATA", DEFAULT_SCAN_INTERVAL, DEFAULT_MAX_ENTRIES,
-                              self.hass, storage)
+        manager = FeedManager("FEED DATA", DEFAULT_SCAN_INTERVAL,
+                              DEFAULT_MAX_ENTRIES, self.hass, storage)
         # Artificially trigger update.
         self.hass.bus.fire(EVENT_HOMEASSISTANT_START)
         # Collect events.

--- a/tests/components/test_feedreader.py
+++ b/tests/components/test_feedreader.py
@@ -12,7 +12,7 @@ from unittest.mock import patch
 from homeassistant.components import feedreader
 from homeassistant.components.feedreader import CONF_URLS, FeedManager, \
     StoredData, EVENT_FEEDREADER, DEFAULT_SCAN_INTERVAL, CONF_MAX_ENTRIES, \
-    MAX_ENTRIES
+    DEFAULT_MAX_ENTRIES
 from homeassistant.const import EVENT_HOMEASSISTANT_START, CONF_SCAN_INTERVAL
 from homeassistant.core import callback
 from homeassistant.setup import setup_component
@@ -78,7 +78,7 @@ class TestFeedreaderComponent(unittest.TestCase):
         self.assertTrue(setup_component(self.hass, feedreader.DOMAIN,
                                         VALID_CONFIG_3))
 
-    def setup_manager(self, feed_data, max_entries=MAX_ENTRIES):
+    def setup_manager(self, feed_data, max_entries=DEFAULT_MAX_ENTRIES):
         """Generic test setup method."""
         events = []
 
@@ -177,7 +177,7 @@ class TestFeedreaderComponent(unittest.TestCase):
         data_file = self.hass.config.path("{}.pickle".format(
             feedreader.DOMAIN))
         storage = StoredData(data_file)
-        manager = FeedManager("FEED DATA", DEFAULT_SCAN_INTERVAL, MAX_ENTRIES,
+        manager = FeedManager("FEED DATA", DEFAULT_SCAN_INTERVAL, DEFAULT_MAX_ENTRIES,
                               self.hass, storage)
         # Artificially trigger update.
         self.hass.bus.fire(EVENT_HOMEASSISTANT_START)

--- a/tests/components/test_feedreader.py
+++ b/tests/components/test_feedreader.py
@@ -16,8 +16,7 @@ from homeassistant.components.feedreader import CONF_URLS, FeedManager, \
 from homeassistant.const import EVENT_HOMEASSISTANT_START, CONF_SCAN_INTERVAL
 from homeassistant.core import callback
 from homeassistant.setup import setup_component
-from tests.common import get_test_home_assistant, assert_setup_component, \
-    load_fixture
+from tests.common import get_test_home_assistant, load_fixture
 
 _LOGGER = getLogger(__name__)
 


### PR DESCRIPTION
## Description:
This change makes two features of the feedreader component configurable:
* The scan interval that determines how often the feed is updated is now configurable. The default is 1 hour which is slightly different to the previous behaviour where the update interval was fixed to the top of the clock every hour.
* The number of max entries extracted from the feed is now configurable. The default is 20 which is the previous behaviour.

**Related issue (if applicable):** n/a

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5382

## Example entry for `configuration.yaml` (if applicable):
```yaml
feedreader:
  urls:
    - https://www.home-assistant.io/atom.xml
    - https://github.com/blog.atom
    - https://hasspodcast.io/feed/podcast
  scan_interval:
    minutes: 30
  max_entries: 50
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
