### PR TITLE
Add ecovacs component

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -104,6 +104,9 @@ omit =
     homeassistant/components/fritzbox.py
     homeassistant/components/switch/fritzbox.py
 
+    homeassistant/components/ecovacs.py
+    homeassistant/components/*/ecovacs.py
+
     homeassistant/components/eufy.py
     homeassistant/components/*/eufy.py
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -87,6 +87,8 @@ homeassistant/components/*/axis.py @kane610
 homeassistant/components/*/bmw_connected_drive.py @ChristianKuehnel
 homeassistant/components/*/broadlink.py @danielhiversen
 homeassistant/components/*/deconz.py @kane610
+homeassistant/components/ecovacs.py @OverloadUT
+homeassistant/components/*/ecovacs.py @OverloadUT
 homeassistant/components/eight_sleep.py @mezz64
 homeassistant/components/*/eight_sleep.py @mezz64
 homeassistant/components/hive.py @Rendili @KJonline

--- a/homeassistant/components/ecovacs.py
+++ b/homeassistant/components/ecovacs.py
@@ -1,0 +1,83 @@
+"""Parent component for Ecovacs Deebot vacuums.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/ecovacs/
+"""
+
+import logging
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers import discovery
+from homeassistant.const import CONF_USERNAME, CONF_PASSWORD, CONF_TIMEOUT, \
+    CONF_DEVICES, EVENT_HOMEASSISTANT_STOP
+
+REQUIREMENTS = ['sucks==0.8.1']
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = "ecovacs"
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_USERNAME): cv.string,
+        vol.Required(CONF_PASSWORD): cv.string,
+        vol.Optional(CONF_DEVICES, default=[]):
+            vol.All(cv.ensure_list, [dict]),
+    })
+}, extra=vol.ALLOW_EXTRA)
+
+ECOVACS_DEVICES = "ecovacs_devices"
+# TODO: const or generated?
+ECOVACS_API_DEVICEID = "6d6ce034ef01ae6c66b21729ffa3b23e"
+
+def setup(hass, config):
+    """Set up the Ecovacs component."""
+    _LOGGER.info("Creating new Ecovacs component")
+
+    if ECOVACS_DEVICES not in hass.data:
+        hass.data[ECOVACS_DEVICES] = []
+
+    from sucks import EcoVacsAPI, VacBot
+
+    # Convenient hack for debugging to pipe sucks logging to the Hass logger
+    import sucks
+    sucks.logging = _LOGGER
+
+    ecovacs_api = EcoVacsAPI(ECOVACS_API_DEVICEID,
+                             config[DOMAIN].get(CONF_USERNAME),
+                             EcoVacsAPI.md5(config[DOMAIN].get(CONF_PASSWORD)),
+                             'us', #TODO: Make configurable
+                             'na') #TODO: Make configurable
+
+    devices = ecovacs_api.devices()
+    _LOGGER.debug("Ecobot devices: %s", devices)
+
+    for device in devices:
+        _LOGGER.info("Discovered Ecovacs device on account: %s",
+                     device['nick'])
+        vacbot = VacBot(ecovacs_api.uid,
+                        ecovacs_api.REALM,
+                        ecovacs_api.resource,
+                        ecovacs_api.user_access_token,
+                        device,
+                        'na') #TODO: Make configurable
+        hass.data[ECOVACS_DEVICES].append(vacbot)
+
+    # pylint: disable=unused-argument
+    def stop(event: object) -> None:
+        for device in hass.data[ECOVACS_DEVICES]:
+            _LOGGER.info("Shutting down connection to Ecovacs device %s",
+                         device.vacuum['nick'])
+            device.disconnect()
+
+    # Listen for HA stop to disconnect.
+    hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, stop)
+
+    if hass.data[ECOVACS_DEVICES]:
+        _LOGGER.debug("Starting vacuum components")
+        # discovery.load_platform(hass, "sensor", DOMAIN, {}, config)
+        discovery.load_platform(hass, "vacuum", DOMAIN, {}, config)
+
+    return True

--- a/homeassistant/components/ecovacs.py
+++ b/homeassistant/components/ecovacs.py
@@ -37,7 +37,7 @@ ECOVACS_DEVICES = "ecovacs_devices"
 
 # Generate a random device ID on each bootup
 ECOVACS_API_DEVICEID = ''.join(
-    random.choices(string.ascii_uppercase + string.digits, k=8)
+    random.choice(string.ascii_uppercase + string.digits) for _ in range(8)
 )
 
 

--- a/homeassistant/components/ecovacs.py
+++ b/homeassistant/components/ecovacs.py
@@ -13,7 +13,7 @@ from homeassistant.helpers import discovery
 from homeassistant.const import CONF_USERNAME, CONF_PASSWORD, CONF_TIMEOUT, \
     CONF_DEVICES, EVENT_HOMEASSISTANT_STOP
 
-REQUIREMENTS = ['sucks==0.8.1']
+REQUIREMENTS = ['sucks==0.8.3']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -42,6 +42,7 @@ def setup(hass, config):
     from sucks import EcoVacsAPI, VacBot
 
     # Convenient hack for debugging to pipe sucks logging to the Hass logger
+    # TODO: Comment out before commit
     import sucks
     sucks.logging = _LOGGER
 

--- a/homeassistant/components/ecovacs.py
+++ b/homeassistant/components/ecovacs.py
@@ -15,7 +15,7 @@ from homeassistant.helpers import discovery
 from homeassistant.const import CONF_USERNAME, CONF_PASSWORD, \
     EVENT_HOMEASSISTANT_STOP
 
-REQUIREMENTS = ['sucks==0.9.1']
+REQUIREMENTS = ['sucks==0.9.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/ecovacs.py
+++ b/homeassistant/components/ecovacs.py
@@ -13,7 +13,7 @@ from homeassistant.helpers import discovery
 from homeassistant.const import CONF_USERNAME, CONF_PASSWORD, CONF_TIMEOUT, \
     CONF_DEVICES, EVENT_HOMEASSISTANT_STOP
 
-REQUIREMENTS = ['sucks==0.8.3']
+REQUIREMENTS = ['sucks==0.8.4']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/ecovacs.py
+++ b/homeassistant/components/ecovacs.py
@@ -5,6 +5,8 @@ https://home-assistant.io/components/ecovacs/
 """
 
 import logging
+import random
+import string
 
 import voluptuous as vol
 
@@ -32,7 +34,11 @@ CONFIG_SCHEMA = vol.Schema({
 }, extra=vol.ALLOW_EXTRA)
 
 ECOVACS_DEVICES = "ecovacs_devices"
-ECOVACS_API_DEVICEID = "homeasst"
+
+# Generate a random device ID on each bootup
+ECOVACS_API_DEVICEID = ''.join(
+    random.choices(string.ascii_uppercase + string.digits, k=8)
+)
 
 
 def setup(hass, config):

--- a/homeassistant/components/ecovacs.py
+++ b/homeassistant/components/ecovacs.py
@@ -15,7 +15,7 @@ from homeassistant.helpers import discovery
 from homeassistant.const import CONF_USERNAME, CONF_PASSWORD, \
     EVENT_HOMEASSISTANT_STOP
 
-REQUIREMENTS = ['sucks==0.9.0']
+REQUIREMENTS = ['sucks==0.9.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/ecovacs.py
+++ b/homeassistant/components/ecovacs.py
@@ -15,7 +15,7 @@ from homeassistant.helpers import discovery
 from homeassistant.const import CONF_USERNAME, CONF_PASSWORD, \
     EVENT_HOMEASSISTANT_STOP
 
-REQUIREMENTS = ['sucks==0.9.2']
+REQUIREMENTS = ['sucks==0.9.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/vacuum/ecovacs.py
+++ b/homeassistant/components/vacuum/ecovacs.py
@@ -97,7 +97,6 @@ class EcovacsVacuum(VacuumDevice):
         This will not change the entity's state. If the error caused the state
         to change, that will come through as a separate on_status event
         """
-
         if error == 'no_error':
             self._error = None
         else:

--- a/homeassistant/components/vacuum/ecovacs.py
+++ b/homeassistant/components/vacuum/ecovacs.py
@@ -116,10 +116,7 @@ class EcovacsVacuum(VacuumDevice):
     @property
     def unique_id(self) -> str:
         """Return an unique ID."""
-        if hasattr(self.device.vacuum, 'did'):
-            # `did` is the Ecovacs-reported Device ID
-            return self.device.vacuum['did']
-        return None
+        return self.device.vacuum.get('did', None)
 
     @property
     def is_on(self):

--- a/homeassistant/components/vacuum/ecovacs.py
+++ b/homeassistant/components/vacuum/ecovacs.py
@@ -190,6 +190,10 @@ class EcovacsVacuum(VacuumDevice):
 
         for key, val in self.device.components.items():
             attr_name = ATTR_COMPONENT_PREFIX + key
-            data[attr_name] = int(val * 100)
+            data[attr_name] = int(val * 100 / 0.2777778)
+            # The above calculation includes a fix for a bug in sucks 0.9.1
+            # When sucks 0.9.2+ is released, it should be changed to the
+            # following:
+            # data[attr_name] = int(val * 100)
 
         return data

--- a/homeassistant/components/vacuum/ecovacs.py
+++ b/homeassistant/components/vacuum/ecovacs.py
@@ -182,10 +182,9 @@ class EcovacsVacuum(VacuumDevice):
         self.device.run(VacBotCommand(command, params))
 
     @property
-    def state_attributes(self):
-        """Return the state attributes of the vacuum cleaner."""
-        data = super().state_attributes
-
+    def device_state_attributes(self):
+        """Return the device-specific state attributes of this vacuum."""
+        data = {}
         data[ATTR_ERROR] = self._error
 
         for key, val in self.device.components.items():

--- a/homeassistant/components/vacuum/ecovacs.py
+++ b/homeassistant/components/vacuum/ecovacs.py
@@ -4,6 +4,7 @@ Support for Ecovacs Ecovacs Vaccums.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/vacuum.neato/
 """
+import asyncio
 import logging
 
 from homeassistant.components.vacuum import (
@@ -56,18 +57,17 @@ class EcovacsVacuum(VacuumDevice):
         self._fan_speed = None
         self._battery_level = None
         self._state = None
-        self._first_update_done = False
         _LOGGER.debug("Vacuum initialized: %s", self.name)
 
-    def update(self):
-        if not self._first_update_done:
-            from sucks import VacBotCommand
-            # Fire off some queries to get initial state
-            self.device.run(VacBotCommand('GetCleanState', {}))
-            self.device.run(VacBotCommand('GetChargeState', {}))
-            self.device.run(VacBotCommand('GetBatteryInfo', {}))
-            self._first_update_done = True
+    @asyncio.coroutine
+    def async_added_to_hass(self) -> None:
+        # Fire off some queries to get initial state
+        from sucks import VacBotCommand
+        self.device.run(VacBotCommand('GetCleanState', {}))
+        self.device.run(VacBotCommand('GetChargeState', {}))
+        self.device.run(VacBotCommand('GetBatteryInfo', {}))
 
+    def update(self):
         self._clean_status = self.device.clean_status
         self._charge_status = self.device.charge_status
         self._fan_speed = 'unknown' # TODO: implement in sucks

--- a/homeassistant/components/vacuum/ecovacs.py
+++ b/homeassistant/components/vacuum/ecovacs.py
@@ -1,0 +1,185 @@
+"""
+Support for Ecovacs Deebot Vaccums.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/vacuum.neato/
+"""
+import logging
+
+from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.components.vacuum import (
+    VacuumDevice, SUPPORT_BATTERY, SUPPORT_PAUSE, SUPPORT_RETURN_HOME,
+    SUPPORT_STATUS, SUPPORT_STOP, SUPPORT_TURN_OFF, SUPPORT_TURN_ON)
+from homeassistant.components.ecovacs import (
+    ECOVACS_DEVICES)
+from homeassistant.helpers.icon import icon_for_battery_level
+
+_LOGGER = logging.getLogger(__name__)
+
+DEPENDENCIES = ['ecovacs']
+
+SUPPORT_DEEBOT = SUPPORT_BATTERY | SUPPORT_PAUSE | SUPPORT_RETURN_HOME | \
+                 SUPPORT_STOP | SUPPORT_TURN_OFF | SUPPORT_TURN_ON | \
+                 SUPPORT_STATUS
+
+ICON = "mdi:roomba"
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the Deebot vacuums."""
+    vacuums = []
+    for device in hass.data[ECOVACS_DEVICES]:
+        vacuums.append(DeebotVacuum(device))
+    _LOGGER.debug("Adding Deebot Vacuums to Hass: %s", vacuums)
+    add_devices(vacuums, True)
+
+
+class DeebotVacuum(VacuumDevice):
+    """Neato Connected Vacuums."""
+
+    def __init__(self, device):
+        """Initialize the Neato Connected Vacuums."""
+        self.device = device
+        self.device.connect_and_wait_until_ready()
+        try:
+            self._name = '{}'.format(self.device.vacuum['nick'])
+        except KeyError:
+            # In case there is no nickname defined, use the device id
+            self._name = '{}'.format(self.device.vacuum['did'])
+
+        self._clean_status = None
+        self._charge_status = None
+        self._battery_level = None
+        self._state = None
+        self._first_update_done = False
+        _LOGGER.debug("Vacuum initialized: %s", self.name)
+
+    def update(self):
+        if not self._first_update_done:
+            from sucks import VacBotCommand
+            # Fire off some queries to get initial state
+            self.device.run(VacBotCommand('GetCleanState', {}))
+            self.device.run(VacBotCommand('GetChargeState', {}))
+            self.device.run(VacBotCommand('GetBatteryInfo', {}))
+            self._first_update_done = True
+
+        self._clean_status = self.device.clean_status
+        self._charge_status = self.device.charge_status
+
+        try:
+            if self.device.battery_status is not None:
+                self._battery_level = self.device.battery_status * 100
+        except AttributeError:
+            # No battery_status property
+            pass
+
+    @property
+    def is_on(self):
+        """Return true if vacuum is currently cleaning."""
+        if self._clean_status is None:
+            return False
+        else:
+            return self._clean_status != 'stop'
+
+    @property
+    def is_charging(self):
+        """Return true if vacuum is currently cleaning."""
+        if self._charge_status is None:
+            return False
+        else:
+            return self._charge_status != 'charging'
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return self._name
+
+    @property
+    def icon(self):
+        """Return the icon to use for device."""
+        return ICON
+
+    @property
+    def supported_features(self):
+        """Flag vacuum cleaner robot features that are supported."""
+        return SUPPORT_DEEBOT
+
+    def return_to_base(self, **kwargs):
+        """Set the vacuum cleaner to return to the dock."""
+        from sucks import Charge
+        self.device.run(Charge())
+
+    @property
+    def battery_icon(self):
+        """Return the battery icon for the vacuum cleaner."""
+        return icon_for_battery_level(
+            battery_level=self.battery_level, charging=self.is_charging)
+
+    @property
+    def battery_level(self):
+        """Return the battery level of the vacuum cleaner."""
+        return self._battery_level
+
+    @property
+    def fan_speed(self):
+        """Return the fan speed of the vacuum cleaner."""
+        # TODO: Implement
+        return None
+
+    @property
+    def fan_speed_list(self):
+        """Get the list of available fan speed steps of the vacuum cleaner."""
+        # TODO: Implement
+        raise NotImplementedError()
+
+    def turn_on(self, **kwargs):
+        """Turn the vacuum on and start cleaning."""
+        # TODO: Implement
+        raise NotImplementedError()
+
+    def turn_off(self, **kwargs):
+        """Turn the vacuum off stopping the cleaning and returning home."""
+        # TODO: Implement
+        raise NotImplementedError()
+
+    def stop(self, **kwargs):
+        """Stop the vacuum cleaner."""
+        # TODO: Implement
+        raise NotImplementedError()
+
+
+    def clean_spot(self, **kwargs):
+        """Perform a spot clean-up."""
+        # TODO: Implement
+        raise NotImplementedError()
+
+    def locate(self, **kwargs):
+        """Locate the vacuum cleaner."""
+        # TODO: Implement
+        raise NotImplementedError()
+
+    def set_fan_speed(self, fan_speed, **kwargs):
+        """Set fan speed."""
+        # TODO: Implement
+        raise NotImplementedError()
+
+    def start_pause(self, **kwargs):
+        """Start, pause or resume the cleaning task."""
+        # TODO: Implement
+        raise NotImplementedError()
+
+    def send_command(self, command, params=None, **kwargs):
+        """Send a command to a vacuum cleaner."""
+        # TODO: Implement
+        raise NotImplementedError()
+
+    @property
+    def state_attributes(self):
+        """Return the state attributes of the vacuum cleaner."""
+        # TODO: Implement
+        data = super().state_attributes
+
+        # TODO: attribute names should be consts
+        data['clean_status'] = self._clean_status
+        data['charge_status'] = self._charge_status
+
+        return data

--- a/homeassistant/components/vacuum/ecovacs.py
+++ b/homeassistant/components/vacuum/ecovacs.py
@@ -6,10 +6,10 @@ https://home-assistant.io/components/vacuum.neato/
 """
 import logging
 
-from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.components.vacuum import (
-    VacuumDevice, SUPPORT_BATTERY, SUPPORT_PAUSE, SUPPORT_RETURN_HOME,
-    SUPPORT_STATUS, SUPPORT_STOP, SUPPORT_TURN_OFF, SUPPORT_TURN_ON)
+    VacuumDevice, SUPPORT_BATTERY, SUPPORT_RETURN_HOME, SUPPORT_CLEAN_SPOT,
+    SUPPORT_STATUS, SUPPORT_STOP, SUPPORT_TURN_OFF, SUPPORT_TURN_ON,
+    SUPPORT_LOCATE, SUPPORT_FAN_SPEED, SUPPORT_SEND_COMMAND, )
 from homeassistant.components.ecovacs import (
     ECOVACS_DEVICES)
 from homeassistant.helpers.icon import icon_for_battery_level
@@ -18,11 +18,14 @@ _LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = ['ecovacs']
 
-SUPPORT_ECOVACS = SUPPORT_BATTERY | SUPPORT_PAUSE | SUPPORT_RETURN_HOME | \
-                 SUPPORT_STOP | SUPPORT_TURN_OFF | SUPPORT_TURN_ON | \
-                 SUPPORT_STATUS
+# Note: SUPPORT_FAN_SPEED gets dynamically added to this list based on vacuum
+# state in the supported_features Property getter
+SUPPORT_ECOVACS = (
+    SUPPORT_BATTERY | SUPPORT_RETURN_HOME | SUPPORT_CLEAN_SPOT |
+    SUPPORT_STOP | SUPPORT_TURN_OFF | SUPPORT_TURN_ON |
+    SUPPORT_STATUS | SUPPORT_LOCATE | SUPPORT_SEND_COMMAND)
 
-ECOVACS_FAN_SPEED_LIST = ['standard', 'strong']
+ECOVACS_FAN_SPEED_LIST = ['normal', 'high']
 
 ICON = "mdi:roomba"
 
@@ -50,6 +53,7 @@ class EcovacsVacuum(VacuumDevice):
 
         self._clean_status = None
         self._charge_status = None
+        self._fan_speed = None
         self._battery_level = None
         self._state = None
         self._first_update_done = False
@@ -66,13 +70,11 @@ class EcovacsVacuum(VacuumDevice):
 
         self._clean_status = self.device.clean_status
         self._charge_status = self.device.charge_status
+        self._fan_speed = 'unknown' # TODO: implement in sucks
 
-        try:
-            if self.device.battery_status is not None:
-                self._battery_level = self.device.battery_status * 100
-        except AttributeError:
-            # No battery_status property
-            pass
+        if (hasattr(self.device, 'battery_status')
+            and self.device.battery_status is not None):
+            self._battery_level = self.device.battery_status * 100
 
     @property
     def is_on(self):
@@ -80,7 +82,9 @@ class EcovacsVacuum(VacuumDevice):
         if self._clean_status is None:
             return False
         else:
-            return self._clean_status != 'stop'
+            return (
+                self._clean_status != 'stop'
+                and self._charge_status != 'charging')
 
     @property
     def is_charging(self):
@@ -103,7 +107,12 @@ class EcovacsVacuum(VacuumDevice):
     @property
     def supported_features(self):
         """Flag vacuum cleaner robot features that are supported."""
-        return SUPPORT_ECOVACS
+        support = SUPPORT_ECOVACS
+        if self.is_on:
+            # Fan speed can only be adjusted while cleaning
+            support = support | SUPPORT_FAN_SPEED
+
+        return support
 
     def return_to_base(self, **kwargs):
         """Set the vacuum cleaner to return to the dock."""
@@ -124,8 +133,7 @@ class EcovacsVacuum(VacuumDevice):
     @property
     def fan_speed(self):
         """Return the fan speed of the vacuum cleaner."""
-        # TODO: Implement
-        return None
+        return self._fan_speed
 
     @property
     def fan_speed_list(self):
@@ -135,7 +143,7 @@ class EcovacsVacuum(VacuumDevice):
     def turn_on(self, **kwargs):
         """Turn the vacuum on and start cleaning."""
         from sucks import Clean
-        self.device.run(Clean(False))
+        self.device.run(Clean())
 
     def turn_off(self, **kwargs):
         """Turn the vacuum off stopping the cleaning and returning home."""
@@ -143,41 +151,41 @@ class EcovacsVacuum(VacuumDevice):
 
     def stop(self, **kwargs):
         """Stop the vacuum cleaner."""
-        from sucks import VacBotCommand
-        self.device.run(VacBotCommand('Move', {'action': 'stop'}))
+        from sucks import Stop
+        self.device.run(Stop())
 
     def clean_spot(self, **kwargs):
         """Perform a spot clean-up."""
-        # TODO: Implement
-        raise NotImplementedError()
+        from sucks import Spot
+        self.device.run(Spot())
 
     def locate(self, **kwargs):
         """Locate the vacuum cleaner."""
-        # TODO: Implement
         raise NotImplementedError()
+
+        # TODO: Needs support in sucks library
+        from sucks import Locate
+        self.device.run(Locate())
 
     def set_fan_speed(self, fan_speed, **kwargs):
         """Set fan speed."""
-        # TODO: Implement
-        raise NotImplementedError()
-
-    def start_pause(self, **kwargs):
-        """Start, pause or resume the cleaning task."""
-        # TODO: Implement
-        raise NotImplementedError()
+        if self.is_on:
+            from sucks import Clean
+            self.device.run(Clean(
+                mode=self._clean_status, speed=fan_speed))
 
     def send_command(self, command, params=None, **kwargs):
         """Send a command to a vacuum cleaner."""
-        # TODO: Implement
-        raise NotImplementedError()
+        from sucks import VacBotCommand
+        self.device.run(VacBotCommand(command, params))
 
     @property
     def state_attributes(self):
         """Return the state attributes of the vacuum cleaner."""
-        # TODO: Implement
         data = super().state_attributes
 
         # TODO: attribute names should be consts
+        # TODO: Maybe don't need these attributes at all?
         data['clean_status'] = self._clean_status
         data['charge_status'] = self._charge_status
 

--- a/homeassistant/components/vacuum/ecovacs.py
+++ b/homeassistant/components/vacuum/ecovacs.py
@@ -1,5 +1,5 @@
 """
-Support for Ecovacs Deebot Vaccums.
+Support for Ecovacs Ecovacs Vaccums.
 
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/vacuum.neato/
@@ -18,26 +18,28 @@ _LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = ['ecovacs']
 
-SUPPORT_DEEBOT = SUPPORT_BATTERY | SUPPORT_PAUSE | SUPPORT_RETURN_HOME | \
+SUPPORT_ECOVACS = SUPPORT_BATTERY | SUPPORT_PAUSE | SUPPORT_RETURN_HOME | \
                  SUPPORT_STOP | SUPPORT_TURN_OFF | SUPPORT_TURN_ON | \
                  SUPPORT_STATUS
+
+ECOVACS_FAN_SPEED_LIST = ['standard', 'strong']
 
 ICON = "mdi:roomba"
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Set up the Deebot vacuums."""
+    """Set up the Ecovacs vacuums."""
     vacuums = []
     for device in hass.data[ECOVACS_DEVICES]:
-        vacuums.append(DeebotVacuum(device))
-    _LOGGER.debug("Adding Deebot Vacuums to Hass: %s", vacuums)
+        vacuums.append(EcovacsVacuum(device))
+    _LOGGER.debug("Adding Ecovacs Vacuums to Hass: %s", vacuums)
     add_devices(vacuums, True)
 
 
-class DeebotVacuum(VacuumDevice):
-    """Neato Connected Vacuums."""
+class EcovacsVacuum(VacuumDevice):
+    """Ecovacs Vacuums such as Deebot."""
 
     def __init__(self, device):
-        """Initialize the Neato Connected Vacuums."""
+        """Initialize the Ecovacs Vacuum."""
         self.device = device
         self.device.connect_and_wait_until_ready()
         try:
@@ -82,11 +84,11 @@ class DeebotVacuum(VacuumDevice):
 
     @property
     def is_charging(self):
-        """Return true if vacuum is currently cleaning."""
+        """Return true if vacuum is currently charging."""
         if self._charge_status is None:
             return False
         else:
-            return self._charge_status != 'charging'
+            return self._charge_status == 'charging'
 
     @property
     def name(self):
@@ -101,7 +103,7 @@ class DeebotVacuum(VacuumDevice):
     @property
     def supported_features(self):
         """Flag vacuum cleaner robot features that are supported."""
-        return SUPPORT_DEEBOT
+        return SUPPORT_ECOVACS
 
     def return_to_base(self, **kwargs):
         """Set the vacuum cleaner to return to the dock."""
@@ -128,24 +130,21 @@ class DeebotVacuum(VacuumDevice):
     @property
     def fan_speed_list(self):
         """Get the list of available fan speed steps of the vacuum cleaner."""
-        # TODO: Implement
-        raise NotImplementedError()
+        return ECOVACS_FAN_SPEED_LIST
 
     def turn_on(self, **kwargs):
         """Turn the vacuum on and start cleaning."""
-        # TODO: Implement
-        raise NotImplementedError()
+        from sucks import Clean
+        self.device.run(Clean(False))
 
     def turn_off(self, **kwargs):
         """Turn the vacuum off stopping the cleaning and returning home."""
-        # TODO: Implement
-        raise NotImplementedError()
+        self.return_to_base()
 
     def stop(self, **kwargs):
         """Stop the vacuum cleaner."""
-        # TODO: Implement
-        raise NotImplementedError()
-
+        from sucks import VacBotCommand
+        self.device.run(VacBotCommand('Move', {'action': 'stop'}))
 
     def clean_spot(self, **kwargs):
         """Perform a spot clean-up."""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1296,7 +1296,7 @@ statsd==3.2.1
 steamodd==4.21
 
 # homeassistant.components.ecovacs
-sucks==0.9.2
+sucks==0.9.1
 
 # homeassistant.components.camera.onvif
 suds-passworddigest-homeassistant==0.1.2a0.dev0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1296,7 +1296,7 @@ statsd==3.2.1
 steamodd==4.21
 
 # homeassistant.components.ecovacs
-sucks==0.9.1
+sucks==0.9.2
 
 # homeassistant.components.camera.onvif
 suds-passworddigest-homeassistant==0.1.2a0.dev0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1295,6 +1295,9 @@ statsd==3.2.1
 # homeassistant.components.sensor.steam_online
 steamodd==4.21
 
+# homeassistant.components.ecovacs
+sucks==0.9.0
+
 # homeassistant.components.camera.onvif
 suds-passworddigest-homeassistant==0.1.2a0.dev0
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1296,7 +1296,7 @@ statsd==3.2.1
 steamodd==4.21
 
 # homeassistant.components.ecovacs
-sucks==0.9.0
+sucks==0.9.1
 
 # homeassistant.components.camera.onvif
 suds-passworddigest-homeassistant==0.1.2a0.dev0


### PR DESCRIPTION
## Description:
Adds support for Ecovacs vacuums (DEEBOT vacuums) via an `ecovacs` component that creates `vacuum` entities for each vacuum in the user's account.

Supports pretty much the full vacuum feature-set, and the vacuums respond _instantly_ to Hass service calls due to the always-open XMPP connection, which is pretty cool! It also supports showing the lifespan of the various replaceable components as attributes on the vacuum state.

Support for the reverse-engineered API is very early, and as such it's likely that not all vacuums and not all regions will work correctly on this first release. The Hass documentation will link to the `sucks` project for users to find more information about what vacuums and regions have been tested.

This PR has been tested with two DEEBOT M80 Pros on the same account.

**Related issue (if applicable):** n/a

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.io#5922

## Example entry for `configuration.yaml` (if applicable):
```yaml
ecovacs:
  username: !secret ecovacs_username
  password: !secret ecovacs_password
  country: us
  continent: na
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54