### PR TITLE
Numeric integer

### DIFF
--- a/homeassistant/components/numeric_float.py
+++ b/homeassistant/components/numeric_float.py
@@ -1,0 +1,164 @@
+"""
+Component to offer a way to store a numeric float.
+
+For more details about this component, please refer to the documentation
+at https://home-assistant.io/components/numeric_float/
+"""
+import asyncio
+import logging
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.const import (
+    ATTR_ENTITY_ID, ATTR_UNIT_OF_MEASUREMENT, CONF_ICON, CONF_NAME)
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.entity_component import EntityComponent
+from homeassistant.loader import bind_hass
+from homeassistant.helpers.restore_state import async_get_last_state
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = 'numeric_float'
+ENTITY_ID_FORMAT = DOMAIN + '.{}'
+
+CONF_INITIAL = 'initial'
+ATTR_VALUE = 'value'
+
+SERVICE_SET_VALUE = 'set_value'
+
+SERVICE_DEFAULT_SCHEMA = vol.Schema({
+    vol.Optional(ATTR_ENTITY_ID): cv.entity_ids
+})
+
+SERVICE_SET_VALUE_SCHEMA = vol.Schema({
+    vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
+    vol.Required(ATTR_VALUE): vol.Coerce(float),
+})
+
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        cv.slug: vol.All({
+            vol.Optional(CONF_NAME): cv.string,
+            vol.Optional(CONF_INITIAL): vol.Coerce(float),
+            vol.Optional(CONF_ICON): cv.icon,
+            vol.Optional(ATTR_UNIT_OF_MEASUREMENT): cv.string,
+        })
+    })
+}, required=True, extra=vol.ALLOW_EXTRA)
+
+
+SERVICE_TO_METHOD = {
+    SERVICE_SET_VALUE: {
+        'method': 'async_set_value',
+        'schema': SERVICE_SET_VALUE_SCHEMA},
+}
+
+
+@bind_hass
+def set_value(hass, entity_id, value):
+    """Set numeric_value to a value."""
+    hass.services.call(DOMAIN, SERVICE_SET_VALUE, {
+        ATTR_ENTITY_ID: entity_id,
+        ATTR_VALUE: value,
+    })
+
+
+@asyncio.coroutine
+def async_setup(hass, config):
+    """Set up an Numeric Float."""
+    component = EntityComponent(_LOGGER, DOMAIN, hass)
+
+    entities = []
+
+    for object_id, cfg in config[DOMAIN].items():
+        name = cfg.get(CONF_NAME)
+        initial = cfg.get(CONF_INITIAL)
+        icon = cfg.get(CONF_ICON)
+        unit = cfg.get(ATTR_UNIT_OF_MEASUREMENT)
+        entities.append(NumericValue(object_id, name, initial, icon, unit))
+
+    if not entities:
+        return False
+
+    @asyncio.coroutine
+    def async_handle_service(service):
+        """Handle calls to numeric_float services."""
+        target_inputs = component.async_extract_from_service(service)
+        method = SERVICE_TO_METHOD.get(service.service)
+        params = service.data.copy()
+        params.pop(ATTR_ENTITY_ID, None)
+
+        update_tasks = []
+        for target_input in target_inputs:
+            yield from getattr(target_input, method['method'])(**params)
+            if not target_input.should_poll:
+                continue
+            update_tasks.append(target_input.async_update_ha_state(True))
+
+        if update_tasks:
+            yield from asyncio.wait(update_tasks, loop=hass.loop)
+
+    for service, data in SERVICE_TO_METHOD.items():
+        hass.services.async_register(
+            DOMAIN, service, async_handle_service, schema=data['schema'])
+
+    yield from component.async_add_entities(entities)
+    return True
+
+
+class NumericValue(Entity):
+    """Representation of a Numeric Float."""
+
+    def __init__(self, object_id, name, initial, icon, unit):
+        """Initialize an Numeric Float."""
+        self.entity_id = ENTITY_ID_FORMAT.format(object_id)
+        self._name = name
+        self._current_value = initial
+        self._icon = icon
+        self._unit = unit
+
+    @property
+    def should_poll(self):
+        """If entity should be polled."""
+        return False
+
+    @property
+    def name(self):
+        """Return the name of the Numeric Float."""
+        return self._name
+
+    @property
+    def icon(self):
+        """Return the icon to be used for this entity."""
+        return self._icon
+
+    @property
+    def state(self):
+        """Return the state of the component."""
+        return self._current_value
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit the value is expressed in."""
+        return self._unit
+
+    @asyncio.coroutine
+    def async_added_to_hass(self):
+        """Run when entity about to be added to hass."""
+        if self._current_value is not None:
+            return
+
+        state = yield from async_get_last_state(self.hass, self.entity_id)
+        value = state and float(state.state)
+
+        if value is not None:
+            self._current_value = value
+
+    @asyncio.coroutine
+    def async_set_value(self, value):
+        """Set new value."""
+        num_value = float(value)
+        self._current_value = num_value
+        yield from self.async_update_ha_state()

--- a/homeassistant/components/numeric_integer.py
+++ b/homeassistant/components/numeric_integer.py
@@ -1,8 +1,8 @@
 """
-Component to offer a way to store a numeric float.
+Component to offer a way to store a numeric value as an Integer.
 
 For more details about this component, please refer to the documentation
-at https://home-assistant.io/components/numeric_float/
+at https://home-assistant.io/components/numeric_integer/
 """
 import asyncio
 import logging
@@ -19,7 +19,7 @@ from homeassistant.helpers.restore_state import async_get_last_state
 
 _LOGGER = logging.getLogger(__name__)
 
-DOMAIN = 'numeric_float'
+DOMAIN = 'numeric_integer'
 ENTITY_ID_FORMAT = DOMAIN + '.{}'
 
 CONF_INITIAL = 'initial'
@@ -33,7 +33,7 @@ SERVICE_DEFAULT_SCHEMA = vol.Schema({
 
 SERVICE_SET_VALUE_SCHEMA = vol.Schema({
     vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
-    vol.Required(ATTR_VALUE): vol.Coerce(float),
+    vol.Required(ATTR_VALUE): vol.Coerce(int),
 })
 
 
@@ -41,13 +41,12 @@ CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         cv.slug: vol.All({
             vol.Optional(CONF_NAME): cv.string,
-            vol.Optional(CONF_INITIAL): vol.Coerce(float),
+            vol.Optional(CONF_INITIAL): vol.Coerce(int),
             vol.Optional(CONF_ICON): cv.icon,
             vol.Optional(ATTR_UNIT_OF_MEASUREMENT): cv.string,
         })
     })
 }, required=True, extra=vol.ALLOW_EXTRA)
-
 
 SERVICE_TO_METHOD = {
     SERVICE_SET_VALUE: {
@@ -58,7 +57,7 @@ SERVICE_TO_METHOD = {
 
 @bind_hass
 def set_value(hass, entity_id, value):
-    """Set numeric_value to a value."""
+    """Set numeric_integer to a value."""
     hass.services.call(DOMAIN, SERVICE_SET_VALUE, {
         ATTR_ENTITY_ID: entity_id,
         ATTR_VALUE: value,
@@ -67,7 +66,7 @@ def set_value(hass, entity_id, value):
 
 @asyncio.coroutine
 def async_setup(hass, config):
-    """Set up an Numeric Float."""
+    """Set up an Numeric Integer."""
     component = EntityComponent(_LOGGER, DOMAIN, hass)
 
     entities = []
@@ -77,14 +76,14 @@ def async_setup(hass, config):
         initial = cfg.get(CONF_INITIAL)
         icon = cfg.get(CONF_ICON)
         unit = cfg.get(ATTR_UNIT_OF_MEASUREMENT)
-        entities.append(NumericValue(object_id, name, initial, icon, unit))
+        entities.append(NumericValueInt(object_id, name, initial, icon, unit))
 
     if not entities:
         return False
 
     @asyncio.coroutine
     def async_handle_service(service):
-        """Handle calls to numeric_float services."""
+        """Handle calls to numeric_integer services."""
         target_inputs = component.async_extract_from_service(service)
         method = SERVICE_TO_METHOD.get(service.service)
         params = service.data.copy()
@@ -108,11 +107,11 @@ def async_setup(hass, config):
     return True
 
 
-class NumericValue(Entity):
-    """Representation of a Numeric Float."""
+class NumericValueInt(Entity):
+    """Representation of a Numeric Integer."""
 
     def __init__(self, object_id, name, initial, icon, unit):
-        """Initialize an Numeric Float."""
+        """Initialize an Numeric Integer."""
         self.entity_id = ENTITY_ID_FORMAT.format(object_id)
         self._name = name
         self._current_value = initial
@@ -126,7 +125,7 @@ class NumericValue(Entity):
 
     @property
     def name(self):
-        """Return the name of the Numeric Float."""
+        """Return the name of the Numeric Integer."""
         return self._name
 
     @property
@@ -151,7 +150,7 @@ class NumericValue(Entity):
             return
 
         state = yield from async_get_last_state(self.hass, self.entity_id)
-        value = state and float(state.state)
+        value = state and int(state.state)
 
         if value is not None:
             self._current_value = value
@@ -159,6 +158,6 @@ class NumericValue(Entity):
     @asyncio.coroutine
     def async_set_value(self, value):
         """Set new value."""
-        num_value = float(value)
+        num_value = int(value)
         self._current_value = num_value
         yield from self.async_update_ha_state()


### PR DESCRIPTION
## Description:
The numeric_integer component allows the user to store values that can be controlled with automation

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):**
https://github.com/home-assistant/home-assistant.github.io/pull/5663

## Example entry for `configuration.yaml` (if applicable):
```yaml
numeric_integer:
  days_till_run_value:
    name: Days Till Run Value
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
