### PR TITLE
Add zoneminder run state sensor and service

### DIFF
--- a/homeassistant/components/sensor/zoneminder.py
+++ b/homeassistant/components/sensor/zoneminder.py
@@ -162,7 +162,7 @@ class ZMSensorRunState(Entity):
 
     def update(self):
         """Update the sensor."""
-        s = zoneminder.get_run_states()[1]
+        s = zoneminder.get_active_state()
         if s is None:
             self._state = STATE_UNKNOWN
         else:

--- a/homeassistant/components/sensor/zoneminder.py
+++ b/homeassistant/components/sensor/zoneminder.py
@@ -58,6 +58,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                                include_archived, sensor)
             )
 
+    sensors.append(ZMSensorRunState())
     add_devices(sensors)
 
 
@@ -140,3 +141,29 @@ class ZMSensorEvents(Entity):
             self._state = event['results'][str(self._monitor_id)]
         except (TypeError, KeyError):
             self._state = '0'
+
+
+class ZMSensorRunState(Entity):
+    """Get the ZoneMinder run state."""
+
+    def __init__(self):
+        """Initialize run state sensor."""
+        self._state = None
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return 'Run State'
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    def update(self):
+        """Update the sensor."""
+        s = zoneminder.get_run_states()[1]
+        if s is None:
+            self._state = STATE_UNKNOWN
+        else:
+            self._state = s

--- a/homeassistant/components/sensor/zoneminder.py
+++ b/homeassistant/components/sensor/zoneminder.py
@@ -162,8 +162,8 @@ class ZMSensorRunState(Entity):
 
     def update(self):
         """Update the sensor."""
-        s = zoneminder.get_active_state()
-        if s is None:
+        state_name = zoneminder.get_active_state()
+        if state_name is None:
             self._state = STATE_UNKNOWN
         else:
-            self._state = s
+            self._state = state_name

--- a/homeassistant/components/sensor/zoneminder.py
+++ b/homeassistant/components/sensor/zoneminder.py
@@ -164,6 +164,6 @@ class ZMSensorRunState(Entity):
         """Update the sensor."""
         state_name = zoneminder.get_active_state()
         if state_name is None:
-            self._state = STATE_UNKNOWN
+            self._state = None
         else:
             self._state = state_name

--- a/homeassistant/components/services.yaml
+++ b/homeassistant/components/services.yaml
@@ -601,3 +601,11 @@ nest:
       trip_id:
         description: Optional identity of a trip. Using the same trip_ID will update the estimation.
         example: trip_back_home
+
+zoneminder:
+  set_run_state:
+    description: Set the ZoneMinder run state
+    fields:
+      name:
+        description: The string name of the ZoneMinder run state to set as active.
+        example: 'Home'

--- a/homeassistant/components/zoneminder.py
+++ b/homeassistant/components/zoneminder.py
@@ -125,3 +125,21 @@ def get_state(api_url):
 def change_state(api_url, post_data):
     """Update a state using the Zoneminder API."""
     return _zm_request('post', api_url, data=post_data)
+
+
+# pylint: disable=no-member
+def get_run_states():
+    """
+    Get all run state names and the current run state from Zoneminder API.
+
+    Returns a 2-tuple of the list of state names (str) and the active state
+    name (str).
+    """
+    state_names = []
+    active_state = None
+    for i in get_state('api/states.json')['states']:
+        state_names.append(i['State']['Name'])
+        # yes, the ZM API uses the *string* "1" for this...
+        if i['State']['IsActive'] == '1':
+            active_state = i['State']['Name']
+    return state_names, active_state

--- a/homeassistant/components/zoneminder.py
+++ b/homeassistant/components/zoneminder.py
@@ -128,18 +128,13 @@ def change_state(api_url, post_data):
 
 
 # pylint: disable=no-member
-def get_run_states():
+def get_active_state():
     """
-    Get all run state names and the current run state from Zoneminder API.
-
-    Returns a 2-tuple of the list of state names (str) and the active state
-    name (str).
+    Get the current (string) run state from Zoneminder API.
     """
-    state_names = []
     active_state = None
     for i in get_state('api/states.json')['states']:
-        state_names.append(i['State']['Name'])
         # yes, the ZM API uses the *string* "1" for this...
         if i['State']['IsActive'] == '1':
             active_state = i['State']['Name']
-    return state_names, active_state
+    return active_state

--- a/homeassistant/components/zoneminder.py
+++ b/homeassistant/components/zoneminder.py
@@ -23,7 +23,7 @@ DEFAULT_SSL = False
 DEFAULT_TIMEOUT = 10
 DOMAIN = 'zoneminder'
 
-SET_RUN_STATE = 'set_run_state'
+SERVICE_SET_RUN_STATE = 'set_run_state'
 
 LOGIN_RETRIES = 2
 
@@ -71,7 +71,7 @@ def setup(hass, config):
     hass.data[DOMAIN] = ZM
 
     hass.services.register(
-        DOMAIN, SET_RUN_STATE, set_active_state,
+        DOMAIN, SERVICE_SET_RUN_STATE, set_active_state,
         schema=SET_RUN_STATE_SCHEMA
     )
 
@@ -142,10 +142,10 @@ def change_state(api_url, post_data):
 def get_active_state():
     """Get the current (string) run state from Zoneminder API."""
     active_state = None
-    for i in get_state('api/states.json')['states']:
+    for state in get_state('api/states.json')['states']:
         # yes, the ZM API uses the *string* "1" for this...
-        if i['State']['IsActive'] == '1':
-            active_state = i['State']['Name']
+        if state['State']['IsActive'] == '1':
+            active_state = state['State']['Name']
     return active_state
 
 
@@ -160,6 +160,6 @@ def set_active_state(call):
     timeout of 120, which should be adequate for most users.
     """
     state_name = call.data.get('name')
-    url = 'api/states/change/%s.json' % state_name
+    url = 'api/states/change/{}.json'.format(state_name)
     _LOGGER.debug('Setting ZoneMinder run state via GET %s', url)
     return _zm_request('GET', url, timeout=120)


### PR DESCRIPTION
## Description:

One of the core concepts of ZoneMinder is [run states](http://zoneminder.readthedocs.io/en/stable/userguide/gettingstarted.html#understanding-the-web-console), named sets of monitor states for each of ZoneMinder's cameras. This is an internal construct of ZoneMinder that's user-editable and exposed over the API, and is commonly used very similarly to burgular alarm states (i.e. run states of "Home", "Away", and "Disarmed" each map to different settings for different cameras). It's exposed prominently in the ZoneMinder UI and far more deeply integrated with ZoneMinder than controlling individual cameras ad-hoc (as the zoneminder component currently does with switches, which is effectively incompatible with run states).

This PR adds a sensor for the current run state and a ``set_run_state`` service to update the run state. This will allow users to write automations that query manipulate zoneminder run state (i.e. set state to "Away" when presence is lost or when an alarm is armed).

It should be noted that while the list of possible run states is available from ZoneMinder's API, there doesn't appear to be any way to use that in hass (see my related RFC for that, https://github.com/home-assistant/architecture/issues/43 ).

_Note:_ This supersedes a previous PR, https://github.com/home-assistant/home-assistant/pull/15281

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** https://github.com/home-assistant/home-assistant.github.io/pull/5655

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. _Note:_ for some reason, I'm unable to 

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works. - *None of the changed files currently have any test coverage.*

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
