### PR TITLE
Make Yi platform async

### DIFF
--- a/homeassistant/components/camera/yi.py
+++ b/homeassistant/components/camera/yi.py
@@ -15,6 +15,7 @@ from homeassistant.const import (
     CONF_HOST, CONF_NAME, CONF_PATH, CONF_PASSWORD, CONF_PORT, CONF_USERNAME)
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_aiohttp_proxy_stream
+from homeassistant.exceptions import PlatformNotReady
 
 REQUIREMENTS = ['aioftp==0.10.1']
 DEPENDENCIES = ['ffmpeg']
@@ -52,6 +53,7 @@ class YiCamera(Camera):
         """Initialize."""
         super().__init__()
         self._extra_arguments = config.get(CONF_FFMPEG_ARGUMENTS)
+        self._ftp = None
         self._last_image = None
         self._last_url = None
         self._manager = hass.data[DATA_FFMPEG]
@@ -61,6 +63,8 @@ class YiCamera(Camera):
         self.path = config[CONF_PATH]
         self.user = config[CONF_USERNAME]
         self.passwd = config[CONF_PASSWORD]
+
+        hass.async_add_job(self._connect_to_client)
 
     @property
     def brand(self):
@@ -72,36 +76,44 @@ class YiCamera(Camera):
         """Return the name of this camera."""
         return self._name
 
-    async def _get_latest_video_url(self):
-        """Retrieve the latest video file from the customized Yi FTP server."""
+    async def _connect_to_client(self):
+        """Attempt to establish a connection via FTP."""
         from aioftp import Client, StatusCodeError
 
         ftp = Client()
         try:
             await ftp.connect(self.host)
             await ftp.login(self.user, self.passwd)
+            self._ftp = ftp
+        except StatusCodeError as err:
+            raise PlatformNotReady(err)
 
-            await ftp.change_directory(self.path)
+    async def _get_latest_video_url(self):
+        """Retrieve the latest video file from the customized Yi FTP server."""
+        from aioftp import StatusCodeError
+
+        try:
+            await self._ftp.change_directory(self.path)
             dirs = []
-            for path, attrs in await ftp.list():
+            for path, attrs in await self._ftp.list():
                 if attrs['type'] == 'dir' and '.' not in str(path):
                     dirs.append(path)
             latest_dir = dirs[-1]
-            await ftp.change_directory(latest_dir)
+            await self._ftp.change_directory(latest_dir)
 
             videos = []
-            for path, _ in await ftp.list():
+            for path, _ in await self._ftp.list():
                 videos.append(path)
             if not videos:
                 _LOGGER.info('Video folder "%s" empty; delaying', latest_dir)
-                return False
+                return None
 
             return 'ftp://{0}:{1}@{2}:{3}{4}/{5}/{6}'.format(
                 self.user, self.passwd, self.host, self.port, self.path,
                 latest_dir, videos[-1])
         except (ConnectionRefusedError, StatusCodeError) as err:
-            print('There was an issue: {0}'.format(err))
-            return
+            _LOGGER.error('Error while fetching video: %s', err)
+            return None
 
     async def async_camera_image(self):
         """Return a still image response from the camera."""

--- a/homeassistant/components/camera/yi.py
+++ b/homeassistant/components/camera/yi.py
@@ -89,7 +89,9 @@ class YiCamera(Camera):
             latest_dir = dirs[-1]
             await ftp.change_directory(latest_dir)
 
-            videos = [path async for path, _ in ftp.list()]
+            videos = []
+            for path, _ in await ftp.list():
+                videos.append(path)
             if not videos:
                 _LOGGER.info('Video folder "%s" empty; delaying', latest_dir)
                 return False

--- a/homeassistant/components/camera/yi.py
+++ b/homeassistant/components/camera/yi.py
@@ -11,11 +11,12 @@ import voluptuous as vol
 
 from homeassistant.components.camera import Camera, PLATFORM_SCHEMA
 from homeassistant.components.ffmpeg import DATA_FFMPEG
-from homeassistant.const import (CONF_HOST, CONF_NAME, CONF_PATH,
-                                 CONF_PASSWORD, CONF_PORT, CONF_USERNAME)
+from homeassistant.const import (
+    CONF_HOST, CONF_NAME, CONF_PATH, CONF_PASSWORD, CONF_PORT, CONF_USERNAME)
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_aiohttp_proxy_stream
 
+REQUIREMENTS = ['aioftp==0.10.1']
 DEPENDENCIES = ['ffmpeg']
 _LOGGER = logging.getLogger(__name__)
 
@@ -38,12 +39,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-async def async_setup_platform(hass,
-                               config,
-                               async_add_devices,
-                               discovery_info=None):
+async def async_setup_platform(
+        hass, config, async_add_devices, discovery_info=None):
     """Set up a Yi Camera."""
-    _LOGGER.debug('Received configuration: %s', config)
     async_add_devices([YiCamera(hass, config)], True)
 
 
@@ -57,68 +55,65 @@ class YiCamera(Camera):
         self._last_image = None
         self._last_url = None
         self._manager = hass.data[DATA_FFMPEG]
-        self._name = config.get(CONF_NAME)
-        self.host = config.get(CONF_HOST)
-        self.port = config.get(CONF_PORT)
-        self.path = config.get(CONF_PATH)
-        self.user = config.get(CONF_USERNAME)
-        self.passwd = config.get(CONF_PASSWORD)
-
-    @property
-    def name(self):
-        """Return the name of this camera."""
-        return self._name
+        self._name = config[CONF_NAME]
+        self.host = config[CONF_HOST]
+        self.port = config[CONF_PORT]
+        self.path = config[CONF_PATH]
+        self.user = config[CONF_USERNAME]
+        self.passwd = config[CONF_PASSWORD]
 
     @property
     def brand(self):
         """Camera brand."""
         return DEFAULT_BRAND
 
-    def get_latest_video_url(self):
+    @property
+    def name(self):
+        """Return the name of this camera."""
+        return self._name
+
+    async def _get_latest_video_url(self):
         """Retrieve the latest video file from the customized Yi FTP server."""
-        from ftplib import FTP, error_perm
+        from aioftp import Client, StatusCodeError
 
-        ftp = FTP(self.host)
+        ftp = Client()
         try:
-            ftp.login(self.user, self.passwd)
-        except error_perm as exc:
-            _LOGGER.error('There was an error while logging into the camera')
-            _LOGGER.debug(exc)
-            return False
+            await ftp.connect(self.host)
+            await ftp.login(self.user, self.passwd)
 
-        try:
-            ftp.cwd(self.path)
-        except error_perm as exc:
-            _LOGGER.error('Unable to find path: %s', self.path)
-            _LOGGER.debug(exc)
-            return False
+            await ftp.change_directory(self.path)
+            dirs = [
+                path async for path, attrs in ftp.list()
+                if attrs['type'] == 'dir' and '.' not in str(path)
+            ]
+            latest_dir = dirs[-1]
+            await ftp.change_directory(latest_dir)
 
-        dirs = [d for d in ftp.nlst() if '.' not in d]
-        if not dirs:
-            _LOGGER.warning("There don't appear to be any uploaded videos")
-            return False
+            videos = [path async for path, _ in ftp.list()]
+            if not videos:
+                _LOGGER.info('Video folder "%s" empty; delaying', latest_dir)
+                return False
 
-        latest_dir = dirs[-1]
-        ftp.cwd(latest_dir)
-        videos = ftp.nlst()
-        if not videos:
-            _LOGGER.info('Video folder "%s" is empty; delaying', latest_dir)
-            return False
-
-        return 'ftp://{0}:{1}@{2}:{3}{4}/{5}/{6}'.format(
-            self.user, self.passwd, self.host, self.port, self.path,
-            latest_dir, videos[-1])
+            return 'ftp://{0}:{1}@{2}:{3}{4}/{5}/{6}'.format(
+                self.user, self.passwd, self.host, self.port, self.path,
+                latest_dir, videos[-1])
+        except (ConnectionRefusedError, StatusCodeError) as err:
+            print('There was an issue: {0}'.format(err))
+            return
 
     async def async_camera_image(self):
         """Return a still image response from the camera."""
         from haffmpeg import ImageFrame, IMAGE_JPEG
 
-        url = await self.hass.async_add_job(self.get_latest_video_url)
+        url = await self._get_latest_video_url()
         if url != self._last_url:
             ffmpeg = ImageFrame(self._manager.binary, loop=self.hass.loop)
-            self._last_image = await asyncio.shield(ffmpeg.get_image(
-                url, output_format=IMAGE_JPEG,
-                extra_cmd=self._extra_arguments), loop=self.hass.loop)
+            self._last_image = await asyncio.shield(
+                ffmpeg.get_image(
+                    url,
+                    output_format=IMAGE_JPEG,
+                    extra_cmd=self._extra_arguments),
+                loop=self.hass.loop)
             self._last_url = url
 
         return self._last_image

--- a/homeassistant/components/camera/yi.py
+++ b/homeassistant/components/camera/yi.py
@@ -82,10 +82,10 @@ class YiCamera(Camera):
             await ftp.login(self.user, self.passwd)
 
             await ftp.change_directory(self.path)
-            dirs = [
-                path async for path, attrs in ftp.list()
-                if attrs['type'] == 'dir' and '.' not in str(path)
-            ]
+            dirs = []
+            for path, attrs in await ftp.list():
+                if attrs['type'] == 'dir' and '.' not in str(path):
+                    dirs.append(path)
             latest_dir = dirs[-1]
             await ftp.change_directory(latest_dir)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -84,6 +84,9 @@ aiodns==1.1.1
 # homeassistant.components.device_tracker.freebox
 aiofreepybox==0.0.3
 
+# homeassistant.components.camera.yi
+aioftp==0.10.1
+
 # homeassistant.components.emulated_hue
 # homeassistant.components.http
 aiohttp_cors==0.7.0


### PR DESCRIPTION
## Description:
This PR makes the Yi camera platform async.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
camera:
  - platform: yi
    name: Kitchen Camera
    host: 192.168.1.100
    username: root
    password: password123
    ffmpeg_arguments: -s 800x450
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  ~- [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)~

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  ~- [ ] New files were added to `.coveragerc`.~

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
