### PR TITLE
Add experimental UI backend

### DIFF
--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -262,10 +262,10 @@ async def async_setup(hass, config):
         """Finalize setup of a panel."""
         panel.async_register_index_routes(hass.http.app.router, index_view)
 
-    await asyncio.wait([
-        async_register_built_in_panel(hass, panel)
-        for panel in ('dev-event', 'dev-info', 'dev-service', 'dev-state',
-                      'dev-template', 'dev-mqtt', 'kiosk', 'experimental-ui')],
+    await asyncio.wait(
+        [async_register_built_in_panel(hass, panel) for panel in (
+            'dev-event', 'dev-info', 'dev-service', 'dev-state',
+            'dev-template', 'dev-mqtt', 'kiosk', 'experimental-ui')],
         loop=hass.loop)
 
     hass.data[DATA_FINALIZE_PANEL] = async_finalize_panel

--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -23,6 +23,7 @@ from homeassistant.const import CONF_NAME, EVENT_THEMES_UPDATED
 from homeassistant.core import callback
 from homeassistant.helpers.translation import async_get_translations
 from homeassistant.loader import bind_hass
+from homeassistant.util.yaml import load_yaml
 
 REQUIREMENTS = ['home-assistant-frontend==20180615.0']
 
@@ -104,6 +105,10 @@ WS_TYPE_GET_TRANSLATIONS = 'frontend/get_translations'
 SCHEMA_GET_TRANSLATIONS = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend({
     vol.Required('type'): WS_TYPE_GET_TRANSLATIONS,
     vol.Required('language'): str,
+})
+WS_TYPE_GET_EXPERIMENTAL_UI = 'frontend/experimental_ui'
+SCHEMA_GET_EXPERIMENTAL_UI = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend({
+    vol.Required('type'): WS_TYPE_GET_EXPERIMENTAL_UI,
 })
 
 
@@ -210,6 +215,9 @@ async def async_setup(hass, config):
     hass.components.websocket_api.async_register_command(
         WS_TYPE_GET_TRANSLATIONS, websocket_get_translations,
         SCHEMA_GET_TRANSLATIONS)
+    hass.components.websocket_api.async_register_command(
+        WS_TYPE_GET_EXPERIMENTAL_UI, websocket_experimental_config,
+        SCHEMA_GET_EXPERIMENTAL_UI)
     hass.http.register_view(ManifestJSONView)
 
     conf = config.get(DOMAIN, {})
@@ -257,7 +265,8 @@ async def async_setup(hass, config):
     await asyncio.wait([
         async_register_built_in_panel(hass, panel)
         for panel in ('dev-event', 'dev-info', 'dev-service', 'dev-state',
-                      'dev-template', 'dev-mqtt', 'kiosk')], loop=hass.loop)
+                      'dev-template', 'dev-mqtt', 'kiosk', 'experimental-ui')],
+        loop=hass.loop)
 
     hass.data[DATA_FINALIZE_PANEL] = async_finalize_panel
 
@@ -488,3 +497,17 @@ def websocket_get_translations(hass, connection, msg):
         ))
 
     hass.async_add_job(send_translations())
+
+
+def websocket_experimental_config(hass, connection, msg):
+    """Send experimental UI config over websocket config."""
+    async def send_exp_config():
+        """Send experimental frontend config."""
+        config = await hass.async_add_job(
+            load_yaml, hass.config.path('experimental-ui.yaml'))
+
+        connection.send_message_outside(websocket_api.result_message(
+            msg['id'], config
+        ))
+
+    hass.async_add_job(send_exp_config())

--- a/tests/components/test_frontend.py
+++ b/tests/components/test_frontend.py
@@ -278,3 +278,22 @@ async def test_get_translations(hass, hass_ws_client):
     assert msg['type'] == wapi.TYPE_RESULT
     assert msg['success']
     assert msg['result'] == {'resources': {'lang': 'nl'}}
+
+
+async def test_experimental_ui(hass, hass_ws_client):
+    """Test experimental_ui command."""
+    await async_setup_component(hass, 'frontend')
+    client = await hass_ws_client(hass)
+
+    with patch('homeassistant.components.frontend.load_yaml',
+               return_value={'hello': 'world'}):
+        await client.send_json({
+            'id': 5,
+            'type': 'frontend/experimental_ui',
+        })
+        msg = await client.receive_json()
+
+    assert msg['id'] == 5
+    assert msg['type'] == wapi.TYPE_RESULT
+    assert msg['success']
+    assert msg['result'] == {'hello': 'world'}


### PR DESCRIPTION
## Description:
Add backend for experimental UI. More work is being hashed out [here](https://github.com/home-assistant/ui-schema).

It's not visible in the UI. Will only be visible if you navigate to special url `/experimental-ui`.


## Example entry for `configuration.yaml` (if applicable):
```yaml
frontend:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
