### PR TITLE
Added support for Duke Energy smart meters

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -612,6 +612,7 @@ omit =
     homeassistant/components/sensor/domain_expiry.py
     homeassistant/components/sensor/dte_energy_bridge.py
     homeassistant/components/sensor/dublin_bus_transport.py
+    homeassistant/components/sensor/duke_energy.py
     homeassistant/components/sensor/dwd_weather_warnings.py
     homeassistant/components/sensor/ebox.py
     homeassistant/components/sensor/eddystone_temperature.py

--- a/homeassistant/components/sensor/duke_energy.py
+++ b/homeassistant/components/sensor/duke_energy.py
@@ -22,6 +22,10 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_PASSWORD): cv.string,
 })
 
+LAST_BILL_USAGE = "lastBillsUsage"
+LAST_BILL_AVERAGE_USAGE = "lastBillsAverageUsage"
+LAST_BILL_DAYS_BILLED = "lastBillsDaysBilled"
+
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup all Duke Energy meters."""
@@ -35,13 +39,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         _LOGGER.error("Failed to setup Duke Energy")
         return False
 
-    meters = duke.get_meters()
-    sensors = []
-    for meter in meters:
-        sensors.append(DukeEnergyMeter(meter))
-    add_devices(sensors)
-
-    return True
+    add_devices([DukeEnergyMeter(meter) for meter in duke.get_meters()])
 
 
 class DukeEnergyMeter(Entity):
@@ -57,6 +55,10 @@ class DukeEnergyMeter(Entity):
         return "duke_energy_" + self.duke_meter.id
 
     @property
+    def unique_id(self):
+        return self.duke_meter.id
+
+    @property
     def state(self):
         """Return yesterdays usage."""
         return self.duke_meter.get_usage()
@@ -70,9 +72,9 @@ class DukeEnergyMeter(Entity):
     def device_state_attributes(self):
         """Return the state attributes."""
         attributes = {
-            "lastBillsUsage": self.duke_meter.get_total(),
-            "lastBillsAverageUsage": self.duke_meter.get_average(),
-            "lastBillsDaysBilled": self.duke_meter.get_days_billed()
+            LAST_BILL_USAGE: self.duke_meter.get_total(),
+            LAST_BILL_AVERAGE_USAGE: self.duke_meter.get_average(),
+            LAST_BILL_DAYS_BILLED: self.duke_meter.get_days_billed()
         }
         return attributes
 

--- a/homeassistant/components/sensor/duke_energy.py
+++ b/homeassistant/components/sensor/duke_energy.py
@@ -2,7 +2,7 @@
 Support for Duke Energy Gas and Electric meters.
 
 For more details about this component, please refer to the documentation at
-https://home-assistant.io/components/sensor/duke_energy/
+https://home-assistant.io/components/sensor.duke_energy/
 """
 import logging
 
@@ -22,9 +22,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_PASSWORD): cv.string,
 })
 
-LAST_BILL_USAGE = "lastBillsUsage"
-LAST_BILL_AVERAGE_USAGE = "lastBillsAverageUsage"
-LAST_BILL_DAYS_BILLED = "lastBillsDaysBilled"
+LAST_BILL_USAGE = "last_bills_usage"
+LAST_BILL_AVERAGE_USAGE = "last_bills_average_usage"
+LAST_BILL_DAYS_BILLED = "last_bills_days_billed"
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -32,12 +32,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     from pydukeenergy.api import DukeEnergy, DukeEnergyException
 
     try:
-        duke = DukeEnergy(config.get(CONF_USERNAME),
-                          config.get(CONF_PASSWORD),
-                          update_interval=500)
+        duke = DukeEnergy(config[CONF_USERNAME],
+                          config[CONF_PASSWORD],
+                          update_interval=60)
     except DukeEnergyException:
         _LOGGER.error("Failed to setup Duke Energy")
-        return False
+        return
 
     add_devices([DukeEnergyMeter(meter) for meter in duke.get_meters()])
 
@@ -52,7 +52,7 @@ class DukeEnergyMeter(Entity):
     @property
     def name(self):
         """Return the name."""
-        return "duke_energy_" + self.duke_meter.id
+        return "duke_energy_{}".format(self.duke_meter.id)
 
     @property
     def unique_id(self):

--- a/homeassistant/components/sensor/duke_energy.py
+++ b/homeassistant/components/sensor/duke_energy.py
@@ -1,0 +1,82 @@
+"""
+Support for Duke Energy Gas and Electric meters.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/sensor/duke_energy/
+"""
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
+from homeassistant.helpers.entity import Entity
+import homeassistant.helpers.config_validation as cv
+import homeassistant.util as util
+
+REQUIREMENTS = ['pydukeenergy==0.0.5']
+
+_LOGGER = logging.getLogger(__name__)
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_USERNAME): cv.string,
+    vol.Required(CONF_PASSWORD): cv.string,
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    from pydukeenergy.api import DukeEnergy, DukeEnergyException
+
+    try:
+        duke = DukeEnergy(config.get(CONF_USERNAME),
+            config.get(CONF_PASSWORD),
+            update_interval=500)
+    except DukeEnergyException:
+        _LOGGER.error("Failed to setup Duke Energy")
+        return False
+
+    meters = duke.get_meters()
+    sensors = []
+    for meter in meters:
+        sensors.append(DukeEnergyMeter(meter))
+    add_devices(sensors)
+
+    return True
+
+
+class DukeEnergyMeter(Entity):
+    """Representation of a Duke Energy meter."""
+
+    def __init__(self, meter):
+        """Initialize the meter."""
+        self.duke_meter = meter
+
+    @property
+    def name(self):
+        """Return the name."""
+        return "duke_energy_" + self.duke_meter.id
+
+    @property
+    def state(self):
+        """Return yesterdays usage."""
+        return self.duke_meter.get_usage()
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement this sensor expresses itself in."""
+        return self.duke_meter.get_unit()
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        attributes = {
+            "lastBillsUsage": self.duke_meter.get_total(),
+            "lastBillsAverageUsage": self.duke_meter.get_average(),
+            "lastBillsDaysBilled": self.duke_meter.get_days_billed()
+        }
+        return attributes
+
+    def update(self):
+        """Update meter."""
+        self.duke_meter.update()
+

--- a/homeassistant/components/sensor/duke_energy.py
+++ b/homeassistant/components/sensor/duke_energy.py
@@ -24,6 +24,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup all Duke Energy meters."""
     from pydukeenergy.api import DukeEnergy, DukeEnergyException
 
     try:

--- a/homeassistant/components/sensor/duke_energy.py
+++ b/homeassistant/components/sensor/duke_energy.py
@@ -13,7 +13,7 @@ from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['pydukeenergy==0.0.5']
+REQUIREMENTS = ['pydukeenergy==0.0.6']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -34,7 +34,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     try:
         duke = DukeEnergy(config[CONF_USERNAME],
                           config[CONF_PASSWORD],
-                          update_interval=60)
+                          update_interval=120)
     except DukeEnergyException:
         _LOGGER.error("Failed to setup Duke Energy")
         return

--- a/homeassistant/components/sensor/duke_energy.py
+++ b/homeassistant/components/sensor/duke_energy.py
@@ -56,6 +56,7 @@ class DukeEnergyMeter(Entity):
 
     @property
     def unique_id(self):
+        """Return the unique ID."""
         return self.duke_meter.id
 
     @property

--- a/homeassistant/components/sensor/duke_energy.py
+++ b/homeassistant/components/sensor/duke_energy.py
@@ -12,7 +12,6 @@ from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
-import homeassistant.util as util
 
 REQUIREMENTS = ['pydukeenergy==0.0.5']
 
@@ -29,8 +28,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     try:
         duke = DukeEnergy(config.get(CONF_USERNAME),
-            config.get(CONF_PASSWORD),
-            update_interval=500)
+                          config.get(CONF_PASSWORD),
+                          update_interval=500)
     except DukeEnergyException:
         _LOGGER.error("Failed to setup Duke Energy")
         return False
@@ -79,4 +78,3 @@ class DukeEnergyMeter(Entity):
     def update(self):
         """Update meter."""
         self.duke_meter.update()
-

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -798,7 +798,7 @@ pydispatcher==2.0.5
 pydroid-ipcam==0.8
 
 # homeassistant.components.sensor.duke_energy
-pydukeenergy==0.0.5
+pydukeenergy==0.0.6
 
 # homeassistant.components.sensor.ebox
 pyebox==1.1.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -797,6 +797,9 @@ pydispatcher==2.0.5
 # homeassistant.components.android_ip_webcam
 pydroid-ipcam==0.8
 
+# homeassistant.components.sensor.duke_energy
+pydukeenergy==0.0.5
+
 # homeassistant.components.sensor.ebox
 pyebox==1.1.4
 


### PR DESCRIPTION
## Description:
This adds support for reading previous days smart meter readings, both gas and electric. Each meter will be represented as a sensor `sensor.duke_energy_123456` where 123456 is the meter ID.

Each meter will also include attributes for total usage for last bill, average usage for last bill, and total number of days billed.

This will only work for users who have a smart meter installed and actively reporting data here https://www.duke-energy.com/my-account/usage-analysis

The only issue I have seen while testing this (only happened once) is that the API took really long to respond but didn't timeout or get any errors. The entity never showed up in HA. It showed up after doing another reboot. Is there something that is needed to let HA know setup can take a long time? 

## Couple of notes:
- This isn't an official API
- beautiful soup is used to parse the site to obtain the meter ID which is need to call the API for usage
- Previous days usage isn't available exactly at 00:00:01 and in my experience it isn't available prior to 00:07:30 I assume this time is different for everyone/every day. The update is only pulled from the API approximately every 2 hours.
- The previous days usage is reported as 0 until Duke updates the information.
- The service doesn't return any useful information if the username/password are bad so a generic error will occur.


**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5644

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: duke_energy
    username: !secret duke_username
    password: !secret duke_password
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
