### PR TITLE
Upgrade postnl_api to 1.0.2

### DIFF
--- a/homeassistant/components/sensor/postnl.py
+++ b/homeassistant/components/sensor/postnl.py
@@ -16,7 +16,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['postnl_api==1.0.1']
+REQUIREMENTS = ['postnl_api==1.0.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -654,7 +654,7 @@ pmsensor==0.4
 pocketcasts==0.1
 
 # homeassistant.components.sensor.postnl
-postnl_api==1.0.1
+postnl_api==1.0.2
 
 # homeassistant.components.climate.proliphix
 proliphix==0.4.1


### PR DESCRIPTION
## Description:
Update python_postnl_api to 1.0.2 which solves an exception when no DeliveryDate is set for a delivery

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**