### PR TITLE
Allow defining default turn-on values for lights in the profiles file.

### DIFF
--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -346,7 +346,11 @@ async def async_setup(hass, config):
         update_tasks = []
         for light in target_lights:
             if service.service == SERVICE_TURN_ON:
-                await light.async_turn_on(**params)
+                pars = params.copy()
+                if not pars:
+                    pars[ATTR_PROFILE] = Profiles.get_default(light.entity_id)
+                    preprocess_turn_on_alternatives(pars)
+                await light.async_turn_on(**pars)
             elif service.service == SERVICE_TURN_OFF:
                 await light.async_turn_off(**params)
             else:
@@ -430,6 +434,17 @@ class Profiles:
     def get(cls, name):
         """Return a named profile."""
         return cls._all.get(name)
+
+    @classmethod
+    def get_default(cls, entity_id):
+        """Return the default turn-on profile for the given light."""
+        name = entity_id + ".default"
+        if name in cls._all:
+            return name
+        name = ENTITY_ID_ALL_LIGHTS + ".default"
+        if name in cls._all:
+            return name
+        return None
 
 
 class Light(ToggleEntity):

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -346,8 +346,9 @@ async def async_setup(hass, config):
         update_tasks = []
         for light in target_lights:
             if service.service == SERVICE_TURN_ON:
-                pars = params.copy()
+                pars = params
                 if not pars:
+                    pars = params.copy()
                     pars[ATTR_PROFILE] = Profiles.get_default(light.entity_id)
                     preprocess_turn_on_alternatives(pars)
                 await light.async_turn_on(**pars)

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -308,6 +308,56 @@ class TestLight(unittest.TestCase):
             light.ATTR_BRIGHTNESS: 100
         }, data)
 
+    def test_default_profiles(self):
+        """Test default turn-on light profiles."""
+        platform = loader.get_component(self.hass, 'light.test')
+        platform.init()
+
+        user_light_file = self.hass.config.path(light.LIGHT_PROFILES_FILE)
+
+        with open(user_light_file, 'w') as user_file:
+            user_file.write('id,x,y,brightness\n')
+            user_file.write('group.all_lights.default,.4,.6,100\n')
+
+        self.assertTrue(setup_component(
+            self.hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: 'test'}}
+        ))
+
+        dev1, _, _ = platform.DEVICES
+
+        light.turn_on(self.hass, dev1.entity_id)
+
+        self.hass.block_till_done()
+
+        _, data = dev1.last_call('turn_on')
+
+        self.assertEqual({
+            light.ATTR_HS_COLOR: (71.059, 100),
+            light.ATTR_BRIGHTNESS: 100
+        }, data)
+
+        with open(user_light_file, 'w') as user_file:
+            user_file.write('id,x,y,brightness\n')
+            user_file.write('group.all_lights.default,.3,.5,200\n')
+            user_file.write('light.ceiling_2.default,.4,.6,100\n')
+
+        self.assertTrue(setup_component(
+            self.hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: 'test'}}
+        ))
+
+        dev1, _, _ = platform.DEVICES
+
+        light.turn_on(self.hass, dev1.entity_id)
+
+        self.hass.block_till_done()
+
+        _, data = dev1.last_call('turn_on')
+
+        self.assertEqual({
+            light.ATTR_HS_COLOR: (71.059, 100),
+            light.ATTR_BRIGHTNESS: 100
+        }, data)
+
 
 async def test_intent_set_color(hass):
     """Test the set color intent."""

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -376,7 +376,8 @@ class TestLight(unittest.TestCase):
                     {light.DOMAIN: {CONF_PLATFORM: 'test'}}
                 ))
 
-        dev, _, _ = platform.DEVICES
+        dev = next(filter(lambda x: x.entity_id == 'light.ceiling_2',
+                          platform.DEVICES))
         light.turn_on(self.hass, dev.entity_id)
         self.hass.block_till_done()
         _, data = dev.last_call('turn_on')

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -1,7 +1,9 @@
 """The tests for the Light component."""
 # pylint: disable=protected-access
 import unittest
+import unittest.mock as mock
 import os
+from io import StringIO
 
 from homeassistant.setup import setup_component
 import homeassistant.loader as loader
@@ -308,53 +310,78 @@ class TestLight(unittest.TestCase):
             light.ATTR_BRIGHTNESS: 100
         }, data)
 
-    def test_default_profiles(self):
-        """Test default turn-on light profiles."""
+    def test_default_profiles_group(self):
+        """Test default turn-on light profile for all lights."""
         platform = loader.get_component(self.hass, 'light.test')
         platform.init()
 
         user_light_file = self.hass.config.path(light.LIGHT_PROFILES_FILE)
+        real_isfile = os.path.isfile
+        real_open = open
 
-        with open(user_light_file, 'w') as user_file:
-            user_file.write('id,x,y,brightness\n')
-            user_file.write('group.all_lights.default,.4,.6,100\n')
+        def _mock_isfile(path):
+            if path == user_light_file:
+                return True
+            return real_isfile(path)
 
-        self.assertTrue(setup_component(
-            self.hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: 'test'}}
-        ))
+        def _mock_open(path):
+            if path == user_light_file:
+                return StringIO(profile_data)
+            return real_open(path)
 
-        dev1, _, _ = platform.DEVICES
+        profile_data = "id,x,y,brightness\n" +\
+                       "group.all_lights.default,.4,.6,99\n"
+        with mock.patch('os.path.isfile', side_effect=_mock_isfile):
+            with mock.patch('builtins.open', side_effect=_mock_open):
+                self.assertTrue(setup_component(
+                    self.hass, light.DOMAIN,
+                    {light.DOMAIN: {CONF_PLATFORM: 'test'}}
+                ))
 
-        light.turn_on(self.hass, dev1.entity_id)
-
+        dev, _, _ = platform.DEVICES
+        light.turn_on(self.hass, dev.entity_id)
         self.hass.block_till_done()
-
-        _, data = dev1.last_call('turn_on')
-
+        _, data = dev.last_call('turn_on')
         self.assertEqual({
             light.ATTR_HS_COLOR: (71.059, 100),
-            light.ATTR_BRIGHTNESS: 100
+            light.ATTR_BRIGHTNESS: 99
         }, data)
 
-        with open(user_light_file, 'w') as user_file:
-            user_file.write('id,x,y,brightness\n')
-            user_file.write('group.all_lights.default,.3,.5,200\n')
-            user_file.write('light.ceiling_2.default,.4,.6,100\n')
+    def test_default_profiles_light(self):
+        """Test default turn-on light profile for a specific light."""
+        platform = loader.get_component(self.hass, 'light.test')
+        platform.init()
 
-        self.assertTrue(setup_component(
-            self.hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: 'test'}}
-        ))
+        user_light_file = self.hass.config.path(light.LIGHT_PROFILES_FILE)
+        real_isfile = os.path.isfile
+        real_open = open
 
-        dev1, _, _ = platform.DEVICES
+        def _mock_isfile(path):
+            if path == user_light_file:
+                return True
+            return real_isfile(path)
 
-        light.turn_on(self.hass, dev1.entity_id)
+        def _mock_open(path):
+            if path == user_light_file:
+                return StringIO(profile_data)
+            return real_open(path)
 
+        profile_data = "id,x,y,brightness\n" +\
+                       "group.all_lights.default,.3,.5,200\n" +\
+                       "light.ceiling_2.default,.6,.6,100\n"
+        with mock.patch('os.path.isfile', side_effect=_mock_isfile):
+            with mock.patch('builtins.open', side_effect=_mock_open):
+                self.assertTrue(setup_component(
+                    self.hass, light.DOMAIN,
+                    {light.DOMAIN: {CONF_PLATFORM: 'test'}}
+                ))
+
+        dev, _, _ = platform.DEVICES
+        light.turn_on(self.hass, dev.entity_id)
         self.hass.block_till_done()
-
-        _, data = dev1.last_call('turn_on')
-
+        _, data = dev.last_call('turn_on')
         self.assertEqual({
-            light.ATTR_HS_COLOR: (71.059, 100),
+            light.ATTR_HS_COLOR: (50.353, 100),
             light.ATTR_BRIGHTNESS: 100
         }, data)
 


### PR DESCRIPTION
## Description:

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

Will add documentation if PR is generally accepted.

## Example entry for `light_profiles.csv`
```csv
id,x,y,brightness
light.bedroom_lights.default,0.345669,0.358496,100
group.all_lights.default,0.345669,0.358496,100
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

Will add documentation if PR is generally accepted.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
