### PR TITLE
Show notification when user configures Nest client_id/secret

### DIFF
--- a/homeassistant/components/hue/__init__.py
+++ b/homeassistant/components/hue/__init__.py
@@ -9,6 +9,7 @@ import logging
 
 import voluptuous as vol
 
+from homeassistant import data_entry_flow
 from homeassistant.const import CONF_FILENAME, CONF_HOST
 from homeassistant.helpers import aiohttp_client, config_validation as cv
 
@@ -107,7 +108,7 @@ async def async_setup(hass, config):
         # deadlock: creating a config entry will set up the component but the
         # setup would block till the entry is created!
         hass.async_add_job(hass.config_entries.flow.async_init(
-            DOMAIN, source='import', data={
+            DOMAIN, source=data_entry_flow.SOURCE_IMPORT, data={
                 'host': bridge_conf[CONF_HOST],
                 'path': bridge_conf[CONF_FILENAME],
             }

--- a/homeassistant/components/nest/__init__.py
+++ b/homeassistant/components/nest/__init__.py
@@ -6,7 +6,6 @@ https://home-assistant.io/components/nest/
 """
 from concurrent.futures import ThreadPoolExecutor
 import logging
-import os.path
 import socket
 from datetime import datetime, timedelta
 

--- a/homeassistant/components/nest/__init__.py
+++ b/homeassistant/components/nest/__init__.py
@@ -102,12 +102,11 @@ async def async_setup(hass, config):
     filename = config.get(CONF_FILENAME, NEST_CONFIG_FILE)
     access_token_cache_file = hass.config.path(filename)
 
-    if await hass.async_add_job(os.path.isfile, access_token_cache_file):
-        hass.async_add_job(hass.config_entries.flow.async_init(
-            DOMAIN, source='import', data={
-                'nest_conf_path': access_token_cache_file,
-            }
-        ))
+    hass.async_add_job(hass.config_entries.flow.async_init(
+        DOMAIN, source='import', data={
+            'nest_conf_path': access_token_cache_file,
+        }
+    ))
 
     # Store config to be used during entry setup
     hass.data[DATA_NEST_CONFIG] = conf

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -146,7 +146,10 @@ ENTRY_STATE_NOT_LOADED = 'not_loaded'
 ENTRY_STATE_FAILED_UNLOAD = 'failed_unload'
 
 DISCOVERY_NOTIFICATION_ID = 'config_entry_discovery'
-DISCOVERY_SOURCES = (data_entry_flow.SOURCE_DISCOVERY,)
+DISCOVERY_SOURCES = (
+    data_entry_flow.SOURCE_DISCOVERY,
+    data_entry_flow.SOURCE_IMPORT,
+)
 
 
 class ConfigEntry:

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -9,6 +9,7 @@ _LOGGER = logging.getLogger(__name__)
 
 SOURCE_USER = 'user'
 SOURCE_DISCOVERY = 'discovery'
+SOURCE_IMPORT = 'import'
 
 RESULT_TYPE_FORM = 'form'
 RESULT_TYPE_CREATE_ENTRY = 'create_entry'


### PR DESCRIPTION
## Description:

@awarecan noticed me in the dev chat that with the switch to config entries, we lost the notification that would ask users to configure their Nest from the frontend.

This PR adds that notification back by leveraging the built-in notification from a discovered config entry.

Implementing this feature made me realize I didn't add tests for the import step, so adding those missing tests too.

## Example entry for `configuration.yaml` (if applicable):
```yaml
nest:
  client_id: bla
  client_secret: bla
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
