### PR TITLE
Fix deprecated code

### DIFF
--- a/homeassistant/components/cloud/iot.py
+++ b/homeassistant/components/cloud/iot.py
@@ -185,7 +185,7 @@ class CloudIoT:
                 yield from client.send_json(response)
 
         except client_exceptions.WSServerHandshakeError as err:
-            if err.code == 401:
+            if err.status == 401:
                 disconnect_warn = 'Invalid auth.'
                 self.close_requested = True
                 # Should we notify user?

--- a/tests/components/cloud/test_iot.py
+++ b/tests/components/cloud/test_iot.py
@@ -210,7 +210,7 @@ def test_cloud_connect_invalid_auth(mock_client, caplog, mock_cloud):
     """Test invalid auth detected by server."""
     conn = iot.CloudIoT(mock_cloud)
     mock_client.receive.side_effect = \
-        client_exceptions.WSServerHandshakeError(None, None, code=401)
+        client_exceptions.WSServerHandshakeError(None, None, status=401)
 
     yield from conn.connect()
 

--- a/tests/components/test_conversation.py
+++ b/tests/components/test_conversation.py
@@ -89,7 +89,7 @@ async def test_register_before_setup(hass):
     assert intent.text_input == 'I would like the Grolsch beer'
 
 
-async def test_http_processing_intent(hass, test_client):
+async def test_http_processing_intent(hass, aiohttp_client):
     """Test processing intent via HTTP API."""
     class TestIntentHandler(intent.IntentHandler):
         """Test Intent Handler."""
@@ -119,7 +119,7 @@ async def test_http_processing_intent(hass, test_client):
     })
     assert result
 
-    client = await test_client(hass.http.app)
+    client = await aiohttp_client(hass.http.app)
     resp = await client.post('/api/conversation/process', json={
         'text': 'I would like the Grolsch beer'
     })
@@ -243,7 +243,7 @@ async def test_toggle_intent(hass, sentence):
     assert call.data == {'entity_id': 'light.kitchen'}
 
 
-async def test_http_api(hass, test_client):
+async def test_http_api(hass, aiohttp_client):
     """Test the HTTP conversation API."""
     result = await component.async_setup(hass, {})
     assert result
@@ -251,7 +251,7 @@ async def test_http_api(hass, test_client):
     result = await async_setup_component(hass, 'conversation', {})
     assert result
 
-    client = await test_client(hass.http.app)
+    client = await aiohttp_client(hass.http.app)
     hass.states.async_set('light.kitchen', 'off')
     calls = async_mock_service(hass, 'homeassistant', 'turn_on')
 
@@ -267,7 +267,7 @@ async def test_http_api(hass, test_client):
     assert call.data == {'entity_id': 'light.kitchen'}
 
 
-async def test_http_api_wrong_data(hass, test_client):
+async def test_http_api_wrong_data(hass, aiohttp_client):
     """Test the HTTP conversation API."""
     result = await component.async_setup(hass, {})
     assert result
@@ -275,7 +275,7 @@ async def test_http_api_wrong_data(hass, test_client):
     result = await async_setup_component(hass, 'conversation', {})
     assert result
 
-    client = await test_client(hass.http.app)
+    client = await aiohttp_client(hass.http.app)
 
     resp = await client.post('/api/conversation/process', json={
         'text': 123


### PR DESCRIPTION
## Description:
Fix some usage of deprecated parts of aiohttp.
Found by running `py.test tests/components/ -W error`

I would love to make this part of our test suite, however we can't because the dependency `feedparser` causes a deprecation warning :(

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
