### PR TITLE
Add zigate component and platforms

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -592,6 +592,8 @@ omit =
     homeassistant/components/zeroconf.py
     homeassistant/components/zwave/util.py
     homeassistant/components/vacuum/mqtt.py
+    homeassistant/components/zigate.py
+    homeassistant/components/*/zigate.py
 
 
 [report]

--- a/.coveragerc
+++ b/.coveragerc
@@ -592,8 +592,6 @@ omit =
     homeassistant/components/zeroconf.py
     homeassistant/components/zwave/util.py
     homeassistant/components/vacuum/mqtt.py
-    homeassistant/components/zigate.py
-    homeassistant/components/*/zigate.py
 
 
 [report]

--- a/homeassistant/components/binary_sensor/zigate.py
+++ b/homeassistant/components/binary_sensor/zigate.py
@@ -69,6 +69,7 @@ class ZiGateBinarySensor(BinarySensorDevice):
                                                attribute['cluster'],
                                                attribute['attribute'],
                                                )
+        self.registry_name = '{} {}'.format(name, device)
 
         if name == 'presence':
             self._device_class = 'motion'

--- a/homeassistant/components/binary_sensor/zigate.py
+++ b/homeassistant/components/binary_sensor/zigate.py
@@ -1,0 +1,114 @@
+"""
+ZiGate platform.
+
+For more details about this platform, please refer to the documentation
+https://home-assistant.io/components/ZiGate/
+"""
+import logging
+from homeassistant.components.binary_sensor import BinarySensorDevice
+
+DOMAIN = 'zigate'
+DATA_ZIGATE_DEVICES = 'zigate_devices'
+DATA_ZIGATE_ATTRS = 'zigate_attributes'
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the ZiGate sensors."""
+    if discovery_info is None:
+        return
+
+    z = hass.data[DOMAIN]
+
+    def sync_attributes():
+        devs = []
+        for device in z.devices:
+            for attribute in device.attributes:
+                if attribute['cluster'] == 0:
+                    continue
+                if 'name' in attribute:
+                    key = '{}-{}-{}-{}'.format(device.addr,
+                                               attribute['endpoint'],
+                                               attribute['cluster'],
+                                               attribute['attribute'],
+                                               )
+                    value = attribute.get('value')
+                    if value is None:
+                        continue
+                    if key not in hass.data[DATA_ZIGATE_ATTRS]:
+                        if isinstance(value, bool):
+                            _LOGGER.debug(('Creating binary sensor '
+                                           'for device '
+                                           '{} {}').format(device,
+                                                           attribute))
+                            entity = ZiGateBinarySensor(device, attribute)
+                            devs.append(entity)
+                            hass.data[DATA_ZIGATE_ATTRS][key] = entity
+
+        add_devices(devs)
+    sync_attributes()
+    import zigate
+    zigate.dispatcher.connect(sync_attributes,
+                              zigate.ZIGATE_ATTRIBUTE_ADDED, weak=False)
+
+
+class ZiGateBinarySensor(BinarySensorDevice):
+    """representation of a ZiGate binary sensor."""
+
+    def __init__(self, device, attribute):
+        """Initialize the sensor."""
+        self._device = device
+        self._attribute = attribute
+        self._device_class = None
+        name = attribute.get('name')
+        self._name = 'zigate_{}_{}'.format(device.addr,
+                                           name)
+        self._unique_id = '{}-{}-{}-{}'.format(device.addr,
+                                               attribute['endpoint'],
+                                               attribute['cluster'],
+                                               attribute['attribute'],
+                                               )
+
+        if name == 'presence':
+            self._device_class = 'motion'
+        elif 'magnet' in self._device.get_value('type', ''):
+            self._device_class = 'door'
+
+    @property
+    def device_class(self):
+        return self._device_class
+
+    @property
+    def unique_id(self)->str:
+        return self._unique_id
+
+    @property
+    def should_poll(self):
+        """No polling needed for a ZiGate binary sensor."""
+        return False
+
+    @property
+    def name(self):
+        """Return the name of the binary sensor."""
+        return self._name
+
+    @property
+    def is_on(self):
+        """Return true if the binary sensor is on."""
+        a = self._device.get_attribute(self._attribute['endpoint'],
+                                       self._attribute['cluster'],
+                                       self._attribute['attribute'])
+        if a:
+            return a.get('value', False)
+        return False
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        return {
+            'addr': self._device.addr,
+            'endpoint': self._attribute['endpoint'],
+            'cluster': self._attribute['cluster'],
+            'attribute': self._attribute['attribute'],
+        }

--- a/homeassistant/components/light/zigate.py
+++ b/homeassistant/components/light/zigate.py
@@ -72,6 +72,7 @@ class ZiGateLight(Light):
         self._unique_id = '{}-{}-{}'.format(device.addr,
                                             'light',
                                             endpoint)
+        self.registry_name = '{} {}'.format(device, endpoint)
         import zigate
         supported_features = set()
         for action_type in device.available_actions(endpoint)[endpoint]:

--- a/homeassistant/components/light/zigate.py
+++ b/homeassistant/components/light/zigate.py
@@ -1,0 +1,183 @@
+"""
+ZiGate light platform that implements lights.
+
+For more details about this platform, please refer to the documentation
+https://home-assistant.io/components/ZiGate/
+"""
+import logging
+from functools import reduce
+from operator import ior
+
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS, ATTR_COLOR_TEMP, ATTR_EFFECT, ATTR_HS_COLOR,
+    ATTR_WHITE_VALUE, SUPPORT_BRIGHTNESS, SUPPORT_COLOR_TEMP, SUPPORT_EFFECT,
+    SUPPORT_COLOR, SUPPORT_WHITE_VALUE, Light)
+
+DOMAIN = 'zigate'
+DATA_ZIGATE_DEVICES = 'zigate_devices'
+DATA_ZIGATE_ATTRS = 'zigate_attributes'
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the ZiGate sensors."""
+    if discovery_info is None:
+        return
+
+    z = hass.data[DOMAIN]
+    import zigate
+    LIGHT_ACTIONS = [zigate.ACTIONS_LEVEL,
+                     zigate.ACTIONS_COLOR,
+                     zigate.ACTIONS_TEMPERATURE,
+                     zigate.ACTIONS_HUE,
+                     ]
+
+    def sync_attributes():
+        devs = []
+        for device in z.devices:
+            actions = device.available_actions()
+            if not actions:
+                continue
+            for endpoint, action_type in actions.items():
+                if any(i in action_type for i in LIGHT_ACTIONS):
+                    key = '{}-{}-{}'.format(device.addr,
+                                            'light',
+                                            endpoint
+                                            )
+                    if key not in hass.data[DATA_ZIGATE_ATTRS]:
+                        _LOGGER.debug(('Creating light '
+                                       'for device '
+                                       '{} {}').format(device,
+                                                       endpoint))
+                        entity = ZiGateLight(device, endpoint)
+                        devs.append(entity)
+                        hass.data[DATA_ZIGATE_ATTRS][key] = entity
+
+        add_devices(devs)
+    sync_attributes()
+    zigate.dispatcher.connect(sync_attributes,
+                              zigate.ZIGATE_ATTRIBUTE_ADDED, weak=False)
+
+
+class ZiGateLight(Light):
+    """Representation of a ZiGate light."""
+
+    def __init__(self, device, endpoint):
+        """Initialize the light."""
+        self._device = device
+        self._endpoint = endpoint
+        self._name = 'zigate_{}_{}_{}'.format(device.addr,
+                                              'light',
+                                              endpoint)
+        self._unique_id = '{}-{}-{}'.format(device.addr,
+                                            'light',
+                                            endpoint)
+        import zigate
+        supported_features = set()
+        for action_type in device.available_actions(endpoint)[endpoint]:
+            if action_type == zigate.ACTIONS_LEVEL:
+                supported_features.add(SUPPORT_BRIGHTNESS)
+            elif action_type == zigate.ACTIONS_COLOR:
+                supported_features.add(SUPPORT_COLOR)
+            elif action_type == zigate.ACTIONS_TEMPERATURE:
+                supported_features.add(SUPPORT_COLOR_TEMP)
+            elif action_type == zigate.ACTIONS_HUE:
+                supported_features.add(SUPPORT_COLOR)
+        self._supported_features = reduce(ior, supported_features)
+
+    @property
+    def should_poll(self) -> bool:
+        """No polling needed for a ZiGate light."""
+        return False
+
+    @property
+    def name(self) -> str:
+        """Return the name of the light if any."""
+        return self._name
+
+    @property
+    def unique_id(self):
+        """Return unique ID for light."""
+        return self._unique_id
+
+    @property
+    def brightness(self) -> int:
+        """Return the brightness of this light between 0..255."""
+        a = self._device.get_attribute(self._endpoint, 8, 0)
+        if a:
+            return int(a.get('value', 0)*255/100)
+        return 0
+
+#     @property
+#     def hs_color(self) -> tuple:
+#         """Return the hs color value."""
+#         return self._hs_color
+# 
+#     @property
+#     def color_temp(self) -> int:
+#         """Return the CT color temperature."""
+#         return self._ct
+# 
+#     @property
+#     def white_value(self) -> int:
+#         """Return the white value of this light between 0..255."""
+#         return self._white
+# 
+#     @property
+#     def effect_list(self) -> list:
+#         """Return the list of supported effects."""
+#         return self._effect_list
+# 
+#     @property
+#     def effect(self) -> str:
+#         """Return the current effect."""
+#         return self._effect
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if light is on."""
+        a = self._device.get_attribute(self._endpoint, 6, 0)
+        if a:
+            return a.get('value', False)
+        return False
+
+    @property
+    def supported_features(self) -> int:
+        """Flag supported features."""
+        return self._supported_features
+
+    def turn_on(self, **kwargs):
+        """Turn the switch on."""
+        if ATTR_BRIGHTNESS in kwargs:
+            brightness = kwargs[ATTR_BRIGHTNESS]
+            brightness = int((brightness / 255) * 100)
+            self.hass.data[DOMAIN].action_move_level_onoff(self._device.addr,
+                                                           self._endpoint,
+                                                           1,
+                                                           brightness
+                                                           )
+        else:
+            self.hass.data[DOMAIN].action_onoff(self._device.addr,
+                                                self._endpoint,
+                                                1)
+
+    def turn_off(self, **kwargs):
+        """Turn the device off."""
+        self.hass.data[DOMAIN].action_onoff(self._device.addr,
+                                            self._endpoint,
+                                            0)
+
+    def toggle(self, **kwargs):
+        """Toggle the device"""
+        self.hass.data[DOMAIN].action_onoff(self._device.addr,
+                                            self._endpoint,
+                                            2)
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        return {
+            'addr': self._device.addr,
+            'endpoint': self._endpoint,
+        }

--- a/homeassistant/components/light/zigate.py
+++ b/homeassistant/components/light/zigate.py
@@ -9,9 +9,8 @@ from functools import reduce
 from operator import ior
 
 from homeassistant.components.light import (
-    ATTR_BRIGHTNESS, ATTR_COLOR_TEMP, ATTR_EFFECT, ATTR_HS_COLOR,
-    ATTR_WHITE_VALUE, SUPPORT_BRIGHTNESS, SUPPORT_COLOR_TEMP, SUPPORT_EFFECT,
-    SUPPORT_COLOR, SUPPORT_WHITE_VALUE, Light)
+    ATTR_BRIGHTNESS, SUPPORT_BRIGHTNESS, SUPPORT_COLOR_TEMP,
+    SUPPORT_COLOR, Light)
 
 DOMAIN = 'zigate'
 DATA_ZIGATE_DEVICES = 'zigate_devices'
@@ -113,22 +112,22 @@ class ZiGateLight(Light):
 #     def hs_color(self) -> tuple:
 #         """Return the hs color value."""
 #         return self._hs_color
-# 
+#
 #     @property
 #     def color_temp(self) -> int:
 #         """Return the CT color temperature."""
 #         return self._ct
-# 
+#
 #     @property
 #     def white_value(self) -> int:
 #         """Return the white value of this light between 0..255."""
 #         return self._white
-# 
+#
 #     @property
 #     def effect_list(self) -> list:
 #         """Return the list of supported effects."""
 #         return self._effect_list
-# 
+#
 #     @property
 #     def effect(self) -> str:
 #         """Return the current effect."""

--- a/homeassistant/components/sensor/zigate.py
+++ b/homeassistant/components/sensor/zigate.py
@@ -73,6 +73,7 @@ class ZiGateSensor(Entity):
                                                attribute['cluster'],
                                                attribute['attribute'],
                                                )
+        self.registry_name = '{} {}'.format(name, device)
         if 'temperature' in name:
             self._device_class = DEVICE_CLASS_TEMPERATURE
         elif 'humidity' in name:

--- a/homeassistant/components/sensor/zigate.py
+++ b/homeassistant/components/sensor/zigate.py
@@ -53,7 +53,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     sync_attributes()
     import zigate
-    zigate.dispatcher.connect(sync_attributes, zigate.ZIGATE_ATTRIBUTE_ADDED, weak=False)
+    zigate.dispatcher.connect(sync_attributes,
+                              zigate.ZIGATE_ATTRIBUTE_ADDED, weak=False)
 
 
 class ZiGateSensor(Entity):

--- a/homeassistant/components/sensor/zigate.py
+++ b/homeassistant/components/sensor/zigate.py
@@ -1,0 +1,127 @@
+"""
+ZiGate platform.
+
+For more details about this platform, please refer to the documentation
+https://home-assistant.io/components/ZiGate/
+"""
+import logging
+from homeassistant.const import (DEVICE_CLASS_HUMIDITY,
+                                 DEVICE_CLASS_TEMPERATURE,
+                                 DEVICE_CLASS_ILLUMINANCE)
+from homeassistant.helpers.entity import Entity
+
+DOMAIN = 'zigate'
+DATA_ZIGATE_DEVICES = 'zigate_devices'
+DATA_ZIGATE_ATTRS = 'zigate_attributes'
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the ZiGate sensors."""
+    if discovery_info is None:
+        return
+
+    z = hass.data[DOMAIN]
+
+    def sync_attributes(**kwargs):
+        devs = []
+        for device in z.devices:
+            for attribute in device.attributes:
+                if attribute['cluster'] == 0:
+                    continue
+                if 'name' in attribute:
+                    key = '{}-{}-{}-{}'.format(device.addr,
+                                               attribute['endpoint'],
+                                               attribute['cluster'],
+                                               attribute['attribute'],
+                                               )
+                    value = attribute.get('value')
+                    if value is None:
+                        continue
+                    if key not in hass.data[DATA_ZIGATE_ATTRS]:
+                        if not isinstance(value, bool):
+                            _LOGGER.debug(('Creating sensor '
+                                           'for device '
+                                           '{} {}').format(device,
+                                                           attribute))
+                            entity = ZiGateSensor(device, attribute)
+                            devs.append(entity)
+                            hass.data[DATA_ZIGATE_ATTRS][key] = entity
+
+        add_devices(devs)
+
+    sync_attributes()
+    import zigate
+    zigate.dispatcher.connect(sync_attributes, zigate.ZIGATE_ATTRIBUTE_ADDED, weak=False)
+
+
+class ZiGateSensor(Entity):
+    """Representation of a ZiGate sensor."""
+
+    def __init__(self, device, attribute):
+        """Initialize the sensor."""
+        self._device = device
+        self._attribute = attribute
+        self._device_class = None
+        name = attribute.get('name')
+        self._name = 'zigate_{}_{}'.format(device.addr,
+                                           attribute.get('name'))
+        self._unique_id = '{}-{}-{}-{}'.format(device.addr,
+                                               attribute['endpoint'],
+                                               attribute['cluster'],
+                                               attribute['attribute'],
+                                               )
+        if 'temperature' in name:
+            self._device_class = DEVICE_CLASS_TEMPERATURE
+        elif 'humidity' in name:
+            self._device_class = DEVICE_CLASS_HUMIDITY
+        elif 'luminosity' in name:
+            self._device_class = DEVICE_CLASS_ILLUMINANCE
+
+    @property
+    def unique_id(self)->str:
+        return self._unique_id
+
+    @property
+    def should_poll(self):
+        """No polling needed for a ZiGate sensor."""
+        return False
+
+    @property
+    def device_class(self):
+        """Return the device class of the sensor."""
+        return self._device_class
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        a = self._device.get_attribute(self._attribute['endpoint'],
+                                       self._attribute['cluster'],
+                                       self._attribute['attribute'])
+        if a:
+            return a.get('value')
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit this state is expressed in."""
+        return self._attribute.get('unit')
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        attrs = {
+            'addr': self._device.addr,
+            'endpoint': self._attribute['endpoint'],
+            'cluster': self._attribute['cluster'],
+            'attribute': self._attribute['attribute'],
+        }
+        state = self.state
+        if isinstance(self.state, dict):
+            attrs.update(state)
+        return attrs

--- a/homeassistant/components/switch/zigate.py
+++ b/homeassistant/components/switch/zigate.py
@@ -36,9 +36,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                                             )
                     if key not in hass.data[DATA_ZIGATE_ATTRS]:
                         _LOGGER.debug(('Creating switch '
-                                           'for device '
-                                           '{} {}').format(device,
-                                                           endpoint))
+                                       'for device '
+                                       '{} {}').format(device,
+                                                       endpoint))
                         entity = ZiGateSwitch(device, endpoint)
                         devs.append(entity)
                         hass.data[DATA_ZIGATE_ATTRS][key] = entity

--- a/homeassistant/components/switch/zigate.py
+++ b/homeassistant/components/switch/zigate.py
@@ -62,6 +62,7 @@ class ZiGateSwitch(SwitchDevice):
         self._unique_id = '{}-{}-{}'.format(device.addr,
                                             'switch',
                                             endpoint)
+        self.registry_name = '{} {}'.format(device, endpoint)
 
     @property
     def unique_id(self)->str:

--- a/homeassistant/components/switch/zigate.py
+++ b/homeassistant/components/switch/zigate.py
@@ -1,0 +1,123 @@
+"""
+ZiGate platform.
+
+For more details about this platform, please refer to the documentation
+https://home-assistant.io/components/ZiGate/
+"""
+import logging
+from homeassistant.components.switch import SwitchDevice
+
+DOMAIN = 'zigate'
+DATA_ZIGATE_DEVICES = 'zigate_devices'
+DATA_ZIGATE_ATTRS = 'zigate_attributes'
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the ZiGate sensors."""
+    if discovery_info is None:
+        return
+
+    z = hass.data[DOMAIN]
+    import zigate
+
+    def sync_attributes():
+        devs = []
+        for device in z.devices:
+            actions = device.available_actions()
+            if not actions:
+                continue
+            for endpoint, action_type in actions.items():
+                if [zigate.ACTIONS_ONOFF] == action_type:
+                    key = '{}-{}-{}'.format(device.addr,
+                                            'switch',
+                                            endpoint
+                                            )
+                    if key not in hass.data[DATA_ZIGATE_ATTRS]:
+                        _LOGGER.debug(('Creating switch '
+                                           'for device '
+                                           '{} {}').format(device,
+                                                           endpoint))
+                        entity = ZiGateSwitch(device, endpoint)
+                        devs.append(entity)
+                        hass.data[DATA_ZIGATE_ATTRS][key] = entity
+
+        add_devices(devs)
+    sync_attributes()
+    zigate.dispatcher.connect(sync_attributes,
+                              zigate.ZIGATE_ATTRIBUTE_ADDED, weak=False)
+
+
+class ZiGateSwitch(SwitchDevice):
+    """Representation of a ZiGate switch."""
+
+    def __init__(self, device, endpoint):
+        """Initialize the ZiGate switch."""
+        self._device = device
+        self._endpoint = endpoint
+        self._name = 'zigate_{}_{}_{}'.format(device.addr,
+                                              'switch',
+                                              endpoint)
+        self._unique_id = '{}-{}-{}'.format(device.addr,
+                                            'switch',
+                                            endpoint)
+
+    @property
+    def unique_id(self)->str:
+        return self._unique_id
+
+    @property
+    def should_poll(self):
+        """No polling needed for a ZiGate switch."""
+        return False
+
+    @property
+    def name(self):
+        """Return the name of the device if any."""
+        return self._name
+
+#     @property
+#     def current_power_w(self):
+#         """Return the current power usage in W."""
+#         if self._state:
+#             return 100
+#
+#     @property
+#     def today_energy_kwh(self):
+#         """Return the today total energy usage in kWh."""
+#         return 15
+
+    @property
+    def is_on(self):
+        """Return true if switch is on."""
+        a = self._device.get_attribute(self._endpoint, 6, 0)
+        if a:
+            return a.get('value', False)
+        return False
+
+    def turn_on(self, **kwargs):
+        """Turn the switch on."""
+        self.hass.data[DOMAIN].action_onoff(self._device.addr,
+                                            self._endpoint,
+                                            1)
+
+    def turn_off(self, **kwargs):
+        """Turn the device off."""
+        self.hass.data[DOMAIN].action_onoff(self._device.addr,
+                                            self._endpoint,
+                                            0)
+
+    def toggle(self, **kwargs):
+        """Toggle the device"""
+        self.hass.data[DOMAIN].action_onoff(self._device.addr,
+                                            self._endpoint,
+                                            2)
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        return {
+            'addr': self._device.addr,
+            'endpoint': self._endpoint,
+        }

--- a/homeassistant/components/zigate.py
+++ b/homeassistant/components/zigate.py
@@ -56,7 +56,7 @@ def setup(hass, config):
     _LOGGER.debug('Persistent file {}'.format(persistent_file))
 
     z = zigate.ZiGate(port,
-                      persistent_file, 
+                      persistent_file,
                       auto_start=False)
 
     hass.data[DOMAIN] = z

--- a/homeassistant/components/zigate.py
+++ b/homeassistant/components/zigate.py
@@ -18,7 +18,7 @@ import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['zigate==0.17.1']
+REQUIREMENTS = ['zigate==0.17.3']
 DEPENDENCIES = ['persistent_notification']
 
 DOMAIN = 'zigate'
@@ -114,6 +114,14 @@ def setup(hass, config):
                 entity.schedule_update_ha_state()
         key = '{}-{}-{}'.format(device.addr,
                                 'switch',
+                                attribute['endpoint'],
+                                )
+        entity = hass.data[DATA_ZIGATE_ATTRS].get(key)
+        if entity:
+            if entity.hass:
+                entity.schedule_update_ha_state()
+        key = '{}-{}-{}'.format(device.addr,
+                                'light',
                                 attribute['endpoint'],
                                 )
         entity = hass.data[DATA_ZIGATE_ATTRS].get(key)

--- a/homeassistant/components/zigate.py
+++ b/homeassistant/components/zigate.py
@@ -72,6 +72,12 @@ def setup(hass, config):
             entity = ZiGateDeviceEntity(device)
             hass.data[DATA_ZIGATE_DEVICES][device.addr] = entity
             component.add_entities([entity])
+            if 'signal' in kwargs:
+                persistent_notification.create(hass,
+                                               ('A new ZiGate device "{}"'
+                                                ' has been added !'
+                                                ).format(device),
+                                               title='ZiGate')
 
     def device_removed(**kwargs):
         # component.async_remove_entity

--- a/homeassistant/components/zigate.py
+++ b/homeassistant/components/zigate.py
@@ -1,0 +1,264 @@
+"""
+ZiGate component.
+
+For more details about this platform, please refer to the documentation
+https://home-assistant.io/components/ZiGate/
+"""
+import logging
+import voluptuous as vol
+import os
+
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.entity_component import EntityComponent
+from homeassistant.helpers.discovery import load_platform
+from homeassistant.const import (ATTR_BATTERY_LEVEL, CONF_PORT,
+                                 EVENT_HOMEASSISTANT_START,
+                                 EVENT_HOMEASSISTANT_STOP)
+import homeassistant.helpers.config_validation as cv
+
+_LOGGER = logging.getLogger(__name__)
+
+REQUIREMENTS = ['zigate==0.17.1']
+DEPENDENCIES = ['persistent_notification']
+
+DOMAIN = 'zigate'
+DATA_ZIGATE_DEVICES = 'zigate_devices'
+DATA_ZIGATE_ATTRS = 'zigate_attributes'
+ADDR = 'addr'
+
+CONFIG_SCHEMA = vol.Schema({
+    vol.Optional(CONF_PORT): cv.string,
+}, extra=vol.ALLOW_EXTRA)
+
+
+REFRESH_DEVICE_SCHEMA = vol.Schema({
+    vol.Optional(ADDR): cv.string,
+})
+
+RAW_COMMAND_SCHEMA = vol.Schema({
+    vol.Required('cmd'): cv.positive_int,
+    vol.Optional('data'): cv.string,
+})
+
+IDENTIFY_SCHEMA = vol.Schema({
+    vol.Required(ADDR): cv.string,
+})
+
+
+def setup(hass, config):
+    """Setup zigate platform."""
+    from homeassistant.components import persistent_notification
+    import zigate
+
+    port = config.get(CONF_PORT)
+    persistent_file = os.path.join(hass.config.config_dir,
+                                   'zigate.json')
+    _LOGGER.debug('Persistent file {}'.format(persistent_file))
+
+    z = zigate.ZiGate(port,
+                      persistent_file, 
+                      auto_start=False)
+
+    hass.data[DOMAIN] = z
+    hass.data[DATA_ZIGATE_DEVICES] = {}
+    hass.data[DATA_ZIGATE_ATTRS] = {}
+
+    component = EntityComponent(_LOGGER, DOMAIN, hass)
+
+    def device_added(**kwargs):
+        device = kwargs['device']
+        _LOGGER.debug('Add device {}'.format(device))
+        if device.addr not in hass.data[DATA_ZIGATE_DEVICES]:
+            entity = ZiGateDeviceEntity(device)
+            hass.data[DATA_ZIGATE_DEVICES][device.addr] = entity
+            component.add_entities([entity])
+
+    def device_removed(**kwargs):
+        # component.async_remove_entity
+        pass
+
+    def device_need_refresh(**kwargs):
+        device = kwargs['device']
+        persistent_notification.create(hass,
+                                       ('The ZiGate device {} needs some'
+                                        ' refresh (missing important'
+                                        ' information)').format(device.addr),
+                                       title='ZiGate')
+
+    zigate.dispatcher.connect(device_added,
+                              zigate.ZIGATE_DEVICE_ADDED, weak=False)
+    zigate.dispatcher.connect(device_removed,
+                              zigate.ZIGATE_DEVICE_REMOVED, weak=False)
+    zigate.dispatcher.connect(device_need_refresh,
+                              zigate.ZIGATE_DEVICE_NEED_REFRESH, weak=False)
+
+    def attribute_updated(**kwargs):
+        device = kwargs['device']
+        attribute = kwargs['attribute']
+        _LOGGER.debug('Update attribute for device {} {}'.format(device,
+                                                                 attribute))
+        key = '{}-{}-{}-{}'.format(device.addr,
+                                   attribute['endpoint'],
+                                   attribute['cluster'],
+                                   attribute['attribute'],
+                                   )
+        entity = hass.data[DATA_ZIGATE_ATTRS].get(key)
+        if entity:
+            if entity.hass:
+                entity.schedule_update_ha_state()
+        key = '{}-{}-{}'.format(device.addr,
+                                'switch',
+                                attribute['endpoint'],
+                                )
+        entity = hass.data[DATA_ZIGATE_ATTRS].get(key)
+        if entity:
+            if entity.hass:
+                entity.schedule_update_ha_state()
+        entity = hass.data[DATA_ZIGATE_DEVICES].get(device.addr)
+        if entity:
+            if entity.hass:
+                entity.schedule_update_ha_state()
+
+    zigate.dispatcher.connect(attribute_updated,
+                              zigate.ZIGATE_ATTRIBUTE_UPDATED, weak=False)
+
+    def device_updated(**kwargs):
+        device = kwargs['device']
+        _LOGGER.debug('Update device {}'.format(device))
+        entity = hass.data[DATA_ZIGATE_DEVICES].get(device.addr)
+        if entity:
+            if entity.hass:
+                entity.schedule_update_ha_state()
+        else:
+            _LOGGER.debug('Device not found {}, adding it'.format(device))
+            device_added(device=device)
+
+        zigate.dispatcher.connect(device_updated,
+                                  zigate.ZIGATE_DEVICE_UPDATED, weak=False)
+        zigate.dispatcher.connect(device_updated,
+                                  zigate.ZIGATE_ATTRIBUTE_ADDED, weak=False)
+
+    def zigate_reset(service):
+        z.reset()
+
+    def permit_join(service):
+        z.permit_join()
+
+    def zigate_cleanup(service):
+        '''
+        Remove missing device
+        '''
+        z.cleanup_devices()
+
+    def start_zigate(service_event):
+        z.autoStart()
+        z.start_auto_save()
+        # firt load
+        for device in z.devices:
+            device_added(device=device)
+
+        load_platform(hass, 'sensor', DOMAIN, {}, config)
+        load_platform(hass, 'binary_sensor', DOMAIN, {}, config)
+        load_platform(hass, 'switch', DOMAIN, {}, config)
+        load_platform(hass, 'light', DOMAIN, {}, config)
+
+    def stop_zigate(service_event):
+        z.save_state()
+        z.close()
+
+    def refresh_device(service):
+        addr = service.data.get(ADDR)
+        if addr:
+            z.refresh_device(addr)
+        else:
+            for device in z.devices:
+                device.refresh_device()
+
+    def network_scan(service):
+        z.start_network_scan()
+
+    def raw_command(service):
+        cmd = service.data.get('cmd')
+        data = service.data.get('data', '')
+        z.send_data(cmd, data)
+
+    def identify_device(service):
+        addr = service.data.get('addr')
+        z.identify_device(addr)
+
+    def initiate_touchlink(service):
+        z.initiate_touchlink()
+
+    def touchlink_factory_reset(service):
+        z.touchlink_factory_reset()
+
+    hass.bus.listen_once(EVENT_HOMEASSISTANT_START, start_zigate)
+    hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, stop_zigate)
+
+    hass.services.register(DOMAIN, 'reset', zigate_reset)
+    hass.services.register(DOMAIN, 'permit_join', permit_join)
+    hass.services.register(DOMAIN, 'start_zigate', start_zigate)
+    hass.services.register(DOMAIN, 'stop_zigate', stop_zigate)
+    hass.services.register(DOMAIN, 'cleanup_devices', zigate_cleanup)
+    hass.services.register(DOMAIN, 'refresh_device',
+                           refresh_device,
+                           schema=REFRESH_DEVICE_SCHEMA)
+    hass.services.register(DOMAIN, 'network_scan', network_scan)
+    hass.services.register(DOMAIN, 'raw_command', raw_command,
+                           schema=RAW_COMMAND_SCHEMA)
+    hass.services.register(DOMAIN, 'identify_device', identify_device,
+                           schema=IDENTIFY_SCHEMA)
+    hass.services.register(DOMAIN, 'initiate_touchlink', initiate_touchlink)
+    hass.services.register(DOMAIN, 'touchlink_factory_reset',
+                           touchlink_factory_reset)
+
+    return True
+
+
+class ZiGateDeviceEntity(Entity):
+    '''Representation of ZiGate device'''
+
+    def __init__(self, device):
+        """Initialize the sensor."""
+        self._device = device
+        self._name = self._device.addr
+        self.registry_name = str(device)
+
+    @property
+    def should_poll(self):
+        """No polling."""
+        return False
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._device.info.get('last_seen')
+
+    @property
+    def unique_id(self)->str:
+        return self._device.ieee
+
+    @property
+    def device_state_attributes(self):
+        """Return the device specific state attributes."""
+        attrs = {'battery': self._device.get_value('battery'),
+                 ATTR_BATTERY_LEVEL: int(self._device.battery_percent),
+                 'rssi_percent': int(self._device.rssi_percent),
+                 'type': self._device.get_value('type'),
+                 'manufacturer': self._device.get_value('manufacturer'),
+                 'receiver_on_when_idle': self._device.receiver_on_when_idle(),
+                 'missing': self._device.missing
+                 }
+        attrs.update(self._device.info)
+        return attrs
+
+    @property
+    def icon(self):
+        if self._device.missing:
+            return 'mdi:emoticon-dead'
+        return 'mdi:access-point'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1057,3 +1057,6 @@ zengge==0.2
 
 # homeassistant.components.zeroconf
 zeroconf==0.19.1
+
+# homeassistant.components.zigate
+zigate==0.17.1


### PR DESCRIPTION
## Description:
Add component and platforms to use zigate gateway (http://www.zigate.fr)
ZiGate is an universal gateway compatible with a lot of ZigBee device (like Xiaomi, Philipps Hue, Ikea, etc)

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** 
https://github.com/home-assistant/home-assistant.github.io/pull/5665

## Example entry for `configuration.yaml` (if applicable):
```yaml
zigate:
```
or 
```yaml
zigate:
  port: /dev/ttyS0
```
## Checklist:

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
