### PR TITLE
Lint cleanups

### DIFF
--- a/homeassistant/components/google_assistant/http.py
+++ b/homeassistant/components/google_assistant/http.py
@@ -10,10 +10,8 @@ from aiohttp.hdrs import AUTHORIZATION
 from aiohttp.web import Request, Response
 
 # Typing imports
-# pylint: disable=unused-import
 from homeassistant.components.http import HomeAssistantView
-from homeassistant.core import HomeAssistant, callback  # NOQA
-from homeassistant.helpers.entity import Entity  # NOQA
+from homeassistant.core import callback
 
 from .const import (
     GOOGLE_ASSISTANT_API_ENDPOINT,

--- a/homeassistant/components/google_assistant/smart_home.py
+++ b/homeassistant/components/google_assistant/smart_home.py
@@ -3,14 +3,6 @@ import collections
 from itertools import product
 import logging
 
-# Typing imports
-# pylint: disable=unused-import
-# if False:
-from aiohttp.web import Request, Response  # NOQA
-from typing import Dict, Tuple, Any, Optional  # NOQA
-from homeassistant.helpers.entity import Entity  # NOQA
-from homeassistant.core import HomeAssistant  # NOQA
-from homeassistant.util.unit_system import UnitSystem  # NOQA
 from homeassistant.util.decorator import Registry
 
 from homeassistant.core import callback

--- a/homeassistant/components/sensor/tibber.py
+++ b/homeassistant/components/sensor/tibber.py
@@ -123,7 +123,7 @@ class TibberSensor(Entity):
     async def _fetch_data(self):
         try:
             await self._tibber_home.update_info()
-            await  self._tibber_home.update_price_info()
+            await self._tibber_home.update_price_info()
         except (asyncio.TimeoutError, aiohttp.ClientError):
             return
         data = self._tibber_home.info['viewer']['home']

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -7,7 +7,7 @@ import os
 import re
 import shutil
 # pylint: disable=unused-import
-from typing import Any, List, Tuple, Optional  # NOQA
+from typing import Any, Tuple, Optional  # noqa: F401
 
 import voluptuous as vol
 from voluptuous.humanize import humanize_error

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -1,7 +1,5 @@
 """Service calling related helpers."""
 import logging
-# pylint: disable=unused-import
-from typing import Optional  # NOQA
 from os import path
 
 import voluptuous as vol

--- a/homeassistant/helpers/translation.py
+++ b/homeassistant/helpers/translation.py
@@ -1,7 +1,5 @@
 """Translation string lookup helpers."""
 import logging
-# pylint: disable=unused-import
-from typing import Optional  # NOQA
 from os import path
 
 from homeassistant import config_entries

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -16,16 +16,10 @@ import logging
 import sys
 from types import ModuleType
 
-# pylint: disable=unused-import
-from typing import Dict, List, Optional, Sequence, Set  # NOQA
+from typing import Optional, Set
 
 from homeassistant.const import PLATFORM_FORMAT
 from homeassistant.util import OrderedSet
-
-# Typing imports
-# pylint: disable=using-constant-test,unused-import
-if False:
-    from homeassistant.core import HomeAssistant  # NOQA
 
 PREPARED = False
 


### PR DESCRIPTION
## Description:

Remove some unused/unneeded typing related imports and associated linter settings.

The E271 in tibber.py occurs for me only when linting on Python 3.7.0, but the fix is obviously trivial and correct everywhere.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
