### PR TITLE
Broadlink media_player platform

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -494,6 +494,7 @@ omit =
     homeassistant/components/media_player/aquostv.py
     homeassistant/components/media_player/bluesound.py
     homeassistant/components/media_player/braviatv.py
+    homeassistant/components/media_player/broadlink.py
     homeassistant/components/media_player/channels.py
     homeassistant/components/media_player/clementine.py
     homeassistant/components/media_player/cmus.py

--- a/homeassistant/components/media_player/broadlink.py
+++ b/homeassistant/components/media_player/broadlink.py
@@ -122,7 +122,7 @@ async def async_setup_platform(hass,
 
 
 def get_supported_by_config(config):
-    """ Calculate support flags based on available configuration entries """
+    """ Calculate support flags based on available configuration entries. """
     support = 0
 
     for mapping in SUPPORT_MAPPING:
@@ -139,7 +139,7 @@ def get_supported_by_config(config):
 
 
 def get_broadlink_mac(mac: str):
-    """ Convert a mac address string with : in it to just a flat string """
+    """ Convert a mac address string with : in it to just a flat string. """
     binascii.unhexlify(mac.encode().replace(b':', b''))
 
 

--- a/homeassistant/components/media_player/broadlink.py
+++ b/homeassistant/components/media_player/broadlink.py
@@ -156,8 +156,6 @@ class BroadlinkRM(MediaPlayerDevice):
         self.config  = config
         self.hass    = hass
 
-        self.host    = config.get(CONF_HOST)
-
         self._link   = link
         self._state  = STATE_OFF
         self._source = None

--- a/homeassistant/components/media_player/broadlink.py
+++ b/homeassistant/components/media_player/broadlink.py
@@ -152,11 +152,11 @@ class BroadlinkRM(MediaPlayerDevice):
     def __init__(self, link, config):
         super().__init__()
 
-        self.support = get_supported_by_config(config)
-        self.config  = config
-        self._link   = link
-        self._state  = STATE_OFF
-        self._source = None
+        self._support = get_supported_by_config(config)
+        self._config  = config
+        self._link    = link
+        self._state   = STATE_OFF
+        self._source  = None
 
     async def send(self, command):
         if command is None:
@@ -167,7 +167,7 @@ class BroadlinkRM(MediaPlayerDevice):
 
     @property
     def name(self):
-        return self.config.get(CONF_NAME)
+        return self._config.get(CONF_NAME)
 
     @property
     def state(self):
@@ -175,33 +175,33 @@ class BroadlinkRM(MediaPlayerDevice):
 
     @property
     def supported_features(self):
-        return self.support
+        return self._support
 
     async def async_turn_on(self):
-        await self.send(self.config.get(CONF_COMMAND_ON))
+        await self.send(self._config.get(CONF_COMMAND_ON))
         self._state = STATE_ON
 
     async def async_turn_off(self):
-        await self.send(self.config.get(CONF_COMMAND_OFF))
+        await self.send(self._config.get(CONF_COMMAND_OFF))
         self._state = STATE_OFF
 
     async def async_volume_up(self):
-        await self.send(self.config.get(CONF_VOLUME_UP))
+        await self.send(self._config.get(CONF_VOLUME_UP))
 
     async def async_volume_down(self):
-        await self.send(self.config.get(CONF_VOLUME_DOWN))
+        await self.send(self._config.get(CONF_VOLUME_DOWN))
 
     async def async_volume_mute(self):
-        await self.send(self.config.get(CONF_VOLUME_MUTE))
+        await self.send(self._config.get(CONF_VOLUME_MUTE))
 
     async def async_media_next_track(self):
-        await self.send(self.config.get(CONF_NEXT_TRACK))
+        await self.send(self._config.get(CONF_NEXT_TRACK))
 
     async def async_media_previous_track(self):
-        await self.send(self.config.get(CONF_PREVIOUS_TRACK))
+        await self.send(self._config.get(CONF_PREVIOUS_TRACK))
 
     async def async_select_source(self, source):
-        await self.send(self.config.get(CONF_SOURCES)[source])
+        await self.send(self._config.get(CONF_SOURCES)[source])
         self._source = source
 
     async def async_play_media(self, media_type, media_id, **kwargs):
@@ -212,8 +212,8 @@ class BroadlinkRM(MediaPlayerDevice):
         cv.positive_int(media_id)
 
         for digit in media_id:
-            await self.send(self.config.get(CONF_DIGITS).get(digit))
-            await asyncio.sleep(self.config.get(CONF_DIGITDELAY))
+            await self.send(self._config.get(CONF_DIGITS).get(digit))
+            await asyncio.sleep(self._config.get(CONF_DIGITDELAY))
 
     @property
     def media_content_type(self):
@@ -225,4 +225,4 @@ class BroadlinkRM(MediaPlayerDevice):
 
     @property
     def source_list(self):
-        return list(self.config.get(CONF_SOURCES).keys())
+        return list(self._config.get(CONF_SOURCES).keys())

--- a/homeassistant/components/media_player/broadlink.py
+++ b/homeassistant/components/media_player/broadlink.py
@@ -202,12 +202,12 @@ class BroadlinkRM(MediaPlayerDevice):
         await self.send(self._config.get(CONF_PREVIOUS_TRACK))
 
     async def async_select_source(self, source):
-        """Selectes a specific source."""
+        """Select a specific source."""
         await self.send(self._config.get(CONF_SOURCES)[source])
         self._source = source
 
     async def async_play_media(self, media_type, media_id, **kwargs):
-        """Switches to a specific channel."""
+        """Switch to a specific channel."""
         if media_type != MEDIA_TYPE_CHANNEL:
             _LOGGER.error('Unsupported media type %s', media_type)
             return

--- a/homeassistant/components/media_player/broadlink.py
+++ b/homeassistant/components/media_player/broadlink.py
@@ -144,7 +144,7 @@ def get_supported_by_config(config):
 
 def get_broadlink_mac(mac: str):
     """ Convert a mac address string with : in it to just a flat string. """
-    binascii.unhexlify(mac.encode().replace(b':', b''))
+    return binascii.unhexlify(mac.encode().replace(b':', b''))
 
 
 class BroadlinkRM(MediaPlayerDevice):

--- a/homeassistant/components/media_player/broadlink.py
+++ b/homeassistant/components/media_player/broadlink.py
@@ -1,6 +1,6 @@
 
 """
-Support for broadlink remote control of a media device
+Support for broadlink remote control of a media device.
 
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/media_player.broadlink/
@@ -92,6 +92,7 @@ async def async_setup_platform(hass,
                                config,
                                async_add_devices,
                                discovery_info=None):
+    """Set up platform."""
     import broadlink
 
     host = (config.get(CONF_HOST),
@@ -135,8 +136,10 @@ def get_broadlink_mac(mac: str):
 
 
 class BroadlinkRM(MediaPlayerDevice):
+    """Representation of a media device."""
 
     def __init__(self, link, config):
+        """Initialize device."""
         super().__init__()
 
         self._support = get_supported_by_config(config)
@@ -146,6 +149,7 @@ class BroadlinkRM(MediaPlayerDevice):
         self._source = None
 
     async def send(self, command):
+        """Send b64 encoded command to device."""
         if command is None:
             raise Exception('No command defined!')
 
@@ -154,37 +158,47 @@ class BroadlinkRM(MediaPlayerDevice):
 
     @property
     def name(self):
+        """Return the name of the controlled device."""
         return self._config.get(CONF_NAME)
 
     @property
     def state(self):
+        """Return the state of the device."""
         return self._state
 
     @property
     def supported_features(self):
+        """Flag media player features that are supported."""
         return self._support
 
     async def async_turn_on(self):
+        """Turn on media player."""
         await self.send(self._config.get(CONF_COMMAND_ON))
         self._state = STATE_ON
 
     async def async_turn_off(self):
+        """Turn off media player."""
         await self.send(self._config.get(CONF_COMMAND_OFF))
         self._state = STATE_OFF
 
     async def async_volume_up(self):
+        """Volume up media player."""
         await self.send(self._config.get(CONF_VOLUME_UP))
 
     async def async_volume_down(self):
+        """Volume down media player."""
         await self.send(self._config.get(CONF_VOLUME_DOWN))
 
     async def async_volume_mute(self):
+        """Send mute command."""
         await self.send(self._config.get(CONF_VOLUME_MUTE))
 
     async def async_media_next_track(self):
+        """Send next track command."""
         await self.send(self._config.get(CONF_NEXT_TRACK))
 
     async def async_media_previous_track(self):
+        """Send the previous track command."""
         await self.send(self._config.get(CONF_PREVIOUS_TRACK))
 
     async def async_select_source(self, source):
@@ -204,12 +218,15 @@ class BroadlinkRM(MediaPlayerDevice):
 
     @property
     def media_content_type(self):
+        """Return content type currently active."""
         return MEDIA_TYPE_CHANNEL
 
     @property
     def source(self):
+        """Return the current input source."""
         return self._source
 
     @property
     def source_list(self):
+        """List of available input sources."""
         return list(self._config.get(CONF_SOURCES).keys())

--- a/homeassistant/components/media_player/broadlink.py
+++ b/homeassistant/components/media_player/broadlink.py
@@ -1,0 +1,208 @@
+
+import asyncio
+import voluptuous as vol
+import logging
+from base64 import b64decode, b64encode
+import binascii
+
+from homeassistant.components.media_player import (
+    MediaPlayerDevice,
+    PLATFORM_SCHEMA,
+    ENTITY_ID_FORMAT,
+    MEDIA_TYPE_CHANNEL,
+    SUPPORT_TURN_OFF,
+    SUPPORT_TURN_ON,
+    SUPPORT_VOLUME_STEP,
+    SUPPORT_SELECT_SOURCE,
+    SUPPORT_VOLUME_MUTE,
+    SUPPORT_PREVIOUS_TRACK,
+    SUPPORT_NEXT_TRACK,
+    SUPPORT_PLAY_MEDIA)
+
+from homeassistant.const import (
+    CONF_NAME,
+    CONF_HOST,
+    CONF_MAC,
+    CONF_TIMEOUT,
+    CONF_TYPE,
+    CONF_COMMAND_ON,
+    CONF_COMMAND_OFF,
+    STATE_OFF,
+    STATE_ON,
+    STATE_PLAYING,
+    STATE_UNKNOWN)
+
+import homeassistant.helpers.config_validation as cv
+
+DEFAULT_NAME    = "Broadlink IR Media Player"
+DEFAULT_TIMEOUT = 10
+
+REQUIREMENTS    = ['broadlink==0.9.0']
+DOMAIN          = 'broadlink'
+
+CONF_VOLUME_UP       = 'volume_up'
+CONF_VOLUME_DOWN     = 'volume_down'
+CONF_VOLUME_MUTE     = 'volume_mute'
+CONF_NEXT_TRACK      = 'next_track'
+CONF_PREVIOUS_TRACK  = 'previous_track'
+CONF_SOURCES         = 'sources'
+CONF_CHANNELS        = 'channels'
+CONF_DIGITS          = 'digits'
+CONF_DIGITDELAY      = 'digitdelay'
+
+DIGITS_SCHEMA = vol.Schema({
+    vol.Required('0'): cv.string,
+    vol.Required('1'): cv.string,
+    vol.Required('2'): cv.string,
+    vol.Required('3'): cv.string,
+    vol.Required('4'): cv.string,
+    vol.Required('5'): cv.string,
+    vol.Required('6'): cv.string,
+    vol.Required('7'): cv.string,
+    vol.Required('8'): cv.string,
+    vol.Required('9'): cv.string,
+})
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_HOST): cv.string,
+    vol.Required(CONF_MAC): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int,
+
+    vol.Optional(CONF_DIGITDELAY, default=0.5): float,
+    vol.Optional(CONF_COMMAND_ON)    : cv.string,
+    vol.Optional(CONF_COMMAND_OFF)   : cv.string,
+    vol.Optional(CONF_VOLUME_UP)     : cv.string,
+    vol.Optional(CONF_VOLUME_DOWN)   : cv.string,
+    vol.Optional(CONF_VOLUME_MUTE)   : cv.string,
+    vol.Optional(CONF_NEXT_TRACK)    : cv.string,
+    vol.Optional(CONF_PREVIOUS_TRACK): cv.string,
+    vol.Optional(CONF_SOURCES, default = {}): dict,
+    vol.Optional(CONF_DIGITS): DIGITS_SCHEMA,
+})
+
+SUPPORT_MAPPING = [
+    (CONF_COMMAND_ON         , SUPPORT_TURN_ON),
+    (CONF_COMMAND_OFF        , SUPPORT_TURN_OFF),
+    (CONF_VOLUME_UP          , SUPPORT_VOLUME_STEP),
+    (CONF_VOLUME_DOWN        , SUPPORT_VOLUME_STEP),
+    (CONF_VOLUME_MUTE        , SUPPORT_VOLUME_MUTE),
+    (CONF_NEXT_TRACK         , SUPPORT_NEXT_TRACK),
+    (CONF_PREVIOUS_TRACK     , SUPPORT_PREVIOUS_TRACK ),
+]
+
+_LOGGER = logging.getLogger(__name__)
+
+async def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+    import broadlink
+
+    host = config.get(CONF_HOST)
+    mac  = binascii.unhexlify(config.get(CONF_MAC).encode().replace(b':', b''))
+
+    link = broadlink.rm( (host, 80)
+                       , mac
+                       , None)
+
+    await hass.async_add_job(link.auth)
+
+    async_add_devices([BroadlinkRM(hass, link, config)])
+
+def get_supported_by_config(config):
+    support = 0
+
+    for mapping in SUPPORT_MAPPING:
+        if mapping[0] in config:
+            support = support | mapping[1]
+
+    if config.get(CONF_SOURCES):
+        support = support | SUPPORT_SELECT_SOURCE
+
+    if config.get(CONF_DIGITS):
+        support = support | SUPPORT_PLAY_MEDIA
+
+    return support
+
+class BroadlinkRM(MediaPlayerDevice):
+
+    def __init__(self, hass, link, config):
+        super().__init__()
+
+        self.support = get_supported_by_config(config)
+        self.config  = config
+        self.hass    = hass
+
+        self.host    = config.get(CONF_HOST)
+        self.mac     = binascii.unhexlify(config.get(CONF_MAC).encode().replace(b':', b''))
+
+        self.link    = link
+        self._state  = STATE_OFF
+        self._source = None
+
+    async def send(self, command):
+        if command is None:
+            raise Exception('No command defined!')
+
+        packet = b64decode(command)
+        await self.hass.async_add_job(self.link.send_data, packet)
+
+    @property
+    def name(self):
+        return self.config.get(CONF_NAME)
+
+    @property
+    def state(self):
+        return self._state
+
+    @property
+    def supported_features(self):
+        return self.support
+
+    async def async_turn_on(self):
+        await self.send(self.config.get(CONF_COMMAND_ON))
+        self._state = STATE_ON
+
+    async def async_turn_off(self):
+        await self.send(self.config.get(CONF_COMMAND_OFF))
+        self._state = STATE_OFF
+
+    async def async_volume_up(self):
+        await self.send(self.config.get(CONF_VOLUME_UP))
+
+    async def async_volume_down(self):
+        await self.send(self.config.get(CONF_VOLUME_DOWN))
+
+    async def async_volume_mute(self):
+        await self.send(self.config.get(CONF_VOLUME_MUTE))
+
+    async def async_media_next_track(self):
+        await self.send(self.config.get(CONF_NEXT_TRACK))
+
+    async def async_media_previous_track(self):
+        await self.send(self.config.get(CONF_PREVIOUS_TRACK))
+
+    async def async_select_source(self, source):
+        await self.send(self.config.get(CONF_SOURCES)[source])
+        self._source = source
+
+    async def async_play_media(self, media_type, media_id, **kwargs):
+        if media_type != MEDIA_TYPE_CHANNEL:
+            _LOGGER.error('Unsupported media type')
+            return
+
+        cv.positive_int(media_id)
+
+        for digit in media_id:
+            await self.send(self.config.get(CONF_DIGITS).get(digit))
+            await asyncio.sleep(self.config.get(CONF_DIGITDELAY), self.hass.loop)
+
+    @property
+    def media_content_type(self):
+        return MEDIA_TYPE_CHANNEL
+
+    @property
+    def source(self):
+        return self._source
+
+    @property
+    def source_list(self):
+        return list(self.config.get(CONF_SOURCES).keys())

--- a/homeassistant/components/media_player/broadlink.py
+++ b/homeassistant/components/media_player/broadlink.py
@@ -1,4 +1,11 @@
 
+"""
+Support for broadlink remote control of a media device
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/media_player.broadlink/
+"""
+
 import asyncio
 import voluptuous as vol
 import logging

--- a/homeassistant/components/media_player/broadlink.py
+++ b/homeassistant/components/media_player/broadlink.py
@@ -7,7 +7,7 @@ https://home-assistant.io/components/media_player.broadlink/
 """
 
 import asyncio
-from base64 import b64decode, b64encode
+from base64 import b64decode
 import binascii
 import logging
 import socket
@@ -15,14 +15,13 @@ import socket
 import voluptuous as vol
 
 from homeassistant.components.media_player import (
-    ENTITY_ID_FORMAT, MEDIA_TYPE_CHANNEL, PLATFORM_SCHEMA, SUPPORT_NEXT_TRACK,
+    MEDIA_TYPE_CHANNEL, PLATFORM_SCHEMA, SUPPORT_NEXT_TRACK,
     SUPPORT_PLAY_MEDIA, SUPPORT_PREVIOUS_TRACK, SUPPORT_SELECT_SOURCE,
     SUPPORT_TURN_OFF, SUPPORT_TURN_ON, SUPPORT_VOLUME_MUTE,
     SUPPORT_VOLUME_STEP, MediaPlayerDevice)
 from homeassistant.const import (
     CONF_COMMAND_OFF, CONF_COMMAND_ON, CONF_HOST, CONF_MAC, CONF_NAME,
-    CONF_PORT, CONF_TIMEOUT, CONF_TYPE, STATE_OFF, STATE_ON, STATE_PLAYING,
-    STATE_UNKNOWN)
+    CONF_PORT, CONF_TIMEOUT, STATE_OFF, STATE_ON)
 from homeassistant.exceptions import PlatformNotReady
 import homeassistant.helpers.config_validation as cv
 

--- a/homeassistant/components/media_player/broadlink.py
+++ b/homeassistant/components/media_player/broadlink.py
@@ -158,7 +158,7 @@ class BroadlinkRM(MediaPlayerDevice):
 
         self.host    = config.get(CONF_HOST)
 
-        self.link    = link
+        self._link   = link
         self._state  = STATE_OFF
         self._source = None
 
@@ -167,7 +167,7 @@ class BroadlinkRM(MediaPlayerDevice):
             raise Exception('No command defined!')
 
         packet = b64decode(command)
-        await self.hass.async_add_job(self.link.send_data, packet)
+        await self.hass.async_add_job(self._link.send_data, packet)
 
     @property
     def name(self):

--- a/homeassistant/components/media_player/broadlink.py
+++ b/homeassistant/components/media_player/broadlink.py
@@ -202,10 +202,12 @@ class BroadlinkRM(MediaPlayerDevice):
         await self.send(self._config.get(CONF_PREVIOUS_TRACK))
 
     async def async_select_source(self, source):
+        """Selectes a specific source."""
         await self.send(self._config.get(CONF_SOURCES)[source])
         self._source = source
 
     async def async_play_media(self, media_type, media_id, **kwargs):
+        """Switches to a specific channel."""
         if media_type != MEDIA_TYPE_CHANNEL:
             _LOGGER.error('Unsupported media type %s', media_type)
             return

--- a/homeassistant/components/media_player/broadlink.py
+++ b/homeassistant/components/media_player/broadlink.py
@@ -114,7 +114,7 @@ async def async_setup_platform(hass,
 
 
 def get_supported_by_config(config):
-    """ Calculate support flags based on available configuration entries. """
+    """Calculate support flags based on available configuration entries."""
     support = 0
 
     for mapping in SUPPORT_MAPPING:
@@ -131,7 +131,7 @@ def get_supported_by_config(config):
 
 
 def get_broadlink_mac(mac: str):
-    """ Convert a mac address string with : in it to just a flat string. """
+    """Convert a mac address string with : in it to just a flat string."""
     return binascii.unhexlify(mac.encode().replace(b':', b''))
 
 

--- a/homeassistant/components/media_player/broadlink.py
+++ b/homeassistant/components/media_player/broadlink.py
@@ -11,6 +11,8 @@ import voluptuous as vol
 import logging
 from base64 import b64decode, b64encode
 import binascii
+from homeassistant.exceptions import PlatformNotReady
+import socket
 
 from homeassistant.components.media_player import (
     MediaPlayerDevice,
@@ -120,7 +122,11 @@ async def async_setup_platform(hass,
         mac,
         None)
 
-    await hass.async_add_job(link.auth)
+    try:
+        await hass.async_add_job(link.auth)
+    except socket.timeout:
+        _LOGGER.warning("Timeout trying to authenticate to broadlink")
+        raise PlatformNotReady
 
     async_add_devices([BroadlinkRM(link, config)])
 

--- a/homeassistant/components/media_player/broadlink.py
+++ b/homeassistant/components/media_player/broadlink.py
@@ -122,7 +122,7 @@ async def async_setup_platform(hass,
 
     await hass.async_add_job(link.auth)
 
-    async_add_devices([BroadlinkRM(hass, link, config)])
+    async_add_devices([BroadlinkRM(link, config)])
 
 
 def get_supported_by_config(config):
@@ -149,13 +149,11 @@ def get_broadlink_mac(mac: str):
 
 class BroadlinkRM(MediaPlayerDevice):
 
-    def __init__(self, hass, link, config):
+    def __init__(self, link, config):
         super().__init__()
 
         self.support = get_supported_by_config(config)
         self.config  = config
-        self.hass    = hass
-
         self._link   = link
         self._state  = STATE_OFF
         self._source = None

--- a/homeassistant/components/media_player/broadlink.py
+++ b/homeassistant/components/media_player/broadlink.py
@@ -34,6 +34,7 @@ from homeassistant.const import (
     CONF_TYPE,
     CONF_COMMAND_ON,
     CONF_COMMAND_OFF,
+    CONF_PORT,
     STATE_OFF,
     STATE_ON,
     STATE_PLAYING,
@@ -47,6 +48,7 @@ DOMAIN               = 'broadlink'
 DEFAULT_NAME         = "Broadlink IR Media Player"
 DEFAULT_TIMEOUT      = 10
 DEFAULT_DELAY        = 0.5
+DEFAULT_PORT         = 80
 
 CONF_VOLUME_UP       = 'volume_up'
 CONF_VOLUME_DOWN     = 'volume_down'
@@ -73,6 +75,7 @@ DIGITS_SCHEMA = vol.Schema({
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
+    vol.Required(CONF_PORT, default=DEFAULT_PORT): cv.positive_int,
     vol.Required(CONF_MAC): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int,
@@ -108,11 +111,12 @@ async def async_setup_platform(hass,
                                discovery_info=None):
     import broadlink
 
-    host = config.get(CONF_HOST)
+    host = (config.get(CONF_HOST),
+            config.get(CONF_PORT))
     mac  = get_broadlink_mac(config.get(CONF_MAC))
 
     link = broadlink.rm(
-        (host, 80),
+        host,
         mac,
         None)
 

--- a/homeassistant/components/media_player/broadlink.py
+++ b/homeassistant/components/media_player/broadlink.py
@@ -206,7 +206,7 @@ class BroadlinkRM(MediaPlayerDevice):
 
     async def async_play_media(self, media_type, media_id, **kwargs):
         if media_type != MEDIA_TYPE_CHANNEL:
-            _LOGGER.error('Unsupported media type')
+            _LOGGER.error('Unsupported media type %s', media_type)
             return
 
         cv.positive_int(media_id)

--- a/homeassistant/components/media_player/broadlink.py
+++ b/homeassistant/components/media_player/broadlink.py
@@ -26,23 +26,23 @@ from homeassistant.const import (
 from homeassistant.exceptions import PlatformNotReady
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS         = ['broadlink==0.9.0']
-DOMAIN               = 'broadlink'
+REQUIREMENTS = ['broadlink==0.9.0']
+DOMAIN = 'broadlink'
 
-DEFAULT_NAME         = "Broadlink IR Media Player"
-DEFAULT_TIMEOUT      = 10
-DEFAULT_DELAY        = 0.5
-DEFAULT_PORT         = 80
+DEFAULT_NAME = "Broadlink IR Media Player"
+DEFAULT_TIMEOUT = 10
+DEFAULT_DELAY = 0.5
+DEFAULT_PORT = 80
 
-CONF_VOLUME_UP       = 'volume_up'
-CONF_VOLUME_DOWN     = 'volume_down'
-CONF_VOLUME_MUTE     = 'volume_mute'
-CONF_NEXT_TRACK      = 'next_track'
-CONF_PREVIOUS_TRACK  = 'previous_track'
-CONF_SOURCES         = 'sources'
-CONF_CHANNELS        = 'channels'
-CONF_DIGITS          = 'digits'
-CONF_DIGITDELAY      = 'digitdelay'
+CONF_VOLUME_UP = 'volume_up'
+CONF_VOLUME_DOWN = 'volume_down'
+CONF_VOLUME_MUTE = 'volume_mute'
+CONF_NEXT_TRACK = 'next_track'
+CONF_PREVIOUS_TRACK = 'previous_track'
+CONF_SOURCES = 'sources'
+CONF_CHANNELS = 'channels'
+CONF_DIGITS = 'digits'
+CONF_DIGITDELAY = 'digitdelay'
 
 DIGITS_SCHEMA = vol.Schema({
     vol.Required('0'): cv.string,
@@ -97,7 +97,7 @@ async def async_setup_platform(hass,
 
     host = (config.get(CONF_HOST),
             config.get(CONF_PORT))
-    mac  = get_broadlink_mac(config.get(CONF_MAC))
+    mac = get_broadlink_mac(config.get(CONF_MAC))
 
     link = broadlink.rm(
         host,
@@ -141,10 +141,10 @@ class BroadlinkRM(MediaPlayerDevice):
         super().__init__()
 
         self._support = get_supported_by_config(config)
-        self._config  = config
-        self._link    = link
-        self._state   = STATE_OFF
-        self._source  = None
+        self._config = config
+        self._link = link
+        self._state = STATE_OFF
+        self._source = None
 
     async def send(self, command):
         if command is None:

--- a/homeassistant/components/media_player/broadlink.py
+++ b/homeassistant/components/media_player/broadlink.py
@@ -7,41 +7,23 @@ https://home-assistant.io/components/media_player.broadlink/
 """
 
 import asyncio
-import voluptuous as vol
-import logging
 from base64 import b64decode, b64encode
 import binascii
-from homeassistant.exceptions import PlatformNotReady
+import logging
 import socket
 
+import voluptuous as vol
+
 from homeassistant.components.media_player import (
-    MediaPlayerDevice,
-    PLATFORM_SCHEMA,
-    ENTITY_ID_FORMAT,
-    MEDIA_TYPE_CHANNEL,
-    SUPPORT_TURN_OFF,
-    SUPPORT_TURN_ON,
-    SUPPORT_VOLUME_STEP,
-    SUPPORT_SELECT_SOURCE,
-    SUPPORT_VOLUME_MUTE,
-    SUPPORT_PREVIOUS_TRACK,
-    SUPPORT_NEXT_TRACK,
-    SUPPORT_PLAY_MEDIA)
-
+    ENTITY_ID_FORMAT, MEDIA_TYPE_CHANNEL, PLATFORM_SCHEMA, SUPPORT_NEXT_TRACK,
+    SUPPORT_PLAY_MEDIA, SUPPORT_PREVIOUS_TRACK, SUPPORT_SELECT_SOURCE,
+    SUPPORT_TURN_OFF, SUPPORT_TURN_ON, SUPPORT_VOLUME_MUTE,
+    SUPPORT_VOLUME_STEP, MediaPlayerDevice)
 from homeassistant.const import (
-    CONF_NAME,
-    CONF_HOST,
-    CONF_MAC,
-    CONF_TIMEOUT,
-    CONF_TYPE,
-    CONF_COMMAND_ON,
-    CONF_COMMAND_OFF,
-    CONF_PORT,
-    STATE_OFF,
-    STATE_ON,
-    STATE_PLAYING,
+    CONF_COMMAND_OFF, CONF_COMMAND_ON, CONF_HOST, CONF_MAC, CONF_NAME,
+    CONF_PORT, CONF_TIMEOUT, CONF_TYPE, STATE_OFF, STATE_ON, STATE_PLAYING,
     STATE_UNKNOWN)
-
+from homeassistant.exceptions import PlatformNotReady
 import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS         = ['broadlink==0.9.0']

--- a/homeassistant/components/media_player/broadlink.py
+++ b/homeassistant/components/media_player/broadlink.py
@@ -74,9 +74,9 @@ DIGITS_SCHEMA = vol.Schema({
 })
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_HOST): cv.string,
+    vol.Required(CONF_HOST): cv.ipv4_address,
     vol.Required(CONF_PORT, default=DEFAULT_PORT): cv.positive_int,
-    vol.Required(CONF_MAC): cv.string,
+    vol.Required(CONF_MAC): cv.mac_address,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int,
 

--- a/homeassistant/components/media_player/broadlink.py
+++ b/homeassistant/components/media_player/broadlink.py
@@ -189,7 +189,7 @@ class BroadlinkRM(MediaPlayerDevice):
         """Volume down media player."""
         await self.send(self._config.get(CONF_VOLUME_DOWN))
 
-    async def async_volume_mute(self):
+    async def async_mute_volume(self, mute):
         """Send mute command."""
         await self.send(self._config.get(CONF_VOLUME_MUTE))
 

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -465,6 +465,22 @@ def x10_address(value):
     return str(value).lower()
 
 
+def ipv4_address(value):
+    """Validate an ipv4 address."""
+    regex = re.compile(r'^\d+.\d+.\d+.\d+$')
+    if not regex.match(value):
+        raise vol.Invalid('Invalid Ipv4 address, expected a.b.c.d')
+    return value
+
+
+def mac_address(value):
+    """Validate an mac address."""
+    regex = re.compile(r'^([0-9a-fA-F]{2})(:[0-9a-fA-F]{2}){5}$')
+    if not regex.match(value):
+        raise vol.Invalid('Invalid MAC address, expected AA:BB:CC:DD:EE:FF')
+    return str(value).lower()
+
+
 def ensure_list_csv(value: Any) -> Sequence:
     """Ensure that input is a list or make one from comma-separated string."""
     if isinstance(value, str):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -194,6 +194,7 @@ braviarc-homeassistant==0.3.7.dev0
 
 # homeassistant.components.sensor.broadlink
 # homeassistant.components.switch.broadlink
+# homeassistant.components.media_player.broadlink
 broadlink==0.9.0
 
 # homeassistant.components.device_tracker.bluetooth_tracker

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -192,9 +192,9 @@ botocore==1.7.34
 # homeassistant.components.media_player.braviatv
 braviarc-homeassistant==0.3.7.dev0
 
+# homeassistant.components.media_player.broadlink
 # homeassistant.components.sensor.broadlink
 # homeassistant.components.switch.broadlink
-# homeassistant.components.media_player.broadlink
 broadlink==0.9.0
 
 # homeassistant.components.device_tracker.bluetooth_tracker

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -386,6 +386,31 @@ def test_x10_address():
     schema('C11')
 
 
+def test_ipv4_address():
+    """Test ipv4 addr validator."""
+    schema = vol.Schema(cv.ipv4_address)
+    with pytest.raises(vol.Invalid):
+        schema('1')
+        schema('1.1')
+        schema('1.1.1.')
+        schema('hostname')
+
+    schema('192.168.0.0')
+    schema('0.0.0.0')
+
+
+def test_mac_address():
+    """Test mac addr validator."""
+    schema = vol.Schema(cv.mac_address)
+    with pytest.raises(vol.Invalid):
+        schema('00:00:00:00:00')
+        schema('00:00:00:00:00:00:00')
+        schema('hostname')
+
+    schema('00:AA:BB:CC:DD:EE')
+    schema('00:aa:bb:cc:dd:ee')
+
+
 def test_template():
     """Test template validator."""
     schema = vol.Schema(cv.template)


### PR DESCRIPTION
## Description:
Add a media player platform for use with an broadlink IR transmitter.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5791

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  - platform: broadlink
    host: 192.168.0.2
    mac: '11:22:33:44:55:66'
    name: 'Samsung Living Room TV'

    command_on    : 'JgBGAJKVETkRORA6ERQRFBEUERQRFBE5ETkQOhAVEBUQFREUEBUQOhEUERQRORE5EBURFBA6EBUQOhE5EBUQFRA6EDoRFBEADQUAAA=='
    command_off   : 'JgBGAJOVEDoQOhA6DxYPFhAVEBUQFRA6ETkROREUERQRFBEUEBUQFREUERQRORE5EBUQFRE5ETkRORE5ERUQFRA6DzsPFhAADQUAAA=='

    volume_up     : 'JgBGAJOTEjcSNxI3EhISEhISEhISEhI3EjcSNxISEhISEhISEhISNxI3EjcSEhISEhISEhISEhISEhISEjcSNxI3EjcSNxIABfgNBQ=='
    volume_down   : 'JgBGAJOTEjcSNxI3EhISEhISEhISEhI3EjcSNxISEhISEhISEhISNxI3EhISNxISEhISEhISEhISEhI3EhISNxI3EjcSNxIABfgNBQ=='

    previous_track: 'JgBGAJOTEjcSNxI3EhISEhISEhISEhI3EjcSNxISEhISEhISEhISEhISEhISEhI3EhISEhISEjcSNxI3EjcSEhI3EjcSNxIABfgNBQ=='
    next_track    : 'JgBGAJOTEjcSNxI3EhISEhISEhISEhI3EjcSNxISEhISEhISEhISEhI3EhISEhI3EhISEhISEjcSEhI3EjcSEhI3EjcSNxIABfgNBQ=='

    digits:
      '0'     : 'JgBGAJOTEjcSNxI3EhISEhISEhISEhI3EjcSNxISEhISEhISEhISEhISEhISEhISEjcSNxISEjcSNxI3EjcSNxISEhISNxIABfgNBQ=='
      '1'     : 'JgBGAJOTEjcSNxI3EhISEhISEhISEhI3EjcSNxISEhISEhISEhISEhISEhISEhISEjcSNxISEjcSNxI3EjcSNxISEhISNxIABfgNBQ=='
      '2'     : 'JgBGAJOTEjcSNxI3EhISEhISEhISEhI3EjcSNxISEhISEhISEhISEhISEhISEhISEjcSNxISEjcSNxI3EjcSNxISEhISNxIABfgNBQ=='
      '3'     : 'JgBGAJOTEjcSNxI3EhISEhISEhISEhI3EjcSNxISEhISEhISEhISEhISEhISEhISEjcSNxISEjcSNxI3EjcSNxISEhISNxIABfgNBQ=='
      '4'     : 'JgBGAJOTEjcSNxI3EhISEhISEhISEhI3EjcSNxISEhISEhISEhISEhISEhISEhISEjcSNxISEjcSNxI3EjcSNxISEhISNxIABfgNBQ=='
      '5'     : 'JgBGAJOTEjcSNxI3EhISEhISEhISEhI3EjcSNxISEhISEhISEhISEhISEhISEhISEjcSNxISEjcSNxI3EjcSNxISEhISNxIABfgNBQ=='
      '6'     : 'JgBGAJOTEjcSNxI3EhISEhISEhISEhI3EjcSNxISEhISEhISEhISEhISEhISEhISEjcSNxISEjcSNxI3EjcSNxISEhISNxIABfgNBQ=='
      '7'     : 'JgBGAJOTEjcSNxI3EhISEhISEhISEhI3EjcSNxISEhISEhISEhISEhISEhISEhISEjcSNxISEjcSNxI3EjcSNxISEhISNxIABfgNBQ=='
      '8'     : 'JgBGAJOTEjcSNxI3EhISEhISEhISEhI3EjcSNxISEhISEhISEhISEhISEhISEhISEjcSNxISEjcSNxI3EjcSNxISEhISNxIABfgNBQ=='
      '9'     : 'JgBGAJOTEjcSNxI3EhISEhISEhISEhI3EjcSNxISEhISEhISEhISEhISEhISEhISEjcSNxISEjcSNxI3EjcSNxISEhISNxIABfgNBQ=='

    sources:
      hdmi  : 'JgBGAJGWETkRORI4ERQRFBAVERQRFBE5ETkROREUEBURFBEUERQQOxA6EBUPOw8WDxYQFRA6DxYQFRA6EBUPOxA6ETkRFBEADQUAAA=='
      dtv   : 'JgBGAJSTEjgSOBI4EhMSExITEhMSExI4EjgSNxMTEhQRFBEUERQRORE4EhQSExITEhMSOBITEhMSExI4EjgSOBI4EhMSOBIADQUAAA=='
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
