### PR TITLE
Bump to denonavr 0.7.3

### DIFF
--- a/homeassistant/components/media_player/denonavr.py
+++ b/homeassistant/components/media_player/denonavr.py
@@ -20,7 +20,7 @@ from homeassistant.const import (
     CONF_NAME, STATE_ON, CONF_ZONE, CONF_TIMEOUT)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['denonavr==0.7.2']
+REQUIREMENTS = ['denonavr==0.7.3']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -249,7 +249,7 @@ defusedxml==0.5.0
 deluge-client==1.4.0
 
 # homeassistant.components.media_player.denonavr
-denonavr==0.7.2
+denonavr==0.7.3
 
 # homeassistant.components.media_player.directv
 directpy==0.5


### PR DESCRIPTION
Closes #14792

See #14794

See also scarface-4711/denonavr#49

## Description:

**Operating environment (Hass.io/Docker/Windows/etc.):**

Debian/Python 3.5/venv

**Component/platform:**

denonavr (with Denon AVR-X6300H)

**Description of problem:**

The updated denonavr component fixes an issue where the power state is not set for newer AVR models.
