### PR TITLE
Add entity support to Waze Travel Time

### DIFF
--- a/homeassistant/components/sensor/waze_travel_time.py
+++ b/homeassistant/components/sensor/waze_travel_time.py
@@ -62,7 +62,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         incl_filter = config.get(CONF_INCL_FILTER)
         excl_filter = config.get(CONF_EXCL_FILTER)
 
-        sensor = WazeTravelTime(hass, name, origin, destination, region, 
+        sensor = WazeTravelTime(hass, name, origin, destination, region,
                                 incl_filter, excl_filter)
         add_devices([sensor])
 
@@ -72,7 +72,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class WazeTravelTime(Entity):
     """Representation of a Waze travel time sensor."""
 
-    def __init__(self, hass, name, origin, destination, region, 
+    def __init__(self, hass, name, origin, destination, region,
                  incl_filter, excl_filter):
         """Initialize the Waze travel time sensor."""
         self._hass = hass
@@ -201,11 +201,11 @@ class WazeTravelTime(Entity):
 
                 if self._incl_filter is not None:
                     routes = {k: v for k, v in routes.items() if
-                        self._incl_filter.lower() in k.lower()}
+                              self._incl_filter.lower() in k.lower()}
 
                 if self._excl_filter is not None:
                     routes = {k: v for k, v in routes.items() if
-                        self._excl_filter.lower() not in k.lower()}
+                              self._excl_filter.lower() not in k.lower()}
 
                 route = sorted(routes, key=(lambda key: routes[key][0]))[0]
                 duration, distance = routes[route]

--- a/homeassistant/components/sensor/waze_travel_time.py
+++ b/homeassistant/components/sensor/waze_travel_time.py
@@ -55,6 +55,7 @@ TRACKABLE_DOMAINS = ['device_tracker', 'sensor', 'zone']
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Waze travel time sensor platform."""
     def run_setup(event):
+        """Set up the waze travel time sensor."""
         destination = config.get(CONF_DESTINATION)
         name = config.get(CONF_NAME)
         origin = config.get(CONF_ORIGIN)
@@ -220,4 +221,3 @@ class WazeTravelTime(Entity):
             except KeyError:
                 _LOGGER.error("Error retrieving data from server")
                 return
-

--- a/homeassistant/components/sensor/waze_travel_time.py
+++ b/homeassistant/components/sensor/waze_travel_time.py
@@ -62,7 +62,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         incl_filter = config.get(CONF_INCL_FILTER)
         excl_filter = config.get(CONF_EXCL_FILTER)
 
-        sensor = WazeTravelTime(hass, name, origin, destination, region, incl_filter, excl_filter)
+        sensor = WazeTravelTime(hass, name, origin, destination, region, 
+                                incl_filter, excl_filter)
         add_devices([sensor])
 
     hass.bus.listen_once(EVENT_HOMEASSISTANT_START, run_setup)
@@ -71,7 +72,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class WazeTravelTime(Entity):
     """Representation of a Waze travel time sensor."""
 
-    def __init__(self, hass, name, origin, destination, region, incl_filter, excl_filter):
+    def __init__(self, hass, name, origin, destination, region, 
+                 incl_filter, excl_filter):
         """Initialize the Waze travel time sensor."""
         self._hass = hass
         self._name = name
@@ -159,7 +161,10 @@ class WazeTravelTime(Entity):
     def _get_location_from_attributes(entity):
         """Get the lat/long string from an entities attributes."""
         attr = entity.attributes
-        return "{},{}".format(attr.get(ATTR_LATITUDE), attr.get(ATTR_LONGITUDE))
+        return "{},{}".format(
+            attr.get(ATTR_LATITUDE), 
+            attr.get(ATTR_LONGITUDE)
+        )
 
     def _resolve_zone(self, friendly_name):
         """Get a lat/long from a zones friendly_name."""
@@ -193,7 +198,7 @@ class WazeTravelTime(Entity):
                 params = WazeRouteCalculator.WazeRouteCalculator(
                     self._origin, self._destination, self._region)
                 routes = params.calc_all_routes_info()
-                
+
                 if self._incl_filter is not None:
                     routes = {k: v for k, v in routes.items() if
                         self._incl_filter.lower() in k.lower()}
@@ -202,7 +207,7 @@ class WazeTravelTime(Entity):
                     routes = {k: v for k, v in routes.items() if
                         self._excl_filter.lower() not in k.lower()}
 
-                route = sorted(routes,key=(lambda key: routes[key][0]))[0]
+                route = sorted(routes, key=(lambda key: routes[key][0]))[0]
                 duration, distance = routes[route]
                 route = bytes(route, 'ISO-8859-1').decode('UTF-8')
                 self._state = {

--- a/homeassistant/components/sensor/waze_travel_time.py
+++ b/homeassistant/components/sensor/waze_travel_time.py
@@ -147,7 +147,7 @@ class WazeTravelTime(Entity):
         state = self.hass.states.get(entity_id)
 
         if state is None:
-            _LOGGER.error('Unable to find entity %s', entity_id)
+            _LOGGER.error("Unable to find entity %s", entity_id)
             return None
 
         # Check if the entity has location attributes (zone)
@@ -158,7 +158,7 @@ class WazeTravelTime(Entity):
         zone_state = self.hass.states.get('zone.{}'.format(state.state))
         if location.has_location(zone_state):
             _LOGGER.debug(
-                '%s is in %s, getting zone location',
+                "%s is in %s, getting zone location",
                 entity_id, zone_state.entity_id
             )
             return _get_location_from_attributes(zone_state)
@@ -219,8 +219,8 @@ class WazeTravelTime(Entity):
                     'distance': distance,
                     'route': route}
             except WazeRouteCalculator.WRCError as exp:
-                _LOGGER.error('Error on retrieving data: %s', exp)
+                _LOGGER.error("Error on retrieving data: %s", exp)
                 return
             except KeyError:
-                _LOGGER.error('Error retrieving data from server')
+                _LOGGER.error("Error retrieving data from server")
                 return

--- a/homeassistant/components/sensor/waze_travel_time.py
+++ b/homeassistant/components/sensor/waze_travel_time.py
@@ -143,7 +143,7 @@ class WazeTravelTime(Entity):
         return res
 
     def _get_location_from_entity(self, entity_id):
-        """Get the location from the entity state or attributes."""
+        """Get the location from the entity_id."""
         state = self.hass.states.get(entity_id)
 
         if state is None:

--- a/homeassistant/components/sensor/waze_travel_time.py
+++ b/homeassistant/components/sensor/waze_travel_time.py
@@ -7,12 +7,14 @@ https://home-assistant.io/components/sensor.waze_travel_time/
 from datetime import timedelta
 import logging
 
-import requests
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import ATTR_ATTRIBUTION, CONF_NAME, CONF_REGION
+from homeassistant.const import (
+    ATTR_ATTRIBUTION, CONF_NAME, CONF_REGION, EVENT_HOMEASSISTANT_START,
+    ATTR_LATITUDE, ATTR_LONGITUDE)
 import homeassistant.helpers.config_validation as cv
+import homeassistant.helpers.location as location
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 
@@ -20,6 +22,7 @@ REQUIREMENTS = ['WazeRouteCalculator==0.5']
 
 _LOGGER = logging.getLogger(__name__)
 
+ATTR_DURATION = 'duration'
 ATTR_DISTANCE = 'distance'
 ATTR_ROUTE = 'route'
 
@@ -46,34 +49,46 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_EXCL_FILTER): cv.string,
 })
 
+TRACKABLE_DOMAINS = ['device_tracker', 'sensor', 'zone']
+
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Waze travel time sensor platform."""
-    destination = config.get(CONF_DESTINATION)
-    name = config.get(CONF_NAME)
-    origin = config.get(CONF_ORIGIN)
-    region = config.get(CONF_REGION)
-    incl_filter = config.get(CONF_INCL_FILTER)
-    excl_filter = config.get(CONF_EXCL_FILTER)
+    def run_setup(event):
+        destination = config.get(CONF_DESTINATION)
+        name = config.get(CONF_NAME)
+        origin = config.get(CONF_ORIGIN)
+        region = config.get(CONF_REGION)
+        incl_filter = config.get(CONF_INCL_FILTER)
+        excl_filter = config.get(CONF_EXCL_FILTER)
 
-    try:
-        waze_data = WazeRouteData(
-            origin, destination, region, incl_filter, excl_filter)
-    except requests.exceptions.HTTPError as error:
-        _LOGGER.error("%s", error)
-        return
+        sensor = WazeTravelTime(hass, name, origin, destination, region, incl_filter, excl_filter)
+        add_devices([sensor])
 
-    add_devices([WazeTravelTime(waze_data, name)], True)
+    hass.bus.listen_once(EVENT_HOMEASSISTANT_START, run_setup)
 
 
 class WazeTravelTime(Entity):
     """Representation of a Waze travel time sensor."""
 
-    def __init__(self, waze_data, name):
+    def __init__(self, hass, name, origin, destination, region, incl_filter, excl_filter):
         """Initialize the Waze travel time sensor."""
+        self._hass = hass
         self._name = name
+        self._region = region
+        self._incl_filter = incl_filter
+        self._excl_filter = excl_filter
         self._state = None
-        self.waze_data = waze_data
+
+        if origin.split('.', 1)[0] in TRACKABLE_DOMAINS:
+            self._origin_entity_id = origin
+        else:
+            self._origin = origin
+
+        if destination.split('.', 1)[0] in TRACKABLE_DOMAINS:
+            self._destination_entity_id = destination
+        else:
+            self._destination = destination
 
     @property
     def name(self):
@@ -83,7 +98,12 @@ class WazeTravelTime(Entity):
     @property
     def state(self):
         """Return the state of the sensor."""
-        return round(self._state['duration'])
+        if self._state is None:
+            return None
+
+        if 'duration' in self._state:
+            return round(self._state['duration'])
+        return None
 
     @property
     def unit_of_measurement(self):
@@ -98,54 +118,101 @@ class WazeTravelTime(Entity):
     @property
     def device_state_attributes(self):
         """Return the state attributes of the last update."""
-        return {
-            ATTR_ATTRIBUTION: CONF_ATTRIBUTION,
-            ATTR_DISTANCE: round(self._state['distance']),
-            ATTR_ROUTE: self._state['route'],
-        }
+        res = {ATTR_ATTRIBUTION: CONF_ATTRIBUTION}
+        if 'duration' in self._state:
+            res[ATTR_DURATION] = self._state['duration']
+        if 'distance' in self._state:
+            res[ATTR_DISTANCE] = self._state['distance']
+        if 'route' in self._state:
+            res[ATTR_ROUTE] = self._state['route']
+        return res
 
-    def update(self):
-        """Fetch new state data for the sensor."""
-        try:
-            self.waze_data.update()
-            self._state = self.waze_data.data
-        except KeyError:
-            _LOGGER.error("Error retrieving data from server")
+    def _get_location_from_entity(self, entity_id):
+        """Get the location from the entity state or attributes."""
+        entity = self._hass.states.get(entity_id)
 
+        if entity is None:
+            _LOGGER.error("Unable to find entity %s", entity_id)
+            return None
 
-class WazeRouteData(object):
-    """Get data from Waze."""
+        # Check if the entity has location attributes (zone)
+        if location.has_location(entity):
+            return self._get_location_from_attributes(entity)
 
-    def __init__(self, origin, destination, region, incl_filter, excl_filter):
-        """Initialize the data object."""
-        self._destination = destination
-        self._origin = origin
-        self._region = region
-        self._incl_filter = incl_filter
-        self._excl_filter = excl_filter
-        self.data = {}
+        # Check if device is in a zone (device_tracker)
+        zone_entity = self._hass.states.get("zone.%s" % entity.state)
+        if location.has_location(zone_entity):
+            _LOGGER.debug(
+                "%s is in %s, getting zone location",
+                entity_id, zone_entity.entity_id
+            )
+            return self._get_location_from_attributes(zone_entity)
+
+        # If zone was not found in state then use the state as the location
+        if entity_id.startswith("sensor."):
+            return entity.state
+
+        # When everything fails just return nothing
+        return None
+
+    @staticmethod
+    def _get_location_from_attributes(entity):
+        """Get the lat/long string from an entities attributes."""
+        attr = entity.attributes
+        return "{},{}".format(attr.get(ATTR_LATITUDE), attr.get(ATTR_LONGITUDE))
+
+    def _resolve_zone(self, friendly_name):
+        """Get a lat/long from a zones friendly_name."""
+        entities = self._hass.states.all()
+        for entity in entities:
+            if entity.domain == 'zone' and entity.name == friendly_name:
+                return self._get_location_from_attributes(entity)
+
+        return friendly_name
 
     @Throttle(SCAN_INTERVAL)
     def update(self):
-        """Fetch latest data from Waze."""
+        """Fetch new state data for the sensor."""
         import WazeRouteCalculator
-        _LOGGER.debug("Update in progress...")
-        try:
-            params = WazeRouteCalculator.WazeRouteCalculator(
-                self._origin, self._destination, self._region, None)
-            results = params.calc_all_routes_info()
-            if self._incl_filter is not None:
-                results = {k: v for k, v in results.items() if
-                           self._incl_filter.lower() in k.lower()}
-            if self._excl_filter is not None:
-                results = {k: v for k, v in results.items() if
-                           self._excl_filter.lower() not in k.lower()}
-            best_route = next(iter(results))
-            (duration, distance) = results[best_route]
-            best_route_str = bytes(best_route, 'ISO-8859-1').decode('UTF-8')
-            self.data['duration'] = duration
-            self.data['distance'] = distance
-            self.data['route'] = best_route_str
-        except WazeRouteCalculator.WRCError as exp:
-            _LOGGER.error("Error on retrieving data: %s", exp)
-            return
+
+        if hasattr(self, '_origin_entity_id'):
+            self._origin = self._get_location_from_entity(
+                self._origin_entity_id
+            )
+
+        if hasattr(self, '_destination_entity_id'):
+            self._destination = self._get_location_from_entity(
+                self._destination_entity_id
+            )
+
+        self._destination = self._resolve_zone(self._destination)
+        self._origin = self._resolve_zone(self._origin)
+
+        if self._destination is not None and self._origin is not None:
+            try:
+                params = WazeRouteCalculator.WazeRouteCalculator(
+                    self._origin, self._destination, self._region)
+                routes = params.calc_all_routes_info()
+                
+                if self._incl_filter is not None:
+                    routes = {k: v for k, v in routes.items() if
+                        self._incl_filter.lower() in k.lower()}
+
+                if self._excl_filter is not None:
+                    routes = {k: v for k, v in routes.items() if
+                        self._excl_filter.lower() not in k.lower()}
+
+                route = sorted(routes,key=(lambda key: routes[key][0]))[0]
+                duration, distance = routes[route]
+                route = bytes(route, 'ISO-8859-1').decode('UTF-8')
+                self._state = {
+                    'duration': duration,
+                    'distance': distance,
+                    'route': route}
+            except WazeRouteCalculator.WRCError as exp:
+                _LOGGER.error("Error on retrieving data: %s", exp)
+                return
+            except KeyError:
+                _LOGGER.error("Error retrieving data from server")
+                return
+

--- a/homeassistant/components/sensor/waze_travel_time.py
+++ b/homeassistant/components/sensor/waze_travel_time.py
@@ -162,7 +162,7 @@ class WazeTravelTime(Entity):
         """Get the lat/long string from an entities attributes."""
         attr = entity.attributes
         return "{},{}".format(
-            attr.get(ATTR_LATITUDE), 
+            attr.get(ATTR_LATITUDE),
             attr.get(ATTR_LONGITUDE)
         )
 


### PR DESCRIPTION
Current version only supports latitude and longitude or an address for the origin and destination fields. This update allows those fields to use entity IDs of device_tracker, zone, and sensor.

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5461

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
