### PR TITLE
Homekit Bugfixes

### DIFF
--- a/homeassistant/components/homekit/accessories.py
+++ b/homeassistant/components/homekit/accessories.py
@@ -121,10 +121,10 @@ class HomeDriver(AccessoryDriver):
 
     def pair(self, client_uuid, client_public):
         """Override super function to dismiss setup message if paired."""
-        value = super().pair(client_uuid, client_public)
-        if value:
+        success = super().pair(client_uuid, client_public)
+        if success:
             dismiss_setup_message(self.hass)
-        return value
+        return success
 
     def unpair(self, client_uuid):
         """Override super function to show setup message if unpaired."""

--- a/homeassistant/components/homekit/accessories.py
+++ b/homeassistant/components/homekit/accessories.py
@@ -77,10 +77,13 @@ class HomeAccessory(Accessory):
         self.entity_id = entity_id
         self.hass = hass
 
-    def run(self):
-        """Method called by accessory after driver is started."""
+    async def run(self):
+        """Method called by accessory after driver is started.
+
+        Run inside the HAP-python event loop.
+        """
         state = self.hass.states.get(self.entity_id)
-        self.update_state_callback(new_state=state)
+        self.hass.add_job(self.update_state_callback, None, None, state)
         async_track_state_change(
             self.hass, self.entity_id, self.update_state_callback)
 

--- a/tests/components/homekit/test_accessories.py
+++ b/tests/components/homekit/test_accessories.py
@@ -26,7 +26,7 @@ async def test_debounce(hass):
 
     arguments = None
     counter = 0
-    mock = Mock(hass=hass)
+    mock = Mock(hass=hass, debounce={})
 
     debounce_demo = debounce(demo_func)
     assert debounce_demo.__name__ == 'demo_func'

--- a/tests/components/homekit/test_accessories.py
+++ b/tests/components/homekit/test_accessories.py
@@ -76,6 +76,7 @@ async def test_home_accessory(hass, hk_driver):
     with patch('homeassistant.components.homekit.accessories.'
                'HomeAccessory.update_state') as mock_update_state:
         await hass.async_add_job(acc.run)
+        await hass.async_block_till_done()
         state = hass.states.get(entity_id)
         mock_update_state.assert_called_with(state)
 

--- a/tests/components/homekit/test_type_thermostats.py
+++ b/tests/components/homekit/test_type_thermostats.py
@@ -35,6 +35,7 @@ async def test_default_thermostat(hass, hk_driver, cls):
     await hass.async_block_till_done()
     acc = cls.thermostat(hass, hk_driver, 'Climate', entity_id, 2, None)
     await hass.async_add_job(acc.run)
+    await hass.async_block_till_done()
 
     assert acc.aid == 2
     assert acc.category == 9  # Thermostat
@@ -175,6 +176,7 @@ async def test_auto_thermostat(hass, hk_driver, cls):
     await hass.async_block_till_done()
     acc = cls.thermostat(hass, hk_driver, 'Climate', entity_id, 2, None)
     await hass.async_add_job(acc.run)
+    await hass.async_block_till_done()
 
     assert acc.char_cooling_thresh_temp.value == 23.0
     assert acc.char_heating_thresh_temp.value == 19.0
@@ -254,6 +256,7 @@ async def test_power_state(hass, hk_driver, cls):
     await hass.async_block_till_done()
     acc = cls.thermostat(hass, hk_driver, 'Climate', entity_id, 2, None)
     await hass.async_add_job(acc.run)
+    await hass.async_block_till_done()
     assert acc.support_power_state is True
 
     assert acc.char_current_heat_cool.value == 1
@@ -306,6 +309,7 @@ async def test_thermostat_fahrenheit(hass, hk_driver, cls):
     await hass.async_block_till_done()
     acc = cls.thermostat(hass, hk_driver, 'Climate', entity_id, 2, None)
     await hass.async_add_job(acc.run)
+    await hass.async_block_till_done()
 
     hass.states.async_set(entity_id, STATE_AUTO,
                           {ATTR_OPERATION_MODE: STATE_AUTO,


### PR DESCRIPTION
### Bug #.1 - Async Accessory.run
With the recent HAP-python update #14674, the `HomeAccessory.run` method can now be async and will be executed in the pyhap event loop. In addition I noticed that the `update_state_callback` wasn't called threadsafe.

### Bug #.2 - Debounce decorator
Previously the `debounce` decorator was only bound to the function not the `HomeAccessory` object. That lead to some issues when controlling multiple accessories at once from HomeKit (e.g. through a scene). See #14500

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**