### PR TITLE
Ignore the mistaken long_both_click event of the 86sw (Closes: #14802)

### DIFF
--- a/homeassistant/components/binary_sensor/xiaomi_aqara.py
+++ b/homeassistant/components/binary_sensor/xiaomi_aqara.py
@@ -330,7 +330,7 @@ class XiaomiButton(XiaomiBinarySensor):
             click_type = 'both'
         elif value == 'shake':
             click_type = 'shake'
-        elif value == 'long_click':
+        elif value in ['long_click', 'long_both_click']:
             return False
         else:
             _LOGGER.warning("Unsupported click_type detected: %s", value)


### PR DESCRIPTION
**Related issue (if applicable):** fixes #14802