### PR TITLE
Fix hue discovery popping up

### DIFF
--- a/homeassistant/auth.py
+++ b/homeassistant/auth.py
@@ -347,6 +347,9 @@ class AuthManager:
 
     async def _async_finish_login_flow(self, result):
         """Result of a credential login flow."""
+        if result['type'] != data_entry_flow.RESULT_TYPE_CREATE_ENTRY:
+            return None
+
         auth_provider = self._providers[result['handler']]
         return await auth_provider.async_get_or_create_credentials(
             result['data'])

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -347,6 +347,15 @@ class ConfigEntries:
 
     async def _async_finish_flow(self, result):
         """Finish a config flow and add an entry."""
+        # If no discovery config entries in progress, remove notification.
+        if not any(ent['source'] in DISCOVERY_SOURCES for ent
+                   in self.hass.config_entries.flow.async_progress()):
+            self.hass.components.persistent_notification.async_dismiss(
+                DISCOVERY_NOTIFICATION_ID)
+
+        if result['type'] != data_entry_flow.RESULT_TYPE_CREATE_ENTRY:
+            return None
+
         entry = ConfigEntry(
             version=result['version'],
             domain=result['handler'],
@@ -369,12 +378,6 @@ class ConfigEntries:
         # Return Entry if they not from a discovery request
         if result['source'] not in DISCOVERY_SOURCES:
             return entry
-
-        # If no discovery config entries in progress, remove notification.
-        if not any(ent['source'] in DISCOVERY_SOURCES for ent
-                   in self.hass.config_entries.flow.async_progress()):
-            self.hass.components.persistent_notification.async_dismiss(
-                DISCOVERY_NOTIFICATION_ID)
 
         return entry
 

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -110,9 +110,6 @@ class FlowManager:
         # Abort and Success results both finish the flow
         self._progress.pop(flow.flow_id)
 
-        if result['type'] == RESULT_TYPE_ABORT:
-            return result
-
         # We pass a copy of the result because we're mutating our version
         result['result'] = await self._async_finish_flow(dict(result))
         return result

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -111,7 +111,10 @@ class FlowManager:
         self._progress.pop(flow.flow_id)
 
         # We pass a copy of the result because we're mutating our version
-        result['result'] = await self._async_finish_flow(dict(result))
+        entry = await self._async_finish_flow(dict(result))
+
+        if result['type'] == RESULT_TYPE_CREATE_ENTRY:
+            result['result'] = entry
         return result
 
 

--- a/tests/test_data_entry_flow.py
+++ b/tests/test_data_entry_flow.py
@@ -21,7 +21,8 @@ def manager():
         return handler()
 
     async def async_add_entry(result):
-        entries.append(result)
+        if (result['type'] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY):
+            entries.append(result)
 
     manager = data_entry_flow.FlowManager(
         None, async_create_flow, async_add_entry)


### PR DESCRIPTION
## Description:
Fix showing a discovery notification even if notification is not going through.

**Related issue (if applicable):** fixes #14474

## Example entry for `configuration.yaml` (if applicable):
```yaml
discovery:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
