### PR TITLE
Add unique_id for mqtt binary sensor

### DIFF
--- a/tests/components/binary_sensor/test_mqtt.py
+++ b/tests/components/binary_sensor/test_mqtt.py
@@ -92,6 +92,9 @@ class TestSensorMQTT(unittest.TestCase):
                 'unique_id': 'TOTALLY_UNIQUE'
             }]
         })
+        fire_mqtt_message(self.hass, 'test-topic', 'payload')
+        self.hass.block_till_done()
+        assert len(self.hass.states.all()) == 1
 
     def test_availability_without_topic(self):
         """Test availability without defined availability topic."""

--- a/tests/components/binary_sensor/test_mqtt.py
+++ b/tests/components/binary_sensor/test_mqtt.py
@@ -77,6 +77,22 @@ class TestSensorMQTT(unittest.TestCase):
         state = self.hass.states.get('binary_sensor.test')
         self.assertIsNone(state)
 
+    def test_unique_id(self):
+        """Test unique id option only creates one sensor per unique_id."""
+        assert setup_component(self.hass, binary_sensor.DOMAIN, {
+            binary_sensor.DOMAIN: [{
+                'platform': 'mqtt',
+                'name': 'Test 1',
+                'state_topic': 'test-topic',
+                'unique_id': 'TOTALLY_UNIQUE'
+            }, {
+                'platform': 'mqtt',
+                'name': 'Test 2',
+                'state_topic': 'test-topic',
+                'unique_id': 'TOTALLY_UNIQUE'
+            }]
+        })
+
     def test_availability_without_topic(self):
         """Test availability without defined availability topic."""
         self.assertTrue(setup_component(self.hass, binary_sensor.DOMAIN, {


### PR DESCRIPTION
## Description:
Added unique_id for mqtt binary sensor. Use case for zigbee2mqtt to allow renaming just like xiaomi_aqara. 

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5538

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)


If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.
