### PR TITLE
Add unique IDs to SNMP sensors & switches.

### DIFF
--- a/homeassistant/components/sensor/snmp.py
+++ b/homeassistant/components/sensor/snmp.py
@@ -120,7 +120,7 @@ class SnmpSensor(Entity):
     @property
     def unique_id(self):
         """Return a unique id for the sensor, host + OID."""
-        return self.data.unique_id()
+        return self.data.unique_id
 
     def update(self):
         """Get the latest data and updates the states."""

--- a/homeassistant/components/sensor/snmp.py
+++ b/homeassistant/components/sensor/snmp.py
@@ -117,6 +117,11 @@ class SnmpSensor(Entity):
         """Return the unit the value is expressed in."""
         return self._unit_of_measurement
 
+    @property
+    def unique_id(self):
+        """Return a unique id for the sensor, host + OID."""
+        return self.data.unique_id()
+
     def update(self):
         """Get the latest data and updates the states."""
         self.data.update()
@@ -145,6 +150,11 @@ class SnmpData(object):
         self._accept_errors = accept_errors
         self._default_value = default_value
         self.value = None
+
+    @property
+    def unique_id(self):
+        """Return a unique id for the sensor, host + OID."""
+        return self._host + self._baseoid
 
     def update(self):
         """Get the latest data from the remote SNMP capable host."""

--- a/homeassistant/components/switch/snmp.py
+++ b/homeassistant/components/switch/snmp.py
@@ -145,6 +145,11 @@ class SnmpSwitch(SwitchDevice):
         return self._name
 
     @property
+    def unique_id(self):
+        """Return a unique ID for the switch, host plus OID."""
+        return self._host + self._baseoid
+
+    @property
     def is_on(self):
         """Return true if switch is on; False if off. None if unknown."""
         return self._state


### PR DESCRIPTION
## Description:
Catenate the host & OID to create a unique ID for snmp sensors.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
