### PR TITLE
Allow hassio frontend development

### DIFF
--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -28,6 +28,15 @@ _LOGGER = logging.getLogger(__name__)
 DOMAIN = 'hassio'
 DEPENDENCIES = ['http']
 
+CONF_FRONTEND_REPO = 'development_repo'
+
+CONFIG_SCHEMA = vol.Schema({
+    vol.Optional(DOMAIN): vol.Schema({
+        vol.Optional(CONF_FRONTEND_REPO): cv.isdir,
+    }),
+}, extra=vol.ALLOW_EXTRA)
+
+
 DATA_HOMEASSISTANT_VERSION = 'hassio_hass_version'
 HASSIO_UPDATE_INTERVAL = timedelta(minutes=55)
 
@@ -142,7 +151,13 @@ def async_setup(hass, config):
     try:
         host = os.environ['HASSIO']
     except KeyError:
-        _LOGGER.error("No Hass.io supervisor detect")
+        _LOGGER.error("Missing HASSIO environment variable.")
+        return False
+
+    try:
+        os.environ['HASSIO_TOKEN']
+    except KeyError:
+        _LOGGER.error("Missing HASSIO_TOKEN environment variable.")
         return False
 
     websession = hass.helpers.aiohttp_client.async_get_clientsession()
@@ -151,6 +166,13 @@ def async_setup(hass, config):
     if not (yield from hassio.is_connected()):
         _LOGGER.error("Not connected with Hass.io")
         return False
+
+    # This overrides the normal API call that would be forwarded
+    development_repo = config.get(DOMAIN, {}).get(CONF_FRONTEND_REPO)
+    if development_repo is not None:
+        hass.http.register_static_path(
+            '/api/hassio/app-es5',
+            os.path.join(development_repo, 'hassio/build-es5'), False)
 
     hass.http.register_view(HassIOView(host, websession))
 

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -9,6 +9,12 @@ from homeassistant.components.hassio import async_check_config
 from tests.common import mock_coro
 
 
+MOCK_ENVIRON = {
+    'HASSIO': '127.0.0.1',
+    'HASSIO_TOKEN': 'abcdefgh',
+}
+
+
 @asyncio.coroutine
 def test_setup_api_ping(hass, aioclient_mock):
     """Test setup with API ping."""
@@ -18,7 +24,7 @@ def test_setup_api_ping(hass, aioclient_mock):
         "http://127.0.0.1/homeassistant/info", json={
             'result': 'ok', 'data': {'last_version': '10.0'}})
 
-    with patch.dict(os.environ, {'HASSIO': "127.0.0.1"}):
+    with patch.dict(os.environ, MOCK_ENVIRON):
         result = yield from async_setup_component(hass, 'hassio', {})
         assert result
 
@@ -38,7 +44,7 @@ def test_setup_api_push_api_data(hass, aioclient_mock):
     aioclient_mock.post(
         "http://127.0.0.1/homeassistant/options", json={'result': 'ok'})
 
-    with patch.dict(os.environ, {'HASSIO': "127.0.0.1"}):
+    with patch.dict(os.environ, MOCK_ENVIRON):
         result = yield from async_setup_component(hass, 'hassio', {
             'http': {
                 'api_password': "123456",
@@ -66,7 +72,7 @@ def test_setup_api_push_api_data_server_host(hass, aioclient_mock):
     aioclient_mock.post(
         "http://127.0.0.1/homeassistant/options", json={'result': 'ok'})
 
-    with patch.dict(os.environ, {'HASSIO': "127.0.0.1"}):
+    with patch.dict(os.environ, MOCK_ENVIRON):
         result = yield from async_setup_component(hass, 'hassio', {
             'http': {
                 'api_password': "123456",
@@ -95,7 +101,7 @@ def test_setup_api_push_api_data_default(hass, aioclient_mock):
     aioclient_mock.post(
         "http://127.0.0.1/homeassistant/options", json={'result': 'ok'})
 
-    with patch.dict(os.environ, {'HASSIO': "127.0.0.1"}):
+    with patch.dict(os.environ, MOCK_ENVIRON):
         result = yield from async_setup_component(hass, 'hassio', {
             'http': {},
             'hassio': {}
@@ -119,7 +125,7 @@ def test_setup_core_push_timezone(hass, aioclient_mock):
     aioclient_mock.post(
         "http://127.0.0.1/supervisor/options", json={'result': 'ok'})
 
-    with patch.dict(os.environ, {'HASSIO': "127.0.0.1"}):
+    with patch.dict(os.environ, MOCK_ENVIRON):
         result = yield from async_setup_component(hass, 'hassio', {
             'hassio': {},
             'homeassistant': {
@@ -143,7 +149,7 @@ def test_setup_hassio_no_additional_data(hass, aioclient_mock):
     aioclient_mock.get(
         "http://127.0.0.1/homeassistant/info", json={'result': 'ok'})
 
-    with patch.dict(os.environ, {'HASSIO': "127.0.0.1"}), \
+    with patch.dict(os.environ, MOCK_ENVIRON), \
             patch.dict(os.environ, {'HASSIO_TOKEN': "123456"}):
         result = yield from async_setup_component(hass, 'hassio', {
             'hassio': {},
@@ -165,7 +171,7 @@ def test_fail_setup_without_environ_var(hass):
 @asyncio.coroutine
 def test_fail_setup_cannot_connect(hass):
     """Fail setup if cannot connect."""
-    with patch.dict(os.environ, {'HASSIO': "127.0.0.1"}), \
+    with patch.dict(os.environ, MOCK_ENVIRON), \
             patch('homeassistant.components.hassio.HassIO.is_connected',
                   Mock(return_value=mock_coro(None))):
         result = yield from async_setup_component(hass, 'hassio', {})


### PR DESCRIPTION
## Description:
Allow local Hass.io frontend development with the new frontend.

For complete instructions, see https://developers.home-assistant.io/docs/en/hassio_hass.html

## Example entry for `configuration.yaml` (if applicable):
```yaml
hassio:
  development_repo: ../home-assistant-polymer
```
