### PR TITLE
Uncomment pybluez requirement in requirements_all.txt

### DIFF
--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -11,7 +11,7 @@ pyyaml>=3.13,<4
 requests==2.19.1
 voluptuous==0.11.1
 
-# homeassistant.components.nuimo_controller
+# homeassistant.components.nuimo_controlle
 --only-binary=all nuimo==0.1.0
 
 # homeassistant.components.sensor.sht31
@@ -753,7 +753,7 @@ pybbox==0.0.5-alpha
 pyblackbird==0.5
 
 # homeassistant.components.device_tracker.bluetooth_tracker
-# pybluez==0.22
+pybluez==0.22
 
 # homeassistant.components.neato
 pybotvac==0.0.7


### PR DESCRIPTION
## Description: Uncomment the pybluez requirement in requirements_all.txt


**Related issue (if applicable):** none

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** none

## Example entry for `configuration.yaml` (if applicable):
none

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
