### PR TITLE
Added EAP-Controller (Omada)

### DIFF
--- a/homeassistant/components/device_tracker/tplink.py
+++ b/homeassistant/components/device_tracker/tplink.py
@@ -413,7 +413,7 @@ class Tplink5DeviceScanner(TplinkDeviceScanner):
 
         return False
 
- class TplinkEAPControllerDeviceScanner(TplinkDeviceScanner):
+class TplinkEAPControllerDeviceScanner(TplinkDeviceScanner):
     """This class queries a TP-Link EAP Controller Server"""
     _LOGGER.info("Using EAP Controller Scanner")
 

--- a/homeassistant/components/device_tracker/tplink.py
+++ b/homeassistant/components/device_tracker/tplink.py
@@ -430,7 +430,7 @@ class TplinkEAPControllerDeviceScanner(TplinkDeviceScanner):
 
     def get_extra_attributes(self, device):
         return self.last_results.get(device)
-    
+
     def _update_info(self):
         """Ensure the information from the TP-Link AP is up to date.
 
@@ -444,18 +444,20 @@ class TplinkEAPControllerDeviceScanner(TplinkDeviceScanner):
         session.verify = False
 
         login = session.post('{}/login'.format(base_url),
-                             data=(('name',self.username),
-                             ('password',self.password)))
+                             data=(('name', self.username),
+                             ('password', self.password)))
         if(login.status_code != 200):
-            _LOGGER.error('HTTP Request failed! Status: '+str(login.status_code))
+            _LOGGER.error('HTTP Request failed with Status: '
+                          +str(login.status_code))
         else:
             json = login.json()
             if not json['success']:
                 _LOGGER.error('Login failed, response was: '+json['message'])
             else:
                 _LOGGER.info("Loading wireless clients...")
-                client_list_url = '{}/monitor/allActiveClients'.format(base_url)
-                post_data = (('currentPage',1), ('currentPageSize',1000))
+                client_list_url = '{}/monitor/allActiveClients'
+                                  .format(base_url)
+                post_data = (('currentPage', 1), ('currentPageSize', 1000))
 
                 clients = session.post(client_list_url, data=post_data)
 

--- a/homeassistant/components/device_tracker/tplink.py
+++ b/homeassistant/components/device_tracker/tplink.py
@@ -447,8 +447,8 @@ class TplinkEAPControllerDeviceScanner(TplinkDeviceScanner):
                              data=(('name', self.username),
                              ('password', self.password)))
         if(login.status_code != 200):
-            _LOGGER.error('HTTP Request failed with Status: '
-                          +str(login.status_code))
+            _LOGGER.error('HTTP Request failed with status {}'
+                          .format(login.status_code))
         else:
             json = login.json()
             if not json['success']:
@@ -456,7 +456,7 @@ class TplinkEAPControllerDeviceScanner(TplinkDeviceScanner):
             else:
                 _LOGGER.info("Loading wireless clients...")
                 client_list_url = '{}/monitor/allActiveClients'
-                                  .format(base_url)
+                                    .format(base_url)
                 post_data = (('currentPage', 1), ('currentPageSize', 1000))
 
                 clients = session.post(client_list_url, data=post_data)


### PR DESCRIPTION
## Description:
Added possibility to get data from EAP-Controller (new name 'Omada').
Tested with Controller V2.5.3 running on Linux.

## Example entry for `configuration.yaml` (if applicable):
unchanged

## Checklist:
  - [X] The code change is tested and works locally.

If the code communicates with devices, web services, or third-party tools:
no new requirements

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
