### PR TITLE
Add HomematicIP Cloud light power consumption and energie attributes

### DIFF
--- a/homeassistant/components/light/homematicip_cloud.py
+++ b/homeassistant/components/light/homematicip_cloud.py
@@ -72,7 +72,8 @@ class HomematicipLightMeasuring(HomematicipLight):
         attr = super().device_state_attributes
         if self._device.currentPowerConsumption > 0.05:
             attr.update({
-                ATTR_POWER_CONSUMPTION: round(self._device.currentPowerConsumption, 2)
+                ATTR_POWER_CONSUMPTION:
+                    round(self._device.currentPowerConsumption, 2)
             })
         attr.update({
             ATTR_ENERGIE_COUNTER: round(self._device.energyCounter, 2)

--- a/homeassistant/components/light/homematicip_cloud.py
+++ b/homeassistant/components/light/homematicip_cloud.py
@@ -29,13 +29,13 @@ async def async_setup_platform(hass, config, async_add_devices,
 
 async def async_setup_entry(hass, config_entry, async_add_devices):
     """Set up the HomematicIP lights from a config entry."""
-    from homematicip.device import (
-        BrandSwitchMeasuring)
+    from homematicip.aio.device import (
+        AsyncBrandSwitchMeasuring)
 
     home = hass.data[HMIPC_DOMAIN][config_entry.data[HMIPC_HAPID]].home
     devices = []
     for device in home.devices:
-        if isinstance(device, BrandSwitchMeasuring):
+        if isinstance(device, AsyncBrandSwitchMeasuring):
             devices.append(HomematicipLightMeasuring(home, device))
 
     if devices:
@@ -67,13 +67,14 @@ class HomematicipLightMeasuring(HomematicipLight):
     """MomematicIP measuring light device."""
 
     @property
-    def current_power_w(self):
-        """Return the current power usage in W."""
-        return self._device.currentPowerConsumption
-
-    @property
-    def today_energy_kwh(self):
-        """Return the today total energy usage in kWh."""
-        if self._device.energyCounter is None:
-            return 0
-        return round(self._device.energyCounter)
+    def device_state_attributes(self):
+        """Return the state attributes of the generic device."""
+        attr = super().device_state_attributes
+        if self._device.currentPowerConsumption > 0.05:
+            attr.update({
+                ATTR_POWER_CONSUMPTION: round(self._device.currentPowerConsumption, 2)
+            })
+        attr.update({
+            ATTR_ENERGIE_COUNTER: round(self._device.energyCounter, 2)
+        })
+        return attr

--- a/homeassistant/components/light/homematicip_cloud.py
+++ b/homeassistant/components/light/homematicip_cloud.py
@@ -17,7 +17,7 @@ DEPENDENCIES = ['homematicip_cloud']
 _LOGGER = logging.getLogger(__name__)
 
 ATTR_POWER_CONSUMPTION = 'power_consumption'
-ATTR_ENERGIE_COUNTER = 'energie_counter'
+ATTR_ENERGIE_COUNTER = 'energie_counter_kwh'
 ATTR_PROFILE_MODE = 'profile_mode'
 
 


### PR DESCRIPTION
## Description:
- Add power consumption and energy counter attributes to the HomematicIP light.
- Change instance check to async class version

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54