### PR TITLE
Added option to connect via SSL for OpenWRT(luci) device tracker

### DIFF
--- a/homeassistant/components/device_tracker/luci.py
+++ b/homeassistant/components/device_tracker/luci.py
@@ -152,7 +152,7 @@ def _req_json_rpc(url, method, *args, **kwargs):
         raise InvalidLuciTokenError
 
     else:
-        _LOGGER.error('Invalid response from luci: %s', res)
+        _LOGGER.error("Invalid response from luci: %s", res)
 
 
 def _get_token(origin, username, password):

--- a/homeassistant/components/device_tracker/luci.py
+++ b/homeassistant/components/device_tracker/luci.py
@@ -50,7 +50,7 @@ class LuciDeviceScanner(DeviceScanner):
         """Initialize the scanner."""
         host = config[CONF_HOST]
         protocol = 'http' if not config[CONF_SSL] else 'https'
-        self.origin =  '{}://{}'.format(protocol, host)
+        self.origin = '{}://{}'.format(protocol, host)
         self.username = config[CONF_USERNAME]
         self.password = config[CONF_PASSWORD]
 

--- a/homeassistant/components/device_tracker/luci.py
+++ b/homeassistant/components/device_tracker/luci.py
@@ -15,14 +15,18 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.components.device_tracker import (
     DOMAIN, PLATFORM_SCHEMA, DeviceScanner)
-from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.const import (
+    CONF_HOST, CONF_USERNAME, CONF_PASSWORD, CONF_SSL)
 
 _LOGGER = logging.getLogger(__name__)
+
+DEFAULT_SSL = False
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
     vol.Required(CONF_USERNAME): cv.string,
-    vol.Required(CONF_PASSWORD): cv.string
+    vol.Required(CONF_PASSWORD): cv.string,
+    vol.Optional(CONF_SSL, default=DEFAULT_SSL): cv.boolean
 })
 
 
@@ -44,7 +48,9 @@ class LuciDeviceScanner(DeviceScanner):
 
     def __init__(self, config):
         """Initialize the scanner."""
-        self.host = config[CONF_HOST]
+        host = config[CONF_HOST]
+        protocol = 'http' if not config[CONF_SSL] else 'https'
+        self.origin = protocol + '://' + host
         self.username = config[CONF_USERNAME]
         self.password = config[CONF_PASSWORD]
 
@@ -57,7 +63,7 @@ class LuciDeviceScanner(DeviceScanner):
 
     def refresh_token(self):
         """Get a new token."""
-        self.token = _get_token(self.host, self.username, self.password)
+        self.token = _get_token(self.origin, self.username, self.password)
 
     def scan_devices(self):
         """Scan for new devices and return a list with found device IDs."""
@@ -67,7 +73,7 @@ class LuciDeviceScanner(DeviceScanner):
     def get_device_name(self, device):
         """Return the name of the given device or None if we don't know."""
         if self.mac2name is None:
-            url = 'http://{}/cgi-bin/luci/rpc/uci'.format(self.host)
+            url = '{}/cgi-bin/luci/rpc/uci'.format(self.origin)
             result = _req_json_rpc(url, 'get_all', 'dhcp',
                                    params={'auth': self.token})
             if result:
@@ -92,7 +98,7 @@ class LuciDeviceScanner(DeviceScanner):
 
         _LOGGER.info("Checking ARP")
 
-        url = 'http://{}/cgi-bin/luci/rpc/sys'.format(self.host)
+        url = '{}/cgi-bin/luci/rpc/sys'.format(self.origin)
 
         try:
             result = _req_json_rpc(url, 'net.arptable',
@@ -149,7 +155,7 @@ def _req_json_rpc(url, method, *args, **kwargs):
         _LOGGER.error('Invalid response from luci: %s', res)
 
 
-def _get_token(host, username, password):
-    """Get authentication token for the given host+username+password."""
-    url = 'http://{}/cgi-bin/luci/rpc/auth'.format(host)
+def _get_token(origin, username, password):
+    """Get authentication token for the given origin+username+password."""
+    url = '{}/cgi-bin/luci/rpc/auth'.format(origin)
     return _req_json_rpc(url, 'login', username, password)

--- a/homeassistant/components/device_tracker/luci.py
+++ b/homeassistant/components/device_tracker/luci.py
@@ -50,7 +50,7 @@ class LuciDeviceScanner(DeviceScanner):
         """Initialize the scanner."""
         host = config[CONF_HOST]
         protocol = 'http' if not config[CONF_SSL] else 'https'
-        self.origin = protocol + '://' + host
+        self.origin =  '{}://{}'.format(protocol, host)
         self.username = config[CONF_USERNAME]
         self.password = config[CONF_PASSWORD]
 
@@ -74,8 +74,8 @@ class LuciDeviceScanner(DeviceScanner):
         """Return the name of the given device or None if we don't know."""
         if self.mac2name is None:
             url = '{}/cgi-bin/luci/rpc/uci'.format(self.origin)
-            result = _req_json_rpc(url, 'get_all', 'dhcp',
-                                   params={'auth': self.token})
+            result = _req_json_rpc(
+                url, 'get_all', 'dhcp', params={'auth': self.token})
             if result:
                 hosts = [x for x in result.values()
                          if x['.type'] == 'host' and
@@ -101,8 +101,8 @@ class LuciDeviceScanner(DeviceScanner):
         url = '{}/cgi-bin/luci/rpc/sys'.format(self.origin)
 
         try:
-            result = _req_json_rpc(url, 'net.arptable',
-                                   params={'auth': self.token})
+            result = _req_json_rpc(
+                url, 'net.arptable', params={'auth': self.token})
         except InvalidLuciTokenError:
             _LOGGER.info("Refreshing token")
             self.refresh_token()
@@ -156,6 +156,6 @@ def _req_json_rpc(url, method, *args, **kwargs):
 
 
 def _get_token(origin, username, password):
-    """Get authentication token for the given origin+username+password."""
+    """Get authentication token for the given configuration."""
     url = '{}/cgi-bin/luci/rpc/auth'.format(origin)
     return _req_json_rpc(url, 'login', username, password)


### PR DESCRIPTION
## Description:

Extension of existing device tracker `luci` for OpenWRT routers. Newly added:

- Optional Option `SSL`(Default: `False` as previous behaviour) to allow to connect to OpenWRT routers via SSL (needed for certain routers enforcing SSL)

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation:** home-assistant/home-assistant.github.io#5430

## Example entry for `configuration.yaml`:
```yaml
device_tracker:
  - platform: luci
    host: ROUTER_IP_ADDRESS
    username: YOUR_ADMIN_USERNAME
    password: YOUR_ADMIN_PASSWORD
    ssl: True
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54