### PR TITLE
device_tracker: save and restore consider_home attribute

### DIFF
--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -465,6 +465,7 @@ class Device(Entity):
     def state_attributes(self):
         """Return the device state attributes."""
         attr = {
+            ATTR_CONSIDER_HOME: self.consider_home.total_seconds(),
             ATTR_SOURCE_TYPE: self.source_type
         }
 
@@ -563,6 +564,13 @@ class Device(Entity):
         if not state:
             return
         self._state = state.state
+
+        if self._state == STATE_HOME:
+            self.last_seen = state.last_updated
+            self.last_update_home = True
+            seconds = state.attributes.get(ATTR_CONSIDER_HOME)
+            if seconds:
+                self.consider_home = timedelta(seconds=seconds)
 
         for attr, var in (
                 (ATTR_SOURCE_TYPE, 'source_type'),


### PR DESCRIPTION
When using the device tracker 'see' API without explicit 'not_home'
events, HA used to show all previously seen devices as 'home' after
restarts, because the consider_home attribute got lost.

When no consider_home attribute has been saved for an entity before,
apply the global default value in order to mark previously seen one-
time visitors as away.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`.