### PR TITLE
Epson projector support

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -490,6 +490,7 @@ omit =
     homeassistant/components/media_player/directv.py
     homeassistant/components/media_player/dunehd.py
     homeassistant/components/media_player/emby.py
+    homeassistant/components/media_player/epson.py
     homeassistant/components/media_player/firetv.py
     homeassistant/components/media_player/frontier_silicon.py
     homeassistant/components/media_player/gpmdp.py

--- a/homeassistant/components/media_player/epson.py
+++ b/homeassistant/components/media_player/epson.py
@@ -1,0 +1,245 @@
+"""
+Support for Epson projector.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/media_player.epson/
+"""
+import asyncio
+import logging
+
+import aiohttp
+import voluptuous as vol
+from homeassistant.components.media_player import (
+    DOMAIN, MEDIA_PLAYER_SCHEMA, PLATFORM_SCHEMA, SUPPORT_NEXT_TRACK,
+    SUPPORT_PREVIOUS_TRACK, SUPPORT_SELECT_SOURCE, SUPPORT_TURN_OFF,
+    SUPPORT_TURN_ON, SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_STEP,
+    MediaPlayerDevice)
+from homeassistant.const import (
+    ATTR_ENTITY_ID, CONF_HOST, CONF_NAME, CONF_PORT, CONF_SSL, STATE_OFF,
+    STATE_ON)
+from homeassistant.exceptions import PlatformNotReady
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+import homeassistant.helpers.config_validation as cv
+
+
+REQUIREMENTS = ['epson-projector==0.1.1']
+
+DATA_EPSON = 'epson'
+DEFAULT_NAME = 'EPSON Projector'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_HOST): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_PORT, default=80): cv.port,
+    vol.Optional(CONF_SSL, default=False): cv.boolean
+})
+
+ATTR_CMODE = 'cmode'
+SUPPORT_CMODE = 33001
+
+SUPPORT_EPSON = SUPPORT_TURN_ON | SUPPORT_TURN_OFF | SUPPORT_SELECT_SOURCE |\
+            SUPPORT_CMODE | SUPPORT_VOLUME_MUTE | SUPPORT_VOLUME_STEP | \
+            SUPPORT_NEXT_TRACK | SUPPORT_PREVIOUS_TRACK
+
+EPSON_SCHEMA = MEDIA_PLAYER_SCHEMA.extend({
+    vol.Required(ATTR_ENTITY_ID): cv.entity_id,
+    vol.Optional(ATTR_CMODE): cv.string
+})
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_platform(
+        hass,
+        config,
+        async_add_devices,
+        discovery_info=None):
+    """Set up the Epson media player platform."""
+    if DATA_EPSON not in hass.data:
+        hass.data[DATA_EPSON] = []
+    name = config.get(CONF_NAME)
+    host = config.get(CONF_HOST)
+
+    try:
+        epson = EpsonProjector(
+            hass, name, host,
+            config.get(CONF_PORT), config.get(CONF_SSL))
+        await epson.update()
+    except (aiohttp.client_exceptions.ClientConnectorError,
+            asyncio.TimeoutError):
+        raise PlatformNotReady
+    if epson:
+        hass.data[DATA_EPSON].append(epson)
+        async_add_devices([epson], update_before_add=True)
+
+    async def async_service_handler(service):
+        """Handle for services."""
+        from epson_projector.const import (CMODE_LIST_SET)
+        entity_ids = service.data.get(ATTR_ENTITY_ID)
+        if entity_ids:
+            devices = [device for device in hass.data[DATA_EPSON]
+                       if device.entity_id in entity_ids]
+        else:
+            devices = hass.data[DATA_EPSON]
+        for device in devices:
+            if service.service == ATTR_CMODE:
+                cmode = service.data.get(ATTR_CMODE).lower()
+                if cmode in CMODE_LIST_SET:
+                    await device.select_cmode(cmode)
+            await device.update()
+    hass.services.async_register(
+        DOMAIN, ATTR_CMODE, async_service_handler,
+        schema=EPSON_SCHEMA)
+    return True
+
+
+class EpsonProjector(MediaPlayerDevice):
+    """Representation of Epson Projector Device."""
+
+    def __init__(self, hass, name, host, port, encryption):
+        """Initialize entity to control Epson projector."""
+        self._hass = hass
+        self._name = name
+        import epson_projector as epson
+        from epson_projector.const import DEFAULT_SOURCES
+        self._projector = epson.Projector(
+            host,
+            websession=self._websession(False),
+            port=port)
+
+        self._cmode = None
+        self._source_list = list(DEFAULT_SOURCES.values())
+        self._source = None
+        self._volume = None
+
+        self._state = None
+
+    def _websession(self, verify_ssl):
+        """Return a websession."""
+        return async_get_clientsession(self._hass, verify_ssl)
+
+    async def update(self):
+        """Update state of device."""
+        from epson_projector.const import (
+            EPSON_CODES, POWER,
+            CMODE, CMODE_LIST, SOURCE, VOLUME,
+            BUSY, SOURCE_LIST)
+        is_turned_on = await self._projector.get_property(POWER)
+        _LOGGER.debug("Is turned on %s", is_turned_on)
+        if is_turned_on and is_turned_on == EPSON_CODES[POWER]:
+            self._state = STATE_ON
+            cmode = await self._projector.get_property(CMODE)
+            if cmode and cmode in CMODE_LIST:
+                self._cmode = CMODE_LIST[cmode]
+            source = await self._projector.get_property(SOURCE)
+            if source and source in SOURCE_LIST:
+                self._source = SOURCE_LIST[source]
+            volume = await self._projector.get_property(VOLUME)
+            if volume:
+                self._volume = volume
+        elif is_turned_on == BUSY:
+            self._state = STATE_ON
+        else:
+            self._state = STATE_OFF
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the device."""
+        return self._state
+
+    @property
+    def supported_features(self):
+        """Flag media player features that are supported."""
+        return SUPPORT_EPSON
+
+    async def async_turn_on(self):
+        """Turn on epson."""
+        from epson_projector.const import TURN_ON
+        return await self._projector.send_command(TURN_ON)
+
+    async def async_turn_off(self):
+        """Turn off epson."""
+        from epson_projector.const import TURN_OFF
+        return await self._projector.send_command(TURN_OFF)
+
+    @property
+    def source_list(self):
+        """List of available input sources."""
+        return self._source_list
+
+    @property
+    def source(self):
+        """Get current input sources."""
+        return self._source
+
+    @property
+    def cmode(self):
+        """Get CMODE/color mode from Epson."""
+        return self._cmode
+
+    @property
+    def volume_level(self):
+        """Return the volume level of the media player (0..1)."""
+        return self._volume
+
+    async def select_cmode(self, cmode):
+        """Set color mode in Epson."""
+        from epson_projector.const import (CMODE_LIST_SET)
+        if cmode in CMODE_LIST_SET:
+            return await self._projector.send_command(CMODE_LIST_SET[cmode])
+
+    async def async_select_source(self, source):
+        """Select input source."""
+        _LOGGER.debug("select source")
+        from epson_projector.const import INV_SOURCES
+        selected_source = INV_SOURCES[source]
+        return await self._projector.send_command(selected_source)
+
+    async def async_mute_volume(self, mute):
+        """Mute (true) or unmute (false) sound."""
+        from epson_projector.const import MUTE
+        return await self._projector.send_command(MUTE)
+
+    async def async_volume_up(self):
+        """Increase volume."""
+        _LOGGER.debug("volume up")
+        from epson_projector.const import VOL_UP
+        return await self._projector.send_command(VOL_UP)
+
+    async def async_volume_down(self):
+        """Decrease volume."""
+        from epson_projector.const import VOL_DOWN
+        return await self._projector.send_command(VOL_DOWN)
+
+    async def async_media_play(self):
+        """Play media via Epson."""
+        from epson_projector.const import PLAY
+        return await self._projector.send_command(PLAY)
+
+    async def async_media_pause(self):
+        """Pause media via Epson."""
+        from epson_projector.const import PAUSE
+        return await self._projector.send_command(PAUSE)
+
+    async def async_media_next_track(self):
+        """Skip to next."""
+        from epson_projector.const import FAST
+        return await self._projector.send_command(FAST)
+
+    async def async_media_previous_track(self):
+        """Skip to previous."""
+        from epson_projector.const import BACK
+        return await self._projector.send_command(BACK)
+
+    @property
+    def device_state_attributes(self):
+        """Return device specific state attributes."""
+        attributes = {}
+        if self._cmode is not None:
+            attributes[ATTR_CMODE] = self._cmode
+        return attributes

--- a/homeassistant/components/media_player/epson.py
+++ b/homeassistant/components/media_player/epson.py
@@ -30,7 +30,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_SSL, default=False): cv.boolean
 })
 
-SERVICE_ATTR_CMODE = 'epson_select_cmode'
+SERVICE_SELECT_CMODE = 'epson_select_cmode'
 ATTR_CMODE = 'cmode'
 SUPPORT_CMODE = 33001
 
@@ -63,7 +63,7 @@ async def async_setup_platform(hass, config, async_add_devices,
         else:
             devices = hass.data[DATA_EPSON]
         for device in devices:
-            if service.service == SERVICE_ATTR_CMODE:
+            if service.service == SERVICE_SELECT_CMODE:
                 cmode = service.data.get(ATTR_CMODE)
                 await device.select_cmode(cmode)
             await device.update()
@@ -72,7 +72,7 @@ async def async_setup_platform(hass, config, async_add_devices,
         vol.Required(ATTR_CMODE): vol.All(cv.string, vol.Any(*CMODE_LIST_SET))
     })
     hass.services.async_register(
-        DOMAIN, SERVICE_ATTR_CMODE, async_service_handler,
+        DOMAIN, SERVICE_SELECT_CMODE, async_service_handler,
         schema=epson_schema)
 
 

--- a/homeassistant/components/media_player/epson.py
+++ b/homeassistant/components/media_player/epson.py
@@ -4,11 +4,8 @@ Support for Epson projector.
 For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/media_player.epson/
 """
-import asyncio
 import logging
 
-import aiohttp
-import voluptuous as vol
 from homeassistant.components.media_player import (
     DOMAIN, MEDIA_PLAYER_SCHEMA, PLATFORM_SCHEMA, SUPPORT_NEXT_TRACK,
     SUPPORT_PREVIOUS_TRACK, SUPPORT_SELECT_SOURCE, SUPPORT_TURN_OFF,
@@ -17,12 +14,11 @@ from homeassistant.components.media_player import (
 from homeassistant.const import (
     ATTR_ENTITY_ID, CONF_HOST, CONF_NAME, CONF_PORT, CONF_SSL, STATE_OFF,
     STATE_ON)
-from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
+import voluptuous as vol
 
-
-REQUIREMENTS = ['epson-projector==0.1.1']
+REQUIREMENTS = ['epson-projector==0.1.3']
 
 DATA_EPSON = 'epson'
 DEFAULT_NAME = 'EPSON Projector'
@@ -34,18 +30,13 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_SSL, default=False): cv.boolean
 })
 
+SERVICE_ATTR_CMODE = 'epson_cmode'
 ATTR_CMODE = 'cmode'
 SUPPORT_CMODE = 33001
 
 SUPPORT_EPSON = SUPPORT_TURN_ON | SUPPORT_TURN_OFF | SUPPORT_SELECT_SOURCE |\
             SUPPORT_CMODE | SUPPORT_VOLUME_MUTE | SUPPORT_VOLUME_STEP | \
             SUPPORT_NEXT_TRACK | SUPPORT_PREVIOUS_TRACK
-
-EPSON_SCHEMA = MEDIA_PLAYER_SCHEMA.extend({
-    vol.Required(ATTR_ENTITY_ID): cv.entity_id,
-    vol.Optional(ATTR_CMODE): cv.string
-})
-
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -60,14 +51,11 @@ async def async_setup_platform(
     name = config.get(CONF_NAME)
     host = config.get(CONF_HOST)
 
-    try:
-        epson = EpsonProjector(
-            hass, name, host,
-            config.get(CONF_PORT), config.get(CONF_SSL))
-        await epson.update()
-    except (aiohttp.client_exceptions.ClientConnectorError,
-            asyncio.TimeoutError):
-        raise PlatformNotReady
+    epson = EpsonProjector(
+        async_get_clientsession(hass, verify_ssl=False),
+        name, host,
+        config.get(CONF_PORT), config.get(CONF_SSL))
+    await epson.update()
     if epson:
         hass.data[DATA_EPSON].append(epson)
         async_add_devices([epson], update_before_add=True)
@@ -82,13 +70,17 @@ async def async_setup_platform(
         else:
             devices = hass.data[DATA_EPSON]
         for device in devices:
-            if service.service == ATTR_CMODE:
-                cmode = service.data.get(ATTR_CMODE).lower()
+            if service.service == SERVICE_ATTR_CMODE:
+                cmode = service.data.get(SERVICE_ATTR_CMODE)
                 if cmode in CMODE_LIST_SET:
                     await device.select_cmode(cmode)
             await device.update()
+    from epson_projector.const import (CMODE_LIST_SET)
+    EPSON_SCHEMA = MEDIA_PLAYER_SCHEMA.extend({
+        vol.Required(ATTR_CMODE): vol.All(cv.string, vol.Any(*CMODE_LIST_SET))
+    })
     hass.services.async_register(
-        DOMAIN, ATTR_CMODE, async_service_handler,
+        DOMAIN, SERVICE_ATTR_CMODE, async_service_handler,
         schema=EPSON_SCHEMA)
     return True
 
@@ -96,27 +88,20 @@ async def async_setup_platform(
 class EpsonProjector(MediaPlayerDevice):
     """Representation of Epson Projector Device."""
 
-    def __init__(self, hass, name, host, port, encryption):
+    def __init__(self, websession, name, host, port, encryption):
         """Initialize entity to control Epson projector."""
-        self._hass = hass
         self._name = name
         import epson_projector as epson
         from epson_projector.const import DEFAULT_SOURCES
         self._projector = epson.Projector(
             host,
-            websession=self._websession(False),
+            websession=websession,
             port=port)
-
         self._cmode = None
         self._source_list = list(DEFAULT_SOURCES.values())
         self._source = None
         self._volume = None
-
         self._state = None
-
-    def _websession(self, verify_ssl):
-        """Return a websession."""
-        return async_get_clientsession(self._hass, verify_ssl)
 
     async def update(self):
         """Update state of device."""
@@ -130,10 +115,10 @@ class EpsonProjector(MediaPlayerDevice):
             self._state = STATE_ON
             cmode = await self._projector.get_property(CMODE)
             if cmode and cmode in CMODE_LIST:
-                self._cmode = CMODE_LIST[cmode]
+                self._cmode = CMODE_LIST.get(cmode, self._cmode).lower()
             source = await self._projector.get_property(SOURCE)
             if source and source in SOURCE_LIST:
-                self._source = SOURCE_LIST[source]
+                self._source = SOURCE_LIST.get(source, self._source)
             volume = await self._projector.get_property(VOLUME)
             if volume:
                 self._volume = volume
@@ -160,12 +145,12 @@ class EpsonProjector(MediaPlayerDevice):
     async def async_turn_on(self):
         """Turn on epson."""
         from epson_projector.const import TURN_ON
-        return await self._projector.send_command(TURN_ON)
+        await self._projector.send_command(TURN_ON)
 
     async def async_turn_off(self):
         """Turn off epson."""
         from epson_projector.const import TURN_OFF
-        return await self._projector.send_command(TURN_OFF)
+        await self._projector.send_command(TURN_OFF)
 
     @property
     def source_list(self):
@@ -190,56 +175,55 @@ class EpsonProjector(MediaPlayerDevice):
     async def select_cmode(self, cmode):
         """Set color mode in Epson."""
         from epson_projector.const import (CMODE_LIST_SET)
-        if cmode in CMODE_LIST_SET:
-            return await self._projector.send_command(CMODE_LIST_SET[cmode])
+        await self._projector.send_command(CMODE_LIST_SET[cmode])
 
     async def async_select_source(self, source):
         """Select input source."""
         _LOGGER.debug("select source")
         from epson_projector.const import INV_SOURCES
         selected_source = INV_SOURCES[source]
-        return await self._projector.send_command(selected_source)
+        await self._projector.send_command(selected_source)
 
     async def async_mute_volume(self, mute):
         """Mute (true) or unmute (false) sound."""
         from epson_projector.const import MUTE
-        return await self._projector.send_command(MUTE)
+        await self._projector.send_command(MUTE)
 
     async def async_volume_up(self):
         """Increase volume."""
         _LOGGER.debug("volume up")
         from epson_projector.const import VOL_UP
-        return await self._projector.send_command(VOL_UP)
+        await self._projector.send_command(VOL_UP)
 
     async def async_volume_down(self):
         """Decrease volume."""
         from epson_projector.const import VOL_DOWN
-        return await self._projector.send_command(VOL_DOWN)
+        await self._projector.send_command(VOL_DOWN)
 
     async def async_media_play(self):
         """Play media via Epson."""
         from epson_projector.const import PLAY
-        return await self._projector.send_command(PLAY)
+        await self._projector.send_command(PLAY)
 
     async def async_media_pause(self):
         """Pause media via Epson."""
         from epson_projector.const import PAUSE
-        return await self._projector.send_command(PAUSE)
+        await self._projector.send_command(PAUSE)
 
     async def async_media_next_track(self):
         """Skip to next."""
         from epson_projector.const import FAST
-        return await self._projector.send_command(FAST)
+        await self._projector.send_command(FAST)
 
     async def async_media_previous_track(self):
         """Skip to previous."""
         from epson_projector.const import BACK
-        return await self._projector.send_command(BACK)
+        await self._projector.send_command(BACK)
 
     @property
     def device_state_attributes(self):
         """Return device specific state attributes."""
         attributes = {}
         if self._cmode is not None:
-            attributes[ATTR_CMODE] = self._cmode
+            attributes[SERVICE_ATTR_CMODE] = self._cmode
         return attributes

--- a/homeassistant/components/media_player/epson.py
+++ b/homeassistant/components/media_player/epson.py
@@ -5,6 +5,7 @@ For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/media_player.epson/
 """
 import logging
+import voluptuous as vol
 
 from homeassistant.components.media_player import (
     DOMAIN, MEDIA_PLAYER_SCHEMA, PLATFORM_SCHEMA, SUPPORT_NEXT_TRACK,
@@ -16,7 +17,6 @@ from homeassistant.const import (
     STATE_ON)
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
-import voluptuous as vol
 
 REQUIREMENTS = ['epson-projector==0.1.3']
 
@@ -115,7 +115,7 @@ class EpsonProjector(MediaPlayerDevice):
             self._state = STATE_ON
             cmode = await self._projector.get_property(CMODE)
             if cmode and cmode in CMODE_LIST:
-                self._cmode = CMODE_LIST.get(cmode, self._cmode).lower()
+                self._cmode = CMODE_LIST.get(cmode, self._cmode)
             source = await self._projector.get_property(SOURCE)
             if source and source in SOURCE_LIST:
                 self._source = SOURCE_LIST.get(source, self._source)
@@ -161,11 +161,6 @@ class EpsonProjector(MediaPlayerDevice):
     def source(self):
         """Get current input sources."""
         return self._source
-
-    @property
-    def cmode(self):
-        """Get CMODE/color mode from Epson."""
-        return self._cmode
 
     @property
     def volume_level(self):

--- a/homeassistant/components/media_player/epson.py
+++ b/homeassistant/components/media_player/epson.py
@@ -76,12 +76,12 @@ async def async_setup_platform(
                     await device.select_cmode(cmode)
             await device.update()
     from epson_projector.const import (CMODE_LIST_SET)
-    EPSON_SCHEMA = MEDIA_PLAYER_SCHEMA.extend({
+    epson_schema = MEDIA_PLAYER_SCHEMA.extend({
         vol.Required(ATTR_CMODE): vol.All(cv.string, vol.Any(*CMODE_LIST_SET))
     })
     hass.services.async_register(
         DOMAIN, SERVICE_ATTR_CMODE, async_service_handler,
-        schema=EPSON_SCHEMA)
+        schema=epson_schema)
     return True
 
 

--- a/homeassistant/components/media_player/services.yaml
+++ b/homeassistant/components/media_player/services.yaml
@@ -423,7 +423,7 @@ blackbird_set_all_zones:
       description: Name of source to switch to.
       example: 'Source 1'
 
-epson_cmode:
+epson_select_cmode:
   description: Select Color mode of Epson projector
   fields:
     entity_id:

--- a/homeassistant/components/media_player/services.yaml
+++ b/homeassistant/components/media_player/services.yaml
@@ -422,3 +422,13 @@ blackbird_set_all_zones:
     source:
       description: Name of source to switch to.
       example: 'Source 1'
+
+epson_cmode:
+  description: Select Color mode of Epson projector
+  fields:
+    entity_id:
+      description: Name of projector
+      example: 'media_player.epson_projector'
+    cmode:
+      description: Name of Cmode
+      example: 'cinema'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -295,7 +295,7 @@ enocean==0.40
 ephem==3.7.6.0
 
 # homeassistant.components.media_player.epson
-epson-projector==0.1.1
+epson-projector==0.1.3
 
 # homeassistant.components.netgear_lte
 eternalegypt==0.0.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -294,6 +294,9 @@ enocean==0.40
 # homeassistant.components.sensor.season
 ephem==3.7.6.0
 
+# homeassistant.components.media_player.epson
+epson-projector==0.1.1
+
 # homeassistant.components.netgear_lte
 eternalegypt==0.0.1
 


### PR DESCRIPTION
## Description:
I created epson projector support.
It is based on Android app (packet sniffing) from epson.
Tested with Epson EH-TW5350

Made new PR to get rid of mistakes I made trying to catch up with reality.
Old PR: https://github.com/home-assistant/home-assistant/pull/13416

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5005

## Example entry for `configuration.yaml` (if applicable):
```yaml
- platform: epson
  host: 192.168.1.2
  name: Epson Projector
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
```
Tests passed but needed to change test_feedreader.py date time from 5 to 6.
datetime(2018, 4, 30, 6, 10, 0)
```

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
