### PR TITLE
Add additional parameters to NUT UPS sensor

### DIFF
--- a/homeassistant/components/sensor/nut.py
+++ b/homeassistant/components/sensor/nut.py
@@ -107,6 +107,15 @@ SENSOR_TYPES = {
         ['Voltage Transfer Reason', '', 'mdi:information-outline'],
     'input.voltage': ['Input Voltage', 'V', 'mdi:flash'],
     'input.voltage.nominal': ['Nominal Input Voltage', 'V', 'mdi:flash'],
+    'input.frequency': ['Input Line Frequency','hz','mdi:flash'],
+    'input.frequency.nominal': ['Nominal Input Line Frequency','hz','mdi:flash'],
+    'input.frequency.status': ['Input Frequency Status','','mdi:information-outline'],
+    'output.current': ['Output Current', 'A', 'mdi:flash'],
+    'output.current.nominal': ['Nominal Output Current', 'A', 'mdi:flash'],
+    'output.voltage': ['Output Voltage', 'V', 'mdi:flash'],
+    'output.voltage.nominal': ['Nominal Output Voltage', 'V', 'mdi:flash'],
+    'output.frequency': ['Output Frequency', 'hz', 'mdi:flash'],
+    'output.frequency.nominal': ['Nominal Output Frequency', 'hz', 'mdi:flash'],
 }
 
 STATE_TYPES = {

--- a/homeassistant/components/sensor/nut.py
+++ b/homeassistant/components/sensor/nut.py
@@ -32,19 +32,6 @@ KEY_STATUS_DISPLAY = 'ups.status.display'
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=60)
 
 SENSOR_TYPES = {
-    'device.model': ['Device model', '', 'mdi:information-outline'],
-    'device.mfr': ['Device manufacturer', '', 'mdi:information-outline'],
-    'device.serial': ['Device serial', '', 'mdi:information-outline'],
-    'device.type': ['Device type', '', 'mdi:information-outline'],
-    'device.description':
-        ['Device description', '', 'mdi:information-outline'],
-    'device.contact':
-        ['Device administrator name', '', 'mdi:information-outline'],
-    'device.location':
-        ['Device physical location', '', 'mdi:information-outline'],
-    'device.part': ['Device part number', '', 'mdi:information-outline'],
-    'device.macaddr':
-        ['Device network address', '', 'mdi:information-outline'],
     'ups.status.display': ['Status', '', 'mdi:information-outline'],
     'ups.status': ['Status Data', '', 'mdi:information-outline'],
     'ups.alarm': ['Alarms', '', 'mdi:alarm'],

--- a/homeassistant/components/sensor/nut.py
+++ b/homeassistant/components/sensor/nut.py
@@ -36,7 +36,8 @@ SENSOR_TYPES = {
     'device.mfr': ['Device manufacturer', '', 'mdi:information-outline'],
     'device.serial': ['Device serial', '', 'mdi:information-outline'],
     'device.type': ['Device type', '', 'mdi:information-outline'],
-    'device.description': ['Device description', '', 'mdi:information-outline'],
+    'device.description':
+        ['Device description', '', 'mdi:information-outline'],
     'device.contact':
         ['Device administrator name', '', 'mdi:information-outline'],
     'device.location':

--- a/homeassistant/components/sensor/nut.py
+++ b/homeassistant/components/sensor/nut.py
@@ -32,6 +32,18 @@ KEY_STATUS_DISPLAY = 'ups.status.display'
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=60)
 
 SENSOR_TYPES = {
+    'device.model': ['Device model', '', 'mdi:information-outline'],
+    'device.mfr': ['Device manufacturer', '', 'mdi:information-outline'],
+    'device.serial': ['Device serial', '', 'mdi:information-outline'],
+    'device.type': ['Device type', '', 'mdi:information-outline'],
+    'device.description': ['Device description', '', 'mdi:information-outline'],
+    'device.contact':
+        ['Device administrator name', '', 'mdi:information-outline'],
+    'device.location':
+        ['Device physical location', '', 'mdi:information-outline'],
+    'device.part': ['Device part number', '', 'mdi:information-outline'],
+    'device.macaddr':
+        ['Device network address', '', 'mdi:information-outline'],
     'ups.status.display': ['Status', '', 'mdi:information-outline'],
     'ups.status': ['Status Data', '', 'mdi:information-outline'],
     'ups.alarm': ['Alarms', '', 'mdi:alarm'],
@@ -107,15 +119,20 @@ SENSOR_TYPES = {
         ['Voltage Transfer Reason', '', 'mdi:information-outline'],
     'input.voltage': ['Input Voltage', 'V', 'mdi:flash'],
     'input.voltage.nominal': ['Nominal Input Voltage', 'V', 'mdi:flash'],
-    'input.frequency': ['Input Line Frequency','hz','mdi:flash'],
-    'input.frequency.nominal': ['Nominal Input Line Frequency','hz','mdi:flash'],
-    'input.frequency.status': ['Input Frequency Status','','mdi:information-outline'],
+    'input.frequency': ['Input Line Frequency', 'hz', 'mdi:flash'],
+    'input.frequency.nominal':
+        ['Nominal Input Line Frequency', 'hz', 'mdi:flash'],
+    'input.frequency.status':
+        ['Input Frequency Status', '', 'mdi:information-outline'],
     'output.current': ['Output Current', 'A', 'mdi:flash'],
-    'output.current.nominal': ['Nominal Output Current', 'A', 'mdi:flash'],
+    'output.current.nominal':
+        ['Nominal Output Current', 'A', 'mdi:flash'],
     'output.voltage': ['Output Voltage', 'V', 'mdi:flash'],
-    'output.voltage.nominal': ['Nominal Output Voltage', 'V', 'mdi:flash'],
+    'output.voltage.nominal':
+        ['Nominal Output Voltage', 'V', 'mdi:flash'],
     'output.frequency': ['Output Frequency', 'hz', 'mdi:flash'],
-    'output.frequency.nominal': ['Nominal Output Frequency', 'hz', 'mdi:flash'],
+    'output.frequency.nominal':
+        ['Nominal Output Frequency', 'hz', 'mdi:flash'],
 }
 
 STATE_TYPES = {


### PR DESCRIPTION
## Description:

Added additional parameters to NUT UPS sensor
input.frequency
output.current
output.voltage
output.frequency

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5623

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
