### PR TITLE
MQTT Cover Fix Assumed State

### DIFF
--- a/homeassistant/components/cover/mqtt.py
+++ b/homeassistant/components/cover/mqtt.py
@@ -236,6 +236,11 @@ class MqttCover(MqttAvailability, CoverDevice):
         return False
 
     @property
+    def assumed_state(self):
+        """Return true if we do optimistic updates."""
+        return self._optimistic
+
+    @property
     def name(self):
         """Return the name of the cover."""
         return self._name

--- a/tests/components/cover/test_mqtt.py
+++ b/tests/components/cover/test_mqtt.py
@@ -2,8 +2,8 @@
 import unittest
 
 from homeassistant.setup import setup_component
-from homeassistant.const import STATE_OPEN, STATE_CLOSED, STATE_UNKNOWN,\
-    STATE_UNAVAILABLE
+from homeassistant.const import STATE_OPEN, STATE_CLOSED, STATE_UNKNOWN, \
+    STATE_UNAVAILABLE, ATTR_ASSUMED_STATE
 import homeassistant.components.cover as cover
 from homeassistant.components.cover.mqtt import MqttCover
 
@@ -40,6 +40,7 @@ class TestCoverMQTT(unittest.TestCase):
 
         state = self.hass.states.get('cover.test')
         self.assertEqual(STATE_UNKNOWN, state.state)
+        self.assertFalse(state.attributes.get(ATTR_ASSUMED_STATE))
 
         fire_mqtt_message(self.hass, 'state-topic', '0')
         self.hass.block_till_done()
@@ -112,6 +113,7 @@ class TestCoverMQTT(unittest.TestCase):
 
         state = self.hass.states.get('cover.test')
         self.assertEqual(STATE_UNKNOWN, state.state)
+        self.assertTrue(state.attributes.get(ATTR_ASSUMED_STATE))
 
         cover.open_cover(self.hass, 'cover.test')
         self.hass.block_till_done()


### PR DESCRIPTION
## Description:

Usually, if an MQTT platform has an `optimistic` mode, it means that `assumed_state` will also be True. This is usually used in cases where the actual state of a device (such as a cover) is unknown and causes the front-end to show the up AND down actions.

Right now, if optimistic is False, only one action is shown as seen below. However, if optimistic is True, ideally both actions should be enabled.

<img width="411" alt="screen shot 2018-05-28 at 22 28 35" src="https://user-images.githubusercontent.com/6833237/40628645-7e17947c-62c6-11e8-86a4-4c97e2bf27f6.png">

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
cover:
  - platform: mqtt
    optimistic: True
    # ...
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
