### PR TITLE
Upgrade python_opendata_transport to 0.1.3

### DIFF
--- a/homeassistant/components/sensor/swiss_public_transport.py
+++ b/homeassistant/components/sensor/swiss_public_transport.py
@@ -16,7 +16,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 import homeassistant.util.dt as dt_util
 
-REQUIREMENTS = ['python_opendata_transport==0.1.0']
+REQUIREMENTS = ['python_opendata_transport==0.1.3']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1090,7 +1090,7 @@ python-vlc==1.1.2
 python-wink==1.7.3
 
 # homeassistant.components.sensor.swiss_public_transport
-python_opendata_transport==0.1.0
+python_opendata_transport==0.1.3
 
 # homeassistant.components.zwave
 python_openzwave==0.4.3


### PR DESCRIPTION
## Description:
Changelog: https://github.com/fabaff/python-opendata-transport/blob/master/CHANGES.rst#changes

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: swiss_public_transport
    name: Train
    from: Bern
    to: Biel
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
