### PR TITLE
Upgrade ring_doorbell to 0.2.1 to fix oauth issues

### DIFF
--- a/homeassistant/components/ring.py
+++ b/homeassistant/components/ring.py
@@ -12,7 +12,7 @@ import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
 from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
 
-REQUIREMENTS = ['ring_doorbell==0.1.8']
+REQUIREMENTS = ['ring_doorbell==0.2.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1189,7 +1189,7 @@ restrictedpython==4.0b4
 rflink==0.0.37
 
 # homeassistant.components.ring
-ring_doorbell==0.1.8
+ring_doorbell==0.2.1
 
 # homeassistant.components.notify.rocketchat
 rocketchat-API==0.6.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -180,7 +180,7 @@ restrictedpython==4.0b4
 rflink==0.0.37
 
 # homeassistant.components.ring
-ring_doorbell==0.1.8
+ring_doorbell==0.2.1
 
 # homeassistant.components.media_player.yamaha
 rxv==0.5.1

--- a/tests/components/binary_sensor/test_ring.py
+++ b/tests/components/binary_sensor/test_ring.py
@@ -44,6 +44,8 @@ class TestRingBinarySensorSetup(unittest.TestCase):
     @requests_mock.Mocker()
     def test_binary_sensor(self, mock):
         """Test the Ring sensor class and methods."""
+        mock.post('https://oauth.ring.com/oauth/token',
+                  text=load_fixture('ring_oauth.json'))
         mock.post('https://api.ring.com/clients_api/session',
                   text=load_fixture('ring_session.json'))
         mock.get('https://api.ring.com/clients_api/ring_devices',

--- a/tests/components/sensor/test_ring.py
+++ b/tests/components/sensor/test_ring.py
@@ -51,6 +51,8 @@ class TestRingSensorSetup(unittest.TestCase):
     @requests_mock.Mocker()
     def test_sensor(self, mock):
         """Test the Ring sensor class and methods."""
+        mock.post('https://oauth.ring.com/oauth/token',
+                  text=load_fixture('ring_oauth.json'))
         mock.post('https://api.ring.com/clients_api/session',
                   text=load_fixture('ring_session.json'))
         mock.get('https://api.ring.com/clients_api/ring_devices',

--- a/tests/components/test_ring.py
+++ b/tests/components/test_ring.py
@@ -42,6 +42,8 @@ class TestRing(unittest.TestCase):
     @requests_mock.Mocker()
     def test_setup(self, mock):
         """Test the setup."""
+        mock.post('https://oauth.ring.com/oauth/token',
+                  text=load_fixture('ring_oauth.json'))
         mock.post('https://api.ring.com/clients_api/session',
                   text=load_fixture('ring_session.json'))
         response = ring.setup(self.hass, self.config)

--- a/tests/fixtures/ring_oauth.json
+++ b/tests/fixtures/ring_oauth.json
@@ -1,0 +1,8 @@
+{
+    "access_token": "eyJ0eWfvEQwqfJNKyQ9999", 
+    "token_type": "bearer",
+    "expires_in": 3600,
+    "refresh_token": "67695a26bdefc1ac8999",
+    "scope": "client", 
+    "created_at": 1529099870
+}


### PR DESCRIPTION
## Description:
Ring Doorbell modified their API to use `oauth` authentication which broke temporarily the 3rd party module used in this component. 

This PR fixes the issue and make Ring usable again. Many thanks to all users that tested the fix and reported the issue. 

**Related issue (if applicable):** 
fixes #14826 
fixes #14834

## Example entry for `configuration.yaml` (if applicable):
```yaml
ring:
  username: foo
  password: bar
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.
