### PR TITLE
Fix for OpenGarage cover getting stuck in state (#15395)

### DIFF
--- a/homeassistant/components/cover/opengarage.py
+++ b/homeassistant/components/cover/opengarage.py
@@ -38,6 +38,9 @@ STATES_MAP = {
     1: STATE_OPEN,
 }
 
+""" Update cycles before the internal move state will reset."""
+STATE_RESET_COUNTER = 2
+
 COVER_SCHEMA = vol.Schema({
     vol.Required(CONF_DEVICE_KEY): cv.string,
     vol.Required(CONF_HOST): cv.string,
@@ -82,6 +85,7 @@ class OpenGarageCover(CoverDevice):
         self._device_key = args[CONF_DEVICE_KEY]
         self._state = None
         self._state_before_move = None
+        self._state_reset_count = 0
         self.dist = None
         self.signal = None
         self._available = True
@@ -124,6 +128,7 @@ class OpenGarageCover(CoverDevice):
         if self._state not in [STATE_CLOSED, STATE_CLOSING]:
             self._state_before_move = self._state
             self._state = STATE_CLOSING
+            self._state_reset_count = STATE_RESET_COUNTER
             self._push_button()
 
     def open_cover(self, **kwargs):
@@ -131,12 +136,17 @@ class OpenGarageCover(CoverDevice):
         if self._state not in [STATE_OPEN, STATE_OPENING]:
             self._state_before_move = self._state
             self._state = STATE_OPENING
+            self._state_reset_count = STATE_RESET_COUNTER
             self._push_button()
 
     def update(self):
         """Get updated status from API."""
         try:
             status = self._get_status()
+            if self._state_reset_count > 0:
+                self._state_reset_count -= 1
+                if self._state_reset_count == 0:
+                    self._state_before_move = None
             if self._name is None:
                 if status['name'] is not None:
                     self._name = status['name']


### PR DESCRIPTION
## Description:
OpenGarage cover can get stuck in an open/close state if the wifi connectivity drops to the device


**Related issue (if applicable):** fixes #15395 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
