### PR TITLE
Upgrade pymysensors to 0.16.0

### DIFF
--- a/homeassistant/components/mysensors/__init__.py
+++ b/homeassistant/components/mysensors/__init__.py
@@ -22,7 +22,7 @@ from .const import (
 from .device import get_mysensors_devices
 from .gateway import get_mysensors_gateway, setup_gateways, finish_setup
 
-REQUIREMENTS = ['pymysensors==0.14.0']
+REQUIREMENTS = ['pymysensors==0.16.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -926,7 +926,7 @@ pymusiccast==0.1.6
 pymyq==0.0.11
 
 # homeassistant.components.mysensors
-pymysensors==0.14.0
+pymysensors==0.16.0
 
 # homeassistant.components.lock.nello
 pynello==1.5.1


### PR DESCRIPTION
## Description:
* This upgrades pymysensors to 0.16.0 which fixes a problem with the TCP gateway reconnecting logic.
* See https://github.com/theolind/pymysensors/blob/master/CHANGELOG.md for more info.

**Related issue (if applicable):**
https://community.home-assistant.io/t/losing-connection-to-mysensors-gateway-0-71-0/56237

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
