### PR TITLE
Add calendar local platform

### DIFF
--- a/homeassistant/components/calendar/local.py
+++ b/homeassistant/components/calendar/local.py
@@ -1,0 +1,67 @@
+"""Component to manage a calendar."""
+import asyncio
+import logging
+
+from homeassistant.components import http
+from homeassistant.components.calendar import DOMAIN
+
+SUBDOMAIN = 'local'
+DEPENDENCIES = ['http']
+_LOGGER = logging.getLogger(__name__)
+EVENT = 'calendar_updated'
+
+
+@asyncio.coroutine
+def async_setup_platform(hass, config, add_devices, discovery_info=None):
+    """Initialize the calendar."""
+    hass.http.register_view(CalendarView)
+    hass.http.register_view(CalendarListView)
+
+    yield from hass.components.frontend.async_register_built_in_panel(
+        'calendar', 'calendar', 'mdi:calendar')
+
+    return True
+
+
+class CalendarView(http.HomeAssistantView):
+    """View to retrieve calendar content."""
+
+    url = '/api/calendar'
+    name = "api:calendar"
+    extra_urls = ['/api/calendar/']
+
+    async def post(self, request):
+        """Retrieve calendar items."""
+        data = await request.json()
+        if data.get("calendars"):
+            ret = []
+            for calendar_name in data.get("calendars"):
+                if calendar_name in request.app['hass'].data[DOMAIN]:
+                    ret.extend(request.app['hass'].
+                               data[DOMAIN][calendar_name].items)
+            return self.json(ret)
+        return self.json([])
+
+
+class CalendarListView(http.HomeAssistantView):
+    """View to retrieve calendar list."""
+
+    url = '/api/calendar-list'
+    name = "api:calendar-list"
+
+    async def get(self, request):
+        """Retrieve calendar list."""
+        entity_ids = [e for e in request.app['hass'].states.async_entity_ids()
+                      if e.startswith('calendar.')]
+        calendar_list = []
+        for entity_id in entity_ids:
+            entity = request.app['hass'].states.get(entity_id)
+            entity_short_name = entity.entity_id.split('.', 1)[-1]
+            cal = {"name": entity.attributes.get('friendly_name'),
+                   "color": entity.attributes.get('color'),
+                   "entity_id": entity_short_name}
+            calendar_list.append(cal)
+
+        calendar_list.sort(key=lambda x: x['name'])
+
+        return self.json(calendar_list)

--- a/homeassistant/components/calendar/local.py
+++ b/homeassistant/components/calendar/local.py
@@ -3,7 +3,6 @@ import asyncio
 import logging
 
 from homeassistant.components import http
-from homeassistant.components.calendar import DOMAIN
 
 SUBDOMAIN = 'local'
 DEPENDENCIES = ['http']
@@ -14,7 +13,6 @@ EVENT = 'calendar_updated'
 @asyncio.coroutine
 def async_setup_platform(hass, config, add_devices, discovery_info=None):
     """Initialize the calendar."""
-    hass.http.register_view(CalendarView)
     hass.http.register_view(CalendarListView)
 
     yield from hass.components.frontend.async_register_built_in_panel(
@@ -23,31 +21,11 @@ def async_setup_platform(hass, config, add_devices, discovery_info=None):
     return True
 
 
-class CalendarView(http.HomeAssistantView):
-    """View to retrieve calendar content."""
-
-    url = '/api/calendar'
-    name = "api:calendar"
-    extra_urls = ['/api/calendar/']
-
-    async def post(self, request):
-        """Retrieve calendar items."""
-        data = await request.json()
-        if data.get("calendars"):
-            ret = []
-            for calendar_name in data.get("calendars"):
-                if calendar_name in request.app['hass'].data[DOMAIN]:
-                    ret.extend(request.app['hass'].
-                               data[DOMAIN][calendar_name].items)
-            return self.json(ret)
-        return self.json([])
-
-
 class CalendarListView(http.HomeAssistantView):
     """View to retrieve calendar list."""
 
-    url = '/api/calendar-list'
-    name = "api:calendar-list"
+    url = '/api/calendars'
+    name = "api:calendars"
 
     async def get(self, request):
         """Retrieve calendar list."""

--- a/homeassistant/components/calendar/local.py
+++ b/homeassistant/components/calendar/local.py
@@ -1,21 +1,18 @@
 """Component to manage a calendar."""
-import asyncio
 import logging
 
 from homeassistant.components import http
+from homeassistant.core import split_entity_id
 
-SUBDOMAIN = 'local'
 DEPENDENCIES = ['http']
 _LOGGER = logging.getLogger(__name__)
-EVENT = 'calendar_updated'
 
 
-@asyncio.coroutine
-def async_setup_platform(hass, config, add_devices, discovery_info=None):
+async def async_setup_platform(hass, config, add_devices, discovery_info=None):
     """Initialize the calendar."""
     hass.http.register_view(CalendarListView)
 
-    yield from hass.components.frontend.async_register_built_in_panel(
+    await hass.components.frontend.async_register_built_in_panel(
         'calendar', 'calendar', 'mdi:calendar')
 
     return True
@@ -29,14 +26,13 @@ class CalendarListView(http.HomeAssistantView):
 
     async def get(self, request):
         """Retrieve calendar list."""
-        entity_ids = [e for e in request.app['hass'].states.async_entity_ids()
-                      if e.startswith('calendar.')]
+        entity_ids = [e for e in
+                      request.app['hass'].states.async_entity_ids('calendar')]
         calendar_list = []
         for entity_id in entity_ids:
             entity = request.app['hass'].states.get(entity_id)
-            entity_short_name = entity.entity_id.split('.', 1)[-1]
+            entity_short_name = split_entity_id(entity.entity_id)[-1]
             cal = {"name": entity.attributes.get('friendly_name'),
-                   "color": entity.attributes.get('color'),
                    "entity_id": entity_short_name}
             calendar_list.append(cal)
 


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** replaces #14328

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
calendar:
  - platform: local
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
