### PR TITLE
Bugfix empty entity lists

### DIFF
--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -216,8 +216,11 @@ class EntityPlatform(object):
                                    component_entities, registry)
             for entity in new_entities]
 
-        if tasks:
-            await asyncio.wait(tasks, loop=self.hass.loop)
+        # No entities for processing
+        if not tasks:
+            return
+
+        await asyncio.wait(tasks, loop=self.hass.loop)
         self.async_entities_added_callback()
 
         if self._async_unsub_polling is not None or \

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -216,7 +216,8 @@ class EntityPlatform(object):
                                    component_entities, registry)
             for entity in new_entities]
 
-        await asyncio.wait(tasks, loop=self.hass.loop)
+        if tasks:
+            await asyncio.wait(tasks, loop=self.hass.loop)
         self.async_entities_added_callback()
 
         if self._async_unsub_polling is not None or \

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -596,7 +596,7 @@ async def test_reset_cancels_retry_setup(hass):
 
 @asyncio.coroutine
 def test_not_fails_with_adding_empty_entities_(hass):
-    """Test for not adding duplicate entities."""
+    """Test for not fails on empty entities list."""
     component = EntityComponent(_LOGGER, DOMAIN, hass)
 
     yield from component.async_add_entities([])

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -592,3 +592,13 @@ async def test_reset_cancels_retry_setup(hass):
 
     assert len(mock_call_later.return_value.mock_calls) == 1
     assert ent_platform._async_cancel_retry_setup is None
+
+
+@asyncio.coroutine
+def test_not_fails_with_adding_empty_entities_(hass):
+    """Test for not adding duplicate entities."""
+    component = EntityComponent(_LOGGER, DOMAIN, hass)
+
+    yield from component.async_add_entities([])
+
+    assert len(hass.states.async_entity_ids()) == 0


### PR DESCRIPTION
## Description:

Never call asyncio.wait with empty list.

Fix: #15022
