### PR TITLE
Increase Eufy's requirement on lakeside

### DIFF
--- a/homeassistant/components/eufy.py
+++ b/homeassistant/components/eufy.py
@@ -15,7 +15,7 @@ from homeassistant.helpers import discovery
 import homeassistant.helpers.config_validation as cv
 
 
-REQUIREMENTS = ['lakeside==0.6']
+REQUIREMENTS = ['lakeside==0.7']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -477,7 +477,7 @@ keyrings.alt==3.1
 konnected==0.1.2
 
 # homeassistant.components.eufy
-lakeside==0.6
+lakeside==0.7
 
 # homeassistant.components.device_tracker.owntracks
 # homeassistant.components.device_tracker.owntracks_http


### PR DESCRIPTION
python-lakeside was broken with at least some versions of the Python
protobuf code, so bump the requirement to a fixed version.

**Related issue (if applicable):** fixes #14155


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**


