### PR TITLE
WIP: Add support for automatic discovery of TP-Link switches and bulbs

### DIFF
--- a/homeassistant/components/light/tplink.py
+++ b/homeassistant/components/light/tplink.py
@@ -42,7 +42,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     bulb = SmartBulb(host)
     try:
-        unique_id = bulb.sys_info['deviceId']
+        unique_id = bulb.sys_info['mac']
         if name is None:
             name = bulb.alias
     except SmartDeviceException:

--- a/homeassistant/components/light/tplink.py
+++ b/homeassistant/components/light/tplink.py
@@ -30,7 +30,6 @@ ATTR_MONTHLY_ENERGY_KWH = 'monthly_energy_kwh'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
-    vol.Optional(CONF_NAME): cv.string
 })
 
 
@@ -38,14 +37,14 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Initialise pyLB100 SmartBulb."""
     from pyHS100 import SmartBulb, SmartDeviceException
     host = config.get(CONF_HOST)
-    name = config.get(CONF_NAME)
 
     bulb = SmartBulb(host)
+    # fetch MAC and name already now to avoid I/O inside init
     try:
         unique_id = bulb.sys_info['mac']
-        if name is None:
-            name = bulb.alias
-    except SmartDeviceException:
+        name = bulb.alias
+    except SmartDeviceException as ex:
+        _LOGGER.error("Unable to fetch data from the device: %s", ex)
         raise PlatformNotReady
 
     add_devices([TPLinkSmartBulb(bulb, unique_id, name)], True)
@@ -86,7 +85,7 @@ class TPLinkSmartBulb(Light):
 
     @property
     def name(self):
-        """Return the name of the Smart Bulb, if any."""
+        """Return the name of the Smart Bulb."""
         return self._name
 
     @property

--- a/homeassistant/components/light/tplink.py
+++ b/homeassistant/components/light/tplink.py
@@ -9,7 +9,7 @@ import time
 
 import voluptuous as vol
 
-from homeassistant.const import (CONF_HOST, CONF_NAME)
+from homeassistant.const import CONF_HOST
 from homeassistant.components.light import (
     Light, ATTR_BRIGHTNESS, ATTR_COLOR_TEMP, ATTR_HS_COLOR, SUPPORT_BRIGHTNESS,
     SUPPORT_COLOR_TEMP, SUPPORT_COLOR, PLATFORM_SCHEMA)
@@ -19,6 +19,8 @@ from homeassistant.util.color import \
 from homeassistant.util.color import (
     color_temperature_kelvin_to_mired as kelvin_to_mired)
 from homeassistant.exceptions import PlatformNotReady
+
+DOMAIN = 'tplink'
 
 REQUIREMENTS = ['pyHS100==0.3.2']
 

--- a/homeassistant/components/light/tplink.py
+++ b/homeassistant/components/light/tplink.py
@@ -18,6 +18,7 @@ from homeassistant.util.color import \
     color_temperature_mired_to_kelvin as mired_to_kelvin
 from homeassistant.util.color import (
     color_temperature_kelvin_to_mired as kelvin_to_mired)
+from homeassistant.exceptions import PlatformNotReady
 
 REQUIREMENTS = ['pyHS100==0.3.2']
 
@@ -35,14 +36,17 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Initialise pyLB100 SmartBulb."""
-    from pyHS100 import SmartBulb
+    from pyHS100 import SmartBulb, SmartDeviceException
     host = config.get(CONF_HOST)
     name = config.get(CONF_NAME)
 
     bulb = SmartBulb(host)
-    unique_id = bulb.sys_info['deviceId']
-    if name is None:
-        name = bulb.alias
+    try:
+        unique_id = bulb.sys_info['deviceId']
+        if name is None:
+            name = bulb.alias
+    except SmartDeviceException:
+        raise PlatformNotReady
 
     add_devices([TPLinkSmartBulb(bulb, unique_id, name)], True)
 

--- a/homeassistant/components/switch/tplink.py
+++ b/homeassistant/components/switch/tplink.py
@@ -40,7 +40,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     plug = SmartPlug(host)
     try:
-        unique_id = plug.sys_info['deviceId']
+        unique_id = plug.sys_info['mac']
         if name is None:
             name = plug.alias
     except SmartDeviceException:

--- a/homeassistant/components/switch/tplink.py
+++ b/homeassistant/components/switch/tplink.py
@@ -11,9 +11,11 @@ import voluptuous as vol
 
 from homeassistant.components.switch import (
     SwitchDevice, PLATFORM_SCHEMA, ATTR_CURRENT_POWER_W, ATTR_TODAY_ENERGY_KWH)
-from homeassistant.const import (CONF_HOST, CONF_NAME, ATTR_VOLTAGE)
+from homeassistant.const import (CONF_HOST, ATTR_VOLTAGE)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.exceptions import PlatformNotReady
+
+DOMAIN = 'tplink'
 
 REQUIREMENTS = ['pyHS100==0.3.2']
 
@@ -30,8 +32,20 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
+async def async_setup_entry(hass, config_entry, async_add_devices):
+    """Set up discovered switches."""
+    devs = []
+    for dev in hass.data[DOMAIN]['switch']:
+        unique_id = dev.sys_info['mac']
+        name = dev.alias
+        devs.append(SmartPlugSwitch(dev, unique_id, name, leds_on=None))
+
+    async_add_devices(devs, True)
+
+
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the TPLink switch platform."""
+    _LOGGER.error("TPLINK setup_platform")
     from pyHS100 import SmartPlug, SmartDeviceException
     host = config.get(CONF_HOST)
     leds_on = config.get(CONF_LEDS)

--- a/homeassistant/components/switch/tplink.py
+++ b/homeassistant/components/switch/tplink.py
@@ -26,7 +26,6 @@ CONF_LEDS = 'enable_leds'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
-    vol.Optional(CONF_NAME): cv.string,
     vol.Optional(CONF_LEDS): cv.boolean,
 })
 
@@ -35,15 +34,15 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the TPLink switch platform."""
     from pyHS100 import SmartPlug, SmartDeviceException
     host = config.get(CONF_HOST)
-    name = config.get(CONF_NAME)
     leds_on = config.get(CONF_LEDS)
 
     plug = SmartPlug(host)
+    # fetch MAC and name already now to avoid I/O inside init
     try:
         unique_id = plug.sys_info['mac']
-        if name is None:
-            name = plug.alias
-    except SmartDeviceException:
+        name = plug.alias
+    except SmartDeviceException as ex:
+        _LOGGER.error("Unable to fetch data from the device: %s", ex)
         raise PlatformNotReady
 
     add_devices([SmartPlugSwitch(plug, unique_id, name, leds_on)], True)
@@ -70,7 +69,7 @@ class SmartPlugSwitch(SwitchDevice):
 
     @property
     def name(self):
-        """Return the name of the Smart Plug, if any."""
+        """Return the name of the Smart Plug."""
         return self._name
 
     @property

--- a/homeassistant/components/switch/tplink.py
+++ b/homeassistant/components/switch/tplink.py
@@ -13,6 +13,7 @@ from homeassistant.components.switch import (
     SwitchDevice, PLATFORM_SCHEMA, ATTR_CURRENT_POWER_W, ATTR_TODAY_ENERGY_KWH)
 from homeassistant.const import (CONF_HOST, CONF_NAME, ATTR_VOLTAGE)
 import homeassistant.helpers.config_validation as cv
+from homeassistant.exceptions import PlatformNotReady
 
 REQUIREMENTS = ['pyHS100==0.3.2']
 
@@ -32,15 +33,18 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the TPLink switch platform."""
-    from pyHS100 import SmartPlug
+    from pyHS100 import SmartPlug, SmartDeviceException
     host = config.get(CONF_HOST)
     name = config.get(CONF_NAME)
     leds_on = config.get(CONF_LEDS)
 
     plug = SmartPlug(host)
-    unique_id = plug.sys_info['deviceId']
-    if name is None:
-        name = plug.alias
+    try:
+        unique_id = plug.sys_info['deviceId']
+        if name is None:
+            name = plug.alias
+    except SmartDeviceException:
+        raise PlatformNotReady
 
     add_devices([SmartPlugSwitch(plug, unique_id, name, leds_on)], True)
 

--- a/homeassistant/components/switch/tplink.py
+++ b/homeassistant/components/switch/tplink.py
@@ -23,11 +23,9 @@ ATTR_CURRENT_A = 'current_a'
 
 CONF_LEDS = 'enable_leds'
 
-DEFAULT_NAME = 'TP-Link Switch'
-
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
-    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_NAME): cv.string,
     vol.Optional(CONF_LEDS): cv.boolean,
 })
 
@@ -39,21 +37,32 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     name = config.get(CONF_NAME)
     leds_on = config.get(CONF_LEDS)
 
-    add_devices([SmartPlugSwitch(SmartPlug(host), name, leds_on)], True)
+    plug = SmartPlug(host)
+    unique_id = plug.sys_info['deviceId']
+    if name is None:
+        name = plug.alias
+
+    add_devices([SmartPlugSwitch(plug, unique_id, name, leds_on)], True)
 
 
 class SmartPlugSwitch(SwitchDevice):
     """Representation of a TPLink Smart Plug switch."""
 
-    def __init__(self, smartplug, name, leds_on):
+    def __init__(self, smartplug, unique_id, name, leds_on):
         """Initialize the switch."""
         self.smartplug = smartplug
+        self._unique_id = unique_id
         self._name = name
         self._leds_on = leds_on
         self._state = None
         self._available = True
         # Set up emeter cache
         self._emeter_params = {}
+
+    @property
+    def unique_id(self):
+        """Return a unique ID."""
+        return self._unique_id
 
     @property
     def name(self):
@@ -93,10 +102,6 @@ class SmartPlugSwitch(SwitchDevice):
             if self._leds_on is not None:
                 self.smartplug.led = self._leds_on
                 self._leds_on = None
-
-            # Pull the name from the device if a name was not specified
-            if self._name == DEFAULT_NAME:
-                self._name = self.smartplug.alias
 
             if self.smartplug.has_emeter:
                 emeter_readings = self.smartplug.get_emeter_realtime()

--- a/homeassistant/components/tplink/.translations/en.json
+++ b/homeassistant/components/tplink/.translations/en.json
@@ -1,0 +1,15 @@
+{
+  "config": {
+    "title": "TP-Link Smart Home",
+    "step": {
+      "confirm": {
+        "title": "TP-Link Smart Home",
+        "description": "Do you want to setup TP-Link smart devices?"
+      }
+    },
+    "abort": {
+      "single_instance_allowed": "Only a single configuration is necessary.",
+      "no_devices_found": "No TP-Link devices found on the network."
+    }
+  }
+}

--- a/homeassistant/components/tplink/__init__.py
+++ b/homeassistant/components/tplink/__init__.py
@@ -1,0 +1,61 @@
+"""Component to embed TP-Link smart home devices."""
+from homeassistant import config_entries
+from homeassistant.helpers import config_entry_flow
+import logging
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = 'tplink'
+REQUIREMENTS = ['pyHS100==0.3.2']
+
+
+async def async_setup(hass, config):
+    """Set up the TP-Link component."""
+    conf = config.get(DOMAIN)
+
+    hass.data[DOMAIN] = conf or {}
+
+    if conf is not None:
+        hass.async_create_task(hass.config_entries.flow.async_init(
+            DOMAIN, context={'source': config_entries.SOURCE_IMPORT}))
+
+    return True
+
+
+async def async_setup_entry(hass, entry):
+    """Set up Sonos from a config entry."""
+    from pyHS100 import Discover, SmartBulb, SmartPlug
+
+    hass.data[DOMAIN] = {'light': [], 'switch': []}
+    devices = await hass.async_add_executor_job(Discover.discover)
+    for dev in devices.values():
+        if isinstance(dev, SmartPlug):
+            hass.data[DOMAIN]['switch'].append(dev)
+        elif isinstance(dev, SmartBulb):
+            hass.data[DOMAIN]['light'].append(dev)
+        else:
+            _LOGGER.error("Unknown smart device type: %s" % type(dev))
+
+    if len(hass.data[DOMAIN]['light']) > 0:
+        hass.async_add_job(
+            hass.config_entries.async_forward_entry_setup(entry, 'light'))
+    if len(hass.data[DOMAIN]['switch']) > 0:
+        hass.async_add_job(
+            hass.config_entries.async_forward_entry_setup(entry, 'switch'))
+
+    return True
+
+
+async def _async_has_devices(hass):
+    """Return if there are devices that can be discovered."""
+    from pyHS100 import Discover
+
+    def discover():
+        devs = Discover.discover()
+        return devs.values()
+    return await hass.async_add_executor_job(discover)
+
+
+config_entry_flow.register_discovery_flow(DOMAIN,
+                                          'TP-Link Smart Home',
+                                          _async_has_devices)

--- a/homeassistant/components/tplink/__init__.py
+++ b/homeassistant/components/tplink/__init__.py
@@ -1,7 +1,8 @@
 """Component to embed TP-Link smart home devices."""
+import logging
+
 from homeassistant import config_entries
 from homeassistant.helpers import config_entry_flow
-import logging
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -34,12 +35,12 @@ async def async_setup_entry(hass, entry):
         elif isinstance(dev, SmartBulb):
             hass.data[DOMAIN]['light'].append(dev)
         else:
-            _LOGGER.error("Unknown smart device type: %s" % type(dev))
+            _LOGGER.error("Unknown smart device type: %s", type(dev))
 
-    if len(hass.data[DOMAIN]['light']) > 0:
+    if hass.data[DOMAIN]['light']:
         hass.async_add_job(
             hass.config_entries.async_forward_entry_setup(entry, 'light'))
-    if len(hass.data[DOMAIN]['switch']) > 0:
+    if hass.data[DOMAIN]['switch']:
         hass.async_add_job(
             hass.config_entries.async_forward_entry_setup(entry, 'switch'))
 

--- a/homeassistant/components/tplink/strings.json
+++ b/homeassistant/components/tplink/strings.json
@@ -1,0 +1,15 @@
+{
+  "config": {
+    "title": "TP-Link Smart Home",
+    "step": {
+      "confirm": {
+        "title": "TP-Link Smart Home",
+        "description": "Do you want to setup TP-Link smart devices?"
+      }
+    },
+    "abort": {
+      "single_instance_allowed": "Only a single configuration is necessary.",
+      "no_devices_found": "No TP-Link devices found on the network."
+    }
+  }
+}

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -142,6 +142,7 @@ FLOWS = [
     'nest',
     'sonos',
     'zone',
+    'tplink',
 ]
 
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -726,6 +726,7 @@ py-synology==0.2.0
 # homeassistant.components.hdmi_cec
 pyCEC==0.4.13
 
+# homeassistant.components.tplink
 # homeassistant.components.light.tplink
 # homeassistant.components.switch.tplink
 pyHS100==0.3.2


### PR DESCRIPTION
## Description:
This PR adds support for automatic discovery of TP-Link bulbs and switches, based on the new config flow. The integration needs to be enable either in the integration configurations or alternatively by adding `tplink` component to the configuration file.

Breaking change: the device name is not configurable over configuration file but is read from the device. To change the name it has to be either changed inside homeassistant, or alternatively on the device itself.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**