### PR TITLE
Add Magicseaweed API support

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -626,6 +626,7 @@ omit =
     homeassistant/components/sensor/loopenergy.py
     homeassistant/components/sensor/luftdaten.py
     homeassistant/components/sensor/lyft.py
+    homeassistant/components/sensor/magicseaweed.py
     homeassistant/components/sensor/metoffice.py
     homeassistant/components/sensor/miflora.py
     homeassistant/components/sensor/mitemp_bt.py

--- a/homeassistant/components/sensor/magicseaweed.py
+++ b/homeassistant/components/sensor/magicseaweed.py
@@ -1,0 +1,259 @@
+"""
+Support for magicseaweed data from magicseaweed.com.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.magicseaweed/
+"""
+from datetime import timedelta, datetime, timezone
+import logging
+
+import requests
+import voluptuous as vol
+
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import (
+    CONF_API_KEY, CONF_NAME, CONF_MONITORED_CONDITIONS, ATTR_ATTRIBUTION)
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import Entity
+from homeassistant.util import Throttle
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_ATTRIBUTION = "Data provided by magicseaweed.com"
+CONF_EXTENDED_ATTRIBUTES = 'extended_attributes'
+CONF_HOURS = 'hours'
+CONF_SPOT_ID = 'spot_id'
+CONF_UNITS = 'units'
+CONF_UPDATE_INTERVAL = 'update_interval'
+
+ICON = 'mdi:waves'
+
+DEFAULT_UNIT = 'us'
+DEFAULT_NAME = 'MSW'
+
+API_URL = 'http://magicseaweed.com/api/{}/forecast/'
+
+HOURS = ['12AM', '3AM', '6AM', '9AM', '12PM', '3PM',
+        '6PM', '9PM']
+
+SENSOR_TYPES = {
+        'max_breaking_swell' : ['Max'],
+        'min_breaking_swell' : ['Min'],
+        'swell_forecast' : ['Forecast'],
+}
+
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_MONITORED_CONDITIONS):
+        vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
+    vol.Required(CONF_API_KEY): cv.string,
+    vol.Required(CONF_SPOT_ID): vol.All(cv.ensure_list, [cv.string]),
+    vol.Optional(CONF_HOURS, default=None):
+        vol.All(cv.ensure_list, [vol.In(HOURS)]),
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_UNITS): vol.In(['eu', 'uk', 'us']),
+    vol.Optional(CONF_UPDATE_INTERVAL, default=timedelta(seconds=300)): (
+        vol.All(cv.time_period, cv.positive_timedelta)),
+})
+
+
+# Return cached results if last scan was less then this time ago.
+MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=30)
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the Magicseaweed sensor."""
+    name = config.get(CONF_NAME)
+    spot_id = config.get(CONF_SPOT_ID)
+    api_key = config.get(CONF_API_KEY)
+    hours = config.get(CONF_HOURS)
+
+    if CONF_UNITS in config:
+        units = config.get(CONF_UNITS)
+    elif hass.config.units.is_metric:
+        units = 'eu'
+    else:
+        units = 'us'
+
+    forecast_data = MagicSeaweedData(
+        api_key=config.get(CONF_API_KEY, None),
+        spot_id=spot_id,
+        units=units,
+        interval=config.get(CONF_UPDATE_INTERVAL))
+    forecast_data.update()
+
+    # If connection failed don't setup platform.
+    if forecast_data.currently is None or forecast_data.hourly is None:
+        return False
+
+    sensors = []
+    for variable in config[CONF_MONITORED_CONDITIONS]:
+        if 'forecast' in variable:
+            sensors.append(MagicSeaweedSensor(forecast_data, variable, name,
+            units))
+
+        else:
+            sensors.append(MagicSeaweedSensor(forecast_data, variable, name,
+            units))
+            if hours is not None:
+                for hour in hours:
+                    sensors.append(MagicSeaweedSensor(
+                        forecast_data, variable, name, units, hour))
+    add_devices(sensors, True)
+
+class MagicSeaweedSensor(Entity):
+    """Implementation of a MagicSeaweed sensor."""
+
+    def __init__(self, forecast_data, sensor_type, name, unit_system,
+            hour=None):
+        """Initialize the sensor."""
+        self.client_name = name
+        self._name = SENSOR_TYPES[sensor_type][0]
+        self.data = forecast_data
+        self.type = sensor_type
+        self.hour = hour
+        self._unit_system = unit_system
+        self._state = None
+        self._icon = None
+        self._unit_of_measurement = None
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        if self.hour == None and 'forecast' in self.type:
+            return "{} {}".format(self.client_name, self._name)
+        elif self.hour == None:
+            return "Current {} {}".format(self.client_name, self._name)
+        return "{} {} {}".format(
+            self.hour, self.client_name, self._name)
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def unit_system(self):
+        """Return the unit system of this entity."""
+        return self._unit_system
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement of this entity, if any."""
+        return self._unit_of_measurement
+
+    @property
+    def icon(self):
+        """Return the entity weather icon, if any."""
+        return ICON
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+
+        if self.type == 'swell_forecast' and self.hour is None:
+            summaries = {ATTR_ATTRIBUTION : CONF_ATTRIBUTION}
+            for hour, data in self.data.hourly.items():
+                occurs = hour
+                swell = data.get('swell')
+                summary = "{} - {} {}".format( \
+                    swell.get('minBreakingHeight'), \
+                    swell.get('maxBreakingHeight'), \
+                    swell.get('unit'))
+                summaries[occurs] = summary
+            return summaries
+
+        if self.hour is None:
+            forecast = self.data.currently
+        else:
+            forecast = self.data.hourly[self.hour]
+
+        occurs = datetime.utcfromtimestamp( \
+                forecast.get('localTimestamp')).strftime("%a %-I %p")
+        utc_issue = datetime.utcfromtimestamp( \
+                forecast.get('issueTimestamp')).strftime("%a %-I %p")
+        swell = forecast.get('swell')
+        wind = forecast.get('wind', None)
+        condition = forecast.get('condition', None)
+        rating = "{} stars, {} faded".format( \
+                forecast.get('solidRating') + forecast.get('fadedRating'),
+                forecast.get('solidRating'))
+
+        return {
+            'air_pressure' : "{}{}".format(condition.get('pressure'),
+                condition.get('unitPressure')),
+            'air_temp' : "{}° {}".format(condition.get('temperature'),
+                condition.get('unit')),
+            'rating' : rating,
+            'begins' : occurs,
+            'issued' : utc_issue,
+            'max_breaking_height' : swell.get('maxBreakingHeight'),
+            'min_breaking_height' : swell.get('minBreakingHeight'),
+            'probability' : "{}%".format(swell.get('probability')),
+            'swell_period' : "{} seconds".format( \
+                swell.get('components',{}) \
+                    .get('combined',{}).get('period',{})),
+            'wind_chill' : "{}°".format(wind.get('chill')),
+            'wind_direction' : "{}° {}".format(wind.get('direction'),
+                wind.get('compassDirection')),
+            'wind_gusts' : "{} {}".format(wind.get('gusts'), wind.get('unit')),
+            'wind_speed' : "{} {}".format(wind.get('speed'), wind.get('unit')),
+            ATTR_ATTRIBUTION : CONF_ATTRIBUTION
+            }
+
+    def update(self):
+        """Get the latest data from Magicseaweed and updates the states."""
+
+        self.data.update()
+        if self.hour is None:
+            forecast = self.data.currently
+        else:
+            forecast = self.data.hourly[self.hour]
+
+        swell = forecast.get('swell')
+        self._unit_of_measurement = swell.get('unit', None)
+        if self.type == 'min_breaking_swell':
+            self._state = swell.get('minBreakingHeight')
+        elif self.type == 'max_breaking_swell':
+            self._state = swell.get('maxBreakingHeight')
+        elif self.type == 'swell_forecast':
+            summary = "{} - {}".format(\
+                    swell.get('minBreakingHeight'), \
+                    swell.get('maxBreakingHeight'))
+            self._state = summary
+
+
+class MagicSeaweedData(object):
+    """Get the latest data from MagicSeaweed."""
+
+    def __init__(self, api_key, spot_id, units, interval):
+        """Initialize the data object."""
+        self._api_key = api_key
+        self._spot_id = spot_id
+        self.currently = None
+        self.hourly = {}
+        self.params = {'spot_id' : self._spot_id,
+                       'units' : units }
+
+        # Apply throttling to methods using configured interval
+        self.update = Throttle(interval)(self._update)
+
+    def _update(self):
+        """Get the latest data from MagicSeaweed."""
+        try:
+            now = datetime.now()
+            plus_24 = now + timedelta(hours=24)
+            self.params['start'] = now.timestamp()
+            self.params['end'] = plus_24.timestamp()
+            response = requests.get(API_URL.format(self._api_key),
+                                    params=self.params, timeout=5)
+            data = response.json()
+            self.currently = data[0]
+            for forecast in data:
+                dt = datetime.utcfromtimestamp( \
+                        forecast.get('localTimestamp')).strftime("%-I%p")
+                self.hourly[dt] = forecast
+
+        except requests.exceptions.ConnectionError:
+            _LOGGER.error("Unable to retrieve data from %s", API_URL)
+            self.data = None

--- a/homeassistant/components/sensor/magicseaweed.py
+++ b/homeassistant/components/sensor/magicseaweed.py
@@ -4,7 +4,7 @@ Support for magicseaweed data from magicseaweed.com.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.magicseaweed/
 """
-from datetime import timedelta, datetime, timezone
+from datetime import timedelta, datetime
 import logging
 
 import requests
@@ -33,13 +33,12 @@ DEFAULT_NAME = 'MSW'
 
 API_URL = 'http://magicseaweed.com/api/{}/forecast/'
 
-HOURS = ['12AM', '3AM', '6AM', '9AM', '12PM', '3PM',
-        '6PM', '9PM']
+HOURS = ['12AM', '3AM', '6AM', '9AM', '12PM', '3PM', '6PM', '9PM']
 
 SENSOR_TYPES = {
-        'max_breaking_swell' : ['Max'],
-        'min_breaking_swell' : ['Min'],
-        'swell_forecast' : ['Forecast'],
+    'max_breaking_swell': ['Max'],
+    'min_breaking_swell': ['Min'],
+    'swell_forecast': ['Forecast'],
 }
 
 
@@ -76,7 +75,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         units = 'us'
 
     forecast_data = MagicSeaweedData(
-        api_key=config.get(CONF_API_KEY, None),
+        api_key=api_key,
         spot_id=spot_id,
         units=units,
         interval=config.get(CONF_UPDATE_INTERVAL))
@@ -90,22 +89,23 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     for variable in config[CONF_MONITORED_CONDITIONS]:
         if 'forecast' in variable:
             sensors.append(MagicSeaweedSensor(forecast_data, variable, name,
-            units))
+                                              units))
 
         else:
             sensors.append(MagicSeaweedSensor(forecast_data, variable, name,
-            units))
+                                              units))
             if hours is not None:
                 for hour in hours:
                     sensors.append(MagicSeaweedSensor(
                         forecast_data, variable, name, units, hour))
     add_devices(sensors, True)
 
+
 class MagicSeaweedSensor(Entity):
     """Implementation of a MagicSeaweed sensor."""
 
     def __init__(self, forecast_data, sensor_type, name, unit_system,
-            hour=None):
+                 hour=None):
         """Initialize the sensor."""
         self.client_name = name
         self._name = SENSOR_TYPES[sensor_type][0]
@@ -120,9 +120,9 @@ class MagicSeaweedSensor(Entity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        if self.hour == None and 'forecast' in self.type:
+        if self.hour is None and 'forecast' in self.type:
             return "{} {}".format(self.client_name, self._name)
-        elif self.hour == None:
+        elif self.hour is None:
             return "Current {} {}".format(self.client_name, self._name)
         return "{} {} {}".format(
             self.hour, self.client_name, self._name)
@@ -150,15 +150,14 @@ class MagicSeaweedSensor(Entity):
     @property
     def device_state_attributes(self):
         """Return the state attributes."""
-
         if self.type == 'swell_forecast' and self.hour is None:
-            summaries = {ATTR_ATTRIBUTION : CONF_ATTRIBUTION}
+            summaries = {ATTR_ATTRIBUTION: CONF_ATTRIBUTION}
             for hour, data in self.data.hourly.items():
                 occurs = hour
                 swell = data.get('swell')
-                summary = "{} - {} {}".format( \
-                    swell.get('minBreakingHeight'), \
-                    swell.get('maxBreakingHeight'), \
+                summary = "{} - {} {}".format(
+                    swell.get('minBreakingHeight'),
+                    swell.get('maxBreakingHeight'),
                     swell.get('unit'))
                 summaries[occurs] = summary
             return summaries
@@ -168,42 +167,42 @@ class MagicSeaweedSensor(Entity):
         else:
             forecast = self.data.hourly[self.hour]
 
-        occurs = datetime.utcfromtimestamp( \
-                forecast.get('localTimestamp')).strftime("%a %-I %p")
-        utc_issue = datetime.utcfromtimestamp( \
-                forecast.get('issueTimestamp')).strftime("%a %-I %p")
+        occurs = datetime.utcfromtimestamp(
+            forecast.get('localTimestamp')).strftime("%a %-I %p")
+        utc_issue = datetime.utcfromtimestamp(
+            forecast.get('issueTimestamp')).strftime("%a %-I %p")
         swell = forecast.get('swell')
         wind = forecast.get('wind', None)
         condition = forecast.get('condition', None)
-        rating = "{} stars, {} faded".format( \
-                forecast.get('solidRating') + forecast.get('fadedRating'),
-                forecast.get('solidRating'))
+        rating = "{} stars, {} faded".format(
+            forecast.get('solidRating') + forecast.get('fadedRating'),
+            forecast.get('solidRating'))
 
         return {
-            'air_pressure' : "{}{}".format(condition.get('pressure'),
-                condition.get('unitPressure')),
-            'air_temp' : "{}° {}".format(condition.get('temperature'),
-                condition.get('unit')),
-            'rating' : rating,
-            'begins' : occurs,
-            'issued' : utc_issue,
-            'max_breaking_height' : swell.get('maxBreakingHeight'),
-            'min_breaking_height' : swell.get('minBreakingHeight'),
-            'probability' : "{}%".format(swell.get('probability')),
-            'swell_period' : "{} seconds".format( \
-                swell.get('components',{}) \
-                    .get('combined',{}).get('period',{})),
-            'wind_chill' : "{}°".format(wind.get('chill')),
-            'wind_direction' : "{}° {}".format(wind.get('direction'),
-                wind.get('compassDirection')),
-            'wind_gusts' : "{} {}".format(wind.get('gusts'), wind.get('unit')),
-            'wind_speed' : "{} {}".format(wind.get('speed'), wind.get('unit')),
-            ATTR_ATTRIBUTION : CONF_ATTRIBUTION
+            'air_pressure': "{}{}".format(condition.get('pressure'),
+                                          condition.get('unitPressure')),
+            'air_temp': "{}° {}".format(condition.get('temperature'),
+                                        condition.get('unit')),
+            'rating': rating,
+            'begins': occurs,
+            'issued': utc_issue,
+            'max_breaking_height': swell.get('maxBreakingHeight'),
+            'min_breaking_height': swell.get('minBreakingHeight'),
+            'probability': "{}%".format(swell.get('probability')),
+            'swell_period': "{} seconds".format(
+                swell.get('components', {})
+                .get('combined', {})
+                .get('period', {})),
+            'wind_chill': "{}°".format(wind.get('chill')),
+            'wind_direction': "{}° {}".format(wind.get('direction'),
+                                              wind.get('compassDirection')),
+            'wind_gusts': "{} {}".format(wind.get('gusts'), wind.get('unit')),
+            'wind_speed': "{} {}".format(wind.get('speed'), wind.get('unit')),
+            ATTR_ATTRIBUTION: CONF_ATTRIBUTION
             }
 
     def update(self):
         """Get the latest data from Magicseaweed and updates the states."""
-
         self.data.update()
         if self.hour is None:
             forecast = self.data.currently
@@ -217,9 +216,9 @@ class MagicSeaweedSensor(Entity):
         elif self.type == 'max_breaking_swell':
             self._state = swell.get('maxBreakingHeight')
         elif self.type == 'swell_forecast':
-            summary = "{} - {}".format(\
-                    swell.get('minBreakingHeight'), \
-                    swell.get('maxBreakingHeight'))
+            summary = "{} - {}".format(
+                swell.get('minBreakingHeight'),
+                swell.get('maxBreakingHeight'))
             self._state = summary
 
 
@@ -232,8 +231,8 @@ class MagicSeaweedData(object):
         self._spot_id = spot_id
         self.currently = None
         self.hourly = {}
-        self.params = {'spot_id' : self._spot_id,
-                       'units' : units }
+        self.params = {'spot_id': self._spot_id,
+                       'units': units}
 
         # Apply throttling to methods using configured interval
         self.update = Throttle(interval)(self._update)
@@ -250,10 +249,10 @@ class MagicSeaweedData(object):
             data = response.json()
             self.currently = data[0]
             for forecast in data:
-                dt = datetime.utcfromtimestamp( \
-                        forecast.get('localTimestamp')).strftime("%-I%p")
-                self.hourly[dt] = forecast
+                hour = datetime.utcfromtimestamp(
+                    forecast.get('localTimestamp')).strftime("%-I%p")
+                self.hourly[hour] = forecast
 
         except requests.exceptions.ConnectionError:
             _LOGGER.error("Unable to retrieve data from %s", API_URL)
-            self.data = None
+            data = None

--- a/homeassistant/components/sensor/magicseaweed.py
+++ b/homeassistant/components/sensor/magicseaweed.py
@@ -184,7 +184,7 @@ class MagicSeaweedData(object):
 
     def __init__(self, api_key, spot_id, units):
         """Initialize the data object."""
-        import magicseaweed # pylint: disable=E1101
+        import magicseaweed  # pylint: disable=E1101
         self._msw = magicseaweed.MSW_Forecast(api_key, spot_id,
                                               None, units)
         self.currently = None

--- a/homeassistant/components/sensor/magicseaweed.py
+++ b/homeassistant/components/sensor/magicseaweed.py
@@ -184,7 +184,7 @@ class MagicSeaweedData(object):
 
     def __init__(self, api_key, spot_id, units):
         """Initialize the data object."""
-        import magicseaweed
+        import magicseaweed # pylint: disable=E1101
         self._msw = magicseaweed.MSW_Forecast(api_key, spot_id,
                                               None, units)
         self.currently = None

--- a/homeassistant/components/sensor/magicseaweed.py
+++ b/homeassistant/components/sensor/magicseaweed.py
@@ -84,7 +84,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     for variable in config[CONF_MONITORED_CONDITIONS]:
         sensors.append(MagicSeaweedSensor(forecast_data, variable, name,
                                           units))
-        if 'forecast' in variable and hours is not None:
+        if 'forecast' not in variable and hours is not None:
             for hour in hours:
                 sensors.append(MagicSeaweedSensor(
                     forecast_data, variable, name, units, hour))

--- a/homeassistant/components/sensor/magicseaweed.py
+++ b/homeassistant/components/sensor/magicseaweed.py
@@ -174,7 +174,7 @@ class MagicSeaweedSensor(Entity):
             self._attrs.update(forecast.attrs)
 
 
-class MagicSeaweedData(object):
+class MagicSeaweedData:
     """Get the latest data from MagicSeaweed."""
 
     def __init__(self, api_key, spot_id, units):

--- a/homeassistant/components/sensor/magicseaweed.py
+++ b/homeassistant/components/sensor/magicseaweed.py
@@ -78,21 +78,16 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     # If connection failed don't setup platform.
     if forecast_data.currently is None or forecast_data.hourly is None:
-        return False
+        return
 
     sensors = []
     for variable in config[CONF_MONITORED_CONDITIONS]:
-        if 'forecast' in variable:
-            sensors.append(MagicSeaweedSensor(forecast_data, variable, name,
-                                              units))
-
-        else:
-            sensors.append(MagicSeaweedSensor(forecast_data, variable, name,
-                                              units))
-            if hours is not None:
-                for hour in hours:
-                    sensors.append(MagicSeaweedSensor(
-                        forecast_data, variable, name, units, hour))
+        sensors.append(MagicSeaweedSensor(forecast_data, variable, name,
+                                          units))
+        if 'forecast' in variable and hours is not None:
+            for hour in hours:
+                sensors.append(MagicSeaweedSensor(
+                    forecast_data, variable, name, units, hour))
     add_devices(sensors, True)
 
 
@@ -118,7 +113,7 @@ class MagicSeaweedSensor(Entity):
         """Return the name of the sensor."""
         if self.hour is None and 'forecast' in self.type:
             return "{} {}".format(self.client_name, self._name)
-        elif self.hour is None:
+        if self.hour is None:
             return "Current {} {}".format(self.client_name, self._name)
         return "{} {} {}".format(
             self.hour, self.client_name, self._name)
@@ -184,7 +179,7 @@ class MagicSeaweedData(object):
 
     def __init__(self, api_key, spot_id, units):
         """Initialize the data object."""
-        import magicseaweed  # pylint: disable=E1101
+        import magicseaweed
         self._msw = magicseaweed.MSW_Forecast(api_key, spot_id,
                                               None, units)
         self.currently = None

--- a/homeassistant/components/sensor/magicseaweed.py
+++ b/homeassistant/components/sensor/magicseaweed.py
@@ -4,10 +4,8 @@ Support for magicseaweed data from magicseaweed.com.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.magicseaweed/
 """
-from datetime import timedelta, datetime
+from datetime import timedelta
 import logging
-
-import requests
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
@@ -158,7 +156,7 @@ class MagicSeaweedSensor(Entity):
 
     def update(self):
         """Get the latest data from Magicseaweed and updates the states."""
-        self.data._update()
+        self.data.update()
         if self.hour is None:
             forecast = self.data.currently
         else:
@@ -194,7 +192,7 @@ class MagicSeaweedData(object):
         """Initialize the data object."""
         import magicseaweed
         self._msw = magicseaweed.MSW_Forecast(api_key, spot_id,
-                None, units)
+                                              None, units)
         self.currently = None
         self.hourly = {}
 
@@ -208,8 +206,7 @@ class MagicSeaweedData(object):
             self.currently = forecasts.data[0]
             for forecast in forecasts.data[:8]:
                 hour = dt_util.utc_from_timestamp(
-                        forecast.localTimestamp).strftime("%-I%p")
+                    forecast.localTimestamp).strftime("%-I%p")
                 self.hourly[hour] = forecast
-        except:
+        except ConnectionError:
             _LOGGER.error("Unable to retrieve data from %s", API_URL)
-            data = None

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -514,6 +514,9 @@ luftdaten==0.1.3
 # homeassistant.components.sensor.lyft
 lyft_rides==0.2
 
+# homeassistant.components.sensor.magicseaweed
+magicseaweed==1.0.0
+
 # homeassistant.components.matrix
 matrix-client==0.2.0
 


### PR DESCRIPTION
## Description:

The Magicseaweed sensor allows users to add surf forecast information to their Home Assistant installation.

Magicseaweed currently offers up to 5 days of forecast information, in 3 hours intervals. This sensor only utilizes the forecasts for a rolling 24 hour period.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5598

## Example entry for `configuration.yaml` (if applicable):
```yaml
  - platform: magicseaweed
    api_key: YOUR_API_KEY
    spot_id: 1092
    monitored_conditions:
      - max_breaking_swell
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New files were added to `.coveragerc`.