### PR TITLE
Update ha-philipsjs to 0.0.5

### DIFF
--- a/homeassistant/components/media_player/philips_js.py
+++ b/homeassistant/components/media_player/philips_js.py
@@ -20,7 +20,7 @@ from homeassistant.const import (
 from homeassistant.helpers.script import Script
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['ha-philipsjs==0.0.4']
+REQUIREMENTS = ['ha-philipsjs==0.0.5']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -391,7 +391,7 @@ gstreamer-player==1.1.0
 ha-ffmpeg==1.9
 
 # homeassistant.components.media_player.philips_js
-ha-philipsjs==0.0.4
+ha-philipsjs==0.0.5
 
 # homeassistant.components.sensor.geo_rss_events
 haversine==0.4.5


### PR DESCRIPTION
## Description:
This is the wrapper library used to communicate with Philips TVs. The dependency has been upgraded to work better with new TV models.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
