### PR TITLE
Add sleep to prevent API throttling

### DIFF
--- a/homeassistant/components/sensor/alpha_vantage.py
+++ b/homeassistant/components/sensor/alpha_vantage.py
@@ -5,6 +5,7 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.alpha_vantage/
 """
 from datetime import timedelta
+import time
 import logging
 
 import voluptuous as vol

--- a/homeassistant/components/sensor/alpha_vantage.py
+++ b/homeassistant/components/sensor/alpha_vantage.py
@@ -80,17 +80,20 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         _LOGGER.warning(msg)
         return
 
-    timeseries = TimeSeries(key=api_key)
-
     dev = []
+
+    timeseries = TimeSeries(key=api_key)
     for symbol in symbols:
         try:
             _LOGGER.debug("Configuring timeseries for symbols: %s",
                           symbol[CONF_SYMBOL])
             timeseries.get_intraday(symbol[CONF_SYMBOL])
-        except ValueError:
+            _LOGGER.debug("Sleep %s seconds to prevent API throttling...", 10)
+            time.sleep(10)
+        except ValueError as error:
             _LOGGER.error(
                 "API Key is not valid or symbol '%s' not known", symbol)
+            _LOGGER.debug(str(error))
         dev.append(AlphaVantageSensor(timeseries, symbol))
 
     forex = ForeignExchange(key=api_key)
@@ -101,6 +104,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             _LOGGER.debug("Configuring forex %s - %s", from_cur, to_cur)
             forex.get_currency_exchange_rate(
                 from_currency=from_cur, to_currency=to_cur)
+            _LOGGER.debug("Sleep %s seconds to prevent API throttling...", 10)
+            time.sleep(10)
         except ValueError as error:
             _LOGGER.error(
                 "API Key is not valid or currencies '%s'/'%s' not known",
@@ -162,6 +167,8 @@ class AlphaVantageSensor(Entity):
         all_values, _ = self._timeseries.get_intraday(self._symbol)
         self.values = next(iter(all_values.values()))
         _LOGGER.debug("Received new values for symbol %s", self._symbol)
+        _LOGGER.debug("Sleep %s seconds to prevent API throttling...", 10)
+        time.sleep(10)
 
 
 class AlphaVantageForeignExchange(Entity):
@@ -218,3 +225,5 @@ class AlphaVantageForeignExchange(Entity):
             from_currency=self._from_currency, to_currency=self._to_currency)
         _LOGGER.debug("Received new data for forex %s - %s",
                       self._from_currency, self._to_currency)
+        _LOGGER.debug("Sleep %s seconds to prevent API throttling...", 10)
+        time.sleep(10)


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #15271

This PR builds in some sleep time to prevent the API from throttling. Although the API has no daily, weekly or monthly limits, it limits the number of calls in a smaller (minutely?) timeframe. This prevents creating more than a few sensors at startup and/or updating those at the required interval.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here> **n/a**

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54