### PR TITLE
Make RS room thermostat discoverable

### DIFF
--- a/homeassistant/components/zwave/discovery_schemas.py
+++ b/homeassistant/components/zwave/discovery_schemas.py
@@ -39,7 +39,7 @@ DISCOVERY_SCHEMAS = [
     {const.DISC_COMPONENT: 'climate',
      const.DISC_GENERIC_DEVICE_CLASS: [
          const.GENERIC_TYPE_THERMOSTAT,
-         const.GENERIC_TYPE_MULTILEVEL_SENSOR],
+         const.GENERIC_TYPE_SENSOR_MULTILEVEL],
      const.DISC_VALUES: dict(DEFAULT_VALUES_SCHEMA, **{
          const.DISC_PRIMARY: {
              const.DISC_COMMAND_CLASS: [

--- a/homeassistant/components/zwave/discovery_schemas.py
+++ b/homeassistant/components/zwave/discovery_schemas.py
@@ -37,7 +37,9 @@ DISCOVERY_SCHEMAS = [
              const.DISC_OPTIONAL: True,
          }})},
     {const.DISC_COMPONENT: 'climate',
-     const.DISC_GENERIC_DEVICE_CLASS: [const.GENERIC_TYPE_THERMOSTAT],
+     const.DISC_GENERIC_DEVICE_CLASS: [
+         const.GENERIC_TYPE_THERMOSTAT,
+         const.GENERIC_TYPE_MULTILEVEL_SENSOR],
      const.DISC_VALUES: dict(DEFAULT_VALUES_SCHEMA, **{
          const.DISC_PRIMARY: {
              const.DISC_COMMAND_CLASS: [


### PR DESCRIPTION
## Description:
Makes the Danfoss/devolo RS room thermostat discoverable in hass.
This device is defined as a multilevel sensor and not a thermostat.
Ref: https://community.home-assistant.io/t/devolo-zwave-thermostat/58739
