### PR TITLE
Return None to indicate no config found

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -323,6 +323,10 @@ class ConfigEntries:
             old_conf_migrate_func=_old_conf_migrator
         )
 
+        if config is None:
+            self._entries = []
+            return
+
         self._entries = [ConfigEntry(**entry) for entry in config['entries']]
 
     async def async_forward_entry_setup(self, entry, component):

--- a/homeassistant/helpers/storage.py
+++ b/homeassistant/helpers/storage.py
@@ -72,7 +72,7 @@ class Store:
                 json.load_json, self.path, None)
 
             if data is None:
-                return {}
+                return None
 
         if data['version'] == self.version:
             return data['data']

--- a/tests/helpers/test_storage.py
+++ b/tests/helpers/test_storage.py
@@ -52,7 +52,7 @@ async def test_loading_non_existing(hass, store):
     """Test we can save and load data."""
     with patch('homeassistant.util.json.open', side_effect=FileNotFoundError):
         data = await store.async_load()
-    assert data == {}
+    assert data is None
 
 
 async def test_saving_with_delay(hass, store, mock_save):

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -318,4 +318,4 @@ async def test_loading_default_config(hass):
     with patch('homeassistant.util.json.open', side_effect=FileNotFoundError):
         await manager.async_load()
 
-    assert len(manager.async_entries) == 0
+    assert len(manager.async_entries()) == 0

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -309,3 +309,13 @@ async def test_discovery_notification_not_created(hass):
     await hass.async_block_till_done()
     state = hass.states.get('persistent_notification.config_entry_discovery')
     assert state is None
+
+
+async def test_loading_default_config(hass):
+    """Test loading the default config."""
+    manager = config_entries.ConfigEntries(hass, {})
+
+    with patch('homeassistant.util.json.open', side_effect=FileNotFoundError):
+        await manager.async_load()
+
+    assert len(manager.async_entries) == 0


### PR DESCRIPTION
## Description:
Focused so much on the migration story of the storage helper that I forgot to test config entries without any entries. This fixes that.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
