### PR TITLE
Update homematicip_cloud with enum states

### DIFF
--- a/homeassistant/components/binary_sensor/homematicip_cloud.py
+++ b/homeassistant/components/binary_sensor/homematicip_cloud.py
@@ -21,8 +21,6 @@ ATTR_EVENT_DELAY = 'event_delay'
 ATTR_MOTION_DETECTED = 'motion_detected'
 ATTR_ILLUMINATION = 'illumination'
 
-HMIP_OPEN = 'open'
-
 
 async def async_setup_platform(hass, config, async_add_devices,
                                discovery_info=None):
@@ -61,11 +59,13 @@ class HomematicipShutterContact(HomematicipGenericDevice, BinarySensorDevice):
     @property
     def is_on(self):
         """Return true if the shutter contact is on/open."""
+        from homematicip.base.enums import WindowState
+
         if self._device.sabotage:
             return True
         if self._device.windowState is None:
             return None
-        return self._device.windowState.lower() == HMIP_OPEN
+        return self._device.windowState == WindowState.OPEN
 
 
 class HomematicipMotionDetector(HomematicipGenericDevice, BinarySensorDevice):

--- a/homeassistant/components/homematicip_cloud/__init__.py
+++ b/homeassistant/components/homematicip_cloud/__init__.py
@@ -19,7 +19,7 @@ from .config_flow import configured_haps
 from .hap import HomematicipHAP, HomematicipAuth  # noqa: F401
 from .device import HomematicipGenericDevice  # noqa: F401
 
-REQUIREMENTS = ['homematicip==0.9.7']
+REQUIREMENTS = ['homematicip==0.9.8']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/homematicip_cloud/__init__.py
+++ b/homeassistant/components/homematicip_cloud/__init__.py
@@ -19,7 +19,7 @@ from .config_flow import configured_haps
 from .hap import HomematicipHAP, HomematicipAuth  # noqa: F401
 from .device import HomematicipGenericDevice  # noqa: F401
 
-REQUIREMENTS = ['homematicip==0.9.6']
+REQUIREMENTS = ['homematicip==0.9.7']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/light/homematicip_cloud.py
+++ b/homeassistant/components/light/homematicip_cloud.py
@@ -31,14 +31,14 @@ async def async_setup_platform(hass, config, async_add_devices,
 async def async_setup_entry(hass, config_entry, async_add_devices):
     """Set up the HomematicIP lights from a config entry."""
     from homematicip.aio.device import (
-        AsyncBrandSwitchMeasuring, AsyncPluggableDimmer)
+        AsyncBrandSwitchMeasuring, AsyncDimmer)
 
     home = hass.data[HMIPC_DOMAIN][config_entry.data[HMIPC_HAPID]].home
     devices = []
     for device in home.devices:
         if isinstance(device, AsyncBrandSwitchMeasuring):
             devices.append(HomematicipLightMeasuring(home, device))
-        elif isinstance(device, AsyncPluggableDimmer):
+        elif isinstance(device, AsyncDimmer):
             devices.append(HomematicipDimmer(home, device))
 
     if devices:

--- a/homeassistant/components/sensor/homematicip_cloud.py
+++ b/homeassistant/components/sensor/homematicip_cloud.py
@@ -76,6 +76,11 @@ class HomematicipAccesspointStatus(HomematicipGenericDevice):
         return self._home.connected
 
     @property
+    def unit_of_measurement(self):
+        """Return the unit this state is expressed in."""
+        return '%'
+
+    @property
     def device_state_attributes(self):
         """Return the state attributes of the access point."""
         return {}
@@ -125,11 +130,6 @@ class HomematicipHumiditySensor(HomematicipGenericDevice):
         return DEVICE_CLASS_HUMIDITY
 
     @property
-    def icon(self):
-        """Return the icon."""
-        return 'mdi:water-percent'
-
-    @property
     def state(self):
         """Return the state."""
         return self._device.humidity
@@ -151,11 +151,6 @@ class HomematicipTemperatureSensor(HomematicipGenericDevice):
     def device_class(self):
         """Return the device class of the sensor."""
         return DEVICE_CLASS_TEMPERATURE
-
-    @property
-    def icon(self):
-        """Return the icon."""
-        return 'mdi:thermometer'
 
     @property
     def state(self):

--- a/homeassistant/components/sensor/homematicip_cloud.py
+++ b/homeassistant/components/sensor/homematicip_cloud.py
@@ -24,14 +24,6 @@ ATTR_TEMPERATURE = 'temperature'
 ATTR_TEMPERATURE_OFFSET = 'temperature_offset'
 ATTR_HUMIDITY = 'humidity'
 
-HMIP_UPTODATE = 'up_to_date'
-HMIP_VALVE_DONE = 'adaption_done'
-HMIP_SABOTAGE = 'sabotage'
-
-STATE_OK = 'ok'
-STATE_LOW_BATTERY = 'low_battery'
-STATE_SABOTAGE = 'sabotage'
-
 
 async def async_setup_platform(hass, config, async_add_devices,
                                discovery_info=None):
@@ -89,38 +81,6 @@ class HomematicipAccesspointStatus(HomematicipGenericDevice):
         return {}
 
 
-class HomematicipDeviceStatus(HomematicipGenericDevice):
-    """Representation of an HomematicIP device status."""
-
-    def __init__(self, home, device):
-        """Initialize generic status device."""
-        super().__init__(home, device, 'Status')
-
-    @property
-    def icon(self):
-        """Return the icon of the status device."""
-        if (hasattr(self._device, 'sabotage') and
-                self._device.sabotage == HMIP_SABOTAGE):
-            return 'mdi:alert'
-        elif self._device.lowBat:
-            return 'mdi:battery-outline'
-        elif self._device.updateState.lower() != HMIP_UPTODATE:
-            return 'mdi:refresh'
-        return 'mdi:check'
-
-    @property
-    def state(self):
-        """Return the state of the generic device."""
-        if (hasattr(self._device, 'sabotage') and
-                self._device.sabotage == HMIP_SABOTAGE):
-            return STATE_SABOTAGE
-        elif self._device.lowBat:
-            return STATE_LOW_BATTERY
-        elif self._device.updateState.lower() != HMIP_UPTODATE:
-            return self._device.updateState.lower()
-        return STATE_OK
-
-
 class HomematicipHeatingThermostat(HomematicipGenericDevice):
     """MomematicIP heating thermostat representation."""
 
@@ -131,15 +91,19 @@ class HomematicipHeatingThermostat(HomematicipGenericDevice):
     @property
     def icon(self):
         """Return the icon."""
-        if self._device.valveState.lower() != HMIP_VALVE_DONE:
+        from homematicip.base.enums import ValveState
+
+        if self._device.valveState != ValveState.ADAPTION_DONE:
             return 'mdi:alert'
         return 'mdi:radiator'
 
     @property
     def state(self):
         """Return the state of the radiator valve."""
-        if self._device.valveState.lower() != HMIP_VALVE_DONE:
-            return self._device.valveState.lower()
+        from homematicip.base.enums import ValveState
+
+        if self._device.valveState != ValveState.ADAPTION_DONE:
+            return self._device.valveState
         return round(self._device.valvePosition*100)
 
     @property

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -421,7 +421,7 @@ home-assistant-frontend==20180713.0
 # homekit==0.6
 
 # homeassistant.components.homematicip_cloud
-homematicip==0.9.6
+homematicip==0.9.7
 
 # homeassistant.components.google
 # homeassistant.components.remember_the_milk

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -421,7 +421,7 @@ home-assistant-frontend==20180713.0
 # homekit==0.6
 
 # homeassistant.components.homematicip_cloud
-homematicip==0.9.7
+homematicip==0.9.8
 
 # homeassistant.components.google
 # homeassistant.components.remember_the_milk

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -84,7 +84,7 @@ holidays==0.9.5
 home-assistant-frontend==20180713.0
 
 # homeassistant.components.homematicip_cloud
-homematicip==0.9.6
+homematicip==0.9.7
 
 # homeassistant.components.influxdb
 # homeassistant.components.sensor.influxdb

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -84,7 +84,7 @@ holidays==0.9.5
 home-assistant-frontend==20180713.0
 
 # homeassistant.components.homematicip_cloud
-homematicip==0.9.7
+homematicip==0.9.8
 
 # homeassistant.components.influxdb
 # homeassistant.components.sensor.influxdb


### PR DESCRIPTION
## Description:
- Update lib version to 0.9.7 with enum states
- Change to generic Dimmer class 
- Cleanup of used icon properties

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54