### PR TITLE
Add original message as dialogflow_query to parameters

### DIFF
--- a/homeassistant/components/dialogflow.py
+++ b/homeassistant/components/dialogflow.py
@@ -99,7 +99,8 @@ async def async_handle_message(hass, message):
         return None
 
     action = req.get('action', '')
-    parameters = req.get('parameters')
+    parameters = req.get('parameters').copy()
+    parameters["dialogflow_query"] = message
     dialogflow_response = DialogflowResponse(parameters)
 
     if action == "":


### PR DESCRIPTION
## Description:
Add original message from dialogflow to the parameters as dialogflow_query so you can access for example sessionId as {{ dialogflow_query.sessionId }} in intent templates.
Another example is contexts, access them like {{ dialogflow_query.result.contexts[0].test }}

**Related issue (if applicable):** fixes #12437

## Checklist:
  - [x] The code change is tested and works locally.
