### PR TITLE
Make LIFX color/temperature attributes mutually exclusive

### DIFF
--- a/homeassistant/components/light/lifx.py
+++ b/homeassistant/components/light/lifx.py
@@ -446,7 +446,9 @@ class LIFXLight(Light):
     @property
     def color_temp(self):
         """Return the color temperature."""
-        kelvin = self.device.color[3]
+        _, sat, _, kelvin = self.device.color
+        if sat:
+            return None
         return color_util.color_temperature_kelvin_to_mired(kelvin)
 
     @property
@@ -601,7 +603,7 @@ class LIFXColor(LIFXLight):
         hue, sat, _, _ = self.device.color
         hue = hue / 65535 * 360
         sat = sat / 65535 * 100
-        return (hue, sat)
+        return (hue, sat) if sat else None
 
 
 class LIFXStrip(LIFXColor):


### PR DESCRIPTION
## Description:

Since a light cannot be white and colored at the same time, this PR changes LIFX to only report one of the `hs_color`/`color_temp` attributes. LIFX does not have separate color/white modes so we treat it as white when the color is fully desaturated.

**Breaking change:** LIFX will no longer report `hs_color`/`rgb_color` and `color_temp` simultaneously.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54