### PR TITLE
Upgrade directpy to 0.5

### DIFF
--- a/homeassistant/components/media_player/directv.py
+++ b/homeassistant/components/media_player/directv.py
@@ -16,7 +16,7 @@ from homeassistant.const import (
     CONF_DEVICE, CONF_HOST, CONF_NAME, STATE_OFF, STATE_PLAYING, CONF_PORT)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['directpy==0.2']
+REQUIREMENTS = ['directpy==0.5']
 
 DEFAULT_DEVICE = '0'
 DEFAULT_NAME = 'DirecTV Receiver'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -249,7 +249,7 @@ deluge-client==1.4.0
 denonavr==0.7.2
 
 # homeassistant.components.media_player.directv
-directpy==0.2
+directpy==0.5
 
 # homeassistant.components.sensor.discogs
 discogs_client==2.2.1


### PR DESCRIPTION
Bump required version to 0.5 to allow component to work with Genie Mini clients using the clientAddr variable.

## Description: Version requirement bump
This bumps the required version of DirectPy.py to 0.5, which allows the DirecTV component to better work with C31, C41, C51, C61, C61K, and C41W Genie mini clients when paired with HR44 or HR54 Genie hubs or the HS17 Genie server. This version bump corrects an error when attempting to poll status using the clientAddr variable to specify a genie mini client. 

**Related issue (if applicable):** fixes #N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```
media_player:
  - platform: directv
    host: 192.168.1.10
    port: 8080
    name: Main DirecTV Box
    device: 0
  - platform: directv
    host: 192.168.1.10
    port: 8080
    name: Bedroom DirecTV
    device: 5009591D6969
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works. **N/A**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
