### PR TITLE
Add scan_interval to RainMachine

### DIFF
--- a/homeassistant/components/rainmachine/__init__.py
+++ b/homeassistant/components/rainmachine/__init__.py
@@ -11,8 +11,8 @@ import voluptuous as vol
 
 from homeassistant.const import (
     ATTR_ATTRIBUTION, CONF_BINARY_SENSORS, CONF_IP_ADDRESS, CONF_PASSWORD,
-    CONF_PORT, CONF_SENSORS, CONF_SSL, CONF_MONITORED_CONDITIONS,
-    CONF_SWITCHES)
+    CONF_PORT, CONF_SCAN_INTERVAL, CONF_SENSORS, CONF_SSL,
+    CONF_MONITORED_CONDITIONS, CONF_SWITCHES)
 from homeassistant.helpers import (
     aiohttp_client, config_validation as cv, discovery)
 from homeassistant.helpers.dispatcher import async_dispatcher_send
@@ -107,6 +107,8 @@ CONFIG_SCHEMA = vol.Schema(
             vol.Required(CONF_PASSWORD): cv.string,
             vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
             vol.Optional(CONF_SSL, default=DEFAULT_SSL): cv.boolean,
+            vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL):
+                cv.time_period,
             vol.Optional(CONF_BINARY_SENSORS, default={}):
                 BINARY_SENSOR_SCHEMA,
             vol.Optional(CONF_SENSORS, default={}): SENSOR_SCHEMA,
@@ -159,7 +161,7 @@ async def async_setup(hass, config):
         await rainmachine.async_update()
         async_dispatcher_send(hass, SENSOR_UPDATE_TOPIC)
 
-    async_track_time_interval(hass, refresh_sensors, DEFAULT_SCAN_INTERVAL)
+    async_track_time_interval(hass, refresh_sensors, conf[CONF_SCAN_INTERVAL])
 
     async def start_program(service):
         """Start a particular program."""


### PR DESCRIPTION
## Description:
This PR adds makes RainMachine compatible with the `scan_machine` configuration key.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** https://github.com/home-assistant/home-assistant.github.io/pull/5535

## Example entry for `configuration.yaml` (if applicable):
```yaml
rainmachine:
  ip_address: 192.168.2.16
  password: password_123
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  ~- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).~
  ~- [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).~
  ~- [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.~
  ~- [ ] New files were added to `.coveragerc`.~

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
