### PR TITLE
Add support for new fixer API (fixes #14911)

### DIFF
--- a/homeassistant/components/sensor/fixer.py
+++ b/homeassistant/components/sensor/fixer.py
@@ -10,15 +10,14 @@ import logging
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import ATTR_ATTRIBUTION, CONF_BASE, CONF_NAME
+from homeassistant.const import ATTR_ATTRIBUTION, CONF_API_KEY, CONF_NAME
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['fixerio==0.1.1']
+REQUIREMENTS = ['fixerio==1.0.0a0']
 
 _LOGGER = logging.getLogger(__name__)
 
-ATTR_BASE = 'Base currency'
 ATTR_EXCHANGE_RATE = 'Exchange rate'
 ATTR_TARGET = 'Target currency'
 
@@ -33,8 +32,8 @@ ICON = 'mdi:currency-usd'
 SCAN_INTERVAL = timedelta(days=1)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_API_KEY): cv.string,
     vol.Required(CONF_TARGET): cv.string,
-    vol.Optional(CONF_BASE, default=DEFAULT_BASE): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 })
 
@@ -43,17 +42,17 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Fixer.io sensor."""
     from fixerio import Fixerio, exceptions
 
+    api_key = config.get(CONF_API_KEY)
     name = config.get(CONF_NAME)
-    base = config.get(CONF_BASE)
     target = config.get(CONF_TARGET)
 
     try:
-        Fixerio(base=base, symbols=[target], secure=True).latest()
+        Fixerio(symbols=[target], access_key=api_key).latest()
     except exceptions.FixerioException:
         _LOGGER.error("One of the given currencies is not supported")
-        return False
+        return
 
-    data = ExchangeData(base, target)
+    data = ExchangeData(target, api_key)
     add_devices([ExchangeRateSensor(data, name, target)], True)
 
 
@@ -87,10 +86,9 @@ class ExchangeRateSensor(Entity):
         """Return the state attributes."""
         if self.data.rate is not None:
             return {
-                ATTR_BASE: self.data.rate['base'],
-                ATTR_TARGET: self._target,
-                ATTR_EXCHANGE_RATE: self.data.rate['rates'][self._target],
                 ATTR_ATTRIBUTION: CONF_ATTRIBUTION,
+                ATTR_EXCHANGE_RATE: self.data.rate['rates'][self._target],
+                ATTR_TARGET: self._target,
             }
 
     @property
@@ -107,16 +105,15 @@ class ExchangeRateSensor(Entity):
 class ExchangeData(object):
     """Get the latest data and update the states."""
 
-    def __init__(self, base_currency, target_currency):
+    def __init__(self, target_currency, api_key):
         """Initialize the data object."""
         from fixerio import Fixerio
 
+        self.api_key = api_key
         self.rate = None
-        self.base_currency = base_currency
         self.target_currency = target_currency
         self.exchange = Fixerio(
-            base=self.base_currency, symbols=[self.target_currency],
-            secure=True)
+            symbols=[self.target_currency], access_key=self.api_key)
 
     def update(self):
         """Get the latest data from Fixer.io."""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -338,7 +338,7 @@ fints==0.2.1
 fitbit==0.3.0
 
 # homeassistant.components.sensor.fixer
-fixerio==0.1.1
+fixerio==1.0.0a0
 
 # homeassistant.components.light.flux_led
 flux_led==0.21


### PR DESCRIPTION
## Description:
Fixer.io updated their API and now it's required to have an API key. Support for SSL/TLS is only available for paying customers.

**Related issue (if applicable):** fixes #14911

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5654

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: fixer
    api_key: !secret fixer_api
    target: CHF
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
 

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
