### PR TITLE
Remove inline pylint disables for messages disabled in pylintrc

### DIFF
--- a/homeassistant/components/axis.py
+++ b/homeassistant/components/axis.py
@@ -145,7 +145,7 @@ def request_configuration(hass, config, name, host, serialnumber):
 
 def setup(hass, config):
     """Set up for Axis devices."""
-    def _shutdown(call):  # pylint: disable=unused-argument
+    def _shutdown(call):
         """Stop the event stream on shutdown."""
         for serialnumber, device in AXIS_DEVICES.items():
             _LOGGER.info("Stopping event stream for %s.", serialnumber)

--- a/homeassistant/components/binary_sensor/command_line.py
+++ b/homeassistant/components/binary_sensor/command_line.py
@@ -35,7 +35,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Command line Binary Sensor."""
     name = config.get(CONF_NAME)

--- a/homeassistant/components/binary_sensor/gc100.py
+++ b/homeassistant/components/binary_sensor/gc100.py
@@ -23,7 +23,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the GC100 devices."""
     binary_sensors = []

--- a/homeassistant/components/binary_sensor/isy994.py
+++ b/homeassistant/components/binary_sensor/isy994.py
@@ -28,7 +28,6 @@ ISY_DEVICE_TYPES = {
 }
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config: ConfigType,
                    add_devices: Callable[[list], None], discovery_info=None):
     """Set up the ISY994 binary sensor platform."""
@@ -299,7 +298,6 @@ class ISYBinarySensorHeartbeat(ISYDevice, BinarySensorDevice):
             # No heartbeat timer is active
             pass
 
-        # pylint: disable=unused-argument
         @callback
         def timer_elapsed(now) -> None:
             """Heartbeat missed; set state to indicate dead battery."""
@@ -314,7 +312,6 @@ class ISYBinarySensorHeartbeat(ISYDevice, BinarySensorDevice):
         self._heartbeat_timer = async_track_point_in_utc_time(
             self.hass, timer_elapsed, point_in_time)
 
-    # pylint: disable=unused-argument
     def on_update(self, event: object) -> None:
         """Ignore node status updates.
 

--- a/homeassistant/components/binary_sensor/knx.py
+++ b/homeassistant/components/binary_sensor/knx.py
@@ -115,7 +115,6 @@ class KNXBinarySensor(BinarySensorDevice):
         """Register callbacks to update hass after device was changed."""
         async def after_update_callback(device):
             """Call after device was updated."""
-            # pylint: disable=unused-argument
             await self.async_update_ha_state()
         self.device.register_device_updated_cb(after_update_callback)
 

--- a/homeassistant/components/binary_sensor/netatmo.py
+++ b/homeassistant/components/binary_sensor/netatmo.py
@@ -57,7 +57,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the access to Netatmo binary sensor."""
     netatmo = hass.components.netatmo

--- a/homeassistant/components/binary_sensor/octoprint.py
+++ b/homeassistant/components/binary_sensor/octoprint.py
@@ -33,7 +33,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the available OctoPrint binary sensors."""
     octoprint_api = hass.data[DOMAIN]["api"]

--- a/homeassistant/components/binary_sensor/pilight.py
+++ b/homeassistant/components/binary_sensor/pilight.py
@@ -44,7 +44,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up Pilight Binary Sensor."""
     disarm = config.get(CONF_DISARM_AFTER_TRIGGER)

--- a/homeassistant/components/binary_sensor/raspihats.py
+++ b/homeassistant/components/binary_sensor/raspihats.py
@@ -42,7 +42,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the raspihats binary_sensor devices."""
     I2CHatBinarySensor.I2C_HATS_MANAGER = hass.data[I2C_HATS_MANAGER]

--- a/homeassistant/components/binary_sensor/rpi_gpio.py
+++ b/homeassistant/components/binary_sensor/rpi_gpio.py
@@ -39,7 +39,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Raspberry PI GPIO devices."""
     pull_mode = config.get(CONF_PULL_MODE)

--- a/homeassistant/components/binary_sensor/trend.py
+++ b/homeassistant/components/binary_sensor/trend.py
@@ -57,7 +57,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the trend sensors."""
     sensors = []

--- a/homeassistant/components/binary_sensor/wemo.py
+++ b/homeassistant/components/binary_sensor/wemo.py
@@ -13,7 +13,7 @@ DEPENDENCIES = ['wemo']
 _LOGGER = logging.getLogger(__name__)
 
 
-# pylint: disable=unused-argument, too-many-function-args
+# pylint: disable=too-many-function-args
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     """Register discovered WeMo binary sensors."""
     import pywemo.discovery as discovery

--- a/homeassistant/components/bloomsky.py
+++ b/homeassistant/components/bloomsky.py
@@ -34,7 +34,6 @@ CONFIG_SCHEMA = vol.Schema({
 }, extra=vol.ALLOW_EXTRA)
 
 
-# pylint: disable=unused-argument
 def setup(hass, config):
     """Set up the BloomSky component."""
     api_key = config[DOMAIN][CONF_API_KEY]

--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -60,7 +60,6 @@ def get_date(date):
     return dt.as_local(dt.parse_datetime(date['dateTime']))
 
 
-# pylint: disable=too-many-instance-attributes
 class CalendarEventDevice(Entity):
     """A calendar event device."""
 
@@ -68,7 +67,6 @@ class CalendarEventDevice(Entity):
     # with an update() method
     data = None
 
-    # pylint: disable=too-many-arguments
     def __init__(self, hass, data):
         """Create the Calendar Event Device."""
         self._name = data.get(CONF_NAME)

--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -1,4 +1,3 @@
-# pylint: disable=too-many-lines
 """
 Component to interface with cameras.
 

--- a/homeassistant/components/camera/bloomsky.py
+++ b/homeassistant/components/camera/bloomsky.py
@@ -13,7 +13,6 @@ from homeassistant.components.camera import Camera
 DEPENDENCIES = ['bloomsky']
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up access to BloomSky cameras."""
     bloomsky = hass.components.bloomsky

--- a/homeassistant/components/camera/foscam.py
+++ b/homeassistant/components/camera/foscam.py
@@ -33,7 +33,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up a Foscam IP Camera."""
     add_devices([FoscamCam(config)])

--- a/homeassistant/components/camera/generic.py
+++ b/homeassistant/components/camera/generic.py
@@ -46,7 +46,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 
 @asyncio.coroutine
-# pylint: disable=unused-argument
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up a generic IP Camera."""
     async_add_devices([GenericCamera(hass, config)])

--- a/homeassistant/components/camera/mjpeg.py
+++ b/homeassistant/components/camera/mjpeg.py
@@ -42,7 +42,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 
 @asyncio.coroutine
-# pylint: disable=unused-argument
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up a MJPEG IP Camera."""
     if discovery_info:

--- a/homeassistant/components/camera/netatmo.py
+++ b/homeassistant/components/camera/netatmo.py
@@ -29,7 +29,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up access to Netatmo cameras."""
     netatmo = hass.components.netatmo

--- a/homeassistant/components/camera/zoneminder.py
+++ b/homeassistant/components/camera/zoneminder.py
@@ -49,7 +49,6 @@ def _get_image_url(hass, monitor, mode):
 
 
 @asyncio.coroutine
-# pylint: disable=unused-argument
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up the ZoneMinder cameras."""
     cameras = []

--- a/homeassistant/components/climate/knx.py
+++ b/homeassistant/components/climate/knx.py
@@ -136,7 +136,6 @@ class KNXClimate(ClimateDevice):
         """Register callbacks to update hass after device was changed."""
         async def after_update_callback(device):
             """Call after device was updated."""
-            # pylint: disable=unused-argument
             await self.async_update_ha_state()
         self.device.register_device_updated_cb(after_update_callback)
 

--- a/homeassistant/components/climate/wink.py
+++ b/homeassistant/components/climate/wink.py
@@ -84,7 +84,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             add_devices([WinkWaterHeater(water_heater, hass)])
 
 
-# pylint: disable=abstract-method
 class WinkThermostat(WinkDevice, ClimateDevice):
     """Representation of a Wink thermostat."""
 

--- a/homeassistant/components/cover/isy994.py
+++ b/homeassistant/components/cover/isy994.py
@@ -25,7 +25,6 @@ VALUE_TO_STATE = {
 }
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config: ConfigType,
                    add_devices: Callable[[list], None], discovery_info=None):
     """Set up the ISY994 cover platform."""

--- a/homeassistant/components/cover/knx.py
+++ b/homeassistant/components/cover/knx.py
@@ -107,7 +107,6 @@ class KNXCover(CoverDevice):
         """Register callbacks to update hass after device was changed."""
         async def after_update_callback(device):
             """Call after device was updated."""
-            # pylint: disable=unused-argument
             await self.async_update_ha_state()
         self.device.register_device_updated_cb(after_update_callback)
 
@@ -197,7 +196,6 @@ class KNXCover(CoverDevice):
     @callback
     def auto_updater_hook(self, now):
         """Call for the autoupdater."""
-        # pylint: disable=unused-argument
         self.async_schedule_update_ha_state()
         if self.device.position_reached():
             self.stop_auto_updater()

--- a/homeassistant/components/cover/lutron.py
+++ b/homeassistant/components/cover/lutron.py
@@ -17,7 +17,6 @@ _LOGGER = logging.getLogger(__name__)
 DEPENDENCIES = ['lutron']
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Lutron shades."""
     devs = []

--- a/homeassistant/components/cover/lutron_caseta.py
+++ b/homeassistant/components/cover/lutron_caseta.py
@@ -18,7 +18,6 @@ _LOGGER = logging.getLogger(__name__)
 DEPENDENCIES = ['lutron_caseta']
 
 
-# pylint: disable=unused-argument
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up the Lutron Caseta shades as a cover device."""

--- a/homeassistant/components/cover/rpi_gpio.py
+++ b/homeassistant/components/cover/rpi_gpio.py
@@ -54,7 +54,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the RPi cover platform."""
     relay_time = config.get(CONF_RELAY_TIME)

--- a/homeassistant/components/device_tracker/actiontec.py
+++ b/homeassistant/components/device_tracker/actiontec.py
@@ -31,7 +31,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def get_scanner(hass, config):
     """Validate the configuration and return an Actiontec scanner."""
     scanner = ActiontecDeviceScanner(config[DOMAIN])

--- a/homeassistant/components/device_tracker/aruba.py
+++ b/homeassistant/components/device_tracker/aruba.py
@@ -30,7 +30,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def get_scanner(hass, config):
     """Validate the configuration and return a Aruba scanner."""
     scanner = ArubaDeviceScanner(config[DOMAIN])

--- a/homeassistant/components/device_tracker/asuswrt.py
+++ b/homeassistant/components/device_tracker/asuswrt.py
@@ -78,7 +78,6 @@ _ARP_REGEX = re.compile(
     r'.*')
 
 
-# pylint: disable=unused-argument
 def get_scanner(hass, config):
     """Validate the configuration and return an ASUS-WRT scanner."""
     scanner = AsusWrtDeviceScanner(config[DOMAIN])

--- a/homeassistant/components/device_tracker/bt_home_hub_5.py
+++ b/homeassistant/components/device_tracker/bt_home_hub_5.py
@@ -26,7 +26,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def get_scanner(hass, config):
     """Return a BT Home Hub 5 scanner if successful."""
     scanner = BTHomeHub5DeviceScanner(config[DOMAIN])

--- a/homeassistant/components/device_tracker/ddwrt.py
+++ b/homeassistant/components/device_tracker/ddwrt.py
@@ -27,7 +27,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def get_scanner(hass, config):
     """Validate the configuration and return a DD-WRT scanner."""
     try:

--- a/homeassistant/components/device_tracker/huawei_router.py
+++ b/homeassistant/components/device_tracker/huawei_router.py
@@ -26,7 +26,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def get_scanner(hass, config):
     """Validate the configuration and return a HUAWEI scanner."""
     scanner = HuaweiDeviceScanner(config[DOMAIN])

--- a/homeassistant/components/device_tracker/sky_hub.py
+++ b/homeassistant/components/device_tracker/sky_hub.py
@@ -23,7 +23,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def get_scanner(hass, config):
     """Return a Sky Hub scanner if successful."""
     scanner = SkyHubDeviceScanner(config[DOMAIN])

--- a/homeassistant/components/device_tracker/snmp.py
+++ b/homeassistant/components/device_tracker/snmp.py
@@ -34,7 +34,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def get_scanner(hass, config):
     """Validate the configuration and return an SNMP scanner."""
     scanner = SnmpScanner(config[DOMAIN])

--- a/homeassistant/components/device_tracker/thomson.py
+++ b/homeassistant/components/device_tracker/thomson.py
@@ -33,7 +33,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def get_scanner(hass, config):
     """Validate the configuration and return a THOMSON scanner."""
     scanner = ThomsonDeviceScanner(config[DOMAIN])

--- a/homeassistant/components/device_tracker/unifi_direct.py
+++ b/homeassistant/components/device_tracker/unifi_direct.py
@@ -33,7 +33,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def get_scanner(hass, config):
     """Validate the configuration and return a Unifi direct scanner."""
     scanner = UnifiDeviceScanner(config[DOMAIN])

--- a/homeassistant/components/ecobee.py
+++ b/homeassistant/components/ecobee.py
@@ -48,7 +48,6 @@ def request_configuration(network, hass, config):
 
         return
 
-    # pylint: disable=unused-argument
     def ecobee_configuration_callback(callback_data):
         """Handle configuration callbacks."""
         network.request_tokens()
@@ -106,7 +105,7 @@ def setup(hass, config):
     Will automatically load thermostat and sensor components to support
     devices discovered on the network.
     """
-    # pylint: disable=global-statement, import-error
+    # pylint: disable=import-error
     global NETWORK
 
     if 'ecobee' in _CONFIGURING:

--- a/homeassistant/components/fan/demo.py
+++ b/homeassistant/components/fan/demo.py
@@ -13,7 +13,6 @@ FULL_SUPPORT = SUPPORT_SET_SPEED | SUPPORT_OSCILLATE | SUPPORT_DIRECTION
 LIMITED_SUPPORT = SUPPORT_SET_SPEED
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     """Set up the demo fan platform."""
     add_devices_callback([

--- a/homeassistant/components/fan/isy994.py
+++ b/homeassistant/components/fan/isy994.py
@@ -30,7 +30,6 @@ for key in VALUE_TO_STATE:
     STATE_TO_VALUE[VALUE_TO_STATE[key]] = key
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config: ConfigType,
                    add_devices: Callable[[list], None], discovery_info=None):
     """Set up the ISY994 fan platform."""

--- a/homeassistant/components/fan/xiaomi_miio.py
+++ b/homeassistant/components/fan/xiaomi_miio.py
@@ -314,7 +314,6 @@ SERVICE_TO_METHOD = {
 }
 
 
-# pylint: disable=unused-argument
 async def async_setup_platform(hass, config, async_add_devices,
                                discovery_info=None):
     """Set up the miio fan device from config."""

--- a/homeassistant/components/ios.py
+++ b/homeassistant/components/ios.py
@@ -203,7 +203,7 @@ def device_name_for_push_id(push_id):
 
 def setup(hass, config):
     """Set up the iOS component."""
-    # pylint: disable=global-statement, import-error
+    # pylint: disable=import-error
     global CONFIG_FILE
     global CONFIG_FILE_PATH
 

--- a/homeassistant/components/isy994.py
+++ b/homeassistant/components/isy994.py
@@ -425,7 +425,6 @@ class ISYDevice(Entity):
             self._control_handler = self._node.controlEvents.subscribe(
                 self.on_control)
 
-    # pylint: disable=unused-argument
     def on_update(self, event: object) -> None:
         """Handle the update event from the ISY994 Node."""
         self.schedule_update_ha_state()

--- a/homeassistant/components/light/blinksticklight.py
+++ b/homeassistant/components/light/blinksticklight.py
@@ -31,7 +31,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up Blinkstick device specified by serial number."""
     from blinkstick import blinkstick

--- a/homeassistant/components/light/isy994.py
+++ b/homeassistant/components/light/isy994.py
@@ -15,7 +15,6 @@ from homeassistant.helpers.typing import ConfigType
 _LOGGER = logging.getLogger(__name__)
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config: ConfigType,
                    add_devices: Callable[[list], None], discovery_info=None):
     """Set up the ISY994 light platform."""

--- a/homeassistant/components/light/knx.py
+++ b/homeassistant/components/light/knx.py
@@ -88,7 +88,6 @@ class KNXLight(Light):
         """Register callbacks to update hass after device was changed."""
         async def after_update_callback(device):
             """Call after device was updated."""
-            # pylint: disable=unused-argument
             await self.async_update_ha_state()
         self.device.register_device_updated_cb(after_update_callback)
 

--- a/homeassistant/components/light/lifx_legacy.py
+++ b/homeassistant/components/light/lifx_legacy.py
@@ -45,7 +45,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the LIFX platform."""
     server_addr = config.get(CONF_SERVER)
@@ -118,7 +117,6 @@ class LIFX(object):
             bulb.set_power(power)
             bulb.schedule_update_ha_state()
 
-    # pylint: disable=unused-argument
     def poll(self, now):
         """Set up polling for the light."""
         self.probe()

--- a/homeassistant/components/light/lutron.py
+++ b/homeassistant/components/light/lutron.py
@@ -16,7 +16,6 @@ _LOGGER = logging.getLogger(__name__)
 DEPENDENCIES = ['lutron']
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Lutron lights."""
     devs = []

--- a/homeassistant/components/light/lutron_caseta.py
+++ b/homeassistant/components/light/lutron_caseta.py
@@ -19,7 +19,6 @@ _LOGGER = logging.getLogger(__name__)
 DEPENDENCIES = ['lutron_caseta']
 
 
-# pylint: disable=unused-argument
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up the Lutron Caseta lights."""

--- a/homeassistant/components/light/tellstick.py
+++ b/homeassistant/components/light/tellstick.py
@@ -15,7 +15,6 @@ from homeassistant.components.tellstick import (
 SUPPORT_TELLSTICK = SUPPORT_BRIGHTNESS
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Tellstick lights."""
     if (discovery_info is None or

--- a/homeassistant/components/light/tikteck.py
+++ b/homeassistant/components/light/tikteck.py
@@ -31,7 +31,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Tikteck platform."""
     lights = []

--- a/homeassistant/components/light/vera.py
+++ b/homeassistant/components/light/vera.py
@@ -18,7 +18,6 @@ _LOGGER = logging.getLogger(__name__)
 DEPENDENCIES = ['vera']
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Vera lights."""
     add_devices(

--- a/homeassistant/components/light/xiaomi_miio.py
+++ b/homeassistant/components/light/xiaomi_miio.py
@@ -100,7 +100,6 @@ SERVICE_TO_METHOD = {
 }
 
 
-# pylint: disable=unused-argument
 async def async_setup_platform(hass, config, async_add_devices,
                                discovery_info=None):
     """Set up the light from config."""

--- a/homeassistant/components/light/zengge.py
+++ b/homeassistant/components/light/zengge.py
@@ -30,7 +30,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Zengge platform."""
     lights = []

--- a/homeassistant/components/lock/demo.py
+++ b/homeassistant/components/lock/demo.py
@@ -8,7 +8,6 @@ from homeassistant.components.lock import LockDevice, SUPPORT_OPEN
 from homeassistant.const import (STATE_LOCKED, STATE_UNLOCKED)
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Demo lock platform."""
     add_devices([

--- a/homeassistant/components/lock/isy994.py
+++ b/homeassistant/components/lock/isy994.py
@@ -21,7 +21,6 @@ VALUE_TO_STATE = {
 }
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config: ConfigType,
                    add_devices: Callable[[list], None], discovery_info=None):
     """Set up the ISY994 lock platform."""

--- a/homeassistant/components/lock/lockitron.py
+++ b/homeassistant/components/lock/lockitron.py
@@ -26,7 +26,6 @@ API_STATE_URL = BASE_URL + '/v2/locks/{}?access_token={}'
 API_ACTION_URL = BASE_URL + '/v2/locks/{}?access_token={}&state={}'
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Lockitron platform."""
     access_token = config.get(CONF_ACCESS_TOKEN)

--- a/homeassistant/components/lock/nello.py
+++ b/homeassistant/components/lock/nello.py
@@ -27,7 +27,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Nello lock platform."""
     from pynello import Nello

--- a/homeassistant/components/lock/nuki.py
+++ b/homeassistant/components/lock/nuki.py
@@ -50,7 +50,6 @@ UNLATCH_SERVICE_SCHEMA = vol.Schema({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Nuki lock platform."""
     from pynuki import NukiBridge

--- a/homeassistant/components/lock/sesame.py
+++ b/homeassistant/components/lock/sesame.py
@@ -24,7 +24,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(
         hass, config: ConfigType,
         add_devices: Callable[[list], None], discovery_info=None):

--- a/homeassistant/components/lock/volvooncall.py
+++ b/homeassistant/components/lock/volvooncall.py
@@ -12,7 +12,6 @@ from homeassistant.components.volvooncall import VolvoEntity
 _LOGGER = logging.getLogger(__name__)
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Volvo On Call lock."""
     if discovery_info is None:

--- a/homeassistant/components/logbook.py
+++ b/homeassistant/components/logbook.py
@@ -372,7 +372,6 @@ def _exclude_events(events, config):
     return filtered_events
 
 
-# pylint: disable=too-many-return-statements
 def _entry_message_from_state(domain, state):
     """Convert a state to a message for the logbook."""
     # We pass domain in so we don't have to split entity_id again

--- a/homeassistant/components/media_player/aquostv.py
+++ b/homeassistant/components/media_player/aquostv.py
@@ -59,7 +59,6 @@ SOURCES = {0: 'TV / Antenna',
            8: 'PC_IN'}
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Sharp Aquos TV platform."""
     import sharp_aquos_rc
@@ -104,7 +103,6 @@ def _retry(func):
     return wrapper
 
 
-# pylint: disable=abstract-method
 class SharpAquosTVDevice(MediaPlayerDevice):
     """Representation of a Aquos TV."""
 

--- a/homeassistant/components/media_player/blackbird.py
+++ b/homeassistant/components/media_player/blackbird.py
@@ -61,7 +61,6 @@ PLATFORM_SCHEMA = vol.All(
     }))
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Monoprice Blackbird 4k 8x8 HDBaseT Matrix platform."""
     if DATA_BLACKBIRD not in hass.data:

--- a/homeassistant/components/media_player/braviatv.py
+++ b/homeassistant/components/media_player/braviatv.py
@@ -60,7 +60,6 @@ def _get_mac_address(ip_address):
     return None
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Sony Bravia TV platform."""
     host = config.get(CONF_HOST)

--- a/homeassistant/components/media_player/channels.py
+++ b/homeassistant/components/media_player/channels.py
@@ -105,7 +105,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class ChannelsPlayer(MediaPlayerDevice):
     """Representation of a Channels instance."""
 
-    # pylint: disable=too-many-public-methods
     def __init__(self, name, host, port):
         """Initialize the Channels app."""
         from pychannels import Channels

--- a/homeassistant/components/media_player/clementine.py
+++ b/homeassistant/components/media_player/clementine.py
@@ -43,7 +43,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Clementine platform."""
     from clementineremote import ClementineRemote

--- a/homeassistant/components/media_player/demo.py
+++ b/homeassistant/components/media_player/demo.py
@@ -14,7 +14,6 @@ from homeassistant.const import STATE_OFF, STATE_PAUSED, STATE_PLAYING
 import homeassistant.util.dt as dt_util
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the media player demo platform."""
     add_devices([

--- a/homeassistant/components/media_player/dunehd.py
+++ b/homeassistant/components/media_player/dunehd.py
@@ -32,7 +32,6 @@ DUNEHD_PLAYER_SUPPORT = \
     SUPPORT_PLAY
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the DuneHD media player platform."""
     from pdunehd import DuneHDPlayer

--- a/homeassistant/components/media_player/firetv.py
+++ b/homeassistant/components/media_player/firetv.py
@@ -43,7 +43,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the FireTV platform."""
     name = config.get(CONF_NAME)

--- a/homeassistant/components/media_player/frontier_silicon.py
+++ b/homeassistant/components/media_player/frontier_silicon.py
@@ -41,7 +41,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up the Frontier Silicon platform."""

--- a/homeassistant/components/media_player/gpmdp.py
+++ b/homeassistant/components/media_player/gpmdp.py
@@ -59,7 +59,6 @@ def request_configuration(hass, config, url, add_devices_callback):
                                'method': 'connect',
                                'arguments': ['Home Assistant']}))
 
-    # pylint: disable=unused-argument
     def gpmdp_configuration_callback(callback_data):
         """Handle configuration changes."""
         while True:

--- a/homeassistant/components/media_player/gstreamer.py
+++ b/homeassistant/components/media_player/gstreamer.py
@@ -34,7 +34,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Gstreamer platform."""
     from gsp import GstreamerPlayer

--- a/homeassistant/components/media_player/lg_netcast.py
+++ b/homeassistant/components/media_player/lg_netcast.py
@@ -43,7 +43,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the LG TV platform."""
     from pylgnetcast import LgNetCastClient

--- a/homeassistant/components/media_player/monoprice.py
+++ b/homeassistant/components/media_player/monoprice.py
@@ -55,7 +55,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Monoprice 6-zone amplifier platform."""
     port = config.get(CONF_PORT)

--- a/homeassistant/components/media_player/mpchc.py
+++ b/homeassistant/components/media_player/mpchc.py
@@ -35,7 +35,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the MPC-HC platform."""
     name = config.get(CONF_NAME)

--- a/homeassistant/components/media_player/mpd.py
+++ b/homeassistant/components/media_player/mpd.py
@@ -46,7 +46,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the MPD platform."""
     host = config.get(CONF_HOST)

--- a/homeassistant/components/media_player/openhome.py
+++ b/homeassistant/components/media_player/openhome.py
@@ -25,7 +25,6 @@ _LOGGER = logging.getLogger(__name__)
 DEVICES = []
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Openhome platform."""
     from openhomedevice.Device import Device

--- a/homeassistant/components/media_player/panasonic_viera.py
+++ b/homeassistant/components/media_player/panasonic_viera.py
@@ -42,7 +42,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Panasonic Viera TV platform."""
     from panasonic_viera import RemoteControl

--- a/homeassistant/components/media_player/pandora.py
+++ b/homeassistant/components/media_player/pandora.py
@@ -43,7 +43,6 @@ CURRENT_SONG_PATTERN = re.compile(r'"(.*?)"\s+by\s+"(.*?)"\son\s+"(.*?)"',
 STATION_PATTERN = re.compile(r'Station\s"(.+?)"', re.MULTILINE)
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Pandora media player platform."""
     if not _pianobar_exists():

--- a/homeassistant/components/media_player/philips_js.py
+++ b/homeassistant/components/media_player/philips_js.py
@@ -48,7 +48,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Philips TV platform."""
     import haphilipsjs

--- a/homeassistant/components/media_player/samsungtv.py
+++ b/homeassistant/components/media_player/samsungtv.py
@@ -47,7 +47,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Samsung TV platform."""
     known_devices = hass.data.get(KNOWN_DEVICES_KEY)

--- a/homeassistant/components/media_player/snapcast.py
+++ b/homeassistant/components/media_player/snapcast.py
@@ -46,7 +46,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up the Snapcast platform."""

--- a/homeassistant/components/media_player/vlc.py
+++ b/homeassistant/components/media_player/vlc.py
@@ -34,7 +34,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the vlc platform."""
     add_devices([VlcDevice(config.get(CONF_NAME, DEFAULT_NAME),

--- a/homeassistant/components/media_player/webostv.py
+++ b/homeassistant/components/media_player/webostv.py
@@ -61,7 +61,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the LG WebOS TV platform."""
     if discovery_info is not None:
@@ -139,7 +138,6 @@ def request_configuration(
             _CONFIGURING[host], 'Failed to pair, please try again.')
         return
 
-    # pylint: disable=unused-argument
     def lgtv_configuration_callback(data):
         """Handle actions when configuration callback is called."""
         setup_tv(host, name, customize, config, timeout, hass,

--- a/homeassistant/components/modbus.py
+++ b/homeassistant/components/modbus.py
@@ -75,11 +75,11 @@ HUB = None
 def setup(hass, config):
     """Set up Modbus component."""
     # Modbus connection type
-    # pylint: disable=global-statement, import-error
+    # pylint: disable=import-error
     client_type = config[DOMAIN][CONF_TYPE]
 
     # Connect to Modbus network
-    # pylint: disable=global-statement, import-error
+    # pylint: disable=import-error
 
     if client_type == 'serial':
         from pymodbus.client.sync import ModbusSerialClient as ModbusClient

--- a/homeassistant/components/notify/message_bird.py
+++ b/homeassistant/components/notify/message_bird.py
@@ -24,7 +24,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def get_service(hass, config, discovery_info=None):
     """Get the MessageBird notification service."""
     import messagebird

--- a/homeassistant/components/notify/mysensors.py
+++ b/homeassistant/components/notify/mysensors.py
@@ -36,8 +36,6 @@ class MySensorsNotificationDevice(mysensors.MySensorsDevice):
 class MySensorsNotificationService(BaseNotificationService):
     """Implement a MySensors notification service."""
 
-    # pylint: disable=too-few-public-methods
-
     def __init__(self, hass):
         """Initialize the service."""
         self.devices = mysensors.get_mysensors_devices(hass, DOMAIN)

--- a/homeassistant/components/notify/nfandroidtv.py
+++ b/homeassistant/components/notify/nfandroidtv.py
@@ -86,7 +86,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def get_service(hass, config, discovery_info=None):
     """Get the Notifications for Android TV notification service."""
     remoteip = config.get(CONF_IP)

--- a/homeassistant/components/notify/pushbullet.py
+++ b/homeassistant/components/notify/pushbullet.py
@@ -29,7 +29,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def get_service(hass, config, discovery_info=None):
     """Get the Pushbullet notification service."""
     from pushbullet import PushBullet

--- a/homeassistant/components/nuimo_controller.py
+++ b/homeassistant/components/nuimo_controller.py
@@ -97,7 +97,6 @@ class NuimoThread(threading.Thread):
             self._nuimo.disconnect()
             self._nuimo = None
 
-    # pylint: disable=unused-argument
     def stop(self, event):
         """Terminate Thread by unsetting flag."""
         _LOGGER.debug('Stopping thread for Nuimo %s', self._mac)

--- a/homeassistant/components/raspihats.py
+++ b/homeassistant/components/raspihats.py
@@ -34,7 +34,6 @@ I2C_HAT_NAMES = [
 I2C_HATS_MANAGER = 'I2CH_MNG'
 
 
-# pylint: disable=unused-argument
 def setup(hass, config):
     """Set up the raspihats component."""
     hass.data[I2C_HATS_MANAGER] = I2CHatsManager()

--- a/homeassistant/components/remote/demo.py
+++ b/homeassistant/components/remote/demo.py
@@ -8,7 +8,6 @@ from homeassistant.components.remote import RemoteDevice
 from homeassistant.const import DEVICE_DEFAULT_NAME
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     """Set up the demo remotes."""
     add_devices_callback([

--- a/homeassistant/components/remote/itach.py
+++ b/homeassistant/components/remote/itach.py
@@ -44,7 +44,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the ITach connection and devices."""
     import pyitachip2ir

--- a/homeassistant/components/scene/lifx_cloud.py
+++ b/homeassistant/components/scene/lifx_cloud.py
@@ -29,7 +29,6 @@ PLATFORM_SCHEMA = vol.Schema({
 })
 
 
-# pylint: disable=unused-argument
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up the scenes stored in the LIFX Cloud."""

--- a/homeassistant/components/sensor/bloomsky.py
+++ b/homeassistant/components/sensor/bloomsky.py
@@ -41,7 +41,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the available BloomSky weather sensors."""
     bloomsky = hass.components.bloomsky

--- a/homeassistant/components/sensor/broadlink.py
+++ b/homeassistant/components/sensor/broadlink.py
@@ -47,7 +47,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Broadlink device sensors."""
     host = config.get(CONF_HOST)

--- a/homeassistant/components/sensor/citybikes.py
+++ b/homeassistant/components/sensor/citybikes.py
@@ -125,7 +125,6 @@ def async_citybikes_request(hass, uri, schema):
     raise CityBikesRequestError
 
 
-# pylint: disable=unused-argument
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices,
                          discovery_info=None):

--- a/homeassistant/components/sensor/command_line.py
+++ b/homeassistant/components/sensor/command_line.py
@@ -35,7 +35,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Command Sensor."""
     name = config.get(CONF_NAME)

--- a/homeassistant/components/sensor/crimereports.py
+++ b/homeassistant/components/sensor/crimereports.py
@@ -41,7 +41,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Crime Reports platform."""
     latitude = config.get(CONF_LATITUDE, hass.config.latitude)

--- a/homeassistant/components/sensor/deluge.py
+++ b/homeassistant/components/sensor/deluge.py
@@ -42,7 +42,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Deluge sensors."""
     from deluge_client import DelugeRPCClient

--- a/homeassistant/components/sensor/demo.py
+++ b/homeassistant/components/sensor/demo.py
@@ -10,7 +10,6 @@ from homeassistant.const import (
 from homeassistant.helpers.entity import Entity
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Demo sensors."""
     add_devices([

--- a/homeassistant/components/sensor/eddystone_temperature.py
+++ b/homeassistant/components/sensor/eddystone_temperature.py
@@ -39,7 +39,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Validate configuration, create devices and start monitoring thread."""
     bt_device_id = config.get("bt_device_id")

--- a/homeassistant/components/sensor/fedex.py
+++ b/homeassistant/components/sensor/fedex.py
@@ -41,7 +41,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Fedex platform."""
     import fedexdeliverymanager

--- a/homeassistant/components/sensor/fints.py
+++ b/homeassistant/components/sensor/fints.py
@@ -50,7 +50,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the sensors.
 

--- a/homeassistant/components/sensor/fitbit.py
+++ b/homeassistant/components/sensor/fitbit.py
@@ -156,7 +156,6 @@ def request_app_setup(hass, config, add_devices, config_path,
     """Assist user with configuring the Fitbit dev application."""
     configurator = hass.components.configurator
 
-    # pylint: disable=unused-argument
     def fitbit_configuration_callback(callback_data):
         """Handle configuration updates."""
         config_path = hass.config.path(FITBIT_CONFIG_FILE)
@@ -202,7 +201,6 @@ def request_oauth_completion(hass):
 
         return
 
-    # pylint: disable=unused-argument
     def fitbit_configuration_callback(callback_data):
         """Handle configuration updates."""
 

--- a/homeassistant/components/sensor/haveibeenpwned.py
+++ b/homeassistant/components/sensor/haveibeenpwned.py
@@ -35,7 +35,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the HaveIBeenPwned sensor."""
     emails = config.get(CONF_EMAIL)

--- a/homeassistant/components/sensor/hp_ilo.py
+++ b/homeassistant/components/sensor/hp_ilo.py
@@ -59,7 +59,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the HP ILO sensor."""
     hostname = config.get(CONF_HOST)

--- a/homeassistant/components/sensor/isy994.py
+++ b/homeassistant/components/sensor/isy994.py
@@ -235,7 +235,6 @@ UOM_TO_STATES = {
 }
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config: ConfigType,
                    add_devices: Callable[[list], None], discovery_info=None):
     """Set up the ISY994 sensor platform."""

--- a/homeassistant/components/sensor/kira.py
+++ b/homeassistant/components/sensor/kira.py
@@ -18,7 +18,7 @@ ICON = 'mdi:remote'
 CONF_SENSOR = 'sensor'
 
 
-# pylint: disable=unused-argument, too-many-function-args
+# pylint: disable=too-many-function-args
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up a Kira sensor."""
     if discovery_info is not None:

--- a/homeassistant/components/sensor/knx.py
+++ b/homeassistant/components/sensor/knx.py
@@ -73,7 +73,6 @@ class KNXSensor(Entity):
         """Register callbacks to update hass after device was changed."""
         async def after_update_callback(device):
             """Call after device was updated."""
-            # pylint: disable=unused-argument
             await self.async_update_ha_state()
         self.device.register_device_updated_cb(after_update_callback)
 

--- a/homeassistant/components/sensor/lastfm.py
+++ b/homeassistant/components/sensor/lastfm.py
@@ -29,7 +29,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Last.fm platform."""
     import pylast as lastfm

--- a/homeassistant/components/sensor/mold_indicator.py
+++ b/homeassistant/components/sensor/mold_indicator.py
@@ -41,7 +41,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up MoldIndicator sensor."""
     name = config.get(CONF_NAME, DEFAULT_NAME)

--- a/homeassistant/components/sensor/mopar.py
+++ b/homeassistant/components/sensor/mopar.py
@@ -41,7 +41,6 @@ REMOTE_COMMAND_SCHEMA = vol.Schema({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Mopar platform."""
     import motorparts

--- a/homeassistant/components/sensor/mvglive.py
+++ b/homeassistant/components/sensor/mvglive.py
@@ -72,7 +72,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices(sensors, True)
 
 
-# pylint: disable=too-few-public-methods
 class MVGLiveSensor(Entity):
     """Implementation of an MVG Live sensor."""
 

--- a/homeassistant/components/sensor/nzbget.py
+++ b/homeassistant/components/sensor/nzbget.py
@@ -50,7 +50,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the NZBGet sensors."""
     host = config.get(CONF_HOST)

--- a/homeassistant/components/sensor/octoprint.py
+++ b/homeassistant/components/sensor/octoprint.py
@@ -38,7 +38,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the available OctoPrint sensors."""
     octoprint_api = hass.data[DOMAIN]["api"]

--- a/homeassistant/components/sensor/ohmconnect.py
+++ b/homeassistant/components/sensor/ohmconnect.py
@@ -31,7 +31,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the OhmConnect sensor."""
     name = config.get(CONF_NAME)

--- a/homeassistant/components/sensor/onewire.py
+++ b/homeassistant/components/sensor/onewire.py
@@ -47,7 +47,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the one wire Sensors."""
     base_dir = config.get(CONF_MOUNT_DIR)

--- a/homeassistant/components/sensor/opensky.py
+++ b/homeassistant/components/sensor/opensky.py
@@ -50,7 +50,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Open Sky platform."""
     latitude = config.get(CONF_LATITUDE, hass.config.latitude)

--- a/homeassistant/components/sensor/pilight.py
+++ b/homeassistant/components/sensor/pilight.py
@@ -30,7 +30,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up Pilight Sensor."""
     add_devices([PilightSensor(

--- a/homeassistant/components/sensor/plex.py
+++ b/homeassistant/components/sensor/plex.py
@@ -41,7 +41,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Plex sensor."""
     name = config.get(CONF_NAME)

--- a/homeassistant/components/sensor/postnl.py
+++ b/homeassistant/components/sensor/postnl.py
@@ -35,7 +35,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the PostNL sensor platform."""
     from postnl_api import PostNL_API, UnauthorizedException

--- a/homeassistant/components/sensor/pyload.py
+++ b/homeassistant/components/sensor/pyload.py
@@ -43,7 +43,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the pyLoad sensors."""
     host = config.get(CONF_HOST)

--- a/homeassistant/components/sensor/qnap.py
+++ b/homeassistant/components/sensor/qnap.py
@@ -102,7 +102,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the QNAP NAS sensor."""
     api = QNAPStatsAPI(config)

--- a/homeassistant/components/sensor/skybeacon.py
+++ b/homeassistant/components/sensor/skybeacon.py
@@ -39,7 +39,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Skybeacon sensor."""
     # pylint: disable=unreachable

--- a/homeassistant/components/sensor/spotcrime.py
+++ b/homeassistant/components/sensor/spotcrime.py
@@ -44,7 +44,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Crime Reports platform."""
     latitude = config.get(CONF_LATITUDE, hass.config.latitude)

--- a/homeassistant/components/sensor/steam_online.py
+++ b/homeassistant/components/sensor/steam_online.py
@@ -36,7 +36,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Steam platform."""
     import steam as steamod

--- a/homeassistant/components/sensor/supervisord.py
+++ b/homeassistant/components/sensor/supervisord.py
@@ -26,7 +26,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Supervisord platform."""
     url = config.get(CONF_URL)

--- a/homeassistant/components/sensor/systemmonitor.py
+++ b/homeassistant/components/sensor/systemmonitor.py
@@ -67,7 +67,6 @@ IF_ADDRS = {
 }
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the system monitor sensors."""
     dev = []

--- a/homeassistant/components/sensor/tellstick.py
+++ b/homeassistant/components/sensor/tellstick.py
@@ -37,7 +37,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Tellstick sensors."""
     import tellcore.telldus as telldus

--- a/homeassistant/components/sensor/temper.py
+++ b/homeassistant/components/sensor/temper.py
@@ -33,7 +33,6 @@ def get_temper_devices():
     return TemperHandler().get_devices()
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Temper sensors."""
     temp_unit = hass.config.units.temperature_unit

--- a/homeassistant/components/sensor/template.py
+++ b/homeassistant/components/sensor/template.py
@@ -42,7 +42,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 
 @asyncio.coroutine
-# pylint: disable=unused-argument
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up the template sensors."""
     sensors = []

--- a/homeassistant/components/sensor/torque.py
+++ b/homeassistant/components/sensor/torque.py
@@ -46,7 +46,6 @@ def convert_pid(value):
     return int(value, 16)
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Torque platform."""
     vehicle = config.get(CONF_NAME)

--- a/homeassistant/components/sensor/twitch.py
+++ b/homeassistant/components/sensor/twitch.py
@@ -31,7 +31,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Twitch platform."""
     channels = config.get(CONF_CHANNELS, [])

--- a/homeassistant/components/sensor/ups.py
+++ b/homeassistant/components/sensor/ups.py
@@ -38,7 +38,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the UPS platform."""
     import upsmychoice

--- a/homeassistant/components/sensor/worldtidesinfo.py
+++ b/homeassistant/components/sensor/worldtidesinfo.py
@@ -31,7 +31,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the WorldTidesInfo sensor."""
     name = config.get(CONF_NAME)

--- a/homeassistant/components/sensor/xbox_live.py
+++ b/homeassistant/components/sensor/xbox_live.py
@@ -27,7 +27,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Xbox platform."""
     from xboxapi import xbox_api

--- a/homeassistant/components/sensor/xiaomi_miio.py
+++ b/homeassistant/components/sensor/xiaomi_miio.py
@@ -36,7 +36,6 @@ ATTR_MODEL = 'model'
 SUCCESS = ['ok']
 
 
-# pylint: disable=unused-argument
 async def async_setup_platform(hass, config, async_add_devices,
                                discovery_info=None):
     """Set up the sensor from config."""

--- a/homeassistant/components/sleepiq.py
+++ b/homeassistant/components/sleepiq.py
@@ -51,7 +51,6 @@ def setup(hass, config):
     Will automatically load sensor components to support
     devices discovered on the account.
     """
-    # pylint: disable=global-statement
     global DATA
 
     from sleepyq import Sleepyq

--- a/homeassistant/components/switch/bbb_gpio.py
+++ b/homeassistant/components/switch/bbb_gpio.py
@@ -34,7 +34,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the BeagleBone Black GPIO devices."""
     pins = config.get(CONF_PINS)

--- a/homeassistant/components/switch/command_line.py
+++ b/homeassistant/components/switch/command_line.py
@@ -32,7 +32,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Find and return switches controlled by shell commands."""
     devices = config.get(CONF_SWITCHES, {})

--- a/homeassistant/components/switch/deluge.py
+++ b/homeassistant/components/switch/deluge.py
@@ -32,7 +32,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Deluge switch."""
     from deluge_client import DelugeRPCClient

--- a/homeassistant/components/switch/demo.py
+++ b/homeassistant/components/switch/demo.py
@@ -8,7 +8,6 @@ from homeassistant.components.switch import SwitchDevice
 from homeassistant.const import DEVICE_DEFAULT_NAME
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     """Set up the demo switches."""
     add_devices_callback([

--- a/homeassistant/components/switch/dlink.py
+++ b/homeassistant/components/switch/dlink.py
@@ -36,7 +36,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up a D-Link Smart Plug."""
     from pyW215.pyW215 import SmartPlug

--- a/homeassistant/components/switch/edimax.py
+++ b/homeassistant/components/switch/edimax.py
@@ -29,7 +29,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Find and return Edimax Smart Plugs."""
     from pyedimax.smartplug import SmartPlug

--- a/homeassistant/components/switch/flux.py
+++ b/homeassistant/components/switch/flux.py
@@ -95,7 +95,6 @@ def set_lights_rgb(hass, lights, rgb, transition):
                     transition=transition)
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Flux switches."""
     name = config.get(CONF_NAME)

--- a/homeassistant/components/switch/gc100.py
+++ b/homeassistant/components/switch/gc100.py
@@ -23,7 +23,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the GC100 devices."""
     switches = []

--- a/homeassistant/components/switch/isy994.py
+++ b/homeassistant/components/switch/isy994.py
@@ -15,7 +15,6 @@ from homeassistant.helpers.typing import ConfigType  # noqa
 _LOGGER = logging.getLogger(__name__)
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config: ConfigType,
                    add_devices: Callable[[list], None], discovery_info=None):
     """Set up the ISY994 switch platform."""

--- a/homeassistant/components/switch/kankun.py
+++ b/homeassistant/components/switch/kankun.py
@@ -34,7 +34,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     """Set up Kankun Wifi switches."""
     switches = config.get('switches', {})

--- a/homeassistant/components/switch/knx.py
+++ b/homeassistant/components/switch/knx.py
@@ -72,7 +72,6 @@ class KNXSwitch(SwitchDevice):
         """Register callbacks to update hass after device was changed."""
         async def after_update_callback(device):
             """Call after device was updated."""
-            # pylint: disable=unused-argument
             await self.async_update_ha_state()
         self.device.register_device_updated_cb(after_update_callback)
 

--- a/homeassistant/components/switch/lutron_caseta.py
+++ b/homeassistant/components/switch/lutron_caseta.py
@@ -16,7 +16,6 @@ _LOGGER = logging.getLogger(__name__)
 DEPENDENCIES = ['lutron_caseta']
 
 
-# pylint: disable=unused-argument
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up Lutron switch."""

--- a/homeassistant/components/switch/orvibo.py
+++ b/homeassistant/components/switch/orvibo.py
@@ -31,7 +31,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     """Set up S20 switches."""
     from orvibo.s20 import discover, S20, S20Exception

--- a/homeassistant/components/switch/pulseaudio_loopback.py
+++ b/homeassistant/components/switch/pulseaudio_loopback.py
@@ -54,7 +54,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Read in all of our configuration, and initialize the loopback switch."""
     name = config.get(CONF_NAME)

--- a/homeassistant/components/switch/raspihats.py
+++ b/homeassistant/components/switch/raspihats.py
@@ -39,7 +39,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the raspihats switch devices."""
     I2CHatSwitch.I2C_HATS_MANAGER = hass.data[I2C_HATS_MANAGER]

--- a/homeassistant/components/switch/rest.py
+++ b/homeassistant/components/switch/rest.py
@@ -47,7 +47,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up the RESTful switch."""

--- a/homeassistant/components/switch/rpi_gpio.py
+++ b/homeassistant/components/switch/rpi_gpio.py
@@ -34,7 +34,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Raspberry PI GPIO devices."""
     invert_logic = config.get(CONF_INVERT_LOGIC)

--- a/homeassistant/components/switch/rpi_rf.py
+++ b/homeassistant/components/switch/rpi_rf.py
@@ -44,7 +44,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument, import-error, no-member
+# pylint: disable=import-error, no-member
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Find and return switches controlled by a generic RF device via GPIO."""
     import rpi_rf

--- a/homeassistant/components/switch/tellstick.py
+++ b/homeassistant/components/switch/tellstick.py
@@ -10,7 +10,6 @@ from homeassistant.components.tellstick import (
 from homeassistant.helpers.entity import ToggleEntity
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up Tellstick switches."""
     if (discovery_info is None or

--- a/homeassistant/components/switch/telnet.py
+++ b/homeassistant/components/switch/telnet.py
@@ -38,7 +38,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 SCAN_INTERVAL = timedelta(seconds=10)
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Find and return switches controlled by telnet commands."""
     devices = config.get(CONF_SWITCHES, {})

--- a/homeassistant/components/switch/template.py
+++ b/homeassistant/components/switch/template.py
@@ -44,7 +44,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 
 @asyncio.coroutine
-# pylint: disable=unused-argument
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up the Template switch."""
     switches = []

--- a/homeassistant/components/switch/tplink.py
+++ b/homeassistant/components/switch/tplink.py
@@ -32,7 +32,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the TPLink switch platform."""
     from pyHS100 import SmartPlug

--- a/homeassistant/components/switch/transmission.py
+++ b/homeassistant/components/switch/transmission.py
@@ -31,7 +31,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Transmission switch."""
     import transmissionrpc

--- a/homeassistant/components/switch/wemo.py
+++ b/homeassistant/components/switch/wemo.py
@@ -33,7 +33,7 @@ WEMO_OFF = 0
 WEMO_STANDBY = 8
 
 
-# pylint: disable=unused-argument, too-many-function-args
+# pylint: disable=too-many-function-args
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     """Set up discovered WeMo switches."""
     import pywemo.discovery as discovery

--- a/homeassistant/components/switch/xiaomi_miio.py
+++ b/homeassistant/components/switch/xiaomi_miio.py
@@ -97,7 +97,6 @@ SERVICE_TO_METHOD = {
 }
 
 
-# pylint: disable=unused-argument
 async def async_setup_platform(hass, config, async_add_devices,
                                discovery_info=None):
     """Set up the switch from config."""

--- a/homeassistant/components/vera.py
+++ b/homeassistant/components/vera.py
@@ -53,7 +53,7 @@ VERA_COMPONENTS = [
 ]
 
 
-# pylint: disable=unused-argument, too-many-function-args
+# pylint: disable=too-many-function-args
 def setup(hass, base_config):
     """Set up for Vera devices."""
     import pyvera as veraApi

--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -44,7 +44,7 @@ CONFIG_SCHEMA = vol.Schema({
 }, extra=vol.ALLOW_EXTRA)
 
 
-# pylint: disable=unused-argument, too-many-function-args
+# pylint: disable=too-many-function-args
 def setup(hass, config):
     """Set up for WeMo devices."""
     import pywemo

--- a/homeassistant/components/wink/__init__.py
+++ b/homeassistant/components/wink/__init__.py
@@ -210,7 +210,6 @@ def _request_oauth_completion(hass, config):
             "Failed to register, please try again.")
         return
 
-    # pylint: disable=unused-argument
     def wink_configuration_callback(callback_data):
         """Call setup again."""
         setup(hass, config)

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -4,7 +4,7 @@ Core components of Home Assistant.
 Home Assistant is a Home Automation framework for observing the state
 of entities and react to changes.
 """
-# pylint: disable=unused-import, too-many-lines
+# pylint: disable=unused-import
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
 import enum

--- a/homeassistant/util/dt.py
+++ b/homeassistant/util/dt.py
@@ -27,7 +27,7 @@ def set_default_time_zone(time_zone: dt.tzinfo) -> None:
 
     Async friendly.
     """
-    global DEFAULT_TIME_ZONE  # pylint: disable=global-statement
+    global DEFAULT_TIME_ZONE
 
     # NOTE: Remove in the future in favour of typing
     assert isinstance(time_zone, dt.tzinfo)


### PR DESCRIPTION
## Description:

There are a lot of unnecessary inline `pylint disable=...` in the code. This cleans the low-hanging fruits -- messages that are already disabled in pylintrc.

## Checklist:
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
