### PR TITLE
Add sound mode support

### DIFF
--- a/homeassistant/components/media_player/denonavr.py
+++ b/homeassistant/components/media_player/denonavr.py
@@ -229,11 +229,6 @@ class DenonDevice(MediaPlayerDevice):
         return self._sound_mode
 
     @property
-    def sound_mode_raw(self):
-        """Return the current raw sound mode."""
-        return self._sound_mode_raw
-
-    @property
     def sound_mode_list(self):
         """Return a list of available sound modes."""
         return self._sound_mode_list

--- a/homeassistant/components/media_player/denonavr.py
+++ b/homeassistant/components/media_player/denonavr.py
@@ -329,9 +329,9 @@ class DenonDevice(MediaPlayerDevice):
     def device_state_attributes(self):
         """Return device specific state attributes."""
         attributes = {}
-        if self._sound_mode_raw is not None and self._sound_mode_support\
-         and self._power == 'ON':
-            attributes[ATTR_SOUND_MODE_RAW] = self._sound_mode_raw
+        if (self._sound_mode_raw is not None and self._sound_mode_support and
+            self._power == 'ON'):
+              attributes[ATTR_SOUND_MODE_RAW] = self._sound_mode_raw
         return attributes
 
     def media_play_pause(self):

--- a/homeassistant/components/media_player/denonavr.py
+++ b/homeassistant/components/media_player/denonavr.py
@@ -330,7 +330,7 @@ class DenonDevice(MediaPlayerDevice):
         """Return device specific state attributes."""
         attributes = {}
         if (self._sound_mode_raw is not None and self._sound_mode_support and
-            self._power == 'ON'):
+                self._power == 'ON'):
             attributes[ATTR_SOUND_MODE_RAW] = self._sound_mode_raw
         return attributes
 

--- a/homeassistant/components/media_player/denonavr.py
+++ b/homeassistant/components/media_player/denonavr.py
@@ -31,7 +31,6 @@ DEFAULT_SOUND_MODE = True
 CONF_SHOW_ALL_SOURCES = 'show_all_sources'
 CONF_ZONES = 'zones'
 CONF_SOUND_MODE = 'sound_mode'
-CONF_SOUND_MODE_DICT = 'sound_mode_dict'
 CONF_VALID_ZONES = ['Zone2', 'Zone3']
 CONF_INVALID_ZONES_ERR = 'Invalid Zone (expected Zone2 or Zone3)'
 KEY_DENON_CACHE = 'denonavr_hosts'
@@ -55,7 +54,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_HOST): cv.string,
     vol.Optional(CONF_NAME): cv.string,
     vol.Optional(CONF_SOUND_MODE, default=DEFAULT_SOUND_MODE): cv.boolean,
-    vol.Optional(CONF_SOUND_MODE_DICT): vol.Schema({str: list}),
     vol.Optional(CONF_SHOW_ALL_SOURCES, default=DEFAULT_SHOW_SOURCES):
         cv.boolean,
     vol.Optional(CONF_ZONES):
@@ -93,7 +91,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     # Get config option for sound mode
     sound_mode_support = config.get(CONF_SOUND_MODE)
-    sound_mode_dict = config.get(CONF_SOUND_MODE_DICT)
 
     # Start assignment of host and name
     new_hosts = []
@@ -129,8 +126,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                 add_zones=add_zones)
             for new_zone in new_device.zones.values():
                 receivers.append(DenonDevice(new_zone,
-                                             sound_mode_support,
-                                             sound_mode_dict))
+                                             sound_mode_support))
             cache.add(host)
             _LOGGER.info("Denon receiver at host %s initialized", host)
 
@@ -142,7 +138,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class DenonDevice(MediaPlayerDevice):
     """Representation of a Denon Media Player Device."""
 
-    def __init__(self, receiver, sound_mode_support, sound_mode_dict):
+    def __init__(self, receiver, sound_mode_support):
         """Initialize the device."""
         self._receiver = receiver
         self._name = self._receiver.name
@@ -164,11 +160,7 @@ class DenonDevice(MediaPlayerDevice):
         if sound_mode_support:
             self._sound_mode = self._receiver.sound_mode
             self._sound_mode_raw = self._receiver.sound_mode_raw
-            if sound_mode_dict is None:
-                self._sound_mode_list = self._receiver.sound_mode_list
-            else:
-                self._receiver.set_sound_mode_dict(sound_mode_dict)
-                self._sound_mode_list = list(sound_mode_dict)
+            self._sound_mode_list = self._receiver.sound_mode_list
         else:
             self._sound_mode = None
             self._sound_mode_raw = None

--- a/homeassistant/components/media_player/denonavr.py
+++ b/homeassistant/components/media_player/denonavr.py
@@ -331,7 +331,7 @@ class DenonDevice(MediaPlayerDevice):
         attributes = {}
         if (self._sound_mode_raw is not None and self._sound_mode_support and
             self._power == 'ON'):
-              attributes[ATTR_SOUND_MODE_RAW] = self._sound_mode_raw
+            attributes[ATTR_SOUND_MODE_RAW] = self._sound_mode_raw
         return attributes
 
     def media_play_pause(self):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -249,7 +249,7 @@ defusedxml==0.5.0
 deluge-client==1.4.0
 
 # homeassistant.components.media_player.denonavr
-denonavr==0.7.3
+denonavr==0.7.4
 
 # homeassistant.components.media_player.directv
 directpy==0.5


### PR DESCRIPTION
## Description:
Add sound mode support for the DenonAVR platform.
Using the just merged [general sound mode support](https://github.com/home-assistant/home-assistant/commit/f6963315631bdecd7f6acca41369eeb0b9b473bb).

Added backend support for selecting the sound mode and updating the sound mode status.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5521

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  - platform: denonavr
    host: IP_ADRESS
    name: "Marantz"
    show_all_sources: False
    timeout: 2
    sound_mode: True
    sound_mode_dict: {'MUSIC':['PLII MUSIC'], 'MOVIE':['PLII MOVIE'], 'GAME':['PLII GAME'], 'PURE DIRECT':['DIRECT'], 'AUTO':['None'], 'DOLBY DIGITAL':['DOLBY DIGITAL'], 'MCH STEREO':['MULTI CH STEREO'], 'STEREO':['STEREO']}
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
