### PR TITLE
Adds a device class of 'garage' to MyQ covers

### DIFF
--- a/homeassistant/components/cover/myq.py
+++ b/homeassistant/components/cover/myq.py
@@ -17,6 +17,7 @@ REQUIREMENTS = ['pymyq==0.0.8']
 
 _LOGGER = logging.getLogger(__name__)
 
+DEFAULT_DEVICE_CLASS = 'garage'
 DEFAULT_NAME = 'myq'
 
 NOTIFICATION_ID = 'myq_notification'
@@ -68,6 +69,11 @@ class MyQDevice(CoverDevice):
         self.device_id = device['deviceid']
         self._name = device['name']
         self._status = STATE_CLOSED
+
+    @property
+    def device_class(self):
+        """Poll for state."""
+        return DEFAULT_DEVICE_CLASS
 
     @property
     def should_poll(self):

--- a/homeassistant/components/cover/myq.py
+++ b/homeassistant/components/cover/myq.py
@@ -17,7 +17,6 @@ REQUIREMENTS = ['pymyq==0.0.8']
 
 _LOGGER = logging.getLogger(__name__)
 
-DEFAULT_DEVICE_CLASS = 'garage'
 DEFAULT_NAME = 'myq'
 
 NOTIFICATION_ID = 'myq_notification'
@@ -72,8 +71,8 @@ class MyQDevice(CoverDevice):
 
     @property
     def device_class(self):
-        """Poll for state."""
-        return DEFAULT_DEVICE_CLASS
+        """Define this cover as a garage door."""
+        return 'garage'
 
     @property
     def should_poll(self):


### PR DESCRIPTION
## Description:
Adds a device class of 'garage' to MyQ covers. This specifically helps HomeKit recognize these covers as garages.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
cover:
  - platform: myq
    username: YOUR_USERNAME
    password: YOUR_PASSWORD
    type: chamberlain
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  ~- [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)~

If the code communicates with devices, web services, or third-party tools:
  ~- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).~
  ~- [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).~
  ~- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.~
  ~- [ ] New files were added to `.coveragerc`.~

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
