### PR TITLE
Add entity registry support to media_player.snapcast

### DIFF
--- a/homeassistant/components/media_player/snapcast.py
+++ b/homeassistant/components/media_player/snapcast.py
@@ -105,6 +105,11 @@ class SnapcastGroupDevice(MediaPlayerDevice):
         }.get(self._group.stream_status, STATE_UNKNOWN)
 
     @property
+    def unique_id(self):
+        """Return the ID of snapcast group."""
+        return '{}{}'.format(GROUP_PREFIX, self._group.identifier)
+
+    @property
     def name(self):
         """Return the name of the device."""
         return '{}{}'.format(GROUP_PREFIX, self._group.identifier)
@@ -184,6 +189,11 @@ class SnapcastClientDevice(MediaPlayerDevice):
         """Initialize the Snapcast client device."""
         client.set_callback(self.schedule_update_ha_state)
         self._client = client
+
+    @property
+    def unique_id(self):
+        """Return the ID of this snapcast client."""
+        return '{}{}'.format(CLIENT_PREFIX, self._client.identifier)
 
     @property
     def name(self):


### PR DESCRIPTION
Unique id for client is generated from prefix 'snapcast_client_'
and MAC address

Unique id for group is generated from prefix 'snapcast_group_'
and UUID provided by snapcast library

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
