### PR TITLE
Restore support for duplicate Hue scene names

### DIFF
--- a/homeassistant/components/hue/__init__.py
+++ b/homeassistant/components/hue/__init__.py
@@ -17,7 +17,8 @@ from .bridge import HueBridge
 # Loading the config flow file will register the flow
 from .config_flow import configured_hosts
 
-REQUIREMENTS = ['aiohue==1.3.0']
+#REQUIREMENTS = ['aiohue==1.3.0']
+REQUIREMENTS = ['https://github.com/MizterB/aiohue/archive/master.zip#aiohue==1.3.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/hue/__init__.py
+++ b/homeassistant/components/hue/__init__.py
@@ -17,8 +17,7 @@ from .bridge import HueBridge
 # Loading the config flow file will register the flow
 from .config_flow import configured_hosts
 
-#REQUIREMENTS = ['aiohue==1.3.0']
-REQUIREMENTS = ['https://github.com/MizterB/aiohue/archive/master.zip#aiohue==1.3.1']
+REQUIREMENTS = ['aiohue==1.5.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/hue/bridge.py
+++ b/homeassistant/components/hue/bridge.py
@@ -124,9 +124,21 @@ class HueBridge(object):
             (group for group in self.api.groups.values()
              if group.name == group_name), None)
 
-        scene_id = next(
-            (scene.id for scene in self.api.scenes.values()
-             if scene.name == scene_name), None)
+        # The same scene name can exist in multiple groups.
+        # In this case, activate first scene that contains the
+        # the exact same light IDs as the group
+        scenes = []
+        for scene in self.api.scenes.values():
+            if scene.name == scene_name:
+                scenes.append(scene)
+        if len(scenes) == 1:
+            scene_id = scenes[0].id
+        else:
+            group_lights = sorted(group.lights)
+            for scene in scenes:
+                if group_lights == scene.lights:
+                    scene_id = scene.id
+                    break
 
         # If we can't find it, fetch latest info.
         if not updated and (group is None or scene_id is None):

--- a/homeassistant/components/notify/twitter.py
+++ b/homeassistant/components/notify/twitter.py
@@ -19,7 +19,7 @@ from homeassistant.components.notify import (
 from homeassistant.const import CONF_ACCESS_TOKEN, CONF_USERNAME
 from homeassistant.helpers.event import async_track_point_in_time
 
-REQUIREMENTS = ['TwitterAPI==2.5.3']
+REQUIREMENTS = ['TwitterAPI==2.5.4']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -86,7 +86,7 @@ aiodns==1.1.1
 aiohttp_cors==0.7.0
 
 # homeassistant.components.hue
-aiohue==1.3.0
+aiohue==1.5.0
 
 # homeassistant.components.sensor.imap
 aioimaplib==0.7.13

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -344,7 +344,7 @@ gTTS-token==1.1.1
 gearbest_parser==1.0.5
 
 # homeassistant.components.sensor.gitter
-gitterpy==0.1.6
+gitterpy==0.1.7
 
 # homeassistant.components.notify.gntp
 gntp==1.0.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -61,7 +61,7 @@ SoCo==0.14
 TravisPy==0.3.5
 
 # homeassistant.components.notify.twitter
-TwitterAPI==2.5.3
+TwitterAPI==2.5.4
 
 # homeassistant.components.sensor.waze_travel_time
 WazeRouteCalculator==0.5

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -523,6 +523,9 @@ luftdaten==0.2.0
 # homeassistant.components.light.lw12wifi
 lw12==0.9.2
 
+# homeassistant.components.light.lw12wifi
+lw12==0.9.2
+
 # homeassistant.components.sensor.lyft
 lyft_rides==0.2
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -523,9 +523,6 @@ luftdaten==0.2.0
 # homeassistant.components.light.lw12wifi
 lw12==0.9.2
 
-# homeassistant.components.light.lw12wifi
-lw12==0.9.2
-
 # homeassistant.components.sensor.lyft
 lyft_rides==0.2
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -35,7 +35,7 @@ aioautomatic==0.6.5
 aiohttp_cors==0.7.0
 
 # homeassistant.components.hue
-aiohue==1.3.0
+aiohue==1.5.0
 
 # homeassistant.components.notify.apns
 apns2==0.3.0


### PR DESCRIPTION
## Description:
The Hue component requires a scene name and group name in order to activate a scene.  However, this fails for scenes with names that exist in multiple Hue groups (such as the default ones).  Logic to handle duplicate scene names existed prior to converting the Hue API to aiohue, but was removed during the transition.  This restores the original logic using the new API (aiohue 1.5.0)

**Related issue (if applicable):** fixes #13685

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54