### PR TITLE
Update Hue flow title

### DIFF
--- a/homeassistant/components/hue/strings.json
+++ b/homeassistant/components/hue/strings.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "title": "Philips Hue Bridge",
+    "title": "Philips Hue",
     "step": {
       "init": {
         "title": "Pick Hue bridge",


### PR DESCRIPTION
## Description:
Remove the word "bridge" from the Hue config entry title.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
