### PR TITLE
Update pyhomematic to 0.1.44

### DIFF
--- a/homeassistant/components/homematic/__init__.py
+++ b/homeassistant/components/homematic/__init__.py
@@ -20,7 +20,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.loader import bind_hass
 
-REQUIREMENTS = ['pyhomematic==0.1.43']
+REQUIREMENTS = ['pyhomematic==0.1.44']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -846,7 +846,7 @@ pyhik==0.1.8
 pyhiveapi==0.2.14
 
 # homeassistant.components.homematic
-pyhomematic==0.1.43
+pyhomematic==0.1.44
 
 # homeassistant.components.sensor.hydroquebec
 pyhydroquebec==2.2.2


### PR DESCRIPTION
## Description:
Update pyhomematic to 0.1.44.
Changelog:
- Added HM-Sen-MDIR-O-3
- Allow custom port for JSON-RPC (optional)
- Switched HM-CC-TC to LOWBAT parameter

After merging this https://github.com/home-assistant/home-assistant/pull/15029 has to be merged as well to keep homematic working.

@hanzoh 
Please don't forget to write the documentation for the new port-option.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
