### PR TITLE
Add Waze config option for normal/average travel time

### DIFF
--- a/homeassistant/components/sensor/waze_travel_time.py
+++ b/homeassistant/components/sensor/waze_travel_time.py
@@ -31,8 +31,10 @@ CONF_DESTINATION = 'destination'
 CONF_ORIGIN = 'origin'
 CONF_INCL_FILTER = 'incl_filter'
 CONF_EXCL_FILTER = 'excl_filter'
+CONF_REALTIME = 'realtime'
 
 DEFAULT_NAME = 'Waze Travel Time'
+DEFAULT_REALTIME = True
 
 ICON = 'mdi:car'
 
@@ -47,6 +49,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_INCL_FILTER): cv.string,
     vol.Optional(CONF_EXCL_FILTER): cv.string,
+    vol.Optional(CONF_REALTIME, default=DEFAULT_REALTIME): cv.boolean,
 })
 
 TRACKABLE_DOMAINS = ['device_tracker', 'sensor', 'zone']
@@ -60,9 +63,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     region = config.get(CONF_REGION)
     incl_filter = config.get(CONF_INCL_FILTER)
     excl_filter = config.get(CONF_EXCL_FILTER)
+    realtime = config.get(CONF_REALTIME)
 
     sensor = WazeTravelTime(name, origin, destination, region,
-                            incl_filter, excl_filter)
+                            incl_filter, excl_filter, realtime)
 
     add_devices([sensor], True)
 
@@ -82,12 +86,13 @@ class WazeTravelTime(Entity):
     """Representation of a Waze travel time sensor."""
 
     def __init__(self, name, origin, destination, region,
-                 incl_filter, excl_filter):
+                 incl_filter, excl_filter, realtime):
         """Initialize the Waze travel time sensor."""
         self._name = name
         self._region = region
         self._incl_filter = incl_filter
         self._excl_filter = excl_filter
+        self._realtime = realtime
         self._state = None
         self._origin_entity_id = None
         self._destination_entity_id = None
@@ -201,7 +206,7 @@ class WazeTravelTime(Entity):
             try:
                 params = WazeRouteCalculator.WazeRouteCalculator(
                     self._origin, self._destination, self._region)
-                routes = params.calc_all_routes_info()
+                routes = params.calc_all_routes_info(real_time=self._realtime)
 
                 if self._incl_filter is not None:
                     routes = {k: v for k, v in routes.items() if


### PR DESCRIPTION
## Description:
By default, the Waze sensor returns the real-time current travel time for a route. With this PR, users can optionally request the "normal"/average travel time that Waze expects for the route at the current time of day - disregarding the current traffic situation but taking into account average traffic situation.

The key use case for this change is as follows:
- Setup two identical Waze sensors, one with default config one with realtime=false.
- Monitor for exceptional traffic by comparing realtime with normal travel times, e.g. if (current > 1,25 * Normal) alert the user that they should expect 25% longer travel than usual.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5634

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: waze_travel_time
    origin: Montréal, QC
    destination: Québec, QC
    region: 'US'
    realtime: false
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
