### PR TITLE
add option to receive fullstate on /api/stream establish

### DIFF
--- a/homeassistant/components/api.py
+++ b/homeassistant/components/api.py
@@ -120,7 +120,7 @@ class APIEventStream(HomeAssistantView):
             # Fire off one message so browsers fire open event right away
             if fullstate:
                 msg = json.dumps(request.app['hass'].states.async_all(),
-                    cls=rem.JSONEncoder)
+                                 cls=rem.JSONEncoder)
             else:
                 msg = STREAM_PING_PAYLOAD
 


### PR DESCRIPTION
# summary

This changes add a GET query parameter to the `/api/stream` endpoint (`fullstate`).  If this parameter is set, the state of all entities will be returned immediately when the stream is established instead of the first ping packet.

# example

`GET /api/stream`

```
$ ./curl-hass /api/stream
data: ping

^C
```

`GET /api/stream?fullstate=true`
```
$ ./curl-hass /api/stream?fullstate=true
data: [{"entity_id": "zone.home", "state": "zoning", "attributes": {"hidden": true, ...}}] (snipped for brevity)
```

The first data packet received is functionally equivalent to the data received by `GET /api/states`

# reasoning

I want to make a home assistant dashboard (HTML/CSS/JavaScript) for my home, and want it to consume the stream api for realtime updates.  In order to get the initial state (for when the dashboard first starts), I'd have to hit `/api/states` - this seemed inherently racy to me.  Basically, a connection would have to be made to `/api/states` and `/api/stream` and there is no guarantee which one will be handled first, or if messages would have possibly been lost in the time between 1 connection completed to when both completed.   I *could* create the stream request first, then query the full states, and then try to coalesce that data into 1 view of the current system.

Instead, I thought it would be easiest for the `/api/stream` endpoint to just dump its current view of the world first, and then give subsequent updates that can be "applied" to the original dump so the consumer can always have the most up-to-date view of the entities in the system.

This is a new flag, so existing consumers of this endpoint should not be affected.