### PR TITLE
Don't run unnecessary methods in executor pool

### DIFF
--- a/homeassistant/components/axis.py
+++ b/homeassistant/components/axis.py
@@ -272,8 +272,7 @@ class AxisDeviceEvent(Entity):
 
     def _update_callback(self):
         """Update the sensor's state, if needed."""
-        self.update()
-        self.schedule_update_ha_state()
+        self.schedule_update_ha_state(True)
 
     @property
     def name(self):

--- a/homeassistant/components/binary_sensor/vera.py
+++ b/homeassistant/components/binary_sensor/vera.py
@@ -19,8 +19,8 @@ _LOGGER = logging.getLogger(__name__)
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Perform the setup for Vera controller devices."""
     add_devices(
-        VeraBinarySensor(device, hass.data[VERA_CONTROLLER])
-        for device in hass.data[VERA_DEVICES]['binary_sensor'])
+        [VeraBinarySensor(device, hass.data[VERA_CONTROLLER])
+         for device in hass.data[VERA_DEVICES]['binary_sensor']], True)
 
 
 class VeraBinarySensor(VeraDevice, BinarySensorDevice):

--- a/homeassistant/components/binary_sensor/verisure.py
+++ b/homeassistant/components/binary_sensor/verisure.py
@@ -54,6 +54,7 @@ class VerisureDoorWindowSensor(BinarySensorDevice):
             "$.doorWindow.doorWindowDevice[?(@.deviceLabel=='%s')]",
             self._device_label) is not None
 
+    # pylint: disable=no-self-use
     def update(self):
         """Update the state of the sensor."""
         hub.update_overview()

--- a/homeassistant/components/climate/vera.py
+++ b/homeassistant/components/climate/vera.py
@@ -101,10 +101,6 @@ class VeraThermostat(VeraDevice, ClimateDevice):
         if power:
             return convert(power, float, 0.0)
 
-    def update(self):
-        """Handle state updates."""
-        self._state = self.vera_device.get_hvac_mode()
-
     @property
     def temperature_unit(self):
         """Return the unit of measurement."""

--- a/homeassistant/components/climate/vera.py
+++ b/homeassistant/components/climate/vera.py
@@ -32,8 +32,8 @@ SUPPORT_FLAGS = (SUPPORT_TARGET_TEMPERATURE | SUPPORT_OPERATION_MODE |
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     """Set up of Vera thermostats."""
     add_devices_callback(
-        VeraThermostat(device, hass.data[VERA_CONTROLLER]) for
-        device in hass.data[VERA_DEVICES]['climate'])
+        [VeraThermostat(device, hass.data[VERA_CONTROLLER]) for
+         device in hass.data[VERA_DEVICES]['climate']], True)
 
 
 class VeraThermostat(VeraDevice, ClimateDevice):

--- a/homeassistant/components/cover/vera.py
+++ b/homeassistant/components/cover/vera.py
@@ -19,8 +19,8 @@ _LOGGER = logging.getLogger(__name__)
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Vera covers."""
     add_devices(
-        VeraCover(device, hass.data[VERA_CONTROLLER]) for
-        device in hass.data[VERA_DEVICES]['cover'])
+        [VeraCover(device, hass.data[VERA_CONTROLLER]) for
+         device in hass.data[VERA_DEVICES]['cover']], True)
 
 
 class VeraCover(VeraDevice, CoverDevice):

--- a/homeassistant/components/light/vera.py
+++ b/homeassistant/components/light/vera.py
@@ -22,8 +22,8 @@ DEPENDENCIES = ['vera']
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Vera lights."""
     add_devices(
-        VeraLight(device, hass.data[VERA_CONTROLLER]) for
-        device in hass.data[VERA_DEVICES]['light'])
+        [VeraLight(device, hass.data[VERA_CONTROLLER]) for
+         device in hass.data[VERA_DEVICES]['light']], True)
 
 
 class VeraLight(VeraDevice, Light):

--- a/homeassistant/components/lock/vera.py
+++ b/homeassistant/components/lock/vera.py
@@ -19,8 +19,8 @@ DEPENDENCIES = ['vera']
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Find and return Vera locks."""
     add_devices(
-        VeraLock(device, hass.data[VERA_CONTROLLER]) for
-        device in hass.data[VERA_DEVICES]['lock'])
+        [VeraLock(device, hass.data[VERA_CONTROLLER]) for
+         device in hass.data[VERA_DEVICES]['lock']], True)
 
 
 class VeraLock(VeraDevice, LockDevice):

--- a/homeassistant/components/sensor/vera.py
+++ b/homeassistant/components/sensor/vera.py
@@ -25,8 +25,8 @@ SCAN_INTERVAL = timedelta(seconds=5)
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Vera controller devices."""
     add_devices(
-        VeraSensor(device, hass.data[VERA_CONTROLLER])
-        for device in hass.data[VERA_DEVICES]['sensor'])
+        [VeraSensor(device, hass.data[VERA_CONTROLLER])
+         for device in hass.data[VERA_DEVICES]['sensor']], True)
 
 
 class VeraSensor(VeraDevice, Entity):

--- a/homeassistant/components/sensor/verisure.py
+++ b/homeassistant/components/sensor/verisure.py
@@ -74,6 +74,7 @@ class VerisureThermometer(Entity):
         """Return the unit of measurement of this entity."""
         return TEMP_CELSIUS
 
+    # pylint: disable=no-self-use
     def update(self):
         """Update the sensor."""
         hub.update_overview()
@@ -112,6 +113,7 @@ class VerisureHygrometer(Entity):
         """Return the unit of measurement of this entity."""
         return '%'
 
+    # pylint: disable=no-self-use
     def update(self):
         """Update the sensor."""
         hub.update_overview()
@@ -150,6 +152,7 @@ class VerisureMouseDetection(Entity):
         """Return the unit of measurement of this entity."""
         return 'Mice'
 
+    # pylint: disable=no-self-use
     def update(self):
         """Update the sensor."""
         hub.update_overview()

--- a/homeassistant/components/switch/vera.py
+++ b/homeassistant/components/switch/vera.py
@@ -19,8 +19,8 @@ _LOGGER = logging.getLogger(__name__)
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Vera switches."""
     add_devices(
-        VeraSwitch(device, hass.data[VERA_CONTROLLER]) for
-        device in hass.data[VERA_DEVICES]['switch'])
+        [VeraSwitch(device, hass.data[VERA_CONTROLLER]) for
+         device in hass.data[VERA_DEVICES]['switch']], True)
 
 
 class VeraSwitch(VeraDevice, SwitchDevice):

--- a/homeassistant/components/switch/verisure.py
+++ b/homeassistant/components/switch/verisure.py
@@ -72,6 +72,7 @@ class VerisureSmartplug(SwitchDevice):
         self._state = False
         self._change_timestamp = time()
 
+    # pylint: disable=no-self-use
     def update(self):
         """Get the latest date of the smartplug."""
         hub.update_overview()

--- a/homeassistant/components/vera.py
+++ b/homeassistant/components/vera.py
@@ -148,12 +148,10 @@ class VeraDevice(Entity):
             slugify(vera_device.name), vera_device.device_id)
 
         self.controller.register(vera_device, self._update_callback)
-        self.update()
 
     def _update_callback(self, _device):
         """Update the state."""
-        self.update()
-        self.schedule_update_ha_state()
+        self.schedule_update_ha_state(True)
 
     @property
     def name(self):

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -171,13 +171,6 @@ class Entity(object):
         """Flag supported features."""
         return None
 
-    def update(self):
-        """Retrieve latest state.
-
-        For asyncio use coroutine async_update.
-        """
-        pass
-
     # DO NOT OVERWRITE
     # These properties and methods are either managed by Home Assistant or they
     # are used to perform a very specific function. Overwriting these may
@@ -320,10 +313,10 @@ class Entity(object):
             )
 
         try:
+            # pylint: disable=no-member
             if hasattr(self, 'async_update'):
-                # pylint: disable=no-member
                 yield from self.async_update()
-            else:
+            elif hasattr(self, 'update'):
                 yield from self.hass.async_add_job(self.update)
         finally:
             self._update_staged = False


### PR DESCRIPTION
## Description:
For the rare case that an entity is "should_poll" but does not implement an update method (poor design), we should not run an empty method in the executor thread.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
