### PR TITLE
Migrate entity registry to using websocket

### DIFF
--- a/homeassistant/components/config/entity_registry.py
+++ b/homeassistant/components/config/entity_registry.py
@@ -2,48 +2,85 @@
 import voluptuous as vol
 
 from homeassistant.core import callback
-from homeassistant.components.http import HomeAssistantView
-from homeassistant.components.http.data_validator import RequestDataValidator
 from homeassistant.helpers.entity_registry import async_get_registry
+from homeassistant.components import websocket_api
+from homeassistant.helpers import config_validation as cv
+
+DEPENDENCIES = ['websocket_api']
+
+WS_TYPE_GET = 'config/entity_registry/get'
+SCHEMA_WS_GET = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend({
+    vol.Required('type'): WS_TYPE_GET,
+    vol.Required('entity_id'): cv.entity_id
+})
+
+WS_TYPE_UPDATE = 'config/entity_registry/update'
+SCHEMA_WS_UPDATE = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend({
+    vol.Required('type'): WS_TYPE_UPDATE,
+    vol.Required('entity_id'): cv.entity_id,
+    # If passed in, we update value. Passing None will remove old value.
+    vol.Optional('name'): vol.Any(str, None),
+})
 
 
 async def async_setup(hass):
     """Enable the Entity Registry views."""
-    hass.http.register_view(ConfigManagerEntityView)
+    hass.components.websocket_api.async_register_command(
+        WS_TYPE_GET, websocket_get_entity,
+        SCHEMA_WS_GET
+    )
+    hass.components.websocket_api.async_register_command(
+        WS_TYPE_UPDATE, websocket_update_entity,
+        SCHEMA_WS_UPDATE
+    )
     return True
 
 
-class ConfigManagerEntityView(HomeAssistantView):
-    """View to interact with an entity registry entry."""
+@callback
+def websocket_get_entity(hass, connection, msg):
+    """Handle get entity registry entry command.
 
-    url = '/api/config/entity_registry/{entity_id}'
-    name = 'api:config:entity_registry:entity'
-
-    async def get(self, request, entity_id):
-        """Get the entity registry settings for an entity."""
-        hass = request.app['hass']
+    Async friendly.
+    """
+    async def retrieve_entity():
+        """Get entity from registry."""
         registry = await async_get_registry(hass)
-        entry = registry.entities.get(entity_id)
+        entry = registry.entities.get(msg['entity_id'])
 
         if entry is None:
-            return self.json_message('Entry not found', 404)
+            connection.send_message_outside(websocket_api.error_message(
+                msg['id'], websocket_api.ERR_NOT_FOUND, 'Entity not found'))
+            return
 
-        return self.json(_entry_dict(entry))
+        connection.send_message_outside(websocket_api.result_message(
+            msg['id'], _entry_dict(entry)
+        ))
 
-    @RequestDataValidator(vol.Schema({
-        # If passed in, we update value. Passing None will remove old value.
-        vol.Optional('name'): vol.Any(str, None),
-    }))
-    async def post(self, request, entity_id, data):
-        """Update the entity registry settings for an entity."""
-        hass = request.app['hass']
+    hass.async_add_job(retrieve_entity())
+
+
+@callback
+def websocket_update_entity(hass, connection, msg):
+    """Handle get camera thumbnail websocket command.
+
+    Async friendly.
+    """
+    async def update_entity():
+        """Get entity from registry."""
         registry = await async_get_registry(hass)
 
-        if entity_id not in registry.entities:
-            return self.json_message('Entry not found', 404)
+        if msg['entity_id'] not in registry.entities:
+            connection.send_message_outside(websocket_api.error_message(
+                msg['id'], websocket_api.ERR_NOT_FOUND, 'Entity not found'))
+            return
 
-        entry = registry.async_update_entity(entity_id, **data)
-        return self.json(_entry_dict(entry))
+        entry = registry.async_update_entity(
+            msg['entity_id'], name=msg['name'])
+        connection.send_message_outside(websocket_api.result_message(
+            msg['id'], _entry_dict(entry)
+        ))
+
+    hass.async_add_job(update_entity())
 
 
 @callback

--- a/tests/components/config/test_entity_registry.py
+++ b/tests/components/config/test_entity_registry.py
@@ -8,11 +8,10 @@ from tests.common import mock_registry, MockEntity, MockEntityPlatform
 
 
 @pytest.fixture
-def client(hass, aiohttp_client):
+def client(hass, hass_ws_client):
     """Fixture that can interact with the config manager API."""
-    hass.loop.run_until_complete(async_setup_component(hass, 'http', {}))
     hass.loop.run_until_complete(entity_registry.async_setup(hass))
-    yield hass.loop.run_until_complete(aiohttp_client(hass.http.app))
+    yield hass.loop.run_until_complete(hass_ws_client(hass))
 
 
 async def test_get_entity(hass, client):
@@ -31,20 +30,26 @@ async def test_get_entity(hass, client):
         ),
     })
 
-    resp = await client.get(
-        '/api/config/entity_registry/test_domain.name')
-    assert resp.status == 200
-    data = await resp.json()
-    assert data == {
+    await client.send_json({
+        'id': 5,
+        'type': 'config/entity_registry/get',
+        'entity_id': 'test_domain.name',
+    })
+    msg = await client.receive_json()
+
+    assert msg['result'] == {
         'entity_id': 'test_domain.name',
         'name': 'Hello World'
     }
 
-    resp = await client.get(
-        '/api/config/entity_registry/test_domain.no_name')
-    assert resp.status == 200
-    data = await resp.json()
-    assert data == {
+    await client.send_json({
+        'id': 6,
+        'type': 'config/entity_registry/get',
+        'entity_id': 'test_domain.no_name',
+    })
+    msg = await client.receive_json()
+
+    assert msg['result'] == {
         'entity_id': 'test_domain.no_name',
         'name': None
     }
@@ -69,13 +74,16 @@ async def test_update_entity(hass, client):
     assert state is not None
     assert state.name == 'before update'
 
-    resp = await client.post(
-        '/api/config/entity_registry/test_domain.world', json={
-            'name': 'after update'
-        })
-    assert resp.status == 200
-    data = await resp.json()
-    assert data == {
+    await client.send_json({
+        'id': 6,
+        'type': 'config/entity_registry/update',
+        'entity_id': 'test_domain.world',
+        'name': 'after update',
+    })
+
+    msg = await client.receive_json()
+
+    assert msg['result'] == {
         'entity_id': 'test_domain.world',
         'name': 'after update'
     }
@@ -103,13 +111,16 @@ async def test_update_entity_no_changes(hass, client):
     assert state is not None
     assert state.name == 'name of entity'
 
-    resp = await client.post(
-        '/api/config/entity_registry/test_domain.world', json={
-            'name': 'name of entity'
-        })
-    assert resp.status == 200
-    data = await resp.json()
-    assert data == {
+    await client.send_json({
+        'id': 6,
+        'type': 'config/entity_registry/update',
+        'entity_id': 'test_domain.world',
+        'name': 'name of entity',
+    })
+
+    msg = await client.receive_json()
+
+    assert msg['result'] == {
         'entity_id': 'test_domain.world',
         'name': 'name of entity'
     }
@@ -120,15 +131,24 @@ async def test_update_entity_no_changes(hass, client):
 
 async def test_get_nonexisting_entity(client):
     """Test get entry."""
-    resp = await client.get(
-        '/api/config/entity_registry/test_domain.non_existing')
-    assert resp.status == 404
+    await client.send_json({
+        'id': 6,
+        'type': 'config/entity_registry/get',
+        'entity_id': 'test_domain.no_name',
+    })
+    msg = await client.receive_json()
+
+    assert not msg['success']
 
 
 async def test_update_nonexisting_entity(client):
     """Test get entry."""
-    resp = await client.post(
-        '/api/config/entity_registry/test_domain.non_existing', json={
-            'name': 'some name'
-        })
-    assert resp.status == 404
+    await client.send_json({
+        'id': 6,
+        'type': 'config/entity_registry/update',
+        'entity_id': 'test_domain.no_name',
+        'name': 'new-name'
+    })
+    msg = await client.receive_json()
+
+    assert not msg['success']

--- a/tests/components/config/test_entity_registry.py
+++ b/tests/components/config/test_entity_registry.py
@@ -1,7 +1,6 @@
 """Test entity_registry API."""
 import pytest
 
-from homeassistant.setup import async_setup_component
 from homeassistant.helpers.entity_registry import RegistryEntry
 from homeassistant.components.config import entity_registry
 from tests.common import mock_registry, MockEntity, MockEntityPlatform


### PR DESCRIPTION
## Description:
Move entity registry API from HTTP to WebSocket.

Frontend PR: https://github.com/home-assistant/home-assistant-polymer/pull/1261

## Example entry for `configuration.yaml` (if applicable):
```yaml
frontend:
config:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
