### PR TITLE
Update Tile platform to be async

### DIFF
--- a/homeassistant/components/device_tracker/tile.py
+++ b/homeassistant/components/device_tracker/tile.py
@@ -109,14 +109,11 @@ class TileScanner(object):
         _LOGGER.debug('Updating Tile data')
 
         try:
-            progress = self._hass.async_add_job(
-                self._client.tiles.all(
-                    whitelist=self._types, show_inactive=self._show_inactive))
-            tiles = await progress
+            await self._client.asayn_init()
+            tiles = await self._client.tiles.all(
+                whitelist=self._types, show_inactive=self._show_inactive))
         except SessionExpiredError:
             _LOGGER.info('Session expired; trying again shortly')
-            progress.cancel()
-            self._hass.async_add_job(self._client.async_init())
             return
         except TileError as err:
             _LOGGER.error('There was an error while updating: %s', err)

--- a/homeassistant/components/device_tracker/tile.py
+++ b/homeassistant/components/device_tracker/tile.py
@@ -33,15 +33,12 @@ ATTR_VOIP_STATE = 'voip_state'
 CONF_SHOW_INACTIVE = 'show_inactive'
 
 DEFAULT_ICON = 'mdi:bluetooth'
-DEFAULT_SCAN_INTERVAL = timedelta(minutes=1)
+DEFAULT_SCAN_INTERVAL = timedelta(minutes=2)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_USERNAME):
-        cv.string,
-    vol.Required(CONF_PASSWORD):
-        cv.string,
-    vol.Optional(CONF_SHOW_INACTIVE, default=False):
-        cv.boolean,
+    vol.Required(CONF_USERNAME): cv.string,
+    vol.Required(CONF_PASSWORD): cv.string,
+    vol.Optional(CONF_SHOW_INACTIVE, default=False): cv.boolean,
     vol.Optional(CONF_MONITORED_VARIABLES, default=list(DEVICE_TYPES)):
         vol.All(cv.ensure_list, [vol.In(DEVICE_TYPES)]),
 })

--- a/homeassistant/components/device_tracker/tile.py
+++ b/homeassistant/components/device_tracker/tile.py
@@ -5,24 +5,22 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/device_tracker.tile/
 """
 import logging
+from datetime import timedelta
 
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
-from homeassistant.components.device_tracker import (
-    PLATFORM_SCHEMA, DeviceScanner)
+from homeassistant.components.device_tracker import PLATFORM_SCHEMA
 from homeassistant.const import (
     CONF_USERNAME, CONF_MONITORED_VARIABLES, CONF_PASSWORD)
-from homeassistant.helpers.event import track_utc_time_change
+from homeassistant.helpers import aiohttp_client, config_validation as cv
+from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.util import slugify
 from homeassistant.util.json import load_json, save_json
 
 _LOGGER = logging.getLogger(__name__)
-
-REQUIREMENTS = ['pytile==1.1.0']
+REQUIREMENTS = ['pytile==2.0.1']
 
 CLIENT_UUID_CONFIG_FILE = '.tile.conf'
-DEFAULT_ICON = 'mdi:bluetooth'
 DEVICE_TYPES = ['PHONE', 'TILE']
 
 ATTR_ALTITUDE = 'altitude'
@@ -34,89 +32,102 @@ ATTR_VOIP_STATE = 'voip_state'
 
 CONF_SHOW_INACTIVE = 'show_inactive'
 
+DEFAULT_ICON = 'mdi:bluetooth'
+DEFAULT_SCAN_INTERVAL = timedelta(minutes=1)
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_USERNAME): cv.string,
-    vol.Required(CONF_PASSWORD): cv.string,
-    vol.Optional(CONF_SHOW_INACTIVE, default=False): cv.boolean,
-    vol.Optional(CONF_MONITORED_VARIABLES):
+    vol.Required(CONF_USERNAME):
+        cv.string,
+    vol.Required(CONF_PASSWORD):
+        cv.string,
+    vol.Optional(CONF_SHOW_INACTIVE, default=False):
+        cv.boolean,
+    vol.Optional(CONF_MONITORED_VARIABLES, default=list(DEVICE_TYPES)):
         vol.All(cv.ensure_list, [vol.In(DEVICE_TYPES)]),
 })
 
 
-def setup_scanner(hass, config: dict, see, discovery_info=None):
+async def async_setup_scanner(hass, config, async_see, discovery_info=None):
     """Validate the configuration and return a Tile scanner."""
-    TileDeviceScanner(hass, config, see)
-    return True
+    from pytile import Client
+
+    websession = aiohttp_client.async_get_clientsession(hass)
+
+    config_data = await hass.async_add_job(
+        load_json, hass.config.path(CLIENT_UUID_CONFIG_FILE))
+    if config_data:
+        client = Client(
+            config[CONF_USERNAME],
+            config[CONF_PASSWORD],
+            websession,
+            client_uuid=config_data['client_uuid'])
+    else:
+        client = Client(
+            config[CONF_USERNAME], config[CONF_PASSWORD], websession)
+
+        config_data = {'client_uuid': client.client_uuid}
+        config_saved = await hass.async_add_job(
+            save_json, hass.config.path(CLIENT_UUID_CONFIG_FILE), config_data)
+        if not config_saved:
+            _LOGGER.error('Failed to save the client UUID')
+
+    scanner = TileScanner(
+        client, hass, async_see, config[CONF_MONITORED_VARIABLES],
+        config[CONF_SHOW_INACTIVE])
+    return await scanner.async_init()
 
 
-class TileDeviceScanner(DeviceScanner):
-    """Define a device scanner for Tiles."""
+class TileScanner(object):
+    """Define an object to retrieve Tile data."""
 
-    def __init__(self, hass, config, see):
+    def __init__(self, client, hass, async_see, types, show_inactive):
         """Initialize."""
-        from pytile import Client
+        self._async_see = async_see
+        self._client = client
+        self._hass = hass
+        self._show_inactive = show_inactive
+        self._types = types
 
-        _LOGGER.debug('Received configuration data: %s', config)
+    async def async_init(self):
+        """Further initialize connection to the Tile servers."""
+        from pytile.errors import TileError
 
-        # Load the client UUID (if it exists):
-        config_data = load_json(hass.config.path(CLIENT_UUID_CONFIG_FILE))
-        if config_data:
-            _LOGGER.debug('Using existing client UUID')
-            self._client = Client(
-                config[CONF_USERNAME],
-                config[CONF_PASSWORD],
-                config_data['client_uuid'])
-        else:
-            _LOGGER.debug('Generating new client UUID')
-            self._client = Client(
-                config[CONF_USERNAME],
-                config[CONF_PASSWORD])
+        try:
+            await self._client.get_session()
+            await self._async_update()
 
-            if not save_json(
-                    hass.config.path(CLIENT_UUID_CONFIG_FILE),
-                    {'client_uuid': self._client.client_uuid}):
-                _LOGGER.error("Failed to save configuration file")
+            async_track_time_interval(
+                self._hass, self._async_update, DEFAULT_SCAN_INTERVAL)
 
-        _LOGGER.debug('Client UUID: %s', self._client.client_uuid)
-        _LOGGER.debug('User UUID: %s', self._client.user_uuid)
+            return True
+        except TileError as err:
+            _LOGGER.error('Unable to set up Tile scanner: %s', err)
+            return False
 
-        self._show_inactive = config.get(CONF_SHOW_INACTIVE)
-        self._types = config.get(CONF_MONITORED_VARIABLES)
+    async def _async_update(self, now=None):
+        """Update info from Tile."""
+        _LOGGER.debug('Updating Tile data')
 
-        self.devices = {}
-        self.see = see
+        tiles = await self._client.tiles.all(
+            whitelist=self._types, show_inactive=self._show_inactive)
 
-        track_utc_time_change(
-            hass, self._update_info, second=range(0, 60, 30))
-
-        self._update_info()
-
-    def _update_info(self, now=None) -> None:
-        """Update the device info."""
-        self.devices = self._client.get_tiles(
-            type_whitelist=self._types, show_inactive=self._show_inactive)
-
-        if not self.devices:
+        if not tiles:
             _LOGGER.warning('No Tiles found')
             return
 
-        for dev in self.devices:
-            dev_id = 'tile_{0}'.format(slugify(dev['name']))
-            lat = dev['tileState']['latitude']
-            lon = dev['tileState']['longitude']
-
-            attrs = {
-                ATTR_ALTITUDE: dev['tileState']['altitude'],
-                ATTR_CONNECTION_STATE: dev['tileState']['connection_state'],
-                ATTR_IS_DEAD: dev['is_dead'],
-                ATTR_IS_LOST: dev['tileState']['is_lost'],
-                ATTR_RING_STATE: dev['tileState']['ring_state'],
-                ATTR_VOIP_STATE: dev['tileState']['voip_state'],
-            }
-
-            self.see(
-                dev_id=dev_id,
-                gps=(lat, lon),
-                attributes=attrs,
-                icon=DEFAULT_ICON
-            )
+        for tile in tiles:
+            await self._async_see(
+                dev_id='tile_{0}'.format(slugify(tile['name'])),
+                gps=(
+                    tile['tileState']['latitude'],
+                    tile['tileState']['longitude']),
+                attributes={
+                    ATTR_ALTITUDE: tile['tileState']['altitude'],
+                    ATTR_CONNECTION_STATE:
+                        tile['tileState']['connection_state'],
+                    ATTR_IS_DEAD: tile['is_dead'],
+                    ATTR_IS_LOST: tile['tileState']['is_lost'],
+                    ATTR_RING_STATE: tile['tileState']['ring_state'],
+                    ATTR_VOIP_STATE: tile['tileState']['voip_state'],
+                },
+                icon=DEFAULT_ICON)

--- a/homeassistant/components/device_tracker/tile.py
+++ b/homeassistant/components/device_tracker/tile.py
@@ -18,7 +18,7 @@ from homeassistant.util import slugify
 from homeassistant.util.json import load_json, save_json
 
 _LOGGER = logging.getLogger(__name__)
-REQUIREMENTS = ['pytile==2.0.1']
+REQUIREMENTS = ['pytile==2.0.2']
 
 CLIENT_UUID_CONFIG_FILE = '.tile.conf'
 DEVICE_TYPES = ['PHONE', 'TILE']
@@ -90,7 +90,7 @@ class TileScanner(object):
         from pytile.errors import TileError
 
         try:
-            await self._client.get_session()
+            await self._client.async_init()
         except TileError as err:
             _LOGGER.error('Unable to set up Tile scanner: %s', err)
             return False
@@ -113,7 +113,7 @@ class TileScanner(object):
                 whitelist=self._types, show_inactive=self._show_inactive)
         except SessionExpiredError:
             _LOGGER.warning('Session expired; trying again shortly')
-            await self._client.get_session()
+            await self._client.async_init()
             return
         except TileError as err:
             _LOGGER.error('There was an error while updating: %s', err)

--- a/homeassistant/components/device_tracker/tile.py
+++ b/homeassistant/components/device_tracker/tile.py
@@ -111,7 +111,7 @@ class TileScanner(object):
         try:
             await self._client.asayn_init()
             tiles = await self._client.tiles.all(
-                whitelist=self._types, show_inactive=self._show_inactive))
+                whitelist=self._types, show_inactive=self._show_inactive)
         except SessionExpiredError:
             _LOGGER.info('Session expired; trying again shortly')
             return
@@ -130,12 +130,17 @@ class TileScanner(object):
                     tile['tileState']['latitude'],
                     tile['tileState']['longitude']),
                 attributes={
-                    ATTR_ALTITUDE: tile['tileState']['altitude'],
+                    ATTR_ALTITUDE:
+                        tile['tileState']['altitude'],
                     ATTR_CONNECTION_STATE:
                         tile['tileState']['connection_state'],
-                    ATTR_IS_DEAD: tile['is_dead'],
-                    ATTR_IS_LOST: tile['tileState']['is_lost'],
-                    ATTR_RING_STATE: tile['tileState']['ring_state'],
-                    ATTR_VOIP_STATE: tile['tileState']['voip_state'],
+                    ATTR_IS_DEAD:
+                        tile['is_dead'],
+                    ATTR_IS_LOST:
+                        tile['tileState']['is_lost'],
+                    ATTR_RING_STATE:
+                        tile['tileState']['ring_state'],
+                    ATTR_VOIP_STATE:
+                        tile['tileState']['voip_state'],
                 },
                 icon=DEFAULT_ICON)

--- a/homeassistant/components/device_tracker/tile.py
+++ b/homeassistant/components/device_tracker/tile.py
@@ -128,19 +128,15 @@ class TileScanner(object):
                 dev_id='tile_{0}'.format(slugify(tile['name'])),
                 gps=(
                     tile['tileState']['latitude'],
-                    tile['tileState']['longitude']),
+                    tile['tileState']['longitude']
+                ),
                 attributes={
-                    ATTR_ALTITUDE:
-                        tile['tileState']['altitude'],
+                    ATTR_ALTITUDE: tile['tileState']['altitude'],
                     ATTR_CONNECTION_STATE:
                         tile['tileState']['connection_state'],
-                    ATTR_IS_DEAD:
-                        tile['is_dead'],
-                    ATTR_IS_LOST:
-                        tile['tileState']['is_lost'],
-                    ATTR_RING_STATE:
-                        tile['tileState']['ring_state'],
-                    ATTR_VOIP_STATE:
-                        tile['tileState']['voip_state'],
+                    ATTR_IS_DEAD: tile['is_dead'],
+                    ATTR_IS_LOST: tile['tileState']['is_lost'],
+                    ATTR_RING_STATE: tile['tileState']['ring_state'],
+                    ATTR_VOIP_STATE: tile['tileState']['voip_state'],
                 },
                 icon=DEFAULT_ICON)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1113,7 +1113,7 @@ pythonegardia==1.0.39
 pythonwhois==2.4.3
 
 # homeassistant.components.device_tracker.tile
-pytile==1.1.0
+pytile==2.0.1
 
 # homeassistant.components.climate.touchline
 pytouchline==0.7

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1113,7 +1113,7 @@ pythonegardia==1.0.39
 pythonwhois==2.4.3
 
 # homeassistant.components.device_tracker.tile
-pytile==2.0.1
+pytile==2.0.2
 
 # homeassistant.components.climate.touchline
 pytouchline==0.7


### PR DESCRIPTION
## Description:
This PR:

* Updates the Tile device tracker to be async
* Re-architects the platform to be cleaner, more consistent, and easier to understand.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
device_tracker:
  - platform: tile
    username: email@address.com
    password: password_123
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  ~- [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)~

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  ~- [ ] New files were added to `.coveragerc`.~

If the code does not interact with devices:
  ~- [ ] Tests have been added to verify that the new code works.~

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
