### PR TITLE
Add set_default_level to logger

### DIFF
--- a/homeassistant/components/logger.py
+++ b/homeassistant/components/logger.py
@@ -47,11 +47,6 @@ CONFIG_SCHEMA = vol.Schema({
 }, extra=vol.ALLOW_EXTRA)
 
 
-def set_default_level(hass, level):
-    """Set default log level for components."""
-    hass.services.call(DOMAIN, SERVICE_SET_DEFAULT_LEVEL, level)
-
-
 def set_level(hass, logs):
     """Set log level for components."""
     hass.services.call(DOMAIN, SERVICE_SET_LEVEL, logs)
@@ -110,9 +105,10 @@ async def async_setup(hass, config):
         )
 
     # Set default log severity
-    set_default_log_level('DEBUG')
     if LOGGER_DEFAULT in config.get(DOMAIN):
         set_default_log_level(config.get(DOMAIN)[LOGGER_DEFAULT])
+    else:
+        set_default_log_level('DEBUG')
 
     logger = logging.getLogger('')
     logger.setLevel(logging.NOTSET)

--- a/homeassistant/components/logger.py
+++ b/homeassistant/components/logger.py
@@ -51,6 +51,7 @@ def set_default_level(hass, level):
     """Set default log level for components."""
     hass.services.call(DOMAIN, SERVICE_SET_DEFAULT_LEVEL, level)
 
+
 def set_level(hass, logs):
     """Set log level for components."""
     hass.services.call(DOMAIN, SERVICE_SET_LEVEL, logs)

--- a/homeassistant/components/logger.py
+++ b/homeassistant/components/logger.py
@@ -15,6 +15,7 @@ DOMAIN = 'logger'
 
 DATA_LOGGER = 'logger'
 
+SERVICE_SET_DEFAULT_LEVEL = 'set_default_level'
 SERVICE_SET_LEVEL = 'set_level'
 
 LOGSEVERITY = {
@@ -31,8 +32,11 @@ LOGSEVERITY = {
 LOGGER_DEFAULT = 'default'
 LOGGER_LOGS = 'logs'
 
+ATTR_LEVEL = 'level'
+
 _VALID_LOG_LEVEL = vol.All(vol.Upper, vol.In(LOGSEVERITY))
 
+SERVICE_SET_DEFAULT_LEVEL_SCHEMA = vol.Schema({ATTR_LEVEL: _VALID_LOG_LEVEL})
 SERVICE_SET_LEVEL_SCHEMA = vol.Schema({cv.string: _VALID_LOG_LEVEL})
 
 CONFIG_SCHEMA = vol.Schema({
@@ -42,6 +46,10 @@ CONFIG_SCHEMA = vol.Schema({
     }),
 }, extra=vol.ALLOW_EXTRA)
 
+
+def set_default_level(hass, level):
+    """Set default log level for components."""
+    hass.services.call(DOMAIN, SERVICE_SET_DEFAULT_LEVEL, level)
 
 def set_level(hass, logs):
     """Set log level for components."""
@@ -76,12 +84,9 @@ async def async_setup(hass, config):
     """Set up the logger component."""
     logfilter = {}
 
-    # Set default log severity
-    logfilter[LOGGER_DEFAULT] = LOGSEVERITY['DEBUG']
-    if LOGGER_DEFAULT in config.get(DOMAIN):
-        logfilter[LOGGER_DEFAULT] = LOGSEVERITY[
-            config.get(DOMAIN)[LOGGER_DEFAULT]
-        ]
+    def set_default_log_level(level):
+        """Set the default log level for components."""
+        logfilter[LOGGER_DEFAULT] = LOGSEVERITY[level]
 
     def set_log_levels(logpoints):
         """Set the specified log levels."""
@@ -103,6 +108,11 @@ async def async_setup(hass, config):
             )
         )
 
+    # Set default log severity
+    set_default_log_level('DEBUG')
+    if LOGGER_DEFAULT in config.get(DOMAIN):
+        set_default_log_level(config.get(DOMAIN)[LOGGER_DEFAULT])
+
     logger = logging.getLogger('')
     logger.setLevel(logging.NOTSET)
 
@@ -116,7 +126,14 @@ async def async_setup(hass, config):
 
     async def async_service_handler(service):
         """Handle logger services."""
-        set_log_levels(service.data)
+        if service.service == SERVICE_SET_DEFAULT_LEVEL:
+            set_default_log_level(service.data.get(ATTR_LEVEL))
+        else:
+            set_log_levels(service.data)
+
+    hass.services.async_register(
+        DOMAIN, SERVICE_SET_DEFAULT_LEVEL, async_service_handler,
+        schema=SERVICE_SET_DEFAULT_LEVEL_SCHEMA)
 
     hass.services.async_register(
         DOMAIN, SERVICE_SET_LEVEL, async_service_handler,

--- a/homeassistant/components/services.yaml
+++ b/homeassistant/components/services.yaml
@@ -175,6 +175,12 @@ ffmpeg:
         example: 'binary_sensor.ffmpeg_noise'
 
 logger:
+  set_default_level:
+    description: Set the default log level for components.
+    fields:
+      level:
+        description: Default severity level. Possible values are notset, debug, info, warn, warning, error, fatal, critical
+        example: 'debug'
   set_level:
     description: Set log level for components.
 

--- a/tests/components/test_logger.py
+++ b/tests/components/test_logger.py
@@ -10,6 +10,7 @@ from tests.common import get_test_home_assistant
 
 RECORD = namedtuple('record', ('name', 'levelno'))
 
+NO_DEFAULT_CONFIG = {'logger': {}}
 NO_LOGS_CONFIG = {'logger': {'default': 'info'}}
 TEST_CONFIG = {
     'logger': {
@@ -95,6 +96,32 @@ class TestUpdater(unittest.TestCase):
 
         self.hass.services.call(logger.DOMAIN, 'set_level',
                                 {'asdf': 'debug', 'dummy': 'info'})
+        self.hass.block_till_done()
+
+        self.assert_logged('asdf', logging.DEBUG)
+        self.assert_logged('dummy', logging.WARNING)
+
+    def test_set_default_filter_empty_config(self):
+        """Test change default log level from empty configuration."""
+        self.setup_logger(NO_DEFAULT_CONFIG)
+
+        self.assert_logged('test', logging.DEBUG)
+
+        self.hass.services.call(
+            logger.DOMAIN, 'set_default_level', {'level': 'warning'})
+        self.hass.block_till_done()
+
+        self.assert_not_logged('test', logging.DEBUG)
+
+    def test_set_default_filter(self):
+        """Test change default log level with existing default."""
+        self.setup_logger(TEST_CONFIG)
+
+        self.assert_not_logged('asdf', logging.DEBUG)
+        self.assert_logged('dummy', logging.WARNING)
+
+        self.hass.services.call(
+            logger.DOMAIN, 'set_default_level', {'level': 'debug'})
         self.hass.block_till_done()
 
         self.assert_logged('asdf', logging.DEBUG)


### PR DESCRIPTION
## Description:
This adds a new service to the `logger` component that allows setting the default log level dynamically.

## Todo
  - [x] Submit PR for documentation changes
  - [x] Add tests (if necessary services)
  - [x] Remove set_default_level function
  - [x] Update services.yaml

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5460

## Example entry for `configuration.yaml` (if applicable):
```yaml
logger:
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.