### PR TITLE
Wemo custom ports and network errors handling

### DIFF
--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -40,7 +40,9 @@ _LOGGER = logging.getLogger(__name__)
 
 def coerce_host_port(value):
     """Validate that provided value is either just host or host:port.
-    Returns (host, None) or (host, port) respectively."""
+
+    Returns (host, None) or (host, port) respectively.
+    """
     host, _, port = value.partition(':')
 
     if not host:

--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -49,12 +49,7 @@ def coerce_host_port(value):
         raise vol.Invalid('host cannot be empty')
 
     if port:
-        try:
-            port = cv.port(port)
-        except vol.Invalid as exc:
-            _slice = slice(value.index(':') + 1, len(value))
-            exc.path.append(_slice)
-            raise
+        port = cv.port(port)
     else:
         port = None
 


### PR DESCRIPTION
## Description:

Follow-up for https://github.com/home-assistant/home-assistant/pull/8307 and https://github.com/home-assistant/home-assistant/pull/8414 - support emulated switches sitting behind one ip on different ports.

- <s>Updated pywemo-0.4.27 to properly handle alternative ports when reconnecting.</s> pywemo is already 0.4.28
- Support 'host:port' in static section (+config validation)
- Fail on inaccessible static addresses, and do it before doing discovery
- Handle network exceptions raised from `pywemo.discovery.device_from_description` / `requests.get(...setup.xml url...)` for discovery and switch/light/binary_sensor wemos.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5401

## Example entry for `configuration.yaml` (if applicable):
```yaml
wemo:
  static:
    - 10.1.0.1
    - 10.1.0.2
    - 10.0.0.1:1111
    - 10.0.0.1:2222
    - 10.0.0.1:3333
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)