### PR TITLE
Fix #14919. Should throw exception when camera stream closed by frontend

### DIFF
--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -319,10 +319,10 @@ class Camera(Entity):
 
                 await asyncio.sleep(interval)
 
-        except asyncio.CancelledError as error:
+        except asyncio.CancelledError:
             _LOGGER.debug("Stream closed by frontend.")
             response = None
-            raise error
+            raise
 
         finally:
             if response is not None:

--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -319,9 +319,10 @@ class Camera(Entity):
 
                 await asyncio.sleep(interval)
 
-        except asyncio.CancelledError:
+        except asyncio.CancelledError as error:
             _LOGGER.debug("Stream closed by frontend.")
             response = None
+            raise error
 
         finally:
             if response is not None:

--- a/homeassistant/components/camera/proxy.py
+++ b/homeassistant/components/camera/proxy.py
@@ -229,11 +229,11 @@ class ProxyCamera(Camera):
                         _resize_image, image, self._stream_opts)
                     await write(image)
                     data = data[jpg_end + 2:]
-        except asyncio.CancelledError as error:
+        except asyncio.CancelledError:
             _LOGGER.debug("Stream closed by frontend.")
             req.close()
             response = None
-            raise error
+            raise
 
         finally:
             if response is not None:

--- a/homeassistant/components/camera/proxy.py
+++ b/homeassistant/components/camera/proxy.py
@@ -229,10 +229,11 @@ class ProxyCamera(Camera):
                         _resize_image, image, self._stream_opts)
                     await write(image)
                     data = data[jpg_end + 2:]
-        except asyncio.CancelledError:
+        except asyncio.CancelledError as error:
             _LOGGER.debug("Stream closed by frontend.")
             req.close()
             response = None
+            raise error
 
         finally:
             if response is not None:


### PR DESCRIPTION
## Description:
When user closed camera stream window, we should simply abort the stream by thrown exception. The issue has been masked before aiohttp 3.3.0. However after 3.3.0, if you try to operate on closed connection, a ConnectionResetError will be thrown instead of asyncio.CancelledError. ConnectionResetError will eventually throw to top level, since nobody handle it (should not be handled)

Change to re-throw asyncio.CancelledError fix the issue.

**Related issue (if applicable):** fixes #14919

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

