### PR TITLE
deconz: fix light.turn_off with transition (2)

### DIFF
--- a/homeassistant/components/light/deconz.py
+++ b/homeassistant/components/light/deconz.py
@@ -174,6 +174,7 @@ class DeconzLight(Light):
         data = {'on': False}
 
         if ATTR_TRANSITION in kwargs:
+            data['bri'] = 0
             data['transitiontime'] = int(kwargs[ATTR_TRANSITION]) * 10
 
         if ATTR_FLASH in kwargs:


### PR DESCRIPTION
## Description:
Previous commit `d4f7dfa` successfully fixed the bug in which lights
would not turn off if a transition was specified, however if `bri` is not
present in the payload of the PUT request set to deCONZ, then any
`transitiontime` ends up being ignored. This commit addresses the
unintended side effect by reintroducing `bri`, resulting in the following
payload:
```
{ "on": false, "bri": 0, "transitiontime": ... }
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
