### PR TITLE
Added WS endpoint for changing homeassistant password.

### DIFF
--- a/homeassistant/auth/providers/homeassistant.py
+++ b/homeassistant/auth/providers/homeassistant.py
@@ -199,6 +199,14 @@ class HassAuthProvider(AuthProvider):
             # Can happen if somehow we didn't clean up a credential
             pass
 
+    async def async_change_password(self, username, new_password):
+        """Helper to change a user's password."""
+        if self.data is None:
+            await self.async_initialize()
+
+        await self.hass.async_add_executor_job(
+            self.data.change_password, username, new_password)
+
 
 class LoginFlow(data_entry_flow.FlowHandler):
     """Handler for the login flow."""

--- a/homeassistant/auth/providers/homeassistant.py
+++ b/homeassistant/auth/providers/homeassistant.py
@@ -199,14 +199,6 @@ class HassAuthProvider(AuthProvider):
             # Can happen if somehow we didn't clean up a credential
             pass
 
-    async def async_change_password(self, username, new_password):
-        """Helper to change a user's password."""
-        if self.data is None:
-            await self.async_initialize()
-
-        await self.hass.async_add_executor_job(
-            self.data.change_password, username, new_password)
-
 
 class LoginFlow(data_entry_flow.FlowHandler):
     """Handler for the login flow."""

--- a/homeassistant/components/config/auth_provider_homeassistant.py
+++ b/homeassistant/components/config/auth_provider_homeassistant.py
@@ -168,7 +168,7 @@ def websocket_change_password(hass, connection, msg):
             provider.data.change_password, username, msg['new_password'])
         await provider.data.async_save()
 
-        connection.to_write.put_nowait(
+        connection.send_message_outside(
             websocket_api.result_message(msg['id']))
 
     hass.async_add_job(change_password())

--- a/homeassistant/components/config/auth_provider_homeassistant.py
+++ b/homeassistant/components/config/auth_provider_homeassistant.py
@@ -20,6 +20,13 @@ SCHEMA_WS_DELETE = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend({
     vol.Required('username'): str,
 })
 
+WS_TYPE_CHANGE_PASSWORD = 'config/auth_provider/homeassistant/change_password'
+SCHEMA_WS_CHANGE_PASSWORD = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend({
+    vol.Required('type'): WS_TYPE_CHANGE_PASSWORD,
+    vol.Required('current_password'): str,
+    vol.Required('new_password'): str
+})
+
 
 async def async_setup(hass):
     """Enable the Home Assistant views."""
@@ -30,6 +37,10 @@ async def async_setup(hass):
     hass.components.websocket_api.async_register_command(
         WS_TYPE_DELETE, websocket_delete,
         SCHEMA_WS_DELETE
+    )
+    hass.components.websocket_api.async_register_command(
+        WS_TYPE_CHANGE_PASSWORD, websocket_change_password,
+        SCHEMA_WS_CHANGE_PASSWORD
     )
     return True
 
@@ -118,3 +129,44 @@ def websocket_delete(hass, connection, msg):
             websocket_api.result_message(msg['id']))
 
     hass.async_add_job(delete_creds())
+
+
+@callback
+def websocket_change_password(hass, connection, msg):
+    """Change user password."""
+    async def change_password():
+        """Change user password."""
+        provider = _get_provider(hass)
+        await provider.async_initialize()
+
+        user = connection.request.get('hass_user')
+        if user is None:
+            connection.send_message_outside(websocket_api.error_message(
+                msg['id'], 'user_not_found', 'User not found'))
+            return
+
+        username = None
+        for credential in user.credentials:
+            if credential.auth_provider_type == provider.type:
+                username = credential.data['username']
+
+        if username is None:
+            connection.send_message_outside(websocket_api.error_message(
+                msg['id'], 'credentials_not_found', 'Credentials not found'))
+            return
+
+        try:
+            await provider.async_validate_login(
+                username, msg['current_password'])
+        except auth_ha.InvalidAuth:
+            connection.send_message_outside(websocket_api.error_message(
+                msg['id'], 'invalid_password', 'Invalid password'))
+            return
+
+        await provider.async_change_password(username, msg['new_password'])
+        await provider.data.async_save()
+
+        connection.to_write.put_nowait(
+            websocket_api.result_message(msg['id']))
+
+    hass.async_add_job(change_password())


### PR DESCRIPTION
## Description:
Adds websocket endpoint to allow changing a user's password using the homeassistant auth_provider.

Related frontend PR: https://github.com/home-assistant/home-assistant-polymer/pull/1464

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
