### PR TITLE
Fix Facebox face data parsing

### DIFF
--- a/homeassistant/components/image_processing/facebox.py
+++ b/homeassistant/components/image_processing/facebox.py
@@ -24,6 +24,7 @@ ATTR_BOUNDING_BOX = 'bounding_box'
 ATTR_IMAGE_ID = 'image_id'
 ATTR_MATCHED = 'matched'
 CLASSIFIER = 'facebox'
+TIMEOUT = 9
 
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -98,17 +99,17 @@ class FaceClassifyEntity(ImageProcessingFaceEntity):
             response = requests.post(
                 self._url,
                 json={"base64": encode_image(image)},
-                timeout=9
+                timeout=TIMEOUT
                 ).json()
         except requests.exceptions.ConnectionError:
             _LOGGER.error("ConnectionError: Is %s running?", CLASSIFIER)
             response['success'] = False
 
         if response['success']:
-            self.total_faces = response['facesCount']
-            self.faces = parse_faces(response['faces'])
-            self._matched = get_matched_faces(self.faces)
-            self.process_faces(self.faces, self.total_faces)
+            total_faces = response['facesCount']
+            faces = parse_faces(response['faces'])
+            self._matched = get_matched_faces(faces)
+            self.process_faces(faces, total_faces)
 
         else:
             self.total_faces = None

--- a/homeassistant/components/image_processing/facebox.py
+++ b/homeassistant/components/image_processing/facebox.py
@@ -10,16 +10,21 @@ import logging
 import requests
 import voluptuous as vol
 
+from homeassistant.const import ATTR_NAME
 from homeassistant.core import split_entity_id
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.image_processing import (
-    PLATFORM_SCHEMA, ImageProcessingFaceEntity, CONF_SOURCE, CONF_ENTITY_ID,
-    CONF_NAME)
+    PLATFORM_SCHEMA, ImageProcessingFaceEntity, ATTR_CONFIDENCE, CONF_SOURCE,
+    CONF_ENTITY_ID, CONF_NAME)
 from homeassistant.const import (CONF_IP_ADDRESS, CONF_PORT)
 
 _LOGGER = logging.getLogger(__name__)
 
+ATTR_BOUNDING_BOX = 'bounding_box'
+ATTR_IMAGE_ID = 'image_id'
+ATTR_MATCHED = 'matched'
 CLASSIFIER = 'facebox'
+
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_IP_ADDRESS): cv.string,
@@ -30,13 +35,31 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 def encode_image(image):
     """base64 encode an image stream."""
     base64_img = base64.b64encode(image).decode('ascii')
-    return {"base64": base64_img}
+    return base64_img
 
 
 def get_matched_faces(faces):
     """Return the name and rounded confidence of matched faces."""
     return {face['name']: round(face['confidence'], 2)
             for face in faces if face['matched']}
+
+
+def parse_faces(api_faces):
+    """Parse the API face data into the format required."""
+    known_faces = []
+    for entry in api_faces:
+        face = {}
+        if entry['matched']:  # This data is only in matched faces.
+            face[ATTR_NAME] = entry['name']
+            face[ATTR_IMAGE_ID] = entry['id']
+        else:  # Lets be explicit.
+            face[ATTR_NAME] = None
+            face[ATTR_IMAGE_ID] = None
+        face[ATTR_CONFIDENCE] = round(100.0*entry['confidence'], 2)
+        face[ATTR_MATCHED] = entry['matched']
+        face[ATTR_BOUNDING_BOX] = entry['rect']
+        known_faces.append(face)
+    return known_faces
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -74,7 +97,7 @@ class FaceClassifyEntity(ImageProcessingFaceEntity):
         try:
             response = requests.post(
                 self._url,
-                json=encode_image(image),
+                json={"base64": encode_image(image)},
                 timeout=9
                 ).json()
         except requests.exceptions.ConnectionError:
@@ -82,10 +105,10 @@ class FaceClassifyEntity(ImageProcessingFaceEntity):
             response['success'] = False
 
         if response['success']:
-            faces = response['faces']
-            total = response['facesCount']
-            self.process_faces(faces, total)
-            self._matched = get_matched_faces(faces)
+            self.total_faces = response['facesCount']
+            self.faces = parse_faces(response['faces'])
+            self._matched = get_matched_faces(self.faces)
+            self.process_faces(self.faces, self.total_faces)
 
         else:
             self.total_faces = None


### PR DESCRIPTION
## Description:
Currently the facebox component does not explicitly parse the `self.faces`, leaving it to `async_process_faces` to set this attribute. This PR addresses this by explicitly parsing the data for `self.faces` and additionally keeps all data returned by the API in the faces attribute, which now includes the `bounding_box` and matched image `id` info. This PR includes variables for these attributes (`ATTR_BOUNDING_BOX`) which can be merged into `homeassistant.components.image_processing` in a future PR. The PR also tidies up `encode_image` so that it can be merged into `homeassistant.components.image_processing` and reused by the upcoming Tagbox component I'm working on. This fix also addresses https://github.com/home-assistant/home-assistant/issues/14950. NO CONFIG CHANGES.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
