### PR TITLE
Added Push Camera

### DIFF
--- a/homeassistant/components/camera/push.py
+++ b/homeassistant/components/camera/push.py
@@ -12,7 +12,6 @@ import voluptuous as vol
 
 from homeassistant.components.camera import Camera, PLATFORM_SCHEMA,\
     STATE_IDLE, STATE_RECORDING
-from homeassistant.util.async_ import run_coroutine_threadsafe
 from homeassistant.core import callback
 from homeassistant.components.http.view import HomeAssistantView
 from homeassistant.const import CONF_NAME, CONF_TIMEOUT, HTTP_BAD_REQUEST,\

--- a/homeassistant/components/camera/push.py
+++ b/homeassistant/components/camera/push.py
@@ -1,0 +1,174 @@
+"""
+Camera platform that receives images through HTTP POST.
+
+For more details about this platform, please refer to the documentation
+https://home-assistant.io/components/camera.push/
+"""
+import logging
+import datetime
+
+from collections import deque
+import voluptuous as vol
+
+from homeassistant.components.camera import Camera, PLATFORM_SCHEMA,\
+    STATE_IDLE, STATE_RECORDING
+from homeassistant.util.async_ import run_coroutine_threadsafe
+from homeassistant.core import callback
+from homeassistant.components.http.view import HomeAssistantView
+from homeassistant.const import CONF_NAME, CONF_TIMEOUT, HTTP_BAD_REQUEST,\
+    ATTR_LAST_TRIP_TIME
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.event import async_track_point_in_utc_time
+import homeassistant.util.dt as dt_util
+
+_LOGGER = logging.getLogger(__name__)
+
+API_URL = "/api/camera_push/{entity_id}"
+
+CONF_BUFFER_SIZE = "cache"
+
+DEFAULT_NAME = 'Push Camera'
+
+BLANK_IMAGE_SIZE = (640, 480)
+
+ATTR_FILENAME = "filename"
+
+REQUIREMENTS = ['pillow==5.0.0']
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_BUFFER_SIZE, default=1): cv.positive_int,
+    vol.Optional(CONF_TIMEOUT, default=5): cv.positive_int,
+})
+
+
+async def async_setup_platform(hass, config, async_add_devices,
+                               discovery_info=None):
+    """Set up the Push Camera platform."""
+    cameras = [PushCamera(config.get(CONF_NAME),
+                          config.get(CONF_BUFFER_SIZE),
+                          config.get(CONF_TIMEOUT))]
+
+    hass.http.register_view(CameraPushReceiver(cameras))
+
+    async_add_devices(cameras)
+
+
+class CameraPushReceiver(HomeAssistantView):
+    """Handle pushes from remote camera."""
+
+    url = API_URL
+    name = 'api:camera:push'
+
+    def __init__(self, cameras):
+        """Initialize CameraPushReceiver with camera entity."""
+        self._cameras = cameras
+
+    async def post(self, request, entity_id):
+        """Accept the POST from Camera."""
+        try:
+            (_camera,) = [camera for camera in self._cameras
+                          if camera.entity_id == entity_id]
+        except ValueError:
+            return self.json_message('Unknown Push Camera',
+                                     HTTP_BAD_REQUEST)
+
+        try:
+            data = await request.post()
+            _LOGGER.debug("Received Camera push: %s", data['image'])
+            await _camera.update_image(data['image'].file.read(),
+                                       data['image'].filename)
+        except ValueError:
+            return self.json_message('Invalid POST', HTTP_BAD_REQUEST)
+
+
+class PushCamera(Camera):
+    """The representation of a Push camera."""
+
+    def __init__(self, name, buffer_size, timeout):
+        """Initialize push camera component."""
+        super().__init__()
+        self._name = name
+        self._motion_status = False
+        self._last_trip = None
+        self._filename = None
+        self._expired = None
+        self._state = STATE_IDLE
+        self._timeout = datetime.timedelta(seconds=timeout)
+        self.queue = deque([], buffer_size)
+
+        from PIL import Image
+        import io
+
+        image = Image.new('RGB', BLANK_IMAGE_SIZE)
+
+        imgbuf = io.BytesIO()
+        image.save(imgbuf, "JPEG")
+
+        self.queue.append(imgbuf.getvalue())
+        self._current_image = imgbuf.getvalue()
+
+    @property
+    def state(self):
+        """Current state of the camera."""
+        return self._state
+
+    async def update_image(self, image, filename):
+        """Update the camera image."""
+        if self._state == STATE_IDLE:
+            self._last_trip = dt_util.utcnow()
+            self.queue.clear()
+
+        self._state = STATE_RECORDING
+        self._filename = filename
+        self.queue.append(image)
+
+        @callback
+        def reset_state(now):
+            """Set state to idle after no new images for a period of time."""
+            self._state = STATE_IDLE
+            self.async_schedule_update_ha_state()
+            self._expired = None
+            _LOGGER.debug("Reset state")
+
+        if self._expired:
+            self._expired()
+
+        self._expired = async_track_point_in_utc_time(
+            self.hass, reset_state, dt_util.utcnow() + self._timeout)
+
+        self.schedule_update_ha_state()
+
+    def camera_image(self):
+        """Return a still image response."""
+        return run_coroutine_threadsafe(
+            self.async_camera_image(), self.hass.loop).result()
+
+    async def async_camera_image(self):
+        """Return a still image response."""
+        if self.queue:
+            if self._state == STATE_IDLE:
+                self.queue.rotate(-1)
+            self._current_image = self.queue[0]
+
+        return self._current_image
+
+    @property
+    def name(self):
+        """Return the name of this camera."""
+        return self._name
+
+    @property
+    def motion_detection_enabled(self):
+        """Camera Motion Detection Status."""
+        return self._motion_status
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        return {
+            name: value for name, value in (
+                (ATTR_LAST_TRIP_TIME, self._last_trip),
+                (ATTR_FILENAME, self._filename),
+            ) if value is not None
+        }

--- a/homeassistant/components/camera/push.py
+++ b/homeassistant/components/camera/push.py
@@ -22,7 +22,7 @@ import homeassistant.util.dt as dt_util
 _LOGGER = logging.getLogger(__name__)
 
 CONF_BUFFER_SIZE = 'cache'
-CONF_IMAGE_FIELD = 'image'
+CONF_IMAGE_FIELD = 'field'
 
 DEFAULT_NAME = "Push Camera"
 
@@ -81,12 +81,12 @@ class CameraPushReceiver(HomeAssistantView):
             _LOGGER.debug("Received Camera push: %s", data[self._image])
             await _camera.update_image(data[self._image].file.read(),
                                        data[self._image].filename)
-        except ValueError as v:
-            _LOGGER.error("Unknown value %s", v)
+        except ValueError as value_error:
+            _LOGGER.error("Unknown value %s", value_error)
             return self.json_message('Invalid POST', HTTP_BAD_REQUEST)
-        except KeyError as k:
-            _LOGGER.error('In your POST message %s', k)
-            return self.json_message('Parameter %s missing', HTTP_BAD_REQUEST)
+        except KeyError as key_error:
+            _LOGGER.error('In your POST message %s', key_error)
+            return self.json_message('Parameter {} missing'.format(self._image), HTTP_BAD_REQUEST)
 
 
 class PushCamera(Camera):

--- a/homeassistant/components/camera/push.py
+++ b/homeassistant/components/camera/push.py
@@ -104,6 +104,11 @@ class PushCamera(Camera):
         self._timeout = timeout
         self.queue = deque([], buffer_size)
 
+        self.queue.append(self._blank_image())
+        self._current_image = self.queue[0]
+
+    @classmethod
+    def _blank_image(cls):
         from PIL import Image
         import io
 
@@ -112,8 +117,7 @@ class PushCamera(Camera):
         imgbuf = io.BytesIO()
         image.save(imgbuf, "JPEG")
 
-        self.queue.append(imgbuf.getvalue())
-        self._current_image = imgbuf.getvalue()
+        return imgbuf.getvalue()
 
     @property
     def state(self):
@@ -144,6 +148,7 @@ class PushCamera(Camera):
         self._expired = async_track_point_in_utc_time(
             self.hass, reset_state, dt_util.utcnow() + self._timeout)
 
+        self._current_image = self.queue[-1]
         self.async_schedule_update_ha_state()
 
     async def async_camera_image(self):

--- a/homeassistant/components/camera/push.py
+++ b/homeassistant/components/camera/push.py
@@ -31,8 +31,6 @@ BLANK_IMAGE_SIZE = (640, 480)
 ATTR_FILENAME = 'filename'
 ATTR_LAST_TRIP = 'last_trip'
 
-REQUIREMENTS = ['pillow==5.0.0']
-
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_BUFFER_SIZE, default=1): cv.positive_int,
@@ -103,21 +101,7 @@ class PushCamera(Camera):
         self._state = STATE_IDLE
         self._timeout = timeout
         self.queue = deque([], buffer_size)
-
-        self.queue.append(self._blank_image())
-        self._current_image = self.queue[0]
-
-    @classmethod
-    def _blank_image(cls):
-        from PIL import Image
-        import io
-
-        image = Image.new('RGB', BLANK_IMAGE_SIZE)
-
-        imgbuf = io.BytesIO()
-        image.save(imgbuf, "JPEG")
-
-        return imgbuf.getvalue()
+        self._current_image = None 
 
     @property
     def state(self):

--- a/homeassistant/components/camera/push.py
+++ b/homeassistant/components/camera/push.py
@@ -26,8 +26,6 @@ CONF_IMAGE_FIELD = 'field'
 
 DEFAULT_NAME = "Push Camera"
 
-BLANK_IMAGE_SIZE = (640, 480)
-
 ATTR_FILENAME = 'filename'
 ATTR_LAST_TRIP = 'last_trip'
 

--- a/homeassistant/components/camera/push.py
+++ b/homeassistant/components/camera/push.py
@@ -14,8 +14,7 @@ from homeassistant.components.camera import Camera, PLATFORM_SCHEMA,\
     STATE_IDLE, STATE_RECORDING
 from homeassistant.core import callback
 from homeassistant.components.http.view import HomeAssistantView
-from homeassistant.const import CONF_NAME, CONF_TIMEOUT, HTTP_BAD_REQUEST,\
-    ATTR_LAST_TRIP_TIME
+from homeassistant.const import CONF_NAME, CONF_TIMEOUT, HTTP_BAD_REQUEST
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.event import async_track_point_in_utc_time
 import homeassistant.util.dt as dt_util
@@ -30,6 +29,7 @@ DEFAULT_NAME = "Push Camera"
 BLANK_IMAGE_SIZE = (640, 480)
 
 ATTR_FILENAME = 'filename'
+ATTR_LAST_TRIP = 'last_trip'
 
 REQUIREMENTS = ['pillow==5.0.0']
 
@@ -169,7 +169,7 @@ class PushCamera(Camera):
         """Return the state attributes."""
         return {
             name: value for name, value in (
-                (ATTR_LAST_TRIP_TIME, self._last_trip),
+                (ATTR_LAST_TRIP, self._last_trip),
                 (ATTR_FILENAME, self._filename),
             ) if value is not None
         }

--- a/homeassistant/components/camera/push.py
+++ b/homeassistant/components/camera/push.py
@@ -86,7 +86,7 @@ class CameraPushReceiver(HomeAssistantView):
             return self.json_message('Invalid POST', HTTP_BAD_REQUEST)
         except KeyError as key_error:
             _LOGGER.error('In your POST message %s', key_error)
-            return self.json_message('Parameter {} missing'.format(self._image),
+            return self.json_message('{} missing'.format(self._image),
                                      HTTP_BAD_REQUEST)
 
 

--- a/homeassistant/components/camera/push.py
+++ b/homeassistant/components/camera/push.py
@@ -95,7 +95,7 @@ class PushCamera(Camera):
         self._name = name
         self._last_trip = None
         self._filename = None
-        self._expired = None
+        self._expired_listener = None
         self._state = STATE_IDLE
         self._timeout = timeout
         self.queue = deque([], buffer_size)
@@ -120,14 +120,14 @@ class PushCamera(Camera):
         def reset_state(now):
             """Set state to idle after no new images for a period of time."""
             self._state = STATE_IDLE
-            self.async_schedule_update_ha_state()
-            self._expired = None
+            self._expired_listener = None
             _LOGGER.debug("Reset state")
+            self.async_schedule_update_ha_state()
 
-        if self._expired:
-            self._expired()
+        if self._expired_listener:
+            self._expired_listener()
 
-        self._expired = async_track_point_in_utc_time(
+        self._expired_listener = async_track_point_in_utc_time(
             self.hass, reset_state, dt_util.utcnow() + self._timeout)
 
         self.async_schedule_update_ha_state()

--- a/homeassistant/components/camera/push.py
+++ b/homeassistant/components/camera/push.py
@@ -86,7 +86,8 @@ class CameraPushReceiver(HomeAssistantView):
             return self.json_message('Invalid POST', HTTP_BAD_REQUEST)
         except KeyError as key_error:
             _LOGGER.error('In your POST message %s', key_error)
-            return self.json_message('Parameter {} missing'.format(self._image), HTTP_BAD_REQUEST)
+            return self.json_message('Parameter {} missing'.format(self._image),
+                                     HTTP_BAD_REQUEST)
 
 
 class PushCamera(Camera):

--- a/homeassistant/components/camera/push.py
+++ b/homeassistant/components/camera/push.py
@@ -14,8 +14,7 @@ from homeassistant.components.camera import Camera, PLATFORM_SCHEMA,\
     STATE_IDLE, STATE_RECORDING
 from homeassistant.core import callback
 from homeassistant.components.http.view import HomeAssistantView
-from homeassistant.const import CONF_NAME, CONF_TIMEOUT, CONF_FORCE_UPDATE,\
-    HTTP_BAD_REQUEST
+from homeassistant.const import CONF_NAME, CONF_TIMEOUT, HTTP_BAD_REQUEST
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.event import async_track_point_in_utc_time
 import homeassistant.util.dt as dt_util
@@ -26,7 +25,6 @@ CONF_BUFFER_SIZE = 'cache'
 CONF_IMAGE_FIELD = 'field'
 
 DEFAULT_NAME = "Push Camera"
-DEFAULT_FORCE_UPDATE = False
 
 ATTR_FILENAME = 'filename'
 ATTR_LAST_TRIP = 'last_trip'
@@ -36,7 +34,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_BUFFER_SIZE, default=1): cv.positive_int,
     vol.Optional(CONF_TIMEOUT, default=timedelta(seconds=5)): vol.All(
         cv.time_period, cv.positive_timedelta),
-    vol.Optional(CONF_FORCE_UPDATE, default=DEFAULT_FORCE_UPDATE): cv.boolean,
     vol.Optional(CONF_IMAGE_FIELD, default='image'): cv.string,
 })
 
@@ -46,8 +43,7 @@ async def async_setup_platform(hass, config, async_add_devices,
     """Set up the Push Camera platform."""
     cameras = [PushCamera(config[CONF_NAME],
                           config[CONF_BUFFER_SIZE],
-                          config[CONF_TIMEOUT],
-                          config[CONF_FORCE_UPDATE])]
+                          config[CONF_TIMEOUT])]
 
     hass.http.register_view(CameraPushReceiver(cameras,
                                                config[CONF_IMAGE_FIELD]))
@@ -93,7 +89,7 @@ class CameraPushReceiver(HomeAssistantView):
 class PushCamera(Camera):
     """The representation of a Push camera."""
 
-    def __init__(self, name, buffer_size, timeout, force_update):
+    def __init__(self, name, buffer_size, timeout):
         """Initialize push camera component."""
         super().__init__()
         self._name = name
@@ -104,26 +100,18 @@ class PushCamera(Camera):
         self._timeout = timeout
         self.queue = deque([], buffer_size)
         self._current_image = None
-        self._force_update = force_update
 
     @property
     def state(self):
         """Current state of the camera."""
         return self._state
 
-    @property
-    def force_update(self):
-        """Force update."""
-        return self._force_update
-
     async def update_image(self, image, filename):
         """Update the camera image."""
-        _first_image = False
         if self._state == STATE_IDLE:
             self._state = STATE_RECORDING
             self._last_trip = dt_util.utcnow()
             self.queue.clear()
-            _first_image = True
 
         self._filename = filename
         self.queue.appendleft(image)
@@ -142,8 +130,7 @@ class PushCamera(Camera):
         self._expired_listener = async_track_point_in_utc_time(
             self.hass, reset_state, dt_util.utcnow() + self._timeout)
 
-        if self.force_update or _first_image:
-            self.async_schedule_update_ha_state()
+        self.async_schedule_update_ha_state()
 
     async def async_camera_image(self):
         """Return a still image response."""

--- a/homeassistant/components/camera/push.py
+++ b/homeassistant/components/camera/push.py
@@ -21,7 +21,7 @@ import homeassistant.util.dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
 
-CONF_BUFFER_SIZE = 'cache'
+CONF_BUFFER_SIZE = 'buffer'
 CONF_IMAGE_FIELD = 'field'
 
 DEFAULT_NAME = "Push Camera"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -651,7 +651,6 @@ piglow==1.2.4
 pilight==0.1.1
 
 # homeassistant.components.camera.proxy
-# homeassistant.components.camera.push
 pillow==5.0.0
 
 # homeassistant.components.dominos

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -651,6 +651,7 @@ piglow==1.2.4
 pilight==0.1.1
 
 # homeassistant.components.camera.proxy
+# homeassistant.components.camera.push
 pillow==5.0.0
 
 # homeassistant.components.dominos

--- a/tests/components/camera/test_push.py
+++ b/tests/components/camera/test_push.py
@@ -1,0 +1,63 @@
+"""The tests for generic camera component."""
+import io
+
+from datetime import timedelta
+
+from homeassistant import core as ha
+from homeassistant.setup import async_setup_component
+from homeassistant.util import dt as dt_util
+from tests.components.auth import async_setup_auth
+
+
+async def test_bad_posting(aioclient_mock, hass, aiohttp_client):
+    """Test that posting to wrong api endpoint fails."""
+    await async_setup_component(hass, 'camera', {
+        'camera': {
+            'platform': 'push',
+            'name': 'config_test',
+        }})
+
+    client = await async_setup_auth(hass, aiohttp_client)
+
+    # missing file
+    resp = await client.post('/api/camera_push/camera.config_test')
+    assert resp.status == 400
+
+    files = {'image': io.BytesIO(b'fake')}
+
+    # wrong entity
+    resp = await client.post('/api/camera_push/camera.wrong', data=files)
+    assert resp.status == 400
+
+
+async def test_posting_url(aioclient_mock, hass, aiohttp_client):
+    """Test that posting to api endpoint works."""
+    await async_setup_component(hass, 'camera', {
+        'camera': {
+            'platform': 'push',
+            'name': 'config_test',
+        }})
+
+    client = await async_setup_auth(hass, aiohttp_client)
+    files = {'image': io.BytesIO(b'fake')}
+
+    # initial state
+    camera_state = hass.states.get('camera.config_test')
+    assert camera_state.state == 'idle'
+
+    # post image
+    resp = await client.post('/api/camera_push/camera.config_test', data=files)
+    assert resp.status == 200
+
+    # state recording
+    camera_state = hass.states.get('camera.config_test')
+    assert camera_state.state == 'recording'
+
+    # await timeout
+    shifted_time = dt_util.utcnow() + timedelta(seconds=15)
+    hass.bus.async_fire(ha.EVENT_TIME_CHANGED, {ha.ATTR_NOW: shifted_time})
+    await hass.async_block_till_done()
+
+    # back to initial state
+    camera_state = hass.states.get('camera.config_test')
+    assert camera_state.state == 'idle'

--- a/tests/components/camera/test_push.py
+++ b/tests/components/camera/test_push.py
@@ -12,13 +12,11 @@ from tests.components.auth import async_setup_auth
 
 async def test_bad_posting(aioclient_mock, hass, aiohttp_client):
     """Test that posting to wrong api endpoint fails."""
-    with patch('homeassistant.components.camera.push.PushCamera._blank_image',
-               return_value=io.BytesIO(b'fakeinit')):
-        await async_setup_component(hass, 'camera', {
-            'camera': {
-                'platform': 'push',
-                'name': 'config_test',
-            }})
+    await async_setup_component(hass, 'camera', {
+        'camera': {
+            'platform': 'push',
+            'name': 'config_test',
+        }})
 
     client = await async_setup_auth(hass, aiohttp_client)
 
@@ -35,13 +33,11 @@ async def test_bad_posting(aioclient_mock, hass, aiohttp_client):
 
 async def test_posting_url(aioclient_mock, hass, aiohttp_client):
     """Test that posting to api endpoint works."""
-    with patch('homeassistant.components.camera.push.PushCamera._blank_image',
-               return_value=io.BytesIO(b'fakeinit')):
-        await async_setup_component(hass, 'camera', {
-            'camera': {
-                'platform': 'push',
-                'name': 'config_test',
-            }})
+    await async_setup_component(hass, 'camera', {
+        'camera': {
+            'platform': 'push',
+            'name': 'config_test',
+        }})
 
     client = await async_setup_auth(hass, aiohttp_client)
     files = {'image': io.BytesIO(b'fake')}

--- a/tests/components/camera/test_push.py
+++ b/tests/components/camera/test_push.py
@@ -2,7 +2,7 @@
 import io
 
 from datetime import timedelta
-from unittest import mock
+from unittest.mock import patch
 
 from homeassistant import core as ha
 from homeassistant.setup import async_setup_component
@@ -10,14 +10,15 @@ from homeassistant.util import dt as dt_util
 from tests.components.auth import async_setup_auth
 
 
-@mock.patch("PIL.Image.new")
 async def test_bad_posting(aioclient_mock, hass, aiohttp_client):
     """Test that posting to wrong api endpoint fails."""
-    await async_setup_component(hass, 'camera', {
-        'camera': {
-            'platform': 'push',
-            'name': 'config_test',
-        }})
+    with patch('homeassistant.components.camera.push.PushCamera._blank_image',
+               return_value=io.BytesIO(b'fakeinit')):
+        await async_setup_component(hass, 'camera', {
+            'camera': {
+                'platform': 'push',
+                'name': 'config_test',
+            }})
 
     client = await async_setup_auth(hass, aiohttp_client)
 
@@ -32,14 +33,15 @@ async def test_bad_posting(aioclient_mock, hass, aiohttp_client):
     assert resp.status == 400
 
 
-@mock.patch("PIL.Image.new")
 async def test_posting_url(aioclient_mock, hass, aiohttp_client):
     """Test that posting to api endpoint works."""
-    await async_setup_component(hass, 'camera', {
-        'camera': {
-            'platform': 'push',
-            'name': 'config_test',
-        }})
+    with patch('homeassistant.components.camera.push.PushCamera._blank_image',
+               return_value=io.BytesIO(b'fakeinit')):
+        await async_setup_component(hass, 'camera', {
+            'camera': {
+                'platform': 'push',
+                'name': 'config_test',
+            }})
 
     client = await async_setup_auth(hass, aiohttp_client)
     files = {'image': io.BytesIO(b'fake')}

--- a/tests/components/camera/test_push.py
+++ b/tests/components/camera/test_push.py
@@ -2,7 +2,6 @@
 import io
 
 from datetime import timedelta
-from unittest.mock import patch
 
 from homeassistant import core as ha
 from homeassistant.setup import async_setup_component

--- a/tests/components/camera/test_push.py
+++ b/tests/components/camera/test_push.py
@@ -2,13 +2,14 @@
 import io
 
 from datetime import timedelta
+from unittest import mock
 
 from homeassistant import core as ha
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 from tests.components.auth import async_setup_auth
 
-
+@mock.patch("PIL.Image.new")
 async def test_bad_posting(aioclient_mock, hass, aiohttp_client):
     """Test that posting to wrong api endpoint fails."""
     await async_setup_component(hass, 'camera', {
@@ -29,7 +30,7 @@ async def test_bad_posting(aioclient_mock, hass, aiohttp_client):
     resp = await client.post('/api/camera_push/camera.wrong', data=files)
     assert resp.status == 400
 
-
+@mock.patch("PIL.Image.new")
 async def test_posting_url(aioclient_mock, hass, aiohttp_client):
     """Test that posting to api endpoint works."""
     await async_setup_component(hass, 'camera', {

--- a/tests/components/camera/test_push.py
+++ b/tests/components/camera/test_push.py
@@ -9,6 +9,7 @@ from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 from tests.components.auth import async_setup_auth
 
+
 @mock.patch("PIL.Image.new")
 async def test_bad_posting(aioclient_mock, hass, aiohttp_client):
     """Test that posting to wrong api endpoint fails."""
@@ -29,6 +30,7 @@ async def test_bad_posting(aioclient_mock, hass, aiohttp_client):
     # wrong entity
     resp = await client.post('/api/camera_push/camera.wrong', data=files)
     assert resp.status == 400
+
 
 @mock.patch("PIL.Image.new")
 async def test_posting_url(aioclient_mock, hass, aiohttp_client):


### PR DESCRIPTION
## Description:

Push Camera is a meta-platform that can receive images through the http API.

A use case, is the integration with [motioneye](https://github.com/ccrisan/motioneye). Motioneye is usually configured to save/record files ONLY when motion is detected. It provides a hook to run a command whenever an image is saved, which can be used together with cURL to send the motion detected images to Push Camera, as showed in this example:

```bash
curl -X POST -F "image=@%f" http://hassio.test:8123/api/camera_push/camera.my_push_camera
```

Optionally the Push Camera is able to **buffer** a given number of images, creating an animation of the detected motion.

Images are cleared on new events, and events are separated by a soft (configurable) **timeout**.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5606

## Example entry for `configuration.yaml` (if applicable):
```yaml
camera:
  - platform: push
    buffer: 3
    timeout: 5
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54