### PR TITLE
Fix unit conversion

### DIFF
--- a/homeassistant/components/climate/generic_thermostat.py
+++ b/homeassistant/components/climate/generic_thermostat.py
@@ -14,8 +14,7 @@ from homeassistant.core import DOMAIN as HA_DOMAIN
 from homeassistant.components.climate import (
     STATE_HEAT, STATE_COOL, STATE_IDLE, STATE_AUTO, ClimateDevice,
     ATTR_OPERATION_MODE, ATTR_AWAY_MODE, SUPPORT_OPERATION_MODE,
-    SUPPORT_AWAY_MODE, SUPPORT_TARGET_TEMPERATURE, PLATFORM_SCHEMA,
-    DEFAULT_MIN_TEMP, DEFAULT_MAX_TEMP)
+    SUPPORT_AWAY_MODE, SUPPORT_TARGET_TEMPERATURE, PLATFORM_SCHEMA)
 from homeassistant.const import (
     ATTR_UNIT_OF_MEASUREMENT, STATE_ON, STATE_OFF, ATTR_TEMPERATURE,
     CONF_NAME, ATTR_ENTITY_ID, SERVICE_TURN_ON, SERVICE_TURN_OFF,
@@ -268,7 +267,8 @@ class GenericThermostat(ClimateDevice):
         if self._min_temp:
             return self._min_temp
 
-        return DEFAULT_MIN_TEMP
+        # get default temp from super class
+        return ClimateDevice.min_temp.fget(self)
 
     @property
     def max_temp(self):
@@ -277,7 +277,8 @@ class GenericThermostat(ClimateDevice):
         if self._max_temp:
             return self._max_temp
 
-        return DEFAULT_MAX_TEMP
+        # Get default temp from super class
+        return ClimateDevice.max_temp.fget(self)
 
     @asyncio.coroutine
     def _async_sensor_changed(self, entity_id, old_state, new_state):

--- a/homeassistant/components/climate/generic_thermostat.py
+++ b/homeassistant/components/climate/generic_thermostat.py
@@ -268,7 +268,7 @@ class GenericThermostat(ClimateDevice):
             return self._min_temp
 
         # get default temp from super class
-        return ClimateDevice.min_temp.fget(self)
+        return super().min_temp
 
     @property
     def max_temp(self):
@@ -278,7 +278,7 @@ class GenericThermostat(ClimateDevice):
             return self._max_temp
 
         # Get default temp from super class
-        return ClimateDevice.max_temp.fget(self)
+        return super().max_temp
 
     @asyncio.coroutine
     def _async_sensor_changed(self, entity_id, old_state, new_state):

--- a/homeassistant/components/climate/sensibo.py
+++ b/homeassistant/components/climate/sensibo.py
@@ -19,7 +19,7 @@ from homeassistant.components.climate import (
     ATTR_CURRENT_HUMIDITY, ClimateDevice, DOMAIN, PLATFORM_SCHEMA,
     SUPPORT_TARGET_TEMPERATURE, SUPPORT_OPERATION_MODE,
     SUPPORT_FAN_MODE, SUPPORT_SWING_MODE,
-    SUPPORT_ON_OFF, DEFAULT_MIN_TEMP, DEFAULT_MAX_TEMP)
+    SUPPORT_ON_OFF)
 from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -240,13 +240,13 @@ class SensiboClimate(ClimateDevice):
     def min_temp(self):
         """Return the minimum temperature."""
         return self._temperatures_list[0] \
-            if self._temperatures_list else DEFAULT_MIN_TEMP
+            if self._temperatures_list else super().min_temp
 
     @property
     def max_temp(self):
         """Return the maximum temperature."""
         return self._temperatures_list[-1] \
-            if self._temperatures_list else DEFAULT_MAX_TEMP
+            if self._temperatures_list else super().max_temp
 
     @property
     def unique_id(self):

--- a/homeassistant/components/climate/tado.py
+++ b/homeassistant/components/climate/tado.py
@@ -8,8 +8,7 @@ import logging
 
 from homeassistant.const import (PRECISION_TENTHS, TEMP_CELSIUS)
 from homeassistant.components.climate import (
-    ClimateDevice, SUPPORT_TARGET_TEMPERATURE, SUPPORT_OPERATION_MODE,
-    DEFAULT_MIN_TEMP, DEFAULT_MAX_TEMP)
+    ClimateDevice, SUPPORT_TARGET_TEMPERATURE, SUPPORT_OPERATION_MODE)
 from homeassistant.util.temperature import convert as convert_temperature
 from homeassistant.const import ATTR_TEMPERATURE
 from homeassistant.components.tado import DATA_TADO

--- a/homeassistant/components/climate/tado.py
+++ b/homeassistant/components/climate/tado.py
@@ -10,6 +10,7 @@ from homeassistant.const import (PRECISION_TENTHS, TEMP_CELSIUS)
 from homeassistant.components.climate import (
     ClimateDevice, SUPPORT_TARGET_TEMPERATURE, SUPPORT_OPERATION_MODE,
     DEFAULT_MIN_TEMP, DEFAULT_MAX_TEMP)
+from homeassistant.util.temperature import convert as convert_temperature
 from homeassistant.const import ATTR_TEMPERATURE
 from homeassistant.components.tado import DATA_TADO
 
@@ -231,18 +232,14 @@ class TadoClimate(ClimateDevice):
     @property
     def min_temp(self):
         """Return the minimum temperature."""
-        if self._min_temp:
-            return self._min_temp
-
-        return DEFAULT_MIN_TEMP
+        return convert_temperature(self._min_temp, self._unit,
+                                   hass.config.units.temperature_unit)
 
     @property
     def max_temp(self):
         """Return the maximum temperature."""
-        if self._max_temp:
-            return self._max_temp
-
-        return DEFAULT_MAX_TEMP
+        return convert_temperature(self._max_temp, self._unit,
+                                   hass.config.units.temperature_unit)
 
     def update(self):
         """Update the state of this climate device."""

--- a/homeassistant/components/climate/tado.py
+++ b/homeassistant/components/climate/tado.py
@@ -233,13 +233,13 @@ class TadoClimate(ClimateDevice):
     def min_temp(self):
         """Return the minimum temperature."""
         return convert_temperature(self._min_temp, self._unit,
-                                   hass.config.units.temperature_unit)
+                                   self.hass.config.units.temperature_unit)
 
     @property
     def max_temp(self):
         """Return the maximum temperature."""
         return convert_temperature(self._max_temp, self._unit,
-                                   hass.config.units.temperature_unit)
+                                   self.hass.config.units.temperature_unit)
 
     def update(self):
         """Update the state of this climate device."""


### PR DESCRIPTION
## Description:

In a previous accepted PR #14690 a bug was introduced when global HA temperature unit in Fahrenheit.

This PR reverts changes in generic_thermostat and sensible, but re-engineers tado, since tado always has a min_temp/max_temp and doesn't require the DEFAULT_*.

**Related issue (if applicable):** fixes #14690

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54