### PR TITLE
Show warning if no locations are shared (fixes #14177)

### DIFF
--- a/homeassistant/components/device_tracker/google_maps.py
+++ b/homeassistant/components/device_tracker/google_maps.py
@@ -72,7 +72,7 @@ class GoogleMapsScanner(object):
             try:
                 dev_id = 'google_maps_{0}'.format(person.id)
             except TypeError:
-                _LOGGER.error("No location(s) shared with this account")
+                _LOGGER.warning("No location(s) shared with this account")
                 return
 
             attrs = {

--- a/homeassistant/components/device_tracker/google_maps.py
+++ b/homeassistant/components/device_tracker/google_maps.py
@@ -12,14 +12,18 @@ import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.device_tracker import (
     PLATFORM_SCHEMA, SOURCE_TYPE_GPS)
-from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
+from homeassistant.const import CONF_USERNAME, CONF_PASSWORD, ATTR_ID
 from homeassistant.helpers.event import track_time_interval
 from homeassistant.helpers.typing import ConfigType
-from homeassistant.util import slugify
+
+REQUIREMENTS = ['locationsharinglib==2.0.2']
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['locationsharinglib==2.0.2']
+ATTR_ADDRESS = 'address'
+ATTR_FULL_NAME = 'full_name'
+ATTR_LAST_SEEN = 'last_seen'
+ATTR_NICKNAME = 'nickname'
 
 CREDENTIALS_FILE = '.google_maps_location_sharing.cookies'
 
@@ -60,19 +64,23 @@ class GoogleMapsScanner(object):
             self.success_init = True
 
         except InvalidUser:
-            _LOGGER.error('You have specified invalid login credentials')
+            _LOGGER.error("You have specified invalid login credentials")
             self.success_init = False
 
     def _update_info(self, now=None):
         for person in self.service.get_all_people():
-            dev_id = 'google_maps_{0}'.format(slugify(person.id))
+            try:
+                dev_id = 'google_maps_{0}'.format(person.id)
+            except TypeError:
+                _LOGGER.error("No location(s) shared with this account")
+                return
 
             attrs = {
-                'id': person.id,
-                'nickname': person.nickname,
-                'full_name': person.full_name,
-                'last_seen': person.datetime,
-                'address': person.address
+                ATTR_ADDRESS: person.address,
+                ATTR_FULL_NAME: person.full_name,
+                ATTR_ID: person.id,
+                ATTR_LAST_SEEN: person.datetime,
+                ATTR_NICKNAME: person.nickname,
             }
             self.see(
                 dev_id=dev_id,
@@ -80,5 +88,5 @@ class GoogleMapsScanner(object):
                 picture=person.picture_url,
                 source_type=SOURCE_TYPE_GPS,
                 gps_accuracy=person.accuracy,
-                attributes=attrs
+                attributes=attrs,
             )


### PR DESCRIPTION
## Description:
If people try to use their primary account then the module is not able to retrieve the ID. Only the Google ID of accounts which are sharing their location with the account set in the configuration are shown.

Perhaps it would make sense to allow this as it would make it possible to use the integration with creating an additional account only for location sharing. The downside is that it could get messy quickly.

**Related issue (if applicable):** fixes #14177

## Example entry for `configuration.yaml` (if applicable):
```yaml
device_tracker:
  - platform: google_maps
    username: you@gmail.com
    password: password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

