### PR TITLE
Don't poll ZHA switch devices

### DIFF
--- a/homeassistant/components/binary_sensor/zha.py
+++ b/homeassistant/components/binary_sensor/zha.py
@@ -212,6 +212,11 @@ class Switch(zha.Entity, BinarySensorDevice):
         }
 
     @property
+    def should_poll(self) -> bool:
+        """Let zha handle polling."""
+        return False
+
+    @property
     def is_on(self) -> bool:
         """Return true if the binary sensor is on."""
         return self._state


### PR DESCRIPTION
## Description:
Don't poll switch devices. For devices like the Osram Lightify dimmer this will quickly drain the battery.
