### PR TITLE
Add storage helper and migrate config entries

### DIFF
--- a/homeassistant/components/sensor/fitbit.py
+++ b/homeassistant/components/sensor/fitbit.py
@@ -225,7 +225,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                 hass, config, add_devices, config_path, discovery_info=None)
             return False
     else:
-        config_file = save_json(config_path, DEFAULT_CONFIG)
+        save_json(config_path, DEFAULT_CONFIG)
         request_app_setup(
             hass, config, add_devices, config_path, discovery_info=None)
         return False

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -112,14 +112,12 @@ the flow from the config panel.
 """
 
 import logging
-import os
 import uuid
 
 from . import data_entry_flow
 from .core import callback
 from .exceptions import HomeAssistantError
 from .setup import async_setup_component, async_process_deps_reqs
-from .util.json import load_json, save_json
 from .util.decorator import Registry
 
 
@@ -136,6 +134,9 @@ FLOWS = [
 ]
 
 
+STORAGE_KEY = 'core.config_entries'
+
+# Deprecated since 0.73
 PATH_CONFIG = '.config_entries.json'
 
 SAVE_DELAY = 1
@@ -271,7 +272,7 @@ class ConfigEntries:
             hass, self._async_create_flow, self._async_finish_flow)
         self._hass_config = hass_config
         self._entries = None
-        self._sched_save = None
+        self._store = hass.helpers.storage.Store(STORAGE_KEY)
 
     @callback
     def async_domains(self):
@@ -305,7 +306,7 @@ class ConfigEntries:
             raise UnknownEntry
 
         entry = self._entries.pop(found)
-        self._async_schedule_save()
+        await self._async_schedule_save()
 
         unloaded = await entry.async_unload(self.hass)
 
@@ -314,14 +315,14 @@ class ConfigEntries:
         }
 
     async def async_load(self):
-        """Load the config."""
-        path = self.hass.config.path(PATH_CONFIG)
-        if not os.path.isfile(path):
-            self._entries = []
-            return
+        """Handle loading the config."""
+        # Migrating for confg entries stored before 0.73
+        config = await self.hass.helpers.storage.async_migrator(
+            self.hass.config.path(PATH_CONFIG), self._store,
+            migrate_func=lambda old_conf: {'entries': old_conf}
+        )
 
-        entries = await self.hass.async_add_job(load_json, path)
-        self._entries = [ConfigEntry(**entry) for entry in entries]
+        self._entries = [ConfigEntry(**entry) for entry in config['entries']]
 
     async def async_forward_entry_setup(self, entry, component):
         """Forward the setup of an entry to a different component.
@@ -372,7 +373,7 @@ class ConfigEntries:
             source=result['source'],
         )
         self._entries.append(entry)
-        self._async_schedule_save()
+        await self._async_schedule_save()
 
         # Setup entry
         if entry.domain in self.hass.config.components:
@@ -416,20 +417,9 @@ class ConfigEntries:
 
         return handler()
 
-    @callback
-    def _async_schedule_save(self):
-        """Schedule saving the entity registry."""
-        if self._sched_save is not None:
-            self._sched_save.cancel()
-
-        self._sched_save = self.hass.loop.call_later(
-            SAVE_DELAY, self.hass.async_add_job, self._async_save
-        )
-
-    async def _async_save(self):
+    async def _async_schedule_save(self):
         """Save the entity registry to a file."""
-        self._sched_save = None
-        data = [entry.as_dict() for entry in self._entries]
-
-        await self.hass.async_add_job(
-            save_json, self.hass.config.path(PATH_CONFIG), data)
+        data = {
+            'entries': [entry.as_dict() for entry in self._entries]
+        }
+        await self._store.async_save(data, delay=SAVE_DELAY)

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -323,9 +323,6 @@ class ConfigEntries:
             old_conf_migrate_func=_old_conf_migrator
         )
 
-        if config is None:
-            config = await self._store.async_load()
-
         self._entries = [ConfigEntry(**entry) for entry in config['entries']]
 
     async def async_forward_entry_setup(self, entry, component):

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -114,11 +114,11 @@ the flow from the config panel.
 import logging
 import uuid
 
-from . import data_entry_flow
-from .core import callback
-from .exceptions import HomeAssistantError
-from .setup import async_setup_component, async_process_deps_reqs
-from .util.decorator import Registry
+from homeassistant import data_entry_flow
+from homeassistant.core import callback
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.setup import async_setup_component, async_process_deps_reqs
+from homeassistant.util.decorator import Registry
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -273,7 +273,7 @@ class ConfigEntries:
             hass, self._async_create_flow, self._async_finish_flow)
         self._hass_config = hass_config
         self._entries = None
-        self._store = hass.helpers.storage.Store(STORAGE_KEY)
+        self._store = hass.helpers.storage.Store(STORAGE_VERSION, STORAGE_KEY)
 
     @callback
     def async_domains(self):
@@ -319,12 +319,12 @@ class ConfigEntries:
         """Handle loading the config."""
         # Migrating for config entries stored before 0.73
         config = await self.hass.helpers.storage.async_migrator(
-            self.hass.config.path(PATH_CONFIG), self._store, STORAGE_VERSION,
+            self.hass.config.path(PATH_CONFIG), self._store,
             old_conf_migrate_func=_old_conf_migrator
         )
 
         if config is None:
-            config = await self._store.async_load(STORAGE_VERSION)
+            config = await self._store.async_load()
 
         self._entries = [ConfigEntry(**entry) for entry in config['entries']]
 
@@ -426,7 +426,7 @@ class ConfigEntries:
         data = {
             'entries': [entry.as_dict() for entry in self._entries]
         }
-        await self._store.async_save(STORAGE_VERSION, data, delay=SAVE_DELAY)
+        await self._store.async_save(data, delay=SAVE_DELAY)
 
 
 async def _old_conf_migrator(old_config):

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -231,6 +231,20 @@ class HomeAssistant(object):
         return task
 
     @callback
+    def async_add_executor_job(
+            self,
+            target: Callable[..., Any],
+            *args: Any) -> asyncio.tasks.Task:
+        """Add an executor job from within the event loop."""
+        task = self.loop.run_in_executor(None, target, *args)
+
+        # If a task is scheduled
+        if self._track_task:
+            self._pending_tasks.append(task)
+
+        return task
+
+    @callback
     def async_track_tasks(self):
         """Track tasks so you can wait for all tasks to be done."""
         self._track_task = True

--- a/homeassistant/helpers/storage.py
+++ b/homeassistant/helpers/storage.py
@@ -30,7 +30,7 @@ async def async_migrator(hass, old_path, store, *, old_conf_migrate_func=None):
     config = await hass.async_add_executor_job(load_old_config)
 
     if config is None:
-        return None
+        return await store.async_load()
 
     if old_conf_migrate_func is not None:
         config = await old_conf_migrate_func(config)

--- a/homeassistant/helpers/storage.py
+++ b/homeassistant/helpers/storage.py
@@ -1,0 +1,99 @@
+"""Helper to help store data."""
+import logging
+import os
+from typing import Dict
+
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+from homeassistant.loader import bind_hass
+from homeassistant.util import json
+from homeassistant.helpers.event import async_call_later
+
+STORAGE_DIR = '.storage'
+_LOGGER = logging.getLogger(__name__)
+
+
+@bind_hass
+async def async_migrator(hass, old_path, store, *, migrate_func=None):
+    """Helper function to migrate old configs to a store and return config."""
+    def load_old_config():
+        """Helper to load old config."""
+        if not os.path.isfile(old_path):
+            return None
+
+        return json.load_json(old_path)
+
+    config = await hass.async_add_executor_job(load_old_config)
+
+    if config is None:
+        return await store.async_load()
+
+    if migrate_func is not None:
+        config = migrate_func(config)
+
+    await store.async_save(config)
+    return config
+
+
+@bind_hass
+class Store:
+    """Class to help storing data."""
+
+    def __init__(self, hass, key: str):
+        """Initialize storage class."""
+        self.hass = hass
+        self.key = key
+        self.path = hass.config.path(STORAGE_DIR, key)
+        self._data = None
+        self._unsub_delay_listener = None
+        self._unsub_stop_listener = None
+
+    async def async_load(self):
+        """Load data."""
+        if self._data is not None:
+            return self._data
+
+        return await self.hass.async_add_executor_job(
+            json.load_json, self.path)
+
+    async def async_save(self, data: Dict, *, delay: int=None):
+        """Save data with an optional delay."""
+        self._data = data
+
+        if delay is None:
+            await self._handle_write_data()
+            return
+
+        self._unsub_delay_listener = async_call_later(
+            self.hass, delay, self._handle_write_data)
+
+        # Ensure that we write if we quit before delay has passed.
+        self._unsub_stop_listener = self.hass.bus.async_listen(
+            EVENT_HOMEASSISTANT_STOP, self._handle_write_data)
+
+    async def _handle_write_data(self, *_args):
+        """Handler to handle writing the config."""
+        if self._unsub_delay_listener is not None:
+            self._unsub_delay_listener()
+            self._unsub_delay_listener = None
+
+        if self._unsub_stop_listener is not None:
+            self._unsub_stop_listener()
+            self._unsub_stop_listener = None
+
+        data = self._data
+        self._data = None
+
+        try:
+            await self.hass.async_add_executor_job(
+                self._write_data, self.path, data)
+        except json.SerializationError as err:
+            _LOGGER.error('Error writing config for %s: %s', self.key, err)
+        except json.WriteError as err:
+            _LOGGER.error('Error writing config for %s: %s', self.key, err)
+
+    def _write_data(self, path: str, data: Dict):
+        """Write the data."""
+        if not os.path.isdir(os.path.dirname(path)):
+            os.makedirs(os.path.dirname(path))
+
+        json.save_json(path, data)

--- a/homeassistant/helpers/storage.py
+++ b/homeassistant/helpers/storage.py
@@ -91,7 +91,7 @@ class Store:
 
         if delay is None:
             self._async_cleanup_stop_listener()
-            await self._handle_write_data()
+            await self._async_handle_write_data()
             return
 
         self._unsub_delay_listener = async_call_later(
@@ -124,15 +124,15 @@ class Store:
         """Handle a delayed write callback."""
         self._unsub_delay_listener = None
         self._async_cleanup_stop_listener()
-        await self._handle_write_data()
+        await self._async_handle_write_data()
 
     async def _async_callback_stop_write(self, _event):
         """Handle a write because Home Assistant is stopping."""
         self._unsub_stop_listener = None
         self._async_cleanup_delay_listener()
-        await self._handle_write_data()
+        await self._async_handle_write_data()
 
-    async def _handle_write_data(self, *_args):
+    async def _async_handle_write_data(self, *_args):
         """Handler to handle writing the config."""
         data = self._data
         self._data = None
@@ -141,9 +141,7 @@ class Store:
             try:
                 await self.hass.async_add_executor_job(
                     self._write_data, self.path, data)
-            except json.SerializationError as err:
-                _LOGGER.error('Error writing config for %s: %s', self.key, err)
-            except json.WriteError as err:
+            except (json.SerializationError, json.WriteError) as err:
                 _LOGGER.error('Error writing config for %s: %s', self.key, err)
 
     def _write_data(self, path: str, data: Dict):

--- a/homeassistant/util/json.py
+++ b/homeassistant/util/json.py
@@ -11,6 +11,14 @@ _LOGGER = logging.getLogger(__name__)
 _UNDEFINED = object()
 
 
+class SerializationError(HomeAssistantError):
+    """Error serializing the data to JSON."""
+
+
+class WriteError(HomeAssistantError):
+    """Error writing the data."""
+
+
 def load_json(filename: str, default: Union[List, Dict] = _UNDEFINED) \
         -> Union[List, Dict]:
     """Load JSON data from a file and return as dict or list.
@@ -41,13 +49,11 @@ def save_json(filename: str, data: Union[List, Dict]):
         data = json.dumps(data, sort_keys=True, indent=4)
         with open(filename, 'w', encoding='utf-8') as fdesc:
             fdesc.write(data)
-            return True
     except TypeError as error:
         _LOGGER.exception('Failed to serialize to JSON: %s',
                           filename)
-        raise HomeAssistantError(error)
+        raise SerializationError(error)
     except OSError as error:
         _LOGGER.exception('Saving JSON file failed: %s',
                           filename)
-        raise HomeAssistantError(error)
-    return False
+        raise WriteError(error)

--- a/tests/common.py
+++ b/tests/common.py
@@ -14,7 +14,7 @@ from homeassistant import auth, core as ha, data_entry_flow, config_entries
 from homeassistant.setup import setup_component, async_setup_component
 from homeassistant.config import async_process_component_config
 from homeassistant.helpers import (
-    intent, entity, restore_state,  entity_registry,
+    intent, entity, restore_state, entity_registry,
     entity_platform)
 from homeassistant.util.unit_system import METRIC_SYSTEM
 import homeassistant.util.dt as date_util
@@ -137,6 +137,7 @@ def async_test_home_assistant(loop):
 
     hass.config_entries = config_entries.ConfigEntries(hass, {})
     hass.config_entries._entries = []
+    hass.config_entries._store._async_ensure_stop_listener = lambda: None
 
     hass.state = ha.CoreState.running
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -110,8 +110,6 @@ def get_test_home_assistant():
 def async_test_home_assistant(loop):
     """Return a Home Assistant object pointing at test config dir."""
     hass = ha.HomeAssistant(loop)
-    hass.config_entries = config_entries.ConfigEntries(hass, {})
-    hass.config_entries._entries = []
     hass.config.async_load = Mock()
     store = auth.AuthStore(hass)
     hass.auth = auth.AuthManager(hass, store, {})
@@ -136,6 +134,9 @@ def async_test_home_assistant(loop):
     hass.config.time_zone = date_util.get_time_zone('US/Pacific')
     hass.config.units = METRIC_SYSTEM
     hass.config.skip_pip = True
+
+    hass.config_entries = config_entries.ConfigEntries(hass, {})
+    hass.config_entries._entries = []
 
     hass.state = ha.CoreState.running
 

--- a/tests/helpers/test_storage.py
+++ b/tests/helpers/test_storage.py
@@ -35,9 +35,8 @@ def mock_load(mock_save):
 def store(hass):
     """Fixture of a store that prevents writing on HASS stop."""
     store = storage.Store(hass, 'test')
+    store._async_ensure_stop_listener = lambda: None
     yield store
-    if store._unsub_stop_listener is not None:
-        store._unsub_stop_listener()
 
 
 async def test_loading(hass, store, mock_save, mock_load):
@@ -64,8 +63,9 @@ async def test_saving_with_delay(hass, store, mock_save):
     assert len(mock_save) == 1
 
 
-async def test_saving_on_stop(hass, store, mock_save):
+async def test_saving_on_stop(hass, mock_save):
     """Test delayed saves trigger when we quit Home Assistant."""
+    store = storage.Store(hass, 'test')
     await store.async_save(MOCK_DATA, delay=1)
     assert len(mock_save) == 0
 

--- a/tests/helpers/test_storage.py
+++ b/tests/helpers/test_storage.py
@@ -1,0 +1,138 @@
+"""Tests for the storage helper."""
+from datetime import timedelta
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+from homeassistant.helpers import storage
+from homeassistant.util import dt
+
+from tests.common import async_fire_time_changed, mock_coro
+
+
+MOCK_DATA = {'hello': 'world'}
+
+
+@pytest.fixture
+def mock_save():
+    """Fixture to mock JSON save."""
+    written = []
+    with patch('homeassistant.util.json.save_json',
+               side_effect=lambda *args: written.append(args)):
+        yield written
+
+
+@pytest.fixture
+def mock_load(mock_save):
+    """Fixture to mock JSON read."""
+    with patch('homeassistant.util.json.load_json',
+               side_effect=lambda *args: mock_save[-1][1]):
+        yield
+
+
+@pytest.fixture
+def store(hass):
+    """Fixture of a store that prevents writing on HASS stop."""
+    store = storage.Store(hass, 'test')
+    yield store
+    if store._unsub_stop_listener is not None:
+        store._unsub_stop_listener()
+
+
+async def test_loading(hass, store, mock_save, mock_load):
+    """Test we can save and load data."""
+    await store.async_save(MOCK_DATA)
+    data = await store.async_load()
+    assert data == MOCK_DATA
+
+
+async def test_loading_non_existing(hass, store):
+    """Test we can save and load data."""
+    with patch('homeassistant.util.json.open', side_effect=FileNotFoundError):
+        data = await store.async_load()
+    assert data == {}
+
+
+async def test_saving_with_delay(hass, store, mock_save):
+    """Test saving data after a delay."""
+    await store.async_save(MOCK_DATA, delay=1)
+    assert len(mock_save) == 0
+
+    async_fire_time_changed(hass, dt.utcnow() + timedelta(seconds=1))
+    await hass.async_block_till_done()
+    assert len(mock_save) == 1
+
+
+async def test_saving_on_stop(hass, store, mock_save):
+    """Test delayed saves trigger when we quit Home Assistant."""
+    await store.async_save(MOCK_DATA, delay=1)
+    assert len(mock_save) == 0
+
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
+    await hass.async_block_till_done()
+    assert len(mock_save) == 1
+
+
+async def test_loading_while_delay(hass, store, mock_save, mock_load):
+    """Test we load new data even if not written yet."""
+    await store.async_save({'delay': 'no'})
+    assert len(mock_save) == 1
+
+    await store.async_save({'delay': 'yes'}, delay=1)
+    assert len(mock_save) == 1
+
+    data = await store.async_load()
+    assert data == {'delay': 'yes'}
+
+
+async def test_writing_while_writing_delay(hass, store, mock_save, mock_load):
+    """Test a write while a write with delay is active."""
+    await store.async_save({'delay': 'yes'}, delay=1)
+    assert len(mock_save) == 0
+    await store.async_save({'delay': 'no'})
+    assert len(mock_save) == 1
+
+    async_fire_time_changed(hass, dt.utcnow() + timedelta(seconds=1))
+    await hass.async_block_till_done()
+    assert len(mock_save) == 1
+
+    data = await store.async_load()
+    assert data == {'delay': 'no'}
+
+
+async def test_migrator_no_existing_config(hass, store, mock_save):
+    """Test migrator with no existing config."""
+    with patch('os.path.isfile', return_value=False), \
+        patch.object(store, 'async_load',
+                     return_value=mock_coro({'cur': 'config'})):
+        data = await storage.async_migrator(hass, 'old-path', store)
+
+    assert data == {'cur': 'config'}
+    assert len(mock_save) == 0
+
+
+async def test_migrator_existing_config(hass, store, mock_save):
+    """Test migrating existing config."""
+    with patch('os.path.isfile', return_value=True), \
+        patch('homeassistant.util.json.load_json',
+              return_value={'old': 'config'}):
+        data = await storage.async_migrator(hass, 'old-path', store)
+
+    assert data == {'old': 'config'}
+    assert len(mock_save) == 1
+    assert mock_save[0][1] == data
+
+
+async def test_migrator_transforming_config(hass, store, mock_save):
+    """Test migrating config to new format."""
+    with patch('os.path.isfile', return_value=True), \
+        patch('homeassistant.util.json.load_json',
+              return_value={'old': 'config'}):
+        data = await storage.async_migrator(
+            hass, 'old-path', store,
+            migrate_func=lambda old_config: {'new': old_config['old']})
+
+    assert data == {'new': 'config'}
+    assert len(mock_save) == 1
+    assert mock_save[0][1] == data

--- a/tests/helpers/test_storage.py
+++ b/tests/helpers/test_storage.py
@@ -111,7 +111,7 @@ async def test_migrator_no_existing_config(hass, store, mock_save):
         data = await storage.async_migrator(
             hass, 'old-path', store)
 
-    assert data is None
+    assert data == {'cur': 'config'}
     assert len(mock_save) == 0
 
 

--- a/tests/helpers/test_storage.py
+++ b/tests/helpers/test_storage.py
@@ -136,6 +136,7 @@ async def test_migrator_transforming_config(hass, store, mock_save):
             hass, 'old-path', store,
             migrate_func=lambda old_config: {'new': old_config['old']})
 
+    assert len(mock_remove.mock_calls) == 1
     assert data == {'new': 'config'}
     assert len(mock_save) == 1
     assert mock_save[0][1] == data

--- a/tests/helpers/test_storage.py
+++ b/tests/helpers/test_storage.py
@@ -12,6 +12,7 @@ from tests.common import async_fire_time_changed, mock_coro
 
 
 MOCK_VERSION = 1
+MOCK_KEY = 'storage-test'
 MOCK_DATA = {'hello': 'world'}
 
 
@@ -35,28 +36,28 @@ def mock_load(mock_save):
 @pytest.fixture
 def store(hass):
     """Fixture of a store that prevents writing on HASS stop."""
-    store = storage.Store(hass, 'test')
+    store = storage.Store(hass, MOCK_VERSION, MOCK_KEY)
     store._async_ensure_stop_listener = lambda: None
     yield store
 
 
 async def test_loading(hass, store, mock_save, mock_load):
     """Test we can save and load data."""
-    await store.async_save(MOCK_VERSION, MOCK_DATA)
-    data = await store.async_load(MOCK_VERSION)
+    await store.async_save(MOCK_DATA)
+    data = await store.async_load()
     assert data == MOCK_DATA
 
 
 async def test_loading_non_existing(hass, store):
     """Test we can save and load data."""
     with patch('homeassistant.util.json.open', side_effect=FileNotFoundError):
-        data = await store.async_load(MOCK_VERSION)
+        data = await store.async_load()
     assert data == {}
 
 
 async def test_saving_with_delay(hass, store, mock_save):
     """Test saving data after a delay."""
-    await store.async_save(MOCK_VERSION, MOCK_DATA, delay=1)
+    await store.async_save(MOCK_DATA, delay=1)
     assert len(mock_save) == 0
 
     async_fire_time_changed(hass, dt.utcnow() + timedelta(seconds=1))
@@ -66,8 +67,8 @@ async def test_saving_with_delay(hass, store, mock_save):
 
 async def test_saving_on_stop(hass, mock_save):
     """Test delayed saves trigger when we quit Home Assistant."""
-    store = storage.Store(hass, 'test')
-    await store.async_save(MOCK_VERSION, MOCK_DATA, delay=1)
+    store = storage.Store(hass, MOCK_VERSION, MOCK_KEY)
+    await store.async_save(MOCK_DATA, delay=1)
     assert len(mock_save) == 0
 
     hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
@@ -77,28 +78,28 @@ async def test_saving_on_stop(hass, mock_save):
 
 async def test_loading_while_delay(hass, store, mock_save, mock_load):
     """Test we load new data even if not written yet."""
-    await store.async_save(MOCK_VERSION, {'delay': 'no'})
+    await store.async_save({'delay': 'no'})
     assert len(mock_save) == 1
 
-    await store.async_save(MOCK_VERSION, {'delay': 'yes'}, delay=1)
+    await store.async_save({'delay': 'yes'}, delay=1)
     assert len(mock_save) == 1
 
-    data = await store.async_load(MOCK_VERSION)
+    data = await store.async_load()
     assert data == {'delay': 'yes'}
 
 
 async def test_writing_while_writing_delay(hass, store, mock_save, mock_load):
     """Test a write while a write with delay is active."""
-    await store.async_save(MOCK_VERSION, {'delay': 'yes'}, delay=1)
+    await store.async_save({'delay': 'yes'}, delay=1)
     assert len(mock_save) == 0
-    await store.async_save(MOCK_VERSION, {'delay': 'no'})
+    await store.async_save({'delay': 'no'})
     assert len(mock_save) == 1
 
     async_fire_time_changed(hass, dt.utcnow() + timedelta(seconds=1))
     await hass.async_block_till_done()
     assert len(mock_save) == 1
 
-    data = await store.async_load(MOCK_VERSION)
+    data = await store.async_load()
     assert data == {'delay': 'no'}
 
 
@@ -108,7 +109,7 @@ async def test_migrator_no_existing_config(hass, store, mock_save):
         patch.object(store, 'async_load',
                      return_value=mock_coro({'cur': 'config'})):
         data = await storage.async_migrator(
-            hass, 'old-path', store, MOCK_VERSION)
+            hass, 'old-path', store)
 
     assert data is None
     assert len(mock_save) == 0
@@ -121,13 +122,13 @@ async def test_migrator_existing_config(hass, store, mock_save):
         patch('homeassistant.util.json.load_json',
               return_value={'old': 'config'}):
         data = await storage.async_migrator(
-            hass, 'old-path', store, MOCK_VERSION)
+            hass, 'old-path', store)
 
     assert len(mock_remove.mock_calls) == 1
     assert data == {'old': 'config'}
     assert len(mock_save) == 1
     assert mock_save[0][1] == {
-        'key': 'test',
+        'key': MOCK_KEY,
         'version': MOCK_VERSION,
         'data': data,
     }
@@ -144,14 +145,14 @@ async def test_migrator_transforming_config(hass, store, mock_save):
         patch('homeassistant.util.json.load_json',
               return_value={'old': 'config'}):
         data = await storage.async_migrator(
-            hass, 'old-path', store, MOCK_VERSION,
+            hass, 'old-path', store,
             old_conf_migrate_func=old_conf_migrate_func)
 
     assert len(mock_remove.mock_calls) == 1
     assert data == {'new': 'config'}
     assert len(mock_save) == 1
     assert mock_save[0][1] == {
-        'key': 'test',
+        'key': MOCK_KEY,
         'version': MOCK_VERSION,
         'data': data,
     }

--- a/tests/helpers/test_storage.py
+++ b/tests/helpers/test_storage.py
@@ -115,10 +115,12 @@ async def test_migrator_no_existing_config(hass, store, mock_save):
 async def test_migrator_existing_config(hass, store, mock_save):
     """Test migrating existing config."""
     with patch('os.path.isfile', return_value=True), \
+        patch('os.remove') as mock_remove, \
         patch('homeassistant.util.json.load_json',
               return_value={'old': 'config'}):
         data = await storage.async_migrator(hass, 'old-path', store)
 
+    assert len(mock_remove.mock_calls) == 1
     assert data == {'old': 'config'}
     assert len(mock_save) == 1
     assert mock_save[0][1] == data
@@ -127,6 +129,7 @@ async def test_migrator_existing_config(hass, store, mock_save):
 async def test_migrator_transforming_config(hass, store, mock_save):
     """Test migrating config to new format."""
     with patch('os.path.isfile', return_value=True), \
+        patch('os.remove') as mock_remove, \
         patch('homeassistant.util.json.load_json',
               return_value={'old': 'config'}):
         data = await storage.async_migrator(

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -1,13 +1,16 @@
 """Test the config manager."""
 import asyncio
+from datetime import timedelta
 from unittest.mock import MagicMock, patch, mock_open
 
 import pytest
 
 from homeassistant import config_entries, loader, data_entry_flow
 from homeassistant.setup import async_setup_component
+from homeassistant.util import dt
 
-from tests.common import MockModule, mock_coro, MockConfigEntry
+from tests.common import (
+    MockModule, mock_coro, MockConfigEntry, async_fire_time_changed)
 
 
 @pytest.fixture
@@ -151,7 +154,9 @@ def test_domains_gets_uniques(manager):
 @asyncio.coroutine
 def test_saving_and_loading(hass):
     """Test that we're saving and loading correctly."""
-    loader.set_component(hass, 'test', MockModule('test'))
+    loader.set_component(
+        hass, 'test',
+        MockModule('test', async_setup_entry=lambda *args: mock_coro(True)))
 
     class TestFlow(data_entry_flow.FlowHandler):
         VERSION = 5
@@ -183,13 +188,12 @@ def test_saving_and_loading(hass):
     json_path = 'homeassistant.util.json.open'
 
     with patch('homeassistant.config_entries.HANDLERS.get',
-               return_value=Test2Flow), \
-            patch.object(config_entries, 'SAVE_DELAY', 0):
+               return_value=Test2Flow):
         yield from hass.config_entries.flow.async_init('test')
 
     with patch(json_path, mock_open(), create=True) as mock_write:
         # To trigger the call_later
-        yield from asyncio.sleep(0, loop=hass.loop)
+        async_fire_time_changed(hass, dt.utcnow() + timedelta(seconds=1))
         # To execute the save
         yield from hass.async_block_till_done()
 
@@ -199,7 +203,7 @@ def test_saving_and_loading(hass):
     # Now load written data in new config manager
     manager = config_entries.ConfigEntries(hass, {})
 
-    with patch('os.path.isfile', return_value=True), \
+    with patch('os.path.isfile', return_value=False), \
             patch(json_path, mock_open(read_data=written), create=True):
         yield from manager.async_load()
 

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -18,6 +18,7 @@ def manager(hass):
     """Fixture of a loaded config manager."""
     manager = config_entries.ConfigEntries(hass, {})
     manager._entries = []
+    manager._store._async_ensure_stop_listener = lambda: None
     hass.config_entries = manager
     return manager
 


### PR DESCRIPTION
## Description:
This adds a storage helper. This will make it easier for components and core pieces to store and load data.

 - Stored data needs to be JSON serializable. However when and where the config is stored is opaque to the developer. This leaves options open for the future 👍 
 - Optionally add a write delay in case you expect a lot of writes
 - If delayed write is scheduled, load will return correct config
 - If delayed write, shutting down Home Assistant will trigger the write
 - Add a migrator from old formats so that it helps existing code migrate to the storage helper. 
 - Track versioned data and migrate if necessary

Since I did not want to add logic that is unused, I've migrated the config entries logic to use the new storage helper.

Bonus:
 - Fixes https://github.com/home-assistant/architecture/issues/37#issuecomment-397961432. Adds a new `hass.async_add_executor_job` if we know it's going to be a sync method. This will be the new preferred way for sync methods. Will help step towards https://github.com/home-assistant/home-assistant/pull/14429#discussion_r188084991

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
