### PR TITLE
Switch to own packaged version of spotipy

### DIFF
--- a/homeassistant/components/media_player/spotify.py
+++ b/homeassistant/components/media_player/spotify.py
@@ -20,9 +20,7 @@ from homeassistant.const import (
     CONF_NAME, STATE_PLAYING, STATE_PAUSED, STATE_IDLE, STATE_UNKNOWN)
 import homeassistant.helpers.config_validation as cv
 
-COMMIT = '544614f4b1d508201d363e84e871f86c90aa26b2'
-REQUIREMENTS = ['https://github.com/happyleavesaoc/spotipy/'
-                'archive/%s.zip#spotipy==2.4.4' % COMMIT]
+REQUIREMENTS = ['spotipy-homeassistant==2.4.4.dev1']
 
 DEPENDENCIES = ['http']
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -424,9 +424,6 @@ httplib2==0.10.3
 # homeassistant.components.media_player.braviatv
 https://github.com/aparraga/braviarc/archive/0.3.7.zip#braviarc==0.3.7
 
-# homeassistant.components.media_player.spotify
-https://github.com/happyleavesaoc/spotipy/archive/544614f4b1d508201d363e84e871f86c90aa26b2.zip#spotipy==2.4.4
-
 # homeassistant.components.neato
 https://github.com/jabesq/pybotvac/archive/v0.0.5.zip#pybotvac==0.0.5
 
@@ -1280,6 +1277,9 @@ speedtest-cli==2.0.2
 
 # homeassistant.components.sensor.spotcrime
 spotcrime==1.0.3
+
+# homeassistant.components.media_player.spotify
+spotipy-homeassistant==2.4.4.dev1
 
 # homeassistant.components.recorder
 # homeassistant.scripts.db_migrator


### PR DESCRIPTION
## Description:

Switch to own packaged version of spotipy - `spotipy-homeassistant====2.4.4.dev1`

Relevant issue: #7069