### PR TITLE
Fix formatting pylint comments in test

### DIFF
--- a/tests/components/binary_sensor/test_trend.py
+++ b/tests/components/binary_sensor/test_trend.py
@@ -273,8 +273,7 @@ class TestTrendBinarySensor:
         state = self.hass.states.get('binary_sensor.test_trend_sensor')
         assert state.state == 'off'
 
-    def test_invalid_name_does_not_create(self): \
-            # pylint: disable=invalid-name
+    def test_invalid_name_does_not_create(self):
         """Test invalid name."""
         with assert_setup_component(0):
             assert setup.setup_component(self.hass, 'binary_sensor', {
@@ -290,8 +289,7 @@ class TestTrendBinarySensor:
             })
         assert self.hass.states.all() == []
 
-    def test_invalid_sensor_does_not_create(self): \
-            # pylint: disable=invalid-name
+    def test_invalid_sensor_does_not_create(self):
         """Test invalid sensor."""
         with assert_setup_component(0):
             assert setup.setup_component(self.hass, 'binary_sensor', {

--- a/tests/components/device_tracker/test_asuswrt.py
+++ b/tests/components/device_tracker/test_asuswrt.py
@@ -168,8 +168,7 @@ class TestComponentsDeviceTrackerASUSWRT(unittest.TestCase):
         scanner.last_results = WAKE_DEVICES
         self.assertEqual(list(WAKE_DEVICES), scanner.scan_devices())
 
-    def test_password_or_pub_key_required(self): \
-            # pylint: disable=invalid-name
+    def test_password_or_pub_key_required(self):
         """Test creating an AsusWRT scanner without a pass or pubkey."""
         with assert_setup_component(0, DOMAIN):
             assert setup_component(
@@ -183,8 +182,7 @@ class TestComponentsDeviceTrackerASUSWRT(unittest.TestCase):
     @mock.patch(
         'homeassistant.components.device_tracker.asuswrt.AsusWrtDeviceScanner',
         return_value=mock.MagicMock())
-    def test_get_scanner_with_password_no_pubkey(self, asuswrt_mock): \
-            # pylint: disable=invalid-name
+    def test_get_scanner_with_password_no_pubkey(self, asuswrt_mock):
         """Test creating an AsusWRT scanner with a password and no pubkey."""
         conf_dict = {
             DOMAIN: {
@@ -213,8 +211,7 @@ class TestComponentsDeviceTrackerASUSWRT(unittest.TestCase):
     @mock.patch(
         'homeassistant.components.device_tracker.asuswrt.AsusWrtDeviceScanner',
         return_value=mock.MagicMock())
-    def test_get_scanner_with_pubkey_no_password(self, asuswrt_mock): \
-            # pylint: disable=invalid-name
+    def test_get_scanner_with_pubkey_no_password(self, asuswrt_mock):
         """Test creating an AsusWRT scanner with a pubkey and no password."""
         conf_dict = {
             device_tracker.DOMAIN: {
@@ -292,8 +289,7 @@ class TestComponentsDeviceTrackerASUSWRT(unittest.TestCase):
                       password='fake_pass', port=22)
         )
 
-    def test_ssh_login_without_password_or_pubkey(self): \
-            # pylint: disable=invalid-name
+    def test_ssh_login_without_password_or_pubkey(self):
         """Test that login is not called without password or pub_key."""
         ssh = mock.MagicMock()
         ssh_mock = mock.patch('pexpect.pxssh.pxssh', return_value=ssh)
@@ -363,8 +359,7 @@ class TestComponentsDeviceTrackerASUSWRT(unittest.TestCase):
             mock.call(b'#')
         )
 
-    def test_telnet_login_without_password(self): \
-            # pylint: disable=invalid-name
+    def test_telnet_login_without_password(self):
         """Test that login is not called without password or pub_key."""
         telnet = mock.MagicMock()
         telnet_mock = mock.patch('telnetlib.Telnet', return_value=telnet)

--- a/tests/components/device_tracker/test_mqtt.py
+++ b/tests/components/device_tracker/test_mqtt.py
@@ -31,8 +31,7 @@ class TestComponentsDeviceTrackerMQTT(unittest.TestCase):
         except FileNotFoundError:
             pass
 
-    def test_ensure_device_tracker_platform_validation(self): \
-            # pylint: disable=invalid-name
+    def test_ensure_device_tracker_platform_validation(self):
         """Test if platform validation was done."""
         @asyncio.coroutine
         def mock_setup_scanner(hass, config, see, discovery_info=None):

--- a/tests/components/device_tracker/test_mqtt_json.py
+++ b/tests/components/device_tracker/test_mqtt_json.py
@@ -41,8 +41,7 @@ class TestComponentsDeviceTrackerJSONMQTT(unittest.TestCase):
         except FileNotFoundError:
             pass
 
-    def test_ensure_device_tracker_platform_validation(self): \
-            # pylint: disable=invalid-name
+    def test_ensure_device_tracker_platform_validation(self):
         """Test if platform validation was done."""
         @asyncio.coroutine
         def mock_setup_scanner(hass, config, see, discovery_info=None):

--- a/tests/components/device_tracker/test_unifi_direct.py
+++ b/tests/components/device_tracker/test_unifi_direct.py
@@ -45,8 +45,7 @@ class TestComponentsDeviceTrackerUnifiDirect(unittest.TestCase):
 
     @mock.patch(scanner_path,
                 return_value=mock.MagicMock())
-    def test_get_scanner(self, unifi_mock):  \
-            # pylint: disable=invalid-name
+    def test_get_scanner(self, unifi_mock):
         """Test creating an Unifi direct scanner with a password."""
         conf_dict = {
             DOMAIN: {

--- a/tests/components/light/test_mqtt.py
+++ b/tests/components/light/test_mqtt.py
@@ -177,8 +177,7 @@ class TestLightMQTT(unittest.TestCase):
             })
         self.assertIsNone(self.hass.states.get('light.test'))
 
-    def test_no_color_brightness_color_temp_white_xy_if_no_topics(self): \
-            # pylint: disable=invalid-name
+    def test_no_color_brightness_color_temp_white_xy_if_no_topics(self):
         """Test if there is no color and brightness if no topic."""
         with assert_setup_component(1, light.DOMAIN):
             assert setup_component(self.hass, light.DOMAIN, {
@@ -209,8 +208,7 @@ class TestLightMQTT(unittest.TestCase):
         self.assertIsNone(state.attributes.get('white_value'))
         self.assertIsNone(state.attributes.get('xy_color'))
 
-    def test_controlling_state_via_topic(self): \
-            # pylint: disable=invalid-name
+    def test_controlling_state_via_topic(self):
         """Test the controlling of the state via topic."""
         config = {light.DOMAIN: {
             'platform': 'mqtt',
@@ -410,8 +408,7 @@ class TestLightMQTT(unittest.TestCase):
         self.assertEqual(255,
                          light_state.attributes['white_value'])
 
-    def test_controlling_state_via_topic_with_templates(self): \
-            # pylint: disable=invalid-name
+    def test_controlling_state_via_topic_with_templates(self):
         """Test the setting og the state with a template."""
         config = {light.DOMAIN: {
             'platform': 'mqtt',
@@ -466,8 +463,7 @@ class TestLightMQTT(unittest.TestCase):
         self.assertEqual(75, state.attributes.get('white_value'))
         self.assertEqual((0.14, 0.131), state.attributes.get('xy_color'))
 
-    def test_sending_mqtt_commands_and_optimistic(self): \
-            # pylint: disable=invalid-name
+    def test_sending_mqtt_commands_and_optimistic(self):
         """Test the sending of command in optimistic mode."""
         config = {light.DOMAIN: {
             'platform': 'mqtt',

--- a/tests/components/light/test_mqtt_json.py
+++ b/tests/components/light/test_mqtt_json.py
@@ -115,8 +115,7 @@ class TestLightMQTTJSON(unittest.TestCase):
         """Stop everything that was started."""
         self.hass.stop()
 
-    def test_fail_setup_if_no_command_topic(self): \
-            # pylint: disable=invalid-name
+    def test_fail_setup_if_no_command_topic(self):
         """Test if setup fails with no command topic."""
         with assert_setup_component(0, light.DOMAIN):
             assert setup_component(self.hass, light.DOMAIN, {
@@ -127,8 +126,7 @@ class TestLightMQTTJSON(unittest.TestCase):
             })
         self.assertIsNone(self.hass.states.get('light.test'))
 
-    def test_no_color_brightness_color_temp_white_val_if_no_topics(self): \
-            # pylint: disable=invalid-name
+    def test_no_color_brightness_color_temp_white_val_if_no_topics(self):
         """Test for no RGB, brightness, color temp, effect, white val or XY."""
         assert setup_component(self.hass, light.DOMAIN, {
             light.DOMAIN: {
@@ -163,8 +161,7 @@ class TestLightMQTTJSON(unittest.TestCase):
         self.assertIsNone(state.attributes.get('xy_color'))
         self.assertIsNone(state.attributes.get('hs_color'))
 
-    def test_controlling_state_via_topic(self): \
-            # pylint: disable=invalid-name
+    def test_controlling_state_via_topic(self):
         """Test the controlling of the state via topic."""
         assert setup_component(self.hass, light.DOMAIN, {
             light.DOMAIN: {
@@ -283,8 +280,7 @@ class TestLightMQTTJSON(unittest.TestCase):
         light_state = self.hass.states.get('light.test')
         self.assertEqual(155, light_state.attributes.get('white_value'))
 
-    def test_sending_mqtt_commands_and_optimistic(self): \
-            # pylint: disable=invalid-name
+    def test_sending_mqtt_commands_and_optimistic(self):
         """Test the sending of command in optimistic mode."""
         fake_state = ha.State('light.test', 'on', {'brightness': 95,
                                                    'hs_color': [100, 100],
@@ -413,8 +409,7 @@ class TestLightMQTTJSON(unittest.TestCase):
             's': 50.0,
         }, message_json["color"])
 
-    def test_flash_short_and_long(self): \
-            # pylint: disable=invalid-name
+    def test_flash_short_and_long(self):
         """Test for flash length being sent when included."""
         assert setup_component(self.hass, light.DOMAIN, {
             light.DOMAIN: {
@@ -547,8 +542,7 @@ class TestLightMQTTJSON(unittest.TestCase):
         self.assertEqual(STATE_ON, state.state)
         self.assertEqual(255, state.attributes.get('brightness'))
 
-    def test_invalid_color_brightness_and_white_values(self): \
-            # pylint: disable=invalid-name
+    def test_invalid_color_brightness_and_white_values(self):
         """Test that invalid color/brightness/white values are ignored."""
         assert setup_component(self.hass, light.DOMAIN, {
             light.DOMAIN: {

--- a/tests/components/light/test_mqtt_template.py
+++ b/tests/components/light/test_mqtt_template.py
@@ -51,8 +51,7 @@ class TestLightMQTTTemplate(unittest.TestCase):
         """Stop everything that was started."""
         self.hass.stop()
 
-    def test_setup_fails(self): \
-            # pylint: disable=invalid-name
+    def test_setup_fails(self):
         """Test that setup fails with missing required configuration items."""
         with assert_setup_component(0, light.DOMAIN):
             assert setup_component(self.hass, light.DOMAIN, {
@@ -63,8 +62,7 @@ class TestLightMQTTTemplate(unittest.TestCase):
             })
         self.assertIsNone(self.hass.states.get('light.test'))
 
-    def test_state_change_via_topic(self): \
-            # pylint: disable=invalid-name
+    def test_state_change_via_topic(self):
         """Test state change via topic."""
         with assert_setup_component(1, light.DOMAIN):
             assert setup_component(self.hass, light.DOMAIN, {
@@ -103,8 +101,7 @@ class TestLightMQTTTemplate(unittest.TestCase):
         self.assertIsNone(state.attributes.get('color_temp'))
         self.assertIsNone(state.attributes.get('white_value'))
 
-    def test_state_brightness_color_effect_temp_white_change_via_topic(self): \
-            # pylint: disable=invalid-name
+    def test_state_brightness_color_effect_temp_white_change_via_topic(self):
         """Test state, bri, color, effect, color temp, white val change."""
         with assert_setup_component(1, light.DOMAIN):
             assert setup_component(self.hass, light.DOMAIN, {
@@ -206,8 +203,7 @@ class TestLightMQTTTemplate(unittest.TestCase):
         light_state = self.hass.states.get('light.test')
         self.assertEqual('rainbow', light_state.attributes.get('effect'))
 
-    def test_optimistic(self): \
-            # pylint: disable=invalid-name
+    def test_optimistic(self):
         """Test optimistic mode."""
         fake_state = ha.State('light.test', 'on', {'brightness': 95,
                                                    'hs_color': [100, 100],
@@ -289,8 +285,7 @@ class TestLightMQTTTemplate(unittest.TestCase):
         self.assertEqual(200, state.attributes['color_temp'])
         self.assertEqual(139, state.attributes['white_value'])
 
-    def test_flash(self): \
-            # pylint: disable=invalid-name
+    def test_flash(self):
         """Test flash."""
         with assert_setup_component(1, light.DOMAIN):
             assert setup_component(self.hass, light.DOMAIN, {
@@ -353,8 +348,7 @@ class TestLightMQTTTemplate(unittest.TestCase):
         self.mock_publish.async_publish.assert_called_once_with(
             'test_light_rgb/set', 'off,4', 0, False)
 
-    def test_invalid_values(self): \
-            # pylint: disable=invalid-name
+    def test_invalid_values(self):
         """Test that invalid values are ignored."""
         with assert_setup_component(1, light.DOMAIN):
             assert setup_component(self.hass, light.DOMAIN, {

--- a/tests/components/test_device_sun_light_trigger.py
+++ b/tests/components/test_device_sun_light_trigger.py
@@ -79,8 +79,7 @@ class TestDeviceSunLightTrigger(unittest.TestCase):
 
         self.assertTrue(light.is_on(self.hass))
 
-    def test_lights_turn_off_when_everyone_leaves(self): \
-            # pylint: disable=invalid-name
+    def test_lights_turn_off_when_everyone_leaves(self):
         """Test lights turn off when everyone leaves the house."""
         light.turn_on(self.hass)
 
@@ -97,8 +96,7 @@ class TestDeviceSunLightTrigger(unittest.TestCase):
 
         self.assertFalse(light.is_on(self.hass))
 
-    def test_lights_turn_on_when_coming_home_after_sun_set(self): \
-            # pylint: disable=invalid-name
+    def test_lights_turn_on_when_coming_home_after_sun_set(self):
         """Test lights turn on when coming home after sun set."""
         test_time = datetime(2017, 4, 5, 3, 2, 3, tzinfo=dt_util.UTC)
         with patch('homeassistant.util.dt.utcnow', return_value=test_time):

--- a/tests/components/test_history.py
+++ b/tests/components/test_history.py
@@ -428,8 +428,7 @@ class TestComponentHistory(unittest.TestCase):
                     history.CONF_ENTITIES: ['media_player.test']}}})
         self.check_significant_states(zero, four, states, config)
 
-    def check_significant_states(self, zero, four, states, config): \
-            # pylint: disable=no-self-use
+    def check_significant_states(self, zero, four, states, config):
         """Check if significant states are retrieved."""
         filters = history.Filters()
         exclude = config[history.DOMAIN].get(history.CONF_EXCLUDE)

--- a/tests/components/test_logbook.py
+++ b/tests/components/test_logbook.py
@@ -542,8 +542,7 @@ class TestComponentLogbook(unittest.TestCase):
 
     def create_state_changed_event(self, event_time_fired, entity_id, state,
                                    attributes=None, last_changed=None,
-                                   last_updated=None): \
-            # pylint: disable=no-self-use
+                                   last_updated=None):
         """Create state changed event."""
         # Logbook only cares about state change events that
         # contain an old state but will not actually act on it.

--- a/tests/scripts/test_check_config.py
+++ b/tests/scripts/test_check_config.py
@@ -168,8 +168,7 @@ class TestCheckConfig(unittest.TestCase):
                 '.../configuration.yaml', '.../secrets.yaml']
 
     @patch('os.path.isfile', return_value=True)
-    def test_package_invalid(self, isfile_patch): \
-            # pylint: disable=no-self-use,invalid-name
+    def test_package_invalid(self, isfile_patch):
         """Test a valid platform setup."""
         files = {
             YAML_CONFIG_FILE: BASE_CONFIG + (
@@ -190,8 +189,7 @@ class TestCheckConfig(unittest.TestCase):
             assert res['secrets'] == {}
             assert len(res['yaml_files']) == 1
 
-    def test_bootstrap_error(self): \
-            # pylint: disable=no-self-use,invalid-name
+    def test_bootstrap_error(self):
         """Test a valid platform setup."""
         files = {
             YAML_CONFIG_FILE: BASE_CONFIG + 'automation: !include no.yaml',


### PR DESCRIPTION
## Description:
We don't run pylint on tests. If we would, we would disable this check for sure. It's also such weird formatting that it's breaking black (with which I am experimenting).

