### PR TITLE
Fix tplink max/min kelvin

### DIFF
--- a/homeassistant/components/light/tplink.py
+++ b/homeassistant/components/light/tplink.py
@@ -19,7 +19,7 @@ from homeassistant.util.color import \
 from homeassistant.util.color import (
     color_temperature_kelvin_to_mired as kelvin_to_mired)
 
-REQUIREMENTS = ['pyHS100==0.3.1']
+REQUIREMENTS = ['pyHS100==0.3.2']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -103,6 +103,16 @@ class TPLinkSmartBulb(Light):
     def turn_off(self, **kwargs):
         """Turn the light off."""
         self.smartbulb.state = self.smartbulb.BULB_STATE_OFF
+
+    @property
+    def min_mireds(self):
+        """Return minimum supported color temperature."""
+        return kelvin_to_mired(self.smartbulb.valid_temperature_range[1])
+
+    @property
+    def max_mireds(self):
+        """Return maximum supported color temperature."""
+        return kelvin_to_mired(self.smartbulb.valid_temperature_range[0])
 
     @property
     def color_temp(self):

--- a/homeassistant/components/switch/tplink.py
+++ b/homeassistant/components/switch/tplink.py
@@ -14,7 +14,7 @@ from homeassistant.components.switch import (
 from homeassistant.const import (CONF_HOST, CONF_NAME, ATTR_VOLTAGE)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['pyHS100==0.3.1']
+REQUIREMENTS = ['pyHS100==0.3.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -718,7 +718,7 @@ pyCEC==0.4.13
 
 # homeassistant.components.light.tplink
 # homeassistant.components.switch.tplink
-pyHS100==0.3.1
+pyHS100==0.3.2
 
 # homeassistant.components.rfxtrx
 pyRFXtrx==0.22.1


### PR DESCRIPTION
## Description:
The max/min for the slider in the UI for the white temperature is not correctly defined.
This patch fixes that.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
