### PR TITLE
WIP: Generic Thermostat - Add AUTO support with heat/cool switches

### DIFF
--- a/tests/components/climate/test_generic_thermostat.py
+++ b/tests/components/climate/test_generic_thermostat.py
@@ -14,6 +14,7 @@ from homeassistant.const import (
     SERVICE_TURN_ON,
     STATE_ON,
     STATE_OFF,
+    STATE_IDLE,
     TEMP_CELSIUS,
     ATTR_TEMPERATURE
 )
@@ -28,21 +29,13 @@ from tests.common import (assert_setup_component, get_test_home_assistant,
 
 ENTITY = 'climate.test'
 ENT_SENSOR = 'sensor.test'
-ENT_SWITCH_HEAT = 'switch.test_heat'
-ENT_SWITCH_AC = 'switch.test_ac'
+ENT_SWITCH = 'switch.test'
 ATTR_AWAY_MODE = 'away_mode'
 MIN_TEMP = 3.0
 MAX_TEMP = 65.0
 TARGET_TEMP = 42.0
-COLD_TOLERANCE = 0.3
-HOT_TOLERANCE = 0.3
-
-DEFAULT_MIN_TEMP = 7.0
-DEFAULT_MAX_TEMP = 35.0
-DEFAULT_AWAY_TEMP_COOL = 30.0
-DEFAULT_AWAY_TEMP_HEAT = 16.0
-DEFAULT_TARGET_TEMP_HIGH = 21.0
-DEFAULT_TARGET_TEMP_LOW = 18.0
+COLD_TOLERANCE = 0.5
+HOT_TOLERANCE = 0.5
 
 
 class TestSetupClimateGenericThermostat(unittest.TestCase):
@@ -59,20 +52,21 @@ class TestSetupClimateGenericThermostat(unittest.TestCase):
     def test_setup_missing_conf(self):
         """Test set up heat_control with missing config values."""
         config = {
-            'name': 'test'
+            'name': 'test',
+            'target_sensor': ENT_SENSOR
         }
         with assert_setup_component(0):
             setup_component(self.hass, 'climate', {
                 'climate': config})
 
-    def test_setup_valid_conf(self):
+    def test_valid_conf(self):
         """Test set up generic_thermostat with valid config values."""
         self.assertTrue(
             setup_component(self.hass, 'climate',
                             {'climate': {
                                 'platform': 'generic_thermostat',
                                 'name': 'test',
-                                'heater_control': ENT_SWITCH_HEAT,
+                                'heater': ENT_SWITCH,
                                 'target_sensor': ENT_SENSOR
                                 }})
         )
@@ -105,15 +99,16 @@ class TestGenericThermostatHeaterSwitching(unittest.TestCase):
         assert setup_component(self.hass, climate.DOMAIN, {'climate': {
             'platform': 'generic_thermostat',
             'name': 'test',
-            'heater_control': heater_switch,
-            'target_sensor': ENT_SENSOR,
-            'initial_operation_mode': climate.STATE_HEAT
+            'heater': heater_switch,
+            'target_sensor': ENT_SENSOR
         }})
 
         self.assertEqual(STATE_OFF,
                          self.hass.states.get(heater_switch).state)
 
-        self._setup_sensor(16)
+        self._setup_sensor(18)
+        self.hass.block_till_done()
+        climate.set_temperature(self.hass, 23)
         self.hass.block_till_done()
 
         self.assertEqual(STATE_ON,
@@ -131,15 +126,16 @@ class TestGenericThermostatHeaterSwitching(unittest.TestCase):
         assert setup_component(self.hass, climate.DOMAIN, {'climate': {
             'platform': 'generic_thermostat',
             'name': 'test',
-            'heater_control': heater_switch,
-            'target_sensor': ENT_SENSOR,
-            'initial_operation_mode': climate.STATE_HEAT
+            'heater': heater_switch,
+            'target_sensor': ENT_SENSOR
         }})
 
         self.assertEqual(STATE_OFF,
                          self.hass.states.get(heater_switch).state)
 
-        self._setup_sensor(16)
+        self._setup_sensor(18)
+        self.hass.block_till_done()
+        climate.set_temperature(self.hass, 23)
         self.hass.block_till_done()
 
         self.assertEqual(STATE_ON,
@@ -152,8 +148,8 @@ class TestGenericThermostatHeaterSwitching(unittest.TestCase):
         })
 
 
-class TestClimateGenericThermostatHeat(unittest.TestCase):
-    """Test the Generic thermostat in Heat mode."""
+class TestClimateGenericThermostat(unittest.TestCase):
+    """Test the Generic thermostat."""
 
     def setUp(self):  # pylint: disable=invalid-name
         """Setup things to be run when tests are started."""
@@ -164,86 +160,51 @@ class TestClimateGenericThermostatHeat(unittest.TestCase):
             'name': 'test',
             'cold_tolerance': 2,
             'hot_tolerance': 4,
-            'heater_control': ENT_SWITCH_HEAT,
+            'heater': ENT_SWITCH,
             'target_sensor': ENT_SENSOR,
-            'away_temp_heat': 16
+            'away_temp': 16
         }})
 
     def tearDown(self):  # pylint: disable=invalid-name
         """Stop down everything that was started."""
         self.hass.stop()
 
-    def test_setup_defaults_to_off(self):
-        """Test the setting of defaults to STATE_OFF."""
-        self.assertEqual(STATE_OFF, self.hass.states.get(ENTITY).state)
+    def test_setup_defaults_to_unknown(self):
+        """Test the setting of defaults to unknown."""
+        self.assertEqual(STATE_IDLE, self.hass.states.get(ENTITY).state)
 
     def test_default_setup_params(self):
         """Test the setup with default parameters."""
         state = self.hass.states.get(ENTITY)
-        self.assertEqual(DEFAULT_MIN_TEMP, state.attributes.get('min_temp'))
-        self.assertEqual(DEFAULT_MAX_TEMP, state.attributes.get('max_temp'))
-        self.assertEqual(DEFAULT_TARGET_TEMP_LOW,
-                         state.attributes.get(ATTR_TEMPERATURE))
+        self.assertEqual(7, state.attributes.get('min_temp'))
+        self.assertEqual(35, state.attributes.get('max_temp'))
+        self.assertEqual(7, state.attributes.get('temperature'))
 
     def test_get_operation_modes(self):
         """Test that the operation list returns the correct modes."""
         state = self.hass.states.get(ENTITY)
         modes = state.attributes.get('operation_list')
-        self.assertEqual([STATE_OFF, climate.STATE_HEAT], modes)
+        self.assertEqual([climate.STATE_HEAT, STATE_OFF], modes)
 
     def test_set_target_temp(self):
         """Test the setting of the target temperature."""
         climate.set_temperature(self.hass, 30)
         self.hass.block_till_done()
         state = self.hass.states.get(ENTITY)
-        self.assertEqual(30.0, state.attributes.get(ATTR_TEMPERATURE))
+        self.assertEqual(30.0, state.attributes.get('temperature'))
         climate.set_temperature(self.hass, None)
         self.hass.block_till_done()
         state = self.hass.states.get(ENTITY)
-        self.assertEqual(30.0, state.attributes.get(ATTR_TEMPERATURE))
+        self.assertEqual(30.0, state.attributes.get('temperature'))
 
-    def test_set_operation_mode(self):
-        """Test the setting operation mode."""
-        climate.set_operation_mode(self.hass, climate.STATE_HEAT)
-        self.hass.block_till_done()
-        state = self.hass.states.get(ENTITY)
-        self.assertEqual(climate.STATE_HEAT,
-                         state.attributes.get('operation_mode'))
-        climate.set_operation_mode(self.hass, climate.STATE_OFF)
-        self.hass.block_till_done()
-        state = self.hass.states.get(ENTITY)
-        self.assertEqual(climate.STATE_OFF,
-                         state.attributes.get('operation_mode'))
-        climate.set_operation_mode(self.hass, climate.STATE_AUTO)
-        self.hass.block_till_done()
-        state = self.hass.states.get(ENTITY)
-        self.assertEqual(climate.STATE_OFF,
-                         state.attributes.get('operation_mode'))
-
-    def test_set_away_mode_from_off(self):
+    def test_set_away_mode(self):
         """Test the setting away mode."""
         climate.set_temperature(self.hass, 23)
         self.hass.block_till_done()
         climate.set_away_mode(self.hass, True)
         self.hass.block_till_done()
         state = self.hass.states.get(ENTITY)
-        self.assertEqual(DEFAULT_AWAY_TEMP_HEAT,
-                         state.attributes.get('temperature'))
-        self.assertEqual(STATE_ON,
-                         state.attributes.get('away_mode'))
-
-    def test_set_away_mode_from_heat(self):
-        """Test the setting away mode."""
-        climate.set_operation_mode(self.hass, climate.STATE_HEAT)
-        climate.set_temperature(self.hass, 23)
-        self.hass.block_till_done()
-        climate.set_away_mode(self.hass, True)
-        self.hass.block_till_done()
-        state = self.hass.states.get(ENTITY)
-        self.assertEqual(DEFAULT_AWAY_TEMP_HEAT,
-                         state.attributes.get('temperature'))
-        self.assertEqual(STATE_ON,
-                         state.attributes.get('away_mode'))
+        self.assertEqual(16, state.attributes.get('temperature'))
 
     def test_set_away_mode_and_restore_prev_temp(self):
         """Test the setting and removing away mode.
@@ -255,8 +216,7 @@ class TestClimateGenericThermostatHeat(unittest.TestCase):
         climate.set_away_mode(self.hass, True)
         self.hass.block_till_done()
         state = self.hass.states.get(ENTITY)
-        self.assertEqual(DEFAULT_AWAY_TEMP_HEAT,
-                         state.attributes.get('temperature'))
+        self.assertEqual(16, state.attributes.get('temperature'))
         climate.set_away_mode(self.hass, False)
         self.hass.block_till_done()
         state = self.hass.states.get(ENTITY)
@@ -264,10 +224,7 @@ class TestClimateGenericThermostatHeat(unittest.TestCase):
 
     def test_sensor_bad_unit(self):
         """Test sensor that have bad unit."""
-        climate.set_temperature(self.hass, 19)
-        self.hass.block_till_done()
         state = self.hass.states.get(ENTITY)
-
         temp = state.attributes.get('current_temperature')
         unit = state.attributes.get('unit_of_measurement')
 
@@ -293,8 +250,6 @@ class TestClimateGenericThermostatHeat(unittest.TestCase):
 
     def test_set_target_temp_heater_on(self):
         """Test if target temperature turn heater on."""
-        climate.set_operation_mode(self.hass, climate.STATE_HEAT)
-        climate.set_temperature(self.hass, 18)
         self._setup_switch(False)
         self._setup_sensor(25)
         self.hass.block_till_done()
@@ -304,22 +259,20 @@ class TestClimateGenericThermostatHeat(unittest.TestCase):
         call = self.calls[0]
         self.assertEqual('homeassistant', call.domain)
         self.assertEqual(SERVICE_TURN_ON, call.service)
-        self.assertEqual(ENT_SWITCH_HEAT, call.data['entity_id'])
+        self.assertEqual(ENT_SWITCH, call.data['entity_id'])
 
     def test_set_target_temp_heater_off(self):
         """Test if target temperature turn heater off."""
-        climate.set_operation_mode(self.hass, climate.STATE_HEAT)
         self._setup_switch(True)
-        climate.set_temperature(self.hass, 35)
         self._setup_sensor(30)
         self.hass.block_till_done()
         climate.set_temperature(self.hass, 25)
         self.hass.block_till_done()
-        self.assertEqual(1, len(self.calls))
+        self.assertEqual(2, len(self.calls))
         call = self.calls[0]
         self.assertEqual('homeassistant', call.domain)
         self.assertEqual(SERVICE_TURN_OFF, call.service)
-        self.assertEqual(ENT_SWITCH_HEAT, call.data['entity_id'])
+        self.assertEqual(ENT_SWITCH, call.data['entity_id'])
 
     def test_temp_change_heater_on_within_tolerance(self):
         """Test if temperature change doesn't turn on within tolerance."""
@@ -334,7 +287,6 @@ class TestClimateGenericThermostatHeat(unittest.TestCase):
         """Test if temperature change turn heater on outside cold tolerance."""
         self._setup_switch(False)
         climate.set_temperature(self.hass, 30)
-        climate.set_operation_mode(self.hass, climate.STATE_HEAT)
         self.hass.block_till_done()
         self._setup_sensor(27)
         self.hass.block_till_done()
@@ -342,7 +294,7 @@ class TestClimateGenericThermostatHeat(unittest.TestCase):
         call = self.calls[0]
         self.assertEqual('homeassistant', call.domain)
         self.assertEqual(SERVICE_TURN_ON, call.service)
-        self.assertEqual(ENT_SWITCH_HEAT, call.data['entity_id'])
+        self.assertEqual(ENT_SWITCH, call.data['entity_id'])
 
     def test_temp_change_heater_off_within_tolerance(self):
         """Test if temperature change doesn't turn off within tolerance."""
@@ -357,7 +309,6 @@ class TestClimateGenericThermostatHeat(unittest.TestCase):
         """Test if temperature change turn heater off outside hot tolerance."""
         self._setup_switch(True)
         climate.set_temperature(self.hass, 30)
-        climate.set_operation_mode(self.hass, climate.STATE_HEAT)
         self.hass.block_till_done()
         self._setup_sensor(35)
         self.hass.block_till_done()
@@ -365,11 +316,10 @@ class TestClimateGenericThermostatHeat(unittest.TestCase):
         call = self.calls[0]
         self.assertEqual('homeassistant', call.domain)
         self.assertEqual(SERVICE_TURN_OFF, call.service)
-        self.assertEqual(ENT_SWITCH_HEAT, call.data['entity_id'])
+        self.assertEqual(ENT_SWITCH, call.data['entity_id'])
 
     def test_running_when_operating_mode_is_off(self):
         """Test that the switch turns off when enabled is set False."""
-        climate.set_operation_mode(self.hass, climate.STATE_HEAT)
         self._setup_switch(True)
         climate.set_temperature(self.hass, 30)
         self.hass.block_till_done()
@@ -379,7 +329,7 @@ class TestClimateGenericThermostatHeat(unittest.TestCase):
         call = self.calls[0]
         self.assertEqual('homeassistant', call.domain)
         self.assertEqual(SERVICE_TURN_OFF, call.service)
-        self.assertEqual(ENT_SWITCH_HEAT, call.data['entity_id'])
+        self.assertEqual(ENT_SWITCH, call.data['entity_id'])
 
     def test_no_state_change_when_operation_mode_off(self):
         """Test that the switch doesn't turn on when enabled is False."""
@@ -415,7 +365,7 @@ class TestClimateGenericThermostatHeat(unittest.TestCase):
         call = self.calls[0]
         self.assertEqual('homeassistant', call.domain)
         self.assertEqual(SERVICE_TURN_ON, call.service)
-        self.assertEqual(ENT_SWITCH_HEAT, call.data['entity_id'])
+        self.assertEqual(ENT_SWITCH, call.data['entity_id'])
 
     def _setup_sensor(self, temp, unit=TEMP_CELSIUS):
         """Setup the test sensor."""
@@ -425,7 +375,7 @@ class TestClimateGenericThermostatHeat(unittest.TestCase):
 
     def _setup_switch(self, is_on):
         """Setup the test switch."""
-        self.hass.states.set(ENT_SWITCH_HEAT, STATE_ON if is_on else STATE_OFF)
+        self.hass.states.set(ENT_SWITCH, STATE_ON if is_on else STATE_OFF)
         self.calls = []
 
         @callback
@@ -449,10 +399,10 @@ class TestClimateGenericThermostatACMode(unittest.TestCase):
             'name': 'test',
             'cold_tolerance': 2,
             'hot_tolerance': 4,
-            'away_temp_cool': DEFAULT_AWAY_TEMP_COOL,
-            'ac_control': ENT_SWITCH_AC,
+            'away_temp': 30,
+            'heater': ENT_SWITCH,
             'target_sensor': ENT_SENSOR,
-            'initial_operation_mode': climate.STATE_COOL
+            'ac_mode': True
         }})
 
     def tearDown(self):  # pylint: disable=invalid-name
@@ -466,13 +416,13 @@ class TestClimateGenericThermostatACMode(unittest.TestCase):
         self.hass.block_till_done()
         climate.set_temperature(self.hass, 30)
         self.hass.block_till_done()
-        self.assertEqual(1, len(self.calls))
+        self.assertEqual(2, len(self.calls))
         call = self.calls[0]
         self.assertEqual('homeassistant', call.domain)
         self.assertEqual(SERVICE_TURN_OFF, call.service)
-        self.assertEqual(ENT_SWITCH_AC, call.data['entity_id'])
+        self.assertEqual(ENT_SWITCH, call.data['entity_id'])
 
-    def test_turn_away_mode_on_cooling_from_cool(self):
+    def test_turn_away_mode_on_cooling(self):
         """Test the setting away mode when cooling."""
         self._setup_sensor(25)
         self.hass.block_till_done()
@@ -481,21 +431,7 @@ class TestClimateGenericThermostatACMode(unittest.TestCase):
         climate.set_away_mode(self.hass, True)
         self.hass.block_till_done()
         state = self.hass.states.get(ENTITY)
-        self.assertEqual(DEFAULT_AWAY_TEMP_COOL,
-                         state.attributes.get(ATTR_TEMPERATURE))
-
-    def test_turn_away_mode_on_cooling_from_off(self):
-        """Test the setting away mode when cooling."""
-        self._setup_sensor(25)
-        climate.set_operation_mode(self.hass, climate.STATE_OFF)
-        self.hass.block_till_done()
-        climate.set_temperature(self.hass, 19)
-        self.hass.block_till_done()
-        climate.set_away_mode(self.hass, True)
-        self.hass.block_till_done()
-        state = self.hass.states.get(ENTITY)
-        self.assertEqual(DEFAULT_AWAY_TEMP_COOL,
-                         state.attributes.get(ATTR_TEMPERATURE))
+        self.assertEqual(30, state.attributes.get('temperature'))
 
     def test_operating_mode_cool(self):
         """Test change mode from OFF to COOL.
@@ -513,12 +449,11 @@ class TestClimateGenericThermostatACMode(unittest.TestCase):
         call = self.calls[0]
         self.assertEqual('homeassistant', call.domain)
         self.assertEqual(SERVICE_TURN_ON, call.service)
-        self.assertEqual(ENT_SWITCH_AC, call.data['entity_id'])
+        self.assertEqual(ENT_SWITCH, call.data['entity_id'])
 
     def test_set_target_temp_ac_on(self):
         """Test if target temperature turn ac on."""
         self._setup_switch(False)
-        climate.set_temperature(self.hass, 31)
         self._setup_sensor(30)
         self.hass.block_till_done()
         climate.set_temperature(self.hass, 25)
@@ -527,7 +462,7 @@ class TestClimateGenericThermostatACMode(unittest.TestCase):
         call = self.calls[0]
         self.assertEqual('homeassistant', call.domain)
         self.assertEqual(SERVICE_TURN_ON, call.service)
-        self.assertEqual(ENT_SWITCH_AC, call.data['entity_id'])
+        self.assertEqual(ENT_SWITCH, call.data['entity_id'])
 
     def test_temp_change_ac_off_within_tolerance(self):
         """Test if temperature change doesn't turn ac off within tolerance."""
@@ -549,7 +484,7 @@ class TestClimateGenericThermostatACMode(unittest.TestCase):
         call = self.calls[0]
         self.assertEqual('homeassistant', call.domain)
         self.assertEqual(SERVICE_TURN_OFF, call.service)
-        self.assertEqual(ENT_SWITCH_AC, call.data['entity_id'])
+        self.assertEqual(ENT_SWITCH, call.data['entity_id'])
 
     def test_temp_change_ac_on_within_tolerance(self):
         """Test if temperature change doesn't turn ac on within tolerance."""
@@ -563,7 +498,6 @@ class TestClimateGenericThermostatACMode(unittest.TestCase):
     def test_temp_change_ac_on_outside_tolerance(self):
         """Test if temperature change turn ac on."""
         self._setup_switch(False)
-        climate.set_operation_mode(self.hass, climate.STATE_COOL)
         climate.set_temperature(self.hass, 25)
         self.hass.block_till_done()
         self._setup_sensor(30)
@@ -572,7 +506,7 @@ class TestClimateGenericThermostatACMode(unittest.TestCase):
         call = self.calls[0]
         self.assertEqual('homeassistant', call.domain)
         self.assertEqual(SERVICE_TURN_ON, call.service)
-        self.assertEqual(ENT_SWITCH_AC, call.data['entity_id'])
+        self.assertEqual(ENT_SWITCH, call.data['entity_id'])
 
     def test_running_when_operating_mode_is_off(self):
         """Test that the switch turns off when enabled is set False."""
@@ -585,7 +519,7 @@ class TestClimateGenericThermostatACMode(unittest.TestCase):
         call = self.calls[0]
         self.assertEqual('homeassistant', call.domain)
         self.assertEqual(SERVICE_TURN_OFF, call.service)
-        self.assertEqual(ENT_SWITCH_AC, call.data['entity_id'])
+        self.assertEqual(ENT_SWITCH, call.data['entity_id'])
 
     def test_no_state_change_when_operation_mode_off(self):
         """Test that the switch doesn't turn on when enabled is False."""
@@ -606,7 +540,7 @@ class TestClimateGenericThermostatACMode(unittest.TestCase):
 
     def _setup_switch(self, is_on):
         """Setup the test switch."""
-        self.hass.states.set(ENT_SWITCH_AC, STATE_ON if is_on else STATE_OFF)
+        self.hass.states.set(ENT_SWITCH, STATE_ON if is_on else STATE_OFF)
         self.calls = []
 
         @callback
@@ -630,10 +564,10 @@ class TestClimateGenericThermostatACModeMinCycle(unittest.TestCase):
             'name': 'test',
             'cold_tolerance': 0.3,
             'hot_tolerance': 0.3,
-            'ac_control': ENT_SWITCH_AC,
+            'heater': ENT_SWITCH,
             'target_sensor': ENT_SENSOR,
-            'min_cycle_duration': datetime.timedelta(minutes=10),
-            'initial_operation_mode': climate.STATE_COOL
+            'ac_mode': True,
+            'min_cycle_duration': datetime.timedelta(minutes=10)
         }})
 
     def tearDown(self):  # pylint: disable=invalid-name
@@ -664,7 +598,7 @@ class TestClimateGenericThermostatACModeMinCycle(unittest.TestCase):
         call = self.calls[0]
         self.assertEqual('homeassistant', call.domain)
         self.assertEqual(SERVICE_TURN_ON, call.service)
-        self.assertEqual(ENT_SWITCH_AC, call.data['entity_id'])
+        self.assertEqual(ENT_SWITCH, call.data['entity_id'])
 
     def test_temp_change_ac_trigger_off_not_long_enough(self):
         """Test if temperature change turn ac on."""
@@ -690,7 +624,7 @@ class TestClimateGenericThermostatACModeMinCycle(unittest.TestCase):
         call = self.calls[0]
         self.assertEqual('homeassistant', call.domain)
         self.assertEqual(SERVICE_TURN_OFF, call.service)
-        self.assertEqual(ENT_SWITCH_AC, call.data['entity_id'])
+        self.assertEqual(ENT_SWITCH, call.data['entity_id'])
 
     def _setup_sensor(self, temp, unit=TEMP_CELSIUS):
         """Setup the test sensor."""
@@ -700,7 +634,7 @@ class TestClimateGenericThermostatACModeMinCycle(unittest.TestCase):
 
     def _setup_switch(self, is_on):
         """Setup the test switch."""
-        self.hass.states.set(ENT_SWITCH_AC, STATE_ON if is_on else STATE_OFF)
+        self.hass.states.set(ENT_SWITCH, STATE_ON if is_on else STATE_OFF)
         self.calls = []
 
         @callback
@@ -724,10 +658,9 @@ class TestClimateGenericThermostatMinCycle(unittest.TestCase):
             'name': 'test',
             'cold_tolerance': 0.3,
             'hot_tolerance': 0.3,
-            'heater_control': ENT_SWITCH_HEAT,
+            'heater': ENT_SWITCH,
             'target_sensor': ENT_SENSOR,
-            'min_cycle_duration': datetime.timedelta(minutes=10),
-            'initial_operation_mode': climate.STATE_HEAT
+            'min_cycle_duration': datetime.timedelta(minutes=10)
         }})
 
     def tearDown(self):  # pylint: disable=invalid-name
@@ -759,7 +692,6 @@ class TestClimateGenericThermostatMinCycle(unittest.TestCase):
         with mock.patch('homeassistant.helpers.condition.dt_util.utcnow',
                         return_value=fake_changed):
             self._setup_switch(False)
-        self.hass.block_till_done()
         climate.set_temperature(self.hass, 30)
         self.hass.block_till_done()
         self._setup_sensor(25)
@@ -768,7 +700,7 @@ class TestClimateGenericThermostatMinCycle(unittest.TestCase):
         call = self.calls[0]
         self.assertEqual('homeassistant', call.domain)
         self.assertEqual(SERVICE_TURN_ON, call.service)
-        self.assertEqual(ENT_SWITCH_HEAT, call.data['entity_id'])
+        self.assertEqual(ENT_SWITCH, call.data['entity_id'])
 
     def test_temp_change_heater_trigger_off_long_enough(self):
         """Test if temperature change turn heater off after min cycle."""
@@ -785,7 +717,7 @@ class TestClimateGenericThermostatMinCycle(unittest.TestCase):
         call = self.calls[0]
         self.assertEqual('homeassistant', call.domain)
         self.assertEqual(SERVICE_TURN_OFF, call.service)
-        self.assertEqual(ENT_SWITCH_HEAT, call.data['entity_id'])
+        self.assertEqual(ENT_SWITCH, call.data['entity_id'])
 
     def _setup_sensor(self, temp, unit=TEMP_CELSIUS):
         """Setup the test sensor."""
@@ -795,7 +727,7 @@ class TestClimateGenericThermostatMinCycle(unittest.TestCase):
 
     def _setup_switch(self, is_on):
         """Setup the test switch."""
-        self.hass.states.set(ENT_SWITCH_HEAT, STATE_ON if is_on else STATE_OFF)
+        self.hass.states.set(ENT_SWITCH, STATE_ON if is_on else STATE_OFF)
         self.calls = []
 
         @callback
@@ -819,7 +751,8 @@ class TestClimateGenericThermostatACKeepAlive(unittest.TestCase):
             'name': 'test',
             'cold_tolerance': 0.3,
             'hot_tolerance': 0.3,
-            'ac_control': ENT_SWITCH_AC,
+            'heater': ENT_SWITCH,
+            'target_temp': 25,
             'target_sensor': ENT_SENSOR,
             'ac_mode': True,
             'keep_alive': datetime.timedelta(minutes=10)
@@ -850,7 +783,7 @@ class TestClimateGenericThermostatACKeepAlive(unittest.TestCase):
         call = self.calls[0]
         self.assertEqual('homeassistant', call.domain)
         self.assertEqual(SERVICE_TURN_ON, call.service)
-        self.assertEqual(ENT_SWITCH_AC, call.data['entity_id'])
+        self.assertEqual(ENT_SWITCH, call.data['entity_id'])
 
     def test_temp_change_ac_trigger_off_long_enough(self):
         """Test if turn on signal is sent at keep-alive intervals."""
@@ -873,7 +806,7 @@ class TestClimateGenericThermostatACKeepAlive(unittest.TestCase):
         call = self.calls[0]
         self.assertEqual('homeassistant', call.domain)
         self.assertEqual(SERVICE_TURN_OFF, call.service)
-        self.assertEqual(ENT_SWITCH_AC, call.data['entity_id'])
+        self.assertEqual(ENT_SWITCH, call.data['entity_id'])
 
     def _send_time_changed(self, now):
         """Send a time changed event."""
@@ -887,7 +820,7 @@ class TestClimateGenericThermostatACKeepAlive(unittest.TestCase):
 
     def _setup_switch(self, is_on):
         """Setup the test switch."""
-        self.hass.states.set(ENT_SWITCH_AC, STATE_ON if is_on else STATE_OFF)
+        self.hass.states.set(ENT_SWITCH, STATE_ON if is_on else STATE_OFF)
         self.calls = []
 
         @callback
@@ -911,7 +844,8 @@ class TestClimateGenericThermostatKeepAlive(unittest.TestCase):
             'name': 'test',
             'cold_tolerance': 0.3,
             'hot_tolerance': 0.3,
-            'heater_control': ENT_SWITCH_HEAT,
+            'target_temp': 25,
+            'heater': ENT_SWITCH,
             'target_sensor': ENT_SENSOR,
             'keep_alive': datetime.timedelta(minutes=10)
         }})
@@ -941,7 +875,7 @@ class TestClimateGenericThermostatKeepAlive(unittest.TestCase):
         call = self.calls[0]
         self.assertEqual('homeassistant', call.domain)
         self.assertEqual(SERVICE_TURN_ON, call.service)
-        self.assertEqual(ENT_SWITCH_HEAT, call.data['entity_id'])
+        self.assertEqual(ENT_SWITCH, call.data['entity_id'])
 
     def test_temp_change_heater_trigger_off_long_enough(self):
         """Test if turn on signal is sent at keep-alive intervals."""
@@ -964,7 +898,7 @@ class TestClimateGenericThermostatKeepAlive(unittest.TestCase):
         call = self.calls[0]
         self.assertEqual('homeassistant', call.domain)
         self.assertEqual(SERVICE_TURN_OFF, call.service)
-        self.assertEqual(ENT_SWITCH_HEAT, call.data['entity_id'])
+        self.assertEqual(ENT_SWITCH, call.data['entity_id'])
 
     def _send_time_changed(self, now):
         """Send a time changed event."""
@@ -978,342 +912,7 @@ class TestClimateGenericThermostatKeepAlive(unittest.TestCase):
 
     def _setup_switch(self, is_on):
         """Setup the test switch."""
-        self.hass.states.set(ENT_SWITCH_HEAT, STATE_ON if is_on else STATE_OFF)
-        self.calls = []
-
-        @callback
-        def log_call(call):
-            """Log service calls."""
-            self.calls.append(call)
-
-        self.hass.services.register(ha.DOMAIN, SERVICE_TURN_ON, log_call)
-        self.hass.services.register(ha.DOMAIN, SERVICE_TURN_OFF, log_call)
-
-
-class TestClimateGenericThermostatDualSwitchMinCycle(unittest.TestCase):
-    """Test the Generic thermostat."""
-
-    def setUp(self):  # pylint: disable=invalid-name
-        """Setup things to be run when tests are started."""
-        self.hass = get_test_home_assistant()
-        self.hass.config.temperature_unit = TEMP_CELSIUS
-        assert setup_component(self.hass, climate.DOMAIN, {'climate': {
-            'platform': 'generic_thermostat',
-            'name': 'test',
-            'heater_control': ENT_SWITCH_HEAT,
-            'ac_control': ENT_SWITCH_AC,
-            'target_sensor': ENT_SENSOR,
-            'min_cycle_duration': datetime.timedelta(minutes=10),
-            'initial_operation_mode': climate.STATE_AUTO
-        }})
-
-    def tearDown(self):  # pylint: disable=invalid-name
-        """Stop down everything that was started."""
-        self.hass.stop()
-
-    def test_temp_change_ac_trigger_on_not_long_enough(self):
-        """Test if temperature change turn ac on."""
-        self._setup_switch_heat(False)
-        self._setup_switch_ac(False)
-        climate.set_temperature(self.hass, None, None, 25, 20)
-        self.hass.block_till_done()
-        self._setup_sensor(30)
-        self.hass.block_till_done()
-        self.assertEqual(0, len(self.calls))
-
-    def test_temp_change_ac_trigger_on_long_enough(self):
-        """Test if temperature change turn ac on."""
-        fake_changed = datetime.datetime(1918, 11, 11, 11, 11, 11,
-                                         tzinfo=datetime.timezone.utc)
-        with mock.patch('homeassistant.helpers.condition.dt_util.utcnow',
-                        return_value=fake_changed):
-            self._setup_switch_heat(False)
-            self._setup_switch_ac(False)
-        climate.set_operation_mode(self.hass, climate.STATE_COOL)
-        climate.set_temperature(self.hass, None, None, 25, 20)
-        self.hass.block_till_done()
-        self._setup_sensor(30)
-        self.hass.block_till_done()
-        self.assertEqual(1, len(self.calls))
-        call = self.calls[0]
-        self.assertEqual('homeassistant', call.domain)
-        self.assertEqual(SERVICE_TURN_ON, call.service)
-        self.assertEqual(ENT_SWITCH_AC, call.data['entity_id'])
-
-    def test_temp_change_heat_trigger_on_long_enough(self):
-        """Test if temperature change turn ac on."""
-        fake_changed = datetime.datetime(1918, 11, 11, 11, 11, 11,
-                                         tzinfo=datetime.timezone.utc)
-        with mock.patch('homeassistant.helpers.condition.dt_util.utcnow',
-                        return_value=fake_changed):
-            self._setup_switch_heat(False)
-            self._setup_switch_ac(False)
-        climate.set_operation_mode(self.hass, climate.STATE_HEAT)
-        climate.set_temperature(self.hass, None, None, 25, 20)
-        self.hass.block_till_done()
-        self._setup_sensor(17)
-        self.hass.block_till_done()
-        self.assertEqual(1, len(self.calls))
-        call = self.calls[0]
-        self.assertEqual('homeassistant', call.domain)
-        self.assertEqual(SERVICE_TURN_ON, call.service)
-        self.assertEqual(ENT_SWITCH_HEAT, call.data['entity_id'])
-
-    def _setup_sensor(self, temp, unit=TEMP_CELSIUS):
-        """Setup the test sensor."""
-        self.hass.states.set(ENT_SENSOR, temp, {
-            ATTR_UNIT_OF_MEASUREMENT: unit
-        })
-
-    def _setup_switch_heat(self, is_on):
-        """Setup the test heating switch."""
-        self.hass.states.set(ENT_SWITCH_HEAT, STATE_ON if is_on else STATE_OFF)
-        self.calls = []
-
-        @callback
-        def log_call(call):
-            """Log service calls."""
-            self.calls.append(call)
-
-        self.hass.services.register(ha.DOMAIN, SERVICE_TURN_ON, log_call)
-        self.hass.services.register(ha.DOMAIN, SERVICE_TURN_OFF, log_call)
-
-    def _setup_switch_ac(self, is_on):
-        """Setup the test A/C switch."""
-        self.hass.states.set(ENT_SWITCH_AC, STATE_ON if is_on else STATE_OFF)
-        self.calls = []
-
-        @callback
-        def log_call(call):
-            """Log service calls."""
-            self.calls.append(call)
-
-        self.hass.services.register(ha.DOMAIN, SERVICE_TURN_ON, log_call)
-        self.hass.services.register(ha.DOMAIN, SERVICE_TURN_OFF, log_call)
-
-
-class TestClimateGenericThermostatDualSwitch(unittest.TestCase):
-    """Test the Generic thermostat."""
-
-    def setUp(self):  # pylint: disable=invalid-name
-        """Setup things to be run when tests are started."""
-        self.hass = get_test_home_assistant()
-        self.hass.config.temperature_unit = TEMP_CELSIUS
-        assert setup_component(self.hass, climate.DOMAIN, {'climate': {
-            'platform': 'generic_thermostat',
-            'name': 'test',
-            'heater_control': ENT_SWITCH_HEAT,
-            'ac_control': ENT_SWITCH_AC,
-            'away_temp_cool': DEFAULT_AWAY_TEMP_COOL,
-            'away_temp_heat': DEFAULT_AWAY_TEMP_HEAT,
-            'target_sensor': ENT_SENSOR,
-            'initial_operation_mode': climate.STATE_AUTO
-        }})
-
-    def tearDown(self):  # pylint: disable=invalid-name
-        """Stop down everything that was started."""
-        self.hass.stop()
-
-    def test_setup_defaults_to_initial_state(self):
-        """Test the setting of defaults to STATE_AUTO."""
-        self.assertEqual(climate.STATE_AUTO,
-                         self.hass.states.get(ENTITY).
-                         attributes.get('operation_mode'))
-
-    def test_default_setup_params(self):
-        """Test the setup with default parameters."""
-        state = self.hass.states.get(ENTITY)
-        self.assertEqual(DEFAULT_TARGET_TEMP_HIGH,
-                         state.attributes.get('target_temp_high'))
-        self.assertEqual(DEFAULT_TARGET_TEMP_LOW,
-                         state.attributes.get('target_temp_low'))
-        self.assertEqual(None,
-                         state.attributes.get(ATTR_TEMPERATURE))
-
-    def test_set_operation_mode(self):
-        """Test the setting operation mode."""
-        climate.set_operation_mode(self.hass, climate.STATE_HEAT)
-        self.hass.block_till_done()
-        state = self.hass.states.get(ENTITY)
-        self.assertEqual(climate.STATE_HEAT,
-                         state.attributes.get('operation_mode'))
-        climate.set_operation_mode(self.hass, climate.STATE_OFF)
-        self.hass.block_till_done()
-        state = self.hass.states.get(ENTITY)
-        self.assertEqual(climate.STATE_OFF,
-                         state.attributes.get('operation_mode'))
-        climate.set_operation_mode(self.hass, climate.STATE_AUTO)
-        self.hass.block_till_done()
-        state = self.hass.states.get(ENTITY)
-        self.assertEqual(climate.STATE_AUTO,
-                         state.attributes.get('operation_mode'))
-        climate.set_operation_mode(self.hass, 'invalid mode')
-        self.hass.block_till_done()
-        state = self.hass.states.get(ENTITY)
-        self.assertEqual(climate.STATE_AUTO,
-                         state.attributes.get('operation_mode'))
-
-    def test_set_away_mode_and_restore_prev_temp(self):
-        """Test the setting and removing away mode.
-
-        Verify original temperature is restored.
-        """
-        climate.set_temperature(self.hass, None, None, 22, 20)
-        self.hass.block_till_done()
-        climate.set_away_mode(self.hass, True)
-        self.hass.block_till_done()
-        state = self.hass.states.get(ENTITY)
-        self.assertEqual(DEFAULT_AWAY_TEMP_COOL,
-                         state.attributes.get('target_temp_high'))
-        self.assertEqual(DEFAULT_AWAY_TEMP_HEAT,
-                         state.attributes.get('target_temp_low'))
-        climate.set_away_mode(self.hass, False)
-        self.hass.block_till_done()
-        state = self.hass.states.get(ENTITY)
-        self.assertEqual(22, state.attributes.get('target_temp_high'))
-        self.assertEqual(20, state.attributes.get('target_temp_low'))
-
-    def test_set_target_temp_heater_off(self):
-        """Test if target temperature turn heater off."""
-        self._setup_switch_heat(True)
-        climate.set_temperature(self.hass, None, None, 25, 20)
-        self._setup_sensor(19)
-        self.hass.block_till_done()
-        climate.set_temperature(self.hass, None, None, 25, 18)
-        self.hass.block_till_done()
-        self.assertEqual(1, len(self.calls))
-        call = self.calls[0]
-        self.assertEqual('homeassistant', call.domain)
-        self.assertEqual(SERVICE_TURN_OFF, call.service)
-        self.assertEqual(ENT_SWITCH_HEAT, call.data['entity_id'])
-
-    def test_sensor_move_inside_heater_interval(self):
-        """Test complete intervals.
-
-        Verify all positions of sensor temperature.
-        Observe correct service calls.
-        """
-        self._setup_sensor(19)
-        self._setup_switch_heat(False)
-        self._setup_switch_ac(False)
-        self.hass.block_till_done()
-        self._setup_sensor(17.9)
-        self.hass.block_till_done()
-        self.assertEqual(0, len(self.calls))
-        self._setup_sensor(17)
-        self.hass.block_till_done()
-        self.assertEqual(1, len(self.calls))
-        call = self.calls[0]
-        self.assertEqual('homeassistant', call.domain)
-        self.assertEqual(SERVICE_TURN_ON, call.service)
-        self.assertEqual(ENT_SWITCH_HEAT, call.data['entity_id'])
-
-    def test_sensor_move_outside_heater(self):
-        """Test complete intervals.
-
-        Verify all positions of sensor temperature.
-        Observe correct service calls.
-        """
-        self._setup_sensor(17)
-        self._setup_switch_heat(True)
-        self._setup_switch_ac(False)
-        self.hass.block_till_done()
-        self._setup_sensor(18.2)
-        self.hass.block_till_done()
-        self.assertEqual(0, len(self.calls))
-        self._setup_sensor(19)
-        self.hass.block_till_done()
-        self.assertEqual(1, len(self.calls))
-        call = self.calls[0]
-        self.assertEqual('homeassistant', call.domain)
-        self.assertEqual(SERVICE_TURN_OFF, call.service)
-        self.assertEqual(ENT_SWITCH_HEAT, call.data['entity_id'])
-
-    def test_sensor_move_inside_ac_interval(self):
-        """Test complete intervals.
-
-        Verify all positions of sensor temperature.
-        Observe correct service calls.
-        """
-        self._setup_sensor(19)
-        self._setup_switch_heat(False)
-        self._setup_switch_ac(False)
-        self.hass.block_till_done()
-        self._setup_sensor(21.1)
-        self.hass.block_till_done()
-        self.assertEqual(0, len(self.calls))
-        self._setup_sensor(22)
-        self.hass.block_till_done()
-        self.assertEqual(1, len(self.calls))
-        call = self.calls[0]
-        self.assertEqual('homeassistant', call.domain)
-        self.assertEqual(SERVICE_TURN_ON, call.service)
-        self.assertEqual(ENT_SWITCH_AC, call.data['entity_id'])
-
-    @mock.patch('logging.Logger.error')
-    def test_invalid_both_heating_and_cooling_on(self, log_mock):
-        """Test error handling for state of heat and cool."""
-        self._setup_switch_heat(False)
-        self._setup_switch_ac(False)
-        self.hass.block_till_done()
-        self._setup_switch_ac(True)
-        self.hass.block_till_done()
-        self._setup_switch_heat(True)
-        self.hass.block_till_done()
-        self.assertEqual(log_mock.call_count, 1)
-        self.assertEqual(2, len(self.calls))
-        call1 = self.calls[0]
-        self.assertEqual('homeassistant', call1.domain)
-        self.assertEqual(SERVICE_TURN_OFF, call1.service)
-        self.assertEqual(ENT_SWITCH_HEAT, call1.data['entity_id'])
-        call2 = self.calls[1]
-        self.assertEqual('homeassistant', call2.domain)
-        self.assertEqual(SERVICE_TURN_OFF, call2.service)
-        self.assertEqual(ENT_SWITCH_AC, call2.data['entity_id'])
-
-    def test_sensor_move_outside_ac(self):
-        """Test complete intervals.
-
-        Verify all positions of sensor temperature.
-        Observe correct service calls.
-        """
-        self._setup_sensor(22)
-        self._setup_switch_heat(False)
-        self._setup_switch_ac(True)
-        self.hass.block_till_done()
-        self._setup_sensor(20.9)
-        self.hass.block_till_done()
-        self.assertEqual(0, len(self.calls))
-        self._setup_sensor(19)
-        self.hass.block_till_done()
-        self.assertEqual(1, len(self.calls))
-        call = self.calls[0]
-        self.assertEqual('homeassistant', call.domain)
-        self.assertEqual(SERVICE_TURN_OFF, call.service)
-        self.assertEqual(ENT_SWITCH_AC, call.data['entity_id'])
-
-    def _setup_sensor(self, temp, unit=TEMP_CELSIUS):
-        """Setup the test sensor."""
-        self.hass.states.set(ENT_SENSOR, temp, {
-            ATTR_UNIT_OF_MEASUREMENT: unit
-        })
-
-    def _setup_switch_heat(self, is_on):
-        """Setup the test heating switch."""
-        self.hass.states.set(ENT_SWITCH_HEAT, STATE_ON if is_on else STATE_OFF)
-        self.calls = []
-
-        @callback
-        def log_call(call):
-            """Log service calls."""
-            self.calls.append(call)
-
-        self.hass.services.register(ha.DOMAIN, SERVICE_TURN_ON, log_call)
-        self.hass.services.register(ha.DOMAIN, SERVICE_TURN_OFF, log_call)
-
-    def _setup_switch_ac(self, is_on):
-        """Setup the test A/C switch."""
-        self.hass.states.set(ENT_SWITCH_AC, STATE_ON if is_on else STATE_OFF)
+        self.hass.states.set(ENT_SWITCH, STATE_ON if is_on else STATE_OFF)
         self.calls = []
 
         @callback
@@ -1332,7 +931,7 @@ def test_custom_setup_params(hass):
         hass, climate.DOMAIN, {'climate': {
             'platform': 'generic_thermostat',
             'name': 'test',
-            'heater_control': ENT_SWITCH_HEAT,
+            'heater': ENT_SWITCH,
             'target_sensor': ENT_SENSOR,
             'min_temp': MIN_TEMP,
             'max_temp': MAX_TEMP,
@@ -1342,7 +941,7 @@ def test_custom_setup_params(hass):
     state = hass.states.get(ENTITY)
     assert state.attributes.get('min_temp') == MIN_TEMP
     assert state.attributes.get('max_temp') == MAX_TEMP
-    assert state.attributes.get(ATTR_TEMPERATURE) == TARGET_TEMP
+    assert state.attributes.get('temperature') == TARGET_TEMP
 
 
 @asyncio.coroutine
@@ -1350,9 +949,7 @@ def test_restore_state(hass):
     """Ensure states are restored on startup."""
     mock_restore_cache(hass, (
         State('climate.test_thermostat', '0', {ATTR_TEMPERATURE: "20",
-              climate.ATTR_OPERATION_MODE: "off", ATTR_AWAY_MODE: "on",
-              climate.ATTR_TARGET_TEMP_LOW: "17",
-              climate.ATTR_TARGET_TEMP_HIGH: "23"}),
+              climate.ATTR_OPERATION_MODE: "off", ATTR_AWAY_MODE: "on"}),
     ))
 
     hass.state = CoreState.starting
@@ -1361,7 +958,7 @@ def test_restore_state(hass):
         hass, climate.DOMAIN, {'climate': {
             'platform': 'generic_thermostat',
             'name': 'test_thermostat',
-            'heater_control': ENT_SWITCH_HEAT,
+            'heater': ENT_SWITCH,
             'target_sensor': ENT_SENSOR,
         }})
 
@@ -1372,33 +969,6 @@ def test_restore_state(hass):
 
 
 @asyncio.coroutine
-def test_restore_dual_temp(hass):
-    """Ensure states are restored on startup."""
-    mock_restore_cache(hass, (
-        State('climate.test_thermostat', '0', {
-              climate.ATTR_OPERATION_MODE: "off",
-              ATTR_AWAY_MODE: "on",
-              climate.ATTR_TARGET_TEMP_LOW: "17",
-              climate.ATTR_TARGET_TEMP_HIGH: "23"}),
-    ))
-
-    hass.state = CoreState.starting
-
-    yield from async_setup_component(
-        hass, climate.DOMAIN, {'climate': {
-            'platform': 'generic_thermostat',
-            'name': 'test_thermostat',
-            'heater_control': ENT_SWITCH_HEAT,
-            'ac_control': ENT_SWITCH_AC,
-            'target_sensor': ENT_SENSOR,
-        }})
-
-    state = hass.states.get('climate.test_thermostat')
-    assert(state.attributes[climate.ATTR_TARGET_TEMP_LOW] == 17)
-    assert(state.attributes[climate.ATTR_TARGET_TEMP_HIGH] == 23)
-
-
-@asyncio.coroutine
 def test_no_restore_state(hass):
     """Ensure states are restored on startup if they exist.
 
@@ -1406,7 +976,7 @@ def test_no_restore_state(hass):
     """
     mock_restore_cache(hass, (
         State('climate.test_thermostat', '0', {ATTR_TEMPERATURE: "20",
-              climate.ATTR_OPERATION_MODE: "cool", ATTR_AWAY_MODE: "on"}),
+              climate.ATTR_OPERATION_MODE: "off", ATTR_AWAY_MODE: "on"}),
     ))
 
     hass.state = CoreState.starting
@@ -1415,11 +985,91 @@ def test_no_restore_state(hass):
         hass, climate.DOMAIN, {'climate': {
             'platform': 'generic_thermostat',
             'name': 'test_thermostat',
-            'heater_control': ENT_SWITCH_HEAT,
+            'heater': ENT_SWITCH,
             'target_sensor': ENT_SENSOR,
             'target_temp': 22
         }})
 
     state = hass.states.get('climate.test_thermostat')
     assert(state.attributes[ATTR_TEMPERATURE] == 22)
-    assert(state.attributes[climate.ATTR_OPERATION_MODE] == "off")
+    assert(state.state == STATE_OFF)
+
+
+class TestClimateGenericThermostatRestoreState(unittest.TestCase):
+    """Test generic thermostat when restore state from HA startup."""
+
+    def setUp(self):  # pylint: disable=invalid-name
+        """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+        self.hass.config.temperature_unit = TEMP_CELSIUS
+
+    def tearDown(self):  # pylint: disable=invalid-name
+        """Stop down everything that was started."""
+        self.hass.stop()
+
+    def test_restore_state_uncoherence_case(self):
+        """
+        Test restore from a strange state.
+
+        - Turn the generic thermostat off
+        - Restart HA and restore state from DB
+        """
+        self._mock_restore_cache(temperature=20)
+
+        self._setup_switch(False)
+        self._setup_sensor(15)
+        self._setup_climate()
+        self.hass.block_till_done()
+
+        state = self.hass.states.get(ENTITY)
+        self.assertEqual(20, state.attributes[ATTR_TEMPERATURE])
+        self.assertEqual(STATE_OFF,
+                         state.attributes[climate.ATTR_OPERATION_MODE])
+        self.assertEqual(STATE_OFF, state.state)
+        self.assertEqual(0, len(self.calls))
+
+        self._setup_switch(False)
+        self.hass.block_till_done()
+        state = self.hass.states.get(ENTITY)
+        self.assertEqual(STATE_OFF,
+                         state.attributes[climate.ATTR_OPERATION_MODE])
+        self.assertEqual(STATE_OFF, state.state)
+
+    def _setup_climate(self):
+        assert setup_component(self.hass, climate.DOMAIN, {'climate': {
+            'platform': 'generic_thermostat',
+            'name': 'test',
+            'cold_tolerance': 2,
+            'hot_tolerance': 4,
+            'away_temp': 30,
+            'heater': ENT_SWITCH,
+            'target_sensor': ENT_SENSOR,
+            'ac_mode': True
+        }})
+
+    def _setup_sensor(self, temp, unit=TEMP_CELSIUS):
+        """Setup the test sensor."""
+        self.hass.states.set(ENT_SENSOR, temp, {
+            ATTR_UNIT_OF_MEASUREMENT: unit
+        })
+
+    def _setup_switch(self, is_on):
+        """Setup the test switch."""
+        self.hass.states.set(ENT_SWITCH, STATE_ON if is_on else STATE_OFF)
+        self.calls = []
+
+        @callback
+        def log_call(call):
+            """Log service calls."""
+            self.calls.append(call)
+
+        self.hass.services.register(ha.DOMAIN, SERVICE_TURN_ON, log_call)
+        self.hass.services.register(ha.DOMAIN, SERVICE_TURN_OFF, log_call)
+
+    def _mock_restore_cache(self, temperature=20, operation_mode=STATE_OFF):
+        mock_restore_cache(self.hass, (
+            State(ENTITY, '0', {
+                ATTR_TEMPERATURE: str(temperature),
+                climate.ATTR_OPERATION_MODE: operation_mode,
+                ATTR_AWAY_MODE: "on"}),
+        ))

--- a/tests/components/climate/test_generic_thermostat.py
+++ b/tests/components/climate/test_generic_thermostat.py
@@ -184,7 +184,7 @@ class TestClimateGenericThermostat(unittest.TestCase):
         """Test that the operation list returns the correct modes."""
         state = self.hass.states.get(ENTITY)
         modes = state.attributes.get('operation_list')
-        self.assertEqual([climate.STATE_HEAT, STATE_OFF], modes)
+        self.assertEqual([STATE_OFF, climate.STATE_HEAT], modes)
 
     def test_set_target_temp(self):
         """Test the setting of the target temperature."""

--- a/tests/components/climate/test_generic_thermostat.py
+++ b/tests/components/climate/test_generic_thermostat.py
@@ -77,23 +77,6 @@ class TestSetupClimateGenericThermostat(unittest.TestCase):
                                 }})
         )
 
-    @mock.patch('logging.Logger.error')
-    def test_setup_valid_conf_with_error(self, log_mock):
-        """Test set up generic_thermostat with valid config values."""
-        self.assertTrue(
-            setup_component(self.hass, 'climate',
-                            {'climate': {
-                                'platform': 'generic_thermostat',
-                                'name': 'test',
-                                'target_temp_high': 21.1,
-                                'target_temp_low': 21,
-                                'heater_control': ENT_SWITCH_HEAT,
-                                'ac_control': ENT_SWITCH_AC,
-                                'target_sensor': ENT_SENSOR
-                                }})
-        )
-        self.assertEqual(log_mock.call_count, 1)
-
 
 class TestGenericThermostatHeaterSwitching(unittest.TestCase):
     """Test the Generic thermostat heater switching.

--- a/tests/components/climate/test_generic_thermostat.py
+++ b/tests/components/climate/test_generic_thermostat.py
@@ -29,13 +29,22 @@ from tests.common import (assert_setup_component, get_test_home_assistant,
 
 ENTITY = 'climate.test'
 ENT_SENSOR = 'sensor.test'
-ENT_SWITCH = 'switch.test'
+ENT_SWITCH_HEAT = 'switch.test_heat'
+ENT_SWITCH_AC = 'switch.test_ac'
 ATTR_AWAY_MODE = 'away_mode'
 MIN_TEMP = 3.0
 MAX_TEMP = 65.0
 TARGET_TEMP = 42.0
-COLD_TOLERANCE = 0.5
-HOT_TOLERANCE = 0.5
+COLD_TOLERANCE = 0.3
+HOT_TOLERANCE = 0.3
+
+DEFAULT_MIN_TEMP = 7.0
+DEFAULT_MAX_TEMP = 35.0
+DEFAULT_AWAY_TEMP_COOL = 30.0
+DEFAULT_AWAY_TEMP_HEAT = 16.0
+DEFAULT_TARGET_TEMP_HIGH = 21.0
+DEFAULT_TARGET_TEMP_LOW = 18.0
+DEFAULT_TARGET_TEMP = 20.0
 
 
 class TestSetupClimateGenericThermostat(unittest.TestCase):
@@ -52,24 +61,40 @@ class TestSetupClimateGenericThermostat(unittest.TestCase):
     def test_setup_missing_conf(self):
         """Test set up heat_control with missing config values."""
         config = {
-            'name': 'test',
-            'target_sensor': ENT_SENSOR
+            'name': 'test'
         }
         with assert_setup_component(0):
             setup_component(self.hass, 'climate', {
                 'climate': config})
 
-    def test_valid_conf(self):
+    def test_setup_valid_conf(self):
         """Test set up generic_thermostat with valid config values."""
         self.assertTrue(
             setup_component(self.hass, 'climate',
                             {'climate': {
                                 'platform': 'generic_thermostat',
                                 'name': 'test',
-                                'heater': ENT_SWITCH,
+                                'heater_control': ENT_SWITCH_HEAT,
                                 'target_sensor': ENT_SENSOR
                                 }})
         )
+
+    @mock.patch('logging.Logger.error')
+    def test_setup_valid_conf_with_error(self, log_mock):
+        """Test set up generic_thermostat with valid config values."""
+        self.assertTrue(
+            setup_component(self.hass, 'climate',
+                            {'climate': {
+                                'platform': 'generic_thermostat',
+                                'name': 'test',
+                                'target_temp_high': 21.1,
+                                'target_temp_low': 21,
+                                'heater_control': ENT_SWITCH_HEAT,
+                                'ac_control': ENT_SWITCH_AC,
+                                'target_sensor': ENT_SENSOR
+                                }})
+        )
+        self.assertEqual(log_mock.call_count, 1)
 
 
 class TestGenericThermostatHeaterSwitching(unittest.TestCase):
@@ -99,16 +124,15 @@ class TestGenericThermostatHeaterSwitching(unittest.TestCase):
         assert setup_component(self.hass, climate.DOMAIN, {'climate': {
             'platform': 'generic_thermostat',
             'name': 'test',
-            'heater': heater_switch,
-            'target_sensor': ENT_SENSOR
+            'heater_control': heater_switch,
+            'target_sensor': ENT_SENSOR,
+            'initial_operation_mode': climate.STATE_HEAT
         }})
 
         self.assertEqual(STATE_OFF,
                          self.hass.states.get(heater_switch).state)
 
         self._setup_sensor(18)
-        self.hass.block_till_done()
-        climate.set_temperature(self.hass, 23)
         self.hass.block_till_done()
 
         self.assertEqual(STATE_ON,
@@ -126,16 +150,15 @@ class TestGenericThermostatHeaterSwitching(unittest.TestCase):
         assert setup_component(self.hass, climate.DOMAIN, {'climate': {
             'platform': 'generic_thermostat',
             'name': 'test',
-            'heater': heater_switch,
-            'target_sensor': ENT_SENSOR
+            'heater_control': heater_switch,
+            'target_sensor': ENT_SENSOR,
+            'initial_operation_mode': climate.STATE_HEAT
         }})
 
         self.assertEqual(STATE_OFF,
                          self.hass.states.get(heater_switch).state)
 
         self._setup_sensor(18)
-        self.hass.block_till_done()
-        climate.set_temperature(self.hass, 23)
         self.hass.block_till_done()
 
         self.assertEqual(STATE_ON,
@@ -148,8 +171,8 @@ class TestGenericThermostatHeaterSwitching(unittest.TestCase):
         })
 
 
-class TestClimateGenericThermostat(unittest.TestCase):
-    """Test the Generic thermostat."""
+class TestClimateGenericThermostatHeat(unittest.TestCase):
+    """Test the Generic thermostat in Heat mode."""
 
     def setUp(self):  # pylint: disable=invalid-name
         """Setup things to be run when tests are started."""
@@ -160,25 +183,25 @@ class TestClimateGenericThermostat(unittest.TestCase):
             'name': 'test',
             'cold_tolerance': 2,
             'hot_tolerance': 4,
-            'heater': ENT_SWITCH,
-            'target_sensor': ENT_SENSOR,
-            'away_temp': 16
+            'heater_control': ENT_SWITCH_HEAT,
+            'target_sensor': ENT_SENSOR
         }})
 
     def tearDown(self):  # pylint: disable=invalid-name
         """Stop down everything that was started."""
         self.hass.stop()
 
-    def test_setup_defaults_to_unknown(self):
-        """Test the setting of defaults to unknown."""
-        self.assertEqual(STATE_IDLE, self.hass.states.get(ENTITY).state)
+    def test_setup_defaults_to_off(self):
+        """Test the setting of defaults to STATE_OFF."""
+        self.assertEqual(STATE_OFF, self.hass.states.get(ENTITY).state)
 
     def test_default_setup_params(self):
         """Test the setup with default parameters."""
         state = self.hass.states.get(ENTITY)
-        self.assertEqual(7, state.attributes.get('min_temp'))
-        self.assertEqual(35, state.attributes.get('max_temp'))
-        self.assertEqual(7, state.attributes.get('temperature'))
+        self.assertEqual(DEFAULT_MIN_TEMP, state.attributes.get('min_temp'))
+        self.assertEqual(DEFAULT_MAX_TEMP, state.attributes.get('max_temp'))
+        self.assertEqual(DEFAULT_TARGET_TEMP,
+                         state.attributes.get(ATTR_TEMPERATURE))
 
     def test_get_operation_modes(self):
         """Test that the operation list returns the correct modes."""
@@ -191,20 +214,54 @@ class TestClimateGenericThermostat(unittest.TestCase):
         climate.set_temperature(self.hass, 30)
         self.hass.block_till_done()
         state = self.hass.states.get(ENTITY)
-        self.assertEqual(30.0, state.attributes.get('temperature'))
+        self.assertEqual(30.0, state.attributes.get(ATTR_TEMPERATURE))
         climate.set_temperature(self.hass, None)
         self.hass.block_till_done()
         state = self.hass.states.get(ENTITY)
-        self.assertEqual(30.0, state.attributes.get('temperature'))
+        self.assertEqual(30.0, state.attributes.get(ATTR_TEMPERATURE))
 
-    def test_set_away_mode(self):
+    def test_set_operation_mode(self):
+        """Test the setting operation mode."""
+        climate.set_operation_mode(self.hass, climate.STATE_HEAT)
+        self.hass.block_till_done()
+        state = self.hass.states.get(ENTITY)
+        self.assertEqual(climate.STATE_HEAT,
+                         state.attributes.get('operation_mode'))
+        climate.set_operation_mode(self.hass, climate.STATE_OFF)
+        self.hass.block_till_done()
+        state = self.hass.states.get(ENTITY)
+        self.assertEqual(climate.STATE_OFF,
+                         state.attributes.get('operation_mode'))
+        climate.set_operation_mode(self.hass, climate.STATE_AUTO)
+        self.hass.block_till_done()
+        state = self.hass.states.get(ENTITY)
+        self.assertEqual(climate.STATE_OFF,
+                         state.attributes.get('operation_mode'))
+
+    def test_set_away_mode_from_off(self):
         """Test the setting away mode."""
         climate.set_temperature(self.hass, 23)
         self.hass.block_till_done()
         climate.set_away_mode(self.hass, True)
         self.hass.block_till_done()
         state = self.hass.states.get(ENTITY)
-        self.assertEqual(16, state.attributes.get('temperature'))
+        self.assertEqual(DEFAULT_AWAY_TEMP_HEAT,
+                         state.attributes.get('temperature'))
+        self.assertEqual(STATE_ON,
+                         state.attributes.get('away_mode'))
+
+    def test_set_away_mode_from_heat(self):
+        """Test the setting away mode."""
+        climate.set_operation_mode(self.hass, climate.STATE_HEAT)
+        climate.set_temperature(self.hass, 23)
+        self.hass.block_till_done()
+        climate.set_away_mode(self.hass, True)
+        self.hass.block_till_done()
+        state = self.hass.states.get(ENTITY)
+        self.assertEqual(DEFAULT_AWAY_TEMP_HEAT,
+                         state.attributes.get('temperature'))
+        self.assertEqual(STATE_ON,
+                         state.attributes.get('away_mode'))
 
     def test_set_away_mode_and_restore_prev_temp(self):
         """Test the setting and removing away mode.
@@ -216,7 +273,8 @@ class TestClimateGenericThermostat(unittest.TestCase):
         climate.set_away_mode(self.hass, True)
         self.hass.block_till_done()
         state = self.hass.states.get(ENTITY)
-        self.assertEqual(16, state.attributes.get('temperature'))
+        self.assertEqual(DEFAULT_AWAY_TEMP_HEAT,
+                         state.attributes.get('temperature'))
         climate.set_away_mode(self.hass, False)
         self.hass.block_till_done()
         state = self.hass.states.get(ENTITY)
@@ -224,7 +282,10 @@ class TestClimateGenericThermostat(unittest.TestCase):
 
     def test_sensor_bad_unit(self):
         """Test sensor that have bad unit."""
+        climate.set_temperature(self.hass, 19)
+        self.hass.block_till_done()
         state = self.hass.states.get(ENTITY)
+
         temp = state.attributes.get('current_temperature')
         unit = state.attributes.get('unit_of_measurement')
 
@@ -250,6 +311,8 @@ class TestClimateGenericThermostat(unittest.TestCase):
 
     def test_set_target_temp_heater_on(self):
         """Test if target temperature turn heater on."""
+        climate.set_operation_mode(self.hass, climate.STATE_HEAT)
+        climate.set_temperature(self.hass, 18)
         self._setup_switch(False)
         self._setup_sensor(25)
         self.hass.block_till_done()
@@ -259,11 +322,13 @@ class TestClimateGenericThermostat(unittest.TestCase):
         call = self.calls[0]
         self.assertEqual('homeassistant', call.domain)
         self.assertEqual(SERVICE_TURN_ON, call.service)
-        self.assertEqual(ENT_SWITCH, call.data['entity_id'])
+        self.assertEqual(ENT_SWITCH_HEAT, call.data['entity_id'])
 
     def test_set_target_temp_heater_off(self):
         """Test if target temperature turn heater off."""
+        climate.set_operation_mode(self.hass, climate.STATE_HEAT)
         self._setup_switch(True)
+        climate.set_temperature(self.hass, 35)
         self._setup_sensor(30)
         self.hass.block_till_done()
         climate.set_temperature(self.hass, 25)
@@ -272,7 +337,7 @@ class TestClimateGenericThermostat(unittest.TestCase):
         call = self.calls[0]
         self.assertEqual('homeassistant', call.domain)
         self.assertEqual(SERVICE_TURN_OFF, call.service)
-        self.assertEqual(ENT_SWITCH, call.data['entity_id'])
+        self.assertEqual(ENT_SWITCH_HEAT, call.data['entity_id'])
 
     def test_temp_change_heater_on_within_tolerance(self):
         """Test if temperature change doesn't turn on within tolerance."""
@@ -287,6 +352,7 @@ class TestClimateGenericThermostat(unittest.TestCase):
         """Test if temperature change turn heater on outside cold tolerance."""
         self._setup_switch(False)
         climate.set_temperature(self.hass, 30)
+        climate.set_operation_mode(self.hass, climate.STATE_HEAT)
         self.hass.block_till_done()
         self._setup_sensor(27)
         self.hass.block_till_done()
@@ -294,7 +360,7 @@ class TestClimateGenericThermostat(unittest.TestCase):
         call = self.calls[0]
         self.assertEqual('homeassistant', call.domain)
         self.assertEqual(SERVICE_TURN_ON, call.service)
-        self.assertEqual(ENT_SWITCH, call.data['entity_id'])
+        self.assertEqual(ENT_SWITCH_HEAT, call.data['entity_id'])
 
     def test_temp_change_heater_off_within_tolerance(self):
         """Test if temperature change doesn't turn off within tolerance."""
@@ -309,6 +375,7 @@ class TestClimateGenericThermostat(unittest.TestCase):
         """Test if temperature change turn heater off outside hot tolerance."""
         self._setup_switch(True)
         climate.set_temperature(self.hass, 30)
+        climate.set_operation_mode(self.hass, climate.STATE_HEAT)
         self.hass.block_till_done()
         self._setup_sensor(35)
         self.hass.block_till_done()
@@ -316,10 +383,11 @@ class TestClimateGenericThermostat(unittest.TestCase):
         call = self.calls[0]
         self.assertEqual('homeassistant', call.domain)
         self.assertEqual(SERVICE_TURN_OFF, call.service)
-        self.assertEqual(ENT_SWITCH, call.data['entity_id'])
+        self.assertEqual(ENT_SWITCH_HEAT, call.data['entity_id'])
 
     def test_running_when_operating_mode_is_off(self):
         """Test that the switch turns off when enabled is set False."""
+        climate.set_operation_mode(self.hass, climate.STATE_HEAT)
         self._setup_switch(True)
         climate.set_temperature(self.hass, 30)
         self.hass.block_till_done()
@@ -329,7 +397,7 @@ class TestClimateGenericThermostat(unittest.TestCase):
         call = self.calls[0]
         self.assertEqual('homeassistant', call.domain)
         self.assertEqual(SERVICE_TURN_OFF, call.service)
-        self.assertEqual(ENT_SWITCH, call.data['entity_id'])
+        self.assertEqual(ENT_SWITCH_HEAT, call.data['entity_id'])
 
     def test_no_state_change_when_operation_mode_off(self):
         """Test that the switch doesn't turn on when enabled is False."""
@@ -365,7 +433,7 @@ class TestClimateGenericThermostat(unittest.TestCase):
         call = self.calls[0]
         self.assertEqual('homeassistant', call.domain)
         self.assertEqual(SERVICE_TURN_ON, call.service)
-        self.assertEqual(ENT_SWITCH, call.data['entity_id'])
+        self.assertEqual(ENT_SWITCH_HEAT, call.data['entity_id'])
 
     def _setup_sensor(self, temp, unit=TEMP_CELSIUS):
         """Setup the test sensor."""
@@ -375,7 +443,7 @@ class TestClimateGenericThermostat(unittest.TestCase):
 
     def _setup_switch(self, is_on):
         """Setup the test switch."""
-        self.hass.states.set(ENT_SWITCH, STATE_ON if is_on else STATE_OFF)
+        self.hass.states.set(ENT_SWITCH_HEAT, STATE_ON if is_on else STATE_OFF)
         self.calls = []
 
         @callback
@@ -399,10 +467,10 @@ class TestClimateGenericThermostatACMode(unittest.TestCase):
             'name': 'test',
             'cold_tolerance': 2,
             'hot_tolerance': 4,
-            'away_temp': 30,
-            'heater': ENT_SWITCH,
+            'away_temp_cool': DEFAULT_AWAY_TEMP_COOL,
+            'ac_control': ENT_SWITCH_AC,
             'target_sensor': ENT_SENSOR,
-            'ac_mode': True
+            'initial_operation_mode': climate.STATE_COOL
         }})
 
     def tearDown(self):  # pylint: disable=invalid-name
@@ -420,9 +488,9 @@ class TestClimateGenericThermostatACMode(unittest.TestCase):
         call = self.calls[0]
         self.assertEqual('homeassistant', call.domain)
         self.assertEqual(SERVICE_TURN_OFF, call.service)
-        self.assertEqual(ENT_SWITCH, call.data['entity_id'])
+        self.assertEqual(ENT_SWITCH_AC, call.data['entity_id'])
 
-    def test_turn_away_mode_on_cooling(self):
+    def test_turn_away_mode_on_cooling_from_cool(self):
         """Test the setting away mode when cooling."""
         self._setup_sensor(25)
         self.hass.block_till_done()
@@ -431,7 +499,21 @@ class TestClimateGenericThermostatACMode(unittest.TestCase):
         climate.set_away_mode(self.hass, True)
         self.hass.block_till_done()
         state = self.hass.states.get(ENTITY)
-        self.assertEqual(30, state.attributes.get('temperature'))
+        self.assertEqual(DEFAULT_AWAY_TEMP_COOL,
+                         state.attributes.get(ATTR_TEMPERATURE))
+
+    def test_turn_away_mode_on_cooling_from_off(self):
+        """Test the setting away mode when cooling."""
+        self._setup_sensor(25)
+        climate.set_operation_mode(self.hass, climate.STATE_OFF)
+        self.hass.block_till_done()
+        climate.set_temperature(self.hass, 19)
+        self.hass.block_till_done()
+        climate.set_away_mode(self.hass, True)
+        self.hass.block_till_done()
+        state = self.hass.states.get(ENTITY)
+        self.assertEqual(DEFAULT_AWAY_TEMP_COOL,
+                         state.attributes.get(ATTR_TEMPERATURE))
 
     def test_operating_mode_cool(self):
         """Test change mode from OFF to COOL.
@@ -449,11 +531,12 @@ class TestClimateGenericThermostatACMode(unittest.TestCase):
         call = self.calls[0]
         self.assertEqual('homeassistant', call.domain)
         self.assertEqual(SERVICE_TURN_ON, call.service)
-        self.assertEqual(ENT_SWITCH, call.data['entity_id'])
+        self.assertEqual(ENT_SWITCH_AC, call.data['entity_id'])
 
     def test_set_target_temp_ac_on(self):
         """Test if target temperature turn ac on."""
         self._setup_switch(False)
+        climate.set_temperature(self.hass, 31)
         self._setup_sensor(30)
         self.hass.block_till_done()
         climate.set_temperature(self.hass, 25)
@@ -462,7 +545,7 @@ class TestClimateGenericThermostatACMode(unittest.TestCase):
         call = self.calls[0]
         self.assertEqual('homeassistant', call.domain)
         self.assertEqual(SERVICE_TURN_ON, call.service)
-        self.assertEqual(ENT_SWITCH, call.data['entity_id'])
+        self.assertEqual(ENT_SWITCH_AC, call.data['entity_id'])
 
     def test_temp_change_ac_off_within_tolerance(self):
         """Test if temperature change doesn't turn ac off within tolerance."""
@@ -484,7 +567,7 @@ class TestClimateGenericThermostatACMode(unittest.TestCase):
         call = self.calls[0]
         self.assertEqual('homeassistant', call.domain)
         self.assertEqual(SERVICE_TURN_OFF, call.service)
-        self.assertEqual(ENT_SWITCH, call.data['entity_id'])
+        self.assertEqual(ENT_SWITCH_AC, call.data['entity_id'])
 
     def test_temp_change_ac_on_within_tolerance(self):
         """Test if temperature change doesn't turn ac on within tolerance."""
@@ -498,6 +581,7 @@ class TestClimateGenericThermostatACMode(unittest.TestCase):
     def test_temp_change_ac_on_outside_tolerance(self):
         """Test if temperature change turn ac on."""
         self._setup_switch(False)
+        climate.set_operation_mode(self.hass, climate.STATE_COOL)
         climate.set_temperature(self.hass, 25)
         self.hass.block_till_done()
         self._setup_sensor(30)
@@ -506,7 +590,7 @@ class TestClimateGenericThermostatACMode(unittest.TestCase):
         call = self.calls[0]
         self.assertEqual('homeassistant', call.domain)
         self.assertEqual(SERVICE_TURN_ON, call.service)
-        self.assertEqual(ENT_SWITCH, call.data['entity_id'])
+        self.assertEqual(ENT_SWITCH_AC, call.data['entity_id'])
 
     def test_running_when_operating_mode_is_off(self):
         """Test that the switch turns off when enabled is set False."""
@@ -519,7 +603,7 @@ class TestClimateGenericThermostatACMode(unittest.TestCase):
         call = self.calls[0]
         self.assertEqual('homeassistant', call.domain)
         self.assertEqual(SERVICE_TURN_OFF, call.service)
-        self.assertEqual(ENT_SWITCH, call.data['entity_id'])
+        self.assertEqual(ENT_SWITCH_AC, call.data['entity_id'])
 
     def test_no_state_change_when_operation_mode_off(self):
         """Test that the switch doesn't turn on when enabled is False."""
@@ -540,7 +624,7 @@ class TestClimateGenericThermostatACMode(unittest.TestCase):
 
     def _setup_switch(self, is_on):
         """Setup the test switch."""
-        self.hass.states.set(ENT_SWITCH, STATE_ON if is_on else STATE_OFF)
+        self.hass.states.set(ENT_SWITCH_AC, STATE_ON if is_on else STATE_OFF)
         self.calls = []
 
         @callback
@@ -564,10 +648,10 @@ class TestClimateGenericThermostatACModeMinCycle(unittest.TestCase):
             'name': 'test',
             'cold_tolerance': 0.3,
             'hot_tolerance': 0.3,
-            'heater': ENT_SWITCH,
+            'ac_control': ENT_SWITCH_AC,
             'target_sensor': ENT_SENSOR,
-            'ac_mode': True,
-            'min_cycle_duration': datetime.timedelta(minutes=10)
+            'min_cycle_duration': datetime.timedelta(minutes=10),
+            'initial_operation_mode': climate.STATE_COOL
         }})
 
     def tearDown(self):  # pylint: disable=invalid-name
@@ -598,7 +682,7 @@ class TestClimateGenericThermostatACModeMinCycle(unittest.TestCase):
         call = self.calls[0]
         self.assertEqual('homeassistant', call.domain)
         self.assertEqual(SERVICE_TURN_ON, call.service)
-        self.assertEqual(ENT_SWITCH, call.data['entity_id'])
+        self.assertEqual(ENT_SWITCH_AC, call.data['entity_id'])
 
     def test_temp_change_ac_trigger_off_not_long_enough(self):
         """Test if temperature change turn ac on."""
@@ -624,7 +708,7 @@ class TestClimateGenericThermostatACModeMinCycle(unittest.TestCase):
         call = self.calls[0]
         self.assertEqual('homeassistant', call.domain)
         self.assertEqual(SERVICE_TURN_OFF, call.service)
-        self.assertEqual(ENT_SWITCH, call.data['entity_id'])
+        self.assertEqual(ENT_SWITCH_AC, call.data['entity_id'])
 
     def _setup_sensor(self, temp, unit=TEMP_CELSIUS):
         """Setup the test sensor."""
@@ -634,7 +718,7 @@ class TestClimateGenericThermostatACModeMinCycle(unittest.TestCase):
 
     def _setup_switch(self, is_on):
         """Setup the test switch."""
-        self.hass.states.set(ENT_SWITCH, STATE_ON if is_on else STATE_OFF)
+        self.hass.states.set(ENT_SWITCH_AC, STATE_ON if is_on else STATE_OFF)
         self.calls = []
 
         @callback
@@ -658,9 +742,10 @@ class TestClimateGenericThermostatMinCycle(unittest.TestCase):
             'name': 'test',
             'cold_tolerance': 0.3,
             'hot_tolerance': 0.3,
-            'heater': ENT_SWITCH,
+            'heater_control': ENT_SWITCH_HEAT,
             'target_sensor': ENT_SENSOR,
-            'min_cycle_duration': datetime.timedelta(minutes=10)
+            'min_cycle_duration': datetime.timedelta(minutes=10),
+            'initial_operation_mode': climate.STATE_HEAT
         }})
 
     def tearDown(self):  # pylint: disable=invalid-name
@@ -692,6 +777,7 @@ class TestClimateGenericThermostatMinCycle(unittest.TestCase):
         with mock.patch('homeassistant.helpers.condition.dt_util.utcnow',
                         return_value=fake_changed):
             self._setup_switch(False)
+        self.hass.block_till_done()
         climate.set_temperature(self.hass, 30)
         self.hass.block_till_done()
         self._setup_sensor(25)
@@ -700,7 +786,7 @@ class TestClimateGenericThermostatMinCycle(unittest.TestCase):
         call = self.calls[0]
         self.assertEqual('homeassistant', call.domain)
         self.assertEqual(SERVICE_TURN_ON, call.service)
-        self.assertEqual(ENT_SWITCH, call.data['entity_id'])
+        self.assertEqual(ENT_SWITCH_HEAT, call.data['entity_id'])
 
     def test_temp_change_heater_trigger_off_long_enough(self):
         """Test if temperature change turn heater off after min cycle."""
@@ -717,7 +803,7 @@ class TestClimateGenericThermostatMinCycle(unittest.TestCase):
         call = self.calls[0]
         self.assertEqual('homeassistant', call.domain)
         self.assertEqual(SERVICE_TURN_OFF, call.service)
-        self.assertEqual(ENT_SWITCH, call.data['entity_id'])
+        self.assertEqual(ENT_SWITCH_HEAT, call.data['entity_id'])
 
     def _setup_sensor(self, temp, unit=TEMP_CELSIUS):
         """Setup the test sensor."""
@@ -727,7 +813,7 @@ class TestClimateGenericThermostatMinCycle(unittest.TestCase):
 
     def _setup_switch(self, is_on):
         """Setup the test switch."""
-        self.hass.states.set(ENT_SWITCH, STATE_ON if is_on else STATE_OFF)
+        self.hass.states.set(ENT_SWITCH_HEAT, STATE_ON if is_on else STATE_OFF)
         self.calls = []
 
         @callback
@@ -751,8 +837,7 @@ class TestClimateGenericThermostatACKeepAlive(unittest.TestCase):
             'name': 'test',
             'cold_tolerance': 0.3,
             'hot_tolerance': 0.3,
-            'heater': ENT_SWITCH,
-            'target_temp': 25,
+            'ac_control': ENT_SWITCH_AC,
             'target_sensor': ENT_SENSOR,
             'ac_mode': True,
             'keep_alive': datetime.timedelta(minutes=10)
@@ -783,7 +868,7 @@ class TestClimateGenericThermostatACKeepAlive(unittest.TestCase):
         call = self.calls[0]
         self.assertEqual('homeassistant', call.domain)
         self.assertEqual(SERVICE_TURN_ON, call.service)
-        self.assertEqual(ENT_SWITCH, call.data['entity_id'])
+        self.assertEqual(ENT_SWITCH_AC, call.data['entity_id'])
 
     def test_temp_change_ac_trigger_off_long_enough(self):
         """Test if turn on signal is sent at keep-alive intervals."""
@@ -806,7 +891,7 @@ class TestClimateGenericThermostatACKeepAlive(unittest.TestCase):
         call = self.calls[0]
         self.assertEqual('homeassistant', call.domain)
         self.assertEqual(SERVICE_TURN_OFF, call.service)
-        self.assertEqual(ENT_SWITCH, call.data['entity_id'])
+        self.assertEqual(ENT_SWITCH_AC, call.data['entity_id'])
 
     def _send_time_changed(self, now):
         """Send a time changed event."""
@@ -820,7 +905,7 @@ class TestClimateGenericThermostatACKeepAlive(unittest.TestCase):
 
     def _setup_switch(self, is_on):
         """Setup the test switch."""
-        self.hass.states.set(ENT_SWITCH, STATE_ON if is_on else STATE_OFF)
+        self.hass.states.set(ENT_SWITCH_AC, STATE_ON if is_on else STATE_OFF)
         self.calls = []
 
         @callback
@@ -844,8 +929,7 @@ class TestClimateGenericThermostatKeepAlive(unittest.TestCase):
             'name': 'test',
             'cold_tolerance': 0.3,
             'hot_tolerance': 0.3,
-            'target_temp': 25,
-            'heater': ENT_SWITCH,
+            'heater_control': ENT_SWITCH_HEAT,
             'target_sensor': ENT_SENSOR,
             'keep_alive': datetime.timedelta(minutes=10)
         }})
@@ -875,7 +959,7 @@ class TestClimateGenericThermostatKeepAlive(unittest.TestCase):
         call = self.calls[0]
         self.assertEqual('homeassistant', call.domain)
         self.assertEqual(SERVICE_TURN_ON, call.service)
-        self.assertEqual(ENT_SWITCH, call.data['entity_id'])
+        self.assertEqual(ENT_SWITCH_HEAT, call.data['entity_id'])
 
     def test_temp_change_heater_trigger_off_long_enough(self):
         """Test if turn on signal is sent at keep-alive intervals."""
@@ -898,7 +982,7 @@ class TestClimateGenericThermostatKeepAlive(unittest.TestCase):
         call = self.calls[0]
         self.assertEqual('homeassistant', call.domain)
         self.assertEqual(SERVICE_TURN_OFF, call.service)
-        self.assertEqual(ENT_SWITCH, call.data['entity_id'])
+        self.assertEqual(ENT_SWITCH_HEAT, call.data['entity_id'])
 
     def _send_time_changed(self, now):
         """Send a time changed event."""
@@ -912,7 +996,338 @@ class TestClimateGenericThermostatKeepAlive(unittest.TestCase):
 
     def _setup_switch(self, is_on):
         """Setup the test switch."""
-        self.hass.states.set(ENT_SWITCH, STATE_ON if is_on else STATE_OFF)
+        self.hass.states.set(ENT_SWITCH_HEAT, STATE_ON if is_on else STATE_OFF)
+        self.calls = []
+
+        @callback
+        def log_call(call):
+            """Log service calls."""
+            self.calls.append(call)
+
+        self.hass.services.register(ha.DOMAIN, SERVICE_TURN_ON, log_call)
+        self.hass.services.register(ha.DOMAIN, SERVICE_TURN_OFF, log_call)
+
+
+class TestClimateGenericThermostatDualSwitchMinCycle(unittest.TestCase):
+    """Test the Generic thermostat."""
+
+    def setUp(self):  # pylint: disable=invalid-name
+        """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+        self.hass.config.temperature_unit = TEMP_CELSIUS
+        assert setup_component(self.hass, climate.DOMAIN, {'climate': {
+            'platform': 'generic_thermostat',
+            'name': 'test',
+            'heater_control': ENT_SWITCH_HEAT,
+            'ac_control': ENT_SWITCH_AC,
+            'target_sensor': ENT_SENSOR,
+            'min_cycle_duration': datetime.timedelta(minutes=10),
+            'initial_operation_mode': climate.STATE_AUTO
+        }})
+
+    def tearDown(self):  # pylint: disable=invalid-name
+        """Stop down everything that was started."""
+        self.hass.stop()
+
+    def test_temp_change_ac_trigger_on_not_long_enough(self):
+        """Test if temperature change turn ac on."""
+        self._setup_switch_heat(False)
+        self._setup_switch_ac(False)
+        climate.set_temperature(self.hass, None, None, 25, 20)
+        self.hass.block_till_done()
+        self._setup_sensor(30)
+        self.hass.block_till_done()
+        self.assertEqual(0, len(self.calls))
+
+    def test_temp_change_ac_trigger_on_long_enough(self):
+        """Test if temperature change turn ac on."""
+        fake_changed = datetime.datetime(1918, 11, 11, 11, 11, 11,
+                                         tzinfo=datetime.timezone.utc)
+        with mock.patch('homeassistant.helpers.condition.dt_util.utcnow',
+                        return_value=fake_changed):
+            self._setup_switch_heat(False)
+            self._setup_switch_ac(False)
+        climate.set_operation_mode(self.hass, climate.STATE_COOL)
+        climate.set_temperature(self.hass, None, None, 25, 20)
+        self.hass.block_till_done()
+        self._setup_sensor(30)
+        self.hass.block_till_done()
+        self.assertEqual(1, len(self.calls))
+        call = self.calls[0]
+        self.assertEqual('homeassistant', call.domain)
+        self.assertEqual(SERVICE_TURN_ON, call.service)
+        self.assertEqual(ENT_SWITCH_AC, call.data['entity_id'])
+
+    def test_temp_change_heat_trigger_on_long_enough(self):
+        """Test if temperature change turn ac on."""
+        fake_changed = datetime.datetime(1918, 11, 11, 11, 11, 11,
+                                         tzinfo=datetime.timezone.utc)
+        with mock.patch('homeassistant.helpers.condition.dt_util.utcnow',
+                        return_value=fake_changed):
+            self._setup_switch_heat(False)
+            self._setup_switch_ac(False)
+        climate.set_operation_mode(self.hass, climate.STATE_HEAT)
+        climate.set_temperature(self.hass, None, None, 25, 20)
+        self.hass.block_till_done()
+        self._setup_sensor(17)
+        self.hass.block_till_done()
+        self.assertEqual(1, len(self.calls))
+        call = self.calls[0]
+        self.assertEqual('homeassistant', call.domain)
+        self.assertEqual(SERVICE_TURN_ON, call.service)
+        self.assertEqual(ENT_SWITCH_HEAT, call.data['entity_id'])
+
+    def _setup_sensor(self, temp, unit=TEMP_CELSIUS):
+        """Setup the test sensor."""
+        self.hass.states.set(ENT_SENSOR, temp, {
+            ATTR_UNIT_OF_MEASUREMENT: unit
+        })
+
+    def _setup_switch_heat(self, is_on):
+        """Setup the test heating switch."""
+        self.hass.states.set(ENT_SWITCH_HEAT, STATE_ON if is_on else STATE_OFF)
+        self.calls = []
+
+        @callback
+        def log_call(call):
+            """Log service calls."""
+            self.calls.append(call)
+
+        self.hass.services.register(ha.DOMAIN, SERVICE_TURN_ON, log_call)
+        self.hass.services.register(ha.DOMAIN, SERVICE_TURN_OFF, log_call)
+
+    def _setup_switch_ac(self, is_on):
+        """Setup the test A/C switch."""
+        self.hass.states.set(ENT_SWITCH_AC, STATE_ON if is_on else STATE_OFF)
+        self.calls = []
+
+        @callback
+        def log_call(call):
+            """Log service calls."""
+            self.calls.append(call)
+
+        self.hass.services.register(ha.DOMAIN, SERVICE_TURN_ON, log_call)
+        self.hass.services.register(ha.DOMAIN, SERVICE_TURN_OFF, log_call)
+
+
+class TestClimateGenericThermostatDualSwitch(unittest.TestCase):
+    """Test the Generic thermostat."""
+
+    def setUp(self):  # pylint: disable=invalid-name
+        """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+        self.hass.config.temperature_unit = TEMP_CELSIUS
+        assert setup_component(self.hass, climate.DOMAIN, {'climate': {
+            'platform': 'generic_thermostat',
+            'name': 'test',
+            'heater_control': ENT_SWITCH_HEAT,
+            'ac_control': ENT_SWITCH_AC,
+            'target_sensor': ENT_SENSOR,
+            'initial_operation_mode': climate.STATE_AUTO
+        }})
+
+    def tearDown(self):  # pylint: disable=invalid-name
+        """Stop down everything that was started."""
+        self.hass.stop()
+
+    def test_setup_defaults_to_initial_state(self):
+        """Test the setting of defaults to STATE_AUTO."""
+        self.assertEqual(climate.STATE_AUTO,
+                         self.hass.states.get(ENTITY).
+                         attributes.get('operation_mode'))
+
+    def test_default_setup_params(self):
+        """Test the setup with default parameters."""
+        state = self.hass.states.get(ENTITY)
+        self.assertEqual(DEFAULT_TARGET_TEMP_HIGH,
+                         state.attributes.get('target_temp_high'))
+        self.assertEqual(DEFAULT_TARGET_TEMP_LOW,
+                         state.attributes.get('target_temp_low'))
+        self.assertEqual(None,
+                         state.attributes.get(ATTR_TEMPERATURE))
+
+    def test_set_operation_mode(self):
+        """Test the setting operation mode."""
+        climate.set_operation_mode(self.hass, climate.STATE_HEAT)
+        self.hass.block_till_done()
+        state = self.hass.states.get(ENTITY)
+        self.assertEqual(climate.STATE_HEAT,
+                         state.attributes.get('operation_mode'))
+        climate.set_operation_mode(self.hass, climate.STATE_OFF)
+        self.hass.block_till_done()
+        state = self.hass.states.get(ENTITY)
+        self.assertEqual(climate.STATE_OFF,
+                         state.attributes.get('operation_mode'))
+        climate.set_operation_mode(self.hass, climate.STATE_AUTO)
+        self.hass.block_till_done()
+        state = self.hass.states.get(ENTITY)
+        self.assertEqual(climate.STATE_AUTO,
+                         state.attributes.get('operation_mode'))
+        climate.set_operation_mode(self.hass, 'invalid mode')
+        self.hass.block_till_done()
+        state = self.hass.states.get(ENTITY)
+        self.assertEqual(climate.STATE_AUTO,
+                         state.attributes.get('operation_mode'))
+
+    def test_set_away_mode_and_restore_prev_temp(self):
+        """Test the setting and removing away mode.
+
+        Verify original temperature is restored.
+        """
+        climate.set_temperature(self.hass, None, None, 22, 20)
+        self.hass.block_till_done()
+        climate.set_away_mode(self.hass, True)
+        self.hass.block_till_done()
+        state = self.hass.states.get(ENTITY)
+        self.assertEqual(DEFAULT_AWAY_TEMP_COOL,
+                         state.attributes.get('target_temp_high'))
+        self.assertEqual(DEFAULT_AWAY_TEMP_HEAT,
+                         state.attributes.get('target_temp_low'))
+        climate.set_away_mode(self.hass, False)
+        self.hass.block_till_done()
+        state = self.hass.states.get(ENTITY)
+        self.assertEqual(22, state.attributes.get('target_temp_high'))
+        self.assertEqual(20, state.attributes.get('target_temp_low'))
+
+    def test_set_target_temp_heater_off(self):
+        """Test if target temperature turn heater off."""
+        self._setup_switch_heat(True)
+        climate.set_temperature(self.hass, None, None, 25, 20)
+        self._setup_sensor(19)
+        self.hass.block_till_done()
+        climate.set_temperature(self.hass, None, None, 25, 18)
+        self.hass.block_till_done()
+        self.assertEqual(1, len(self.calls))
+        call = self.calls[0]
+        self.assertEqual('homeassistant', call.domain)
+        self.assertEqual(SERVICE_TURN_OFF, call.service)
+        self.assertEqual(ENT_SWITCH_HEAT, call.data['entity_id'])
+
+    def test_sensor_move_inside_heater_interval(self):
+        """Test complete intervals.
+
+        Verify all positions of sensor temperature.
+        Observe correct service calls.
+        """
+        self._setup_sensor(19)
+        self._setup_switch_heat(False)
+        self._setup_switch_ac(False)
+        self.hass.block_till_done()
+        self._setup_sensor(17.9)
+        self.hass.block_till_done()
+        self.assertEqual(0, len(self.calls))
+        self._setup_sensor(17)
+        self.hass.block_till_done()
+        self.assertEqual(1, len(self.calls))
+        call = self.calls[0]
+        self.assertEqual('homeassistant', call.domain)
+        self.assertEqual(SERVICE_TURN_ON, call.service)
+        self.assertEqual(ENT_SWITCH_HEAT, call.data['entity_id'])
+
+    def test_sensor_move_outside_heater(self):
+        """Test complete intervals.
+
+        Verify all positions of sensor temperature.
+        Observe correct service calls.
+        """
+        self._setup_sensor(17)
+        self._setup_switch_heat(True)
+        self._setup_switch_ac(False)
+        self.hass.block_till_done()
+        self._setup_sensor(18.2)
+        self.hass.block_till_done()
+        self.assertEqual(0, len(self.calls))
+        self._setup_sensor(19)
+        self.hass.block_till_done()
+        self.assertEqual(1, len(self.calls))
+        call = self.calls[0]
+        self.assertEqual('homeassistant', call.domain)
+        self.assertEqual(SERVICE_TURN_OFF, call.service)
+        self.assertEqual(ENT_SWITCH_HEAT, call.data['entity_id'])
+
+    def test_sensor_move_inside_ac_interval(self):
+        """Test complete intervals.
+
+        Verify all positions of sensor temperature.
+        Observe correct service calls.
+        """
+        self._setup_sensor(19)
+        self._setup_switch_heat(False)
+        self._setup_switch_ac(False)
+        self.hass.block_till_done()
+        self._setup_sensor(21.1)
+        self.hass.block_till_done()
+        self.assertEqual(0, len(self.calls))
+        self._setup_sensor(22)
+        self.hass.block_till_done()
+        self.assertEqual(1, len(self.calls))
+        call = self.calls[0]
+        self.assertEqual('homeassistant', call.domain)
+        self.assertEqual(SERVICE_TURN_ON, call.service)
+        self.assertEqual(ENT_SWITCH_AC, call.data['entity_id'])
+
+    @mock.patch('logging.Logger.error')
+    def test_invalid_both_heating_and_cooling_on(self, log_mock):
+        """Test error handling for state of heat and cool."""
+        self._setup_switch_heat(True)
+        self._setup_switch_ac(False)
+        self.hass.block_till_done()
+        self._setup_switch_ac(True)
+        self.hass.block_till_done()
+        self.assertEqual(log_mock.call_count, 1)
+        self.assertEqual(2, len(self.calls))
+        call1 = self.calls[0]
+        self.assertEqual('homeassistant', call1.domain)
+        self.assertEqual(SERVICE_TURN_OFF, call1.service)
+        self.assertEqual(ENT_SWITCH_HEAT, call1.data['entity_id'])
+        call2 = self.calls[1]
+        self.assertEqual('homeassistant', call2.domain)
+        self.assertEqual(SERVICE_TURN_OFF, call2.service)
+        self.assertEqual(ENT_SWITCH_AC, call2.data['entity_id'])
+
+    def test_sensor_move_outside_ac(self):
+        """Test complete intervals.
+
+        Verify all positions of sensor temperature.
+        Observe correct service calls.
+        """
+        self._setup_sensor(22)
+        self._setup_switch_heat(False)
+        self._setup_switch_ac(True)
+        self.hass.block_till_done()
+        self._setup_sensor(20.9)
+        self.hass.block_till_done()
+        self.assertEqual(0, len(self.calls))
+        self._setup_sensor(19)
+        self.hass.block_till_done()
+        self.assertEqual(1, len(self.calls))
+        call = self.calls[0]
+        self.assertEqual('homeassistant', call.domain)
+        self.assertEqual(SERVICE_TURN_OFF, call.service)
+        self.assertEqual(ENT_SWITCH_AC, call.data['entity_id'])
+
+    def _setup_sensor(self, temp, unit=TEMP_CELSIUS):
+        """Setup the test sensor."""
+        self.hass.states.set(ENT_SENSOR, temp, {
+            ATTR_UNIT_OF_MEASUREMENT: unit
+        })
+
+    def _setup_switch_heat(self, is_on):
+        """Setup the test heating switch."""
+        self.hass.states.set(ENT_SWITCH_HEAT, STATE_ON if is_on else STATE_OFF)
+        self.calls = []
+
+        @callback
+        def log_call(call):
+            """Log service calls."""
+            self.calls.append(call)
+
+        self.hass.services.register(ha.DOMAIN, SERVICE_TURN_ON, log_call)
+        self.hass.services.register(ha.DOMAIN, SERVICE_TURN_OFF, log_call)
+
+    def _setup_switch_ac(self, is_on):
+        """Setup the test A/C switch."""
+        self.hass.states.set(ENT_SWITCH_AC, STATE_ON if is_on else STATE_OFF)
         self.calls = []
 
         @callback
@@ -931,7 +1346,7 @@ def test_custom_setup_params(hass):
         hass, climate.DOMAIN, {'climate': {
             'platform': 'generic_thermostat',
             'name': 'test',
-            'heater': ENT_SWITCH,
+            'heater_control': ENT_SWITCH_HEAT,
             'target_sensor': ENT_SENSOR,
             'min_temp': MIN_TEMP,
             'max_temp': MAX_TEMP,
@@ -941,7 +1356,7 @@ def test_custom_setup_params(hass):
     state = hass.states.get(ENTITY)
     assert state.attributes.get('min_temp') == MIN_TEMP
     assert state.attributes.get('max_temp') == MAX_TEMP
-    assert state.attributes.get('temperature') == TARGET_TEMP
+    assert state.attributes.get(ATTR_TEMPERATURE) == TARGET_TEMP
 
 
 @asyncio.coroutine
@@ -949,7 +1364,9 @@ def test_restore_state(hass):
     """Ensure states are restored on startup."""
     mock_restore_cache(hass, (
         State('climate.test_thermostat', '0', {ATTR_TEMPERATURE: "20",
-              climate.ATTR_OPERATION_MODE: "off", ATTR_AWAY_MODE: "on"}),
+              climate.ATTR_OPERATION_MODE: "off", ATTR_AWAY_MODE: "on",
+              climate.ATTR_TARGET_TEMP_LOW: "17",
+              climate.ATTR_TARGET_TEMP_HIGH: "23"}),
     ))
 
     hass.state = CoreState.starting
@@ -958,7 +1375,7 @@ def test_restore_state(hass):
         hass, climate.DOMAIN, {'climate': {
             'platform': 'generic_thermostat',
             'name': 'test_thermostat',
-            'heater': ENT_SWITCH,
+            'heater_control': ENT_SWITCH_HEAT,
             'target_sensor': ENT_SENSOR,
         }})
 
@@ -969,14 +1386,14 @@ def test_restore_state(hass):
 
 
 @asyncio.coroutine
-def test_no_restore_state(hass):
-    """Ensure states are restored on startup if they exist.
-
-    Allows for graceful reboot.
-    """
+def test_restore_dual_temp(hass):
+    """Ensure states are restored on startup."""
     mock_restore_cache(hass, (
-        State('climate.test_thermostat', '0', {ATTR_TEMPERATURE: "20",
-              climate.ATTR_OPERATION_MODE: "off", ATTR_AWAY_MODE: "on"}),
+        State('climate.test_thermostat', '0', {
+              climate.ATTR_OPERATION_MODE: "off",
+              ATTR_AWAY_MODE: "on",
+              climate.ATTR_TARGET_TEMP_LOW: "17",
+              climate.ATTR_TARGET_TEMP_HIGH: "23"}),
     ))
 
     hass.state = CoreState.starting
@@ -985,91 +1402,38 @@ def test_no_restore_state(hass):
         hass, climate.DOMAIN, {'climate': {
             'platform': 'generic_thermostat',
             'name': 'test_thermostat',
-            'heater': ENT_SWITCH,
+            'heater_control': ENT_SWITCH_HEAT,
+            'ac_control': ENT_SWITCH_AC,
+            'target_sensor': ENT_SENSOR,
+        }})
+
+    state = hass.states.get('climate.test_thermostat')
+    assert(state.attributes[climate.ATTR_TARGET_TEMP_LOW] == 17)
+    assert(state.attributes[climate.ATTR_TARGET_TEMP_HIGH] == 23)
+
+
+@asyncio.coroutine
+def test_no_restore_state(hass):
+    """Ensure states are restored on startup if they exist.
+
+    Allows for graceful reboot.
+    """
+    mock_restore_cache(hass, (
+        State('climate.test_thermostat', '0', {ATTR_TEMPERATURE: "20",
+              climate.ATTR_OPERATION_MODE: "cool", ATTR_AWAY_MODE: "on"}),
+    ))
+
+    hass.state = CoreState.starting
+
+    yield from async_setup_component(
+        hass, climate.DOMAIN, {'climate': {
+            'platform': 'generic_thermostat',
+            'name': 'test_thermostat',
+            'heater_control': ENT_SWITCH_HEAT,
             'target_sensor': ENT_SENSOR,
             'target_temp': 22
         }})
 
     state = hass.states.get('climate.test_thermostat')
     assert(state.attributes[ATTR_TEMPERATURE] == 22)
-    assert(state.state == STATE_OFF)
-
-
-class TestClimateGenericThermostatRestoreState(unittest.TestCase):
-    """Test generic thermostat when restore state from HA startup."""
-
-    def setUp(self):  # pylint: disable=invalid-name
-        """Setup things to be run when tests are started."""
-        self.hass = get_test_home_assistant()
-        self.hass.config.temperature_unit = TEMP_CELSIUS
-
-    def tearDown(self):  # pylint: disable=invalid-name
-        """Stop down everything that was started."""
-        self.hass.stop()
-
-    def test_restore_state_uncoherence_case(self):
-        """
-        Test restore from a strange state.
-
-        - Turn the generic thermostat off
-        - Restart HA and restore state from DB
-        """
-        self._mock_restore_cache(temperature=20)
-
-        self._setup_switch(False)
-        self._setup_sensor(15)
-        self._setup_climate()
-        self.hass.block_till_done()
-
-        state = self.hass.states.get(ENTITY)
-        self.assertEqual(20, state.attributes[ATTR_TEMPERATURE])
-        self.assertEqual(STATE_OFF,
-                         state.attributes[climate.ATTR_OPERATION_MODE])
-        self.assertEqual(STATE_OFF, state.state)
-        self.assertEqual(0, len(self.calls))
-
-        self._setup_switch(False)
-        self.hass.block_till_done()
-        state = self.hass.states.get(ENTITY)
-        self.assertEqual(STATE_OFF,
-                         state.attributes[climate.ATTR_OPERATION_MODE])
-        self.assertEqual(STATE_OFF, state.state)
-
-    def _setup_climate(self):
-        assert setup_component(self.hass, climate.DOMAIN, {'climate': {
-            'platform': 'generic_thermostat',
-            'name': 'test',
-            'cold_tolerance': 2,
-            'hot_tolerance': 4,
-            'away_temp': 30,
-            'heater': ENT_SWITCH,
-            'target_sensor': ENT_SENSOR,
-            'ac_mode': True
-        }})
-
-    def _setup_sensor(self, temp, unit=TEMP_CELSIUS):
-        """Setup the test sensor."""
-        self.hass.states.set(ENT_SENSOR, temp, {
-            ATTR_UNIT_OF_MEASUREMENT: unit
-        })
-
-    def _setup_switch(self, is_on):
-        """Setup the test switch."""
-        self.hass.states.set(ENT_SWITCH, STATE_ON if is_on else STATE_OFF)
-        self.calls = []
-
-        @callback
-        def log_call(call):
-            """Log service calls."""
-            self.calls.append(call)
-
-        self.hass.services.register(ha.DOMAIN, SERVICE_TURN_ON, log_call)
-        self.hass.services.register(ha.DOMAIN, SERVICE_TURN_OFF, log_call)
-
-    def _mock_restore_cache(self, temperature=20, operation_mode=STATE_OFF):
-        mock_restore_cache(self.hass, (
-            State(ENTITY, '0', {
-                ATTR_TEMPERATURE: str(temperature),
-                climate.ATTR_OPERATION_MODE: operation_mode,
-                ATTR_AWAY_MODE: "on"}),
-        ))
+    assert(state.attributes[climate.ATTR_OPERATION_MODE] == "off")


### PR DESCRIPTION
# This is a remake of https://github.com/home-assistant/home-assistant/pull/11472 with a rebase. Apologies for the noise. 
There is an extensive discussion here: https://github.com/home-assistant/architecture/issues/22 around climate, and I know I must have went the wrong way in some cases, so please point them out. 

I am not that good with python, so I might end up asking stupid questions around some of the async stuff. Currently for anyone else trying to wrap their had around, read: https://snarky.ca/how-the-heck-does-async-await-work-in-python-3-5/

## Description:
Add the possibility to have `AUTO` with `temperature_high` and `temperature_low` when component configured to use two switches (one controlling heating and one cooling)

## Notes
- Decided to renamed `heater` in `heater_control` to avoid some users of `ac_mode` to get undesired behaviour after upgrade if they didn't read breaking changes
- It also keeps current functionality if you only specify `heater_control` or `ac_control`
- `away_temp_cool` and `away_temp_heat` are used based on the `operation_mode` that the thermostat is in 
- Introduced `target_temp_high` and `target_temp_low` for `AUTO` mode

## Breaking changes:
- Modified `initial_operation_mode` to support 'auto', 'heat', 'cool', 'off' when restarting Hass setting `operation_mode` state, previously just 'off' was being used
- Renamed `heater` to `heater_control`
- Removed `ac_mode`
- Added `ac_control` to replace `ac_mode` and enable the new functionality
- Removed `away_temp` and added `away_temp_cool` and `away_temp_heat` for the corresponding modes

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#4355

## Example entry for `configuration.yaml` (if applicable):
```yaml
climate:
  - platform: generic_thermostat
    name: Study
    heater_control: switch.study_heater
    ac_control: switch.study_ac
    target_sensor: sensor.study_temperature
```

![screen shot 2018-01-05 at 22 00 57](https://user-images.githubusercontent.com/7738048/34626089-f9da7bde-f263-11e7-934c-52cde081406e.png)

## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.
  