### PR TITLE
Enhancements in the Throttle decorator

### DIFF
--- a/homeassistant/util/__init__.py
+++ b/homeassistant/util/__init__.py
@@ -316,11 +316,11 @@ class Throttle(object):
 
             try:
                 if force or utcnow() - throttle[1] > self.min_time:
-                    result = method(*args, **kwargs)
                     throttle[1] = utcnow()
+                    result = method(*args, **kwargs)
                     return result
-
                 return throttled_value()
+
             finally:
                 throttle[0].release()
 


### PR DESCRIPTION
## Description:

Following PR #14546, a suggestion was made to synchronize the data polling to HA with the effective refresh in the NetAtmo cloud.

More generically, sensors polling data from 'the cloud' may wish to get the freshest data, whilst avoiding to execute a remote call too often. In order to do so, they would need to re-adjust the timing of their throttled `update()` method.

The proposal here is to enhance the `Throttle()` decorator, so that the wrapped method/function could be immediately throttled (i.e. the first effective call will not happen before `min_time` seconds have passed).

Beside that, the other commit improves the behavior of the throttling by being independent from the time spent for the actuall call to `method`.

This is NOT a breaking change, but nevertheless it touches one of the core classes of Home Assistant, therefore I appreciate an adequate review. By the way, it has been inspiring to look at this code :-)

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable): N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
