### PR TITLE
Cleanup of HomematicIP Cloud code

### DIFF
--- a/homeassistant/components/alarm_control_panel/homematicip_cloud.py
+++ b/homeassistant/components/alarm_control_panel/homematicip_cloud.py
@@ -63,9 +63,11 @@ class HomematicipSecurityZone(HomematicipGenericDevice, AlarmControlPanel):
                     self._device.windowState == WindowState.OPEN):
                 return STATE_ALARM_TRIGGERED
 
-            if self._device.label == HMIP_ZONE_AWAY:
+            active = self._home.get_security_zones_activation()
+            if active == (True, True):
+                return STATE_ALARM_ARMED_AWAY
+            elif active == (False, True):
                 return STATE_ALARM_ARMED_HOME
-            return STATE_ALARM_ARMED_AWAY
 
         return STATE_ALARM_DISARMED
 

--- a/homeassistant/components/alarm_control_panel/homematicip_cloud.py
+++ b/homeassistant/components/alarm_control_panel/homematicip_cloud.py
@@ -20,7 +20,6 @@ DEPENDENCIES = ['homematicip_cloud']
 
 _LOGGER = logging.getLogger(__name__)
 
-HMIP_OPEN = 'OPEN'
 HMIP_ZONE_AWAY = 'EXTERNAL'
 HMIP_ZONE_HOME = 'INTERNAL'
 
@@ -57,12 +56,14 @@ class HomematicipSecurityZone(HomematicipGenericDevice, AlarmControlPanel):
     @property
     def state(self):
         """Return the state of the device."""
+        from homematicip.base.enums import WindowState
+
         if self._device.active:
             if (self._device.sabotage or self._device.motionDetected or
-                    self._device.windowState == HMIP_OPEN):
+                    self._device.windowState == WindowState.OPEN):
                 return STATE_ALARM_TRIGGERED
 
-            if self._device.label == HMIP_ZONE_HOME:
+            if self._device.label == HMIP_ZONE_AWAY:
                 return STATE_ALARM_ARMED_HOME
             return STATE_ALARM_ARMED_AWAY
 
@@ -79,10 +80,3 @@ class HomematicipSecurityZone(HomematicipGenericDevice, AlarmControlPanel):
     async def async_alarm_arm_away(self, code=None):
         """Send arm away command."""
         await self._home.set_security_zones_activation(True, True)
-
-    @property
-    def device_state_attributes(self):
-        """Return the state attributes of the alarm control device."""
-        # The base class is loading the battery property, but device doesn't
-        # have this property - base class needs clean-up.
-        return None

--- a/homeassistant/components/homematicip_cloud/device.py
+++ b/homeassistant/components/homematicip_cloud/device.py
@@ -67,6 +67,8 @@ class HomematicipGenericDevice(Entity):
         """Return the icon."""
         if hasattr(self._device, 'lowBat') and self._device.lowBat:
             return 'mdi:battery-outline'
+        if hasattr(self._device, 'sabotage') and self._device.sabotage:
+            return 'mdi:alert'
         return None
 
     @property
@@ -75,4 +77,6 @@ class HomematicipGenericDevice(Entity):
         attr = {ATTR_MODEL_TYPE: self._device.modelType}
         if hasattr(self._device, 'lowBat') and self._device.lowBat:
             attr.update({ATTR_LOW_BATTERY: self._device.lowBat})
+        if hasattr(self._device, 'sabotage') and self._device.sabotage:
+            attr.update({ATTR_SABOTAGE: self._device.sabotage})
         return attr

--- a/homeassistant/components/homematicip_cloud/device.py
+++ b/homeassistant/components/homematicip_cloud/device.py
@@ -67,6 +67,7 @@ class HomematicipGenericDevice(Entity):
         """Return the icon."""
         if hasattr(self._device, 'lowBat') and self._device.lowBat:
             return 'mdi:battery-outline'
+        return None
 
     @property
     def device_state_attributes(self):

--- a/homeassistant/components/homematicip_cloud/device.py
+++ b/homeassistant/components/homematicip_cloud/device.py
@@ -63,9 +63,15 @@ class HomematicipGenericDevice(Entity):
         return not self._device.unreach
 
     @property
+    def icon(self):
+        """Return the icon."""
+        if hasattr(self._device, 'lowBat') and self._device.lowBat:
+            return 'mdi:battery-outline'
+
+    @property
     def device_state_attributes(self):
         """Return the state attributes of the generic device."""
         attr = {ATTR_MODEL_TYPE: self._device.modelType}
-        if hasattr(self._device, 'lowBat') and self._device.lowBat: 
+        if hasattr(self._device, 'lowBat') and self._device.lowBat:
             attr.update({ATTR_LOW_BATTERY: self._device.lowBat})
         return attr

--- a/homeassistant/components/homematicip_cloud/device.py
+++ b/homeassistant/components/homematicip_cloud/device.py
@@ -65,7 +65,7 @@ class HomematicipGenericDevice(Entity):
     @property
     def device_state_attributes(self):
         """Return the state attributes of the generic device."""
-        return {
-            ATTR_LOW_BATTERY: self._device.lowBat,
-            ATTR_MODEL_TYPE: self._device.modelType
-        }
+        attr = {ATTR_MODEL_TYPE: self._device.modelType}
+        if hasattr(self._device, 'lowBat') and self._device.lowBat: 
+            attr.update({ATTR_LOW_BATTERY: self._device.lowBat})
+        return attr

--- a/homeassistant/components/sensor/homematicip_cloud.py
+++ b/homeassistant/components/sensor/homematicip_cloud.py
@@ -80,11 +80,6 @@ class HomematicipAccesspointStatus(HomematicipGenericDevice):
         """Return the unit this state is expressed in."""
         return '%'
 
-    @property
-    def device_state_attributes(self):
-        """Return the state attributes of the access point."""
-        return {}
-
 
 class HomematicipHeatingThermostat(HomematicipGenericDevice):
     """MomematicIP heating thermostat representation."""
@@ -98,6 +93,8 @@ class HomematicipHeatingThermostat(HomematicipGenericDevice):
         """Return the icon."""
         from homematicip.base.enums import ValveState
 
+        if super().icon:
+            return super().icon
         if self._device.valveState != ValveState.ADAPTION_DONE:
             return 'mdi:alert'
         return 'mdi:radiator'


### PR DESCRIPTION
## Description:
- [x] Check if device supports lowBat and shows it only if battery is low and show also a empty battery icon
- [x] Cleanup device classes
- [x] Cleanup of sabotage attribute
- [x] Bug fix `alarm_control_panel` - lib update and fix of home/away armed 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54