### PR TITLE
Remove relative time from state machine

### DIFF
--- a/homeassistant/components/sensor/netatmo.py
+++ b/homeassistant/components/sensor/netatmo.py
@@ -51,7 +51,6 @@ SENSOR_TYPES = {
     'rf_status_lvl': ['Radio_lvl', '', 'mdi:signal', None],
     'wifi_status': ['Wifi', '', 'mdi:wifi', None],
     'wifi_status_lvl': ['Wifi_lvl', 'dBm', 'mdi:wifi', None],
-    'lastupdated': ['Last Updated', 's', 'mdi:timer', None],
 }
 
 MODULE_SCHEMA = vol.Schema({
@@ -286,8 +285,6 @@ class NetAtmoSensor(Entity):
                 self._state = "High"
             elif data['wifi_status'] <= 55:
                 self._state = "Full"
-        elif self.type == 'lastupdated':
-            self._state = int(time() - data['When'])
 
 
 class NetAtmoData(object):


### PR DESCRIPTION
## Description:
Missed in my code review of #14866.

It is not allowed to store relative times in the state machine. If you want a last updated timestamp, you can look at the last changed from an entity.

Not a breaking change because the PR has not been released yet.