### PR TITLE
Add relay addr & chan config to alarmdecoder zones

### DIFF
--- a/homeassistant/components/alarmdecoder.py
+++ b/homeassistant/components/alarmdecoder.py
@@ -34,6 +34,8 @@ CONF_ZONE_NAME = 'name'
 CONF_ZONE_TYPE = 'type'
 CONF_ZONE_RFID = 'rfid'
 CONF_ZONES = 'zones'
+CONF_RELAY_ADDR = 'relayaddr'
+CONF_RELAY_CHAN = 'relaychan'
 
 DEFAULT_DEVICE_TYPE = 'socket'
 DEFAULT_DEVICE_HOST = 'localhost'
@@ -53,6 +55,7 @@ SIGNAL_PANEL_DISARM = 'alarmdecoder.panel_disarm'
 SIGNAL_ZONE_FAULT = 'alarmdecoder.zone_fault'
 SIGNAL_ZONE_RESTORE = 'alarmdecoder.zone_restore'
 SIGNAL_RFX_MESSAGE = 'alarmdecoder.rfx_message'
+SIGNAL_REL_MESSAGE = 'alarmdecoder.rel_message'
 
 DEVICE_SOCKET_SCHEMA = vol.Schema({
     vol.Required(CONF_DEVICE_TYPE): 'socket',
@@ -71,7 +74,9 @@ ZONE_SCHEMA = vol.Schema({
     vol.Required(CONF_ZONE_NAME): cv.string,
     vol.Optional(CONF_ZONE_TYPE,
                  default=DEFAULT_ZONE_TYPE): vol.Any(DEVICE_CLASSES_SCHEMA),
-    vol.Optional(CONF_ZONE_RFID): cv.string})
+    vol.Optional(CONF_ZONE_RFID): cv.string,
+    vol.Optional(CONF_RELAY_ADDR): cv.byte,
+    vol.Optional(CONF_RELAY_CHAN): cv.byte})
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
@@ -153,6 +158,11 @@ def setup(hass, config):
         hass.helpers.dispatcher.dispatcher_send(
             SIGNAL_ZONE_RESTORE, zone)
 
+    def handle_rel_message(sender, message):
+        """Handle Relay message from AlarmDecoder."""
+        hass.helpers.dispatcher.dispatcher_send(
+            SIGNAL_REL_MESSAGE, message)
+
     controller = False
     if device_type == 'socket':
         host = device.get(CONF_DEVICE_HOST)
@@ -171,6 +181,7 @@ def setup(hass, config):
     controller.on_zone_fault += zone_fault_callback
     controller.on_zone_restore += zone_restore_callback
     controller.on_close += handle_closed_connection
+    controller.on_relay_changed += handle_rel_message
 
     hass.data[DATA_AD] = controller
 

--- a/homeassistant/components/alarmdecoder.py
+++ b/homeassistant/components/alarmdecoder.py
@@ -75,8 +75,10 @@ ZONE_SCHEMA = vol.Schema({
     vol.Optional(CONF_ZONE_TYPE,
                  default=DEFAULT_ZONE_TYPE): vol.Any(DEVICE_CLASSES_SCHEMA),
     vol.Optional(CONF_ZONE_RFID): cv.string,
-    vol.Optional(CONF_RELAY_ADDR): cv.byte,
-    vol.Optional(CONF_RELAY_CHAN): cv.byte})
+    vol.Inclusive(CONF_RELAY_ADDR, 'relaylocation',
+                  'Relay address and channel must exist together'): cv.byte,
+    vol.Inclusive(CONF_RELAY_CHAN, 'relaylocation',
+                  'Relay address and channel must exist together'): cv.byte})
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({

--- a/homeassistant/components/alarmdecoder.py
+++ b/homeassistant/components/alarmdecoder.py
@@ -159,7 +159,7 @@ def setup(hass, config):
             SIGNAL_ZONE_RESTORE, zone)
 
     def handle_rel_message(sender, message):
-        """Handle Relay message from AlarmDecoder."""
+        """Handle relay message from AlarmDecoder."""
         hass.helpers.dispatcher.dispatcher_send(
             SIGNAL_REL_MESSAGE, message)
 

--- a/homeassistant/components/binary_sensor/alarmdecoder.py
+++ b/homeassistant/components/binary_sensor/alarmdecoder.py
@@ -11,7 +11,8 @@ from homeassistant.components.binary_sensor import BinarySensorDevice
 from homeassistant.components.alarmdecoder import (
     ZONE_SCHEMA, CONF_ZONES, CONF_ZONE_NAME, CONF_ZONE_TYPE,
     CONF_ZONE_RFID, SIGNAL_ZONE_FAULT, SIGNAL_ZONE_RESTORE,
-    SIGNAL_RFX_MESSAGE)
+    SIGNAL_RFX_MESSAGE, SIGNAL_REL_MESSAGE, CONF_RELAY_ADDR,
+    CONF_RELAY_CHAN)
 
 DEPENDENCIES = ['alarmdecoder']
 
@@ -37,8 +38,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         zone_type = device_config_data[CONF_ZONE_TYPE]
         zone_name = device_config_data[CONF_ZONE_NAME]
         zone_rfid = device_config_data.get(CONF_ZONE_RFID)
+        relay_addr = device_config_data.get(CONF_RELAY_ADDR)
+        relay_chan = device_config_data.get(CONF_RELAY_CHAN)
         device = AlarmDecoderBinarySensor(
-            zone_num, zone_name, zone_type, zone_rfid)
+            zone_num, zone_name, zone_type, zone_rfid, relay_addr, relay_chan)
         devices.append(device)
 
     add_devices(devices)
@@ -49,7 +52,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class AlarmDecoderBinarySensor(BinarySensorDevice):
     """Representation of an AlarmDecoder binary sensor."""
 
-    def __init__(self, zone_number, zone_name, zone_type, zone_rfid):
+    def __init__(self, zone_number, zone_name, zone_type, zone_rfid, relay_addr, relay_chan):
         """Initialize the binary_sensor."""
         self._zone_number = zone_number
         self._zone_type = zone_type
@@ -57,6 +60,8 @@ class AlarmDecoderBinarySensor(BinarySensorDevice):
         self._name = zone_name
         self._rfid = zone_rfid
         self._rfstate = None
+        self._relay_addr = relay_addr
+        self._relay_chan = relay_chan
 
     @asyncio.coroutine
     def async_added_to_hass(self):
@@ -69,6 +74,9 @@ class AlarmDecoderBinarySensor(BinarySensorDevice):
 
         self.hass.helpers.dispatcher.async_dispatcher_connect(
             SIGNAL_RFX_MESSAGE, self._rfx_message_callback)
+
+        self.hass.helpers.dispatcher.async_dispatcher_connect(
+            SIGNAL_REL_MESSAGE, self._rel_message_callback)
 
     @property
     def name(self):
@@ -121,4 +129,10 @@ class AlarmDecoderBinarySensor(BinarySensorDevice):
         """Update RF state."""
         if self._rfid and message and message.serial_number == self._rfid:
             self._rfstate = message.value
+            self.schedule_update_ha_state()
+
+    def _rel_message_callback(self, message):
+        """Update Relay state."""
+        if self._relay_addr == message.address and self._relay_chan == message.channel:
+            self._state = message.value
             self.schedule_update_ha_state()

--- a/homeassistant/components/binary_sensor/alarmdecoder.py
+++ b/homeassistant/components/binary_sensor/alarmdecoder.py
@@ -135,6 +135,6 @@ class AlarmDecoderBinarySensor(BinarySensorDevice):
     def _rel_message_callback(self, message):
         """Update Relay state."""
         if (self._relay_addr == message.address and
-            self._relay_chan == message.channel):
+                self._relay_chan == message.channel):
             self._state = message.value
             self.schedule_update_ha_state()

--- a/homeassistant/components/binary_sensor/alarmdecoder.py
+++ b/homeassistant/components/binary_sensor/alarmdecoder.py
@@ -52,7 +52,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class AlarmDecoderBinarySensor(BinarySensorDevice):
     """Representation of an AlarmDecoder binary sensor."""
 
-    def __init__(self, zone_number, zone_name, zone_type, zone_rfid, relay_addr, relay_chan):
+    def __init__(self, zone_number, zone_name, zone_type, zone_rfid,
+                 relay_addr, relay_chan):
         """Initialize the binary_sensor."""
         self._zone_number = zone_number
         self._zone_type = zone_type
@@ -133,6 +134,7 @@ class AlarmDecoderBinarySensor(BinarySensorDevice):
 
     def _rel_message_callback(self, message):
         """Update Relay state."""
-        if self._relay_addr == message.address and self._relay_chan == message.channel:
+        if (self._relay_addr == message.address and
+            self._relay_chan == message.channel):
             self._state = message.value
             self.schedule_update_ha_state()

--- a/homeassistant/components/binary_sensor/alarmdecoder.py
+++ b/homeassistant/components/binary_sensor/alarmdecoder.py
@@ -136,8 +136,7 @@ class AlarmDecoderBinarySensor(BinarySensorDevice):
         """Update relay state."""
         if (self._relay_addr == message.address and
                 self._relay_chan == message.channel):
-            _LOGGER.debug("Relay " + str(message.address) + "-" +
-                          str(message.channel) + " value:" +
-                          str(message.value))
+            _LOGGER.debug("Relay %d:%d value:%d", message.address,
+                          message.channel, message.value)
             self._state = message.value
             self.schedule_update_ha_state()

--- a/homeassistant/components/binary_sensor/alarmdecoder.py
+++ b/homeassistant/components/binary_sensor/alarmdecoder.py
@@ -133,7 +133,7 @@ class AlarmDecoderBinarySensor(BinarySensorDevice):
             self.schedule_update_ha_state()
 
     def _rel_message_callback(self, message):
-        """Update Relay state."""
+        """Update relay state."""
         if (self._relay_addr == message.address and
                 self._relay_chan == message.channel):
             self._state = message.value

--- a/homeassistant/components/binary_sensor/alarmdecoder.py
+++ b/homeassistant/components/binary_sensor/alarmdecoder.py
@@ -136,5 +136,8 @@ class AlarmDecoderBinarySensor(BinarySensorDevice):
         """Update relay state."""
         if (self._relay_addr == message.address and
                 self._relay_chan == message.channel):
+            _LOGGER.debug("Relay " + str(message.address) + "-" +
+                          str(message.channel) + " value:" +
+                          str(message.value))
             self._state = message.value
             self.schedule_update_ha_state()


### PR DESCRIPTION
## Description:

Some panels do not send bypassed zones such as motion while armed home.  Alarmdecoder can emulate a zone expander and the panel can be programmed to push zone events to this expander.  This allows the bypassed zone binary sensors to be utilized.  One example is using bypassed motion sensors at night for motion based automated lights while the system is armed with the motion sensor bypassed.

## Example entry for `configuration.yaml` (if applicable):
```yaml
  zones:
    01:
      name: 'Main Door'
      type: 'door'
      relayaddr: 12
      relaychan: 1
    02:
      name: 'Main Motion'
      type: 'motion'
      relayaddr: 12
      relaychan: 2
    03:
      name: 'Main Glass'
      type: 'vibration'
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)
Docs: https://github.com/home-assistant/home-assistant.github.io/pull/5645