### PR TITLE
Fix cast config

### DIFF
--- a/homeassistant/components/media_player/cast.py
+++ b/homeassistant/components/media_player/cast.py
@@ -4,6 +4,7 @@ Provide functionality to interact with Cast devices on the network.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/media_player.cast/
 """
+import asyncio
 import logging
 import threading
 from typing import Optional, Tuple
@@ -199,9 +200,13 @@ async def async_setup_platform(hass: HomeAssistantType, config: ConfigType,
 
 async def async_setup_entry(hass, config_entry, async_add_devices):
     """Set up Cast from a config entry."""
-    await _async_setup_platform(
-        hass, hass.data[CAST_DOMAIN].get('media_player', {}),
-        async_add_devices, None)
+    config = hass.data[CAST_DOMAIN].get('media_player', {})
+    if not isinstance(config, list):
+        config = [config]
+
+    await asyncio.wait([
+        _async_setup_platform(hass, cfg, async_add_devices, None)
+        for cfg in config])
 
 
 async def _async_setup_platform(hass: HomeAssistantType, config: ConfigType,


### PR DESCRIPTION
## Description:
Allow specifying no, a single or a list of config options to configure Cast media players.

**Related issue (if applicable):** fixes #15097

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
cast:
  media_player:
    host: bla
```

```yaml
cast:
  media_player:
    - host: bla
    - host: another-host
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
