### PR TITLE
Use cached states for neato when possible

### DIFF
--- a/homeassistant/components/switch/neato.py
+++ b/homeassistant/components/switch/neato.py
@@ -67,7 +67,7 @@ class NeatoConnectedSwitch(ToggleEntity):
         _LOGGER.debug('self._state=%s', self._state)
         if self.type == SWITCH_TYPE_SCHEDULE:
             _LOGGER.debug("State: %s", self._state)
-            if self.robot.schedule_enabled:
+            if self._state['details']['isScheduleEnabled']:
                 self._schedule_state = STATE_ON
             else:
                 self._schedule_state = STATE_OFF

--- a/homeassistant/components/vacuum/neato.py
+++ b/homeassistant/components/vacuum/neato.py
@@ -96,14 +96,14 @@ class NeatoConnectedVacuum(VacuumDevice):
         elif self._state['state'] == 4:
             self._status_state = ERRORS.get(self._state['error'])
 
-        if (self.robot.state['action'] == 1 or
-                self.robot.state['action'] == 2 or
-                self.robot.state['action'] == 3 and
-                self.robot.state['state'] == 2):
+        if (self._state['action'] == 1 or
+                self._state['action'] == 2 or
+                self._state['action'] == 3 and
+                self._state['state'] == 2):
             self._clean_state = STATE_ON
-        elif (self.robot.state['action'] == 11 or
-              self.robot.state['action'] == 12 and
-              self.robot.state['state'] == 2):
+        elif (self._state['action'] == 11 or
+              self._state['action'] == 12 and
+              self._state['state'] == 2):
             self._clean_state = STATE_ON
         else:
             self._clean_state = STATE_OFF


### PR DESCRIPTION
## Description:

The neato `vacuum` and `switch` components were not making correct use of cached states.  This PR makes sure to use the cached states when possible.  Thanks to @MartinHjelmare for pointing this out in #15161 !

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
neato:
  username: username
  password: password
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
