### PR TITLE
Simplify broadlink sensor and add support for energy sensor SP2/SP3.

### DIFF
--- a/homeassistant/components/sensor/broadlink.py
+++ b/homeassistant/components/sensor/broadlink.py
@@ -11,15 +11,16 @@ import socket
 
 import voluptuous as vol
 
-from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.components.sensor import PLATFORM_SCHEMA, ENTITY_ID_FORMAT
 from homeassistant.const import (
     CONF_HOST, CONF_MAC, CONF_MONITORED_CONDITIONS, CONF_NAME, TEMP_CELSIUS,
-    CONF_TIMEOUT)
+    CONF_TIMEOUT, CONF_TYPE)
 from homeassistant.helpers.entity import Entity
-from homeassistant.util import Throttle
+from homeassistant.util import Throttle, slugify
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['broadlink==0.9.0']
+REQUIREMENTS = ['https://github.com/mjg59/python-broadlink'
+                '/archive/master.zip#broadlink']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -33,16 +34,18 @@ SENSOR_TYPES = {
     'humidity': ['Humidity', '%'],
     'light': ['Light', ' '],
     'noise': ['Noise', ' '],
+    'energy': ['Energy', 'W'],
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEVICE_DEFAULT_NAME): vol.Coerce(str),
     vol.Optional(CONF_MONITORED_CONDITIONS, default=[]):
         vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
-    vol.Optional(CONF_UPDATE_INTERVAL, default=timedelta(seconds=300)): (
+    vol.Optional(CONF_UPDATE_INTERVAL, default=timedelta(seconds=30)): (
         vol.All(cv.time_period, cv.positive_timedelta)),
     vol.Required(CONF_HOST): cv.string,
     vol.Required(CONF_MAC): cv.string,
+    vol.Optional(CONF_TYPE): cv.string,
     vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int
 })
 
@@ -51,28 +54,58 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Broadlink device sensors."""
     host = config.get(CONF_HOST)
+    type = config.get(CONF_TYPE)
     mac = config.get(CONF_MAC).encode().replace(b':', b'')
     mac_addr = binascii.unhexlify(mac)
     name = config.get(CONF_NAME)
     timeout = config.get(CONF_TIMEOUT)
     update_interval = config.get(CONF_UPDATE_INTERVAL)
-    broadlink_data = BroadlinkData(update_interval, host, mac_addr, timeout)
     dev = []
     for variable in config[CONF_MONITORED_CONDITIONS]:
-        dev.append(BroadlinkSensor(name, broadlink_data, variable))
+        dev.append(BroadlinkSensor(name, variable, host,
+                                   mac_addr, timeout, type,
+                                   update_interval))
     add_devices(dev, True)
 
 
 class BroadlinkSensor(Entity):
     """Representation of a Broadlink device sensor."""
 
-    def __init__(self, name, broadlink_data, sensor_type):
+    def __init__(self, name, sensor_type, ip_addr,
+                 mac_addr, timeout, device_type=None,
+                 update_interval=None):
         """Initialize the sensor."""
         self._name = '{} {}'.format(name, SENSOR_TYPES[sensor_type][0])
+        self.entity_id = ENTITY_ID_FORMAT.format(slugify(self._name))
         self._state = None
+        self._device_type = device_type
         self._type = sensor_type
-        self._broadlink_data = broadlink_data
+        # self._broadlink_data = broadlink_data
         self._unit_of_measurement = SENSOR_TYPES[sensor_type][1]
+        self.ip_addr = ip_addr
+        self.mac_addr = mac_addr
+        self.timeout = timeout
+
+        self._schema = vol.Schema({
+            vol.Optional('temperature'): vol.Range(min=-50, max=150),
+            vol.Optional('humidity'): vol.Range(min=0, max=100),
+            vol.Optional('light'): vol.Any(0, 1, 2, 3),
+            vol.Optional('air_quality'): vol.Any(0, 1, 2, 3),
+            vol.Optional('noise'): vol.Any(0, 1, 2),
+        })
+
+        self._connect()
+        if not self._auth():
+            _LOGGER.warning("Failed to connect to device")
+
+        self.update = Throttle(update_interval)(self._update)
+
+    def _connect(self):
+        import broadlink
+        _type = self._device_type or 'a1'
+        self._device = getattr(broadlink, _type)(
+            (self.ip_addr, 80), self.mac_addr, None)
+        self._device.timeout = self.timeout
 
     @property
     def name(self):
@@ -89,50 +122,21 @@ class BroadlinkSensor(Entity):
         """Return the unit this state is expressed in."""
         return self._unit_of_measurement
 
-    def update(self):
-        """Get the latest data from the sensor."""
-        self._broadlink_data.update()
-        if self._broadlink_data.data is None:
-            return
-        self._state = self._broadlink_data.data[self._type]
-
-
-class BroadlinkData(object):
-    """Representation of a Broadlink data object."""
-
-    def __init__(self, interval, ip_addr, mac_addr, timeout):
-        """Initialize the data object."""
-        self.data = None
-        self.ip_addr = ip_addr
-        self.mac_addr = mac_addr
-        self.timeout = timeout
-        self._connect()
-        self._schema = vol.Schema({
-            vol.Optional('temperature'): vol.Range(min=-50, max=150),
-            vol.Optional('humidity'): vol.Range(min=0, max=100),
-            vol.Optional('light'): vol.Any(0, 1, 2, 3),
-            vol.Optional('air_quality'): vol.Any(0, 1, 2, 3),
-            vol.Optional('noise'): vol.Any(0, 1, 2),
-            })
-        self.update = Throttle(interval)(self._update)
-        if not self._auth():
-            _LOGGER.warning("Failed to connect to device")
-
-    def _connect(self):
-        import broadlink
-        self._device = broadlink.a1((self.ip_addr, 80), self.mac_addr, None)
-        self._device.timeout = self.timeout
-
     def _update(self, retry=3):
+        """Get the latest data from the sensor."""
         try:
-            data = self._device.check_sensors_raw()
-            if data is not None:
-                self.data = self._schema(data)
-                return
+            if self._type == 'energy':
+                self._state = self._device.get_energy()
+            else:
+                data = self._device.check_sensors_raw()
+                if data is not None:
+                    self._data = self._schema(data)
+                    self._state = self._data[self._type]
+            self.schedule_update_ha_state()
+            return
         except socket.timeout as error:
-            if retry < 1:
-                _LOGGER.error(error)
-                return
+            _LOGGER.error(error)
+            return
         except (vol.Invalid, vol.MultipleInvalid):
             pass  # Continue quietly if device returned malformed data
         if retry > 0 and self._auth():

--- a/homeassistant/components/sensor/broadlink.py
+++ b/homeassistant/components/sensor/broadlink.py
@@ -11,15 +11,16 @@ import socket
 
 import voluptuous as vol
 
-from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.components.sensor import PLATFORM_SCHEMA, ENTITY_ID_FORMAT
 from homeassistant.const import (
     CONF_HOST, CONF_MAC, CONF_MONITORED_CONDITIONS, CONF_NAME, TEMP_CELSIUS,
-    CONF_TIMEOUT)
+    CONF_TIMEOUT, CONF_TYPE)
 from homeassistant.helpers.entity import Entity
-from homeassistant.util import Throttle
+from homeassistant.util import Throttle, slugify
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['broadlink==0.9.0']
+REQUIREMENTS = [
+    'https://github.com/mjg59/python-broadlink/archive/master.zip#broadlink']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -33,16 +34,18 @@ SENSOR_TYPES = {
     'humidity': ['Humidity', '%'],
     'light': ['Light', ' '],
     'noise': ['Noise', ' '],
+    'energy': ['Energy', 'W'],
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEVICE_DEFAULT_NAME): vol.Coerce(str),
     vol.Optional(CONF_MONITORED_CONDITIONS, default=[]):
         vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
-    vol.Optional(CONF_UPDATE_INTERVAL, default=timedelta(seconds=300)): (
+    vol.Optional(CONF_UPDATE_INTERVAL, default=timedelta(seconds=30)): (
         vol.All(cv.time_period, cv.positive_timedelta)),
     vol.Required(CONF_HOST): cv.string,
     vol.Required(CONF_MAC): cv.string,
+    vol.Optional(CONF_TYPE): cv.string,
     vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int
 })
 
@@ -51,28 +54,58 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Broadlink device sensors."""
     host = config.get(CONF_HOST)
+    type = config.get(CONF_TYPE)
     mac = config.get(CONF_MAC).encode().replace(b':', b'')
     mac_addr = binascii.unhexlify(mac)
     name = config.get(CONF_NAME)
     timeout = config.get(CONF_TIMEOUT)
     update_interval = config.get(CONF_UPDATE_INTERVAL)
-    broadlink_data = BroadlinkData(update_interval, host, mac_addr, timeout)
     dev = []
     for variable in config[CONF_MONITORED_CONDITIONS]:
-        dev.append(BroadlinkSensor(name, broadlink_data, variable))
+        dev.append(BroadlinkSensor(name, variable, host,
+                                   mac_addr, timeout, type,
+                                   update_interval))
     add_devices(dev, True)
 
 
 class BroadlinkSensor(Entity):
     """Representation of a Broadlink device sensor."""
 
-    def __init__(self, name, broadlink_data, sensor_type):
+    def __init__(self, name, sensor_type, ip_addr,
+                 mac_addr, timeout, device_type=None,
+                 update_interval=None):
         """Initialize the sensor."""
         self._name = '{} {}'.format(name, SENSOR_TYPES[sensor_type][0])
+        self.entity_id = ENTITY_ID_FORMAT.format(slugify(self._name))
         self._state = None
+        self._device_type = device_type
         self._type = sensor_type
-        self._broadlink_data = broadlink_data
+        # self._broadlink_data = broadlink_data
         self._unit_of_measurement = SENSOR_TYPES[sensor_type][1]
+        self.ip_addr = ip_addr
+        self.mac_addr = mac_addr
+        self.timeout = timeout
+
+        self._schema = vol.Schema({
+            vol.Optional('temperature'): vol.Range(min=-50, max=150),
+            vol.Optional('humidity'): vol.Range(min=0, max=100),
+            vol.Optional('light'): vol.Any(0, 1, 2, 3),
+            vol.Optional('air_quality'): vol.Any(0, 1, 2, 3),
+            vol.Optional('noise'): vol.Any(0, 1, 2),
+        })
+
+        self._connect()
+        if not self._auth():
+            _LOGGER.warning("Failed to connect to device")
+
+        self.update = Throttle(update_interval)(self._update)
+
+    def _connect(self):
+        import broadlink
+        _type = self._device_type or 'a1'
+        self._device = getattr(broadlink, _type)(
+            (self.ip_addr, 80), self.mac_addr, None)
+        self._device.timeout = self.timeout
 
     @property
     def name(self):
@@ -89,50 +122,21 @@ class BroadlinkSensor(Entity):
         """Return the unit this state is expressed in."""
         return self._unit_of_measurement
 
-    def update(self):
-        """Get the latest data from the sensor."""
-        self._broadlink_data.update()
-        if self._broadlink_data.data is None:
-            return
-        self._state = self._broadlink_data.data[self._type]
-
-
-class BroadlinkData(object):
-    """Representation of a Broadlink data object."""
-
-    def __init__(self, interval, ip_addr, mac_addr, timeout):
-        """Initialize the data object."""
-        self.data = None
-        self.ip_addr = ip_addr
-        self.mac_addr = mac_addr
-        self.timeout = timeout
-        self._connect()
-        self._schema = vol.Schema({
-            vol.Optional('temperature'): vol.Range(min=-50, max=150),
-            vol.Optional('humidity'): vol.Range(min=0, max=100),
-            vol.Optional('light'): vol.Any(0, 1, 2, 3),
-            vol.Optional('air_quality'): vol.Any(0, 1, 2, 3),
-            vol.Optional('noise'): vol.Any(0, 1, 2),
-            })
-        self.update = Throttle(interval)(self._update)
-        if not self._auth():
-            _LOGGER.warning("Failed to connect to device")
-
-    def _connect(self):
-        import broadlink
-        self._device = broadlink.a1((self.ip_addr, 80), self.mac_addr, None)
-        self._device.timeout = self.timeout
-
     def _update(self, retry=3):
+        """Get the latest data from the sensor."""
         try:
-            data = self._device.check_sensors_raw()
-            if data is not None:
-                self.data = self._schema(data)
-                return
+            if self._type == 'energy':
+                self._state = self._device.get_energy()
+            else:
+                data = self._device.check_sensors_raw()
+                if data is not None:
+                    self._data = self._schema(data)
+                    self._state = self._data[self._type]
+            self.schedule_update_ha_state()
+            return
         except socket.timeout as error:
-            if retry < 1:
-                _LOGGER.error(error)
-                return
+            _LOGGER.error(error)
+            return
         except (vol.Invalid, vol.MultipleInvalid):
             pass  # Continue quietly if device returned malformed data
         if retry > 0 and self._auth():

--- a/homeassistant/components/switch/broadlink.py
+++ b/homeassistant/components/switch/broadlink.py
@@ -22,7 +22,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.util import Throttle, slugify
 from homeassistant.util.dt import utcnow
 
-REQUIREMENTS = ['broadlink==0.9.0']
+REQUIREMENTS = ['https://github.com/mjg59/python-broadlink/archive/master.zip#broadlink']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -294,6 +294,7 @@ class BroadlinkSP2Switch(BroadlinkSP1Switch):
 
     def _update(self, retry=2):
         """Update the state of the device."""
+        self._auth()
         try:
             state = self._device.check_power()
         except (socket.timeout, ValueError) as error:


### PR DESCRIPTION
## Description:

Add support for energy sensors like SP2 and SP3.
Remove DataObject and initialize sensor per metric

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
