### PR TITLE
Add api_host option to Konnected config

### DIFF
--- a/homeassistant/components/konnected.py
+++ b/homeassistant/components/konnected.py
@@ -31,6 +31,7 @@ REQUIREMENTS = ['konnected==0.1.2']
 DOMAIN = 'konnected'
 
 CONF_ACTIVATION = 'activation'
+CONF_API_HOST = 'api_host'
 STATE_LOW = 'low'
 STATE_HIGH = 'high'
 
@@ -60,6 +61,7 @@ CONFIG_SCHEMA = vol.Schema(
     {
         DOMAIN: vol.Schema({
             vol.Required(CONF_ACCESS_TOKEN): cv.string,
+            vol.Optional(CONF_API_HOST): vol.Url(),
             vol.Required(CONF_DEVICES): [{
                 vol.Required(CONF_ID): cv.string,
                 vol.Optional(CONF_BINARY_SENSORS): vol.All(
@@ -87,7 +89,10 @@ async def async_setup(hass, config):
 
     access_token = cfg.get(CONF_ACCESS_TOKEN)
     if DOMAIN not in hass.data:
-        hass.data[DOMAIN] = {CONF_ACCESS_TOKEN: access_token}
+        hass.data[DOMAIN] = {
+            CONF_ACCESS_TOKEN: access_token,
+            CONF_API_HOST: cfg.get(CONF_API_HOST)
+        }
 
     def device_discovered(service, info):
         """Call when a Konnected device has been discovered."""
@@ -254,14 +259,26 @@ class KonnectedDevice(object):
         _LOGGER.debug('%s: current actuator config: %s', self.device_id,
                       current_actuator_config)
 
+        desired_api_host = \
+            self.hass.data[DOMAIN].get(CONF_API_HOST) or \
+            self.hass.config.api.base_url
+        desired_api_endpoint = desired_api_host + ENDPOINT_ROOT
+        current_api_endpoint = self.status.get('endpoint')
+
+        _LOGGER.debug('%s: desired api endpoint: %s', self.device_id,
+                      desired_api_endpoint)
+        _LOGGER.debug('%s: current api endpoint: %s', self.device_id,
+                      current_api_endpoint)
+
         if (desired_sensor_configuration != current_sensor_configuration) or \
-                (current_actuator_config != desired_actuator_config):
+                (current_actuator_config != desired_actuator_config) or \
+                (current_api_endpoint != desired_api_endpoint):
             _LOGGER.debug('pushing settings to device %s', self.device_id)
             self.client.put_settings(
                 desired_sensor_configuration,
                 desired_actuator_config,
                 self.hass.data[DOMAIN].get(CONF_ACCESS_TOKEN),
-                self.hass.config.api.base_url + ENDPOINT_ROOT
+                desired_api_endpoint
             )
 
 

--- a/homeassistant/components/konnected.py
+++ b/homeassistant/components/konnected.py
@@ -57,6 +57,7 @@ _SWITCH_SCHEMA = vol.All(
     }), cv.has_at_least_one_key(CONF_PIN, CONF_ZONE)
 )
 
+# pylint: disable=no-value-for-parameter
 CONFIG_SCHEMA = vol.Schema(
     {
         DOMAIN: vol.Schema({


### PR DESCRIPTION
## Description:
Adds a `api_host` configuration option to give Konnected a local address to reach the Home Assistant API. This is useful in the case that `base_url` is set to an external hostname, but Konnected devices should connect to Hass over the local LAN.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation:** https://github.com/home-assistant/home-assistant.github.io/pull/5517

## Example entry for `configuration.yaml` (if applicable):
```yaml
konnected:
  access_token: REPLACE_ME_WITH_RANDOM_STRING
  api_host: http://192.168.1.105:8123
  devices:
    - id: fe2cb2
      binary_sensors:
        - name: Motion
          pin: 1
          type: motion
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)
