### PR TITLE
Return ISO formated datetime in forecast

### DIFF
--- a/homeassistant/components/weather/ecobee.py
+++ b/homeassistant/components/weather/ecobee.py
@@ -135,8 +135,10 @@ class EcobeeWeather(WeatherEntity):
         try:
             forecasts = []
             for day in self.weather['forecasts']:
+                date_time = datetime.strptime(day['dateTime'],
+                                              '%Y-%m-%d %H:%M:%S').isoformat()
                 forecast = {
-                    ATTR_FORECAST_TIME: datetime.strptime(day['dateTime'], '%Y-%m-%d %H:%M:%S').isoformat(),
+                    ATTR_FORECAST_TIME: date_time,
                     ATTR_FORECAST_CONDITION: day['condition'],
                     ATTR_FORECAST_TEMP: float(day['tempHigh']) / 10,
                 }

--- a/homeassistant/components/weather/ecobee.py
+++ b/homeassistant/components/weather/ecobee.py
@@ -4,6 +4,7 @@ Support for displaying weather info from Ecobee API.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/weather.ecobee/
 """
+from datetime import datetime
 from homeassistant.components import ecobee
 from homeassistant.components.weather import (
     WeatherEntity, ATTR_FORECAST_CONDITION, ATTR_FORECAST_TEMP,
@@ -135,7 +136,7 @@ class EcobeeWeather(WeatherEntity):
             forecasts = []
             for day in self.weather['forecasts']:
                 forecast = {
-                    ATTR_FORECAST_TIME: day['dateTime'],
+                    ATTR_FORECAST_TIME: datetime.strptime(day['dateTime'], '%Y-%m-%d %H:%M:%S').isoformat(),
                     ATTR_FORECAST_CONDITION: day['condition'],
                     ATTR_FORECAST_TEMP: float(day['tempHigh']) / 10,
                 }


### PR DESCRIPTION
## Description:

changes `2018-06-15 14:04:33` to `2018-06-15T14:04:33`

**Related issue (if applicable):** fixes #14509

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
