### PR TITLE
Remove some unused imports

### DIFF
--- a/homeassistant/__main__.py
+++ b/homeassistant/__main__.py
@@ -8,7 +8,7 @@ import subprocess
 import sys
 import threading
 
-from typing import Optional, List, Dict, Any  # noqa #pylint: disable=unused-import
+from typing import List, Dict, Any  # noqa pylint: disable=unused-import
 
 
 from homeassistant import monkey_patch

--- a/homeassistant/helpers/__init__.py
+++ b/homeassistant/helpers/__init__.py
@@ -5,11 +5,6 @@ from typing import Any, Iterable, Tuple, Sequence, Dict
 
 from homeassistant.const import CONF_PLATFORM
 
-# Typing Imports and TypeAlias
-# pylint: disable=using-constant-test,unused-import
-if False:
-    from logging import Logger  # NOQA
-
 # pylint: disable=invalid-name
 ConfigType = Dict[str, Any]
 

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -17,7 +17,7 @@ import sys
 from types import ModuleType
 
 # pylint: disable=unused-import
-from typing import Dict, List, Optional, Sequence, Set, TYPE_CHECKING  # NOQA
+from typing import Optional, Set, TYPE_CHECKING  # NOQA
 
 from homeassistant.const import PLATFORM_FORMAT
 from homeassistant.util import OrderedSet


### PR DESCRIPTION
## Description:

Remove some unused imports.

**Related issue (if applicable):** Some discussion in #15487

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
