### PR TITLE
Catch the ValueError if the bulb was in the wrong mode

### DIFF
--- a/homeassistant/components/light/mystrom.py
+++ b/homeassistant/components/light/mystrom.py
@@ -155,7 +155,11 @@ class MyStromLight(Light):
             self._state = self._bulb.get_status()
 
             colors = self._bulb.get_color()['color']
-            color_h, color_s, color_v = colors.split(';')
+            try:
+                color_h, color_s, color_v = colors.split(';')
+            except ValueError:
+                color_s, color_v = colors.split(';')
+                color_h = 0
 
             self._color_h = int(color_h)
             self._color_s = int(color_s)


### PR DESCRIPTION
## Description:
If the bulb is set to `mono` with the App then it appear as `not available` in Home Assistant. Currently there is no conversion from `mono` to `hsv` but I will try to get the HSV values for the `mono` mode from the vendor.

## Example entry for `configuration.yaml` (if applicable):
```yaml
light:
  - platform: mystrom
    name: Office
    host: 192.168.0.51
    mac: 5CA37GA0GF40
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
