### PR TITLE
Add support for configuring default turn-on values for lights.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -96,6 +96,7 @@ homeassistant/components/knx.py @Julius2342
 homeassistant/components/*/knx.py @Julius2342
 homeassistant/components/konnected.py @heythisisnate
 homeassistant/components/*/konnected.py @heythisisnate
+homeassistant/components/light_defaults.py @kalimaul
 homeassistant/components/matrix.py @tinloaf
 homeassistant/components/*/matrix.py @tinloaf
 homeassistant/components/qwikswitch.py @kellerza

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -14,6 +14,7 @@ import voluptuous as vol
 
 from homeassistant.components.group import \
     ENTITY_ID_FORMAT as GROUP_ENTITY_ID_FORMAT
+from homeassistant.components.light_defaults import get_light_default
 from homeassistant.const import (
     ATTR_ENTITY_ID, SERVICE_TOGGLE, SERVICE_TURN_OFF, SERVICE_TURN_ON,
     STATE_ON)
@@ -357,6 +358,10 @@ async def async_setup(hass, config):
         update_tasks = []
         for light in target_lights:
             if service.service == SERVICE_TURN_ON:
+                params = params or \
+                         get_light_default(hass, light.entity_id) or \
+                         get_light_default(hass, ENTITY_ID_ALL_LIGHTS)
+                preprocess_turn_on_alternatives(params)
                 await light.async_turn_on(**params)
             elif service.service == SERVICE_TURN_OFF:
                 await light.async_turn_off(**params)

--- a/homeassistant/components/light_defaults.py
+++ b/homeassistant/components/light_defaults.py
@@ -1,0 +1,87 @@
+"""
+Component to hold default turn-on values for lights.
+
+For more details about this component, please refer to the documentation
+at https://home-assistant.io/components/light_defaults/
+"""
+import logging
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+
+_LOGGER = logging.getLogger(__name__)
+DOMAIN = 'light_defaults'
+
+# NOTE: Schema params here were copied from components/light/__init__.py
+# They must match the schema of the light turn on service call.
+
+# String representing a profile (built-in ones or external defined).
+ATTR_PROFILE = "profile"
+
+COLOR_GROUP = "Color descriptors"
+
+# Lists holding color values
+ATTR_RGB_COLOR = "rgb_color"
+ATTR_XY_COLOR = "xy_color"
+ATTR_HS_COLOR = "hs_color"
+ATTR_COLOR_TEMP = "color_temp"
+ATTR_KELVIN = "kelvin"
+ATTR_COLOR_NAME = "color_name"
+
+# Brightness of the light, 0..255 or percentage
+ATTR_BRIGHTNESS = "brightness"
+ATTR_BRIGHTNESS_PCT = "brightness_pct"
+
+VALID_BRIGHTNESS = vol.All(vol.Coerce(int), vol.Clamp(min=0, max=255))
+VALID_BRIGHTNESS_PCT = vol.All(vol.Coerce(float), vol.Range(min=0, max=100))
+
+LIGHT_VALUES_SCHEMA = vol.Schema({
+    vol.Exclusive(ATTR_PROFILE, COLOR_GROUP): cv.string,
+    ATTR_BRIGHTNESS: VALID_BRIGHTNESS,
+    ATTR_BRIGHTNESS_PCT: VALID_BRIGHTNESS_PCT,
+    vol.Exclusive(ATTR_COLOR_NAME, COLOR_GROUP): cv.string,
+    vol.Exclusive(ATTR_RGB_COLOR, COLOR_GROUP):
+        vol.All(vol.ExactSequence((cv.byte, cv.byte, cv.byte)),
+                vol.Coerce(tuple)),
+    vol.Exclusive(ATTR_XY_COLOR, COLOR_GROUP):
+        vol.All(vol.ExactSequence((cv.small_float, cv.small_float)),
+                vol.Coerce(tuple)),
+    vol.Exclusive(ATTR_HS_COLOR, COLOR_GROUP):
+        vol.All(vol.ExactSequence(
+            (vol.All(vol.Coerce(float), vol.Range(min=0, max=360)),
+             vol.All(vol.Coerce(float), vol.Range(min=0, max=100)))),
+                vol.Coerce(tuple)),
+    vol.Exclusive(ATTR_COLOR_TEMP, COLOR_GROUP):
+        vol.All(vol.Coerce(int), vol.Range(min=1)),
+    vol.Exclusive(ATTR_KELVIN, COLOR_GROUP):
+        vol.All(vol.Coerce(int), vol.Range(min=0)),
+})
+
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: {
+        cv.entity_id: LIGHT_VALUES_SCHEMA,
+    },
+}, extra=vol.ALLOW_EXTRA)
+
+
+async def async_setup(hass, config):
+    """Set up the default values."""
+    hass.data[DOMAIN] = dict()
+
+    for object_id, defaults in config[DOMAIN].items():
+        params = dict()
+        for key, value in defaults.items():
+            params[key] = value
+        _LOGGER.debug("Got default turn on params for %s: %s.",
+                      object_id, str(params))
+        hass.data[DOMAIN][object_id] = params
+    return True
+
+
+def get_light_default(hass, object_id):
+    """Get default values for a given light."""
+    if DOMAIN not in hass.data or object_id not in hass.data[DOMAIN]:
+        return dict()
+    return hass.data[DOMAIN][object_id]

--- a/tests/components/test_light_defaults.py
+++ b/tests/components/test_light_defaults.py
@@ -1,0 +1,85 @@
+"""The tests for the light defaults component."""
+# pylint: disable=protected-access
+import unittest
+
+from homeassistant.setup import setup_component
+import homeassistant.components.light as light
+
+from tests.common import get_test_home_assistant
+from homeassistant.components import light_defaults
+
+ENTITY_LIGHT_BED = 'light.bed_light'
+ENTITY_LIGHT_CEILING = 'light.ceiling_lights'
+
+
+class TestLightDefaults(unittest.TestCase):
+    """Test the light defaults using the demo lights."""
+
+    # pylint: disable=invalid-name
+    def setUp(self):
+        """Setup things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+        self.assertTrue(setup_component(self.hass, light.DOMAIN, {'light': {
+            'platform': 'demo',
+        }}))
+        self.assertTrue(setup_component(self.hass, light_defaults.DOMAIN, {
+            'light_defaults': {
+                ENTITY_LIGHT_BED: {
+                    'color_name': 'blue',
+                    'brightness_pct': 25,
+                },
+                ENTITY_LIGHT_CEILING: {
+                    'color_name': 'red',
+                    'brightness_pct': 50,
+                },
+            },
+        }))
+
+    # pylint: disable=invalid-name
+    def tearDown(self):
+        """Stop down everything that was started."""
+        self.hass.stop()
+
+    def test_state_attributes_bed(self):
+        """Test light state attributes."""
+        light.turn_on(
+            self.hass, ENTITY_LIGHT_BED, xy_color=(.4, .4), brightness=25)
+        self.hass.block_till_done()
+        state = self.hass.states.get(ENTITY_LIGHT_BED)
+        self.assertTrue(light.is_on(self.hass, ENTITY_LIGHT_BED))
+        self.assertEqual((0.4, 0.4), state.attributes.get(
+            light.ATTR_XY_COLOR))
+        self.assertEqual(25, state.attributes.get(light.ATTR_BRIGHTNESS))
+        self.assertEqual(
+            (255, 234, 164), state.attributes.get(light.ATTR_RGB_COLOR))
+
+        light.turn_off(self.hass, ENTITY_LIGHT_BED)
+        self.hass.block_till_done()
+        light.turn_on(self.hass, ENTITY_LIGHT_BED)
+        self.hass.block_till_done()
+        state = self.hass.states.get(ENTITY_LIGHT_BED)
+        self.assertEqual(
+            (0, 0, 255), state.attributes.get(light.ATTR_RGB_COLOR))
+        self.assertEqual(63, state.attributes.get(light.ATTR_BRIGHTNESS))
+
+    def test_state_attributes_ceiling(self):
+        """Test light state attributes."""
+        light.turn_on(
+            self.hass, ENTITY_LIGHT_CEILING, xy_color=(.4, .4), brightness=25)
+        self.hass.block_till_done()
+        state = self.hass.states.get(ENTITY_LIGHT_CEILING)
+        self.assertTrue(light.is_on(self.hass, ENTITY_LIGHT_CEILING))
+        self.assertEqual((0.4, 0.4), state.attributes.get(
+            light.ATTR_XY_COLOR))
+        self.assertEqual(25, state.attributes.get(light.ATTR_BRIGHTNESS))
+        self.assertEqual(
+            (255, 234, 164), state.attributes.get(light.ATTR_RGB_COLOR))
+
+        light.turn_off(self.hass, ENTITY_LIGHT_CEILING)
+        self.hass.block_till_done()
+        light.turn_on(self.hass, ENTITY_LIGHT_CEILING)
+        self.hass.block_till_done()
+        state = self.hass.states.get(ENTITY_LIGHT_CEILING)
+        self.assertEqual(
+            (255, 0, 0), state.attributes.get(light.ATTR_RGB_COLOR))
+        self.assertEqual(127, state.attributes.get(light.ATTR_BRIGHTNESS))


### PR DESCRIPTION
## Description:

Add configurable default values for lights. When a light is turned on it will be set to this default (brightness and/or color) regardless of what it was set to before.

I'm not sure if this is the nicest way to implement this so looking for feedback.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** Will create documentation if this change is accepted.

## Example entry for `configuration.yaml` (if applicable):
```yaml
light_defaults:
  group.all_lights:
    color_name: blue
    brightness_pct: 50
  light.bedroom_lights:
    color_name: red
    brightness_pct: 80
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)
I will create documentation if this approach is accepted.

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
