### PR TITLE
Add device_descriptor and device_name to keyboard event

### DIFF
--- a/homeassistant/components/keyboard_remote.py
+++ b/homeassistant/components/keyboard_remote.py
@@ -174,7 +174,11 @@ class KeyboardRemoteThread(threading.Thread):
                 _LOGGER.debug(categorize(event))
                 self.hass.bus.fire(
                     KEYBOARD_REMOTE_COMMAND_RECEIVED,
-                    {KEY_CODE: event.code}
+                    {
+                        KEY_CODE: event.code,
+                        DEVICE_DESCRIPTOR: self.device_descriptor,
+                        DEVICE_NAME: self.device_name
+                    }
                 )
 
 

--- a/homeassistant/components/keyboard_remote.py
+++ b/homeassistant/components/keyboard_remote.py
@@ -4,6 +4,7 @@ Receive signals from a keyboard and use it as a remote control.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/keyboard_remote/
 """
+# pylint: disable=import-error
 import threading
 import logging
 import os

--- a/homeassistant/components/keyboard_remote.py
+++ b/homeassistant/components/keyboard_remote.py
@@ -4,7 +4,6 @@ Receive signals from a keyboard and use it as a remote control.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/keyboard_remote/
 """
-# pylint: disable=import-error
 import threading
 import logging
 import os
@@ -50,10 +49,7 @@ def setup(hass, config):
     """Set up the keyboard_remote."""
     config = config.get(DOMAIN)
 
-    keyboard_remote = KeyboardRemote(
-        hass,
-        config
-    )
+    keyboard_remote = KeyboardRemote(hass, config)
 
     def _start_keyboard_remote(_event):
         keyboard_remote.run()
@@ -61,14 +57,8 @@ def setup(hass, config):
     def _stop_keyboard_remote(_event):
         keyboard_remote.stop()
 
-    hass.bus.listen_once(
-        EVENT_HOMEASSISTANT_START,
-        _start_keyboard_remote
-    )
-    hass.bus.listen_once(
-        EVENT_HOMEASSISTANT_STOP,
-        _stop_keyboard_remote
-    )
+    hass.bus.listen_once(EVENT_HOMEASSISTANT_START, _start_keyboard_remote)
+    hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, _stop_keyboard_remote)
 
     return True
 
@@ -93,10 +83,8 @@ class KeyboardRemoteThread(threading.Thread):
             _LOGGER.debug("Keyboard connected, %s", self.device_id)
         else:
             _LOGGER.debug(
-                'Keyboard not connected, %s.\n\
-                Check /dev/input/event* permissions.',
-                self.device_id
-                )
+                "Keyboard not connected, %s. "
+                "Check /dev/input/event* permissions", self.device_id)
 
             id_folder = '/dev/input/by-id/'
 
@@ -105,12 +93,9 @@ class KeyboardRemoteThread(threading.Thread):
                 device_names = [InputDevice(file_name).name
                                 for file_name in list_devices()]
                 _LOGGER.debug(
-                    'Possible device names are:\n %s.\n \
-                    Possible device descriptors are %s:\n %s',
-                    device_names,
-                    id_folder,
-                    os.listdir(id_folder)
-                    )
+                    "Possible device names are: %s. "
+                    "Possible device descriptors are %s: %s",
+                    device_names, id_folder, os.listdir(id_folder))
 
         threading.Thread.__init__(self)
         self.stopped = threading.Event()
@@ -149,9 +134,7 @@ class KeyboardRemoteThread(threading.Thread):
                 self.dev = self._get_keyboard_device()
                 if self.dev is not None:
                     self.dev.grab()
-                    self.hass.bus.fire(
-                        KEYBOARD_REMOTE_CONNECTED
-                    )
+                    self.hass.bus.fire(KEYBOARD_REMOTE_CONNECTED)
                     _LOGGER.debug("Keyboard re-connected, %s", self.device_id)
                 else:
                     continue
@@ -160,9 +143,7 @@ class KeyboardRemoteThread(threading.Thread):
                 event = self.dev.read_one()
             except IOError:  # Keyboard Disconnected
                 self.dev = None
-                self.hass.bus.fire(
-                    KEYBOARD_REMOTE_DISCONNECTED
-                )
+                self.hass.bus.fire(KEYBOARD_REMOTE_DISCONNECTED)
                 _LOGGER.debug("Keyboard disconnected, %s", self.device_id)
                 continue
 
@@ -195,9 +176,8 @@ class KeyboardRemote(object):
 
             if device_descriptor is not None\
                     or device_name is not None:
-                thread = KeyboardRemoteThread(hass, device_name,
-                                              device_descriptor,
-                                              key_value)
+                thread = KeyboardRemoteThread(
+                    hass, device_name, device_descriptor, key_value)
                 self.threads.append(thread)
 
     def run(self):


### PR DESCRIPTION
This allows automations to identify which device has generated the keypress. 

This is especially useful for bluetooth remotes to control different devices.

Proposed change is backward compatible with all existing usage of the keyboard_remote component.

## Description:

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5443

## Example entry for `automation.yaml` (if applicable):
```yaml
automation:
  alias: Keyboard all lights on
  trigger:
    platform: event
    event_type: keyboard_remote_command_received
    event_data:
      device_descriptor: "/dev/input/event0"
      key_code: 107 # inspect log to obtain desired keycode
  action:
    service: light.turn_on
    entity_id: light.all
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
