### PR TITLE
netatmo api is now in pip as pyatmo

### DIFF
--- a/homeassistant/components/binary_sensor/netatmo.py
+++ b/homeassistant/components/binary_sensor/netatmo.py
@@ -68,12 +68,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     module_name = None
 
-    import lnetatmo
+    import pyatmo
     try:
         data = CameraData(netatmo.NETATMO_AUTH, home)
         if not data.get_camera_names():
             return None
-    except lnetatmo.NoDevice:
+    except pyatmo.NoDevice:
         return None
 
     welcome_sensors = config.get(

--- a/homeassistant/components/camera/netatmo.py
+++ b/homeassistant/components/camera/netatmo.py
@@ -35,7 +35,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     netatmo = hass.components.netatmo
     home = config.get(CONF_HOME)
     verify_ssl = config.get(CONF_VERIFY_SSL, True)
-    import lnetatmo
+    import pyatmo
     try:
         data = CameraData(netatmo.NETATMO_AUTH, home)
         for camera_name in data.get_camera_names():
@@ -46,7 +46,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                     continue
             add_devices([NetatmoCamera(data, camera_name, home,
                                        camera_type, verify_ssl)])
-    except lnetatmo.NoDevice:
+    except pyatmo.NoDevice:
         return None
 
 

--- a/homeassistant/components/climate/netatmo.py
+++ b/homeassistant/components/climate/netatmo.py
@@ -44,7 +44,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     netatmo = hass.components.netatmo
     device = config.get(CONF_RELAY)
 
-    import lnetatmo
+    import pyatmo
     try:
         data = ThermostatData(netatmo.NETATMO_AUTH, device)
         for module_name in data.get_module_names():
@@ -53,7 +53,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                    module_name not in config[CONF_THERMOSTAT]:
                     continue
             add_devices([NetatmoThermostat(data, module_name)], True)
-    except lnetatmo.NoDevice:
+    except pyatmo.NoDevice:
         return None
 
 
@@ -168,8 +168,8 @@ class ThermostatData(object):
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
         """Call the NetAtmo API to update the data."""
-        import lnetatmo
-        self.thermostatdata = lnetatmo.ThermostatData(self.auth)
+        import pyatmo
+        self.thermostatdata = pyatmo.ThermostatData(self.auth)
         self.target_temperature = self.thermostatdata.setpoint_temp
         self.setpoint_mode = self.thermostatdata.setpoint_mode
         self.current_temperature = self.thermostatdata.temp

--- a/homeassistant/components/netatmo.py
+++ b/homeassistant/components/netatmo.py
@@ -16,9 +16,7 @@ from homeassistant.helpers import discovery
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import Throttle
 
-REQUIREMENTS = [
-    'https://github.com/jabesq/netatmo-api-python/archive/'
-    'v0.9.2.1.zip#lnetatmo==0.9.2.1']
+REQUIREMENTS = ['pyatmo==1.0.0']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -45,11 +43,11 @@ CONFIG_SCHEMA = vol.Schema({
 
 def setup(hass, config):
     """Set up the Netatmo devices."""
-    import lnetatmo
+    import pyatmo
 
     global NETATMO_AUTH
     try:
-        NETATMO_AUTH = lnetatmo.ClientAuth(
+        NETATMO_AUTH = pyatmo.ClientAuth(
             config[DOMAIN][CONF_API_KEY], config[DOMAIN][CONF_SECRET_KEY],
             config[DOMAIN][CONF_USERNAME], config[DOMAIN][CONF_PASSWORD],
             'read_station read_camera access_camera '
@@ -111,8 +109,8 @@ class CameraData(object):
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
         """Call the Netatmo API to update the data."""
-        import lnetatmo
-        self.camera_data = lnetatmo.CameraData(self.auth, size=100)
+        import pyatmo
+        self.camera_data = pyatmo.CameraData(self.auth, size=100)
 
     @Throttle(MIN_TIME_BETWEEN_EVENT_UPDATES)
     def update_event(self):

--- a/homeassistant/components/sensor/netatmo.py
+++ b/homeassistant/components/sensor/netatmo.py
@@ -70,7 +70,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     data = NetAtmoData(netatmo.NETATMO_AUTH, config.get(CONF_STATION, None))
 
     dev = []
-    import lnetatmo
+    import pyatmo
     try:
         if CONF_MODULES in config:
             # Iterate each module
@@ -92,7 +92,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                     else:
                         _LOGGER.warning("Ignoring unknown var %s for mod %s",
                                         variable, module_name)
-    except lnetatmo.NoDevice:
+    except pyatmo.NoDevice:
         return None
 
     add_devices(dev, True)
@@ -305,8 +305,8 @@ class NetAtmoData(object):
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
         """Call the Netatmo API to update the data."""
-        import lnetatmo
-        self.station_data = lnetatmo.WeatherStationData(self.auth)
+        import pyatmo
+        self.station_data = pyatmo.WeatherStationData(self.auth)
 
         if self.station is not None:
             self.data = self.station_data.lastData(

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -412,9 +412,6 @@ https://github.com/aparraga/braviarc/archive/0.3.7.zip#braviarc==0.3.7
 # homeassistant.components.media_player.spotify
 https://github.com/happyleavesaoc/spotipy/archive/544614f4b1d508201d363e84e871f86c90aa26b2.zip#spotipy==2.4.4
 
-# homeassistant.components.netatmo
-https://github.com/jabesq/netatmo-api-python/archive/v0.9.2.1.zip#lnetatmo==0.9.2.1
-
 # homeassistant.components.neato
 https://github.com/jabesq/pybotvac/archive/v0.0.5.zip#pybotvac==0.0.5
 
@@ -729,6 +726,9 @@ pyasn1-modules==0.1.5
 
 # homeassistant.components.notify.xmpp
 pyasn1==0.3.7
+
+# homeassistant.components.netatmo
+pyatmo==1.0.0
 
 # homeassistant.components.apple_tv
 pyatv==0.3.10


### PR DESCRIPTION
my fork for netatmo api is now available on pypi

## Description:


## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
