### PR TITLE
Expose Wemo component availability to home assistant

### DIFF
--- a/homeassistant/components/light/wemo.py
+++ b/homeassistant/components/light/wemo.py
@@ -107,6 +107,11 @@ class WemoLight(Light):
         """Flag supported features."""
         return SUPPORT_WEMO
 
+    @property
+    def available(self):
+        """Return if light is available."""
+        return self.device.state['available']
+
     def turn_on(self, **kwargs):
         """Turn the light on."""
         transitiontime = int(kwargs.get(ATTR_TRANSITION, 0))
@@ -194,6 +199,11 @@ class WemoDimmer(Light):
     def is_on(self):
         """Return true if dimmer is on. Standby is on."""
         return self._state
+
+    @property
+    def available(self):
+        """Return if dimmer is available."""
+        return self.device.state['available']
 
     def _update(self, force_update=True):
         """Update the device state."""

--- a/homeassistant/components/light/wemo.py
+++ b/homeassistant/components/light/wemo.py
@@ -227,3 +227,7 @@ class WemoDimmer(Light):
         else:
             brightness = 255
         self.wemo.set_brightness(brightness)
+
+    def turn_off(self, **kwargs):
+        """Turn the dimmer off."""
+        self.wemo.off()

--- a/homeassistant/components/light/wemo.py
+++ b/homeassistant/components/light/wemo.py
@@ -200,11 +200,6 @@ class WemoDimmer(Light):
         """Return true if dimmer is on. Standby is on."""
         return self._state
 
-    @property
-    def available(self):
-        """Return if dimmer is available."""
-        return self.device.state['available']
-
     def _update(self, force_update=True):
         """Update the device state."""
         try:

--- a/homeassistant/components/light/wemo.py
+++ b/homeassistant/components/light/wemo.py
@@ -227,7 +227,3 @@ class WemoDimmer(Light):
         else:
             brightness = 255
         self.wemo.set_brightness(brightness)
-
-    def turn_off(self, **kwargs):
-        """Turn the dimmer off."""
-        self.wemo.off()


### PR DESCRIPTION
This is a simple change to expose the Wemo availability (i.e. does it have external power or connectivity) in home assistant. 

This feature works a bit better with the following update to pywemo, although it is not required. Prior to the pull request below, pywemo had a tendency to report non-connectable devices as a 'available' in some cases.
https://github.com/pavoni/pywemo/pull/100