### PR TITLE
Whitelist all urls inside Hass.io panel to be accessed.

### DIFF
--- a/homeassistant/components/hassio/http.py
+++ b/homeassistant/components/hassio/http.py
@@ -36,7 +36,7 @@ NO_TIMEOUT = {
 }
 
 NO_AUTH = {
-    re.compile(r'^app-(es5|latest)/(index|hassio-app).html$'),
+    re.compile(r'^app-(es5|latest)/.+$'),
     re.compile(r'^addons/[^/]*/logo$')
 }
 

--- a/tests/components/hassio/test_http.py
+++ b/tests/components/hassio/test_http.py
@@ -48,7 +48,7 @@ def test_auth_required_forward_request(hassio_client):
 @pytest.mark.parametrize(
     'build_type', [
         'es5/index.html', 'es5/hassio-app.html', 'latest/index.html',
-        'latest/hassio-app.html'
+        'latest/hassio-app.html', 'es5/some-chunk.js', 'es5/app.js',
     ])
 def test_forward_request_no_auth_for_panel(hassio_client, build_type):
     """Test no auth needed for ."""


### PR DESCRIPTION
## Description:
The Hass.io panel can now be codesplit and thus no longer is just an HTML file that is loaded from the frontend. This change will allow serving `/api/hassio/app-es5/*` and `/api/hassio/app-latest/*` without auth.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
