### PR TITLE
Delay setup of waze travel time component

### DIFF
--- a/homeassistant/components/sensor/waze_travel_time.py
+++ b/homeassistant/components/sensor/waze_travel_time.py
@@ -68,7 +68,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         sensor = WazeTravelTime(name, origin, destination, region,
                                 incl_filter, excl_filter)
 
-        add_devices([sensor], True)
+        add_devices([sensor])
 
     # Wait until start event is sent to load this component.
     hass.bus.listen_once(EVENT_HOMEASSISTANT_START, sensor.update)

--- a/homeassistant/components/sensor/waze_travel_time.py
+++ b/homeassistant/components/sensor/waze_travel_time.py
@@ -54,18 +54,23 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Waze travel time sensor platform."""
-    destination = config.get(CONF_DESTINATION)
-    name = config.get(CONF_NAME)
-    origin = config.get(CONF_ORIGIN)
-    region = config.get(CONF_REGION)
-    incl_filter = config.get(CONF_INCL_FILTER)
-    excl_filter = config.get(CONF_EXCL_FILTER)
+    def run_setup(event):
+        """Delay the setup until Home Assistant is fully initialized.
+        This allows any entities to be created already
+        """
+        destination = config.get(CONF_DESTINATION)
+        name = config.get(CONF_NAME)
+        origin = config.get(CONF_ORIGIN)
+        region = config.get(CONF_REGION)
+        incl_filter = config.get(CONF_INCL_FILTER)
+        excl_filter = config.get(CONF_EXCL_FILTER)
 
-    sensor = WazeTravelTime(name, origin, destination, region,
-                            incl_filter, excl_filter)
+        sensor = WazeTravelTime(name, origin, destination, region,
+                                incl_filter, excl_filter)
 
-    add_devices([sensor], True)
+        add_devices([sensor], True)
 
+    # Wait until start event is sent to load this component.
     hass.bus.listen_once(EVENT_HOMEASSISTANT_START, sensor.update)
 
 

--- a/homeassistant/components/sensor/waze_travel_time.py
+++ b/homeassistant/components/sensor/waze_travel_time.py
@@ -54,21 +54,17 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Waze travel time sensor platform."""
-    def run_setup(event):
-        """Delay the setup until Home Assistant is fully initialized.
-        This allows any entities to be created already
-        """
-        destination = config.get(CONF_DESTINATION)
-        name = config.get(CONF_NAME)
-        origin = config.get(CONF_ORIGIN)
-        region = config.get(CONF_REGION)
-        incl_filter = config.get(CONF_INCL_FILTER)
-        excl_filter = config.get(CONF_EXCL_FILTER)
+    destination = config.get(CONF_DESTINATION)
+    name = config.get(CONF_NAME)
+    origin = config.get(CONF_ORIGIN)
+    region = config.get(CONF_REGION)
+    incl_filter = config.get(CONF_INCL_FILTER)
+    excl_filter = config.get(CONF_EXCL_FILTER)
 
-        sensor = WazeTravelTime(name, origin, destination, region,
-                                incl_filter, excl_filter)
+    sensor = WazeTravelTime(name, origin, destination, region,
+                            incl_filter, excl_filter)
 
-        add_devices([sensor])
+    add_devices([sensor])
 
     # Wait until start event is sent to load this component.
     hass.bus.listen_once(EVENT_HOMEASSISTANT_START, sensor.update)


### PR DESCRIPTION
Copied the necessary lines of code from the google travel time component to fix the setup delay in waze travel time component.  Previously it was only watching the homeassistant start event on the bus, but doing nothing with it.

## Description:


**Related issue (if applicable):**
fixes #15491

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
