### PR TITLE
Update pydocstyle to 2.1.1 and flake8-docstrings to 1.3.0

### DIFF
--- a/homeassistant/auth/__init__.py
+++ b/homeassistant/auth/__init__.py
@@ -390,7 +390,7 @@ class AuthManager:
     @callback
     def _async_get_auth_provider(
             self, credentials: models.Credentials) -> Optional[AuthProvider]:
-        """Helper to get auth provider from a set of credentials."""
+        """Get auth provider from a set of credentials."""
         auth_provider_key = (credentials.auth_provider_type,
                              credentials.auth_provider_id)
         return self._providers.get(auth_provider_key)

--- a/homeassistant/auth/providers/homeassistant.py
+++ b/homeassistant/auth/providers/homeassistant.py
@@ -164,7 +164,7 @@ class HassAuthProvider(AuthProvider):
         return HassLoginFlow(self)
 
     async def async_validate_login(self, username: str, password: str) -> None:
-        """Helper to validate a username and password."""
+        """Validate a username and password."""
         if self.data is None:
             await self.async_initialize()
             assert self.data is not None

--- a/homeassistant/auth/providers/insecure_example.py
+++ b/homeassistant/auth/providers/insecure_example.py
@@ -38,7 +38,7 @@ class ExampleAuthProvider(AuthProvider):
 
     @callback
     def async_validate_login(self, username: str, password: str) -> None:
-        """Helper to validate a username and password."""
+        """Validate a username and password."""
         user = None
 
         # Compare all users to avoid timing attacks.

--- a/homeassistant/auth/providers/legacy_api_password.py
+++ b/homeassistant/auth/providers/legacy_api_password.py
@@ -43,7 +43,7 @@ class LegacyApiPasswordAuthProvider(AuthProvider):
 
     @callback
     def async_validate_login(self, password: str) -> None:
-        """Helper to validate a username and password."""
+        """Validate a username and password."""
         hass_http = getattr(self.hass, 'http', None)  # type: HomeAssistantHTTP
 
         if not hmac.compare_digest(hass_http.api_password.encode('utf-8'),

--- a/homeassistant/components/binary_sensor/bmw_connected_drive.py
+++ b/homeassistant/components/binary_sensor/bmw_connected_drive.py
@@ -71,7 +71,10 @@ class BMWConnectedDriveSensor(BinarySensorDevice):
 
     @property
     def should_poll(self) -> bool:
-        """Data update is triggered from BMWConnectedDriveEntity."""
+        """Return False.
+
+        Data update is triggered from BMWConnectedDriveEntity.
+        """
         return False
 
     @property

--- a/homeassistant/components/binary_sensor/egardia.py
+++ b/homeassistant/components/binary_sensor/egardia.py
@@ -58,7 +58,7 @@ class EgardiaBinarySensor(BinarySensorDevice):
 
     @property
     def name(self):
-        """The name of the device."""
+        """Return the name of the device."""
         return self._name
 
     @property
@@ -74,5 +74,5 @@ class EgardiaBinarySensor(BinarySensorDevice):
 
     @property
     def device_class(self):
-        """The device class."""
+        """Return the device class."""
         return self._device_class

--- a/homeassistant/components/camera/onvif.py
+++ b/homeassistant/components/camera/onvif.py
@@ -183,7 +183,7 @@ class ONVIFHassCamera(Camera):
             _LOGGER.debug("Camera '%s' doesn't support PTZ.", self._name)
 
     async def async_added_to_hass(self):
-        """Callback when entity is added to hass."""
+        """Handle entity addition to hass."""
         if ONVIF_DATA not in self.hass.data:
             self.hass.data[ONVIF_DATA] = {}
             self.hass.data[ONVIF_DATA][ENTITIES] = []

--- a/homeassistant/components/camera/push.py
+++ b/homeassistant/components/camera/push.py
@@ -113,7 +113,7 @@ class PushCamera(Camera):
 
     @property
     def state(self):
-        """Current state of the camera."""
+        """Return current state of the camera."""
         return self._state
 
     async def update_image(self, image, filename):

--- a/homeassistant/components/climate/melissa.py
+++ b/homeassistant/components/climate/melissa.py
@@ -166,7 +166,7 @@ class MelissaClimate(ClimateDevice):
         self.send({self._api.STATE: self._api.STATE_OFF})
 
     def send(self, value):
-        """Sending action to service."""
+        """Send action to service."""
         try:
             old_value = self._cur_settings.copy()
             self._cur_settings.update(value)

--- a/homeassistant/components/climate/nest.py
+++ b/homeassistant/components/climate/nest.py
@@ -124,7 +124,7 @@ class NestThermostat(ClimateDevice):
 
     @property
     def unique_id(self):
-        """Unique ID for this device."""
+        """Return unique ID for this device."""
         return self._device.serial
 
     @property

--- a/homeassistant/components/climate/zhong_hong.py
+++ b/homeassistant/components/climate/zhong_hong.py
@@ -100,7 +100,7 @@ class ZhongHongClimate(ClimateDevice):
         async_dispatcher_send(self.hass, SIGNAL_DEVICE_ADDED)
 
     def _after_update(self, climate):
-        """Callback to update state."""
+        """Handle state update."""
         _LOGGER.debug("async update ha state")
         if self._device.current_operation:
             self._current_operation = self._device.current_operation.lower()

--- a/homeassistant/components/config/entity_registry.py
+++ b/homeassistant/components/config/entity_registry.py
@@ -101,7 +101,7 @@ def websocket_update_entity(hass, connection, msg):
 
 @callback
 def _entry_dict(entry):
-    """Helper to convert entry to API format."""
+    """Convert entry to API format."""
     return {
         'entity_id': entry.entity_id,
         'name': entry.name

--- a/homeassistant/components/config/zwave.py
+++ b/homeassistant/components/config/zwave.py
@@ -212,7 +212,7 @@ class ZWaveProtectionView(HomeAssistantView):
         network = hass.data.get(const.DATA_NETWORK)
 
         def _fetch_protection():
-            """Helper to get protection data."""
+            """Get protection data."""
             node = network.nodes.get(nodeid)
             if node is None:
                 return self.json_message('Node not found', HTTP_NOT_FOUND)
@@ -236,7 +236,7 @@ class ZWaveProtectionView(HomeAssistantView):
         protection_data = await request.json()
 
         def _set_protection():
-            """Helper to get protection data."""
+            """Set protection data."""
             node = network.nodes.get(nodeid)
             selection = protection_data["selection"]
             value_id = int(protection_data[const.ATTR_VALUE_ID])

--- a/homeassistant/components/deconz/__init__.py
+++ b/homeassistant/components/deconz/__init__.py
@@ -82,7 +82,7 @@ async def async_setup_entry(hass, config_entry):
 
     @callback
     def async_add_device_callback(device_type, device):
-        """Called when a new device has been created in deCONZ."""
+        """Handle event of new device creation in deCONZ."""
         async_dispatcher_send(
             hass, 'deconz_new_{}'.format(device_type), [device])
 

--- a/homeassistant/components/device_tracker/xiaomi_miio.py
+++ b/homeassistant/components/device_tracker/xiaomi_miio.py
@@ -73,5 +73,8 @@ class XiaomiMiioDeviceScanner(DeviceScanner):
         return devices
 
     async def async_get_device_name(self, device):
-        """The repeater doesn't provide the name of the associated device."""
+        """Return None.
+
+        The repeater doesn't provide the name of the associated device.
+        """
         return None

--- a/homeassistant/components/doorbird.py
+++ b/homeassistant/components/doorbird.py
@@ -139,17 +139,17 @@ class ConfiguredDoorbird():
 
     @property
     def name(self):
-        """Custom device name."""
+        """Get custom device name."""
         return self._name
 
     @property
     def device(self):
-        """The configured device."""
+        """Get the configured device."""
         return self._device
 
     @property
     def custom_url(self):
-        """Custom url for device."""
+        """Get custom url for device."""
         return self._custom_url
 
     @property

--- a/homeassistant/components/egardia.py
+++ b/homeassistant/components/egardia.py
@@ -101,7 +101,7 @@ def setup(hass, config):
                 server.start()
 
             def handle_stop_event(event):
-                """Callback function for HA stop event."""
+                """Handle HA stop event."""
                 server.stop()
 
             # listen to home assistant stop event

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -49,7 +49,7 @@ TRAITS = []
 
 
 def register_trait(trait):
-    """Decorator to register a trait."""
+    """Decorate a function to register a trait."""
     TRAITS.append(trait)
     return trait
 

--- a/homeassistant/components/group/__init__.py
+++ b/homeassistant/components/group/__init__.py
@@ -550,12 +550,12 @@ class Group(Entity):
         self._async_update_group_state()
 
     async def async_added_to_hass(self):
-        """Callback when added to HASS."""
+        """Handle addition to HASS."""
         if self.tracking:
             self.async_start()
 
     async def async_will_remove_from_hass(self):
-        """Callback when removed from HASS."""
+        """Handle removal from HASS."""
         if self._async_unsub_state_changed:
             self._async_unsub_state_changed()
             self._async_unsub_state_changed = None

--- a/homeassistant/components/homekit/accessories.py
+++ b/homeassistant/components/homekit/accessories.py
@@ -27,17 +27,17 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def debounce(func):
-    """Decorator function. Debounce callbacks form HomeKit."""
+    """Decorate function to debounce callbacks from HomeKit."""
     @ha_callback
     def call_later_listener(self, *args):
-        """Callback listener called from call_later."""
+        """Handle call_later callback."""
         debounce_params = self.debounce.pop(func.__name__, None)
         if debounce_params:
             self.hass.async_add_job(func, self, *debounce_params[1:])
 
     @wraps(func)
     def wrapper(self, *args):
-        """Wrapper starts async timer."""
+        """Start async timer."""
         debounce_params = self.debounce.pop(func.__name__, None)
         if debounce_params:
             debounce_params[0]()  # remove listener
@@ -88,7 +88,7 @@ class HomeAccessory(Accessory):
             CHAR_STATUS_LOW_BATTERY, value=0)
 
     async def run(self):
-        """Method called by accessory after driver is started.
+        """Handle accessory driver started event.
 
         Run inside the HAP-python event loop.
         """
@@ -100,7 +100,7 @@ class HomeAccessory(Accessory):
     @ha_callback
     def update_state_callback(self, entity_id=None, old_state=None,
                               new_state=None):
-        """Callback from state change listener."""
+        """Handle state change listener callback."""
         _LOGGER.debug('New_state: %s', new_state)
         if new_state is None:
             return
@@ -131,7 +131,7 @@ class HomeAccessory(Accessory):
                       hk_charging)
 
     def update_state(self, new_state):
-        """Method called on state change to update HomeKit value.
+        """Handle state change to update HomeKit value.
 
         Overridden by accessory types.
         """

--- a/homeassistant/components/http/ban.py
+++ b/homeassistant/components/http/ban.py
@@ -71,7 +71,7 @@ async def ban_middleware(request, handler):
 
 
 def log_invalid_auth(func):
-    """Decorator to handle invalid auth or failed login attempts."""
+    """Decorate function to handle invalid auth or failed login attempts."""
     async def handle_req(view, request, *args, **kwargs):
         """Try to log failed login attempts if response status >= 400."""
         resp = await func(view, request, *args, **kwargs)

--- a/homeassistant/components/ihc/ihcdevice.py
+++ b/homeassistant/components/ihc/ihcdevice.py
@@ -57,7 +57,7 @@ class IHCDevice(Entity):
         }
 
     def on_ihc_change(self, ihc_id, value):
-        """Callback when IHC resource changes.
+        """Handle IHC resource change.
 
         Derived classes must overwrite this to do device specific stuff.
         """

--- a/homeassistant/components/iota.py
+++ b/homeassistant/components/iota.py
@@ -57,7 +57,7 @@ class IotaDevice(Entity):
     """Representation of a IOTA device."""
 
     def __init__(self, name, seed, iri, is_testnet=False):
-        """Initialisation of the IOTA device."""
+        """Initialise the IOTA device."""
         self._name = name
         self._seed = seed
         self.iri = iri

--- a/homeassistant/components/knx.py
+++ b/homeassistant/components/knx.py
@@ -334,7 +334,7 @@ class KNXExposeSensor:
             self.hass, self.entity_id, self._async_entity_changed)
 
     async def _async_entity_changed(self, entity_id, old_state, new_state):
-        """Callback after entity changed."""
+        """Handle entity change."""
         if new_state is None:
             return
         await self.device.set(float(new_state.state))

--- a/homeassistant/components/light/group.py
+++ b/homeassistant/components/light/group.py
@@ -80,7 +80,7 @@ class LightGroup(light.Light):
         await self.async_update()
 
     async def async_will_remove_from_hass(self):
-        """Callback when removed from HASS."""
+        """Handle removal from HASS."""
         if self._async_unsub_state_changed is not None:
             self._async_unsub_state_changed()
             self._async_unsub_state_changed = None

--- a/homeassistant/components/light/ihc.py
+++ b/homeassistant/components/light/ihc.py
@@ -109,7 +109,7 @@ class IhcLight(IHCDevice, Light):
             self.ihc_controller.set_runtime_value_bool(self.ihc_id, False)
 
     def on_ihc_change(self, ihc_id, value):
-        """Callback from IHC notifications."""
+        """Handle IHC notifications."""
         if isinstance(value, bool):
             self._dimmable = False
             self._state = value != 0

--- a/homeassistant/components/light/limitlessled.py
+++ b/homeassistant/components/light/limitlessled.py
@@ -190,7 +190,7 @@ class LimitlessLEDGroup(Light):
 
     @asyncio.coroutine
     def async_added_to_hass(self):
-        """Called when entity is about to be added to hass."""
+        """Handle entity about to be added to hass event."""
         last_state = yield from async_get_last_state(self.hass, self.entity_id)
         if last_state:
             self._is_on = (last_state.state == STATE_ON)

--- a/homeassistant/components/light/lw12wifi.py
+++ b/homeassistant/components/light/lw12wifi.py
@@ -53,7 +53,7 @@ class LW12WiFi(Light):
     """LW-12 WiFi LED Controller."""
 
     def __init__(self, name, lw12_light):
-        """Initialisation of LW-12 WiFi LED Controller.
+        """Initialise LW-12 WiFi LED Controller.
 
         Args:
             name: Friendly name for this platform to use.

--- a/homeassistant/components/media_player/cast.py
+++ b/homeassistant/components/media_player/cast.py
@@ -146,7 +146,7 @@ def _setup_internal_discovery(hass: HomeAssistantType) -> None:
     import pychromecast
 
     def internal_callback(name):
-        """Called when zeroconf has discovered a new chromecast."""
+        """Handle zeroconf discovery of a new chromecast."""
         mdns = listener.services[name]
         _discover_chromecast(hass, ChromecastInfo(*mdns))
 
@@ -229,7 +229,7 @@ async def _async_setup_platform(hass: HomeAssistantType, config: ConfigType,
 
     @callback
     def async_cast_discovered(discover: ChromecastInfo) -> None:
-        """Callback for when a new chromecast is discovered."""
+        """Handle discovery of a new chromecast."""
         if info is not None and info.host_port != discover.host_port:
             # Not our requested cast device.
             return
@@ -277,17 +277,17 @@ class CastStatusListener:
         chromecast.register_connection_listener(self)
 
     def new_cast_status(self, cast_status):
-        """Called when a new CastStatus is received."""
+        """Handle reception of a new CastStatus."""
         if self._valid:
             self._cast_device.new_cast_status(cast_status)
 
     def new_media_status(self, media_status):
-        """Called when a new MediaStatus is received."""
+        """Handle reception of a new MediaStatus."""
         if self._valid:
             self._cast_device.new_media_status(media_status)
 
     def new_connection_status(self, connection_status):
-        """Called when a new ConnectionStatus is received."""
+        """Handle reception of a new ConnectionStatus."""
         if self._valid:
             self._cast_device.new_connection_status(connection_status)
 
@@ -321,7 +321,7 @@ class CastDevice(MediaPlayerDevice):
         """Create chromecast object when added to hass."""
         @callback
         def async_cast_discovered(discover: ChromecastInfo):
-            """Callback for changing elected leaders / IP."""
+            """Handle discovery of new Chromecast."""
             if self._cast_info.uuid is None:
                 # We can't handle empty UUIDs
                 return

--- a/homeassistant/components/media_player/channels.py
+++ b/homeassistant/components/media_player/channels.py
@@ -70,7 +70,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     hass.data[DATA_CHANNELS].append(device)
 
     def service_handler(service):
-        """Handler for services."""
+        """Handle service."""
         entity_id = service.data.get(ATTR_ENTITY_ID)
 
         device = next((device for device in hass.data[DATA_CHANNELS] if

--- a/homeassistant/components/media_player/dlna_dmr.py
+++ b/homeassistant/components/media_player/dlna_dmr.py
@@ -180,7 +180,7 @@ class DlnaDmrDevice(MediaPlayerDevice):
         self._subscription_renew_time = None
 
     async def async_added_to_hass(self):
-        """Callback when added."""
+        """Handle addition."""
         self._device.on_event = self._on_event
 
         # register unsubscribe on stop

--- a/homeassistant/components/media_player/mediaroom.py
+++ b/homeassistant/components/media_player/mediaroom.py
@@ -103,7 +103,7 @@ class MediaroomDevice(MediaPlayerDevice):
     """Representation of a Mediaroom set-up-box on the network."""
 
     def set_state(self, mediaroom_state):
-        """Helper method to map pymediaroom states to HA states."""
+        """Map pymediaroom state to HA state."""
         from pymediaroom import State
 
         state_map = {

--- a/homeassistant/components/remote/xiaomi_miio.py
+++ b/homeassistant/components/remote/xiaomi_miio.py
@@ -249,7 +249,7 @@ class XiaomiMiioRemote(RemoteDevice):
                 payload, ex)
 
     def send_command(self, command, **kwargs):
-        """Wrapper for _send_command."""
+        """Send a command."""
         num_repeats = kwargs.get(ATTR_NUM_REPEATS)
 
         delay = kwargs.get(ATTR_DELAY_SECS, DEFAULT_DELAY_SECS)

--- a/homeassistant/components/sabnzbd.py
+++ b/homeassistant/components/sabnzbd.py
@@ -193,7 +193,7 @@ def async_request_configuration(hass, config, host):
             return
 
         def success():
-            """Setup was successful."""
+            """Signal successful setup."""
             conf = load_json(hass.config.path(CONFIG_FILE))
             conf[host] = {CONF_API_KEY: api_key}
             save_json(hass.config.path(CONFIG_FILE), conf)

--- a/homeassistant/components/sensor/bmw_connected_drive.py
+++ b/homeassistant/components/sensor/bmw_connected_drive.py
@@ -58,7 +58,10 @@ class BMWConnectedDriveSensor(Entity):
 
     @property
     def should_poll(self) -> bool:
-        """Data update is triggered from BMWConnectedDriveEntity."""
+        """Return False.
+
+        Data update is triggered from BMWConnectedDriveEntity.
+        """
         return False
 
     @property

--- a/homeassistant/components/sensor/fints.py
+++ b/homeassistant/components/sensor/fints.py
@@ -108,7 +108,7 @@ class FinTsClient:
     """
 
     def __init__(self, credentials: BankCredentials, name: str):
-        """Constructor for class FinTsClient."""
+        """Initialize a FinTsClient."""
         self._credentials = credentials
         self.name = name
 
@@ -158,7 +158,7 @@ class FinTsAccount(Entity):
     """
 
     def __init__(self, client: FinTsClient, account, name: str) -> None:
-        """Constructor for class FinTsAccount."""
+        """Initialize a FinTs balance account."""
         self._client = client  # type: FinTsClient
         self._account = account
         self._name = name  # type: str
@@ -167,7 +167,10 @@ class FinTsAccount(Entity):
 
     @property
     def should_poll(self) -> bool:
-        """Data needs to be polled from the bank servers."""
+        """Return True.
+
+        Data needs to be polled from the bank servers.
+        """
         return True
 
     def update(self) -> None:
@@ -218,7 +221,7 @@ class FinTsHoldingsAccount(Entity):
     """
 
     def __init__(self, client: FinTsClient, account, name: str) -> None:
-        """Constructor for class FinTsHoldingsAccount."""
+        """Initialize a FinTs holdings account."""
         self._client = client  # type: FinTsClient
         self._name = name  # type: str
         self._account = account
@@ -227,7 +230,10 @@ class FinTsHoldingsAccount(Entity):
 
     @property
     def should_poll(self) -> bool:
-        """Data needs to be polled from the bank servers."""
+        """Return True.
+
+        Data needs to be polled from the bank servers.
+        """
         return True
 
     def update(self) -> None:

--- a/homeassistant/components/sensor/ihc.py
+++ b/homeassistant/components/sensor/ihc.py
@@ -77,6 +77,6 @@ class IHCSensor(IHCDevice, Entity):
         return self._unit_of_measurement
 
     def on_ihc_change(self, ihc_id, value):
-        """Callback when IHC resource changes."""
+        """Handle IHC resource change."""
         self._state = value
         self.schedule_update_ha_state()

--- a/homeassistant/components/sensor/uscis.py
+++ b/homeassistant/components/sensor/uscis.py
@@ -72,7 +72,7 @@ class UscisSensor(Entity):
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
-        """Using Request to access USCIS website and fetch data."""
+        """Fetch data from the USCIS website and update state attributes."""
         import uscisstatus
         try:
             status = uscisstatus.get_case_status(self._case_id)

--- a/homeassistant/components/sensor/wirelesstag.py
+++ b/homeassistant/components/sensor/wirelesstag.py
@@ -98,7 +98,7 @@ class WirelessTagSensor(WirelessTagBaseSensor):
             else all_sensors)
 
     def __init__(self, api, tag, sensor_type, config):
-        """Constructor with platform(api), tag and hass sensor type."""
+        """Initialize a WirelessTag sensor."""
         super().__init__(api, tag)
 
         self._sensor_type = sensor_type

--- a/homeassistant/components/switch/ihc.py
+++ b/homeassistant/components/switch/ihc.py
@@ -70,6 +70,6 @@ class IHCSwitch(IHCDevice, SwitchDevice):
         self.ihc_controller.set_runtime_value_bool(self.ihc_id, False)
 
     def on_ihc_change(self, ihc_id, value):
-        """Callback when the IHC resource changes."""
+        """Handle IHC resource change."""
         self._state = value
         self.schedule_update_ha_state()

--- a/homeassistant/components/switch/wemo.py
+++ b/homeassistant/components/switch/wemo.py
@@ -77,7 +77,7 @@ class WemoSwitch(SwitchDevice):
             self._async_locked_subscription_callback(not updated))
 
     async def _async_locked_subscription_callback(self, force_update):
-        """Helper to handle an update from a subscription."""
+        """Handle an update from a subscription."""
         # If an update is in progress, we don't do anything
         if self._update_lock.locked():
             return

--- a/homeassistant/components/wirelesstag.py
+++ b/homeassistant/components/wirelesstag.py
@@ -80,7 +80,7 @@ class WirelessTagPlatform:
 
     # pylint: disable=no-self-use
     def make_push_notitication(self, name, url, content):
-        """Factory for notification config."""
+        """Create notification config."""
         from wirelesstagpy import NotificationConfig
         return NotificationConfig(name, {
             'url': url, 'verb': 'POST',
@@ -129,7 +129,7 @@ class WirelessTagPlatform:
             self.hass.config.api.base_url)
 
     def handle_update_tags_event(self, event):
-        """Main entry to handle push event from wireless tag manager."""
+        """Handle push event from wireless tag manager."""
         _LOGGER.info("push notification for update arrived: %s", event)
         dispatcher_send(
             self.hass,
@@ -215,7 +215,10 @@ class WirelessTagBaseSensor(Entity):
         return 0
 
     def updated_state_value(self):
-        """Default implementation formats princial value."""
+        """Return formatted value.
+
+        The default implementation formats principal value.
+        """
         return self.decorate_value(self.principal_value)
 
     # pylint: disable=no-self-use

--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -341,7 +341,7 @@ class Entity(entity.Entity):
         application_listener.register_entity(ieee, self)
 
     async def async_added_to_hass(self):
-        """Callback once the entity is added to hass.
+        """Handle entity addition to hass.
 
         It is now safe to update the entity state
         """

--- a/homeassistant/components/zwave/node_entity.py
+++ b/homeassistant/components/zwave/node_entity.py
@@ -107,7 +107,7 @@ class ZWaveNodeEntity(ZWaveBaseEntity):
 
     @property
     def unique_id(self):
-        """Unique ID of Z-wave node."""
+        """Return unique ID of Z-wave node."""
         return self._unique_id
 
     def network_node_changed(self, node=None, value=None, args=None):

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -87,7 +87,7 @@ class DeviceRegistry:
 
     @callback
     def _data_to_save(self):
-        """Data of device registry to store in a file."""
+        """Return data of device registry to store in a file."""
         data = {}
 
         data['devices'] = [

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -378,7 +378,7 @@ class Entity:
 
     @callback
     def async_registry_updated(self, old, new):
-        """Called when the entity registry has been updated."""
+        """Handle entity registry update."""
         self.registry_name = new.name
 
         if new.entity_id == self.entity_id:

--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -52,7 +52,7 @@ class EntityComponent:
                                    in self._platforms.values())
 
     def get_entity(self, entity_id):
-        """Helper method to get an entity."""
+        """Get an entity."""
         for platform in self._platforms.values():
             entity = platform.entities.get(entity_id)
             if entity is not None:
@@ -243,7 +243,7 @@ class EntityComponent:
 
     def _async_init_entity_platform(self, platform_type, platform,
                                     scan_interval=None, entity_namespace=None):
-        """Helper to initialize an entity platform."""
+        """Initialize an entity platform."""
         if scan_interval is None:
             scan_interval = self.scan_interval
 

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -106,7 +106,7 @@ class EntityPlatform:
         return await self._async_setup_platform(async_create_setup_task)
 
     async def _async_setup_platform(self, async_create_setup_task, tries=0):
-        """Helper to set up a platform via config file or config entry.
+        """Set up a platform via config file or config entry.
 
         async_create_setup_task creates a coroutine that sets up platform.
         """
@@ -168,7 +168,7 @@ class EntityPlatform:
             warn_task.cancel()
 
     def _schedule_add_entities(self, new_entities, update_before_add=False):
-        """Synchronously schedule adding entities for a single platform."""
+        """Schedule adding entities for a single platform, synchronously."""
         run_callback_threadsafe(
             self.hass.loop,
             self._async_schedule_add_entities, list(new_entities),
@@ -237,7 +237,7 @@ class EntityPlatform:
     async def _async_add_entity(self, entity, update_before_add,
                                 component_entities, entity_registry,
                                 device_registry):
-        """Helper method to add an entity to the platform."""
+        """Add an entity to the platform."""
         if entity is None:
             raise ValueError('Entity cannot be None')
 

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -234,7 +234,7 @@ class EntityRegistry:
 
     @callback
     def _data_to_save(self):
-        """Data of entity registry to store in a file."""
+        """Return data of entity registry to store in a file."""
         data = {}
 
         data['entities'] = [

--- a/homeassistant/helpers/storage.py
+++ b/homeassistant/helpers/storage.py
@@ -18,12 +18,12 @@ _LOGGER = logging.getLogger(__name__)
 async def async_migrator(hass, old_path, store, *,
                          old_conf_load_func=json.load_json,
                          old_conf_migrate_func=None):
-    """Helper function to migrate old data to a store and then load data.
+    """Migrate old data to a store and then load data.
 
     async def old_conf_migrate_func(old_data)
     """
     def load_old_config():
-        """Helper to load old config."""
+        """Load old config."""
         if not os.path.isfile(old_path):
             return None
 
@@ -77,7 +77,7 @@ class Store:
         return await self._load_task
 
     async def _async_load(self):
-        """Helper to load the data."""
+        """Load the data."""
         # Check if we have a pending write
         if self._data is not None:
             data = self._data
@@ -165,7 +165,7 @@ class Store:
         await self._async_handle_write_data()
 
     async def _async_handle_write_data(self, *_args):
-        """Handler to handle writing the config."""
+        """Handle writing the config."""
         data = self._data
 
         if 'data_func' in data:

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,11 +3,11 @@
 # new version
 asynctest==0.12.2
 coveralls==1.2.0
-flake8-docstrings==1.0.3
+flake8-docstrings==1.3.0
 flake8==3.5
 mock-open==1.3.1
 mypy==0.620
-pydocstyle==1.1.1
+pydocstyle==2.1.1
 pylint==2.1.1
 pytest-aiohttp==0.3.0
 pytest-cov==2.5.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -4,11 +4,11 @@
 # new version
 asynctest==0.12.2
 coveralls==1.2.0
-flake8-docstrings==1.0.3
+flake8-docstrings==1.3.0
 flake8==3.5
 mock-open==1.3.1
 mypy==0.620
-pydocstyle==1.1.1
+pydocstyle==2.1.1
 pylint==2.1.1
 pytest-aiohttp==0.3.0
 pytest-cov==2.5.1

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -156,7 +156,7 @@ def core_requirements():
 
 
 def comment_requirement(req):
-    """Some requirements don't install on all systems."""
+    """Comment out requirement. Some don't install on all systems."""
     return any(ign in req for ign in COMMENT_REQUIREMENTS)
 
 
@@ -295,7 +295,7 @@ def validate_constraints_file(data):
 
 
 def main(validate):
-    """Main section of the script."""
+    """Run the script."""
     if not os.path.isfile('requirements_all.txt'):
         print('Run this from HA root dir')
         return 1

--- a/script/inspect_schemas.py
+++ b/script/inspect_schemas.py
@@ -18,7 +18,7 @@ def explore_module(package):
 
 
 def main():
-    """Main section of the script."""
+    """Run the script."""
     if not os.path.isfile('requirements_all.txt'):
         print('Run this from HA root dir')
         return

--- a/script/lazytox.py
+++ b/script/lazytox.py
@@ -153,7 +153,7 @@ async def lint(files):
 
 
 async def main():
-    """The main loop."""
+    """Run the main loop."""
     # Ensure we are in the homeassistant root
     os.chdir(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
 

--- a/script/translations_download_split.py
+++ b/script/translations_download_split.py
@@ -88,7 +88,7 @@ def save_language_translations(lang, translations):
 
 
 def main():
-    """Main section of the script."""
+    """Run the script."""
     if not os.path.isfile("requirements_all.txt"):
         print("Run this from HA root dir")
         return

--- a/script/translations_upload_merge.py
+++ b/script/translations_upload_merge.py
@@ -73,7 +73,7 @@ def get_translation_dict(translations, component, platform):
 
 
 def main():
-    """Main section of the script."""
+    """Run the script."""
     if not os.path.isfile("requirements_all.txt"):
         print("Run this from HA root dir")
         return

--- a/tests/common.py
+++ b/tests/common.py
@@ -360,7 +360,7 @@ class MockUser(auth_models.User):
 
 
 async def register_auth_provider(hass, config):
-    """Helper to register an auth provider."""
+    """Register an auth provider."""
     provider = await auth_providers.auth_provider_from_config(
         hass, hass.auth._store, config)
     assert provider is not None, 'Invalid config specified'
@@ -749,7 +749,7 @@ class MockEntity(entity.Entity):
         return self._handle('available')
 
     def _handle(self, attr):
-        """Helper for the attributes."""
+        """Return attribute value."""
         if attr in self._values:
             return self._values[attr]
         return getattr(super(), attr)

--- a/tests/components/auth/__init__.py
+++ b/tests/components/auth/__init__.py
@@ -20,7 +20,7 @@ EMPTY_CONFIG = []
 
 async def async_setup_auth(hass, aiohttp_client, provider_configs=BASE_CONFIG,
                            module_configs=EMPTY_CONFIG, setup_api=False):
-    """Helper to set up authentication and create an HTTP client."""
+    """Set up authentication and create an HTTP client."""
     hass.auth = await auth.auth_manager_from_config(
         hass, provider_configs, module_configs)
     ensure_auth_manager_loaded(hass.auth)

--- a/tests/components/auth/test_init_link_user.py
+++ b/tests/components/auth/test_init_link_user.py
@@ -5,7 +5,7 @@ from tests.common import CLIENT_ID, CLIENT_REDIRECT_URI
 
 
 async def async_get_code(hass, aiohttp_client):
-    """Helper for link user tests that returns authorization code."""
+    """Return authorization code for link user tests."""
     config = [{
         'name': 'Example',
         'type': 'insecure_example',

--- a/tests/components/automation/test_event.py
+++ b/tests/components/automation/test_event.py
@@ -20,7 +20,7 @@ class TestAutomationEvent(unittest.TestCase):
 
         @callback
         def record_call(service):
-            """Helper for recording the call."""
+            """Record the call."""
             self.calls.append(service)
 
         self.hass.services.register('test', 'automation', record_call)

--- a/tests/components/automation/test_mqtt.py
+++ b/tests/components/automation/test_mqtt.py
@@ -22,7 +22,7 @@ class TestAutomationMQTT(unittest.TestCase):
 
         @callback
         def record_call(service):
-            """Helper to record calls."""
+            """Record calls."""
             self.calls.append(service)
 
         self.hass.services.register('test', 'automation', record_call)

--- a/tests/components/automation/test_numeric_state.py
+++ b/tests/components/automation/test_numeric_state.py
@@ -25,7 +25,7 @@ class TestAutomationNumericState(unittest.TestCase):
 
         @callback
         def record_call(service):
-            """Helper to record calls."""
+            """Record calls."""
             self.calls.append(service)
 
         self.hass.services.register('test', 'automation', record_call)

--- a/tests/components/automation/test_template.py
+++ b/tests/components/automation/test_template.py
@@ -22,7 +22,7 @@ class TestAutomationTemplate(unittest.TestCase):
 
         @callback
         def record_call(service):
-            """Helper to record calls."""
+            """Record calls."""
             self.calls.append(service)
 
         self.hass.services.register('test', 'automation', record_call)

--- a/tests/components/automation/test_time.py
+++ b/tests/components/automation/test_time.py
@@ -25,7 +25,7 @@ class TestAutomationTime(unittest.TestCase):
 
         @callback
         def record_call(service):
-            """Helper to record calls."""
+            """Record calls."""
             self.calls.append(service)
 
         self.hass.services.register('test', 'automation', record_call)

--- a/tests/components/automation/test_zone.py
+++ b/tests/components/automation/test_zone.py
@@ -29,7 +29,7 @@ class TestAutomationZone(unittest.TestCase):
 
         @callback
         def record_call(service):
-            """Helper to record calls."""
+            """Record calls."""
             self.calls.append(service)
 
         self.hass.services.register('test', 'automation', record_call)

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -323,7 +323,7 @@ class TestComponentsDeviceTracker(unittest.TestCase):
 
         @callback
         def listener(event):
-            """Helper method that will verify our event got called."""
+            """Record that our event got called."""
             test_events.append(event)
 
         self.hass.bus.listen("device_tracker_new_device", listener)

--- a/tests/components/device_tracker/test_locative.py
+++ b/tests/components/device_tracker/test_locative.py
@@ -11,7 +11,7 @@ from homeassistant.components.device_tracker.locative import URL
 
 
 def _url(data=None):
-    """Helper method to generate URLs."""
+    """Generate URL."""
     data = data or {}
     data = "&".join(["{}={}".format(name, value) for
                      name, value in data.items()])

--- a/tests/components/fan/test_demo.py
+++ b/tests/components/fan/test_demo.py
@@ -15,7 +15,7 @@ class TestDemoFan(unittest.TestCase):
     """Test the fan demo platform."""
 
     def get_entity(self):
-        """Helper method to get the fan entity."""
+        """Get the fan entity."""
         return self.hass.states.get(FAN_ENTITY_ID)
 
     def setUp(self):

--- a/tests/components/http/test_real_ip.py
+++ b/tests/components/http/test_real_ip.py
@@ -8,7 +8,7 @@ from homeassistant.components.http.const import KEY_REAL_IP
 
 
 async def mock_handler(request):
-    """Handler that returns the real IP as text."""
+    """Return the real IP as text."""
     return web.Response(text=str(request[KEY_REAL_IP]))
 
 

--- a/tests/components/media_player/test_cast.py
+++ b/tests/components/media_player/test_cast.py
@@ -48,7 +48,7 @@ def get_fake_chromecast_info(host='192.168.178.42', port=8009,
 
 
 async def async_setup_cast(hass, config=None, discovery_info=None):
-    """Helper to set up the cast platform."""
+    """Set up the cast platform."""
     if config is None:
         config = {}
     add_devices = Mock()

--- a/tests/components/media_player/test_samsungtv.py
+++ b/tests/components/media_player/test_samsungtv.py
@@ -52,7 +52,7 @@ class TestSamsungTv(unittest.TestCase):
     @MockDependency('samsungctl')
     @MockDependency('wakeonlan')
     def setUp(self, samsung_mock, wol_mock):
-        """Setting up test environment."""
+        """Set up test environment."""
         self.hass = tests.common.get_test_home_assistant()
         self.hass.start()
         self.hass.block_till_done()

--- a/tests/components/media_player/test_universal.py
+++ b/tests/components/media_player/test_universal.py
@@ -94,7 +94,7 @@ class MockMediaPlayer(media_player.MediaPlayerDevice):
 
     @property
     def volume_level(self):
-        """The volume level of player."""
+        """Return the volume level of player."""
         return self._volume_level
 
     @property

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -56,7 +56,7 @@ class TestMQTTComponent(unittest.TestCase):
 
     @callback
     def record_calls(self, *args):
-        """Helper for recording calls."""
+        """Record calls."""
         self.calls.append(args)
 
     def aiohttp_client_stops_on_home_assistant_start(self):
@@ -199,7 +199,7 @@ class TestMQTTCallbacks(unittest.TestCase):
 
     @callback
     def record_calls(self, *args):
-        """Helper for recording calls."""
+        """Record calls."""
         self.calls.append(args)
 
     def aiohttp_client_starts_on_home_assistant_mqtt_setup(self):

--- a/tests/components/notify/test_demo.py
+++ b/tests/components/notify/test_demo.py
@@ -73,7 +73,7 @@ class TestNotifyDemo(unittest.TestCase):
 
     @callback
     def record_calls(self, *args):
-        """Helper for recording calls."""
+        """Record calls."""
         self.calls.append(args)
 
     def test_sending_none_message(self):

--- a/tests/components/sensor/test_yweather.py
+++ b/tests/components/sensor/test_yweather.py
@@ -100,7 +100,7 @@ class YahooWeatherMock():
 
     @property
     def Now(self):  # pylint: disable=invalid-name
-        """Current weather data."""
+        """Return current weather data."""
         if self.woeid == '111':
             raise ValueError
         return self._data['query']['results']['channel']['item']['condition']

--- a/tests/components/test_api.py
+++ b/tests/components/test_api.py
@@ -154,7 +154,7 @@ def test_api_fire_event_with_no_data(hass, mock_api_client):
 
     @ha.callback
     def listener(event):
-        """Helper method that will verify our event got called."""
+        """Record that our event got called."""
         test_value.append(1)
 
     hass.bus.async_listen_once("test.event_no_data", listener)
@@ -174,7 +174,7 @@ def test_api_fire_event_with_data(hass, mock_api_client):
 
     @ha.callback
     def listener(event):
-        """Helper method that will verify that our event got called.
+        """Record that our event got called.
 
         Also test if our data came through.
         """
@@ -200,7 +200,7 @@ def test_api_fire_event_with_invalid_json(hass, mock_api_client):
 
     @ha.callback
     def listener(event):
-        """Helper method that will verify our event got called."""
+        """Record that our event got called."""
         test_value.append(1)
 
     hass.bus.async_listen_once("test_event_bad_data", listener)
@@ -281,7 +281,7 @@ def test_api_call_service_no_data(hass, mock_api_client):
 
     @ha.callback
     def listener(service_call):
-        """Helper method that will verify that our service got called."""
+        """Record that our service got called."""
         test_value.append(1)
 
     hass.services.async_register("test_domain", "test_service", listener)
@@ -300,7 +300,7 @@ def test_api_call_service_with_data(hass, mock_api_client):
 
     @ha.callback
     def listener(service_call):
-        """Helper method that will verify that our service got called.
+        """Record that our service got called.
 
         Also test if our data came through.
         """
@@ -440,7 +440,7 @@ async def test_api_fire_event_context(hass, mock_api_client,
 
     @ha.callback
     def listener(event):
-        """Helper method that will verify our event got called."""
+        """Record that our event got called."""
         test_value.append(event)
 
     hass.bus.async_listen("test.event", listener)

--- a/tests/components/test_discovery.py
+++ b/tests/components/test_discovery.py
@@ -47,7 +47,7 @@ def netdisco_mock():
 
 
 async def mock_discovery(hass, discoveries, config=BASE_CONFIG):
-    """Helper to mock discoveries."""
+    """Mock discoveries."""
     result = await async_setup_component(hass, 'discovery', config)
     assert result
 

--- a/tests/components/test_feedreader.py
+++ b/tests/components/test_feedreader.py
@@ -79,7 +79,7 @@ class TestFeedreaderComponent(unittest.TestCase):
                                         VALID_CONFIG_3))
 
     def setup_manager(self, feed_data, max_entries=DEFAULT_MAX_ENTRIES):
-        """Generic test setup method."""
+        """Set up feed manager."""
         events = []
 
         @callback

--- a/tests/components/test_pilight.py
+++ b/tests/components/test_pilight.py
@@ -41,11 +41,11 @@ class PilightDaemonSim:
         pass
 
     def send_code(self, call):  # pylint: disable=no-self-use
-        """Called pilight.send service is called."""
+        """Handle pilight.send service callback."""
         _LOGGER.error('PilightDaemonSim payload: ' + str(call))
 
     def start(self):
-        """Called homeassistant.start is called.
+        """Handle homeassistant.start callback.
 
         Also sends one test message after start up
         """
@@ -56,11 +56,11 @@ class PilightDaemonSim:
             self.called = True
 
     def stop(self):  # pylint: disable=no-self-use
-        """Called homeassistant.stop is called."""
+        """Handle homeassistant.stop callback."""
         _LOGGER.error('PilightDaemonSim stop')
 
     def set_callback(self, function):
-        """Callback called  on event pilight.pilight_received."""
+        """Handle pilight.pilight_received event callback."""
         self.callback = function
         _LOGGER.error('PilightDaemonSim callback: ' + str(function))
 

--- a/tests/components/test_upnp.py
+++ b/tests/components/test_upnp.py
@@ -47,7 +47,7 @@ class MockResp(MagicMock):
 
 @pytest.fixture
 def mock_msearch_first(*args, **kwargs):
-    """Wrapper to async mock function."""
+    """Wrap async mock msearch_first."""
     async def async_mock_msearch_first(*args, **kwargs):
         """Mock msearch_first."""
         return MockResp(*args, **kwargs)
@@ -58,7 +58,7 @@ def mock_msearch_first(*args, **kwargs):
 
 @pytest.fixture
 def mock_async_exception(*args, **kwargs):
-    """Wrapper to async mock function with exception."""
+    """Wrap async mock exception."""
     async def async_mock_exception(*args, **kwargs):
         return Exception
 

--- a/tests/components/weather/test_yweather.py
+++ b/tests/components/weather/test_yweather.py
@@ -41,31 +41,31 @@ class YahooWeatherMock():
 
     @property
     def RawData(self):  # pylint: disable=invalid-name
-        """Raw Data."""
+        """Return raw Data."""
         if self.woeid == '12345':
             return json.loads('[]')
         return self._data
 
     @property
     def Now(self):  # pylint: disable=invalid-name
-        """Current weather data."""
+        """Return current weather data."""
         if self.woeid == '111':
             raise ValueError
         return self._data['query']['results']['channel']['item']['condition']
 
     @property
     def Atmosphere(self):  # pylint: disable=invalid-name
-        """Atmosphere weather data."""
+        """Return atmosphere weather data."""
         return self._data['query']['results']['channel']['atmosphere']
 
     @property
     def Wind(self):  # pylint: disable=invalid-name
-        """Wind weather data."""
+        """Return wind weather data."""
         return self._data['query']['results']['channel']['wind']
 
     @property
     def Forecast(self):  # pylint: disable=invalid-name
-        """Forecast data 0-5 Days."""
+        """Return forecast data 0-5 Days."""
         if self.woeid == '123123':
             raise ValueError
         return self._data['query']['results']['channel']['item']['forecast']

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -336,7 +336,7 @@ def test_raise_error_on_update(hass):
     entity2 = MockEntity(name='test_2')
 
     def _raise():
-        """Helper to raise an exception."""
+        """Raise an exception."""
         raise AssertionError
 
     entity1.update = _raise

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -257,7 +257,7 @@ class TestSetup:
     def test_component_exception_setup(self):
         """Test component that raises exception during setup."""
         def exception_setup(hass, config):
-            """Setup that raises exception."""
+            """Raise exception."""
             raise Exception('fail!')
 
         loader.set_component(
@@ -269,7 +269,7 @@ class TestSetup:
     def test_component_setup_with_validation_and_dependency(self):
         """Test all config is passed to dependencies."""
         def config_check_setup(hass, config):
-            """Setup method that tests config is passed in."""
+            """Test that config is passed in."""
             if config.get('comp_a', {}).get('valid', False):
                 return True
             raise Exception('Config not passed in: {}'.format(config))


### PR DESCRIPTION
## Description:

This pull request is for now primarily meant for discussion/comments, as there are lots of new errors, and I'm not sure if starting to fix these is desirable.

The full Travis run is at https://travis-ci.org/scop/home-assistant/jobs/381288453, there are a lot of errors like `D401 First line should be in imperative mood; try rephrasing`. A couple of sample fixes (for homeassistant/auth.py) for these would be:

```diff
-        """Result of a credential login flow."""
+        """Get result of a credential login flow."""
```
...and:
```diff
-        """Helper to get auth provider from a set of credentials."""
+        """Get auth provider from a set of credentials."""
```

I think other errors besides the D401's have already been fixed (see e.g. e20f88c143ecedd18cf502896282f3bd3fb4bd78 and 843789528ed800268362782782d7c857bc68c6f6).

So, there is IMO value in some of the checks, but the D401 should maybe be ignored. And adding to the (default) ignore list is somewhat painful with flake8 at the moment, so I suggest either:

1. Bite the bullet and fix all the D401's, or
1. Wait until it's easy to just add stuff to flake8's default ignore list (instead of having to enumerate it completely if you want to start adding to it), then mark D401 as ignored and merge. See https://gitlab.com/pycqa/flake8/merge_requests/233, https://gitlab.com/pycqa/flake8/issues/365

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**