### PR TITLE
WorxLandroid always shows moving as state.

### DIFF
--- a/homeassistant/components/sensor/worxlandroid.py
+++ b/homeassistant/components/sensor/worxlandroid.py
@@ -1,5 +1,6 @@
 """
 Support for Worx Landroid mower.
+
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.worxlandroid/
 """
@@ -32,12 +33,14 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int,
 })
 
+
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices,
                          discovery_info=None):
     """Set up the Worx Landroid sensors."""
     for typ in ('battery', 'state', 'error', 'battchargestate'):
         async_add_devices([WorxLandroidSensor(typ, config)])
+
 
 class WorxLandroidSensor(Entity):
     """Implementation of a Worx Landroid sensor."""

--- a/homeassistant/components/sensor/worxlandroid.py
+++ b/homeassistant/components/sensor/worxlandroid.py
@@ -57,15 +57,15 @@ class WorxLandroidSensor(Entity):
         """Return the name of the sensor."""
         if self.sensor == 'battery':
             return 'WorxLandroid - Battery'
-            
+
         # sensor state
         elif self.sensor == 'state':
             return 'WorxLandroid - State'
-            
+
         # sensor error
         elif self.sensor == 'error':
             return 'WorxLandroid - Error'
-            
+
         # sensor battery charger state
         elif self.sensor == 'battchargestate':
             return 'WorxLandroid - BatteryChargerState'
@@ -122,12 +122,12 @@ class WorxLandroidSensor(Entity):
             # sensor error
             elif self.sensor == 'error':
                 self._state = data['message']
-                #self._state = 'no' if self.get_error(data) is None else 'yes'
-                
+#                self._state = 'no' if self.get_error(data) is None else 'yes'
+
             # sensor battery charger state
             elif self.sensor == 'battchargestate':
                 self._state = data['batteryChargerState']
-                
+
         else:
             if self.sensor == 'error':
                 self._state = 'no'
@@ -136,30 +136,30 @@ class WorxLandroidSensor(Entity):
     def icon(self):
         """Icon to use in the frontend."""
         if self.sensor == 'battery':
-            
+
             if self._state == '100':
                 return 'mdi:battery'
-            
+
             elif self._state > '80':
                 return 'mdi:battery-80'
-            
+
             elif self._state > '60':
                 return 'mdi:battery-60'
-            
+
             elif self._state > '40':
                 return 'mdi:battery-40'
-            
+
             elif self._state > '20':
                 return 'mdi:battery-20'
-                
+
         # sensor state
         elif self.sensor == 'state':
             return 'mdi:robot-vacuum'
-            
+
         # sensor error
         elif self.sensor == 'error':
             return 'mdi:alert-circle-outline'
-            
+
         # sensor battery charger state
         elif self.sensor == 'battchargestate':
             return 'mdi:battery-charging-30'


### PR DESCRIPTION
Fix to show correct state, also implemented two extra sensors "error" and "batteryChargerState".
Add icons for these sensor etc..

## Description:

**Related issue (if applicable):** fixes #455

## Example entry for `configuration.yaml` (if applicable):
```
sensor:
  - platform: worxlandroid
    host: !secret worxlandorid_IP
    pin: !secret worxlandroid
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
