### PR TITLE
Allow extra values in the slot schema of intent handlers

### DIFF
--- a/homeassistant/helpers/intent.py
+++ b/homeassistant/helpers/intent.py
@@ -137,7 +137,8 @@ class IntentHandler:
         if self._slot_schema is None:
             self._slot_schema = vol.Schema({
                 key: SLOT_SCHEMA.extend({'value': validator})
-                for key, validator in self.slot_schema.items()})
+                for key, validator in self.slot_schema.items()},
+                                           extra=vol.ALLOW_EXTRA)
 
         return self._slot_schema(slots)
 

--- a/tests/helpers/test_intent.py
+++ b/tests/helpers/test_intent.py
@@ -1,6 +1,18 @@
 """Tests for the intent helpers."""
+
+import unittest
+import voluptuous as vol
+
 from homeassistant.core import State
-from homeassistant.helpers import intent
+from homeassistant.helpers import (intent, config_validation as cv)
+
+
+class MockIntentHandler(intent.IntentHandler):
+    """Provide a mock intent handler."""
+
+    def __init__(self, slot_schema):
+        """Initialize the mock handler."""
+        self.slot_schema = slot_schema
 
 
 def test_async_match_state():
@@ -10,3 +22,25 @@ def test_async_match_state():
 
     state = intent.async_match_state(None, 'kitch', [state1, state2])
     assert state is state1
+
+
+class TestIntentHandler(unittest.TestCase):
+    """Test the Home Assistant event helpers."""
+
+    def test_async_validate_slots(self):
+        """Test async_validate_slots of IntentHandler."""
+        handler1 = MockIntentHandler({
+            vol.Required('name'): cv.string,
+            })
+
+        self.assertRaises(vol.error.MultipleInvalid,
+                          handler1.async_validate_slots, {})
+        self.assertRaises(vol.error.MultipleInvalid,
+                          handler1.async_validate_slots, {'name': 1})
+        self.assertRaises(vol.error.MultipleInvalid,
+                          handler1.async_validate_slots, {'name': 'kitchen'})
+        handler1.async_validate_slots({'name': {'value': 'kitchen'}})
+        handler1.async_validate_slots({
+            'name': {'value': 'kitchen'},
+            'probability': {'value': '0.5'}
+            })


### PR DESCRIPTION
## Description:
PR #14315 introduced additional slot values for the siteId and probability in the snips component. Unfortunately this caused the schema validation in the IntentHandler to fail for ServiceIntentHandlers used for example by HassTurnOn.
The problem was also reported in issue #14918

As a solution I propose to allow arbitrary extra keys when validating the schema.

**Related issue (if applicable):** fixes #14918 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54