### PR TITLE
Update broadlink.py, fix a problem using MP1

### DIFF
--- a/homeassistant/components/switch/broadlink.py
+++ b/homeassistant/components/switch/broadlink.py
@@ -351,7 +351,7 @@ class BroadlinkMP1Slot(BroadlinkRMSwitch):
 
     def update(self):
         """Trigger update for all switches on the parent device."""
-        if timer()-self.last_click_time <3:
+        if timer()-self.last_click_time < 3:
             return
         self._parent_device.update()
         self._state = self._parent_device.get_outlet_status(self._slot)

--- a/homeassistant/components/switch/broadlink.py
+++ b/homeassistant/components/switch/broadlink.py
@@ -10,7 +10,7 @@ import binascii
 from datetime import timedelta
 import logging
 import socket
-
+from timeit import default_timer as timer
 import voluptuous as vol
 
 from homeassistant.components.switch import (
@@ -193,6 +193,11 @@ class BroadlinkRMSwitch(SwitchDevice):
         self._command_on = b64decode(command_on) if command_on else None
         self._command_off = b64decode(command_off) if command_off else None
         self._device = device
+        self._last_click_time = timer()
+
+    @property
+    def last_click_time(self):
+        return self._last_click_time
 
     @property
     def name(self):
@@ -217,12 +222,14 @@ class BroadlinkRMSwitch(SwitchDevice):
     def turn_on(self, **kwargs):
         """Turn the device on."""
         if self._sendpacket(self._command_on):
+            self._last_click_time = timer()
             self._state = True
             self.schedule_update_ha_state()
 
     def turn_off(self, **kwargs):
         """Turn the device off."""
         if self._sendpacket(self._command_off):
+            self._last_click_time = timer()
             self._state = False
             self.schedule_update_ha_state()
 
@@ -344,6 +351,8 @@ class BroadlinkMP1Slot(BroadlinkRMSwitch):
 
     def update(self):
         """Trigger update for all switches on the parent device."""
+        if timer()-self.last_click_time <3:
+            return
         self._parent_device.update()
         self._state = self._parent_device.get_outlet_status(self._slot)
 


### PR DESCRIPTION
After controll MP1's slot switch, it will update slot's state twice: One in broadlink.py calls schedule_update_ha_state() manually after send turn_on or turn_off command to MP1 , another calls switch.async_update_ha_state(True) by switch service sending request to MP1 and get real status. The problem is these two operation execute with short interval, the latter operation usually get a old state since MP1 takes time to refresh it's state. So I add some timer to ensure getting a real state, giving MP1 3 second to reresh states and ignoring update request during that time.

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
