### PR TITLE
0.72.1

### DIFF
--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -26,7 +26,7 @@ from homeassistant.helpers.translation import async_get_translations
 from homeassistant.loader import bind_hass
 from homeassistant.util.yaml import load_yaml
 
-REQUIREMENTS = ['home-assistant-frontend==20180622.1']
+REQUIREMENTS = ['home-assistant-frontend==20180625.0']
 
 DOMAIN = 'frontend'
 DEPENDENCIES = ['api', 'websocket_api', 'http', 'system_log']

--- a/homeassistant/components/media_player/cast.py
+++ b/homeassistant/components/media_player/cast.py
@@ -4,7 +4,7 @@ Provide functionality to interact with Cast devices on the network.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/media_player.cast/
 """
-# pylint: disable=import-error
+import asyncio
 import logging
 import threading
 from typing import Optional, Tuple
@@ -200,9 +200,13 @@ async def async_setup_platform(hass: HomeAssistantType, config: ConfigType,
 
 async def async_setup_entry(hass, config_entry, async_add_devices):
     """Set up Cast from a config entry."""
-    await _async_setup_platform(
-        hass, hass.data[CAST_DOMAIN].get('media_player', {}),
-        async_add_devices, None)
+    config = hass.data[CAST_DOMAIN].get('media_player', {})
+    if not isinstance(config, list):
+        config = [config]
+
+    await asyncio.wait([
+        _async_setup_platform(hass, cfg, async_add_devices, None)
+        for cfg in config])
 
 
 async def _async_setup_platform(hass: HomeAssistantType, config: ConfigType,

--- a/homeassistant/components/nest/__init__.py
+++ b/homeassistant/components/nest/__init__.py
@@ -23,7 +23,7 @@ from homeassistant.helpers.entity import Entity
 from .const import DOMAIN
 from . import local_auth
 
-REQUIREMENTS = ['python-nest==4.0.2']
+REQUIREMENTS = ['python-nest==4.0.3']
 
 _CONFIGURING = {}
 _LOGGER = logging.getLogger(__name__)
@@ -86,6 +86,7 @@ async def async_nest_update_event_broker(hass, nest):
                 _LOGGER.debug("dispatching nest data update")
                 async_dispatcher_send(hass, SIGNAL_NEST_UPDATE)
             else:
+                _LOGGER.debug("stop listening nest.update_event")
                 return
 
 

--- a/homeassistant/components/sensor/nest.py
+++ b/homeassistant/components/sensor/nest.py
@@ -145,7 +145,8 @@ class NestBasicSensor(NestSensorDevice):
         elif self.variable in PROTECT_SENSOR_TYPES \
                 and self.variable != 'color_status':
             # keep backward compatibility
-            self._state = getattr(self.device, self.variable).capitalize()
+            state = getattr(self.device, self.variable)
+            self._state = state.capitalize() if state is not None else None
         else:
             self._state = getattr(self.device, self.variable)
 

--- a/homeassistant/components/sensor/nest.py
+++ b/homeassistant/components/sensor/nest.py
@@ -24,10 +24,14 @@ PROTECT_SENSOR_TYPES = ['co_status',
                         # color_status: "gray", "green", "yellow", "red"
                         'color_status']
 
-STRUCTURE_SENSOR_TYPES = ['eta', 'security_state']
+STRUCTURE_SENSOR_TYPES = ['eta']
+
+# security_state is structure level sensor, but only meaningful when
+# Nest Cam exist
+STRUCTURE_CAMERA_SENSOR_TYPES = ['security_state']
 
 _VALID_SENSOR_TYPES = SENSOR_TYPES + TEMP_SENSOR_TYPES + PROTECT_SENSOR_TYPES \
-                      + STRUCTURE_SENSOR_TYPES
+                      + STRUCTURE_SENSOR_TYPES + STRUCTURE_CAMERA_SENSOR_TYPES
 
 SENSOR_UNITS = {'humidity': '%'}
 
@@ -104,6 +108,14 @@ async def async_setup_entry(hass, entry, async_add_devices):
             all_sensors += [NestBasicSensor(structure, device, variable)
                             for variable in conditions
                             if variable in PROTECT_SENSOR_TYPES]
+
+        structures_has_camera = {}
+        for structure, device in nest.cameras():
+            structures_has_camera[structure] = True
+        for structure in structures_has_camera:
+            all_sensors += [NestBasicSensor(structure, None, variable)
+                            for variable in conditions
+                            if variable in STRUCTURE_CAMERA_SENSOR_TYPES]
 
         return all_sensors
 

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -2,7 +2,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 72
-PATCH_VERSION = '0'
+PATCH_VERSION = '1'
 __short_version__ = '{}.{}'.format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = '{}.{}'.format(__short_version__, PATCH_VERSION)
 REQUIRED_PYTHON_VER = (3, 5, 3)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1060,7 +1060,7 @@ python-mpd2==1.0.0
 python-mystrom==0.4.4
 
 # homeassistant.components.nest
-python-nest==4.0.2
+python-nest==4.0.3
 
 # homeassistant.components.device_tracker.nmap_tracker
 python-nmap==0.6.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -404,7 +404,7 @@ hipnotify==1.0.8
 holidays==0.9.5
 
 # homeassistant.components.frontend
-home-assistant-frontend==20180622.1
+home-assistant-frontend==20180625.0
 
 # homeassistant.components.homekit_controller
 # homekit==0.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -81,7 +81,7 @@ hbmqtt==0.9.2
 holidays==0.9.5
 
 # homeassistant.components.frontend
-home-assistant-frontend==20180622.1
+home-assistant-frontend==20180625.0
 
 # homeassistant.components.influxdb
 # homeassistant.components.sensor.influxdb

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -156,7 +156,7 @@ pyqwikswitch==0.8
 python-forecastio==1.4.0
 
 # homeassistant.components.nest
-python-nest==4.0.2
+python-nest==4.0.3
 
 # homeassistant.components.sensor.whois
 pythonwhois==2.4.3


### PR DESCRIPTION
- Prevent Nest component setup crash due insufficient permission. ([@awarecan] - [#14966]) ([nest docs])
- Fix socket bug with Yi in 0.72 ([@bachya] - [#15109]) ([camera.yi docs])
- Skip nest security state sensor if no Nest Cam exists ([@awarecan] - [#15112]) ([sensor.nest docs])
- Fix cast config ([@balloob] - [#15143]) ([media_player.cast docs])
- Bump python-nest to 4.0.3 ([@awarecan] - [#15098]) ([nest docs]) ([sensor.nest docs])
- Fix custom panels (including Hass.io panel) on ES5 version of frontend ([@balloob])

[#14966]: https://github.com/home-assistant/home-assistant/pull/14966
[#15098]: https://github.com/home-assistant/home-assistant/pull/15098
[#15109]: https://github.com/home-assistant/home-assistant/pull/15109
[#15112]: https://github.com/home-assistant/home-assistant/pull/15112
[#15143]: https://github.com/home-assistant/home-assistant/pull/15143
[@awarecan]: https://github.com/awarecan
[@bachya]: https://github.com/bachya
[@balloob]: https://github.com/balloob
[camera.yi docs]: https://www.home-assistant.io/components/camera.yi/
[media_player.cast docs]: https://www.home-assistant.io/components/media_player.cast/
[nest docs]: https://www.home-assistant.io/components/nest/
[sensor.nest docs]: https://www.home-assistant.io/components/sensor.nest/
