### PR TITLE
Samsung TV can't be turn off after idle period

### DIFF
--- a/homeassistant/components/media_player/samsungtv.py
+++ b/homeassistant/components/media_player/samsungtv.py
@@ -155,16 +155,25 @@ class SamsungTVDevice(MediaPlayerDevice):
             _LOGGER.info("TV is powering off, not sending command: %s", key)
             return
         try:
-            self.get_remote().control(key)
+            # recreate connection if connection was dead
+            retry_count = 1
+            for _ in range(retry_count + 1):
+                try:
+                    self.get_remote().control(key)
+                    break
+                except (self._exceptions_class.ConnectionClosed,
+                        BrokenPipeError):
+                    # BrokenPipe can occur when the commands is sent to fast
+                    self._remote = None
             self._state = STATE_ON
         except (self._exceptions_class.UnhandledResponse,
-                self._exceptions_class.AccessDenied, BrokenPipeError):
+                self._exceptions_class.AccessDenied):
             # We got a response so it's on.
-            # BrokenPipe can occur when the commands is sent to fast
             self._state = STATE_ON
             self._remote = None
+            _LOGGER.debug("Failed sending command %s", key, exc_info=True)
             return
-        except (self._exceptions_class.ConnectionClosed, OSError):
+        except OSError:
             self._state = STATE_OFF
             self._remote = None
         if self._power_off_in_progress():
@@ -207,6 +216,7 @@ class SamsungTVDevice(MediaPlayerDevice):
         # Force closing of remote session to provide instant UI feedback
         try:
             self.get_remote().close()
+            self._remote = None
         except OSError:
             _LOGGER.debug("Could not establish connection.")
 


### PR DESCRIPTION
## Description:
When Samsung TV is idle for a period of time after issued a command,
subsequent 'turn_off' command won't turn off the TV. The issue is seen
in Samsung models with websocket as discussed in #12302.

Detailed explanation of the root cause and fix is in the commit message.

**Related issue (if applicable):** fixes #12302 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
