### PR TITLE
Allow auth providers to influence is_active

### DIFF
--- a/homeassistant/auth/__init__.py
+++ b/homeassistant/auth/__init__.py
@@ -124,6 +124,7 @@ class AuthManager:
         return await self._store.async_create_user(
             credentials=credentials,
             name=info.get('name'),
+            is_active=info.get('is_active', False)
         )
 
     async def async_link_user(self, user, credentials):

--- a/homeassistant/auth/providers/__init__.py
+++ b/homeassistant/auth/providers/__init__.py
@@ -135,5 +135,9 @@ class AuthProvider:
         """Return extra user metadata for credentials.
 
         Will be used to populate info when creating a new user.
+
+        Values to populate:
+         - name: string
+         - is_active: boolean
         """
         return {}

--- a/homeassistant/auth/providers/homeassistant.py
+++ b/homeassistant/auth/providers/homeassistant.py
@@ -184,7 +184,8 @@ class HassAuthProvider(AuthProvider):
     async def async_user_meta_for_credentials(self, credentials):
         """Get extra info for this credential."""
         return {
-            'name': credentials.data['username']
+            'name': credentials.data['username'],
+            'is_active': True,
         }
 
     async def async_will_remove_credentials(self, credentials):

--- a/homeassistant/auth/providers/insecure_example.py
+++ b/homeassistant/auth/providers/insecure_example.py
@@ -75,14 +75,16 @@ class ExampleAuthProvider(AuthProvider):
         Will be used to populate info when creating a new user.
         """
         username = credentials.data['username']
+        info = {
+            'is_active': True,
+        }
 
         for user in self.config['users']:
             if user['username'] == username:
-                return {
-                    'name': user.get('name')
-                }
+                info['name'] = user.get('name')
+                break
 
-        return {}
+        return info
 
 
 class LoginFlow(data_entry_flow.FlowHandler):

--- a/homeassistant/auth/providers/legacy_api_password.py
+++ b/homeassistant/auth/providers/legacy_api_password.py
@@ -70,7 +70,10 @@ class LegacyApiPasswordAuthProvider(AuthProvider):
 
         Will be used to populate info when creating a new user.
         """
-        return {'name': LEGACY_USER}
+        return {
+            'name': LEGACY_USER,
+            'is_active': True,
+        }
 
 
 class LoginFlow(data_entry_flow.FlowHandler):

--- a/homeassistant/scripts/auth.py
+++ b/homeassistant/scripts/auth.py
@@ -81,16 +81,9 @@ async def add_user(hass, provider, args):
         print("Username already exists!")
         return
 
-    credentials = await provider.async_get_or_create_credentials({
-        'username': args.username
-    })
-
-    user = await hass.auth.async_create_user(args.username)
-    await hass.auth.async_link_user(user, credentials)
-
     # Save username/password
     await provider.data.async_save()
-    print("User created")
+    print("Auth created")
 
 
 async def validate_login(hass, provider, args):

--- a/tests/auth/providers/test_legacy_api_password.py
+++ b/tests/auth/providers/test_legacy_api_password.py
@@ -30,11 +30,15 @@ def manager(hass, store, provider):
     })
 
 
-async def test_create_new_credential(provider):
+async def test_create_new_credential(manager, provider):
     """Test that we create a new credential."""
     credentials = await provider.async_get_or_create_credentials({})
     assert credentials.data["username"] is legacy_api_password.LEGACY_USER
     assert credentials.is_new is True
+
+    user = await manager.async_get_or_create_user(credentials)
+    assert user.name == legacy_api_password.LEGACY_USER
+    assert user.is_active
 
 
 async def test_only_one_credentials(manager, provider):

--- a/tests/scripts/test_auth.py
+++ b/tests/scripts/test_auth.py
@@ -47,7 +47,7 @@ async def test_add_user(hass, provider, capsys, hass_storage):
     assert len(hass_storage[hass_auth.STORAGE_KEY]['data']['users']) == 1
 
     captured = capsys.readouterr()
-    assert captured.out == 'User created\n'
+    assert captured.out == 'Auth created\n'
 
     assert len(data.users) == 1
     data.validate_login('paulus', 'test-pass')


### PR DESCRIPTION
## Description:
When a new credential is used in Home Assistant, the auth core will ask the auth provider for more info on this user to help creation of the new user. It used to just be name, but now I want to suggest that we add `is_active`. If the auth provider knows it is authenticated against a trusted source, it can choose to activate users by default.

**Related issue (if applicable):** legacy_api_password api provider currently never results in an activated user.

CC @awarecan @jeradM 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
