### PR TITLE
X-Forwarded-For improvements and bug fixes

### DIFF
--- a/homeassistant/components/emulated_hue/__init__.py
+++ b/homeassistant/components/emulated_hue/__init__.py
@@ -95,6 +95,7 @@ def setup(hass, yaml_config):
         ssl_key=None,
         cors_origins=None,
         use_x_forwarded_for=False,
+        trusted_proxies=[],
         trusted_networks=[],
         login_threshold=0,
         is_ban_enabled=False

--- a/homeassistant/components/http/real_ip.py
+++ b/homeassistant/components/http/real_ip.py
@@ -21,12 +21,15 @@ def setup_real_ip(app, use_x_forwarded_for, trusted_proxies):
         request[KEY_REAL_IP] = connected_ip
 
         # Only use the XFF header if enabled, present, and from a trusted proxy
-        if (use_x_forwarded_for and
-                X_FORWARDED_FOR in request.headers and
-                any(connected_ip in trusted_proxy
-                    for trusted_proxy in trusted_proxies)):
-            request[KEY_REAL_IP] = ip_address(
-                request.headers.get(X_FORWARDED_FOR).split(', ')[-1])
+        try:
+            if (use_x_forwarded_for and
+                    X_FORWARDED_FOR in request.headers and
+                    any(connected_ip in trusted_proxy
+                        for trusted_proxy in trusted_proxies)):
+                request[KEY_REAL_IP] = ip_address(
+                    request.headers.get(X_FORWARDED_FOR).split(', ')[-1])
+        except ValueError:
+            pass
 
         return await handler(request)
 

--- a/homeassistant/components/http/real_ip.py
+++ b/homeassistant/components/http/real_ip.py
@@ -26,7 +26,7 @@ def setup_real_ip(app, use_x_forwarded_for, trusted_proxies):
                 any(connected_ip in trusted_proxy
                     for trusted_proxy in trusted_proxies)):
             request[KEY_REAL_IP] = ip_address(
-                request.headers.get(X_FORWARDED_FOR).split(',')[0])
+                request.headers.get(X_FORWARDED_FOR).split(', ')[-1])
 
         return await handler(request)
 

--- a/homeassistant/components/http/real_ip.py
+++ b/homeassistant/components/http/real_ip.py
@@ -11,7 +11,7 @@ from .const import KEY_REAL_IP
 
 
 @callback
-def setup_real_ip(app, use_x_forwarded_for, trusted_networks):
+def setup_real_ip(app, use_x_forwarded_for, trusted_proxies):
     """Create IP Ban middleware for the app."""
     @middleware
     async def real_ip_middleware(request, handler):
@@ -23,8 +23,8 @@ def setup_real_ip(app, use_x_forwarded_for, trusted_networks):
         # Only use the XFF header if enabled, present, and from a trusted proxy
         if (use_x_forwarded_for and
                 X_FORWARDED_FOR in request.headers and
-                any(connected_ip in trusted_network
-                    for trusted_network in trusted_networks)):
+                any(connected_ip in trusted_proxy
+                    for trusted_proxy in trusted_proxies)):
             request[KEY_REAL_IP] = ip_address(
                 request.headers.get(X_FORWARDED_FOR).split(',')[0])
 

--- a/tests/components/http/test_real_ip.py
+++ b/tests/components/http/test_real_ip.py
@@ -58,3 +58,35 @@ async def test_use_x_forwarded_for_with_trusted_proxy(aiohttp_client):
     assert resp.status == 200
     text = await resp.text()
     assert text == '255.255.255.255'
+
+
+async def test_use_x_forwarded_for_with_untrusted_proxy(aiohttp_client):
+    """Test that we get the IP from the transport."""
+    app = web.Application()
+    app.router.add_get('/', mock_handler)
+    setup_real_ip(app, True, [ip_network('1.1.1.1')])
+
+    mock_api_client = await aiohttp_client(app)
+
+    resp = await mock_api_client.get('/', headers={
+        X_FORWARDED_FOR: '255.255.255.255'
+    })
+    assert resp.status == 200
+    text = await resp.text()
+    assert text != '255.255.255.255'
+
+
+async def test_use_x_forwarded_for_with_spoofed_header(aiohttp_client):
+    """Test that we get the IP from the transport."""
+    app = web.Application()
+    app.router.add_get('/', mock_handler)
+    setup_real_ip(app, True, [ip_network('127.0.0.1')])
+
+    mock_api_client = await aiohttp_client(app)
+
+    resp = await mock_api_client.get('/', headers={
+        X_FORWARDED_FOR: '222.222.222.222, 255.255.255.255'
+    })
+    assert resp.status == 200
+    text = await resp.text()
+    assert text == '255.255.255.255'

--- a/tests/components/http/test_real_ip.py
+++ b/tests/components/http/test_real_ip.py
@@ -90,3 +90,19 @@ async def test_use_x_forwarded_for_with_spoofed_header(aiohttp_client):
     assert resp.status == 200
     text = await resp.text()
     assert text == '255.255.255.255'
+
+
+async def test_use_x_forwarded_for_with_nonsense_header(aiohttp_client):
+    """Test that we get the IP from the transport."""
+    app = web.Application()
+    app.router.add_get('/', mock_handler)
+    setup_real_ip(app, True, [ip_network('127.0.0.1')])
+
+    mock_api_client = await aiohttp_client(app)
+
+    resp = await mock_api_client.get('/', headers={
+        X_FORWARDED_FOR: 'This value is invalid'
+    })
+    assert resp.status == 200
+    text = await resp.text()
+    assert text == '127.0.0.1'

--- a/tests/scripts/test_check_config.py
+++ b/tests/scripts/test_check_config.py
@@ -160,6 +160,7 @@ class TestCheckConfig(unittest.TestCase):
                 'server_host': '0.0.0.0',
                 'server_port': 8123,
                 'trusted_networks': [],
+                'trusted_proxies': [],
                 'use_x_forwarded_for': False}
             assert res['secret_cache'] == {secrets_path: {'http_pw': 'abc123'}}
             assert res['secrets'] == {'http_pw': 'abc123'}


### PR DESCRIPTION
**Breaking change:** Anyone who has enabled `use_x_forwarded_for` will need to explicitly whitelist their proxy/proxies using the new `trusted_proxies` setting.

---

This PR builds upon #15182 by making four changes:

 - **Enhancement:**  Adds a new `trusted_proxies` setting exclusively for the `X-Forwarded-For` whitelist
 - **Bug fix:** Only trust the last IP in the `X-Forwarded-For` header
 - **Bug fix:** Ignore nonsense `X-Forwarded-For` header values instead of issuing HTTP 500 errors
 - Adds two additional tests to cover some cases mentioned in https://github.com/home-assistant/home-assistant/issues/14345#issuecomment-401324487

## Description:

### New `trusted_proxies` setting

PR #15182 fixed issues where `X-Forwarded-For` headers were blindly trusted by HA.  That PR used the `trusted_networks` setting (originally designed to bypass password authentication) to also determine whether the request was sent from a trusted proxy.

While this did resolve the security issue, it also introduced a potential downside:  If (for some reason) the HTTP requests **originates from the same IP as the proxy server**, then authentication will be bypassed.  (Note that this does not affect traffic originating from outside the proxy server, which is the typical use case.)

For example, let's say you're running HA on your local machine with this configuration:

```yaml
http:
  api_password: YOUR_PASSWORD
  use_x_forwarded_for: True
  trusted_networks:
    - 127.0.0.1
```

And let's say you've also got nginx running locally as your proxy.  Well, nginx is going to send an `X-Forwarded-For: 127.0.0.1` header, so that'll be your real IP, and that'll also match the `trusted_networks` used by the auth middleware.

Some users may need to set a wider range of trusted proxies without allowing proxied requests from those same IPs to bypass password authentication.  **This PR therefore adds a new `trusted_proxies` setting exclusively for the `X-Forwarded-For` whitelist to use.**

This change allows the user to trust a wide range of proxies (perhaps they're using a cloud proxy like Cloudflare with multiple IP ranges) while keeping the auth-bypass range extremely small.

See https://github.com/home-assistant/home-assistant/pull/15182#issuecomment-401080609 for further information.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** https://github.com/home-assistant/home-assistant.github.io/pull/5624

### Use last IP in header

The `X-Forwarded-For` header usually only contains a single IP.  However, it's possible that some reverse proxies may respect an existing header and append the IP they detect at the end.  [According to Wikipedia](https://en.wikipedia.org/wiki/X-Forwarded-For#Format):

> The last IP address is always the IP address that connects to the last proxy, which means it is the most reliable source of information

If multiple IPs are present, we should not trust any previous ones in the string since those come from potentially untrusted sources - only the last one is from our trusted proxy.  The second commit in this PR therefore ensures that we only look at this IP.

(It may be possible to add support for checking those intermediate proxies in the future.  However, because HA has previously only supported a single upstream proxy via the `use_x_forwarded_for` feature, we're doing the same here and via #15182 - just in a safer way.)

## Example entry for `configuration.yaml` (if applicable):

Let's pretend our home IP is `12.34.56.78` and we're using proxying through Cloudflare.  We don't want to be prompted for a password if we're connecting from home.

**Before:**
```yaml
http:
  api_password: YOUR_PASSWORD
  use_x_forwarded_for: True
  trusted_networks:
    # Pretend this is your home IP
    - 12.34.56.78
    # IPs from https://www.cloudflare.com/ips/
    - 103.21.244.0/22
    - 103.22.200.0/22
    - 103.31.4.0/22
    - 104.16.0.0/12
    - 108.162.192.0/18
    - 131.0.72.0/22
    - 141.101.64.0/18
    - 162.158.0.0/15
    - 172.64.0.0/13
    - 173.245.48.0/20
    - 188.114.96.0/20
    - 190.93.240.0/20
    - 197.234.240.0/22
    - 198.41.128.0/17
```

If a malicious attacker is able to issue HTTP requests from within Cloudflare's infrastucture (maybe they hacked a CF server), those requests would bypass password authentication.  Remember, this does NOT affect proxied traffic originating outside of Cloudflare.

**After:**
```yaml
http:
  api_password: YOUR_PASSWORD
  use_x_forwarded_for: True
  trusted_networks:
    # Pretend this is your home IP
    - 12.34.56.78
  trusted_proxies:
    # IPs from https://www.cloudflare.com/ips/
    - 103.21.244.0/22
    - 103.22.200.0/22
    - 103.31.4.0/22
    - 104.16.0.0/12
    - 108.162.192.0/18
    - 131.0.72.0/22
    - 141.101.64.0/18
    - 162.158.0.0/15
    - 172.64.0.0/13
    - 173.245.48.0/20
    - 188.114.96.0/20
    - 190.93.240.0/20
    - 197.234.240.0/22
    - 198.41.128.0/17
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Tests have been ~~added~~ modified to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
