### PR TITLE
UVC camera platform handling unavailable NVR or cameras better

### DIFF
--- a/tests/components/camera/test_uvc.py
+++ b/tests/components/camera/test_uvc.py
@@ -133,19 +133,28 @@ class TestUVCSetup(unittest.TestCase):
 
     @mock.patch.object(uvc, 'UnifiVideoCamera')
     @mock.patch('uvcclient.nvr.UVCRemote')
-    def test_setup_nvr_errors(self, mock_remote, mock_uvc):
-        """Test for NVR errors."""
-        errors = [nvr.NotAuthorized, nvr.NvrError,
-                  requests.exceptions.ConnectionError]
+    def setup_nvr_errors(self, error, mock_remote, mock_uvc):
+        """Setup test for NVR errors."""
         config = {
             'platform': 'uvc',
             'nvr': 'foo',
             'key': 'secret',
         }
-        for error in errors:
-            mock_remote.return_value.index.side_effect = error
-            assert setup_component(self.hass, 'camera', config)
-            assert not mock_uvc.called
+        mock_remote.return_value.index.side_effect = error
+        assert setup_component(self.hass, 'camera', {'camera': config})
+        assert not mock_uvc.called
+
+    def test_setup_nvr_error_notauthorized(self):
+        """Test for error: nvr.NotAuthorized"""
+        self.setup_nvr_errors(nvr.NotAuthorized)
+
+    def test_setup_nvr_error_nvrerror(self):
+        """Test for error: nvr.NvrError"""
+        self.setup_nvr_errors(nvr.NvrError)
+
+    def test_setup_nvr_error_connectionerror(self):
+        """Test for error: requests.exceptions.ConnectionError"""
+        self.setup_nvr_errors(requests.exceptions.ConnectionError)
 
 
 class TestUVC(unittest.TestCase):

--- a/tests/components/camera/test_uvc.py
+++ b/tests/components/camera/test_uvc.py
@@ -7,6 +7,7 @@ import requests
 from uvcclient import camera
 from uvcclient import nvr
 
+from homeassistant.exceptions import PlatformNotReady
 from homeassistant.setup import setup_component
 from homeassistant.components.camera import uvc
 from tests.common import get_test_home_assistant
@@ -34,21 +35,21 @@ class TestUVCSetup(unittest.TestCase):
             'port': 123,
             'key': 'secret',
         }
-        fake_cameras = [
+        mock_cameras = [
             {'uuid': 'one', 'name': 'Front', 'id': 'id1'},
             {'uuid': 'two', 'name': 'Back', 'id': 'id2'},
             {'uuid': 'three', 'name': 'Old AirCam', 'id': 'id3'},
         ]
 
-        def fake_get_camera(uuid):
-            """Create a fake camera."""
+        def mock_get_camera(uuid):
+            """Create a mock camera."""
             if uuid == 'id3':
                 return {'model': 'airCam'}
             else:
                 return {'model': 'UVC'}
 
-        mock_remote.return_value.index.return_value = fake_cameras
-        mock_remote.return_value.get_camera.side_effect = fake_get_camera
+        mock_remote.return_value.index.return_value = mock_cameras
+        mock_remote.return_value.get_camera.side_effect = mock_get_camera
         mock_remote.return_value.server_version = (3, 2, 0)
 
         assert setup_component(self.hass, 'camera', {'camera': config})
@@ -71,11 +72,11 @@ class TestUVCSetup(unittest.TestCase):
             'nvr': 'foo',
             'key': 'secret',
         }
-        fake_cameras = [
+        mock_cameras = [
             {'uuid': 'one', 'name': 'Front', 'id': 'id1'},
             {'uuid': 'two', 'name': 'Back', 'id': 'id2'},
         ]
-        mock_remote.return_value.index.return_value = fake_cameras
+        mock_remote.return_value.index.return_value = mock_cameras
         mock_remote.return_value.get_camera.return_value = {'model': 'UVC'}
         mock_remote.return_value.server_version = (3, 2, 0)
 
@@ -99,11 +100,11 @@ class TestUVCSetup(unittest.TestCase):
             'nvr': 'foo',
             'key': 'secret',
         }
-        fake_cameras = [
+        mock_cameras = [
             {'uuid': 'one', 'name': 'Front', 'id': 'id1'},
             {'uuid': 'two', 'name': 'Back', 'id': 'id2'},
         ]
-        mock_remote.return_value.index.return_value = fake_cameras
+        mock_remote.return_value.index.return_value = mock_cameras
         mock_remote.return_value.get_camera.return_value = {'model': 'UVC'}
         mock_remote.return_value.server_version = (3, 1, 3)
 
@@ -133,8 +134,8 @@ class TestUVCSetup(unittest.TestCase):
 
     @mock.patch.object(uvc, 'UnifiVideoCamera')
     @mock.patch('uvcclient.nvr.UVCRemote')
-    def setup_nvr_errors(self, error, mock_remote, mock_uvc):
-        """Setup test for NVR errors."""
+    def setup_nvr_errors_during_indexing(self, error, mock_remote, mock_uvc):
+        """Setup test for NVR errors during indexing."""
         config = {
             'platform': 'uvc',
             'nvr': 'foo',
@@ -144,17 +145,51 @@ class TestUVCSetup(unittest.TestCase):
         assert setup_component(self.hass, 'camera', {'camera': config})
         assert not mock_uvc.called
 
-    def test_setup_nvr_error_notauthorized(self):
+    def test_setup_nvr_error_during_indexing_notauthorized(self):
         """Test for error: nvr.NotAuthorized"""
-        self.setup_nvr_errors(nvr.NotAuthorized)
+        self.setup_nvr_errors_during_indexing(nvr.NotAuthorized)
 
-    def test_setup_nvr_error_nvrerror(self):
+    def test_setup_nvr_error_during_indexing_nvrerror(self):
         """Test for error: nvr.NvrError"""
-        self.setup_nvr_errors(nvr.NvrError)
+        self.setup_nvr_errors_during_indexing(nvr.NvrError)
+        self.assertRaises(PlatformNotReady)
 
-    def test_setup_nvr_error_connectionerror(self):
+    def test_setup_nvr_error_during_indexing_connectionerror(self):
         """Test for error: requests.exceptions.ConnectionError"""
-        self.setup_nvr_errors(requests.exceptions.ConnectionError)
+        self.setup_nvr_errors_during_indexing(
+            requests.exceptions.ConnectionError)
+        self.assertRaises(PlatformNotReady)
+
+    @mock.patch.object(uvc, 'UnifiVideoCamera')
+    @mock.patch('uvcclient.nvr.UVCRemote.__init__')
+    def setup_nvr_errors_during_initialization(self, error, mock_remote,
+                                               mock_uvc):
+        """Setup test for NVR errors during initialization."""
+        config = {
+            'platform': 'uvc',
+            'nvr': 'foo',
+            'key': 'secret',
+        }
+        mock_remote.return_value = None
+        mock_remote.side_effect = error
+        assert setup_component(self.hass, 'camera', {'camera': config})
+        assert not mock_remote.index.called
+        assert not mock_uvc.called
+
+    def test_setup_nvr_error_during_initialization_notauthorized(self):
+        """Test for error: nvr.NotAuthorized"""
+        self.setup_nvr_errors_during_initialization(nvr.NotAuthorized)
+
+    def test_setup_nvr_error_during_initialization_nvrerror(self):
+        """Test for error: nvr.NvrError"""
+        self.setup_nvr_errors_during_initialization(nvr.NvrError)
+        self.assertRaises(PlatformNotReady)
+
+    def test_setup_nvr_error_during_initialization_connectionerror(self):
+        """Test for error: requests.exceptions.ConnectionError"""
+        self.setup_nvr_errors_during_initialization(
+            requests.exceptions.ConnectionError)
+        self.assertRaises(PlatformNotReady)
 
 
 class TestUVC(unittest.TestCase):
@@ -217,8 +252,8 @@ class TestUVC(unittest.TestCase):
         """Test the login tries."""
         responses = [0]
 
-        def fake_login(*a):
-            """Fake login."""
+        def mock_login(*a):
+            """Mock login."""
             try:
                 responses.pop(0)
                 raise socket.error
@@ -226,7 +261,7 @@ class TestUVC(unittest.TestCase):
                 pass
 
         mock_store.return_value.get_camera_password.return_value = None
-        mock_camera.return_value.login.side_effect = fake_login
+        mock_camera.return_value.login.side_effect = mock_login
         self.uvc._login()
         self.assertEqual(2, mock_camera.call_count)
         self.assertEqual('host-b', self.uvc._connect_addr)
@@ -272,8 +307,8 @@ class TestUVC(unittest.TestCase):
         """Test the re-authentication."""
         responses = [0]
 
-        def fake_snapshot():
-            """Fake snapshot."""
+        def mock_snapshot():
+            """Mock snapshot."""
             try:
                 responses.pop()
                 raise camera.CameraAuthError()
@@ -282,7 +317,7 @@ class TestUVC(unittest.TestCase):
             return 'image'
 
         self.uvc._camera = mock.MagicMock()
-        self.uvc._camera.get_snapshot.side_effect = fake_snapshot
+        self.uvc._camera.get_snapshot.side_effect = mock_snapshot
         with mock.patch.object(self.uvc, '_login') as mock_login:
             self.assertEqual('image', self.uvc.camera_image())
             self.assertEqual(mock_login.call_count, 1)

--- a/tests/components/camera/test_uvc.py
+++ b/tests/components/camera/test_uvc.py
@@ -146,16 +146,16 @@ class TestUVCSetup(unittest.TestCase):
         assert not mock_uvc.called
 
     def test_setup_nvr_error_during_indexing_notauthorized(self):
-        """Test for error: nvr.NotAuthorized"""
+        """Test for error: nvr.NotAuthorized."""
         self.setup_nvr_errors_during_indexing(nvr.NotAuthorized)
 
     def test_setup_nvr_error_during_indexing_nvrerror(self):
-        """Test for error: nvr.NvrError"""
+        """Test for error: nvr.NvrError."""
         self.setup_nvr_errors_during_indexing(nvr.NvrError)
         self.assertRaises(PlatformNotReady)
 
     def test_setup_nvr_error_during_indexing_connectionerror(self):
-        """Test for error: requests.exceptions.ConnectionError"""
+        """Test for error: requests.exceptions.ConnectionError."""
         self.setup_nvr_errors_during_indexing(
             requests.exceptions.ConnectionError)
         self.assertRaises(PlatformNotReady)
@@ -177,16 +177,16 @@ class TestUVCSetup(unittest.TestCase):
         assert not mock_uvc.called
 
     def test_setup_nvr_error_during_initialization_notauthorized(self):
-        """Test for error: nvr.NotAuthorized"""
+        """Test for error: nvr.NotAuthorized."""
         self.setup_nvr_errors_during_initialization(nvr.NotAuthorized)
 
     def test_setup_nvr_error_during_initialization_nvrerror(self):
-        """Test for error: nvr.NvrError"""
+        """Test for error: nvr.NvrError."""
         self.setup_nvr_errors_during_initialization(nvr.NvrError)
         self.assertRaises(PlatformNotReady)
 
     def test_setup_nvr_error_during_initialization_connectionerror(self):
-        """Test for error: requests.exceptions.ConnectionError"""
+        """Test for error: requests.exceptions.ConnectionError."""
         self.setup_nvr_errors_during_initialization(
             requests.exceptions.ConnectionError)
         self.assertRaises(PlatformNotReady)


### PR DESCRIPTION
## Description:
Fixes #14838 by surrounding all interactions with the NVR or cameras into a try-block and catching and handling any exceptions during the initial setup of the component. Also, raising `PlatformNotReady` in those cases that are likely recoverable to make HA try the setup again after 30 seconds. Some test cases corrected that were previously wrong (but not failing). Some test cases modified and some added to test the modified or new functionality.

**Related issue (if applicable):** fixes #14838

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable): n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
