### PR TITLE
Fix python-miio 0.4 compatibility of the xiaomi miio device tracker

### DIFF
--- a/homeassistant/components/device_tracker/xiaomi_miio.py
+++ b/homeassistant/components/device_tracker/xiaomi_miio.py
@@ -64,7 +64,7 @@ class XiaomiMiioDeviceScanner(DeviceScanner):
             station_info = await self.hass.async_add_job(self.device.status)
             _LOGGER.debug("Got new station info: %s", station_info)
 
-            for device in station_info['mat']:
+            for device in station_info.associated_stations:
                 devices.append(device['mac'])
 
         except DeviceException as ex:


### PR DESCRIPTION


## Description:

station_info['mat'] -> station_info.associated_stations

**Related issue (if applicable):**

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
