### PR TITLE
Added support to HTTPS URLs on SynologyDSM

### DIFF
--- a/homeassistant/components/sensor/synologydsm.py
+++ b/homeassistant/components/sensor/synologydsm.py
@@ -13,15 +13,16 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
     CONF_HOST, CONF_USERNAME, CONF_PASSWORD, CONF_PORT, CONF_SSL,
-    TEMP_CELSIUS, CONF_MONITORED_CONDITIONS, EVENT_HOMEASSISTANT_START,
-    CONF_DISKS)
+    ATTR_ATTRIBUTION, TEMP_CELSIUS, CONF_MONITORED_CONDITIONS,
+    EVENT_HOMEASSISTANT_START, CONF_DISKS)
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['python-synology==0.1.1']
+REQUIREMENTS = ['python-synology==0.2.0']
 
 _LOGGER = logging.getLogger(__name__)
 
+CONF_ATTRIBUTION = 'Data provided by Synology'
 CONF_VOLUMES = 'volumes'
 DEFAULT_NAME = 'Synology DSM'
 DEFAULT_PORT = 5000
@@ -188,6 +189,13 @@ class SynoNasSensor(Entity):
         """Get the latest data for the states."""
         if self._api is not None:
             self._api.update()
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        return {
+            ATTR_ATTRIBUTION: CONF_ATTRIBUTION,
+        }
 
 
 class SynoNasUtilSensor(SynoNasSensor):

--- a/homeassistant/components/sensor/synologydsm.py
+++ b/homeassistant/components/sensor/synologydsm.py
@@ -137,7 +137,8 @@ class SynoApi(object):
         self.temp_unit = temp_unit
 
         try:
-            self._api = SynologyDSM(host, port, username, password, use_https=use_ssl)
+            self._api = SynologyDSM(host, port, username, password,
+                                    use_https=use_ssl)
         except:  # noqa: E722  # pylint: disable=bare-except
             _LOGGER.error("Error setting up Synology DSM")
 

--- a/homeassistant/components/sensor/synologydsm.py
+++ b/homeassistant/components/sensor/synologydsm.py
@@ -25,7 +25,7 @@ _LOGGER = logging.getLogger(__name__)
 CONF_ATTRIBUTION = 'Data provided by Synology'
 CONF_VOLUMES = 'volumes'
 DEFAULT_NAME = 'Synology DSM'
-DEFAULT_PORT = 5000
+DEFAULT_PORT = 5001
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=15)
 
@@ -76,7 +76,7 @@ _MONITORED_CONDITIONS = list(_UTILISATION_MON_COND.keys()) + \
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
-    vol.Optional(CONF_SSL, default=False): cv.boolean,
+    vol.Optional(CONF_SSL, default=True): cv.boolean,
     vol.Required(CONF_USERNAME): cv.string,
     vol.Required(CONF_PASSWORD): cv.string,
     vol.Optional(CONF_MONITORED_CONDITIONS):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1083,7 +1083,7 @@ python-sochain-api==0.0.2
 python-songpal==0.0.7
 
 # homeassistant.components.sensor.synologydsm
-python-synology==0.1.0
+python-synology==0.1.1
 
 # homeassistant.components.tado
 python-tado==0.2.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1083,7 +1083,7 @@ python-sochain-api==0.0.2
 python-songpal==0.0.7
 
 # homeassistant.components.sensor.synologydsm
-python-synology==0.1.1
+python-synology==0.2.0
 
 # homeassistant.components.tado
 python-tado==0.2.3


### PR DESCRIPTION
## Description:

Added support to HTTPS URLs on Synology DSM

[x] 3rd party PR approved https://github.com/StaticCube/python-synology/pull/6

**Related issue (if applicable):** fixes #15269

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5650

## Example entry for `configuration.yaml` (if applicable):
```yaml
  - platform: synologydsm
    host: 192.168.0.1
    username: admin
    ssl: true
    password: 'secret#qq'
    port: 5001
    monitored_conditions:
      - cpu_total_load
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) **WIP**

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
