### PR TITLE
Extend package support

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -654,21 +654,81 @@ def test_merge_type_mismatch(merge_log_err, hass):
     assert len(config['light']) == 2
 
 
-def test_merge_once_only(merge_log_err, hass):
-    """Test if we have a merge for a comp that may occur only once."""
-    packages = {
-        'pack_2': {
-            'mqtt': {},
-            'api': {},  # No config schema
-        },
-    }
+def test_merge_once_only_keys(merge_log_err, hass):
+    """Test if we have a merge for a comp that may occur only once. Keys."""
+    packages = {'pack_2': {'api': {
+        'key_3': 3,
+    }}}
     config = {
         config_util.CONF_CORE: {config_util.CONF_PACKAGES: packages},
-        'mqtt': {}, 'api': {}
+        'api': {
+            'key_1': 1,
+            'key_2': 2,
+        }
+    }
+    config_util.merge_packages_config(hass, config, packages)
+    assert config['api'] == {'key_1': 1, 'key_2': 2, 'key_3': 3, }
+
+    # Duplicate keys error
+    packages = {'pack_2': {'api': {
+        'key': 2,
+    }}}
+    config = {
+        config_util.CONF_CORE: {config_util.CONF_PACKAGES: packages},
+        'api': {'key': 1, }
     }
     config_util.merge_packages_config(hass, config, packages)
     assert merge_log_err.call_count == 1
-    assert len(config) == 3
+
+
+def test_merge_once_only_lists(hass):
+    """Test if we have a merge for a comp that may occur only once. Lists."""
+    packages = {'pack_2': {'api': {
+        'list_1': ['item_2', 'item_3'],
+        'list_2': ['item_1'],
+        'list_3': [],
+    }}}
+    config = {
+        config_util.CONF_CORE: {config_util.CONF_PACKAGES: packages},
+        'api': {
+            'list_1': ['item_1'],
+        }
+    }
+    config_util.merge_packages_config(hass, config, packages)
+    assert config['api'] == {
+        'list_1': ['item_1', 'item_2', 'item_3'],
+        'list_2': ['item_1'],
+    }
+
+
+def test_merge_once_only_dictionaries(hass):
+    """Test if we have a merge for a comp that may occur only once. Dicts."""
+    packages = {'pack_2': {'api': {
+        'dict_1': {
+            'key_2': 2,
+            'dict_1.1': {'key_1.2': 1.2, },
+        },
+        'dict_2': {'key_1': 1, },
+        'dict_3': {},
+    }}}
+    config = {
+        config_util.CONF_CORE: {config_util.CONF_PACKAGES: packages},
+        'api': {
+            'dict_1': {
+                'key_1': 1,
+                'dict_1.1': {'key_1.1': 1.1, }
+            },
+        }
+    }
+    config_util.merge_packages_config(hass, config, packages)
+    assert config['api'] == {
+        'dict_1': {
+            'key_1': 1,
+            'key_2': 2,
+            'dict_1.1': {'key_1.1': 1.1, 'key_1.2': 1.2, },
+        },
+        'dict_2': {'key_1': 1, },
+    }
 
 
 def test_merge_id_schema(hass):


### PR DESCRIPTION
## Description:
Added package support for sections the previously where only allowed once, through recursive merging.
This could be useful for components that support filtering, as you are now able to define the filter in multiple packages.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation:** home-assistant/home-assistant.github.io#5425

## Example entry for `configuration.yaml` (if applicable):
```yaml
# Example for the HomeKit filter

# Configuration
homekit:
  auto_start: False
  filter:
    include_domains:
      - switch

# Package
homekit:
  filter:
    include_domains:
      - lights
    include_entities:
      - climate.demo
      - climate.test
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)
  - [x] Tests have been added to verify that the new code works.

CC: @kellerza 