### PR TITLE
Add support for Tahoma smoke sensor, light switch and two awning io components

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -470,6 +470,7 @@ omit =
     homeassistant/components/light/yeelightsunflower.py
     homeassistant/components/light/zengge.py
     homeassistant/components/lirc.py
+    homeassistant/components/lock/kiwi.py
     homeassistant/components/lock/lockitron.py
     homeassistant/components/lock/nello.py
     homeassistant/components/lock/nuki.py

--- a/homeassistant/components/arlo.py
+++ b/homeassistant/components/arlo.py
@@ -5,14 +5,18 @@ For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/arlo/
 """
 import logging
+from datetime import timedelta
 
 import voluptuous as vol
 from requests.exceptions import HTTPError, ConnectTimeout
 
 from homeassistant.helpers import config_validation as cv
-from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
+from homeassistant.const import (
+    CONF_USERNAME, CONF_PASSWORD, CONF_SCAN_INTERVAL)
+from homeassistant.helpers.event import track_time_interval
+from homeassistant.helpers.dispatcher import dispatcher_send
 
-REQUIREMENTS = ['pyarlo==0.1.2']
+REQUIREMENTS = ['pyarlo==0.1.6']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -25,10 +29,16 @@ DOMAIN = 'arlo'
 NOTIFICATION_ID = 'arlo_notification'
 NOTIFICATION_TITLE = 'Arlo Component Setup'
 
+SCAN_INTERVAL = timedelta(seconds=60)
+
+SIGNAL_UPDATE_ARLO = "arlo_update"
+
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Required(CONF_USERNAME): cv.string,
         vol.Required(CONF_PASSWORD): cv.string,
+        vol.Optional(CONF_SCAN_INTERVAL, default=SCAN_INTERVAL):
+            cv.time_period,
     }),
 }, extra=vol.ALLOW_EXTRA)
 
@@ -38,6 +48,7 @@ def setup(hass, config):
     conf = config[DOMAIN]
     username = conf.get(CONF_USERNAME)
     password = conf.get(CONF_PASSWORD)
+    scan_interval = conf.get(CONF_SCAN_INTERVAL)
 
     try:
         from pyarlo import PyArlo
@@ -45,7 +56,17 @@ def setup(hass, config):
         arlo = PyArlo(username, password, preload=False)
         if not arlo.is_connected:
             return False
+
+        # assign refresh period to base station thread
+        arlo_base_station = next((
+            station for station in arlo.base_stations), None)
+
+        if arlo_base_station is None:
+            return False
+
+        arlo_base_station.refresh_rate = scan_interval.total_seconds()
         hass.data[DATA_ARLO] = arlo
+
     except (ConnectTimeout, HTTPError) as ex:
         _LOGGER.error("Unable to connect to Netgear Arlo: %s", str(ex))
         hass.components.persistent_notification.create(
@@ -55,4 +76,17 @@ def setup(hass, config):
             title=NOTIFICATION_TITLE,
             notification_id=NOTIFICATION_ID)
         return False
+
+    def hub_refresh(event_time):
+        """Call ArloHub to refresh information."""
+        _LOGGER.info("Updating Arlo Hub component")
+        hass.data[DATA_ARLO].update(update_cameras=True,
+                                    update_base_station=True)
+        dispatcher_send(hass, SIGNAL_UPDATE_ARLO)
+
+    # register service
+    hass.services.register(DOMAIN, 'update', hub_refresh)
+
+    # register scan interval for ArloHub
+    track_time_interval(hass, hub_refresh, scan_interval)
     return True

--- a/homeassistant/components/binary_sensor/tahoma.py
+++ b/homeassistant/components/binary_sensor/tahoma.py
@@ -12,7 +12,7 @@ from homeassistant.components.binary_sensor import (
     BinarySensorDevice)
 from homeassistant.components.tahoma import (
     DOMAIN as TAHOMA_DOMAIN, TahomaDevice)
-from homeassistant.const import (STATE_OFF, STATE_ON)
+from homeassistant.const import (STATE_OFF, STATE_ON, ATTR_BATTERY_LEVEL)
 
 DEPENDENCIES = ['tahoma']
 
@@ -67,6 +67,12 @@ class TahomaBinarySensor(TahomaDevice, BinarySensorDevice):
             else:
                 self._state = STATE_ON
 
-        # FIXME: Check for low battery state.
-        # self.tahoma_device.active_states['core:SensorDefectState'] ==
-        #     'lowBattery' """
+    @property
+    def state_attributes(self):
+        """Return the state attributes of the sensor."""
+        attr = {}
+        if 'core:SensorDefectState' in self.tahoma_device.active_states:
+            # Set to 'lowBattery' for low battery warning.
+            attr[ATTR_BATTERY_LEVEL] = self.tahoma_device.active_states[
+                'core:SensorDefectState']
+        return attr

--- a/homeassistant/components/binary_sensor/tahoma.py
+++ b/homeassistant/components/binary_sensor/tahoma.py
@@ -1,0 +1,72 @@
+"""
+Support for Tahoma binary sensors.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/binary_sensor.tahoma/
+"""
+
+import logging
+from datetime import timedelta
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDevice)
+from homeassistant.components.tahoma import (
+    DOMAIN as TAHOMA_DOMAIN, TahomaDevice)
+from homeassistant.const import (STATE_OFF, STATE_ON)
+
+DEPENDENCIES = ['tahoma']
+
+_LOGGER = logging.getLogger(__name__)
+
+SCAN_INTERVAL = timedelta(seconds=120)
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up Tahoma controller devices."""
+    _LOGGER.debug("Setup Tahoma Binary sensor platform")
+    controller = hass.data[TAHOMA_DOMAIN]['controller']
+    devices = []
+    for device in hass.data[TAHOMA_DOMAIN]['devices']['smoke']:
+        devices.append(TahomaBinarySensor(device, controller))
+    add_devices(devices, True)
+
+
+class TahomaBinarySensor(TahomaDevice, BinarySensorDevice):
+    """Representation of a Tahoma Binary Sensor."""
+
+    def __init__(self, tahoma_device, controller):
+        """Initialize the sensor."""
+        self._state = None
+        super().__init__(tahoma_device, controller)
+
+    @property
+    def is_on(self):
+        """Return the state of the sensor."""
+        return bool(self._state == STATE_ON)
+
+    @property
+    def device_class(self):
+        """Return the class of the device."""
+        if self.tahoma_device.type == 'rtds:RTDSSmokeSensor':
+            return 'smoke'
+        return None
+
+    @property
+    def icon(self):
+        """Icon for device by its type."""
+        if self.is_on:
+            return "mdi:fire"
+
+    def update(self):
+        """Update the state."""
+        self.controller.get_states([self.tahoma_device])
+        if self.tahoma_device.type == 'rtds:RTDSSmokeSensor':
+            if self.tahoma_device.active_states['core:SmokeState']\
+                    == 'notDetected':
+                self._state = STATE_OFF
+            else:
+                self._state = STATE_ON
+
+        # FIXME: Check for low battery state.
+        # self.tahoma_device.active_states['core:SensorDefectState'] ==
+        #     'lowBattery' """

--- a/homeassistant/components/binary_sensor/tahoma.py
+++ b/homeassistant/components/binary_sensor/tahoma.py
@@ -60,9 +60,13 @@ class TahomaBinarySensor(TahomaDevice, BinarySensorDevice):
         return self._icon
 
     @property
-    def state_attributes(self):
-        """Return the state attributes of the sensor."""
+    def device_state_attributes(self):
+        """Return the device state attributes."""
         attr = {}
+        super_attr = super().device_state_attributes
+        if super_attr is not None:
+            attr.update(super_attr)
+
         if self._battery is not None:
             attr[ATTR_BATTERY_LEVEL] = self._battery
         return attr

--- a/homeassistant/components/cover/tahoma.py
+++ b/homeassistant/components/cover/tahoma.py
@@ -68,11 +68,19 @@ class TahomaCover(TahomaDevice, CoverDevice):
 
     def open_cover(self, **kwargs):
         """Open the cover."""
-        self.apply_action('open')
+        if self.tahoma_device.type == 'io:HorizontalAwningIOComponent':
+            # The commands open and close seem to be reversed.
+            self.apply_action('close')
+        else:
+            self.apply_action('open')
 
     def close_cover(self, **kwargs):
         """Close the cover."""
-        self.apply_action('close')
+        if self.tahoma_device.type == 'io:HorizontalAwningIOComponent':
+            # The commands open and close seem to be reversed.
+            self.apply_action('open')
+        else:
+            self.apply_action('close')
 
     def stop_cover(self, **kwargs):
         """Stop the cover."""
@@ -83,5 +91,9 @@ class TahomaCover(TahomaDevice, CoverDevice):
                 ('rts:BlindRTSComponent',
                  'io:ExteriorVenetianBlindIOComponent'):
             self.apply_action('my')
+        elif self.tahoma_device.type in \
+                ('io:VerticalExteriorAwningIOComponent',
+                 'io:HorizontalAwningIOComponent'):
+            self.apply_action('stop')
         else:
             self.apply_action('stopIdentify')

--- a/homeassistant/components/cover/tahoma.py
+++ b/homeassistant/components/cover/tahoma.py
@@ -14,6 +14,15 @@ DEPENDENCIES = ['tahoma']
 
 _LOGGER = logging.getLogger(__name__)
 
+ATTR_CLOSURE = 'closure'
+ATTR_MEM_POS = 'memorized_position'
+ATTR_RSSI_LEVEL = 'rssi_level'
+ATTR_OPEN_CLOSE = 'open_close'
+ATTR_STATUS = 'status'
+ATTR_LOCK_TIMER = 'priority_lock_timer'
+ATTR_LOCK_LEVEL = 'priority_lock_level'
+ATTR_LOCK_ORIG = 'priority_lock_originator'
+
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Tahoma covers."""
@@ -99,7 +108,7 @@ class TahomaCover(TahomaDevice, CoverDevice):
             else:
                 self._closed = False
 
-        _LOGGER.debug("update(%s): position: %d", self._name, self._position)
+        _LOGGER.debug("Update %s, position: %d", self._name, self._position)
 
     @property
     def current_cover_position(self):
@@ -131,26 +140,25 @@ class TahomaCover(TahomaDevice, CoverDevice):
             attr.update(super_attr)
 
         if self._closure is not None:
-            attr['Closure'] = self._closure
+            attr[ATTR_CLOSURE] = self._closure
         if 'core:Memorized1PositionState' in self.tahoma_device.active_states:
-            attr['Memorized Position'] = \
-                self.tahoma_device.active_states[
-                    'core:Memorized1PositionState']
+            attr[ATTR_MEM_POS] = self.tahoma_device.active_states[
+                'core:Memorized1PositionState']
         if 'core:RSSILevelState' in self.tahoma_device.active_states:
-            attr['RSSI Level'] = self.tahoma_device.active_states[
+            attr[ATTR_RSSI_LEVEL] = self.tahoma_device.active_states[
                 'core:RSSILevelState']
         if 'core:OpenClosedState' in self.tahoma_device.active_states:
-            attr['Open Closed'] = self.tahoma_device.active_states[
+            attr[ATTR_OPEN_CLOSE] = self.tahoma_device.active_states[
                 'core:OpenClosedState']
-        # if 'core:StatusState' in self.tahoma_device.active_states:
-        #    attr['Status'] = self.tahoma_device.active_states[
-        #        'core:StatusState']
+        if 'core:StatusState' in self.tahoma_device.active_states:
+            attr[ATTR_STATUS] = self.tahoma_device.active_states[
+                'core:StatusState']
         if self._lock_timer is not None:
-            attr['Priority Lock Timer'] = self._lock_timer
+            attr[ATTR_LOCK_TIMER] = self._lock_timer
         if self._lock_level is not None:
-            attr['Priority Lock Level'] = self._lock_level
+            attr[ATTR_LOCK_LEVEL] = self._lock_level
         if self._lock_originator is not None:
-            attr['Priority Lock Originator'] = self._lock_originator
+            attr[ATTR_LOCK_ORIG] = self._lock_originator
         return attr
 
     @property

--- a/homeassistant/components/cover/tahoma.py
+++ b/homeassistant/components/cover/tahoma.py
@@ -132,10 +132,10 @@ class TahomaCover(TahomaDevice, CoverDevice):
         return None
 
     @property
-    def state_attributes(self):
-        """Return the state attributes of the sensor."""
+    def device_state_attributes(self):
+        """Return the device state attributes."""
         attr = {}
-        super_attr = super().state_attributes
+        super_attr = super().device_state_attributes
         if super_attr is not None:
             attr.update(super_attr)
 

--- a/homeassistant/components/cover/tahoma.py
+++ b/homeassistant/components/cover/tahoma.py
@@ -27,27 +27,84 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class TahomaCover(TahomaDevice, CoverDevice):
     """Representation a Tahoma Cover."""
 
+    def __init__(self, tahoma_device, controller):
+        """Initialize the device."""
+        super().__init__(tahoma_device, controller)
+
+        self._closure = 0
+        # 100 equals open
+        self._position = 100
+        self._closed = False
+        self._icon = None
+        # Can be 0 and bigger
+        self._lock_timer = 0
+        # Can be 'comfortLevel1'
+        self._lock_level = None
+        # Can be 'wind'
+        self._lock_originator = None
+
     def update(self):
         """Update method."""
         self.controller.get_states([self.tahoma_device])
 
+        if 'core:ClosureState' in self.tahoma_device.active_states:
+            self._closure = \
+                self.tahoma_device.active_states['core:ClosureState']
+        else:
+            self._closure = None
+        if 'core:PriorityLockTimerState' in self.tahoma_device.active_states:
+            self._lock_timer = \
+                self.tahoma_device.active_states['core:PriorityLockTimerState']
+        else:
+            self._lock_timer = None
+        if 'io:PriorityLockLevelState' in self.tahoma_device.active_states:
+            self._lock_level = \
+                self.tahoma_device.active_states['io:PriorityLockLevelState']
+        else:
+            self._lock_level = None
+        if 'io:PriorityLockOriginatorState' in \
+                self.tahoma_device.active_states:
+            self._lock_originator = \
+                self.tahoma_device.active_states[
+                    'io:PriorityLockOriginatorState']
+        else:
+            self._lock_originator = None
+
+        # Define which icon to use
+        if self._lock_timer > 0:
+            if self._lock_originator == 'wind':
+                self._icon = 'mdi:weather-windy'
+            else:
+                self._icon = 'mdi:lock-alert'
+        else:
+            self._icon = None
+
+        # Define current position.
+        #   _position: 0 is closed, 100 is fully open.
+        #   'core:ClosureState': 100 is closed, 0 is fully open.
+        if 'core:ClosureState' in self.tahoma_device.active_states:
+            self._position = 100 - \
+                self.tahoma_device.active_states['core:ClosureState']
+            if self._position <= 5:
+                self._position = 0
+            if self._position >= 95:
+                self._position = 100
+            self._closed = self._position == 0
+        else:
+            self._position = None
+            if 'core:OpenClosedState' in self.tahoma_device.active_states:
+                self._closed = \
+                    self.tahoma_device.active_states['core:OpenClosedState']\
+                    == 'closed'
+            else:
+                self._closed = False
+
+        _LOGGER.debug("update(%s): position: %d", self._name, self._position)
+
     @property
     def current_cover_position(self):
-        """
-        Return current position of cover.
-
-        0 is closed, 100 is fully open.
-        """
-        try:
-            position = 100 - \
-                self.tahoma_device.active_states['core:ClosureState']
-            if position <= 5:
-                return 0
-            if position >= 95:
-                return 100
-            return position
-        except KeyError:
-            return None
+        """Return current position of cover."""
+        return self._position
 
     def set_cover_position(self, **kwargs):
         """Move the cover to a specific position."""
@@ -56,8 +113,7 @@ class TahomaCover(TahomaDevice, CoverDevice):
     @property
     def is_closed(self):
         """Return if the cover is closed."""
-        if self.current_cover_position is not None:
-            return self.current_cover_position == 0
+        return self._closed
 
     @property
     def device_class(self):
@@ -65,6 +121,42 @@ class TahomaCover(TahomaDevice, CoverDevice):
         if self.tahoma_device.type == 'io:WindowOpenerVeluxIOComponent':
             return 'window'
         return None
+
+    @property
+    def state_attributes(self):
+        """Return the state attributes of the sensor."""
+        attr = {}
+        super_attr = super().state_attributes
+        if super_attr is not None:
+            attr.update(super_attr)
+
+        if self._closure is not None:
+            attr['Closure'] = self._closure
+        if 'core:Memorized1PositionState' in self.tahoma_device.active_states:
+            attr['Memorized Position'] = \
+                self.tahoma_device.active_states[
+                    'core:Memorized1PositionState']
+        if 'core:RSSILevelState' in self.tahoma_device.active_states:
+            attr['RSSI Level'] = self.tahoma_device.active_states[
+                'core:RSSILevelState']
+        if 'core:OpenClosedState' in self.tahoma_device.active_states:
+            attr['Open Closed'] = self.tahoma_device.active_states[
+                'core:OpenClosedState']
+        # if 'core:StatusState' in self.tahoma_device.active_states:
+        #    attr['Status'] = self.tahoma_device.active_states[
+        #        'core:StatusState']
+        if self._lock_timer is not None:
+            attr['Priority Lock Timer'] = self._lock_timer
+        if self._lock_level is not None:
+            attr['Priority Lock Level'] = self._lock_level
+        if self._lock_originator is not None:
+            attr['Priority Lock Originator'] = self._lock_originator
+        return attr
+
+    @property
+    def icon(self):
+        """Return the icon to use in the frontend, if any."""
+        return self._icon
 
     def open_cover(self, **kwargs):
         """Open the cover."""

--- a/homeassistant/components/lock/kiwi.py
+++ b/homeassistant/components/lock/kiwi.py
@@ -1,0 +1,110 @@
+"""
+Support for the KIWI.KI lock platform.
+
+For more details about this platform, please refer to the documentation
+https://home-assistant.io/components/lock.kiwi/
+"""
+import logging
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.lock import (LockDevice, PLATFORM_SCHEMA)
+from homeassistant.const import (
+    CONF_PASSWORD, CONF_USERNAME, ATTR_ID, ATTR_LONGITUDE, ATTR_LATITUDE,
+    STATE_LOCKED, STATE_UNLOCKED)
+from homeassistant.helpers.event import async_call_later
+from homeassistant.core import callback
+
+REQUIREMENTS = ['kiwiki-client==0.1.1']
+
+_LOGGER = logging.getLogger(__name__)
+
+ATTR_TYPE = 'hardware_type'
+ATTR_PERMISSION = 'permission'
+ATTR_CAN_INVITE = 'can_invite_others'
+
+UNLOCK_MAINTAIN_TIME = 5
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_USERNAME): cv.string,
+    vol.Required(CONF_PASSWORD): cv.string
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the KIWI lock platform."""
+    from kiwiki import KiwiClient, KiwiException
+    try:
+        kiwi = KiwiClient(config[CONF_USERNAME], config[CONF_PASSWORD])
+    except KiwiException as exc:
+        _LOGGER.error(exc)
+        return
+    available_locks = kiwi.get_locks()
+    if not available_locks:
+        # No locks found; abort setup routine.
+        _LOGGER.info("No KIWI locks found in your account.")
+        return
+    add_devices([KiwiLock(lock, kiwi) for lock in available_locks], True)
+
+
+class KiwiLock(LockDevice):
+    """Representation of a Kiwi lock."""
+
+    def __init__(self, kiwi_lock, client):
+        """Initialize the lock."""
+        self._sensor = kiwi_lock
+        self._client = client
+        self.lock_id = kiwi_lock['sensor_id']
+        self._state = STATE_LOCKED
+
+        address = kiwi_lock.get('address')
+        address.update({
+            ATTR_LATITUDE: address.pop('lat', None),
+            ATTR_LONGITUDE: address.pop('lng', None)
+        })
+
+        self._device_attrs = {
+            ATTR_ID: self.lock_id,
+            ATTR_TYPE: kiwi_lock.get('hardware_type'),
+            ATTR_PERMISSION: kiwi_lock.get('highest_permission'),
+            ATTR_CAN_INVITE: kiwi_lock.get('can_invite'),
+            **address
+        }
+
+    @property
+    def name(self):
+        """Return the name of the lock."""
+        name = self._sensor.get('name')
+        specifier = self._sensor['address'].get('specifier')
+        return name or specifier
+
+    @property
+    def is_locked(self):
+        """Return true if lock is locked."""
+        return self._state == STATE_LOCKED
+
+    @property
+    def device_state_attributes(self):
+        """Return the device specific state attributes."""
+        return self._device_attrs
+
+    @callback
+    def clear_unlock_state(self, _):
+        """Clear unlock state automatically."""
+        self._state = STATE_LOCKED
+        self.async_schedule_update_ha_state()
+
+    def unlock(self, **kwargs):
+        """Unlock the device."""
+        from kiwiki import KiwiException
+        try:
+            self._client.open_door(self.lock_id)
+        except KiwiException:
+            _LOGGER.error("failed to open door")
+        else:
+            self._state = STATE_UNLOCKED
+            self.hass.add_job(
+                async_call_later, self.hass, UNLOCK_MAINTAIN_TIME,
+                self.clear_unlock_state
+            )

--- a/homeassistant/components/nest.py
+++ b/homeassistant/components/nest.py
@@ -52,8 +52,8 @@ AWAY_SCHEMA = vol.Schema({
     vol.Required(ATTR_HOME_MODE): vol.In([HOME_MODE_AWAY, HOME_MODE_HOME]),
     vol.Optional(ATTR_STRUCTURE): vol.All(cv.ensure_list, cv.string),
     vol.Optional(ATTR_TRIP_ID): cv.string,
-    vol.Optional(ATTR_ETA): cv.time_period_str,
-    vol.Optional(ATTR_ETA_WINDOW): cv.time_period_str
+    vol.Optional(ATTR_ETA): cv.time_period,
+    vol.Optional(ATTR_ETA_WINDOW): cv.time_period
 })
 
 CONFIG_SCHEMA = vol.Schema({

--- a/homeassistant/components/sensor/arlo.py
+++ b/homeassistant/components/sensor/arlo.py
@@ -4,25 +4,23 @@ This component provides HA sensor for Netgear Arlo IP cameras.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.arlo/
 """
-import asyncio
 import logging
-from datetime import timedelta
 
 import voluptuous as vol
 
+from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.arlo import (
-    CONF_ATTRIBUTION, DEFAULT_BRAND, DATA_ARLO)
+    CONF_ATTRIBUTION, DEFAULT_BRAND, DATA_ARLO, SIGNAL_UPDATE_ARLO)
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (ATTR_ATTRIBUTION, CONF_MONITORED_CONDITIONS)
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.icon import icon_for_battery_level
 
 _LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = ['arlo']
-
-SCAN_INTERVAL = timedelta(seconds=90)
 
 # sensor_type [ description, unit, icon ]
 SENSOR_TYPES = {
@@ -39,8 +37,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-@asyncio.coroutine
-def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up an Arlo IP sensor."""
     arlo = hass.data.get(DATA_ARLO)
     if not arlo:
@@ -50,24 +47,22 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     for sensor_type in config.get(CONF_MONITORED_CONDITIONS):
         if sensor_type == 'total_cameras':
             sensors.append(ArloSensor(
-                hass, SENSOR_TYPES[sensor_type][0], arlo, sensor_type))
+                SENSOR_TYPES[sensor_type][0], arlo, sensor_type))
         else:
             for camera in arlo.cameras:
                 name = '{0} {1}'.format(
                     SENSOR_TYPES[sensor_type][0], camera.name)
-                sensors.append(ArloSensor(hass, name, camera, sensor_type))
+                sensors.append(ArloSensor(name, camera, sensor_type))
 
-    async_add_devices(sensors, True)
+    add_devices(sensors, True)
 
 
 class ArloSensor(Entity):
     """An implementation of a Netgear Arlo IP sensor."""
 
-    def __init__(self, hass, name, device, sensor_type):
+    def __init__(self, name, device, sensor_type):
         """Initialize an Arlo sensor."""
-        super().__init__()
         self._name = name
-        self._hass = hass
         self._data = device
         self._sensor_type = sensor_type
         self._state = None
@@ -77,6 +72,16 @@ class ArloSensor(Entity):
     def name(self):
         """Return the name of this camera."""
         return self._name
+
+    async def async_added_to_hass(self):
+        """Register callbacks."""
+        async_dispatcher_connect(
+            self.hass, SIGNAL_UPDATE_ARLO, self._update_callback)
+
+    @callback
+    def _update_callback(self):
+        """Call update method."""
+        self.async_schedule_update_ha_state(True)
 
     @property
     def state(self):
@@ -98,18 +103,7 @@ class ArloSensor(Entity):
 
     def update(self):
         """Get the latest data and updates the state."""
-        try:
-            base_station = self._data.base_station
-        except (AttributeError, IndexError):
-            return
-
-        if not base_station:
-            return
-
-        base_station.refresh_rate = SCAN_INTERVAL.total_seconds()
-
-        self._data.update()
-
+        _LOGGER.debug("Updating Arlo sensor %s", self.name)
         if self._sensor_type == 'total_cameras':
             self._state = len(self._data.cameras)
 
@@ -118,9 +112,13 @@ class ArloSensor(Entity):
 
         elif self._sensor_type == 'last_capture':
             try:
-                video = self._data.videos()[0]
+                video = self._data.last_video
                 self._state = video.created_at_pretty("%m-%d-%Y %H:%M:%S")
             except (AttributeError, IndexError):
+                error_msg = \
+                    'Video not found for {0}. Older than {1} days?'.format(
+                        self.name, self._data.min_days_vdo_cache)
+                _LOGGER.debug(error_msg)
                 self._state = None
 
         elif self._sensor_type == 'battery_level':

--- a/homeassistant/components/sensor/nest.py
+++ b/homeassistant/components/sensor/nest.py
@@ -23,7 +23,7 @@ PROTECT_SENSOR_TYPES = ['co_status',
                         # color_status: "gray", "green", "yellow", "red"
                         'color_status']
 
-STRUCTURE_SENSOR_TYPES = ['eta']
+STRUCTURE_SENSOR_TYPES = ['eta', 'security_state']
 
 _VALID_SENSOR_TYPES = SENSOR_TYPES + TEMP_SENSOR_TYPES + PROTECT_SENSOR_TYPES \
                       + STRUCTURE_SENSOR_TYPES

--- a/homeassistant/components/sensor/tahoma.py
+++ b/homeassistant/components/sensor/tahoma.py
@@ -17,7 +17,10 @@ DEPENDENCIES = ['tahoma']
 
 _LOGGER = logging.getLogger(__name__)
 
-SCAN_INTERVAL = timedelta(seconds=10)
+SCAN_INTERVAL = timedelta(seconds=120)
+
+ATTR_RSSI_LEVEL = 'rssi_level'
+ATTR_STATUS = 'status'
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -54,6 +57,21 @@ class TahomaSensor(TahomaDevice, Entity):
         elif self.tahoma_device.type == 'Humidity Sensor':
             return '%'
 
+    @property
+    def state_attributes(self):
+        """Return the state attributes of the sensor."""
+        attr = {}
+        if 'core:RSSILevelState' in self.tahoma_device.active_states:
+            attr[ATTR_RSSI_LEVEL] = \
+                self.tahoma_device.active_states['core:RSSILevelState']
+        if 'core:SensorDefectState' in self.tahoma_device.active_states:
+            attr[ATTR_BATTERY_LEVEL] = \
+                self.tahoma_device.active_states['core:SensorDefectState']
+        if 'core:StatusState' in self.tahoma_device.active_states:
+            attr[ATTR_STATUS] = \
+                self.tahoma_device.active_states['core:StatusState']
+        return attr
+
     def update(self):
         """Update the state."""
         self.controller.get_states([self.tahoma_device])
@@ -64,17 +82,4 @@ class TahomaSensor(TahomaDevice, Entity):
             self.current_value = self.tahoma_device.active_states[
                 'core:ContactState']
 
-    @property
-    def state_attributes(self):
-        """Return the state attributes of the sensor."""
-        attr = {}
-        if 'core:RSSILevelState' in self.tahoma_device.active_states:
-            attr['RSSI Level'] = self.tahoma_device.active_states[
-                'core:RSSILevelState']
-        if 'core:SensorDefectState' in self.tahoma_device.active_states:
-            attr[ATTR_BATTERY_LEVEL] = self.tahoma_device.active_states[
-                'core:SensorDefectState']
-        if 'core:StatusState' in self.tahoma_device.active_states:
-            attr['Status'] = self.tahoma_device.active_states[
-                'core:StatusState']
-        return attr
+        _LOGGER.debug("Update %s, value: %d", self._name, self.current_value)

--- a/homeassistant/components/sensor/tahoma.py
+++ b/homeassistant/components/sensor/tahoma.py
@@ -58,9 +58,13 @@ class TahomaSensor(TahomaDevice, Entity):
             return '%'
 
     @property
-    def state_attributes(self):
-        """Return the state attributes of the sensor."""
+    def device_state_attributes(self):
+        """Return the device state attributes."""
         attr = {}
+        super_attr = super().device_state_attributes
+        if super_attr is not None:
+            attr.update(super_attr)
+
         if 'core:RSSILevelState' in self.tahoma_device.active_states:
             attr[ATTR_RSSI_LEVEL] = \
                 self.tahoma_device.active_states['core:RSSILevelState']

--- a/homeassistant/components/sensor/tahoma.py
+++ b/homeassistant/components/sensor/tahoma.py
@@ -11,6 +11,7 @@ from datetime import timedelta
 from homeassistant.helpers.entity import Entity
 from homeassistant.components.tahoma import (
     DOMAIN as TAHOMA_DOMAIN, TahomaDevice)
+from homeassistant.const import (ATTR_BATTERY_LEVEL)
 
 DEPENDENCIES = ['tahoma']
 
@@ -62,3 +63,18 @@ class TahomaSensor(TahomaDevice, Entity):
         if self.tahoma_device.type == 'io:SomfyContactIOSystemSensor':
             self.current_value = self.tahoma_device.active_states[
                 'core:ContactState']
+
+    @property
+    def state_attributes(self):
+        """Return the state attributes of the sensor."""
+        attr = {}
+        if 'core:RSSILevelState' in self.tahoma_device.active_states:
+            attr['RSSI Level'] = self.tahoma_device.active_states[
+                'core:RSSILevelState']
+        if 'core:SensorDefectState' in self.tahoma_device.active_states:
+            attr[ATTR_BATTERY_LEVEL] = self.tahoma_device.active_states[
+                'core:SensorDefectState']
+        if 'core:StatusState' in self.tahoma_device.active_states:
+            attr['Status'] = self.tahoma_device.active_states[
+                'core:StatusState']
+        return attr

--- a/homeassistant/components/services.yaml
+++ b/homeassistant/components/services.yaml
@@ -576,3 +576,28 @@ shopping_list:
       name:
         description: The name of the item to mark as completed.
         example: Beer
+
+nest:
+  set_mode:
+    description: >
+                  Set the home/away mode for a Nest structure.
+                  Set to away mode will also set Estimated Arrival Time if provided.
+                  Set ETA will cause the thermostat to begin warming or cooling the home before the user arrives.
+                  After ETA set other Automation can read ETA sensor as a signal to prepare the home for
+                  the user's arrival.
+    fields:
+      home_mode:
+        description: home or away
+        example: home
+      structure:
+        description: Optional structure name. Default set all structures managed by Home Assistant.
+        example: My Home
+      eta:
+        description: Optional Estimated Arrival Time from now.
+        example: 0:10
+      eta_window:
+        description: Optional ETA window. Default is 1 minute.
+        example: 0:5
+      trip_id:
+        description: Optional identity of a trip. Using the same trip_ID will update the estimation.
+        example: trip_back_home

--- a/homeassistant/components/switch/tahoma.py
+++ b/homeassistant/components/switch/tahoma.py
@@ -33,8 +33,8 @@ class TahomaSwitch(TahomaDevice, SwitchDevice):
 
     def __init__(self, tahoma_device, controller):
         """Initialize the switch."""
-        self._state = STATE_OFF
         super().__init__(tahoma_device, controller)
+        self._state = STATE_OFF
 
     def update(self):
         """Update method."""
@@ -85,3 +85,33 @@ class TahomaSwitch(TahomaDevice, SwitchDevice):
             return False
         _LOGGER.debug("Is on (%s): %s", self._name, self._state)
         return bool(self._state == STATE_ON)
+
+    @property
+    def state_attributes(self):
+        """Return the state attributes of the switch."""
+        attr = {}
+        super_attr = super().state_attributes
+        if super_attr is not None:
+            attr.update(super_attr)
+
+        if 'core:OnOffState' in self.tahoma_device.active_states:
+            attr['On Off'] = self.tahoma_device.active_states[
+                'core:OnOffState']
+        if 'core:PriorityLockTimerState' in self.tahoma_device.active_states:
+            attr['Priority Lock Timer'] = \
+                self.tahoma_device.active_states['core:PriorityLockTimerState']
+        if 'core:RSSILevelState' in self.tahoma_device.active_states:
+            attr['RSSI Level'] = self.tahoma_device.active_states[
+                'core:RSSILevelState']
+        if 'core:StatusState' in self.tahoma_device.active_states:
+            attr['Status'] = self.tahoma_device.active_states[
+                'core:StatusState']
+        if 'io:PriorityLockLevelState' in self.tahoma_device.active_states:
+            attr['Priority Lock Level'] = \
+                self.tahoma_device.active_states['io:PriorityLockLevelState']
+        if 'io:PriorityLockOriginatorState' in \
+                self.tahoma_device.active_states:
+            attr['Priority Lock Originator'] = \
+                self.tahoma_device.active_states[
+                    'io:PriorityLockOriginatorState']
+        return attr

--- a/homeassistant/components/switch/tahoma.py
+++ b/homeassistant/components/switch/tahoma.py
@@ -97,10 +97,10 @@ class TahomaSwitch(TahomaDevice, SwitchDevice):
         return bool(self._state == STATE_ON)
 
     @property
-    def state_attributes(self):
-        """Return the state attributes of the switch."""
+    def device_state_attributes(self):
+        """Return the device state attributes."""
         attr = {}
-        super_attr = super().state_attributes
+        super_attr = super().device_state_attributes
         if super_attr is not None:
             attr.update(super_attr)
 

--- a/homeassistant/components/switch/tahoma.py
+++ b/homeassistant/components/switch/tahoma.py
@@ -12,6 +12,7 @@ import logging
 from homeassistant.components.switch import SwitchDevice
 from homeassistant.components.tahoma import (
     DOMAIN as TAHOMA_DOMAIN, TahomaDevice)
+from homeassistant.const import (STATE_OFF, STATE_ON)
 
 DEPENDENCIES = ['tahoma']
 
@@ -30,6 +31,20 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class TahomaSwitch(TahomaDevice, SwitchDevice):
     """Representation a Tahoma Switch."""
 
+    def __init__(self, tahoma_device, controller):
+        """Initialize the switch."""
+        self._state = STATE_OFF
+        super().__init__(tahoma_device, controller)
+
+    def update(self):
+        """Update method."""
+        self.controller.get_states([self.tahoma_device])
+        if self.tahoma_device.type == 'io:OnOffLightIOComponent':
+            if self.tahoma_device.active_states['core:OnOffState'] == 'on':
+                self._state = STATE_ON
+            else:
+                self._state = STATE_OFF
+
     @property
     def device_class(self):
         """Return the class of the device."""
@@ -39,7 +54,25 @@ class TahomaSwitch(TahomaDevice, SwitchDevice):
 
     def turn_on(self, **kwargs):
         """Send the on command."""
-        self.toggle()
+        _LOGGER.debug("Turn on: %s", self._name)
+        if self.tahoma_device.type == 'rts:GarageDoor4TRTSComponent':
+            self.toggle()
+        else:
+            self.apply_action('on')
+            # FIXME: State immediately overwritten by update function.
+            # How to deferre update, till REST request is done?
+            self._state = STATE_ON
+
+    def turn_off(self, **kwargs):
+        """Send the off command."""
+        _LOGGER.debug("Turn off: %s", self._name)
+        if self.tahoma_device.type == 'rts:GarageDoor4TRTSComponent':
+            return
+        else:
+            self.apply_action('off')
+            # FIXME: State immediately overwritten by update function.
+            # How to deferre update, till REST request is done?
+            self._state = STATE_OFF
 
     def toggle(self, **kwargs):
         """Click the switch."""
@@ -48,4 +81,7 @@ class TahomaSwitch(TahomaDevice, SwitchDevice):
     @property
     def is_on(self):
         """Get whether the switch is in on state."""
-        return False
+        if self.tahoma_device.type == 'rts:GarageDoor4TRTSComponent':
+            return False
+        _LOGGER.debug("Is on (%s): %s", self._name, self._state)
+        return bool(self._state == STATE_ON)

--- a/homeassistant/components/tahoma.py
+++ b/homeassistant/components/tahoma.py
@@ -32,7 +32,7 @@ CONFIG_SCHEMA = vol.Schema({
 }, extra=vol.ALLOW_EXTRA)
 
 TAHOMA_COMPONENTS = [
-    'scene', 'sensor', 'cover', 'switch'
+    'scene', 'sensor', 'cover', 'switch', 'binary_sensor'
 ]
 
 TAHOMA_TYPES = {
@@ -48,6 +48,10 @@ TAHOMA_TYPES = {
     'io:WindowOpenerVeluxIOComponent': 'cover',
     'io:LightIOSystemSensor': 'sensor',
     'rts:GarageDoor4TRTSComponent': 'switch',
+    'io:VerticalExteriorAwningIOComponent': 'cover',
+    'io:HorizontalAwningIOComponent': 'cover',
+    'io:OnOffLightIOComponent': 'switch',
+    'rtds:RTDSSmokeSensor': 'smoke',
 }
 
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -734,7 +734,7 @@ pyairvisual==1.0.0
 pyalarmdotcom==0.3.2
 
 # homeassistant.components.arlo
-pyarlo==0.1.2
+pyarlo==0.1.6
 
 # homeassistant.components.notify.xmpp
 pyasn1-modules==0.1.5

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1051,7 +1051,7 @@ python-mpd2==1.0.0
 python-mystrom==0.4.4
 
 # homeassistant.components.nest
-python-nest==4.0.1
+python-nest==4.0.2
 
 # homeassistant.components.device_tracker.nmap_tracker
 python-nmap==0.6.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -482,6 +482,9 @@ keyring==12.2.1
 # homeassistant.scripts.keyring
 keyrings.alt==3.1
 
+# homeassistant.components.lock.kiwi
+kiwiki-client==0.1.1
+
 # homeassistant.components.konnected
 konnected==0.1.2
 


### PR DESCRIPTION
## Description:
Add support for 4 Tahoma devices:
- io:VerticalExteriorAwningIOComponent: a new cover type
- io:HorizontalAwningIOComponent: a new cover type (just added, because I have them not available for testing - they should behave like the vertical ones)
- io:OnOffLightIOComponent: light switch
- rtds:RTDSSmokeSensor: smoke sensor

Additional improvements:
- added all available state attributes, like battery warning, rssi level, memorised position, lock timer/level/originator.
- added special icon for the awnings, if they are locked by wind or something else.
- added special icon for the smoke sensor, if fire is detected or the battery is low.
- increase sensor update time from 10s to 120s

**Related issue (if applicable):** fixes #13965

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5590

## Example entry for `configuration.yaml` (if applicable):
nothing

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - No new dependencies.
  - New file already covered by `components/*/tahoma.py` (`.coveragerc`).

If the code does not interact with devices:
  - N/A (interacts with devices).
