### PR TITLE
Implement is_on

### DIFF
--- a/homeassistant/components/switch/insteon_plm.py
+++ b/homeassistant/components/switch/insteon_plm.py
@@ -46,8 +46,7 @@ class InsteonPLMSwitchDevice(InsteonPLMEntity, SwitchDevice):
     @property
     def is_on(self):
         """Return the boolean response if the node is on."""
-        onlevel = self._insteon_device_state.value
-        return bool(onlevel)
+        return bool(self._insteon_device_state.value)
 
     @asyncio.coroutine
     def async_turn_on(self, **kwargs):
@@ -66,8 +65,7 @@ class InsteonPLMOpenClosedDevice(InsteonPLMEntity, SwitchDevice):
     @property
     def is_on(self):
         """Return the boolean response if the node is on."""
-        onlevel = self._insteon_device_state.value
-        return bool(onlevel)
+        return bool(self._insteon_device_state.value)
 
     @asyncio.coroutine
     def async_turn_on(self, **kwargs):

--- a/homeassistant/components/switch/insteon_plm.py
+++ b/homeassistant/components/switch/insteon_plm.py
@@ -63,6 +63,12 @@ class InsteonPLMSwitchDevice(InsteonPLMEntity, SwitchDevice):
 class InsteonPLMOpenClosedDevice(InsteonPLMEntity, SwitchDevice):
     """A Class for an Insteon device."""
 
+    @property
+    def is_on(self):
+        """Return the boolean response if the node is on."""
+        onlevel = self._insteon_device_state.value
+        return bool(onlevel)
+
     @asyncio.coroutine
     def async_turn_on(self, **kwargs):
         """Turn device on."""


### PR DESCRIPTION
## Description:
The Open Close switch did not implement the is_on method and so it fails when the switich entity is created.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
