### PR TITLE
WIP: Change version of broadlink switch dependency and add extra auth call.

### DIFF
--- a/homeassistant/components/switch/broadlink.py
+++ b/homeassistant/components/switch/broadlink.py
@@ -22,7 +22,8 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.util import Throttle, slugify
 from homeassistant.util.dt import utcnow
 
-REQUIREMENTS = ['broadlink==0.9.0']
+REQUIREMENTS = ['https://github.com/mjg59/python-broadlink'
+                '/archive/master.zip#broadlink']
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Description:

Fix problem with SP2/SP3 devices which is caused by error in driver. Update fix this devices, maybe another devices from this family.

maybe we should use commit hash freeze ?

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>
```

2018-05-16 23:26:09 ERROR (MainThread) [homeassistant.helpers.entity] Update for switch.broadlink_switch fails
Traceback (most recent call last):
  File "/srv/home_assistant/src/homeassistant/homeassistant/helpers/entity.py", line 204, in async_update_ha_state
    yield from self.async_device_update()
  File "/srv/home_assistant/src/homeassistant/homeassistant/helpers/entity.py", line 327, in async_device_update
    yield from self.hass.async_add_job(self.update)
  File "/usr/lib/python3.5/asyncio/futures.py", line 380, in __iter__
    yield self  # This tells Task to wait for completion.
  File "/usr/lib/python3.5/asyncio/tasks.py", line 304, in _wakeup
    future.result()
  File "/usr/lib/python3.5/asyncio/futures.py", line 293, in result
    raise self._exception
  File "/usr/lib/python3.5/concurrent/futures/thread.py", line 55, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/srv/home_assistant/src/homeassistant/homeassistant/components/switch/broadlink.py", line 293, in update
    self._update()
  File "/srv/home_assistant/src/homeassistant/homeassistant/components/switch/broadlink.py", line 299, in _update
    state = self._device.check_power()
  File "/srv/home_assistant/lib/python3.5/site-packages/broadlink/__init__.py", line 418, in check_power
    if ord(payload[0x4]) == 1 or ord(payload[0x4]) == 3:
TypeError: ord() expected string of length 1, but int found
```

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensors:
- platform: broadlink
  host: 'ip'
  mac: 'mac'
  type: sp2
  monitored_conditions:
    - 'energy'
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
