### PR TITLE
Set zha binary sensor default state to false

### DIFF
--- a/homeassistant/components/binary_sensor/zha.py
+++ b/homeassistant/components/binary_sensor/zha.py
@@ -203,8 +203,8 @@ class Switch(zha.Entity, BinarySensorDevice):
     def __init__(self, **kwargs):
         """Initialize Switch."""
         super().__init__(**kwargs)
-        self._state = True
-        self._level = 255
+        self._state = False
+        self._level = 0
         from zigpy.zcl.clusters import general
         self._out_listeners = {
             general.OnOff.cluster_id: self.OnOffListener(self),


### PR DESCRIPTION
## Description:

During device initialization we query the device for the actual state by sending a read attribute request. We might not receive a response either because the device does not respond (Xiaomi devices) or the device is asleep. The Xiaomi OpenClose Sensor for example will therefore always have 'open' as the initial state after a HA restart. False/Off seems to be the 'better' default and is also consistent with other platforms.

## Checklist:
  - [x] The code change is tested and works locally.
