### PR TITLE
Add Flock notification platform

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -519,9 +519,10 @@ omit =
     homeassistant/components/notify/aws_sqs.py
     homeassistant/components/notify/ciscospark.py
     homeassistant/components/notify/clickatell.py
-    homeassistant/components/notify/clicksend_tts.py
     homeassistant/components/notify/clicksend.py
+    homeassistant/components/notify/clicksend_tts.py
     homeassistant/components/notify/discord.py
+    homeassistant/components/notify/flock.py
     homeassistant/components/notify/free_mobile.py
     homeassistant/components/notify/gntp.py
     homeassistant/components/notify/group.py

--- a/homeassistant/components/notify/flock.py
+++ b/homeassistant/components/notify/flock.py
@@ -1,0 +1,61 @@
+"""
+Flock platform for notify component.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/notify.flock/
+"""
+import asyncio
+import logging
+
+import async_timeout
+import voluptuous as vol
+
+from homeassistant.components.notify import (
+    PLATFORM_SCHEMA, BaseNotificationService)
+from homeassistant.const import CONF_ACCESS_TOKEN
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+import homeassistant.helpers.config_validation as cv
+
+_LOGGER = logging.getLogger(__name__)
+_RESOURCE = 'https://api.flock.com/hooks/sendMessage/'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_ACCESS_TOKEN): cv.string,
+})
+
+
+async def get_service(hass, config, discovery_info=None):
+    """Get the Flock.io notification service."""
+    access_token = config.get(CONF_ACCESS_TOKEN)
+    url = '{}{}'.format(_RESOURCE, access_token)
+
+    return FlockNotificationService(hass, url)
+
+
+class FlockNotificationService(BaseNotificationService):
+    """Implement the notification service for Flock."""
+
+    def __init__(self, hass, url):
+        """Initialize the Flock.io notification service."""
+        self._hass = hass
+        self._url = url
+
+    @asyncio.coroutine
+    def async_send_message(self, message, **kwargs):
+        """Send the message to the user."""
+        payload = {'text': message}
+
+        _LOGGER.debug("Attempting to call Flock at %s", self._url)
+        session = async_get_clientsession(self._hass)
+
+        try:
+            with async_timeout.timeout(10, loop=self._hass.loop):
+                response = yield from session.post(self._url, json=payload)
+                result = yield from response.json()
+
+            if response.status != 200 or 'error' in result:
+                _LOGGER.error(
+                    "Flock service returned HTTP status %d, response %s",
+                    response.status, result)
+        except asyncio.TimeoutError:
+            _LOGGER.error("Timeout accessing Flock at %s", self._url)


### PR DESCRIPTION
## Description:
Add support for sending notifications from home Assistant to [Flock](https://flock.com/).

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5395

## Example entry for `configuration.yaml` (if applicable):
```yaml
notify:
  - platform: flock
    name: flock
    access_token: a3c1d25c-b9e4-40d2-9b0e-ea3de17ccef8
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
