### PR TITLE
Feature/gearbest library update

### DIFF
--- a/homeassistant/components/sensor/gearbest.py
+++ b/homeassistant/components/sensor/gearbest.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import track_time_interval
 from homeassistant.const import (CONF_NAME, CONF_ID, CONF_URL, CONF_CURRENCY)
 
-REQUIREMENTS = ['gearbest_parser==1.0.6']
+REQUIREMENTS = ['gearbest_parser==1.0.7']
 _LOGGER = logging.getLogger(__name__)
 
 CONF_ITEMS = 'items'

--- a/homeassistant/components/sensor/gearbest.py
+++ b/homeassistant/components/sensor/gearbest.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import track_time_interval
 from homeassistant.const import (CONF_NAME, CONF_ID, CONF_URL, CONF_CURRENCY)
 
-REQUIREMENTS = ['gearbest_parser==1.0.5']
+REQUIREMENTS = ['gearbest_parser==1.0.6']
 _LOGGER = logging.getLogger(__name__)
 
 CONF_ITEMS = 'items'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -344,7 +344,7 @@ gTTS-token==1.1.1
 # gattlib==0.20150805
 
 # homeassistant.components.sensor.gearbest
-gearbest_parser==1.0.5
+gearbest_parser==1.0.7
 
 # homeassistant.components.sensor.gitter
 gitterpy==0.1.7


### PR DESCRIPTION
## Description:
Due to a change on the gearbest website the currency converter was not working anymore, I've updated the gearbest_parser.py library, made it failsafe (in case they change it again it will not convert but rather display the original USD price).

**Related issue (if applicable):** fixes #14813

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. 

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
