### PR TITLE
Include request.path in legacy api password warning message

### DIFF
--- a/homeassistant/components/http/auth.py
+++ b/homeassistant/components/http/auth.py
@@ -27,7 +27,8 @@ def setup_auth(app, trusted_networks, use_auth,
 
         if use_auth and (HTTP_HEADER_HA_AUTH in request.headers or
                          DATA_API_PASSWORD in request.query):
-            _LOGGER.warning('Please use access_token instead api_password.')
+            _LOGGER.warning('Please change to use bearer token access %s',
+                            request.path)
 
         legacy_auth = (not use_auth or support_legacy) and api_password
         if (hdrs.AUTHORIZATION in request.headers and


### PR DESCRIPTION
## Description:
Add reqeust.path in legacy api password warning message, to better help user migrate to new auth system.

**Related issue (if applicable):** fixes #15423

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

