### PR TITLE
Custom panel

### DIFF
--- a/homeassistant/components/panel_custom.py
+++ b/homeassistant/components/panel_custom.py
@@ -22,6 +22,7 @@ CONF_CONFIG = 'config'
 CONF_WEBCOMPONENT_PATH = 'webcomponent_path'
 CONF_JS_URL = 'js_url'
 CONF_EMBED_IFRAME = 'embed_iframe'
+CONF_TRUST_EXTERNAL_SCRIPT = 'trust_external_script'
 
 DEFAULT_ICON = 'mdi:bookmark'
 LEGACY_URL = '/api/panel_custom/{}'
@@ -38,6 +39,7 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(CONF_WEBCOMPONENT_PATH): cv.isfile,
         vol.Optional(CONF_JS_URL): cv.string,
         vol.Optional(CONF_EMBED_IFRAME, default=False): cv.boolean,
+        vol.Optional(CONF_TRUST_EXTERNAL_SCRIPT, default=False): cv.boolean,
     })])
 }, extra=vol.ALLOW_EXTRA)
 
@@ -58,6 +60,7 @@ async def async_setup(hass, config):
         config = {
             'name': name,
             'embed_iframe': panel[CONF_EMBED_IFRAME],
+            'trust_external': panel[CONF_TRUST_EXTERNAL_SCRIPT],
             'config': panel.get(CONF_CONFIG),
         }
 

--- a/homeassistant/components/panel_custom.py
+++ b/homeassistant/components/panel_custom.py
@@ -4,7 +4,6 @@ Register a custom front end panel.
 For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/panel_custom/
 """
-import asyncio
 import logging
 import os
 
@@ -22,6 +21,7 @@ CONF_URL_PATH = 'url_path'
 CONF_CONFIG = 'config'
 CONF_WEBCOMPONENT_PATH = 'webcomponent_path'
 CONF_JS_URL = 'js_url'
+CONF_EMBED_IFRAME = 'embed_iframe'
 
 DEFAULT_ICON = 'mdi:bookmark'
 LEGACY_URL = '/api/panel_custom/{}'
@@ -29,7 +29,7 @@ LEGACY_URL = '/api/panel_custom/{}'
 PANEL_DIR = 'panels'
 
 CONFIG_SCHEMA = vol.Schema({
-    DOMAIN: vol.All(cv.ensure_list, [{
+    DOMAIN: vol.All(cv.ensure_list, [vol.Schema({
         vol.Required(CONF_COMPONENT_NAME): cv.string,
         vol.Optional(CONF_SIDEBAR_TITLE): cv.string,
         vol.Optional(CONF_SIDEBAR_ICON, default=DEFAULT_ICON): cv.icon,
@@ -37,7 +37,8 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(CONF_CONFIG): cv.match_all,
         vol.Optional(CONF_WEBCOMPONENT_PATH): cv.isfile,
         vol.Optional(CONF_JS_URL): cv.string,
-    }])
+        vol.Optional(CONF_EMBED_IFRAME, default=False): cv.boolean,
+    })])
 }, extra=vol.ALLOW_EXTRA)
 
 _LOGGER = logging.getLogger(__name__)
@@ -56,6 +57,7 @@ async def async_setup(hass, config):
 
         config = {
             'name': name,
+            'embed_iframe': panel[CONF_EMBED_IFRAME],
             'config': panel.get(CONF_CONFIG),
         }
 

--- a/homeassistant/components/panel_custom.py
+++ b/homeassistant/components/panel_custom.py
@@ -67,7 +67,7 @@ async def async_setup(hass, config):
         if CONF_JS_URL in panel:
             config['js_url'] = panel[CONF_JS_URL]
 
-        elif not os.path.isfile(panel_path):
+        elif not await hass.async_add_job(os.path.isfile, panel_path):
             _LOGGER.error('Unable to find webcomponent for %s: %s',
                           name, panel_path)
             continue

--- a/homeassistant/components/panel_custom.py
+++ b/homeassistant/components/panel_custom.py
@@ -21,27 +21,29 @@ CONF_SIDEBAR_ICON = 'sidebar_icon'
 CONF_URL_PATH = 'url_path'
 CONF_CONFIG = 'config'
 CONF_WEBCOMPONENT_PATH = 'webcomponent_path'
+CONF_JS_URL = 'js_url'
 
 DEFAULT_ICON = 'mdi:bookmark'
+LEGACY_URL = '/api/panel_custom/{}'
 
 PANEL_DIR = 'panels'
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.All(cv.ensure_list, [{
-        vol.Required(CONF_COMPONENT_NAME): cv.slug,
+        vol.Required(CONF_COMPONENT_NAME): cv.string,
         vol.Optional(CONF_SIDEBAR_TITLE): cv.string,
         vol.Optional(CONF_SIDEBAR_ICON, default=DEFAULT_ICON): cv.icon,
         vol.Optional(CONF_URL_PATH): cv.string,
         vol.Optional(CONF_CONFIG): cv.match_all,
         vol.Optional(CONF_WEBCOMPONENT_PATH): cv.isfile,
+        vol.Optional(CONF_JS_URL): cv.string,
     }])
 }, extra=vol.ALLOW_EXTRA)
 
 _LOGGER = logging.getLogger(__name__)
 
 
-@asyncio.coroutine
-def async_setup(hass, config):
+async def async_setup(hass, config):
     """Initialize custom panel."""
     success = False
 
@@ -52,17 +54,30 @@ def async_setup(hass, config):
         if panel_path is None:
             panel_path = hass.config.path(PANEL_DIR, '{}.html'.format(name))
 
-        if not os.path.isfile(panel_path):
+        config = {
+            'name': name,
+            'config': panel.get(CONF_CONFIG),
+        }
+
+        if CONF_JS_URL in panel:
+            config['js_url'] = panel[CONF_JS_URL]
+
+        elif not os.path.isfile(panel_path):
             _LOGGER.error('Unable to find webcomponent for %s: %s',
                           name, panel_path)
             continue
 
-        yield from hass.components.frontend.async_register_panel(
-            name, panel_path,
+        else:
+            url = LEGACY_URL.format(name)
+            hass.http.register_static_path(url, panel_path)
+            config['html_url'] = LEGACY_URL.format(name)
+
+        await hass.components.frontend.async_register_built_in_panel(
+            component_name='custom',
             sidebar_title=panel.get(CONF_SIDEBAR_TITLE),
             sidebar_icon=panel.get(CONF_SIDEBAR_ICON),
             frontend_url_path=panel.get(CONF_URL_PATH),
-            config=panel.get(CONF_CONFIG),
+            config=config
         )
 
         success = True

--- a/tests/components/test_panel_custom.py
+++ b/tests/components/test_panel_custom.py
@@ -1,23 +1,11 @@
 """The tests for the panel_custom component."""
-import asyncio
 from unittest.mock import Mock, patch
-
-import pytest
 
 from homeassistant import setup
 from homeassistant.components import frontend
 
-from tests.common import mock_component
 
-
-@pytest.fixture(autouse=True)
-def mock_frontend_loaded(hass):
-    """Mock frontend is loaded."""
-    mock_component(hass, 'frontend')
-
-
-@asyncio.coroutine
-def test_webcomponent_custom_path_not_found(hass):
+async def test_webcomponent_custom_path_not_found(hass):
     """Test if a web component is found in config panels dir."""
     filename = 'mock.file'
 
@@ -33,21 +21,20 @@ def test_webcomponent_custom_path_not_found(hass):
     }
 
     with patch('os.path.isfile', Mock(return_value=False)):
-        result = yield from setup.async_setup_component(
+        result = await setup.async_setup_component(
             hass, 'panel_custom', config
         )
         assert not result
         assert len(hass.data.get(frontend.DATA_PANELS, {})) == 0
 
 
-@asyncio.coroutine
-def test_webcomponent_custom_path(hass):
+async def test_webcomponent_custom_path(hass):
     """Test if a web component is found in config panels dir."""
     filename = 'mock.file'
 
     config = {
         'panel_custom': {
-            'name': 'todomvc',
+            'name': 'todo-mvc',
             'webcomponent_path': filename,
             'sidebar_title': 'Sidebar Title',
             'sidebar_icon': 'mdi:iconicon',
@@ -58,20 +45,61 @@ def test_webcomponent_custom_path(hass):
 
     with patch('os.path.isfile', Mock(return_value=True)):
         with patch('os.access', Mock(return_value=True)):
-            result = yield from setup.async_setup_component(
+            result = await setup.async_setup_component(
                 hass, 'panel_custom', config
             )
             assert result
 
             panels = hass.data.get(frontend.DATA_PANELS, [])
 
-            assert len(panels) == 1
+            assert panels
             assert 'nice_url' in panels
 
             panel = panels['nice_url']
 
-            assert panel.config == 5
+            assert panel.config == {
+                'config': 5,
+                'html_url': '/api/panel_custom/todo-mvc',
+                'name': 'todo-mvc',
+                'embed_iframe': False,
+            }
             assert panel.frontend_url_path == 'nice_url'
             assert panel.sidebar_icon == 'mdi:iconicon'
             assert panel.sidebar_title == 'Sidebar Title'
-            assert panel.path == filename
+
+
+async def test_js_webcomponent(hass):
+    """Test if a web component is found in config panels dir."""
+    config = {
+        'panel_custom': {
+            'name': 'todo-mvc',
+            'js_url': '/local/bla.js',
+            'sidebar_title': 'Sidebar Title',
+            'sidebar_icon': 'mdi:iconicon',
+            'url_path': 'nice_url',
+            'config': 5,
+            'embed_iframe': True,
+        }
+    }
+
+    result = await setup.async_setup_component(
+        hass, 'panel_custom', config
+    )
+    assert result
+
+    panels = hass.data.get(frontend.DATA_PANELS, [])
+
+    assert panels
+    assert 'nice_url' in panels
+
+    panel = panels['nice_url']
+
+    assert panel.config == {
+        'config': 5,
+        'js_url': '/local/bla.js',
+        'name': 'todo-mvc',
+        'embed_iframe': True,
+    }
+    assert panel.frontend_url_path == 'nice_url'
+    assert panel.sidebar_icon == 'mdi:iconicon'
+    assert panel.sidebar_title == 'Sidebar Title'

--- a/tests/components/test_panel_custom.py
+++ b/tests/components/test_panel_custom.py
@@ -62,6 +62,7 @@ async def test_webcomponent_custom_path(hass):
                 'html_url': '/api/panel_custom/todo-mvc',
                 'name': 'todo-mvc',
                 'embed_iframe': False,
+                'trust_external': False,
             }
             assert panel.frontend_url_path == 'nice_url'
             assert panel.sidebar_icon == 'mdi:iconicon'
@@ -79,6 +80,7 @@ async def test_js_webcomponent(hass):
             'url_path': 'nice_url',
             'config': 5,
             'embed_iframe': True,
+            'trust_external_script': True,
         }
     }
 
@@ -99,6 +101,7 @@ async def test_js_webcomponent(hass):
         'js_url': '/local/bla.js',
         'name': 'todo-mvc',
         'embed_iframe': True,
+        'trust_external': True,
     }
     assert panel.frontend_url_path == 'nice_url'
     assert panel.sidebar_icon == 'mdi:iconicon'

--- a/tests/components/test_panel_custom.py
+++ b/tests/components/test_panel_custom.py
@@ -39,7 +39,9 @@ async def test_webcomponent_custom_path(hass):
             'sidebar_title': 'Sidebar Title',
             'sidebar_icon': 'mdi:iconicon',
             'url_path': 'nice_url',
-            'config': 5,
+            'config': {
+                'hello': 'world',
+            }
         }
     }
 
@@ -58,11 +60,13 @@ async def test_webcomponent_custom_path(hass):
             panel = panels['nice_url']
 
             assert panel.config == {
-                'config': 5,
-                'html_url': '/api/panel_custom/todo-mvc',
-                'name': 'todo-mvc',
-                'embed_iframe': False,
-                'trust_external': False,
+                'hello': 'world',
+                '_panel_custom': {
+                    'html_url': '/api/panel_custom/todo-mvc',
+                    'name': 'todo-mvc',
+                    'embed_iframe': False,
+                    'trust_external': False,
+                },
             }
             assert panel.frontend_url_path == 'nice_url'
             assert panel.sidebar_icon == 'mdi:iconicon'
@@ -78,7 +82,9 @@ async def test_js_webcomponent(hass):
             'sidebar_title': 'Sidebar Title',
             'sidebar_icon': 'mdi:iconicon',
             'url_path': 'nice_url',
-            'config': 5,
+            'config': {
+                'hello': 'world',
+            },
             'embed_iframe': True,
             'trust_external_script': True,
         }
@@ -97,11 +103,13 @@ async def test_js_webcomponent(hass):
     panel = panels['nice_url']
 
     assert panel.config == {
-        'config': 5,
-        'js_url': '/local/bla.js',
-        'name': 'todo-mvc',
-        'embed_iframe': True,
-        'trust_external': True,
+        'hello': 'world',
+        '_panel_custom': {
+            'js_url': '/local/bla.js',
+            'name': 'todo-mvc',
+            'embed_iframe': True,
+            'trust_external': True,
+        }
     }
     assert panel.frontend_url_path == 'nice_url'
     assert panel.sidebar_icon == 'mdi:iconicon'


### PR DESCRIPTION
## Description:
Add three new options to custom panel:

 - `embed_iframe`: this will render the custom panel in an iframe. This is needed if your panel has conflicting custom elements or if you're using React (because it's not ShadowDOM compatible)
 - `js_url`: this will load the custom panel from a URL.
 - `trust_external_script`: if set to false, frontend will ask user to confirm before loading the script

Depends on frontend PR: https://github.com/home-assistant/home-assistant-polymer/pull/1236

## Example entry for `configuration.yaml` (if applicable):
```yaml
# Configuration.yaml example
panel_custom:
  - name: react-panel
    url_path: react-panel-prod
    sidebar_title: React Prod
    sidebar_icon: mdi:react
    js_url: https://s3.amazonaws.com/home-assistant-demos/panel-examples/react-demo.js
    embed_iframe: true
    config:
      name: World
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
