### PR TITLE
Fix Skybell binary sensor state update

### DIFF
--- a/homeassistant/components/binary_sensor/skybell.py
+++ b/homeassistant/components/binary_sensor/skybell.py
@@ -94,4 +94,4 @@ class SkybellBinarySensor(SkybellDevice, BinarySensorDevice):
 
         self._state = bool(event and event.get('id') != self._event.get('id'))
 
-        self._event = event
+        self._event = event or {}


### PR DESCRIPTION
## Description:
The `binary_sensor.skybell` platform can fail to update its state when the event list returned by the Skybell API does not have entries for the monitored conditions. This is due to an bug that makes the event list `None` rather than an empty dictionary.

Both `binary_sensor.skybell` and `sensor.skybell` can also return `None` instead of `STATE_UNKNOWN` as their state, this is also fixed.

**Related issue (if applicable):** fixes #14871

## Example entry for `configuration.yaml` (if applicable):
```yaml
skybell:
  username: ...
  password: ...
binary_sensor:
  - platform: skybell
    monitored_conditions:
      - button
      - motion
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**