### PR TITLE
Storage auth

### DIFF
--- a/homeassistant/helpers/storage.py
+++ b/homeassistant/helpers/storage.py
@@ -53,6 +53,7 @@ class Store:
         self._unsub_delay_listener = None
         self._unsub_stop_listener = None
         self._write_lock = asyncio.Lock()
+        self._load_task = None
 
     @property
     def path(self):
@@ -64,7 +65,17 @@ class Store:
 
         If the expected version does not match the given version, the migrate
         function will be invoked with await migrate_func(version, config).
+
+        Will ensure that when a call comes in while another one is in progress,
+        the second call will wait and return the result of the first call.
         """
+        if self._load_task is None:
+            self._load_task = self.hass.async_add_job(self._async_load())
+
+        return await self._load_task
+
+    async def _async_load(self):
+        """Helper to load the data."""
         if self._data is not None:
             data = self._data
         else:
@@ -75,9 +86,13 @@ class Store:
                 return None
 
         if data['version'] == self.version:
-            return data['data']
+            stored = data['data']
+        else:
+            stored = await self._async_migrate_func(
+                data['version'], data['data'])
 
-        return await self._async_migrate_func(data['version'], data['data'])
+        self._load_task = None
+        return stored
 
     async def async_save(self, data: Dict, *, delay: Optional[int] = None):
         """Save data with an optional delay."""

--- a/homeassistant/helpers/storage.py
+++ b/homeassistant/helpers/storage.py
@@ -88,6 +88,8 @@ class Store:
         if data['version'] == self.version:
             stored = data['data']
         else:
+            _LOGGER.info('Migrating %s storage from %s to %s',
+                         self.key, data['version'], self.version)
             stored = await self._async_migrate_func(
                 data['version'], data['data'])
 

--- a/tests/auth_providers/test_insecure_example.py
+++ b/tests/auth_providers/test_insecure_example.py
@@ -11,15 +11,15 @@ from tests.common import mock_coro
 
 
 @pytest.fixture
-def store():
+def store(hass):
     """Mock store."""
-    return auth.AuthStore(Mock())
+    return auth.AuthStore(hass)
 
 
 @pytest.fixture
-def provider(store):
+def provider(hass, store):
     """Mock provider."""
-    return insecure_example.ExampleAuthProvider(None, store, {
+    return insecure_example.ExampleAuthProvider(hass, store, {
         'type': 'insecure_example',
         'users': [
             {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,8 @@ from homeassistant import util
 from homeassistant.util import location
 
 from tests.common import (
-    async_test_home_assistant, INSTANCES, async_mock_mqtt_component, mock_coro)
+    async_test_home_assistant, INSTANCES, async_mock_mqtt_component, mock_coro,
+    mock_storage as mock_storage)
 from tests.test_util.aiohttp import mock_aiohttp_client
 from tests.mock.zwave import MockNetwork, MockOption
 
@@ -59,7 +60,14 @@ def verify_cleanup():
 
 
 @pytest.fixture
-def hass(loop):
+def hass_storage():
+    """Fixture to mock storage."""
+    with mock_storage() as stored_data:
+        yield stored_data
+
+
+@pytest.fixture
+def hass(loop, hass_storage):
     """Fixture to provide a test instance of HASS."""
     hass = loop.run_until_complete(async_test_home_assistant(loop))
 

--- a/tests/helpers/test_storage.py
+++ b/tests/helpers/test_storage.py
@@ -18,31 +18,12 @@ MOCK_DATA = {'hello': 'world'}
 
 
 @pytest.fixture
-def mock_save():
-    """Fixture to mock JSON save."""
-    written = []
-    with patch('homeassistant.util.json.save_json',
-               side_effect=lambda *args: written.append(args)):
-        yield written
-
-
-@pytest.fixture
-def mock_load(mock_save):
-    """Fixture to mock JSON read."""
-    with patch('homeassistant.util.json.load_json',
-               side_effect=lambda *args: mock_save[-1][1]):
-        yield
-
-
-@pytest.fixture
 def store(hass):
     """Fixture of a store that prevents writing on HASS stop."""
-    store = storage.Store(hass, MOCK_VERSION, MOCK_KEY)
-    store._async_ensure_stop_listener = lambda: None
-    yield store
+    yield storage.Store(hass, MOCK_VERSION, MOCK_KEY)
 
 
-async def test_loading(hass, store, mock_save, mock_load):
+async def test_loading(hass, store):
     """Test we can save and load data."""
     await store.async_save(MOCK_DATA)
     data = await store.async_load()
@@ -56,73 +37,96 @@ async def test_loading_non_existing(hass, store):
     assert data is None
 
 
-async def test_loading_parallel(hass, store, mock_save):
+async def test_loading_parallel(hass, store, hass_storage, caplog):
     """Test we can save and load data."""
-    data = {
+    hass_storage[store.key] = {
         'version': MOCK_VERSION,
         'data': MOCK_DATA,
     }
 
-    with patch('homeassistant.util.json.load_json',
-               side_effect=[data, Exception]):
-        results = await asyncio.gather(
-            store.async_load(),
-            store.async_load()
-        )
+    results = await asyncio.gather(
+        store.async_load(),
+        store.async_load()
+    )
 
     assert results[0] is MOCK_DATA
     assert results[1] is MOCK_DATA
+    assert caplog.text.count('Loading data for {}'.format(store.key))
 
 
-async def test_saving_with_delay(hass, store, mock_save):
+async def test_saving_with_delay(hass, store, hass_storage):
     """Test saving data after a delay."""
     await store.async_save(MOCK_DATA, delay=1)
-    assert len(mock_save) == 0
+    assert store.key not in hass_storage
 
     async_fire_time_changed(hass, dt.utcnow() + timedelta(seconds=1))
     await hass.async_block_till_done()
-    assert len(mock_save) == 1
+    assert hass_storage[store.key] == {
+        'version': MOCK_VERSION,
+        'key': MOCK_KEY,
+        'data': MOCK_DATA,
+    }
 
 
-async def test_saving_on_stop(hass, mock_save):
+async def test_saving_on_stop(hass, hass_storage):
     """Test delayed saves trigger when we quit Home Assistant."""
     store = storage.Store(hass, MOCK_VERSION, MOCK_KEY)
     await store.async_save(MOCK_DATA, delay=1)
-    assert len(mock_save) == 0
+    assert store.key not in hass_storage
 
     hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
     await hass.async_block_till_done()
-    assert len(mock_save) == 1
+    assert hass_storage[store.key] == {
+        'version': MOCK_VERSION,
+        'key': MOCK_KEY,
+        'data': MOCK_DATA,
+    }
 
 
-async def test_loading_while_delay(hass, store, mock_save, mock_load):
+async def test_loading_while_delay(hass, store, hass_storage):
     """Test we load new data even if not written yet."""
     await store.async_save({'delay': 'no'})
-    assert len(mock_save) == 1
+    assert hass_storage[store.key] == {
+        'version': MOCK_VERSION,
+        'key': MOCK_KEY,
+        'data': {'delay': 'no'},
+    }
 
     await store.async_save({'delay': 'yes'}, delay=1)
-    assert len(mock_save) == 1
+    assert hass_storage[store.key] == {
+        'version': MOCK_VERSION,
+        'key': MOCK_KEY,
+        'data': {'delay': 'no'},
+    }
 
     data = await store.async_load()
     assert data == {'delay': 'yes'}
 
 
-async def test_writing_while_writing_delay(hass, store, mock_save, mock_load):
+async def test_writing_while_writing_delay(hass, store, hass_storage):
     """Test a write while a write with delay is active."""
     await store.async_save({'delay': 'yes'}, delay=1)
-    assert len(mock_save) == 0
+    assert store.key not in hass_storage
     await store.async_save({'delay': 'no'})
-    assert len(mock_save) == 1
+    assert hass_storage[store.key] == {
+        'version': MOCK_VERSION,
+        'key': MOCK_KEY,
+        'data': {'delay': 'no'},
+    }
 
     async_fire_time_changed(hass, dt.utcnow() + timedelta(seconds=1))
     await hass.async_block_till_done()
-    assert len(mock_save) == 1
+    assert hass_storage[store.key] == {
+        'version': MOCK_VERSION,
+        'key': MOCK_KEY,
+        'data': {'delay': 'no'},
+    }
 
     data = await store.async_load()
     assert data == {'delay': 'no'}
 
 
-async def test_migrator_no_existing_config(hass, store, mock_save):
+async def test_migrator_no_existing_config(hass, store, hass_storage):
     """Test migrator with no existing config."""
     with patch('os.path.isfile', return_value=False), \
         patch.object(store, 'async_load',
@@ -131,10 +135,10 @@ async def test_migrator_no_existing_config(hass, store, mock_save):
             hass, 'old-path', store)
 
     assert data == {'cur': 'config'}
-    assert len(mock_save) == 0
+    assert store.key not in hass_storage
 
 
-async def test_migrator_existing_config(hass, store, mock_save):
+async def test_migrator_existing_config(hass, store, hass_storage):
     """Test migrating existing config."""
     with patch('os.path.isfile', return_value=True), \
         patch('os.remove') as mock_remove, \
@@ -145,15 +149,14 @@ async def test_migrator_existing_config(hass, store, mock_save):
 
     assert len(mock_remove.mock_calls) == 1
     assert data == {'old': 'config'}
-    assert len(mock_save) == 1
-    assert mock_save[0][1] == {
+    assert hass_storage[store.key] == {
         'key': MOCK_KEY,
         'version': MOCK_VERSION,
         'data': data,
     }
 
 
-async def test_migrator_transforming_config(hass, store, mock_save):
+async def test_migrator_transforming_config(hass, store, hass_storage):
     """Test migrating config to new format."""
     async def old_conf_migrate_func(old_config):
         """Migrate old config to new format."""
@@ -169,8 +172,7 @@ async def test_migrator_transforming_config(hass, store, mock_save):
 
     assert len(mock_remove.mock_calls) == 1
     assert data == {'new': 'config'}
-    assert len(mock_save) == 1
-    assert mock_save[0][1] == {
+    assert hass_storage[store.key] == {
         'key': MOCK_KEY,
         'version': MOCK_VERSION,
         'data': data,

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -1,7 +1,7 @@
 """Test the config manager."""
 import asyncio
 from datetime import timedelta
-from unittest.mock import MagicMock, patch, mock_open
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -152,8 +152,7 @@ def test_domains_gets_uniques(manager):
     assert manager.async_domains() == ['test', 'test2', 'test3']
 
 
-@asyncio.coroutine
-def test_saving_and_loading(hass):
+async def test_saving_and_loading(hass):
     """Test that we're saving and loading correctly."""
     loader.set_component(
         hass, 'test',
@@ -172,7 +171,7 @@ def test_saving_and_loading(hass):
             )
 
     with patch.dict(config_entries.HANDLERS, {'test': TestFlow}):
-        yield from hass.config_entries.flow.async_init('test')
+        await hass.config_entries.flow.async_init('test')
 
     class Test2Flow(data_entry_flow.FlowHandler):
         VERSION = 3
@@ -186,27 +185,18 @@ def test_saving_and_loading(hass):
                 }
             )
 
-    json_path = 'homeassistant.util.json.open'
-
     with patch('homeassistant.config_entries.HANDLERS.get',
                return_value=Test2Flow):
-        yield from hass.config_entries.flow.async_init('test')
+        await hass.config_entries.flow.async_init('test')
 
-    with patch(json_path, mock_open(), create=True) as mock_write:
-        # To trigger the call_later
-        async_fire_time_changed(hass, dt.utcnow() + timedelta(seconds=1))
-        # To execute the save
-        yield from hass.async_block_till_done()
-
-    # Mock open calls are: open file, context enter, write, context leave
-    written = mock_write.mock_calls[2][1][0]
+    # To trigger the call_later
+    async_fire_time_changed(hass, dt.utcnow() + timedelta(seconds=1))
+    # To execute the save
+    await hass.async_block_till_done()
 
     # Now load written data in new config manager
     manager = config_entries.ConfigEntries(hass, {})
-
-    with patch('os.path.isfile', return_value=False), \
-            patch(json_path, mock_open(read_data=written), create=True):
-        yield from manager.async_load()
+    await manager.async_load()
 
     # Ensure same order
     for orig, loaded in zip(hass.config_entries.async_entries(),


### PR DESCRIPTION
## Description:
- Storage helper now supports parallel loading
- Add mock for storage helper to prevent any I/O during tests and allow easy access to written data in tests.
 - Store and restore auth data. This makes it possible to use authentication and have it still work after restarting Home Assistant.

### Note: do not use yet in production. [work in progress](https://github.com/home-assistant/home-assistant/issues?q=is%3Aopen+is%3Aissue+label%3Aauth)

## Example entry for `configuration.yaml` (if applicable):
```yaml
homeassistant:
  auth_providers:
    - type: homeassistant

auth:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
