### PR TITLE
Add support for Occupancy sensor

### DIFF
--- a/homeassistant/components/zha/const.py
+++ b/homeassistant/components/zha/const.py
@@ -45,6 +45,7 @@ def populate_data():
 
     SINGLE_INPUT_CLUSTER_DEVICE_CLASS.update({
         zcl.clusters.general.OnOff: 'switch',
+        zcl.clusters.measurement.OccupancySensing: 'binary_sensor',
         zcl.clusters.measurement.RelativeHumidity: 'sensor',
         zcl.clusters.measurement.TemperatureMeasurement: 'sensor',
         zcl.clusters.measurement.PressureMeasurement: 'sensor',


### PR DESCRIPTION
## Description:
This is based mostly on #14188 Tested and confirmed to work with Centralite Motion Sensor and Xiaomi Aquara motion sensors


## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
