### PR TITLE
Added user credentials to current_user ws endpoint.

### DIFF
--- a/homeassistant/components/auth/__init__.py
+++ b/homeassistant/components/auth/__init__.py
@@ -412,6 +412,7 @@ def websocket_current_user(hass, connection, msg):
         'id': user.id,
         'name': user.name,
         'is_owner': user.is_owner,
-        'allow_change_password': any(c.auth_provider_type == 'homeassistant'
-                                     for c in user.credentials)
+        'credentials': [{'auth_provider_type': c.auth_provider_type,
+                         'auth_provider_id': c.auth_provider_id}
+                        for c in user.credentials]
     }))

--- a/homeassistant/components/auth/__init__.py
+++ b/homeassistant/components/auth/__init__.py
@@ -412,4 +412,6 @@ def websocket_current_user(hass, connection, msg):
         'id': user.id,
         'name': user.name,
         'is_owner': user.is_owner,
+        'credentials': [{'auth_provider_type': c.auth_provider_type,
+                         'id': c.id} for c in user.credentials]
     }))

--- a/homeassistant/components/auth/__init__.py
+++ b/homeassistant/components/auth/__init__.py
@@ -412,6 +412,6 @@ def websocket_current_user(hass, connection, msg):
         'id': user.id,
         'name': user.name,
         'is_owner': user.is_owner,
-        'credentials': [{'auth_provider_type': c.auth_provider_type,
-                         'id': c.id} for c in user.credentials]
+        'allow_change_password': any(c.auth_provider_type == 'homeassistant'
+                                     for c in user.credentials)
     }))

--- a/tests/components/auth/test_init.py
+++ b/tests/components/auth/test_init.py
@@ -71,7 +71,7 @@ def test_credential_store_expiration():
 
 
 async def test_ws_current_user(hass, hass_ws_client, hass_access_token):
-    """Test the current user command."""
+    """Test the current user command with homeassistant creds."""
     assert await async_setup_component(hass, 'auth', {
         'http': {
             'api_password': 'bla'
@@ -80,7 +80,7 @@ async def test_ws_current_user(hass, hass_ws_client, hass_access_token):
 
     user = hass_access_token.refresh_token.user
     credential = Credentials(auth_provider_type='homeassistant',
-                             auth_provider_id='hass-test-id',
+                             auth_provider_id=None,
                              data={}, id='test-id')
     user.credentials.append(credential)
     assert len(user.credentials) == 1
@@ -97,15 +97,40 @@ async def test_ws_current_user(hass, hass_ws_client, hass_access_token):
     assert result['success'], result
 
     user_dict = result['result']
+
     assert user_dict['name'] == user.name
     assert user_dict['id'] == user.id
     assert user_dict['is_owner'] == user.is_owner
-    assert len(user_dict['credentials']) == 1
+    assert user_dict['allow_change_password']
 
-    hass_cred = user_dict['credentials'][0]
-    assert hass_cred['auth_provider_type'] == 'homeassistant'
-    assert hass_cred['id'] == 'test-id'
-    assert 'data' not in hass_cred
+
+async def test_ws_current_user_cant_change_pw(hass, hass_ws_client,
+                                              hass_access_token):
+    """Test the current user can't change pw without homeassistant creds."""
+    assert await async_setup_component(hass, 'auth', {
+        'http': {
+            'api_password': 'bla'
+        }
+    })
+
+    user = hass_access_token.refresh_token.user
+    credential = Credentials(auth_provider_type='not-homeassistant',
+                             auth_provider_id=None,
+                             data={}, id='test-id')
+    user.credentials.append(credential)
+    assert len(user.credentials) == 1
+
+    with patch('homeassistant.auth.AuthManager.active', return_value=True):
+        client = await hass_ws_client(hass, hass_access_token)
+
+    await client.send_json({
+        'id': 5,
+        'type': auth.WS_TYPE_CURRENT_USER,
+    })
+
+    result = await client.receive_json()
+    assert result['success'], result
+    assert not result['result']['allow_change_password']
 
 
 async def test_cors_on_token(hass, aiohttp_client):

--- a/tests/components/auth/test_init.py
+++ b/tests/components/auth/test_init.py
@@ -2,6 +2,7 @@
 from datetime import timedelta
 from unittest.mock import patch
 
+from homeassistant.auth.models import Credentials
 from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
 from homeassistant.components import auth
@@ -76,6 +77,14 @@ async def test_ws_current_user(hass, hass_ws_client, hass_access_token):
             'api_password': 'bla'
         }
     })
+
+    user = hass_access_token.refresh_token.user
+    credential = Credentials(auth_provider_type='homeassistant',
+                             auth_provider_id='hass-test-id',
+                             data={}, id='test-id')
+    user.credentials.append(credential)
+    assert len(user.credentials) == 1
+
     with patch('homeassistant.auth.AuthManager.active', return_value=True):
         client = await hass_ws_client(hass, hass_access_token)
 
@@ -87,12 +96,16 @@ async def test_ws_current_user(hass, hass_ws_client, hass_access_token):
     result = await client.receive_json()
     assert result['success'], result
 
-    user = hass_access_token.refresh_token.user
     user_dict = result['result']
-
     assert user_dict['name'] == user.name
     assert user_dict['id'] == user.id
     assert user_dict['is_owner'] == user.is_owner
+    assert len(user_dict['credentials']) == 1
+
+    hass_cred = user_dict['credentials'][0]
+    assert hass_cred['auth_provider_type'] == 'homeassistant'
+    assert hass_cred['id'] == 'test-id'
+    assert 'data' not in hass_cred
 
 
 async def test_cors_on_token(hass, aiohttp_client):


### PR DESCRIPTION
## Description:
Adds list of user credentials to the `current_user` ws endpoint so they are accessible in the frontend.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
