### PR TITLE
Fix bom sensor name (fixes #14535)

### DIFF
--- a/homeassistant/components/sensor/bom.py
+++ b/homeassistant/components/sensor/bom.py
@@ -28,6 +28,12 @@ import homeassistant.helpers.config_validation as cv
 _RESOURCE = 'http://www.bom.gov.au/fwo/{}/{}.{}.json'
 _LOGGER = logging.getLogger(__name__)
 
+ATTR_LAST_UPDATE = 'last_update'
+ATTR_SENSOR_ID = 'sensor_id'
+ATTR_STATION_ID = 'station_id'
+ATTR_STATION_NAME = 'station_name'
+ATTR_ZONE_ID = 'zone_id'
+
 CONF_ATTRIBUTION = "Data provided by the Australian Bureau of Meteorology"
 CONF_STATION = 'station'
 CONF_ZONE_ID = 'zone_id'
@@ -35,7 +41,6 @@ CONF_WMO_ID = 'wmo_id'
 
 MIN_TIME_BETWEEN_UPDATES = datetime.timedelta(minutes=35)
 
-# Sensor types are defined like: Name, units
 SENSOR_TYPES = {
     'wmo': ['wmo', None],
     'name': ['Station Name', None],
@@ -70,7 +75,7 @@ SENSOR_TYPES = {
     'weather': ['Weather', None],
     'wind_dir': ['Wind Direction', None],
     'wind_spd_kmh': ['Wind Speed kmh', 'km/h'],
-    'wind_spd_kt': ['Wind Direction kt', 'kt']
+    'wind_spd_kt': ['Wind Speed kt', 'kt']
 }
 
 
@@ -98,6 +103,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the BOM sensor."""
     station = config.get(CONF_STATION)
     zone_id, wmo_id = config.get(CONF_ZONE_ID), config.get(CONF_WMO_ID)
+
     if station is not None:
         if zone_id and wmo_id:
             _LOGGER.warning(
@@ -111,17 +117,18 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             hass.config.config_dir)
         if station is None:
             _LOGGER.error("Could not get BOM weather station from lat/lon")
-            return False
+            return
 
     bom_data = BOMCurrentData(hass, station)
+
     try:
         bom_data.update()
     except ValueError as err:
-        _LOGGER.error("Received error from BOM_Current: %s", err)
-        return False
+        _LOGGER.error("Received error from BOM Current: %s", err)
+        return
+
     add_devices([BOMCurrentSensor(bom_data, variable, config.get(CONF_NAME))
                  for variable in config[CONF_MONITORED_CONDITIONS]])
-    return True
 
 
 class BOMCurrentSensor(Entity):
@@ -150,14 +157,17 @@ class BOMCurrentSensor(Entity):
     @property
     def device_state_attributes(self):
         """Return the state attributes of the device."""
-        attr = {}
-        attr['Sensor Id'] = self._condition
-        attr['Zone Id'] = self.bom_data.latest_data['history_product']
-        attr['Station Id'] = self.bom_data.latest_data['wmo']
-        attr['Station Name'] = self.bom_data.latest_data['name']
-        attr['Last Update'] = datetime.datetime.strptime(str(
-            self.bom_data.latest_data['local_date_time_full']), '%Y%m%d%H%M%S')
-        attr[ATTR_ATTRIBUTION] = CONF_ATTRIBUTION
+        attr = {
+            ATTR_ATTRIBUTION: CONF_ATTRIBUTION,
+            ATTR_LAST_UPDATE: datetime.datetime.strptime(
+                str(self.bom_data.latest_data['local_date_time_full']),
+                '%Y%m%d%H%M%S'),
+            ATTR_SENSOR_ID: self._condition,
+            ATTR_STATION_ID: self.bom_data.latest_data['wmo'],
+            ATTR_STATION_NAME: self.bom_data.latest_data['name'],
+            ATTR_ZONE_ID: self.bom_data.latest_data['history_product'],
+        }
+
         return attr
 
     @property
@@ -180,8 +190,9 @@ class BOMCurrentData(object):
         self._data = None
 
     def _build_url(self):
+        """Build the URL for the requests."""
         url = _RESOURCE.format(self._zone_id, self._zone_id, self._wmo_id)
-        _LOGGER.info("BOM URL %s", url)
+        _LOGGER.debug("BOM URL: %s", url)
         return url
 
     @property
@@ -200,7 +211,7 @@ class BOMCurrentData(object):
         for the latest value that is not `-`.
 
         Iterators are used in this method to avoid iterating needlessly
-        iterating through the entire BOM provided dataset
+        iterating through the entire BOM provided dataset.
         """
         condition_readings = (entry[condition] for entry in self._data)
         return next((x for x in condition_readings if x != '-'), None)
@@ -257,7 +268,7 @@ def _get_bom_stations():
 def bom_stations(cache_dir):
     """Return {CONF_STATION: (lat, lon)} for all stations, for auto-config.
 
-    Results from internet requests are cached as compressed json, making
+    Results from internet requests are cached as compressed JSON, making
     subsequent calls very much faster.
     """
     cache_file = os.path.join(cache_dir, '.bom-stations.json.gz')
@@ -277,7 +288,7 @@ def closest_station(lat, lon, cache_dir):
     stations = bom_stations(cache_dir)
 
     def comparable_dist(wmo_id):
-        """Create a psudeo-distance from lat/lon."""
+        """Create a psudeo-distance from latitude/longitude."""
         station_lat, station_lon = stations[wmo_id]
         return (lat - station_lat) ** 2 + (lon - station_lon) ** 2
 

--- a/tests/components/sensor/test_bom.py
+++ b/tests/components/sensor/test_bom.py
@@ -1,16 +1,16 @@
 """The tests for the BOM Weather sensor platform."""
+import json
 import re
 import unittest
-import json
-import requests
 from unittest.mock import patch
 from urllib.parse import urlparse
 
-from homeassistant.setup import setup_component
-from homeassistant.components import sensor
-
+import requests
 from tests.common import (
-    get_test_home_assistant, assert_setup_component, load_fixture)
+    assert_setup_component, get_test_home_assistant, load_fixture)
+
+from homeassistant.components import sensor
+from homeassistant.setup import setup_component
 
 VALID_CONFIG = {
     'platform': 'bom',
@@ -89,9 +89,11 @@ class TestBOMWeatherSensor(unittest.TestCase):
         self.assertTrue(setup_component(
             self.hass, sensor.DOMAIN, {'sensor': VALID_CONFIG}))
 
-        self.assertEqual('Fine', self.hass.states.get(
-            'sensor.bom_fake_weather').state)
-        self.assertEqual('1021.7', self.hass.states.get(
-            'sensor.bom_fake_pressure_mb').state)
-        self.assertEqual('25.0', self.hass.states.get(
-            'sensor.bom_fake_feels_like_c').state)
+        weather = self.hass.states.get('sensor.bom_fake_weather').state
+        self.assertEqual('Fine', weather)
+
+        pressure = self.hass.states.get('sensor.bom_fake_pressure_mb').state
+        self.assertEqual('1021.7', pressure)
+
+        feels_like = self.hass.states.get('sensor.bom_fake_feels_like_c').state
+        self.assertEqual('25.0', feels_like)


### PR DESCRIPTION
## Description:
- Change `'Wind Direction kt'` to `'Wind Speed kt'`
- Use constants
- Update ordering of the import

**Related issue (if applicable):** fixes #14535

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: bom
    station: IDS60801.94675
    name: Adelaide
    monitored_conditions:
      - apparent_t
      - cloud
      - cloud_base_m
      - cloud_oktas
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

