### PR TITLE
Disallow automation.trigger without entity_id

### DIFF
--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -98,7 +98,7 @@ SERVICE_SCHEMA = vol.Schema({
 })
 
 TRIGGER_SERVICE_SCHEMA = vol.Schema({
-    vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
+    vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
     vol.Optional(ATTR_VARIABLES, default={}): dict,
 })
 

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -207,6 +207,7 @@ class TestAutomation(unittest.TestCase):
         """Test triggers."""
         assert setup_component(self.hass, automation.DOMAIN, {
             automation.DOMAIN: {
+                'alias': 'test',
                 'trigger': [
                     {
                         'platform': 'event',
@@ -228,7 +229,9 @@ class TestAutomation(unittest.TestCase):
         self.hass.block_till_done()
         assert len(self.calls) == 0
 
-        self.hass.services.call('automation', 'trigger', blocking=True)
+        self.hass.services.call('automation', 'trigger',
+                                {'entity_id': 'automation.test'},
+                                blocking=True)
         self.hass.block_till_done()
         assert len(self.calls) == 1
 


### PR DESCRIPTION
## Breaking change note

Using `automation.trigger` without an `entity_id` no longer works.

## Description:

Triggering all automations at once is most likely a user mistake but if it is really needed, one can use `entity_id: group.all_automations`.

**Related issue (if applicable):** fixes #12512

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.
