### PR TITLE
Default to using all available resources

### DIFF
--- a/homeassistant/components/sensor/nut.py
+++ b/homeassistant/components/sensor/nut.py
@@ -147,7 +147,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_ALIAS): cv.string,
     vol.Optional(CONF_USERNAME): cv.string,
     vol.Optional(CONF_PASSWORD): cv.string,
-    vol.Required(CONF_RESOURCES):
+    vol.Optional(CONF_RESOURCES):
         vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
 })
 
@@ -171,7 +171,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     entities = []
 
-    for resource in config[CONF_RESOURCES]:
+    for resource in config.get(CONF_RESOURCES, SENSOR_TYPES.keys()):
         sensor_type = resource.lower()
 
         # Display status is a special case that falls back to the status value
@@ -179,7 +179,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         if sensor_type in data.status or (sensor_type == KEY_STATUS_DISPLAY
                                           and KEY_STATUS in data.status):
             entities.append(NUTSensor(name, data, sensor_type))
-        else:
+        elif CONF_RESOURCES in config:
+            # Warn only if resources are specified explicitly in the config.
             _LOGGER.warning(
                 "Sensor type: %s does not appear in the NUT status "
                 "output, cannot add", sensor_type)


### PR DESCRIPTION
## Description:
NUT sensor: Default to using all available resources.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5778

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
