### PR TITLE
No longer use backports for ffmpeg

### DIFF
--- a/virtualization/Docker/scripts/ffmpeg
+++ b/virtualization/Docker/scripts/ffmpeg
@@ -8,9 +8,4 @@ PACKAGES=(
   ffmpeg
 )
 
-# Add jessie-backports
-echo "Adding jessie-backports"
-echo "deb http://deb.debian.org/debian jessie-backports main" >> /etc/apt/sources.list
-apt-get update
-
-apt-get install -y --no-install-recommends -t jessie-backports ${PACKAGES[@]}
+apt-get install -y --no-install-recommends ${PACKAGES[@]}


### PR DESCRIPTION
## Description:
Because of Docker upgrade, ffmpeg doesn't need to be installed from backports anymore.

