### PR TITLE
Pass tox posargs to pylint

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ deps =
      -r{toxinidir}/requirements_test.txt
      -c{toxinidir}/homeassistant/package_constraints.txt
 commands =
-     pylint homeassistant
+     pylint {posargs} homeassistant
 
 [testenv:lint]
 basepython = {env:PYTHON3_PATH:python3}


### PR DESCRIPTION
## Description:

Being able to pass arguments to pylint is useful, for example `--jobs=N`, `-f parseable` etc.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**