### PR TITLE
Fixed issue 15340. Alexa Smart Home now handles unsupported properties correctly

### DIFF
--- a/homeassistant/components/alexa/smart_home.py
+++ b/homeassistant/components/alexa/smart_home.py
@@ -270,11 +270,14 @@ class _AlexaInterface(object):
         """Return properties serialized for an API response."""
         for prop in self.properties_supported():
             prop_name = prop['name']
-            yield {
-                'name': prop_name,
-                'namespace': self.name(),
-                'value': self.get_property(prop_name),
-            }
+            # pylint: disable=assignment-from-no-return
+            prop_value = self.get_property(prop_name)
+            if prop_value is not None:
+                yield {
+                    'name': prop_name,
+                    'namespace': self.name(),
+                    'value': prop_value,
+                }
 
 
 class _AlexaPowerController(_AlexaInterface):
@@ -438,13 +441,16 @@ class _AlexaThermostatController(_AlexaInterface):
         unit = self.entity.attributes[CONF_UNIT_OF_MEASUREMENT]
         temp = None
         if name == 'targetSetpoint':
-            temp = self.entity.attributes.get(ATTR_TEMPERATURE)
+            temp = self.entity.attributes.get(climate.ATTR_TEMPERATURE)
         elif name == 'lowerSetpoint':
             temp = self.entity.attributes.get(climate.ATTR_TARGET_TEMP_LOW)
         elif name == 'upperSetpoint':
             temp = self.entity.attributes.get(climate.ATTR_TARGET_TEMP_HIGH)
-        if temp is None:
+        else:
             raise _UnsupportedProperty(name)
+
+        if temp is None:
+            return None
 
         return {
             'value': float(temp),


### PR DESCRIPTION
Fixed issue 15340.  alexa/smart home now properly skips over properties that aren't supported in the current state, eg lowerSetpoint in Heat mode or targetSetpoint in Eco mode for Nest devices.

## Description:
As described in issue 15340, the Alexa smart home skill cannot retrieve the properties of a climate device like the Nest (not sure about other devices).  When Alexa asks for a state report, alexa/smart_home.py attempts to return all of the properties of the climate component, even if the properties are null.  Properties can be null depending on the state of the device.  For example, target_temp_low is null if the thermostat mode only has a single setpoint, and target_temperature is null when the mode has two setpoints (lower and upper).  So, when Alexa asks for a state report, some property values are always null, causing ThermostatController.get_property() to always fail with the UnsupportedProperty exception.

The fix is to have the only caller, serialize_properties, handle a None return value from get_property, and have get_property return None if the associated value is actually null or None.

**Related issue (if applicable):** fixes #15340 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** N/A


## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed - N/A

If the code communicates with devices, web services, or third-party tools: N/A

If the code does not interact with devices: N/A

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
