### PR TITLE
Prevent Nest component setup crash due insufficient permission.

### DIFF
--- a/homeassistant/components/nest/__init__.py
+++ b/homeassistant/components/nest/__init__.py
@@ -249,7 +249,7 @@ class NestDevice(object):
                         # it is here for verify Nest API permission.
                         device.name_long
                     except KeyError:
-                        _LOGGER.warning("Cannot retrieve device name for [%s], "
+                        _LOGGER.warning("Cannot retrieve device name for %s,"
                                         "please check your Nest developer "
                                         "account permission settings.",
                                         device.serial)

--- a/homeassistant/components/nest/__init__.py
+++ b/homeassistant/components/nest/__init__.py
@@ -194,21 +194,32 @@ class NestDevice(object):
 
     def initialize(self):
         """Initialize Nest."""
-        if self.local_structure is None:
-            self.local_structure = [s.name for s in self.nest.structures]
+        from nest.nest import AuthorizationError, APIError
+        try:
+            # Do not optimize next statement, it is here for initialize
+            # persistence Nest API connection.
+            structure_names = [s.name for s in self.nest.structures]
+            if self.local_structure is None:
+                self.local_structure = structure_names
+
+        except (AuthorizationError, APIError, socket.error) as err:
+            _LOGGER.error(
+                "Connection error while access Nest web service: %s", err)
 
     def structures(self):
         """Generate a list of structures."""
+        from nest.nest import AuthorizationError, APIError
         try:
             for structure in self.nest.structures:
-                if structure.name in self.local_structure:
-                    yield structure
-                else:
+                if structure.name not in self.local_structure:
                     _LOGGER.debug("Ignoring structure %s, not in %s",
                                   structure.name, self.local_structure)
-        except socket.error:
+                    continue
+                yield structure
+
+        except (AuthorizationError, APIError, socket.error) as err:
             _LOGGER.error(
-                "Connection error logging into the nest web service.")
+                "Connection error while access Nest web service: %s", err)
 
     def thermostats(self):
         """Generate a list of thermostats."""
@@ -224,25 +235,30 @@ class NestDevice(object):
 
     def _devices(self, device_type):
         """Generate a list of Nest devices."""
+        from nest.nest import AuthorizationError, APIError
         try:
             for structure in self.nest.structures:
-                if structure.name in self.local_structure:
-                    for device in getattr(structure, device_type, []):
-                        try:
-                            device.name_long
-                        except KeyError:
-                            _LOGGER.warning("Cannot retrieve device name for "
-                                            "[%s], please check your Nest "
-                                            "developer account permission "
-                                            "settings.", device.serial)
-                            continue
-                        yield (structure, device)
-                else:
+                if structure.name not in self.local_structure:
                     _LOGGER.debug("Ignoring structure %s, not in %s",
                                   structure.name, self.local_structure)
-        except socket.error:
+                    continue
+
+                for device in getattr(structure, device_type, []):
+                    try:
+                        # Do not optimize next statement,
+                        # it is here for verify Nest API permission.
+                        device.name_long
+                    except KeyError:
+                        _LOGGER.warning("Cannot retrieve device name for [%s], "
+                                        "please check your Nest developer "
+                                        "account permission settings.",
+                                        device.serial)
+                        continue
+                    yield (structure, device)
+
+        except (AuthorizationError, APIError, socket.error) as err:
             _LOGGER.error(
-                "Connection error logging into the nest web service.")
+                "Connection error while access Nest web service: %s", err)
 
 
 class NestSensorDevice(Entity):

--- a/homeassistant/components/nest/__init__.py
+++ b/homeassistant/components/nest/__init__.py
@@ -124,7 +124,8 @@ async def async_setup_entry(hass, entry):
     _LOGGER.debug("proceeding with setup")
     conf = hass.data.get(DATA_NEST_CONFIG, {})
     hass.data[DATA_NEST] = NestDevice(hass, conf, nest)
-    await hass.async_add_job(hass.data[DATA_NEST].initialize)
+    if not await hass.async_add_job(hass.data[DATA_NEST].initialize):
+        return False
 
     for component in 'climate', 'camera', 'sensor', 'binary_sensor':
         hass.async_add_job(hass.config_entries.async_forward_entry_setup(
@@ -205,7 +206,8 @@ class NestDevice(object):
         except (AuthorizationError, APIError, socket.error) as err:
             _LOGGER.error(
                 "Connection error while access Nest web service: %s", err)
-            raise err
+            return False
+        return True
 
     def structures(self):
         """Generate a list of structures."""

--- a/homeassistant/components/nest/__init__.py
+++ b/homeassistant/components/nest/__init__.py
@@ -205,6 +205,7 @@ class NestDevice(object):
         except (AuthorizationError, APIError, socket.error) as err:
             _LOGGER.error(
                 "Connection error while access Nest web service: %s", err)
+            raise err
 
     def structures(self):
         """Generate a list of structures."""

--- a/homeassistant/components/nest/__init__.py
+++ b/homeassistant/components/nest/__init__.py
@@ -249,8 +249,8 @@ class NestDevice(object):
                         # it is here for verify Nest API permission.
                         device.name_long
                     except KeyError:
-                        _LOGGER.warning("Cannot retrieve device name for %s,"
-                                        "please check your Nest developer "
+                        _LOGGER.warning("Cannot retrieve device name for [%s]"
+                                        ", please check your Nest developer "
                                         "account permission settings.",
                                         device.serial)
                         continue

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -164,8 +164,7 @@ async def _async_setup_component(hass: core.HomeAssistant,
         return False
 
     for entry in hass.config_entries.async_entries(domain):
-        if not await entry.async_setup(hass, component=component):
-            async_notify_setup_error(hass, entry.domain, True)
+        await entry.async_setup(hass, component=component)
 
     hass.config.components.add(component.DOMAIN)  # type: ignore
 

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -164,7 +164,8 @@ async def _async_setup_component(hass: core.HomeAssistant,
         return False
 
     for entry in hass.config_entries.async_entries(domain):
-        await entry.async_setup(hass, component=component)
+        if not await entry.async_setup(hass, component=component):
+            async_notify_setup_error(hass, entry.domain, True)
 
     hass.config.components.add(component.DOMAIN)  # type: ignore
 


### PR DESCRIPTION
## Description:
Nest component setup will crash if the client_id lack permission for specific APIs. For example, if user didn't select `Smoke+CO Alarm read` permission, not only Nest Protect, but all Nest sensors will failed to setup.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

