### PR TITLE
Python wink update

### DIFF
--- a/homeassistant/components/cover/wink.py
+++ b/homeassistant/components/cover/wink.py
@@ -21,6 +21,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         _id = shade.object_id() + shade.name()
         if _id not in hass.data[DOMAIN]['unique_ids']:
             add_devices([WinkCoverDevice(shade, hass)])
+    for shade in pywink.get_shade_groups():
+        _id = shade.object_id() + shade.name()
+        if _id not in hass.data[DOMAIN]['unique_ids']:
+            add_devices([WinkCoverDevice(shade, hass)])
     for door in pywink.get_garage_doors():
         _id = door.object_id() + door.name()
         if _id not in hass.data[DOMAIN]['unique_ids']:

--- a/homeassistant/components/wink/__init__.py
+++ b/homeassistant/components/wink/__init__.py
@@ -26,7 +26,7 @@ from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.event import track_time_interval
 from homeassistant.util.json import load_json, save_json
 
-REQUIREMENTS = ['python-wink==1.8.0', 'pubnubsub-handler==1.0.2']
+REQUIREMENTS = ['python-wink==1.9.0', 'pubnubsub-handler==1.0.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1098,7 +1098,7 @@ python-velbus==2.0.11
 python-vlc==1.1.2
 
 # homeassistant.components.wink
-python-wink==1.8.0
+python-wink==1.9.0
 
 # homeassistant.components.sensor.swiss_public_transport
 python_opendata_transport==0.1.3


### PR DESCRIPTION
## Description:
Update to the newest version of python-wink which adds support for groups of Shades (covers). @yang3535 can you test this? Sorry it took so long.

This update also fixes a rare bug where the the API doesn't return needed information to setup local control. This currently results in lights/switches/locks not working. Now all request will fall back to online if the information needed isn't present.

This also includes an attempted fix for users that sometimes get 401 responses from the Wink API at startup. I believe this is due to an expired token. So, if a 401 is received at startup we will attempt to refresh the token and then make the call again.

**Related issue (if applicable):**
fixes #11709, fixes #13076

## Checklist:
  - [ ] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
