### PR TITLE
Use api name instead of ID for friendly name

### DIFF
--- a/homeassistant/components/media_player/snapcast.py
+++ b/homeassistant/components/media_player/snapcast.py
@@ -208,7 +208,7 @@ class SnapcastClientDevice(MediaPlayerDevice):
     @property
     def name(self):
         """Return the name of the device."""
-        return '{}{}'.format(CLIENT_PREFIX, self._client.identifier)
+        return self._client.name
 
     @property
     def volume_level(self):


### PR DESCRIPTION
## Description:

In snapcast, a name for each client _can_ be set via the API (it is used in the snapcast app for example). This commit adds that name for homeassistant too, which still can be overridden there via the UI.

The name can be `None` but it seems like homeassistant is using the ID then without problems. Means if people have not set custom names in the snapcast API, nothing should change for them.

Everything worked for me, but as I have no experience with this project otherwise, I'm not sure if the above described "None" behaviour is normal, so treat it with a grain of salt please.


## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
