### PR TITLE
Added daily and hourly modes to Openweathermap

### DIFF
--- a/homeassistant/components/weather/openweathermap.py
+++ b/homeassistant/components/weather/openweathermap.py
@@ -156,11 +156,11 @@ class OpenWeatherMapWeather(WeatherEntity):
                     ATTR_FORECAST_TIME: entry.get_reference_time('unix') * 1000,
                     ATTR_FORECAST_TEMP: round(entry.get_temperature('celsius').get('day')),
                     ATTR_FORECAST_TEMP_LOW: round(entry.get_temperature('celsius').get('night')),
-					ATTR_FORECAST_WIND_SPEED: round(entry.get_wind().get('speed')),
-					ATTR_FORECAST_WIND_BEARING: round(entry.get_wind().get('deg')),
+                    ATTR_FORECAST_WIND_SPEED: round(entry.get_wind().get('speed')),
+                    ATTR_FORECAST_WIND_BEARING: round(entry.get_wind().get('deg')),
                     ATTR_FORECAST_CONDITION:
                         [k for k, v in CONDITION_CLASSES.items()
-                          if entry.get_weather_code() in v][0]
+                            if entry.get_weather_code() in v][0]
                 })
             else:
                 data.append({
@@ -169,7 +169,7 @@ class OpenWeatherMapWeather(WeatherEntity):
                     ATTR_FORECAST_PRECIPITATION: entry.get_rain().get('3h'),
                     ATTR_FORECAST_CONDITION:
                         [k for k, v in CONDITION_CLASSES.items()
-                          if entry.get_weather_code() in v][0]
+                            if entry.get_weather_code() in v][0]
                 })
         return data
 

--- a/homeassistant/components/weather/openweathermap.py
+++ b/homeassistant/components/weather/openweathermap.py
@@ -1,6 +1,5 @@
 """
 Support for the OpenWeatherMap (OWM) service.
-
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/weather.openweathermap/
 """
@@ -11,9 +10,9 @@ import voluptuous as vol
 
 from homeassistant.components.weather import (
     ATTR_FORECAST_CONDITION, ATTR_FORECAST_PRECIPITATION, ATTR_FORECAST_TEMP,
-    ATTR_FORECAST_TIME, PLATFORM_SCHEMA, WeatherEntity)
+    ATTR_FORECAST_TEMP_LOW, ATTR_FORECAST_TIME, PLATFORM_SCHEMA, WeatherEntity)
 from homeassistant.const import (
-    CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME, STATE_UNKNOWN,
+    CONF_API_KEY, CONF_MODE, CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME, STATE_UNKNOWN,
     TEMP_CELSIUS)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import Throttle
@@ -22,7 +21,13 @@ REQUIREMENTS = ['pyowm==2.8.0']
 
 _LOGGER = logging.getLogger(__name__)
 
-ATTRIBUTION = 'Data provided by OpenWeatherMap'
+ATTR_FORECAST_WIND_SPEED = 'wind_speed'
+ATTR_FORECAST_WIND_BEARING = 'wind_bearing'
+
+ATTRIBUTION_DAILY = "Weather data provided by OpenWeatherMap"
+ATTRIBUTION_HOURLY = "Data provided by OpenWeatherMap"
+
+FORECAST_MODE = ['hourly', 'daily']
 
 DEFAULT_NAME = 'OpenWeatherMap'
 
@@ -30,12 +35,12 @@ MIN_TIME_BETWEEN_FORECAST_UPDATES = timedelta(minutes=30)
 MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=10)
 
 CONDITION_CLASSES = {
-    'cloudy': [804],
+    'cloudy': [803, 804],
     'fog': [701, 741],
     'hail': [906],
     'lightning': [210, 211, 212, 221],
     'lightning-rainy': [200, 201, 202, 230, 231, 232],
-    'partlycloudy': [801, 802, 803],
+    'partlycloudy': [801, 802],
     'pouring': [504, 314, 502, 503, 522],
     'rainy': [300, 301, 302, 310, 311, 312, 313, 500, 501, 520, 521],
     'snowy': [600, 601, 602, 611, 612, 620, 621, 622],
@@ -49,6 +54,7 @@ CONDITION_CLASSES = {
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_API_KEY): cv.string,
+    vol.Optional(CONF_MODE, default='hourly'): vol.In(FORECAST_MODE),
     vol.Optional(CONF_LATITUDE): cv.latitude,
     vol.Optional(CONF_LONGITUDE): cv.longitude,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
@@ -62,6 +68,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     longitude = config.get(CONF_LONGITUDE, round(hass.config.longitude, 5))
     latitude = config.get(CONF_LATITUDE, round(hass.config.latitude, 5))
     name = config.get(CONF_NAME)
+    mode = config.get(CONF_MODE)
 
     try:
         owm = pyowm.OWM(config.get(CONF_API_KEY))
@@ -69,20 +76,21 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         _LOGGER.error("Error while connecting to OpenWeatherMap")
         return False
 
-    data = WeatherData(owm, latitude, longitude)
+    data = WeatherData(owm, latitude, longitude, mode)
 
     add_devices([OpenWeatherMapWeather(
-        name, data, hass.config.units.temperature_unit)], True)
+        name, data, hass.config.units.temperature_unit, mode)], True)
 
 
 class OpenWeatherMapWeather(WeatherEntity):
     """Implementation of an OpenWeatherMap sensor."""
 
-    def __init__(self, name, owm, temperature_unit):
+    def __init__(self, name, owm, temperature_unit, mode):
         """Initialize the sensor."""
         self._name = name
         self._owm = owm
         self._temperature_unit = temperature_unit
+        self._mode = mode
         self.data = None
         self.forecast_data = None
 
@@ -113,7 +121,7 @@ class OpenWeatherMapWeather(WeatherEntity):
     @property
     def pressure(self):
         """Return the pressure."""
-        return self.data.get_pressure().get('press')
+        return round(self.data.get_pressure().get('press'))
 
     @property
     def humidity(self):
@@ -123,7 +131,7 @@ class OpenWeatherMapWeather(WeatherEntity):
     @property
     def wind_speed(self):
         """Return the wind speed."""
-        return self.data.get_wind().get('speed')
+        return round(self.data.get_wind().get('speed'), 1)
 
     @property
     def wind_bearing(self):
@@ -132,23 +140,37 @@ class OpenWeatherMapWeather(WeatherEntity):
 
     @property
     def attribution(self):
-        """Return the attribution."""
-        return ATTRIBUTION
+        """Return the attribution. Passing different attributes to correctly display the time in the frontend weather card"""
+        if self._mode == 'daily':
+            return ATTRIBUTION_DAILY
+        else:
+            return ATTRIBUTION_HOURLY
 
     @property
     def forecast(self):
         """Return the forecast array."""
         data = []
         for entry in self.forecast_data.get_weathers():
-            data.append({
-                ATTR_FORECAST_TIME: entry.get_reference_time('unix') * 1000,
-                ATTR_FORECAST_TEMP:
-                    entry.get_temperature('celsius').get('temp'),
-                ATTR_FORECAST_PRECIPITATION: entry.get_rain().get('3h'),
-                ATTR_FORECAST_CONDITION:
-                    [k for k, v in CONDITION_CLASSES.items()
-                     if entry.get_weather_code() in v][0]
-            })
+            if self._mode == 'daily':
+                data.append({
+                    ATTR_FORECAST_TIME: entry.get_reference_time('unix') * 1000,
+                    ATTR_FORECAST_TEMP: round(entry.get_temperature('celsius').get('day')),
+                    ATTR_FORECAST_TEMP_LOW: round(entry.get_temperature('celsius').get('night')),
+					ATTR_FORECAST_WIND_SPEED: round(entry.get_wind().get('speed')),
+					ATTR_FORECAST_WIND_BEARING: round(entry.get_wind().get('deg')),
+                    ATTR_FORECAST_CONDITION:
+                        [k for k, v in CONDITION_CLASSES.items()
+                          if entry.get_weather_code() in v][0]
+                })
+            else:
+                data.append({
+                    ATTR_FORECAST_TIME: entry.get_reference_time('unix') * 1000,
+                    ATTR_FORECAST_TEMP: round(entry.get_temperature('celsius').get('temp')),
+                    ATTR_FORECAST_PRECIPITATION: entry.get_rain().get('3h'),
+                    ATTR_FORECAST_CONDITION:
+                        [k for k, v in CONDITION_CLASSES.items()
+                          if entry.get_weather_code() in v][0]
+                })
         return data
 
     def update(self):
@@ -169,8 +191,9 @@ class OpenWeatherMapWeather(WeatherEntity):
 class WeatherData(object):
     """Get the latest data from OpenWeatherMap."""
 
-    def __init__(self, owm, latitude, longitude):
+    def __init__(self, owm, latitude, longitude, mode):
         """Initialize the data object."""
+        self._mode = mode
         self.owm = owm
         self.latitude = latitude
         self.longitude = longitude
@@ -193,8 +216,10 @@ class WeatherData(object):
         from pyowm.exceptions.api_call_error import APICallError
 
         try:
-            fcd = self.owm.three_hours_forecast_at_coords(
-                self.latitude, self.longitude)
+            if self._mode == 'daily':
+                fcd = self.owm.daily_forecast_at_coords(self.latitude, self.longitude, 15)
+            else:
+                fcd = self.owm.three_hours_forecast_at_coords(self.latitude, self.longitude)
         except APICallError:
             _LOGGER.error("Exception when calling OWM web API "
                           "to update forecast")

--- a/homeassistant/components/weather/openweathermap.py
+++ b/homeassistant/components/weather/openweathermap.py
@@ -1,5 +1,6 @@
 """
 Support for the OpenWeatherMap (OWM) service.
+
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/weather.openweathermap/
 """
@@ -12,8 +13,8 @@ from homeassistant.components.weather import (
     ATTR_FORECAST_CONDITION, ATTR_FORECAST_PRECIPITATION, ATTR_FORECAST_TEMP,
     ATTR_FORECAST_TEMP_LOW, ATTR_FORECAST_TIME, PLATFORM_SCHEMA, WeatherEntity)
 from homeassistant.const import (
-    CONF_API_KEY, CONF_MODE, CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME, STATE_UNKNOWN,
-    TEMP_CELSIUS)
+    CONF_API_KEY, CONF_MODE, CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME,
+    STATE_UNKNOWN, TEMP_CELSIUS)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import Throttle
 
@@ -121,7 +122,7 @@ class OpenWeatherMapWeather(WeatherEntity):
     @property
     def pressure(self):
         """Return the pressure."""
-        return round(self.data.get_pressure().get('press'))
+        return self.data.get_pressure().get('press')
 
     @property
     def humidity(self):
@@ -131,7 +132,7 @@ class OpenWeatherMapWeather(WeatherEntity):
     @property
     def wind_speed(self):
         """Return the wind speed."""
-        return round(self.data.get_wind().get('speed'), 1)
+        return self.data.get_wind().get('speed')
 
     @property
     def wind_bearing(self):
@@ -140,7 +141,12 @@ class OpenWeatherMapWeather(WeatherEntity):
 
     @property
     def attribution(self):
-        """Return the attribution. Passing different attributes to correctly display the time in the frontend weather card"""
+        """
+        Return the attribution.
+
+        Passing different attributes to correctly display
+        the time in the frontend weather card.
+        """
         if self._mode == 'daily':
             return ATTRIBUTION_DAILY
         else:
@@ -153,20 +159,28 @@ class OpenWeatherMapWeather(WeatherEntity):
         for entry in self.forecast_data.get_weathers():
             if self._mode == 'daily':
                 data.append({
-                    ATTR_FORECAST_TIME: entry.get_reference_time('unix') * 1000,
-                    ATTR_FORECAST_TEMP: round(entry.get_temperature('celsius').get('day')),
-                    ATTR_FORECAST_TEMP_LOW: round(entry.get_temperature('celsius').get('night')),
-                    ATTR_FORECAST_WIND_SPEED: round(entry.get_wind().get('speed')),
-                    ATTR_FORECAST_WIND_BEARING: round(entry.get_wind().get('deg')),
+                    ATTR_FORECAST_TIME:
+                        entry.get_reference_time('unix') * 1000,
+                    ATTR_FORECAST_TEMP:
+                        entry.get_temperature('celsius').get('day'),
+                    ATTR_FORECAST_TEMP_LOW:
+                        entry.get_temperature('celsius').get('night'),
+                    ATTR_FORECAST_WIND_SPEED:
+                        entry.get_wind().get('speed'),
+                    ATTR_FORECAST_WIND_BEARING:
+                        entry.get_wind().get('deg'),
                     ATTR_FORECAST_CONDITION:
                         [k for k, v in CONDITION_CLASSES.items()
                             if entry.get_weather_code() in v][0]
                 })
             else:
                 data.append({
-                    ATTR_FORECAST_TIME: entry.get_reference_time('unix') * 1000,
-                    ATTR_FORECAST_TEMP: round(entry.get_temperature('celsius').get('temp')),
-                    ATTR_FORECAST_PRECIPITATION: entry.get_rain().get('3h'),
+                    ATTR_FORECAST_TIME:
+                        entry.get_reference_time('unix') * 1000,
+                    ATTR_FORECAST_TEMP:
+                        entry.get_temperature('celsius').get('temp'),
+                    ATTR_FORECAST_PRECIPITATION:
+                        entry.get_rain().get('3h'),
                     ATTR_FORECAST_CONDITION:
                         [k for k, v in CONDITION_CLASSES.items()
                             if entry.get_weather_code() in v][0]
@@ -217,9 +231,13 @@ class WeatherData(object):
 
         try:
             if self._mode == 'daily':
-                fcd = self.owm.daily_forecast_at_coords(self.latitude, self.longitude, 15)
+                fcd = self.owm.daily_forecast_at_coords(
+                    self.latitude, self.longitude, 15
+                )
             else:
-                fcd = self.owm.three_hours_forecast_at_coords(self.latitude, self.longitude)
+                fcd = self.owm.three_hours_forecast_at_coords(
+                    self.latitude, self.longitude
+                )
         except APICallError:
             _LOGGER.error("Exception when calling OWM web API "
                           "to update forecast")

--- a/homeassistant/components/weather/openweathermap.py
+++ b/homeassistant/components/weather/openweathermap.py
@@ -148,9 +148,10 @@ class OpenWeatherMapWeather(WeatherEntity):
         the time in the frontend weather card.
         """
         if self._mode == 'daily':
-            return ATTRIBUTION_DAILY
+            result = ATTRIBUTION_DAILY
         else:
-            return ATTRIBUTION_HOURLY
+            result = ATTRIBUTION_HOURLY
+        return result
 
     @property
     def forecast(self):
@@ -171,7 +172,7 @@ class OpenWeatherMapWeather(WeatherEntity):
                         entry.get_wind().get('deg'),
                     ATTR_FORECAST_CONDITION:
                         [k for k, v in CONDITION_CLASSES.items()
-                            if entry.get_weather_code() in v][0]
+                         if entry.get_weather_code() in v][0]
                 })
             else:
                 data.append({
@@ -183,7 +184,7 @@ class OpenWeatherMapWeather(WeatherEntity):
                         entry.get_rain().get('3h'),
                     ATTR_FORECAST_CONDITION:
                         [k for k, v in CONDITION_CLASSES.items()
-                            if entry.get_weather_code() in v][0]
+                         if entry.get_weather_code() in v][0]
                 })
         return data
 

--- a/homeassistant/components/weather/openweathermap.py
+++ b/homeassistant/components/weather/openweathermap.py
@@ -13,8 +13,8 @@ from homeassistant.components.weather import (
     ATTR_FORECAST_CONDITION, ATTR_FORECAST_PRECIPITATION, ATTR_FORECAST_TEMP,
     ATTR_FORECAST_TEMP_LOW, ATTR_FORECAST_TIME, PLATFORM_SCHEMA, WeatherEntity)
 from homeassistant.const import (
-    CONF_API_KEY, CONF_MODE, CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME,
-    STATE_UNKNOWN, TEMP_CELSIUS)
+    CONF_API_KEY, TEMP_CELSIUS, CONF_LATITUDE, CONF_LONGITUDE, CONF_MODE,
+    CONF_NAME, STATE_UNKNOWN)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import Throttle
 
@@ -25,8 +25,7 @@ _LOGGER = logging.getLogger(__name__)
 ATTR_FORECAST_WIND_SPEED = 'wind_speed'
 ATTR_FORECAST_WIND_BEARING = 'wind_bearing'
 
-ATTRIBUTION_DAILY = "Weather data provided by OpenWeatherMap"
-ATTRIBUTION_HOURLY = "Data provided by OpenWeatherMap"
+ATTRIBUTION = 'Data provided by OpenWeatherMap'
 
 FORECAST_MODE = ['hourly', 'daily']
 
@@ -55,9 +54,9 @@ CONDITION_CLASSES = {
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_API_KEY): cv.string,
-    vol.Optional(CONF_MODE, default='hourly'): vol.In(FORECAST_MODE),
     vol.Optional(CONF_LATITUDE): cv.latitude,
     vol.Optional(CONF_LONGITUDE): cv.longitude,
+    vol.Optional(CONF_MODE, default='hourly'): vol.In(FORECAST_MODE),
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 })
 
@@ -141,17 +140,8 @@ class OpenWeatherMapWeather(WeatherEntity):
 
     @property
     def attribution(self):
-        """
-        Return the attribution.
-
-        Passing different attributes to correctly display
-        the time in the frontend weather card.
-        """
-        if self._mode == 'daily':
-            result = ATTRIBUTION_DAILY
-        else:
-            result = ATTRIBUTION_HOURLY
-        return result
+        """Return the attribution."""
+        return ATTRIBUTION
 
     @property
     def forecast(self):


### PR DESCRIPTION
## Description:
Added daily and hourly modes, wind speed and bearing to forecast

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation:** home-assistant/home-assistant.github.io#5510

## Example entry for `configuration.yaml` (if applicable):
```yaml
weather:
  - platform: openweathermap
    api_key: YOUR_API_KEY
    mode: daily
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
