### PR TITLE
Force update of zha remotes to make automation easier

### DIFF
--- a/homeassistant/components/binary_sensor/zha.py
+++ b/homeassistant/components/binary_sensor/zha.py
@@ -212,6 +212,10 @@ class Switch(zha.Entity, BinarySensorDevice):
         }
 
     @property
+    def force_update(self) -> bool:
+        return True
+
+    @property
     def should_poll(self) -> bool:
         """Let zha handle polling."""
         return False

--- a/homeassistant/components/binary_sensor/zha.py
+++ b/homeassistant/components/binary_sensor/zha.py
@@ -213,6 +213,7 @@ class Switch(zha.Entity, BinarySensorDevice):
 
     @property
     def force_update(self) -> bool:
+        """Force state updates."""
         return True
 
     @property


### PR DESCRIPTION
## Description:
Because these are "remotes" and not true switches each button press should result in a state change. This may not be necessary once zha supports groups. 

addresses: https://github.com/zigpy/zigpy/issues/55
