### PR TITLE
Action parameter doesn't longer have to be the first parameter

### DIFF
--- a/homeassistant/components/binary_sensor/mystrom.py
+++ b/homeassistant/components/binary_sensor/mystrom.py
@@ -29,6 +29,7 @@ class MyStromView(HomeAssistantView):
 
     url = '/api/mystrom'
     name = 'api:mystrom'
+    supported_actions = ['single', 'double', 'long', 'touch']
 
     def __init__(self, add_devices):
         """Initialize the myStrom URL endpoint."""
@@ -44,16 +45,21 @@ class MyStromView(HomeAssistantView):
     @asyncio.coroutine
     def _handle(self, hass, data):
         """Handle requests to the myStrom endpoint."""
-        button_action = list(data.keys())[0]
-        button_id = data[button_action]
-        entity_id = '{}.{}_{}'.format(DOMAIN, button_id, button_action)
+        button_action = None
+        parameter_list = list(data.keys())
+        for parameter in parameter_list:
+            if parameter in self.supported_actions:
+                button_action = parameter
+                break
 
-        if button_action not in ['single', 'double', 'long', 'touch']:
+        if button_action is None:
             _LOGGER.error(
                 "Received unidentified message from myStrom button: %s", data)
             return ("Received unidentified message: {}".format(data),
                     HTTP_UNPROCESSABLE_ENTITY)
 
+        button_id = data[button_action]
+        entity_id = '{}.{}_{}'.format(DOMAIN, button_id, button_action)
         if entity_id not in self.buttons:
             _LOGGER.info("New myStrom button/action detected: %s/%s",
                          button_id, button_action)

--- a/homeassistant/components/binary_sensor/mystrom.py
+++ b/homeassistant/components/binary_sensor/mystrom.py
@@ -45,12 +45,9 @@ class MyStromView(HomeAssistantView):
     @asyncio.coroutine
     def _handle(self, hass, data):
         """Handle requests to the myStrom endpoint."""
-        button_action = None
-        parameter_list = list(data.keys())
-        for parameter in parameter_list:
-            if parameter in self.supported_actions:
-                button_action = parameter
-                break
+        button_action = next((
+            parameter for parameter in data
+            if parameter in self.supported_actions), None)
 
         if button_action is None:
             _LOGGER.error(


### PR DESCRIPTION
## Description:
The component no longer asumes, that the first parameter is the desired action. Looks throw the list and takes the first acceptable action.
Previously if the api_password parameter was passed and it was the first in the list, the component didn't work.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5497

## Checklist:
  - [X] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

>couldn't test with tox, because tox command doesn't continue after `py35 installdeps:`
>but flake8, pylint, pydocstyle and py.test are passing

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
