### PR TITLE
Call self._async_update_light() last (after color and dimmer levels)

### DIFF
--- a/homeassistant/components/light/mysensors.py
+++ b/homeassistant/components/light/mysensors.py
@@ -173,8 +173,8 @@ class MySensorsLightDimmer(MySensorsLight):
 
     async def async_turn_on(self, **kwargs):
         """Turn the device on."""
-        self._turn_on_light()
         self._turn_on_dimmer(**kwargs)
+        self._turn_on_light()
         if self.gateway.optimistic:
             self.async_schedule_update_ha_state()
 
@@ -198,9 +198,9 @@ class MySensorsLightRGB(MySensorsLight):
 
     async def async_turn_on(self, **kwargs):
         """Turn the device on."""
-        self._turn_on_light()
         self._turn_on_dimmer(**kwargs)
         self._turn_on_rgb_and_w('%02x%02x%02x', **kwargs)
+        self._turn_on_light()
         if self.gateway.optimistic:
             self.async_schedule_update_ha_state()
 
@@ -227,8 +227,8 @@ class MySensorsLightRGBW(MySensorsLightRGB):
 
     async def async_turn_on(self, **kwargs):
         """Turn the device on."""
-        self._turn_on_light()
         self._turn_on_dimmer(**kwargs)
         self._turn_on_rgb_and_w('%02x%02x%02x%02x', **kwargs)
+        self._turn_on_light()
         if self.gateway.optimistic:
             self.async_schedule_update_ha_state()


### PR DESCRIPTION

## Description:

As discussed briefly via email with Martin Hjelmare (on July 9th):

For my mysensors lights, sending _turn_on_light() before _turn_on_dimmer can lead to multiple (undesired) changes in brightness. Reordering the calls like in this patch fixes the issue for me.


## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**