### PR TITLE
Change nest to cloud push

### DIFF
--- a/homeassistant/components/binary_sensor/nest.py
+++ b/homeassistant/components/binary_sensor/nest.py
@@ -8,9 +8,9 @@ from itertools import chain
 import logging
 
 from homeassistant.components.binary_sensor import (BinarySensorDevice)
+from homeassistant.components.nest import DATA_NEST, EVENT_NEST_UPDATE
 from homeassistant.components.sensor.nest import NestSensor
 from homeassistant.const import CONF_MONITORED_CONDITIONS
-from homeassistant.components.nest import DATA_NEST
 
 DEPENDENCIES = ['nest']
 
@@ -103,6 +103,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                                                    device,
                                                    activity_zone)]
     add_devices(sensors, True)
+
+    for sensor in sensors:
+        hass.bus.listen(EVENT_NEST_UPDATE,
+                        sensor.async_nest_update_event_handler)
 
 
 class NestBinarySensor(NestSensor, BinarySensorDevice):

--- a/homeassistant/components/binary_sensor/nest.py
+++ b/homeassistant/components/binary_sensor/nest.py
@@ -8,10 +8,9 @@ from itertools import chain
 import logging
 
 from homeassistant.components.binary_sensor import (BinarySensorDevice)
-from homeassistant.components.nest import DATA_NEST, SIGNAL_NEST_UPDATE
+from homeassistant.components.nest import DATA_NEST
 from homeassistant.components.sensor.nest import NestSensor
 from homeassistant.const import CONF_MONITORED_CONDITIONS
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 DEPENDENCIES = ['nest']
 

--- a/homeassistant/components/binary_sensor/nest.py
+++ b/homeassistant/components/binary_sensor/nest.py
@@ -8,9 +8,10 @@ from itertools import chain
 import logging
 
 from homeassistant.components.binary_sensor import (BinarySensorDevice)
-from homeassistant.components.nest import DATA_NEST, EVENT_NEST_UPDATE
+from homeassistant.components.nest import DATA_NEST, SIGNAL_NEST_UPDATE
 from homeassistant.components.sensor.nest import NestSensor
 from homeassistant.const import CONF_MONITORED_CONDITIONS
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 DEPENDENCIES = ['nest']
 
@@ -105,8 +106,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices(sensors, True)
 
     for sensor in sensors:
-        hass.bus.listen(EVENT_NEST_UPDATE,
-                        sensor.async_nest_update_event_handler)
+        async_dispatcher_connect(hass, SIGNAL_NEST_UPDATE,
+                                 sensor.async_nest_update_callback)
 
 
 class NestBinarySensor(NestSensor, BinarySensorDevice):

--- a/homeassistant/components/binary_sensor/nest.py
+++ b/homeassistant/components/binary_sensor/nest.py
@@ -107,7 +107,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     for sensor in sensors:
         async_dispatcher_connect(hass, SIGNAL_NEST_UPDATE,
-                                 sensor.async_nest_update_callback)
+                                 sensor.async_update_state)
 
 
 class NestBinarySensor(NestSensor, BinarySensorDevice):

--- a/homeassistant/components/binary_sensor/nest.py
+++ b/homeassistant/components/binary_sensor/nest.py
@@ -105,10 +105,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                                                    activity_zone)]
     add_devices(sensors, True)
 
-    for sensor in sensors:
-        async_dispatcher_connect(hass, SIGNAL_NEST_UPDATE,
-                                 sensor.async_update_state)
-
 
 class NestBinarySensor(NestSensor, BinarySensorDevice):
     """Represents a Nest binary sensor."""

--- a/homeassistant/components/climate/nest.py
+++ b/homeassistant/components/climate/nest.py
@@ -43,10 +43,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     add_devices(all_devices, True)
 
-    for device in all_devices:
-        async_dispatcher_connect(hass, SIGNAL_NEST_UPDATE,
-                                 device.async_update_state)
-
 
 class NestThermostat(ClimateDevice):
     """Representation of a Nest thermostat."""
@@ -109,6 +105,11 @@ class NestThermostat(ClimateDevice):
     async def async_update_state(self):
         """Update device state."""
         await self.async_update_ha_state(True)
+
+    async def async_added_to_hass(self):
+        """Register update signal handler."""
+        async_dispatcher_connect(self.hass, SIGNAL_NEST_UPDATE,
+                                 self.async_update_state)
 
     @property
     def supported_features(self):

--- a/homeassistant/components/climate/nest.py
+++ b/homeassistant/components/climate/nest.py
@@ -108,8 +108,7 @@ class NestThermostat(ClimateDevice):
 
     async def async_nest_update_callback(self):
         """Update device state."""
-        await self.async_device_update()
-        await self.async_update_ha_state()
+        await self.async_update_ha_state(True)
 
     @property
     def supported_features(self):

--- a/homeassistant/components/climate/nest.py
+++ b/homeassistant/components/climate/nest.py
@@ -8,7 +8,7 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.components.nest import DATA_NEST, EVENT_NEST_UPDATE
+from homeassistant.components.nest import DATA_NEST, SIGNAL_NEST_UPDATE
 from homeassistant.components.climate import (
     STATE_AUTO, STATE_COOL, STATE_HEAT, STATE_ECO, ClimateDevice,
     PLATFORM_SCHEMA, ATTR_TARGET_TEMP_HIGH, ATTR_TARGET_TEMP_LOW,
@@ -18,6 +18,7 @@ from homeassistant.components.climate import (
 from homeassistant.const import (
     TEMP_CELSIUS, TEMP_FAHRENHEIT,
     CONF_SCAN_INTERVAL, STATE_ON, STATE_OFF, STATE_UNKNOWN)
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 DEPENDENCIES = ['nest']
 _LOGGER = logging.getLogger(__name__)
@@ -43,8 +44,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices(all_devices, True)
 
     for device in all_devices:
-        hass.bus.listen(EVENT_NEST_UPDATE,
-                        device.async_nest_update_event_handler)
+        async_dispatcher_connect(hass, SIGNAL_NEST_UPDATE,
+                                 device.async_nest_update_callback)
 
 
 class NestThermostat(ClimateDevice):
@@ -105,7 +106,7 @@ class NestThermostat(ClimateDevice):
         """Do not need poll thanks using Nest streaming API."""
         return False
 
-    async def async_nest_update_event_handler(self, event):
+    async def async_nest_update_callback(self):
         """Update device state."""
         await self.async_device_update()
         await self.async_update_ha_state()

--- a/homeassistant/components/climate/nest.py
+++ b/homeassistant/components/climate/nest.py
@@ -102,11 +102,11 @@ class NestThermostat(ClimateDevice):
 
     @property
     def should_poll(self):
-        """Do not need poll thanks using Nest streaming API"""
+        """Do not need poll thanks using Nest streaming API."""
         return False
 
     async def async_nest_update_event_handler(self, event):
-        """Update device state"""
+        """Update device state."""
         await self.async_device_update()
         await self.async_update_ha_state()
 

--- a/homeassistant/components/climate/nest.py
+++ b/homeassistant/components/climate/nest.py
@@ -102,14 +102,14 @@ class NestThermostat(ClimateDevice):
         """Do not need poll thanks using Nest streaming API."""
         return False
 
-    async def async_update_state(self):
-        """Update device state."""
-        await self.async_update_ha_state(True)
-
     async def async_added_to_hass(self):
         """Register update signal handler."""
+        async def async_update_state():
+            """Update device state."""
+            await self.async_update_ha_state(True)
+
         async_dispatcher_connect(self.hass, SIGNAL_NEST_UPDATE,
-                                 self.async_update_state)
+                                 async_update_state)
 
     @property
     def supported_features(self):
@@ -199,7 +199,7 @@ class NestThermostat(ClimateDevice):
             _LOGGER.error("An error occurred while setting temperature: %s",
                           api_error)
             # restore target temperature
-            self.hass.add_job(self.async_update_state)
+            self.schedule_update_ha_state(True)
 
     def set_operation_mode(self, operation_mode):
         """Set operation mode."""

--- a/homeassistant/components/climate/nest.py
+++ b/homeassistant/components/climate/nest.py
@@ -195,8 +195,11 @@ class NestThermostat(ClimateDevice):
         try:
             if temp is not None:
                 self.device.target = temp
-        except nest.nest.APIError:
-            _LOGGER.error("An error occurred while setting the temperature")
+        except nest.nest.APIError as api_error:
+            _LOGGER.error("An error occurred while setting temperature: %s",
+                          api_error)
+            # restore target temperature
+            self.hass.add_job(self.async_update_state)
 
     def set_operation_mode(self, operation_mode):
         """Set operation mode."""

--- a/homeassistant/components/climate/nest.py
+++ b/homeassistant/components/climate/nest.py
@@ -45,7 +45,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     for device in all_devices:
         async_dispatcher_connect(hass, SIGNAL_NEST_UPDATE,
-                                 device.async_nest_update_callback)
+                                 device.async_update_state)
 
 
 class NestThermostat(ClimateDevice):
@@ -106,7 +106,7 @@ class NestThermostat(ClimateDevice):
         """Do not need poll thanks using Nest streaming API."""
         return False
 
-    async def async_nest_update_callback(self):
+    async def async_update_state(self):
         """Update device state."""
         await self.async_update_ha_state(True)
 

--- a/homeassistant/components/nest.py
+++ b/homeassistant/components/nest.py
@@ -109,6 +109,7 @@ async def async_setup_nest(hass, nest, config, pin=None):
         _LOGGER.debug("pin acquired, requesting access token")
         try:
             nest.request_token(pin)
+        # pylint: disable=broad-except
         except Exception as auth_error:
             message = "Nest authorization failed: {}".format(auth_error)
             _LOGGER.warning(message)
@@ -135,7 +136,7 @@ async def async_setup_nest(hass, nest, config, pin=None):
             ('camera', {}),
             ('sensor', conf.get(CONF_SENSORS, {})),
             ('binary_sensor', conf.get(CONF_BINARY_SENSORS, {}))]:
-        _LOGGER.debug("proceeding with discovery -- {}".format(component))
+        _LOGGER.debug("proceeding with discovery -- %s", component)
         hass.async_add_job(discovery.async_load_platform,
                            hass, component, DOMAIN, discovered, config)
 

--- a/homeassistant/components/nest.py
+++ b/homeassistant/components/nest.py
@@ -57,10 +57,10 @@ CONFIG_SCHEMA = vol.Schema({
 
 async def async_nest_update_event_broker(hass, nest):
     """
-    Fire a EVENT_NEST_UPDATE event when nest stream API received data
+    Fire a EVENT_NEST_UPDATE event when nest stream API received data.
 
-    nest.update_event.wait will block the thread in most of time
-    so specific an executor to save default thread pool
+    nest.update_event.wait will block the thread in most of time,
+    so specific an executor to save default thread pool.
     """
     _LOGGER.debug("listening nest.update_event")
     with ThreadPoolExecutor(max_workers=1) as executor:

--- a/homeassistant/components/nest.py
+++ b/homeassistant/components/nest.py
@@ -83,7 +83,7 @@ async def async_request_configuration(nest, hass, config):
             _CONFIGURING['nest'], "Failed to configure, please try again.")
         return
 
-    async def async_nest_configuration_callback(data):
+    async def async_nest_configuration_call_back(data):
         """Run when the configuration callback is called."""
         _LOGGER.debug("configurator callback")
         pin = data.get('pin')
@@ -92,7 +92,7 @@ async def async_request_configuration(nest, hass, config):
         hass.async_add_job(async_nest_update_event_broker, hass, nest)
 
     _CONFIGURING['nest'] = configurator.async_request_config(
-        "Nest", async_nest_configuration_callback,
+        "Nest", async_nest_configuration_call_back,
         description=('To configure Nest, click Request Authorization below, '
                      'log into your Nest account, '
                      'and then enter the resulting PIN'),
@@ -139,11 +139,13 @@ async def async_setup_nest(hass, nest, config, pin=None):
                                         binary_sensor_config, config)
 
     def start_up(event):
+        """Start Nest update event listener."""
         hass.async_add_job(async_nest_update_event_broker, hass, nest)
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, start_up)
 
     def shut_down(event):
+        """Stop Nest update event listener."""
         if nest:
             nest.update_event.set()
 

--- a/homeassistant/components/nest.py
+++ b/homeassistant/components/nest.py
@@ -79,7 +79,7 @@ async def async_request_configuration(nest, hass, config):
     configurator = hass.components.configurator
     if 'nest' in _CONFIGURING:
         _LOGGER.debug("configurator failed")
-        await configurator.async_notify_errors(
+        configurator.async_notify_errors(
             _CONFIGURING['nest'], "Failed to configure, please try again.")
         return
 

--- a/homeassistant/components/nest.py
+++ b/homeassistant/components/nest.py
@@ -17,7 +17,7 @@ from homeassistant.const import (
 from homeassistant.helpers import discovery, config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
-REQUIREMENTS = ['python-nest==4.0.0']
+REQUIREMENTS = ['python-nest==4.0.1']
 
 _CONFIGURING = {}
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/nest.py
+++ b/homeassistant/components/nest.py
@@ -83,7 +83,7 @@ async def async_request_configuration(nest, hass, config):
             _CONFIGURING['nest'], "Failed to configure, please try again.")
         return
 
-    async def async_nest_configuration_call_back(data):
+    async def async_nest_config_callback(data):
         """Run when the configuration callback is called."""
         _LOGGER.debug("configurator callback")
         pin = data.get('pin')
@@ -92,7 +92,7 @@ async def async_request_configuration(nest, hass, config):
         hass.async_add_job(async_nest_update_event_broker, hass, nest)
 
     _CONFIGURING['nest'] = configurator.async_request_config(
-        "Nest", async_nest_configuration_call_back,
+        "Nest", async_nest_config_callback,
         description=('To configure Nest, click Request Authorization below, '
                      'log into your Nest account, '
                      'and then enter the resulting PIN'),

--- a/homeassistant/components/sensor/nest.py
+++ b/homeassistant/components/sensor/nest.py
@@ -98,10 +98,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     add_devices(all_sensors, True)
 
-    for sensor in all_sensors:
-        async_dispatcher_connect(hass, SIGNAL_NEST_UPDATE,
-                                 sensor.async_update_state)
-
 
 class NestSensor(Entity):
     """Representation of a Nest sensor."""
@@ -144,6 +140,11 @@ class NestSensor(Entity):
     async def async_update_state(self):
         """Update sensor state."""
         await self.async_update_ha_state(True)
+
+    async def async_added_to_hass(self):
+        """Register update signal handler."""
+        async_dispatcher_connect(self.hass, SIGNAL_NEST_UPDATE,
+                                 self.async_update_state)
 
 
 class NestBasicSensor(NestSensor):

--- a/homeassistant/components/sensor/nest.py
+++ b/homeassistant/components/sensor/nest.py
@@ -100,7 +100,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     for sensor in all_sensors:
         async_dispatcher_connect(hass, SIGNAL_NEST_UPDATE,
-                                 sensor.async_nest_update_callback)
+                                 sensor.async_update_state)
 
 
 class NestSensor(Entity):
@@ -141,7 +141,7 @@ class NestSensor(Entity):
         """Do not need poll thanks using Nest streaming API."""
         return False
 
-    async def async_nest_update_callback(self):
+    async def async_update_state(self):
         """Update sensor state."""
         await self.async_update_ha_state(True)
 

--- a/homeassistant/components/sensor/nest.py
+++ b/homeassistant/components/sensor/nest.py
@@ -137,11 +137,11 @@ class NestSensor(Entity):
 
     @property
     def should_poll(self):
-        """Do not need poll thanks using Nest streaming API"""
+        """Do not need poll thanks using Nest streaming API."""
         return False
 
     async def async_nest_update_event_handler(self, event):
-        """Update sensor state"""
+        """Update sensor state."""
         await self.async_device_update()
         await self.async_update_ha_state()
 

--- a/homeassistant/components/sensor/nest.py
+++ b/homeassistant/components/sensor/nest.py
@@ -7,7 +7,8 @@ https://home-assistant.io/components/sensor.nest/
 from itertools import chain
 import logging
 
-from homeassistant.components.nest import DATA_NEST, EVENT_NEST_UPDATE
+from homeassistant.components.nest import DATA_NEST, SIGNAL_NEST_UPDATE
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
 from homeassistant.const import (
     TEMP_CELSIUS, TEMP_FAHRENHEIT, CONF_MONITORED_CONDITIONS,
@@ -98,8 +99,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices(all_sensors, True)
 
     for sensor in all_sensors:
-        hass.bus.listen(EVENT_NEST_UPDATE,
-                        sensor.async_nest_update_event_handler)
+        async_dispatcher_connect(hass, SIGNAL_NEST_UPDATE,
+                                 sensor.async_nest_update_callback)
 
 
 class NestSensor(Entity):
@@ -140,7 +141,7 @@ class NestSensor(Entity):
         """Do not need poll thanks using Nest streaming API."""
         return False
 
-    async def async_nest_update_event_handler(self, event):
+    async def async_nest_update_callback(self):
         """Update sensor state."""
         await self.async_device_update()
         await self.async_update_ha_state()

--- a/homeassistant/components/sensor/nest.py
+++ b/homeassistant/components/sensor/nest.py
@@ -143,8 +143,7 @@ class NestSensor(Entity):
 
     async def async_nest_update_callback(self):
         """Update sensor state."""
-        await self.async_device_update()
-        await self.async_update_ha_state()
+        await self.async_update_ha_state(True)
 
 
 class NestBasicSensor(NestSensor):

--- a/homeassistant/components/sensor/nest.py
+++ b/homeassistant/components/sensor/nest.py
@@ -137,14 +137,14 @@ class NestSensor(Entity):
         """Do not need poll thanks using Nest streaming API."""
         return False
 
-    async def async_update_state(self):
-        """Update sensor state."""
-        await self.async_update_ha_state(True)
-
     async def async_added_to_hass(self):
         """Register update signal handler."""
+        async def async_update_state():
+            """Update sensor state."""
+            await self.async_update_ha_state(True)
+
         async_dispatcher_connect(self.hass, SIGNAL_NEST_UPDATE,
-                                 self.async_update_state)
+                                 async_update_state)
 
 
 class NestBasicSensor(NestSensor):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1027,7 +1027,7 @@ python-mpd2==1.0.0
 python-mystrom==0.4.2
 
 # homeassistant.components.nest
-python-nest==4.0.0
+python-nest==4.0.1
 
 # homeassistant.components.device_tracker.nmap_tracker
 python-nmap==0.6.1


### PR DESCRIPTION
## Description:
This is the follow up of python-nest upgrade #14638. After python-nest change to stream API, we can change nest component to Cloud Push mode.

**Related issue (if applicable):** fixes #10442 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):**
home-assistant/home-assistant.github.io#5442

## Example entry for `configuration.yaml` (if applicable):
No configuration changes
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.