### PR TITLE
Add HomeKit support for automations

### DIFF
--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -143,7 +143,8 @@ def get_accessory(hass, state, aid, config):
         elif device_class == DEVICE_CLASS_ILLUMINANCE or unit in ('lm', 'lx'):
             a_type = 'LightSensor'
 
-    elif state.domain in ('switch', 'remote', 'input_boolean', 'script'):
+    elif state.domain in ('automation', 'input_boolean', 'remote', 'script',
+                          'switch'):
         a_type = 'Switch'
 
     if a_type is None:

--- a/tests/components/homekit/test_get_accessories.py
+++ b/tests/components/homekit/test_get_accessories.py
@@ -109,9 +109,11 @@ def test_type_sensors(type_name, entity_id, state, attrs):
 
 
 @pytest.mark.parametrize('type_name, entity_id, state, attrs', [
-    ('Switch', 'switch.test', 'on', {}),
-    ('Switch', 'remote.test', 'on', {}),
+    ('Switch', 'automation.test', 'on', {}),
     ('Switch', 'input_boolean.test', 'on', {}),
+    ('Switch', 'remote.test', 'on', {}),
+    ('Switch', 'script.test', 'on', {}),
+    ('Switch', 'switch.test', 'on', {}),
 ])
 def test_type_switches(type_name, entity_id, state, attrs):
     """Test if switch types are associated correctly."""

--- a/tests/components/homekit/test_type_switches.py
+++ b/tests/components/homekit/test_type_switches.py
@@ -9,7 +9,9 @@ from tests.common import async_mock_service
 
 
 @pytest.mark.parametrize('entity_id', [
-    'switch.test', 'remote.test', 'input_boolean.test'])
+    'automation.test', 'input_boolean.test', 'remote.test', 'script.test',
+    'switch.test'
+])
 async def test_switch_set_state(hass, entity_id):
     """Test if accessory and HA are updated accordingly."""
     domain = split_entity_id(entity_id)[0]

--- a/tests/components/homekit/test_type_switches.py
+++ b/tests/components/homekit/test_type_switches.py
@@ -9,8 +9,11 @@ from tests.common import async_mock_service
 
 
 @pytest.mark.parametrize('entity_id', [
-    'automation.test', 'input_boolean.test', 'remote.test', 'script.test',
-    'switch.test'
+    'automation.test',
+    'input_boolean.test',
+    'remote.test',
+    'script.test',
+    'switch.test',
 ])
 async def test_switch_set_state(hass, entity_id):
     """Test if accessory and HA are updated accordingly."""


### PR DESCRIPTION
## Description:
Adds support for automations in HomeKit. Entities will be shown as switches within HomeKit.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5418

## Example entry for `configuration.yaml` (if applicable):
```yaml
homekit:
  filter:
    include_domains:
      - automation.garage_door_open
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54