### PR TITLE
Upgrade python_opendata_transport to 0.1.0

### DIFF
--- a/homeassistant/components/sensor/swiss_public_transport.py
+++ b/homeassistant/components/sensor/swiss_public_transport.py
@@ -4,7 +4,6 @@ Support for transport.opendata.ch.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.swiss_public_transport/
 """
-import asyncio
 from datetime import timedelta
 import logging
 
@@ -17,7 +16,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 import homeassistant.util.dt as dt_util
 
-REQUIREMENTS = ['python_opendata_transport==0.0.3']
+REQUIREMENTS = ['python_opendata_transport==0.1.0']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -48,8 +47,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-@asyncio.coroutine
-def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+async def async_setup_platform(
+        hass, config, async_add_devices, discovery_info=None):
     """Set up the Swiss public transport sensor."""
     from opendata_transport import OpendataTransport, exceptions
 
@@ -61,7 +60,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     opendata = OpendataTransport(start, destination, hass.loop, session)
 
     try:
-        yield from opendata.async_get_data()
+        await opendata.async_get_data()
     except exceptions.OpendataTransportError:
         _LOGGER.error(
             "Check at http://transport.opendata.ch/examples/stationboard.html "
@@ -122,12 +121,11 @@ class SwissPublicTransportSensor(Entity):
         """Icon to use in the frontend, if any."""
         return ICON
 
-    @asyncio.coroutine
-    def async_update(self):
+    async def async_update(self):
         """Get the latest data from opendata.ch and update the states."""
         from opendata_transport.exceptions import OpendataTransportError
 
         try:
-            yield from self._opendata.async_get_data()
+            await self._opendata.async_get_data()
         except OpendataTransportError:
             _LOGGER.error("Unable to retrieve data from transport.opendata.ch")

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1063,7 +1063,7 @@ python-vlc==1.1.2
 python-wink==1.7.3
 
 # homeassistant.components.sensor.swiss_public_transport
-python_opendata_transport==0.0.3
+python_opendata_transport==0.1.0
 
 # homeassistant.components.zwave
 python_openzwave==0.4.3


### PR DESCRIPTION
## Description:
Changelog: https://github.com/fabaff/python-opendata-transport/blob/master/CHANGES.rst#changes

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: swiss_public_transport
    name: Train
    from: Bern
    to: Biel
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
