### PR TITLE
Add kodi unique id based on discovery

### DIFF
--- a/homeassistant/components/media_player/kodi.py
+++ b/homeassistant/components/media_player/kodi.py
@@ -176,10 +176,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         tcp_port = DEFAULT_TCP_PORT
         encryption = DEFAULT_PROXY_SSL
         websocket = DEFAULT_ENABLE_WEBSOCKET
-        properties = discovery_info.get('properties')
-        unique_id = None
-        if properties is not None:
-            unique_id = properties.get('mac', None)
+        unique_id = discovery_info.get('mac_address')
 
     # Only add a device once, so discovered devices do not override manual
     # config.

--- a/homeassistant/components/media_player/kodi.py
+++ b/homeassistant/components/media_player/kodi.py
@@ -177,6 +177,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         encryption = DEFAULT_PROXY_SSL
         websocket = DEFAULT_ENABLE_WEBSOCKET
         properties = discovery_info.get('properties')
+        unique_id = None
         if properties is not None:
             unique_id = properties.get('mac', None)
 

--- a/homeassistant/components/media_player/kodi.py
+++ b/homeassistant/components/media_player/kodi.py
@@ -160,6 +160,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     if DATA_KODI not in hass.data:
         hass.data[DATA_KODI] = dict()
 
+    unique_id = None
     # Is this a manual configuration?
     if discovery_info is None:
         name = config.get(CONF_NAME)
@@ -168,7 +169,6 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         tcp_port = config.get(CONF_TCP_PORT)
         encryption = config.get(CONF_PROXY_SSL)
         websocket = config.get(CONF_ENABLE_WEBSOCKET)
-        unique_id = None
     else:
         name = "{} ({})".format(DEFAULT_NAME, discovery_info.get('hostname'))
         host = discovery_info.get('host')
@@ -176,7 +176,9 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         tcp_port = DEFAULT_TCP_PORT
         encryption = DEFAULT_PROXY_SSL
         websocket = DEFAULT_ENABLE_WEBSOCKET
-        unique_id = discovery_info.get('mac_address')
+        properties = discovery_info.get('properties')
+        if properties is not None:
+            unique_id = properties.get('uuid', None)
 
     # Only add a device once, so discovered devices do not override manual
     # config.

--- a/homeassistant/components/media_player/kodi.py
+++ b/homeassistant/components/media_player/kodi.py
@@ -186,6 +186,14 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     if ip_addr in hass.data[DATA_KODI]:
         return
 
+    # If we got an unique id, check that it does not exist already.
+    # This is necessary as netdisco does not deterministally return the same
+    # advertisement when the service is offered over multiple IP addresses.
+    if unique_id is not None:
+        for device in hass.data[DATA_KODI].values():
+            if device.unique_id == unique_id:
+                return
+    
     entity = KodiDevice(
         hass,
         name=name,

--- a/homeassistant/components/media_player/kodi.py
+++ b/homeassistant/components/media_player/kodi.py
@@ -193,7 +193,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         for device in hass.data[DATA_KODI].values():
             if device.unique_id == unique_id:
                 return
-    
+
     entity = KodiDevice(
         hass,
         name=name,

--- a/homeassistant/components/media_player/kodi.py
+++ b/homeassistant/components/media_player/kodi.py
@@ -393,6 +393,7 @@ class KodiDevice(MediaPlayerDevice):
 
     @property
     def unique_id(self):
+        """Return the unique id of the device."""
         return self._unique_id
 
     @property


### PR DESCRIPTION
## Description:

Adds unique ID to avoid duplicate kodi players, which happens when netdisco decides to pick an advertisement from a different network interface.

Depends on https://github.com/xbmc/xbmc/pull/14089 .

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
