### PR TITLE
Add color_status sensor for Nest Protect

### DIFF
--- a/homeassistant/components/sensor/nest.py
+++ b/homeassistant/components/sensor/nest.py
@@ -17,7 +17,11 @@ SENSOR_TYPES = ['humidity', 'operation_mode', 'hvac_state']
 
 TEMP_SENSOR_TYPES = ['temperature', 'target']
 
-PROTECT_SENSOR_TYPES = ['co_status', 'smoke_status', 'battery_health']
+PROTECT_SENSOR_TYPES = ['co_status',
+                        'smoke_status',
+                        'battery_health',
+                        # color_status: "gray", "green", "yellow", "red"
+                        'color_status']
 
 STRUCTURE_SENSOR_TYPES = ['eta']
 
@@ -115,7 +119,8 @@ class NestBasicSensor(NestSensorDevice):
         if self.variable in VARIABLE_NAME_MAPPING:
             self._state = getattr(self.device,
                                   VARIABLE_NAME_MAPPING[self.variable])
-        elif self.variable in PROTECT_SENSOR_TYPES:
+        elif self.variable in PROTECT_SENSOR_TYPES \
+                and self.variable != 'color_status':
             # keep backward compatibility
             self._state = getattr(self.device, self.variable).capitalize()
         else:


### PR DESCRIPTION
## Description:
Add color status sensor for Nest Protect. Address feature request from https://community.home-assistant.io/t/nest-protect-ui-light-color-motion-sensor/8781
Nest API ref: https://developers.nest.com/documentation/cloud/api-smoke-co-alarm#ui_color_state

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5506

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

