### PR TITLE
Fix liveboxplaytv empty channel list

### DIFF
--- a/homeassistant/components/media_player/liveboxplaytv.py
+++ b/homeassistant/components/media_player/liveboxplaytv.py
@@ -88,6 +88,8 @@ class LiveboxPlayTvDevice(MediaPlayerDevice):
         import pyteleloisirs
         try:
             self._state = self.refresh_state()
+            # Update channel list
+            self.refresh_channel_list()
             # Update current channel
             channel = self._client.channel
             if channel is not None:


### PR DESCRIPTION
## Description:
In #10076 I mistakenly removed the call to `refresh_channel_list` which resulted in an empty channel list. This PR fixes that.