### PR TITLE
Trigger an event when a rfxtrx device is automatically added

### DIFF
--- a/homeassistant/components/binary_sensor/rfxtrx.py
+++ b/homeassistant/components/binary_sensor/rfxtrx.py
@@ -12,8 +12,8 @@ from homeassistant.components import rfxtrx
 from homeassistant.components.binary_sensor import (
     DEVICE_CLASSES_SCHEMA, PLATFORM_SCHEMA, BinarySensorDevice)
 from homeassistant.components.rfxtrx import (
-    ATTR_NAME, CONF_AUTOMATIC_ADD, CONF_DATA_BITS, CONF_DEVICES,
-    CONF_FIRE_EVENT, CONF_OFF_DELAY)
+    ATTR_ENTITY_ID, ATTR_NAME, EVENT_NEW_DEVICE, CONF_AUTOMATIC_ADD,
+    CONF_DATA_BITS, CONF_DEVICES, CONF_FIRE_EVENT, CONF_OFF_DELAY)
 from homeassistant.const import (
     CONF_COMMAND_OFF, CONF_COMMAND_ON, CONF_DEVICE_CLASS, CONF_NAME)
 from homeassistant.helpers import config_validation as cv
@@ -100,6 +100,11 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             pkt_id = "".join("{0:02x}".format(x) for x in event.data)
             sensor = RfxtrxBinarySensor(event, pkt_id)
             sensor.hass = hass
+            hass.bus.fire(
+                EVENT_NEW_DEVICE, {
+                    ATTR_ENTITY_ID: sensor.entity_id,
+                }
+            )
             rfxtrx.RFX_DEVICES[device_id] = sensor
             add_devices([sensor])
             _LOGGER.info(

--- a/homeassistant/components/rfxtrx.py
+++ b/homeassistant/components/rfxtrx.py
@@ -38,6 +38,7 @@ CONF_DUMMY = 'dummy'
 CONF_DEBUG = 'debug'
 CONF_OFF_DELAY = 'off_delay'
 EVENT_BUTTON_PRESSED = 'button_pressed'
+EVENT_NEW_DEVICE = 'new_device_added'
 
 DATA_TYPES = OrderedDict([
     ('Temperature', TEMP_CELSIUS),
@@ -250,6 +251,11 @@ def get_new_device(event, config, device):
     signal_repetitions = config[CONF_SIGNAL_REPETITIONS]
     new_device = device(pkt_id, event, datas,
                         signal_repetitions)
+    new_device.hass.bus.fire(
+        EVENT_NEW_DEVICE, {
+            ATTR_ENTITY_ID: new_device.entity_id,
+        }
+    )
     RFX_DEVICES[device_id] = new_device
     return new_device
 

--- a/homeassistant/components/sensor/rfxtrx.py
+++ b/homeassistant/components/sensor/rfxtrx.py
@@ -10,8 +10,8 @@ import voluptuous as vol
 
 import homeassistant.components.rfxtrx as rfxtrx
 from homeassistant.components.rfxtrx import (
-    ATTR_DATA_TYPE, ATTR_FIRE_EVENT, CONF_AUTOMATIC_ADD, CONF_DATA_TYPE,
-    CONF_DEVICES, CONF_FIRE_EVENT, DATA_TYPES)
+    ATTR_DATA_TYPE, ATTR_FIRE_EVENT, EVENT_NEW_DEVICE, CONF_AUTOMATIC_ADD,
+    CONF_DATA_TYPE, CONF_DEVICES, CONF_FIRE_EVENT, DATA_TYPES)
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_NAME, CONF_NAME
 import homeassistant.helpers.config_validation as cv
@@ -104,6 +104,11 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         sub_sensors = {}
         sub_sensors[new_sensor.data_type] = new_sensor
         rfxtrx.RFX_DEVICES[device_id] = sub_sensors
+        hass.bus.fire(
+            EVENT_NEW_DEVICE, {
+                ATTR_ENTITY_ID: new_sensor.entity_id,
+            }
+        )
         add_devices([new_sensor])
 
     if sensor_update not in rfxtrx.RECEIVED_EVT_SUBSCRIBERS:


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
