### PR TITLE
Finalize BotVac D7 Support And Further Reduce Cloud Calls

### DIFF
--- a/homeassistant/components/camera/neato.py
+++ b/homeassistant/components/camera/neato.py
@@ -45,7 +45,7 @@ class NeatoCleaningMap(Camera):
         self.update()
         return self._image
 
-    @Throttle(timedelta(seconds=60))
+    @Throttle(timedelta(seconds=600))
     def update(self):
         """Check the contents of the map list."""
         self.neato.update_robots()

--- a/homeassistant/components/camera/neato.py
+++ b/homeassistant/components/camera/neato.py
@@ -10,13 +10,13 @@ from datetime import timedelta
 from homeassistant.components.camera import Camera
 from homeassistant.components.neato import (
     NEATO_MAP_DATA, NEATO_ROBOTS, NEATO_LOGIN)
-from homeassistant.util import Throttle
 
 _LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = ['neato']
 
 SCAN_INTERVAL = timedelta(minutes=10)
+
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Neato Camera."""

--- a/homeassistant/components/camera/neato.py
+++ b/homeassistant/components/camera/neato.py
@@ -16,6 +16,7 @@ _LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = ['neato']
 
+SCAN_INTERVAL=timedelta(minutes=10)
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Neato Camera."""
@@ -45,7 +46,6 @@ class NeatoCleaningMap(Camera):
         self.update()
         return self._image
 
-    @Throttle(timedelta(seconds=600))
     def update(self):
         """Check the contents of the map list."""
         self.neato.update_robots()

--- a/homeassistant/components/camera/neato.py
+++ b/homeassistant/components/camera/neato.py
@@ -16,7 +16,7 @@ _LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = ['neato']
 
-SCAN_INTERVAL=timedelta(minutes=10)
+SCAN_INTERVAL = timedelta(minutes=10)
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Neato Camera."""

--- a/homeassistant/components/neato.py
+++ b/homeassistant/components/neato.py
@@ -54,7 +54,12 @@ ACTION = {
     7: 'Updating...',
     8: 'Copying logs...',
     9: 'Calculating position...',
-    10: 'IEC test'
+    10: 'IEC test',
+    11: 'Map cleaning',
+    12: 'Exploring map (creating a persistent map)',
+    13: 'Acquiring Persistent Map IDs',
+    14: 'Creating & Uploading Map',
+    15: 'Suspended Exploration'
 }
 
 ERRORS = {
@@ -70,12 +75,30 @@ ERRORS = {
     'ui_error_navigation_pathproblems_returninghome': 'Cannot return to base',
     'ui_error_navigation_falling': 'Clear my path',
     'ui_error_picked_up': 'Picked up',
-    'ui_error_stuck': 'Stuck!'
+    'ui_error_stuck': 'Stuck!',
+    'dustbin_full': 'Dust bin full',
+    'dustbin_missing': 'Dust bin missing',
+    'maint_brush_stuck': 'Brush stuck',
+    'maint_brush_overload': 'Brush overloaded',
+    'maint_bumper_stuck': 'Bumper stuck',
+    'maint_vacuum_stuck': 'Vacuum is stuck',
+    'maint_left_drop_stuck': 'Vacuum is stuck',
+    'maint_left_wheel_stuck': 'Vacuum is stuck',
+    'maint_right_drop_stuck': 'Vacuum is stuck',
+    'maint_right_wheel_stuck': 'Vacuum is stuck',
+    'not_on_charge_base': 'Not on the charge base',
+    'nav_robot_falling': 'Clear my path',
+    'nav_no_path': 'Clear my path',
+    'nav_path_problem': 'Clear my path'
 }
 
 ALERTS = {
     'ui_alert_dust_bin_full': 'Please empty dust bin',
-    'ui_alert_recovering_location': 'Returning to start'
+    'ui_alert_recovering_location': 'Returning to start',
+    'dustbin_full': 'Please empty dust bin',
+    'maint_brush_change': 'Change the brush',
+    'maint_filter_change': 'Change the filter',
+    'clean_completed_to_start': 'Cleaning completed'
 }
 
 
@@ -121,7 +144,7 @@ class NeatoHub(object):
             _LOGGER.error("Unable to connect to Neato API")
             return False
 
-    @Throttle(timedelta(seconds=60))
+    @Throttle(timedelta(seconds=300))
     def update_robots(self):
         """Update the robot states."""
         _LOGGER.debug("Running HUB.update_robots %s",

--- a/homeassistant/components/switch/neato.py
+++ b/homeassistant/components/switch/neato.py
@@ -52,7 +52,7 @@ class NeatoConnectedSwitch(ToggleEntity):
         self._schedule_state = None
         self._clean_state = None
 
-    @Throttle(timedelta(seconds=60))
+    @Throttle(timedelta(seconds=600))
     def update(self):
         """Update the states of Neato switches."""
         _LOGGER.debug("Running switch update")

--- a/homeassistant/components/switch/neato.py
+++ b/homeassistant/components/switch/neato.py
@@ -10,7 +10,6 @@ import requests
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.components.neato import NEATO_ROBOTS, NEATO_LOGIN
-from homeassistant.util import Throttle
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/switch/neato.py
+++ b/homeassistant/components/switch/neato.py
@@ -16,6 +16,8 @@ _LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = ['neato']
 
+SCAN_INTERVAL=timedelta(minutes=10)
+
 SWITCH_TYPE_SCHEDULE = 'schedule'
 
 SWITCH_TYPES = {
@@ -52,7 +54,6 @@ class NeatoConnectedSwitch(ToggleEntity):
         self._schedule_state = None
         self._clean_state = None
 
-    @Throttle(timedelta(seconds=600))
     def update(self):
         """Update the states of Neato switches."""
         _LOGGER.debug("Running switch update")

--- a/homeassistant/components/switch/neato.py
+++ b/homeassistant/components/switch/neato.py
@@ -16,7 +16,7 @@ _LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = ['neato']
 
-SCAN_INTERVAL=timedelta(minutes=10)
+SCAN_INTERVAL = timedelta(minutes=10)
 
 SWITCH_TYPE_SCHEDULE = 'schedule'
 

--- a/homeassistant/components/vacuum/neato.py
+++ b/homeassistant/components/vacuum/neato.py
@@ -98,8 +98,10 @@ class NeatoConnectedVacuum(VacuumDevice):
 
         if (self.robot.state['action'] == 1 or
                 self.robot.state['action'] == 2 or
-                self.robot.state['action'] == 3 or
-                self.robot.state['action'] == 11 or
+                self.robot.state['action'] == 3 and
+                self.robot.state['state'] == 2):
+            self._clean_state = STATE_ON
+        elif (self.robot.state['action'] == 11 or
                 self.robot.state['action'] == 12 and
                 self.robot.state['state'] == 2):
             self._clean_state = STATE_ON

--- a/homeassistant/components/vacuum/neato.py
+++ b/homeassistant/components/vacuum/neato.py
@@ -63,7 +63,7 @@ class NeatoConnectedVacuum(VacuumDevice):
         self.clean_suspension_charge_count = None
         self.clean_suspension_time = None
 
-    @Throttle(timedelta(seconds=60))
+    @Throttle(timedelta(seconds=300))
     def update(self):
         """Update the states of Neato Vacuums."""
         _LOGGER.debug("Running Neato Vacuums update")
@@ -98,7 +98,9 @@ class NeatoConnectedVacuum(VacuumDevice):
 
         if (self.robot.state['action'] == 1 or
                 self.robot.state['action'] == 2 or
-                self.robot.state['action'] == 3 and
+                self.robot.state['action'] == 3 or
+                self.robot.state['action'] == 11 or
+                self.robot.state['action'] == 12 and
                 self.robot.state['state'] == 2):
             self._clean_state = STATE_ON
         else:

--- a/homeassistant/components/vacuum/neato.py
+++ b/homeassistant/components/vacuum/neato.py
@@ -21,6 +21,8 @@ _LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = ['neato']
 
+SCAN_INTERVAL=timedelta(minutes=5)
+
 SUPPORT_NEATO = SUPPORT_BATTERY | SUPPORT_PAUSE | SUPPORT_RETURN_HOME | \
                  SUPPORT_STOP | SUPPORT_TURN_OFF | SUPPORT_TURN_ON | \
                  SUPPORT_STATUS | SUPPORT_MAP
@@ -63,7 +65,6 @@ class NeatoConnectedVacuum(VacuumDevice):
         self.clean_suspension_charge_count = None
         self.clean_suspension_time = None
 
-    @Throttle(timedelta(seconds=300))
     def update(self):
         """Update the states of Neato Vacuums."""
         _LOGGER.debug("Running Neato Vacuums update")

--- a/homeassistant/components/vacuum/neato.py
+++ b/homeassistant/components/vacuum/neato.py
@@ -15,7 +15,6 @@ from homeassistant.components.vacuum import (
     SUPPORT_MAP, ATTR_STATUS, ATTR_BATTERY_LEVEL, ATTR_BATTERY_ICON)
 from homeassistant.components.neato import (
     NEATO_ROBOTS, NEATO_LOGIN, NEATO_MAP_DATA, ACTION, ERRORS, MODE, ALERTS)
-from homeassistant.util import Throttle
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/vacuum/neato.py
+++ b/homeassistant/components/vacuum/neato.py
@@ -21,7 +21,7 @@ _LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = ['neato']
 
-SCAN_INTERVAL=timedelta(minutes=5)
+SCAN_INTERVAL = timedelta(minutes=5)
 
 SUPPORT_NEATO = SUPPORT_BATTERY | SUPPORT_PAUSE | SUPPORT_RETURN_HOME | \
                  SUPPORT_STOP | SUPPORT_TURN_OFF | SUPPORT_TURN_ON | \

--- a/homeassistant/components/vacuum/neato.py
+++ b/homeassistant/components/vacuum/neato.py
@@ -102,8 +102,8 @@ class NeatoConnectedVacuum(VacuumDevice):
                 self.robot.state['state'] == 2):
             self._clean_state = STATE_ON
         elif (self.robot.state['action'] == 11 or
-                self.robot.state['action'] == 12 and
-                self.robot.state['state'] == 2):
+              self.robot.state['action'] == 12 and
+              self.robot.state['state'] == 2):
             self._clean_state = STATE_ON
         else:
             self._clean_state = STATE_OFF


### PR DESCRIPTION
## Description:

This PR finalizes BotVac D7 support (new ACTIONS, ERRORS and ALERTS) which was added in the python library update from #15115 

This PR also reduces cloud calls by another 50%

**Related issue (if applicable):** fixes #13950 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
neato:
  username: username
  password: password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
