### PR TITLE
MQTT Alarm Control Panel: add retain option for publishing for cases...

### DIFF
--- a/homeassistant/components/alarm_control_panel/mqtt.py
+++ b/homeassistant/components/alarm_control_panel/mqtt.py
@@ -136,7 +136,7 @@ class MqttAlarm(MqttAvailability, alarm.AlarmControlPanel):
         if not self._validate_code(code, 'disarming'):
             return
         mqtt.async_publish(
-	    self.hass, self._command_topic, self._payload_disarm, self._qos,
+            self.hass, self._command_topic, self._payload_disarm, self._qos,
             self._retain)
 
     @asyncio.coroutine
@@ -148,7 +148,7 @@ class MqttAlarm(MqttAvailability, alarm.AlarmControlPanel):
         if not self._validate_code(code, 'arming home'):
             return
         mqtt.async_publish(
-	    self.hass, self._command_topic, self._payload_arm_home, self._qos,
+            self.hass, self._command_topic, self._payload_arm_home, self._qos,
             self._retain)
 
     @asyncio.coroutine
@@ -160,7 +160,7 @@ class MqttAlarm(MqttAvailability, alarm.AlarmControlPanel):
         if not self._validate_code(code, 'arming away'):
             return
         mqtt.async_publish(
-	    self.hass, self._command_topic, self._payload_arm_away, self._qos,
+            self.hass, self._command_topic, self._payload_arm_away, self._qos,
             self._retain)
 
     def _validate_code(self, code, state):

--- a/homeassistant/components/alarm_control_panel/mqtt.py
+++ b/homeassistant/components/alarm_control_panel/mqtt.py
@@ -20,7 +20,7 @@ from homeassistant.const import (
 from homeassistant.components.mqtt import (
     CONF_AVAILABILITY_TOPIC, CONF_STATE_TOPIC, CONF_COMMAND_TOPIC,
     CONF_PAYLOAD_AVAILABLE, CONF_PAYLOAD_NOT_AVAILABLE, CONF_QOS,
-    MqttAvailability)
+    CONF_RETAIN, MqttAvailability)
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
@@ -54,6 +54,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         config.get(CONF_STATE_TOPIC),
         config.get(CONF_COMMAND_TOPIC),
         config.get(CONF_QOS),
+        config.get(CONF_RETAIN),
         config.get(CONF_PAYLOAD_DISARM),
         config.get(CONF_PAYLOAD_ARM_HOME),
         config.get(CONF_PAYLOAD_ARM_AWAY),
@@ -66,9 +67,9 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 class MqttAlarm(MqttAvailability, alarm.AlarmControlPanel):
     """Representation of a MQTT alarm status."""
 
-    def __init__(self, name, state_topic, command_topic, qos, payload_disarm,
-                 payload_arm_home, payload_arm_away, code, availability_topic,
-                 payload_available, payload_not_available):
+    def __init__(self, name, state_topic, command_topic, qos, retain,
+                 payload_disarm, payload_arm_home, payload_arm_away, code,
+                 availability_topic, payload_available, payload_not_available):
         """Init the MQTT Alarm Control Panel."""
         super().__init__(availability_topic, qos, payload_available,
                          payload_not_available)
@@ -77,6 +78,7 @@ class MqttAlarm(MqttAvailability, alarm.AlarmControlPanel):
         self._state_topic = state_topic
         self._command_topic = command_topic
         self._qos = qos
+        self._retain = retain
         self._payload_disarm = payload_disarm
         self._payload_arm_home = payload_arm_home
         self._payload_arm_away = payload_arm_away
@@ -134,7 +136,8 @@ class MqttAlarm(MqttAvailability, alarm.AlarmControlPanel):
         if not self._validate_code(code, 'disarming'):
             return
         mqtt.async_publish(
-            self.hass, self._command_topic, self._payload_disarm, self._qos)
+	    self.hass, self._command_topic, self._payload_disarm, self._qos,
+            self._retain)
 
     @asyncio.coroutine
     def async_alarm_arm_home(self, code=None):
@@ -145,7 +148,8 @@ class MqttAlarm(MqttAvailability, alarm.AlarmControlPanel):
         if not self._validate_code(code, 'arming home'):
             return
         mqtt.async_publish(
-            self.hass, self._command_topic, self._payload_arm_home, self._qos)
+	    self.hass, self._command_topic, self._payload_arm_home, self._qos,
+            self._retain)
 
     @asyncio.coroutine
     def async_alarm_arm_away(self, code=None):
@@ -156,7 +160,8 @@ class MqttAlarm(MqttAvailability, alarm.AlarmControlPanel):
         if not self._validate_code(code, 'arming away'):
             return
         mqtt.async_publish(
-            self.hass, self._command_topic, self._payload_arm_away, self._qos)
+	    self.hass, self._command_topic, self._payload_arm_away, self._qos,
+            self._retain)
 
     def _validate_code(self, code, state):
         """Validate given code."""

--- a/homeassistant/components/alarm_control_panel/mqtt.py
+++ b/homeassistant/components/alarm_control_panel/mqtt.py
@@ -20,7 +20,7 @@ from homeassistant.const import (
 from homeassistant.components.mqtt import (
     CONF_AVAILABILITY_TOPIC, CONF_STATE_TOPIC, CONF_COMMAND_TOPIC,
     CONF_PAYLOAD_AVAILABLE, CONF_PAYLOAD_NOT_AVAILABLE, CONF_QOS,
-    MqttAvailability)
+    CONF_RETAIN, MqttAvailability)
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
@@ -54,6 +54,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
         config.get(CONF_STATE_TOPIC),
         config.get(CONF_COMMAND_TOPIC),
         config.get(CONF_QOS),
+        config.get(CONF_RETAIN),
         config.get(CONF_PAYLOAD_DISARM),
         config.get(CONF_PAYLOAD_ARM_HOME),
         config.get(CONF_PAYLOAD_ARM_AWAY),
@@ -66,9 +67,9 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
 class MqttAlarm(MqttAvailability, alarm.AlarmControlPanel):
     """Representation of a MQTT alarm status."""
 
-    def __init__(self, name, state_topic, command_topic, qos, payload_disarm,
-                 payload_arm_home, payload_arm_away, code, availability_topic,
-                 payload_available, payload_not_available):
+    def __init__(self, name, state_topic, command_topic, qos, retain,
+                 payload_disarm, payload_arm_home, payload_arm_away, code,
+                 availability_topic, payload_available, payload_not_available):
         """Init the MQTT Alarm Control Panel."""
         super().__init__(availability_topic, qos, payload_available,
                          payload_not_available)
@@ -77,6 +78,7 @@ class MqttAlarm(MqttAvailability, alarm.AlarmControlPanel):
         self._state_topic = state_topic
         self._command_topic = command_topic
         self._qos = qos
+        self._retain = retain
         self._payload_disarm = payload_disarm
         self._payload_arm_home = payload_arm_home
         self._payload_arm_away = payload_arm_away
@@ -134,7 +136,7 @@ class MqttAlarm(MqttAvailability, alarm.AlarmControlPanel):
         if not self._validate_code(code, 'disarming'):
             return
         mqtt.async_publish(
-            self.hass, self._command_topic, self._payload_disarm, self._qos)
+            self.hass, self._command_topic, self._payload_disarm, self._qos, self._retain)
 
     @asyncio.coroutine
     def async_alarm_arm_home(self, code=None):
@@ -145,7 +147,7 @@ class MqttAlarm(MqttAvailability, alarm.AlarmControlPanel):
         if not self._validate_code(code, 'arming home'):
             return
         mqtt.async_publish(
-            self.hass, self._command_topic, self._payload_arm_home, self._qos)
+            self.hass, self._command_topic, self._payload_arm_home, self._qos, self._retain)
 
     @asyncio.coroutine
     def async_alarm_arm_away(self, code=None):
@@ -156,7 +158,7 @@ class MqttAlarm(MqttAvailability, alarm.AlarmControlPanel):
         if not self._validate_code(code, 'arming away'):
             return
         mqtt.async_publish(
-            self.hass, self._command_topic, self._payload_arm_away, self._qos)
+            self.hass, self._command_topic, self._payload_arm_away, self._qos, self._retain)
 
     def _validate_code(self, code, state):
         """Validate given code."""


### PR DESCRIPTION
…where receiver is asleep

## Description:

Add configuration option to set MQTT ratain flag for publishing commands. This helps for cases where the receiver is not always on/listening.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
retain: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54