### PR TITLE
Add support container status for Glances on RPi3

### DIFF
--- a/homeassistant/components/sensor/glances.py
+++ b/homeassistant/components/sensor/glances.py
@@ -161,7 +161,7 @@ class GlancesSensor(Entity):
             elif self.type == 'docker_active':
                 count = 0
                 for container in value['docker']['containers']:
-                    if container['Status'] == 'running':
+                    if container['Status'] == 'running' or "Up" in container['Status']:
                         count += 1
                 self._state = count
             elif self.type == 'docker_cpu_use':

--- a/homeassistant/components/sensor/glances.py
+++ b/homeassistant/components/sensor/glances.py
@@ -161,8 +161,9 @@ class GlancesSensor(Entity):
             elif self.type == 'docker_active':
                 count = 0
                 for container in value['docker']['containers']:
-                    if container['Status'] == 'running' or "Up" in container['Status']:
-                        count += 1
+                    if container['Status'] == 'running' or 
+                       "Up" in container['Status']:
+                          count += 1
                 self._state = count
             elif self.type == 'docker_cpu_use':
                 use = 0.0

--- a/homeassistant/components/sensor/glances.py
+++ b/homeassistant/components/sensor/glances.py
@@ -162,8 +162,8 @@ class GlancesSensor(Entity):
                 count = 0
                 for container in value['docker']['containers']:
                     if container['Status'] == 'running' or \
-                        'Up' in container['Status']:
-                           count += 1
+                            'Up' in container['Status']:
+                            count += 1
                 self._state = count
             elif self.type == 'docker_cpu_use':
                 use = 0.0

--- a/homeassistant/components/sensor/glances.py
+++ b/homeassistant/components/sensor/glances.py
@@ -161,9 +161,9 @@ class GlancesSensor(Entity):
             elif self.type == 'docker_active':
                 count = 0
                 for container in value['docker']['containers']:
-                    if container['Status'] == 'running' or 
-                       "Up" in container['Status']:
-                          count += 1
+                    if container['Status'] == 'running' or
+                        "Up" in container['Status']:
+                           count += 1
                 self._state = count
             elif self.type == 'docker_cpu_use':
                 use = 0.0

--- a/homeassistant/components/sensor/glances.py
+++ b/homeassistant/components/sensor/glances.py
@@ -161,8 +161,8 @@ class GlancesSensor(Entity):
             elif self.type == 'docker_active':
                 count = 0
                 for container in value['docker']['containers']:
-                    if container['Status'] == 'running' or
-                        "Up" in container['Status']:
+                    if container['Status'] == 'running' or \
+                        'Up' in container['Status']:
                            count += 1
                 self._state = count
             elif self.type == 'docker_cpu_use':

--- a/homeassistant/components/sensor/glances.py
+++ b/homeassistant/components/sensor/glances.py
@@ -163,7 +163,7 @@ class GlancesSensor(Entity):
                 for container in value['docker']['containers']:
                     if container['Status'] == 'running' or \
                             'Up' in container['Status']:
-                            count += 1
+                        count += 1
                 self._state = count
             elif self.type == 'docker_cpu_use':
                 use = 0.0


### PR DESCRIPTION
Glances on RPi3 return different container status. 
```
"containers": [
        {
            "Status": "Up 2 hours",
            "name": "HASS",
            "io": {
                "iow": 0,
                "time_since_update": 5.1789350509643555,
                "cumulative_ior": 94208,
                "ior": 0,
                "cumulative_iow": 4096
            },
```
This small PR adds support dealing with this differences.

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
