### PR TITLE
Change Ring binary_sensor polling frequency to avoid rate limit exceeded errors

### DIFF
--- a/homeassistant/components/binary_sensor/ring.py
+++ b/homeassistant/components/binary_sensor/ring.py
@@ -23,7 +23,7 @@ DEPENDENCIES = ['ring']
 
 _LOGGER = logging.getLogger(__name__)
 
-SCAN_INTERVAL = timedelta(seconds=5)
+SCAN_INTERVAL = timedelta(seconds=10)
 
 # Sensor types: Name, category, device_class
 SENSOR_TYPES = {


### PR DESCRIPTION
## Description:
This PR changes the Ring binary_sensor polling frequency to avoid rate limit exceeded errors.

Many thanks to @dshokouhi, @Bergasha, and @JerryWorkman for testing and reports. :+1: 


**Related issue (if applicable):** fixes #14693


## Example entry for `configuration.yaml` (if applicable):
```yaml
ring:
  username: foo
  password: bar

binary_sensor:
   - platform: ring
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.