### PR TITLE
Update aiofreepybox to fix HTTPS connection issues

### DIFF
--- a/homeassistant/components/device_tracker/freebox.py
+++ b/homeassistant/components/device_tracker/freebox.py
@@ -22,7 +22,7 @@ from homeassistant.components.device_tracker import (
 from homeassistant.const import (
     CONF_HOST, CONF_PORT)
 
-REQUIREMENTS = ['aiofreepybox==0.0.3']
+REQUIREMENTS = ['aiofreepybox==0.0.4']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -84,7 +84,7 @@ aioautomatic==0.6.5
 aiodns==1.1.1
 
 # homeassistant.components.device_tracker.freebox
-aiofreepybox==0.0.3
+aiofreepybox==0.0.4
 
 # homeassistant.components.camera.yi
 aioftp==0.10.1


### PR DESCRIPTION
## Description:

The previous version of aiofreepybox was not working with custom domain names, which use a Let's Encrypt certificates. Also, it was not working with the default domain name when connecting to Freebox v6. This should be fixed in aiofreepybox 0.0.4.

See https://github.com/stilllman/freepybox/pull/1, https://github.com/stilllman/freepybox/pull/3 and https://github.com/stilllman/freepybox/issues/2 for more info.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.