### PR TITLE
Warn when using custom components

### DIFF
--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -102,8 +102,11 @@ def get_component(hass, comp_or_platform) -> Optional[ModuleType]:
 
             if index == 0:
                 _LOGGER.warning(
-                    'You are using a custom component for %s. Stop using it if'
-                    ' you are experiencing issues.', comp_or_platform)
+                    'You are using a custom component for %s which has not '
+                    'been tested by Home Assistant. This component might '
+                    'cause stability problems, be sure to disable it if you '
+                    'do experience issues with Home Assistant.',
+                    comp_or_platform)
 
             return module
 

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -81,7 +81,7 @@ def get_component(hass, comp_or_platform) -> Optional[ModuleType]:
     potential_paths = ['custom_components.{}'.format(comp_or_platform),
                        'homeassistant.components.{}'.format(comp_or_platform)]
 
-    for path in potential_paths:
+    for index, path in enumerate(potential_paths):
         try:
             module = importlib.import_module(path)
 
@@ -99,6 +99,11 @@ def get_component(hass, comp_or_platform) -> Optional[ModuleType]:
             _LOGGER.info("Loaded %s from %s", comp_or_platform, path)
 
             cache[comp_or_platform] = module
+
+            if index == 0:
+                _LOGGER.warning(
+                    'You are using a custom component for %s. Stop using it if'
+                    ' you are experiencing issues.', comp_or_platform)
 
             return module
 

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -130,7 +130,7 @@ async def test_log_warning_custom_component(hass, caplog):
     """Test that we log a warning when loading a custom component."""
     loader.get_component(hass, 'test_standalone')
     assert \
-        'You are using a custom component for test_standalone.' in caplog.text
+        'You are using a custom component for test_standalone' in caplog.text
 
     loader.get_component(hass, 'light.test')
-    assert 'You are using a custom component for light.test.' in caplog.text
+    assert 'You are using a custom component for light.test' in caplog.text

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -124,3 +124,13 @@ async def test_custom_component_name(hass):
     # Test custom components is mounted
     from custom_components.test_package import TEST
     assert TEST == 5
+
+
+async def test_log_warning_custom_component(hass, caplog):
+    """Test that we log a warning when loading a custom component."""
+    loader.get_component(hass, 'test_standalone')
+    assert \
+        'You are using a custom component for test_standalone.' in caplog.text
+
+    loader.get_component(hass, 'light.test')
+    assert 'You are using a custom component for light.test.' in caplog.text


### PR DESCRIPTION
## Description:
Custom components are making the system unstable and people will blame that incorrectly on us. We have added it to the issue template but people don't read 😢 

This will print a warning in the logs when people are using custom components. 

**Related issue (if applicable):** #15153

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
