### PR TITLE
Upgrade python-nest, add security_state sensor, nest.set_mode service set ETA as well

### DIFF
--- a/homeassistant/components/nest.py
+++ b/homeassistant/components/nest.py
@@ -160,6 +160,7 @@ async def async_setup_nest(hass, nest, config, pin=None):
     def set_mode(service):
         """
         Set the home/away mode for a Nest structure.
+
         You can set optional eta information when set mode to away.
         """
         if ATTR_STRUCTURE in service.data:

--- a/homeassistant/components/nest.py
+++ b/homeassistant/components/nest.py
@@ -7,6 +7,7 @@ https://home-assistant.io/components/nest/
 from concurrent.futures import ThreadPoolExecutor
 import logging
 import socket
+from datetime import datetime, timedelta
 
 import voluptuous as vol
 
@@ -36,14 +37,23 @@ CONF_CLIENT_SECRET = 'client_secret'
 
 ATTR_HOME_MODE = 'home_mode'
 ATTR_STRUCTURE = 'structure'
+ATTR_TRIP_ID = 'trip_id'
+ATTR_ETA = 'eta'
+ATTR_ETA_WINDOW = 'eta_window'
+
+HOME_MODE_AWAY = 'away'
+HOME_MODE_HOME = 'home'
 
 SENSOR_SCHEMA = vol.Schema({
     vol.Optional(CONF_MONITORED_CONDITIONS): vol.All(cv.ensure_list)
 })
 
 AWAY_SCHEMA = vol.Schema({
-    vol.Required(ATTR_HOME_MODE): cv.string,
-    vol.Optional(ATTR_STRUCTURE): vol.All(cv.ensure_list, cv.string)
+    vol.Required(ATTR_HOME_MODE): vol.In([HOME_MODE_AWAY, HOME_MODE_HOME]),
+    vol.Optional(ATTR_STRUCTURE): vol.All(cv.ensure_list, cv.string),
+    vol.Optional(ATTR_TRIP_ID): cv.string,
+    vol.Optional(ATTR_ETA): cv.time_period_str,
+    vol.Optional(ATTR_ETA_WINDOW): cv.time_period_str
 })
 
 CONFIG_SCHEMA = vol.Schema({
@@ -148,7 +158,10 @@ async def async_setup_nest(hass, nest, config, pin=None):
                            hass, component, DOMAIN, discovered, config)
 
     def set_mode(service):
-        """Set the home/away mode for a Nest structure."""
+        """
+        Set the home/away mode for a Nest structure.
+        You can set optional eta information when set mode to away.
+        """
         if ATTR_STRUCTURE in service.data:
             structures = service.data[ATTR_STRUCTURE]
         else:
@@ -158,6 +171,19 @@ async def async_setup_nest(hass, nest, config, pin=None):
             if structure.name in structures:
                 _LOGGER.info("Setting mode for %s", structure.name)
                 structure.away = service.data[ATTR_HOME_MODE]
+
+                if service.data[ATTR_HOME_MODE] == HOME_MODE_AWAY \
+                        and ATTR_ETA in service.data:
+                    now = datetime.utcnow()
+                    eta_begin = now + service.data[ATTR_ETA]
+                    eta_window = service.data.get(ATTR_ETA_WINDOW,
+                                                  timedelta(minutes=1))
+                    eta_end = eta_begin + eta_window
+                    trip_id = service.data.get(
+                        ATTR_TRIP_ID, "trip_{}".format(int(now.timestamp())))
+                    _LOGGER.info("Setting eta for %s, eta window starts at "
+                                 "%s ends at %s", trip_id, eta_begin, eta_end)
+                    structure.set_eta(trip_id, eta_begin, eta_end)
             else:
                 _LOGGER.error("Invalid structure %s",
                               service.data[ATTR_STRUCTURE])

--- a/homeassistant/components/nest.py
+++ b/homeassistant/components/nest.py
@@ -19,7 +19,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_send, \
     async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['python-nest==4.0.1']
+REQUIREMENTS = ['python-nest==4.0.2']
 
 _CONFIGURING = {}
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/sensor/nest.py
+++ b/homeassistant/components/sensor/nest.py
@@ -23,7 +23,7 @@ PROTECT_SENSOR_TYPES = ['co_status',
                         # color_status: "gray", "green", "yellow", "red"
                         'color_status']
 
-STRUCTURE_SENSOR_TYPES = ['eta']
+STRUCTURE_SENSOR_TYPES = ['eta', 'security_state']
 
 _VALID_SENSOR_TYPES = SENSOR_TYPES + TEMP_SENSOR_TYPES + PROTECT_SENSOR_TYPES \
                       + STRUCTURE_SENSOR_TYPES

--- a/homeassistant/components/services.yaml
+++ b/homeassistant/components/services.yaml
@@ -576,3 +576,28 @@ shopping_list:
       name:
         description: The name of the item to mark as completed.
         example: Beer
+
+nest:
+  set_mode:
+    description: >
+                  Set the home/away mode for a Nest structure.
+                  Set to away mode will also set Estimated Arrival Time if provided.
+                  Set ETA will cause the thermostat to begin warming or cooling the home before the user arrives.
+                  After ETA set other Automation can read ETA sensor as a signal to prepare the home for
+                  the user's arrival.
+    fields:
+      home_mode:
+        description: home or away
+        example: home
+      structure:
+        description: Optional structure name. Default set all structures managed by Home Assistant.
+        example: My Home
+      eta:
+        description: Optional Estimated Arrival Time from now.
+        example: 0:10
+      eta_window:
+        description: Optional ETA window. Default is 1 minute.
+        example: 0:5
+      trip_id:
+        description: Optional the identity of a trip. Use same trip_id will update the estimation for a trip.
+        example: trip_back_home

--- a/homeassistant/components/services.yaml
+++ b/homeassistant/components/services.yaml
@@ -599,5 +599,5 @@ nest:
         description: Optional ETA window. Default is 1 minute.
         example: 0:5
       trip_id:
-        description: Optional the identity of a trip. Use same trip_id will update the estimation for a trip.
+        description: Optional identity of a trip. Using the same trip_ID will update the estimation.
         example: trip_back_home

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1048,7 +1048,7 @@ python-mpd2==1.0.0
 python-mystrom==0.4.2
 
 # homeassistant.components.nest
-python-nest==4.0.1
+python-nest==4.0.2
 
 # homeassistant.components.device_tracker.nmap_tracker
 python-nmap==0.6.1


### PR DESCRIPTION
## Description:
Upgrade python-nest to 4.0.2, which allows follows changes possible.

### Add security_state sensor
`security_state` is provided by [Nest Security API](https://developers.nest.com/documentation/cloud/security-guide), please note, it is *NOT* API for Nest Secure Alarm System.
You can use this sensor to convert your HA + Nest Cam to a cheap security system
>When all family members are away from home, the structure enters `away` mode. When a Nest Cam detects a person, the Camera API's `/last_event/has_person` field changes to `true`.
>
>These two states work together to trigger the Works with Nest Security API, as follows:
>- If a Nest Cam detects the presence of a person while the structure is in `away` mode, the structure enters `deter` mode.
>- When your product detects that the structure is in `deter` mode, your product can make the home "pretend" to be occupied by altering the home environment in some way, such as turning on the lights, playing music, or opening blinds to make an intruder more visible.
>
>In this way, the home becomes a less inviting target for attack.

### Set ETA
`nest.set_mode` service extended to allow set ETA when you set `away` mode. 
>In some cases, users have a 3rd-party app that uses GPS to provide estimated time of arrival (ETA) data to the Nest API. In other cases, the user might use an app to manually enter their ETA. Or maybe the ETA is calcluated based on the user's regular schedule.
>
>ETA apps that are integrated with the Nest Thermostat cause the thermostat to begin warming or cooling the home before the user arrives.
>
>When the ETA/thermostat integration exists in the user's account, the ETA data is available for other Works with Nest developers to use in their Works with Nest integrations.
>
>After the ETA is input into the Nest service, another Works with Nest integration can use it as a signal to prepare the home for the user's arrival.

[See here](https://developers.nest.com/documentation/cloud/away-guide#how_eta_works) for more information

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5518

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

