### PR TITLE
Add SSL peer certificate support to HTTP server

### DIFF
--- a/homeassistant/components/emulated_hue/__init__.py
+++ b/homeassistant/components/emulated_hue/__init__.py
@@ -91,6 +91,7 @@ def setup(hass, yaml_config):
         server_port=config.listen_port,
         api_password=None,
         ssl_certificate=None,
+        ssl_peer_certificate=None,
         ssl_key=None,
         cors_origins=None,
         use_x_forwarded_for=False,

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -40,6 +40,7 @@ CONF_SERVER_HOST = 'server_host'
 CONF_SERVER_PORT = 'server_port'
 CONF_BASE_URL = 'base_url'
 CONF_SSL_CERTIFICATE = 'ssl_certificate'
+CONF_SSL_PEER_CERTIFICATE = 'ssl_peer_certificate'
 CONF_SSL_KEY = 'ssl_key'
 CONF_CORS_ORIGINS = 'cors_allowed_origins'
 CONF_USE_X_FORWARDED_FOR = 'use_x_forwarded_for'
@@ -80,6 +81,7 @@ HTTP_SCHEMA = vol.Schema({
     vol.Optional(CONF_SERVER_PORT, default=SERVER_PORT): cv.port,
     vol.Optional(CONF_BASE_URL): cv.string,
     vol.Optional(CONF_SSL_CERTIFICATE): cv.isfile,
+    vol.Optional(CONF_SSL_PEER_CERTIFICATE): cv.isfile,
     vol.Optional(CONF_SSL_KEY): cv.isfile,
     vol.Optional(CONF_CORS_ORIGINS, default=[]):
         vol.All(cv.ensure_list, [cv.string]),
@@ -108,6 +110,7 @@ async def async_setup(hass, config):
     server_host = conf[CONF_SERVER_HOST]
     server_port = conf[CONF_SERVER_PORT]
     ssl_certificate = conf.get(CONF_SSL_CERTIFICATE)
+    ssl_peer_certificate = conf.get(CONF_SSL_PEER_CERTIFICATE)
     ssl_key = conf.get(CONF_SSL_KEY)
     cors_origins = conf[CONF_CORS_ORIGINS]
     use_x_forwarded_for = conf[CONF_USE_X_FORWARDED_FOR]
@@ -125,6 +128,7 @@ async def async_setup(hass, config):
         server_port=server_port,
         api_password=api_password,
         ssl_certificate=ssl_certificate,
+        ssl_peer_certificate=ssl_peer_certificate,
         ssl_key=ssl_key,
         cors_origins=cors_origins,
         use_x_forwarded_for=use_x_forwarded_for,
@@ -166,7 +170,8 @@ async def async_setup(hass, config):
 class HomeAssistantHTTP(object):
     """HTTP server for Home Assistant."""
 
-    def __init__(self, hass, api_password, ssl_certificate,
+    def __init__(self, hass, api_password,
+                 ssl_certificate, ssl_peer_certificate,
                  ssl_key, server_host, server_port, cors_origins,
                  use_x_forwarded_for, trusted_networks,
                  login_threshold, is_ban_enabled):
@@ -190,6 +195,7 @@ class HomeAssistantHTTP(object):
         self.hass = hass
         self.api_password = api_password
         self.ssl_certificate = ssl_certificate
+        self.ssl_peer_certificate = ssl_peer_certificate
         self.ssl_key = ssl_key
         self.server_host = server_host
         self.server_port = server_port
@@ -289,6 +295,19 @@ class HomeAssistantHTTP(object):
                               self.ssl_certificate, error)
                 context = None
                 return
+
+            try:
+                if self.ssl_peer_certificate:
+                    context.verify_mode = ssl.CERT_REQUIRED
+                    context.load_verify_locations(
+                        cafile=self.ssl_peer_certificate)
+            except OSError as error:
+                _LOGGER.error(
+                    "Could not read peer SSL certificate from %s: %s",
+                    self.ssl_peer_certificate, error)
+                context = None
+                return
+
         else:
             context = None
 

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -293,20 +293,11 @@ class HomeAssistantHTTP(object):
             except OSError as error:
                 _LOGGER.error("Could not read SSL certificate from %s: %s",
                               self.ssl_certificate, error)
-                context = None
                 return
 
-            try:
-                if self.ssl_peer_certificate:
-                    context.verify_mode = ssl.CERT_REQUIRED
-                    context.load_verify_locations(
-                        cafile=self.ssl_peer_certificate)
-            except OSError as error:
-                _LOGGER.error(
-                    "Could not read peer SSL certificate from %s: %s",
-                    self.ssl_peer_certificate, error)
-                context = None
-                return
+            if self.ssl_peer_certificate:
+                context.verify_mode = ssl.CERT_REQUIRED
+                context.load_verify_locations(cafile=self.ssl_peer_certificate)
 
         else:
             context = None


### PR DESCRIPTION
## Description:
Adds support for requiring SSL peer certificate from users connecting to the web frontend.
This can be an additional protection layer on top of the `api_password` HTTP basic authentication. Another use-case could be to only allow connections from Cloudflare servers as described [here](https://support.cloudflare.com/hc/en-us/articles/115000088491-Cloudflare-TLS-Client-Auth) in case you use Cloudflare to provide SSL certificate for the Home Assistant web frontend.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation:** home-assistant/home-assistant.github.io#5566

## Example entry for `configuration.yaml`:
```yaml
http:
  ssl_peer_certificate: /etc/ssl/origin-pull-ca.pem
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)
