### PR TITLE
Add support for ZhongHong HVAC Controllers

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -378,6 +378,7 @@ omit =
     homeassistant/components/climate/sensibo.py
     homeassistant/components/climate/touchline.py
     homeassistant/components/climate/venstar.py
+    homeassistant/components/climate/zhong_hong.py
     homeassistant/components/cover/garadget.py
     homeassistant/components/cover/gogogate2.py
     homeassistant/components/cover/homematic.py

--- a/homeassistant/components/climate/zhong_hong.py
+++ b/homeassistant/components/climate/zhong_hong.py
@@ -20,7 +20,7 @@ _LOGGER = logging.getLogger(__name__)
 
 CONF_GW_ADDR = 'gw_addr'
 
-REQUIREMENTS = ['zhong_hong_hvac==1.0.0']
+REQUIREMENTS = ['zhong_hong_hvac==1.0.1']
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST):

--- a/homeassistant/components/climate/zhong_hong.py
+++ b/homeassistant/components/climate/zhong_hong.py
@@ -51,7 +51,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         ]
 
     except Exception as exc:
-        _LOGGER.error("ZhongHong controller is not ready", exc_info=exc)
+        _LOGGER.error("ZhongHong controller is not ready: %s", str(exc))
         raise PlatformNotReady
 
     _LOGGER.debug("We got %s zhong_hong climate devices", len(devices))

--- a/homeassistant/components/climate/zhong_hong.py
+++ b/homeassistant/components/climate/zhong_hong.py
@@ -22,7 +22,7 @@ _LOGGER = logging.getLogger(__name__)
 
 CONF_GATEWAY_ADDRRESS = 'gateway_address'
 
-REQUIREMENTS = ['zhong_hong_hvac==1.0.8']
+REQUIREMENTS = ['zhong_hong_hvac==1.0.9']
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST):

--- a/homeassistant/components/climate/zhong_hong.py
+++ b/homeassistant/components/climate/zhong_hong.py
@@ -216,7 +216,7 @@ class ZhongHongClimate(ClimateDevice):
 
         operation_mode = kwargs.get(ATTR_OPERATION_MODE)
         if operation_mode is not None:
-            self._device.set_operation_mode(operation_mode)
+            self.set_operation_mode(operation_mode)
 
     def set_operation_mode(self, operation_mode):
         """Set new target operation mode."""

--- a/homeassistant/components/climate/zhong_hong.py
+++ b/homeassistant/components/climate/zhong_hong.py
@@ -52,17 +52,20 @@ class ZhongHongClimate(ClimateDevice):
     """Representation of a ZhongHong controller support HVAC."""
 
     def __init__(self, hub, addr_out, addr_in):
+        """Setup platform."""
         from zhong_hong_hvac.hvac import HVAC
         self._device = HVAC(hub, addr_out, addr_in)
         self._hub = hub
         self._device.register_update_callback(self._after_update)
 
     def _after_update(self, climate):
+        """Callback to update state."""
         _LOGGER.info("async update ha state")
         self.schedule_update_ha_state()
 
     @property
     def should_poll(self):
+        """Return the polling state."""
         return False
 
     @property
@@ -72,10 +75,12 @@ class ZhongHongClimate(ClimateDevice):
 
     @property
     def unique_id(self):
+        """Return the unique ID of the HVAC."""
         return "%s-%s" % (self._device.addr_out, self._device.addr_in)
 
     @property
     def supported_features(self):
+        """Return the list of supported features."""
         return (SUPPORT_TARGET_TEMPERATURE | SUPPORT_FAN_MODE
                 | SUPPORT_OPERATION_MODE | SUPPORT_ON_OFF)
 
@@ -137,11 +142,11 @@ class ZhongHongClimate(ClimateDevice):
                                    self.temperature_unit)
 
     def turn_on(self):
-        """turn on ac."""
+        """Turn on ac."""
         return self._device.turn_on()
 
     def turn_off(self):
-        """turn off ac."""
+        """Turn off ac."""
         return self._device.turn_off()
 
     def set_temperature(self, **kwargs):

--- a/homeassistant/components/climate/zhong_hong.py
+++ b/homeassistant/components/climate/zhong_hong.py
@@ -44,15 +44,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     port = config.get(CONF_PORT)
     gw_addr = config.get(CONF_GATEWAY_ADDRRESS)
     hub = ZhongHongGateway(host, port, gw_addr)
-    try:
-        devices = [
-            ZhongHongClimate(hub, addr_out, addr_in)
-            for (addr_out, addr_in) in hub.discovery_ac()
-        ]
-
-    except Exception as exc:
-        _LOGGER.error("ZhongHong controller is not ready: %s", exc)
-        raise PlatformNotReady
+    devices = [
+        ZhongHongClimate(hub, addr_out, addr_in)
+        for (addr_out, addr_in) in hub.discovery_ac()
+    ]
 
     _LOGGER.debug("We got %s zhong_hong climate devices", len(devices))
 
@@ -104,10 +99,6 @@ class ZhongHongClimate(ClimateDevice):
         self._device.register_update_callback(self._after_update)
         self.is_initialized = True
         async_dispatcher_send(self.hass, SIGNAL_DEVICE_ADDED)
-
-    def update(self):
-        """Update device status from hub."""
-        self._device.update()
 
     def _after_update(self, climate):
         """Callback to update state."""

--- a/homeassistant/components/climate/zhong_hong.py
+++ b/homeassistant/components/climate/zhong_hong.py
@@ -76,7 +76,8 @@ class ZhongHongClimate(ClimateDevice):
     @property
     def unique_id(self):
         """Return the unique ID of the HVAC."""
-        return "%s-%s" % (self._device.addr_out, self._device.addr_in)
+        return "zhong_hong_hvac_%s_%s" % (self._device.addr_out,
+                                          self._device.addr_in)
 
     @property
     def supported_features(self):

--- a/homeassistant/components/climate/zhong_hong.py
+++ b/homeassistant/components/climate/zhong_hong.py
@@ -21,7 +21,7 @@ _LOGGER = logging.getLogger(__name__)
 
 CONF_GATEWAY_ADDRRESS = 'gateway_address'
 
-REQUIREMENTS = ['zhong_hong_hvac==1.0.7']
+REQUIREMENTS = ['zhong_hong_hvac==1.0.8']
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST):

--- a/homeassistant/components/climate/zhong_hong.py
+++ b/homeassistant/components/climate/zhong_hong.py
@@ -12,12 +12,11 @@ from homeassistant.components.climate import (
     ATTR_OPERATION_MODE, PLATFORM_SCHEMA, STATE_COOL, STATE_DRY,
     STATE_FAN_ONLY, STATE_HEAT, SUPPORT_FAN_MODE, SUPPORT_ON_OFF,
     SUPPORT_OPERATION_MODE, SUPPORT_TARGET_TEMPERATURE, ClimateDevice)
-from homeassistant.const import (ATTR_TEMPERATURE, CONF_HOST, CONF_PORT,
-                                 EVENT_HOMEASSISTANT_START,
-                                 EVENT_HOMEASSISTANT_STOP, TEMP_CELSIUS)
+from homeassistant.const import (
+    ATTR_TEMPERATURE, CONF_HOST, CONF_PORT, EVENT_HOMEASSISTANT_START,
+    EVENT_HOMEASSISTANT_STOP, TEMP_CELSIUS)
 from homeassistant.exceptions import PlatformNotReady
 import homeassistant.helpers.config_validation as cv
-from homeassistant.util.temperature import convert as convert_temperature
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/climate/zhong_hong.py
+++ b/homeassistant/components/climate/zhong_hong.py
@@ -37,7 +37,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-async def async_setup_platform(hass, config, add_devices, discovery_info=None):
+def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the ZhongHong HVAC platform."""
     from zhong_hong_hvac.hub import ZhongHongGateway
     host = config.get(CONF_HOST)
@@ -68,8 +68,8 @@ async def async_setup_platform(hass, config, add_devices, discovery_info=None):
             return
 
         _LOGGER.debug("zhong_hong hub start listen event")
-        hub.start_listen()
-        hub.query_all_status()
+        await hass.async_add_job(hub.start_listen)
+        await hass.async_add_job(hub.query_all_status)
         hub_is_initialized = True
 
     async_dispatcher_connect(hass, SIGNAL_DEVICE_ADDED, startup)
@@ -81,7 +81,7 @@ async def async_setup_platform(hass, config, add_devices, discovery_info=None):
         """Stop ZhongHongHub socket."""
         hub.stop_listen()
 
-    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, stop_listen)
+    hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, stop_listen)
 
 
 class ZhongHongClimate(ClimateDevice):

--- a/homeassistant/components/climate/zhong_hong.py
+++ b/homeassistant/components/climate/zhong_hong.py
@@ -14,7 +14,6 @@ from homeassistant.components.climate import (
     SUPPORT_OPERATION_MODE, SUPPORT_TARGET_TEMPERATURE, ClimateDevice)
 from homeassistant.const import (ATTR_TEMPERATURE, CONF_HOST, CONF_PORT,
                                  EVENT_HOMEASSISTANT_STOP, TEMP_CELSIUS)
-from homeassistant.exceptions import PlatformNotReady
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import (async_dispatcher_connect,
                                               async_dispatcher_send)

--- a/homeassistant/components/climate/zhong_hong.py
+++ b/homeassistant/components/climate/zhong_hong.py
@@ -4,6 +4,7 @@ Support for ZhongHong HVAC Controller.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/climate.zhong_hong/
 """
+import asyncio
 import logging
 
 import voluptuous as vol
@@ -12,9 +13,8 @@ from homeassistant.components.climate import (
     ATTR_OPERATION_MODE, PLATFORM_SCHEMA, STATE_COOL, STATE_DRY,
     STATE_FAN_ONLY, STATE_HEAT, SUPPORT_FAN_MODE, SUPPORT_ON_OFF,
     SUPPORT_OPERATION_MODE, SUPPORT_TARGET_TEMPERATURE, ClimateDevice)
-from homeassistant.const import (
-    ATTR_TEMPERATURE, CONF_HOST, CONF_PORT, EVENT_HOMEASSISTANT_START,
-    EVENT_HOMEASSISTANT_STOP, TEMP_CELSIUS)
+from homeassistant.const import (ATTR_TEMPERATURE, CONF_HOST, CONF_PORT,
+                                 EVENT_HOMEASSISTANT_STOP, TEMP_CELSIUS)
 from homeassistant.exceptions import PlatformNotReady
 import homeassistant.helpers.config_validation as cv
 
@@ -23,6 +23,8 @@ _LOGGER = logging.getLogger(__name__)
 CONF_GATEWAY_ADDRRESS = 'gateway_address'
 
 REQUIREMENTS = ['zhong_hong_hvac==1.0.9']
+EVENT_DEVICE_SETTED_UP = 'zhong_hong_device_setted_up'
+EVENT_ZHONG_HONG_HUB_START = 'zhong_hong_hub_start'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST):
@@ -34,7 +36,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-def setup_platform(hass, config, add_devices, discovery_info=None):
+async def async_setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the ZhongHong HVAC platform."""
     from zhong_hong_hvac.hub import ZhongHongGateway
     host = config.get(CONF_HOST)
@@ -46,22 +48,44 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             ZhongHongClimate(hub, addr_out, addr_in)
             for (addr_out, addr_in) in hub.discovery_ac()
         ]
+
     except Exception as exc:
         _LOGGER.error("ZhongHong controller is not ready", exc_info=exc)
         raise PlatformNotReady
 
-    def startup(event):
-        """Add devices to HA and start hub socket."""
-        add_devices(devices)
-        hub.start_listen()
+    device_num = len(devices)
+    _LOGGER.debug("We got %s zhong_hong climate devices", device_num)
+    device_ready_num = 0
+    semaphore_lock = asyncio.Semaphore()
 
-    hass.bus.listen_once(EVENT_HOMEASSISTANT_START, startup)
+    async def device_count(event):
+        """Count ready device and fire hub start event."""
+        nonlocal device_ready_num
+        with (await semaphore_lock):
+            device_ready_num += 1
+            _LOGGER.debug("%s zhong_hong device setted up", device_ready_num)
+            if device_ready_num >= device_num:
+                hass.bus.fire(EVENT_ZHONG_HONG_HUB_START)
+
+    async_remove_listener = hass.bus.async_listen(EVENT_DEVICE_SETTED_UP,
+                                                  device_count)
+    # add devices after EVENT_DEVICE_SETTED_UP event is listend
+    add_devices(devices)
+
+    def startup(event):
+        """Start hub socket after all climate entity is setted up."""
+        _LOGGER.debug("zhong_hong hub start listen event")
+        async_remove_listener()
+        hub.start_listen()
+        hub.query_all_status()
+
+    hass.bus.async_listen_once(EVENT_ZHONG_HONG_HUB_START, startup)
 
     def stop_listen(event):
         """Stop ZhongHongHub socket."""
         hub.stop_listen()
 
-    hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, stop_listen)
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, stop_listen)
 
 
 class ZhongHongClimate(ClimateDevice):
@@ -81,7 +105,7 @@ class ZhongHongClimate(ClimateDevice):
     async def async_added_to_hass(self):
         """Register callbacks."""
         self._device.register_update_callback(self._after_update)
-        await self.hass.async_add_job(self.update)
+        self.hass.bus.fire(EVENT_DEVICE_SETTED_UP)
 
     def update(self):
         """Update device status from hub."""

--- a/homeassistant/components/climate/zhong_hong.py
+++ b/homeassistant/components/climate/zhong_hong.py
@@ -24,7 +24,7 @@ _LOGGER = logging.getLogger(__name__)
 CONF_GATEWAY_ADDRRESS = 'gateway_address'
 
 REQUIREMENTS = ['zhong_hong_hvac==1.0.9']
-SIGNAL_DEVICE_SETTED_UP = 'zhong_hong_device_setted_up'
+SIGNAL_DEVICE_ADDED = 'zhong_hong_device_added'
 SIGNAL_ZHONG_HONG_HUB_START = 'zhong_hong_hub_start'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -72,7 +72,7 @@ async def async_setup_platform(hass, config, add_devices, discovery_info=None):
         hub.query_all_status()
         hub_is_initialized = True
 
-    async_dispatcher_connect(hass, SIGNAL_DEVICE_SETTED_UP, startup)
+    async_dispatcher_connect(hass, SIGNAL_DEVICE_ADDED, startup)
 
     # add devices after SIGNAL_DEVICE_SETTED_UP event is listend
     add_devices(devices)
@@ -103,7 +103,7 @@ class ZhongHongClimate(ClimateDevice):
         """Register callbacks."""
         self._device.register_update_callback(self._after_update)
         self.is_initialized = True
-        async_dispatcher_send(self.hass, SIGNAL_DEVICE_SETTED_UP)
+        async_dispatcher_send(self.hass, SIGNAL_DEVICE_ADDED)
 
     def update(self):
         """Update device status from hub."""

--- a/homeassistant/components/climate/zhong_hong.py
+++ b/homeassistant/components/climate/zhong_hong.py
@@ -1,0 +1,160 @@
+"""
+Support for ZhongHong HVAC Controller.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/climate.zhong_hong/
+"""
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components.climate import (
+    PLATFORM_SCHEMA, SUPPORT_FAN_MODE, SUPPORT_ON_OFF, SUPPORT_OPERATION_MODE,
+    SUPPORT_TARGET_TEMPERATURE, ClimateDevice)
+from homeassistant.const import (ATTR_TEMPERATURE, CONF_HOST, CONF_PORT,
+                                 TEMP_CELSIUS)
+import homeassistant.helpers.config_validation as cv
+from homeassistant.util.temperature import convert as convert_temperature
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_GW_ADDR = 'gw_addr'
+
+REQUIREMENTS = ['zhong_hong_hvac']
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_HOST):
+    cv.string,
+    vol.Optional(CONF_PORT, default=9999):
+    vol.Coerce(int),
+    vol.Optional(CONF_GW_ADDR, default=1):
+    vol.Coerce(int),
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the ZhongHong HVAC platform."""
+    from zhong_hong_hvac.hub import ZhongHongGateway
+    host = config.get(CONF_HOST)
+    port = config.get(CONF_PORT)
+    gw_addr = config.get(CONF_GW_ADDR)
+    hub = ZhongHongGateway(host, port, gw_addr)
+    devices = [
+        ZhongHongClimate(hub, addr_out, addr_in)
+        for (addr_out, addr_in) in hub.discovery_ac()
+    ]
+    add_devices(devices)
+    hub.start_listen()
+    hub.query_all_status()
+
+
+class ZhongHongClimate(ClimateDevice):
+    """Representation of a ZhongHong controller support HVAC."""
+
+    def __init__(self, hub, addr_out, addr_in):
+        from zhong_hong_hvac.hvac import HVAC
+        self._device = HVAC(hub, addr_out, addr_in)
+        self._hub = hub
+        self._device.register_update_callback(self._after_update)
+
+    def _after_update(self, climate):
+        _LOGGER.info("async update ha state")
+        self.schedule_update_ha_state()
+
+    @property
+    def should_poll(self):
+        return False
+
+    @property
+    def name(self):
+        """Return the name of the thermostat, if any."""
+        return self.unique_id
+
+    @property
+    def unique_id(self):
+        return "%s-%s" % (self._device.addr_out, self._device.addr_in)
+
+    @property
+    def supported_features(self):
+        return (SUPPORT_TARGET_TEMPERATURE | SUPPORT_FAN_MODE
+                | SUPPORT_OPERATION_MODE | SUPPORT_ON_OFF)
+
+    @property
+    def temperature_unit(self):
+        """Return the unit of measurement used by the platform."""
+        return TEMP_CELSIUS
+
+    @property
+    def current_operation(self):
+        """Return current operation ie. heat, cool, idle."""
+        return self._device.current_operation
+
+    @property
+    def operation_list(self):
+        """Return the list of available operation modes."""
+        return self._device.operation_list
+
+    @property
+    def current_temperature(self):
+        """Return the current temperature."""
+        return self._device.current_temperature
+
+    @property
+    def target_temperature(self):
+        """Return the temperature we try to reach."""
+        return self._device.target_temperature
+
+    @property
+    def target_temperature_step(self):
+        """Return the supported step of target temperature."""
+        return 1
+
+    @property
+    def is_on(self):
+        """Return true if on."""
+        return self._device.is_on
+
+    @property
+    def current_fan_mode(self):
+        """Return the fan setting."""
+        return self._device.current_fan_mode
+
+    @property
+    def fan_list(self):
+        """Return the list of available fan modes."""
+        return self._device.fan_list
+
+    @property
+    def min_temp(self):
+        """Return the minimum temperature."""
+        return convert_temperature(self._device.min_temp, TEMP_CELSIUS,
+                                   self.temperature_unit)
+
+    @property
+    def max_temp(self):
+        """Return the maximum temperature."""
+        return convert_temperature(self._device.max_temp, TEMP_CELSIUS,
+                                   self.temperature_unit)
+
+    def turn_on(self):
+        """turn on ac."""
+        return self._device.turn_on()
+
+    def turn_off(self):
+        """turn off ac."""
+        return self._device.turn_off()
+
+    def set_temperature(self, **kwargs):
+        """Set new target temperature."""
+        temperature = kwargs.get(ATTR_TEMPERATURE)
+        if temperature is None:
+            return
+        self._device.set_temperature(temperature)
+
+    def set_operation_mode(self, operation_mode):
+        """Set new target operation mode."""
+        self._device.set_operation_mode(operation_mode)
+
+    def set_fan_mode(self, fan_mode):
+        """Set new target fan mode."""
+        self._device.set_fan_mode(fan_mode)

--- a/homeassistant/components/climate/zhong_hong.py
+++ b/homeassistant/components/climate/zhong_hong.py
@@ -20,7 +20,7 @@ _LOGGER = logging.getLogger(__name__)
 
 CONF_GW_ADDR = 'gw_addr'
 
-REQUIREMENTS = ['zhong_hong_hvac']
+REQUIREMENTS = ['zhong_hong_hvac==1.0.0']
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST):

--- a/homeassistant/components/climate/zhong_hong.py
+++ b/homeassistant/components/climate/zhong_hong.py
@@ -51,7 +51,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         ]
 
     except Exception as exc:
-        _LOGGER.error("ZhongHong controller is not ready: %s", str(exc))
+        _LOGGER.error("ZhongHong controller is not ready: %s", exc)
         raise PlatformNotReady
 
     _LOGGER.debug("We got %s zhong_hong climate devices", len(devices))

--- a/homeassistant/components/climate/zhong_hong.py
+++ b/homeassistant/components/climate/zhong_hong.py
@@ -21,7 +21,7 @@ _LOGGER = logging.getLogger(__name__)
 
 CONF_GATEWAY_ADDRRESS = 'gateway_address'
 
-REQUIREMENTS = ['zhong_hong_hvac==1.0.4']
+REQUIREMENTS = ['zhong_hong_hvac==1.0.7']
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1396,6 +1396,9 @@ zengge==0.2
 # homeassistant.components.zeroconf
 zeroconf==0.20.0
 
+# homeassistant.components.climate.zhong_hong
+zhong_hong_hvac==1.0.0
+
 # homeassistant.components.media_player.ziggo_mediabox_xl
 ziggo-mediabox-xl==1.0.0
 
@@ -1404,6 +1407,3 @@ zigpy-xbee==0.1.1
 
 # homeassistant.components.zha
 zigpy==0.1.0
-
-# homeassistant.components.climate.zhong_hong_hvac
-zhong_hong_hvac==1.0.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1397,7 +1397,7 @@ zengge==0.2
 zeroconf==0.20.0
 
 # homeassistant.components.climate.zhong_hong
-zhong_hong_hvac==1.0.1
+zhong_hong_hvac==1.0.7
 
 # homeassistant.components.media_player.ziggo_mediabox_xl
 ziggo-mediabox-xl==1.0.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1397,7 +1397,7 @@ zengge==0.2
 zeroconf==0.20.0
 
 # homeassistant.components.climate.zhong_hong
-zhong_hong_hvac==1.0.8
+zhong_hong_hvac==1.0.9
 
 # homeassistant.components.media_player.ziggo_mediabox_xl
 ziggo-mediabox-xl==1.0.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1397,7 +1397,7 @@ zengge==0.2
 zeroconf==0.20.0
 
 # homeassistant.components.climate.zhong_hong
-zhong_hong_hvac==1.0.7
+zhong_hong_hvac==1.0.8
 
 # homeassistant.components.media_player.ziggo_mediabox_xl
 ziggo-mediabox-xl==1.0.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1397,7 +1397,7 @@ zengge==0.2
 zeroconf==0.20.0
 
 # homeassistant.components.climate.zhong_hong
-zhong_hong_hvac==1.0.0
+zhong_hong_hvac==1.0.1
 
 # homeassistant.components.media_player.ziggo_mediabox_xl
 ziggo-mediabox-xl==1.0.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1404,3 +1404,6 @@ zigpy-xbee==0.1.1
 
 # homeassistant.components.zha
 zigpy==0.1.0
+
+# homeassistant.components.climate.zhong_hong_hvac
+zhong_hong_hvac==1.0.0


### PR DESCRIPTION
## Description:

This is a platform for using a HVAC Controller product from [Zhong hong tech](http://zhonghongtech.cn/v1/product.shtml) which sells in China. It can control a bunch of AC brand like Daikin, Hitachi, Meidi, Gree, Haier, Toshiba and Mitsubishi. You can find the product selling page on [taobao.com](https://item.taobao.com/item.htm?spm=a1z09.2.0.0.2d0e2e8dqO47NW&id=525044137797&_u=kbvnc59b59e).

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5402

## Example entry for `configuration.yaml` (if applicable):
```yaml
climate:
  - platform: zhong_hong
    host: 192.168.15.19
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
