### PR TITLE
Read power state from AVR instead of relying on internal state.

### DIFF
--- a/homeassistant/components/media_player/denonavr.py
+++ b/homeassistant/components/media_player/denonavr.py
@@ -173,6 +173,10 @@ class DenonDevice(MediaPlayerDevice):
     @property
     def state(self):
         """Return the state of the device."""
+        if self._power == 'OFF':
+            return STATE_OFF
+        elif self._power == 'ON':
+            return self._state or STATE_ON
         return self._state
 
     @property


### PR DESCRIPTION
## Description:

Right now Home Assistant does not read the power state directly from of a Denon AVR. The power state of the device only gets updated when it is turned on and off through hass. Since the device can also be controlled directly (e.g. through the remote) it would be better to read the power state directly from the device if possible.

**Related issue (if applicable):**

fixes #14792

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
