### PR TITLE
Add ability to set Zwave protection commandclass

### DIFF
--- a/homeassistant/components/config/zwave.py
+++ b/homeassistant/components/config/zwave.py
@@ -214,13 +214,16 @@ class ZWaveProtectionView(HomeAssistantView):
         if node is None:
             return self.json_message('Node not found', HTTP_NOT_FOUND)
         protection_options = {}
-        if not await hass.async_add_executor_job(node.has_command_class, const.COMMAND_CLASS_PROTECTION):
+        if not await hass.async_add_executor_job(
+                node.has_command_class, const.COMMAND_CLASS_PROTECTION):
             return self.json(protection_options)
         protections = await hass.async_add_executor_job(node.get_protections)
         protection_options = {
             'value_id': '{0:d}'.format(list(protections)[0]),
-            'selected': await hass.async_add_executor_job(node.get_protection_item, list(protections)[0]),
-            'options': await hass.async_add_executor_job(node.get_protection_items, list(protections)[0])}
+            'selected': await hass.async_add_executor_job(
+                node.get_protection_item, list(protections)[0]),
+            'options': await hass.async_add_executor_job(
+                node.get_protection_items, list(protections)[0])}
         return self.json(protection_options)
 
     async def post(self, request, node_id):
@@ -235,10 +238,12 @@ class ZWaveProtectionView(HomeAssistantView):
         value_id = int(protection_data[const.ATTR_VALUE_ID])
         if node is None:
             return self.json_message('Node not found', HTTP_NOT_FOUND)
-        if not await hass.async_add_executor_job(node.has_command_class, const.COMMAND_CLASS_PROTECTION):
+        if not await hass.async_add_executor_job(
+                node.has_command_class, const.COMMAND_CLASS_PROTECTION):
             return self.json_message('No protection commandclass on this node',
                                      HTTP_NOT_FOUND)
-        state = await hass.async_add_executor_job(node.set_protection, value_id, selection)
+        state = await hass.async_add_executor_job(
+            node.set_protection, value_id, selection)
         if not state:
             return self.json_message(
                 'Protection setting did not complete', 202)

--- a/homeassistant/components/config/zwave.py
+++ b/homeassistant/components/config/zwave.py
@@ -29,7 +29,7 @@ def async_setup(hass):
     hass.http.register_view(ZWaveUserCodeView)
     hass.http.register_view(ZWaveLogView)
     hass.http.register_view(ZWaveConfigWriteView)
-    hass.http.register_view(ZWaveProtecionView)
+    hass.http.register_view(ZWaveProtectionView)
 
     return True
 
@@ -199,7 +199,7 @@ class ZWaveUserCodeView(HomeAssistantView):
         return self.json(usercodes)
 
 
-class ZWaveProtecionView(HomeAssistantView):
+class ZWaveProtectionView(HomeAssistantView):
     """View for the protection commandclass of a node."""
 
     url = r"/api/zwave/protection/{node_id:\d+}"

--- a/homeassistant/components/config/zwave.py
+++ b/homeassistant/components/config/zwave.py
@@ -218,9 +218,6 @@ class ZWaveProtecionView(HomeAssistantView):
         if not node.has_command_class(const.COMMAND_CLASS_PROTECTION):
             return self.json(protection_options)
         protections = node.get_protections()
-        _LOGGER.info('GET protection data: %s', protections)
-        _LOGGER.info('Value_id=%d', list(protections.keys())[0])
-        _LOGGER.info('Value_id=%s', list(protections.keys())[0])
         protection_options = {'value_id': '{0:d}'.format(list(protections.keys())[0]),
                               'selected': node.get_protection_item(list(protections.keys())[0]),
                               'options': node.get_protection_items(list(protections.keys())[0])}
@@ -234,7 +231,6 @@ class ZWaveProtecionView(HomeAssistantView):
         network = hass.data.get(const.DATA_NETWORK)
         node = network.nodes.get(nodeid)
         protection_data = await request.json()
-        _LOGGER.info("POST protection_data: %s", protection_data)
 
         selection = protection_data["selection"]
         value_id = int(protection_data[const.ATTR_VALUE_ID])
@@ -244,8 +240,6 @@ class ZWaveProtecionView(HomeAssistantView):
             return self.json_message('No protection commandclass on this node',
                                      HTTP_NOT_FOUND)
         state = node.set_protection(value_id, selection)
-        _LOGGER.info("Setting protection commandclass option on Node %s "
-                     "to %s Success=%s", nodeid, selection, state)
-
-        return self.json_message('Protection commandclass option set.',
-                                 HTTP_OK)
+        if not state:
+            return self.json_message('Protection setting did not complete', 202)
+        return self.json_message('Protection setting succsessfully set', HTTP_OK)

--- a/homeassistant/components/config/zwave.py
+++ b/homeassistant/components/config/zwave.py
@@ -210,42 +210,46 @@ class ZWaveProtectionView(HomeAssistantView):
         nodeid = int(node_id)
         hass = request.app['hass']
         network = hass.data.get(const.DATA_NETWORK)
-        node = await hass.async_add_executor_job(network.nodes.get, nodeid)
-        if node is None:
-            return self.json_message('Node not found', HTTP_NOT_FOUND)
-        protection_options = {}
-        if not await hass.async_add_executor_job(
-                node.has_command_class, const.COMMAND_CLASS_PROTECTION):
+
+        def _fetch_protection():
+            """Helper to get protection data."""
+            node = network.nodes.get(nodeid)
+            if node is None:
+                return self.json_message('Node not found', HTTP_NOT_FOUND)
+            protection_options = {}
+            if not node.has_command_class(const.COMMAND_CLASS_PROTECTION):
+                return self.json(protection_options)
+            protections = node.get_protections()
+            protection_options = {
+                'value_id': '{0:d}'.format(list(protections)[0]),
+                'selected': node.get_protection_item(list(protections)[0]),
+                'options': node.get_protection_items(list(protections)[0])}
             return self.json(protection_options)
-        protections = await hass.async_add_executor_job(node.get_protections)
-        protection_options = {
-            'value_id': '{0:d}'.format(list(protections)[0]),
-            'selected': await hass.async_add_executor_job(
-                node.get_protection_item, list(protections)[0]),
-            'options': await hass.async_add_executor_job(
-                node.get_protection_items, list(protections)[0])}
-        return self.json(protection_options)
+
+        return await hass.async_add_executor_job(_fetch_protection)
 
     async def post(self, request, node_id):
         """Change the selected option in protection commandclass."""
         nodeid = int(node_id)
         hass = request.app['hass']
         network = hass.data.get(const.DATA_NETWORK)
-        node = await hass.async_add_executor_job(network.nodes.get, nodeid)
         protection_data = await request.json()
 
-        selection = protection_data["selection"]
-        value_id = int(protection_data[const.ATTR_VALUE_ID])
-        if node is None:
-            return self.json_message('Node not found', HTTP_NOT_FOUND)
-        if not await hass.async_add_executor_job(
-                node.has_command_class, const.COMMAND_CLASS_PROTECTION):
-            return self.json_message('No protection commandclass on this node',
-                                     HTTP_NOT_FOUND)
-        state = await hass.async_add_executor_job(
-            node.set_protection, value_id, selection)
-        if not state:
+        def _set_protection():
+            """Helper to get protection data."""
+            node = network.nodes.get(nodeid)
+            selection = protection_data["selection"]
+            value_id = int(protection_data[const.ATTR_VALUE_ID])
+            if node is None:
+                return self.json_message('Node not found', HTTP_NOT_FOUND)
+            if not node.has_command_class(const.COMMAND_CLASS_PROTECTION):
+                return self.json_message(
+                    'No protection commandclass on this node', HTTP_NOT_FOUND)
+            state = node.set_protection(value_id, selection)
+            if not state:
+                return self.json_message(
+                    'Protection setting did not complete', 202)
             return self.json_message(
-                'Protection setting did not complete', 202)
-        return self.json_message(
-            'Protection setting succsessfully set', HTTP_OK)
+                'Protection setting succsessfully set', HTTP_OK)
+
+        return await hass.async_add_executor_job(_set_protection)

--- a/homeassistant/components/config/zwave.py
+++ b/homeassistant/components/config/zwave.py
@@ -219,7 +219,7 @@ class ZWaveProtectionView(HomeAssistantView):
             return self.json(protection_options)
         protections = node.get_protections()
         protection_options = {
-            'value_id': '{0:d}'.format(list(protections.keys())[0]),
+            'value_id': '{0:d}'.format(list(protections)[0]),
             'selected': node.get_protection_item(list(protections.keys())[0]),
             'options': node.get_protection_items(list(protections.keys())[0])}
         return self.json(protection_options)

--- a/homeassistant/components/config/zwave.py
+++ b/homeassistant/components/config/zwave.py
@@ -205,7 +205,7 @@ class ZWaveProtectionView(HomeAssistantView):
     url = r"/api/zwave/protection/{node_id:\d+}"
     name = "api:zwave:protection"
 
-    @ha.callback
+    @asyncio.coroutine
     def get(self, request, node_id):
         """Retrieve the protection commandclass options of node."""
         nodeid = int(node_id)

--- a/homeassistant/components/config/zwave.py
+++ b/homeassistant/components/config/zwave.py
@@ -220,8 +220,8 @@ class ZWaveProtectionView(HomeAssistantView):
         protections = node.get_protections()
         protection_options = {
             'value_id': '{0:d}'.format(list(protections)[0]),
-            'selected': node.get_protection_item(list(protections.keys())[0]),
-            'options': node.get_protection_items(list(protections.keys())[0])}
+            'selected': node.get_protection_item(list(protections)[0]),
+            'options': node.get_protection_items(list(protections)[0])}
         return self.json(protection_options)
 
     async def post(self, request, node_id):

--- a/homeassistant/components/config/zwave.py
+++ b/homeassistant/components/config/zwave.py
@@ -218,11 +218,11 @@ class ZWaveProtectionView(HomeAssistantView):
         if not node.has_command_class(const.COMMAND_CLASS_PROTECTION):
             return self.json(protection_options)
         protections = node.get_protections()
-        protection_options = {'value_id': '{0:d}'.format(list(protections.keys())[0]),
-                              'selected': node.get_protection_item(list(protections.keys())[0]),
-                              'options': node.get_protection_items(list(protections.keys())[0])}
+        protection_options = {
+            'value_id': '{0:d}'.format(list(protections.keys())[0]),
+            'selected': node.get_protection_item(list(protections.keys())[0]),
+            'options': node.get_protection_items(list(protections.keys())[0])}
         return self.json(protection_options)
-
 
     async def post(self, request, node_id):
         """Change the selected option in protection commandclass."""
@@ -241,5 +241,7 @@ class ZWaveProtectionView(HomeAssistantView):
                                      HTTP_NOT_FOUND)
         state = node.set_protection(value_id, selection)
         if not state:
-            return self.json_message('Protection setting did not complete', 202)
-        return self.json_message('Protection setting succsessfully set', HTTP_OK)
+            return self.json_message(
+                'Protection setting did not complete', 202)
+        return self.json_message(
+            'Protection setting succsessfully set', HTTP_OK)

--- a/tests/components/config/test_zwave.py
+++ b/tests/components/config/test_zwave.py
@@ -544,7 +544,7 @@ def test_set_protection_value_nonexisting_node(hass, client):
 
 @asyncio.coroutine
 def test_set_protection_value_missing_class(hass, client):
-    """Test setting protection value on node without protectionclass"""
+    """Test setting protection value on node without protection lass."""
     network = hass.data[DATA_NETWORK] = MagicMock()
     node = MockNode(node_id=17)
     value = MockValue(

--- a/tests/components/config/test_zwave.py
+++ b/tests/components/config/test_zwave.py
@@ -544,7 +544,7 @@ def test_set_protection_value_nonexisting_node(hass, client):
 
 @asyncio.coroutine
 def test_set_protection_value_missing_class(hass, client):
-    """Test setting protection value on node without protection lass."""
+    """Test setting protection value on node without protectionclass."""
     network = hass.data[DATA_NETWORK] = MagicMock()
     node = MockNode(node_id=17)
     value = MockValue(

--- a/tests/components/config/test_zwave.py
+++ b/tests/components/config/test_zwave.py
@@ -367,3 +367,202 @@ def test_save_config(hass, client):
     result = yield from resp.json()
     assert network.write_config.called
     assert result == {'message': 'Z-Wave configuration saved to file.'}
+
+
+@asyncio.coroutine
+def test_get_protection_values(hass, client):
+    """Test getting protection values on node."""
+    network = hass.data[DATA_NETWORK] = MagicMock()
+    node = MockNode(node_id=18,
+                    command_classes=[const.COMMAND_CLASS_PROTECTION])
+    value = MockValue(
+        value_id=123456,
+        index=0,
+        instance=1,
+        command_class=const.COMMAND_CLASS_PROTECTION)
+    value.label = 'Protection Test'
+    value.data_items = ['Unprotected', 'Protection by Sequence',
+                        'No Operation Possible']
+    value.data = 'Unprotected'
+    network.nodes = {18: node}
+    node.value = value
+
+    node.get_protection_item.return_value = "Unprotected"
+    node.get_protection_items.return_value = value.data_items
+    node.get_protections.return_value = {value.value_id: 'Object'}
+
+
+    resp = yield from client.get('/api/zwave/protection/18')
+
+    assert resp.status == 200
+    result = yield from resp.json()
+    assert node.get_protections.called
+    assert node.get_protection_item.called
+    assert node.get_protection_items.called
+    assert result == {
+         'value_id': '123456',
+         'selected': 'Unprotected',
+         'options': ['Unprotected', 'Protection by Sequence',
+                     'No Operation Possible']
+    }
+
+
+@asyncio.coroutine
+def test_get_protection_values_nonexisting_node(hass, client):
+    """Test getting protection values on node with wrong nodeid."""
+    network = hass.data[DATA_NETWORK] = MagicMock()
+    node = MockNode(node_id=18,
+                    command_classes=[const.COMMAND_CLASS_PROTECTION])
+    value = MockValue(
+        value_id=123456,
+        index=0,
+        instance=1,
+        command_class=const.COMMAND_CLASS_PROTECTION)
+    value.label = 'Protection Test'
+    value.data_items = ['Unprotected', 'Protection by Sequence',
+                        'No Operation Possible']
+    value.data = 'Unprotected'
+    network.nodes = {17: node}
+    node.value = value
+
+    resp = yield from client.get('/api/zwave/protection/18')
+
+    assert resp.status == 404
+    result = yield from resp.json()
+    assert not node.get_protections.called
+    assert not node.get_protection_item.called
+    assert not node.get_protection_items.called
+    assert result == { 'message': 'Node not found' }
+
+
+@asyncio.coroutine
+def test_get_protection_values_without_protectionclass(hass, client):
+    """Test getting protection values on node without protectionclass."""
+    network = hass.data[DATA_NETWORK] = MagicMock()
+    node = MockNode(node_id=18)
+    value = MockValue(
+        value_id=123456,
+        index=0,
+        instance=1)
+    network.nodes = {18: node}
+    node.value = value
+
+    resp = yield from client.get('/api/zwave/protection/18')
+
+    assert resp.status == 200
+    result = yield from resp.json()
+    assert not node.get_protections.called
+    assert not node.get_protection_item.called
+    assert not node.get_protection_items.called
+    assert result == { }
+
+
+@asyncio.coroutine
+def test_set_protection_value(hass, client):
+    """Test setting protection value on node."""
+    network = hass.data[DATA_NETWORK] = MagicMock()
+    node = MockNode(node_id=18,
+                    command_classes=[const.COMMAND_CLASS_PROTECTION])
+    value = MockValue(
+        value_id=123456,
+        index=0,
+        instance=1,
+        command_class=const.COMMAND_CLASS_PROTECTION)
+    value.label = 'Protection Test'
+    value.data_items = ['Unprotected', 'Protection by Sequence',
+                        'No Operation Possible']
+    value.data = 'Unprotected'
+    network.nodes = {18: node}
+    node.value = value
+
+    resp = yield from client.post(
+        '/api/zwave/protection/18', data=json.dumps({
+            'value_id': '123456', 'selection': 'Protection by Sequence'}))
+
+    assert resp.status == 200
+    result = yield from resp.json()
+    assert node.set_protection.called
+    assert result == {'message': 'Protection setting succsessfully set'}
+
+
+@asyncio.coroutine
+def test_set_protection_value_failed(hass, client):
+    """Test setting protection value failed on node."""
+    network = hass.data[DATA_NETWORK] = MagicMock()
+    node = MockNode(node_id=18,
+                    command_classes=[const.COMMAND_CLASS_PROTECTION])
+    value = MockValue(
+        value_id=123456,
+        index=0,
+        instance=1,
+        command_class=const.COMMAND_CLASS_PROTECTION)
+    value.label = 'Protection Test'
+    value.data_items = ['Unprotected', 'Protection by Sequence',
+                        'No Operation Possible']
+    value.data = 'Unprotected'
+    network.nodes = {18: node}
+    node.value = value
+    node.set_protection.return_value = False
+
+    resp = yield from client.post(
+        '/api/zwave/protection/18', data=json.dumps({
+            'value_id': '123456', 'selection': 'Protecton by Seuence'}))
+
+    assert resp.status == 202
+    result = yield from resp.json()
+    assert node.set_protection.called
+    assert result == {'message': 'Protection setting did not complete'}
+
+
+@asyncio.coroutine
+def test_set_protection_value_nonexisting_node(hass, client):
+    """Test setting protection value on nonexisting node."""
+    network = hass.data[DATA_NETWORK] = MagicMock()
+    node = MockNode(node_id=17,
+                    command_classes=[const.COMMAND_CLASS_PROTECTION])
+    value = MockValue(
+        value_id=123456,
+        index=0,
+        instance=1,
+        command_class=const.COMMAND_CLASS_PROTECTION)
+    value.label = 'Protection Test'
+    value.data_items = ['Unprotected', 'Protection by Sequence',
+                        'No Operation Possible']
+    value.data = 'Unprotected'
+    network.nodes = {17: node}
+    node.value = value
+    node.set_protection.return_value = False
+
+    resp = yield from client.post(
+        '/api/zwave/protection/18', data=json.dumps({
+            'value_id': '123456', 'selection': 'Protecton by Seuence'}))
+
+    assert resp.status == 404
+    result = yield from resp.json()
+    assert not node.set_protection.called
+    assert result == {'message': 'Node not found'}
+
+
+@asyncio.coroutine
+def test_set_protection_value_missing_class(hass, client):
+    """Test setting protection value on node without protectionclass"""
+    network = hass.data[DATA_NETWORK] = MagicMock()
+    node = MockNode(node_id=17)
+    value = MockValue(
+        value_id=123456,
+        index=0,
+        instance=1)
+    network.nodes = {17: node}
+    node.value = value
+    node.set_protection.return_value = False
+
+    resp = yield from client.post(
+        '/api/zwave/protection/17', data=json.dumps({
+            'value_id': '123456', 'selection': 'Protecton by Seuence'}))
+
+    assert resp.status == 404
+    result = yield from resp.json()
+    assert not node.set_protection.called
+    assert result == {'message': 'No protection commandclass on this node'}
+
+

--- a/tests/components/config/test_zwave.py
+++ b/tests/components/config/test_zwave.py
@@ -369,8 +369,7 @@ def test_save_config(hass, client):
     assert result == {'message': 'Z-Wave configuration saved to file.'}
 
 
-@asyncio.coroutine
-def test_get_protection_values(hass, client):
+async def test_get_protection_values(hass, client):
     """Test getting protection values on node."""
     network = hass.data[DATA_NETWORK] = MagicMock()
     node = MockNode(node_id=18,
@@ -391,23 +390,22 @@ def test_get_protection_values(hass, client):
     node.get_protection_items.return_value = value.data_items
     node.get_protections.return_value = {value.value_id: 'Object'}
 
-    resp = yield from client.get('/api/zwave/protection/18')
+    resp = await client.get('/api/zwave/protection/18')
 
     assert resp.status == 200
-    result = yield from resp.json()
+    result = await resp.json()
     assert node.get_protections.called
     assert node.get_protection_item.called
     assert node.get_protection_items.called
     assert result == {
-         'value_id': '123456',
-         'selected': 'Unprotected',
-         'options': ['Unprotected', 'Protection by Sequence',
-                     'No Operation Possible']
+        'value_id': '123456',
+        'selected': 'Unprotected',
+        'options': ['Unprotected', 'Protection by Sequence',
+                    'No Operation Possible']
     }
 
 
-@asyncio.coroutine
-def test_get_protection_values_nonexisting_node(hass, client):
+async def test_get_protection_values_nonexisting_node(hass, client):
     """Test getting protection values on node with wrong nodeid."""
     network = hass.data[DATA_NETWORK] = MagicMock()
     node = MockNode(node_id=18,
@@ -424,18 +422,17 @@ def test_get_protection_values_nonexisting_node(hass, client):
     network.nodes = {17: node}
     node.value = value
 
-    resp = yield from client.get('/api/zwave/protection/18')
+    resp = await client.get('/api/zwave/protection/18')
 
     assert resp.status == 404
-    result = yield from resp.json()
+    result = await resp.json()
     assert not node.get_protections.called
     assert not node.get_protection_item.called
     assert not node.get_protection_items.called
     assert result == {'message': 'Node not found'}
 
 
-@asyncio.coroutine
-def test_get_protection_values_without_protectionclass(hass, client):
+async def test_get_protection_values_without_protectionclass(hass, client):
     """Test getting protection values on node without protectionclass."""
     network = hass.data[DATA_NETWORK] = MagicMock()
     node = MockNode(node_id=18)
@@ -446,18 +443,17 @@ def test_get_protection_values_without_protectionclass(hass, client):
     network.nodes = {18: node}
     node.value = value
 
-    resp = yield from client.get('/api/zwave/protection/18')
+    resp = await client.get('/api/zwave/protection/18')
 
     assert resp.status == 200
-    result = yield from resp.json()
+    result = await resp.json()
     assert not node.get_protections.called
     assert not node.get_protection_item.called
     assert not node.get_protection_items.called
     assert result == {}
 
 
-@asyncio.coroutine
-def test_set_protection_value(hass, client):
+async def test_set_protection_value(hass, client):
     """Test setting protection value on node."""
     network = hass.data[DATA_NETWORK] = MagicMock()
     node = MockNode(node_id=18,
@@ -474,18 +470,17 @@ def test_set_protection_value(hass, client):
     network.nodes = {18: node}
     node.value = value
 
-    resp = yield from client.post(
+    resp = await client.post(
         '/api/zwave/protection/18', data=json.dumps({
             'value_id': '123456', 'selection': 'Protection by Sequence'}))
 
     assert resp.status == 200
-    result = yield from resp.json()
+    result = await resp.json()
     assert node.set_protection.called
     assert result == {'message': 'Protection setting succsessfully set'}
 
 
-@asyncio.coroutine
-def test_set_protection_value_failed(hass, client):
+async def test_set_protection_value_failed(hass, client):
     """Test setting protection value failed on node."""
     network = hass.data[DATA_NETWORK] = MagicMock()
     node = MockNode(node_id=18,
@@ -503,18 +498,17 @@ def test_set_protection_value_failed(hass, client):
     node.value = value
     node.set_protection.return_value = False
 
-    resp = yield from client.post(
+    resp = await client.post(
         '/api/zwave/protection/18', data=json.dumps({
             'value_id': '123456', 'selection': 'Protecton by Seuence'}))
 
     assert resp.status == 202
-    result = yield from resp.json()
+    result = await resp.json()
     assert node.set_protection.called
     assert result == {'message': 'Protection setting did not complete'}
 
 
-@asyncio.coroutine
-def test_set_protection_value_nonexisting_node(hass, client):
+async def test_set_protection_value_nonexisting_node(hass, client):
     """Test setting protection value on nonexisting node."""
     network = hass.data[DATA_NETWORK] = MagicMock()
     node = MockNode(node_id=17,
@@ -532,18 +526,17 @@ def test_set_protection_value_nonexisting_node(hass, client):
     node.value = value
     node.set_protection.return_value = False
 
-    resp = yield from client.post(
+    resp = await client.post(
         '/api/zwave/protection/18', data=json.dumps({
             'value_id': '123456', 'selection': 'Protecton by Seuence'}))
 
     assert resp.status == 404
-    result = yield from resp.json()
+    result = await resp.json()
     assert not node.set_protection.called
     assert result == {'message': 'Node not found'}
 
 
-@asyncio.coroutine
-def test_set_protection_value_missing_class(hass, client):
+async def test_set_protection_value_missing_class(hass, client):
     """Test setting protection value on node without protectionclass"""
     network = hass.data[DATA_NETWORK] = MagicMock()
     node = MockNode(node_id=17)
@@ -555,11 +548,11 @@ def test_set_protection_value_missing_class(hass, client):
     node.value = value
     node.set_protection.return_value = False
 
-    resp = yield from client.post(
+    resp = await client.post(
         '/api/zwave/protection/17', data=json.dumps({
             'value_id': '123456', 'selection': 'Protecton by Seuence'}))
 
     assert resp.status == 404
-    result = yield from resp.json()
+    result = await resp.json()
     assert not node.set_protection.called
     assert result == {'message': 'No protection commandclass on this node'}

--- a/tests/components/config/test_zwave.py
+++ b/tests/components/config/test_zwave.py
@@ -537,7 +537,7 @@ async def test_set_protection_value_nonexisting_node(hass, client):
 
 
 async def test_set_protection_value_missing_class(hass, client):
-    """Test setting protection value on node without protectionclass"""
+    """Test setting protection value on node without protectionclass."""
     network = hass.data[DATA_NETWORK] = MagicMock()
     node = MockNode(node_id=17)
     value = MockValue(

--- a/tests/components/config/test_zwave.py
+++ b/tests/components/config/test_zwave.py
@@ -391,7 +391,6 @@ def test_get_protection_values(hass, client):
     node.get_protection_items.return_value = value.data_items
     node.get_protections.return_value = {value.value_id: 'Object'}
 
-
     resp = yield from client.get('/api/zwave/protection/18')
 
     assert resp.status == 200
@@ -432,7 +431,7 @@ def test_get_protection_values_nonexisting_node(hass, client):
     assert not node.get_protections.called
     assert not node.get_protection_item.called
     assert not node.get_protection_items.called
-    assert result == { 'message': 'Node not found' }
+    assert result == {'message': 'Node not found'}
 
 
 @asyncio.coroutine
@@ -454,7 +453,7 @@ def test_get_protection_values_without_protectionclass(hass, client):
     assert not node.get_protections.called
     assert not node.get_protection_item.called
     assert not node.get_protection_items.called
-    assert result == { }
+    assert result == {}
 
 
 @asyncio.coroutine
@@ -564,5 +563,3 @@ def test_set_protection_value_missing_class(hass, client):
     result = yield from resp.json()
     assert not node.set_protection.called
     assert result == {'message': 'No protection commandclass on this node'}
-
-


### PR DESCRIPTION
## Description:
Allows the user via zwave control panel to set values of protection commandclass.
This is needed in some cases to allow programming of some devices.
See #11137 for reference.
Accompanying PR for frontend: https://github.com/home-assistant/home-assistant-polymer/pull/1433
**Related issue (if applicable):** fixes #11137 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
