### PR TITLE
Added support for Wion/EcoPlug devices

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -741,6 +741,7 @@ omit =
     homeassistant/components/switch/deluge.py
     homeassistant/components/switch/digitalloggers.py
     homeassistant/components/switch/dlink.py
+    homeassistant/components/switch/ecoplug.py
     homeassistant/components/switch/edimax.py
     homeassistant/components/switch/fritzdect.py
     homeassistant/components/switch/hikvisioncam.py

--- a/homeassistant/components/switch/ecoplug.py
+++ b/homeassistant/components/switch/ecoplug.py
@@ -1,7 +1,7 @@
 """
-EcoPlugs Component for aut-discovering Wion and EcoPlugs automatically
+EcoPlugs Component for aut-discovering Wion and EcoPlugs automatically.
 
-For more details about this platform, please refer to the documentation
+For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/ecoplug/
 """
 
@@ -22,6 +22,7 @@ SCAN_INTERVAL = timedelta(seconds=5)
 
 class EcoPlugSwitch(SwitchDevice):
     """Return the polling state."""
+    
     def __init__(self, plug):
         """Initialize the switch."""
         self._plug = plug
@@ -61,25 +62,24 @@ class EcoPlugSwitch(SwitchDevice):
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up EcoPlug switches."""
-
     from pyecoplug import EcoDiscovery
-
     discovered = {}
     def add(plug):
         """Find switches on the network."""
+        
         if plug.name not in discovered:
             add_devices([EcoPlugSwitch(plug)])
             discovered[plug.name] = plug
 
     def remove(plug):
-        """Is there a way to remove devices??"""
+        """Unsure if there is a way to remove devices."""
         pass
 
     disco = EcoDiscovery(add, remove)
     disco.start()
 
     def stop_disco(event):
-        """Stop device discovery"""
+        """Stop device discovery."""
         disco.stop()
 
     hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, stop_disco)

--- a/homeassistant/components/switch/ecoplug.py
+++ b/homeassistant/components/switch/ecoplug.py
@@ -64,10 +64,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up EcoPlug switches."""
     from pyecoplug import EcoDiscovery
     discovered = {}
+
     def add(plug):
         """Find switches on the network."""
         if plug.name not in discovered:
-            
             add_devices([EcoPlugSwitch(plug)])
             discovered[plug.name] = plug
 

--- a/homeassistant/components/switch/ecoplug.py
+++ b/homeassistant/components/switch/ecoplug.py
@@ -1,0 +1,75 @@
+# """
+# EcoPlugs Component for auto-discovering Wion and EcoPlugs. No setup necessary.
+
+# For more details about this platform, please refer to the documentation
+# https://home-assistant.io/components/ecoplug/
+# """
+
+import logging
+from datetime import timedelta
+
+from homeassistant.const import (DEVICE_DEFAULT_NAME, ATTR_HIDDEN, EVENT_TIME_CHANGED, EVENT_HOMEASSISTANT_STOP)
+from homeassistant.components.switch import SwitchDevice
+from homeassistant.helpers.entity import ToggleEntity
+from homeassistant.helpers.event import track_time_change
+
+DEFAULT_INVERT_LOGIC = False
+
+DOMAIN = 'ecoplug'
+REQUIREMENTS = ['pyecoplug==0.0.5']
+_LOGGER = logging.getLogger(__name__)
+
+SCAN_INTERVAL = timedelta(seconds=5)
+
+class EcoPlugSwitch(SwitchDevice):
+    def __init__(self, plug):
+        self._plug = plug
+        self._name = plug.name
+        self._state = self._plug.is_on()
+
+    @property
+    def should_poll(self):
+        """Return the polling state."""
+        return True
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def is_on(self):
+        return self._state
+
+    def turn_on(self):
+        self._plug.turn_on()
+        self.update()
+
+    def turn_off(self):
+        self._plug.turn_off()
+        self.update()
+
+    def update(self):
+        _LOGGER.info('update')
+        self._state = self._plug.is_on()
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    from pyecoplug import EcoDiscovery
+
+    discovered = {}
+    def add(plug):
+        if not plug.name in discovered:
+            add_devices([EcoPlugSwitch(plug)])
+            discovered[plug.name] = plug
+
+    def remove(plug):
+        # Is there a way to remove devices??
+        pass
+
+    disco = EcoDiscovery(add, remove)
+    disco.start()
+
+    def stop_disco(event):
+        disco.stop()
+
+    hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, stop_disco)

--- a/homeassistant/components/switch/ecoplug.py
+++ b/homeassistant/components/switch/ecoplug.py
@@ -1,5 +1,5 @@
 # """
-# EcoPlugs Component for auto-discovering Wion and EcoPlugs. No setup necessary.
+# EcoPlugs Component for aut-discovering Wion and EcoPlugs automatically
 
 # For more details about this platform, please refer to the documentation
 # https://home-assistant.io/components/ecoplug/
@@ -8,10 +8,9 @@
 import logging
 from datetime import timedelta
 
-from homeassistant.const import (DEVICE_DEFAULT_NAME, ATTR_HIDDEN, EVENT_TIME_CHANGED, EVENT_HOMEASSISTANT_STOP)
+from homeassistant.const import (DEVICE_DEFAULT_NAME, 
+    EVENT_HOMEASSISTANT_STOP)
 from homeassistant.components.switch import SwitchDevice
-from homeassistant.helpers.entity import ToggleEntity
-from homeassistant.helpers.event import track_time_change
 
 DEFAULT_INVERT_LOGIC = False
 
@@ -24,7 +23,7 @@ SCAN_INTERVAL = timedelta(seconds=5)
 class EcoPlugSwitch(SwitchDevice):
     def __init__(self, plug):
         self._plug = plug
-        self._name = plug.name
+        self._name = plug.name or DEVICE_DEFAULT_NAME
         self._state = self._plug.is_on()
 
     @property

--- a/homeassistant/components/switch/ecoplug.py
+++ b/homeassistant/components/switch/ecoplug.py
@@ -67,8 +67,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     def add(plug):
         """Find switches on the network."""
         if plug.name not in discovered:
+            
             add_devices([EcoPlugSwitch(plug)])
-
             discovered[plug.name] = plug
 
     def remove(plug):

--- a/homeassistant/components/switch/ecoplug.py
+++ b/homeassistant/components/switch/ecoplug.py
@@ -15,7 +15,7 @@ from homeassistant.components.switch import SwitchDevice
 DEFAULT_INVERT_LOGIC = False
 
 DOMAIN = 'ecoplug'
-REQUIREMENTS = ['https://github.com/philburr/pyecoplug/v0.0.5.zip#pyecoplug==0.0.5']
+REQUIREMENTS = ['https://github.com/philburr/pyecoplug/archive/master.zip#pyecoplug==0.0.5']
 _LOGGER = logging.getLogger(__name__)
 SCAN_INTERVAL = timedelta(seconds=5)
 
@@ -61,6 +61,7 @@ class EcoPlugSwitch(SwitchDevice):
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up EcoPlug switches."""
+    
     from pyecoplug import EcoDiscovery
 
     discovered = {}

--- a/homeassistant/components/switch/ecoplug.py
+++ b/homeassistant/components/switch/ecoplug.py
@@ -15,7 +15,7 @@ from homeassistant.components.switch import SwitchDevice
 DEFAULT_INVERT_LOGIC = False
 
 DOMAIN = 'ecoplug'
-REQUIREMENTS = ['pyecoplug==0.0.5']
+REQUIREMENTS = ['https://github.com/philburr/pyecoplug/v0.0.5.zip#pyecoplug==0.0.5']
 _LOGGER = logging.getLogger(__name__)
 SCAN_INTERVAL = timedelta(seconds=5)
 
@@ -78,6 +78,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     disco.start()
 
     def stop_disco(event):
+        """Stop device discovery"""
         disco.stop()
 
     hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, stop_disco)

--- a/homeassistant/components/switch/ecoplug.py
+++ b/homeassistant/components/switch/ecoplug.py
@@ -1,15 +1,14 @@
-# """
-# EcoPlugs Component for aut-discovering Wion and EcoPlugs automatically
+"""
+EcoPlugs Component for aut-discovering Wion and EcoPlugs automatically
 
-# For more details about this platform, please refer to the documentation
-# https://home-assistant.io/components/ecoplug/
-# """
+For more details about this platform, please refer to the documentation
+https://home-assistant.io/components/ecoplug/
+"""
 
 import logging
 from datetime import timedelta
 
-from homeassistant.const import (DEVICE_DEFAULT_NAME, 
-    EVENT_HOMEASSISTANT_STOP)
+from homeassistant.const import (DEVICE_DEFAULT_NAME, EVENT_HOMEASSISTANT_STOP)
 from homeassistant.components.switch import SwitchDevice
 
 DEFAULT_INVERT_LOGIC = False
@@ -17,8 +16,8 @@ DEFAULT_INVERT_LOGIC = False
 DOMAIN = 'ecoplug'
 REQUIREMENTS = ['pyecoplug==0.0.5']
 _LOGGER = logging.getLogger(__name__)
-
 SCAN_INTERVAL = timedelta(seconds=5)
+
 
 class EcoPlugSwitch(SwitchDevice):
     def __init__(self, plug):
@@ -57,12 +56,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     discovered = {}
     def add(plug):
-        if not plug.name in discovered:
+        if plug.name not in discovered:
             add_devices([EcoPlugSwitch(plug)])
             discovered[plug.name] = plug
 
     def remove(plug):
-        # Is there a way to remove devices??
+        """Is there a way to remove devices??"""
         pass
 
     disco = EcoDiscovery(add, remove)

--- a/homeassistant/components/switch/ecoplug.py
+++ b/homeassistant/components/switch/ecoplug.py
@@ -20,7 +20,9 @@ SCAN_INTERVAL = timedelta(seconds=5)
 
 
 class EcoPlugSwitch(SwitchDevice):
+    """Return the polling state."""
     def __init__(self, plug):
+        """Initialize the switch."""
         self._plug = plug
         self._name = plug.name or DEVICE_DEFAULT_NAME
         self._state = self._plug.is_on()
@@ -32,30 +34,37 @@ class EcoPlugSwitch(SwitchDevice):
 
     @property
     def name(self):
+        """Return the name of the device if any."""
         return self._name
 
     @property
     def is_on(self):
+        """Return true if switch is on."""
         return self._state
 
-    def turn_on(self):
+    def turn_on(self, **kwargs):
+        """Turn the switch on."""
         self._plug.turn_on()
         self.update()
 
-    def turn_off(self):
+    def turn_off(self, **kwargs):
+        """Turn the switch off."""
         self._plug.turn_off()
         self.update()
 
     def update(self):
+        """Update the switch's status."""
         _LOGGER.info('update')
         self._state = self._plug.is_on()
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up EcoPlug switches."""
     from pyecoplug import EcoDiscovery
 
     discovered = {}
     def add(plug):
+        """Find switches on the network."""
         if plug.name not in discovered:
             add_devices([EcoPlugSwitch(plug)])
             discovered[plug.name] = plug

--- a/homeassistant/components/switch/ecoplug.py
+++ b/homeassistant/components/switch/ecoplug.py
@@ -15,7 +15,7 @@ from homeassistant.components.switch import SwitchDevice
 DEFAULT_INVERT_LOGIC = False
 
 DOMAIN = 'ecoplug'
-REQUIREMENTS = ['https://github.com/philburr/pyecoplug/archive/master.zip#pyecoplug==0.0.5']
+REQUIREMENTS = ['pyecoplug==0.0.5']
 _LOGGER = logging.getLogger(__name__)
 SCAN_INTERVAL = timedelta(seconds=5)
 
@@ -61,7 +61,7 @@ class EcoPlugSwitch(SwitchDevice):
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up EcoPlug switches."""
-    
+
     from pyecoplug import EcoDiscovery
 
     discovered = {}

--- a/homeassistant/components/switch/ecoplug.py
+++ b/homeassistant/components/switch/ecoplug.py
@@ -22,7 +22,7 @@ SCAN_INTERVAL = timedelta(seconds=5)
 
 class EcoPlugSwitch(SwitchDevice):
     """Return the polling state."""
-    
+
     def __init__(self, plug):
         """Initialize the switch."""
         self._plug = plug
@@ -66,9 +66,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     discovered = {}
     def add(plug):
         """Find switches on the network."""
-        
         if plug.name not in discovered:
             add_devices([EcoPlugSwitch(plug)])
+
             discovered[plug.name] = plug
 
     def remove(plug):

--- a/homeassistant/components/switch/ecoplug.py
+++ b/homeassistant/components/switch/ecoplug.py
@@ -6,6 +6,7 @@ https://home-assistant.io/components/ecoplug/
 """
 
 import logging
+
 from datetime import timedelta
 
 from homeassistant.const import (DEVICE_DEFAULT_NAME, EVENT_HOMEASSISTANT_STOP)

--- a/homeassistant/components/switch/ecoplug.py
+++ b/homeassistant/components/switch/ecoplug.py
@@ -2,7 +2,7 @@
 EcoPlugs Component for aut-discovering Wion and EcoPlugs automatically.
 
 For more details about this platform, please refer to the documentation at
-https://home-assistant.io/components/ecoplug/
+https://home-assistant.io/components/switch.ecoplug/
 """
 
 import logging
@@ -14,10 +14,34 @@ from homeassistant.components.switch import SwitchDevice
 
 DEFAULT_INVERT_LOGIC = False
 
-DOMAIN = 'ecoplug'
 REQUIREMENTS = ['pyecoplug==0.0.5']
 _LOGGER = logging.getLogger(__name__)
 SCAN_INTERVAL = timedelta(seconds=5)
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up EcoPlug switches."""
+    from pyecoplug import EcoDiscovery
+    discovered = hass.data
+
+    def add(plug):
+        """Find switches on the network."""
+        if plug.name not in discovered:
+            add_devices([EcoPlugSwitch(plug)])
+            discovered[plug.name] = plug
+
+    def remove(plug):
+        """Remove switch from the list."""
+        async_remove([EcoPlugSwitch(plug)], True)
+
+    disco = EcoDiscovery(add, remove)
+    disco.start()
+
+    def stop_disco(event):
+        """Stop device discovery."""
+        disco.stop()
+
+    hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, stop_disco)
 
 
 class EcoPlugSwitch(SwitchDevice):
@@ -27,12 +51,7 @@ class EcoPlugSwitch(SwitchDevice):
         """Initialize the switch."""
         self._plug = plug
         self._name = plug.name or DEVICE_DEFAULT_NAME
-        self._state = self._plug.is_on()
-
-    @property
-    def should_poll(self):
-        """Return the polling state."""
-        return True
+        self._state = None
 
     @property
     def name(self):
@@ -47,39 +66,11 @@ class EcoPlugSwitch(SwitchDevice):
     def turn_on(self, **kwargs):
         """Turn the switch on."""
         self._plug.turn_on()
-        self.update()
 
     def turn_off(self, **kwargs):
         """Turn the switch off."""
         self._plug.turn_off()
-        self.update()
 
     def update(self):
         """Update the switch's status."""
-        _LOGGER.info('update')
         self._state = self._plug.is_on()
-
-
-def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Set up EcoPlug switches."""
-    from pyecoplug import EcoDiscovery
-    discovered = {}
-
-    def add(plug):
-        """Find switches on the network."""
-        if plug.name not in discovered:
-            add_devices([EcoPlugSwitch(plug)])
-            discovered[plug.name] = plug
-
-    def remove(plug):
-        """Unsure if there is a way to remove devices."""
-        pass
-
-    disco = EcoDiscovery(add, remove)
-    disco.start()
-
-    def stop_disco(event):
-        """Stop device discovery."""
-        disco.stop()
-
-    hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, stop_disco)

--- a/homeassistant/components/switch/ecoplug.py
+++ b/homeassistant/components/switch/ecoplug.py
@@ -20,7 +20,7 @@ SCAN_INTERVAL = timedelta(seconds=5)
 
 DEVICE_SCHEMA = vol.Schema({
     vol.Optional(CONF_NAME): cv.string,
-    vol.Optional(SCAN_INTERVAL, default=5):
+    vol.Optional(SCAN_INTERVAL, default=5)
 })
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -43,7 +43,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     def remove(plug):
         """Remove switch from the list."""
         async_will_remove_from_hass([EcoPlugSwitch(plug)], True)
-            
+
     disco = EcoDiscovery(add, remove)
     disco.start()
 

--- a/homeassistant/components/switch/ecoplug.py
+++ b/homeassistant/components/switch/ecoplug.py
@@ -30,10 +30,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             add_devices([EcoPlugSwitch(plug)])
             discovered[plug.name] = plug
 
-    def remove(plug):
-        """Remove switch from the list."""
-        async_remove([EcoPlugSwitch(plug)], True)
-
     disco = EcoDiscovery(add, remove)
     disco.start()
 

--- a/homeassistant/components/switch/ecoplug.py
+++ b/homeassistant/components/switch/ecoplug.py
@@ -30,7 +30,11 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             add_devices([EcoPlugSwitch(plug)])
             discovered[plug.name] = plug
 
-    disco = EcoDiscovery(add)
+    def remove(plug):
+         """Remove switch from the list."""
+         async_will_remove_from_hass([EcoPlugSwitch(plug)], True)
+            
+    disco = EcoDiscovery(add, remove)
     disco.start()
 
     def stop_disco(event):

--- a/homeassistant/components/switch/ecoplug.py
+++ b/homeassistant/components/switch/ecoplug.py
@@ -30,7 +30,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             add_devices([EcoPlugSwitch(plug)])
             discovered[plug.name] = plug
 
-    disco = EcoDiscovery(add, remove)
+    disco = EcoDiscovery(add)
     disco.start()
 
     def stop_disco(event):

--- a/homeassistant/components/switch/ecoplug.py
+++ b/homeassistant/components/switch/ecoplug.py
@@ -18,6 +18,16 @@ REQUIREMENTS = ['pyecoplug==0.0.5']
 _LOGGER = logging.getLogger(__name__)
 SCAN_INTERVAL = timedelta(seconds=5)
 
+DEVICE_SCHEMA = vol.Schema({
+    vol.Optional(CONF_NAME): cv.string,
+    vol.Optional(SCAN_INTERVAL, default=5):
+})
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_DEVICES, default={}): {cv.string: DEVICE_SCHEMA},
+    vol.Optional(CONF_AUTOMATIC_ADD, default=TRUE):  cv.boolean,
+})
+
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up EcoPlug switches."""
@@ -31,8 +41,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             discovered[plug.name] = plug
 
     def remove(plug):
-         """Remove switch from the list."""
-         async_will_remove_from_hass([EcoPlugSwitch(plug)], True)
+        """Remove switch from the list."""
+        async_will_remove_from_hass([EcoPlugSwitch(plug)], True)
             
     disco = EcoDiscovery(add, remove)
     disco.start()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -800,6 +800,9 @@ pyebox==1.1.4
 # homeassistant.components.climate.econet
 pyeconet==0.0.5
 
+# homeassistant.components.switch.ecoplug
+pyecoplug==0.0.5
+
 # homeassistant.components.switch.edimax
 pyedimax==0.1
 


### PR DESCRIPTION
Riding the wave of  @philburr's previous work. I've fixed, updated, and gotten these devices working with auto-polling. I haven't tested or worked on any of the power-polling since I don't own any of those devices, but it could be implemented.

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5603

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
