### PR TITLE
Fix linode I/O in state property

### DIFF
--- a/homeassistant/components/binary_sensor/linode.py
+++ b/homeassistant/components/binary_sensor/linode.py
@@ -52,13 +52,13 @@ class LinodeBinarySensor(BinarySensorDevice):
         self._node_id = node_id
         self._state = None
         self.data = None
+        self._attrs = {}
+        self._name = None
 
     @property
     def name(self):
         """Return the name of the sensor."""
-        if self.data is not None:
-            return self.data.label
-        return None
+        return self._name
 
     @property
     def is_on(self):
@@ -73,18 +73,7 @@ class LinodeBinarySensor(BinarySensorDevice):
     @property
     def device_state_attributes(self):
         """Return the state attributes of the Linode Node."""
-        if self.data:
-            return {
-                ATTR_CREATED: self.data.created,
-                ATTR_NODE_ID: self.data.id,
-                ATTR_NODE_NAME: self.data.label,
-                ATTR_IPV4_ADDRESS: self.data.ipv4,
-                ATTR_IPV6_ADDRESS: self.data.ipv6,
-                ATTR_MEMORY: self.data.specs.memory,
-                ATTR_REGION: self.data.region.country,
-                ATTR_VCPUS: self.data.specs.vcpus,
-            }
-        return {}
+        return self._attrs
 
     def update(self):
         """Update state of sensor."""
@@ -95,3 +84,14 @@ class LinodeBinarySensor(BinarySensorDevice):
                     self.data = node
         if self.data is not None:
             self._state = self.data.status == 'running'
+            self._attrs = {
+                ATTR_CREATED: self.data.created,
+                ATTR_NODE_ID: self.data.id,
+                ATTR_NODE_NAME: self.data.label,
+                ATTR_IPV4_ADDRESS: self.data.ipv4,
+                ATTR_IPV6_ADDRESS: self.data.ipv6,
+                ATTR_MEMORY: self.data.specs.memory,
+                ATTR_REGION: self.data.region.country,
+                ATTR_VCPUS: self.data.specs.vcpus,
+            }
+            self._name = self.data.label

--- a/homeassistant/components/binary_sensor/linode.py
+++ b/homeassistant/components/binary_sensor/linode.py
@@ -58,13 +58,12 @@ class LinodeBinarySensor(BinarySensorDevice):
         """Return the name of the sensor."""
         if self.data is not None:
             return self.data.label
+        return None
 
     @property
     def is_on(self):
         """Return true if the binary sensor is on."""
-        if self.data is not None:
-            return self.data.status == 'running'
-        return False
+        return self._state
 
     @property
     def device_class(self):
@@ -94,3 +93,5 @@ class LinodeBinarySensor(BinarySensorDevice):
             for node in self._linode.data:
                 if node.id == self._node_id:
                     self.data = node
+        if self.data is not None:
+            self._state = self.data.status == 'running'

--- a/homeassistant/components/switch/linode.py
+++ b/homeassistant/components/switch/linode.py
@@ -57,13 +57,12 @@ class LinodeSwitch(SwitchDevice):
         """Return the name of the switch."""
         if self.data is not None:
             return self.data.label
+        return None
 
     @property
     def is_on(self):
         """Return true if switch is on."""
-        if self.data is not None:
-            return self.data.status == 'running'
-        return False
+        return self._state
 
     @property
     def device_state_attributes(self):
@@ -98,3 +97,5 @@ class LinodeSwitch(SwitchDevice):
             for node in self._linode.data:
                 if node.id == self._node_id:
                     self.data = node
+        if self.data is not None:
+            self._state = self.data.status == 'running'

--- a/homeassistant/components/switch/linode.py
+++ b/homeassistant/components/switch/linode.py
@@ -51,13 +51,13 @@ class LinodeSwitch(SwitchDevice):
         self._node_id = node_id
         self.data = None
         self._state = None
+        self._attrs = {}
+        self._name = None
 
     @property
     def name(self):
         """Return the name of the switch."""
-        if self.data is not None:
-            return self.data.label
-        return None
+        return self._name
 
     @property
     def is_on(self):
@@ -67,18 +67,7 @@ class LinodeSwitch(SwitchDevice):
     @property
     def device_state_attributes(self):
         """Return the state attributes of the Linode Node."""
-        if self.data:
-            return {
-                ATTR_CREATED: self.data.created,
-                ATTR_NODE_ID: self.data.id,
-                ATTR_NODE_NAME: self.data.label,
-                ATTR_IPV4_ADDRESS: self.data.ipv4,
-                ATTR_IPV6_ADDRESS: self.data.ipv6,
-                ATTR_MEMORY: self.data.specs.memory,
-                ATTR_REGION: self.data.region.country,
-                ATTR_VCPUS: self.data.specs.vcpus,
-            }
-        return {}
+        return self._attrs
 
     def turn_on(self, **kwargs):
         """Boot-up the Node."""
@@ -99,3 +88,14 @@ class LinodeSwitch(SwitchDevice):
                     self.data = node
         if self.data is not None:
             self._state = self.data.status == 'running'
+            self._attrs = {
+                ATTR_CREATED: self.data.created,
+                ATTR_NODE_ID: self.data.id,
+                ATTR_NODE_NAME: self.data.label,
+                ATTR_IPV4_ADDRESS: self.data.ipv4,
+                ATTR_IPV6_ADDRESS: self.data.ipv6,
+                ATTR_MEMORY: self.data.specs.memory,
+                ATTR_REGION: self.data.region.country,
+                ATTR_VCPUS: self.data.specs.vcpus,
+            }
+            self._name = self.data.label


### PR DESCRIPTION
## Description:
The `status` property of linode nodes is marked as volatile which means there will be a request done when the latest data is stale, when accessing the `status` property.

https://github.com/linode/linode-api-python/blob/master/linode/objects/linode/linode.py#L30
https://github.com/linode/linode-api-python/blob/master/linode/objects/base.py#L89-L109

**Related issue (if applicable):**
fixes #15007 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**