### PR TITLE
Added HEALTHCHECK to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,8 @@ RUN pip3 install --no-cache-dir -r requirements_all.txt && \
 # Copy source
 COPY . .
 
+# Enable Docker native health checks to give more detail about whether
+# the service is starting, healthy, or unhealthy.
+HEALTHCHECK CMD curl --fail http://localhost:8123/ || exit 1
+
 CMD [ "python", "-m", "homeassistant", "--config", "/config" ]


### PR DESCRIPTION
## Description:

Adds a HEALTHCHECK feature to Dockerfile, as discussed on forum at https://community.home-assistant.io/t/use-healthcheck-in-dockerfile-to-see-if-service-is-up-offering-normal-responses/59555

I'm not a seasoned developer and haven't worked on this project before. I could use a mentor if this is not enough.

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54