### PR TITLE
Fix probability_threshold in binary_sensor.bayesian

### DIFF
--- a/homeassistant/components/binary_sensor/bayesian.py
+++ b/homeassistant/components/binary_sensor/bayesian.py
@@ -217,4 +217,4 @@ class BayesianBinarySensor(BinarySensorDevice):
     @asyncio.coroutine
     def async_update(self):
         """Get the latest data and update the states."""
-        self._deviation = bool(self.probability > self._probability_threshold)
+        self._deviation = bool(self.probability >= self._probability_threshold)

--- a/tests/components/binary_sensor/test_bayesian.py
+++ b/tests/components/binary_sensor/test_bayesian.py
@@ -154,6 +154,37 @@ class TestBayesianBinarySensor(unittest.TestCase):
 
         assert state.state == 'off'
 
+    def test_threshold(self):
+        """Test sensor on probabilty threshold limits."""
+        config = {
+            'binary_sensor': {
+                'name':
+                'Test_Binary',
+                'platform':
+                'bayesian',
+                'observations': [{
+                    'platform': 'state',
+                    'entity_id': 'sensor.test_monitored',
+                    'to_state': 'on',
+                    'prob_given_true': 1.0,
+                }],
+                'prior':
+                0.5,
+                'probability_threshold':
+                1.0,
+            }
+        }
+
+        assert setup_component(self.hass, 'binary_sensor', config)
+
+        self.hass.states.set('sensor.test_monitored', 'on')
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('binary_sensor.test_binary')
+        self.assertAlmostEqual(1.0, state.attributes.get('probability'))
+
+        assert state.state == 'on'
+
     def test_multiple_observations(self):
         """Test sensor with multiple observations of same entity."""
         config = {


### PR DESCRIPTION
## Description:

Sensor only changed state beyond probability_threshold. This is not in accordance with documentation and fails the logic premisse that if probability is 1.0 then the binary_sensor should be ON when the probability_threshold is 1.0.

**Related issue (if applicable):** fixes #14362

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
~~- [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)~~

If the code communicates with devices, web services, or third-party tools:
  ~~- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).~~
  ~~- [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).~~
  ~~- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.~~
  ~~- [ ] New files were added to `.coveragerc`.~~

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54