### PR TITLE
Fix ZWave RGBW lights not producing color without explicit white_value

### DIFF
--- a/homeassistant/components/light/zwave.py
+++ b/homeassistant/components/light/zwave.py
@@ -328,6 +328,10 @@ class ZwaveColorLight(ZwaveDimmer):
         elif ATTR_HS_COLOR in kwargs:
             self._hs = kwargs[ATTR_HS_COLOR]
 
+        if ATTR_HS_COLOR in kwargs:
+            # white LED must be off in order for color to work
+            self._white = 0
+
         if ATTR_WHITE_VALUE in kwargs or ATTR_HS_COLOR in kwargs:
             rgbw = '#'
             for colorval in color_util.color_hs_to_RGB(*self._hs):

--- a/homeassistant/components/light/zwave.py
+++ b/homeassistant/components/light/zwave.py
@@ -326,8 +326,9 @@ class ZwaveColorLight(ZwaveDimmer):
                     rgbw = '#00000000ff'
         elif ATTR_HS_COLOR in kwargs:
             self._hs = kwargs[ATTR_HS_COLOR]
-            # white LED must be off in order for color to work
-            self._white = 0
+            if ATTR_WHITE_VALUE not in kwargs:
+                # white LED must be off in order for color to work
+                self._white = 0
 
         if ATTR_WHITE_VALUE in kwargs or ATTR_HS_COLOR in kwargs:
             rgbw = '#'

--- a/homeassistant/components/light/zwave.py
+++ b/homeassistant/components/light/zwave.py
@@ -324,11 +324,8 @@ class ZwaveColorLight(ZwaveDimmer):
                 else:
                     self._ct = TEMP_COLD_HASS
                     rgbw = '#00000000ff'
-
         elif ATTR_HS_COLOR in kwargs:
             self._hs = kwargs[ATTR_HS_COLOR]
-
-        if ATTR_HS_COLOR in kwargs:
             # white LED must be off in order for color to work
             self._white = 0
 


### PR DESCRIPTION
## Description:

This addresses #13930. It appears that many RGBW ZWave lights will only activate the RGB LED when the white LED (white_value) is set to zero. According to others, this is a regression since 0.65, likely introduced by #11288. I initially experimented with a [different fix](https://github.com/jantman/home-assistant/commit/deef1e3069d3d1cd1b31dfccbf3c2ab51517db66), but this one seems to work with the minimal code change: if ATTR_HS_COLOR is specified in the kwargs to ``turn_on()``, set ``_white`` to zero. This should ensure the expected behavior from the user perspective, namely that if a color is specified for a color-changing light, the light changes color instead of staying white.

I've updated the existing unit tests (which mirrored the currently-broken behavior) and also added another regression test to specifically ensure that if ATTR_HS_COLOR is passed to ``turn_on()``, ``_white`` is set to zero.

**Related issue (if applicable):** fixes #13930

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54

__Note:__ I'd appreciate help from other users to validate this, as I only have a single RGBW bulb (a Zipato Bulb2).