### PR TITLE
Add Facebox teach service

### DIFF
--- a/homeassistant/components/image_processing/facebox.py
+++ b/homeassistant/components/image_processing/facebox.py
@@ -95,17 +95,15 @@ def valid_file_path(file_path):
         _LOGGER.error(
             "%s error: Invalid file path: %s", CLASSIFIER, file_path)
         return False
-    else:
-        return True
+    return True
 
 
 def valid_image(file_path):
     """Check that a file_path points to an image."""
     if file_path.endswith(VALID_FILETYPES):
         return True
-    else:
-        _LOGGER.error("Not a valid image file: %s", file_path)
-        return False
+    _LOGGER.error("Not a valid image file: %s", file_path)
+    return False
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/homeassistant/components/image_processing/facebox.py
+++ b/homeassistant/components/image_processing/facebox.py
@@ -6,7 +6,6 @@ https://home-assistant.io/components/image_processing.facebox
 """
 import base64
 import logging
-import os
 
 import requests
 import voluptuous as vol
@@ -93,7 +92,7 @@ def valid_file_path(file_path):
     try:
         cv.isfile(file_path)
         return True
-    except:
+    except vol.Invalid:
         _LOGGER.error(
             "%s error: Invalid file path: %s", CLASSIFIER, file_path)
         return False

--- a/homeassistant/components/image_processing/facebox.py
+++ b/homeassistant/components/image_processing/facebox.py
@@ -109,6 +109,7 @@ def valid_image(file_path):
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the classifier."""
     entities = []
+    facebox = None
     for camera in config[CONF_SOURCE]:
         facebox = FaceClassifyEntity(
             config[CONF_IP_ADDRESS],

--- a/homeassistant/components/image_processing/facebox.py
+++ b/homeassistant/components/image_processing/facebox.py
@@ -216,4 +216,5 @@ class FaceClassifyEntity(ImageProcessingFaceEntity):
         """Return the classifier attributes."""
         return {
             'matched_faces': self._matched,
+            'total_matched_faces': len(self._matched),
             }

--- a/homeassistant/components/image_processing/facebox.py
+++ b/homeassistant/components/image_processing/facebox.py
@@ -172,9 +172,11 @@ class FaceClassifyEntity(ImageProcessingFaceEntity):
         """Teach classifier a face name."""
         if (self.hass.config.is_allowed_path(file_path) and
                 valid_file_path(file_path)):
-            data = {ATTR_NAME: name, 'id': file_path}
-            file = {'file': open(file_path, 'rb')}
-            response = requests.post(self._url_teach, data=data, files=file)
+            with open(file_path, 'rb') as open_file:
+                response = requests.post(
+                    self._url_teach,
+                    data={ATTR_NAME: name, 'id': file_path},
+                    files={'file': open_file})
 
             if response.status_code == 200:
                 self.hass.bus.fire(

--- a/homeassistant/components/image_processing/facebox.py
+++ b/homeassistant/components/image_processing/facebox.py
@@ -31,7 +31,6 @@ EVENT_CLASSIFIER_TEACH = 'image_processing.teach_classifier'
 FILE_PATH = 'file_path'
 SERVICE_FACEBOX_TEACH_FACE = 'facebox_teach_face'
 TIMEOUT = 9
-VALID_FILETYPES = ('.jpg', '.png', '.jpeg')
 
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -98,14 +97,6 @@ def valid_file_path(file_path):
     return True
 
 
-def valid_image(file_path):
-    """Check that a file_path points to an image."""
-    if file_path.endswith(VALID_FILETYPES):
-        return True
-    _LOGGER.error("Not a valid image file: %s", file_path)
-    return False
-
-
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the classifier."""
     entities = []
@@ -169,7 +160,7 @@ class FaceClassifyEntity(ImageProcessingFaceEntity):
 
     def teach(self, name, file_path):
         """Teach classifier a face name."""
-        if valid_file_path(file_path) and valid_image(file_path):
+        if valid_file_path(file_path):
             data = {ATTR_NAME: name, 'id': file_path}
             file = {'file': open(file_path, 'rb')}
             response = requests.post(self._url_teach, data=data, files=file)

--- a/homeassistant/components/image_processing/facebox.py
+++ b/homeassistant/components/image_processing/facebox.py
@@ -80,10 +80,10 @@ def post_image(url, image):
     """Post an image to the classifier."""
     try:
         response = requests.post(
-                    url,
-                    json={"base64": encode_image(image)},
-                    timeout=TIMEOUT
-                    )
+            url,
+            json={"base64": encode_image(image)},
+            timeout=TIMEOUT
+            )
         return response
     except requests.exceptions.ConnectionError:
         _LOGGER.error("ConnectionError: Is %s running?", CLASSIFIER)
@@ -187,8 +187,8 @@ class FaceClassifyEntity(ImageProcessingFaceEntity):
 
             elif response.status_code == 400:
                 _LOGGER.warning(
-                    "{} teaching of file {} failed with message:{}".format(
-                        CLASSIFIER, file_path, response.text))
+                    "%s teaching of file %s failed with message:%s",
+                    CLASSIFIER, file_path, response.text)
                 self.hass.bus.fire(
                     EVENT_CLASSIFIER_TEACH, {
                         ATTR_CLASSIFIER: CLASSIFIER,

--- a/homeassistant/components/image_processing/facebox.py
+++ b/homeassistant/components/image_processing/facebox.py
@@ -161,7 +161,8 @@ class FaceClassifyEntity(ImageProcessingFaceEntity):
 
     def teach(self, name, file_path):
         """Teach classifier a face name."""
-        if valid_file_path(file_path):
+        if (self.hass.config.is_allowed_path(file_path) and
+                valid_file_path(file_path)):
             data = {ATTR_NAME: name, 'id': file_path}
             file = {'file': open(file_path, 'rb')}
             response = requests.post(self._url_teach, data=data, files=file)

--- a/homeassistant/components/image_processing/facebox.py
+++ b/homeassistant/components/image_processing/facebox.py
@@ -170,36 +170,37 @@ class FaceClassifyEntity(ImageProcessingFaceEntity):
 
     def teach(self, name, file_path):
         """Teach classifier a face name."""
-        if (self.hass.config.is_allowed_path(file_path) and
-                valid_file_path(file_path)):
-            with open(file_path, 'rb') as open_file:
-                response = requests.post(
-                    self._url_teach,
-                    data={ATTR_NAME: name, 'id': file_path},
-                    files={'file': open_file})
+        if (not self.hass.config.is_allowed_path(file_path)
+                or not valid_file_path(file_path)):
+            return
+        with open(file_path, 'rb') as open_file:
+            response = requests.post(
+                self._url_teach,
+                data={ATTR_NAME: name, 'id': file_path},
+                files={'file': open_file})
 
-            if response.status_code == 200:
-                self.hass.bus.fire(
-                    EVENT_CLASSIFIER_TEACH, {
-                        ATTR_CLASSIFIER: CLASSIFIER,
-                        ATTR_NAME: name,
-                        FILE_PATH: file_path,
-                        'success': True,
-                        'message': None
-                        })
+        if response.status_code == 200:
+            self.hass.bus.fire(
+                EVENT_CLASSIFIER_TEACH, {
+                    ATTR_CLASSIFIER: CLASSIFIER,
+                    ATTR_NAME: name,
+                    FILE_PATH: file_path,
+                    'success': True,
+                    'message': None
+                    })
 
-            elif response.status_code == 400:
-                _LOGGER.warning(
-                    "%s teaching of file %s failed with message:%s",
-                    CLASSIFIER, file_path, response.text)
-                self.hass.bus.fire(
-                    EVENT_CLASSIFIER_TEACH, {
-                        ATTR_CLASSIFIER: CLASSIFIER,
-                        ATTR_NAME: name,
-                        FILE_PATH: file_path,
-                        'success': False,
-                        'message': response.text
-                        })
+        elif response.status_code == 400:
+            _LOGGER.warning(
+                "%s teaching of file %s failed with message:%s",
+                CLASSIFIER, file_path, response.text)
+            self.hass.bus.fire(
+                EVENT_CLASSIFIER_TEACH, {
+                    ATTR_CLASSIFIER: CLASSIFIER,
+                    ATTR_NAME: name,
+                    FILE_PATH: file_path,
+                    'success': False,
+                    'message': response.text
+                    })
 
     @property
     def camera_entity(self):

--- a/homeassistant/components/image_processing/facebox.py
+++ b/homeassistant/components/image_processing/facebox.py
@@ -90,11 +90,13 @@ def post_image(url, image):
 
 def valid_file_path(file_path):
     """Check that a file_path points to a valid file."""
-    if not os.access(file_path, os.R_OK):
+    try:
+        cv.isfile(file_path)
+        return True
+    except:
         _LOGGER.error(
             "%s error: Invalid file path: %s", CLASSIFIER, file_path)
         return False
-    return True
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):

--- a/homeassistant/components/image_processing/services.yaml
+++ b/homeassistant/components/image_processing/services.yaml
@@ -6,3 +6,16 @@ scan:
     entity_id:
       description: Name(s) of entities to scan immediately.
       example: 'image_processing.alpr_garage'
+
+facebox_teach_face:
+  description: Teach facebox a face using a file.
+  fields:
+    entity_id:
+      description: The facebox entity to teach.
+      example: 'image_processing.facebox'
+    name:
+      description: The name of the face to teach.
+      example: 'my_name'
+    file_path:
+      description: The path to the image file.
+      example: '/images/my_image.jpg'

--- a/tests/components/image_processing/test_facebox.py
+++ b/tests/components/image_processing/test_facebox.py
@@ -85,12 +85,6 @@ def test_valid_file_path():
         assert not fb.valid_file_path('test_path')
 
 
-def test_valid_image():
-    """Test for valid images."""
-    assert fb.valid_image('test.jpg')
-    assert not fb.valid_image('test.foo')
-
-
 @pytest.fixture
 def mock_image():
     """Return a mock camera image."""

--- a/tests/components/image_processing/test_facebox.py
+++ b/tests/components/image_processing/test_facebox.py
@@ -79,10 +79,10 @@ def test_parse_faces():
     assert fb.parse_faces(MOCK_JSON['faces']) == PARSED_FACES
 
 
+@patch('os.access', Mock(return_value=False))
 def test_valid_file_path():
     """Test that an invalid file_path is caught."""
-    with mock.patch('os.access', mock.Mock(return_value=False)):
-        assert not fb.valid_file_path('test_path')
+    assert not fb.valid_file_path('test_path')
 
 
 @pytest.fixture

--- a/tests/components/image_processing/test_facebox.py
+++ b/tests/components/image_processing/test_facebox.py
@@ -4,7 +4,6 @@ from unittest.mock import Mock, patch
 import pytest
 import requests
 import requests_mock
-from unittest import mock
 
 from homeassistant.core import callback
 from homeassistant.const import (

--- a/tests/components/image_processing/test_facebox.py
+++ b/tests/components/image_processing/test_facebox.py
@@ -85,11 +85,25 @@ def test_valid_file_path():
 
 
 @pytest.fixture
+def mock_access():
+    """Mock os.access."""
+    with patch('os.access', Mock(return_value=True)) as _mock_access:
+        yield _mock_access
+
+
+@pytest.fixture
 def mock_image():
     """Return a mock camera image."""
     with patch('homeassistant.components.camera.demo.DemoCamera.camera_image',
                return_value=b'Test') as image:
         yield image
+
+
+@pytest.fixture
+def mock_isfile():
+    """Mock os.path.isfile."""
+    with patch('os.path.isfile', Mock(return_value=True)) as _mock_isfile:
+        yield _mock_isfile
 
 
 async def test_setup_platform(hass):
@@ -141,61 +155,6 @@ async def test_process_image(hass, mock_image):
             PARSED_FACES[0][fb.ATTR_BOUNDING_BOX])
 
 
-@patch('os.access', Mock(return_value=True))
-@patch('os.path.isfile', Mock(return_value=True))
-async def test_teach_service(hass):
-    """Test teaching of facebox."""
-    await async_setup_component(hass, ip.DOMAIN, VALID_CONFIG)
-    assert hass.states.get(VALID_ENTITY_ID)
-
-    teach_events = []
-
-    @callback
-    def mock_teach_event(event):
-        """Mock event."""
-        teach_events.append(event)
-
-    hass.bus.async_listen(
-        'image_processing.teach_classifier', mock_teach_event)
-
-    with requests_mock.Mocker() as mock_req:
-        url = "http://{}:{}/facebox/teach".format(MOCK_IP, MOCK_PORT)
-        mock_req.post(url, status_code=200)
-        data = {ATTR_ENTITY_ID: VALID_ENTITY_ID,
-                ATTR_NAME: MOCK_NAME,
-                fb.FILE_PATH: MOCK_FILE_PATH}
-        await hass.services.async_call(ip.DOMAIN,
-                                       fb.SERVICE_FACEBOX_TEACH_FACE,
-                                       service_data=data)
-        await hass.async_block_till_done()
-
-    assert len(teach_events) == 1
-    assert teach_events[0].data[fb.ATTR_CLASSIFIER] == fb.CLASSIFIER
-    assert teach_events[0].data[ATTR_NAME] == MOCK_NAME
-    assert teach_events[0].data[fb.FILE_PATH] == MOCK_FILE_PATH
-    assert teach_events[0].data['success']
-    assert not teach_events[0].data['message']
-
-    # Now test the failed teaching.
-    with requests_mock.Mocker() as mock_req:
-        url = "http://{}:{}/facebox/teach".format(MOCK_IP, MOCK_PORT)
-        mock_req.post(url, status_code=400, text=MOCK_ERROR)
-        data = {ATTR_ENTITY_ID: VALID_ENTITY_ID,
-                ATTR_NAME: MOCK_NAME,
-                fb.FILE_PATH: MOCK_FILE_PATH}
-        await hass.services.async_call(ip.DOMAIN,
-                                       fb.SERVICE_FACEBOX_TEACH_FACE,
-                                       service_data=data)
-        await hass.async_block_till_done()
-
-    assert len(teach_events) == 2
-    assert teach_events[1].data[fb.ATTR_CLASSIFIER] == fb.CLASSIFIER
-    assert teach_events[1].data[ATTR_NAME] == MOCK_NAME
-    assert teach_events[1].data[fb.FILE_PATH] == MOCK_FILE_PATH
-    assert not teach_events[1].data['success']
-    assert teach_events[1].data['message'] == MOCK_ERROR
-
-
 async def test_connection_error(hass, mock_image):
     """Test connection error."""
     await async_setup_component(hass, ip.DOMAIN, VALID_CONFIG)
@@ -229,3 +188,56 @@ async def test_setup_platform_with_name(hass):
     assert hass.states.get(NAMED_ENTITY_ID)
     state = hass.states.get(NAMED_ENTITY_ID)
     assert state.attributes.get(CONF_FRIENDLY_NAME) == MOCK_NAME
+
+
+async def test_teach_service(hass, mock_image, mock_isfile, mock_access):
+    """Test teaching of facebox."""
+    await async_setup_component(hass, ip.DOMAIN, VALID_CONFIG)
+    assert hass.states.get(VALID_ENTITY_ID)
+
+    teach_events = []
+
+    @callback
+    def mock_teach_event(event):
+        """Mock event."""
+        teach_events.append(event)
+
+    hass.bus.async_listen(
+        'image_processing.teach_classifier', mock_teach_event)
+
+    with requests_mock.Mocker() as mock_req:
+        url = "http://{}:{}/facebox/teach".format(MOCK_IP, MOCK_PORT)
+        mock_req.post(url, status_code=200)
+        data = {ATTR_ENTITY_ID: VALID_ENTITY_ID,
+                ATTR_NAME: MOCK_NAME,
+                fb.FILE_PATH: MOCK_FILE_PATH}
+        await hass.services.async_call(ip.DOMAIN,
+                                       fb.SERVICE_TEACH_FACE,
+                                       service_data=data)
+        await hass.async_block_till_done()
+
+    assert len(teach_events) == 1
+    assert teach_events[0].data[fb.ATTR_CLASSIFIER] == fb.CLASSIFIER
+    assert teach_events[0].data[ATTR_NAME] == MOCK_NAME
+    assert teach_events[0].data[fb.FILE_PATH] == MOCK_FILE_PATH
+    assert teach_events[0].data['success']
+    assert not teach_events[0].data['message']
+
+    # Now test the failed teaching.
+    with requests_mock.Mocker() as mock_req:
+        url = "http://{}:{}/facebox/teach".format(MOCK_IP, MOCK_PORT)
+        mock_req.post(url, status_code=400, text=MOCK_ERROR)
+        data = {ATTR_ENTITY_ID: VALID_ENTITY_ID,
+                ATTR_NAME: MOCK_NAME,
+                fb.FILE_PATH: MOCK_FILE_PATH}
+        await hass.services.async_call(ip.DOMAIN,
+                                       fb.SERVICE_TEACH_FACE,
+                                       service_data=data)
+        await hass.async_block_till_done()
+
+    assert len(teach_events) == 2
+    assert teach_events[1].data[fb.ATTR_CLASSIFIER] == fb.CLASSIFIER
+    assert teach_events[1].data[ATTR_NAME] == MOCK_NAME
+    assert teach_events[1].data[fb.FILE_PATH] == MOCK_FILE_PATH
+    assert not teach_events[1].data['success']
+    assert teach_events[1].data['message'] == MOCK_ERROR

--- a/tests/components/image_processing/test_facebox.py
+++ b/tests/components/image_processing/test_facebox.py
@@ -176,21 +176,7 @@ async def test_connection_error(hass, mock_image):
     assert state.attributes.get('matched_faces') == {}
 
 
-async def test_setup_platform_with_name(hass):
-    """Setup platform with one entity and a name."""
-    MOCK_NAME = 'mock_name'
-    NAMED_ENTITY_ID = 'image_processing.{}'.format(MOCK_NAME)
-
-    VALID_CONFIG_NAMED = VALID_CONFIG.copy()
-    VALID_CONFIG_NAMED[ip.DOMAIN][ip.CONF_SOURCE][ip.CONF_NAME] = MOCK_NAME
-
-    await async_setup_component(hass, ip.DOMAIN, VALID_CONFIG_NAMED)
-    assert hass.states.get(NAMED_ENTITY_ID)
-    state = hass.states.get(NAMED_ENTITY_ID)
-    assert state.attributes.get(CONF_FRIENDLY_NAME) == MOCK_NAME
-
-
-async def test_teach_service(hass, mock_image, mock_isfile, mock_access):
+async def test_teach_service(hass, mock_image): # mock_isfile, mock_access
     """Test teaching of facebox."""
     await async_setup_component(hass, ip.DOMAIN, VALID_CONFIG)
     assert hass.states.get(VALID_ENTITY_ID)
@@ -241,3 +227,17 @@ async def test_teach_service(hass, mock_image, mock_isfile, mock_access):
     assert teach_events[1].data[fb.FILE_PATH] == MOCK_FILE_PATH
     assert not teach_events[1].data['success']
     assert teach_events[1].data['message'] == MOCK_ERROR
+
+
+async def test_setup_platform_with_name(hass):
+    """Setup platform with one entity and a name."""
+    MOCK_NAME = 'mock_name'
+    NAMED_ENTITY_ID = 'image_processing.{}'.format(MOCK_NAME)
+
+    VALID_CONFIG_NAMED = VALID_CONFIG.copy()
+    VALID_CONFIG_NAMED[ip.DOMAIN][ip.CONF_SOURCE][ip.CONF_NAME] = MOCK_NAME
+
+    await async_setup_component(hass, ip.DOMAIN, VALID_CONFIG_NAMED)
+    assert hass.states.get(NAMED_ENTITY_ID)
+    state = hass.states.get(NAMED_ENTITY_ID)
+    assert state.attributes.get(CONF_FRIENDLY_NAME) == MOCK_NAME

--- a/tests/components/image_processing/test_facebox.py
+++ b/tests/components/image_processing/test_facebox.py
@@ -124,6 +124,7 @@ async def test_process_image(hass, mock_image):
     state = hass.states.get(VALID_ENTITY_ID)
     assert state.state == '1'
     assert state.attributes.get('matched_faces') == MATCHED_FACES
+    assert state.attributes.get('total_matched_faces') == 1
 
     PARSED_FACES[0][ATTR_ENTITY_ID] = VALID_ENTITY_ID  # Update.
     assert state.attributes.get('faces') == PARSED_FACES

--- a/tests/components/image_processing/test_facebox.py
+++ b/tests/components/image_processing/test_facebox.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 import pytest
 import requests
 import requests_mock
+from unittest import mock
 
 from homeassistant.core import callback
 from homeassistant.const import (
@@ -17,6 +18,7 @@ MOCK_IP = '192.168.0.1'
 MOCK_PORT = '8080'
 
 # Mock data returned by the facebox API.
+MOCK_ERROR = "No face found"
 MOCK_FACE = {'confidence': 0.5812028911604818,
              'id': 'john.jpg',
              'matched': True,
@@ -24,10 +26,14 @@ MOCK_FACE = {'confidence': 0.5812028911604818,
              'rect': {'height': 75, 'left': 63, 'top': 262, 'width': 74}
              }
 
+MOCK_FILE_PATH = '/images/mock.jpg'
+
 MOCK_JSON = {"facesCount": 1,
              "success": True,
              "faces": [MOCK_FACE]
              }
+
+MOCK_NAME = 'mock_name'
 
 # Faces data after parsing.
 PARSED_FACES = [{ATTR_NAME: 'John Lennon',
@@ -63,11 +69,26 @@ def test_encode_image():
     assert fb.encode_image(b'test') == 'dGVzdA=='
 
 
+def test_get_matched_faces():
+    """Test that matched_faces are parsed correctly."""
+    assert fb.get_matched_faces(PARSED_FACES) == MATCHED_FACES
+
+
 def test_parse_faces():
     """Test parsing of raw face data, and generation of matched_faces."""
-    parsed_faces = fb.parse_faces(MOCK_JSON['faces'])
-    assert parsed_faces == PARSED_FACES
-    assert fb.get_matched_faces(parsed_faces) == MATCHED_FACES
+    assert fb.parse_faces(MOCK_JSON['faces']) == PARSED_FACES
+
+
+def test_valid_file_path():
+    """Test that an invalid file_path is caught."""
+    with mock.patch('os.access', mock.Mock(return_value=False)):
+        assert not fb.valid_file_path('test_path')
+
+
+def test_valid_image():
+    """Test for valid images."""
+    assert fb.valid_image('test.jpg')
+    assert not fb.valid_image('test.foo')
 
 
 @pytest.fixture
@@ -124,6 +145,64 @@ async def test_process_image(hass, mock_image):
             PARSED_FACES[0][fb.ATTR_IMAGE_ID])
     assert (face_events[0].data[fb.ATTR_BOUNDING_BOX] ==
             PARSED_FACES[0][fb.ATTR_BOUNDING_BOX])
+
+
+async def test_teach_service(hass):
+    """Test teaching of facebox."""
+    await async_setup_component(hass, ip.DOMAIN, VALID_CONFIG)
+    assert hass.states.get(VALID_ENTITY_ID)
+
+    teach_events = []
+
+    @callback
+    def mock_teach_event(event):
+        """Mock event."""
+        teach_events.append(event)
+
+    hass.bus.async_listen(
+        'image_processing.teach_classifier', mock_teach_event)
+
+    m_open = mock.mock_open(read_data=b'hello')
+    with mock.patch('os.access', mock.Mock(return_value=True)):
+        with patch('builtins.open', m_open, create=True):
+            with requests_mock.Mocker() as mock_req:
+                url = "http://{}:{}/facebox/teach".format(MOCK_IP, MOCK_PORT)
+                mock_req.post(url, status_code=200)
+                data = {ATTR_ENTITY_ID: VALID_ENTITY_ID,
+                        ATTR_NAME: MOCK_NAME,
+                        fb.FILE_PATH: MOCK_FILE_PATH}
+                await hass.services.async_call(ip.DOMAIN,
+                                               fb.SERVICE_FACEBOX_TEACH_FACE,
+                                               service_data=data)
+                await hass.async_block_till_done()
+
+    assert len(teach_events) == 1
+    assert teach_events[0].data[fb.ATTR_CLASSIFIER] == fb.CLASSIFIER
+    assert teach_events[0].data[ATTR_NAME] == MOCK_NAME
+    assert teach_events[0].data[fb.FILE_PATH] == MOCK_FILE_PATH
+    assert teach_events[0].data['success']
+    assert not teach_events[0].data['message']
+
+    # Now test the failed teaching.
+    with mock.patch('os.access', mock.Mock(return_value=True)):
+        with patch('builtins.open', m_open, create=True):
+            with requests_mock.Mocker() as mock_req:
+                url = "http://{}:{}/facebox/teach".format(MOCK_IP, MOCK_PORT)
+                mock_req.post(url, status_code=400, text=MOCK_ERROR)
+                data = {ATTR_ENTITY_ID: VALID_ENTITY_ID,
+                        ATTR_NAME: MOCK_NAME,
+                        fb.FILE_PATH: MOCK_FILE_PATH}
+                await hass.services.async_call(ip.DOMAIN,
+                                               fb.SERVICE_FACEBOX_TEACH_FACE,
+                                               service_data=data)
+                await hass.async_block_till_done()
+
+    assert len(teach_events) == 2
+    assert teach_events[1].data[fb.ATTR_CLASSIFIER] == fb.CLASSIFIER
+    assert teach_events[1].data[ATTR_NAME] == MOCK_NAME
+    assert teach_events[1].data[fb.FILE_PATH] == MOCK_FILE_PATH
+    assert not teach_events[1].data['success']
+    assert teach_events[1].data['message'] == MOCK_ERROR
 
 
 async def test_connection_error(hass, mock_image):

--- a/tests/components/image_processing/test_facebox.py
+++ b/tests/components/image_processing/test_facebox.py
@@ -85,25 +85,11 @@ def test_valid_file_path():
 
 
 @pytest.fixture
-def mock_access():
-    """Mock os.access."""
-    with patch('os.access', Mock(return_value=True)) as _mock_access:
-        yield _mock_access
-
-
-@pytest.fixture
 def mock_image():
     """Return a mock camera image."""
     with patch('homeassistant.components.camera.demo.DemoCamera.camera_image',
                return_value=b'Test') as image:
         yield image
-
-
-@pytest.fixture
-def mock_isfile():
-    """Mock os.path.isfile."""
-    with patch('os.path.isfile', Mock(return_value=True)) as _mock_isfile:
-        yield _mock_isfile
 
 
 async def test_setup_platform(hass):
@@ -176,7 +162,9 @@ async def test_connection_error(hass, mock_image):
     assert state.attributes.get('matched_faces') == {}
 
 
-async def test_teach_service(hass, mock_image): # mock_isfile, mock_access
+@patch('os.access', Mock(return_value=True))
+@patch('os.path.isfile', Mock(return_value=True))
+async def test_teach_service(hass, mock_image):
     """Test teaching of facebox."""
     await async_setup_component(hass, ip.DOMAIN, VALID_CONFIG)
     assert hass.states.get(VALID_ENTITY_ID)


### PR DESCRIPTION
## Description:
This PR adds the service `image_processing.facebox_teach_face` that can be used to teach Facebox faces, as described in [this blog post](https://towardsdatascience.com/every-superheros-secret-identity-wouldn-t-fool-modern-face-recognition-32c6fda07bb9). Example valid service data is:

```yaml
{
  "entity_id": "image_processing.facebox_local_file",
  "name": "superman",
  "file_path": "/Users/robincole/.homeassistant/images/superman_1.jpeg"
}
```
An `image_processing.teach_classifier` event is fired for each service call, providing feedback on whether teaching has been successful or unsuccessful. In the unsuccessful case, the `message` field of the event_data will contain info on the cause of failure, and a warning is also published in the HA logs.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io/pull/5553) with documentation (if applicable):** home-assistant/home-assistant.github.io#5553

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)