### PR TITLE
Allow different identifiers for the CPU temperature (fixes #10104)

### DIFF
--- a/homeassistant/components/sensor/glances.py
+++ b/homeassistant/components/sensor/glances.py
@@ -155,9 +155,9 @@ class GlancesSensor(Entity):
                 self._state = value['processcount']['sleeping']
             elif self.type == 'cpu_temp':
                 for sensor in value['sensors']:
-                    if sensor['label'] == 'CPU':
+                    if sensor['label'] in ['CPU', "Package id 0",
+                                           "Physical id 0"]:
                         self._state = sensor['value']
-                self._state = None
             elif self.type == 'docker_active':
                 count = 0
                 for container in value['docker']['containers']:


### PR DESCRIPTION
## Description:
Allow different identifiers for the CPU temperature.

**Related issue (if applicable):** fixes #10104

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: glances
    resources:
      - 'cpu_temp'
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

