### PR TITLE
fix camera.push API overwrite

### DIFF
--- a/homeassistant/components/camera/push.py
+++ b/homeassistant/components/camera/push.py
@@ -70,7 +70,7 @@ class CameraPushReceiver(HomeAssistantView):
     async def post(self, request, entity_id):
         """Accept the POST from Camera."""
         _camera = self._cameras.get(entity_id)
-        
+
         if _camera is None:
             _LOGGER.error("Unknown %s", entity_id)
             return self.json_message('Unknown {}'.format(entity_id),

--- a/homeassistant/components/camera/push.py
+++ b/homeassistant/components/camera/push.py
@@ -70,7 +70,7 @@ class CameraPushReceiver(HomeAssistantView):
     async def post(self, request, entity_id):
         """Accept the POST from Camera."""
         _camera = self._cameras.get(entity_id)
-        _LOGGER.error(self._cameras)
+        
         if _camera is None:
             _LOGGER.error("Unknown %s", entity_id)
             return self.json_message('Unknown {}'.format(entity_id),


### PR DESCRIPTION
## Description:

When more than one camera exists, the CameraPushReceiver would only have information on a single camera. 

This PR fixes this issue.

**Related issue (if applicable):** fixes #15151

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
camera:
  - platform: push
    name: cam1
  - platform: push
    name: cam2
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54