### PR TITLE
Only use the X-Forwarded-For header if connection is from a trusted network

### DIFF
--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -180,7 +180,7 @@ class HomeAssistantHTTP(object):
             middlewares=[staticresource_middleware])
 
         # This order matters
-        setup_real_ip(app, use_x_forwarded_for)
+        setup_real_ip(app, use_x_forwarded_for, trusted_networks)
 
         if is_ban_enabled:
             setup_bans(hass, app, login_threshold)

--- a/homeassistant/components/http/real_ip.py
+++ b/homeassistant/components/http/real_ip.py
@@ -11,18 +11,22 @@ from .const import KEY_REAL_IP
 
 
 @callback
-def setup_real_ip(app, use_x_forwarded_for):
+def setup_real_ip(app, use_x_forwarded_for, trusted_networks):
     """Create IP Ban middleware for the app."""
     @middleware
     async def real_ip_middleware(request, handler):
         """Real IP middleware."""
+        connected_ip = ip_address(
+            request.transport.get_extra_info('peername')[0])
+        request[KEY_REAL_IP] = connected_ip
+
+        # Only use the XFF header if enabled, present, and from a trusted proxy
         if (use_x_forwarded_for and
-                X_FORWARDED_FOR in request.headers):
+                X_FORWARDED_FOR in request.headers and
+                any(connected_ip in trusted_network
+                    for trusted_network in trusted_networks)):
             request[KEY_REAL_IP] = ip_address(
                 request.headers.get(X_FORWARDED_FOR).split(',')[0])
-        else:
-            request[KEY_REAL_IP] = \
-                ip_address(request.transport.get_extra_info('peername')[0])
 
         return await handler(request)
 

--- a/tests/components/http/test_auth.py
+++ b/tests/components/http/test_auth.py
@@ -41,7 +41,7 @@ def app():
     """Fixture to setup a web.Application."""
     app = web.Application()
     app.router.add_get('/', mock_handler)
-    setup_real_ip(app, False)
+    setup_real_ip(app, False, [])
     return app
 
 

--- a/tests/components/http/test_real_ip.py
+++ b/tests/components/http/test_real_ip.py
@@ -1,6 +1,7 @@
 """Test real IP middleware."""
 from aiohttp import web
 from aiohttp.hdrs import X_FORWARDED_FOR
+from ipaddress import ip_network
 
 from homeassistant.components.http.real_ip import setup_real_ip
 from homeassistant.components.http.const import KEY_REAL_IP
@@ -15,7 +16,7 @@ async def test_ignore_x_forwarded_for(aiohttp_client):
     """Test that we get the IP from the transport."""
     app = web.Application()
     app.router.add_get('/', mock_handler)
-    setup_real_ip(app, False)
+    setup_real_ip(app, False, [])
 
     mock_api_client = await aiohttp_client(app)
 
@@ -27,11 +28,27 @@ async def test_ignore_x_forwarded_for(aiohttp_client):
     assert text != '255.255.255.255'
 
 
-async def test_use_x_forwarded_for(aiohttp_client):
+async def test_use_x_forwarded_for_without_trusted_proxy(aiohttp_client):
     """Test that we get the IP from the transport."""
     app = web.Application()
     app.router.add_get('/', mock_handler)
-    setup_real_ip(app, True)
+    setup_real_ip(app, True, [])
+
+    mock_api_client = await aiohttp_client(app)
+
+    resp = await mock_api_client.get('/', headers={
+        X_FORWARDED_FOR: '255.255.255.255'
+    })
+    assert resp.status == 200
+    text = await resp.text()
+    assert text != '255.255.255.255'
+
+
+async def test_use_x_forwarded_for_with_trusted_proxy(aiohttp_client):
+    """Test that we get the IP from the transport."""
+    app = web.Application()
+    app.router.add_get('/', mock_handler)
+    setup_real_ip(app, True, [ip_network('127.0.0.1')])
 
     mock_api_client = await aiohttp_client(app)
 


### PR DESCRIPTION
## Description:

As noted in #14345, Home Assistant blindly trusts the `X-Forwarded-For` header without checking who sent it or if they should be trusted.  This allows anyone to spoof their IP address during authentication if `http.use_x_forwarded_for` is enabled which can lead to some major security problems:  https://github.com/home-assistant/home-assistant/issues/14345#issuecomment-400854569

This PR changes the behavior of `real_ip_middleware` to only use the `X-Forwarded-For` header if the incoming connection is from a trusted IP address (per the `trusted_networks` setting).

**Related issue (if applicable):** fixes #14345

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** https://github.com/home-assistant/home-assistant.github.io/pull/5618

## Example entry for `configuration.yaml` (if applicable):

Assuming that a reverse proxy is running on the same machine, here's how you'd configure Home Assistant to detect the true IP address of the end-user:

```yaml
http:
  api_password: YOUR_PASSWORD
  use_x_forwarded_for: True
  trusted_networks:
    - 127.0.0.1
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
