### PR TITLE
Add support for multi-channel enocean switches (D2-01-12 profile)

### DIFF
--- a/homeassistant/components/enocean.py
+++ b/homeassistant/components/enocean.py
@@ -75,6 +75,7 @@ class EnOceanDongle:
             _LOGGER.debug("Received radio packet: %s", temp)
             rxtype = None
             value = None
+            channel = 0
             if temp.data[6] == 0x30:
                 rxtype = "wallswitch"
                 value = 1
@@ -84,8 +85,9 @@ class EnOceanDongle:
             elif temp.data[4] == 0x0c:
                 rxtype = "power"
                 value = temp.data[3] + (temp.data[2] << 8)
-            elif temp.data[2] == 0x60:
+            elif temp.data[2] & 0x60 == 0x60:
                 rxtype = "switch_status"
+                channel = temp.data[2] & 0x1F
                 if temp.data[3] == 0xe4:
                     value = 1
                 elif temp.data[3] == 0x80:
@@ -104,7 +106,8 @@ class EnOceanDongle:
                     if temp.sender_int == self._combine_hex(device.dev_id):
                         if value > 10:
                             device.value_changed(1)
-                if rxtype == "switch_status" and device.stype == "switch":
+                if rxtype == "switch_status" and device.stype == "switch" and \
+                        channel == device.channel:
                     if temp.sender_int == self._combine_hex(device.dev_id):
                         device.value_changed(value)
                 if rxtype == "dimmerstatus" and device.stype == "dimmer":

--- a/homeassistant/components/switch/enocean.py
+++ b/homeassistant/components/switch/enocean.py
@@ -18,10 +18,12 @@ _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_NAME = 'EnOcean Switch'
 DEPENDENCIES = ['enocean']
+CONF_CHANNEL = 'channel'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_ID): vol.All(cv.ensure_list, [vol.Coerce(int)]),
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_CHANNEL, default=0): cv.positive_int,
 })
 
 
@@ -29,14 +31,15 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the EnOcean switch platform."""
     dev_id = config.get(CONF_ID)
     devname = config.get(CONF_NAME)
+    channel = config.get(CONF_CHANNEL)
 
-    add_devices([EnOceanSwitch(dev_id, devname)])
+    add_devices([EnOceanSwitch(dev_id, devname, channel)])
 
 
 class EnOceanSwitch(enocean.EnOceanDevice, ToggleEntity):
     """Representation of an EnOcean switch device."""
 
-    def __init__(self, dev_id, devname):
+    def __init__(self, dev_id, devname, channel):
         """Initialize the EnOcean switch device."""
         enocean.EnOceanDevice.__init__(self)
         self.dev_id = dev_id
@@ -44,6 +47,7 @@ class EnOceanSwitch(enocean.EnOceanDevice, ToggleEntity):
         self._light = None
         self._on_state = False
         self._on_state2 = False
+        self.channel = channel
         self.stype = "switch"
 
     @property
@@ -61,7 +65,7 @@ class EnOceanSwitch(enocean.EnOceanDevice, ToggleEntity):
         optional = [0x03, ]
         optional.extend(self.dev_id)
         optional.extend([0xff, 0x00])
-        self.send_command(data=[0xD2, 0x01, 0x00, 0x64, 0x00,
+        self.send_command(data=[0xD2, 0x01, self.channel & 0xFF, 0x64, 0x00,
                                 0x00, 0x00, 0x00, 0x00], optional=optional,
                           packet_type=0x01)
         self._on_state = True
@@ -71,7 +75,7 @@ class EnOceanSwitch(enocean.EnOceanDevice, ToggleEntity):
         optional = [0x03, ]
         optional.extend(self.dev_id)
         optional.extend([0xff, 0x00])
-        self.send_command(data=[0xD2, 0x01, 0x00, 0x00, 0x00,
+        self.send_command(data=[0xD2, 0x01, self.channel & 0xFF, 0x00, 0x00,
                                 0x00, 0x00, 0x00, 0x00], optional=optional,
                           packet_type=0x01)
         self._on_state = False


### PR DESCRIPTION
## Description:

Adds support for multi-channel enocean switches such as these:
https://nodon.fr/en/nodon/enocean-relay-switch-2-channels/
In general this should support many devices that use the D2-01-12 enocean profile.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>  **want to get a first review of this PR first**

## Example entry for `configuration.yaml` (if applicable):
```yaml
# multi-channel switches can be configured like this now:
switch nodon01_0:
  - platform: enocean
    id: [0x05, 0x04, 0x03, 0x02]
    name: enocean_nodon01_0
    channel: 0

switch nodon01_1:
  - platform: enocean
    id: [0x05, 0x04, 0x03, 0x02]
    name: enocean_nodon01_1
    channel: 1

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)  docs PR: https://github.com/home-assistant/home-assistant.github.io/pull/5660
