### PR TITLE
Philips Hue: Add support for Hue sensors

### DIFF
--- a/homeassistant/components/binary_sensor/hue.py
+++ b/homeassistant/components/binary_sensor/hue.py
@@ -1,0 +1,326 @@
+"""
+This component provides binary sensor support for the Philips Hue system.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.hue/
+"""
+import asyncio
+from datetime import timedelta
+import logging
+
+import async_timeout
+
+from aiohue.sensors import (TYPE_CLIP_GENERICFLAG, TYPE_CLIP_OPENCLOSE, TYPE_CLIP_PRESENCE,
+                            TYPE_DAYLIGHT, TYPE_ZLL_PRESENCE)
+import homeassistant.components.hue as hue
+from homeassistant.components.hue.const import (ATTR_LAST_UPDATED, ICON_DAY, ICON_NIGHT)
+from homeassistant.const import ATTR_BATTERY_LEVEL
+from homeassistant.components.binary_sensor import BinarySensorDevice
+
+DEPENDENCIES = ['hue']
+SCAN_INTERVAL = timedelta(seconds=1)
+
+HUE_BINARY_SENSORS = [TYPE_CLIP_GENERICFLAG, TYPE_CLIP_OPENCLOSE, TYPE_CLIP_PRESENCE,
+                      TYPE_DAYLIGHT, TYPE_ZLL_PRESENCE]
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_platform(hass, config, async_add_devices,
+                               discovery_info=None):
+    """Old way of setting up Hue.
+
+    Can only be called when a user accidentally mentions hue platform in their
+    config. But even in that case it would have been ignored.
+    """
+    pass
+
+
+async def async_setup_entry(hass, config_entry, async_add_devices):
+    """Set up the Hue sensors from a config entry."""
+    bridge = hass.data[hue.DOMAIN][config_entry.data['host']]
+    cur_sensors = {}
+
+    # Hue updates all devices via a single API call.
+    #
+    # If we call a service to update 2 devices, we only want the API to be
+    # called once.
+    #
+    # The throttle decorator will return right away if a call is currently
+    # in progress. This means that if we are updating 2 devices, the first one
+    # is in the update method, the second one will skip it and assume the
+    # update went through and updates it's data, not good!
+    #
+    # The current mechanism will make sure that all devices will wait till
+    # the update call is done before writing their data to the state machine.
+    #
+    # An alternative approach would be to disable automatic polling by Home
+    # Assistant and take control ourselves. This works great for polling as now
+    # we trigger from 1 time update an update to all entities. However it gets
+    # tricky from inside async_turn_on and async_turn_off.
+    #
+    # If automatic polling is enabled, Home Assistant will call the entity
+    # update method after it is done calling all the services. This means that
+    # when we update, we know all commands have been processed. If we trigger
+    # the update from inside async_turn_on, the update will not capture the
+    # changes to the second entity until the next polling update because the
+    # throttle decorator will prevent the call.
+
+    progress = None
+    sensor_progress = set()
+
+    async def request_update(object_id):
+        """Request an update.
+
+        We will only make 1 request to the server for updating at a time. If a
+        request is in progress, we will join the request that is in progress.
+
+        This approach is possible because should_poll=True. That means that
+        Home Assistant will ask sensors for updates during a polling cycle or
+        after it has called a service.
+
+        We keep track of the sensors that are waiting for the request to finish.
+        When new data comes in, we'll trigger an update for all non-waiting
+        sensors. This covers the case where a service is called to modify 2
+        sensors but in the meanwhile some other sensor has changed too.
+        """
+        nonlocal progress
+
+        progress_set = sensor_progress
+        progress_set.add(object_id)
+
+        if progress is not None:
+            return await progress
+
+        progress = asyncio.ensure_future(update_bridge())
+        result = await progress
+        progress = None
+        sensor_progress.clear()
+        return result
+
+    async def update_bridge():
+        """Update the values of the bridge.
+
+        Will update sensors from the bridge.
+        """
+        tasks = []
+        tasks.append(async_update_items(
+            hass, bridge, async_add_devices, request_update,
+            cur_sensors, sensor_progress
+        ))
+
+        await asyncio.wait(tasks)
+
+    await update_bridge()
+
+
+async def async_update_items(hass, bridge, async_add_devices,
+                             request_bridge_update, current,
+                             progress_waiting):
+    """Update sensors from the bridge."""
+    import aiohue
+
+    api = bridge.api.sensors
+
+    try:
+        with async_timeout.timeout(4):
+            await api.update()
+    except (asyncio.TimeoutError, aiohue.AiohueException):
+        if not bridge.available:
+            return
+
+        _LOGGER.error('Unable to reach bridge %s', bridge.host)
+        bridge.available = False
+
+        for sensor_id, sensor in current.items():
+            if sensor_id not in progress_waiting:
+                sensor.async_schedule_update_ha_state()
+
+        return
+
+    if not bridge.available:
+        _LOGGER.info('Reconnected to bridge %s', bridge.host)
+        bridge.available = True
+
+    new_sensors = []
+
+    for item_id in api:
+        sensor = api[item_id]
+        if sensor.type in HUE_BINARY_SENSORS:
+            if item_id not in current:
+                current[item_id] = create_binary_sensor(
+                    api[item_id], request_bridge_update, bridge)
+
+                new_sensors.append(current[item_id])
+                _LOGGER.info('Added new Hue binary sensor: %s (Type: %s)',
+                             sensor.name, sensor.type)
+            elif item_id not in progress_waiting:
+                current[item_id].async_schedule_update_ha_state()
+
+    if new_sensors:
+        async_add_devices(new_sensors)
+
+
+class CLIPBinarySensor(BinarySensorDevice):
+    """Base class representing a CLIP Binary Sensor.
+    Contains properties and methods common to all CLIP binary sensors."""
+    def __init__(self, sensor, request_bridge_update, bridge):
+        self.sensor = sensor
+        self.async_request_bridge_update = request_bridge_update
+        self.bridge = bridge
+
+    @property
+    def name(self):
+        """Return the name of the CLIP binary sensor."""
+        return self.sensor.name
+
+    @property
+    def available(self):
+        """Return true if the CLIP binary sensor is available."""
+        return self.sensor.reachable
+
+    async def async_update(self):
+        """Synchronize state with bridge."""
+        await self.async_request_bridge_update(self.sensor.id)
+
+    @property
+    def device_state_attributes(self):
+        """Return the device state attributes."""
+        attributes = {}
+        if self.sensor.battery is not None:
+            attributes[ATTR_BATTERY_LEVEL] = self.sensor.battery
+        attributes[ATTR_LAST_UPDATED] = self.sensor.lastupdated
+        return attributes
+
+
+class CLIPGenericFlag(CLIPBinarySensor):
+    def __init__(self, sensor, request_bridge_update, bridge):
+        """Initialize the sensor."""
+        super().__init__(sensor, request_bridge_update, bridge)
+
+    @property
+    def is_on(self):
+        """Return true if the CLIP binary sensor is on."""
+        return self.sensor.flag
+
+
+class CLIPOpenClose(CLIPBinarySensor):
+    def __init__(self, sensor, request_bridge_update, bridge):
+        """Initialize the sensor."""
+        super().__init__(sensor, request_bridge_update, bridge)
+
+    @property
+    def is_on(self):
+        """Return true if the CLIP binary sensor is on."""
+        return self.sensor.open
+
+    @property
+    def device_class(self):
+        """Return the device class of the CLIP binary sensor."""
+        return 'opening'
+
+
+class CLIPPresence(CLIPBinarySensor):
+    def __init__(self, sensor, request_bridge_update, bridge):
+        """Initialize the sensor."""
+        super().__init__(sensor, request_bridge_update, bridge)
+
+    @property
+    def is_on(self):
+        """Return true if the CLIP binary sensor is on."""
+        return self.sensor.presence
+
+    @property
+    def device_class(self):
+        """Return the device class of the CLIP binary sensor."""
+        return 'presence'
+
+
+class Daylight(BinarySensorDevice):
+    """Class representing the Hue Daylight sensor."""
+    def __init__(self, sensor, request_bridge_update, bridge):
+        self.sensor = sensor
+        self.async_request_bridge_update = request_bridge_update
+        self.bridge = bridge
+
+    @property
+    def name(self):
+        """Return the name of the Hue Daylight sensor."""
+        return self.sensor.name
+
+    @property
+    def unique_id(self):
+        """Generate a unique id for the Daylight sensor, based on the
+        unique bridge id of the bridge and the suffix 'daylight'"""
+        return self.bridge.api.config.bridgeid + '_daylight'
+
+    @property
+    def is_on(self):
+        """Return true if the Hue Daylight sensor is on."""
+        return self.sensor.daylight
+
+    @property
+    def icon(self):
+        """Return an icon for the Hue Daylight sensor based on state."""
+        if self.is_on:
+            return ICON_DAY
+        else:
+            return ICON_NIGHT
+
+    async def async_update(self):
+        """Synchronize state with bridge."""
+        await self.async_request_bridge_update(self.sensor.id)
+
+
+class ZLLPresence(BinarySensorDevice):
+    """Class representing a Hue Motion Sensor."""
+    def __init__(self, sensor, request_bridge_update, bridge):
+        self.sensor = sensor
+        self.async_request_bridge_update = request_bridge_update
+        self.bridge = bridge
+
+    @property
+    def name(self):
+        """Return the name of the Hue Motion Sensor."""
+        return self.sensor.name
+
+    @property
+    def available(self):
+        """Return true if the Hue Motion Sensor. is available."""
+        return self.sensor.reachable
+
+    @property
+    def unique_id(self):
+        """Return the unique id of the Hue Motion Sensor.."""
+        return self.sensor.uniqueid
+
+    @property
+    def is_on(self):
+        """Return true if the Hue Motion Sensor is on."""
+        return self.sensor.presence
+
+    async def async_update(self):
+        """Synchronize state with bridge."""
+        await self.async_request_bridge_update(self.sensor.id)
+
+    @property
+    def device_state_attributes(self):
+        """Return the device state attributes."""
+        attributes = {}
+        attributes[ATTR_BATTERY_LEVEL] = self.sensor.battery
+        attributes[ATTR_LAST_UPDATED] = self.sensor.lastupdated
+        return attributes
+
+
+def create_binary_sensor(sensor, request_bridge_update, bridge):
+    type = sensor.type
+    if type == TYPE_CLIP_GENERICFLAG:
+        return CLIPGenericFlag(sensor, request_bridge_update, bridge)
+    elif type == TYPE_CLIP_OPENCLOSE:
+        return CLIPOpenClose(sensor, request_bridge_update, bridge)
+    elif type == TYPE_CLIP_PRESENCE:
+        return CLIPPresence(sensor, request_bridge_update, bridge)
+    elif type == TYPE_DAYLIGHT:
+        return Daylight(sensor, request_bridge_update, bridge)
+    elif type == TYPE_ZLL_PRESENCE:
+        return ZLLPresence(sensor, request_bridge_update, bridge)

--- a/homeassistant/components/binary_sensor/hue.py
+++ b/homeassistant/components/binary_sensor/hue.py
@@ -20,8 +20,9 @@ from homeassistant.components.binary_sensor import BinarySensorDevice
 DEPENDENCIES = ['hue']
 SCAN_INTERVAL = timedelta(seconds=1)
 
-HUE_BINARY_SENSORS = [TYPE_CLIP_GENERICFLAG, TYPE_CLIP_OPENCLOSE, TYPE_CLIP_PRESENCE,
+ALL_BINARY_SENSORS = [TYPE_CLIP_GENERICFLAG, TYPE_CLIP_OPENCLOSE, TYPE_CLIP_PRESENCE,
                       TYPE_DAYLIGHT, TYPE_ZLL_PRESENCE]
+HUE_BINARY_SENSORS = [TYPE_DAYLIGHT, TYPE_ZLL_PRESENCE]
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -119,6 +120,7 @@ async def async_update_items(hass, bridge, async_add_devices,
                              progress_waiting):
     """Update sensors from the bridge."""
     import aiohue
+    allow_clip_sensors = bridge.allow_clip_sensors
 
     api = bridge.api.sensors
 
@@ -144,9 +146,14 @@ async def async_update_items(hass, bridge, async_add_devices,
 
     new_sensors = []
 
+    if allow_clip_sensors:
+        allowed_binary_sensor_types = ALL_BINARY_SENSORS
+    else:
+        allowed_binary_sensor_types = HUE_BINARY_SENSORS
+
     for item_id in api:
         sensor = api[item_id]
-        if sensor.type in HUE_BINARY_SENSORS:
+        if sensor.type in allowed_binary_sensor_types:
             if item_id not in current:
                 current[item_id] = create_binary_sensor(
                     api[item_id], request_bridge_update, bridge)

--- a/homeassistant/components/binary_sensor/hue.py
+++ b/homeassistant/components/binary_sensor/hue.py
@@ -151,16 +151,15 @@ async def async_update_items(hass, bridge, async_add_devices,
     else:
         allowed_binary_sensor_types = HUE_BINARY_SENSORS
 
-    for item_id in api:
-        sensor = api[item_id]
-        if sensor.type in allowed_binary_sensor_types:
+    for item_id, binary_sensor in api.items():
+        if binary_sensor.type in allowed_binary_sensor_types:
             if item_id not in current:
                 current[item_id] = create_binary_sensor(
-                    api[item_id], request_bridge_update, bridge)
+                    binary_sensor, request_bridge_update, bridge)
 
                 new_sensors.append(current[item_id])
                 _LOGGER.info('Added new Hue binary sensor: %s (Type: %s)',
-                             sensor.name, sensor.type)
+                             binary_sensor.name, binary_sensor.type)
             elif item_id not in progress_waiting:
                 current[item_id].async_schedule_update_ha_state()
 

--- a/homeassistant/components/binary_sensor/hue.py
+++ b/homeassistant/components/binary_sensor/hue.py
@@ -324,14 +324,14 @@ class ZLLPresence(BinarySensorDevice):
 
 
 def create_binary_sensor(sensor, request_bridge_update, bridge):
-    type = sensor.type
-    if type == TYPE_CLIP_GENERICFLAG:
+    binary_sensor_type = sensor.type
+    if binary_sensor_type == TYPE_CLIP_GENERICFLAG:
         return CLIPGenericFlag(sensor, request_bridge_update, bridge)
-    elif type == TYPE_CLIP_OPENCLOSE:
+    elif binary_sensor_type == TYPE_CLIP_OPENCLOSE:
         return CLIPOpenClose(sensor, request_bridge_update, bridge)
-    elif type == TYPE_CLIP_PRESENCE:
+    elif binary_sensor_type == TYPE_CLIP_PRESENCE:
         return CLIPPresence(sensor, request_bridge_update, bridge)
-    elif type == TYPE_DAYLIGHT:
+    elif binary_sensor_type == TYPE_DAYLIGHT:
         return Daylight(sensor, request_bridge_update, bridge)
-    elif type == TYPE_ZLL_PRESENCE:
+    elif binary_sensor_type == TYPE_ZLL_PRESENCE:
         return ZLLPresence(sensor, request_bridge_update, bridge)

--- a/homeassistant/components/binary_sensor/hue.py
+++ b/homeassistant/components/binary_sensor/hue.py
@@ -7,11 +7,11 @@ https://home-assistant.io/components/sensor.hue/
 import asyncio
 from datetime import timedelta
 import logging
-
 import async_timeout
 
 from aiohue.sensors import (TYPE_CLIP_GENERICFLAG, TYPE_CLIP_OPENCLOSE, TYPE_CLIP_PRESENCE,
                             TYPE_DAYLIGHT, TYPE_ZLL_PRESENCE)
+
 import homeassistant.components.hue as hue
 from homeassistant.components.hue.const import (ATTR_LAST_UPDATED, ICON_DAY, ICON_NIGHT)
 from homeassistant.const import ATTR_BATTERY_LEVEL

--- a/homeassistant/components/binary_sensor/hue.py
+++ b/homeassistant/components/binary_sensor/hue.py
@@ -306,6 +306,11 @@ class ZLLPresence(BinarySensorDevice):
         """Return true if the Hue Motion Sensor is on."""
         return self.sensor.presence
 
+    @property
+    def device_class(self):
+        """Return the device class of the Hue Motion Sensor."""
+        return 'motion'
+
     async def async_update(self):
         """Synchronize state with bridge."""
         await self.async_request_bridge_update(self.sensor.id)

--- a/homeassistant/components/binary_sensor/hue.py
+++ b/homeassistant/components/binary_sensor/hue.py
@@ -15,8 +15,7 @@ from aiohue.sensors import (TYPE_CLIP_GENERICFLAG, TYPE_CLIP_OPENCLOSE, TYPE_CLI
 import homeassistant.components.hue as hue
 from homeassistant.components.hue.const import (ICON_DAY, ICON_NIGHT)
 from homeassistant.components.sensor.hue import HueSensor
-from homeassistant.const import (ATTR_BATTERY_LEVEL, STATE_OFF, STATE_ON)
-from homeassistant.components.binary_sensor import BinarySensorDevice
+from homeassistant.const import (STATE_OFF, STATE_ON)
 
 DEPENDENCIES = ['hue']
 SCAN_INTERVAL = timedelta(seconds=1)
@@ -121,8 +120,7 @@ async def async_update_items(hass, bridge, async_add_devices,
                              progress_waiting):
     """Update sensors from the bridge."""
     import aiohue
-    #allow_clip_sensors = bridge.allow_clip_sensors
-    allow_clip_sensors = True
+    allow_clip_sensors = bridge.allow_clip_sensors
 
     api = bridge.api.sensors
 
@@ -251,7 +249,6 @@ class Daylight(HueBinarySensor):
         """Return the device state attributes."""
         attributes = {}
         return attributes
-
 
 
 class ZLLPresence(HueBinarySensor):

--- a/homeassistant/components/hue/__init__.py
+++ b/homeassistant/components/hue/__init__.py
@@ -32,6 +32,9 @@ PHUE_CONFIG_FILE = 'phue.conf'
 CONF_ALLOW_HUE_GROUPS = "allow_hue_groups"
 DEFAULT_ALLOW_HUE_GROUPS = True
 
+CONF_ALLOW_CLIP_SENSORS = 'allow_clip_sensors'
+DEFAULT_ALLOW_CLIP_SENSORS = False
+
 BRIDGE_CONFIG_SCHEMA = vol.Schema({
     # Validate as IP address and then convert back to a string.
     vol.Required(CONF_HOST): vol.All(ipaddress.ip_address, cv.string),
@@ -41,6 +44,8 @@ BRIDGE_CONFIG_SCHEMA = vol.Schema({
                  default=DEFAULT_ALLOW_UNREACHABLE): cv.boolean,
     vol.Optional(CONF_ALLOW_HUE_GROUPS,
                  default=DEFAULT_ALLOW_HUE_GROUPS): cv.boolean,
+    vol.Optional(CONF_ALLOW_CLIP_SENSORS,
+                 default=DEFAULT_ALLOW_CLIP_SENSORS): cv.boolean,
 })
 
 CONFIG_SCHEMA = vol.Schema({
@@ -125,11 +130,14 @@ async def async_setup_entry(hass, entry):
     if config is None:
         allow_unreachable = DEFAULT_ALLOW_UNREACHABLE
         allow_groups = DEFAULT_ALLOW_HUE_GROUPS
+        allow_clip_sensors = DEFAULT_ALLOW_CLIP_SENSORS
     else:
         allow_unreachable = config[CONF_ALLOW_UNREACHABLE]
         allow_groups = config[CONF_ALLOW_HUE_GROUPS]
+        allow_clip_sensors = config[CONF_ALLOW_CLIP_SENSORS]
 
-    bridge = HueBridge(hass, entry, allow_unreachable, allow_groups)
+    bridge = HueBridge(hass, entry, allow_unreachable, allow_groups,
+                       allow_clip_sensors)
     hass.data[DOMAIN][host] = bridge
     return await bridge.async_setup()
 

--- a/homeassistant/components/hue/__init__.py
+++ b/homeassistant/components/hue/__init__.py
@@ -18,7 +18,7 @@ from .bridge import HueBridge
 # Loading the config flow file will register the flow
 from .config_flow import configured_hosts
 
-REQUIREMENTS = ['aiohue==1.5.0']
+REQUIREMENTS = ['aiohue==1.6.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/hue/bridge.py
+++ b/homeassistant/components/hue/bridge.py
@@ -78,8 +78,9 @@ class HueBridge(object):
                              host)
             return False
 
-        hass.async_add_job(hass.config_entries.async_forward_entry_setup(
-            self.config_entry, 'light'))
+        for platform in ['light', 'sensor']:
+            hass.async_add_job(hass.config_entries.async_forward_entry_setup(
+                self.config_entry, platform))
 
         hass.services.async_register(
             DOMAIN, SERVICE_HUE_SCENE, self.hue_activate_scene,

--- a/homeassistant/components/hue/bridge.py
+++ b/homeassistant/components/hue/bridge.py
@@ -22,12 +22,14 @@ SCENE_SCHEMA = vol.Schema({
 class HueBridge(object):
     """Manages a single Hue bridge."""
 
-    def __init__(self, hass, config_entry, allow_unreachable, allow_groups):
+    def __init__(self, hass, config_entry, allow_unreachable, allow_groups,
+                 allow_clip_sensors):
         """Initialize the system."""
         self.config_entry = config_entry
         self.hass = hass
         self.allow_unreachable = allow_unreachable
         self.allow_groups = allow_groups
+        self.allow_clip_sensors = allow_clip_sensors
         self.available = True
         self.api = None
         self._cancel_retry_setup = None

--- a/homeassistant/components/hue/bridge.py
+++ b/homeassistant/components/hue/bridge.py
@@ -78,7 +78,7 @@ class HueBridge(object):
                              host)
             return False
 
-        for platform in ['light', 'sensor']:
+        for platform in ['binary_sensor', 'light', 'sensor']:
             hass.async_add_job(hass.config_entries.async_forward_entry_setup(
                 self.config_entry, platform))
 

--- a/homeassistant/components/hue/const.py
+++ b/homeassistant/components/hue/const.py
@@ -4,3 +4,12 @@ import logging
 LOGGER = logging.getLogger('homeassistant.components.hue')
 DOMAIN = "hue"
 API_NUPNP = 'https://www.meethue.com/api/nupnp'
+
+ATTR_DARK = 'dark'
+ATTR_DAYLIGHT = 'daylight'
+ATTR_LAST_UPDATED = 'last_updated'
+
+ICON_REMOTE = 'mdi:remote'
+
+UOM_HUMIDITY = '%'
+UOM_ILLUMINANCE = 'lx'

--- a/homeassistant/components/hue/const.py
+++ b/homeassistant/components/hue/const.py
@@ -10,6 +10,8 @@ ATTR_DAYLIGHT = 'daylight'
 ATTR_LAST_UPDATED = 'last_updated'
 
 ICON_REMOTE = 'mdi:remote'
+ICON_DAY = 'mdi:weather-sunny'
+ICON_NIGHT = 'mdi:weather-night'
 
 UOM_HUMIDITY = '%'
 UOM_ILLUMINANCE = 'lx'

--- a/homeassistant/components/hue/const.py
+++ b/homeassistant/components/hue/const.py
@@ -7,7 +7,6 @@ API_NUPNP = 'https://www.meethue.com/api/nupnp'
 
 ATTR_DARK = 'dark'
 ATTR_DAYLIGHT = 'daylight'
-ATTR_LAST_UPDATED = 'last_updated'
 
 ICON_REMOTE = 'mdi:remote'
 ICON_DAY = 'mdi:weather-sunny'

--- a/homeassistant/components/sensor/hue.py
+++ b/homeassistant/components/sensor/hue.py
@@ -7,7 +7,6 @@ https://home-assistant.io/components/sensor.hue/
 import asyncio
 from datetime import timedelta
 import logging
-
 import async_timeout
 
 from aiohue.sensors import (ZGP_SWITCH_BUTTON_1, ZGP_SWITCH_BUTTON_2, ZGP_SWITCH_BUTTON_3,
@@ -19,6 +18,7 @@ from aiohue.sensors import (ZGP_SWITCH_BUTTON_1, ZGP_SWITCH_BUTTON_2, ZGP_SWITCH
                             TYPE_CLIP_HUMIDITY, TYPE_CLIP_LIGHTLEVEL, TYPE_CLIP_TEMPERATURE,
                             TYPE_ZGP_SWITCH, TYPE_ZLL_SWITCH, TYPE_ZLL_LIGHTLEVEL,
                             TYPE_ZLL_TEMPERATURE, TYPE_CLIP_SWITCH)
+
 import homeassistant.components.hue as hue
 from homeassistant.components.hue.const import (ATTR_DARK, ATTR_DAYLIGHT, ATTR_LAST_UPDATED,
                                                 ICON_REMOTE, UOM_HUMIDITY, UOM_ILLUMINANCE)

--- a/homeassistant/components/sensor/hue.py
+++ b/homeassistant/components/sensor/hue.py
@@ -163,12 +163,11 @@ async def async_update_items(hass, bridge, async_add_devices,
     else:
         allowed_sensor_types = HUE_SENSORS
 
-    for item_id in api:
-        sensor = api[item_id]
+    for item_id, sensor in api.items():
         if sensor.type in allowed_sensor_types:
             if item_id not in current:
                 current[item_id] = create_sensor(
-                    api[item_id], request_bridge_update, bridge)
+                    sensor, request_bridge_update, bridge)
 
                 new_sensors.append(current[item_id])
                 _LOGGER.info('Added new Hue sensor: %s (Type: %s)',

--- a/homeassistant/components/sensor/hue.py
+++ b/homeassistant/components/sensor/hue.py
@@ -491,22 +491,22 @@ class ZLLTemperatureSensor(ZLLSensor):
 
 
 def create_sensor(sensor, request_bridge_update, bridge):
-    type = sensor.type
-    if type == TYPE_CLIP_GENERICSTATUS:
+    sensor_type = sensor.type
+    if sensor_type == TYPE_CLIP_GENERICSTATUS:
         return CLIPGenericStatus(sensor, request_bridge_update, bridge)
-    elif type == TYPE_CLIP_HUMIDITY:
+    elif sensor_type == TYPE_CLIP_HUMIDITY:
         return CLIPHumidity(sensor, request_bridge_update, bridge)
-    elif type == TYPE_CLIP_LIGHTLEVEL:
+    elif sensor_type == TYPE_CLIP_LIGHTLEVEL:
         return CLIPLightLevel(sensor, request_bridge_update, bridge)
-    elif type == TYPE_CLIP_SWITCH:
+    elif sensor_type == TYPE_CLIP_SWITCH:
         return CLIPSwitch(sensor, request_bridge_update, bridge)
-    elif type == TYPE_CLIP_TEMPERATURE:
+    elif sensor_type == TYPE_CLIP_TEMPERATURE:
         return CLIPTemperature(sensor, request_bridge_update, bridge)
-    elif type == TYPE_ZGP_SWITCH:
+    elif sensor_type == TYPE_ZGP_SWITCH:
         return ZGPSwitch(sensor, request_bridge_update, bridge)
-    elif type == TYPE_ZLL_LIGHTLEVEL:
+    elif sensor_type == TYPE_ZLL_LIGHTLEVEL:
         return ZLLLightLevelSensor(sensor, request_bridge_update, bridge)
-    elif type == TYPE_ZLL_SWITCH:
+    elif sensor_type == TYPE_ZLL_SWITCH:
         return ZLLSwitch(sensor, request_bridge_update, bridge)
-    elif type == TYPE_ZLL_TEMPERATURE:
+    elif sensor_type == TYPE_ZLL_TEMPERATURE:
         return ZLLTemperatureSensor(sensor, request_bridge_update, bridge)

--- a/homeassistant/components/sensor/hue.py
+++ b/homeassistant/components/sensor/hue.py
@@ -1,0 +1,505 @@
+"""
+This component provides sensor support for the Philips Hue system.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.hue/
+"""
+import asyncio
+from datetime import timedelta
+import logging
+
+import async_timeout
+
+from aiohue.sensors import (ZGP_SWITCH_BUTTON_1, ZGP_SWITCH_BUTTON_2, ZGP_SWITCH_BUTTON_3,
+                            ZGP_SWITCH_BUTTON_4, ZLL_SWITCH_BUTTON_1_LONG_RELEASED,
+                            ZLL_SWITCH_BUTTON_1_SHORT_RELEASED, ZLL_SWITCH_BUTTON_2_LONG_RELEASED,
+                            ZLL_SWITCH_BUTTON_2_SHORT_RELEASED, ZLL_SWITCH_BUTTON_3_LONG_RELEASED,
+                            ZLL_SWITCH_BUTTON_3_SHORT_RELEASED, ZLL_SWITCH_BUTTON_4_LONG_RELEASED,
+                            ZLL_SWITCH_BUTTON_4_SHORT_RELEASED, TYPE_CLIP_GENERICSTATUS,
+                            TYPE_CLIP_HUMIDITY, TYPE_CLIP_LIGHTLEVEL, TYPE_CLIP_TEMPERATURE,
+                            TYPE_ZGP_SWITCH, TYPE_ZLL_SWITCH, TYPE_ZLL_LIGHTLEVEL,
+                            TYPE_ZLL_TEMPERATURE, TYPE_CLIP_SWITCH)
+import homeassistant.components.hue as hue
+from homeassistant.components.hue.const import (ATTR_DARK, ATTR_DAYLIGHT, ATTR_LAST_UPDATED,
+                                                ICON_REMOTE, UOM_HUMIDITY, UOM_ILLUMINANCE)
+from homeassistant.components.sensor import (DEVICE_CLASS_HUMIDITY,
+                                             DEVICE_CLASS_ILLUMINANCE,
+                                             DEVICE_CLASS_TEMPERATURE)
+from homeassistant.const import (ATTR_BATTERY_LEVEL, TEMP_CELSIUS)
+from homeassistant.helpers.entity import Entity
+
+DEPENDENCIES = ['hue']
+SCAN_INTERVAL = timedelta(seconds=1)
+
+HUE_SENSORS = [TYPE_CLIP_GENERICSTATUS, TYPE_CLIP_HUMIDITY, TYPE_CLIP_LIGHTLEVEL,
+               TYPE_CLIP_SWITCH, TYPE_CLIP_TEMPERATURE, TYPE_CLIP_HUMIDITY, TYPE_ZGP_SWITCH,
+               TYPE_ZLL_LIGHTLEVEL, TYPE_ZLL_SWITCH, TYPE_ZLL_TEMPERATURE]
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_platform(hass, config, async_add_devices,
+                               discovery_info=None):
+    """Old way of setting up Hue.
+
+    Can only be called when a user accidentally mentions hue platform in their
+    config. But even in that case it would have been ignored.
+    """
+    pass
+
+
+async def async_setup_entry(hass, config_entry, async_add_devices):
+    """Set up the Hue sensors from a config entry."""
+    bridge = hass.data[hue.DOMAIN][config_entry.data['host']]
+    cur_sensors = {}
+
+    # Hue updates all devices via a single API call.
+    #
+    # If we call a service to update 2 devices, we only want the API to be
+    # called once.
+    #
+    # The throttle decorator will return right away if a call is currently
+    # in progress. This means that if we are updating 2 devices, the first one
+    # is in the update method, the second one will skip it and assume the
+    # update went through and updates it's data, not good!
+    #
+    # The current mechanism will make sure that all devices will wait till
+    # the update call is done before writing their data to the state machine.
+    #
+    # An alternative approach would be to disable automatic polling by Home
+    # Assistant and take control ourselves. This works great for polling as now
+    # we trigger from 1 time update an update to all entities. However it gets
+    # tricky from inside async_turn_on and async_turn_off.
+    #
+    # If automatic polling is enabled, Home Assistant will call the entity
+    # update method after it is done calling all the services. This means that
+    # when we update, we know all commands have been processed. If we trigger
+    # the update from inside async_turn_on, the update will not capture the
+    # changes to the second entity until the next polling update because the
+    # throttle decorator will prevent the call.
+
+    progress = None
+    sensor_progress = set()
+
+    async def request_update(object_id):
+        """Request an update.
+
+        We will only make 1 request to the server for updating at a time. If a
+        request is in progress, we will join the request that is in progress.
+
+        This approach is possible because should_poll=True. That means that
+        Home Assistant will ask sensors for updates during a polling cycle or
+        after it has called a service.
+
+        We keep track of the sensors that are waiting for the request to finish.
+        When new data comes in, we'll trigger an update for all non-waiting
+        sensors. This covers the case where a service is called to modify 2
+        sensors but in the meanwhile some other sensor has changed too.
+        """
+        nonlocal progress
+
+        progress_set = sensor_progress
+        progress_set.add(object_id)
+
+        if progress is not None:
+            return await progress
+
+        progress = asyncio.ensure_future(update_bridge())
+        result = await progress
+        progress = None
+        sensor_progress.clear()
+        return result
+
+    async def update_bridge():
+        """Update the values of the bridge.
+
+        Will update sensors from the bridge.
+        """
+        tasks = []
+        tasks.append(async_update_items(
+            hass, bridge, async_add_devices, request_update,
+            cur_sensors, sensor_progress
+        ))
+
+        await asyncio.wait(tasks)
+
+    await update_bridge()
+
+
+async def async_update_items(hass, bridge, async_add_devices,
+                             request_bridge_update, current,
+                             progress_waiting):
+    """Update sensors from the bridge."""
+    import aiohue
+
+    api = bridge.api.sensors
+
+    try:
+        with async_timeout.timeout(4):
+            await api.update()
+    except (asyncio.TimeoutError, aiohue.AiohueException):
+        if not bridge.available:
+            return
+
+        _LOGGER.error('Unable to reach bridge %s', bridge.host)
+        bridge.available = False
+
+        for sensor_id, sensor in current.items():
+            if sensor_id not in progress_waiting:
+                sensor.async_schedule_update_ha_state()
+
+        return
+
+    if not bridge.available:
+        _LOGGER.info('Reconnected to bridge %s', bridge.host)
+        bridge.available = True
+
+    new_sensors = []
+
+    for item_id in api:
+        sensor = api[item_id]
+        if sensor.type in HUE_SENSORS:
+            if item_id not in current:
+                current[item_id] = create_sensor(
+                    api[item_id], request_bridge_update, bridge)
+
+                new_sensors.append(current[item_id])
+                _LOGGER.info('Added new Hue sensor: %s (Type: %s)', sensor.name, sensor.type)
+            elif item_id not in progress_waiting:
+                current[item_id].async_schedule_update_ha_state()
+
+    if new_sensors:
+        async_add_devices(new_sensors)
+
+
+class CLIPSensor(Entity):
+    """Base class representing a CLIP Sensor.
+    Contains properties and methods common to all CLIP sensors."""
+    def __init__(self, sensor, request_bridge_update, bridge):
+        self.sensor = sensor
+        self.async_request_bridge_update = request_bridge_update
+        self.bridge = bridge
+
+    @property
+    def name(self):
+        """Return the name of the CLIP sensor."""
+        return self.sensor.name
+
+    @property
+    def available(self):
+        """Return true if the CLIP sensor is available."""
+        return self.sensor.reachable
+
+    async def async_update(self):
+        """Synchronize state with bridge."""
+        await self.async_request_bridge_update(self.sensor.id)
+
+    @property
+    def device_state_attributes(self):
+        """Return the device state attributes."""
+        attributes = {}
+        if self.sensor.battery is not None:
+            attributes[ATTR_BATTERY_LEVEL] = self.sensor.battery
+        attributes[ATTR_LAST_UPDATED] = self.sensor.lastupdated
+        return attributes
+
+
+class CLIPGenericStatus(CLIPSensor):
+    def __init__(self, sensor, request_bridge_update, bridge):
+        """Initialize the sensor."""
+        super().__init__(sensor, request_bridge_update, bridge)
+
+    @property
+    def state(self):
+        """Return the state of the CLIP sensor."""
+        return self.sensor.status
+
+
+class CLIPHumidity(CLIPSensor):
+    def __init__(self, sensor, request_bridge_update, bridge):
+        """Initialize the sensor."""
+        super().__init__(sensor, request_bridge_update, bridge)
+
+    @property
+    def state(self):
+        """Return the state of the CLIP sensor."""
+        return self.sensor.humidity
+
+    @property
+    def device_class(self):
+        """Return the device class of the CLIP sensor."""
+        return DEVICE_CLASS_HUMIDITY
+
+    @property
+    def unit_of_measurement(self):
+        """Return the uom of the CLIP sensor."""
+        return UOM_HUMIDITY
+
+
+class CLIPLightLevel(CLIPSensor):
+    def __init__(self, sensor, request_bridge_update, bridge):
+        """Initialize the sensor."""
+        super().__init__(sensor, request_bridge_update, bridge)
+
+    @property
+    def state(self):
+        """Return the state of the CLIP sensor."""
+        return self.sensor.lightlevel
+
+    @property
+    def device_class(self):
+        """Return the device class of the CLIP sensor."""
+        return DEVICE_CLASS_ILLUMINANCE
+
+    @property
+    def unit_of_measurement(self):
+        """Return the uom of the CLIP sensor."""
+        return UOM_ILLUMINANCE
+
+
+class CLIPSwitch(CLIPSensor):
+    """Class representing a CLIP Switch."""
+    def __init__(self, sensor, request_bridge_update, bridge):
+        super().__init__(sensor, request_bridge_update, bridge)
+        self._last_update_time = self.sensor.lastupdated
+
+    @property
+    def state(self):
+        """Return the switch's buttonevent if the lastupdated variable changed."""
+        current_time = self.sensor.lastupdated
+        if current_time == self._last_update_time:
+            return None
+        else:
+            self._last_update_time = current_time
+            return self.sensor.buttonevent
+
+    @property
+    def icon(self):
+        """Return the remote icon."""
+        return ICON_REMOTE
+
+
+class CLIPTemperature(CLIPSensor):
+    def __init__(self, sensor, request_bridge_update, bridge):
+        """Initialize the sensor."""
+        super().__init__(sensor, request_bridge_update, bridge)
+
+    @property
+    def state(self):
+        """Return the state of the CLIP sensor."""
+        return round(self.sensor.temperature / 100, 1)
+
+    @property
+    def device_class(self):
+        """Return the device class of the CLIP sensor."""
+        return DEVICE_CLASS_TEMPERATURE
+
+    @property
+    def unit_of_measurement(self):
+        """Return the uom of the CLIP sensor."""
+        return TEMP_CELSIUS
+
+
+class ZGPSwitch(Entity):
+    """Class representing a ZGP (Hue Tap) Switch."""
+    def __init__(self, sensor, request_bridge_update, bridge):
+        self.sensor = sensor
+        self.async_request_bridge_update = request_bridge_update
+        self.bridge = bridge
+        self._last_update_time = self.sensor.lastupdated
+
+    @property
+    def name(self):
+        """Return the name of the ZGP (Hue Tap) Switch."""
+        return self.sensor.name
+
+    @property
+    def unique_id(self):
+        """Return the unique id of the ZGP (Hue Tap) Switch."""
+        return self.sensor.uniqueid
+
+    @property
+    def state(self):
+        """Return the switch's buttonevent if the lastupdated variable changed."""
+        current_time = self.sensor.lastupdated
+        if current_time == self._last_update_time:
+            return None
+        else:
+            self._last_update_time = current_time
+            if self.sensor.buttonevent == ZGP_SWITCH_BUTTON_1:
+                return 1
+            elif self.sensor.buttonevent == ZGP_SWITCH_BUTTON_2:
+                return 2
+            elif self.sensor.buttonevent == ZGP_SWITCH_BUTTON_3:
+                return 3
+            elif self.sensor.buttonevent == ZGP_SWITCH_BUTTON_4:
+                return 4
+
+    @property
+    def icon(self):
+        """Return the remote icon."""
+        return ICON_REMOTE
+
+    async def async_update(self):
+        """Synchronize state with bridge."""
+        await self.async_request_bridge_update(self.sensor.id)
+
+    @property
+    def device_state_attributes(self):
+        """Return the device state attributes."""
+        attributes = {}
+        attributes[ATTR_LAST_UPDATED] = self.sensor.lastupdated
+        return attributes
+
+
+class ZLLSensor(Entity):
+    """Base class representing a Hue ZLL Sensor.
+    Contains properties and methods common to all ZLL sensors.
+    """
+    def __init__(self, sensor, request_bridge_update, bridge):
+        self.sensor = sensor
+        self.async_request_bridge_update = request_bridge_update
+        self.bridge = bridge
+
+    @property
+    def name(self):
+        """Return the name of the Hue sensor."""
+        return self.sensor.name
+
+    @property
+    def available(self):
+        """Return true if the Hue sensor is available."""
+        return self.sensor.reachable
+
+    @property
+    def unique_id(self):
+        """Return the unique id of the Hue sensor."""
+        return self.sensor.uniqueid
+
+    async def async_update(self):
+        """Synchronize state with bridge."""
+        await self.async_request_bridge_update(self.sensor.id)
+
+    @property
+    def device_state_attributes(self):
+        """Return the device state attributes."""
+        attributes = {}
+        attributes[ATTR_BATTERY_LEVEL] = self.sensor.battery
+        attributes[ATTR_LAST_UPDATED] = self.sensor.lastupdated
+        return attributes
+
+
+class ZLLLightLevelSensor(ZLLSensor):
+    """Representation of a Hue ZLL Light Level sensor."""
+
+    def __init__(self, sensor, request_bridge_update, bridge):
+        """Initialize the sensor."""
+        super().__init__(sensor, request_bridge_update, bridge)
+
+    @property
+    def state(self):
+        """Return the state of the Hue sensor."""
+        return pow(10, (self.sensor.lightlevel - 1) / 10000)
+
+    @property
+    def device_class(self):
+        """Return the device class of the Hue sensor."""
+        return DEVICE_CLASS_ILLUMINANCE
+
+    @property
+    def unit_of_measurement(self):
+        """Return the uom of the Hue sensor."""
+        return UOM_ILLUMINANCE
+
+    @property
+    def device_state_attributes(self):
+        """Return the device state attributes."""
+        attributes = {}
+        attributes[ATTR_BATTERY_LEVEL] = self.sensor.battery
+        attributes[ATTR_DARK] = self.sensor.dark
+        attributes[ATTR_DAYLIGHT] = self.sensor.daylight
+        attributes[ATTR_LAST_UPDATED] = self.sensor.lastupdated
+        return attributes
+
+
+class ZLLSwitch(ZLLSensor):
+    """Class representing a ZLL (Hue Wireless Dimmer) Switch."""
+    def __init__(self, sensor, request_bridge_update, bridge):
+        super().__init__(sensor, request_bridge_update, bridge)
+        self._last_update_time = self.sensor.lastupdated
+
+    @property
+    def state(self):
+        """Return the switch's buttonevent if the lastupdated variable changed.
+        If lastupdated hasn't changed, reset the sensor's state to None."""
+        current_time = self.sensor.lastupdated
+        if current_time == self._last_update_time:
+            return None
+        else:
+            self._last_update_time = current_time
+            if self.sensor.buttonevent == ZLL_SWITCH_BUTTON_1_SHORT_RELEASED:
+                return '1_click'
+            elif self.sensor.buttonevent == ZLL_SWITCH_BUTTON_1_LONG_RELEASED:
+                return '1_hold'
+            elif self.sensor.buttonevent == ZLL_SWITCH_BUTTON_2_SHORT_RELEASED:
+                return '2_click'
+            elif self.sensor.buttonevent == ZLL_SWITCH_BUTTON_2_LONG_RELEASED:
+                return '2_hold'
+            elif self.sensor.buttonevent == ZLL_SWITCH_BUTTON_3_SHORT_RELEASED:
+                return '3_click'
+            elif self.sensor.buttonevent == ZLL_SWITCH_BUTTON_3_LONG_RELEASED:
+                return '3_hold'
+            elif self.sensor.buttonevent == ZLL_SWITCH_BUTTON_4_SHORT_RELEASED:
+                return '4_click'
+            elif self.sensor.buttonevent == ZLL_SWITCH_BUTTON_4_LONG_RELEASED:
+                return '4_hold'
+
+    @property
+    def icon(self):
+        """Return the remote icon."""
+        return ICON_REMOTE
+
+
+class ZLLTemperatureSensor(ZLLSensor):
+    """Representation of a Hue ZLL Temperature sensor."""
+
+    def __init__(self, sensor, request_bridge_update, bridge):
+        """Initialize the sensor."""
+        super().__init__(sensor, request_bridge_update, bridge)
+
+    @property
+    def state(self):
+        """Return the state of the Hue sensor."""
+        return round(self.sensor.temperature / 100, 1)
+
+    @property
+    def device_class(self):
+        """Return the device class of the Hue sensor."""
+        return DEVICE_CLASS_TEMPERATURE
+
+    @property
+    def unit_of_measurement(self):
+        """Return the uom of the Hue sensor."""
+        return TEMP_CELSIUS
+
+
+def create_sensor(sensor, request_bridge_update, bridge):
+    type = sensor.type
+    if type == TYPE_CLIP_GENERICSTATUS:
+        return CLIPGenericStatus(sensor, request_bridge_update, bridge)
+    elif type == TYPE_CLIP_HUMIDITY:
+        return CLIPHumidity(sensor, request_bridge_update, bridge)
+    elif type == TYPE_CLIP_LIGHTLEVEL:
+        return CLIPLightLevel(sensor, request_bridge_update, bridge)
+    elif type == TYPE_CLIP_SWITCH:
+        return CLIPSwitch(sensor, request_bridge_update, bridge)
+    elif type == TYPE_CLIP_TEMPERATURE:
+        return CLIPTemperature(sensor, request_bridge_update, bridge)
+    elif type == TYPE_ZGP_SWITCH:
+        return ZGPSwitch(sensor, request_bridge_update, bridge)
+    elif type == TYPE_ZLL_LIGHTLEVEL:
+        return ZLLLightLevelSensor(sensor, request_bridge_update, bridge)
+    elif type == TYPE_ZLL_SWITCH:
+        return ZLLSwitch(sensor, request_bridge_update, bridge)
+    elif type == TYPE_ZLL_TEMPERATURE:
+        return ZLLTemperatureSensor(sensor, request_bridge_update, bridge)

--- a/homeassistant/components/sensor/hue.py
+++ b/homeassistant/components/sensor/hue.py
@@ -165,7 +165,7 @@ async def async_update_items(hass, bridge, async_add_devices,
 
     for item_id in api:
         sensor = api[item_id]
-        if sensor.type in ALL_SENSORS:
+        if sensor.type in allowed_sensor_types:
             if item_id not in current:
                 current[item_id] = create_sensor(
                     sensor, request_bridge_update, bridge)

--- a/homeassistant/components/sensor/hue.py
+++ b/homeassistant/components/sensor/hue.py
@@ -9,19 +9,26 @@ from datetime import timedelta
 import logging
 import async_timeout
 
-from aiohue.sensors import (ZGP_SWITCH_BUTTON_1, ZGP_SWITCH_BUTTON_2, ZGP_SWITCH_BUTTON_3,
-                            ZGP_SWITCH_BUTTON_4, ZLL_SWITCH_BUTTON_1_LONG_RELEASED,
-                            ZLL_SWITCH_BUTTON_1_SHORT_RELEASED, ZLL_SWITCH_BUTTON_2_LONG_RELEASED,
-                            ZLL_SWITCH_BUTTON_2_SHORT_RELEASED, ZLL_SWITCH_BUTTON_3_LONG_RELEASED,
-                            ZLL_SWITCH_BUTTON_3_SHORT_RELEASED, ZLL_SWITCH_BUTTON_4_LONG_RELEASED,
-                            ZLL_SWITCH_BUTTON_4_SHORT_RELEASED, TYPE_CLIP_GENERICSTATUS,
-                            TYPE_CLIP_HUMIDITY, TYPE_CLIP_LIGHTLEVEL, TYPE_CLIP_TEMPERATURE,
-                            TYPE_ZGP_SWITCH, TYPE_ZLL_SWITCH, TYPE_ZLL_LIGHTLEVEL,
-                            TYPE_ZLL_TEMPERATURE, TYPE_CLIP_SWITCH)
+from aiohue.sensors import (ZGP_SWITCH_BUTTON_1, ZGP_SWITCH_BUTTON_2,
+                            ZGP_SWITCH_BUTTON_3, ZGP_SWITCH_BUTTON_4,
+                            ZLL_SWITCH_BUTTON_1_LONG_RELEASED,
+                            ZLL_SWITCH_BUTTON_1_SHORT_RELEASED,
+                            ZLL_SWITCH_BUTTON_2_LONG_RELEASED,
+                            ZLL_SWITCH_BUTTON_2_SHORT_RELEASED,
+                            ZLL_SWITCH_BUTTON_3_LONG_RELEASED,
+                            ZLL_SWITCH_BUTTON_3_SHORT_RELEASED,
+                            ZLL_SWITCH_BUTTON_4_LONG_RELEASED,
+                            ZLL_SWITCH_BUTTON_4_SHORT_RELEASED,
+                            TYPE_CLIP_GENERICSTATUS, TYPE_CLIP_HUMIDITY,
+                            TYPE_CLIP_LIGHTLEVEL, TYPE_CLIP_TEMPERATURE,
+                            TYPE_ZGP_SWITCH, TYPE_ZLL_SWITCH,
+                            TYPE_ZLL_LIGHTLEVEL, TYPE_ZLL_TEMPERATURE,
+                            TYPE_CLIP_SWITCH)
 
 import homeassistant.components.hue as hue
-from homeassistant.components.hue.const import (ATTR_DARK, ATTR_DAYLIGHT, ICON_REMOTE,
-                                                UOM_HUMIDITY, UOM_ILLUMINANCE)
+from homeassistant.components.hue.const import (ATTR_DARK, ATTR_DAYLIGHT,
+                                                ICON_REMOTE, UOM_HUMIDITY,
+                                                UOM_ILLUMINANCE)
 from homeassistant.components.sensor import (DEVICE_CLASS_HUMIDITY,
                                              DEVICE_CLASS_ILLUMINANCE,
                                              DEVICE_CLASS_TEMPERATURE)
@@ -31,10 +38,13 @@ from homeassistant.helpers.entity import Entity
 DEPENDENCIES = ['hue']
 SCAN_INTERVAL = timedelta(seconds=1)
 
-ALL_SENSORS = [TYPE_CLIP_GENERICSTATUS, TYPE_CLIP_HUMIDITY, TYPE_CLIP_LIGHTLEVEL,
-               TYPE_CLIP_SWITCH, TYPE_CLIP_TEMPERATURE, TYPE_CLIP_HUMIDITY, TYPE_ZGP_SWITCH,
-               TYPE_ZLL_LIGHTLEVEL, TYPE_ZLL_SWITCH, TYPE_ZLL_TEMPERATURE]
-HUE_SENSORS = [TYPE_ZGP_SWITCH, TYPE_ZLL_LIGHTLEVEL, TYPE_ZLL_SWITCH, TYPE_ZLL_TEMPERATURE]
+ALL_SENSORS = [TYPE_CLIP_GENERICSTATUS, TYPE_CLIP_HUMIDITY,
+               TYPE_CLIP_LIGHTLEVEL, TYPE_CLIP_SWITCH,
+               TYPE_CLIP_TEMPERATURE, TYPE_CLIP_HUMIDITY,
+               TYPE_ZGP_SWITCH, TYPE_ZLL_LIGHTLEVEL,
+               TYPE_ZLL_SWITCH, TYPE_ZLL_TEMPERATURE]
+HUE_SENSORS = [TYPE_ZGP_SWITCH, TYPE_ZLL_LIGHTLEVEL,
+               TYPE_ZLL_SWITCH, TYPE_ZLL_TEMPERATURE]
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -92,7 +102,7 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
         Home Assistant will ask sensors for updates during a polling cycle or
         after it has called a service.
 
-        We keep track of the sensors that are waiting for the request to finish.
+        We keep track of sensors that are waiting for the request to finish.
         When new data comes in, we'll trigger an update for all non-waiting
         sensors. This covers the case where a service is called to modify 2
         sensors but in the meanwhile some other sensor has changed too.
@@ -270,7 +280,8 @@ class CLIPSwitch(HueSensor):
 
     @property
     def state(self):
-        """Return the switch's buttonevent if the lastupdated variable changed."""
+        """Return the switch's buttonevent if
+        the lastupdated variable changed."""
         current_time = self.sensor.lastupdated
         if current_time == self._hue_last_updated:
             return None
@@ -307,7 +318,8 @@ class ZGPSwitch(HueSensor):
 
     @property
     def state(self):
-        """Return the switch's buttonevent if the lastupdated variable changed."""
+        """Return the switch's buttonevent if
+        the lastupdated variable changed."""
         current_time = self.sensor.lastupdated
         if current_time == self._hue_last_updated:
             return None

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -94,7 +94,7 @@ aioftp==0.10.1
 aiohttp_cors==0.7.0
 
 # homeassistant.components.hue
-aiohue==1.5.0
+aiohue==1.6.0
 
 # homeassistant.components.sensor.imap
 aioimaplib==0.7.13

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -35,7 +35,7 @@ aioautomatic==0.6.5
 aiohttp_cors==0.7.0
 
 # homeassistant.components.hue
-aiohue==1.5.0
+aiohue==1.6.0
 
 # homeassistant.components.notify.apns
 apns2==0.3.0


### PR DESCRIPTION
## Description:

This PR adds support for Hue sensors to Home Assistant, as follows:
- CLIP generic status, humidity, light level, and temperature as sensors
- ZLL temperature and light level (i.e. the Hue Motion Sensor's extra sensors) as sensors
- ZLL and ZGP switches (i.e. the Hue Dimmer and Hue Tap) as sensors 
- CLIP generic flag, open/close, and presence as binary sensors
- ZLL presence (i.e. the Hue Motion Sensor) as binary sensor

There is a new config parameter 'allow_clip_sensors' that defaults to False.

Tests are required and I'll write them after getting feedback on this PR.

Bumping aiohue to 1.6.0 is required to enable sensor support.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** TBD

## Example entry for `configuration.yaml` (if applicable):
```yaml
hue:
  bridges:
    - host: DEVICE_IP_ADDRESS
      allow_unreachable: true
      allow_hue_groups: true
      allow_clip_sensors: true
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54