### PR TITLE
Fixes an issue in Xiaomi TV platform that would some TVs not sleep correctly

### DIFF
--- a/=0.1.4
+++ b/=0.1.4
@@ -1,2 +1,0 @@
-Collecting DTLSSocket
-  Using cached https://files.pythonhosted.org/packages/d3/4d/7bb7699aa4ba47e0b4287165ebaabca13461e17fafe7d2d99e3bfb2c3299/DTLSSocket-0.1.7.tar.gz

--- a/=0.1.4
+++ b/=0.1.4
@@ -1,0 +1,2 @@
+Collecting DTLSSocket
+  Using cached https://files.pythonhosted.org/packages/d3/4d/7bb7699aa4ba47e0b4287165ebaabca13461e17fafe7d2d99e3bfb2c3299/DTLSSocket-0.1.7.tar.gz

--- a/homeassistant/components/media_player/xiaomi_tv.py
+++ b/homeassistant/components/media_player/xiaomi_tv.py
@@ -13,7 +13,7 @@ from homeassistant.components.media_player import (
     SUPPORT_TURN_ON, SUPPORT_TURN_OFF, MediaPlayerDevice, PLATFORM_SCHEMA,
     SUPPORT_VOLUME_STEP)
 
-REQUIREMENTS = ['pymitv==1.0.0']
+REQUIREMENTS = ['pymitv==1.4.0']
 
 DEFAULT_NAME = "Xiaomi TV"
 
@@ -39,7 +39,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     if host is not None:
         # Check if there's a valid TV at the IP address.
-        if not Discover().checkIp(host):
+        if not Discover().check_ip(host):
             _LOGGER.error(
                 "Could not find Xiaomi TV with specified IP: %s", host
             )

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -797,7 +797,7 @@ pymailgunner==1.4
 pymediaroom==0.5
 
 # homeassistant.components.media_player.xiaomi_tv
-pymitv==1.0.0
+pymitv==1.4.0
 
 # homeassistant.components.mochad
 pymochad==0.2.0


### PR DESCRIPTION
## Description:
Some TVs would end up turning off instead of sleeping

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
