### PR TITLE
Removed current_time attribute from Raincloudy sensors to avoid unnecessary updates by recorder

### DIFF
--- a/homeassistant/components/raincloud.py
+++ b/homeassistant/components/raincloud.py
@@ -168,7 +168,6 @@ class RainCloudEntity(Entity):
         """Return the state attributes."""
         return {
             ATTR_ATTRIBUTION: CONF_ATTRIBUTION,
-            'current_time': self.data.current_time,
             'identifier': self.data.serial,
         }
 

--- a/homeassistant/components/switch/raincloud.py
+++ b/homeassistant/components/switch/raincloud.py
@@ -88,7 +88,6 @@ class RainCloudSwitch(RainCloudEntity, SwitchDevice):
         """Return the state attributes."""
         return {
             ATTR_ATTRIBUTION: CONF_ATTRIBUTION,
-            'current_time': self.data.current_time,
             'default_manual_timer': self._default_watering_timer,
             'identifier': self.data.serial
         }


### PR DESCRIPTION
## Description:
Removed attribute current_time from Raincloudy sensors to avoid being triggered by recorder component. 

One of the Raincloudy attributes was the `current_time` on the controller to be displayed at HA. This was causing the `recorder` component to update its status whenever the `attributes` changed and not only the when it the `status` changed. 

Many thanks to @clboles for reporting this issue. :+1: 

This PR fixes this and you can find more discussion about it at https://github.com/tchellomello/raincloudy/issues/23


**Related issue (if applicable):** 
See also:  https://github.com/tchellomello/raincloudy/issues/23

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
raincloud:
  username: !secret raincloud_username
  password: !secret raincloud_password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.


