### PR TITLE
Fix ISY moisure sensors showing unknown until a leak is detected

### DIFF
--- a/homeassistant/components/binary_sensor/isy994.py
+++ b/homeassistant/components/binary_sensor/isy994.py
@@ -161,7 +161,6 @@ class ISYBinarySensorDevice(ISYDevice, BinarySensorDevice):
             # in use for this device. Next we need to check to see if the
             # negative and positive nodes disagree on the state (both ON or
             # both OFF).
-            _LOGGER.debug(self._node)
             if self._negative_node.status._val == self._node.status._val:
                 # The states disagree, therefore we cannot determine the state
                 # of the sensor until we receive our first ON event.

--- a/homeassistant/components/binary_sensor/isy994.py
+++ b/homeassistant/components/binary_sensor/isy994.py
@@ -156,9 +156,14 @@ class ISYBinarySensorDevice(ISYDevice, BinarySensorDevice):
         # pylint: disable=protected-access
         if not _is_val_unknown(self._negative_node.status._val):
             # If the negative node has a value, it means the negative node is
-            # in use for this device. Therefore, we cannot determine the state
-            # of the sensor until we receive our first ON event.
-            self._computed_state = None
+            # in use for this device. Next we need to check to see if the
+            # negative and positive nodes disagree on the state (both ON or
+            # both OFF).
+            _LOGGER.debug(self._node)
+            if self._negative_node.status._val == self._node.status._val:
+                # The states disagree, therefore we cannot determine the state
+                # of the sensor until we receive our first ON event.
+                self._computed_state = None
 
     def _negative_node_control_handler(self, event: object) -> None:
         """Handle an "On" control event from the "negative" node."""

--- a/homeassistant/components/binary_sensor/isy994.py
+++ b/homeassistant/components/binary_sensor/isy994.py
@@ -195,7 +195,6 @@ class ISYBinarySensorDevice(ISYDevice, BinarySensorDevice):
             self.schedule_update_ha_state()
             self._heartbeat()
 
-    # pylint: disable=unused-argument
     def on_update(self, event: object) -> None:
         """Primary node status updates.
 

--- a/homeassistant/components/binary_sensor/isy994.py
+++ b/homeassistant/components/binary_sensor/isy994.py
@@ -209,8 +209,10 @@ class ISYBinarySensorDevice(ISYDevice, BinarySensorDevice):
         """
         if self._status_was_unknown and self._computed_state is None:
             # pylint: disable=protected-access
-            self._computed_state = bool(self._node._val)
+            self._computed_state = bool(self._node.status._val)
             self._status_was_unknown = False
+            self.schedule_update_ha_state()
+            self._heartbeat()
 
     @property
     def value(self) -> object:

--- a/homeassistant/components/binary_sensor/isy994.py
+++ b/homeassistant/components/binary_sensor/isy994.py
@@ -206,8 +206,7 @@ class ISYBinarySensorDevice(ISYDevice, BinarySensorDevice):
         an accompanying Control event, so we need to watch for it.
         """
         if self._status_was_unknown and self._computed_state is None:
-            # pylint: disable=protected-access
-            self._computed_state = bool(self._node.status._val)
+            self._computed_state = bool(int(self._node.status))
             self._status_was_unknown = False
             self.schedule_update_ha_state()
             self._heartbeat()


### PR DESCRIPTION
## Description:
ISY moisture sensors currently show as "Unknown" state until they detect a leak or the user presses the button manually on the sensor. This was due to some obnoxiously nuanced ways that the moisture sensor sends signals. This PR fixes all of the ways that it could show up wrong, including a very specific edge case that can happen for the first 24 hours after the ISY controller reboots. They should be perfect now!

**Related issue (if applicable):** fixes #13384

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** n/a


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

