### PR TITLE
Yi socket bug

### DIFF
--- a/homeassistant/components/camera/yi.py
+++ b/homeassistant/components/camera/yi.py
@@ -53,7 +53,6 @@ class YiCamera(Camera):
         """Initialize."""
         super().__init__()
         self._extra_arguments = config.get(CONF_FFMPEG_ARGUMENTS)
-        self._ftp = None
         self._last_image = None
         self._last_url = None
         self._manager = hass.data[DATA_FFMPEG]
@@ -63,8 +62,6 @@ class YiCamera(Camera):
         self.path = config[CONF_PATH]
         self.user = config[CONF_USERNAME]
         self.passwd = config[CONF_PASSWORD]
-
-        hass.async_add_job(self._connect_to_client)
 
     @property
     def brand(self):
@@ -76,33 +73,28 @@ class YiCamera(Camera):
         """Return the name of this camera."""
         return self._name
 
-    async def _connect_to_client(self):
-        """Attempt to establish a connection via FTP."""
+    async def _get_latest_video_url(self):
+        """Retrieve the latest video file from the customized Yi FTP server."""
         from aioftp import Client, StatusCodeError
 
         ftp = Client()
         try:
             await ftp.connect(self.host)
             await ftp.login(self.user, self.passwd)
-            self._ftp = ftp
         except StatusCodeError as err:
             raise PlatformNotReady(err)
 
-    async def _get_latest_video_url(self):
-        """Retrieve the latest video file from the customized Yi FTP server."""
-        from aioftp import StatusCodeError
-
         try:
-            await self._ftp.change_directory(self.path)
+            await ftp.change_directory(self.path)
             dirs = []
-            for path, attrs in await self._ftp.list():
+            for path, attrs in await ftp.list():
                 if attrs['type'] == 'dir' and '.' not in str(path):
                     dirs.append(path)
             latest_dir = dirs[-1]
-            await self._ftp.change_directory(latest_dir)
+            await ftp.change_directory(latest_dir)
 
             videos = []
-            for path, _ in await self._ftp.list():
+            for path, _ in await ftp.list():
                 videos.append(path)
             if not videos:
                 _LOGGER.info('Video folder "%s" empty; delaying', latest_dir)

--- a/homeassistant/components/camera/yi.py
+++ b/homeassistant/components/camera/yi.py
@@ -100,6 +100,8 @@ class YiCamera(Camera):
                 _LOGGER.info('Video folder "%s" empty; delaying', latest_dir)
                 return None
 
+            await ftp.quit()
+
             return 'ftp://{0}:{1}@{2}:{3}{4}/{5}/{6}'.format(
                 self.user, self.passwd, self.host, self.port, self.path,
                 latest_dir, videos[-1])


### PR DESCRIPTION
## Description:
Addresses exceptions raised through socket timeouts.

**Related issue (if applicable):** fixes #15108 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
camera:
  - platform: yi
    name: Kitchen Camera
    host: 192.168.1.11
    username: root
    password: password123
    ffmpeg_arguments: -s 800x450
  - platform: yi
    name: Guest Bedroom Camera
    host: 192.168.1.12
    username: root
    password: password123
    ffmpeg_arguments: -s 800x450
ffmpeg:
  ffmpeg_bin: /usr/local/bin/ffmpeg
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  ~- [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)~

If the code communicates with devices, web services, or third-party tools:
  ~- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).~
  ~- [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).~
  ~- [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.~
  ~- [ ] New files were added to `.coveragerc`.~

If the code does not interact with devices:
  ~- [ ] Tests have been added to verify that the new code works.~

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
