### PR TITLE
WIP: Add HomeKit support for vacuums as switches

### DIFF
--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -9,6 +9,7 @@ from zlib import adler32
 
 import voluptuous as vol
 
+from homeassistant.components import vacuum
 from homeassistant.components.cover import (
     SUPPORT_CLOSE, SUPPORT_OPEN, SUPPORT_SET_POSITION)
 from homeassistant.const import (
@@ -152,6 +153,11 @@ def get_accessory(hass, state, aid, config):
     elif state.domain in ('automation', 'input_boolean', 'remote', 'script',
                           'switch'):
         a_type = 'Switch'
+
+    elif state.domain == 'vacuum':
+        features = state.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
+        if features & (vacuum.SUPPORT_TURN_OFF | vacuum.SUPPORT_TURN_ON):
+            a_type = 'Switch'
 
     if a_type is None:
         return None

--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -9,9 +9,9 @@ from zlib import adler32
 
 import voluptuous as vol
 
-from homeassistant.components import vacuum
 from homeassistant.components.cover import (
     SUPPORT_CLOSE, SUPPORT_OPEN, SUPPORT_SET_POSITION)
+import homeassistant.components.vacuum as vacuum
 from homeassistant.const import (
     ATTR_DEVICE_CLASS, ATTR_SUPPORTED_FEATURES, ATTR_UNIT_OF_MEASUREMENT,
     CONF_IP_ADDRESS, CONF_MODE, CONF_NAME, CONF_PORT,

--- a/tests/components/homekit/test_get_accessories.py
+++ b/tests/components/homekit/test_get_accessories.py
@@ -5,6 +5,7 @@ import pytest
 import voluptuous as vol
 
 from homeassistant.core import State
+from homeassistant.components import vacuum
 from homeassistant.components.cover import SUPPORT_CLOSE, SUPPORT_OPEN
 from homeassistant.components.climate import (
     SUPPORT_TARGET_TEMPERATURE_HIGH, SUPPORT_TARGET_TEMPERATURE_LOW)
@@ -38,6 +39,13 @@ def test_not_supported_media_player():
 
     # no supported modes for entity
     entity_state = State('media_player.demo', 'on')
+    assert get_accessory(None, entity_state, 2, {}) is None
+
+
+def test_not_supported_switch():
+    """Test that component which don't support TURN_ON / OFF aren't added."""
+    # Vacuum must have supported features TURN_ON and TURN_OFF
+    entity_state = State('vacuum.demo', 'off')
     assert get_accessory(None, entity_state, 2, {}) is None
 
 
@@ -134,6 +142,9 @@ def test_type_sensors(type_name, entity_id, state, attrs):
     ('Switch', 'remote.test', 'on', {}),
     ('Switch', 'script.test', 'on', {}),
     ('Switch', 'switch.test', 'on', {}),
+    ('Switch', 'vacuum.test', 'on',
+     {ATTR_SUPPORTED_FEATURES: vacuum.SUPPORT_TURN_OFF |
+      vacuum.SUPPORT_TURN_ON}),
 ])
 def test_type_switches(type_name, entity_id, state, attrs):
     """Test if switch types are associated correctly."""

--- a/tests/components/homekit/test_get_accessories.py
+++ b/tests/components/homekit/test_get_accessories.py
@@ -5,7 +5,6 @@ import pytest
 import voluptuous as vol
 
 from homeassistant.core import State
-from homeassistant.components import vacuum
 from homeassistant.components.cover import SUPPORT_CLOSE, SUPPORT_OPEN
 from homeassistant.components.climate import (
     SUPPORT_TARGET_TEMPERATURE_HIGH, SUPPORT_TARGET_TEMPERATURE_LOW)
@@ -13,6 +12,7 @@ from homeassistant.components.media_player import (
     SUPPORT_TURN_OFF, SUPPORT_TURN_ON)
 from homeassistant.components.homekit import get_accessory, TYPES
 from homeassistant.components.homekit.const import ON_OFF
+import homeassistant.components.vacuum as vacuum
 from homeassistant.const import (
     ATTR_CODE, ATTR_DEVICE_CLASS, ATTR_SUPPORTED_FEATURES,
     ATTR_UNIT_OF_MEASUREMENT, CONF_MODE, CONF_NAME, TEMP_CELSIUS,

--- a/tests/components/homekit/test_type_switches.py
+++ b/tests/components/homekit/test_type_switches.py
@@ -14,6 +14,7 @@ from tests.common import async_mock_service
     'remote.test',
     'script.test',
     'switch.test',
+    'vacuum.test',
 ])
 async def test_switch_set_state(hass, entity_id):
     """Test if accessory and HA are updated accordingly."""


### PR DESCRIPTION
## Description:
Expose `vacuum` entities as `switches` for HomeKit, as long as they support `TURN_ON` and `TURN_OFF`.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation:** home-assistant/home-assistant.github.io#5426

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)
  - [x] Tests have been added to verify that the new code works.