### PR TITLE
Rename experimental UI to lovelace

### DIFF
--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -26,7 +26,7 @@ from homeassistant.helpers.translation import async_get_translations
 from homeassistant.loader import bind_hass
 from homeassistant.util.yaml import load_yaml
 
-REQUIREMENTS = ['home-assistant-frontend==20180619.0']
+REQUIREMENTS = ['home-assistant-frontend==20180620.0']
 
 DOMAIN = 'frontend'
 DEPENDENCIES = ['api', 'websocket_api', 'http', 'system_log']

--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -21,6 +21,7 @@ from homeassistant.components import websocket_api
 from homeassistant.config import find_config_file, load_yaml_config_file
 from homeassistant.const import CONF_NAME, EVENT_THEMES_UPDATED
 from homeassistant.core import callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.translation import async_get_translations
 from homeassistant.loader import bind_hass
 from homeassistant.util.yaml import load_yaml
@@ -106,9 +107,9 @@ SCHEMA_GET_TRANSLATIONS = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend({
     vol.Required('type'): WS_TYPE_GET_TRANSLATIONS,
     vol.Required('language'): str,
 })
-WS_TYPE_GET_EXPERIMENTAL_UI = 'frontend/experimental_ui'
-SCHEMA_GET_EXPERIMENTAL_UI = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend({
-    vol.Required('type'): WS_TYPE_GET_EXPERIMENTAL_UI,
+WS_TYPE_GET_LOVELACE_UI = 'frontend/lovelace_config'
+SCHEMA_GET_LOVELACE_UI = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend({
+    vol.Required('type'): WS_TYPE_GET_LOVELACE_UI,
 })
 
 
@@ -216,8 +217,8 @@ async def async_setup(hass, config):
         WS_TYPE_GET_TRANSLATIONS, websocket_get_translations,
         SCHEMA_GET_TRANSLATIONS)
     hass.components.websocket_api.async_register_command(
-        WS_TYPE_GET_EXPERIMENTAL_UI, websocket_experimental_config,
-        SCHEMA_GET_EXPERIMENTAL_UI)
+        WS_TYPE_GET_LOVELACE_UI, websocket_lovelace_config,
+        SCHEMA_GET_LOVELACE_UI)
     hass.http.register_view(ManifestJSONView)
 
     conf = config.get(DOMAIN, {})
@@ -265,7 +266,7 @@ async def async_setup(hass, config):
     await asyncio.wait(
         [async_register_built_in_panel(hass, panel) for panel in (
             'dev-event', 'dev-info', 'dev-service', 'dev-state',
-            'dev-template', 'dev-mqtt', 'kiosk', 'experimental-ui')],
+            'dev-template', 'dev-mqtt', 'kiosk', 'lovelace')],
         loop=hass.loop)
 
     hass.data[DATA_FINALIZE_PANEL] = async_finalize_panel
@@ -499,15 +500,26 @@ def websocket_get_translations(hass, connection, msg):
     hass.async_add_job(send_translations())
 
 
-def websocket_experimental_config(hass, connection, msg):
-    """Send experimental UI config over websocket config."""
+def websocket_lovelace_config(hass, connection, msg):
+    """Send lovelace UI config over websocket config."""
     async def send_exp_config():
-        """Send experimental frontend config."""
-        config = await hass.async_add_job(
-            load_yaml, hass.config.path('experimental-ui.yaml'))
+        """Send lovelace frontend config."""
+        error = None
+        try:
+            config = await hass.async_add_job(
+                load_yaml, hass.config.path('ui-lovelace.yaml'))
+            message = websocket_api.result_message(
+                msg['id'], config
+            )
+        except FileNotFoundError:
+            error = ('file_not_found',
+                     'Could not find ui-lovelace.yaml in your config dir.')
+        except HomeAssistantError as err:
+            error = 'load_error', str(err)
 
-        connection.send_message_outside(websocket_api.result_message(
-            msg['id'], config
-        ))
+        if error is not None:
+            message = websocket_api.error_message(msg['id'], *error)
+
+        connection.send_message_outside(message)
 
     hass.async_add_job(send_exp_config())

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -415,7 +415,7 @@ hole==0.3.0
 holidays==0.9.5
 
 # homeassistant.components.frontend
-home-assistant-frontend==20180619.0
+home-assistant-frontend==20180620.0
 
 # homeassistant.components.homekit_controller
 # homekit==0.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -81,7 +81,7 @@ hbmqtt==0.9.2
 holidays==0.9.5
 
 # homeassistant.components.frontend
-home-assistant-frontend==20180619.0
+home-assistant-frontend==20180620.0
 
 # homeassistant.components.influxdb
 # homeassistant.components.sensor.influxdb

--- a/tests/components/frontend/__init__.py
+++ b/tests/components/frontend/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the frontend component."""

--- a/tests/components/frontend/test_init.py
+++ b/tests/components/frontend/test_init.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 import pytest
 
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.setup import async_setup_component
 from homeassistant.components.frontend import (
     DOMAIN, CONF_JS_VERSION, CONF_THEMES, CONF_EXTRA_HTML_URL,
@@ -280,8 +281,8 @@ async def test_get_translations(hass, hass_ws_client):
     assert msg['result'] == {'resources': {'lang': 'nl'}}
 
 
-async def test_experimental_ui(hass, hass_ws_client):
-    """Test experimental_ui command."""
+async def test_lovelace_ui(hass, hass_ws_client):
+    """Test lovelace_ui command."""
     await async_setup_component(hass, 'frontend')
     client = await hass_ws_client(hass)
 
@@ -289,7 +290,7 @@ async def test_experimental_ui(hass, hass_ws_client):
                return_value={'hello': 'world'}):
         await client.send_json({
             'id': 5,
-            'type': 'frontend/experimental_ui',
+            'type': 'frontend/lovelace_config',
         })
         msg = await client.receive_json()
 
@@ -297,3 +298,41 @@ async def test_experimental_ui(hass, hass_ws_client):
     assert msg['type'] == wapi.TYPE_RESULT
     assert msg['success']
     assert msg['result'] == {'hello': 'world'}
+
+
+async def test_lovelace_ui_not_found(hass, hass_ws_client):
+    """Test lovelace_ui command cannot find file."""
+    await async_setup_component(hass, 'frontend')
+    client = await hass_ws_client(hass)
+
+    with patch('homeassistant.components.frontend.load_yaml',
+               side_effect=FileNotFoundError):
+        await client.send_json({
+            'id': 5,
+            'type': 'frontend/lovelace_config',
+        })
+        msg = await client.receive_json()
+
+    assert msg['id'] == 5
+    assert msg['type'] == wapi.TYPE_RESULT
+    assert msg['success'] is False
+    assert msg['error']['code'] == 'file_not_found'
+
+
+async def test_lovelace_ui_load_err(hass, hass_ws_client):
+    """Test lovelace_ui command cannot find file."""
+    await async_setup_component(hass, 'frontend')
+    client = await hass_ws_client(hass)
+
+    with patch('homeassistant.components.frontend.load_yaml',
+               side_effect=HomeAssistantError):
+        await client.send_json({
+            'id': 5,
+            'type': 'frontend/lovelace_config',
+        })
+        msg = await client.receive_json()
+
+    assert msg['id'] == 5
+    assert msg['type'] == wapi.TYPE_RESULT
+    assert msg['success'] is False
+    assert msg['error']['code'] == 'load_error'


### PR DESCRIPTION
## Description:
The experimental UI needed a codename so that we don't have to rename the docs urls in the future. So we're rebranding as Lovelace, the last name of the first ever programmer 👍 

This is not a breaking change as 0.72 was the first with the experimental UI.

The file is now named `ui-lovelace.yaml` instead of `experimental-ui.yaml`.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
