### PR TITLE
Ignore the mistaken long_click event of the 86sw (Closes: #14694)

### DIFF
--- a/homeassistant/components/binary_sensor/xiaomi_aqara.py
+++ b/homeassistant/components/binary_sensor/xiaomi_aqara.py
@@ -330,6 +330,8 @@ class XiaomiButton(XiaomiBinarySensor):
             click_type = 'both'
         elif value == 'shake':
             click_type = 'shake'
+        elif value == 'long_click':
+            return False
         else:
             _LOGGER.warning("Unsupported click_type detected: %s", value)
             return False


### PR DESCRIPTION
## Description:

It looks like a revision of the 86sw fires a `long_click` event simultaneously with the `click` event. The event doesn't indicate a long press / useful information right now and should be ignored for the time being.

**Related issue (if applicable):** fixes #14694
