### PR TITLE
Upgrade linode-api to 4.1.9b1 (#13863)

### DIFF
--- a/homeassistant/components/linode.py
+++ b/homeassistant/components/linode.py
@@ -13,7 +13,7 @@ from homeassistant.const import CONF_ACCESS_TOKEN
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['linode-api==4.1.4b2']
+REQUIREMENTS = ['linode-api==4.1.9b1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -502,7 +502,7 @@ lightify==1.0.6.1
 limitlessled==1.1.0
 
 # homeassistant.components.linode
-linode-api==4.1.4b2
+linode-api==4.1.9b1
 
 # homeassistant.components.media_player.liveboxplaytv
 liveboxplaytv==2.0.2


### PR DESCRIPTION
## Description:

Upgrade the linode-api package. The outdated version was causing HTTP 400 responses from linode.

**Related issue:** fixes #13863 

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**