### PR TITLE
Add device_tracker.bluetooth_update service

### DIFF
--- a/homeassistant/components/device_tracker/bluetooth_tracker.py
+++ b/homeassistant/components/device_tracker/bluetooth_tracker.py
@@ -12,7 +12,8 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import track_point_in_utc_time
 from homeassistant.components.device_tracker import (
     YAML_DEVICES, CONF_TRACK_NEW, CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL,
-    load_config, PLATFORM_SCHEMA, DEFAULT_TRACK_NEW, SOURCE_TYPE_BLUETOOTH)
+    load_config, PLATFORM_SCHEMA, DEFAULT_TRACK_NEW, SOURCE_TYPE_BLUETOOTH,
+    DOMAIN)
 import homeassistant.util.dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
@@ -79,7 +80,7 @@ def setup_scanner(hass, config, see, discovery_info=None):
 
     request_rssi = config.get(CONF_REQUEST_RSSI, False)
 
-    def update_bluetooth(now):
+    def update_bluetooth(now, once = False):
         """Lookup Bluetooth device and update status."""
         try:
             if track_new:
@@ -99,9 +100,17 @@ def setup_scanner(hass, config, see, discovery_info=None):
                 see_device(mac, result, rssi)
         except bluetooth.BluetoothError:
             _LOGGER.exception("Error looking up Bluetooth device")
-        track_point_in_utc_time(
-            hass, update_bluetooth, dt_util.utcnow() + interval)
+        if not once:
+            track_point_in_utc_time(
+                hass, update_bluetooth, dt_util.utcnow() + interval)
+
+    def handle_update_bluetooth(call):
+        """Update bluetooth devices on demand."""
+        now = dt_util.utcnow()
+        update_bluetooth(now, True)
 
     update_bluetooth(dt_util.utcnow())
+    
+    hass.services.register(DOMAIN, "bluetooth_update", handle_update_bluetooth)
 
     return True

--- a/homeassistant/components/device_tracker/bluetooth_tracker.py
+++ b/homeassistant/components/device_tracker/bluetooth_tracker.py
@@ -80,7 +80,7 @@ def setup_scanner(hass, config, see, discovery_info=None):
 
     request_rssi = config.get(CONF_REQUEST_RSSI, False)
 
-    def update_bluetooth(now, once = False):
+    def update_bluetooth(now, once=False):
         """Lookup Bluetooth device and update status."""
         try:
             if track_new:
@@ -110,7 +110,7 @@ def setup_scanner(hass, config, see, discovery_info=None):
         update_bluetooth(now, True)
 
     update_bluetooth(dt_util.utcnow())
-    
+
     hass.services.register(DOMAIN, "bluetooth_update", handle_update_bluetooth)
 
     return True

--- a/homeassistant/components/device_tracker/bluetooth_tracker.py
+++ b/homeassistant/components/device_tracker/bluetooth_tracker.py
@@ -114,6 +114,6 @@ def setup_scanner(hass, config, see, discovery_info=None):
 
     update_bluetooth(dt_util.utcnow())
 
-    hass.services.register(DOMAIN, "bluetooth_update", handle_update_bluetooth)
+    hass.services.register(DOMAIN, "bluetooth_tracker_update", handle_update_bluetooth)
 
     return True

--- a/homeassistant/components/device_tracker/bluetooth_tracker.py
+++ b/homeassistant/components/device_tracker/bluetooth_tracker.py
@@ -81,7 +81,7 @@ def setup_scanner(hass, config, see, discovery_info=None):
     request_rssi = config.get(CONF_REQUEST_RSSI, False)
 
     def update_bluetooth(now):
-        """Update Bluetooth and set timer for the next update"""
+        """Update Bluetooth and set timer for the next update."""
         update_bluetooth_once()
         track_point_in_utc_time(
             hass, update_bluetooth, dt_util.utcnow() + interval)

--- a/homeassistant/components/device_tracker/bluetooth_tracker.py
+++ b/homeassistant/components/device_tracker/bluetooth_tracker.py
@@ -114,6 +114,7 @@ def setup_scanner(hass, config, see, discovery_info=None):
 
     update_bluetooth(dt_util.utcnow())
 
-    hass.services.register(DOMAIN, "bluetooth_tracker_update", handle_update_bluetooth)
+    hass.services.register(
+        DOMAIN, "bluetooth_tracker_update", handle_update_bluetooth)
 
     return True

--- a/homeassistant/components/device_tracker/bluetooth_tracker.py
+++ b/homeassistant/components/device_tracker/bluetooth_tracker.py
@@ -80,7 +80,13 @@ def setup_scanner(hass, config, see, discovery_info=None):
 
     request_rssi = config.get(CONF_REQUEST_RSSI, False)
 
-    def update_bluetooth(now, once=False):
+    def update_bluetooth(now):
+        """Update Bluetooth and set timer for the next update"""
+        update_bluetooth_once()
+        track_point_in_utc_time(
+            hass, update_bluetooth, dt_util.utcnow() + interval)
+
+    def update_bluetooth_once():
         """Lookup Bluetooth device and update status."""
         try:
             if track_new:
@@ -100,9 +106,6 @@ def setup_scanner(hass, config, see, discovery_info=None):
                 see_device(mac, result, rssi)
         except bluetooth.BluetoothError:
             _LOGGER.exception("Error looking up Bluetooth device")
-        if not once:
-            track_point_in_utc_time(
-                hass, update_bluetooth, dt_util.utcnow() + interval)
 
     def handle_update_bluetooth(call):
         """Update bluetooth devices on demand."""

--- a/homeassistant/components/device_tracker/bluetooth_tracker.py
+++ b/homeassistant/components/device_tracker/bluetooth_tracker.py
@@ -80,7 +80,7 @@ def setup_scanner(hass, config, see, discovery_info=None):
 
     request_rssi = config.get(CONF_REQUEST_RSSI, False)
 
-    def update_bluetooth(now):
+    def update_bluetooth():
         """Update Bluetooth and set timer for the next update."""
         update_bluetooth_once()
         track_point_in_utc_time(
@@ -109,10 +109,9 @@ def setup_scanner(hass, config, see, discovery_info=None):
 
     def handle_update_bluetooth(call):
         """Update bluetooth devices on demand."""
-        now = dt_util.utcnow()
-        update_bluetooth(now, True)
+        update_bluetooth_once()
 
-    update_bluetooth(dt_util.utcnow())
+    update_bluetooth()
 
     hass.services.register(
         DOMAIN, "bluetooth_tracker_update", handle_update_bluetooth)


### PR DESCRIPTION
Will immediately scan for Bluetooth devices outside of the interval timer. Allows for less frequent scanning, with scanning on demand via automation.