### PR TITLE
Adding illumination sensor

### DIFF
--- a/homeassistant/components/sensor/onewire.py
+++ b/homeassistant/components/sensor/onewire.py
@@ -28,7 +28,8 @@ DEVICE_SENSORS = {'10': {'temperature': 'temperature'},
                   '22': {'temperature': 'temperature'},
                   '26': {'temperature': 'temperature',
                          'humidity': 'humidity',
-                         'pressure': 'B1-R1-A/pressure'},
+                         'pressure': 'B1-R1-A/pressure',
+                         'illumination': 'S3-R1-A/illumination'},
                   '28': {'temperature': 'temperature'},
                   '3B': {'temperature': 'temperature'},
                   '42': {'temperature': 'temperature'}}
@@ -37,6 +38,7 @@ SENSOR_TYPES = {
     'temperature': ['temperature', TEMP_CELSIUS],
     'humidity': ['humidity', '%'],
     'pressure': ['pressure', 'mb'],
+    'illumination': ['illumination', 'lux'],
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({

--- a/homeassistant/components/sensor/onewire.py
+++ b/homeassistant/components/sensor/onewire.py
@@ -29,7 +29,7 @@ DEVICE_SENSORS = {'10': {'temperature': 'temperature'},
                   '26': {'temperature': 'temperature',
                          'humidity': 'humidity',
                          'pressure': 'B1-R1-A/pressure',
-                         'illumination': 'S3-R1-A/illumination'},
+                         'illuminance': 'S3-R1-A/illuminance'},
                   '28': {'temperature': 'temperature'},
                   '3B': {'temperature': 'temperature'},
                   '42': {'temperature': 'temperature'}}
@@ -38,7 +38,7 @@ SENSOR_TYPES = {
     'temperature': ['temperature', TEMP_CELSIUS],
     'humidity': ['humidity', '%'],
     'pressure': ['pressure', 'mb'],
-    'illumination': ['illumination', 'lux'],
+    'illuminance': ['illuminance', 'lux'],
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({


### PR DESCRIPTION
Adding Illumination sensor of 1wire device DS2438 (DEVICE_SENSOR type 26) according to [OWFS API](http://owfs.org/index.php?page=ds2438)

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
