### PR TITLE
Make Pollen.com platform async

### DIFF
--- a/homeassistant/components/sensor/pollen.py
+++ b/homeassistant/components/sensor/pollen.py
@@ -13,12 +13,13 @@ import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
-    ATTR_ATTRIBUTION, ATTR_STATE, CONF_MONITORED_CONDITIONS
-)
+    ATTR_ATTRIBUTION, ATTR_STATE, CONF_MONITORED_CONDITIONS,
+    CONF_SCAN_INTERVAL)
+from homeassistant.helpers import aiohttp_client
 from homeassistant.helpers.entity import Entity
-from homeassistant.util import Throttle, slugify
+from homeassistant.util import Throttle
 
-REQUIREMENTS = ['pypollencom==1.1.2']
+REQUIREMENTS = ['pypollencom==2.1.0']
 _LOGGER = logging.getLogger(__name__)
 
 ATTR_ALLERGEN_GENUS = 'primary_allergen_genus'
@@ -34,53 +35,29 @@ ATTR_ZIP_CODE = 'zip_code'
 CONF_ZIP_CODE = 'zip_code'
 
 DEFAULT_ATTRIBUTION = 'Data provided by IQVIA™'
+DEFAULT_SCAN_INTERVAL = timedelta(minutes=30)
 
-MIN_TIME_UPDATE_AVERAGES = timedelta(hours=12)
-MIN_TIME_UPDATE_INDICES = timedelta(minutes=10)
+TYPE_ALLERGY_FORECAST = 'allergy_average_forecasted'
+TYPE_ALLERGY_HISTORIC = 'allergy_average_historical'
+TYPE_ALLERGY_INDEX = 'allergy_index'
+TYPE_ALLERGY_TODAY = 'allergy_index_today'
+TYPE_ALLERGY_TOMORROW = 'allergy_index_tomorrow'
+TYPE_ALLERGY_YESTERDAY = 'allergy_index_yesterday'
+TYPE_DISEASE_FORECAST = 'disease_average_forecasted'
 
-CONDITIONS = {
-    'allergy_average_forecasted': (
-        'Allergy Index: Forecasted Average',
-        'AllergyAverageSensor',
-        'allergy_average_data',
-        {'data_attr': 'extended_data'},
-        'mdi:flower'
-    ),
-    'allergy_average_historical': (
-        'Allergy Index: Historical Average',
-        'AllergyAverageSensor',
-        'allergy_average_data',
-        {'data_attr': 'historic_data'},
-        'mdi:flower'
-    ),
-    'allergy_index_today': (
-        'Allergy Index: Today',
-        'AllergyIndexSensor',
-        'allergy_index_data',
-        {'key': 'Today'},
-        'mdi:flower'
-    ),
-    'allergy_index_tomorrow': (
-        'Allergy Index: Tomorrow',
-        'AllergyIndexSensor',
-        'allergy_index_data',
-        {'key': 'Tomorrow'},
-        'mdi:flower'
-    ),
-    'allergy_index_yesterday': (
-        'Allergy Index: Yesterday',
-        'AllergyIndexSensor',
-        'allergy_index_data',
-        {'key': 'Yesterday'},
-        'mdi:flower'
-    ),
-    'disease_average_forecasted': (
-        'Cold & Flu: Forecasted Average',
-        'AllergyAverageSensor',
-        'disease_average_data',
-        {'data_attr': 'extended_data'},
-        'mdi:snowflake'
-    )
+SENSORS = {
+    TYPE_ALLERGY_FORECAST: (
+        'Allergy Index: Forecasted Average', None, 'mdi:flower', 'index'),
+    TYPE_ALLERGY_HISTORIC: (
+        'Allergy Index: Historical Average', None, 'mdi:flower', 'index'),
+    TYPE_ALLERGY_TODAY: (
+        'Allergy Index: Today', TYPE_ALLERGY_INDEX, 'mdi:flower', 'index'),
+    TYPE_ALLERGY_TOMORROW: (
+        'Allergy Index: Tomorrow', TYPE_ALLERGY_INDEX, 'mdi:flower', 'index'),
+    TYPE_ALLERGY_YESTERDAY: (
+        'Allergy Index: Yesterday', TYPE_ALLERGY_INDEX, 'mdi:flower', 'index'),
+    TYPE_DISEASE_FORECAST: (
+        'Cold & Flu: Forecasted Average', None, 'mdi:snowflake', 'index')
 }
 
 RATING_MAPPING = [{
@@ -105,69 +82,72 @@ RATING_MAPPING = [{
     'maximum': 12
 }]
 
+TREND_FLAT = 'Flat'
+TREND_INCREASING = 'Increasing'
+TREND_SUBSIDING = 'Subsiding'
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_ZIP_CODE): str,
-    vol.Required(CONF_MONITORED_CONDITIONS):
-        vol.All(cv.ensure_list, [vol.In(CONDITIONS)]),
+    vol.Required(CONF_ZIP_CODE):
+        str,
+    vol.Required(CONF_MONITORED_CONDITIONS, default=list(SENSORS)):
+        vol.All(cv.ensure_list, [vol.In(SENSORS)]),
+    vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL):
+        cv.time_period
 })
 
 
-def setup_platform(hass, config, add_devices, discovery_info=None):
+async def async_setup_platform(
+        hass, config, async_add_devices, discovery_info=None):
     """Configure the platform and add the sensors."""
     from pypollencom import Client
 
-    _LOGGER.debug('Configuration data: %s', config)
+    websession = aiohttp_client.async_get_clientsession(hass)
 
-    client = Client(config[CONF_ZIP_CODE])
-    datas = {
-        'allergy_average_data': AllergyAveragesData(client),
-        'allergy_index_data': AllergyIndexData(client),
-        'disease_average_data': DiseaseData(client)
-    }
-    classes = {
-        'AllergyAverageSensor': AllergyAverageSensor,
-        'AllergyIndexSensor': AllergyIndexSensor
-    }
+    data = PollenComData(
+        Client(config[CONF_ZIP_CODE], websession),
+        config[CONF_MONITORED_CONDITIONS], config[CONF_SCAN_INTERVAL])
 
-    for data in datas.values():
-        data.update()
+    await data.async_update()
 
     sensors = []
-    for condition in config[CONF_MONITORED_CONDITIONS]:
-        name, sensor_class, data_key, params, icon = CONDITIONS[condition]
-        sensors.append(classes[sensor_class](
-            datas[data_key],
-            params,
-            name,
-            icon,
-            config[CONF_ZIP_CODE]
-        ))
+    for kind in config[CONF_MONITORED_CONDITIONS]:
+        name, category, icon, unit = SENSORS[kind]
+        sensors.append(
+            PollencomSensor(
+                data, config[CONF_ZIP_CODE], kind, category, name, icon, unit))
 
-    add_devices(sensors, True)
+    async_add_devices(sensors, True)
 
 
-def calculate_trend(list_of_nums):
-    """Calculate the most common rating as a trend."""
+def calculate_average_rating(indices):
+    """Calculate the human-friendly historical allergy average."""
     ratings = list(
-        r['label'] for n in list_of_nums
-        for r in RATING_MAPPING
+        r['label'] for n in indices for r in RATING_MAPPING
         if r['minimum'] <= n <= r['maximum'])
     return max(set(ratings), key=ratings.count)
 
 
-class BaseSensor(Entity):
-    """Define a base class for all of our sensors."""
+class PollencomSensor(Entity):
+    """Define a Pollen.com sensor."""
 
-    def __init__(self, data, data_params, name, icon, unique_id):
+    def __init__(self, pollencom, zip_code, kind, category, name, icon, unit):
         """Initialize the sensor."""
         self._attrs = {ATTR_ATTRIBUTION: DEFAULT_ATTRIBUTION}
+        self._category = category
         self._icon = icon
         self._name = name
-        self._data_params = data_params
         self._state = None
-        self._unit = None
-        self._unique_id = unique_id
-        self.data = data
+        self._type = kind
+        self._unit = unit
+        self._zip_code = zip_code
+        self.pollencom = pollencom
+
+    @property
+    def available(self):
+        """Return True if entity is available."""
+        return bool(
+            self.pollencom.data.get(self._type)
+            or self.pollencom.data.get(self._category))
 
     @property
     def device_state_attributes(self):
@@ -192,187 +172,182 @@ class BaseSensor(Entity):
     @property
     def unique_id(self):
         """Return a unique, HASS-friendly identifier for this entity."""
-        return '{0}_{1}'.format(self._unique_id, slugify(self._name))
+        return '{0}_{1}'.format(self._zip_code, self._type)
 
     @property
     def unit_of_measurement(self):
         """Return the unit the value is expressed in."""
         return self._unit
 
+    async def async_update(self):
+        """Update the sensor."""
+        await self.pollencom.async_update()
 
-class AllergyAverageSensor(BaseSensor):
-    """Define a sensor to show allergy average information."""
-
-    def update(self):
-        """Update the status of the sensor."""
-        self.data.update()
-
-        try:
-            data_attr = getattr(self.data, self._data_params['data_attr'])
-            indices = [p['Index'] for p in data_attr['Location']['periods']]
-            self._attrs[ATTR_TREND] = calculate_trend(indices)
-        except KeyError:
-            _LOGGER.error("Pollen.com API didn't return any data")
+        if not self.pollencom.data:
             return
 
-        try:
-            self._attrs[ATTR_CITY] = data_attr['Location']['City'].title()
-            self._attrs[ATTR_STATE] = data_attr['Location']['State']
-            self._attrs[ATTR_ZIP_CODE] = data_attr['Location']['ZIP']
-        except KeyError:
-            _LOGGER.debug('Location data not included in API response')
-            self._attrs[ATTR_CITY] = None
-            self._attrs[ATTR_STATE] = None
-            self._attrs[ATTR_ZIP_CODE] = None
+        if self._category:
+            data = self.pollencom.data[self._category]['Location']
+        else:
+            data = self.pollencom.data[self._type]['Location']
 
-        average = round(mean(indices), 1)
-        [rating] = [
-            i['label'] for i in RATING_MAPPING
-            if i['minimum'] <= average <= i['maximum']
-        ]
-        self._attrs[ATTR_RATING] = rating
+        if self._type == TYPE_ALLERGY_FORECAST:
+            outlook = self.pollencom.data[ATTR_OUTLOOK]
 
-        self._state = average
-        self._unit = 'index'
-
-
-class AllergyIndexSensor(BaseSensor):
-    """Define a sensor to show allergy index information."""
-
-    def update(self):
-        """Update the status of the sensor."""
-        self.data.update()
-
-        try:
-            location_data = self.data.current_data['Location']
-            [period] = [
-                p for p in location_data['periods']
-                if p['Type'] == self._data_params['key']
+            indices = [p['Index'] for p in data['periods']]
+            average = round(mean(indices), 1)
+            [rating] = [
+                i['label'] for i in RATING_MAPPING
+                if i['minimum'] <= average <= i['maximum']
             ]
+
+            self._attrs.update({
+                ATTR_CITY: data['City'].title(),
+                ATTR_OUTLOOK: outlook['Outlook'],
+                ATTR_RATING: rating,
+                ATTR_SEASON: outlook['Season'].title(),
+                ATTR_STATE: data['State'],
+                ATTR_TREND: outlook['Trend'].title(),
+                ATTR_ZIP_CODE: data['ZIP']
+            })
+            self._state = average
+        elif self._type == TYPE_ALLERGY_HISTORIC:
+            indices = [p['Index'] for p in data['periods']]
+            average = round(mean(indices), 1)
+
+            slope = (
+                data['periods'][-1]['Index'] - data['periods'][-2]['Index'])
+            trend = TREND_FLAT
+            if slope > 0:
+                trend = TREND_INCREASING
+            elif slope < 0:
+                trend = TREND_SUBSIDING
+
+            self._attrs.update({
+                ATTR_CITY: data['City'].title(),
+                ATTR_RATING: calculate_average_rating(indices),
+                ATTR_STATE: data['State'],
+                ATTR_TREND: trend,
+                ATTR_ZIP_CODE: data['ZIP']
+            })
+            self._state = average
+        elif self._type in (TYPE_ALLERGY_TODAY, TYPE_ALLERGY_TOMORROW,
+                            TYPE_ALLERGY_YESTERDAY):
+            key = self._type.split('_')[-1].title()
+            [period] = [p for p in data['periods'] if p['Type'] == key]
             [rating] = [
                 i['label'] for i in RATING_MAPPING
                 if i['minimum'] <= period['Index'] <= i['maximum']
             ]
 
-            for i in range(3):
-                index = i + 1
-                try:
-                    data = period['Triggers'][i]
-                    self._attrs['{0}_{1}'.format(
-                        ATTR_ALLERGEN_GENUS, index)] = data['Genus']
-                    self._attrs['{0}_{1}'.format(
-                        ATTR_ALLERGEN_NAME, index)] = data['Name']
-                    self._attrs['{0}_{1}'.format(
-                        ATTR_ALLERGEN_TYPE, index)] = data['PlantType']
-                except IndexError:
-                    self._attrs['{0}_{1}'.format(
-                        ATTR_ALLERGEN_GENUS, index)] = None
-                    self._attrs['{0}_{1}'.format(
-                        ATTR_ALLERGEN_NAME, index)] = None
-                    self._attrs['{0}_{1}'.format(
-                        ATTR_ALLERGEN_TYPE, index)] = None
+            for idx, attrs in enumerate(period['Triggers']):
+                index = idx + 1
+                self._attrs.update({
+                    '{0}_{1}'.format(ATTR_ALLERGEN_GENUS, index):
+                        attrs['Genus'],
+                    '{0}_{1}'.format(ATTR_ALLERGEN_NAME, index):
+                        attrs['Name'],
+                    '{0}_{1}'.format(ATTR_ALLERGEN_GENUS, index):
+                        attrs['PlantType'],
+                })
 
-            self._attrs[ATTR_RATING] = rating
+            self._attrs.update({
+                ATTR_CITY: data['City'].title(),
+                ATTR_RATING: rating,
+                ATTR_STATE: data['State'],
+                ATTR_ZIP_CODE: data['ZIP']
+            })
+            self._state = period['Index']
+        elif self._type == TYPE_DISEASE_FORECAST:
+            indices = [p['Index'] for p in data['periods']]
+            average = round(mean(indices), 1)
+            [rating] = [
+                i['label'] for i in RATING_MAPPING
+                if i['minimum'] <= average <= i['maximum']
+            ]
+            slope = (
+                data['periods'][-1]['Index'] - data['periods'][-2]['Index'])
+            trend = TREND_FLAT
+            if slope > 0:
+                trend = TREND_INCREASING
+            elif slope < 0:
+                trend = TREND_SUBSIDING
 
-        except KeyError:
-            _LOGGER.error("Pollen.com API didn't return any data")
-            return
-
-        try:
-            self._attrs[ATTR_CITY] = location_data['City'].title()
-            self._attrs[ATTR_STATE] = location_data['State']
-            self._attrs[ATTR_ZIP_CODE] = location_data['ZIP']
-        except KeyError:
-            _LOGGER.debug('Location data not included in API response')
-            self._attrs[ATTR_CITY] = None
-            self._attrs[ATTR_STATE] = None
-            self._attrs[ATTR_ZIP_CODE] = None
-
-        try:
-            self._attrs[ATTR_OUTLOOK] = self.data.outlook_data['Outlook']
-        except KeyError:
-            _LOGGER.debug('Outlook data not included in API response')
-            self._attrs[ATTR_OUTLOOK] = None
-
-        try:
-            self._attrs[ATTR_SEASON] = self.data.outlook_data['Season']
-        except KeyError:
-            _LOGGER.debug('Season data not included in API response')
-            self._attrs[ATTR_SEASON] = None
-
-        try:
-            self._attrs[ATTR_TREND] = self.data.outlook_data['Trend'].title()
-        except KeyError:
-            _LOGGER.debug('Trend data not included in API response')
-            self._attrs[ATTR_TREND] = None
-
-        self._state = period['Index']
-        self._unit = 'index'
+            self._attrs.update({
+                ATTR_CITY: data['City'].title(),
+                ATTR_RATING: rating,
+                ATTR_STATE: data['State'],
+                ATTR_TREND: trend,
+                ATTR_ZIP_CODE: data['ZIP']
+            })
+            self._state = average
 
 
-class DataBase(object):
-    """Define a generic data object."""
+class PollenComData(object):
+    """Define a data object to retrieve info from Pollen.com."""
 
-    def __init__(self, client):
+    def __init__(self, client, sensor_types, scan_interval):
         """Initialize."""
         self._client = client
+        self._sensor_types = sensor_types
+        self.data = {}
 
-    def _get_client_data(self, module, operation):
-        """Get data from a particular point in the API."""
-        from pypollencom.exceptions import HTTPError
+        self.async_update = Throttle(scan_interval)(self._async_update)
 
-        data = {}
+    async def _async_update(self):
+        """Update Pollen.com data."""
+        from pypollencom.errors import InvalidZipError, PollenComError
+
+        # Pollen.com requires a bit more complicated error handling, given that
+        # it sometimes has parts (but not the whole thing) go down:
+        #
+        # 1. If `InvalidZipError` is thrown, quit everything immediately.
+        # 2. If an individual request throws any other error, try the others.
+
         try:
-            data = getattr(getattr(self._client, module), operation)()
-            _LOGGER.debug('Received "%s_%s" data: %s', module, operation, data)
-        except HTTPError as exc:
-            _LOGGER.error('An error occurred while retrieving data')
-            _LOGGER.debug(exc)
+            if TYPE_ALLERGY_FORECAST in self._sensor_types:
+                try:
+                    data = await self._client.allergens.extended()
+                    self.data[TYPE_ALLERGY_FORECAST] = data
+                except PollenComError as err:
+                    _LOGGER.error('Unable to get allergy forecast: %s', err)
+                    self.data[TYPE_ALLERGY_FORECAST] = {}
 
-        return data
+                try:
+                    data = await self._client.allergens.outlook()
+                    self.data[ATTR_OUTLOOK] = data
+                except PollenComError as err:
+                    _LOGGER.error('Unable to get allergy outlook: %s', err)
+                    self.data[ATTR_OUTLOOK] = {}
 
+            if TYPE_ALLERGY_HISTORIC in self._sensor_types:
+                try:
+                    data = await self._client.allergens.historic()
+                    self.data[TYPE_ALLERGY_HISTORIC] = data
+                except PollenComError as err:
+                    _LOGGER.error('Unable to get allergy history: %s', err)
+                    self.data[TYPE_ALLERGY_HISTORIC] = {}
 
-class AllergyAveragesData(DataBase):
-    """Define an object to averages on future and historical allergy data."""
+            if all(s in self._sensor_types
+                   for s in [TYPE_ALLERGY_TODAY, TYPE_ALLERGY_TOMORROW,
+                             TYPE_ALLERGY_YESTERDAY]):
+                try:
+                    data = await self._client.allergens.current()
+                    self.data[TYPE_ALLERGY_INDEX] = data
+                except PollenComError as err:
+                    _LOGGER.error('Unable to get current allergies: %s', err)
+                    self.data[TYPE_ALLERGY_TODAY] = {}
 
-    def __init__(self, client):
-        """Initialize."""
-        super().__init__(client)
-        self.extended_data = None
-        self.historic_data = None
+            if TYPE_DISEASE_FORECAST in self._sensor_types:
+                try:
+                    data = await self._client.disease.extended()
+                    self.data[TYPE_DISEASE_FORECAST] = data
+                except PollenComError as err:
+                    _LOGGER.error('Unable to get disease forecast: %s', err)
+                    self.data[TYPE_DISEASE_FORECAST] = {}
 
-    @Throttle(MIN_TIME_UPDATE_AVERAGES)
-    def update(self):
-        """Update with new data."""
-        self.extended_data = self._get_client_data('allergens', 'extended')
-        self.historic_data = self._get_client_data('allergens', 'historic')
-
-
-class AllergyIndexData(DataBase):
-    """Define an object to retrieve current allergy index info."""
-
-    def __init__(self, client):
-        """Initialize."""
-        super().__init__(client)
-        self.current_data = None
-        self.outlook_data = None
-
-    @Throttle(MIN_TIME_UPDATE_INDICES)
-    def update(self):
-        """Update with new index data."""
-        self.current_data = self._get_client_data('allergens', 'current')
-        self.outlook_data = self._get_client_data('allergens', 'outlook')
-
-
-class DiseaseData(DataBase):
-    """Define an object to retrieve current disease index info."""
-
-    def __init__(self, client):
-        """Initialize."""
-        super().__init__(client)
-        self.extended_data = None
-
-    @Throttle(MIN_TIME_UPDATE_INDICES)
-    def update(self):
-        """Update with new cold/flu data."""
-        self.extended_data = self._get_client_data('disease', 'extended')
+            _LOGGER.debug('New data retrieved: %s', self.data)
+        except InvalidZipError:
+            _LOGGER.error(
+                'Cannot retrieve data for ZIP code: %s', self._client.zip_code)
+            self.data = {}

--- a/homeassistant/components/sensor/pollen.py
+++ b/homeassistant/components/sensor/pollen.py
@@ -13,8 +13,7 @@ import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
-    ATTR_ATTRIBUTION, ATTR_STATE, CONF_MONITORED_CONDITIONS,
-    CONF_SCAN_INTERVAL)
+    ATTR_ATTRIBUTION, ATTR_STATE, CONF_MONITORED_CONDITIONS)
 from homeassistant.helpers import aiohttp_client
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
@@ -90,9 +89,7 @@ TREND_SUBSIDING = 'Subsiding'
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_ZIP_CODE): str,
     vol.Required(CONF_MONITORED_CONDITIONS, default=list(SENSORS)):
-        vol.All(cv.ensure_list, [vol.In(SENSORS)]),
-    vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL):
-        cv.time_period
+        vol.All(cv.ensure_list, [vol.In(SENSORS)])
 })
 
 
@@ -105,7 +102,7 @@ async def async_setup_platform(
 
     data = PollenComData(
         Client(config[CONF_ZIP_CODE], websession),
-        config[CONF_MONITORED_CONDITIONS], config[CONF_SCAN_INTERVAL])
+        config[CONF_MONITORED_CONDITIONS])
 
     await data.async_update()
 
@@ -266,13 +263,13 @@ class PollencomSensor(Entity):
 class PollenComData(object):
     """Define a data object to retrieve info from Pollen.com."""
 
-    def __init__(self, client, sensor_types, scan_interval):
+    def __init__(self, client, sensor_types):
         """Initialize."""
         self._client = client
         self._sensor_types = sensor_types
         self.data = {}
 
-        self.async_update = Throttle(scan_interval)(self._async_update)
+        self.async_update = Throttle(DEFAULT_SCAN_INTERVAL)(self._async_update)
 
     async def _async_update(self):
         """Update Pollen.com data."""

--- a/homeassistant/components/sensor/pollen.py
+++ b/homeassistant/components/sensor/pollen.py
@@ -269,9 +269,8 @@ class PollenComData(object):
         self._sensor_types = sensor_types
         self.data = {}
 
-        self.async_update = Throttle(DEFAULT_SCAN_INTERVAL)(self._async_update)
-
-    async def _async_update(self):
+    @Throttle(DEFAULT_SCAN_INTERVAL)
+    async def async_update(self):
         """Update Pollen.com data."""
         from pypollencom.errors import InvalidZipError, PollenComError
 

--- a/homeassistant/components/sensor/pollen.py
+++ b/homeassistant/components/sensor/pollen.py
@@ -22,9 +22,9 @@ from homeassistant.util import Throttle
 REQUIREMENTS = ['pypollencom==2.1.0']
 _LOGGER = logging.getLogger(__name__)
 
-ATTR_ALLERGEN_GENUS = 'primary_allergen_genus'
-ATTR_ALLERGEN_NAME = 'primary_allergen_name'
-ATTR_ALLERGEN_TYPE = 'primary_allergen_type'
+ATTR_ALLERGEN_GENUS = 'allergen_genus'
+ATTR_ALLERGEN_NAME = 'allergen_name'
+ATTR_ALLERGEN_TYPE = 'allergen_type'
 ATTR_CITY = 'city'
 ATTR_OUTLOOK = 'outlook'
 ATTR_RATING = 'rating'
@@ -88,8 +88,7 @@ TREND_INCREASING = 'Increasing'
 TREND_SUBSIDING = 'Subsiding'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_ZIP_CODE):
-        str,
+    vol.Required(CONF_ZIP_CODE): str,
     vol.Required(CONF_MONITORED_CONDITIONS, default=list(SENSORS)):
         vol.All(cv.ensure_list, [vol.In(SENSORS)]),
     vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL):
@@ -242,7 +241,7 @@ class PollencomSensor(Entity):
                         attrs['Genus'],
                     '{0}_{1}'.format(ATTR_ALLERGEN_NAME, index):
                         attrs['Name'],
-                    '{0}_{1}'.format(ATTR_ALLERGEN_GENUS, index):
+                    '{0}_{1}'.format(ATTR_ALLERGEN_TYPE, index):
                         attrs['PlantType'],
                 })
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -954,7 +954,7 @@ pyotp==2.2.6
 pyowm==2.8.0
 
 # homeassistant.components.sensor.pollen
-pypollencom==1.1.2
+pypollencom==2.1.0
 
 # homeassistant.components.qwikswitch
 pyqwikswitch==0.8


### PR DESCRIPTION
## Description:
This PR makes several changes to the Pollen.com sensor platform:

1. Bumps the underlying library (`pypollencom`) to 2.1.0.
2. Makes the platform async.
3. Reorganizes several attributes to more appropriate sensors.
4. Re-architects it to be more consistent with accepted standards.

## Breaking Changes

### Attribute Reorganization

Various attributes have been relocated to sensors that make more sense; additionally, some names are corrected. The mapping of attribute-to-sensor is:

#### `allergy_average_forecasted`
`city`, `outlook`, `rating`, `season`, `state`, `trend`, `zip_code`

#### `allergy_average_historical`
`city`, `rating`, `state`, `trend`, `zip_code`

#### `allergy_index_today`, `allergy_index_tomorrow`, and `allergy_index_yesterday`
`allergen_genus_1`, `allergen_name_1`, `allergen_type_1`, `allergen_genus_2`, `allergen_name_2`, `allergen_type_2`, `allergen_genus_3`, `allergen_name_3`, `allergen_type_3`, `city`, `rating`, `state`, `zip_code`

#### `disease_average_forecasted`
`city`, `rating`, `state`, `trend`, `zip_code`

### New Entity IDs

With the rearchitecture comes a few unique ID alterations:

* `<ZIP>_allergy_index_forecasted_average` becomes `<ZIP>_allergy_average_forecasted`
* `<ZIP>_allergy_index_historical_average` becomes `<ZIP>_allergy_average_historical`
* `<ZIP>_cold__flu_forecasted_average` becomes `<ZIP>_disease_average_forecasted`

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: pollen
    zip_code: "80919"
    monitored_conditions:
      - allergy_average_forecasted
      - allergy_average_historical
      - allergy_index_today
      - allergy_index_tomorrow
      - allergy_index_yesterday
      - disease_average_forecasted
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  ~- [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)~

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  ~- [ ] New files were added to `.coveragerc`.~

If the code does not interact with devices:
  ~- [ ] Tests have been added to verify that the new code works.~

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
