### PR TITLE
Upgrade keyring to 13.2.0

### DIFF
--- a/homeassistant/scripts/keyring.py
+++ b/homeassistant/scripts/keyring.py
@@ -5,7 +5,7 @@ import os
 
 from homeassistant.util.yaml import _SECRET_NAMESPACE
 
-REQUIREMENTS = ['keyring==13.1.0', 'keyrings.alt==3.1']
+REQUIREMENTS = ['keyring==13.2.0', 'keyrings.alt==3.1']
 
 
 def run(args):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -470,7 +470,7 @@ jsonrpc-async==0.6
 jsonrpc-websocket==0.6
 
 # homeassistant.scripts.keyring
-keyring==13.1.0
+keyring==13.2.0
 
 # homeassistant.scripts.keyring
 keyrings.alt==3.1


### PR DESCRIPTION
## Description:
Changelog: https://github.com/jaraco/keyring/blob/master/CHANGES.rst#1320

```bash
$ hass --script keyring --help
INFO:homeassistant.util.package:Attempting install of keyring==13.2.0
INFO:homeassistant.util.package:Attempting install of keyrings.alt==3.1
INFO:keyring.backend:Loading SecretService
INFO:keyring.backend:Loading kwallet
INFO:keyring.backend:Loading macOS
INFO:keyring.backend:Loading windows
INFO:keyring.backend:Loading Gnome
INFO:keyring.backend:Loading Google
INFO:keyring.backend:Loading Windows (alt)
INFO:keyring.backend:Loading file
INFO:keyring.backend:Loading keyczar
INFO:keyring.backend:Loading multi
INFO:keyring.backend:Loading pyfs
usage: hass [-h] [--script {keyring}] {get,set,del,info} [name]

Modify Home Assistant secrets in the default keyring. Use the secrets in
configuration files with: !secret <name>

positional arguments:
  {get,set,del,info}  Get, set or delete a secret
  name                Name of the secret

optional arguments:
  -h, --help          show this help message and exit
  --script {keyring}
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
