### PR TITLE
Send V_STATUS last for mysensors light

### DIFF
--- a/homeassistant/components/light/mysensors.py
+++ b/homeassistant/components/light/mysensors.py
@@ -173,8 +173,8 @@ class MySensorsLightDimmer(MySensorsLight):
 
     async def async_turn_on(self, **kwargs):
         """Turn the device on."""
-        self._turn_on_light()
         self._turn_on_dimmer(**kwargs)
+        self._turn_on_light()
         if self.gateway.optimistic:
             self.async_schedule_update_ha_state()
 
@@ -198,9 +198,9 @@ class MySensorsLightRGB(MySensorsLight):
 
     async def async_turn_on(self, **kwargs):
         """Turn the device on."""
-        self._turn_on_light()
         self._turn_on_dimmer(**kwargs)
         self._turn_on_rgb_and_w('%02x%02x%02x', **kwargs)
+        self._turn_on_light()
         if self.gateway.optimistic:
             self.async_schedule_update_ha_state()
 
@@ -227,8 +227,8 @@ class MySensorsLightRGBW(MySensorsLightRGB):
 
     async def async_turn_on(self, **kwargs):
         """Turn the device on."""
-        self._turn_on_light()
         self._turn_on_dimmer(**kwargs)
         self._turn_on_rgb_and_w('%02x%02x%02x%02x', **kwargs)
+        self._turn_on_light()
         if self.gateway.optimistic:
             self.async_schedule_update_ha_state()


### PR DESCRIPTION
## Description:

As discussed with Martin Hjelmare by email on Monday:

Call _turn_on_light() last (after dimmer and color).
This avoids flickering in some cases (when light has previously been set to a high level, then turned off, and later turned to a lower level).

**Breaking change**
The mysensors light platform will now send the V_STATUS message last, after V_PERCENTAGE and/or V_RGB or V_RGBW, instead of sending V_STATUS message first when the light entity is turned on in the frontend or via service.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
