### PR TITLE
Update to python-pushover 0.4 for sending of image attachments

### DIFF
--- a/homeassistant/components/notify/pushover.py
+++ b/homeassistant/components/notify/pushover.py
@@ -5,6 +5,7 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/notify.pushover/
 """
 import logging
+import mimetypes
 import os
 import re
 import tempfile
@@ -99,7 +100,8 @@ class PushoverNotificationService(BaseNotificationService):
                 auth=file_data.get(ATTR_FILE_AUTH))
 
             if filename is not None:
-                file = (filename, open(filename, "rb"), "image/jpeg")
+                file = (filename, open(
+                    filename, "rb"), mimetypes.guess_type(filename))
 
         for target in targets:
             if target is not None:

--- a/homeassistant/components/notify/pushover.py
+++ b/homeassistant/components/notify/pushover.py
@@ -5,7 +5,13 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/notify.pushover/
 """
 import logging
+import os
+import re
+import tempfile
 
+import requests
+from requests.auth import HTTPBasicAuth
+from requests.auth import HTTPDigestAuth
 import voluptuous as vol
 
 from homeassistant.components.notify import (
@@ -14,10 +20,24 @@ from homeassistant.components.notify import (
 from homeassistant.const import CONF_API_KEY
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['python-pushover==0.3']
+REQUIREMENTS = ['python-pushover==0.4']
 _LOGGER = logging.getLogger(__name__)
 
+# Top level attributes in 'data'
+ATTR_FILE = 'file'
 
+# Attributes contained in file
+ATTR_FILE_URL = 'url'
+ATTR_FILE_PATH = 'path'
+ATTR_FILE_USERNAME = 'username'
+ATTR_FILE_PASSWORD = 'password'
+ATTR_FILE_AUTH = 'auth'
+
+# Valid values for 'auth' attribute
+ATTR_FILE_AUTH_BASIC = 'basic'
+ATTR_FILE_AUTH_DIGEST = 'digest'
+
+CONF_TIMEOUT = 15
 CONF_USER_KEY = 'user_key'
 
 PLATFORM_SCHEMA = cv.PLATFORM_SCHEMA.extend({
@@ -33,7 +53,8 @@ def get_service(hass, config, discovery_info=None):
 
     try:
         return PushoverNotificationService(
-            config[CONF_USER_KEY], config[CONF_API_KEY])
+            config[CONF_USER_KEY], config[CONF_API_KEY],
+            hass.config.is_allowed_path, hass.config.path('www'))
     except InitError:
         _LOGGER.error("Wrong API key supplied")
         return None
@@ -42,11 +63,13 @@ def get_service(hass, config, discovery_info=None):
 class PushoverNotificationService(BaseNotificationService):
     """Implement the notification service for Pushover."""
 
-    def __init__(self, user_key, api_token):
+    def __init__(self, user_key, api_token, is_allowed_path, local_www_path):
         """Initialize the service."""
         from pushover import Client
         self._user_key = user_key
         self._api_token = api_token
+        self._is_allowed_path = is_allowed_path
+        self._local_www_path = local_www_path
         self.pushover = Client(
             self._user_key, api_token=self._api_token)
 
@@ -56,6 +79,7 @@ class PushoverNotificationService(BaseNotificationService):
 
         # Make a copy and use empty dict if necessary
         data = dict(kwargs.get(ATTR_DATA) or {})
+        file_data = data.pop(ATTR_FILE, None)
 
         data['title'] = kwargs.get(ATTR_TITLE, ATTR_TITLE_DEFAULT)
 
@@ -64,13 +88,86 @@ class PushoverNotificationService(BaseNotificationService):
         if not isinstance(targets, list):
             targets = [targets]
 
+        file = {}
+
+        if file_data is not None:
+            filename = self.load_file(
+                url=file_data.get(ATTR_FILE_URL),
+                local_path=file_data.get(ATTR_FILE_PATH),
+                username=file_data.get(ATTR_FILE_USERNAME),
+                password=file_data.get(ATTR_FILE_PASSWORD),
+                auth=file_data.get(ATTR_FILE_AUTH))
+
+            if filename is not None:
+                file = (filename, open(filename, "rb"), "image/jpeg")
+
         for target in targets:
             if target is not None:
                 data['device'] = target
 
             try:
-                self.pushover.send_message(message, **data)
+                self.pushover.send_message(
+                    message=message, attachment=file, **data)
+
             except ValueError as val_err:
                 _LOGGER.error(str(val_err))
             except RequestError:
                 _LOGGER.exception("Could not send pushover notification")
+            finally:
+                # Remove the tempfile if one was created
+                if file_data and file_data.get(ATTR_FILE_URL) and filename:
+                    os.remove(filename)
+
+    def load_file(self, url=None, local_path=None, username=None,
+                  password=None, auth=None):
+        """Load image/document/etc from a local path or URL."""
+        try:
+            # Load the file from URL
+            if url is not None:
+                # Check whether authentication parameters are provided
+                if username is not None and password is not None:
+                    # Use digest or basic authentication
+                    if ATTR_FILE_AUTH_DIGEST == auth:
+                        auth_ = HTTPDigestAuth(username, password)
+                    else:
+                        auth_ = HTTPBasicAuth(username, password)
+                    # Load file from URL with authentication
+                    response = requests.get(
+                        url, auth=auth_, timeout=CONF_TIMEOUT)
+                else:
+                    # Load file from URL without authentication
+                    response = requests.get(url, timeout=CONF_TIMEOUT)
+
+                # Make the request and raise an error if necessary
+                response.raise_for_status()
+
+                downloaded_file = (
+                    tempfile.NamedTemporaryFile(delete=False)
+                )
+
+                filename = downloaded_file.name
+                downloaded_file.write(response.content)
+
+                return filename
+
+            # Load the file from the filesystem
+            elif local_path is not None:
+                # Change the path if the file is in the local www directory
+                regex = re.compile('^/local/')
+                local_path = regex.sub(self._local_www_path + "/", local_path)
+
+                # Check whether path is whitelisted in configuration.yaml
+                if self._is_allowed_path(local_path):
+                    return local_path
+                _LOGGER.warning("'%s' is not secure to load data from!",
+                                local_path)
+            else:
+                _LOGGER.warning("Neither URL nor local path found in params!")
+
+        except requests.exceptions.RequestException as request_error:
+            _LOGGER.error("Can't load from url: %s", request_error)
+
+        except OSError as error:
+            _LOGGER.error("Can't load from url or local path: %s", error)
+
+        return None

--- a/homeassistant/components/notify/pushover.py
+++ b/homeassistant/components/notify/pushover.py
@@ -123,41 +123,40 @@ class PushoverNotificationService(BaseNotificationService):
     def load_file(self, url=None, local_path=None, username=None,
                   password=None, auth=None):
         """Load image/document/etc from a local path or URL."""
-        try:
             # Load the file from URL
-            if url is not None:
+            if url:
                 # Check whether authentication parameters are provided
-                if username is not None and password is not None:
+                if username:
                     # Use digest or basic authentication
                     if ATTR_FILE_AUTH_DIGEST == auth:
-                        auth_ = HTTPDigestAuth(username, password)
+                        auth = HTTPDigestAuth(username, password)
                     else:
-                        auth_ = HTTPBasicAuth(username, password)
-                    # Load file from URL with authentication
-                    response = requests.get(
-                        url, auth=auth_, timeout=CONF_TIMEOUT)
+                        auth = HTTPBasicAuth(username, password)
                 else:
-                    # Load file from URL without authentication
-                    response = requests.get(url, timeout=CONF_TIMEOUT)
+                    auth = None
 
                 # Make the request and raise an error if necessary
-                response.raise_for_status()
+                try:
+                    response = requests.get(url, auth=auth, timeout=CONF_TIMEOUT)
+                    response.raise_for_status()
+                
+                except requests.exceptions.RequestException as request_error:
+                    _LOGGER.error("Can't load from url: %s", request_error)
 
                 downloaded_file = (
                     tempfile.NamedTemporaryFile(delete=False)
                 )
 
-                filename = downloaded_file.name
-                downloaded_file.write(response.content)
+                try:
+                    filename = downloaded_file.name
+                    downloaded_file.write(response.content)
+                except OSError as error:
+                    _LOGGER.error("Can't load from url or local path: %s", error)
 
                 return filename
 
             # Load the file from the filesystem
-            elif local_path is not None:
-                # Change the path if the file is in the local www directory
-                regex = re.compile('^/local/')
-                local_path = regex.sub(self._local_www_path + "/", local_path)
-
+            elif local_path:
                 # Check whether path is whitelisted in configuration.yaml
                 if self._is_allowed_path(local_path):
                     return local_path
@@ -165,11 +164,5 @@ class PushoverNotificationService(BaseNotificationService):
                                 local_path)
             else:
                 _LOGGER.warning("Neither URL nor local path found in params!")
-
-        except requests.exceptions.RequestException as request_error:
-            _LOGGER.error("Can't load from url: %s", request_error)
-
-        except OSError as error:
-            _LOGGER.error("Can't load from url or local path: %s", error)
 
         return None

--- a/homeassistant/components/notify/pushover.py
+++ b/homeassistant/components/notify/pushover.py
@@ -137,9 +137,12 @@ class PushoverNotificationService(BaseNotificationService):
 
                 # Make the request and raise an error if necessary
                 try:
-                    response = requests.get(url, auth=auth, timeout=CONF_TIMEOUT)
+                    if auth:
+                        response = requests.get(url, auth=auth, timeout=CONF_TIMEOUT)
+                    else:
+                        response = requests.get(url, timeout=CONF_TIMEOUT)
+
                     response.raise_for_status()
-                
                 except requests.exceptions.RequestException as request_error:
                     _LOGGER.error("Can't load from url: %s", request_error)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1033,7 +1033,7 @@ python-nest==4.0.0
 python-nmap==0.6.1
 
 # homeassistant.components.notify.pushover
-python-pushover==0.3
+python-pushover==0.4
 
 # homeassistant.components.sensor.ripple
 python-ripple-api==0.0.3


### PR DESCRIPTION
## Description:
This change updates the python-pushover version to 0.4 to support image attachments. I used the 'load_file' function from slack.py as the basis for the work in this module to keep the codebase consistent.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>
This implements the feature request found here: https://community.home-assistant.io/t/pushing-images-with-pushover-3-0/40667

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5524
The documentation has been updated with an example

## Example entry for `configuration.yaml` (if applicable):
```yaml
- alias: Garage Door Opened
  trigger:
    platform: state
    entity_id: sensor.garage_door
    from: '0'
    to: '1'
  condition:
    - condition: state
      entity_id: input_boolean.security_armed
      state: 'on'
  action:
    - service: notify.pushover
      data_template:
        message: "Garage door was opened"
      data:
        title: "Home Assistant"
        data:
          priority: 1
          sound: siren
          file:
            path: "/local/alert.png"

- alias: Garage motion detected
  trigger:
    platform: state
    entity_id: sensor.garage_motion
    from: '0'
    to: '1'
  condition:
    - condition: state
      entity_id: input_boolean.security_armed
      state: 'on'
  action:
    - service: notify.pushover
      data_template:
        message: "Motion in Garage"
      data:
        title: "Home Assistant"
        data:
          priority: 1
          sound: siren
          file:
            url: !secret cam_garage_latest_url
            auth: basic
            username: !secret cam_garage_username
            password: !secret cam_garage_password
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
