### PR TITLE
Bump pyarlo==0.2.0, fixes #15486

### DIFF
--- a/homeassistant/components/arlo.py
+++ b/homeassistant/components/arlo.py
@@ -16,7 +16,7 @@ from homeassistant.const import (
 from homeassistant.helpers.event import track_time_interval
 from homeassistant.helpers.dispatcher import dispatcher_send
 
-REQUIREMENTS = ['pyarlo==0.1.9']
+REQUIREMENTS = ['pyarlo==0.2.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -728,7 +728,7 @@ pyairvisual==2.0.1
 pyalarmdotcom==0.3.2
 
 # homeassistant.components.arlo
-pyarlo==0.1.9
+pyarlo==0.2.0
 
 # homeassistant.components.notify.xmpp
 pyasn1-modules==0.1.5


### PR DESCRIPTION
## Description:
Bump `pyarlo` to 0.2.0 which fixes an issue where an error is logged (potentially interfering with base station updates) when a device without ambient sensors is updated. This bug was introduced in `pyarlo==0.1.9` / `homeassistant==0.74.0b0`.

**Related issue (if applicable):** fixes #15486 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
