### PR TITLE
Make sure Yi utilizes existing event loop

### DIFF
--- a/homeassistant/components/camera/yi.py
+++ b/homeassistant/components/camera/yi.py
@@ -77,7 +77,7 @@ class YiCamera(Camera):
         """Retrieve the latest video file from the customized Yi FTP server."""
         from aioftp import Client, StatusCodeError
 
-        ftp = Client()
+        ftp = Client(loop=self.hass.loop)
         try:
             await ftp.connect(self.host)
             await ftp.login(self.user, self.passwd)


### PR DESCRIPTION
## Description:
Need to ensure Yi (and it's underlying `aioftp`) utilize the existing HASS event loop, rather than creating a new one with each connection.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
camera:
  - platform: yi
    name: Kitchen Camera
    host: 192.168.1.11
    username: root
    password: password123
    ffmpeg_arguments: -s 800x450
  - platform: yi
    name: Guest Bedroom Camera
    host: 192.168.1.12
    username: root
    password: password123
    ffmpeg_arguments: -s 800x450
ffmpeg:
  ffmpeg_bin: /usr/local/bin/ffmpeg
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
 ~- [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)~

If the code communicates with devices, web services, or third-party tools:
  ~- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).~
  ~- [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).~
  ~- [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.~
  ~- [ ] New files were added to `.coveragerc`.~

If the code does not interact with devices:
  ~- [ ] Tests have been added to verify that the new code works.~

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
