### PR TITLE
Entry to enable Qubino ZMHTDx smart meter switches

### DIFF
--- a/homeassistant/components/zwave/discovery_schemas.py
+++ b/homeassistant/components/zwave/discovery_schemas.py
@@ -213,6 +213,7 @@ DISCOVERY_SCHEMAS = [
          }})},
     {const.DISC_COMPONENT: 'switch',
      const.DISC_GENERIC_DEVICE_CLASS: [
+         const.GENERIC_TYPE_METER,
          const.GENERIC_TYPE_SENSOR_ALARM,
          const.GENERIC_TYPE_SENSOR_BINARY,
          const.GENERIC_TYPE_SWITCH_BINARY,


### PR DESCRIPTION
## Description:
Fixes unavailable switches in  Qubino ZMHTDx smart meters.
The Z-wave Generic definintion is a `METER` for this device. We did not include meters in the switch discovery.

**Related issue (if applicable):** fixes #14878 
