### PR TITLE
Remove load power attribute for channel USB

### DIFF
--- a/homeassistant/components/switch/xiaomi_miio.py
+++ b/homeassistant/components/switch/xiaomi_miio.py
@@ -421,8 +421,11 @@ class ChuangMiPlugSwitch(XiaomiPlugGenericSwitch):
             self._device_features = FEATURE_FLAGS_PLUG_V3
             self._state_attrs.update({
                 ATTR_WIFI_LED: None,
-                ATTR_LOAD_POWER: None,
             })
+            if self._channel_usb is False:
+                self._state_attrs.update({
+                    ATTR_LOAD_POWER: None,
+                })
 
     async def async_turn_on(self, **kwargs):
         """Turn a channel on."""
@@ -476,8 +479,8 @@ class ChuangMiPlugSwitch(XiaomiPlugGenericSwitch):
             if state.wifi_led:
                 self._state_attrs[ATTR_WIFI_LED] = state.wifi_led
 
-            if state.load_power:
-                self._state_attrs[ATTR_LOAD_POWER] = state.load_power
+            if self._channel_usb is False and state.load_power:
+                    self._state_attrs[ATTR_LOAD_POWER] = state.load_power
 
         except DeviceException as ex:
             self._available = False

--- a/homeassistant/components/switch/xiaomi_miio.py
+++ b/homeassistant/components/switch/xiaomi_miio.py
@@ -480,7 +480,7 @@ class ChuangMiPlugSwitch(XiaomiPlugGenericSwitch):
                 self._state_attrs[ATTR_WIFI_LED] = state.wifi_led
 
             if self._channel_usb is False and state.load_power:
-                    self._state_attrs[ATTR_LOAD_POWER] = state.load_power
+                self._state_attrs[ATTR_LOAD_POWER] = state.load_power
 
         except DeviceException as ex:
             self._available = False


### PR DESCRIPTION
> In addition the attribute is added to both “switches”, the main switch and the USB switch; but apparently 
> both attributes are the same at the protocol level. I think it should be added just to the main switch.

https://community.home-assistant.io/t/xiaomi-chuangmi-wifi-plug-v3-goes-unavailable-after-5-minutes/54087/9
