### PR TITLE
Fix yeelight light brightness

### DIFF
--- a/homeassistant/components/light/yeelight.py
+++ b/homeassistant/components/light/yeelight.py
@@ -310,7 +310,7 @@ class YeelightLight(Light):
 
             bright = self._properties.get('bright', None)
             if bright:
-                self._brightness = 255 * (int(bright) / 100)
+                self._brightness = round(255 * (int(bright) / 100))
 
             temp_in_k = self._properties.get('ct', None)
             if temp_in_k:


### PR DESCRIPTION
## Description:
The brightness should always be an integer.

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/14354#issuecomment-402252546

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**