### PR TITLE
Disable the calendar panel

### DIFF
--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -41,8 +41,9 @@ async def async_setup(hass, config):
     hass.http.register_view(CalendarListView(component))
     hass.http.register_view(CalendarEventView(component))
 
-    await hass.components.frontend.async_register_built_in_panel(
-        'calendar', 'calendar', 'hass:calendar')
+    # Doesn't work in prod builds of the frontend: home-assistant-polymer#1289
+    # await hass.components.frontend.async_register_built_in_panel(
+    #     'calendar', 'calendar', 'hass:calendar')
 
     await component.async_setup(config)
     return True


### PR DESCRIPTION
## Description:
Disable the calendar panel. It doesn't work in prod builds and we have been unable to find a fix yet.

**Related issue (if applicable):** https://github.com/home-assistant/home-assistant-polymer/issues/1289

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
