### PR TITLE
Add spider thermostat

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -346,6 +346,9 @@ omit =
     homeassistant/components/tuya.py
     homeassistant/components/*/tuya.py
 
+    homeassistant/components/spider.py
+    homeassistant/components/*/spider.py
+
     homeassistant/components/alarm_control_panel/alarmdotcom.py
     homeassistant/components/alarm_control_panel/canary.py
     homeassistant/components/alarm_control_panel/concord232.py

--- a/homeassistant/components/climate/spider.py
+++ b/homeassistant/components/climate/spider.py
@@ -32,25 +32,24 @@ _LOGGER = logging.getLogger(__name__)
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Spider thermostat."""
-    thermostats = hass.data[SPIDER_DOMAIN]['thermostats']
-    api = hass.data[SPIDER_DOMAIN]['controller']
-    for thermostat in thermostats:
-        add_devices(
-            [SpiderThermostat(api, thermostat['id'], thermostat['name'])],
-            True
-        )
+    if discovery_info is None:
+        return
+
+    devices = [SpiderThermostat(hass.data[SPIDER_DOMAIN]['controller'], device)
+               for device in hass.data[SPIDER_DOMAIN]['thermostats']]
+    add_devices(devices, True)
 
 
 class SpiderThermostat(ClimateDevice):
     """Representation of a thermostat."""
 
-    def __init__(self, client, thermostat_id, name):
+    def __init__(self, client, thermostat):
         """Initialize the thermostat."""
         self.client = client
-        self._id = thermostat_id
-        self._name = name
+        self._id = thermostat['id']
+        self._name = thermostat['name']
         self._master = False
-        self._thermostat = None
+        self._thermostat = thermostat
         self._current_temperature = None
         self._target_temperature = None
         self._min_temp = None

--- a/homeassistant/components/climate/spider.py
+++ b/homeassistant/components/climate/spider.py
@@ -9,7 +9,7 @@ import logging
 
 from homeassistant.components.climate import (
     ATTR_TEMPERATURE, STATE_COOL, STATE_HEAT, STATE_IDLE,
-    SUPPORT_TARGET_TEMPERATURE, SUPPORT_OPERATION_MODE, ClimateDevice)
+    SUPPORT_OPERATION_MODE, SUPPORT_TARGET_TEMPERATURE, ClimateDevice)
 from homeassistant.components.spider import DOMAIN as SPIDER_DOMAIN
 from homeassistant.const import TEMP_CELSIUS
 
@@ -61,7 +61,7 @@ class SpiderThermostat(ClimateDevice):
         return supports
 
     @property
-    def id(self):
+    def unique_id(self):
         """Return the id of the thermostat, if any."""
         return self.thermostat.id
 
@@ -101,7 +101,7 @@ class SpiderThermostat(ClimateDevice):
         return self.thermostat.maximum_temperature
 
     @property
-    def current_operation(self: ClimateDevice) -> str:
+    def current_operation(self):
         """Return current operation ie. heat, cool, idle."""
         return SPIDER_STATE_TO_HA[self.thermostat.operation_mode]
 
@@ -131,7 +131,7 @@ class SpiderThermostat(ClimateDevice):
             thermostats = self.api.get_thermostats(
                 force_refresh=self.master)
             for thermostat in thermostats:
-                if thermostat.id == self.id:
+                if thermostat.id == self.unique_id:
                     self.thermostat = thermostat
                     break
 

--- a/homeassistant/components/climate/spider.py
+++ b/homeassistant/components/climate/spider.py
@@ -1,0 +1,143 @@
+"""
+Support for Spider thermostats.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/climate.spider/
+"""
+
+import logging
+
+from homeassistant.components.climate import (
+    ATTR_TEMPERATURE, STATE_COOL, STATE_HEAT, STATE_IDLE,
+    SUPPORT_TARGET_TEMPERATURE, SUPPORT_OPERATION_MODE, ClimateDevice)
+from homeassistant.components.spider import DOMAIN
+from homeassistant.const import TEMP_CELSIUS
+
+DEPENDENCIES = ['spider']
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the Spider thermostat."""
+    thermostats = hass.data[DOMAIN]['thermostats']
+    api = hass.data[DOMAIN]['controller']
+    for thermostat in thermostats:
+        add_devices(
+            [SpiderThermostat(api, thermostat['id'], thermostat['name'])],
+            True
+        )
+
+
+class SpiderThermostat(ClimateDevice):
+    """Representation of a thermostat."""
+
+    def __init__(self, client, thermostat_id, name):
+        """Initialize the thermostat."""
+        self.client = client
+        self._id = thermostat_id
+        self._name = name
+        self._master = False
+        self._thermostat = None
+        self._current_temperature = None
+        self._target_temperature = None
+        self._min_temp = None
+        self._max_temp = None
+        self._operation = STATE_IDLE
+        self._operation_list = [
+            STATE_HEAT,
+            STATE_COOL,
+        ]
+
+    @property
+    def supported_features(self):
+        """Return the list of supported features."""
+        supports = SUPPORT_TARGET_TEMPERATURE
+
+        if self._master is True:
+            supports = supports | SUPPORT_OPERATION_MODE
+
+        return supports
+
+    @property
+    def name(self):
+        """Return the name of the thermostat, if any."""
+        return self._name
+
+    @property
+    def temperature_unit(self):
+        """Return the unit of measurement."""
+        return TEMP_CELSIUS
+
+    @property
+    def current_temperature(self):
+        """Return the current temperature."""
+        return self._current_temperature
+
+    @property
+    def target_temperature(self):
+        """Return the temperature we try to reach."""
+        return self._target_temperature
+
+    @property
+    def min_temp(self):
+        """Return the minimum temperature."""
+        return self._min_temp
+
+    @property
+    def max_temp(self):
+        """Return the maximum temperature."""
+        return self._max_temp
+
+    @property
+    def current_operation(self: ClimateDevice) -> str:
+        """Return current operation ie. heat, cool, idle."""
+        return self._operation
+
+    @property
+    def operation_list(self):
+        """Return the list of available operation modes."""
+        return self._operation_list
+
+    def set_temperature(self, **kwargs):
+        """Set new target temperature."""
+        temperature = kwargs.get(ATTR_TEMPERATURE)
+        if temperature is None:
+            return
+
+        self.client.set_temperature(self._thermostat, temperature)
+
+    def set_operation_mode(self, operation_mode):
+        """Set new target operation mode."""
+        self.client.set_operation_mode(self._thermostat, operation_mode)
+
+    def update(self):
+        """Get the latest data."""
+        try:
+            # Only let the master thermostat refresh
+            # and let the others use the cache
+            thermostats = self.client.get_thermostats(
+                force_refresh=self._master)
+            for thermostat in thermostats:
+                if thermostat['id'] == self._id:
+                    self._thermostat = thermostat
+
+        except StopIteration:
+            _LOGGER.error("No data from the Itho Daalderop API")
+            return
+
+        for prop in self._thermostat['properties']:
+            if prop['id'] == 'AmbientTemperature':
+                self._current_temperature = float(prop['status'])
+            if prop['id'] == 'SetpointTemperature':
+                self._target_temperature = float(prop['status'])
+                self._min_temp = float(prop['min'])
+                self._max_temp = float(prop['max'])
+            if prop['id'] == 'OperationMode':
+                self._master = True
+                if prop['status'] == 'Heat':
+                    self._operation = STATE_HEAT
+                elif prop['status'] == 'Cool':
+                    self._operation = STATE_COOL
+                else:
+                    self._operation = STATE_IDLE

--- a/homeassistant/components/spider.py
+++ b/homeassistant/components/spider.py
@@ -46,7 +46,7 @@ def setup(hass, config):
         }
 
         for component in SPIDER_COMPONENTS:
-            load_platform(hass, component, DOMAIN)
+            load_platform(hass, component, DOMAIN, {})
 
         _LOGGER.debug("Connection with Itho Daalderop API succeeded")
         return True

--- a/homeassistant/components/spider.py
+++ b/homeassistant/components/spider.py
@@ -8,8 +8,8 @@ import logging
 
 import voluptuous as vol
 
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 import homeassistant.helpers.config_validation as cv
-from homeassistant.const import (CONF_USERNAME, CONF_PASSWORD)
 from homeassistant.helpers.discovery import load_platform
 
 REQUIREMENTS = ['spiderpy==1.0.7']

--- a/homeassistant/components/spider.py
+++ b/homeassistant/components/spider.py
@@ -12,7 +12,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.const import (CONF_USERNAME, CONF_PASSWORD)
 from homeassistant.helpers.discovery import load_platform
 
-REQUIREMENTS = ['itho_daalderop_api==1.0.4']
+REQUIREMENTS = ['spiderpy==1.0.7']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -32,13 +32,14 @@ CONFIG_SCHEMA = vol.Schema({
 
 def setup(hass, config):
     """Set up Spider Component."""
-    from itho_daalderop_api import IthoDaalderop_API, UnauthorizedException
+    from spiderpy.spiderapi import SpiderApi
+    from spiderpy.spiderapi import UnauthorizedException
 
     username = config[DOMAIN][CONF_USERNAME]
     password = config[DOMAIN][CONF_PASSWORD]
 
     try:
-        api = IthoDaalderop_API(username, password)
+        api = SpiderApi(username, password)
 
         hass.data[DOMAIN] = {
             'controller': api,
@@ -48,8 +49,8 @@ def setup(hass, config):
         for component in SPIDER_COMPONENTS:
             load_platform(hass, component, DOMAIN, {})
 
-        _LOGGER.debug("Connection with Itho Daalderop API succeeded")
+        _LOGGER.debug("Connection with Spider API succeeded")
         return True
     except UnauthorizedException:
-        _LOGGER.error("Can't connect to the Itho Daalderop API")
+        _LOGGER.error("Can't connect to the Spider API")
         return False

--- a/homeassistant/components/spider.py
+++ b/homeassistant/components/spider.py
@@ -45,7 +45,8 @@ def setup(hass, config):
             'thermostats': api.get_thermostats()
         }
 
-        load_platform(hass, 'climate', DOMAIN)
+        for component in SPIDER_COMPONENTS:
+            load_platform(hass, component, DOMAIN)
 
         _LOGGER.debug("Connection with Itho Daalderop API succeeded")
         return True

--- a/homeassistant/components/spider.py
+++ b/homeassistant/components/spider.py
@@ -1,0 +1,50 @@
+"""
+Support for Spider Smart devices.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/spider/
+"""
+import logging
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.const import (CONF_USERNAME, CONF_PASSWORD)
+
+REQUIREMENTS = ['itho_daalderop_api==1.0.4']
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = 'spider'
+
+SPIDER_COMPONENTS = [
+    'climate'
+]
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_PASSWORD): cv.string,
+        vol.Required(CONF_USERNAME): cv.string,
+    })
+}, extra=vol.ALLOW_EXTRA)
+
+
+def setup(hass, config):
+    """Set up Spider Component."""
+    from itho_daalderop_api import IthoDaalderop_API, UnauthorizedException
+
+    username = config[DOMAIN][CONF_USERNAME]
+    password = config[DOMAIN][CONF_PASSWORD]
+
+    try:
+        api = IthoDaalderop_API(username, password)
+
+        hass.data[DOMAIN] = {
+            'controller': api,
+            'thermostats': api.get_thermostats()
+        }
+        _LOGGER.debug("Connection with Itho Daalderop API succeeded")
+        return True
+    except UnauthorizedException:
+        _LOGGER.error("Can't connect to the Itho Daalderop API")
+        return False

--- a/homeassistant/components/spider.py
+++ b/homeassistant/components/spider.py
@@ -10,6 +10,7 @@ import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.const import (CONF_USERNAME, CONF_PASSWORD)
+from homeassistant.helpers.discovery import load_platform
 
 REQUIREMENTS = ['itho_daalderop_api==1.0.4']
 
@@ -43,6 +44,9 @@ def setup(hass, config):
             'controller': api,
             'thermostats': api.get_thermostats()
         }
+
+        load_platform(hass, 'climate', DOMAIN)
+
         _LOGGER.debug("Connection with Itho Daalderop API succeeded")
         return True
     except UnauthorizedException:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -457,6 +457,9 @@ insteonplm==0.11.7
 # homeassistant.components.sensor.iperf3
 iperf3==0.1.10
 
+# homeassistant.components.spider
+itho_daalderop_api==1.0.4
+
 # homeassistant.components.verisure
 jsonpath==0.75
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -457,9 +457,6 @@ insteonplm==0.11.7
 # homeassistant.components.sensor.iperf3
 iperf3==0.1.10
 
-# homeassistant.components.spider
-spyderpy==1.0.7
-
 # homeassistant.components.verisure
 jsonpath==0.75
 
@@ -1280,6 +1277,9 @@ somecomfort==0.5.2
 
 # homeassistant.components.sensor.speedtest
 speedtest-cli==2.0.2
+
+# homeassistant.components.spider
+spiderpy==1.0.7
 
 # homeassistant.components.sensor.spotcrime
 spotcrime==1.0.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -458,7 +458,7 @@ insteonplm==0.11.7
 iperf3==0.1.10
 
 # homeassistant.components.spider
-itho_daalderop_api==1.0.4
+spyderpy==1.0.7
 
 # homeassistant.components.verisure
 jsonpath==0.75


### PR DESCRIPTION
## Description:

This adds the [Spider](http://www.ithodaalderop.nl/spider-thermostaat) thermostat from Itho Daalderop. For now you can see the actual temperature and set temperature. It also allows you to change the temperature.

Any feedback is welcome to improve anything. (This is my first Python code ever, based on many other parts of code of HA).

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5805

## Example entry for `configuration.yaml` (if applicable):
```yaml
spider:
  username: username
  password: password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
