### PR TITLE
Reduce log churn from Envisalink binary sensors

### DIFF
--- a/homeassistant/components/binary_sensor/envisalink.py
+++ b/homeassistant/components/binary_sensor/envisalink.py
@@ -6,6 +6,7 @@ https://home-assistant.io/components/binary_sensor.envisalink/
 """
 import asyncio
 import logging
+import datetime
 
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -14,6 +15,7 @@ from homeassistant.components.envisalink import (
     DATA_EVL, ZONE_SCHEMA, CONF_ZONENAME, CONF_ZONETYPE, EnvisalinkDevice,
     SIGNAL_ZONE_UPDATE)
 from homeassistant.const import ATTR_LAST_TRIP_TIME
+from homeassistant.util import dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -63,7 +65,25 @@ class EnvisalinkBinarySensor(EnvisalinkDevice, BinarySensorDevice):
     def device_state_attributes(self):
         """Return the state attributes."""
         attr = {}
-        attr[ATTR_LAST_TRIP_TIME] = self._info['last_fault']
+
+        # The Envisalink library returns a "last_fault" value that's the
+        # number of seconds since the last fault, up to a maximum of 327680
+        # seconds (65536 5-second ticks).
+        #
+        # We don't want the HA event log to fill up with a bunch of no-op
+        # "state changes" that are just that number ticking up once per poll
+        # interval, so we subtract it from the current second-accurate time
+        # unless it is already at the maximum value, in which case we set it
+        # to None since we can't determine the actual value.
+        seconds_ago = self._info['last_fault']
+        if seconds_ago < 65536 * 5:
+            now = dt_util.now().replace(microsecond=0)
+            delta = datetime.timedelta(seconds=seconds_ago)
+            last_trip_time = (now - delta).isoformat()
+        else:
+            last_trip_time = None
+
+        attr[ATTR_LAST_TRIP_TIME] = last_trip_time
         return attr
 
     @property


### PR DESCRIPTION
## Description:

The Envisalink binary sensor was logging events with a relative
timestamp that updated every time it polled, so even when nothing
new was happening, the event log would be full of meaningless
state changes. Modify the sensor code to use an absolute time
which stays stable when there isn't new activity.

**Related issue (if applicable):** fixes #14658

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):**
No documentation change needed

## Example entry for `configuration.yaml` (if applicable):

Nothing configuration-specific about this change

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
