### PR TITLE
fix nanoleaf aurora lights min and max temperature

### DIFF
--- a/homeassistant/components/light/nanoleaf_aurora.py
+++ b/homeassistant/components/light/nanoleaf_aurora.py
@@ -29,6 +29,9 @@ DATA_NANOLEAF_AURORA = 'nanoleaf_aurora'
 
 CONFIG_FILE = '.nanoleaf_aurora.conf'
 
+NANOLEAF_AURORA_MIN_MIRED = 154
+NANOLEAF_AURORA_MAX_MIRED = 833
+
 ICON = 'mdi:triangle-outline'
 
 SUPPORT_AURORA = (SUPPORT_BRIGHTNESS | SUPPORT_COLOR_TEMP | SUPPORT_EFFECT |
@@ -124,6 +127,16 @@ class AuroraLight(Light):
     def effect_list(self):
         """Return the list of supported effects."""
         return self._effects_list
+
+    @property
+    def min_mireds(self):
+        """Return the coldest color_temp that this light supports."""
+        return NANOLEAF_AURORA_MIN_MIRED
+
+    @property
+    def max_mireds(self):
+        """Return the warmest color_temp that this light supports."""
+        return NANOLEAF_AURORA_MAX_MIRED
 
     @property
     def name(self):

--- a/homeassistant/components/light/nanoleaf_aurora.py
+++ b/homeassistant/components/light/nanoleaf_aurora.py
@@ -29,9 +29,6 @@ DATA_NANOLEAF_AURORA = 'nanoleaf_aurora'
 
 CONFIG_FILE = '.nanoleaf_aurora.conf'
 
-NANOLEAF_AURORA_MIN_MIRED = 154
-NANOLEAF_AURORA_MAX_MIRED = 833
-
 ICON = 'mdi:triangle-outline'
 
 SUPPORT_AURORA = (SUPPORT_BRIGHTNESS | SUPPORT_COLOR_TEMP | SUPPORT_EFFECT |
@@ -131,12 +128,12 @@ class AuroraLight(Light):
     @property
     def min_mireds(self):
         """Return the coldest color_temp that this light supports."""
-        return NANOLEAF_AURORA_MIN_MIRED
+        return 154
 
     @property
     def max_mireds(self):
         """Return the warmest color_temp that this light supports."""
-        return NANOLEAF_AURORA_MAX_MIRED
+        return 833
 
     @property
     def name(self):


### PR DESCRIPTION
## Description:
Setting Nanoleaf Aurora light panels to min temperature did not work and the max temperature was not the actual max

**Related issue (if applicable):** none

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** none

## Example entry for `configuration.yaml` (if applicable): none

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

