### PR TITLE
Fix pylintrc section order and option placements

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -1,6 +1,4 @@
-[MASTER]
-reports=no
-
+[MESSAGES CONTROL]
 # Reasons disabled:
 # locally-disabled - it spams too much
 # duplicate-code - unavoidable
@@ -14,9 +12,6 @@ reports=no
 # too-few-* - same as too-many-*
 # abstract-method - with intro of async there are always methods missing
 # inconsistent-return-statements - doesn't handle raise
-
-generated-members=botocore.errorfactory
-
 disable=
   abstract-class-little-used,
   abstract-class-not-used,
@@ -39,9 +34,13 @@ disable=
   too-many-statements,
   unused-argument
 
+[REPORTS]
+reports=no
+
+[TYPECHECK]
+# For attrs
+ignored-classes=_CountingAttr
+generated-members=botocore.errorfactory
+
 [EXCEPTIONS]
 overgeneral-exceptions=Exception,HomeAssistantError
-
-# For attrs
-[typecheck]
-ignored-classes=_CountingAttr


### PR DESCRIPTION
## Description:

Make section order and option placements consistent with what pylint --generate-rcfile outputs. I'm not sure if this matters at the moment, but think it's more future proof this way.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**