### PR TITLE
Add postNL letters

### DIFF
--- a/homeassistant/components/sensor/postnl.py
+++ b/homeassistant/components/sensor/postnl.py
@@ -94,7 +94,7 @@ class PostNLSensor(Entity):
     @property
     def icon(self):
         """Icon to use in the frontend."""
-        return ICON_PACKEGE
+        return ICON_PACKAGE
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):

--- a/homeassistant/components/sensor/postnl.py
+++ b/homeassistant/components/sensor/postnl.py
@@ -24,8 +24,8 @@ ATTRIBUTION = 'Information provided by PostNL'
 
 DEFAULT_NAME = 'postnl'
 
-ICONpackage = 'mdi:package-variant-closed'
-ICONletters = 'mdi:email-outline'
+ICON_PACKEGE = 'mdi:package-variant-closed'
+ICON_LETTERS = 'mdi:email-outline'
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=30)
 
@@ -55,7 +55,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         _LOGGER.exception("Can't connect to the PostNL webservice")
         return
 
-    if letter == True:
+    if letter is True:
         add_devices([PostNLSensor(api, name), PostNLletter(api, name)], True)
     else:
         add_devices([PostNLSensor(api, name)], True)
@@ -94,7 +94,7 @@ class PostNLSensor(Entity):
     @property
     def icon(self):
         """Icon to use in the frontend."""
-        return ICONpackage
+        return ICON_PACKEGE
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
@@ -150,7 +150,7 @@ class PostNLletter(Entity):
     @property
     def icon(self):
         """Icon to use in the frontend."""
-        return ICONletters
+        return ICON_LETTERS
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):

--- a/homeassistant/components/sensor/postnl.py
+++ b/homeassistant/components/sensor/postnl.py
@@ -56,9 +56,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         return
 
     if letter == True:
-      add_devices([PostNLSensor(api, name), PostNLletter(api, name)], True)
+        add_devices([PostNLSensor(api, name), PostNLletter(api, name)], True)
     else:
-      add_devices([PostNLSensor(api, name)], True)
+        add_devices([PostNLSensor(api, name)], True)
 
 
 class PostNLSensor(Entity):
@@ -115,7 +115,8 @@ class PostNLSensor(Entity):
         }
 
         self._state = len(status_counts)
-        
+
+
 class PostNLletter(Entity):
     """Representation of a PostNL sensor."""
 

--- a/homeassistant/components/sensor/postnl.py
+++ b/homeassistant/components/sensor/postnl.py
@@ -24,7 +24,8 @@ ATTRIBUTION = 'Information provided by PostNL'
 
 DEFAULT_NAME = 'postnl'
 
-ICON = 'mdi:package-variant-closed'
+ICONpackage = 'mdi:package-variant-closed'
+ICONletters = 'mdi:email-outline'
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=30)
 
@@ -93,7 +94,7 @@ class PostNLSensor(Entity):
     @property
     def icon(self):
         """Icon to use in the frontend."""
-        return ICON
+        return ICONpackage
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
@@ -148,7 +149,7 @@ class PostNLletter(Entity):
     @property
     def icon(self):
         """Icon to use in the frontend."""
-        return ICON
+        return ICONletters
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):

--- a/homeassistant/components/sensor/postnl.py
+++ b/homeassistant/components/sensor/postnl.py
@@ -129,7 +129,7 @@ class PostNLletter(Entity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return 'postnl letter(s)'
+        return self._name
 
     @property
     def state(self):
@@ -139,7 +139,7 @@ class PostNLletter(Entity):
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement of this entity, if any."""
-        return self._name
+        return 'letters'
 
     @property
     def device_state_attributes(self):

--- a/homeassistant/components/sensor/postnl.py
+++ b/homeassistant/components/sensor/postnl.py
@@ -24,7 +24,7 @@ ATTRIBUTION = 'Information provided by PostNL'
 
 DEFAULT_NAME = 'postnl'
 
-ICON_PACKEGE = 'mdi:package-variant-closed'
+ICON_PACKAGE = 'mdi:package-variant-closed'
 ICON_LETTERS = 'mdi:email-outline'
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=30)

--- a/homeassistant/components/sensor/postnl.py
+++ b/homeassistant/components/sensor/postnl.py
@@ -62,7 +62,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         'package-variant-closed',
         'packeges',
         api)])
-									
+
     if letter:
         sensor_items.extend([PostNLSensor(
             hass,
@@ -130,7 +130,7 @@ class PostNLSensor(Entity):
         }
 
         self._state = 5
-        # self._state = len(status_counts)		
+        # self._state = len(status_counts)
         letters = self._api.get_relevant_letters()
 
         self._attributes = {

--- a/homeassistant/components/sensor/postnl.py
+++ b/homeassistant/components/sensor/postnl.py
@@ -24,8 +24,8 @@ ATTRIBUTION = 'Information provided by PostNL'
 
 DEFAULT_NAME = 'postnl'
 
-ICON_PACKAGE = 'mdi:package-variant-closed'
-ICON_LETTERS = 'mdi:email-outline'
+#ICONpackage = 'mdi:package-variant-closed'
+#ICONletters = 'mdi:email-outline'
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=30)
 
@@ -45,7 +45,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     username = config.get(CONF_USERNAME)
     password = config.get(CONF_PASSWORD)
-    name = config.get(CONF_NAME)
+    #name = config.get(CONF_NAME)
     letter = config.get(CONF_LETTER)
 
     try:
@@ -55,21 +55,34 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         _LOGGER.exception("Can't connect to the PostNL webservice")
         return
 
-    if letter is True:
-        add_devices([PostNLSensor(api, name), PostNLletter(api, name)], True)
-    else:
-        add_devices([PostNLSensor(api, name)], True)
+    sensor_items = []
+    sensor_items.extend([PostNLSensor(hass,
+                                    'PostNL-package',
+                                    'package-variant-closed',
+									'packeges',
+                                    api)])
+									
+    if letter:
+        sensor_items.extend([PostNLSensor(hass,
+                                        'PostNL-letter',
+                                        'email-outline',
+										'letters',
+                                        api)])
+
+    add_devices(sensor_items)
 
 
 class PostNLSensor(Entity):
     """Representation of a PostNL sensor."""
 
-    def __init__(self, api, name):
+    def __init__(self, hass, name, icon, unit_of_measurement, api):
         """Initialize the PostNL sensor."""
         self._name = name
         self._attributes = None
         self._state = None
         self._api = api
+        self._icon = "mdi:" + icon
+        self._unit_of_measurement = unit_of_measurement
 
     @property
     def name(self):
@@ -84,7 +97,7 @@ class PostNLSensor(Entity):
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement of this entity, if any."""
-        return 'packages'
+        return self._unit_of_measurement
 
     @property
     def device_state_attributes(self):
@@ -94,7 +107,7 @@ class PostNLSensor(Entity):
     @property
     def icon(self):
         """Icon to use in the frontend."""
-        return ICON_PACKAGE
+        return self._icon
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
@@ -114,51 +127,17 @@ class PostNLSensor(Entity):
             **status_counts
         }
 
-        self._state = len(status_counts)
-
-
-class PostNLletter(Entity):
-    """Representation of a PostNL sensor."""
-
-    def __init__(self, api, name):
-        """Initialize the PostNL sensor."""
-        self._name = name
-        self._attributes = None
-        self._state = None
-        self._api = api
-
-    @property
-    def name(self):
-        """Return the name of the sensor."""
-        return self._name
-
-    @property
-    def state(self):
-        """Return the state of the sensor."""
-        return self._state
-
-    @property
-    def unit_of_measurement(self):
-        """Return the unit of measurement of this entity, if any."""
-        return 'letters'
-
-    @property
-    def device_state_attributes(self):
-        """Return the state attributes."""
-        return self._attributes
-
-    @property
-    def icon(self):
-        """Icon to use in the frontend."""
-        return ICON_LETTERS
-
-    @Throttle(MIN_TIME_BETWEEN_UPDATES)
-    def update(self):
-        """Update device state."""
+        self._state = 5
+        #self._state = len(status_counts)		
+		
+		
+		
         letters = self._api.get_relevant_letters()
 
         self._attributes = {
             ATTR_ATTRIBUTION: ATTRIBUTION,
         }
 
-        self._state = len(letters)
+        self._state = 2
+        #self._state = len(letters)
+		

--- a/homeassistant/components/sensor/postnl.py
+++ b/homeassistant/components/sensor/postnl.py
@@ -59,14 +59,14 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     sensor_items.extend([PostNLSensor(hass,
                                     'PostNL-package',
                                     'package-variant-closed',
-									'packeges',
+                                    'packeges',
                                     api)])
 									
     if letter:
         sensor_items.extend([PostNLSensor(hass,
                                         'PostNL-letter',
                                         'email-outline',
-										'letters',
+                                        'letters',
                                         api)])
 
     add_devices(sensor_items)
@@ -128,10 +128,9 @@ class PostNLSensor(Entity):
         }
 
         self._state = 5
-        #self._state = len(status_counts)		
-		
-		
-		
+        # self._state = len(status_counts)		
+
+
         letters = self._api.get_relevant_letters()
 
         self._attributes = {
@@ -139,5 +138,4 @@ class PostNLSensor(Entity):
         }
 
         self._state = 2
-        #self._state = len(letters)
-		
+        # self._state = len(letters)

--- a/homeassistant/components/sensor/postnl.py
+++ b/homeassistant/components/sensor/postnl.py
@@ -24,8 +24,8 @@ ATTRIBUTION = 'Information provided by PostNL'
 
 DEFAULT_NAME = 'postnl'
 
-#ICONpackage = 'mdi:package-variant-closed'
-#ICONletters = 'mdi:email-outline'
+# ICONpackage = 'mdi:package-variant-closed'
+# ICONletters = 'mdi:email-outline'
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=30)
 
@@ -45,7 +45,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     username = config.get(CONF_USERNAME)
     password = config.get(CONF_PASSWORD)
-    #name = config.get(CONF_NAME)
+    # name = config.get(CONF_NAME)
     letter = config.get(CONF_LETTER)
 
     try:
@@ -129,8 +129,6 @@ class PostNLSensor(Entity):
 
         self._state = 5
         # self._state = len(status_counts)		
-
-
         letters = self._api.get_relevant_letters()
 
         self._attributes = {

--- a/homeassistant/components/sensor/postnl.py
+++ b/homeassistant/components/sensor/postnl.py
@@ -28,10 +28,13 @@ ICON = 'mdi:package-variant-closed'
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=30)
 
+CONF_LETTER = 'letter'
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_USERNAME): cv.string,
     vol.Required(CONF_PASSWORD): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_LETTER, default=False): cv.boolean
 })
 
 
@@ -42,6 +45,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     username = config.get(CONF_USERNAME)
     password = config.get(CONF_PASSWORD)
     name = config.get(CONF_NAME)
+    letter = config.get(CONF_LETTER)
 
     try:
         api = PostNL_API(username, password)
@@ -50,7 +54,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         _LOGGER.exception("Can't connect to the PostNL webservice")
         return
 
-    add_devices([PostNLSensor(api, name)], True)
+    if letter == True:
+      add_devices([PostNLSensor(api, name), PostNLletter(api, name)], True)
+    else:
+      add_devices([PostNLSensor(api, name)], True)
 
 
 class PostNLSensor(Entity):

--- a/homeassistant/components/sensor/postnl.py
+++ b/homeassistant/components/sensor/postnl.py
@@ -22,7 +22,7 @@ _LOGGER = logging.getLogger(__name__)
 
 ATTRIBUTION = 'Information provided by PostNL'
 
-DEFAULT_NAME = 'postnl'
+DEFAULT_NAME = 'PostNL'
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=30)
 
@@ -42,7 +42,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     username = config.get(CONF_USERNAME)
     password = config.get(CONF_PASSWORD)
-    # name = config.get(CONF_NAME)
+    name = config.get(CONF_NAME)
     letter = config.get(CONF_LETTER)
 
     try:
@@ -53,20 +53,20 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         return
 
     sensor_items = []
-    sensor_items.extend([PostNLSensor(
-        hass,
-        'PostNL-package',
-        'package-variant-closed',
-        'packeges',
-        api)])
+    sensor_items.append(PostNLSensor(
+        name,
+        'mdi:package-variant-closed',
+        'packages',
+        api,
+        'package'))
 
     if letter:
-        sensor_items.extend([PostNLSensor(
-            hass,
-            'PostNL-letter',
-            'email-outline',
+        sensor_items.append(PostNLSensor(
+            name,
+            'mdi:email-outline',
             'letters',
-            api)])
+            api,
+            'letter'))
 
     add_devices(sensor_items)
 
@@ -74,14 +74,15 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class PostNLSensor(Entity):
     """Representation of a PostNL sensor."""
 
-    def __init__(self, hass, name, icon, unit_of_measurement, api):
+    def __init__(self, name, icon, unit_of_measurement, api, sensor_type):
         """Initialize the PostNL sensor."""
-        self._name = name
+        self._name = '{} {}'.format(name, sensor_type)
         self._attributes = None
         self._state = None
         self._api = api
-        self._icon = "mdi:" + icon
+        self._icon = icon
         self._unit_of_measurement = unit_of_measurement
+        self._type = sensor_type
 
     @property
     def name(self):
@@ -111,7 +112,7 @@ class PostNLSensor(Entity):
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
         """Update device state."""
-        if self.name == 'PostNL-package':
+        if self._type == 'package':
             shipments = self._api.get_relevant_shipments()
             status_counts = {}
 
@@ -128,7 +129,7 @@ class PostNLSensor(Entity):
 
             self._state = len(status_counts)
 
-        elif self.name == 'PostNL-letter':
+        elif self._type == 'letter':
 
             letters = self._api.get_relevant_letters()
 

--- a/homeassistant/components/sensor/postnl.py
+++ b/homeassistant/components/sensor/postnl.py
@@ -56,18 +56,20 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         return
 
     sensor_items = []
-    sensor_items.extend([PostNLSensor(hass,
-                                    'PostNL-package',
-                                    'package-variant-closed',
-                                    'packeges',
-                                    api)])
+    sensor_items.extend([PostNLSensor(
+        hass,
+        'PostNL-package',
+        'package-variant-closed',
+        'packeges',
+        api)])
 									
     if letter:
-        sensor_items.extend([PostNLSensor(hass,
-                                        'PostNL-letter',
-                                        'email-outline',
-                                        'letters',
-                                        api)])
+        sensor_items.extend([PostNLSensor(
+            hass,
+            'PostNL-letter',
+            'email-outline',
+            'letters',
+            api)])
 
     add_devices(sensor_items)
 

--- a/homeassistant/components/sensor/postnl.py
+++ b/homeassistant/components/sensor/postnl.py
@@ -107,3 +107,49 @@ class PostNLSensor(Entity):
         }
 
         self._state = len(status_counts)
+        
+class PostNLletter(Entity):
+    """Representation of a PostNL sensor."""
+
+    def __init__(self, api, name):
+        """Initialize the PostNL sensor."""
+        self._name = name
+        self._attributes = None
+        self._state = None
+        self._api = api
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return 'postnl letter(s)'
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement of this entity, if any."""
+        return self._name
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        return self._attributes
+
+    @property
+    def icon(self):
+        """Icon to use in the frontend."""
+        return ICON
+
+    @Throttle(MIN_TIME_BETWEEN_UPDATES)
+    def update(self):
+        """Update device state."""
+        letters = self._api.get_relevant_letters()
+
+        self._attributes = {
+            ATTR_ATTRIBUTION: ATTRIBUTION,
+        }
+
+        self._state = len(letters)


### PR DESCRIPTION
## Description:
This change will add a new postNL letter entity to fronted. it is using the same library so i added it to the existing file.

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: postnl
    username: POSTNL_USERNAME
    password: POSTNL_PASSWORD
    letter: (true / falce)
```

## Testing:
  - [x] The code change is tested and works locally.

I can not test what happens if you did not enable the postNL letter service en do enable the entity.

## Documentation 
If user exposed functionality or configuration variables are added/changed:
home-assistant/home-assistant.github.io#5731 
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

- [ ]  waiting for approval / review


backup before big file change 
[Nieuw tekstdocument.txt](https://github.com/home-assistant/home-assistant/files/2181194/Nieuw.tekstdocument.txt)


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
