### PR TITLE
Use random default http password

### DIFF
--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -14,6 +14,7 @@ from voluptuous.humanize import humanize_error
 
 from homeassistant import auth
 from homeassistant.auth import providers as auth_providers
+from homeassistant.auth.util import generate_secret
 from homeassistant.const import (
     ATTR_FRIENDLY_NAME, ATTR_HIDDEN, ATTR_ASSUMED_STATE,
     CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME, CONF_PACKAGES, CONF_UNIT_SYSTEM,
@@ -123,7 +124,7 @@ script: !include scripts.yaml
 DEFAULT_SECRETS = """
 # Use this file to store secrets like usernames and passwords.
 # Learn more at https://home-assistant.io/docs/configuration/secrets/
-http_password: welcome
+http_password: %(http_password)s
 """
 
 
@@ -247,7 +248,9 @@ def create_default_config(config_dir: str, detect_location=True)\
             config_file.write(DEFAULT_CONFIG)
 
         with open(secret_path, 'wt') as secret_file:
-            secret_file.write(DEFAULT_SECRETS)
+            secret_file.write(DEFAULT_SECRETS % dict(
+                http_password=generate_secret(4),
+            ))
 
         with open(version_path, 'wt') as version_file:
             version_file.write(__version__)


### PR DESCRIPTION
## Description:

With the current focus on security, using a random default http password would be a good thing, I think. Here's one implementation; a hex string like this is not the best possible random password, but I didn't spot other password generation utils in home assistant's source tree on a quick look.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
