### PR TITLE
Tradfri: Avoid error if there are no paired sensors

### DIFF
--- a/homeassistant/components/sensor/tradfri.py
+++ b/homeassistant/components/sensor/tradfri.py
@@ -33,7 +33,8 @@ async def async_setup_platform(hass, config, async_add_devices,
     devices_commands = await api(devices_command)
     all_devices = await api(devices_commands)
     devices = [dev for dev in all_devices if not dev.has_light_control]
-    async_add_devices(TradfriDevice(device, api) for device in devices)
+    if devices:
+        async_add_devices(TradfriDevice(device, api) for device in devices)
 
 
 class TradfriDevice(Entity):

--- a/tests/components/light/test_tradfri.py
+++ b/tests/components/light/test_tradfri.py
@@ -224,6 +224,11 @@ async def setup_gateway(hass, mock_gateway, mock_api,
     if known_hosts is None:
         known_hosts = {}
 
+    # Catch any exceptions within the core loop
+    handler = hass.loop.get_exception_handler()
+    exception_handler = Mock(wraps=handler)
+    hass.loop.set_exception_handler(exception_handler)
+
     with patch('pytradfri.api.aiocoap_api.APIFactory.generate_psk',
                generate_psk), \
             patch('pytradfri.api.aiocoap_api.APIFactory.request', mock_api), \
@@ -240,6 +245,7 @@ async def setup_gateway(hass, mock_gateway, mock_api,
                                         }
                                     })
         await hass.async_block_till_done()
+    exception_handler.assert_not_called()
 
 
 async def test_setup_gateway(hass, mock_gateway, mock_api):


### PR DESCRIPTION
## Description:
Checks that there are sensors to add before calling `async_add_devices` 

**Related issue (if applicable):** fixes #15000 and (part of) #9822

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
tradfri:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

<s>If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.
</s>

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54