### PR TITLE
upgrade pyrainbird to 0.1.5

### DIFF
--- a/homeassistant/components/rainbird.py
+++ b/homeassistant/components/rainbird.py
@@ -11,7 +11,7 @@ import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
 from homeassistant.const import (CONF_HOST, CONF_PASSWORD)
 
-REQUIREMENTS = ['pyrainbird==0.1.3']
+REQUIREMENTS = ['pyrainbird==0.1.4']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/rainbird.py
+++ b/homeassistant/components/rainbird.py
@@ -11,7 +11,7 @@ import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
 from homeassistant.const import (CONF_HOST, CONF_PASSWORD)
 
-REQUIREMENTS = ['pyrainbird==0.1.4']
+REQUIREMENTS = ['pyrainbird==0.1.5']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -919,7 +919,7 @@ pypollencom==1.1.2
 pyqwikswitch==0.8
 
 # homeassistant.components.rainbird
-pyrainbird==0.1.4
+pyrainbird==0.1.5
 
 # homeassistant.components.sabnzbd
 pysabnzbd==1.0.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -919,7 +919,7 @@ pypollencom==1.1.2
 pyqwikswitch==0.8
 
 # homeassistant.components.rainbird
-pyrainbird==0.1.3
+pyrainbird==0.1.4
 
 # homeassistant.components.sabnzbd
 pysabnzbd==1.0.1


### PR DESCRIPTION
## Description:

Updates the `pyrainbird` library to 0.1.5 which just fixes a bug where `pycrypto` was missing from the `install_requires` field causing issues if you didn't already have it installed.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
