### PR TITLE
Update PostNL unit of measure to align with UPS

### DIFF
--- a/homeassistant/components/sensor/postnl.py
+++ b/homeassistant/components/sensor/postnl.py
@@ -76,7 +76,7 @@ class PostNLSensor(Entity):
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement of this entity, if any."""
-        return 'package(s)'
+        return 'packages'
 
     @property
     def device_state_attributes(self):


### PR DESCRIPTION
I'm using both the UPS and PostNL package trackers. I'd like to have the unit of measure to be the same, now they appear in two different graphs in the history view. 

If we prefer ```package(s)``` over ```package``` then I'll do a PR for [this line](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/sensor/ups.py#L81)

**Breaking Change**: the unit will now be `packages` (vs. the previously-used `package`).