### PR TITLE
Support for force update on all MySensors sensors types

### DIFF
--- a/homeassistant/components/mysensors.py
+++ b/homeassistant/components/mysensors.py
@@ -18,8 +18,8 @@ import voluptuous as vol
 from homeassistant.components.mqtt import (
     valid_publish_topic, valid_subscribe_topic)
 from homeassistant.const import (
-    ATTR_BATTERY_LEVEL, CONF_NAME, CONF_OPTIMISTIC, EVENT_HOMEASSISTANT_STOP,
-    STATE_OFF, STATE_ON)
+    ATTR_BATTERY_LEVEL, CONF_NAME, CONF_OPTIMISTIC, CONF_FORCE_UPDATE,
+    EVENT_HOMEASSISTANT_STOP, STATE_OFF, STATE_ON)
 from homeassistant.core import callback
 from homeassistant.helpers import discovery
 import homeassistant.helpers.config_validation as cv
@@ -56,6 +56,7 @@ CONF_NODE_NAME = 'name'
 DEFAULT_BAUD_RATE = 115200
 DEFAULT_TCP_PORT = 5003
 DEFAULT_VERSION = '1.4'
+DEFAULT_FORCE_UPDATE = False
 DOMAIN = 'mysensors'
 
 GATEWAY_READY_TIMEOUT = 15.0
@@ -139,7 +140,9 @@ def deprecated(key):
 
 NODE_SCHEMA = vol.Schema({
     cv.positive_int: {
-        vol.Required(CONF_NODE_NAME): cv.string
+        vol.Required(CONF_NODE_NAME): cv.string,
+        vol.Optional(CONF_FORCE_UPDATE,
+                     default=DEFAULT_FORCE_UPDATE): cv.boolean,
     }
 })
 


### PR DESCRIPTION
## Description:
Only MySensors Sensor entities currently support force_update (which is always enabled). As I would like to know every time my door lock sensor (which is binary_sensor) sends data, I added support for all types of MySensors entities we can have. In order to enable force_update for a given node, one simply has to specify `force_update: true` in the configuration file.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5444

## Example entry for `configuration.yaml` (if applicable):
```yaml
mysensors:
  gateways:
    - device: '192.168.1.200'
      persistence_file: '/home/homeassistant/.homeassistant/sensors/mysensors.json'
      tcp_port: 5003
      nodes:
        1:
          name: "Bedroom"
        2:
          name: "Living Room"
        3:
          name: "Front Door"
          force_update: true
  persistence: true
  retain: true
  version: '2.0'
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
