### PR TITLE
Suppress error between 00:00 and 01:00

### DIFF
--- a/homeassistant/components/sensor/buienradar.py
+++ b/homeassistant/components/sensor/buienradar.py
@@ -481,7 +481,7 @@ class BrData(object):
 
         _LOGGER.debug("Buienradar parsed data: %s", result)
         if result.get(SUCCESS) is not True:
-            if (int(datetime.now().strftime('%H')) > 0):
+            if int(datetime.now().strftime('%H')) > 0:
                 _LOGGER.warning("Unable to parse data from Buienradar."
                                 "(Msg: %s)",
                                 result.get(MESSAGE),)

--- a/homeassistant/components/sensor/buienradar.py
+++ b/homeassistant/components/sensor/buienradar.py
@@ -5,7 +5,7 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.buienradar/
 """
 import asyncio
-from datetime import timedelta
+from datetime import datetime, timedelta
 import logging
 
 import async_timeout
@@ -481,7 +481,7 @@ class BrData(object):
 
         _LOGGER.debug("Buienradar parsed data: %s", result)
         if result.get(SUCCESS) is not True:
-            if (int(datetime.now().strftime('%H'))>0):
+            if (int(datetime.now().strftime('%H')) > 0):
                 _LOGGER.warning("Unable to parse data from Buienradar."
                                 "(Msg: %s)",
                                 result.get(MESSAGE),)

--- a/homeassistant/components/sensor/buienradar.py
+++ b/homeassistant/components/sensor/buienradar.py
@@ -481,9 +481,10 @@ class BrData(object):
 
         _LOGGER.debug("Buienradar parsed data: %s", result)
         if result.get(SUCCESS) is not True:
-            _LOGGER.warning("Unable to parse data from Buienradar."
-                            "(Msg: %s)",
-                            result.get(MESSAGE),)
+            if (int(datetime.now().strftime('%H'))>0):
+                _LOGGER.warning("Unable to parse data from Buienradar."
+                                "(Msg: %s)",
+                                result.get(MESSAGE),)
             yield from self.schedule_update(SCHEDULE_NOK)
             return
 


### PR DESCRIPTION
## Description:

Suppress an error that often occers between 00:00 and 01:00 CE(S)T during that time, probably because buienradar.nl is then updating its forcast for the next day. The API does not always work between these times (in the middle of the night).

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
