### PR TITLE
Fix some ISY sensors not getting detected as binary sensors

### DIFF
--- a/homeassistant/components/isy994.py
+++ b/homeassistant/components/isy994.py
@@ -202,7 +202,7 @@ def _check_for_uom_id(hass: HomeAssistant, node,
     node_uom = set(map(str.lower, node.uom))
 
     if uom_list:
-        if node_uom.intersection(NODE_FILTERS[single_domain]['uom']):
+        if node_uom.intersection(uom_list):
             hass.data[ISY994_NODES][single_domain].append(node)
             return True
     else:


### PR DESCRIPTION
## Description:
Sensors that were defined via `sensor_string` were not getting properly identified as binary sensors when they had a uom defining them as binary (the other three methods of detecting binary sensors worked though.)

This was a copy paste error from a ways back.

**Related issue (if applicable):** fixes #12415 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
