### PR TITLE
x10: Add brightness control and proper state handling

### DIFF
--- a/homeassistant/components/light/x10.py
+++ b/homeassistant/components/light/x10.py
@@ -27,20 +27,21 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     ]),
 })
 
-
 def x10_command(command):
     """Execute X10 command and check output."""
     return check_output(["heyu", command])
 
-
 def get_unit_status(code):
     """Get on/off status for given unit."""
     output = check_output('heyu onstate ' + code, shell=True)
+    _LOGGER.debug("unit on/off status %d", int(output))
     return int(output.decode('utf-8')[0])
+
 
 def get_raw_brightness(code):
     """Get current raw brightness for given unit."""
     output = check_output('heyu rawlevel ' + code, shell=True).rstrip()
+    _LOGGER.debug("raw brightness value %d", int(output))
     return (int(output))
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -52,7 +53,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         return False
 
     add_devices(X10Light(light) for light in config[CONF_DEVICES])
-
 
 class X10Light(Light):
     """Representation of an X10 Light."""
@@ -92,6 +92,12 @@ class X10Light(Light):
             delta_brightness = (
                 desired_brightness - int(get_raw_brightness(self._id)))
             delta_step = (abs(delta_brightness / 10) + 1)
+            _LOGGER.debug(
+                """Slider Bright %d Desired bright %d,Delta bright %d,
+                Delta Step %d, Raw bright %d""",
+                kwargs[ATTR_BRIGHTNESS], desired_brightness,
+                delta_brightness, delta_step,
+                int(get_raw_brightness(self._id)))
             if (delta_brightness > 0):
                 x10_command(
                     'bright ' + self._id.ljust(len(self._id)+1) +

--- a/homeassistant/components/light/x10.py
+++ b/homeassistant/components/light/x10.py
@@ -38,7 +38,6 @@ def get_unit_status(code):
     output = check_output('heyu onstate ' + code, shell=True)
     return int(output.decode('utf-8')[0])
 
-
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the x10 Light platform."""
     try:
@@ -59,6 +58,7 @@ class X10Light(Light):
         self._id = light['id']
         self._brightness = 0
         self._state = False
+        self.update()
 
     @property
     def name(self):


### PR DESCRIPTION
## Description:
Our platform stated we had support for brightness control but really it did nothing now it actually works. I also made it so that when home assistant starts up the states for on/off and brightness will reach out to heyu and update themselves because everything would default to off and 0 brightness without that. 

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
