### PR TITLE
Improve NetAtmo sensors update logic

### DIFF
--- a/homeassistant/components/sensor/netatmo.py
+++ b/homeassistant/components/sensor/netatmo.py
@@ -7,6 +7,9 @@ https://home-assistant.io/components/sensor.netatmo/
 import logging
 from datetime import timedelta
 from time import time
+from functools import wraps
+import asyncio
+import threading
 
 import voluptuous as vol
 
@@ -15,8 +18,8 @@ from homeassistant.const import (
     TEMP_CELSIUS, DEVICE_CLASS_HUMIDITY, DEVICE_CLASS_TEMPERATURE,
     STATE_UNKNOWN)
 from homeassistant.helpers.entity import Entity
-from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
+from homeassistant.util.dt import utcnow
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -333,7 +336,116 @@ class NetAtmoData(object):
                 # Never hammer the NetAtmo API more than
                 # twice per update interval
                 newinterval = NETATMO_UPDATE_INTERVAL / 2
-            _LOGGER.info("NetAtmo refresh interval reset to %d seconds",
-                         newinterval)
+            _LOGGER.warning("NetAtmo refresh interval reset to %d seconds",
+                            newinterval)
             self.update = Throttle(timedelta(seconds=newinterval),
                                    immediate_throttle=True)(self._update)
+
+
+class Throttle(object):
+    """A class for throttling the execution of tasks.
+
+    This class is a clone of `homeassistant.util.Throttle`, except for adding
+    the immediate_throttle capability described below. If more sensors wish
+    to benefit from adaptive throttling, this class should be merged in the
+    util package.
+
+    This method decorator adds a cooldown to a method to prevent it from being
+    called more then 1 time within the timedelta interval `min_time` after it
+    returned its result.
+
+    Calling a method a second time during the interval will return None.
+
+    Pass keyword argument `no_throttle=True` to the wrapped method to make
+    the call not throttled.
+
+    Initialize the decorator with the optional `immediate_throttle=True`
+    argument to ensure that the wrapped method is not called until the
+    first `min_time` interval has passed. This option overrides the above
+    `no_throttle` argument.
+
+    Decorator takes in an optional second timedelta interval to throttle the
+    'no_throttle' calls.
+
+    Adds a datetime attribute `last_call` to the method.
+    """
+
+    def __init__(self, min_time, limit_no_throttle=None,
+                 immediate_throttle=False):
+        """Initialize the throttle."""
+        self.min_time = min_time
+        self.limit_no_throttle = limit_no_throttle
+        self.immediate_throttle = immediate_throttle
+
+    def __call__(self, method):
+        """Caller for the throttle."""
+        # Make sure we return a coroutine if the method is async.
+        if asyncio.iscoroutinefunction(method):
+            async def throttled_value():
+                """Stand-in function for when real func is being throttled."""
+                return None
+        else:
+            def throttled_value():
+                """Stand-in function for when real func is being throttled."""
+                return None
+
+        if self.limit_no_throttle is not None:
+            method = Throttle(self.limit_no_throttle)(method)
+
+        # Different methods that can be passed in:
+        #  - a function
+        #  - an unbound function on a class
+        #  - a method (bound function on a class)
+
+        # We want to be able to differentiate between function and unbound
+        # methods (which are considered functions).
+        # All methods have the classname in their qualname separated by a '.'
+        # Functions have a '.' in their qualname if defined inline, but will
+        # be prefixed by '.<locals>.' so we strip that out.
+        is_func = (not hasattr(method, '__self__') and
+                   '.' not in method.__qualname__.split('.<locals>.')[-1])
+
+        @wraps(method)
+        def wrapper(*args, **kwargs):
+            """Wrap that allows wrapped to be called only once per min_time.
+
+            If we cannot acquire the lock, it is running so return None.
+            """
+            # pylint: disable=protected-access
+            if hasattr(method, '__self__'):
+                host = method.__self__
+            elif is_func:
+                host = wrapper
+            else:
+                host = args[0] if args else wrapper
+
+            if not hasattr(host, '_throttle'):
+                host._throttle = {}
+
+            if id(self) not in host._throttle:
+                host._throttle[id(self)] = [threading.Lock(), None]
+            throttle = host._throttle[id(self)]
+
+            if not throttle[0].acquire(False):
+                return throttled_value()
+
+            try:
+                if self.immediate_throttle:
+                    # This only applies the very first time
+                    throttle[1] = utcnow()
+                    self.immediate_throttle = False
+                    return throttled_value()
+
+                # Check if method is never called or no_throttle is given
+                force = kwargs.pop('no_throttle', False) or not throttle[1]
+
+                if force or utcnow() - throttle[1] > self.min_time:
+                    result = method(*args, **kwargs)
+                    throttle[1] = utcnow()
+                    return result
+                return throttled_value()
+
+            finally:
+                throttle[0].release()
+
+        return wrapper

--- a/homeassistant/components/sensor/netatmo.py
+++ b/homeassistant/components/sensor/netatmo.py
@@ -6,6 +6,7 @@ https://home-assistant.io/components/sensor.netatmo/
 """
 import logging
 from datetime import timedelta
+from time import time
 
 import voluptuous as vol
 
@@ -50,7 +51,8 @@ SENSOR_TYPES = {
     'rf_status': ['Radio', '', 'mdi:signal', None],
     'rf_status_lvl': ['Radio_lvl', '', 'mdi:signal', None],
     'wifi_status': ['Wifi', '', 'mdi:wifi', None],
-    'wifi_status_lvl': ['Wifi_lvl', 'dBm', 'mdi:wifi', None]
+    'wifi_status_lvl': ['Wifi_lvl', 'dBm', 'mdi:wifi', None],
+    'lastupdate': ['Last Update', 's', '', None],
 }
 
 MODULE_SCHEMA = vol.Schema({
@@ -76,11 +78,11 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             # Iterate each module
             for module_name, monitored_conditions in\
                     config[CONF_MODULES].items():
-                # Test if module exist """
+                # Test if module exists
                 if module_name not in data.get_module_names():
                     _LOGGER.error('Module name: "%s" not found', module_name)
                     continue
-                # Only create sensor for monitored """
+                # Only create sensors for monitored properties
                 for variable in monitored_conditions:
                     dev.append(NetAtmoSensor(data, module_name, variable))
         else:
@@ -285,6 +287,8 @@ class NetAtmoSensor(Entity):
                 self._state = "High"
             elif data['wifi_status'] <= 55:
                 self._state = "Full"
+        elif self.type == 'lastupdate':
+            self._state = int(time() - data['When'])
 
 
 class NetAtmoData(object):

--- a/homeassistant/components/sensor/netatmo.py
+++ b/homeassistant/components/sensor/netatmo.py
@@ -300,8 +300,8 @@ class NetAtmoData(object):
         self.data = None
         self.station_data = None
         self.station = station
-        self.update = Throttle(timedelta(seconds= \
-                          NETATMO_UPDATE_INTERVAL))(self._update)
+        throttling = timedelta(seconds=NETATMO_UPDATE_INTERVAL)
+        self.update = Throttle(throttling)(self._update)
 
     def get_module_names(self):
         """Return all module available on the API as a list."""
@@ -320,7 +320,7 @@ class NetAtmoData(object):
             self.data = self.station_data.lastData(exclude=3600)
 
         newinterval = 0
-        for module in self.data.keys():
+        for module in self.data:
             if 'When' in self.data[module]:
                 newinterval = self.data[module]['When']
                 break
@@ -333,7 +333,7 @@ class NetAtmoData(object):
                 # Never hammer the NetAtmo API more than
                 # twice per update interval
                 newinterval = NETATMO_UPDATE_INTERVAL / 2
-            _LOGGER.info("NetAtmo refresh interval reset to %d seconds", \
+            _LOGGER.info("NetAtmo refresh interval reset to %d seconds",
                          newinterval)
-            self.update = Throttle(timedelta(seconds=newinterval), \
+            self.update = Throttle(timedelta(seconds=newinterval),
                                    immediate_throttle=True)(self._update)

--- a/homeassistant/components/sensor/netatmo.py
+++ b/homeassistant/components/sensor/netatmo.py
@@ -315,7 +315,7 @@ class NetAtmoData(object):
         of the last update from the cloud.
         """
         if time() < self._next_update or \
-            not self._update_in_progress.acquire(False):
+                not self._update_in_progress.acquire(False):
             return
 
         try:

--- a/homeassistant/components/sensor/netatmo.py
+++ b/homeassistant/components/sensor/netatmo.py
@@ -55,7 +55,7 @@ SENSOR_TYPES = {
     'rf_status_lvl': ['Radio_lvl', '', 'mdi:signal', None],
     'wifi_status': ['Wifi', '', 'mdi:wifi', None],
     'wifi_status_lvl': ['Wifi_lvl', 'dBm', 'mdi:wifi', None],
-    'lastupdate': ['Last Update', 's', '', None],
+    'lastupdated': ['Last Updated', 's', 'mdi:timer', None],
 }
 
 MODULE_SCHEMA = vol.Schema({
@@ -290,7 +290,7 @@ class NetAtmoSensor(Entity):
                 self._state = "High"
             elif data['wifi_status'] <= 55:
                 self._state = "Full"
-        elif self.type == 'lastupdate':
+        elif self.type == 'lastupdated':
             self._state = int(time() - data['When'])
 
 

--- a/homeassistant/components/sensor/netatmo.py
+++ b/homeassistant/components/sensor/netatmo.py
@@ -5,10 +5,7 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.netatmo/
 """
 import logging
-from datetime import timedelta
 from time import time
-from functools import wraps
-import asyncio
 import threading
 
 import voluptuous as vol
@@ -19,7 +16,6 @@ from homeassistant.const import (
     STATE_UNKNOWN)
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
-from homeassistant.util.dt import utcnow
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -303,149 +299,57 @@ class NetAtmoData(object):
         self.data = None
         self.station_data = None
         self.station = station
-        throttling = timedelta(seconds=NETATMO_UPDATE_INTERVAL)
-        self.update = Throttle(throttling)(self._update)
+        self._next_update = time()
+        self._update_in_progress = threading.Lock()
 
     def get_module_names(self):
         """Return all module available on the API as a list."""
         self.update()
         return self.data.keys()
 
-    def _update(self):
-        """Call the Netatmo API to update the data."""
-        import pyatmo
-        self.station_data = pyatmo.WeatherStationData(self.auth)
+    def update(self):
+        """Call the Netatmo API to update the data.
 
-        if self.station is not None:
-            self.data = self.station_data.lastData(
-                station=self.station, exclude=3600)
-        else:
-            self.data = self.station_data.lastData(exclude=3600)
+        This method is not throttled by the builtin Throttle decorator
+        but with a custom logic, which takes into account the time
+        of the last update from the cloud.
+        """
+        if time() < self._next_update or \
+            not self._update_in_progress.acquire(False):
+            return
 
-        newinterval = 0
-        for module in self.data:
-            if 'When' in self.data[module]:
-                newinterval = self.data[module]['When']
-                break
-        if newinterval:
-            # Try and estimate when fresh data will be available
-            newinterval += NETATMO_UPDATE_INTERVAL - time()
-            if newinterval >= NETATMO_UPDATE_INTERVAL - 30:
-                newinterval = NETATMO_UPDATE_INTERVAL
-            elif newinterval < NETATMO_UPDATE_INTERVAL / 2:
-                # Never hammer the NetAtmo API more than
-                # twice per update interval
-                newinterval = NETATMO_UPDATE_INTERVAL / 2
-            _LOGGER.warning("NetAtmo refresh interval reset to %d seconds",
-                            newinterval)
-            self.update = Throttle(timedelta(seconds=newinterval),
-                                   immediate_throttle=True)(self._update)
+        try:
+            import pyatmo
+            self.station_data = pyatmo.WeatherStationData(self.auth)
 
-
-class Throttle(object):
-    """A class for throttling the execution of tasks.
-
-    This class is a clone of `homeassistant.util.Throttle`, except for adding
-    the immediate_throttle capability described below. If more sensors wish
-    to benefit from adaptive throttling, this class should be merged in the
-    util package.
-
-    This method decorator adds a cooldown to a method to prevent it from being
-    called more then 1 time within the timedelta interval `min_time` after it
-    returned its result.
-
-    Calling a method a second time during the interval will return None.
-
-    Pass keyword argument `no_throttle=True` to the wrapped method to make
-    the call not throttled.
-
-    Initialize the decorator with the optional `immediate_throttle=True`
-    argument to ensure that the wrapped method is not called until the
-    first `min_time` interval has passed. This option overrides the above
-    `no_throttle` argument.
-
-    Decorator takes in an optional second timedelta interval to throttle the
-    'no_throttle' calls.
-
-    Adds a datetime attribute `last_call` to the method.
-    """
-
-    def __init__(self, min_time, limit_no_throttle=None,
-                 immediate_throttle=False):
-        """Initialize the throttle."""
-        self.min_time = min_time
-        self.limit_no_throttle = limit_no_throttle
-        self.immediate_throttle = immediate_throttle
-
-    def __call__(self, method):
-        """Caller for the throttle."""
-        # Make sure we return a coroutine if the method is async.
-        if asyncio.iscoroutinefunction(method):
-            async def throttled_value():
-                """Stand-in function for when real func is being throttled."""
-                return None
-        else:
-            def throttled_value():
-                """Stand-in function for when real func is being throttled."""
-                return None
-
-        if self.limit_no_throttle is not None:
-            method = Throttle(self.limit_no_throttle)(method)
-
-        # Different methods that can be passed in:
-        #  - a function
-        #  - an unbound function on a class
-        #  - a method (bound function on a class)
-
-        # We want to be able to differentiate between function and unbound
-        # methods (which are considered functions).
-        # All methods have the classname in their qualname separated by a '.'
-        # Functions have a '.' in their qualname if defined inline, but will
-        # be prefixed by '.<locals>.' so we strip that out.
-        is_func = (not hasattr(method, '__self__') and
-                   '.' not in method.__qualname__.split('.<locals>.')[-1])
-
-        @wraps(method)
-        def wrapper(*args, **kwargs):
-            """Wrap that allows wrapped to be called only once per min_time.
-
-            If we cannot acquire the lock, it is running so return None.
-            """
-            # pylint: disable=protected-access
-            if hasattr(method, '__self__'):
-                host = method.__self__
-            elif is_func:
-                host = wrapper
+            if self.station is not None:
+                self.data = self.station_data.lastData(
+                    station=self.station, exclude=3600)
             else:
-                host = args[0] if args else wrapper
+                self.data = self.station_data.lastData(exclude=3600)
 
-            if not hasattr(host, '_throttle'):
-                host._throttle = {}
+            newinterval = 0
+            for module in self.data:
+                if 'When' in self.data[module]:
+                    newinterval = self.data[module]['When']
+                    break
+            if newinterval:
+                # Try and estimate when fresh data will be available
+                newinterval += NETATMO_UPDATE_INTERVAL - time()
+                if newinterval > NETATMO_UPDATE_INTERVAL - 30:
+                    newinterval = NETATMO_UPDATE_INTERVAL
+                else:
+                    if newinterval < NETATMO_UPDATE_INTERVAL / 2:
+                        # Never hammer the NetAtmo API more than
+                        # twice per update interval
+                        newinterval = NETATMO_UPDATE_INTERVAL / 2
+                    _LOGGER.warning(
+                        "NetAtmo refresh interval reset to %d seconds",
+                        newinterval)
+            else:
+                # Last update time not found, fall back to default value
+                newinterval = NETATMO_UPDATE_INTERVAL
 
-            if id(self) not in host._throttle:
-                host._throttle[id(self)] = [threading.Lock(), None]
-            throttle = host._throttle[id(self)]
-
-            if not throttle[0].acquire(False):
-                return throttled_value()
-
-            try:
-                if self.immediate_throttle:
-                    # This only applies the very first time
-                    throttle[1] = utcnow()
-                    self.immediate_throttle = False
-                    return throttled_value()
-
-                # Check if method is never called or no_throttle is given
-                force = kwargs.pop('no_throttle', False) or not throttle[1]
-
-                if force or utcnow() - throttle[1] > self.min_time:
-                    result = method(*args, **kwargs)
-                    throttle[1] = utcnow()
-                    return result
-                return throttled_value()
-
-            finally:
-                throttle[0].release()
-
-        return wrapper
+            self._next_update = time() + newinterval
+        finally:
+            self._update_in_progress.release()


### PR DESCRIPTION
## Description:

Following PR #14546, a suggestion was made to synchronize the data polling to HA with the effective refresh in the NetAtmo cloud.

This PR changes the throttling logic of the `update` method such that data is refreshed every 10 minutes and at the best time to fetch the fresh data from the cloud.

Note that following code review, the `Throttle` decorator is not used, but its spirit is there, along with a lock to protect the execution of the remote update.

I believe the same approach could be used in other sensors, whenever the timing would represent an added value (this was the case for me to have a quicker reaction in some automations).

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```
sensor:
  - platform: netatmo
    modules:
      <your_module>:
        - ...
        - lastupdated
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
