### PR TITLE
Make zone entries work without radius

### DIFF
--- a/homeassistant/components/zone/__init__.py
+++ b/homeassistant/components/zone/__init__.py
@@ -73,8 +73,8 @@ async def async_setup_entry(hass, config_entry):
     entry = config_entry.data
     name = entry[CONF_NAME]
     zone = Zone(hass, name, entry[CONF_LATITUDE], entry[CONF_LONGITUDE],
-                entry.get(CONF_RADIUS), entry.get(CONF_ICON),
-                entry.get(CONF_PASSIVE))
+                entry.get(CONF_RADIUS, DEFAULT_RADIUS), entry.get(CONF_ICON),
+                entry.get(CONF_PASSIVE, DEFAULT_PASSIVE))
     zone.entity_id = async_generate_entity_id(
         ENTITY_ID_FORMAT, name, None, hass)
     hass.async_add_job(zone.async_update_ha_state())

--- a/tests/components/zone/test_init.py
+++ b/tests/components/zone/test_init.py
@@ -17,7 +17,6 @@ async def test_setup_entry_successful(hass):
         zone.CONF_NAME: 'Test Zone',
         zone.CONF_LATITUDE: 1.1,
         zone.CONF_LONGITUDE: -2.2,
-        zone.CONF_RADIUS: 250,
         zone.CONF_RADIUS: True
     }
     hass.data[zone.DOMAIN] = {}


### PR DESCRIPTION
## Description:
It's not required to specify a radius when creating a zone via a config entry. When that happens, we need to supply the default radius when setting up the zone.


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
