### PR TITLE
Bump insteonplm version to 0.11.2

### DIFF
--- a/homeassistant/components/insteon_plm/__init__.py
+++ b/homeassistant/components/insteon_plm/__init__.py
@@ -17,7 +17,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers import discovery
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['insteonplm==0.10.0']
+REQUIREMENTS = ['insteonplm==0.11.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/insteon_plm/__init__.py
+++ b/homeassistant/components/insteon_plm/__init__.py
@@ -17,7 +17,6 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers import discovery
 from homeassistant.helpers.entity import Entity
 
-
 REQUIREMENTS = ['insteonplm==0.11.2']
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/insteon_plm/__init__.py
+++ b/homeassistant/components/insteon_plm/__init__.py
@@ -17,6 +17,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers import discovery
 from homeassistant.helpers.entity import Entity
 
+
 REQUIREMENTS = ['insteonplm==0.11.2']
 
 _LOGGER = logging.getLogger(__name__)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -460,7 +460,7 @@ influxdb==5.0.0
 insteonlocal==0.53
 
 # homeassistant.components.insteon_plm
-insteonplm==0.10.0
+insteonplm==0.11.2
 
 # homeassistant.components.sensor.iperf3
 iperf3==0.1.10


### PR DESCRIPTION
## Description:
Bump insteonplm version to 0.11.2 to handle Insteon Pre-NAK responses correctly. 

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
