### PR TITLE
Fix exception when parts of Pollen.com can't be reached

### DIFF
--- a/homeassistant/components/sensor/pollen.py
+++ b/homeassistant/components/sensor/pollen.py
@@ -183,9 +183,12 @@ class PollencomSensor(Entity):
             return
 
         if self._category:
-            data = self.pollencom.data[self._category]['Location']
+            data = self.pollencom.data[self._category].get('Location')
         else:
-            data = self.pollencom.data[self._type]['Location']
+            data = self.pollencom.data[self._type].get('Location')
+
+        if not data:
+            return
 
         indices = [p['Index'] for p in data['periods']]
         average = round(mean(indices), 1)


### PR DESCRIPTION
## Description:
#15286 revealed an unhandled exception when parts of Pollen.com's back-of-house API are down. This PR halts updating when such an exception occurs.

**Related issue (if applicable):** fixes #15286

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: pollen
    zip_code: "12345"
    monitored_conditions:
      - allergy_average_forecasted
      - allergy_average_historical
      - allergy_index_today
      - allergy_index_tomorrow
      - allergy_index_yesterday
      - disease_average_forecasted
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  ~- [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)~

If the code communicates with devices, web services, or third-party tools:
  ~- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).~
  ~- [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).~
  ~- [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.~
  ~- [ ] New files were added to `.coveragerc`.~

If the code does not interact with devices:
  ~- [ ] Tests have been added to verify that the new code works.~

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
