### PR TITLE
Expire auth code after 10 minutes

### DIFF
--- a/tests/components/auth/test_init.py
+++ b/tests/components/auth/test_init.py
@@ -1,4 +1,10 @@
 """Integration tests for the auth component."""
+from datetime import timedelta
+from unittest.mock import patch
+
+from homeassistant.util.dt import utcnow
+from homeassistant.components import auth
+
 from . import async_setup_auth
 
 from tests.common import CLIENT_ID, CLIENT_REDIRECT_URI
@@ -58,3 +64,25 @@ async def test_login_new_user_and_refresh_token(hass, aiohttp_client):
         'authorization': 'Bearer {}'.format(tokens['access_token'])
     })
     assert resp.status == 200
+
+
+def test_credential_store_expiration():
+    """Test that the credential store will not return expired tokens."""
+    store, retrieve = auth._create_cred_store()
+    client_id = 'bla'
+    credentials = 'creds'
+    now = utcnow()
+
+    with patch('homeassistant.util.dt.utcnow', return_value=now):
+        code = store(client_id, credentials)
+
+    with patch('homeassistant.util.dt.utcnow',
+               return_value=now + timedelta(minutes=10)):
+        assert retrieve(client_id, code) is None
+
+    with patch('homeassistant.util.dt.utcnow', return_value=now):
+        code = store(client_id, credentials)
+
+    with patch('homeassistant.util.dt.utcnow',
+               return_value=now + timedelta(minutes=9, seconds=59)):
+        assert retrieve(client_id, code) == credentials


### PR DESCRIPTION
## Description:
When a user successfully logs in, they get an authorization code that they can exchange for a pair of access/refresh tokens. This PR makes sure the auth codes expire after 10 minutes as per OAuth 4.2.1

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
