### PR TITLE
Fixes (and stabilizes) some incorrect zone codes in RainMachine

### DIFF
--- a/homeassistant/components/switch/rainmachine.py
+++ b/homeassistant/components/switch/rainmachine.py
@@ -83,7 +83,7 @@ SPRINKLER_TYPE_MAP = {
     1: 'Popup Spray',
     2: 'Rotors',
     3: 'Surface Drip',
-    4: 'Bubblers',
+    4: 'Bubblers Drip',
     99: 'Other'
 }
 
@@ -96,14 +96,14 @@ SUN_EXPOSURE_MAP = {
 
 VEGETATION_MAP = {
     0: 'Not Set',
-    1: 'Not Set',
-    2: 'Grass',
+    2: 'Cool Season Grass',
     3: 'Fruit Trees',
     4: 'Flowers',
     5: 'Vegetables',
     6: 'Citrus',
-    7: 'Bushes',
-    8: 'Xeriscape',
+    7: 'Trees and Bushes',
+    9: 'Dought Tolerant Plants',
+    10: 'Warm Season Grass',
     99: 'Other'
 }
 
@@ -296,15 +296,17 @@ class RainMachineZone(RainMachineSwitch):
                     self._properties_json.get(
                         'waterSense').get('precipitationRate'),
                 ATTR_RESTRICTIONS: self._obj.get('restriction'),
-                ATTR_SLOPE: SLOPE_TYPE_MAP[self._properties_json.get('slope')],
+                ATTR_SLOPE: SLOPE_TYPE_MAP.get(
+                    self._properties_json.get('slope')),
                 ATTR_SOIL_TYPE:
-                    SOIL_TYPE_MAP[self._properties_json.get('sun')],
+                    SOIL_TYPE_MAP.get(self._properties_json.get('sun')),
                 ATTR_SPRINKLER_TYPE:
-                    SPRINKLER_TYPE_MAP[self._properties_json.get('group_id')],
+                    SPRINKLER_TYPE_MAP.get(
+                        self._properties_json.get('group_id')),
                 ATTR_SUN_EXPOSURE:
-                    SUN_EXPOSURE_MAP[self._properties_json.get('sun')],
+                    SUN_EXPOSURE_MAP.get(self._properties_json.get('sun')),
                 ATTR_VEGETATION_TYPE:
-                    VEGETATION_MAP[self._obj.get('type')],
+                    VEGETATION_MAP.get(self._obj.get('type')),
             })
         except RainMachineError as exc_info:
             _LOGGER.error('Unable to update info for zone "%s"',

--- a/homeassistant/components/switch/rainmachine.py
+++ b/homeassistant/components/switch/rainmachine.py
@@ -102,7 +102,7 @@ VEGETATION_MAP = {
     5: 'Vegetables',
     6: 'Citrus',
     7: 'Trees and Bushes',
-    9: 'Dought Tolerant Plants',
+    9: 'Drought Tolerant Plants',
     10: 'Warm Season Grass',
     99: 'Other'
 }


### PR DESCRIPTION
## Description:
[The RainMachine API docs](https://rainmachine.docs.apiary.io/) have some incorrect/missing codes for vegetation types, etc. This PR:

- Adds in the missing codes
- Reduces some brittleness so that any future API changes in this area don't crash the integration

**Related issue (if applicable):** fixes #14715

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
rainmachine:
  ip_address: 192.168.1.100
  password: mypassword123
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  ~- [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)~

If the code communicates with devices, web services, or third-party tools:
  ~- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).~
  ~- [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).~
  ~- [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.~
  ~- [ ] New files were added to `.coveragerc`.~

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
