### PR TITLE
Add isort configuration

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,2 @@
+[settings]
+multi_line_output=4


### PR DESCRIPTION
## Description:
In our [style guidelines](https://developers-home-assistant.netlify.com/docs/en/development_guidelines.html) we are talking about the sorting of the imports. `isort` can do it automatically. The current setting is based on the most used style.

**Pull request in [developers.home-assistant](https://github.com/home-assistant/developer-home-assistant) with documentation:** home-assistant/developers.home-assistant/pull/49

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

