### PR TITLE
Update directpy requirements

### DIFF
--- a/homeassistant/components/media_player/directv.py
+++ b/homeassistant/components/media_player/directv.py
@@ -16,7 +16,7 @@ from homeassistant.const import (
     CONF_DEVICE, CONF_HOST, CONF_NAME, STATE_OFF, STATE_PLAYING, CONF_PORT)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['directpy==0.2']
+REQUIREMENTS = ['directpy==0.3']
 
 DEFAULT_DEVICE = '0'
 DEFAULT_NAME = 'DirecTV Receiver'


### PR DESCRIPTION
[DirectPy developer] I've updated the DirectPy package on PyPi to v0.3 to resolve standby status errors with Genie clients that are not responding. The fix is internal to the get_standby() method and will not break dependencies. Update has already been tested by a HomeAsstant user. This should be a required version now for this project.