### PR TITLE
WIP: New device class for datetime sensors

### DIFF
--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -14,7 +14,7 @@ from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.config_validation import PLATFORM_SCHEMA  # noqa
 from homeassistant.const import (
     DEVICE_CLASS_BATTERY, DEVICE_CLASS_HUMIDITY, DEVICE_CLASS_ILLUMINANCE,
-    DEVICE_CLASS_TEMPERATURE)
+    DEVICE_CLASS_TEMPERATURE, DEVICE_CLASS_TIMESTAMP)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -28,6 +28,7 @@ DEVICE_CLASSES = [
     DEVICE_CLASS_HUMIDITY,  # % of humidity in the air
     DEVICE_CLASS_ILLUMINANCE,  # current light level (lx/lm)
     DEVICE_CLASS_TEMPERATURE,  # temperature (C/F)
+    DEVICE_CLASS_TIMESTAMP,  # ISO formatted timestamp
 ]
 
 DEVICE_CLASSES_SCHEMA = vol.All(vol.Lower, vol.In(DEVICE_CLASSES))

--- a/homeassistant/components/sensor/uptime.py
+++ b/homeassistant/components/sensor/uptime.py
@@ -9,18 +9,17 @@ import logging
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import CONF_NAME
+from homeassistant.const import (
+    CONF_NAME, DEVICE_CLASS_TIMESTAMP)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 import homeassistant.util.dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
 
-DEFAULT_NAME = 'Uptime'
+DEFAULT_NAME = 'Start'
 
 ICON = 'mdi:timer'
-
-DEVICE_CLASS = 'datetime'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
@@ -56,7 +55,7 @@ class UptimeSensor(Entity):
     @property
     def device_class(self):
         """Return the device class of the sensor."""
-        return DEVICE_CLASS
+        return DEVICE_CLASS_TIMESTAMP
 
     @property
     def state(self):

--- a/homeassistant/components/sensor/uptime.py
+++ b/homeassistant/components/sensor/uptime.py
@@ -20,6 +20,12 @@ DEFAULT_NAME = 'Uptime'
 
 ICON = 'mdi:clock'
 
+UNIT_OF_MEASUREMENT = {
+    'hours': 'h',
+    'minutes': 'min',
+    'days': 'd'
+}
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_UNIT_OF_MEASUREMENT, default='days'):
@@ -42,7 +48,7 @@ class UptimeSensor(Entity):
     def __init__(self, name, unit):
         """Initialize the uptime sensor."""
         self._name = name
-        self._unit = unit
+        self._unit = UNIT_OF_MEASUREMENT[unit]
         self.initial = dt_util.now()
         self._state = None
 
@@ -71,9 +77,9 @@ class UptimeSensor(Entity):
         delta = dt_util.now() - self.initial
         div_factor = 3600
 
-        if self.unit_of_measurement == 'days':
+        if self.unit_of_measurement == 'd':
             div_factor *= 24
-        elif self.unit_of_measurement == 'minutes':
+        elif self.unit_of_measurement == 'min':
             div_factor /= 60
 
         delta = delta.total_seconds() / div_factor

--- a/homeassistant/components/sensor/uptime.py
+++ b/homeassistant/components/sensor/uptime.py
@@ -9,7 +9,7 @@ import logging
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import CONF_NAME, CONF_UNIT_OF_MEASUREMENT
+from homeassistant.const import CONF_NAME
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 import homeassistant.util.dt as dt_util
@@ -18,18 +18,12 @@ _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_NAME = 'Uptime'
 
-ICON = 'mdi:clock'
+ICON = 'mdi:timer'
 
-UNIT_OF_MEASUREMENT = {
-    'hours': 'h',
-    'minutes': 'min',
-    'days': 'd'
-}
+DEVICE_CLASS = 'datetime'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional(CONF_UNIT_OF_MEASUREMENT, default='days'):
-        vol.All(cv.string, vol.In(['minutes', 'hours', 'days']))
 })
 
 
@@ -37,20 +31,17 @@ async def async_setup_platform(
         hass, config, async_add_devices, discovery_info=None):
     """Set up the uptime sensor platform."""
     name = config.get(CONF_NAME)
-    units = config.get(CONF_UNIT_OF_MEASUREMENT)
 
-    async_add_devices([UptimeSensor(name, units)], True)
+    async_add_devices([UptimeSensor(name)], True)
 
 
 class UptimeSensor(Entity):
     """Representation of an uptime sensor."""
 
-    def __init__(self, name, unit):
+    def __init__(self, name):
         """Initialize the uptime sensor."""
         self._name = name
-        self._unit = UNIT_OF_MEASUREMENT[unit]
-        self.initial = dt_util.now()
-        self._state = None
+        self._state = dt_util.now()
 
     @property
     def name(self):
@@ -63,25 +54,11 @@ class UptimeSensor(Entity):
         return ICON
 
     @property
-    def unit_of_measurement(self):
-        """Return the unit of measurement the value is expressed in."""
-        return self._unit
+    def device_class(self):
+        """Return the device class of the sensor."""
+        return DEVICE_CLASS
 
     @property
     def state(self):
         """Return the state of the sensor."""
         return self._state
-
-    async def async_update(self):
-        """Update the state of the sensor."""
-        delta = dt_util.now() - self.initial
-        div_factor = 3600
-
-        if self.unit_of_measurement == 'd':
-            div_factor *= 24
-        elif self.unit_of_measurement == 'min':
-            div_factor /= 60
-
-        delta = delta.total_seconds() / div_factor
-        self._state = round(delta, 2)
-        _LOGGER.debug("New value: %s", delta)

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -171,6 +171,7 @@ DEVICE_CLASS_BATTERY = 'battery'
 DEVICE_CLASS_HUMIDITY = 'humidity'
 DEVICE_CLASS_ILLUMINANCE = 'illuminance'
 DEVICE_CLASS_TEMPERATURE = 'temperature'
+DEVICE_CLASS_TIMESTAMP = 'timestamp'
 
 # #### STATES ####
 STATE_ON = 'on'

--- a/tests/components/sensor/test_uptime.py
+++ b/tests/components/sensor/test_uptime.py
@@ -1,9 +1,6 @@
 """The tests for the uptime sensor platform."""
 import unittest
-from unittest.mock import patch
-from datetime import timedelta
 
-from homeassistant.util.async_ import run_coroutine_threadsafe
 from homeassistant.setup import setup_component
 from homeassistant.components.sensor.uptime import UptimeSensor
 from tests.common import get_test_home_assistant
@@ -38,80 +35,3 @@ class TestUptimeSensor(unittest.TestCase):
             }
         }
         assert setup_component(self.hass, 'sensor', config)
-
-    def test_uptime_sensor_config_hours(self):
-        """Test uptime sensor with hours defined in config."""
-        config = {
-            'sensor': {
-                'platform': 'uptime',
-                'unit_of_measurement': 'hours',
-            }
-        }
-        assert setup_component(self.hass, 'sensor', config)
-
-    def test_uptime_sensor_config_minutes(self):
-        """Test uptime sensor with minutes defined in config."""
-        config = {
-            'sensor': {
-                'platform': 'uptime',
-                'unit_of_measurement': 'minutes',
-            }
-        }
-        assert setup_component(self.hass, 'sensor', config)
-
-    def test_uptime_sensor_days_output(self):
-        """Test uptime sensor output data."""
-        sensor = UptimeSensor('test', 'days')
-        self.assertEqual(sensor.unit_of_measurement, 'd')
-        new_time = sensor.initial + timedelta(days=1)
-        with patch('homeassistant.util.dt.now', return_value=new_time):
-            run_coroutine_threadsafe(
-                sensor.async_update(),
-                self.hass.loop
-            ).result()
-            self.assertEqual(sensor.state, 1.00)
-        new_time = sensor.initial + timedelta(days=111.499)
-        with patch('homeassistant.util.dt.now', return_value=new_time):
-            run_coroutine_threadsafe(
-                sensor.async_update(),
-                self.hass.loop
-            ).result()
-            self.assertEqual(sensor.state, 111.50)
-
-    def test_uptime_sensor_hours_output(self):
-        """Test uptime sensor output data."""
-        sensor = UptimeSensor('test', 'hours')
-        self.assertEqual(sensor.unit_of_measurement, 'h')
-        new_time = sensor.initial + timedelta(hours=16)
-        with patch('homeassistant.util.dt.now', return_value=new_time):
-            run_coroutine_threadsafe(
-                sensor.async_update(),
-                self.hass.loop
-            ).result()
-            self.assertEqual(sensor.state, 16.00)
-        new_time = sensor.initial + timedelta(hours=72.499)
-        with patch('homeassistant.util.dt.now', return_value=new_time):
-            run_coroutine_threadsafe(
-                sensor.async_update(),
-                self.hass.loop
-            ).result()
-            self.assertEqual(sensor.state, 72.50)
-
-    def test_uptime_sensor_minutes_output(self):
-        """Test uptime sensor output data."""
-        sensor = UptimeSensor('test', 'minutes')
-        self.assertEqual(sensor.unit_of_measurement, 'min')
-        new_time = sensor.initial + timedelta(minutes=16)
-        with patch('homeassistant.util.dt.now', return_value=new_time):
-            run_coroutine_threadsafe(
-                sensor.async_update(),
-                self.hass.loop
-            ).result()
-            self.assertEqual(sensor.state, 16.00)
-        new_time = sensor.initial + timedelta(minutes=12.499)
-        with patch('homeassistant.util.dt.now', return_value=new_time):
-            run_coroutine_threadsafe(
-                sensor.async_update(),
-                self.hass.loop
-            ).result()
-            self.assertEqual(sensor.state, 12.50)

--- a/tests/components/sensor/test_uptime.py
+++ b/tests/components/sensor/test_uptime.py
@@ -62,7 +62,7 @@ class TestUptimeSensor(unittest.TestCase):
     def test_uptime_sensor_days_output(self):
         """Test uptime sensor output data."""
         sensor = UptimeSensor('test', 'days')
-        self.assertEqual(sensor.unit_of_measurement, 'days')
+        self.assertEqual(sensor.unit_of_measurement, 'd')
         new_time = sensor.initial + timedelta(days=1)
         with patch('homeassistant.util.dt.now', return_value=new_time):
             run_coroutine_threadsafe(
@@ -81,7 +81,7 @@ class TestUptimeSensor(unittest.TestCase):
     def test_uptime_sensor_hours_output(self):
         """Test uptime sensor output data."""
         sensor = UptimeSensor('test', 'hours')
-        self.assertEqual(sensor.unit_of_measurement, 'hours')
+        self.assertEqual(sensor.unit_of_measurement, 'h')
         new_time = sensor.initial + timedelta(hours=16)
         with patch('homeassistant.util.dt.now', return_value=new_time):
             run_coroutine_threadsafe(
@@ -100,7 +100,7 @@ class TestUptimeSensor(unittest.TestCase):
     def test_uptime_sensor_minutes_output(self):
         """Test uptime sensor output data."""
         sensor = UptimeSensor('test', 'minutes')
-        self.assertEqual(sensor.unit_of_measurement, 'minutes')
+        self.assertEqual(sensor.unit_of_measurement, 'min')
         new_time = sensor.initial + timedelta(minutes=16)
         with patch('homeassistant.util.dt.now', return_value=new_time):
             run_coroutine_threadsafe(


### PR DESCRIPTION
## Description:

~~change unit of measurement from `minutes, days, hours` to `min, h, d`~~
~~- it's shorter~~
~~- these are the "official" symbols~~

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: uptime
    name: HA Uptime
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.