### PR TITLE
patch to support HS110(AU) smart plug using a different hardware/software version than

### DIFF
--- a/homeassistant/components/switch/tplink.py
+++ b/homeassistant/components/switch/tplink.py
@@ -123,7 +123,7 @@ class SmartPlugSwitch(SwitchDevice):
                         pass
                 else:
                     self._emeter_params[ATTR_CURRENT_POWER_W] \
-                        = float("{:.2f/}".format(emeter_readings["power_mw"]))/1000
+                        = float("{:.2f}".format(emeter_readings["power_mw"]))/1000
                     self._emeter_params[ATTR_TOTAL_ENERGY_KWH] \
                         = float("{:.3f}".format(emeter_readings["total_wh"]))/1000
                     self._emeter_params[ATTR_VOLTAGE] \

--- a/homeassistant/components/switch/tplink.py
+++ b/homeassistant/components/switch/tplink.py
@@ -104,23 +104,32 @@ class SmartPlugSwitch(SwitchDevice):
             if self.smartplug.has_emeter:
                 emeter_readings = self.smartplug.get_emeter_realtime()
 
-                self._emeter_params[ATTR_CURRENT_POWER_W] \
-                    = "{:.2f}".format(emeter_readings["power"])
-                self._emeter_params[ATTR_TOTAL_ENERGY_KWH] \
-                    = "{:.3f}".format(emeter_readings["total"])
-                self._emeter_params[ATTR_VOLTAGE] \
-                    = "{:.1f}".format(emeter_readings["voltage"])
-                self._emeter_params[ATTR_CURRENT_A] \
-                    = "{:.2f}".format(emeter_readings["current"])
-
-                emeter_statics = self.smartplug.get_emeter_daily()
-                try:
-                    self._emeter_params[ATTR_TODAY_ENERGY_KWH] \
-                        = "{:.3f}".format(
-                            emeter_statics[int(time.strftime("%e"))])
-                except KeyError:
-                    # Device returned no daily history
-                    pass
+                if self.smartplug.emeter_units:
+                    self._emeter_params[ATTR_CURRENT_POWER_W] \
+                        = "{:.2f}".format(emeter_readings["power"])
+                    self._emeter_params[ATTR_TOTAL_ENERGY_KWH] \
+                        = "{:.3f}".format(emeter_readings["total"])
+                    self._emeter_params[ATTR_VOLTAGE] \
+                        = "{:.1f}".format(emeter_readings["voltage"])
+                    self._emeter_params[ATTR_CURRENT_A] \
+                        = "{:.2f}".format(emeter_readings["current"])
+                    emeter_statics = self.smartplug.get_emeter_daily()
+                    try:
+                        self._emeter_params[ATTR_TODAY_ENERGY_KWH] \
+                            = "{:.3f}".format(
+                                emeter_statics[int(time.strftime("%e"))])
+                    except KeyError:
+                        # Device returned no daily history
+                        pass
+                else:
+                    self._emeter_params[ATTR_CURRENT_POWER_W] \
+                        = "{:.2f}".format(emeter_readings["power_mw"])
+                    self._emeter_params[ATTR_TOTAL_ENERGY_KWH] \
+                        = "{:.3f}".format(emeter_readings["total_wh"])
+                    self._emeter_params[ATTR_VOLTAGE] \
+                        = "{:.1f}".format(emeter_readings["voltage_mv"])
+                    self._emeter_params[ATTR_CURRENT_A] \
+                        = "{:.2f}".format(emeter_readings["current_ma"])
 
         except (SmartDeviceException, OSError) as ex:
             _LOGGER.warning("Could not read state for %s: %s", self.name, ex)

--- a/homeassistant/components/switch/tplink.py
+++ b/homeassistant/components/switch/tplink.py
@@ -123,13 +123,13 @@ class SmartPlugSwitch(SwitchDevice):
                         pass
                 else:
                     self._emeter_params[ATTR_CURRENT_POWER_W] \
-                        = "{:.2f}".format(emeter_readings["power_mw"])
+                        = float("{:.2f/}".format(emeter_readings["power_mw"]))/1000
                     self._emeter_params[ATTR_TOTAL_ENERGY_KWH] \
-                        = "{:.3f}".format(emeter_readings["total_wh"])
+                        = float("{:.3f}".format(emeter_readings["total_wh"]))/1000
                     self._emeter_params[ATTR_VOLTAGE] \
-                        = "{:.1f}".format(emeter_readings["voltage_mv"])
+                        = float("{:.1f}".format(emeter_readings["voltage_mv"]))/1000
                     self._emeter_params[ATTR_CURRENT_A] \
-                        = "{:.2f}".format(emeter_readings["current_ma"])
+                        = float("{:.2f}".format(emeter_readings["current_ma"]))/1000
 
         except (SmartDeviceException, OSError) as ex:
             _LOGGER.warning("Could not read state for %s: %s", self.name, ex)


### PR DESCRIPTION
## Description:
The firmware on my smart plug reports it's status in different than the current component.
The json returned by the plug has different set of attributes using different units (off by 1000).

This pull request should allow both versions of the firmware to co-exist but I do  not have a plug with the original firmware to test this.

Below is some info about the hardware:
$ pyhs100 --plug --ip 192.168.0.48 sysinfo
== System info ==
defaultdict(<function SmartDevice.sys_info.<locals>.<lambda> at 0xb6765810>,
            {'active_mode': 'none',
             'alias': 'Washing Machine',
             'dev_name': 'Smart Wi-Fi Plug With Energy Monitoring',
             'deviceId': '8006E465239EF548C890844A63EC1FE119ACA9EB',
             'feature': 'TIM:ENE',
             'fwId': '00000000000000000000000000000000',
             'hwId': 'A28C8BB92AFCB6CAFB83A8C00145F7E2',
             'hw_ver': '2.0',
             'icon_hash': '',
             'latitude_i': -348734,
             'led_off': 0,
             'longitude_i': 1386254,
             'mac': 'B0:4E:26:B7:FE:68',
             'model': 'HS110(AU)',
             'oemId': '6480C2101948463DC65D7009CAECDECC',
             'on_time': 2748203,
             'relay_state': 1,
             'rssi': -54,
             'sw_ver': '1.5.2 Build 171201 Rel.084625',
             'type': 'IOT.SMARTPLUGSWITCH',
             'updating': 0})


$ pyhs100 --plug --ip 192.168.0.48 state
== Washing Machine - HS110(AU) ==
Device state: ON
IP address: 192.168.0.48
On since: 2018-04-29 00:29:04.595436
LED state: True
== Generic information ==
Time:         2018-05-30 19:53:00
Hardware:     2.0
Software:     1.5.2 Build 171201 Rel.084625
MAC (rssi):   B0:4E:26:B7:FE:68 (-55)
Location:     {'latitude': -xxxxxx, 'longitude': xxxxxxx}
== Emeter ==
Current state: {'power_mw': 1066, 'current_ma': 93, 'total_wh': 76668, 'voltage_mv': 232603}




**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
