### PR TITLE
Change libsodium

### DIFF
--- a/virtualization/Docker/setup_docker_prereqs
+++ b/virtualization/Docker/setup_docker_prereqs
@@ -23,7 +23,7 @@ PACKAGES=(
   # homeassistant.components.device_tracker.bluetooth_tracker
   bluetooth libglib2.0-dev libbluetooth-dev
   # homeassistant.components.device_tracker.owntracks
-  libsodium13
+  libsodium18
   # homeassistant.components.zwave
   libudev-dev
   # homeassistant.components.homekit_controller


### PR DESCRIPTION
## Description:
Docker build started failing. Not completely sure what happened but I think base image might have been upgraded? Anyway, it's now libsodium18 instead of libsodium13. It's a dependency for OwnTracks and [they also swap it out in modern Debian](https://github.com/owntracks/recorder/blob/002285d4df824b2886779b08f98bb43c168eacf6/etc/debian/fpm-make.sh#L28)

This will fix the images again.

**Related issue (if applicable):** fixes Docker builds https://hub.docker.com/r/homeassistant/home-assistant/builds/bcqtcypemcjv9on3zcihgo9/
