### PR TITLE
Added json_attributes to binary_sensor/mqtt

### DIFF
--- a/homeassistant/components/binary_sensor/mqtt.py
+++ b/homeassistant/components/binary_sensor/mqtt.py
@@ -6,6 +6,7 @@ https://home-assistant.io/components/binary_sensor.mqtt/
 """
 import asyncio
 import logging
+import json
 from typing import Optional
 
 import voluptuous as vol
@@ -25,6 +26,7 @@ import homeassistant.helpers.config_validation as cv
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_NAME = 'MQTT Binary sensor'
+CONF_JSON_ATTRS = 'json_attributes'
 CONF_UNIQUE_ID = 'unique_id'
 DEFAULT_PAYLOAD_OFF = 'OFF'
 DEFAULT_PAYLOAD_ON = 'ON'
@@ -37,6 +39,7 @@ PLATFORM_SCHEMA = mqtt.MQTT_RO_PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_PAYLOAD_OFF, default=DEFAULT_PAYLOAD_OFF): cv.string,
     vol.Optional(CONF_PAYLOAD_ON, default=DEFAULT_PAYLOAD_ON): cv.string,
     vol.Optional(CONF_DEVICE_CLASS): DEVICE_CLASSES_SCHEMA,
+    vol.Optional(CONF_JSON_ATTRS, default=[]): cv.ensure_list_csv,
     vol.Optional(CONF_FORCE_UPDATE, default=DEFAULT_FORCE_UPDATE): cv.boolean,
     # Integrations shouldn't never expose unique_id through configuration
     # this here is an exception because MQTT is a msg transport, not a protocol
@@ -66,6 +69,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         config.get(CONF_PAYLOAD_AVAILABLE),
         config.get(CONF_PAYLOAD_NOT_AVAILABLE),
         value_template,
+        config.get(CONF_JSON_ATTRS),
         config.get(CONF_UNIQUE_ID),
     )])
 
@@ -75,7 +79,7 @@ class MqttBinarySensor(MqttAvailability, BinarySensorDevice):
 
     def __init__(self, name, state_topic, availability_topic, device_class,
                  qos, force_update, payload_on, payload_off, payload_available,
-                 payload_not_available, value_template,
+                 payload_not_available, value_template, json_attributes,
                  unique_id: Optional[str]):
         """Initialize the MQTT binary sensor."""
         super().__init__(availability_topic, qos, payload_available,
@@ -89,7 +93,9 @@ class MqttBinarySensor(MqttAvailability, BinarySensorDevice):
         self._qos = qos
         self._force_update = force_update
         self._template = value_template
+        self._json_attributes = set(json_attributes)
         self._unique_id = unique_id
+        self._attributes = None
 
     @asyncio.coroutine
     def async_added_to_hass(self):
@@ -99,9 +105,23 @@ class MqttBinarySensor(MqttAvailability, BinarySensorDevice):
         @callback
         def state_message_received(topic, payload, qos):
             """Handle a new received MQTT state message."""
+            if self._json_attributes:
+                self._attributes = {}
+                try:
+                    json_dict = json.loads(payload)
+                    if isinstance(json_dict, dict):
+                        attrs = {k: json_dict[k] for k in
+                                 self._json_attributes & json_dict.keys()}
+                        self._attributes = attrs
+                    else:
+                        _LOGGER.warning("JSON result was not a dictionary")
+                except ValueError:
+                    _LOGGER.warning("MQTT payload could not be parsed as JSON"
+                                    ", %s", payload)
+
             if self._template is not None:
                 payload = self._template.async_render_with_possible_json_value(
-                    payload)
+                    payload, self._state)
             if payload == self._payload_on:
                 self._state = True
             elif payload == self._payload_off:
@@ -110,7 +130,6 @@ class MqttBinarySensor(MqttAvailability, BinarySensorDevice):
                 _LOGGER.warning('No matching payload found'
                                 ' for entity: %s with state_topic: %s',
                                 self._name, self._state_topic)
-                return
 
             self.async_schedule_update_ha_state()
 
@@ -141,6 +160,11 @@ class MqttBinarySensor(MqttAvailability, BinarySensorDevice):
     def force_update(self):
         """Force update."""
         return self._force_update
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        return self._attributes
 
     @property
     def unique_id(self):

--- a/tests/components/binary_sensor/test_mqtt.py
+++ b/tests/components/binary_sensor/test_mqtt.py
@@ -4,6 +4,7 @@ import unittest
 import homeassistant.core as ha
 from homeassistant.setup import setup_component
 import homeassistant.components.binary_sensor as binary_sensor
+from unittest.mock import patch
 
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.const import EVENT_STATE_CHANGED, STATE_UNAVAILABLE
@@ -95,6 +96,118 @@ class TestSensorMQTT(unittest.TestCase):
         fire_mqtt_message(self.hass, 'test-topic', 'payload')
         self.hass.block_till_done()
         assert len(self.hass.states.all()) == 1
+
+    @patch('homeassistant.components.binary_sensor.mqtt._LOGGER')
+    def test_setting_sensor_attribute_via_mqtt_json_message(self, mock_logger):
+        """Test the setting of attribute via MQTT with JSON payload."""
+        mock_component(self.hass, 'mqtt')
+        assert setup_component(self.hass, binary_sensor.DOMAIN, {
+            binary_sensor.DOMAIN: {
+                'platform': 'mqtt',
+                'name': 'test',
+                'state_topic': 'test-topic',
+                'unit_of_measurement': 'fav unit',
+                'json_attributes': 'val'
+            }
+        })
+
+        fire_mqtt_message(self.hass, 'test-topic', '{ "val": "100" }')
+        self.hass.block_till_done()
+        state = self.hass.states.get('binary_sensor.test')
+
+        self.assertEqual('100',
+                         state.attributes.get('val'))
+        self.assertTrue(mock_logger.warning.called)
+
+    @patch('homeassistant.components.binary_sensor.mqtt._LOGGER')
+    def test_update_with_json_attrs_not_dict(self, mock_logger):
+        """Test attributes get extracted from a JSON result."""
+        mock_component(self.hass, 'mqtt')
+        assert setup_component(self.hass, binary_sensor.DOMAIN, {
+            binary_sensor.DOMAIN: {
+                'platform': 'mqtt',
+                'name': 'test',
+                'state_topic': 'test-topic',
+                'unit_of_measurement': 'fav unit',
+                'json_attributes': 'val'
+            }
+        })
+
+        fire_mqtt_message(self.hass, 'test-topic', '[ "list", "of", "things"]')
+        self.hass.block_till_done()
+        state = self.hass.states.get('binary_sensor.test')
+
+        self.assertEqual(None,
+                         state.attributes.get('val'))
+        self.assertTrue(mock_logger.warning.called)
+
+    @patch('homeassistant.components.binary_sensor.mqtt._LOGGER')
+    def test_update_with_json_attrs_bad_JSON(self, mock_logger):
+        """Test attributes get extracted from a JSON result."""
+        mock_component(self.hass, 'mqtt')
+        assert setup_component(self.hass, binary_sensor.DOMAIN, {
+            binary_sensor.DOMAIN: {
+                'platform': 'mqtt',
+                'name': 'test',
+                'state_topic': 'test-topic',
+                'unit_of_measurement': 'fav unit',
+                'json_attributes': 'val'
+            }
+        })
+
+        fire_mqtt_message(self.hass, 'test-topic', 'This is not JSON')
+        self.hass.block_till_done()
+
+        state = self.hass.states.get('binary_sensor.test')
+        self.assertEqual(None,
+                         state.attributes.get('val'))
+        self.assertTrue(mock_logger.warning.called)
+
+    def test_update_with_json_attrs_and_template(self):
+        """Test attributes get extracted from a JSON result."""
+        mock_component(self.hass, 'mqtt')
+        assert setup_component(self.hass, binary_sensor.DOMAIN, {
+            binary_sensor.DOMAIN: {
+                'platform': 'mqtt',
+                'name': 'test',
+                'state_topic': 'test-topic',
+                'payload_on': "100",
+                'unit_of_measurement': 'fav unit',
+                'value_template': '{{ value_json.val }}',
+                'json_attributes': 'val'
+            }
+        })
+
+        fire_mqtt_message(self.hass, 'test-topic', '{ "val": "100" }')
+        self.hass.block_till_done()
+        state = self.hass.states.get('binary_sensor.test')
+
+        self.assertEqual('100',
+                         state.attributes.get('val'))
+        self.assertEqual('on', state.state)
+
+    @patch('homeassistant.components.binary_sensor.mqtt._LOGGER')
+    def test_update_with_json_attrs_and_invalid_value(self, mock_logger):
+        """Test attributes get extracted from a JSON result."""
+        mock_component(self.hass, 'mqtt')
+        assert setup_component(self.hass, binary_sensor.DOMAIN, {
+            binary_sensor.DOMAIN: {
+                'platform': 'mqtt',
+                'name': 'test',
+                'state_topic': 'test-topic',
+                'unit_of_measurement': 'fav unit',
+                'value_template': '{{ value_json.val }}',
+                'json_attributes': 'val'
+            }
+        })
+
+        fire_mqtt_message(self.hass, 'test-topic', '{ "val": "100" }')
+        self.hass.block_till_done()
+        state = self.hass.states.get('binary_sensor.test')
+
+        self.assertEqual('100',
+                         state.attributes.get('val'))
+        self.assertTrue(mock_logger.warning.called)
 
     def test_availability_without_topic(self):
         """Test availability without defined availability topic."""


### PR DESCRIPTION
## Description:
Added unique id and json_attributes to binary_sensor.mqtt

Notes: 
- for `json_attributes` to work properly, the user MUST specify value_template
- the `json_attributes` use case is for binary sensors that need battery attribute to be exposed (ex. [zigbee2mqtt](https://github.com/Koenkk/zigbee2mqtt) for door sensors)

EDIT by @dgomes: zigbee2mqtt integrates with HA through mqtt autodiscovery

Split from https://github.com/home-assistant/home-assistant/pull/14912

**Related issue (if applicable):** fixes N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#TBC

## Example entry for `configuration.yaml` (if applicable):
```yaml
binary_sensor:
  - platform: mqtt
    state_topic: "home-assistant/window/contact"
    value_template: "{{ value_json.val }}"
    json_attributes:
      - battery
      - voltage
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.
