### PR TITLE
Add Tuya fan support

### DIFF
--- a/homeassistant/components/fan/tuya.py
+++ b/homeassistant/components/fan/tuya.py
@@ -1,0 +1,100 @@
+"""
+Support for Tuya fans.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/fan.tuya/
+"""
+
+import asyncio
+
+from homeassistant.components.fan import (
+    ENTITY_ID_FORMAT, FanEntity, SUPPORT_DIRECTION, SUPPORT_OSCILLATE,
+    SUPPORT_SET_SPEED)
+from homeassistant.components.tuya import DOMAIN, DATA_TUYA, TuyaDevice
+from homeassistant.const import STATE_OFF
+
+DEPENDENCIES = ['tuya']
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up Tuya fan platform."""
+    if discovery_info is None:
+        return
+    tuya = hass.data[DATA_TUYA]
+    dev_ids = discovery_info.get('dev_ids')
+    devices = []
+    for dev_id in dev_ids:
+        device = tuya.get_device_by_id(dev_id)
+        if device is None:
+            continue
+        devices.append(TuyaFanDevice(device))
+    add_devices(devices)
+
+
+class TuyaFanDevice(TuyaDevice, FanEntity):
+    """Tuya fan devices."""
+
+    def __init__(self, tuya):
+        """Init Tuya fan device."""
+        super().__init__(tuya)
+        self.entity_id = ENTITY_ID_FORMAT.format(tuya.object_id())
+
+    def set_speed(self, speed: str) -> None:
+        """Set the speed of the fan."""
+        if speed == STATE_OFF:
+            self.turn_off()
+        else:
+            self.tuya.set_speed(speed)
+
+    def turn_on(self, speed: str = None, **kwargs) -> None:
+        """Turn on the fan."""
+        if speed is not None:
+            self.set_speed(speed)
+        else:
+            self.tuya.turn_on()
+
+    def turn_off(self, **kwargs) -> None:
+        """Turn the entity off."""
+        self.tuya.turn_off()
+
+    def oscillate(self, oscillating) -> None:
+        """Oscillate the fan."""
+        self.tuya.oscillate(oscillating)
+
+    @property
+    def oscillating(self):
+        """Return current oscillating status."""
+        if self.supported_features & SUPPORT_OSCILLATE == 0:
+            return None
+        if self.speed == STATE_OFF:
+            return False
+        return self.tuya.oscillating()
+
+    @property
+    def is_on(self):
+        """Return true if the entity is on."""
+        return self.tuya.state()
+
+    @property
+    def speed(self) -> str:
+        """Return the current speed."""
+        if self.is_on:
+            return self.tuya.speed()
+        return STATE_OFF
+
+    @property
+    def speed_list(self) -> list:
+        """Get the list of available speeds."""
+        speed_list = [STATE_OFF]
+        speed_list.extend(self.tuya.speed_list())
+        return speed_list
+
+    @property
+    def supported_features(self) -> int:
+        """Flag supported features."""
+        supports = SUPPORT_SET_SPEED
+        if self.is_on and self.tuya.support_oscillate():
+            supports = supports | SUPPORT_OSCILLATE
+        if self.is_on:
+            supports = supports | SUPPORT_DIRECTION
+        return supports

--- a/homeassistant/components/fan/tuya.py
+++ b/homeassistant/components/fan/tuya.py
@@ -5,12 +5,10 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/fan.tuya/
 """
 
-import asyncio
-
 from homeassistant.components.fan import (
     ENTITY_ID_FORMAT, FanEntity, SUPPORT_DIRECTION, SUPPORT_OSCILLATE,
     SUPPORT_SET_SPEED)
-from homeassistant.components.tuya import DOMAIN, DATA_TUYA, TuyaDevice
+from homeassistant.components.tuya import DATA_TUYA, TuyaDevice
 from homeassistant.const import STATE_OFF
 
 DEPENDENCIES = ['tuya']

--- a/homeassistant/components/tuya.py
+++ b/homeassistant/components/tuya.py
@@ -34,6 +34,7 @@ SERVICE_PULL_DEVICES = 'pull_devices'
 
 TUYA_TYPE_TO_HA = {
     'climate': 'climate',
+    'fan': 'fan',
     'light': 'light',
     'switch': 'switch',
 }


### PR DESCRIPTION
## Description:
Add support for Tuya fan. After configuring username and password and country code in Tuya component, home assistant can discover supported devices which related to user's Tuya account and control them through Tuya cloud service.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5815

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
