### PR TITLE
Handle "step_with_on_off" cluster command in LevelListener

### DIFF
--- a/homeassistant/components/binary_sensor/zha.py
+++ b/homeassistant/components/binary_sensor/zha.py
@@ -187,8 +187,8 @@ class Switch(zha.Entity, BinarySensorDevice):
                 if args[0] == 0xff:
                     rate = 10  # Should read default move rate
                 self._entity.move_level(-rate if args[0] else rate)
-            elif command_id == 0x0002:  # step
-                # Step (technically shouldn't change on/off)
+            elif command_id in (0x0002, 0x0006):  # step, -with_on_off
+                # Step (technically may change on/off)
                 self._entity.move_level(-args[1] if args[0] else args[1])
 
         def attribute_update(self, attrid, value):


### PR DESCRIPTION
## Description:
per [ZCL specification Revision 6 Draft version 1](http://www.zigbee.org/~zigbeeor/wp-content/uploads/2014/10/07-5123-06-zigbee-cluster-library-specification.pdf) (page 3-63) there are two kinds of "step" commands in Level cluster:

Command ID|Command
---------------|---------------
0x02|Step
0x06|Step with On/Off

this pull request adds handling of "Step with On/Off" command, which is being used by 45857GE zigbee wall switches as an example

## Checklist:
  - [x] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
