### PR TITLE
Update pywemo to version 0.4.28

### DIFF
--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -14,7 +14,7 @@ from homeassistant.helpers import config_validation as cv
 
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 
-REQUIREMENTS = ['pywemo==0.4.25']
+REQUIREMENTS = ['pywemo==0.4.28']
 
 DOMAIN = 'wemo'
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1152,7 +1152,7 @@ pyvlx==0.1.3
 pywebpush==1.6.0
 
 # homeassistant.components.wemo
-pywemo==0.4.25
+pywemo==0.4.28
 
 # homeassistant.components.camera.xeoma
 pyxeoma==1.4.0


### PR DESCRIPTION
Update to pywemo 0.4.28. I am guessing I have done this correctly. Let me know if anything else needs to added to bump library versions.

This includes the fix from this pull request:
https://github.com/pavoni/pywemo/pull/100

That helps support the feature added to HA in this pull request:
https://github.com/home-assistant/home-assistant/pull/14995