### PR TITLE
Adhere to scan_interval in platforms when setup via config entry

### DIFF
--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -108,7 +108,8 @@ class EntityComponent(object):
             raise ValueError('Config entry has already been setup!')
 
         self._platforms[key] = self._async_init_entity_platform(
-            platform_type, platform
+            platform_type, platform,
+            scan_interval=getattr(platform, 'SCAN_INTERVAL', None),
         )
 
         return await self._platforms[key].async_setup_entry(config_entry)

--- a/tests/common.py
+++ b/tests/common.py
@@ -373,12 +373,15 @@ class MockPlatform(object):
     # pylint: disable=invalid-name
     def __init__(self, setup_platform=None, dependencies=None,
                  platform_schema=None, async_setup_platform=None,
-                 async_setup_entry=None):
+                 async_setup_entry=None, scan_interval=None):
         """Initialize the platform."""
         self.DEPENDENCIES = dependencies or []
 
         if platform_schema is not None:
             self.PLATFORM_SCHEMA = platform_schema
+
+        if scan_interval is not None:
+            self.SCAN_INTERVAL = scan_interval
 
         if setup_platform is not None:
             # We run this in executor, wrap it in function

--- a/tests/helpers/test_entity_component.py
+++ b/tests/helpers/test_entity_component.py
@@ -346,7 +346,8 @@ async def test_setup_entry(hass):
     mock_setup_entry = Mock(return_value=mock_coro(True))
     loader.set_component(
         hass, 'test_domain.entry_domain',
-        MockPlatform(async_setup_entry=mock_setup_entry))
+        MockPlatform(async_setup_entry=mock_setup_entry,
+                     scan_interval=timedelta(seconds=5)))
 
     component = EntityComponent(_LOGGER, DOMAIN, hass)
     entry = MockConfigEntry(domain='entry_domain')
@@ -356,6 +357,9 @@ async def test_setup_entry(hass):
     p_hass, p_entry, p_add_entities = mock_setup_entry.mock_calls[0][1]
     assert p_hass is hass
     assert p_entry is entry
+
+    assert component._platforms[entry.entry_id].scan_interval == \
+        timedelta(seconds=5)
 
 
 async def test_setup_entry_platform_not_exist(hass):


### PR DESCRIPTION
## Description:
Fix honoring a platform specified config interval when setting up the platform via a config entry.

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/13144#issuecomment-397432316

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
