### PR TITLE
Update color.py to prevent ZeroDivisionError

### DIFF
--- a/homeassistant/util/color.py
+++ b/homeassistant/util/color.py
@@ -466,9 +466,12 @@ def _get_blue(temperature: float) -> float:
 
 def color_temperature_mired_to_kelvin(mired_temperature):
     """Convert absolute mired shift to degrees kelvin."""
-    return math.floor(1000000 / mired_temperature)
+    if mired_temperature > 0:
+        return math.floor(1000000 / mired_temperature)
+    
 
 
 def color_temperature_kelvin_to_mired(kelvin_temperature):
     """Convert degrees kelvin to mired shift."""
-    return math.floor(1000000 / kelvin_temperature)
+    if kelvin_temperature > 0:
+        return math.floor(1000000 / kelvin_temperature)


### PR DESCRIPTION
## Description:
To prevent a ZeroDivisionError I suggest this change to check if the value is bigger then 0 before making a division in line 469 and 476.

Only thing I'm not sure about is wether the functions are expected to return something so maybe an 'else' clause should be included returning null or 0 ?

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>
https://github.com/home-assistant/home-assistant/issues/13381 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
