### PR TITLE
Improve NetAtmo refresh time

### DIFF
--- a/homeassistant/components/sensor/netatmo.py
+++ b/homeassistant/components/sensor/netatmo.py
@@ -22,8 +22,8 @@ CONF_STATION = 'station'
 
 DEPENDENCIES = ['netatmo']
 
-# NetAtmo Data is uploaded to server every 10 minutes
-MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=600)
+# NetAtmo Data is uploaded to server every 5 minutes
+MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=300)
 
 SENSOR_TYPES = {
     'temperature': ['Temperature', TEMP_CELSIUS, 'mdi:thermometer'],

--- a/homeassistant/components/sensor/netatmo.py
+++ b/homeassistant/components/sensor/netatmo.py
@@ -73,11 +73,11 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             # Iterate each module
             for module_name, monitored_conditions in\
                     config[CONF_MODULES].items():
-                # Test if module exist """
+                # Test if module exists
                 if module_name not in data.get_module_names():
-                    _LOGGER.error('Module name: "%s" not found', module_name)
+                    _LOGGER.error('Module name "%s" not found', module_name)
                     continue
-                # Only create sensor for monitored """
+                # Only create sensors for monitored properties
                 for variable in monitored_conditions:
                     dev.append(NetAtmoSensor(data, module_name, variable))
         else:


### PR DESCRIPTION
## Description:

Noting that NetAtmo sensors are updated every 5 minutes, this mini-PR is to refresh the HA state also every 5 minutes as opposed to 10.

This works for several days and made my netatmo sensors based automations more reactive.

**Related issue (if applicable):** N/A
**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable): N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
