### PR TITLE
Upgrade psutil to 5.4.6

### DIFF
--- a/homeassistant/components/sensor/systemmonitor.py
+++ b/homeassistant/components/sensor/systemmonitor.py
@@ -10,13 +10,12 @@ import os
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import (
-    CONF_RESOURCES, STATE_OFF, STATE_ON, STATE_UNKNOWN, CONF_TYPE)
+from homeassistant.const import CONF_RESOURCES, STATE_OFF, STATE_ON, CONF_TYPE
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.dt as dt_util
 
-REQUIREMENTS = ['psutil==5.4.5']
+REQUIREMENTS = ['psutil==5.4.6']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -157,19 +156,19 @@ class SystemMonitorSensor(Entity):
                 counter = counters[self.argument][IO_COUNTER[self.type]]
                 self._state = round(counter / 1024**2, 1)
             else:
-                self._state = STATE_UNKNOWN
+                self._state = None
         elif self.type == 'packets_out' or self.type == 'packets_in':
             counters = psutil.net_io_counters(pernic=True)
             if self.argument in counters:
                 self._state = counters[self.argument][IO_COUNTER[self.type]]
             else:
-                self._state = STATE_UNKNOWN
+                self._state = None
         elif self.type == 'ipv4_address' or self.type == 'ipv6_address':
             addresses = psutil.net_if_addrs()
             if self.argument in addresses:
                 self._state = addresses[self.argument][IF_ADDRS[self.type]][1]
             else:
-                self._state = STATE_UNKNOWN
+                self._state = None
         elif self.type == 'last_boot':
             self._state = dt_util.as_local(
                 dt_util.utc_from_timestamp(psutil.boot_time())

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -672,7 +672,7 @@ proliphix==0.4.1
 prometheus_client==0.1.0
 
 # homeassistant.components.sensor.systemmonitor
-psutil==5.4.5
+psutil==5.4.6
 
 # homeassistant.components.wink
 pubnubsub-handler==1.0.2


### PR DESCRIPTION
## Description:
Changelog: https://github.com/giampaolo/psutil/blob/master/HISTORY.rst#546

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: systemmonitor
    resources:
      - type: disk_use_percent
        arg: /home
      - type: memory_free
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
