### PR TITLE
Enable two factor authentication

### DIFF
--- a/homeassistant/auth_providers/homeassistant.py
+++ b/homeassistant/auth_providers/homeassistant.py
@@ -3,18 +3,34 @@ import base64
 from collections import OrderedDict
 import hashlib
 import hmac
+import logging
+from datetime import timedelta
 
 import voluptuous as vol
 
+import homeassistant.helpers.config_validation as cv
 from homeassistant import auth, data_entry_flow
+from homeassistant.auth import generate_secret
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.util import dt as dt_util
 
+REQUIREMENTS = ['pyotp==2.2.6']
 
 STORAGE_VERSION = 1
 STORAGE_KEY = 'auth_provider.homeassistant'
 
+CONF_ENABLE_2FA = 'enable_2fa'
+
 CONFIG_SCHEMA = auth.AUTH_PROVIDER_SCHEMA.extend({
+    # NOTE this config enable 2FA for all users
+    # TODO support turn on/off 2FA per user basis
+    vol.Optional(CONF_ENABLE_2FA): cv.boolean,
 }, extra=vol.PREVENT_EXTRA)
+
+
+SESSION_TOKEN_EXPIRATION = timedelta(minutes=5)
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class InvalidAuth(HomeAssistantError):
@@ -28,14 +44,23 @@ class InvalidUser(HomeAssistantError):
     """
 
 
+class Request2FA(HomeAssistantError):
+    """Raised when we need user input Two Factor Authentication code."""
+
+    def __init__(self, session_token):
+        """Set session_token."""
+        self.session_token = session_token
+
+
 class Data:
     """Hold the user data."""
 
-    def __init__(self, hass):
+    def __init__(self, hass, enable_2fa=False):
         """Initialize the user data store."""
         self.hass = hass
         self._store = hass.helpers.storage.Store(STORAGE_VERSION, STORAGE_KEY)
         self._data = None
+        self._enable_2fa = enable_2fa
 
     async def async_load(self):
         """Load stored data."""
@@ -44,8 +69,15 @@ class Data:
         if data is None:
             data = {
                 'salt': auth.generate_secret(),
-                'users': []
+                'users': [],
+                'sessions': {}
             }
+
+        if 'users' not in data:
+            data['users'] = []
+
+        if 'sessions' not in data:
+            data['sessions'] = {}
 
         self._data = data
 
@@ -53,6 +85,46 @@ class Data:
     def users(self):
         """Return users."""
         return self._data['users']
+
+    @property
+    def _sessions(self):
+        """Return sessions."""
+        return self._data['sessions']
+
+    def open_session(self, user):
+        """Create a session for 2FA."""
+        # first clean up expired sessions
+        self.cleanup_session()
+
+        session_token = generate_secret(64)
+        expire_time = dt_util.utcnow() + SESSION_TOKEN_EXPIRATION
+        self._sessions[session_token] = (user, expire_time.isoformat())
+        return session_token
+
+    def close_session(self, session_token):
+        """Close a session for 2FA."""
+        user = None
+        session = self._sessions.get(session_token)
+        if session is not None:
+            user = session[0]
+            del self._sessions[session_token]
+        # clean up expired sessions
+        self.cleanup_session()
+        return user
+
+    def get_session(self, session_token):
+        """Find a session for 2FA."""
+        # first clean up expired sessions
+        self.cleanup_session()
+
+        return self._sessions.get(session_token)
+
+    def cleanup_session(self):
+        """Clean up expired sessions."""
+        for session_token in list(self._sessions.keys()):
+            _, expire_time = self._sessions[session_token]
+            if dt_util.utcnow() > dt_util.parse_datetime(expire_time):
+                del self._sessions[session_token]
 
     def validate_login(self, username, password):
         """Validate a username and password.
@@ -64,7 +136,7 @@ class Data:
         found = None
 
         # Compare all users to avoid timing attacks.
-        for user in self._data['users']:
+        for user in self.users:
             if username == user['username']:
                 found = user
 
@@ -77,6 +149,45 @@ class Data:
                                    base64.b64decode(found['password'])):
             raise InvalidAuth
 
+        if self._enable_2fa:
+            if found.get('ota_secret') is None:
+                _LOGGER.warning("Although two factor authentication is enabled"
+                                " user %s dose not setup accordingly. Ignore"
+                                " two factor authentication.",
+                                found['username'])
+                return
+            session_token = self.open_session(found['username'])
+            raise Request2FA(session_token)
+
+    def validate_2fa(self, session_token, code):
+        """Validate two factor authentication code.
+
+        Raises InvalidAuth if auth invalid.
+        """
+        import pyotp
+
+        found = self.get_session(session_token)
+
+        ota_secret = None
+        if found is not None:
+            username, expire_time = found
+            for user in self.users:
+                if username == user['username']:
+                    # double check expire_time
+                    if dt_util.utcnow() < dt_util.parse_datetime(expire_time):
+                        ota_secret = user['ota_secret']
+                    break
+
+        if ota_secret is None:
+            # even we cannot find user or session, we still do verify
+            # to make timing the same as if session was found.
+            pyotp.TOTP(pyotp.random_base32()).verify(code)
+            raise InvalidAuth
+
+        ota = pyotp.TOTP(ota_secret)
+        if not ota.verify(code):
+            raise InvalidAuth
+
     def hash_password(self, password, for_storage=False):
         """Encode a password."""
         hashed = hashlib.pbkdf2_hmac(
@@ -87,13 +198,19 @@ class Data:
 
     def add_user(self, username, password):
         """Add a user."""
+        import pyotp
+
         if any(user['username'] == username for user in self.users):
             raise InvalidUser
+
+        ota_secret = pyotp.random_base32() if self._enable_2fa else None
 
         self.users.append({
             'username': username,
             'password': self.hash_password(password, True),
+            'ota_secret': ota_secret
         })
+        return ota_secret
 
     def change_password(self, username, new_password):
         """Update the password of a user.
@@ -124,10 +241,13 @@ class HassAuthProvider(auth.AuthProvider):
 
     async def async_validate_login(self, username, password):
         """Helper to validate a username and password."""
-        data = Data(self.hass)
+        data = Data(self.hass, self.config.get(CONF_ENABLE_2FA))
         await data.async_load()
-        await self.hass.async_add_executor_job(
-            data.validate_login, username, password)
+        try:
+            await self.hass.async_add_executor_job(
+                data.validate_login, username, password)
+        finally:
+            await data.async_save()
 
     async def async_get_or_create_credentials(self, flow_result):
         """Get credentials based on the flow result."""
@@ -142,6 +262,20 @@ class HassAuthProvider(auth.AuthProvider):
             'username': username
         })
 
+    async def async_validate_2fa(self, session_token, code):
+        """Helper to validate a two factor authentication code."""
+        data = Data(self.hass, self.config.get(CONF_ENABLE_2FA))
+        await data.async_load()
+        try:
+            await self.hass.async_add_executor_job(
+                data.validate_2fa, session_token, code)
+            username = data.close_session(session_token)
+            if username is not None:
+                return username
+            raise InvalidAuth
+        finally:
+            await data.async_save()
+
 
 class LoginFlow(data_entry_flow.FlowHandler):
     """Handler for the login flow."""
@@ -149,27 +283,42 @@ class LoginFlow(data_entry_flow.FlowHandler):
     def __init__(self, auth_provider):
         """Initialize the login flow."""
         self._auth_provider = auth_provider
+        self._session_token = None
+        self._user_name = None
 
     async def async_step_init(self, user_input=None):
         """Handle the step of the form."""
         errors = {}
+        result = None
 
         if user_input is not None:
             try:
-                await self._auth_provider.async_validate_login(
-                    user_input['username'], user_input['password'])
+                if self._session_token and 'code' in user_input:
+                    username = await self._auth_provider.async_validate_2fa(
+                        self._session_token, user_input['code'])
+                    result = {'username': username}
+                else:
+                    await self._auth_provider.async_validate_login(
+                        user_input['username'], user_input['password'])
+                    result = {'username': user_input['username']}
             except InvalidAuth:
                 errors['base'] = 'invalid_auth'
+            except Request2FA as request2fa:
+                self._session_token = request2fa.session_token
+                errors['base'] = 'request_2fa'
 
-            if not errors:
+            if not errors and result:
                 return self.async_create_entry(
                     title=self._auth_provider.name,
-                    data=user_input
+                    data=result
                 )
 
         schema = OrderedDict()
-        schema['username'] = str
-        schema['password'] = str
+        if self._session_token:
+            schema['code'] = str
+        else:
+            schema['username'] = str
+            schema['password'] = str
 
         return self.async_show_form(
             step_id='init',

--- a/homeassistant/auth_providers/homeassistant.py
+++ b/homeassistant/auth_providers/homeassistant.py
@@ -23,7 +23,6 @@ CONF_ENABLE_2FA = 'enable_2fa'
 
 CONFIG_SCHEMA = auth.AUTH_PROVIDER_SCHEMA.extend({
     # NOTE this config enable 2FA for all users
-    # TODO support turn on/off 2FA per user basis
     vol.Optional(CONF_ENABLE_2FA): cv.boolean,
 }, extra=vol.PREVENT_EXTRA)
 
@@ -49,6 +48,7 @@ class Request2FA(HomeAssistantError):
 
     def __init__(self, session_token):
         """Set session_token."""
+        super().__init__()
         self.session_token = session_token
 
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -946,6 +946,7 @@ pynx584==0.4
 # homeassistant.components.iota
 pyota==2.0.5
 
+# homeassistant.auth_providers.homeassistant
 # homeassistant.components.sensor.otp
 pyotp==2.2.6
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -148,6 +148,10 @@ pymonoprice==0.3
 # homeassistant.components.binary_sensor.nx584
 pynx584==0.4
 
+# homeassistant.auth_providers.homeassistant
+# homeassistant.components.sensor.otp
+pyotp==2.2.6
+
 # homeassistant.components.qwikswitch
 pyqwikswitch==0.8
 

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -75,6 +75,7 @@ TEST_REQUIREMENTS = (
     'pylitejet',
     'pymonoprice',
     'pynx584',
+    'pyotp',
     'pyqwikswitch',
     'python-forecastio',
     'python-nest',
@@ -163,8 +164,10 @@ def gather_modules():
 
     errors = []
 
-    for package in sorted(explore_module('homeassistant.components', True) +
-                          explore_module('homeassistant.scripts', True)):
+    for package in sorted(
+            explore_module('homeassistant.components', True) +
+            explore_module('homeassistant.scripts', True) +
+            explore_module('homeassistant.auth_providers', True)):
         try:
             module = importlib.import_module(package)
         except ImportError:

--- a/tests/auth_providers/test_homeassistant.py
+++ b/tests/auth_providers/test_homeassistant.py
@@ -180,17 +180,17 @@ async def test_login_flow_validates_2fa(data_2fa, hass):
         'password': 'test-pass',
     })
     assert result['type'] == data_entry_flow.RESULT_TYPE_FORM
-    assert result['errors']['base'] == 'request_2fa'
+    assert result['step_id'] == '2fa'
 
     with patch('pyotp.TOTP.verify', return_value=False):
-        result = await flow.async_step_init({
+        result = await flow.async_step_2fa({
             'code': 'invalid-code',
         })
         assert result['type'] == data_entry_flow.RESULT_TYPE_FORM
         assert result['errors']['base'] == 'invalid_auth'
 
     with patch('pyotp.TOTP.verify', return_value=True):
-        result = await flow.async_step_init({
+        result = await flow.async_step_2fa({
             'code': MOCK_CODE,
         })
         assert result['type'] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY

--- a/tests/scripts/test_auth.py
+++ b/tests/scripts/test_auth.py
@@ -15,6 +15,14 @@ def data(hass):
     return data
 
 
+@pytest.fixture
+def data_2fa(hass):
+    """Create a loaded data class."""
+    data = hass_auth.Data(hass, True)
+    hass.loop.run_until_complete(data.async_load())
+    return data
+
+
 async def test_list_user(data, capsys):
     """Test we can list users."""
     data.add_user('test-user', 'test-pass')
@@ -47,6 +55,27 @@ async def test_add_user(data, capsys, hass_storage):
     data.validate_login('paulus', 'test-pass')
 
 
+async def test_add_user_2fa(data_2fa, capsys, hass_storage):
+    """Test we can add a user wiht 2fa enabled."""
+    await script_auth.add_user(
+        data_2fa, Mock(username='paulus', password='test-pass'))
+
+    assert len(hass_storage[hass_auth.STORAGE_KEY]['data']['users']) == 1
+
+    captured = capsys.readouterr()
+    assert captured.out.startswith('User created, please set up Google '
+                                   'Authenticator or any other compatible apps'
+                                   ' like Authy with key: ')
+
+    assert len(data_2fa.users) == 1
+    try:
+        data_2fa.validate_login('paulus', 'test-pass')
+        pytest.fail('Shall raise Request2FA')
+    except hass_auth.Request2FA as r:
+        with patch('pyotp.TOTP.verify', return_value=True):
+            data_2fa.validate_2fa(r.session_token, 'code')
+
+
 async def test_validate_login(data, capsys):
     """Test we can validate a user login."""
     data.add_user('test-user', 'test-pass')
@@ -65,6 +94,39 @@ async def test_validate_login(data, capsys):
         data, Mock(username='invalid-user', password='test-pass'))
     captured = capsys.readouterr()
     assert captured.out == 'Auth invalid\n'
+
+
+async def test_validate_login_2fa(data_2fa, capsys):
+    """Test we can validate a user login."""
+    data_2fa.add_user('test-user', 'test-pass')
+
+    with patch('pyotp.TOTP.verify', return_value=True):
+        await script_auth.validate_login(
+            data_2fa, Mock(username='test-user',
+                           password='test-pass', code='code'))
+        captured = capsys.readouterr()
+        assert captured.out == 'Auth valid\n'
+
+    with patch('pyotp.TOTP.verify', return_value=True):
+        await script_auth.validate_login(
+            data_2fa, Mock(username='test-user',
+                           password='invalid-pass', code='code'))
+        captured = capsys.readouterr()
+        assert captured.out == 'Auth invalid\n'
+
+    with patch('pyotp.TOTP.verify', return_value=True):
+        await script_auth.validate_login(
+            data_2fa, Mock(username='invalid-user',
+                           password='test-pass', code='code'))
+        captured = capsys.readouterr()
+        assert captured.out == 'Auth invalid\n'
+
+    with patch('pyotp.TOTP.verify', return_value=False):
+        await script_auth.validate_login(
+            data_2fa, Mock(username='test-user',
+                           password='test-pass', code='invalid-code'))
+        captured = capsys.readouterr()
+        assert captured.out == 'Auth invalid\n'
 
 
 async def test_change_password(data, capsys, hass_storage):


### PR DESCRIPTION
## Description:
Add two factor authentication support to built-in auth_provider

### Enable 2FA
Add `enable_2fa: true` to homeassistant auth_provider. This option will enable all users to use 2FA, however for existing user, no migration method provided yet. For those users, we will give warning message and ignore 2FA step.

### Changing to add user script
Right now, we still don't have UI to create user, the only way is using script documented at #14365. In case to enable 2FA, I make following change:

Add a optional argument `-t True` if you want to enable 2FA, so for create new user, you need
```shell
> hass --script auth -c your_config_dir -t True add your-user your-pass
User created, please set up Google Authenticator or any other compatible apps like Authy with key: SOMEKEY 
```

Script will generate a KEY for that user, you can use this KEY to create an entry in Google Authenticator
![image](https://user-images.githubusercontent.com/7366491/42122725-218e49a0-7bfb-11e8-8740-a3fd51f1dc3c.png)

Then you can test your Time-based OTP by
```shell
hass --script auth -c your_config_dir -t True validate your-user your-pass --code YOURCODE
```

This PR needs home-assistant/home-assistant-polymer#1372 to allow UI login work

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
# configuraiton.yaml
homeassistant:
  auth_providers:
    - type: homeassistant
      enable_2fa: true

auth:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
