### PR TITLE
Change ACP code_format to None|"Number"|"Any"

### DIFF
--- a/homeassistant/components/alarm_control_panel/alarmdecoder.py
+++ b/homeassistant/components/alarm_control_panel/alarmdecoder.py
@@ -101,7 +101,7 @@ class AlarmDecoderAlarmPanel(alarm.AlarmControlPanel):
     @property
     def code_format(self):
         """Return one or more digits/characters."""
-        return '^\\d+$'
+        return 'Number'
 
     @property
     def state(self):

--- a/homeassistant/components/alarm_control_panel/alarmdotcom.py
+++ b/homeassistant/components/alarm_control_panel/alarmdotcom.py
@@ -84,8 +84,8 @@ class AlarmDotCom(alarm.AlarmControlPanel):
         if self._code is None:
             return None
         elif isinstance(self._code, str) and re.search('^\\d+$', self._code):
-            return '^\\d+$'
-        return '.+'
+            return 'Number'
+        return 'Any'
 
     @property
     def state(self):

--- a/homeassistant/components/alarm_control_panel/concord232.py
+++ b/homeassistant/components/alarm_control_panel/concord232.py
@@ -80,7 +80,7 @@ class Concord232Alarm(alarm.AlarmControlPanel):
     @property
     def code_format(self):
         """Return the characters if code is defined."""
-        return '^\\d+$'
+        return 'Number'
 
     @property
     def state(self):

--- a/homeassistant/components/alarm_control_panel/envisalink.py
+++ b/homeassistant/components/alarm_control_panel/envisalink.py
@@ -106,7 +106,7 @@ class EnvisalinkAlarm(EnvisalinkDevice, alarm.AlarmControlPanel):
         """Regex for code format or None if no code is required."""
         if self._code:
             return None
-        return '^\\d+$'
+        return 'Number'
 
     @property
     def state(self):

--- a/homeassistant/components/alarm_control_panel/ifttt.py
+++ b/homeassistant/components/alarm_control_panel/ifttt.py
@@ -129,8 +129,8 @@ class IFTTTAlarmPanel(alarm.AlarmControlPanel):
         if self._code is None:
             return None
         elif isinstance(self._code, str) and re.search('^\\d+$', self._code):
-            return '^\\d+$'
-        return '.+'
+            return 'Number'
+        return 'Any'
 
     def alarm_disarm(self, code=None):
         """Send disarm command."""

--- a/homeassistant/components/alarm_control_panel/manual.py
+++ b/homeassistant/components/alarm_control_panel/manual.py
@@ -206,8 +206,8 @@ class ManualAlarm(alarm.AlarmControlPanel):
         if self._code is None:
             return None
         elif isinstance(self._code, str) and re.search('^\\d+$', self._code):
-            return '^\\d+$'
-        return '.+'
+            return 'Number'
+        return 'Any'
 
     def alarm_disarm(self, code=None):
         """Send disarm command."""

--- a/homeassistant/components/alarm_control_panel/manual_mqtt.py
+++ b/homeassistant/components/alarm_control_panel/manual_mqtt.py
@@ -242,8 +242,8 @@ class ManualMQTTAlarm(alarm.AlarmControlPanel):
         if self._code is None:
             return None
         elif isinstance(self._code, str) and re.search('^\\d+$', self._code):
-            return '^\\d+$'
-        return '.+'
+            return 'Number'
+        return 'Any'
 
     def alarm_disarm(self, code=None):
         """Send disarm command."""

--- a/homeassistant/components/alarm_control_panel/mqtt.py
+++ b/homeassistant/components/alarm_control_panel/mqtt.py
@@ -122,8 +122,8 @@ class MqttAlarm(MqttAvailability, alarm.AlarmControlPanel):
         if self._code is None:
             return None
         elif isinstance(self._code, str) and re.search('^\\d+$', self._code):
-            return '^\\d+$'
-        return '.+'
+            return 'Number'
+        return 'Any'
 
     @asyncio.coroutine
     def async_alarm_disarm(self, code=None):

--- a/homeassistant/components/alarm_control_panel/nx584.py
+++ b/homeassistant/components/alarm_control_panel/nx584.py
@@ -70,7 +70,7 @@ class NX584Alarm(alarm.AlarmControlPanel):
     @property
     def code_format(self):
         """Return one or more digits/characters."""
-        return '^\\d+$'
+        return 'Number'
 
     @property
     def state(self):

--- a/homeassistant/components/alarm_control_panel/satel_integra.py
+++ b/homeassistant/components/alarm_control_panel/satel_integra.py
@@ -66,7 +66,7 @@ class SatelIntegraAlarmPanel(alarm.AlarmControlPanel):
     @property
     def code_format(self):
         """Return the regex for code format or None if no code is required."""
-        return '^\\d{4,6}$'
+        return 'Number'
 
     @property
     def state(self):

--- a/homeassistant/components/alarm_control_panel/simplisafe.py
+++ b/homeassistant/components/alarm_control_panel/simplisafe.py
@@ -88,8 +88,8 @@ class SimpliSafeAlarm(alarm.AlarmControlPanel):
         if self._code is None:
             return None
         elif isinstance(self._code, str) and re.search('^\\d+$', self._code):
-            return '^\\d+$'
-        return '.+'
+            return 'Number'
+        return 'Any'
 
     @property
     def state(self):

--- a/homeassistant/components/alarm_control_panel/verisure.py
+++ b/homeassistant/components/alarm_control_panel/verisure.py
@@ -61,7 +61,7 @@ class VerisureAlarm(alarm.AlarmControlPanel):
     @property
     def code_format(self):
         """Return one or more digits/characters."""
-        return '^\\d+$'
+        return 'Number'
 
     @property
     def changed_by(self):


### PR DESCRIPTION
## Description:
In #14178 we decided to remove the code length as regex parameter. So `code_format` only needs one of these values:
- None = no code required
- Number -> show number pad
- Any -> show text-box only

Frontend-PR: https://github.com/home-assistant/home-assistant-polymer/pull/1226

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
