### PR TITLE
Upgrade to simplisafe-python v2 to use new SimpliSafe API

### DIFF
--- a/homeassistant/components/alarm_control_panel/simplisafe.py
+++ b/homeassistant/components/alarm_control_panel/simplisafe.py
@@ -45,8 +45,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     try:
         simplisafe = SimpliSafeApiInterface(username, password)
     except SimpliSafeAPIException:
-        _LOGGER.error("Failed to setup SimpliSafe.")
-        return False
+        _LOGGER.error("Failed to setup SimpliSafe")
+        return
 
     for system in simplisafe.get_systems():
         add_devices([SimpliSafeAlarm(system, name, code)])

--- a/homeassistant/components/alarm_control_panel/simplisafe.py
+++ b/homeassistant/components/alarm_control_panel/simplisafe.py
@@ -48,7 +48,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         _LOGGER.error("Failed to setup SimpliSafe")
         return
 
-    add_devices([SimpliSafeAlarm(alarm, name, code) for alarm in simplisafe.get_systems()])
+    systems = []
+
+    for system in simplisafe.get_systems():
+        systems.append(SimpliSafeAlarm(system, name, code))
+
+    add_devices(systems)
 
 
 class SimpliSafeAlarm(AlarmControlPanel):

--- a/homeassistant/components/alarm_control_panel/simplisafe.py
+++ b/homeassistant/components/alarm_control_panel/simplisafe.py
@@ -9,23 +9,22 @@ import re
 
 import voluptuous as vol
 
-import homeassistant.components.alarm_control_panel as alarm
-from homeassistant.components.alarm_control_panel import PLATFORM_SCHEMA
+from homeassistant.components.alarm_control_panel import PLATFORM_SCHEMA, AlarmControlPanel
 from homeassistant.const import (
     CONF_CODE, CONF_NAME, CONF_PASSWORD, CONF_USERNAME,
-    EVENT_HOMEASSISTANT_STOP, STATE_ALARM_ARMED_AWAY, STATE_ALARM_ARMED_HOME,
+    STATE_ALARM_ARMED_AWAY, STATE_ALARM_ARMED_HOME,
     STATE_ALARM_DISARMED, STATE_UNKNOWN)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['simplisafe-python==1.0.5']
+REQUIREMENTS = ['simplisafe-python==2.0.1']
 
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_NAME = 'SimpliSafe'
 DOMAIN = 'simplisafe'
 
-NOTIFICATION_ID = 'simplisafe_notification'
-NOTIFICATION_TITLE = 'SimpliSafe Setup'
+ATTR_ALARM_ACTIVE = "alarm_active"
+ATTR_TEMPERATURE = "temperature"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_PASSWORD): cv.string,
@@ -37,36 +36,19 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the SimpliSafe platform."""
-    from simplipy.api import SimpliSafeApiInterface, get_systems
+    from simplipy.api import SimpliSafeApiInterface
     name = config.get(CONF_NAME)
     code = config.get(CONF_CODE)
     username = config.get(CONF_USERNAME)
     password = config.get(CONF_PASSWORD)
 
-    simplisafe = SimpliSafeApiInterface()
-    status = simplisafe.set_credentials(username, password)
-    if status:
-        hass.data[DOMAIN] = simplisafe
-        locations = get_systems(simplisafe)
-        for location in locations:
-            add_devices([SimpliSafeAlarm(location, name, code)])
-    else:
-        message = 'Failed to log into SimpliSafe. Check credentials.'
-        _LOGGER.error(message)
-        hass.components.persistent_notification.create(
-            message,
-            title=NOTIFICATION_TITLE,
-            notification_id=NOTIFICATION_ID)
-        return False
+    simplisafe = SimpliSafeApiInterface(username, password)
 
-    def logout(event):
-        """Logout of the SimpliSafe API."""
-        hass.data[DOMAIN].logout()
-
-    hass.bus.listen(EVENT_HOMEASSISTANT_STOP, logout)
+    for system in simplisafe.get_systems():
+        add_devices([SimpliSafeAlarm(system, name, code)])
 
 
-class SimpliSafeAlarm(alarm.AlarmControlPanel):
+class SimpliSafeAlarm(AlarmControlPanel):
     """Representation of a SimpliSafe alarm."""
 
     def __init__(self, simplisafe, name, code):
@@ -76,11 +58,16 @@ class SimpliSafeAlarm(alarm.AlarmControlPanel):
         self._code = str(code) if code else None
 
     @property
+    def unique_id(self):
+        """Return the unique ID."""
+        return self.simplisafe.location_id
+
+    @property
     def name(self):
         """Return the name of the device."""
         if self._name is not None:
             return self._name
-        return 'Alarm {}'.format(self.simplisafe.location_id())
+        return 'Alarm {}'.format(self.simplisafe.location_id)
 
     @property
     def code_format(self):
@@ -94,12 +81,13 @@ class SimpliSafeAlarm(alarm.AlarmControlPanel):
     @property
     def state(self):
         """Return the state of the device."""
-        status = self.simplisafe.state()
-        if status == 'off':
+        status = self.simplisafe.state
+        if status.lower() == 'off':
             state = STATE_ALARM_DISARMED
-        elif status == 'home':
+        elif status.lower() == 'home' or status.lower() == 'home_count':
             state = STATE_ALARM_ARMED_HOME
-        elif status == 'away':
+        elif (status.lower() == 'away' or status.lower() == 'exitDelay' or
+              status.lower() == 'away_count'):
             state = STATE_ALARM_ARMED_AWAY
         else:
             state = STATE_UNKNOWN
@@ -108,14 +96,13 @@ class SimpliSafeAlarm(alarm.AlarmControlPanel):
     @property
     def device_state_attributes(self):
         """Return the state attributes."""
-        return {
-            'alarm': self.simplisafe.alarm(),
-            'co': self.simplisafe.carbon_monoxide(),
-            'fire': self.simplisafe.fire(),
-            'flood': self.simplisafe.flood(),
-            'last_event': self.simplisafe.last_event(),
-            'temperature': self.simplisafe.temperature(),
-        }
+        attributes = {}
+
+        attributes[ATTR_ALARM_ACTIVE] = self.simplisafe.alarm_active
+        if self.simplisafe.temperature is not None:
+            attributes[ATTR_TEMPERATURE] = self.simplisafe.temperature
+
+        return attributes
 
     def update(self):
         """Update alarm status."""

--- a/homeassistant/components/alarm_control_panel/simplisafe.py
+++ b/homeassistant/components/alarm_control_panel/simplisafe.py
@@ -48,8 +48,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         _LOGGER.error("Failed to setup SimpliSafe")
         return
 
-    for system in simplisafe.get_systems():
-        add_devices([SimpliSafeAlarm(system, name, code)])
+    add_devices([SimpliSafeAlarm(alarm, name, code) for alarm in simplisafe.get_systems()])
 
 
 class SimpliSafeAlarm(AlarmControlPanel):

--- a/homeassistant/components/alarm_control_panel/simplisafe.py
+++ b/homeassistant/components/alarm_control_panel/simplisafe.py
@@ -10,7 +10,7 @@ import re
 import voluptuous as vol
 
 from homeassistant.components.alarm_control_panel import (
-        PLATFORM_SCHEMA, AlarmControlPanel)
+    PLATFORM_SCHEMA, AlarmControlPanel)
 from homeassistant.const import (
     CONF_CODE, CONF_NAME, CONF_PASSWORD, CONF_USERNAME,
     STATE_ALARM_ARMED_AWAY, STATE_ALARM_ARMED_HOME,

--- a/homeassistant/components/alarm_control_panel/simplisafe.py
+++ b/homeassistant/components/alarm_control_panel/simplisafe.py
@@ -9,7 +9,8 @@ import re
 
 import voluptuous as vol
 
-from homeassistant.components.alarm_control_panel import PLATFORM_SCHEMA, AlarmControlPanel
+from homeassistant.components.alarm_control_panel import (
+        PLATFORM_SCHEMA, AlarmControlPanel)
 from homeassistant.const import (
     CONF_CODE, CONF_NAME, CONF_PASSWORD, CONF_USERNAME,
     STATE_ALARM_ARMED_AWAY, STATE_ALARM_ARMED_HOME,

--- a/homeassistant/components/alarm_control_panel/simplisafe.py
+++ b/homeassistant/components/alarm_control_panel/simplisafe.py
@@ -17,12 +17,11 @@ from homeassistant.const import (
     STATE_ALARM_DISARMED, STATE_UNKNOWN)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['simplisafe-python==2.0.1']
+REQUIREMENTS = ['simplisafe-python==2.0.2']
 
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_NAME = 'SimpliSafe'
-DOMAIN = 'simplisafe'
 
 ATTR_ALARM_ACTIVE = "alarm_active"
 ATTR_TEMPERATURE = "temperature"
@@ -37,13 +36,17 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the SimpliSafe platform."""
-    from simplipy.api import SimpliSafeApiInterface
+    from simplipy.api import SimpliSafeApiInterface, SimpliSafeAPIException
     name = config.get(CONF_NAME)
     code = config.get(CONF_CODE)
     username = config.get(CONF_USERNAME)
     password = config.get(CONF_PASSWORD)
 
-    simplisafe = SimpliSafeApiInterface(username, password)
+    try:
+        simplisafe = SimpliSafeApiInterface(username, password)
+    except SimpliSafeAPIException:
+        _LOGGER.error("Failed to setup SimpliSafe.")
+        return False
 
     for system in simplisafe.get_systems():
         add_devices([SimpliSafeAlarm(system, name, code)])

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1241,7 +1241,7 @@ shodan==1.8.1
 simplepush==1.1.4
 
 # homeassistant.components.alarm_control_panel.simplisafe
-simplisafe-python==2.0.1
+simplisafe-python==2.0.2
 
 # homeassistant.components.skybell
 skybellpy==0.1.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1241,7 +1241,7 @@ shodan==1.8.1
 simplepush==1.1.4
 
 # homeassistant.components.alarm_control_panel.simplisafe
-simplisafe-python==1.0.5
+simplisafe-python==2.0.1
 
 # homeassistant.components.skybell
 skybellpy==0.1.2


### PR DESCRIPTION
## Description:
SimpliSafe has a new API that has been out for awhile. This will upgrade the existing component to use that new API. The new API has additional features that will be added at a later date, but the goal here was to move existing functionality to the new API before the old one stops working.

**Note:** -  co, fire, flood, and last_event are no longer part of the SimpliSafe alarm object in the new API and are not available in this upgrade, making this a breaking change for anyone using those. They will be added back in some fashion at a later date (probably exposed as individual sensors)

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
alarm_control_panel:
  platform: simplisafe
  username: YOUR_USERNAME
  password: YOUR_PASSWORD
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
