### PR TITLE
Make influxDB import script more resilient

### DIFF
--- a/homeassistant/scripts/influxdb_import.py
+++ b/homeassistant/scripts/influxdb_import.py
@@ -19,6 +19,7 @@ def run(script_args: List) -> int:
     from homeassistant.helpers import state as state_helper
     from homeassistant.core import State
     from homeassistant.core import HomeAssistantError
+    from homeassistant.exceptions import InvalidStateError
 
     parser = argparse.ArgumentParser(
         description="import data to influxDB.")
@@ -174,7 +175,7 @@ def run(script_args: List) -> int:
 
             try:
                 state = State.from_dict(event_data.get('new_state'))
-            except HomeAssistantError:
+            except (HomeAssistantError, InvalidStateError) as e:
                 invalid_points.append(event_data)
 
             if not state:


### PR DESCRIPTION
## Description:

On a run of the `influxdb_import` script on my database, it failed with an `InvalidStateError` uncaught exception as opposed to skipping that data point and moving on. This PR fixes that - in my case the import completed successfully.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable): N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
