### PR TITLE
Add configurable decimals rounding of display value and upgrade coinmarketcap to 5.0.3 (#14437)

### DIFF
--- a/homeassistant/components/sensor/coinmarketcap.py
+++ b/homeassistant/components/sensor/coinmarketcap.py
@@ -13,64 +13,78 @@ import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
-    ATTR_ATTRIBUTION, CONF_CURRENCY, CONF_DISPLAY_CURRENCY)
+    ATTR_ATTRIBUTION, CONF_DISPLAY_CURRENCY)
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['coinmarketcap==4.2.1']
+REQUIREMENTS = ['coinmarketcap==5.0.3']
 
 _LOGGER = logging.getLogger(__name__)
 
-ATTR_24H_VOLUME = '24h_volume'
+ATTR_VOLUME_24H = 'volume_24h'
 ATTR_AVAILABLE_SUPPLY = 'available_supply'
+ATTR_CIRCULATING_SUPPLY = 'circulating_supply'
 ATTR_MARKET_CAP = 'market_cap'
 ATTR_PERCENT_CHANGE_24H = 'percent_change_24h'
 ATTR_PERCENT_CHANGE_7D = 'percent_change_7d'
 ATTR_PERCENT_CHANGE_1H = 'percent_change_1h'
 ATTR_PRICE = 'price'
+ATTR_RANK = 'rank'
 ATTR_SYMBOL = 'symbol'
 ATTR_TOTAL_SUPPLY = 'total_supply'
 
 CONF_ATTRIBUTION = "Data provided by CoinMarketCap"
+CONF_CURRENCY_ID = 'currency_id'
+CONF_DISPLAY_CURRENCY_DECIMALS = 'display_currency_decimals'
 
-DEFAULT_CURRENCY = 'bitcoin'
+DEFAULT_CURRENCY_ID = 1
 DEFAULT_DISPLAY_CURRENCY = 'USD'
+DEFAULT_DISPLAY_CURRENCY_DECIMALS = 2
 
 ICON = 'mdi:currency-usd'
 
 SCAN_INTERVAL = timedelta(minutes=15)
 
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Optional(CONF_CURRENCY, default=DEFAULT_CURRENCY): cv.string,
+    vol.Optional(CONF_CURRENCY_ID, default=DEFAULT_CURRENCY_ID):
+        cv.positive_int,
     vol.Optional(CONF_DISPLAY_CURRENCY, default=DEFAULT_DISPLAY_CURRENCY):
         cv.string,
+    vol.Optional(CONF_DISPLAY_CURRENCY_DECIMALS,
+                 default=DEFAULT_DISPLAY_CURRENCY_DECIMALS):
+        vol.All(vol.Coerce(int), vol.Range(min=1)),
 })
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the CoinMarketCap sensor."""
-    currency = config.get(CONF_CURRENCY)
-    display_currency = config.get(CONF_DISPLAY_CURRENCY).lower()
+    currency_id = config.get(CONF_CURRENCY_ID)
+    display_currency = config.get(CONF_DISPLAY_CURRENCY).upper()
+    display_currency_decimals = config.get(CONF_DISPLAY_CURRENCY_DECIMALS)
 
     try:
-        CoinMarketCapData(currency, display_currency).update()
+        CoinMarketCapData(currency_id, display_currency).update()
     except HTTPError:
-        _LOGGER.warning("Currency %s or display currency %s is not available. "
-                        "Using bitcoin and USD.", currency, display_currency)
-        currency = DEFAULT_CURRENCY
+        _LOGGER.warning("Currency ID %s or display currency %s "
+                        "is not available. Using 1 (bitcoin) "
+                        "and USD.", currency_id, display_currency)
+        currency_id = DEFAULT_CURRENCY_ID
         display_currency = DEFAULT_DISPLAY_CURRENCY
 
     add_devices([CoinMarketCapSensor(
-        CoinMarketCapData(currency, display_currency))], True)
+        CoinMarketCapData(
+            currency_id, display_currency), display_currency_decimals)], True)
 
 
 class CoinMarketCapSensor(Entity):
     """Representation of a CoinMarketCap sensor."""
 
-    def __init__(self, data):
+    def __init__(self, data, display_currency_decimals):
         """Initialize the sensor."""
         self.data = data
+        self.display_currency_decimals = display_currency_decimals
         self._ticker = None
-        self._unit_of_measurement = self.data.display_currency.upper()
+        self._unit_of_measurement = self.data.display_currency
 
     @property
     def name(self):
@@ -80,8 +94,9 @@ class CoinMarketCapSensor(Entity):
     @property
     def state(self):
         """Return the state of the sensor."""
-        return round(float(self._ticker.get(
-            'price_{}'.format(self.data.display_currency))), 2)
+        return round(float(
+            self._ticker.get('quotes').get(self.data.display_currency)
+            .get('price')), self.display_currency_decimals)
 
     @property
     def unit_of_measurement(self):
@@ -97,15 +112,24 @@ class CoinMarketCapSensor(Entity):
     def device_state_attributes(self):
         """Return the state attributes of the sensor."""
         return {
-            ATTR_24H_VOLUME: self._ticker.get(
-                '24h_volume_{}'.format(self.data.display_currency)),
+            ATTR_VOLUME_24H:
+                self._ticker.get('quotes').get(self.data.display_currency)
+                .get('volume_24h'),
             ATTR_ATTRIBUTION: CONF_ATTRIBUTION,
-            ATTR_AVAILABLE_SUPPLY: self._ticker.get('available_supply'),
-            ATTR_MARKET_CAP: self._ticker.get(
-                'market_cap_{}'.format(self.data.display_currency)),
-            ATTR_PERCENT_CHANGE_24H: self._ticker.get('percent_change_24h'),
-            ATTR_PERCENT_CHANGE_7D: self._ticker.get('percent_change_7d'),
-            ATTR_PERCENT_CHANGE_1H: self._ticker.get('percent_change_1h'),
+            ATTR_CIRCULATING_SUPPLY: self._ticker.get('circulating_supply'),
+            ATTR_MARKET_CAP:
+                self._ticker.get('quotes').get(self.data.display_currency)
+                .get('market_cap'),
+            ATTR_PERCENT_CHANGE_24H:
+                self._ticker.get('quotes').get(self.data.display_currency)
+                .get('percent_change_24h'),
+            ATTR_PERCENT_CHANGE_7D:
+                self._ticker.get('quotes').get(self.data.display_currency)
+                .get('percent_change_7d'),
+            ATTR_PERCENT_CHANGE_1H:
+                self._ticker.get('quotes').get(self.data.display_currency)
+                .get('percent_change_1h'),
+            ATTR_RANK: self._ticker.get('rank'),
             ATTR_SYMBOL: self._ticker.get('symbol'),
             ATTR_TOTAL_SUPPLY: self._ticker.get('total_supply'),
         }
@@ -113,20 +137,20 @@ class CoinMarketCapSensor(Entity):
     def update(self):
         """Get the latest data and updates the states."""
         self.data.update()
-        self._ticker = self.data.ticker[0]
+        self._ticker = self.data.ticker.get('data')
 
 
 class CoinMarketCapData(object):
     """Get the latest data and update the states."""
 
-    def __init__(self, currency, display_currency):
+    def __init__(self, currency_id, display_currency):
         """Initialize the data object."""
-        self.currency = currency
+        self.currency_id = currency_id
         self.display_currency = display_currency
         self.ticker = None
 
     def update(self):
-        """Get the latest data from blockchain.info."""
+        """Get the latest data from coinmarketcap.com."""
         from coinmarketcap import Market
         self.ticker = Market().ticker(
-            self.currency, limit=1, convert=self.display_currency)
+            self.currency_id, convert=self.display_currency)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -199,7 +199,7 @@ ciscosparkapi==0.4.2
 coinbase==2.1.0
 
 # homeassistant.components.sensor.coinmarketcap
-coinmarketcap==4.2.1
+coinmarketcap==5.0.3
 
 # homeassistant.scripts.check_config
 colorlog==3.1.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -44,7 +44,7 @@ apns2==0.3.0
 caldav==0.5.0
 
 # homeassistant.components.sensor.coinmarketcap
-coinmarketcap==4.2.1
+coinmarketcap==5.0.3
 
 # homeassistant.components.device_tracker.upc_connect
 defusedxml==0.5.0

--- a/tests/components/sensor/test_coinmarketcap.py
+++ b/tests/components/sensor/test_coinmarketcap.py
@@ -11,8 +11,9 @@ from tests.common import (
 
 VALID_CONFIG = {
     'platform': 'coinmarketcap',
-    'currency': 'ethereum',
+    'currency_id': 1027,
     'display_currency': 'EUR',
+    'display_currency_decimals': 3
 }
 
 
@@ -39,6 +40,6 @@ class TestCoinMarketCapSensor(unittest.TestCase):
         state = self.hass.states.get('sensor.ethereum')
         assert state is not None
 
-        assert state.state == '240.47'
+        assert state.state == '493.455'
         assert state.attributes.get('symbol') == 'ETH'
         assert state.attributes.get('unit_of_measurement') == 'EUR'

--- a/tests/fixtures/coinmarketcap.json
+++ b/tests/fixtures/coinmarketcap.json
@@ -1,21 +1,36 @@
-[
-    {
-        "id": "ethereum", 
-        "name": "Ethereum", 
-        "symbol": "ETH", 
-        "rank": "2", 
-        "price_usd": "282.423", 
-        "price_btc": "0.048844", 
-        "24h_volume_usd": "407024000.0", 
-        "market_cap_usd": "26908205315.0", 
-        "available_supply": "95276253.0", 
-        "total_supply": "95276253.0", 
-        "percent_change_1h": "0.06", 
-        "percent_change_24h": "-4.57", 
-        "percent_change_7d": "-16.39", 
-        "last_updated": "1508776751", 
-        "price_eur": "240.473299695", 
-        "24h_volume_eur": "346566690.16", 
-        "market_cap_eur": "22911395039.0"
+{
+    "cached": false,
+    "data": {
+        "id": 1027,
+        "name": "Ethereum",
+        "symbol": "ETH",
+        "website_slug": "ethereum",
+        "rank": 2,
+        "circulating_supply": 99619842.0,
+        "total_supply": 99619842.0,
+        "max_supply": null,
+        "quotes": {
+            "USD": {
+                "price": 577.019,
+                "volume_24h": 2839960000.0,
+                "market_cap": 57482541899.0,
+                "percent_change_1h": -2.28,
+                "percent_change_24h": -14.88,
+                "percent_change_7d": -17.51
+            },
+            "EUR": {
+                "price": 493.454724572,
+                "volume_24h": 2428699712.48,
+                "market_cap": 49158380042.0,
+                "percent_change_1h": -2.28,
+                "percent_change_24h": -14.88,
+                "percent_change_7d": -17.51
+            }
+        },
+        "last_updated": 1527098658
+    },
+    "metadata": {
+        "timestamp": 1527098716,
+        "error": null
     }
-]
+}


### PR DESCRIPTION
## Description:
Upgraded coinmarketcap to 5.0.3 which supports the new public v2 API, with that comes a few changes to how the API handles input. It is no longer possible to query a ticker by the name of the currency (i.e. `bitcoin`). The API instead uses IDs (integers) for these tickers (i.e. `bitcoin` -> `1`).

I also made the rounding of decimals configurable, because it made no sense to round to 2 decimals if `display_currency` was set to `BTC`, some values showed up as `0.00`.

**Related issue (if applicable):** fixes #14437

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5422

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: coinmarketcap
    currency_id: 1027
    display_currency: 'EUR'
    display_currency_decimals: 3
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
