### PR TITLE
Add PJLink media player platform

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -523,6 +523,7 @@ omit =
     homeassistant/components/media_player/pandora.py
     homeassistant/components/media_player/philips_js.py
     homeassistant/components/media_player/pioneer.py
+    homeassistant/components/media_player/pjlink.py
     homeassistant/components/media_player/plex.py
     homeassistant/components/media_player/roku.py
     homeassistant/components/media_player/russound_rio.py

--- a/homeassistant/components/media_player/pjlink.py
+++ b/homeassistant/components/media_player/pjlink.py
@@ -1,0 +1,145 @@
+"""
+Support for controlling projector via the PJLink protocol.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/media_player.pjlink/
+"""
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components.media_player import (
+    SUPPORT_TURN_OFF, SUPPORT_TURN_ON, SUPPORT_VOLUME_MUTE,
+    SUPPORT_SELECT_SOURCE, PLATFORM_SCHEMA,
+    MediaPlayerDevice)
+from homeassistant.const import (STATE_OFF, STATE_ON, CONF_HOST,
+    CONF_NAME, CONF_PASSWORD, CONF_PORT)
+import homeassistant.helpers.config_validation as cv
+
+REQUIREMENTS = ['pypjlink2==1.2.0']
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_ENCODING = 'encoding'
+
+DEFAULT_PORT = 4352
+DEFAULT_ENCODING = 'utf-8'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_HOST): cv.string,
+    vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+    vol.Optional(CONF_NAME): cv.string,
+    vol.Optional(CONF_ENCODING, default=DEFAULT_ENCODING): cv.string,
+    vol.Optional(CONF_PASSWORD): cv.string,
+})
+
+SUPPORT_PJLINK = SUPPORT_VOLUME_MUTE | \
+    SUPPORT_TURN_ON | SUPPORT_TURN_OFF | SUPPORT_SELECT_SOURCE
+
+KNOWN_HOSTS = []
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    host = config.get(CONF_HOST)
+    port = config.get(CONF_PORT)
+    name = config.get(CONF_NAME)
+    encoding = config.get(CONF_ENCODING)
+    password = config.get(CONF_PASSWORD)
+    devices = []
+
+    if CONF_HOST in config and host not in KNOWN_HOSTS:
+        device = PjLinkDevice(host, port, name, encoding, password)
+        KNOWN_HOSTS.append("%s:%s" % (host, port))
+        devices.append(device)
+
+    add_devices(devices)
+
+
+class PjLinkDevice(MediaPlayerDevice):
+    def __init__(self, host, port, name, encoding, password):
+        self._host = host
+        self._port = port
+        self._name = name
+        self._encoding = encoding
+        self._muted = False
+        self._pwstate = STATE_OFF
+        self._current_source = None
+        with self.projector() as projector:
+            inputs = self.projector().get_inputs()
+        self._source_name_mapping = dict([("%s %s" % x, x) for x in inputs])
+        self._source_list = sorted(self._source_name_mapping.keys())
+        self.update()
+
+    def projector(self):
+        from pypjlink import Projector
+        projector = Projector.from_address(self._host, self._port,
+            self._encoding)
+        projector.authenticate()
+        return projector
+
+
+    def update(self):
+        with self.projector() as projector:
+            pwstate = projector.get_power()
+            if pwstate == 'off':
+                self._pwstate = STATE_OFF
+            else:
+                self._pwstate = STATE_ON
+            self._muted = projector.get_mute()[1]
+            self._current_source = "%s %s" % projector.get_input()
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the device."""
+        return self._pwstate
+
+    @property
+    def is_volume_muted(self):
+        """Return boolean indicating mute status."""
+        return self._muted
+
+    @property
+    def source(self):
+        """Return current input source."""
+        return self._current_source
+
+    @property
+    def source_list(self):
+        """Return all available input sources."""
+        return self._source_list
+
+    @property
+    def supported_features(self):
+        """Return projector supported features."""
+        return SUPPORT_PJLINK
+
+    def turn_off(self):
+        """Turn projector off."""
+        with self.projector() as projector:
+            projector.set_power('off')
+
+    def turn_on(self):
+        """Turn projector on."""
+        with self.projector() as projector:
+            projector.set_power('on')
+
+    def mute_volume(self, mute):
+        """Mute (true) of unmute (false) media player."""
+        with self.projector() as projector:
+            from pypjlink import MUTE_AUDIO 
+            projector.set_mute(MUTE_AUDIO, mute)
+
+    def select_source(self, source):
+        """Set the input source."""
+        source = self._source_name_mapping[source]
+        with self.projector() as projector:
+            projector.set_input(source[0], source[1])
+
+
+
+
+

--- a/homeassistant/components/media_player/pjlink.py
+++ b/homeassistant/components/media_player/pjlink.py
@@ -88,7 +88,7 @@ class PjLinkDevice(MediaPlayerDevice):
         return projector
 
     def format_input_source(self, input_source_name, input_source_number):
-        """Format input source for display in UI"""
+        """Format input source for display in UI."""
         return "{}_{}".format(
             input_source_name.lower().replace(' ', '_'),
             input_source_number)

--- a/homeassistant/components/media_player/pjlink.py
+++ b/homeassistant/components/media_player/pjlink.py
@@ -10,9 +10,9 @@ import voluptuous as vol
 
 from homeassistant.components.media_player import (
     SUPPORT_TURN_OFF, SUPPORT_TURN_ON, SUPPORT_VOLUME_MUTE,
-    SUPPORT_SELECT_SOURCE, PLATFORM_SCHEMA,
-    MediaPlayerDevice)
-from homeassistant.const import (STATE_OFF, STATE_ON, CONF_HOST,
+    SUPPORT_SELECT_SOURCE, PLATFORM_SCHEMA, MediaPlayerDevice)
+from homeassistant.const import (
+    STATE_OFF, STATE_ON, CONF_HOST,
     CONF_NAME, CONF_PASSWORD, CONF_PORT)
 import homeassistant.helpers.config_validation as cv
 
@@ -37,6 +37,7 @@ SUPPORT_PJLINK = SUPPORT_VOLUME_MUTE | \
     SUPPORT_TURN_ON | SUPPORT_TURN_OFF | SUPPORT_SELECT_SOURCE
 
 KNOWN_HOSTS = []
+
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     host = config.get(CONF_HOST)
@@ -74,10 +75,9 @@ class PjLinkDevice(MediaPlayerDevice):
     def projector(self):
         from pypjlink import Projector
         projector = Projector.from_address(self._host, self._port,
-            self._encoding)
+                                           self._encoding)
         projector.authenticate()
         return projector
-
 
     def update(self):
         with self.projector() as projector:
@@ -132,7 +132,7 @@ class PjLinkDevice(MediaPlayerDevice):
     def mute_volume(self, mute):
         """Mute (true) of unmute (false) media player."""
         with self.projector() as projector:
-            from pypjlink import MUTE_AUDIO 
+            from pypjlink import MUTE_AUDIO
             projector.set_mute(MUTE_AUDIO, mute)
 
     def select_source(self, source):
@@ -140,8 +140,3 @@ class PjLinkDevice(MediaPlayerDevice):
         source = self._source_name_mapping[source]
         with self.projector() as projector:
             projector.set_input(source[0], source[1])
-
-
-
-
-

--- a/homeassistant/components/media_player/pjlink.py
+++ b/homeassistant/components/media_player/pjlink.py
@@ -89,7 +89,9 @@ class PjLinkDevice(MediaPlayerDevice):
 
     def format_input_source(self, input_source_name, input_source_number):
         """Format input source for display in UI"""
-        return "{} {}".format(input_source_name, input_source_number).title()
+        return "{}_{}".format(
+            input_source_name.lower().replace(' ', '_'),
+            input_source_number)
 
     def update(self):
         """Get the latest state from the device."""
@@ -153,4 +155,4 @@ class PjLinkDevice(MediaPlayerDevice):
         """Set the input source."""
         source = self._source_name_mapping[source]
         with self.projector() as projector:
-            projector.set_input(source[0], source[1])
+            projector.set_input(*source)

--- a/homeassistant/components/media_player/pjlink.py
+++ b/homeassistant/components/media_player/pjlink.py
@@ -58,6 +58,13 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices([device], True)
 
 
+def format_input_source(input_source_name, input_source_number):
+    """Format input source for display in UI."""
+    return "{}_{}".format(
+        input_source_name.lower().replace(' ', '_'),
+        input_source_number)
+
+
 class PjLinkDevice(MediaPlayerDevice):
     """Representation of a PJLink device."""
 
@@ -76,7 +83,7 @@ class PjLinkDevice(MediaPlayerDevice):
                 self._name = projector.get_name()
             inputs = projector.get_inputs()
         self._source_name_mapping = \
-            {self.format_input_source(*x): x for x in inputs}
+            {format_input_source(*x): x for x in inputs}
         self._source_list = sorted(self._source_name_mapping.keys())
 
     def projector(self):
@@ -86,12 +93,6 @@ class PjLinkDevice(MediaPlayerDevice):
                                            self._encoding)
         projector.authenticate(self._password)
         return projector
-
-    def format_input_source(self, input_source_name, input_source_number):
-        """Format input source for display in UI."""
-        return "{}_{}".format(
-            input_source_name.lower().replace(' ', '_'),
-            input_source_number)
 
     def update(self):
         """Get the latest state from the device."""
@@ -103,7 +104,7 @@ class PjLinkDevice(MediaPlayerDevice):
                 self._pwstate = STATE_ON
             self._muted = projector.get_mute()[1]
             self._current_source = \
-                self.format_input_source(*projector.get_input())
+                format_input_source(*projector.get_input())
 
     @property
     def name(self):

--- a/homeassistant/components/media_player/pjlink.py
+++ b/homeassistant/components/media_player/pjlink.py
@@ -64,7 +64,9 @@ class PjLinkDevice(MediaPlayerDevice):
         self._pwstate = STATE_OFF
         self._current_source = None
         with self.projector() as projector:
-            inputs = self.projector().get_inputs()
+            if not self._name:
+                self._name = projector.get_name()
+            inputs = projector.get_inputs()
         self._source_name_mapping = dict([("%s %s" % x, x) for x in inputs])
         self._source_list = sorted(self._source_name_mapping.keys())
         self.update()

--- a/homeassistant/components/media_player/pjlink.py
+++ b/homeassistant/components/media_player/pjlink.py
@@ -40,6 +40,7 @@ KNOWN_HOSTS = []
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the PJLink platform."""
     host = config.get(CONF_HOST)
     port = config.get(CONF_PORT)
     name = config.get(CONF_NAME)
@@ -56,7 +57,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
 
 class PjLinkDevice(MediaPlayerDevice):
+    """Representation of a PJLink device."""
+
     def __init__(self, host, port, name, encoding, password):
+        """Iinitialize the PJLink device."""
         self._host = host
         self._port = port
         self._name = name
@@ -73,6 +77,7 @@ class PjLinkDevice(MediaPlayerDevice):
         self.update()
 
     def projector(self):
+        """Create PJLink Projector instance."""
         from pypjlink import Projector
         projector = Projector.from_address(self._host, self._port,
                                            self._encoding)
@@ -80,6 +85,7 @@ class PjLinkDevice(MediaPlayerDevice):
         return projector
 
     def update(self):
+        """Get the latest state from the device."""
         with self.projector() as projector:
             pwstate = projector.get_power()
             if pwstate == 'off':

--- a/homeassistant/components/media_player/pjlink.py
+++ b/homeassistant/components/media_player/pjlink.py
@@ -60,9 +60,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
 def format_input_source(input_source_name, input_source_number):
     """Format input source for display in UI."""
-    return "{}_{}".format(
-        input_source_name.lower().replace(' ', '_'),
-        input_source_number)
+    return "{} {}".format(input_source_name, input_source_number)
 
 
 class PjLinkDevice(MediaPlayerDevice):

--- a/homeassistant/components/media_player/pjlink.py
+++ b/homeassistant/components/media_player/pjlink.py
@@ -75,7 +75,8 @@ class PjLinkDevice(MediaPlayerDevice):
             if not self._name:
                 self._name = projector.get_name()
             inputs = projector.get_inputs()
-        self._source_name_mapping = {self.format_input_source(*x): x for x in inputs}
+        self._source_name_mapping = \
+            {self.format_input_source(*x): x for x in inputs}
         self._source_list = sorted(self._source_name_mapping.keys())
 
     def projector(self):
@@ -99,7 +100,8 @@ class PjLinkDevice(MediaPlayerDevice):
             else:
                 self._pwstate = STATE_ON
             self._muted = projector.get_mute()[1]
-            self._current_source = self.format_input_source(*projector.get_input())
+            self._current_source = \
+                self.format_input_source(*projector.get_input())
 
     @property
     def name(self):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -957,6 +957,9 @@ pyotp==2.2.6
 # homeassistant.components.weather.openweathermap
 pyowm==2.8.0
 
+# homeassistant.components.media_player.pjlink
+pypjlink2==1.2.0
+
 # homeassistant.components.sensor.pollen
 pypollencom==2.1.0
 


### PR DESCRIPTION
## Description:

Add pjlink media player platform to control projectors using the [PJLink protocol](http://pjlink.jbmia.or.jp/english/index.html)

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation:** home-assistant/home-assistant.github.io#5585

## Example entry for `configuration.yaml`
```yaml
media_player:
  - platform: pjlink
    host: 192.168.1.2
    port: 4352
    name: projector
    encoding: utf-8
    password: pw

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54