### PR TITLE
Add battery state to Climate, battery voltage to Sensibo

### DIFF
--- a/homeassistant/components/climate/__init__.py
+++ b/homeassistant/components/climate/__init__.py
@@ -63,7 +63,6 @@ SUPPORT_SWING_MODE = 512
 SUPPORT_AWAY_MODE = 1024
 SUPPORT_AUX_HEAT = 2048
 SUPPORT_ON_OFF = 4096
-SUPPORT_BATTERY = 8192
 
 ATTR_CURRENT_TEMPERATURE = 'current_temperature'
 ATTR_MAX_TEMP = 'max_temp'
@@ -542,9 +541,8 @@ class ClimateDevice(Entity):
             is_aux_heat = self.is_aux_heat_on
             data[ATTR_AUX_HEAT] = STATE_ON if is_aux_heat else STATE_OFF
 
-        if supported_features & SUPPORT_BATTERY:
-            if self.battery:
-                data[ATTR_BATTERY] = self.battery
+        if self.battery:
+            data[ATTR_BATTERY] = self.battery
 
         return data
 

--- a/homeassistant/components/climate/__init__.py
+++ b/homeassistant/components/climate/__init__.py
@@ -63,6 +63,7 @@ SUPPORT_SWING_MODE = 512
 SUPPORT_AWAY_MODE = 1024
 SUPPORT_AUX_HEAT = 2048
 SUPPORT_ON_OFF = 4096
+SUPPORT_BATTERY = 8192
 
 ATTR_CURRENT_TEMPERATURE = 'current_temperature'
 ATTR_MAX_TEMP = 'max_temp'
@@ -83,6 +84,7 @@ ATTR_OPERATION_MODE = 'operation_mode'
 ATTR_OPERATION_LIST = 'operation_list'
 ATTR_SWING_MODE = 'swing_mode'
 ATTR_SWING_LIST = 'swing_list'
+ATTR_BATTERY = 'battery'
 
 CONVERTIBLE_ATTRIBUTE = [
     ATTR_TEMPERATURE,
@@ -540,6 +542,10 @@ class ClimateDevice(Entity):
             is_aux_heat = self.is_aux_heat_on
             data[ATTR_AUX_HEAT] = STATE_ON if is_aux_heat else STATE_OFF
 
+        if supported_features & SUPPORT_BATTERY:
+            if self.battery:
+                data[ATTR_BATTERY] = self.battery
+
         return data
 
     @property
@@ -635,6 +641,11 @@ class ClimateDevice(Entity):
     @property
     def swing_list(self):
         """Return the list of available swing modes."""
+        return None
+
+    @property
+    def battery(self):
+        """Return the current battery state."""
         return None
 
     def set_temperature(self, **kwargs):

--- a/homeassistant/components/climate/sensibo.py
+++ b/homeassistant/components/climate/sensibo.py
@@ -19,7 +19,7 @@ from homeassistant.components.climate import (
     ATTR_CURRENT_HUMIDITY, ClimateDevice, DOMAIN, PLATFORM_SCHEMA,
     SUPPORT_TARGET_TEMPERATURE, SUPPORT_OPERATION_MODE,
     SUPPORT_FAN_MODE, SUPPORT_SWING_MODE,
-    SUPPORT_ON_OFF)
+    SUPPORT_ON_OFF, SUPPORT_BATTERY)
 from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -55,6 +55,7 @@ FIELD_TO_FLAG = {
     'swing': SUPPORT_SWING_MODE,
     'targetTemperature': SUPPORT_TARGET_TEMPERATURE,
     'on': SUPPORT_ON_OFF,
+    'battery': SUPPORT_BATTERY
 }
 
 
@@ -192,8 +193,8 @@ class SensiboClimate(ClimateDevice):
         return self._measurements['humidity']
 
     @property
-    def battery_voltage(self):
-        """Return the current battery level."""
+    def battery(self):
+        """Return the current battery state."""
         return self._measurements['batteryVoltage']
 
     @property

--- a/homeassistant/components/climate/sensibo.py
+++ b/homeassistant/components/climate/sensibo.py
@@ -192,6 +192,11 @@ class SensiboClimate(ClimateDevice):
         return self._measurements['humidity']
 
     @property
+    def battery_voltage(self):
+        """Return the current battery level."""
+        return self._measurements['batteryVoltage']
+
+    @property
     def current_temperature(self):
         """Return the current temperature."""
         # This field is not affected by temperatureUnit.

--- a/homeassistant/components/climate/sensibo.py
+++ b/homeassistant/components/climate/sensibo.py
@@ -55,7 +55,6 @@ FIELD_TO_FLAG = {
     'swing': SUPPORT_SWING_MODE,
     'targetTemperature': SUPPORT_TARGET_TEMPERATURE,
     'on': SUPPORT_ON_OFF,
-    'battery': SUPPORT_BATTERY
 }
 
 

--- a/homeassistant/components/climate/sensibo.py
+++ b/homeassistant/components/climate/sensibo.py
@@ -19,7 +19,7 @@ from homeassistant.components.climate import (
     ATTR_CURRENT_HUMIDITY, ClimateDevice, DOMAIN, PLATFORM_SCHEMA,
     SUPPORT_TARGET_TEMPERATURE, SUPPORT_OPERATION_MODE,
     SUPPORT_FAN_MODE, SUPPORT_SWING_MODE,
-    SUPPORT_ON_OFF, SUPPORT_BATTERY)
+    SUPPORT_ON_OFF, ATTR_BATTERY)
 from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -154,7 +154,8 @@ class SensiboClimate(ClimateDevice):
     @property
     def device_state_attributes(self):
         """Return the state attributes."""
-        return {ATTR_CURRENT_HUMIDITY: self.current_humidity}
+        return {ATTR_CURRENT_HUMIDITY: self.current_humidity,
+                ATTR_BATTERY: self.battery}
 
     @property
     def temperature_unit(self):


### PR DESCRIPTION
## Description:

Adds support for battery state to the Climate component, and adds battery voltage as an attribute for the Sensibo component. This attribute is reported for first generation Sensibo pods.

## Checklist:
  - [ x ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
