### PR TITLE
Switch nuimo to a hopefully working pypi version

### DIFF
--- a/homeassistant/components/nuimo_controller.py
+++ b/homeassistant/components/nuimo_controller.py
@@ -15,9 +15,7 @@ from homeassistant.const import (CONF_MAC, CONF_NAME, EVENT_HOMEASSISTANT_STOP)
 
 REQUIREMENTS = [
     '--only-binary=all '  # avoid compilation of gattlib
-    'https://github.com/getSenic/nuimo-linux-python'
-    '/archive/29fc42987f74d8090d0e2382e8f248ff5990b8c9.zip'
-    '#nuimo==1.0.0']
+    'nuimo==0.1.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -13,7 +13,7 @@ typing>=3,<4
 voluptuous==0.11.1
 
 # homeassistant.components.nuimo_controller
---only-binary=all https://github.com/getSenic/nuimo-linux-python/archive/29fc42987f74d8090d0e2382e8f248ff5990b8c9.zip#nuimo==1.0.0
+--only-binary=all nuimo==0.1.0
 
 # homeassistant.components.sensor.sht31
 Adafruit-GPIO==1.0.3


### PR DESCRIPTION
## Description:

Switch nuimo to a hopefully working pypi version.

I have no way to test this, but it doesn't make sense to create an own package when an official package exists. If this breaks Nuimo we should disable it until proper support is added.

**Related issue (if applicable):** #7069 

