### PR TITLE
deCONZ small improvements

### DIFF
--- a/homeassistant/components/deconz/__init__.py
+++ b/homeassistant/components/deconz/__init__.py
@@ -22,7 +22,7 @@ from .const import (
     CONF_ALLOW_CLIP_SENSOR, CONFIG_FILE, DATA_DECONZ_EVENT,
     DATA_DECONZ_ID, DATA_DECONZ_UNSUB, DOMAIN, _LOGGER)
 
-REQUIREMENTS = ['pydeconz==38']
+REQUIREMENTS = ['pydeconz==39']
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({

--- a/homeassistant/components/deconz/config_flow.py
+++ b/homeassistant/components/deconz/config_flow.py
@@ -163,9 +163,6 @@ class DeconzFlowHandler(data_entry_flow.FlowHandler):
         if CONF_API_KEY not in import_config:
             return await self.async_step_link()
 
-        self.deconz_config[CONF_ALLOW_CLIP_SENSOR] = True
-        self.deconz_config[CONF_ALLOW_DECONZ_GROUPS] = True
-        return self.async_create_entry(
-            title='deCONZ-' + self.deconz_config[CONF_BRIDGEID],
-            data=self.deconz_config
-        )
+        user_input = {CONF_ALLOW_CLIP_SENSOR: True,
+                      CONF_ALLOW_DECONZ_GROUPS: True}
+        return await self.async_step_options(user_input=user_input)

--- a/homeassistant/components/light/deconz.py
+++ b/homeassistant/components/light/deconz.py
@@ -101,9 +101,11 @@ class DeconzLight(Light):
         return self._light.ct
 
     @property
-    def xy_color(self):
-        """Return the XY color value."""
-        return self._light.xy
+    def hs_color(self):
+        """Return the hs color value."""
+        if self._light.colormode in ('xy', 'hs') and self._light.xy:
+            return color_util.color_xy_to_hs(*self._light.xy)
+        return None
 
     @property
     def is_on(self):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -786,7 +786,7 @@ pycsspeechtts==1.0.2
 pydaikin==0.4
 
 # homeassistant.components.deconz
-pydeconz==38
+pydeconz==39
 
 # homeassistant.components.zwave
 pydispatcher==2.0.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -133,7 +133,7 @@ py-canary==0.5.0
 pyblackbird==0.5
 
 # homeassistant.components.deconz
-pydeconz==38
+pydeconz==39
 
 # homeassistant.components.zwave
 pydispatcher==2.0.5


### PR DESCRIPTION
## Description:
Imports wouldn't work since bridge id wasn't available
Make deconz lights report color values properly
Pydeconz now uses aiohttp websockets

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
