### PR TITLE
Ignore some HomeKit devices

### DIFF
--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -26,6 +26,12 @@ HOMEKIT_ACCESSORY_DISPATCH = {
     'thermostat': 'climate',
 }
 
+HOMEKIT_IGNORE = [
+    'BSB002',
+    'Home Assistant Bridge',
+    'TRADFRI gateway'
+]
+
 KNOWN_ACCESSORIES = "{}-accessories".format(DOMAIN)
 KNOWN_DEVICES = "{}-devices".format(DOMAIN)
 
@@ -236,6 +242,9 @@ def setup(hass, config):
         model = discovery_info['properties']['md']
         hkid = discovery_info['properties']['id']
         config_num = int(discovery_info['properties']['c#'])
+
+        if model in HOMEKIT_IGNORE:
+            return
 
         # Only register a device once, but rescan if the config has changed
         if hkid in hass.data[KNOWN_DEVICES]:


### PR DESCRIPTION
There are some devices that speak HomeKit that we shouldn't expose. Some
bridges (such as the Hue) provide reduced functionality over HomeKit and
have a functional native API, so should be ignored. We also shouldn't
offer to configure the built-in Home Assistant HomeKit bridge.

**Breaking change:** Tradfri will no longer be automatically detected by the HomeKit controller. Use the native integration instead.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
