### PR TITLE
Decouple emulated hue from http server

### DIFF
--- a/homeassistant/components/emulated_hue/__init__.py
+++ b/homeassistant/components/emulated_hue/__init__.py
@@ -6,6 +6,7 @@ https://home-assistant.io/components/emulated_hue/
 """
 import logging
 
+from aiohttp import web
 import voluptuous as vol
 
 from homeassistant import util
@@ -13,7 +14,6 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP,
 )
 from homeassistant.components.http import REQUIREMENTS  # NOQA
-from homeassistant.components.http import HomeAssistantHTTP
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.deprecation import get_deprecated
 import homeassistant.helpers.config_validation as cv
@@ -85,28 +85,17 @@ def setup(hass, yaml_config):
     """Activate the emulated_hue component."""
     config = Config(hass, yaml_config.get(DOMAIN, {}))
 
-    server = HomeAssistantHTTP(
-        hass,
-        server_host=config.host_ip_addr,
-        server_port=config.listen_port,
-        api_password=None,
-        ssl_certificate=None,
-        ssl_peer_certificate=None,
-        ssl_key=None,
-        cors_origins=None,
-        use_x_forwarded_for=False,
-        trusted_proxies=[],
-        trusted_networks=[],
-        login_threshold=0,
-        is_ban_enabled=False
-    )
+    app = web.Application()
+    app['hass'] = hass
+    handler = None
+    server = None
 
-    server.register_view(DescriptionXmlView(config))
-    server.register_view(HueUsernameView)
-    server.register_view(HueAllLightsStateView(config))
-    server.register_view(HueOneLightStateView(config))
-    server.register_view(HueOneLightChangeView(config))
-    server.register_view(HueGroupView(config))
+    DescriptionXmlView(config).register(app.router)
+    HueUsernameView().register(app.router)
+    HueAllLightsStateView(config).register(app.router)
+    HueOneLightStateView(config).register(app.router)
+    HueOneLightChangeView(config).register(app.router)
+    HueGroupView(config).register(app.router)
 
     upnp_listener = UPNPResponderThread(
         config.host_ip_addr, config.listen_port,
@@ -116,14 +105,31 @@ def setup(hass, yaml_config):
     async def stop_emulated_hue_bridge(event):
         """Stop the emulated hue bridge."""
         upnp_listener.stop()
-        await server.stop()
+        if server:
+            server.close()
+            await server.wait_closed()
+        await app.shutdown()
+        if handler:
+            await handler.shutdown(10)
+        await app.cleanup()
 
     async def start_emulated_hue_bridge(event):
         """Start the emulated hue bridge."""
         upnp_listener.start()
-        await server.start()
-        hass.bus.async_listen_once(
-            EVENT_HOMEASSISTANT_STOP, stop_emulated_hue_bridge)
+        nonlocal handler
+        nonlocal server
+
+        handler = app.make_handler(loop=hass.loop)
+
+        try:
+            server = await hass.loop.create_server(
+                handler, config.host_ip_addr, config.listen_port)
+        except OSError as error:
+            _LOGGER.error("Failed to create HTTP server at port %d: %s",
+                          config.listen_port, error)
+        else:
+            hass.bus.async_listen_once(
+                EVENT_HOMEASSISTANT_STOP, stop_emulated_hue_bridge)
 
     hass.bus.listen_once(EVENT_HOMEASSISTANT_START, start_emulated_hue_bridge)
 


### PR DESCRIPTION
## Description:
Emulated Hue now starts its own HTTP server instead of using the one from the HTTP component. This crazy coupling keeps creeping in errors. 

## Example entry for `configuration.yaml` (if applicable):
```yaml
emulated_hue:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
