### PR TITLE
Skip nest security state sensor if no Nest Cam exists

### DIFF
--- a/homeassistant/components/sensor/nest.py
+++ b/homeassistant/components/sensor/nest.py
@@ -24,10 +24,14 @@ PROTECT_SENSOR_TYPES = ['co_status',
                         # color_status: "gray", "green", "yellow", "red"
                         'color_status']
 
-STRUCTURE_SENSOR_TYPES = ['eta', 'security_state']
+STRUCTURE_SENSOR_TYPES = ['eta']
+
+# security_state is structure level sensor, but only meaningful when
+# Nest Cam exist
+STRUCTURE_CAMERA_SENSOR_TYPES = ['security_state']
 
 _VALID_SENSOR_TYPES = SENSOR_TYPES + TEMP_SENSOR_TYPES + PROTECT_SENSOR_TYPES \
-                      + STRUCTURE_SENSOR_TYPES
+                      + STRUCTURE_SENSOR_TYPES + STRUCTURE_CAMERA_SENSOR_TYPES
 
 SENSOR_UNITS = {'humidity': '%'}
 
@@ -104,6 +108,14 @@ async def async_setup_entry(hass, entry, async_add_devices):
             all_sensors += [NestBasicSensor(structure, device, variable)
                             for variable in conditions
                             if variable in PROTECT_SENSOR_TYPES]
+
+        structures_has_camera = {}
+        for structure, device in nest.cameras():
+            structures_has_camera[structure] = True
+        for structure in structures_has_camera:
+            all_sensors += [NestBasicSensor(structure, None, variable)
+                            for variable in conditions
+                            if variable in STRUCTURE_CAMERA_SENSOR_TYPES]
 
         return all_sensors
 


### PR DESCRIPTION
## Description:
Fix #15095

Although `security_state` is structure level sensor, it will never update if no Nest Camera in that structure. So we should not add it in that case.

**Related issue (if applicable):** fixes #15095 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5588

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

