### PR TITLE
Make sure we check access token expiration

### DIFF
--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -200,7 +200,7 @@ def add_manifest_json_key(key, val):
 
 async def async_setup(hass, config):
     """Set up the serving of the frontend."""
-    if list(hass.auth.async_auth_providers):
+    if hass.auth.active:
         client = await hass.auth.async_create_client(
             'Home Assistant Frontend',
             redirect_uris=['/'],

--- a/homeassistant/components/websocket_api.py
+++ b/homeassistant/components/websocket_api.py
@@ -324,8 +324,9 @@ class ActiveConnection:
                         request, msg['api_password'])
 
                 elif 'access_token' in msg:
-                    authenticated = \
-                        msg['access_token'] in self.hass.auth.access_tokens
+                    token = self.hass.auth.async_get_access_token(
+                        msg['access_token'])
+                    authenticated = token is not None
 
             if not authenticated:
                 self.debug("Invalid password")

--- a/tests/common.py
+++ b/tests/common.py
@@ -320,6 +320,7 @@ class MockUser(auth.User):
 
     def add_to_auth_manager(self, auth_mgr):
         """Test helper to add entry to hass."""
+        ensure_auth_manager_loaded(auth_mgr)
         auth_mgr._store.users[self.id] = self
         return self
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,14 +1,16 @@
 """Tests for the Home Assistant auth module."""
-from unittest.mock import Mock
+from datetime import timedelta
+from unittest.mock import Mock, patch
 
 import pytest
 
 from homeassistant import auth, data_entry_flow
+from homeassistant.util import dt as dt_util
 from tests.common import MockUser, ensure_auth_manager_loaded, flush_store
 
 
 @pytest.fixture
-def mock_hass():
+def mock_hass(loop):
     """Hass mock with minimum amount of data set to make it work with auth."""
     hass = Mock()
     hass.config.skip_pip = True
@@ -195,3 +197,47 @@ async def test_saving_loading(hass, hass_storage):
 
     assert len(store2.clients) == 1
     assert store2.clients[client.id] == client
+
+
+def test_access_token_expired():
+    """Test that the expired property on access tokens work."""
+    refresh_token = auth.RefreshToken(
+        user=None,
+        client_id='bla'
+    )
+
+    access_token = auth.AccessToken(
+        refresh_token=refresh_token
+    )
+
+    assert access_token.expired is False
+
+    with patch('homeassistant.auth.dt_util.utcnow',
+               return_value=dt_util.utcnow() + auth.ACCESS_TOKEN_EXPIRATION):
+        assert access_token.expired is True
+
+    almost_exp = dt_util.utcnow() + auth.ACCESS_TOKEN_EXPIRATION - timedelta(1)
+    with patch('homeassistant.auth.dt_util.utcnow', return_value=almost_exp):
+        assert access_token.expired is False
+
+
+async def test_cannot_retrieve_expired_access_token(hass):
+    """Test that we cannot retrieve expired access tokens."""
+    manager = await auth.auth_manager_from_config(hass, [])
+    user = MockUser(
+        id='mock-user',
+        is_owner=False,
+        is_active=False,
+        name='Paulus',
+    ).add_to_auth_manager(manager)
+    refresh_token = await manager.async_create_refresh_token(user, 'bla')
+    access_token = manager.async_create_access_token(refresh_token)
+
+    assert manager.async_get_access_token(access_token.token) is access_token
+
+    with patch('homeassistant.auth.dt_util.utcnow',
+               return_value=dt_util.utcnow() + auth.ACCESS_TOKEN_EXPIRATION):
+        assert manager.async_get_access_token(access_token.token) is None
+
+    # Even with unpatched time, it should have been removed from manager
+    assert manager.async_get_access_token(access_token.token) is None


### PR DESCRIPTION
## Description:
Test access token expiration.

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
