### PR TITLE
Fix temperature rounding for ZHA temperature sensors

### DIFF
--- a/homeassistant/components/sensor/zha.py
+++ b/homeassistant/components/sensor/zha.py
@@ -110,9 +110,11 @@ class TemperatureSensor(Sensor):
         """Return the state of the entity."""
         if self._state is None:
             return None
-        celsius = round(float(self._state) / 100, 1)
-        return convert_temperature(
-            celsius, TEMP_CELSIUS, self.unit_of_measurement)
+        celsius = self._state / 100
+        return round(convert_temperature(celsius,
+                                         TEMP_CELSIUS,
+                                         self.unit_of_measurement),
+                     1)
 
 
 class RelativeHumiditySensor(Sensor):


### PR DESCRIPTION
## Description:
round the output of `convert_temperature` for ZHA temperature sensors. The raw measurements of ZHA temperature sensors is using Celsius unit of measurement, where _MeasuredValue_ = 100 x temperature in degrees Celsius.

Current implementation of TemperatureSensor returns output of `convert_temperature`, which may produce "long" results if the HASS is operating in imperial unit of measurements. like
![image](https://user-images.githubusercontent.com/5826160/40627665-3efe3bf2-628e-11e8-8207-c0b0bc17f93d.png)


## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
