### PR TITLE
Add services for adding and removing items to shopping list

### DIFF
--- a/homeassistant/components/services.yaml
+++ b/homeassistant/components/services.yaml
@@ -556,3 +556,17 @@ xiaomi_aqara:
       device_id:
         description: Hardware address of the device to remove.
         example: 158d0000000000
+
+shopping_list:
+  add_item:
+    description: Adds an item to the shopping list.
+    fields:
+      name:
+        description: The name of the item to add.
+        example: Beer
+  complete_item:
+    description: Marks an item as completed in the shopping list. It does not remove the item.
+    fields:
+      name:
+        description: The name of the item to mark as completed.
+        example: Beer

--- a/homeassistant/components/shopping_list.py
+++ b/homeassistant/components/shopping_list.py
@@ -44,7 +44,7 @@ def async_setup(hass, config):
     def add_item_service(call):
         """Add an item with `name`."""
         data = hass.data[DOMAIN]
-        name = call.data.get(ATTR_NAME, None)
+        name = call.data.get(ATTR_NAME)
         if name is not None:
             data.async_add(name)
 
@@ -52,7 +52,7 @@ def async_setup(hass, config):
     def complete_item_service(call):
         """Mark the item provided via `name` as completed."""
         data = hass.data[DOMAIN]
-        name = call.data.get(ATTR_NAME, None)
+        name = call.data.get(ATTR_NAME)
         if name is None:
             return
         try:

--- a/homeassistant/components/shopping_list.py
+++ b/homeassistant/components/shopping_list.py
@@ -14,6 +14,8 @@ from homeassistant.helpers import intent
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util.json import load_json, save_json
 
+ATTR_NAME = 'name'
+
 DOMAIN = 'shopping_list'
 DEPENDENCIES = ['http']
 _LOGGER = logging.getLogger(__name__)
@@ -23,19 +25,56 @@ INTENT_ADD_ITEM = 'HassShoppingListAddItem'
 INTENT_LAST_ITEMS = 'HassShoppingListLastItems'
 ITEM_UPDATE_SCHEMA = vol.Schema({
     'complete': bool,
-    'name': str,
+    ATTR_NAME: str,
 })
 PERSISTENCE = '.shopping_list.json'
+
+SERVICE_ADD_ITEM = 'add_item'
+SERVICE_COMPLETE_ITEM = 'complete_item'
+
+SERVICE_ITEM_SCHEMA = vol.Schema({
+    vol.Required(ATTR_NAME): vol.Any(None, cv.string)
+})
 
 
 @asyncio.coroutine
 def async_setup(hass, config):
     """Initialize the shopping list."""
+    @asyncio.coroutine
+    def add_item_service(call):
+        """Add an item with `name`."""
+        data = hass.data[DOMAIN]
+        name = call.data.get(ATTR_NAME, None)
+        if name is not None:
+            data.async_add(name)
+
+    @asyncio.coroutine
+    def complete_item_service(call):
+        """Mark the item provided via `name` as completed."""
+        data = hass.data[DOMAIN]
+        name = call.data.get(ATTR_NAME, None)
+        if name is None:
+            return
+        try:
+            item = [item for item in data.items if item['name'] == name][0]
+        except IndexError:
+            _LOGGER.error("Removing of item failed: %s cannot be found", name)
+        else:
+            data.async_update(item['id'], {'name': name, 'complete': True})
+
     data = hass.data[DOMAIN] = ShoppingData(hass)
     yield from data.async_load()
 
     intent.async_register(hass, AddItemIntent())
     intent.async_register(hass, ListTopItemsIntent())
+
+    hass.services.async_register(
+        DOMAIN, SERVICE_ADD_ITEM, add_item_service, schema=SERVICE_ITEM_SCHEMA
+    )
+    hass.services.async_register(
+        DOMAIN, SERVICE_COMPLETE_ITEM, complete_item_service,
+        schema=SERVICE_ITEM_SCHEMA
+    )
 
     hass.http.register_view(ShoppingListView)
     hass.http.register_view(CreateShoppingListItemView)


### PR DESCRIPTION
## Description:
This PR adds two services to the shopping list component:
- `shopping_list.add_item`
- `shopping_list.complete_item`

### Example:
```
action:
    - service: shopping_list.add_item
      data_template:
        name: "milk"
    - service: shopping_list.complete_item
      data_template:
        name: "milk"
```

**Related feature request** on community.home-assistant.io: 
https://community.home-assistant.io/t/new-service-calls-and-sensors-for-shopping-list-component/40285

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation:**
home-assistant/home-assistant.github.io#5438

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`.


If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

I didn't add additional tests since the two services are just wrapping the well-tested `ShoppingData` class.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54