### PR TITLE
Improvements to LIFX reliability

### DIFF
--- a/homeassistant/components/light/lifx.py
+++ b/homeassistant/components/light/lifx.py
@@ -201,7 +201,7 @@ def merge_hsbk(base, change):
     """Copy change on top of base, except when None."""
     if change is None:
         return None
-    return list(map(lambda x, y: y if y is not None else x, base, change))
+    return [b if c is None else c for b, c in zip(base, change)]
 
 
 class LIFXManager(object):
@@ -256,7 +256,7 @@ class LIFXManager(object):
 
     async def start_effect(self, entities, service, **kwargs):
         """Start a light effect on entities."""
-        devices = list(map(lambda l: l.device, entities))
+        devices = [light.device for light in entities]
 
         if service == SERVICE_EFFECT_PULSE:
             effect = aiolifx_effects().EffectPulse(
@@ -622,7 +622,7 @@ class LIFXStrip(LIFXColor):
 
             zones = list(range(0, num_zones))
         else:
-            zones = list(filter(lambda x: x < num_zones, set(zones)))
+            zones = [x for x in set(zones) if x < num_zones]
 
         # Zone brightness is not reported when powered off
         if not self.is_on and hsbk[2] is None:

--- a/homeassistant/components/light/lifx.py
+++ b/homeassistant/components/light/lifx.py
@@ -30,7 +30,7 @@ import homeassistant.util.color as color_util
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['aiolifx==0.6.1', 'aiolifx_effects==0.1.2']
+REQUIREMENTS = ['aiolifx==0.6.3', 'aiolifx_effects==0.1.2']
 
 UDP_BROADCAST_PORT = 56700
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -92,7 +92,7 @@ aiohue==1.5.0
 aioimaplib==0.7.13
 
 # homeassistant.components.light.lifx
-aiolifx==0.6.1
+aiolifx==0.6.3
 
 # homeassistant.components.light.lifx
 aiolifx_effects==0.1.2


### PR DESCRIPTION
## Description:

This PR fixes some rare issues with LIFX reliability:
* Unavailable lights would sometimes never return to available (fixed in aiolifx 0.6.3).
* A failed initialization would not unregister the light device, causing re-initialization to be delayed.
* The `device.get_version` call will not use the callback after its first successful call. Work around that by calling it last so it is not retried if `device.get_color` fails.

I also removed some excessive logging and rewrote a few lambda expressions to list comprehension.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54