### PR TITLE
Mitsubishi GB-24a (and similar) controller support

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -386,6 +386,7 @@ omit =
     homeassistant/components/climate/homematic.py
     homeassistant/components/climate/honeywell.py
     homeassistant/components/climate/knx.py
+    homeassistant/components/climate/mitsubishicontroller.py
     homeassistant/components/climate/oem.py
     homeassistant/components/climate/proliphix.py
     homeassistant/components/climate/radiotherm.py

--- a/homeassistant/components/climate/mitsubishicontroller.py
+++ b/homeassistant/components/climate/mitsubishicontroller.py
@@ -1,0 +1,104 @@
+import voluptuous as vol
+
+import asyncio
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.climate import ClimateDevice
+from homeassistant.const import CONF_URL
+from homeassistant.const import TEMP_FAHRENHEIT
+
+DOMAIN = 'mitsubishicontroller'
+
+from mitsPy.manager import Manager
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_URL): cv.string
+    }),
+}, extra=vol.ALLOW_EXTRA)
+
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+    controller = Manager(config[CONF_URL], loop=hass.loop)
+    controller.initialize(lambda raw_devices: async_add_devices(
+        [MitsubishiHvacDevice(device=device, unit_of_measurement=TEMP_FAHRENHEIT) for device in raw_devices]))
+
+
+class MitsubishiHvacDevice(ClimateDevice):
+    def __init__(self, device, unit_of_measurement=None, current_fan_mode=None):
+        self._device = device
+        self._name = self._device.number + " : " + self._device.group_name
+        self._current_swing_mode = self._device.current_air_direction
+        self._unit_of_measurement = unit_of_measurement
+        self._current_fan_mode = current_fan_mode
+        self._device.refresh(self.schedule_update_ha_state)
+
+    def _refresh(self):
+        self._device.refresh(self.schedule_update_ha_state)
+
+    @property
+    def should_poll(self):
+        return True
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def unit_of_measurement(self):
+        return self._unit_of_measurement
+
+    @property
+    def temperature_unit(self):
+        return self._unit_of_measurement
+
+    @property
+    def current_temperature(self):
+        return self._device.current_temp_f
+
+    @property
+    def target_temperature(self):
+        return self._device.set_temp_value_f
+
+    @property
+    def current_operation(self):
+        return self._device.current_operation
+
+    @property
+    def operation_list(self):
+        return self._device.operation_list
+
+    @property
+    def current_fan_mode(self):
+        return self._device.current_fan_speed
+
+    @property
+    def fan_list(self):
+        return self._device.fan_speed_options
+
+    def set_temperature(self, temperature, **kwargs):
+        self._device.set_temperature_f(temperature)
+        self._refresh()
+
+    def set_swing_mode(self, swing_mode):
+        self._device.set_air_direction(swing_mode)
+        self._refresh()
+
+    def set_fan_mode(self, fan):
+        self._device.set_fan_speed(fan)
+        self._refresh()
+
+    def set_operation_mode(self, operation_mode):
+        self._device.set_operation(operation_mode)
+        self._refresh()
+
+    @property
+    def current_swing_mode(self):
+        return self._device.current_air_direction
+
+    @property
+    def swing_list(self):
+        return self._device.air_direction_options
+
+    def update(self):
+        self._device.refresh(self.schedule_update_ha_state)

--- a/homeassistant/components/climate/mitsubishicontroller.py
+++ b/homeassistant/components/climate/mitsubishicontroller.py
@@ -12,108 +12,108 @@ from homeassistant.const import TEMP_FAHRENHEIT
 REQUIREMENTS = ['mitsPy==0.1.9']
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-  vol.Required(CONF_URL): cv.string
+    vol.Required(CONF_URL): cv.string
 })
 
 
 async def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
-  from mitsPy.manager import Manager
-  controller = Manager(config.get(CONF_URL))
+    from mitsPy.manager import Manager
+    controller = Manager(config.get(CONF_URL))
 
-  async def register_devices(raw_devices):
-    async_add_devices(
-      [MitsubishiHvacDevice(device=device, unit_of_measurement=TEMP_FAHRENHEIT) for device in raw_devices])
+    async def register_devices(raw_devices):
+        async_add_devices(
+            [MitsubishiHvacDevice(device=device, unit_of_measurement=TEMP_FAHRENHEIT) for device in raw_devices])
 
-  await controller.initialize(register_devices)
+    await controller.initialize(register_devices)
 
 
 SUPPORT_FLAGS = (SUPPORT_TARGET_TEMPERATURE | SUPPORT_OPERATION_MODE | SUPPORT_FAN_MODE | SUPPORT_SWING_MODE)
 
 
 class MitsubishiHvacDevice(ClimateDevice):
-  def __init__(self, device, unit_of_measurement=None, current_fan_mode=None):
-    self._device = device
-    self._name = self._device.group_name
-    self._current_swing_mode = self._device.current_air_direction
-    self._unit_of_measurement = unit_of_measurement
-    self._current_fan_mode = current_fan_mode
-    self._device.refresh(self.schedule_update_ha_state)
+    def __init__(self, device, unit_of_measurement=None, current_fan_mode=None):
+        self._device = device
+        self._name = self._device.group_name
+        self._current_swing_mode = self._device.current_air_direction
+        self._unit_of_measurement = unit_of_measurement
+        self._current_fan_mode = current_fan_mode
+        self._device.refresh(self.schedule_update_ha_state)
 
-  async def _refresh(self):
-    await self._device.refresh(self.schedule_update_ha_state)
+    async def _refresh(self):
+        await self._device.refresh(self.schedule_update_ha_state)
 
-  @property
-  def should_poll(self):
-    return True
+    @property
+    def should_poll(self):
+        return True
 
-  @property
-  def name(self):
-    return self._name
+    @property
+    def name(self):
+        return self._name
 
-  @property
-  def unit_of_measurement(self):
-    return self._unit_of_measurement
+    @property
+    def unit_of_measurement(self):
+        return self._unit_of_measurement
 
-  @property
-  def temperature_unit(self):
-    return self._unit_of_measurement
+    @property
+    def temperature_unit(self):
+        return self._unit_of_measurement
 
-  @property
-  def current_temperature(self):
-    return float(self._device.current_temp_f)
+    @property
+    def current_temperature(self):
+        return float(self._device.current_temp_f)
 
-  @property
-  def target_temperature(self):
-    return float(self._device.set_temp_value_f)
+    @property
+    def target_temperature(self):
+        return float(self._device.set_temp_value_f)
 
-  @property
-  def state(self):
-    return self.current_operation
+    @property
+    def state(self):
+        return self.current_operation
 
-  @property
-  def current_operation(self):
-    return self._device.current_operation
+    @property
+    def current_operation(self):
+        return self._device.current_operation
 
-  @property
-  def operation_list(self):
-    return self._device.operation_list
+    @property
+    def operation_list(self):
+        return self._device.operation_list
 
-  @property
-  def current_fan_mode(self):
-    return self._device.current_fan_speed
+    @property
+    def current_fan_mode(self):
+        return self._device.current_fan_speed
 
-  @property
-  def fan_list(self):
-    return self._device.fan_speed_options
+    @property
+    def fan_list(self):
+        return self._device.fan_speed_options
 
-  async def async_set_temperature(self, temperature, **kwargs):
-    await self._device.set_temperature_f(temperature)
-    await self._refresh()
+    async def async_set_temperature(self, temperature, **kwargs):
+        await self._device.set_temperature_f(temperature)
+        await self._refresh()
 
-  async def async_set_swing_mode(self, swing_mode):
-    await self._device.set_air_direction(swing_mode)
-    await self._refresh()
+    async def async_set_swing_mode(self, swing_mode):
+        await self._device.set_air_direction(swing_mode)
+        await self._refresh()
 
-  async def async_set_fan_mode(self, fan):
-    await self._device.set_fan_speed(fan)
-    await self._refresh()
+    async def async_set_fan_mode(self, fan):
+        await self._device.set_fan_speed(fan)
+        await self._refresh()
 
-  async def async_set_operation_mode(self, operation_mode):
-    await self._device.set_operation(operation_mode)
-    await self._refresh()
+    async def async_set_operation_mode(self, operation_mode):
+        await self._device.set_operation(operation_mode)
+        await self._refresh()
 
-  @property
-  def current_swing_mode(self):
-    return self._device.current_air_direction
+    @property
+    def current_swing_mode(self):
+        return self._device.current_air_direction
 
-  @property
-  def swing_list(self):
-    return self._device.air_direction_options
+    @property
+    def swing_list(self):
+        return self._device.air_direction_options
 
-  @property
-  def supported_features(self):
-    """Return the list of supported features."""
-    return SUPPORT_FLAGS
+    @property
+    def supported_features(self):
+        """Return the list of supported features."""
+        return SUPPORT_FLAGS
 
-  async def async_update(self):
-    await self._device.refresh(self.schedule_update_ha_state)
+    async def async_update(self):
+        await self._device.refresh(self.schedule_update_ha_state)

--- a/homeassistant/components/climate/mitsubishicontroller.py
+++ b/homeassistant/components/climate/mitsubishicontroller.py
@@ -31,7 +31,11 @@ async def async_setup_platform(hass, config, async_add_devices,
 
 
 SUPPORT_FLAGS = (
-        SUPPORT_TARGET_TEMPERATURE | SUPPORT_OPERATION_MODE | SUPPORT_FAN_MODE | SUPPORT_SWING_MODE)
+        SUPPORT_TARGET_TEMPERATURE |
+        SUPPORT_OPERATION_MODE |
+        SUPPORT_FAN_MODE |
+        SUPPORT_SWING_MODE
+)
 
 
 class MitsubishiHvacDevice(ClimateDevice):

--- a/homeassistant/components/climate/mitsubishicontroller.py
+++ b/homeassistant/components/climate/mitsubishicontroller.py
@@ -9,7 +9,7 @@ from homeassistant.components.climate import (ClimateDevice, PLATFORM_SCHEMA,
 from homeassistant.const import CONF_URL
 from homeassistant.const import TEMP_FAHRENHEIT
 
-REQUIREMENTS = ['mitsPy==0.1.8']
+REQUIREMENTS = ['mitsPy==0.1.9']
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
   vol.Required(CONF_URL): cv.string
@@ -33,7 +33,7 @@ SUPPORT_FLAGS = (SUPPORT_TARGET_TEMPERATURE | SUPPORT_OPERATION_MODE | SUPPORT_F
 class MitsubishiHvacDevice(ClimateDevice):
   def __init__(self, device, unit_of_measurement=None, current_fan_mode=None):
     self._device = device
-    self._name = self._device.number + " : " + self._device.group_name
+    self._name = self._device.group_name
     self._current_swing_mode = self._device.current_air_direction
     self._unit_of_measurement = unit_of_measurement
     self._current_fan_mode = current_fan_mode
@@ -44,7 +44,7 @@ class MitsubishiHvacDevice(ClimateDevice):
 
   @property
   def should_poll(self):
-    return True
+    return False
 
   @property
   def name(self):
@@ -65,6 +65,10 @@ class MitsubishiHvacDevice(ClimateDevice):
   @property
   def target_temperature(self):
     return float(self._device.set_temp_value_f)
+
+  @property
+  def state(self):
+    return self.current_operation
 
   @property
   def current_operation(self):

--- a/homeassistant/components/climate/mitsubishicontroller.py
+++ b/homeassistant/components/climate/mitsubishicontroller.py
@@ -12,8 +12,7 @@ from homeassistant.components.climate import (ClimateDevice, PLATFORM_SCHEMA,
                                               SUPPORT_TARGET_TEMPERATURE,
                                               SUPPORT_FAN_MODE,
                                               SUPPORT_OPERATION_MODE,
-                                              SUPPORT_SWING_MODE,
-                                              ATTR_FAN_MODE)
+                                              SUPPORT_SWING_MODE)
 from homeassistant.const import CONF_URL, ATTR_TEMPERATURE
 from homeassistant.const import TEMP_FAHRENHEIT
 
@@ -53,7 +52,7 @@ SUPPORT_FLAGS = (
 
 
 class MitsubishiHvacDevice(ClimateDevice):
-    """Mitsubishi HVAC Device"""
+    """Mitsubishi HVAC Device."""
 
     def __init__(self, device, unit_of_measurement=None,
                  current_fan_mode=None):

--- a/homeassistant/components/climate/mitsubishicontroller.py
+++ b/homeassistant/components/climate/mitsubishicontroller.py
@@ -29,7 +29,7 @@ async def async_setup_platform(hass, config, async_add_devices,
     from mitsPy.manager import Manager
     controller = Manager(config.get(CONF_URL))
 
-    async def register_devices(raw_devices):
+    async def async_register_devices(raw_devices):
         """Register devices."""
         async_add_devices(
             [MitsubishiHvacDevice(
@@ -37,7 +37,7 @@ async def async_setup_platform(hass, config, async_add_devices,
                 unit_of_measurement=TEMP_FAHRENHEIT) for device in raw_devices]
         )
 
-    await controller.initialize(register_devices)
+    await controller.initialize(async_register_devices)
 
 
 SUPPORT_FLAGS = (
@@ -61,9 +61,9 @@ class MitsubishiHvacDevice(ClimateDevice):
         self._current_fan_mode = current_fan_mode
         self._device.refresh(self.schedule_update_ha_state)
 
-    async def _refresh(self):
+    async def _async_refresh(self):
         """Refresh function."""
-        await self._device.refresh(self.schedule_update_ha_state)
+        await self._device.refresh(lambda: 0)
 
     @property
     def should_poll(self):
@@ -123,12 +123,12 @@ class MitsubishiHvacDevice(ClimateDevice):
     async def async_set_temperature(self, **kwargs):
         """Set the temperature."""
         await self._device.set_temperature_f(kwargs[ATTR_TEMPERATURE])
-        await self._refresh()
+        await self.async_schedule_update_ha_state(True)
 
     async def async_set_swing_mode(self, swing_mode):
         """Set the swing mode."""
         await self._device.set_air_direction(swing_mode)
-        await self._refresh()
+        await self.async_schedule_update_ha_state(True)
 
     async def async_set_fan_mode(self, fan_mode):
         """Set the fan mode."""
@@ -137,7 +137,7 @@ class MitsubishiHvacDevice(ClimateDevice):
     async def async_set_operation_mode(self, operation_mode):
         """Set the operation mode."""
         await self._device.set_operation(operation_mode)
-        await self._refresh()
+        await self.async_schedule_update_ha_state(True)
 
     @property
     def current_swing_mode(self):
@@ -156,4 +156,4 @@ class MitsubishiHvacDevice(ClimateDevice):
 
     async def async_update(self):
         """Update."""
-        await self._device.refresh(self.schedule_update_ha_state)
+        await self._device.refresh(lambda: 0)

--- a/homeassistant/components/climate/mitsubishicontroller.py
+++ b/homeassistant/components/climate/mitsubishicontroller.py
@@ -1,119 +1,104 @@
 import voluptuous as vol
 
+import asyncio
+
 import homeassistant.helpers.config_validation as cv
-from homeassistant.components.climate import (ClimateDevice, PLATFORM_SCHEMA,
-                                              SUPPORT_TARGET_TEMPERATURE,
-                                              SUPPORT_FAN_MODE,
-                                              SUPPORT_OPERATION_MODE,
-                                              SUPPORT_SWING_MODE)
+from homeassistant.components.climate import ClimateDevice
 from homeassistant.const import CONF_URL
 from homeassistant.const import TEMP_FAHRENHEIT
 
-REQUIREMENTS = ['mitsPy==0.1.9']
+DOMAIN = 'mitsubishicontroller'
 
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-  vol.Required(CONF_URL): cv.string
-})
+from mitsPy.manager import Manager
 
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_URL): cv.string
+    }),
+}, extra=vol.ALLOW_EXTRA)
 
-async def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
-  from mitsPy.manager import Manager
-  controller = Manager(config.get(CONF_URL))
-
-  async def register_devices(raw_devices):
-    async_add_devices(
-      [MitsubishiHvacDevice(device=device, unit_of_measurement=TEMP_FAHRENHEIT) for device in raw_devices])
-
-  await controller.initialize(register_devices)
-
-
-SUPPORT_FLAGS = (SUPPORT_TARGET_TEMPERATURE | SUPPORT_OPERATION_MODE | SUPPORT_FAN_MODE | SUPPORT_SWING_MODE)
+@asyncio.coroutine
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+    controller = Manager(config[CONF_URL], loop=hass.loop)
+    controller.initialize(lambda raw_devices: async_add_devices(
+        [MitsubishiHvacDevice(device=device, unit_of_measurement=TEMP_FAHRENHEIT) for device in raw_devices]))
 
 
 class MitsubishiHvacDevice(ClimateDevice):
-  def __init__(self, device, unit_of_measurement=None, current_fan_mode=None):
-    self._device = device
-    self._name = self._device.group_name
-    self._current_swing_mode = self._device.current_air_direction
-    self._unit_of_measurement = unit_of_measurement
-    self._current_fan_mode = current_fan_mode
-    self._device.refresh(self.schedule_update_ha_state)
+    def __init__(self, device, unit_of_measurement=None, current_fan_mode=None):
+        self._device = device
+        self._name = self._device.number + " : " + self._device.group_name
+        self._current_swing_mode = self._device.current_air_direction
+        self._unit_of_measurement = unit_of_measurement
+        self._current_fan_mode = current_fan_mode
+        self._device.refresh(self.schedule_update_ha_state)
 
-  async def _refresh(self):
-    await self._device.refresh(self.schedule_update_ha_state)
+    def _refresh(self):
+        self._device.refresh(self.schedule_update_ha_state)
 
-  @property
-  def should_poll(self):
-    return False
+    @property
+    def should_poll(self):
+        return True
 
-  @property
-  def name(self):
-    return self._name
+    @property
+    def name(self):
+        return self._name
 
-  @property
-  def unit_of_measurement(self):
-    return self._unit_of_measurement
+    @property
+    def unit_of_measurement(self):
+        return self._unit_of_measurement
 
-  @property
-  def temperature_unit(self):
-    return self._unit_of_measurement
+    @property
+    def temperature_unit(self):
+        return self._unit_of_measurement
 
-  @property
-  def current_temperature(self):
-    return float(self._device.current_temp_f)
+    @property
+    def current_temperature(self):
+        return self._device.current_temp_f
 
-  @property
-  def target_temperature(self):
-    return float(self._device.set_temp_value_f)
+    @property
+    def target_temperature(self):
+        return self._device.set_temp_value_f
 
-  @property
-  def state(self):
-    return self.current_operation
+    @property
+    def current_operation(self):
+        return self._device.current_operation
 
-  @property
-  def current_operation(self):
-    return self._device.current_operation
+    @property
+    def operation_list(self):
+        return self._device.operation_list
 
-  @property
-  def operation_list(self):
-    return self._device.operation_list
+    @property
+    def current_fan_mode(self):
+        return self._device.current_fan_speed
 
-  @property
-  def current_fan_mode(self):
-    return self._device.current_fan_speed
+    @property
+    def fan_list(self):
+        return self._device.fan_speed_options
 
-  @property
-  def fan_list(self):
-    return self._device.fan_speed_options
+    def set_temperature(self, temperature, **kwargs):
+        self._device.set_temperature_f(temperature)
+        self._refresh()
 
-  async def async_set_temperature(self, temperature, **kwargs):
-    await self._device.set_temperature_f(temperature)
-    await self._refresh()
+    def set_swing_mode(self, swing_mode):
+        self._device.set_air_direction(swing_mode)
+        self._refresh()
 
-  async def async_set_swing_mode(self, swing_mode):
-    await self._device.set_air_direction(swing_mode)
-    await self._refresh()
+    def set_fan_mode(self, fan):
+        self._device.set_fan_speed(fan)
+        self._refresh()
 
-  async def async_set_fan_mode(self, fan):
-    await self._device.set_fan_speed(fan)
-    await self._refresh()
+    def set_operation_mode(self, operation_mode):
+        self._device.set_operation(operation_mode)
+        self._refresh()
 
-  async def async_set_operation_mode(self, operation_mode):
-    await self._device.set_operation(operation_mode)
-    await self._refresh()
+    @property
+    def current_swing_mode(self):
+        return self._device.current_air_direction
 
-  @property
-  def current_swing_mode(self):
-    return self._device.current_air_direction
+    @property
+    def swing_list(self):
+        return self._device.air_direction_options
 
-  @property
-  def swing_list(self):
-    return self._device.air_direction_options
-
-  @property
-  def supported_features(self):
-    """Return the list of supported features."""
-    return SUPPORT_FLAGS
-
-  async def async_update(self):
-    await self._device.refresh(self.schedule_update_ha_state)
+    def update(self):
+        self._device.refresh(self.schedule_update_ha_state)

--- a/homeassistant/components/climate/mitsubishicontroller.py
+++ b/homeassistant/components/climate/mitsubishicontroller.py
@@ -16,22 +16,27 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-async def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_devices,
+                               discovery_info=None):
     from mitsPy.manager import Manager
     controller = Manager(config.get(CONF_URL))
 
     async def register_devices(raw_devices):
         async_add_devices(
-            [MitsubishiHvacDevice(device=device, unit_of_measurement=TEMP_FAHRENHEIT) for device in raw_devices])
+            [MitsubishiHvacDevice(device=device,
+                                  unit_of_measurement=TEMP_FAHRENHEIT) for
+             device in raw_devices])
 
     await controller.initialize(register_devices)
 
 
-SUPPORT_FLAGS = (SUPPORT_TARGET_TEMPERATURE | SUPPORT_OPERATION_MODE | SUPPORT_FAN_MODE | SUPPORT_SWING_MODE)
+SUPPORT_FLAGS = (
+        SUPPORT_TARGET_TEMPERATURE | SUPPORT_OPERATION_MODE | SUPPORT_FAN_MODE | SUPPORT_SWING_MODE)
 
 
 class MitsubishiHvacDevice(ClimateDevice):
-    def __init__(self, device, unit_of_measurement=None, current_fan_mode=None):
+    def __init__(self, device, unit_of_measurement=None,
+                 current_fan_mode=None):
         self._device = device
         self._name = self._device.group_name
         self._current_swing_mode = self._device.current_air_direction

--- a/homeassistant/components/climate/mitsubishicontroller.py
+++ b/homeassistant/components/climate/mitsubishicontroller.py
@@ -44,7 +44,7 @@ class MitsubishiHvacDevice(ClimateDevice):
 
   @property
   def should_poll(self):
-    return False
+    return True
 
   @property
   def name(self):

--- a/homeassistant/components/climate/mitsubishicontroller.py
+++ b/homeassistant/components/climate/mitsubishicontroller.py
@@ -28,7 +28,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 async def async_setup_platform(hass, config, async_add_devices,
                                discovery_info=None):
-    """setup platform asynchronously"""
+    """Setup platform asynchronously."""
     from mitsPy.manager import Manager
     controller = Manager(config.get(CONF_URL))
 
@@ -57,7 +57,7 @@ class MitsubishiHvacDevice(ClimateDevice):
 
     def __init__(self, device, unit_of_measurement=None,
                  current_fan_mode=None):
-        """initialize device"""
+        """Initialize device."""
         self._device = device
         self._name = self._device.group_name
         self._current_swing_mode = self._device.current_air_direction
@@ -66,92 +66,92 @@ class MitsubishiHvacDevice(ClimateDevice):
         self._device.refresh(self.schedule_update_ha_state)
 
     async def _refresh(self):
-        """refresh function"""
+        """Refresh function."""
         await self._device.refresh(self.schedule_update_ha_state)
 
     @property
     def should_poll(self):
-        """should poll"""
+        """Should poll."""
         return True
 
     @property
     def name(self):
-        """device name"""
+        """Device name."""
         return self._name
 
     @property
     def unit_of_measurement(self):
-        """unit of measurement"""
+        """Unit of measurement."""
         return self._unit_of_measurement
 
     @property
     def temperature_unit(self):
-        """temperature unit"""
+        """Temperature unit."""
         return self._unit_of_measurement
 
     @property
     def current_temperature(self):
-        """current temperature"""
+        """Current temperature."""
         return float(self._device.current_temp_f)
 
     @property
     def target_temperature(self):
-        """target temperature"""
+        """Target temperature."""
         return float(self._device.set_temp_value_f)
 
     @property
     def state(self):
-        """current state"""
+        """Current state."""
         return self.current_operation
 
     @property
     def current_operation(self):
-        """current operation mode"""
+        """Current operation mode."""
         return self._device.current_operation
 
     @property
     def operation_list(self):
-        """list of supported operations"""
+        """List of supported operations."""
         return self._device.operation_list
 
     @property
     def current_fan_mode(self):
-        """current fan mode"""
+        """Current fan mode."""
         return self._device.current_fan_speed
 
     @property
     def fan_list(self):
-        """list of supported fan modes"""
+        """List of supported fan modes."""
         return self._device.fan_speed_options
 
     async def async_set_temperature(self, **kwargs):
-        """set the temperature"""
+        """Set the temperature."""
         await self._device.set_temperature_f(kwargs[ATTR_TEMPERATURE])
         await self._refresh()
 
     async def async_set_swing_mode(self, swing_mode):
-        """set the swing mode"""
+        """Set the swing mode."""
         await self._device.set_air_direction(swing_mode)
         await self._refresh()
 
     async def async_set_fan_mode(self, fan):
-        """set the fan mode"""
+        """Set the fan mode."""
         await self._device.set_fan_speed(fan)
         await self._refresh()
 
     async def async_set_operation_mode(self, operation_mode, **kwargs):
-        """set the operation mode"""
+        """Set the operation mode."""
         await self._device.set_operation(operation_mode)
         await self._refresh()
 
     @property
     def current_swing_mode(self):
-        """get the current swing mode"""
+        """Get the current swing mode."""
         return self._device.current_air_direction
 
     @property
     def swing_list(self):
-        """get the list of available swing lists"""
+        """Get the list of available swing lists."""
         return self._device.air_direction_options
 
     @property
@@ -160,5 +160,5 @@ class MitsubishiHvacDevice(ClimateDevice):
         return SUPPORT_FLAGS
 
     async def async_update(self):
-        """update"""
+        """Update."""
         await self._device.refresh(self.schedule_update_ha_state)

--- a/homeassistant/components/climate/mitsubishicontroller.py
+++ b/homeassistant/components/climate/mitsubishicontroller.py
@@ -12,42 +12,49 @@ from homeassistant.components.climate import (ClimateDevice, PLATFORM_SCHEMA,
                                               SUPPORT_TARGET_TEMPERATURE,
                                               SUPPORT_FAN_MODE,
                                               SUPPORT_OPERATION_MODE,
-                                              SUPPORT_SWING_MODE)
-from homeassistant.const import CONF_URL
+                                              SUPPORT_SWING_MODE,
+                                              ATTR_FAN_MODE)
+from homeassistant.const import CONF_URL, ATTR_TEMPERATURE
 from homeassistant.const import TEMP_FAHRENHEIT
 
+"""pypi requirements"""
 REQUIREMENTS = ['mitsPy==0.1.9']
 
+"""config params"""
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_URL): cv.string
 })
 
-
 async def async_setup_platform(hass, config, async_add_devices,
                                discovery_info=None):
+    """setup platform asynchronously"""
     from mitsPy.manager import Manager
     controller = Manager(config.get(CONF_URL))
 
     async def register_devices(raw_devices):
         async_add_devices(
-            [MitsubishiHvacDevice(device=device,
-                                  unit_of_measurement=TEMP_FAHRENHEIT) for
-             device in raw_devices])
+            [MitsubishiHvacDevice(
+                device=device,
+                unit_of_measurement=TEMP_FAHRENHEIT) for
+                device in raw_devices]
+        )
 
     await controller.initialize(register_devices)
 
-
+"""supported features, for now all units will show the same features"""
 SUPPORT_FLAGS = (
-        SUPPORT_TARGET_TEMPERATURE |
-        SUPPORT_OPERATION_MODE |
-        SUPPORT_FAN_MODE |
-        SUPPORT_SWING_MODE
+    SUPPORT_TARGET_TEMPERATURE
+    | SUPPORT_OPERATION_MODE
+    | SUPPORT_FAN_MODE
+    | SUPPORT_SWING_MODE
 )
 
 
 class MitsubishiHvacDevice(ClimateDevice):
+    """Mitsubishi HVAC Device"""
     def __init__(self, device, unit_of_measurement=None,
                  current_fan_mode=None):
+        """initialize device"""
         self._device = device
         self._name = self._device.group_name
         self._current_swing_mode = self._device.current_air_direction
@@ -55,75 +62,94 @@ class MitsubishiHvacDevice(ClimateDevice):
         self._current_fan_mode = current_fan_mode
         self._device.refresh(self.schedule_update_ha_state)
 
+
     async def _refresh(self):
+        """refresh function"""
         await self._device.refresh(self.schedule_update_ha_state)
 
     @property
     def should_poll(self):
+        """should poll"""
         return True
 
     @property
     def name(self):
+        """device name"""
         return self._name
 
     @property
     def unit_of_measurement(self):
+        """unit of measurement"""
         return self._unit_of_measurement
 
     @property
     def temperature_unit(self):
+        """temperature unit"""
         return self._unit_of_measurement
 
     @property
     def current_temperature(self):
+        """current temperature"""
         return float(self._device.current_temp_f)
 
     @property
     def target_temperature(self):
+        """target temperature"""
         return float(self._device.set_temp_value_f)
 
     @property
     def state(self):
+        """current state"""
         return self.current_operation
 
     @property
     def current_operation(self):
+        """current operation mode"""
         return self._device.current_operation
 
     @property
     def operation_list(self):
+        """list of supported operations"""
         return self._device.operation_list
 
     @property
     def current_fan_mode(self):
+        """current fan mode"""
         return self._device.current_fan_speed
 
     @property
     def fan_list(self):
+        """list of supported fan modes"""
         return self._device.fan_speed_options
 
-    async def async_set_temperature(self, temperature, **kwargs):
-        await self._device.set_temperature_f(temperature)
+    async def async_set_temperature(self, **kwargs):
+        """set the temperature"""
+        await self._device.set_temperature_f(kwargs[ATTR_TEMPERATURE])
         await self._refresh()
 
     async def async_set_swing_mode(self, swing_mode):
+        """set the swing mode"""
         await self._device.set_air_direction(swing_mode)
         await self._refresh()
 
     async def async_set_fan_mode(self, fan):
+        """set the fan mode"""
         await self._device.set_fan_speed(fan)
         await self._refresh()
 
-    async def async_set_operation_mode(self, operation_mode):
+    async def async_set_operation_mode(self, operation_mode, **kwargs):
+        """set the operation mode"""
         await self._device.set_operation(operation_mode)
         await self._refresh()
 
     @property
     def current_swing_mode(self):
+        """get the current swing mode"""
         return self._device.current_air_direction
 
     @property
     def swing_list(self):
+        """get the list of available swing lists"""
         return self._device.air_direction_options
 
     @property
@@ -132,4 +158,5 @@ class MitsubishiHvacDevice(ClimateDevice):
         return SUPPORT_FLAGS
 
     async def async_update(self):
+        """update"""
         await self._device.refresh(self.schedule_update_ha_state)

--- a/homeassistant/components/climate/mitsubishicontroller.py
+++ b/homeassistant/components/climate/mitsubishicontroller.py
@@ -16,10 +16,8 @@ from homeassistant.components.climate import (ClimateDevice, PLATFORM_SCHEMA,
 from homeassistant.const import CONF_URL, ATTR_TEMPERATURE
 from homeassistant.const import TEMP_FAHRENHEIT
 
-"""pypi requirements"""
 REQUIREMENTS = ['mitsPy==0.1.9']
 
-"""config params"""
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_URL): cv.string
 })
@@ -32,17 +30,16 @@ async def async_setup_platform(hass, config, async_add_devices,
     controller = Manager(config.get(CONF_URL))
 
     async def register_devices(raw_devices):
+        """Register devices."""
         async_add_devices(
             [MitsubishiHvacDevice(
                 device=device,
-                unit_of_measurement=TEMP_FAHRENHEIT) for
-                device in raw_devices]
+                unit_of_measurement=TEMP_FAHRENHEIT) for device in raw_devices]
         )
 
     await controller.initialize(register_devices)
 
 
-"""supported features, for now all units will show the same features"""
 SUPPORT_FLAGS = (
     SUPPORT_TARGET_TEMPERATURE
     | SUPPORT_OPERATION_MODE
@@ -133,12 +130,11 @@ class MitsubishiHvacDevice(ClimateDevice):
         await self._device.set_air_direction(swing_mode)
         await self._refresh()
 
-    async def async_set_fan_mode(self, fan):
+    async def async_set_fan_mode(self, fan_mode):
         """Set the fan mode."""
-        await self._device.set_fan_speed(fan)
-        await self._refresh()
+        await self._device.set_fan_speed(fan_mode)
 
-    async def async_set_operation_mode(self, operation_mode, **kwargs):
+    async def async_set_operation_mode(self, operation_mode):
         """Set the operation mode."""
         await self._device.set_operation(operation_mode)
         await self._refresh()

--- a/homeassistant/components/climate/mitsubishicontroller.py
+++ b/homeassistant/components/climate/mitsubishicontroller.py
@@ -1,3 +1,10 @@
+"""
+Platform for a Mitsubishi Controller.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/climate.mitsubishicontroller/
+"""
+
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv

--- a/homeassistant/components/climate/mitsubishicontroller.py
+++ b/homeassistant/components/climate/mitsubishicontroller.py
@@ -1,121 +1,119 @@
 import voluptuous as vol
 
-import asyncio
-
 import homeassistant.helpers.config_validation as cv
-from homeassistant.components.climate import ClimateDevice
+from homeassistant.components.climate import (ClimateDevice, PLATFORM_SCHEMA,
+                                              SUPPORT_TARGET_TEMPERATURE,
+                                              SUPPORT_FAN_MODE,
+                                              SUPPORT_OPERATION_MODE,
+                                              SUPPORT_SWING_MODE)
 from homeassistant.const import CONF_URL
 from homeassistant.const import TEMP_FAHRENHEIT
-from homeassistant.components.climate import ( ClimateDevice, PLATFORM_SCHEMA, 
-SUPPORT_TARGET_TEMPERATURE,
-SUPPORT_TARGET_TEMPERATURE_HIGH,
-SUPPORT_TARGET_TEMPERATURE_LOW,
-SUPPORT_TARGET_HUMIDITY,
-SUPPORT_TARGET_HUMIDITY_HIGH,
-SUPPORT_TARGET_HUMIDITY_LOW,
-SUPPORT_FAN_MODE,
-SUPPORT_OPERATION_MODE,
-SUPPORT_HOLD_MODE,
-SUPPORT_SWING_MODE,
-SUPPORT_AWAY_MODE,
-SUPPORT_AUX_HEAT,
-SUPPORT_ON_OFF)
-REQUIREMENTS = ['mitsPy==0.1.8']
+
+REQUIREMENTS = ['mitsPy==0.1.9']
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_URL): cv.string
+  vol.Required(CONF_URL): cv.string
 })
 
+
 async def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
-    from mitsPy.manager import Manager
-    controller = Manager(config.get(CONF_URL))
-    async def register_devices(raw_devices):
-        async_add_devices(
-        [MitsubishiHvacDevice(device=device, unit_of_measurement=TEMP_FAHRENHEIT) for device in raw_devices])
-    await controller.initialize(register_devices)
+  from mitsPy.manager import Manager
+  controller = Manager(config.get(CONF_URL))
+
+  async def register_devices(raw_devices):
+    async_add_devices(
+      [MitsubishiHvacDevice(device=device, unit_of_measurement=TEMP_FAHRENHEIT) for device in raw_devices])
+
+  await controller.initialize(register_devices)
+
 
 SUPPORT_FLAGS = (SUPPORT_TARGET_TEMPERATURE | SUPPORT_OPERATION_MODE | SUPPORT_FAN_MODE | SUPPORT_SWING_MODE)
 
+
 class MitsubishiHvacDevice(ClimateDevice):
-    def __init__(self, device, unit_of_measurement=None, current_fan_mode=None):
-        self._device = device
-        self._name = self._device.number + " : " + self._device.group_name
-        self._current_swing_mode = self._device.current_air_direction
-        self._unit_of_measurement = unit_of_measurement
-        self._current_fan_mode = current_fan_mode
-        self._device.refresh(self.schedule_update_ha_state)
+  def __init__(self, device, unit_of_measurement=None, current_fan_mode=None):
+    self._device = device
+    self._name = self._device.group_name
+    self._current_swing_mode = self._device.current_air_direction
+    self._unit_of_measurement = unit_of_measurement
+    self._current_fan_mode = current_fan_mode
+    self._device.refresh(self.schedule_update_ha_state)
 
-    async def _refresh(self):
-        await self._device.refresh(self.schedule_update_ha_state)
+  async def _refresh(self):
+    await self._device.refresh(self.schedule_update_ha_state)
 
-    @property
-    def should_poll(self):
-        return True
+  @property
+  def should_poll(self):
+    return False
 
-    @property
-    def name(self):
-        return self._name
+  @property
+  def name(self):
+    return self._name
 
-    @property
-    def unit_of_measurement(self):
-        return self._unit_of_measurement
+  @property
+  def unit_of_measurement(self):
+    return self._unit_of_measurement
 
-    @property
-    def temperature_unit(self):
-        return self._unit_of_measurement
+  @property
+  def temperature_unit(self):
+    return self._unit_of_measurement
 
-    @property
-    def current_temperature(self):
-        return float(self._device.current_temp_f)
+  @property
+  def current_temperature(self):
+    return float(self._device.current_temp_f)
 
-    @property
-    def target_temperature(self):
-        return float(self._device.set_temp_value_f)
+  @property
+  def target_temperature(self):
+    return float(self._device.set_temp_value_f)
 
-    @property
-    def current_operation(self):
-        return self._device.current_operation
+  @property
+  def state(self):
+    return self.current_operation
 
-    @property
-    def operation_list(self):
-        return self._device.operation_list
+  @property
+  def current_operation(self):
+    return self._device.current_operation
 
-    @property
-    def current_fan_mode(self):
-        return self._device.current_fan_speed
+  @property
+  def operation_list(self):
+    return self._device.operation_list
 
-    @property
-    def fan_list(self):
-        return self._device.fan_speed_options
+  @property
+  def current_fan_mode(self):
+    return self._device.current_fan_speed
 
-    async def async_set_temperature(self, temperature, **kwargs):
-        await self._device.set_temperature_f(temperature)
-        await self._refresh()
+  @property
+  def fan_list(self):
+    return self._device.fan_speed_options
 
-    async def async_set_swing_mode(self, swing_mode):
-        await self._device.set_air_direction(swing_mode)
-        await self._refresh()
+  async def async_set_temperature(self, temperature, **kwargs):
+    await self._device.set_temperature_f(temperature)
+    await self._refresh()
 
-    async def async_set_fan_mode(self, fan):
-        await self._device.set_fan_speed(fan)
-        await self._refresh()
+  async def async_set_swing_mode(self, swing_mode):
+    await self._device.set_air_direction(swing_mode)
+    await self._refresh()
 
-    async def async_set_operation_mode(self, operation_mode):
-        await self._device.set_operation(operation_mode)
-        await self._refresh()
+  async def async_set_fan_mode(self, fan):
+    await self._device.set_fan_speed(fan)
+    await self._refresh()
 
-    @property
-    def current_swing_mode(self):
-        return self._device.current_air_direction
+  async def async_set_operation_mode(self, operation_mode):
+    await self._device.set_operation(operation_mode)
+    await self._refresh()
 
-    @property
-    def swing_list(self):
-        return self._device.air_direction_options
-        
-    @property
-    def supported_features(self):
-        """Return the list of supported features."""
-        return SUPPORT_FLAGS
+  @property
+  def current_swing_mode(self):
+    return self._device.current_air_direction
 
-    async def async_update(self):
-        await self._device.refresh(self.schedule_update_ha_state)
+  @property
+  def swing_list(self):
+    return self._device.air_direction_options
+
+  @property
+  def supported_features(self):
+    """Return the list of supported features."""
+    return SUPPORT_FLAGS
+
+  async def async_update(self):
+    await self._device.refresh(self.schedule_update_ha_state)

--- a/homeassistant/components/climate/mitsubishicontroller.py
+++ b/homeassistant/components/climate/mitsubishicontroller.py
@@ -25,6 +25,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_URL): cv.string
 })
 
+
 async def async_setup_platform(hass, config, async_add_devices,
                                discovery_info=None):
     """setup platform asynchronously"""
@@ -41,6 +42,7 @@ async def async_setup_platform(hass, config, async_add_devices,
 
     await controller.initialize(register_devices)
 
+
 """supported features, for now all units will show the same features"""
 SUPPORT_FLAGS = (
     SUPPORT_TARGET_TEMPERATURE
@@ -52,6 +54,7 @@ SUPPORT_FLAGS = (
 
 class MitsubishiHvacDevice(ClimateDevice):
     """Mitsubishi HVAC Device"""
+
     def __init__(self, device, unit_of_measurement=None,
                  current_fan_mode=None):
         """initialize device"""
@@ -61,7 +64,6 @@ class MitsubishiHvacDevice(ClimateDevice):
         self._unit_of_measurement = unit_of_measurement
         self._current_fan_mode = current_fan_mode
         self._device.refresh(self.schedule_update_ha_state)
-
 
     async def _refresh(self):
         """refresh function"""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -560,6 +560,9 @@ miflora==0.4.0
 # homeassistant.components.sensor.mitemp_bt
 mitemp_bt==0.0.1
 
+# homeassistant.components.climate.mitsubishicontroller
+mitsPy==0.1.8
+
 # homeassistant.components.sensor.mopar
 motorparts==1.0.2
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -561,7 +561,7 @@ miflora==0.4.0
 mitemp_bt==0.0.1
 
 # homeassistant.components.climate.mitsubishicontroller
-mitsPy==0.1.8
+mitsPy==0.1.9
 
 # homeassistant.components.sensor.mopar
 motorparts==1.0.2


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5720

## Example entry for `configuration.yaml` (if applicable):
```yaml
climate:
  - platform: mitsubishicontroller
    url: http://192.168.1.3
    scan_interval: 300
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
