### PR TITLE
Only create front-end client_id once

### DIFF
--- a/homeassistant/auth.py
+++ b/homeassistant/auth.py
@@ -512,7 +512,7 @@ class AuthStore:
 
         redirect_uris_counter = Counter(redirect_uris)
 
-        for client_id, client in self.clients.items():
+        for _, client in self.clients.items():
             if (client.name == name
                     and Counter(client.redirect_uris) == redirect_uris_counter
                     and no_secret == (client.secret is None)):

--- a/homeassistant/auth.py
+++ b/homeassistant/auth.py
@@ -1,23 +1,22 @@
 """Provide an authentication layer for Home Assistant."""
 import asyncio
 import binascii
-from collections import OrderedDict, Counter
-from datetime import datetime, timedelta
-import os
 import importlib
 import logging
+import os
 import uuid
+from collections import OrderedDict
+from datetime import datetime, timedelta
 
 import attr
 import voluptuous as vol
 from voluptuous.humanize import humanize_error
 
 from homeassistant import data_entry_flow, requirements
-from homeassistant.core import callback
 from homeassistant.const import CONF_TYPE, CONF_NAME, CONF_ID
-from homeassistant.util.decorator import Registry
+from homeassistant.core import callback
 from homeassistant.util import dt as dt_util
-
+from homeassistant.util.decorator import Registry
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -510,12 +509,8 @@ class AuthStore:
         if self.clients is None:
             await self.async_load()
 
-        redirect_uris_counter = Counter(redirect_uris)
-
-        for _, client in self.clients.items():
-            if (client.name == name
-                    and Counter(client.redirect_uris) == redirect_uris_counter
-                    and no_secret == (client.secret is None)):
+        for client in self.clients.values():
+            if client.name == name:
                 return client
 
         return await self.async_create_client(name, redirect_uris, no_secret)

--- a/homeassistant/auth.py
+++ b/homeassistant/auth.py
@@ -516,7 +516,7 @@ class AuthStore:
         return client
 
     async def async_get_clients(self):
-        """Find a client, if not exists, create a new one."""
+        """Return all clients."""
         if self._clients is None:
             await self.async_load()
 

--- a/homeassistant/auth.py
+++ b/homeassistant/auth.py
@@ -462,6 +462,14 @@ class AuthStore:
 
     async def async_create_refresh_token(self, user, client_id):
         """Create a new token for a user."""
+        local_user = await self.async_get_user(user.id)
+        if local_user is None:
+            raise ValueError('Invalid user')
+
+        local_client = await self.async_get_client(client_id)
+        if local_client is None:
+            raise ValueError('Invalid client_id')
+
         refresh_token = RefreshToken(user, client_id)
         user.refresh_tokens[refresh_token.token] = refresh_token
         await self.async_save()

--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -201,7 +201,7 @@ def add_manifest_json_key(key, val):
 async def async_setup(hass, config):
     """Set up the serving of the frontend."""
     if hass.auth.active:
-        client = await hass.auth.async_create_client(
+        client = await hass.auth.async_get_or_create_client(
             'Home Assistant Frontend',
             redirect_uris=['/'],
             no_secret=True,

--- a/tests/common.py
+++ b/tests/common.py
@@ -321,7 +321,7 @@ class MockUser(auth.User):
     def add_to_auth_manager(self, auth_mgr):
         """Test helper to add entry to hass."""
         ensure_auth_manager_loaded(auth_mgr)
-        auth_mgr._store.users[self.id] = self
+        auth_mgr._store._users[self.id] = self
         return self
 
 
@@ -329,10 +329,10 @@ class MockUser(auth.User):
 def ensure_auth_manager_loaded(auth_mgr):
     """Ensure an auth manager is considered loaded."""
     store = auth_mgr._store
-    if store.clients is None:
-        store.clients = {}
-    if store.users is None:
-        store.users = {}
+    if store._clients is None:
+        store._clients = {}
+    if store._users is None:
+        store._users = {}
 
 
 class MockModule(object):

--- a/tests/components/auth/__init__.py
+++ b/tests/components/auth/__init__.py
@@ -34,7 +34,7 @@ async def async_setup_auth(hass, aiohttp_client, provider_configs=BASE_CONFIG,
     })
     client = auth.Client('Test Client', CLIENT_ID, CLIENT_SECRET,
                          redirect_uris=[CLIENT_REDIRECT_URI])
-    hass.auth._store.clients[client.id] = client
+    hass.auth._store._clients[client.id] = client
     if setup_api:
         await async_setup_component(hass, 'api', {})
     return await aiohttp_client(hass.http.app)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -191,12 +191,13 @@ async def test_saving_loading(hass, hass_storage):
     await flush_store(manager._store._store)
 
     store2 = auth.AuthStore(hass)
-    await store2.async_load()
-    assert len(store2.users) == 1
-    assert store2.users[user.id] == user
+    users = await store2.async_get_users()
+    assert len(users) == 1
+    assert users[0] == user
 
-    assert len(store2.clients) == 1
-    assert store2.clients[client.id] == client
+    clients = await store2.async_get_clients()
+    assert len(clients) == 1
+    assert clients[0] == client
 
 
 def test_access_token_expired():

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -241,3 +241,28 @@ async def test_cannot_retrieve_expired_access_token(hass):
 
     # Even with unpatched time, it should have been removed from manager
     assert manager.async_get_access_token(access_token.token) is None
+
+
+async def test_get_or_create_client(hass):
+    """Test that get_or_create_client works."""
+    manager = await auth.auth_manager_from_config(hass, [])
+
+    client1 = await manager.async_get_or_create_client(
+        'Test Client', redirect_uris=['https://test.com/1'])
+    assert client1.name is 'Test Client'
+
+    client2 = await manager.async_get_or_create_client(
+        'Test Client', redirect_uris=['https://test.com/1'])
+    assert client2.id is client1.id
+
+    client_no_secret = await manager.async_get_or_create_client(
+        'Test Client',
+        redirect_uris=['https://test.com/1', '/'],
+        no_secret=True)
+    assert client_no_secret.id is not client1.id
+
+    client_no_secret2 = await manager.async_get_or_create_client(
+        'Test Client',
+        redirect_uris=['/', 'https://test.com/1'],  # different order
+        no_secret=True)
+    assert client_no_secret2.id is client_no_secret.id

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -258,18 +258,6 @@ async def test_get_or_create_client(hass):
         'Test Client', redirect_uris=['https://test.com/1'])
     assert client2.id is client1.id
 
-    client_no_secret = await manager.async_get_or_create_client(
-        'Test Client',
-        redirect_uris=['https://test.com/1', '/'],
-        no_secret=True)
-    assert client_no_secret.id is not client1.id
-
-    client_no_secret2 = await manager.async_get_or_create_client(
-        'Test Client',
-        redirect_uris=['/', 'https://test.com/1'],  # different order
-        no_secret=True)
-    assert client_no_secret2.id is client_no_secret.id
-
 
 async def test_cannot_create_refresh_token_with_invalide_client_id(hass):
     """Test that we cannot create refresh token with invalid client id."""


### PR DESCRIPTION
## Description:
Only create front-end client_id once
Check user and client_id before create refresh token

**Related issue (if applicable):** fixes #15208 fixes #15201 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.
