### PR TITLE
Ignore unsupported Sonos favorite lists

### DIFF
--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -427,15 +427,18 @@ class SonosDevice(MediaPlayerDevice):
         self.update_volume()
 
         self._favorites = []
-        for fav in self.soco.music_library.get_sonos_favorites():
-            # SoCo 0.14 raises a generic Exception on invalid xml in favorites.
-            # Filter those out now so our list is safe to use.
-            try:
-                if fav.reference.get_uri():
-                    self._favorites.append(fav)
-            # pylint: disable=broad-except
-            except Exception:
-                _LOGGER.debug("Ignoring invalid favorite '%s'", fav.title)
+        # SoCo 0.14 raises a generic Exception on invalid xml in favorites.
+        # Filter those out now so our list is safe to use.
+        # pylint: disable=broad-except
+        try:
+            for fav in self.soco.music_library.get_sonos_favorites():
+                try:
+                    if fav.reference.get_uri():
+                        self._favorites.append(fav)
+                except Exception:
+                    _LOGGER.debug("Ignoring invalid favorite '%s'", fav.title)
+        except Exception:
+            _LOGGER.debug("Ignoring invalid favorite list")
 
     def _radio_artwork(self, url):
         """Return the private URL with artwork for a radio stream."""


### PR DESCRIPTION
## Description:

Apparently the `get_sonos_favorites()` call itself can fail, not just the formatting of each individual favorite via `get_uri()`.

**Related issue (if applicable):** [reported in the forum](https://community.home-assistant.io/t/sonos-speakers-are-not-detected-could-not-create-resource-from-element-protocolinfo-not-found/54127)

## Checklist:
  - [ ] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.
