### PR TITLE
Added zoneminder Run State sensor

### DIFF
--- a/homeassistant/components/sensor/zoneminder.py
+++ b/homeassistant/components/sensor/zoneminder.py
@@ -58,6 +58,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                                include_archived, sensor)
             )
 
+    sensors.append(ZMSensorRunState())
     add_devices(sensors)
 
 
@@ -140,3 +141,29 @@ class ZMSensorEvents(Entity):
             self._state = event['results'][str(self._monitor_id)]
         except (TypeError, KeyError):
             self._state = '0'
+
+
+class ZMSensorRunState(Entity):
+    """Get the ZoneMinder run state."""
+
+    def __init__(self):
+        """Initialize run state sensor."""
+        self._state = None
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return 'Run State'
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    def update(self):
+        """Update the sensor."""
+        s = zoneminder.get_run_states()[1]
+        if s is None:
+            self._state = STATE_UNKNOWN
+        else:
+            self._state = s

--- a/homeassistant/components/zoneminder.py
+++ b/homeassistant/components/zoneminder.py
@@ -125,3 +125,21 @@ def get_state(api_url):
 def change_state(api_url, post_data):
     """Update a state using the Zoneminder API."""
     return _zm_request('post', api_url, data=post_data)
+
+
+# pylint: disable=no-member
+def get_run_states():
+    """
+    Get all run state names and the current run state from Zoneminder API.
+
+    Returns a 2-tuple of the list of state names (str) and the active state
+    name (str).
+    """
+    state_names = []
+    active_state = None
+    for i in get_state('api/states.json')['states']:
+        state_names.append(i['State']['Name'])
+        # yes, the ZM API uses the *string* "1" for this...
+        if i['State']['IsActive'] == '1':
+            active_state = i['State']['Name']
+    return state_names, active_state


### PR DESCRIPTION
## Description:

This adds a sensor for ZoneMinder's [run state](http://zoneminder.readthedocs.io/en/stable/userguide/gettingstarted.html#understanding-the-web-console) - a named set of monitor states for each of ZoneMinder's cameras. This is an internal construct of ZoneMinder that's user-editable and exposed over the API, and is commonly used very similarly to burgular alarm states (i.e. run states of "Home", "Away", and "Disarmed" each map to different settings for different cameras).

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** https://github.com/home-assistant/home-assistant.github.io/pull/5655

## Example entry for `configuration.yaml` (if applicable):

No configuration changes.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. _(All pass except the pylint suite, which fails on a unicode error in the readme for lyft-rides 0.2. The changed files pass flake8 and pydocstyle.)

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) - https://github.com/home-assistant/home-assistant.github.io/pull/5655

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works. _(None of the zoneminder modules have tests currently.)_

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
