### PR TITLE
Show running apps as sources for Fire TV

### DIFF
--- a/homeassistant/components/media_player/firetv.py
+++ b/homeassistant/components/media_player/firetv.py
@@ -108,9 +108,9 @@ class FireTV(object):
                 DEVICE_APPS_URL.format(
                     self.proto, self.host, self.port, self.device_id, 'current'
                     ), timeout=10).json()
-            _current_app = response.get('current_app', None)
-            if _current_app is not None:
-                return _current_app.get('package', None)
+            _current_app = response.get('current_app')
+            if _current_app:
+                return _current_app.get('package')
 
             return None
         except requests.exceptions.RequestException:
@@ -126,7 +126,7 @@ class FireTV(object):
                 DEVICE_APPS_URL.format(
                     self.proto, self.host, self.port, self.device_id, 'running'
                     ), timeout=10).json()
-            return response.get('running_apps', None)
+            return response.get('running_apps')
         except requests.exceptions.RequestException:
             _LOGGER.error(
                 "Could not retrieve running apps for %s", self.device_id)

--- a/homeassistant/components/media_player/firetv.py
+++ b/homeassistant/components/media_player/firetv.py
@@ -112,8 +112,8 @@ class FireTV(object):
             _current_app = response.get('current_app', None)
             if _current_app is not None:
                 return _current_app.get('package', None)
-            else:
-                return None
+
+            return None
         except requests.exceptions.RequestException:
             _LOGGER.error(
                 "Could not retrieve current app for %s", self.device_id)

--- a/homeassistant/components/media_player/firetv.py
+++ b/homeassistant/components/media_player/firetv.py
@@ -11,8 +11,8 @@ import voluptuous as vol
 
 from homeassistant.components.media_player import (
     SUPPORT_NEXT_TRACK, SUPPORT_PAUSE, SUPPORT_PREVIOUS_TRACK, PLATFORM_SCHEMA,
-    SUPPORT_TURN_OFF, SUPPORT_TURN_ON, SUPPORT_VOLUME_SET, SUPPORT_PLAY,
-    MediaPlayerDevice)
+    SUPPORT_SELECT_SOURCE, SUPPORT_TURN_OFF, SUPPORT_TURN_ON,
+    SUPPORT_VOLUME_SET, SUPPORT_PLAY, MediaPlayerDevice)
 from homeassistant.const import (
     STATE_IDLE, STATE_OFF, STATE_PAUSED, STATE_PLAYING, STATE_STANDBY,
     STATE_UNKNOWN, CONF_HOST, CONF_PORT, CONF_SSL, CONF_NAME, CONF_DEVICE,
@@ -23,7 +23,8 @@ _LOGGER = logging.getLogger(__name__)
 
 SUPPORT_FIRETV = SUPPORT_PAUSE | \
     SUPPORT_TURN_ON | SUPPORT_TURN_OFF | SUPPORT_PREVIOUS_TRACK | \
-    SUPPORT_NEXT_TRACK | SUPPORT_VOLUME_SET | SUPPORT_PLAY
+    SUPPORT_NEXT_TRACK | SUPPORT_SELECT_SOURCE | SUPPORT_VOLUME_SET | \
+    SUPPORT_PLAY
 
 DEFAULT_SSL = False
 DEFAULT_DEVICE = 'default'
@@ -33,6 +34,7 @@ DEFAULT_PORT = 5556
 DEVICE_ACTION_URL = '{0}://{1}:{2}/devices/action/{3}/{4}'
 DEVICE_LIST_URL = '{0}://{1}:{2}/devices/list'
 DEVICE_STATE_URL = '{0}://{1}:{2}/devices/state/{3}'
+DEVICE_APPS_URL = '{0}://{1}:{2}/devices/{3}/apps/{4}'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_DEVICE, default=DEFAULT_DEVICE): cv.string,
@@ -43,6 +45,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
+# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the FireTV platform."""
     name = config.get(CONF_NAME)
@@ -98,6 +101,38 @@ class FireTV(object):
                 "Could not retrieve device state for %s", self.device_id)
             return STATE_UNKNOWN
 
+    @property
+    def current_app(self):
+        """Return the current app."""
+        try:
+            response = requests.get(
+                DEVICE_APPS_URL.format(
+                    self.proto, self.host, self.port, self.device_id, 'current'
+                    ), timeout=10).json()
+            _current_app = response.get('current_app', None)
+            if _current_app is not None:
+                return _current_app.get('package', None)
+            else:
+                return None
+        except requests.exceptions.RequestException:
+            _LOGGER.error(
+                "Could not retrieve current app for %s", self.device_id)
+            return None
+
+    @property
+    def running_apps(self):
+        """Return a list of running apps."""
+        try:
+            response = requests.get(
+                DEVICE_APPS_URL.format(
+                    self.proto, self.host, self.port, self.device_id, 'running'
+                    ), timeout=10).json()
+            return response.get('running_apps', None)
+        except requests.exceptions.RequestException:
+            _LOGGER.error(
+                "Could not retrieve running apps for %s", self.device_id)
+            return None
+
     def action(self, action_id):
         """Perform an action on the device."""
         try:
@@ -109,6 +144,16 @@ class FireTV(object):
                 "Action request for %s was not accepted for device %s",
                 action_id, self.device_id)
 
+    def start_app(self, app_name):
+        """Start an app."""
+        try:
+            requests.get(DEVICE_APPS_URL.format(
+                self.proto, self.host, self.port, self.device_id,
+                app_name + '/start'), timeout=10)
+        except requests.exceptions.RequestException:
+            _LOGGER.error(
+                "Could not start %s on %s", app_name, self.device_id)
+
 
 class FireTVDevice(MediaPlayerDevice):
     """Representation of an Amazon Fire TV device on the network."""
@@ -118,6 +163,8 @@ class FireTVDevice(MediaPlayerDevice):
         self._firetv = FireTV(proto, host, port, device)
         self._name = name
         self._state = STATE_UNKNOWN
+        self._running_apps = None
+        self._current_app = None
 
     @property
     def name(self):
@@ -139,6 +186,16 @@ class FireTVDevice(MediaPlayerDevice):
         """Return the state of the player."""
         return self._state
 
+    @property
+    def source(self):
+        """Return the current app."""
+        return self._current_app
+
+    @property
+    def source_list(self):
+        """Return a list of running apps."""
+        return self._running_apps
+
     def update(self):
         """Get the latest date and update device state."""
         self._state = {
@@ -149,6 +206,13 @@ class FireTVDevice(MediaPlayerDevice):
             'standby': STATE_STANDBY,
             'disconnected': STATE_UNKNOWN,
         }.get(self._firetv.state, STATE_UNKNOWN)
+
+        if self._state not in [STATE_OFF, STATE_UNKNOWN]:
+            self._running_apps = self._firetv.running_apps
+            self._current_app = self._firetv.current_app
+        else:
+            self._running_apps = None
+            self._current_app = None
 
     def turn_on(self):
         """Turn on the device."""
@@ -185,3 +249,7 @@ class FireTVDevice(MediaPlayerDevice):
     def media_next_track(self):
         """Send next track command (results in fast-forward)."""
         self._firetv.action('media_next')
+
+    def select_source(self, source):
+        """Select input source."""
+        self._firetv.start_app(source)

--- a/homeassistant/components/media_player/firetv.py
+++ b/homeassistant/components/media_player/firetv.py
@@ -45,7 +45,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-# pylint: disable=unused-argument
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the FireTV platform."""
     name = config.get(CONF_NAME)


### PR DESCRIPTION
## Description:

Show running Fire TV apps as sources and add `SUPPORT_SELECT_SOURCE` functionality.  

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

### Regarding tox testing

I get a "could not install deps" error from tox, so I'm not able to run the tests. However, only one file is modified and it works locally, so it should pass.