### PR TITLE
Upgrade async_timeout to 3.0.0

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -6,7 +6,7 @@ jinja2>=2.10
 voluptuous==0.11.1
 typing>=3,<4
 aiohttp==3.1.3
-async_timeout==2.0.1
+async_timeout==3.0.0
 astral==1.6.1
 certifi>=2017.4.17
 attrs==18.1.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -7,7 +7,7 @@ jinja2>=2.10
 voluptuous==0.11.1
 typing>=3,<4
 aiohttp==3.1.3
-async_timeout==2.0.1
+async_timeout==3.0.0
 astral==1.6.1
 certifi>=2017.4.17
 attrs==18.1.0

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ REQUIRES = [
     'voluptuous==0.11.1',
     'typing>=3,<4',
     'aiohttp==3.1.3',
-    'async_timeout==2.0.1',
+    'async_timeout==3.0.0',
     'astral==1.6.1',
     'certifi>=2017.4.17',
     'attrs==18.1.0',


### PR DESCRIPTION
## Description:
- Drop Python 3.4, the minimal supported version is Python 3.5.3
- Provide type annotations

## Example entry for `configuration.yaml` (if applicable):
```yaml
http:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

