### PR TITLE
Fix panel URL authentication for Hass.io

### DIFF
--- a/homeassistant/components/hassio/http.py
+++ b/homeassistant/components/hassio/http.py
@@ -36,7 +36,7 @@ NO_TIMEOUT = {
 }
 
 NO_AUTH = {
-    re.compile(r'^app(?:-(?:es5|latest))?/.+'),
+    re.compile(r'^app/.*$'),
     re.compile(r'^addons/[^/]*/logo$')
 }
 

--- a/homeassistant/components/hassio/http.py
+++ b/homeassistant/components/hassio/http.py
@@ -36,7 +36,7 @@ NO_TIMEOUT = {
 }
 
 NO_AUTH = {
-    re.compile(r'^app-(es5|latest)/.+$'),
+    re.compile(r'^app(?:-(?:es5|latest))?/.+'),
     re.compile(r'^addons/[^/]*/logo$')
 }
 

--- a/tests/components/hassio/test_http.py
+++ b/tests/components/hassio/test_http.py
@@ -47,8 +47,8 @@ def test_auth_required_forward_request(hassio_client):
 @asyncio.coroutine
 @pytest.mark.parametrize(
     'build_type', [
-        'es5/index.html', 'es5/hassio-app.html', 'latest/index.html',
-        'latest/hassio-app.html', 'es5/some-chunk.js', 'es5/app.js',
+        'app/index.html', 'app/hassio-app.html', 'app/index.html',
+        'app/hassio-app.html', 'app/some-chunk.js', 'app/app.js',
     ])
 def test_forward_request_no_auth_for_panel(hassio_client, build_type):
     """Test no auth needed for ."""

--- a/tests/components/hassio/test_http.py
+++ b/tests/components/hassio/test_http.py
@@ -61,7 +61,7 @@ def test_forward_request_no_auth_for_panel(hassio_client, build_type):
                   '_create_response') as mresp:
         mresp.return_value = 'response'
         resp = yield from hassio_client.get(
-            '/api/hassio/app-{}'.format(build_type))
+            '/api/hassio/{}'.format(build_type))
 
     # Check we got right response
     assert resp.status == 200


### PR DESCRIPTION
## Description:

This regex match the correct panel. We need only match that panel they we support for this Home Assistant version.