### PR TITLE
Allow less modern ciphers for outgoing connections

### DIFF
--- a/homeassistant/util/ssl.py
+++ b/homeassistant/util/ssl.py
@@ -6,21 +6,14 @@ import certifi
 
 def client_context():
     """Return an SSL context for making requests."""
-    context = _get_context()
-    context.verify_mode = ssl.CERT_REQUIRED
-    context.check_hostname = True
-    context.load_verify_locations(cafile=certifi.where(), capath=None)
+    context = ssl.create_default_context(
+        purpose=ssl.Purpose.SERVER_AUTH,
+        cafile=certifi.where()
+    )
     return context
 
 
 def server_context():
-    """Return an SSL context for being a server."""
-    context = _get_context()
-    context.options |= ssl.OP_CIPHER_SERVER_PREFERENCE
-    return context
-
-
-def _get_context():
     """Return an SSL context following the Mozilla recommendations.
 
     TLS configuration follows the best-practice guidelines specified here:
@@ -31,7 +24,8 @@ def _get_context():
 
     context.options |= (
         ssl.OP_NO_SSLv2 | ssl.OP_NO_SSLv3 |
-        ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1
+        ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1 |
+        ssl.OP_CIPHER_SERVER_PREFERENCE
     )
     if hasattr(ssl, 'OP_NO_COMPRESSION'):
         context.options |= ssl.OP_NO_COMPRESSION


### PR DESCRIPTION
## Description:
After the SSLContext incident (Fixed in #15483) I went too strict, enforcing only modern ciphers to be used when making connections to servers. This resulted in a couple of integrations breaking because the servers were using older ciphers.

After some debate, we've decided that server SSL is our issue and we will enforce [Mozilla modern cipher config recommendation](https://mozilla.github.io/server-side-tls/ssl-config-generator/?hsts=no).

For the client, we will use the [Mozilla CA bundle](https://pypi.org/project/certifi/) and use the default context provided by the current Python version.

**Related issue (if applicable):**
 - fixes #15512
 - fixes #15538

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
