### PR TITLE
Limit to 3 decimals (fixes #14773)

### DIFF
--- a/homeassistant/components/sensor/simulated.py
+++ b/homeassistant/components/sensor/simulated.py
@@ -100,7 +100,7 @@ class SimulatedSensor(Entity):
         else:
             periodic = amp * (math.sin((2*math.pi*time_delta/period) + phase))
         noise = self._random.gauss(mu=0, sigma=fwhm)
-        return mean + periodic + noise
+        return round(mean + periodic + noise, 3)
 
     async def async_update(self):
         """Update the sensor."""

--- a/tests/components/sensor/test_simulated.py
+++ b/tests/components/sensor/test_simulated.py
@@ -1,13 +1,14 @@
 """The tests for the simulated sensor."""
 import unittest
 
+from tests.common import get_test_home_assistant
+
 from homeassistant.components.sensor.simulated import (
-    CONF_UNIT, CONF_AMP, CONF_MEAN, CONF_PERIOD, CONF_PHASE, CONF_FWHM,
-    CONF_SEED, DEFAULT_NAME, DEFAULT_AMP, DEFAULT_MEAN,
-    DEFAULT_PHASE, DEFAULT_FWHM, DEFAULT_SEED)
+    CONF_AMP, CONF_FWHM, CONF_MEAN, CONF_PERIOD, CONF_PHASE, CONF_SEED,
+    CONF_UNIT, DEFAULT_AMP, DEFAULT_FWHM, DEFAULT_MEAN, DEFAULT_NAME,
+    DEFAULT_PHASE, DEFAULT_SEED)
 from homeassistant.const import CONF_FRIENDLY_NAME
 from homeassistant.setup import setup_component
-from tests.common import get_test_home_assistant
 
 
 class TestSimulatedSensor(unittest.TestCase):
@@ -27,24 +28,17 @@ class TestSimulatedSensor(unittest.TestCase):
             'sensor': {
                 'platform': 'simulated'}
         }
-        self.assertTrue(
-            setup_component(self.hass, 'sensor', config))
+        self.assertTrue(setup_component(self.hass, 'sensor', config))
         self.hass.block_till_done()
+
         assert len(self.hass.states.entity_ids()) == 1
         state = self.hass.states.get('sensor.simulated')
-        assert state.attributes.get(
-            CONF_FRIENDLY_NAME) == DEFAULT_NAME
-        assert state.attributes.get(
-            CONF_AMP) == DEFAULT_AMP
-        assert state.attributes.get(
-            CONF_UNIT) is None
-        assert state.attributes.get(
-            CONF_MEAN) == DEFAULT_MEAN
-        assert state.attributes.get(
-            CONF_PERIOD) == 60.0
-        assert state.attributes.get(
-            CONF_PHASE) == DEFAULT_PHASE
-        assert state.attributes.get(
-            CONF_FWHM) == DEFAULT_FWHM
-        assert state.attributes.get(
-            CONF_SEED) == DEFAULT_SEED
+
+        assert state.attributes.get(CONF_FRIENDLY_NAME) == DEFAULT_NAME
+        assert state.attributes.get(CONF_AMP) == DEFAULT_AMP
+        assert state.attributes.get(CONF_UNIT) is None
+        assert state.attributes.get(CONF_MEAN) == DEFAULT_MEAN
+        assert state.attributes.get(CONF_PERIOD) == 60.0
+        assert state.attributes.get(CONF_PHASE) == DEFAULT_PHASE
+        assert state.attributes.get(CONF_FWHM) == DEFAULT_FWHM
+        assert state.attributes.get(CONF_SEED) == DEFAULT_SEED


### PR DESCRIPTION
## Description:
Limit the state to 3 decimals as discussed in #14773.

**Related issue (if applicable):** fixes #14773

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5499

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: simulated
    name: Simulated relative humidity
    unit: '%'
    amplitude: 0 # Turns off the periodic contribution
    mean: 50
    spread: 10
    seed: 999
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)
