### PR TITLE
Added Sleep Cycle compatibility in emulated-hue

### DIFF
--- a/homeassistant/components/emulated_hue/__init__.py
+++ b/homeassistant/components/emulated_hue/__init__.py
@@ -268,7 +268,7 @@ class Config(object):
 
         return is_default_exposed or expose
 
-    def entities_response_wrapper(self, json_response):
+    def json_response_dummy_wrapper(self, json_response):
         """Wrapper, adds dummy mac address for sleepcycle."""
         if self.type == TYPE_SLEEPCYCLE:
             return {'lights': json_response,

--- a/homeassistant/components/emulated_hue/__init__.py
+++ b/homeassistant/components/emulated_hue/__init__.py
@@ -44,7 +44,7 @@ CONF_ENTITY_HIDDEN = 'hidden'
 
 TYPE_ALEXA = 'alexa'
 TYPE_GOOGLE = 'google_home'
-TYPE_SLEEPCYCLE = 'sleepcycle'
+TYPE_SLEEPCYCLE = 'sleep_cycle'
 
 DEFAULT_LISTEN_PORT = 8300
 DEFAULT_UPNP_BIND_MULTICAST = True

--- a/homeassistant/components/emulated_hue/__init__.py
+++ b/homeassistant/components/emulated_hue/__init__.py
@@ -44,6 +44,7 @@ CONF_ENTITY_HIDDEN = 'hidden'
 
 TYPE_ALEXA = 'alexa'
 TYPE_GOOGLE = 'google_home'
+TYPE_SLEEPCYCLE = 'sleepcycle'
 
 DEFAULT_LISTEN_PORT = 8300
 DEFAULT_UPNP_BIND_MULTICAST = True
@@ -70,7 +71,7 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(CONF_EXPOSE_BY_DEFAULT): cv.boolean,
         vol.Optional(CONF_EXPOSED_DOMAINS): cv.ensure_list,
         vol.Optional(CONF_TYPE, default=DEFAULT_TYPE):
-            vol.Any(TYPE_ALEXA, TYPE_GOOGLE),
+            vol.Any(TYPE_ALEXA, TYPE_GOOGLE, TYPE_SLEEPCYCLE),
         vol.Optional(CONF_ENTITIES):
             vol.Schema({cv.entity_id: CONFIG_ENTITY_SCHEMA})
     })
@@ -266,6 +267,14 @@ class Config(object):
             domain_exposed_by_default and expose is not False
 
         return is_default_exposed or expose
+
+    def entities_response_wrapper(self, json_response):
+        """Wrapper, adds dummy mac address for sleepcycle."""
+        if self.type == TYPE_SLEEPCYCLE:
+            return {'lights': json_response,
+                    'config': {'mac': '00:00:00:00:00:00'}}
+
+        return json_response
 
 
 def _load_json(filename):

--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -105,7 +105,8 @@ class HueAllLightsStateView(HomeAssistantView):
                 json_response[number] = entity_to_json(
                     self.config, entity, state, brightness)
 
-        return self.json(self.config.json_response_dummy_wrapper(json_response))
+        json_response = self.config.json_response_dummy_wrapper(json_response)
+        return self.json(json_response)
 
 
 class HueOneLightStateView(HomeAssistantView):

--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -33,8 +33,13 @@ class HueUsernameView(HomeAssistantView):
 
     url = '/api'
     name = 'emulated_hue:api:create_username'
-    extra_urls = ['/api/']
+    extra_urls = ['/api/', '/api/(null)', '/api/(null)/']
     requires_auth = False
+
+    @asyncio.coroutine
+    def get(self, request):
+        """Handle a GET request."""
+        return self.json([{'success': {'username': '12345678901234567890'}}])
 
     @asyncio.coroutine
     def post(self, request):
@@ -79,6 +84,7 @@ class HueAllLightsStateView(HomeAssistantView):
 
     url = '/api/{username}/lights'
     name = 'emulated_hue:lights:state'
+    extra_urls = ['/api/{username}']
     requires_auth = False
 
     def __init__(self, config):
@@ -99,7 +105,7 @@ class HueAllLightsStateView(HomeAssistantView):
                 json_response[number] = entity_to_json(
                     self.config, entity, state, brightness)
 
-        return self.json(json_response)
+        return self.json(self.config.entities_response_wrapper(json_response))
 
 
 class HueOneLightStateView(HomeAssistantView):

--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -105,7 +105,7 @@ class HueAllLightsStateView(HomeAssistantView):
                 json_response[number] = entity_to_json(
                     self.config, entity, state, brightness)
 
-        return self.json(self.config.entities_response_wrapper(json_response))
+        return self.json(self.config.json_response_dummy_wrapper(json_response))
 
 
 class HueOneLightStateView(HomeAssistantView):


### PR DESCRIPTION
## Description: Added Sleep Cycle compatibility in emulated-hue
Not able to tested with alexa or google_home. 
Based on this [https://github.com/magicus/ha-local-echo](https://github.com/magicus/ha-local-echo) and on this discussion [https://community.home-assistant.io/t/getting-iphone-apps-that-support-hue-to-work-with-hue-emulator/4409](https://community.home-assistant.io/t/getting-iphone-apps-that-support-hue-to-work-with-hue-emulator/4409)


**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** 
home-assistant/home-assistant.github.io#5496

## Example entry for `configuration.yaml` (if applicable):
```yaml
emulated_hue:
  type: sleep_cycle
  listen_port: 80
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [x] Local tests pass with `tox`.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54