### PR TITLE
Fix confused brightness of xiaomi_aqara gateway light

### DIFF
--- a/homeassistant/components/light/xiaomi_aqara.py
+++ b/homeassistant/components/light/xiaomi_aqara.py
@@ -31,7 +31,7 @@ class XiaomiGatewayLight(XiaomiDevice, Light):
         """Initialize the XiaomiGatewayLight."""
         self._data_key = 'rgb'
         self._hs = (0, 0)
-        self._brightness = 180
+        self._brightness = 100
 
         XiaomiDevice.__init__(self, device, name, xiaomi_hub)
 
@@ -64,7 +64,7 @@ class XiaomiGatewayLight(XiaomiDevice, Light):
         brightness = rgba[0]
         rgb = rgba[1:]
 
-        self._brightness = int(255 * brightness / 100)
+        self._brightness = brightness
         self._hs = color_util.color_RGB_to_hs(*rgb)
         self._state = True
         return True
@@ -72,7 +72,7 @@ class XiaomiGatewayLight(XiaomiDevice, Light):
     @property
     def brightness(self):
         """Return the brightness of this light between 0..255."""
-        return self._brightness
+        return int(255 * self._brightness / 100)
 
     @property
     def hs_color(self):


### PR DESCRIPTION
## Description:

There was a mixup of scales 0-100 (Xiaomi) and 0-255 (Home Assistant). This caused the brightness to change when setting a new `hs_color`.

Now `self._brightness` is always 0-100.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
