### PR TITLE
NUT sensor enhancements

### DIFF
--- a/homeassistant/components/sensor/nut.py
+++ b/homeassistant/components/sensor/nut.py
@@ -215,8 +215,7 @@ class NUTSensor(Entity):
     def device_state_attributes(self):
         """Return the sensor attributes."""
         attr = dict()
-        attr[ATTR_STATE] = "{} ({})".format(self.display_state(),
-                                            self._data.status[KEY_STATUS])
+        attr[ATTR_STATE] = self.display_state()
         return attr
 
     def display_state(self):

--- a/homeassistant/components/sensor/nut.py
+++ b/homeassistant/components/sensor/nut.py
@@ -31,7 +31,7 @@ KEY_STATUS = 'ups.status'
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=60)
 
 SENSOR_TYPES = {
-    'ups.status': ['Status Data', '', 'mdi:information-outline'],
+    'ups.status': ['Status', '', 'mdi:information-outline'],
     'ups.alarm': ['Alarms', '', 'mdi:alarm'],
     'ups.time': ['Internal Time', '', 'mdi:calendar-clock'],
     'ups.date': ['Internal Date', '', 'mdi:calendar'],
@@ -210,7 +210,8 @@ class NUTSensor(Entity):
     def device_state_attributes(self):
         """Return the sensor attributes."""
         attr = dict()
-        attr[ATTR_STATE] = self.operating_state()
+        attr[ATTR_STATE] = self.operating_state() + " (" + \
+            self._data.status[KEY_STATUS] + ")"
         return attr
 
     def operating_state(self):
@@ -294,5 +295,5 @@ class PyNUTData(object):
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self, **kwargs):
-        """Fetch the latest status from APCUPSd."""
+        """Fetch the latest status from NUT."""
         self._status = self._get_status()

--- a/homeassistant/components/sensor/nut.py
+++ b/homeassistant/components/sensor/nut.py
@@ -215,12 +215,12 @@ class NUTSensor(Entity):
     def device_state_attributes(self):
         """Return the sensor attributes."""
         attr = dict()
-        attr[ATTR_STATE] = self.operating_state() + " (" + \
+        attr[ATTR_STATE] = self.display_state() + " (" + \
             self._data.status[KEY_STATUS] + ")"
         return attr
 
-    def operating_state(self):
-        """Return UPS operating state."""
+    def display_state(self):
+        """Return UPS display state."""
         if self._data.status is None:
             return STATE_TYPES['OFF']
         else:
@@ -240,7 +240,7 @@ class NUTSensor(Entity):
         # In case of the display status sensor, keep a human-readable form
         # as the sensor state.
         if self.type == KEY_STATUS_DISPLAY:
-            self._state = self.operating_state()
+            self._state = self.display_state()
         elif self.type not in self._data.status:
             self._state = None
         else:

--- a/homeassistant/components/sensor/nut.py
+++ b/homeassistant/components/sensor/nut.py
@@ -14,6 +14,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.const import (
     CONF_HOST, CONF_PORT, CONF_NAME, CONF_USERNAME, CONF_PASSWORD,
     TEMP_CELSIUS, CONF_RESOURCES, CONF_ALIAS, ATTR_STATE, STATE_UNKNOWN)
+from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 
@@ -130,7 +131,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_ALIAS): cv.string,
     vol.Optional(CONF_USERNAME): cv.string,
     vol.Optional(CONF_PASSWORD): cv.string,
-    vol.Required(CONF_RESOURCES, default=[]):
+    vol.Required(CONF_RESOURCES):
         vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
 })
 
@@ -148,7 +149,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     if data.status is None:
         _LOGGER.error("NUT Sensor has no data, unable to setup")
-        return False
+        raise PlatformNotReady
 
     _LOGGER.debug('NUT Sensors Available: %s', data.status)
 
@@ -169,7 +170,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     except data.pynuterror as err:
         _LOGGER.error("Failure while testing NUT status retrieval. "
                       "Cannot continue setup: %s", err)
-        return False
+        raise PlatformNotReady
 
     add_entities(entities, True)
 
@@ -209,10 +210,10 @@ class NUTSensor(Entity):
     def device_state_attributes(self):
         """Return the sensor attributes."""
         attr = dict()
-        attr[ATTR_STATE] = self.opp_state()
+        attr[ATTR_STATE] = self.operating_state()
         return attr
 
-    def opp_state(self):
+    def operating_state(self):
         """Return UPS operating state."""
         if self._data.status is None:
             return STATE_TYPES['OFF']
@@ -233,7 +234,12 @@ class NUTSensor(Entity):
         if self.type not in self._data.status:
             self._state = None
         else:
-            self._state = self._data.status[self.type]
+            # Special treatment for overall UPS status to make it
+            # human-readable
+            if self.type == KEY_STATUS:
+                self._state = self.operating_state()
+            else:
+                self._state = self._data.status[self.type]
 
 
 class PyNUTData(object):

--- a/homeassistant/components/sensor/nut.py
+++ b/homeassistant/components/sensor/nut.py
@@ -215,8 +215,8 @@ class NUTSensor(Entity):
     def device_state_attributes(self):
         """Return the sensor attributes."""
         attr = dict()
-        attr[ATTR_STATE] = self.display_state() + " (" + \
-            self._data.status[KEY_STATUS] + ")"
+        attr[ATTR_STATE] = "{} ({})".format(self.display_state(),
+                                            self._data.status[KEY_STATUS])
         return attr
 
     def display_state(self):


### PR DESCRIPTION
## Description:
This proposal makes the NUT sensor a bit more user-friendly, and contains the following changes:
* Fix #14324 by introducing a new virtual sensor type `ups.status.display` which outputs the UPS status in a human-readable form. For example, outputs "Online Battery Charging" instead of "OL CHRG" on the sensor's state card.
* ~~Change the more info dialog output by appending the raw status value to the human-readable form. Example output: "state . Online Battery Charging (OL CHRG)".~~
* In two cases where during the setup of the sensor the NUT status is unavailable or the initial sensor update fails, raise a `PlatformNotReady` to make HA try again after a few seconds.

**Related issue (if applicable):** fixes #14324

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5411

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: nut
    resources:
      - ups.status.display
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
