### PR TITLE
Make LimitlessLED color/temperature attributes mutually exclusive

### DIFF
--- a/homeassistant/components/light/limitlessled.py
+++ b/homeassistant/components/light/limitlessled.py
@@ -46,7 +46,7 @@ MIN_SATURATION = 10
 WHITE = [0, 0]
 
 SUPPORT_LIMITLESSLED_WHITE = (SUPPORT_BRIGHTNESS | SUPPORT_COLOR_TEMP |
-                              SUPPORT_TRANSITION)
+                              SUPPORT_EFFECT | SUPPORT_TRANSITION)
 SUPPORT_LIMITLESSLED_DIMMER = (SUPPORT_BRIGHTNESS | SUPPORT_TRANSITION)
 SUPPORT_LIMITLESSLED_RGB = (SUPPORT_BRIGHTNESS | SUPPORT_EFFECT |
                             SUPPORT_FLASH | SUPPORT_COLOR |
@@ -239,12 +239,17 @@ class LimitlessLEDGroup(Light):
     @property
     def color_temp(self):
         """Return the temperature property."""
+        if self.hs_color is not None:
+            return None
         return self._temperature
 
     @property
     def hs_color(self):
         """Return the color property."""
         if self._effect == EFFECT_NIGHT:
+            return None
+
+        if self._color is None or self._color[1] == 0:
             return None
 
         return self._color


### PR DESCRIPTION
## Description:

Since a light cannot be white and colored at the same time, this PR changes LimitlessLED to only report one of the `hs_color`/`color_temp` attributes. The temperature is used when the saturation is zero.

While at it, this PR also adds the effect feature bit for white lights. I missed that in #12567.

**Breaking change**: LimitlessLED will no longer report `hs_color`/`rgb_color` and `color_temp` simultaneously.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54