### PR TITLE
onewire.py

### DIFF
--- a/homeassistant/components/switch/onewire.py
+++ b/homeassistant/components/switch/onewire.py
@@ -33,8 +33,8 @@ DEVICE_SWITCHES = {'05': {'A': 'PIO'},
                    '3A': {'A': 'PIO.A',
                           'B': 'PIO.B'}}
 
-DEVICE_SWITCH_ON = "1"
-DEVICE_SWITCH_OFF = "0"
+DEVICE_SWITCH_ON = '1'
+DEVICE_SWITCH_OFF = '0'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAMES): {cv.string: cv.string},
@@ -46,7 +46,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the one wire Switches."""
     base_dir = config.get(CONF_MOUNT_DIR)
     devs = []
-    device_names = config.get('names', {})
+    device_names = config.get(CONF_NAMES, {})
 
     for family_file_path in glob(os.path.join(base_dir, '*', 'family')):
         with open(family_file_path, "r") as family_file:
@@ -91,24 +91,22 @@ class OneWireSwitch(SwitchDevice):
                             self._device_file)
         except OSError:
             _LOGGER.warning("Error reading switch file %s", self._device_file)
-        return False
+        return None
 
     def _write_value_raw(self, value):
         """Write the value to the switch."""
         if value not in [DEVICE_SWITCH_ON, DEVICE_SWITCH_OFF]:
             _LOGGER.error("Error in setting wrong value %s", value)
-            return False
+            return None
         try:
             with open(self._device_file, 'w') as ds_device_file:
                 ds_device_file.write(value)
-            return True
         except FileNotFoundError:
             _LOGGER.warning("1Wire switch file not found: %s",
                             self._device_file)
         except OSError:
             _LOGGER.warning("Error writing switch file %s",
                             self._device_file)
-        return False
 
     @property
     def name(self):
@@ -127,7 +125,6 @@ class OneWireSwitch(SwitchDevice):
             self._state = value == DEVICE_SWITCH_ON
         else:
             self._state = None
-        return self._state
 
     def turn_on(self, **kwargs):
         """Turn the switch on."""

--- a/homeassistant/components/switch/onewire.py
+++ b/homeassistant/components/switch/onewire.py
@@ -60,7 +60,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         if family in DEVICE_SWITCHES:
             switch_id = os.path.split(
                 os.path.split(family_file_path)[0])[1]
-            device_files = {}
             for switch_key, switch_value in DEVICE_SWITCHES[family].items():
                 switch_id_complete = switch_id + "_" + switch_key
                 device_file = os.path.join(

--- a/homeassistant/components/switch/onewire.py
+++ b/homeassistant/components/switch/onewire.py
@@ -126,6 +126,7 @@ class OneWireSwitch(SwitchDevice):
         return self._state
 
     def update(self):
+        """Get the latest data from the switch and update the state."""
         self._state = self._read_value_raw() == DEVICE_SWITCH_ON
         return self._state
 

--- a/homeassistant/components/switch/onewire.py
+++ b/homeassistant/components/switch/onewire.py
@@ -133,11 +133,9 @@ class OneWireSwitch(SwitchDevice):
     def turn_on(self, **kwargs):
         """Turn the switch on."""
         if self._write_value_raw(DEVICE_SWITCH_ON):
-            self._state = True
             self.schedule_update_ha_state()
 
     def turn_off(self, **kwargs):
         """Turn the device off."""
         if self._write_value_raw(DEVICE_SWITCH_OFF):
-            self._state = False
             self.schedule_update_ha_state()

--- a/homeassistant/components/switch/onewire.py
+++ b/homeassistant/components/switch/onewire.py
@@ -5,7 +5,6 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/switch.onewire/
 """
 import os
-import time
 import logging
 from glob import glob
 
@@ -59,16 +58,16 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         with open(family_file_path, "r") as family_file:
             family = family_file.read()
         if family in DEVICE_SWITCHES:
-           switch_id = os.path.split(
-               os.path.split(family_file_path)[0])[1]
-           device_files = {}
-           for switch_key, switch_value in DEVICE_SWITCHES[family].items():
-               switch_id_complete = switch_id + "_" + switch_key
-               device_file = os.path.join(
+            switch_id = os.path.split(
+                os.path.split(family_file_path)[0])[1]
+            device_files = {}
+            for switch_key, switch_value in DEVICE_SWITCHES[family].items():
+                switch_id_complete = switch_id + "_" + switch_key
+                device_file = os.path.join(
                     os.path.split(family_file_path)[0], switch_value)
-               devs.append(OneWireSwitch(device_names.get(switch_id_complete,
-                                                          switch_id_complete),
-                                         device_file))
+                devs.append(OneWireSwitch(device_names.get(switch_id_complete,
+                                                           switch_id_complete),
+                                          device_file))
 
     if devs == []:
         _LOGGER.error("No onewire sensor found. Check if dtoverlay=w1-gpio "
@@ -95,10 +94,8 @@ class OneWireSwitch(SwitchDevice):
         except ValueError:
             _LOGGER.warning("Invalid value read from %s", self._device_file)
         except FileNotFoundError:
-            _LOGGER.warning("OneWire Switch file not found: %s", self._device_file)
-        except:
-            _LOGGER.warning("Other error in using switch file: %s", self._device_file)
-            raise
+            msg = "1Wire switch file not found: %s", self._device_file
+            _LOGGER.warning(msg)
         return state
 
     def _read_value_raw(self):
@@ -109,7 +106,7 @@ class OneWireSwitch(SwitchDevice):
 
     @property
     def should_poll(self):
-        """Currently easyer - if control of OneWire Switch is only done by hass"""
+        """tbd, if control of OneWire Switch is not only done by hass"""
         return False
 
     @property
@@ -120,7 +117,7 @@ class OneWireSwitch(SwitchDevice):
     @property
     def is_on(self):
         """Return true if switch is on."""
-        if self._state == None:
+        if self._state is None:
             self._state = self._readState()
         return self._state
 

--- a/homeassistant/components/switch/onewire.py
+++ b/homeassistant/components/switch/onewire.py
@@ -12,7 +12,6 @@ import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.switch import (SwitchDevice, PLATFORM_SCHEMA)
-from homeassistant.const import DEVICE_DEFAULT_NAME
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -88,7 +87,7 @@ class OneWireSwitch(SwitchDevice):
                 content = ds_device_file.read()
             return content
         except FileNotFoundError:
-            _LOGGER.warning("1Wire switch file not found: %s", 
+            _LOGGER.warning("1Wire switch file not found: %s",
                             self._device_file)
         except OSError:
             _LOGGER.warning("Error reading switch file %s", self._device_file)
@@ -104,7 +103,7 @@ class OneWireSwitch(SwitchDevice):
                 ds_device_file.write(value)
             return True
         except FileNotFoundError:
-            _LOGGER.warning("1Wire switch file not found: %s", 
+            _LOGGER.warning("1Wire switch file not found: %s",
                             self._device_file)
         except OSError:
             _LOGGER.warning("Error writing switch file %s",
@@ -124,9 +123,9 @@ class OneWireSwitch(SwitchDevice):
     def turn_on(self, **kwargs):
         """Turn the switch on."""
         self._write_value_raw(DEVICE_SWITCH_ON)
-        _LOGGER.debug("1Wire switch %s turned on",self._device_file)
+        _LOGGER.debug("1Wire switch %s turned on", self._device_file)
 
     def turn_off(self, **kwargs):
         """Turn the device off."""
         self._write_value_raw(DEVICE_SWITCH_OFF)
-        _LOGGER.debug("1Wire switch %s turned off",self._device_file)
+        _LOGGER.debug("1Wire switch %s turned off", self._device_file)

--- a/homeassistant/components/switch/onewire.py
+++ b/homeassistant/components/switch/onewire.py
@@ -91,13 +91,13 @@ class OneWireSwitch(SwitchDevice):
                             self._device_file)
         except OSError:
             _LOGGER.warning("Error reading switch file %s", self._device_file)
-        return
+        return None
 
     def _write_value_raw(self, value):
         """Write the value to the switch."""
         if value not in [DEVICE_SWITCH_ON, DEVICE_SWITCH_OFF]:
             _LOGGER.error("Error in setting wrong value %s", value)
-            return None
+            return
         try:
             with open(self._device_file, 'w') as ds_device_file:
                 ds_device_file.write(value)

--- a/homeassistant/components/switch/onewire.py
+++ b/homeassistant/components/switch/onewire.py
@@ -98,9 +98,9 @@ class OneWireSwitch(SwitchDevice):
             _LOGGER.warning("Error reading switch file %s", self._device_file)
         return content
 
-    def _write_value_raw(self,value):
+    def _write_value_raw(self, value):
         """Write the value to the switch."""
-        if not value in [DEVICE_SWITCH_ON,DEVICE_SWITCH_OFF]:
+        if value not in [DEVICE_SWITCH_ON,DEVICE_SWITCH_OFF]:
             _LOGGER.error("Error in setting wrong value %s", value)
             return False
         else:
@@ -112,9 +112,10 @@ class OneWireSwitch(SwitchDevice):
                 msg = "1Wire switch file not found: %s", self._device_file
                 _LOGGER.warning(msg)
             except OSError:
-                _LOGGER.warning("Error writing switch file %s", self._device_file)
+                msg = "Error writing switch file %s", self._device_file
+                _LOGGER.warning(msg)
             return False
-          
+
     @property
     def name(self):
         """Return the name of the device if any."""
@@ -128,15 +129,15 @@ class OneWireSwitch(SwitchDevice):
     def update(self):
         self._state = self._read_value_raw() == DEVICE_SWITCH_ON
         return self._state
-        
+
     def turn_on(self, **kwargs):
         """Turn the switch on."""
-        if self._write_value_raw(self,DEVICE_SWITCH_ON):
+        if self._write_value_raw(self, DEVICE_SWITCH_ON):
             self._state = True
             self.schedule_update_ha_state()
 
     def turn_off(self, **kwargs):
         """Turn the device off."""
-        if self._write_value_raw(self,DEVICE_SWITCH_OFF):
+        if self._write_value_raw(self, DEVICE_SWITCH_OFF):
             self._state = False
             self.schedule_update_ha_state()

--- a/homeassistant/components/switch/onewire.py
+++ b/homeassistant/components/switch/onewire.py
@@ -120,6 +120,15 @@ class OneWireSwitch(SwitchDevice):
         """Return true if switch is on."""
         return self._state
 
+    def update(self):
+        """Get the latest data from the switch and update the state."""
+        value = self._read_value_raw()
+        if value:
+            self._state = value == DEVICE_SWITCH_ON
+        else:
+            self._state = None
+        return self._state
+
     def turn_on(self, **kwargs):
         """Turn the switch on."""
         self._write_value_raw(DEVICE_SWITCH_ON)

--- a/homeassistant/components/switch/onewire.py
+++ b/homeassistant/components/switch/onewire.py
@@ -100,9 +100,8 @@ class OneWireSwitch(SwitchDevice):
 
     def _write_value_raw(self, value):
         """Write the value to the switch."""
-        if value not in [DEVICE_SWITCH_ON,DEVICE_SWITCH_OFF]:
+        if value not in [DEVICE_SWITCH_ON, DEVICE_SWITCH_OFF]:
             _LOGGER.error("Error in setting wrong value %s", value)
-            return False
         else:
             try:
                 with open(self._device_file, 'w') as ds_device_file:
@@ -114,7 +113,7 @@ class OneWireSwitch(SwitchDevice):
             except OSError:
                 msg = "Error writing switch file %s", self._device_file
                 _LOGGER.warning(msg)
-            return False
+        return False
 
     @property
     def name(self):
@@ -132,12 +131,12 @@ class OneWireSwitch(SwitchDevice):
 
     def turn_on(self, **kwargs):
         """Turn the switch on."""
-        if self._write_value_raw(self, DEVICE_SWITCH_ON):
+        if self._write_value_raw(DEVICE_SWITCH_ON):
             self._state = True
             self.schedule_update_ha_state()
 
     def turn_off(self, **kwargs):
         """Turn the device off."""
-        if self._write_value_raw(self, DEVICE_SWITCH_OFF):
+        if self._write_value_raw(DEVICE_SWITCH_OFF):
             self._state = False
             self.schedule_update_ha_state()

--- a/homeassistant/components/switch/onewire.py
+++ b/homeassistant/components/switch/onewire.py
@@ -49,13 +49,13 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     device_names = config.get(CONF_NAMES, {})
 
     for family_file_path in glob(os.path.join(base_dir, '*', 'family')):
-        with open(family_file_path, "r") as family_file:
+        with open(family_file_path, 'r') as family_file:
             family = family_file.read()
         if family in DEVICE_SWITCHES:
             switch_id = os.path.split(
                 os.path.split(family_file_path)[0])[1]
             for switch_key, switch_value in DEVICE_SWITCHES[family].items():
-                switch_id_complete = switch_id + "_" + switch_key
+                switch_id_complete = switch_id + '_' + switch_key
                 device_file = os.path.join(
                     os.path.split(family_file_path)[0], switch_value)
                 devs.append(OneWireSwitch(device_names.get(switch_id_complete,
@@ -91,7 +91,7 @@ class OneWireSwitch(SwitchDevice):
                             self._device_file)
         except OSError:
             _LOGGER.warning("Error reading switch file %s", self._device_file)
-        return None
+        return
 
     def _write_value_raw(self, value):
         """Write the value to the switch."""

--- a/homeassistant/components/switch/onewire.py
+++ b/homeassistant/components/switch/onewire.py
@@ -1,0 +1,139 @@
+"""
+Support for 1-Wire environment switches.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/switch.onewire/
+"""
+import os
+import time
+import logging
+from glob import glob
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.switch import SwitchDevice
+from homeassistant.helpers.config_validation import PLATFORM_SCHEMA  # noqa
+from homeassistant.const import DEVICE_DEFAULT_NAME
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_MOUNT_DIR = 'mount_dir'
+CONF_NAMES = 'names'
+
+DEFAULT_MOUNT_DIR = '/sys/bus/w1/devices/'
+DEVICE_SWITCHES = {'05': {'A': 'PIO'},
+                   '12': {'A': 'PIO.A',
+                          'B': 'PIO.B'},
+                   '29': {'0': 'PIO.0',
+                          '1': 'PIO.1',
+                          '2': 'PIO.2',
+                          '3': 'PIO.3',
+                          '4': 'PIO.4',
+                          '5': 'PIO.5',
+                          '6': 'PIO.6',
+                          '7': 'PIO.7'},
+                   '3A': {'A': 'PIO.A',
+                          'B': 'PIO.B'}}
+
+DEVICE_SWITCH_ON = "1"
+DEVICE_SWITCH_OFF = "0"
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_NAMES): {cv.string: cv.string},
+    vol.Optional(CONF_MOUNT_DIR, default=DEFAULT_MOUNT_DIR): cv.string,
+})
+
+
+# pylint: disable=unused-argument
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the one wire Switches."""
+    base_dir = config.get(CONF_MOUNT_DIR)
+    devs = []
+    device_names = {}
+    if 'names' in config:
+        if isinstance(config['names'], dict):
+            device_names = config['names']
+
+    for family_file_path in glob(os.path.join(base_dir, '*', 'family')):
+        with open(family_file_path, "r") as family_file:
+            family = family_file.read()
+        if family in DEVICE_SWITCHES:
+           switch_id = os.path.split(
+               os.path.split(family_file_path)[0])[1]
+           device_files = {}
+           for switch_key, switch_value in DEVICE_SWITCHES[family].items():
+               switch_id_complete = switch_id + "_" + switch_key
+               device_file = os.path.join(
+                    os.path.split(family_file_path)[0], switch_value)
+               devs.append(OneWireSwitch(device_names.get(switch_id_complete,
+                                                          switch_id_complete),
+                                         device_file))
+
+    if devs == []:
+        _LOGGER.error("No onewire sensor found. Check if dtoverlay=w1-gpio "
+                      "is in your /boot/config.txt. "
+                      "Check the mount_dir parameter if it's defined")
+        return
+
+    add_devices(devs, True)
+
+
+class OneWireSwitch(SwitchDevice):
+    """Representation of a OneWire switch."""
+
+    def __init__(self, name, device_file):
+        """Initialize the OneWire switch."""
+        self._name = name or DEVICE_DEFAULT_NAME
+        self._device_file = device_file
+        self._state = self._readState()
+
+    def _readState(self):
+        state = None
+        try:
+            state = self._read_value_raw() == DEVICE_SWITCH_ON
+        except ValueError:
+            _LOGGER.warning("Invalid value read from %s", self._device_file)
+        except FileNotFoundError:
+            _LOGGER.warning("OneWire Switch file not found: %s", self._device_file)
+        except:
+            _LOGGER.warning("Other error in using switch file: %s", self._device_file)
+            raise
+        return state
+
+    def _read_value_raw(self):
+        """Read the value as it is returned by the switch."""
+        with open(self._device_file, 'r') as ds_device_file:
+            content = ds_device_file.read()
+        return content
+
+    @property
+    def should_poll(self):
+        """Currently easyer - if control of OneWire Switch is only done by hass"""
+        return False
+
+    @property
+    def name(self):
+        """Return the name of the device if any."""
+        return self._name
+
+    @property
+    def is_on(self):
+        """Return true if switch is on."""
+        if self._state == None:
+            self._state = self._readState()
+        return self._state
+
+    def turn_on(self, **kwargs):
+        """Turn the switch on."""
+        with open(self._device_file, 'w') as ds_device_file:
+            ds_device_file.write("1")
+        self._state = True
+        self.schedule_update_ha_state()
+
+    def turn_off(self, **kwargs):
+        """Turn the device off."""
+        with open(self._device_file, 'w') as ds_device_file:
+            ds_device_file.write("0")
+        self._state = False
+        self.schedule_update_ha_state()


### PR DESCRIPTION
Based on file components/sensors/onewire.py I wrote this file components/switch/onewire.py for all onewire switch sensors listed on [owfs family site](http://owfs.sourceforge.net/family.html). It's only tested with family 3A (DS2413) switch, but according to the [owfs DS24xx man pages](http://owfs.org/index.php?page=man-pages-ds24xx) all of the DS24xx switches are similar. This file is working only on an installed [OWFS](http://owfs.org/) filesystem. 

A onewire switch must be configured by **platform: onewire** and **mount_dir: /path/to/owfs-path** in a switch part of the configuration.

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
