### PR TITLE
Added unique id and json_attributes to binary_sensor.mqtt

### DIFF
--- a/homeassistant/components/binary_sensor/mqtt.py
+++ b/homeassistant/components/binary_sensor/mqtt.py
@@ -116,8 +116,7 @@ class MqttBinarySensor(MqttAvailability, BinarySensorDevice):
                     else:
                         _LOGGER.warning("JSON result was not a dictionary")
                 except ValueError:
-                    _LOGGER.warning("MQTT payload could not be parsed as JSON")
-                    _LOGGER.debug("Erroneous JSON: %s", payload)
+                    _LOGGER.warning("MQTT payload could not be parsed as JSON, %s", payload)
 
             if self._template is not None:
                 payload = self._template.async_render_with_possible_json_value(

--- a/homeassistant/components/binary_sensor/mqtt.py
+++ b/homeassistant/components/binary_sensor/mqtt.py
@@ -116,7 +116,8 @@ class MqttBinarySensor(MqttAvailability, BinarySensorDevice):
                     else:
                         _LOGGER.warning("JSON result was not a dictionary")
                 except ValueError:
-                    _LOGGER.warning("MQTT payload could not be parsed as JSON, %s", payload)
+                    _LOGGER.warning("MQTT payload could not be parsed as JSON"
+                                    ", %s", payload)
 
             if self._template is not None:
                 payload = self._template.async_render_with_possible_json_value(

--- a/tests/components/binary_sensor/test_mqtt.py
+++ b/tests/components/binary_sensor/test_mqtt.py
@@ -198,7 +198,6 @@ class TestSensorMQTT(unittest.TestCase):
         self.assertEqual(None,
                          state.attributes.get('val'))
         self.assertTrue(mock_logger.warning.called)
-        self.assertTrue(mock_logger.debug.called)
 
     def test_update_with_json_attrs_and_template(self):
         """Test attributes get extracted from a JSON result."""

--- a/tests/components/binary_sensor/test_mqtt.py
+++ b/tests/components/binary_sensor/test_mqtt.py
@@ -4,6 +4,7 @@ import unittest
 import homeassistant.core as ha
 from homeassistant.setup import setup_component
 import homeassistant.components.binary_sensor as binary_sensor
+from unittest.mock import patch
 
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.const import EVENT_STATE_CHANGED, STATE_UNAVAILABLE
@@ -115,6 +116,135 @@ class TestSensorMQTT(unittest.TestCase):
 
         state = self.hass.states.get('binary_sensor.test')
         self.assertEqual(STATE_UNAVAILABLE, state.state)
+
+    def test_unique_id(self):
+        """Test unique id option only creates one sensor per unique_id."""
+        assert setup_component(self.hass, binary_sensor.DOMAIN, {
+            binary_sensor.DOMAIN: [{
+                'platform': 'mqtt',
+                'name': 'Test 1',
+                'state_topic': 'test-topic',
+                'unique_id': 'TOTALLY_UNIQUE'
+            }, {
+                'platform': 'mqtt',
+                'name': 'Test 2',
+                'state_topic': 'test-topic',
+                'unique_id': 'TOTALLY_UNIQUE'
+            }]
+        })
+
+    @patch('homeassistant.components.binary_sensor.mqtt._LOGGER')
+    def test_setting_sensor_attribute_via_mqtt_json_message(self, mock_logger):
+        """Test the setting of attribute via MQTT with JSON payload."""
+        mock_component(self.hass, 'mqtt')
+        assert setup_component(self.hass, binary_sensor.DOMAIN, {
+            binary_sensor.DOMAIN: {
+                'platform': 'mqtt',
+                'name': 'test',
+                'state_topic': 'test-topic',
+                'unit_of_measurement': 'fav unit',
+                'json_attributes': 'val'
+            }
+        })
+
+        fire_mqtt_message(self.hass, 'test-topic', '{ "val": "100" }')
+        self.hass.block_till_done()
+        state = self.hass.states.get('binary_sensor.test')
+
+        self.assertEqual('100',
+                         state.attributes.get('val'))
+        self.assertTrue(mock_logger.warning.called)
+
+    @patch('homeassistant.components.binary_sensor.mqtt._LOGGER')
+    def test_update_with_json_attrs_not_dict(self, mock_logger):
+        """Test attributes get extracted from a JSON result."""
+        mock_component(self.hass, 'mqtt')
+        assert setup_component(self.hass, binary_sensor.DOMAIN, {
+            binary_sensor.DOMAIN: {
+                'platform': 'mqtt',
+                'name': 'test',
+                'state_topic': 'test-topic',
+                'unit_of_measurement': 'fav unit',
+                'json_attributes': 'val'
+            }
+        })
+
+        fire_mqtt_message(self.hass, 'test-topic', '[ "list", "of", "things"]')
+        self.hass.block_till_done()
+        state = self.hass.states.get('binary_sensor.test')
+
+        self.assertEqual(None,
+                         state.attributes.get('val'))
+        self.assertTrue(mock_logger.warning.called)
+
+    @patch('homeassistant.components.binary_sensor.mqtt._LOGGER')
+    def test_update_with_json_attrs_bad_JSON(self, mock_logger):
+        """Test attributes get extracted from a JSON result."""
+        mock_component(self.hass, 'mqtt')
+        assert setup_component(self.hass, binary_sensor.DOMAIN, {
+            binary_sensor.DOMAIN: {
+                'platform': 'mqtt',
+                'name': 'test',
+                'state_topic': 'test-topic',
+                'unit_of_measurement': 'fav unit',
+                'json_attributes': 'val'
+            }
+        })
+
+        fire_mqtt_message(self.hass, 'test-topic', 'This is not JSON')
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('binary_sensor.test')
+        self.assertEqual(None,
+                         state.attributes.get('val'))
+        self.assertTrue(mock_logger.warning.called)
+        self.assertTrue(mock_logger.debug.called)
+
+    def test_update_with_json_attrs_and_template(self):
+        """Test attributes get extracted from a JSON result."""
+        mock_component(self.hass, 'mqtt')
+        assert setup_component(self.hass, binary_sensor.DOMAIN, {
+            binary_sensor.DOMAIN: {
+                'platform': 'mqtt',
+                'name': 'test',
+                'state_topic': 'test-topic',
+                'payload_on': "100",
+                'unit_of_measurement': 'fav unit',
+                'value_template': '{{ value_json.val }}',
+                'json_attributes': 'val'
+            }
+        })
+
+        fire_mqtt_message(self.hass, 'test-topic', '{ "val": "100" }')
+        self.hass.block_till_done()
+        state = self.hass.states.get('binary_sensor.test')
+
+        self.assertEqual('100',
+                         state.attributes.get('val'))
+        self.assertEqual('on', state.state)
+
+    @patch('homeassistant.components.binary_sensor.mqtt._LOGGER')
+    def test_update_with_json_attrs_and_invalid_value(self, mock_logger):
+        """Test attributes get extracted from a JSON result."""
+        mock_component(self.hass, 'mqtt')
+        assert setup_component(self.hass, binary_sensor.DOMAIN, {
+            binary_sensor.DOMAIN: {
+                'platform': 'mqtt',
+                'name': 'test',
+                'state_topic': 'test-topic',
+                'unit_of_measurement': 'fav unit',
+                'value_template': '{{ value_json.val }}',
+                'json_attributes': 'val'
+            }
+        })
+
+        fire_mqtt_message(self.hass, 'test-topic', '{ "val": "100" }')
+        self.hass.block_till_done()
+        state = self.hass.states.get('binary_sensor.test')
+
+        self.assertEqual('100',
+                         state.attributes.get('val'))
+        self.assertTrue(mock_logger.warning.called)
 
     def test_availability_by_custom_payload(self):
         """Test availability by custom payload with defined topic."""


### PR DESCRIPTION
## Description:
Added unique id and json_attributes to binary_sensor.mqtt

Notes: 
- for `json_attributes` to work properly, the user MUST specify value_template
- the `json_attributes` use case is for binary sensors that need battery attribute to be exposed (ex. [zigbee2mqtt](https://github.com/Koenkk/zigbee2mqtt) for door sensors)

EDIT by @dgomes: zigbee2mqtt integrates with HA through mqtt autodiscovery

**Related issue (if applicable):** fixes N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#TBC

## Example entry for `configuration.yaml` (if applicable):
```yaml
binary_sensor:
  - platform: mqtt
    state_topic: "home-assistant/window/contact"
    value_template: "{{ value_json.val }}"
    json_attributes:
      - battery
      - voltage
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.
