### PR TITLE
Add Version Control component

### DIFF
--- a/homeassistant/components/version_control/__init__.py
+++ b/homeassistant/components/version_control/__init__.py
@@ -8,7 +8,6 @@ from datetime import timedelta
 import logging
 
 from homeassistant.helpers.entity_component import EntityComponent
-from homeassistant.helpers.config_validation import PLATFORM_SCHEMA  # noqa
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/version_control/__init__.py
+++ b/homeassistant/components/version_control/__init__.py
@@ -16,7 +16,10 @@ DOMAIN = 'version_control'
 
 ENTITY_ID_FORMAT = DOMAIN + '.{}'
 
-SCAN_INTERVAL = timedelta(seconds=600)
+SCAN_INTERVAL = timedelta(minutes=5)
+
+ATTR_BRANCH_NAME = 'branch_name'
+ATTR_COMMIT_TITLE = 'commit_title'
 
 
 async def async_setup(hass, config):
@@ -36,3 +39,9 @@ async def async_setup_entry(hass, entry):
 async def async_unload_entry(hass, entry):
     """Unload a config entry."""
     return await hass.data[DOMAIN].async_unload_entry(entry)
+
+
+class VersionControlException(Exception):
+    """Simple Exception class that can be explicitly caught."""
+
+    pass

--- a/homeassistant/components/version_control/__init__.py
+++ b/homeassistant/components/version_control/__init__.py
@@ -8,6 +8,7 @@ from datetime import timedelta
 import logging
 
 from homeassistant.helpers.entity_component import EntityComponent
+from homeassistant.helpers.config_validation import PLATFORM_SCHEMA  # noqa
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/version_control/__init__.py
+++ b/homeassistant/components/version_control/__init__.py
@@ -1,0 +1,38 @@
+"""
+Provide the functionality to add version_control entities.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/version_control/
+"""
+from datetime import timedelta
+import logging
+
+from homeassistant.helpers.entity_component import EntityComponent
+from homeassistant.helpers.config_validation import PLATFORM_SCHEMA  # noqa
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = 'version_control'
+
+ENTITY_ID_FORMAT = DOMAIN + '.{}'
+
+SCAN_INTERVAL = timedelta(seconds=600)
+
+
+async def async_setup(hass, config):
+    """Track states and offer events for version control platforms."""
+    component = hass.data[DOMAIN] = EntityComponent(
+        _LOGGER, DOMAIN, hass, SCAN_INTERVAL)
+
+    await component.async_setup(config)
+    return True
+
+
+async def async_setup_entry(hass, entry):
+    """Setup a config entry."""
+    return await hass.data[DOMAIN].async_setup_entry(entry)
+
+
+async def async_unload_entry(hass, entry):
+    """Unload a config entry."""
+    return await hass.data[DOMAIN].async_unload_entry(entry)

--- a/homeassistant/components/version_control/gitlab.py
+++ b/homeassistant/components/version_control/gitlab.py
@@ -1,5 +1,5 @@
 """
-Support for monitoring a remote Gitlab git repository.
+Support for monitoring a remote GitLab git repository.
 
 Creates entities that breakout information about
 the specified repository.
@@ -50,14 +50,14 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_entities, discovery_info=None):
-    """Set up the Git repository sensor."""
+    """Set up the GitLab repository sensor."""
     if hass.data.get(DATA_GITLAB) is None:
         hass.data[DATA_GITLAB] = []
 
     entities = []
 
     try:
-        gitlab_data = GitlabData(
+        gitlab_data = GitLabData(
             url=config.get(CONF_URL),
             token=config.get(CONF_TOKEN),
             verify_ssl=config.get(CONF_VERIFY_SSL),
@@ -68,7 +68,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         _LOGGER.error(error)
         return False
 
-    gitlab_repo = GitlabRepo(
+    gitlab_repo = GitLabRepo(
         name=config.get(CONF_NAME), gitlab_data=gitlab_data
     )
 
@@ -78,11 +78,11 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     add_entities(entities, update_before_add=True)
 
 
-class GitlabRepo(Entity):
-    """Representation of Gitlab repo entity."""
+class GitLabRepo(Entity):
+    """Representation of GitLab repo entity."""
 
     def __init__(self, name, gitlab_data):
-        """Create a new local Git repo attribute."""
+        """Create a new GitLab repo attribute."""
         self._branch_name = None
         self._commit_title = None
         self._name = name
@@ -99,7 +99,7 @@ class GitlabRepo(Entity):
 
     @property
     def name(self):
-        """Return the name of the Gitlab repo entity."""
+        """Return the name of the GitLab repo entity."""
         return self._name
 
     @property
@@ -123,7 +123,7 @@ class GitlabRepo(Entity):
         return attributes
 
     def update(self):
-        """Get the latest data from Gitlab and updates the state."""
+        """Get the latest data from GitLab and updates the state."""
         # Call the API for new data. Each sensor will re-trigger this
         # same exact call, but that's fine. Results should be cached for
         # a short period of time to prevent hitting API limits.
@@ -142,8 +142,8 @@ class GitlabRepo(Entity):
             self._pipeline_status = self.gitlab_data.pipeline.status
 
 
-class GitlabData(object):
-    """Gets the latest project data from Gitlab."""
+class GitLabData(object):
+    """Gets the latest project data from GitLab."""
 
     def __init__(self, url, token, verify_ssl, project, branch):
         """Initialize the data object."""
@@ -161,7 +161,7 @@ class GitlabData(object):
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
-        """Get the latest data from Gitlab."""
+        """Get the latest data from GitLab."""
         from gitlab import Gitlab
         from gitlab import exceptions as gitlab_exceptions
 
@@ -176,7 +176,7 @@ class GitlabData(object):
         except (gitlab_exceptions.GitlabGetError,
                 gitlab_exceptions.GitlabAuthenticationError) as error:
             raise VersionControlException(
-                "Unable to init Gitlab project {}, {}".format(
+                "Unable to init GitLab project {}, {}".format(
                     self._project, str(error.error_message))
             )
 

--- a/homeassistant/components/version_control/gitlab.py
+++ b/homeassistant/components/version_control/gitlab.py
@@ -1,0 +1,201 @@
+"""
+Support for monitoring a remote Gitlab git repository.
+
+Creates entities that breakout information about
+the specified repository.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/version_control.gitlab/
+"""
+import logging
+from datetime import timedelta
+
+import voluptuous as vol
+
+from homeassistant.components.version_control import (
+    ATTR_BRANCH_NAME, ATTR_COMMIT_TITLE, PLATFORM_SCHEMA,
+    VersionControlException)
+from homeassistant.const import (
+    CONF_NAME, CONF_TOKEN, CONF_URL, CONF_VERIFY_SSL, STATE_UNKNOWN)
+from homeassistant.helpers.entity import Entity
+from homeassistant.util import Throttle
+import homeassistant.helpers.config_validation as cv
+
+REQUIREMENTS = ['python-gitlab==1.4.0']
+
+_LOGGER = logging.getLogger(__name__)
+
+ATTR_PIPELINE_STATUS = 'pipeline_status'
+ATTR_PROJECT = 'project'
+
+CONF_BRANCH = 'branch'
+CONF_PROJECT = 'project'
+
+DATA_GITLAB = 'gitlab'
+
+DEFAULT_GITLAB_BRANCH = 'master'
+DEFAULT_GITLAB_URL = 'https://gitlab.com'
+
+MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=300)
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_NAME): cv.string,
+    vol.Required(CONF_TOKEN): cv.string,
+    vol.Required(CONF_PROJECT): cv.string,
+    vol.Optional(CONF_BRANCH, default=DEFAULT_GITLAB_BRANCH): cv.string,
+    vol.Optional(CONF_URL, default=DEFAULT_GITLAB_URL): cv.url,
+    vol.Optional(CONF_VERIFY_SSL, default=True): cv.boolean
+})
+
+
+# pylint: disable=unused-argument
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    """Set up the Git repository sensor."""
+    if hass.data.get(DATA_GITLAB) is None:
+        hass.data[DATA_GITLAB] = []
+
+    entities = []
+
+    try:
+        gitlab_data = GitlabData(
+            url=config.get(CONF_URL),
+            token=config.get(CONF_TOKEN),
+            verify_ssl=config.get(CONF_VERIFY_SSL),
+            project=config.get(CONF_PROJECT),
+            branch=config.get(CONF_BRANCH)
+        )
+    except VersionControlException as error:
+        _LOGGER.error(error)
+        return False
+
+    gitlab_repo = GitlabRepo(
+        name=config.get(CONF_NAME), gitlab_data=gitlab_data
+    )
+
+    entities.append(gitlab_repo)
+
+    hass.data[DATA_GITLAB].append(gitlab_repo)
+    add_entities(entities, update_before_add=True)
+
+
+class GitlabRepo(Entity):
+    """Representation of Gitlab repo entity."""
+
+    def __init__(self, name, gitlab_data):
+        """Create a new local Git repo attribute."""
+        self._branch_name = None
+        self._commit_title = None
+        self._name = name
+        self._old_value = None
+        self._pipeline_status = None
+        self._project_name = None
+        self._state = STATE_UNKNOWN
+        self.gitlab_data = gitlab_data
+
+    @property
+    def should_poll(self):
+        """Polling is needed."""
+        return True
+
+    @property
+    def name(self):
+        """Return the name of the Gitlab repo entity."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return attribute state."""
+        return self._state
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        attributes = {
+            ATTR_PROJECT: self._project_name,
+            ATTR_BRANCH_NAME: self._branch_name,
+            ATTR_COMMIT_TITLE: self._commit_title
+        }
+
+        # Add additional attributes.
+        if self._pipeline_status is not None:
+            attributes[ATTR_PIPELINE_STATUS] = self._pipeline_status
+
+        return attributes
+
+    def update(self):
+        """Get the latest data from Gitlab and updates the state."""
+        # Call the API for new data. Each sensor will re-trigger this
+        # same exact call, but that's fine. Results should be cached for
+        # a short period of time to prevent hitting API limits.
+        self.gitlab_data.update()
+
+        if self.gitlab_data.project is not None:
+            self._project_name = self.gitlab_data.project.attributes[
+                'path_with_namespace']
+
+        if self.gitlab_data.branch is not None:
+            self._state = self.gitlab_data.branch.commit['id']
+            self._commit_title = self.gitlab_data.branch.commit['title']
+            self._branch_name = self.gitlab_data.branch.name
+
+        if self.gitlab_data.pipeline is not None:
+            self._pipeline_status = self.gitlab_data.pipeline.status
+
+
+class GitlabData(object):
+    """Gets the latest project data from Gitlab."""
+
+    def __init__(self, url, token, verify_ssl, project, branch):
+        """Initialize the data object."""
+        self._url = url
+        self._token = token
+        self._verify_ssl = verify_ssl
+        self._project = project
+        self._branch = branch
+
+        self.project = None
+        self.branch = None
+        self.pipeline = None
+
+        self.update()
+
+    @Throttle(MIN_TIME_BETWEEN_UPDATES)
+    def update(self):
+        """Get the latest data from Gitlab."""
+        from gitlab import Gitlab
+        from gitlab import exceptions as gitlab_exceptions
+
+        try:
+            with Gitlab(
+                    url=self._url,
+                    private_token=self._token,
+                    ssl_verify=self._verify_ssl
+            ) as gitlab:
+                self.project = gitlab.projects.get(id=self._project)
+
+        except (gitlab_exceptions.GitlabGetError,
+                gitlab_exceptions.GitlabAuthenticationError) as error:
+            raise VersionControlException(
+                "Unable to init Gitlab project {}, {}".format(
+                    self._project, str(error.error_message))
+            )
+
+        try:
+            self.branch = self.project.branches.get(
+                id=self._branch
+            )
+        except gitlab_exceptions.GitlabGetError as error:
+            raise VersionControlException(
+                "Unable to load branch {}: {}".format(
+                    self._branch, str(error.error_message))
+            )
+
+        if self.branch is not None:
+            branch_pipelines = self.project.pipelines.list(
+                ref=self._branch,
+                order_by='id',
+                sort='desc'
+            )
+
+            if len(branch_pipelines) > 0:
+                self.pipeline = branch_pipelines[0]

--- a/homeassistant/components/version_control/gitlab.py
+++ b/homeassistant/components/version_control/gitlab.py
@@ -172,7 +172,6 @@ class GitLabData(object):
                 ssl_verify=self._verify_ssl
             ) as gitlab:
                 self.project = gitlab.projects.get(id=self._project)
-
         except (gitlab_exceptions.GitlabGetError,
                 gitlab_exceptions.GitlabAuthenticationError) as error:
             raise VersionControlException(

--- a/homeassistant/components/version_control/gitlab.py
+++ b/homeassistant/components/version_control/gitlab.py
@@ -167,9 +167,9 @@ class GitLabData(object):
 
         try:
             with Gitlab(
-                    url=self._url,
-                    private_token=self._token,
-                    ssl_verify=self._verify_ssl
+                url=self._url,
+                private_token=self._token,
+                ssl_verify=self._verify_ssl
             ) as gitlab:
                 self.project = gitlab.projects.get(id=self._project)
 
@@ -197,5 +197,5 @@ class GitLabData(object):
                 sort='desc'
             )
 
-            if len(branch_pipelines) > 0:
+            if branch_pipelines:
                 self.pipeline = branch_pipelines[0]

--- a/homeassistant/components/version_control/local_git.py
+++ b/homeassistant/components/version_control/local_git.py
@@ -111,9 +111,11 @@ class GitRepo(Entity):
         try:
             self._repo = git.Repo(self._path)
         except NoSuchPathError:
-            raise VersionControlException("No such path: %s" % self._path)
+            raise VersionControlException(
+                "No such path: %s" % self._path)
         except InvalidGitRepositoryError:
-            raise VersionControlException("No Git repository found in %s" % self._path)
+            raise VersionControlException(
+                "No Git repository found in %s" % self._path)
 
     @property
     def should_poll(self):

--- a/homeassistant/components/version_control/local_git.py
+++ b/homeassistant/components/version_control/local_git.py
@@ -52,8 +52,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Git repository sensor."""
-    from git import Repo
-    from git import exc as git_exceptions
+    import git
 
     if hass.data.get(DATA_LOCAL_GIT) is None:
         hass.data[DATA_LOCAL_GIT] = []
@@ -63,13 +62,13 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     try:
         local_git_repo = GitRepo(
             name=config.get(CONF_NAME),
-            repo=Repo(config.get(CONF_PATH))
+            repo=git.Repo(config.get(CONF_PATH))
         )
-    except git_exceptions.NoSuchPathError:
-        _LOGGER.error("No such path: {}", config.get(CONF_PATH))
+    except git.exc.NoSuchPathError:
+        _LOGGER.error("No such path: %s", config.get(CONF_PATH))
         return False
-    except git_exceptions.InvalidGitRepositoryError:
-        _LOGGER.error("No Git repository found in {}", config.get(CONF_PATH))
+    except git.exc.InvalidGitRepositoryError:
+        _LOGGER.error("No Git repository found in %s", config.get(CONF_PATH))
         return False
 
     entities.append(local_git_repo)
@@ -183,12 +182,15 @@ class GitRepo(GitRepoAttribute):
 
     def git_pull(self, remote, reset=False):
         """Pull data from a git remote."""
-        from git import Remote
-        git_remote = Remote(repo=self._repo, name=remote)
+        import git
+        git_remote = git.Remote(repo=self._repo, name=remote)
 
         if not git_remote.exists():
-            _LOGGER.error("{}: Remote {} does not exist!".format(
-                SERVICE_LOCAL_GIT_PULL, remote))
+            _LOGGER.error(
+                "%s: Remote %s does not exist!",
+                SERVICE_LOCAL_GIT_PULL,
+                remote
+            )
             return False
 
         if reset:

--- a/homeassistant/components/version_control/local_git.py
+++ b/homeassistant/components/version_control/local_git.py
@@ -46,12 +46,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_PATH): cv.string
 })
 
-SERVICE_TO_METHOD = {
-    SERVICE_LOCAL_GIT_PULL: {
-        'method': 'async_git_pull',
-        'schema': LOCAL_GIT_PULL_SERVICE_SCHEMA},
-}
-
 
 # pylint: disable=unused-argument
 def setup_platform(hass, config, add_entities, discovery_info=None):

--- a/homeassistant/components/version_control/local_git.py
+++ b/homeassistant/components/version_control/local_git.py
@@ -168,15 +168,8 @@ class GitRepo(Entity):
         else:
             self._status = STATUS_CLEAN
 
-        try:
-            self._state = self._repo.head.commit.hexsha
-        except ValueError:
-            self._state = STATE_UNKNOWN
-
-        try:
-            self._commit_title = self._repo.head.commit.summary
-        except ValueError:
-            self._commit_title = None
+        self._state = self._repo.head.commit.hexsha
+        self._commit_title = self._repo.head.commit.summary
 
     def git_pull(self, remote, reset=False):
         """Pull data from a git remote."""

--- a/homeassistant/components/version_control/local_git.py
+++ b/homeassistant/components/version_control/local_git.py
@@ -1,0 +1,208 @@
+"""
+Support for monitoring a local git repository.
+
+Creates entities that breakout information about
+the specified local git repository.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/version_control.local_git/
+"""
+import logging
+
+import voluptuous as vol
+from homeassistant.components.version_control import DOMAIN, PLATFORM_SCHEMA
+from homeassistant.const import (
+    ATTR_ENTITY_ID, CONF_NAME, CONF_PATH, STATE_UNKNOWN)
+from homeassistant.helpers.entity import Entity
+import homeassistant.helpers.config_validation as cv
+
+REQUIREMENTS = ['gitpython==2.1.9']
+
+_LOGGER = logging.getLogger(__name__)
+
+ATTR_NAME = 'name'
+ATTR_PATH = 'path'
+ATTR_REMOTE = 'remote'
+ATTR_RESET = 'reset'
+ATTR_ACTIVE_COMMIT_SUMMARY = 'commit_summary'
+
+SERVICE_LOCAL_GIT_PULL = 'local_git_pull'
+
+DATA_LOCAL_GIT = 'local_git'
+
+STATE_BARE = 'bare'
+STATE_CLEAN = 'clean'
+STATE_DIRTY = 'dirty'
+STATE_INVALID = 'empty'
+
+LOCAL_GIT_PULL_SERVICE_SCHEMA = vol.Schema({
+    vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
+    vol.Optional(ATTR_REMOTE, default='origin'): cv.string,
+    vol.Optional(ATTR_RESET, default=False): cv.boolean
+})
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_NAME): cv.string,
+    vol.Required(CONF_PATH): cv.string
+})
+
+SERVICE_TO_METHOD = {
+    SERVICE_LOCAL_GIT_PULL: {
+        'method': 'async_git_pull',
+        'schema': LOCAL_GIT_PULL_SERVICE_SCHEMA},
+}
+
+
+# pylint: disable=unused-argument
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    """Set up the Git repository sensor."""
+    from git import Repo
+
+    if hass.data.get(DATA_LOCAL_GIT) is None:
+        hass.data[DATA_LOCAL_GIT] = []
+
+    entities = []
+
+    repository = Repo(config.get(CONF_PATH))
+
+    local_git_repo = GitRepo(name=config.get(CONF_NAME), repo=repository)
+    local_git_repo_activebranch = GitRepoActiveBranch(
+        name=config.get(CONF_NAME), repo=repository)
+    local_git_repo_activecommit = GitRepoActiveCommit(
+        name=config.get(CONF_NAME), repo=repository)
+
+    entities.append(local_git_repo)
+    entities.append(local_git_repo_activebranch)
+    entities.append(local_git_repo_activecommit)
+
+    hass.data[DATA_LOCAL_GIT].append(local_git_repo)
+    add_entities(entities, update_before_add=True)
+
+    def _local_git_pull_service(service):
+        """Service to pull contents from remote repository."""
+        target_repos = [repo for repo in hass.data[DATA_LOCAL_GIT]
+                        if repo.entity_id in service.data.get(ATTR_ENTITY_ID)]
+
+        for repo in target_repos:
+            repo.git_pull(
+                remote=service.data.get(ATTR_REMOTE),
+                reset=service.data.get(ATTR_RESET)
+            )
+            repo.schedule_update_ha_state(True)
+
+    hass.services.register(
+        DOMAIN, SERVICE_LOCAL_GIT_PULL, _local_git_pull_service,
+        schema=LOCAL_GIT_PULL_SERVICE_SCHEMA)
+
+
+class GitRepoAttribute(Entity):
+    """Representation of local Git repo attribute."""
+
+    def __init__(self, name, repo):
+        """Create a new local Git repo attribute."""
+        self._repo = repo
+        self._old_value = None
+        self._name = name
+        self._state = STATE_UNKNOWN
+
+    @property
+    def should_poll(self):
+        """Polling is needed."""
+        return True
+
+    @property
+    def name(self):
+        """Return the name of the local Git repo attribute."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return attribute state."""
+        return self._state
+
+
+class GitRepo(GitRepoAttribute):
+    """Representation of local Git Repo."""
+
+    def __init__(self, name, repo):
+        """Create a new local Git repo entity."""
+        GitRepoAttribute.__init__(self, name, repo)
+        self._name = "{}".format(name)
+        self._path = self._repo.working_dir
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        return {
+            ATTR_PATH: self._path,
+        }
+
+    def update(self):
+        """Retrieve latest state."""
+        if self._repo.bare:
+            self._state = STATE_BARE
+            return
+
+        if self._repo.is_dirty(untracked_files=True):
+            self._state = STATE_DIRTY
+            return
+
+        if not self._repo.active_branch.is_valid():
+            self._state = STATE_INVALID
+            return
+
+        self._state = STATE_CLEAN
+
+    def git_pull(self, remote, reset=False):
+        """Pull data from a git remote."""
+        from git import Remote
+        git_remote = Remote(repo=self._repo, name=remote)
+
+        if not git_remote.exists():
+            _LOGGER.error("{}: Remote {} does not exist!".format(
+                SERVICE_LOCAL_GIT_PULL, remote))
+            return False
+
+        if reset:
+            self._repo.git.reset('--hard')
+
+        git_remote.pull()
+
+
+class GitRepoActiveBranch(GitRepoAttribute):
+    """Representation of an active branch in a local Git Repo."""
+
+    def __init__(self, name, repo):
+        """Create a new local Git repo Active Branch entity."""
+        GitRepoAttribute.__init__(self, name, repo)
+        self._name = "{} Active Branch".format(name)
+
+    def update(self):
+        """Retrieve latest state."""
+        self._state = self._repo.active_branch.name
+
+
+class GitRepoActiveCommit(GitRepoAttribute):
+    """Representation of an active commit in a local Git Repo."""
+
+    def __init__(self, name, repo):
+        """Create a new local Git repo Active Commit entity."""
+        GitRepoAttribute.__init__(self, name, repo)
+        self._name = "{} Active Commit".format(name)
+        self._summary = None
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        return {
+            ATTR_ACTIVE_COMMIT_SUMMARY: self._summary,
+        }
+
+    def update(self):
+        """Retrieve latest state."""
+        if not self._repo.active_branch.is_valid():
+            self._state = STATE_INVALID
+            return
+
+        self._state = self._repo.head.commit.hexsha
+        self._summary = self._repo.head.commit.summary

--- a/homeassistant/components/version_control/services.yaml
+++ b/homeassistant/components/version_control/services.yaml
@@ -1,0 +1,15 @@
+# Describes the format for available calendar services
+
+local_git_pull:
+  description: Perform git pull command on local Git repository.
+  fields:
+    entity_id:
+      description: Entity id representing a specific local Git repository.
+      example: 'version_control.hass_config'
+    remote:
+      description: Remote is a string representing the remote to pull from.
+      example: 'origin'
+    reset:
+      description: Reset is a boolean indicating if a git reset should be performed.
+      example: 'False'
+

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -349,6 +349,9 @@ gTTS-token==1.1.1
 # homeassistant.components.sensor.gearbest
 gearbest_parser==1.0.7
 
+# homeassistant.components.version_control.local_git
+gitpython==2.1.9
+
 # homeassistant.components.sensor.gitter
 gitterpy==0.1.7
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1021,6 +1021,9 @@ python-forecastio==1.4.0
 # homeassistant.components.gc100
 python-gc100==1.0.3a
 
+# homeassistant.components.version_control.gitlab
+python-gitlab==1.4.0
+
 # homeassistant.components.sensor.hp_ilo
 python-hpilo==3.9
 

--- a/tests/components/version_control/__init__.py
+++ b/tests/components/version_control/__init__.py
@@ -1,0 +1,1 @@
+"""The tests for Version Control platforms."""

--- a/tests/components/version_control/test_gitlab.py
+++ b/tests/components/version_control/test_gitlab.py
@@ -1,4 +1,4 @@
-"""The tests for the gitlab component."""
+"""The tests for the GitLab component."""
 import unittest
 from unittest.mock import Mock
 from unittest.mock import patch
@@ -26,14 +26,14 @@ TEST_PROJECT_NAME = 'test/project'
 
 
 class TestGitlab(unittest.TestCase):
-    """Test the gitlab platform."""
+    """Test the GitLab platform."""
 
     def setUp(self):
         """Initialize values for this test case class."""
         self.hass = get_test_home_assistant()
         self.config = TEST_CONFIG
 
-    @patch('homeassistant.components.version_control.gitlab.GitlabData')
+    @patch('homeassistant.components.version_control.gitlab.GitLabData')
     @patch('homeassistant.components.version_control.gitlab._LOGGER')
     @MockDependency('gitlab')
     def test_setup_exception_handling(
@@ -70,12 +70,12 @@ class TestGitlab(unittest.TestCase):
         self.assertTrue(
             isinstance(
                 add_devices.call_args[0][0][0],
-                gitlab.GitlabRepo)
+                gitlab.GitLabRepo)
         )
         self.assertEqual(1, len(self.hass.states.all()))
 
     def test_valid_gitlabrepo_values_with_pipeline(self):
-        """Test valid Gitlab repo values with pipeline."""
+        """Test valid GitLab repo values with pipeline."""
         entity = self._createTestEntity(
             with_pipeline=True
         )
@@ -109,7 +109,7 @@ class TestGitlab(unittest.TestCase):
         )
 
     def test_valid_gitlabrepo_values_without_pipeline(self):
-        """Test valid Gitlab repo values without pipeline."""
+        """Test valid GitLab repo values without pipeline."""
         entity = self._createTestEntity(
             with_pipeline=False
         )
@@ -144,8 +144,8 @@ class TestGitlab(unittest.TestCase):
 
     @staticmethod
     def _createTestEntity(with_pipeline: bool):
-        """Create a test GitlabRepo entity based on input parameters."""
-        entity = gitlab.GitlabRepo(
+        """Create a test GitLabRepo entity based on input parameters."""
+        entity = gitlab.GitLabRepo(
             name=TEST_CONFIG['version_control'][gitlab.CONF_NAME],
             gitlab_data=Mock()
         )

--- a/tests/components/version_control/test_gitlab.py
+++ b/tests/components/version_control/test_gitlab.py
@@ -1,0 +1,168 @@
+"""The tests for the gitlab component."""
+import unittest
+from unittest.mock import Mock
+from unittest.mock import patch
+
+from homeassistant.const import (STATE_UNKNOWN)
+
+from homeassistant.components.version_control import gitlab as gitlab
+from homeassistant.setup import setup_component
+from tests.common import (get_test_home_assistant, MockDependency)
+
+TEST_CONFIG = {
+    'version_control': {
+        'platform': 'gitlab',
+        gitlab.CONF_NAME: 'test_name',
+        gitlab.CONF_TOKEN: 'test_path',
+        gitlab.CONF_PROJECT: 'test_token'
+    }
+}
+
+TEST_BRANCH_NAME = 'master'
+TEST_COMMIT_HEXSHA = 'test_hexsha'
+TEST_COMMIT_TITLE = 'test_title'
+TEST_PIPELINE_STATUS = 'success'
+TEST_PROJECT_NAME = 'test/project'
+
+
+class TestGitlab(unittest.TestCase):
+    """Test the gitlab platform."""
+
+    def setUp(self):
+        """Initialize values for this test case class."""
+        self.hass = get_test_home_assistant()
+        self.config = TEST_CONFIG
+
+    @patch('homeassistant.components.version_control.gitlab.GitlabData')
+    @patch('homeassistant.components.version_control.gitlab._LOGGER')
+    @MockDependency('gitlab')
+    def test_setup_exception_handling(
+            self, mock_logging, mock_gitlab_data, mock_gitlab):
+        """Test setup exception handling."""
+        add_entities = Mock()
+        exception = gitlab.VersionControlException('test')
+
+        mock_gitlab_data.side_effect = exception
+
+        self.assertFalse(
+            gitlab.setup_platform(self.hass, self.config, add_entities)
+        )
+
+        mock_logging.error.assert_called_with(exception)
+
+    def tearDown(self):  # pylint: disable=invalid-name
+        """Stop everything that we started."""
+        self.hass.stop()
+
+    @MockDependency('gitlab')
+    def test_setup_platform(self, mock_gitlab):
+        """Test successful setup."""
+        self.assertTrue(
+            setup_component(self.hass, 'version_control', TEST_CONFIG)
+        )
+
+        add_devices = Mock()
+        gitlab.setup_platform(
+            self.hass, TEST_CONFIG['version_control'], add_devices
+        )
+
+        self.assertTrue(add_devices.called)
+        self.assertTrue(
+            isinstance(
+                add_devices.call_args[0][0][0],
+                gitlab.GitlabRepo)
+        )
+        self.assertEqual(1, len(self.hass.states.all()))
+
+    def test_valid_gitlabrepo_values_with_pipeline(self):
+        """Test valid Gitlab repo values with pipeline."""
+        entity = self._createTestEntity(
+            with_pipeline=True
+        )
+
+        self.assertEqual(STATE_UNKNOWN, entity.state)
+
+        entity.update()
+
+        self.assertEqual(
+            "{}".format(
+                TEST_CONFIG['version_control'][gitlab.CONF_NAME]
+            ),
+            entity.name
+        )
+        self.assertEqual(TEST_COMMIT_HEXSHA, entity.state)
+        self.assertEqual(
+            TEST_PROJECT_NAME,
+            entity.device_state_attributes[gitlab.ATTR_PROJECT]
+        )
+        self.assertEqual(
+            TEST_BRANCH_NAME,
+            entity.device_state_attributes[gitlab.ATTR_BRANCH_NAME]
+        )
+        self.assertEqual(
+            TEST_COMMIT_TITLE,
+            entity.device_state_attributes[gitlab.ATTR_COMMIT_TITLE]
+        )
+        self.assertEqual(
+            TEST_PIPELINE_STATUS,
+            entity.device_state_attributes[gitlab.ATTR_PIPELINE_STATUS]
+        )
+
+    def test_valid_gitlabrepo_values_without_pipeline(self):
+        """Test valid Gitlab repo values without pipeline."""
+        entity = self._createTestEntity(
+            with_pipeline=False
+        )
+
+        self.assertEqual(STATE_UNKNOWN, entity.state)
+
+        entity.update()
+
+        self.assertEqual(
+            "{}".format(
+                TEST_CONFIG['version_control'][gitlab.CONF_NAME]
+            ),
+            entity.name
+        )
+        self.assertEqual(TEST_COMMIT_HEXSHA, entity.state)
+        self.assertEqual(
+            TEST_PROJECT_NAME,
+            entity.device_state_attributes[gitlab.ATTR_PROJECT]
+        )
+        self.assertEqual(
+            TEST_BRANCH_NAME,
+            entity.device_state_attributes[gitlab.ATTR_BRANCH_NAME]
+        )
+        self.assertEqual(
+            TEST_COMMIT_TITLE,
+            entity.device_state_attributes[gitlab.ATTR_COMMIT_TITLE]
+        )
+        self.assertNotIn(
+            gitlab.ATTR_PIPELINE_STATUS,
+            entity.device_state_attributes
+        )
+
+    @staticmethod
+    def _createTestEntity(with_pipeline: bool):
+        """Create a test GitlabRepo entity based on input parameters."""
+        entity = gitlab.GitlabRepo(
+            name=TEST_CONFIG['version_control'][gitlab.CONF_NAME],
+            gitlab_data=Mock()
+        )
+
+        entity.gitlab_data.project.attributes = {
+            'path_with_namespace': TEST_PROJECT_NAME
+        }
+
+        entity.gitlab_data.branch.name = TEST_BRANCH_NAME
+        entity.gitlab_data.branch.commit = {
+            'id': TEST_COMMIT_HEXSHA,
+            'title': TEST_COMMIT_TITLE
+        }
+
+        if with_pipeline:
+            entity.gitlab_data.pipeline.status = TEST_PIPELINE_STATUS
+        else:
+            entity.gitlab_data.pipeline = None
+
+        return entity

--- a/tests/components/version_control/test_local_git.py
+++ b/tests/components/version_control/test_local_git.py
@@ -221,7 +221,7 @@ class TestLocalGit(unittest.TestCase):
         )
 
         entity.git_pull(TEST_REMOTE, reset=True)
-        entity._repo.git.reset.assert_called()
+        assert entity._repo.git.reset.called
 
     @patch('homeassistant.components.version_control.local_git._LOGGER')
     @MockDependency('git')
@@ -237,7 +237,7 @@ class TestLocalGit(unittest.TestCase):
         )
 
         self.assertFalse(entity.git_pull("fake{}".format(TEST_REMOTE)))
-        mock_logging.error.assert_called()
+        assert mock_logging.error.called
 
     @MockDependency('git')
     def test_valid_repo_git_pull_without_reset(self, mock_git):
@@ -294,7 +294,12 @@ class TestLocalGit(unittest.TestCase):
         entity._repo.is_dirty.return_value = is_dirty
         entity._repo.active_branch.name = TEST_BRANCH_NAME
         entity._repo.active_branch.is_valid.return_value = is_valid
-        entity._repo.head.commit.hexsha = TEST_COMMIT_HEXSHA
-        entity._repo.head.commit.summary = TEST_COMMIT_TITLE
+
+        if is_valid:
+            entity._repo.head.commit.hexsha = TEST_COMMIT_HEXSHA
+            entity._repo.head.commit.summary = TEST_COMMIT_TITLE
+        else:
+            entity._repo.head.commit.hexsha.side_effect = ValueError()
+            entity._repo.head.commit.summary.side_effect = ValueError()
 
         return entity

--- a/tests/components/version_control/test_local_git.py
+++ b/tests/components/version_control/test_local_git.py
@@ -1,0 +1,167 @@
+"""The tests for the local_git component."""
+import unittest
+from unittest.mock import Mock
+
+from homeassistant.const import (STATE_UNKNOWN)
+
+from homeassistant.components.version_control import local_git as local_git
+from homeassistant.setup import setup_component
+from tests.common import (get_test_home_assistant, MockDependency)
+
+TEST_CONFIG = {
+    'version_control': {
+        'platform': 'local_git',
+        local_git.CONF_NAME: 'test_name',
+        local_git.CONF_PATH: 'test_path'
+    }
+}
+
+
+class TestLocalGit(unittest.TestCase):
+    """Test the local_git platform."""
+
+    def setUp(self):
+        """Initialize values for this test case class."""
+        self.hass = get_test_home_assistant()
+        self.config = TEST_CONFIG
+
+    def tearDown(self):  # pylint: disable=invalid-name
+        """Stop everything that we started."""
+        self.hass.stop()
+
+    @MockDependency('git')
+    def test_setup_platform(self, mock_git):
+        """Test successful setup."""
+        self.assertTrue(
+            setup_component(self.hass, 'version_control', TEST_CONFIG)
+        )
+
+        add_devices = Mock()
+        local_git.setup_platform(
+            self.hass, TEST_CONFIG['version_control'], add_devices
+        )
+
+        self.assertTrue(add_devices.called)
+        self.assertTrue(
+            isinstance(
+                add_devices.call_args[0][0][0],
+                local_git.GitRepo)
+        )
+        self.assertTrue(
+            isinstance(
+                add_devices.call_args[0][0][1],
+                local_git.GitRepoActiveBranch)
+        )
+        self.assertTrue(
+            isinstance(
+                add_devices.call_args[0][0][2],
+                local_git.GitRepoActiveCommit)
+        )
+        self.assertEqual(3, len(self.hass.states.all()))
+
+    def test_setup_invalid_path(self):
+        """Test setup with invalid path."""
+        add_entities = Mock()
+
+        with self.assertRaises(Exception):
+            local_git.setup_platform(self.hass, self.config, add_entities)
+
+    def test_gitrepo_with_values(self):
+        """Test GitRepo with values."""
+        entity = local_git.GitRepo(
+            TEST_CONFIG['version_control'][local_git.CONF_NAME], repo=Mock()
+        )
+        entity.update()
+
+        self.assertEqual(
+            "{}".format(
+                TEST_CONFIG['version_control'][local_git.CONF_NAME]
+            ),
+            entity.name
+        )
+
+    def test_gitrepo_activebranch_with_values(self):
+        """Test GitRepoActiveBranch with values."""
+        branch_name = 'master'
+        entity = local_git.GitRepoActiveBranch(
+            TEST_CONFIG['version_control'][local_git.CONF_NAME], repo=Mock()
+        )
+        entity._repo.active_branch.name = branch_name
+
+        self.assertEqual(
+            "{} Active Branch".format(
+                TEST_CONFIG['version_control'][local_git.CONF_NAME]
+            ),
+            entity.name
+        )
+        self.assertEqual(STATE_UNKNOWN, entity.state)
+
+        entity.update()
+
+        self.assertEqual(branch_name, entity.state)
+
+    def test_gitrepo_activecommit_values_with_valid_branch(self):
+        """Test GitRepoActiveCommit values with valid branch."""
+        commit_hexsha = 'test_hexsha'
+        commit_summary = 'test_summary'
+
+        entity = local_git.GitRepoActiveCommit(
+            TEST_CONFIG['version_control'][local_git.CONF_NAME], repo=Mock()
+        )
+        entity._repo.active_branch.is_valid.return_value = True
+        entity._repo.head.commit.hexsha = commit_hexsha
+        entity._repo.head.commit.summary = commit_summary
+
+        self.assertEqual(
+            "{} Active Commit".format(
+                TEST_CONFIG['version_control'][local_git.CONF_NAME]
+            ),
+            entity.name
+        )
+        self.assertEqual(STATE_UNKNOWN, entity.state)
+        self.assertEqual(
+            None,
+            entity.device_state_attributes[
+                local_git.ATTR_ACTIVE_COMMIT_SUMMARY
+            ]
+        )
+
+        entity.update()
+
+        self.assertEqual(commit_hexsha, entity.state)
+        self.assertEqual(
+            commit_summary,
+            entity.device_state_attributes[
+                local_git.ATTR_ACTIVE_COMMIT_SUMMARY
+            ]
+        )
+
+    def test_gitrepo_activebranch_values_with_invalid_branch(self):
+        """Test GitRepoActiveCommit values with invalid branch."""
+        entity = local_git.GitRepoActiveCommit(
+            TEST_CONFIG['version_control'][local_git.CONF_NAME], repo=Mock())
+        entity._repo.active_branch.is_valid.return_value = False
+
+        self.assertEqual(
+            "{} Active Commit".format(
+                TEST_CONFIG['version_control'][local_git.CONF_NAME]
+            ),
+            entity.name
+        )
+        self.assertEqual(STATE_UNKNOWN, entity.state)
+        self.assertEqual(
+            None,
+            entity.device_state_attributes[
+                local_git.ATTR_ACTIVE_COMMIT_SUMMARY
+            ]
+        )
+
+        entity.update()
+
+        self.assertEqual(local_git.STATE_INVALID, entity.state)
+        self.assertEqual(
+            None,
+            entity.device_state_attributes[
+                local_git.ATTR_ACTIVE_COMMIT_SUMMARY
+            ]
+        )


### PR DESCRIPTION
## Description:
This PR contains the code for the Version Control component and the first two platforms within it (`local_git` and `gitlab`).

Both platforms can be used to monitor a Git repository. A use case for these could be to monitor the Home Assistant configuration and if a newer version is available, pull it from the remote.

**Related issue (if applicable):** n/a

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5515

## Example entry for `configuration.yaml` (if applicable):
```yaml
version_control:
  - platform: local_git
    name: My Local Repo
    path: /PATH/TO/REPO

  - platform: gitlab
    name: My Gitlab Repo
    token: API_ACCESS_TOKEN
    project: godfat/gitlab-ce
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
