### PR TITLE
Update eternalegypt

### DIFF
--- a/homeassistant/components/netgear_lte.py
+++ b/homeassistant/components/netgear_lte.py
@@ -33,8 +33,8 @@ CONFIG_SCHEMA = vol.Schema({
 
 
 @attr.s
-class LTEData:
-    """Class for LTE state."""
+class ModemData:
+    """Class for modem state."""
 
     modem = attr.ib()
     unread_count = attr.ib(init=False)
@@ -49,18 +49,18 @@ class LTEData:
 
 
 @attr.s
-class LTEHostData:
-    """Container for LTE states."""
+class LTEData:
+    """Shared state."""
 
     websession = attr.ib()
-    hostdata = attr.ib(init=False, factory=dict)
+    modem_data = attr.ib(init=False, factory=dict)
 
-    def get(self, config):
-        """Get the requested or the only hostdata value."""
+    def get_modem_data(self, config):
+        """Get the requested or the only modem_data value."""
         if CONF_HOST in config:
-            return self.hostdata.get(config[CONF_HOST])
-        elif len(self.hostdata) == 1:
-            return next(iter(self.hostdata.values()))
+            return self.modem_data.get(config[CONF_HOST])
+        elif len(self.modem_data) == 1:
+            return next(iter(self.modem_data.values()))
 
         return None
 
@@ -70,7 +70,7 @@ async def async_setup(hass, config):
     if DATA_KEY not in hass.data:
         websession = async_create_clientsession(
             hass, cookie_jar=aiohttp.CookieJar(unsafe=True))
-        hass.data[DATA_KEY] = LTEHostData(websession)
+        hass.data[DATA_KEY] = LTEData(websession)
 
     tasks = [_setup_lte(hass, conf) for conf in config.get(DOMAIN, [])]
     if tasks:
@@ -91,9 +91,9 @@ async def _setup_lte(hass, lte_config):
     modem = eternalegypt.Modem(hostname=host, websession=websession)
     await modem.login(password=password)
 
-    lte_data = LTEData(modem)
-    await lte_data.async_update()
-    hass.data[DATA_KEY].hostdata[host] = lte_data
+    modem_data = ModemData(modem)
+    await modem_data.async_update()
+    hass.data[DATA_KEY].modem_data[host] = modem_data
 
     async def cleanup(event):
         """Clean up resources."""

--- a/homeassistant/components/notify/netgear_lte.py
+++ b/homeassistant/components/notify/netgear_lte.py
@@ -25,16 +25,16 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 async def async_get_service(hass, config, discovery_info=None):
     """Get the notification service."""
-    lte_data = hass.data[DATA_KEY].get(config)
+    modem_data = hass.data[DATA_KEY].get_modem_data(config)
     phone = config.get(ATTR_TARGET)
-    return NetgearNotifyService(lte_data, phone)
+    return NetgearNotifyService(modem_data, phone)
 
 
 @attr.s
 class NetgearNotifyService(BaseNotificationService):
     """Implementation of a notification service."""
 
-    lte_data = attr.ib()
+    modem_data = attr.ib()
     phone = attr.ib()
 
     async def async_send_message(self, message="", **kwargs):
@@ -42,4 +42,4 @@ class NetgearNotifyService(BaseNotificationService):
         targets = kwargs.get(ATTR_TARGET, self.phone)
         if targets and message:
             for target in targets:
-                await self.lte_data.modem.sms(target, message)
+                await self.modem_data.modem.sms(target, message)

--- a/homeassistant/components/notify/netgear_lte.py
+++ b/homeassistant/components/notify/netgear_lte.py
@@ -42,4 +42,4 @@ class NetgearNotifyService(BaseNotificationService):
         targets = kwargs.get(ATTR_TARGET, self.phone)
         if targets and message:
             for target in targets:
-                await self.lte_data.eternalegypt.sms(target, message)
+                await self.lte_data.modem.sms(target, message)

--- a/homeassistant/components/sensor/netgear_lte.py
+++ b/homeassistant/components/sensor/netgear_lte.py
@@ -29,14 +29,14 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 async def async_setup_platform(
         hass, config, async_add_devices, discovery_info):
     """Set up Netgear LTE sensor devices."""
-    lte_data = hass.data[DATA_KEY].get(config)
+    modem_data = hass.data[DATA_KEY].get_modem_data(config)
 
     sensors = []
     for sensortype in config[CONF_SENSORS]:
         if sensortype == SENSOR_SMS:
-            sensors.append(SMSSensor(lte_data))
+            sensors.append(SMSSensor(modem_data))
         elif sensortype == SENSOR_USAGE:
-            sensors.append(UsageSensor(lte_data))
+            sensors.append(UsageSensor(modem_data))
 
     async_add_devices(sensors, True)
 
@@ -45,11 +45,11 @@ async def async_setup_platform(
 class LTESensor(Entity):
     """Data usage sensor entity."""
 
-    lte_data = attr.ib()
+    modem_data = attr.ib()
 
     async def async_update(self):
         """Update state."""
-        await self.lte_data.async_update()
+        await self.modem_data.async_update()
 
 
 class SMSSensor(LTESensor):
@@ -63,7 +63,7 @@ class SMSSensor(LTESensor):
     @property
     def state(self):
         """Return the state of the sensor."""
-        return self.lte_data.unread_count
+        return self.modem_data.unread_count
 
 
 class UsageSensor(LTESensor):
@@ -82,4 +82,4 @@ class UsageSensor(LTESensor):
     @property
     def state(self):
         """Return the state of the sensor."""
-        return round(self.lte_data.usage / 1024**2, 1)
+        return round(self.modem_data.usage / 1024**2, 1)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -309,7 +309,7 @@ ephem==3.7.6.0
 epson-projector==0.1.3
 
 # homeassistant.components.netgear_lte
-eternalegypt==0.0.1
+eternalegypt==0.0.2
 
 # homeassistant.components.keyboard_remote
 # evdev==0.6.1


### PR DESCRIPTION
## Description:

This updates netgear_lte to use eternalegypt 0.0.2 where clients provide a websession and do the login/logout by hand. This keeps the session open and each operation no longer does an implicit login.

Also, the `LB2120` class is changed to the more generic `Modem` class that will hopefully handle other LTE modems in the future.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54