### PR TITLE
light.tplink: initialize supported features in setup_platform

### DIFF
--- a/homeassistant/components/light/tplink.py
+++ b/homeassistant/components/light/tplink.py
@@ -40,7 +40,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     from pyHS100 import SmartBulb
     host = config.get(CONF_HOST)
     name = config.get(CONF_NAME)
-    add_devices([TPLinkSmartBulb(SmartBulb(host), name)], True)
+    bulb = TPLinkSmartBulb(SmartBulb(host), name)
+    bulb.get_features()
+    add_devices([bulb], True)
 
 
 def brightness_to_percentage(byt):
@@ -139,9 +141,6 @@ class TPLinkSmartBulb(Light):
         from pyHS100 import SmartDeviceException
         try:
             self._available = True
-
-            if self._supported_features == 0:
-                self.get_features()
 
             self._state = (
                 self.smartbulb.state == self.smartbulb.BULB_STATE_ON)


### PR DESCRIPTION
## Description:
Fetch supported features already in setup_platform, avoids calling `{min,max}_minreds` (thanks to https://github.com/home-assistant/home-assistant/pull/15484 ) causing a zerodivisionerror on bulbs not supporting temperature changing. 

**Related issue (if applicable):** fixes #15339

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
