### PR TITLE
Change climate default limits to constants

### DIFF
--- a/homeassistant/components/climate/__init__.py
+++ b/homeassistant/components/climate/__init__.py
@@ -22,6 +22,12 @@ from homeassistant.const import (
     ATTR_ENTITY_ID, ATTR_TEMPERATURE, SERVICE_TURN_ON, SERVICE_TURN_OFF,
     STATE_ON, STATE_OFF, STATE_UNKNOWN, TEMP_CELSIUS, PRECISION_WHOLE,
     PRECISION_TENTHS, )
+
+DEFAULT_MIN_TEMP = 7
+DEFAULT_MAX_TEMP = 35
+DEFAULT_MIN_HUMITIDY = 30
+DEFAULT_MAX_HUMIDITY = 99
+
 DOMAIN = 'climate'
 
 ENTITY_ID_FORMAT = DOMAIN + '.{}'
@@ -778,19 +784,19 @@ class ClimateDevice(Entity):
     @property
     def min_temp(self):
         """Return the minimum temperature."""
-        return convert_temperature(7, TEMP_CELSIUS, self.temperature_unit)
+        return convert_temperature(DEFAULT_MIN_TEMP, TEMP_CELSIUS, self.temperature_unit)
 
     @property
     def max_temp(self):
         """Return the maximum temperature."""
-        return convert_temperature(35, TEMP_CELSIUS, self.temperature_unit)
+        return convert_temperature(DEFAULT_MAX_TEMP, TEMP_CELSIUS, self.temperature_unit)
 
     @property
     def min_humidity(self):
         """Return the minimum humidity."""
-        return 30
+        return DEFAULT_MIN_HUMITIDY
 
     @property
     def max_humidity(self):
         """Return the maximum humidity."""
-        return 99
+        return DEFAULT_MAX_HUMIDITY

--- a/homeassistant/components/climate/__init__.py
+++ b/homeassistant/components/climate/__init__.py
@@ -784,12 +784,14 @@ class ClimateDevice(Entity):
     @property
     def min_temp(self):
         """Return the minimum temperature."""
-        return convert_temperature(DEFAULT_MIN_TEMP, TEMP_CELSIUS, self.temperature_unit)
+        return convert_temperature(DEFAULT_MIN_TEMP, TEMP_CELSIUS,
+                                   self.temperature_unit)
 
     @property
     def max_temp(self):
         """Return the maximum temperature."""
-        return convert_temperature(DEFAULT_MAX_TEMP, TEMP_CELSIUS, self.temperature_unit)
+        return convert_temperature(DEFAULT_MAX_TEMP, TEMP_CELSIUS,
+                                   self.temperature_unit)
 
     @property
     def min_humidity(self):

--- a/homeassistant/components/climate/generic_thermostat.py
+++ b/homeassistant/components/climate/generic_thermostat.py
@@ -14,7 +14,8 @@ from homeassistant.core import DOMAIN as HA_DOMAIN
 from homeassistant.components.climate import (
     STATE_HEAT, STATE_COOL, STATE_IDLE, STATE_AUTO, ClimateDevice,
     ATTR_OPERATION_MODE, ATTR_AWAY_MODE, SUPPORT_OPERATION_MODE,
-    SUPPORT_AWAY_MODE, SUPPORT_TARGET_TEMPERATURE, PLATFORM_SCHEMA)
+    SUPPORT_AWAY_MODE, SUPPORT_TARGET_TEMPERATURE, PLATFORM_SCHEMA,
+    DEFAULT_MIN_TEMP, DEFAULT_MAX_TEMP)
 from homeassistant.const import (
     ATTR_UNIT_OF_MEASUREMENT, STATE_ON, STATE_OFF, ATTR_TEMPERATURE,
     CONF_NAME, ATTR_ENTITY_ID, SERVICE_TURN_ON, SERVICE_TURN_OFF,
@@ -268,7 +269,7 @@ class GenericThermostat(ClimateDevice):
             return self._min_temp
 
         # get default temp from super class
-        return ClimateDevice.min_temp.fget(self)
+        return DEFAULT_MIN_TEMP
 
     @property
     def max_temp(self):
@@ -278,7 +279,7 @@ class GenericThermostat(ClimateDevice):
             return self._max_temp
 
         # Get default temp from super class
-        return ClimateDevice.max_temp.fget(self)
+        return DEFAULT_MAX_TEMP
 
     @asyncio.coroutine
     def _async_sensor_changed(self, entity_id, old_state, new_state):

--- a/homeassistant/components/climate/generic_thermostat.py
+++ b/homeassistant/components/climate/generic_thermostat.py
@@ -268,7 +268,6 @@ class GenericThermostat(ClimateDevice):
         if self._min_temp:
             return self._min_temp
 
-        # get default temp from super class
         return DEFAULT_MIN_TEMP
 
     @property
@@ -278,7 +277,6 @@ class GenericThermostat(ClimateDevice):
         if self._max_temp:
             return self._max_temp
 
-        # Get default temp from super class
         return DEFAULT_MAX_TEMP
 
     @asyncio.coroutine

--- a/homeassistant/components/climate/sensibo.py
+++ b/homeassistant/components/climate/sensibo.py
@@ -19,7 +19,7 @@ from homeassistant.components.climate import (
     ATTR_CURRENT_HUMIDITY, ClimateDevice, DOMAIN, PLATFORM_SCHEMA,
     SUPPORT_TARGET_TEMPERATURE, SUPPORT_OPERATION_MODE,
     SUPPORT_FAN_MODE, SUPPORT_SWING_MODE,
-    SUPPORT_ON_OFF)
+    SUPPORT_ON_OFF, DEFAULT_MIN_TEMP, DEFAULT_MAX_TEMP)
 from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -240,13 +240,13 @@ class SensiboClimate(ClimateDevice):
     def min_temp(self):
         """Return the minimum temperature."""
         return self._temperatures_list[0] \
-            if self._temperatures_list else super().min_temp
+            if self._temperatures_list else DEFAULT_MIN_TEMP
 
     @property
     def max_temp(self):
         """Return the maximum temperature."""
         return self._temperatures_list[-1] \
-            if self._temperatures_list else super().max_temp
+            if self._temperatures_list else DEFAULT_MAX_TEMP
 
     @property
     def unique_id(self):

--- a/homeassistant/components/climate/tado.py
+++ b/homeassistant/components/climate/tado.py
@@ -8,7 +8,8 @@ import logging
 
 from homeassistant.const import (PRECISION_TENTHS, TEMP_CELSIUS)
 from homeassistant.components.climate import (
-    ClimateDevice, SUPPORT_TARGET_TEMPERATURE, SUPPORT_OPERATION_MODE)
+    ClimateDevice, SUPPORT_TARGET_TEMPERATURE, SUPPORT_OPERATION_MODE,
+    DEFAULT_MIN_TEMP, DEFAULT_MAX_TEMP)
 from homeassistant.const import ATTR_TEMPERATURE
 from homeassistant.components.tado import DATA_TADO
 
@@ -233,7 +234,7 @@ class TadoClimate(ClimateDevice):
         if self._min_temp:
             return self._min_temp
         # get default temp from super class
-        return super().min_temp
+        return DEFAULT_MIN_TEMP
 
     @property
     def max_temp(self):
@@ -241,7 +242,7 @@ class TadoClimate(ClimateDevice):
         if self._max_temp:
             return self._max_temp
         #  Get default temp from super class
-        return super().max_temp
+        return DEFAULT_MAX_TEMP
 
     def update(self):
         """Update the state of this climate device."""

--- a/homeassistant/components/climate/tado.py
+++ b/homeassistant/components/climate/tado.py
@@ -233,7 +233,7 @@ class TadoClimate(ClimateDevice):
         """Return the minimum temperature."""
         if self._min_temp:
             return self._min_temp
-        # get default temp from super class
+
         return DEFAULT_MIN_TEMP
 
     @property
@@ -241,7 +241,7 @@ class TadoClimate(ClimateDevice):
         """Return the maximum temperature."""
         if self._max_temp:
             return self._max_temp
-        #  Get default temp from super class
+
         return DEFAULT_MAX_TEMP
 
     def update(self):

--- a/tests/components/climate/test_mqtt.py
+++ b/tests/components/climate/test_mqtt.py
@@ -9,9 +9,9 @@ from homeassistant.setup import setup_component
 from homeassistant.components import climate
 from homeassistant.const import STATE_OFF, STATE_UNAVAILABLE
 from homeassistant.components.climate import (
-    SUPPORT_OPERATION_MODE, SUPPORT_TARGET_TEMPERATURE,
-    SUPPORT_FAN_MODE, SUPPORT_SWING_MODE, SUPPORT_HOLD_MODE,
-    SUPPORT_AWAY_MODE, SUPPORT_AUX_HEAT, DEFAULT_MAX_TEMP, DEFAULT_MIN_TEMP)
+               SUPPORT_OPERATION_MODE, SUPPORT_TARGET_TEMPERATURE,
+               SUPPORT_FAN_MODE, SUPPORT_SWING_MODE, SUPPORT_HOLD_MODE,
+               SUPPORT_AWAY_MODE, SUPPORT_AUX_HEAT)
 from tests.common import (get_test_home_assistant, mock_mqtt_component,
                           fire_mqtt_message, mock_component)
 

--- a/tests/components/climate/test_mqtt.py
+++ b/tests/components/climate/test_mqtt.py
@@ -9,9 +9,9 @@ from homeassistant.setup import setup_component
 from homeassistant.components import climate
 from homeassistant.const import STATE_OFF, STATE_UNAVAILABLE
 from homeassistant.components.climate import (
-               SUPPORT_OPERATION_MODE, SUPPORT_TARGET_TEMPERATURE,
-               SUPPORT_FAN_MODE, SUPPORT_SWING_MODE, SUPPORT_HOLD_MODE,
-               SUPPORT_AWAY_MODE, SUPPORT_AUX_HEAT)
+    SUPPORT_OPERATION_MODE, SUPPORT_TARGET_TEMPERATURE,
+    SUPPORT_FAN_MODE, SUPPORT_SWING_MODE, SUPPORT_HOLD_MODE,
+    SUPPORT_AWAY_MODE, SUPPORT_AUX_HEAT, DEFAULT_MAX_TEMP, DEFAULT_MIN_TEMP)
 from tests.common import (get_test_home_assistant, mock_mqtt_component,
                           fire_mqtt_message, mock_component)
 


### PR DESCRIPTION
## Description:

Min and max temp and humidity are now defined in climate \_\_init\_\_.py and are available for import in subclasses.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
