### PR TITLE
Add set_cover_position support in cover/command_line

### DIFF
--- a/homeassistant/components/cover/command_line.py
+++ b/homeassistant/components/cover/command_line.py
@@ -1,6 +1,5 @@
 """
 Support for command line covers.
-
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/cover.command_line/
 """
@@ -22,6 +21,7 @@ COVER_SCHEMA = vol.Schema({
     vol.Optional(CONF_COMMAND_OPEN, default='true'): cv.string,
     vol.Optional(CONF_COMMAND_STATE): cv.string,
     vol.Optional(CONF_COMMAND_STOP, default='true'): cv.string,
+    vol.Optional('command_set_position', default='true'): cv.string,
     vol.Optional(CONF_FRIENDLY_NAME): cv.string,
     vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
 })
@@ -49,6 +49,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                 device_config.get(CONF_COMMAND_CLOSE),
                 device_config.get(CONF_COMMAND_STOP),
                 device_config.get(CONF_COMMAND_STATE),
+                device_config.get('command_set_position'),
                 value_template,
             )
         )
@@ -64,7 +65,7 @@ class CommandCover(CoverDevice):
     """Representation a command line cover."""
 
     def __init__(self, hass, name, command_open, command_close, command_stop,
-                 command_state, value_template):
+                 command_state, command_set_position, value_template):
         """Initialize the cover."""
         self._hass = hass
         self._name = name
@@ -73,6 +74,7 @@ class CommandCover(CoverDevice):
         self._command_close = command_close
         self._command_stop = command_stop
         self._command_state = command_state
+        self._command_set_position = command_set_position
         self._value_template = value_template
 
     @staticmethod
@@ -117,7 +119,6 @@ class CommandCover(CoverDevice):
     @property
     def current_cover_position(self):
         """Return current position of cover.
-
         None is unknown, 0 is closed, 100 is fully open.
         """
         return self._state
@@ -149,3 +150,10 @@ class CommandCover(CoverDevice):
     def stop_cover(self, **kwargs):
         """Stop the cover."""
         self._move_cover(self._command_stop)
+
+    def set_cover_position(self, **kwargs):
+        """Move the cover to a specific position."""
+        position = kwargs.get('position')
+        if self._state == position:
+            return
+        self._move_cover(self._command_set_position + str(position))


### PR DESCRIPTION
## Description:

The `set_cover_position` support is achieved by appending the position number (1~100) after the `command_set_position` command. 

In my case, I'm using a http GET request to control my cover. The command_set_position is set as "curl -X GET http://mycoverurl/set/" in my configuration. So if I need to set the position at 50, it will execute command "curl -X GET http://mycoverurl/set/50".

Also, something like this needed to add in const.py to make this work:
CONF_COMMAND_SET_POSITION = "command_set_position"


**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
  - platform: cmd_line_v2
    covers:
      test_cover:
        command_open: "curl -X GET http://mycoverurl/cw"
        command_close: "curl -X GET http://mycoverurl/ccw"
        command_stop: "curl -X GET http://mycoverurl/stop"
        command_state: "curl -X GET http://mycoverurl/stat"
        command_set_position: "curl -X GET http://mycoverurl/set/"

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
