### PR TITLE
Add NAD DB volume to attributes

### DIFF
--- a/homeassistant/components/media_player/nadtcp.py
+++ b/homeassistant/components/media_player/nadtcp.py
@@ -25,7 +25,7 @@ DEFAULT_MAX_VOLUME = -10
 DEFAULT_VOLUME_STEP = 4
 
 SUPPORT_NAD = SUPPORT_VOLUME_SET | SUPPORT_VOLUME_MUTE | SUPPORT_TURN_ON | \
-              SUPPORT_TURN_OFF | SUPPORT_VOLUME_STEP | SUPPORT_SELECT_SOURCE
+    SUPPORT_TURN_OFF | SUPPORT_VOLUME_STEP | SUPPORT_SELECT_SOURCE
 
 CONF_MIN_VOLUME = 'min_volume'
 CONF_MAX_VOLUME = 'max_volume'
@@ -119,12 +119,12 @@ class NADtcp(MediaPlayerDevice):
             volume_internal = (nad_volume - self._min_vol) / \
                               (self._max_vol - self._min_vol)
         return volume_internal
-		
+
     def nad_vol_to_db_vol(self, nad_volume):
         """Convert nad volume range (0-200) to dB (-90 - +10) volume range"""
-        
+
         nad_volume_db = (nad_volume / 2) - 90
-        
+
         return nad_volume_db
 
     @property
@@ -192,5 +192,5 @@ class NADtcp(MediaPlayerDevice):
         NAD Volume in DB """
         attr = {}
         attr['nad_volume_db'] = self._nad_volume_db
-        
+
         return attr

--- a/homeassistant/components/media_player/nadtcp.py
+++ b/homeassistant/components/media_player/nadtcp.py
@@ -68,6 +68,7 @@ class NADtcp(MediaPlayerDevice):
         self._volume = None
         self._source = None
         self._source_list = self.nad_device.available_sources()
+        self._nad_volume_db = None
 
     @property
     def name(self):
@@ -97,6 +98,7 @@ class NADtcp(MediaPlayerDevice):
         # Update current volume
         self._volume = self.nad_vol_to_internal_vol(nad_status['volume'])
         self._nad_volume = nad_status['volume']
+        self._nad_volume_db = self.nad_vol_to_db_vol(nad_status['volume'])
 
         # Update muted state
         self._mute = nad_status['muted']
@@ -117,6 +119,13 @@ class NADtcp(MediaPlayerDevice):
             volume_internal = (nad_volume - self._min_vol) / \
                               (self._max_vol - self._min_vol)
         return volume_internal
+		
+    def nad_vol_to_db_vol(self, nad_volume):
+        """Convert nad volume range (0-200) to dB (-90 - +10) volume range"""
+        
+        nad_volume_db = (nad_volume / 2) - 90
+        
+        return nad_volume_db
 
     @property
     def supported_features(self):
@@ -176,3 +185,12 @@ class NADtcp(MediaPlayerDevice):
     def is_volume_muted(self):
         """Boolean if volume is currently muted."""
         return self._mute
+
+    @property
+    def device_state_attributes(self):
+        """Return device specific state attributes.
+        NAD Volume in DB """
+        attr = {}
+        attr['nad_volume_db'] = self._nad_volume_db
+        
+        return attr

--- a/homeassistant/components/media_player/nadtcp.py
+++ b/homeassistant/components/media_player/nadtcp.py
@@ -183,8 +183,8 @@ class NADtcp(MediaPlayerDevice):
     def device_state_attributes(self):
         """Return device specific state attributes.
 
-		NAD Volume in DB.
-		"""
+                NAD Volume in DB.
+                """
         attr = {}
         attr['nad_volume_db'] = self._nad_volume_db
 

--- a/homeassistant/components/media_player/nadtcp.py
+++ b/homeassistant/components/media_player/nadtcp.py
@@ -98,7 +98,7 @@ class NADtcp(MediaPlayerDevice):
         # Update current volume
         self._volume = self.nad_vol_to_internal_vol(nad_status['volume'])
         self._nad_volume = nad_status['volume']
-        self._nad_volume_db = self.nad_vol_to_db_vol(nad_status['volume'])
+        self._nad_volume_db = ((nad_status['volume'] / 2) - 90)
 
         # Update muted state
         self._mute = nad_status['muted']
@@ -119,13 +119,6 @@ class NADtcp(MediaPlayerDevice):
             volume_internal = (nad_volume - self._min_vol) / \
                               (self._max_vol - self._min_vol)
         return volume_internal
-
-    def nad_vol_to_db_vol(self, nad_volume):
-        """Convert nad volume range (0-200) to dB (-90 - +10) volume range"""
-
-        nad_volume_db = (nad_volume / 2) - 90
-
-        return nad_volume_db
 
     @property
     def supported_features(self):
@@ -189,7 +182,9 @@ class NADtcp(MediaPlayerDevice):
     @property
     def device_state_attributes(self):
         """Return device specific state attributes.
-        NAD Volume in DB """
+
+		NAD Volume in DB.
+		"""
         attr = {}
         attr['nad_volume_db'] = self._nad_volume_db
 

--- a/homeassistant/components/media_player/nadtcp.py
+++ b/homeassistant/components/media_player/nadtcp.py
@@ -183,8 +183,8 @@ class NADtcp(MediaPlayerDevice):
     def device_state_attributes(self):
         """Return device specific state attributes.
 
-                NAD Volume in DB.
-                """
+        NAD Volume in DB.
+        """
         attr = {}
         attr['nad_volume_db'] = self._nad_volume_db
 


### PR DESCRIPTION
## Description:
NAD DB volume added to front end as attribute.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
