### PR TITLE
Refactored json_attributes support

### DIFF
--- a/homeassistant/components/json_attributes.py
+++ b/homeassistant/components/json_attributes.py
@@ -3,7 +3,6 @@ Core support for mapping a subset of values in a JSON dictionary
 into component attributes.
 """
 
-import voluptuous as vol
 import json
 import logging
 
@@ -15,8 +14,10 @@ CONF_JSON_ATTRS = 'json_attributes'
 
 json_attrs_validation = cv.ensure_list_csv
 
+
 def extract_json_attrs(json_attrs_conf, value):
-    _LOGGER.debug("extract_json_attrs called with value %s and conf %s", value, json_attrs_conf)
+    _LOGGER.debug("extract_json_attrs called with value %s and conf %s",
+                  value, json_attrs_conf)
     attributes = {}
     if value:
         try:
@@ -24,7 +25,7 @@ def extract_json_attrs(json_attrs_conf, value):
             if isinstance(json_dict, dict):
                 attributes = {k: json_dict[k]
                               for k in json_attrs_conf
-                              if k in json_dict }
+                              if k in json_dict}
             else:
                 _LOGGER.warning("JSON result was not a dictionary")
         except ValueError:

--- a/homeassistant/components/json_attributes.py
+++ b/homeassistant/components/json_attributes.py
@@ -1,0 +1,35 @@
+"""
+Core support for mapping a subset of values in a JSON dictionary
+into component attributes.
+"""
+
+import voluptuous as vol
+import json
+import logging
+
+import homeassistant.helpers.config_validation as cv
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_JSON_ATTRS = 'json_attributes'
+
+json_attrs_validation = cv.ensure_list_csv
+
+def extract_json_attrs(json_attrs_conf, value):
+    _LOGGER.debug("extract_json_attrs called with value %s and conf %s", value, json_attrs_conf)
+    attributes = {}
+    if value:
+        try:
+            json_dict = json.loads(value)
+            if isinstance(json_dict, dict):
+                attributes = {k: json_dict[k]
+                              for k in json_attrs_conf
+                              if k in json_dict }
+            else:
+                _LOGGER.warning("JSON result was not a dictionary")
+        except ValueError:
+            _LOGGER.warning("REST result could not be parsed as JSON")
+            _LOGGER.debug("Erroneous JSON: %s", value)
+    else:
+        _LOGGER.warning("Empty reply found when expecting JSON data")
+    return attributes

--- a/homeassistant/components/sensor/mqtt.py
+++ b/homeassistant/components/sensor/mqtt.py
@@ -24,8 +24,8 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import HomeAssistantType, ConfigType
 from homeassistant.helpers.event import async_track_point_in_utc_time
 from homeassistant.util import dt as dt_util
-from homeassistant.components.json_attributes import (
-    CONF_JSON_ATTRS, json_attrs_validation, extract_json_attrs)
+from homeassistant.helpers.json_attributes import (
+    CONF_JSON_ATTRS, JSON_ATTRS_VALIDATION, extract_json_attrs)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -41,7 +41,7 @@ PLATFORM_SCHEMA = mqtt.MQTT_RO_PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
     vol.Optional(CONF_ICON): cv.icon,
     vol.Optional(CONF_DEVICE_CLASS): DEVICE_CLASSES_SCHEMA,
-    vol.Optional(CONF_JSON_ATTRS, default=[]): json_attrs_validation,
+    vol.Optional(CONF_JSON_ATTRS, default=[]): JSON_ATTRS_VALIDATION,
     vol.Optional(CONF_EXPIRE_AFTER): cv.positive_int,
     vol.Optional(CONF_FORCE_UPDATE, default=DEFAULT_FORCE_UPDATE): cv.boolean,
     # Integrations shouldn't never expose unique_id through configuration

--- a/homeassistant/components/sensor/mqtt.py
+++ b/homeassistant/components/sensor/mqtt.py
@@ -5,7 +5,6 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.mqtt/
 """
 import logging
-import json
 from datetime import timedelta
 from typing import Optional
 
@@ -25,11 +24,12 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import HomeAssistantType, ConfigType
 from homeassistant.helpers.event import async_track_point_in_utc_time
 from homeassistant.util import dt as dt_util
+from homeassistant.components.json_attributes import (
+    CONF_JSON_ATTRS, json_attrs_validation, extract_json_attrs)
 
 _LOGGER = logging.getLogger(__name__)
 
 CONF_EXPIRE_AFTER = 'expire_after'
-CONF_JSON_ATTRS = 'json_attributes'
 CONF_UNIQUE_ID = 'unique_id'
 
 DEFAULT_NAME = 'MQTT Sensor'
@@ -41,7 +41,7 @@ PLATFORM_SCHEMA = mqtt.MQTT_RO_PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
     vol.Optional(CONF_ICON): cv.icon,
     vol.Optional(CONF_DEVICE_CLASS): DEVICE_CLASSES_SCHEMA,
-    vol.Optional(CONF_JSON_ATTRS, default=[]): cv.ensure_list_csv,
+    vol.Optional(CONF_JSON_ATTRS, default=[]): json_attrs_validation,
     vol.Optional(CONF_EXPIRE_AFTER): cv.positive_int,
     vol.Optional(CONF_FORCE_UPDATE, default=DEFAULT_FORCE_UPDATE): cv.boolean,
     # Integrations shouldn't never expose unique_id through configuration
@@ -126,18 +126,7 @@ class MqttSensor(MqttAvailability, Entity):
                     self.hass, self.value_is_expired, expiration_at)
 
             if self._json_attributes:
-                self._attributes = {}
-                try:
-                    json_dict = json.loads(payload)
-                    if isinstance(json_dict, dict):
-                        attrs = {k: json_dict[k] for k in
-                                 self._json_attributes & json_dict.keys()}
-                        self._attributes = attrs
-                    else:
-                        _LOGGER.warning("JSON result was not a dictionary")
-                except ValueError:
-                    _LOGGER.warning("MQTT payload could not be parsed as JSON")
-                    _LOGGER.debug("Erroneous JSON: %s", payload)
+                self._attributes = extract_json_attrs(self._json_attributes, payload)
 
             if self._template is not None:
                 payload = self._template.async_render_with_possible_json_value(

--- a/homeassistant/components/sensor/mqtt.py
+++ b/homeassistant/components/sensor/mqtt.py
@@ -126,7 +126,8 @@ class MqttSensor(MqttAvailability, Entity):
                     self.hass, self.value_is_expired, expiration_at)
 
             if self._json_attributes:
-                self._attributes = extract_json_attrs(self._json_attributes, payload)
+                self._attributes = extract_json_attrs(self._json_attributes,
+                                                      payload)
 
             if self._template is not None:
                 payload = self._template.async_render_with_possible_json_value(

--- a/homeassistant/components/sensor/rest.py
+++ b/homeassistant/components/sensor/rest.py
@@ -19,8 +19,8 @@ from homeassistant.const import (
     HTTP_BASIC_AUTHENTICATION, HTTP_DIGEST_AUTHENTICATION, STATE_UNKNOWN)
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
-from homeassistant.components.json_attributes import (
-    CONF_JSON_ATTRS, json_attrs_validation, extract_json_attrs)
+from homeassistant.helpers.json_attributes import (
+    CONF_JSON_ATTRS, JSON_ATTRS_VALIDATION, extract_json_attrs)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -36,7 +36,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_AUTHENTICATION):
         vol.In([HTTP_BASIC_AUTHENTICATION, HTTP_DIGEST_AUTHENTICATION]),
     vol.Optional(CONF_HEADERS): vol.Schema({cv.string: cv.string}),
-    vol.Optional(CONF_JSON_ATTRS, default=[]): json_attrs_validation,
+    vol.Optional(CONF_JSON_ATTRS, default=[]): JSON_ATTRS_VALIDATION,
     vol.Optional(CONF_METHOD, default=DEFAULT_METHOD): vol.In(METHODS),
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_PASSWORD): cv.string,

--- a/homeassistant/components/sensor/rest.py
+++ b/homeassistant/components/sensor/rest.py
@@ -5,7 +5,6 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.rest/
 """
 import logging
-import json
 
 import voluptuous as vol
 import requests
@@ -20,6 +19,8 @@ from homeassistant.const import (
     HTTP_BASIC_AUTHENTICATION, HTTP_DIGEST_AUTHENTICATION, STATE_UNKNOWN)
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
+from homeassistant.components.json_attributes import (
+    CONF_JSON_ATTRS, json_attrs_validation, extract_json_attrs)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -28,7 +29,6 @@ DEFAULT_NAME = 'REST Sensor'
 DEFAULT_VERIFY_SSL = True
 DEFAULT_FORCE_UPDATE = False
 
-CONF_JSON_ATTRS = 'json_attributes'
 METHODS = ['POST', 'GET']
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -36,7 +36,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_AUTHENTICATION):
         vol.In([HTTP_BASIC_AUTHENTICATION, HTTP_DIGEST_AUTHENTICATION]),
     vol.Optional(CONF_HEADERS): vol.Schema({cv.string: cv.string}),
-    vol.Optional(CONF_JSON_ATTRS, default=[]): cv.ensure_list_csv,
+    vol.Optional(CONF_JSON_ATTRS, default=[]): json_attrs_validation,
     vol.Optional(CONF_METHOD, default=DEFAULT_METHOD): vol.In(METHODS),
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_PASSWORD): cv.string,
@@ -129,21 +129,8 @@ class RestSensor(Entity):
         value = self.rest.data
 
         if self._json_attrs:
-            self._attributes = {}
-            if value:
-                try:
-                    json_dict = json.loads(value)
-                    if isinstance(json_dict, dict):
-                        attrs = {k: json_dict[k] for k in self._json_attrs
-                                 if k in json_dict}
-                        self._attributes = attrs
-                    else:
-                        _LOGGER.warning("JSON result was not a dictionary")
-                except ValueError:
-                    _LOGGER.warning("REST result could not be parsed as JSON")
-                    _LOGGER.debug("Erroneous JSON: %s", value)
-            else:
-                _LOGGER.warning("Empty reply found when expecting JSON data")
+            self._attributes = extract_json_attrs(self._json_attrs, value)
+
         if value is None:
             value = STATE_UNKNOWN
         elif self._value_template is not None:

--- a/homeassistant/helpers/json_attributes.py
+++ b/homeassistant/helpers/json_attributes.py
@@ -1,5 +1,8 @@
 """
-Core support for mapping a subset of values in a JSON dictionary
+Common code for json_attributes.
+
+Implements the common code for validating json_attributes
+configuration and for mapping a subset of values in a JSON dictionary
 into component attributes.
 """
 
@@ -12,10 +15,11 @@ _LOGGER = logging.getLogger(__name__)
 
 CONF_JSON_ATTRS = 'json_attributes'
 
-json_attrs_validation = cv.ensure_list_csv
+JSON_ATTRS_VALIDATION = cv.ensure_list_csv
 
 
 def extract_json_attrs(json_attrs_conf, value):
+    """Extract JSON dictionary and copy specified keys to attributes."""
     _LOGGER.debug("extract_json_attrs called with value %s and conf %s",
                   value, json_attrs_conf)
     attributes = {}

--- a/tests/components/sensor/test_mqtt.py
+++ b/tests/components/sensor/test_mqtt.py
@@ -264,7 +264,7 @@ class TestSensorMQTT(unittest.TestCase):
         self.assertEqual('100',
                          state.attributes.get('val'))
 
-    @patch('homeassistant.components.json_attributes._LOGGER')
+    @patch('homeassistant.helpers.json_attributes._LOGGER')
     def test_update_with_json_attrs_not_dict(self, mock_logger):
         """Test attributes get extracted from a JSON result."""
         mock_component(self.hass, 'mqtt')
@@ -286,7 +286,7 @@ class TestSensorMQTT(unittest.TestCase):
                          state.attributes.get('val'))
         self.assertTrue(mock_logger.warning.called)
 
-    @patch('homeassistant.components.json_attributes._LOGGER')
+    @patch('homeassistant.helpers.json_attributes._LOGGER')
     def test_update_with_json_attrs_bad_JSON(self, mock_logger):
         """Test attributes get extracted from a JSON result."""
         mock_component(self.hass, 'mqtt')

--- a/tests/components/sensor/test_mqtt.py
+++ b/tests/components/sensor/test_mqtt.py
@@ -264,7 +264,7 @@ class TestSensorMQTT(unittest.TestCase):
         self.assertEqual('100',
                          state.attributes.get('val'))
 
-    @patch('homeassistant.components.sensor.mqtt._LOGGER')
+    @patch('homeassistant.components.json_attributes._LOGGER')
     def test_update_with_json_attrs_not_dict(self, mock_logger):
         """Test attributes get extracted from a JSON result."""
         mock_component(self.hass, 'mqtt')
@@ -286,7 +286,7 @@ class TestSensorMQTT(unittest.TestCase):
                          state.attributes.get('val'))
         self.assertTrue(mock_logger.warning.called)
 
-    @patch('homeassistant.components.sensor.mqtt._LOGGER')
+    @patch('homeassistant.components.json_attributes._LOGGER')
     def test_update_with_json_attrs_bad_JSON(self, mock_logger):
         """Test attributes get extracted from a JSON result."""
         mock_component(self.hass, 'mqtt')

--- a/tests/components/sensor/test_rest.py
+++ b/tests/components/sensor/test_rest.py
@@ -207,7 +207,7 @@ class TestRestSensor(unittest.TestCase):
         self.assertEqual('some_json_value',
                          self.sensor.device_state_attributes['key'])
 
-    @patch('homeassistant.components.sensor.rest._LOGGER')
+    @patch('homeassistant.components.json_attributes._LOGGER')
     def test_update_with_json_attrs_no_data(self, mock_logger):
         """Test attributes when no JSON result fetched."""
         self.rest.update = Mock('rest.RestData.update',
@@ -219,7 +219,7 @@ class TestRestSensor(unittest.TestCase):
         self.assertEqual({}, self.sensor.device_state_attributes)
         self.assertTrue(mock_logger.warning.called)
 
-    @patch('homeassistant.components.sensor.rest._LOGGER')
+    @patch('homeassistant.components.json_attributes._LOGGER')
     def test_update_with_json_attrs_not_dict(self, mock_logger):
         """Test attributes get extracted from a JSON result."""
         self.rest.update = Mock('rest.RestData.update',
@@ -232,7 +232,7 @@ class TestRestSensor(unittest.TestCase):
         self.assertEqual({}, self.sensor.device_state_attributes)
         self.assertTrue(mock_logger.warning.called)
 
-    @patch('homeassistant.components.sensor.rest._LOGGER')
+    @patch('homeassistant.components.json_attributes._LOGGER')
     def test_update_with_json_attrs_bad_JSON(self, mock_logger):
         """Test attributes get extracted from a JSON result."""
         self.rest.update = Mock('rest.RestData.update',

--- a/tests/components/sensor/test_rest.py
+++ b/tests/components/sensor/test_rest.py
@@ -207,7 +207,7 @@ class TestRestSensor(unittest.TestCase):
         self.assertEqual('some_json_value',
                          self.sensor.device_state_attributes['key'])
 
-    @patch('homeassistant.components.json_attributes._LOGGER')
+    @patch('homeassistant.helpers.json_attributes._LOGGER')
     def test_update_with_json_attrs_no_data(self, mock_logger):
         """Test attributes when no JSON result fetched."""
         self.rest.update = Mock('rest.RestData.update',
@@ -219,7 +219,7 @@ class TestRestSensor(unittest.TestCase):
         self.assertEqual({}, self.sensor.device_state_attributes)
         self.assertTrue(mock_logger.warning.called)
 
-    @patch('homeassistant.components.json_attributes._LOGGER')
+    @patch('homeassistant.helpers.json_attributes._LOGGER')
     def test_update_with_json_attrs_not_dict(self, mock_logger):
         """Test attributes get extracted from a JSON result."""
         self.rest.update = Mock('rest.RestData.update',
@@ -232,7 +232,7 @@ class TestRestSensor(unittest.TestCase):
         self.assertEqual({}, self.sensor.device_state_attributes)
         self.assertTrue(mock_logger.warning.called)
 
-    @patch('homeassistant.components.json_attributes._LOGGER')
+    @patch('homeassistant.helpers.json_attributes._LOGGER')
     def test_update_with_json_attrs_bad_JSON(self, mock_logger):
         """Test attributes get extracted from a JSON result."""
         self.rest.update = Mock('rest.RestData.update',


### PR DESCRIPTION
## Description:
When json_attributes support was added to `sensor/mqtt.py` it was done by cutting and pasting the support from `sensor/rest.py`. This PR replaces the cut-and-paste replicated code with a single implementation and updates the mock hooks in the test cases to catch the right warnings.

**Related issue (if applicable):** None

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** 
No functionality change so no new documentation

## Example entry for `configuration.yaml` (if applicable):
**N/A** Configuration remains the same

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] **N/A** Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] **N/A** New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] **N/A** New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] **N/A** New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] **N/A** New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

