### PR TITLE
Properly parse currentX and currentY on async_update()

### DIFF
--- a/homeassistant/components/light/zha.py
+++ b/homeassistant/components/light/zha.py
@@ -172,7 +172,8 @@ class Light(zha.Entity, light.Light):
             result = await zha.safe_read(self._endpoint.light_color,
                                          ['current_x', 'current_y'])
             if 'current_x' in result and 'current_y' in result:
-                xy_color = (result['current_x'], result['current_y'])
+                xy_color = (round(result['current_x']/65535, 3),
+                            round(result['current_y']/65535, 3))
                 self._hs_color = color_util.color_xy_to_hs(*xy_color)
 
     @property


### PR DESCRIPTION
## Description:
Currently zha light component doesn't correctly retrieve the state of 'xy_color'. Per ZCL specification, attributes CurrentX and CurrentY of "Color" cluster have the following relation to x and y:
`The value of x SHALL be related to the CurrentX attribute by the relationship
x = CurrentX / 65536 (CurrentX in the range 0 to 65279 inclusive)`. This causes the color of the zha.light device to be incorectly updated when hass is restarted and async_update() is called on zha.light entity.



**Related issue (if applicable):** fixes #<home-assistant issue number goes here>


## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
