### PR TITLE
0.73.2 - security release

### DIFF
--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -19,6 +19,7 @@ import homeassistant.helpers.config_validation as cv
 import homeassistant.remote as rem
 import homeassistant.util as hass_util
 from homeassistant.util.logging import HideSensitiveDataFilter
+from homeassistant.util import ssl as ssl_util
 
 from .auth import setup_auth
 from .ban import setup_bans
@@ -48,21 +49,6 @@ CONF_TRUSTED_PROXIES = 'trusted_proxies'
 CONF_TRUSTED_NETWORKS = 'trusted_networks'
 CONF_LOGIN_ATTEMPTS_THRESHOLD = 'login_attempts_threshold'
 CONF_IP_BAN_ENABLED = 'ip_ban_enabled'
-
-# TLS configuration follows the best-practice guidelines specified here:
-# https://wiki.mozilla.org/Security/Server_Side_TLS
-# Modern guidelines are followed.
-SSL_VERSION = ssl.PROTOCOL_TLS  # pylint: disable=no-member
-SSL_OPTS = ssl.OP_NO_SSLv2 | ssl.OP_NO_SSLv3 | \
-           ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1 | \
-           ssl.OP_CIPHER_SERVER_PREFERENCE
-if hasattr(ssl, 'OP_NO_COMPRESSION'):
-    SSL_OPTS |= ssl.OP_NO_COMPRESSION
-CIPHERS = "ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:" \
-          "ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:" \
-          "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:" \
-          "ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:" \
-          "ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -300,9 +286,7 @@ class HomeAssistantHTTP(object):
 
         if self.ssl_certificate:
             try:
-                context = ssl.SSLContext(SSL_VERSION)
-                context.options |= SSL_OPTS
-                context.set_ciphers(CIPHERS)
+                context = ssl_util.server_context()
                 context.load_cert_chain(self.ssl_certificate, self.ssl_key)
             except OSError as error:
                 _LOGGER.error("Could not read SSL certificate from %s: %s",

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -2,7 +2,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 73
-PATCH_VERSION = '1'
+PATCH_VERSION = '2'
 __short_version__ = '{}.{}'.format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = '{}.{}'.format(__short_version__, PATCH_VERSION)
 REQUIRED_PYTHON_VER = (3, 5, 3)

--- a/homeassistant/helpers/aiohttp_client.py
+++ b/homeassistant/helpers/aiohttp_client.py
@@ -1,6 +1,5 @@
 """Helper for aiohttp webclient stuff."""
 import asyncio
-import ssl
 import sys
 
 import aiohttp
@@ -8,11 +7,11 @@ from aiohttp.hdrs import USER_AGENT, CONTENT_TYPE
 from aiohttp import web
 from aiohttp.web_exceptions import HTTPGatewayTimeout, HTTPBadGateway
 import async_timeout
-import certifi
 
 from homeassistant.core import callback
 from homeassistant.const import EVENT_HOMEASSISTANT_CLOSE, __version__
 from homeassistant.loader import bind_hass
+from homeassistant.util import ssl as ssl_util
 
 DATA_CONNECTOR = 'aiohttp_connector'
 DATA_CONNECTOR_NOTVERIFY = 'aiohttp_connector_notverify'
@@ -154,9 +153,7 @@ def _async_get_connector(hass, verify_ssl=True):
         return hass.data[key]
 
     if verify_ssl:
-        ssl_context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
-        ssl_context.load_verify_locations(cafile=certifi.where(),
-                                          capath=None)
+        ssl_context = ssl_util.client_context()
     else:
         ssl_context = False
 

--- a/homeassistant/util/ssl.py
+++ b/homeassistant/util/ssl.py
@@ -1,0 +1,46 @@
+"""Helper to create SSL contexts."""
+import ssl
+
+import certifi
+
+
+def client_context():
+    """Return an SSL context for making requests."""
+    context = _get_context()
+    context.verify_mode = ssl.CERT_REQUIRED
+    context.check_hostname = True
+    context.load_verify_locations(cafile=certifi.where(), capath=None)
+    return context
+
+
+def server_context():
+    """Return an SSL context for being a server."""
+    context = _get_context()
+    context.options |= ssl.OP_CIPHER_SERVER_PREFERENCE
+    return context
+
+
+def _get_context():
+    """Return an SSL context following the Mozilla recommendations.
+
+    TLS configuration follows the best-practice guidelines specified here:
+    https://wiki.mozilla.org/Security/Server_Side_TLS
+    Modern guidelines are followed.
+    """
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS)  # pylint: disable=no-member
+
+    context.options |= (
+        ssl.OP_NO_SSLv2 | ssl.OP_NO_SSLv3 |
+        ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1
+    )
+    if hasattr(ssl, 'OP_NO_COMPRESSION'):
+        context.options |= ssl.OP_NO_COMPRESSION
+
+    context.set_ciphers(
+        "ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:"
+        "ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:"
+        "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:"
+        "ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:"
+        "ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256"
+    )
+    return context


### PR DESCRIPTION
Today we are releasing 0.73.2 to fix a security incident. We've discovered that 9 months ago, with the release of Home Assistant 0.56, we misconfigured the SSL context that aiohttp used ([PR](https://github.com/home-assistant/home-assistant/pull/9958)). By trying to do the right thing (use an up to date cert store instead of relying on the system certs), we ended up doing the complete opposite: SSL verification was disabled for **outgoing** requests that were done using the shared aiohttp session. This is our fault, and not aiohttp's faults. The impact of this is that certain integrations in Home Assistant have been susceptible to [man in the middle attacks](https://en.wikipedia.org/wiki/Man-in-the-middle_attack). 

A man in the middle attack is when an attacker is able to inject itself between you and the server you're communicating with, allowing it to read and alter the communication. The odds of this happening at home is very rare, yet we wanted to be transparent about this incident.

After research, the following integrations have been impacted. Although the odds are extremely small, we still suggest that if you use any of these integrations, to create new API keys or change your password.

- [alarm_control_panel.alarmdotcom](https://www.home-assistant.io/components/alarm_control_panel.alarmdotcom/)
- [climate.sensibo](https://www.home-assistant.io/components/climate.sensibo/)
- [cloud](https://www.home-assistant.io/components/cloud/) (only short lived tokens impacted)
- [device_tracker.automatic](https://www.home-assistant.io/components/device_tracker.automatic/)
- [duckdns](https://www.home-assistant.io/components/duckdns/)
- [freedns](https://www.home-assistant.io/components/freedns/)
- [google_assistant](https://www.home-assistant.io/components/google_assistant/) (manual setup)
- [google_domains](https://www.home-assistant.io/components/google_domains/)
- [homematicip_cloud](https://www.home-assistant.io/components/homematicip_cloud/)
- [image_processing.openalpr_cloud](https://www.home-assistant.io/components/image_processing.openalpr_cloud/)
- [microsoft_face](https://www.home-assistant.io/components/microsoft_face/)
- [namecheapdns](https://www.home-assistant.io/components/namecheapdns/)
- [no_ip](https://www.home-assistant.io/components/no_ip/)
- [notify.flock](https://www.home-assistant.io/components/notify.flock/)
- [notify.prowl](https://www.home-assistant.io/components/notify.prowl/)
- [rest_command](https://www.home-assistant.io/components/rest_command/)
- [scene.lifx_cloud](https://www.home-assistant.io/components/scene.lifx_cloud/)
- [switch.hook](https://www.home-assistant.io/components/switch.hook/)
- [switch.rest](https://www.home-assistant.io/components/switch.rest/)
- [telegram_bot.polling](https://www.home-assistant.io/components/telegram_bot.polling/)
- [tts.voicerss](https://www.home-assistant.io/components/tts.voicerss/)

Also impacted, but integrations are read only:

- [sensor.airvisual](https://www.home-assistant.io/components/sensor.airvisual/)
- [sensor.ebox](https://www.home-assistant.io/components/sensor.ebox/)
- [sensor.fido](https://www.home-assistant.io/components/sensor.fido/)
- [sensor.foobot](https://www.home-assistant.io/components/sensor.foobot/)
- [sensor.hydroquebec](https://www.home-assistant.io/components/sensor.hydroquebec/)
- [sensor.startca](https://www.home-assistant.io/components/sensor.startca/)
- [sensor.teksavvy](https://www.home-assistant.io/components/sensor.teksavvy/)
- [sensor.thethingsnetwork](https://www.home-assistant.io/components/sensor.thethingsnetwork/)
- [sensor.tibber](https://www.home-assistant.io/components/sensor.tibber/)
- [sensor.waqi](https://www.home-assistant.io/components/sensor.waqi/)

<!--more-->

For complete transparency, the following two sets of integrations also used aiohttp to send or retrieve data. However, they either did not transmit authentication or only communicated with local devices and services.

Affected, but not transmitting authentication:

- [sensor.buienradar](https://www.home-assistant.io/components/sensor.buienradar/)
- [sensor.citybikes](https://www.home-assistant.io/components/sensor.citybikes/)
- [sensor.comed_hourly_pricing](https://www.home-assistant.io/components/sensor.comed_hourly_pricing/)
- [sensor.luftdaten](https://www.home-assistant.io/components/sensor.luftdaten/)
- [sensor.pollen](https://www.home-assistant.io/components/sensor.pollen/)
- [sensor.sochain](https://www.home-assistant.io/components/sensor.sochain/)
- [sensor.swiss_public_transport](https://www.home-assistant.io/components/sensor.swiss_public_transport/)
- [sensor.viaggiatreno](https://www.home-assistant.io/components/sensor.viaggiatreno/)
- [sensor.wunderground](https://www.home-assistant.io/components/sensor.wunderground/)
- [sensor.yr](https://www.home-assistant.io/components/sensor.yr/)
- [weather.ipma](https://www.home-assistant.io/components/weather.ipma/)
- [tts.google](https://www.home-assistant.io/components/tts.google/)
- [tts.yandextts](https://www.home-assistant.io/components/tts.yandextts/)
- [updater](https://www.home-assistant.io/components/updater/)

Local, so cannot be impacted:

- [android_ip_webcam](https://www.home-assistant.io/components/android_ip_webcam/)
- [apple_tv](https://www.home-assistant.io/components/apple_tv/)
- [camera.amcrest](https://www.home-assistant.io/components/camera.amcrest/)
- [camera.doorbird](https://www.home-assistant.io/components/camera.doorbird/)
- [camera.familyhub](https://www.home-assistant.io/components/camera.familyhub/)
- [camera.generic](https://www.home-assistant.io/components/camera.generic/)
- [camera.mjpeg](https://www.home-assistant.io/components/camera.mjpeg/)
- [camera.proxy](https://www.home-assistant.io/components/camera.proxy/)
- [camera.synology](https://www.home-assistant.io/components/camera.synology/)
- [deconz](https://www.home-assistant.io/components/deconz/)
- [device_tracker.upc_connect](https://www.home-assistant.io/components/device_tracker.upc_connect/)
- [hassio](https://www.home-assistant.io/components/hassio/)
- [hue](https://www.home-assistant.io/components/hue/)
- [media_player.bluesound](https://www.home-assistant.io/components/media_player.bluesound/)
- [media_player.epson](https://www.home-assistant.io/components/media_player.epson/)
- [media_player.kodi](https://www.home-assistant.io/components/media_player.kodi/)
- [media_player.squeezebox](https://www.home-assistant.io/components/media_player.squeezebox/)
- [media_player.volumio](https://www.home-assistant.io/components/media_player.volumio/)
- [notify.kodi](https://www.home-assistant.io/components/notify.kodi/)
- [qwikswitch](https://www.home-assistant.io/components/qwikswitch/)
- [rainmachine](https://www.home-assistant.io/components/rainmachine/)
- [scene.hunterdouglas_powerview](https://www.home-assistant.io/components/scene.hunterdouglas_powerview/)
- [sensor.netdata](https://www.home-assistant.io/components/sensor.netdata/)
- [sensor.pi_hole](https://www.home-assistant.io/components/sensor.pi_hole/)
- [sensor.sma](https://www.home-assistant.io/components/sensor.sma/)
- [sensor.worxlandroid](https://www.home-assistant.io/components/sensor.worxlandroid/)
- [spc](https://www.home-assistant.io/components/spc/)
- [tts.marytts](https://www.home-assistant.io/components/tts.marytts/)



