### PR TITLE
Breaking Change: Reset failed login attempts counter when login success

### DIFF
--- a/homeassistant/components/http/ban.py
+++ b/homeassistant/components/http/ban.py
@@ -72,7 +72,11 @@ async def ban_middleware(request, handler):
 
 
 async def process_wrong_login(request):
-    """Process a wrong login attempt."""
+    """Process a wrong login attempt.
+
+    Increase failed login attempts counter for remote IP address.
+    Add ip ban entry if failed login attempts exceeds threshold.
+    """
     remote_addr = request[KEY_REAL_IP]
 
     msg = ('Login attempt or request with invalid authentication '
@@ -105,6 +109,27 @@ async def process_wrong_login(request):
             hass,
             'Too many login attempts from {}'.format(remote_addr),
             'Banning IP address', NOTIFICATION_ID_BAN)
+
+
+async def process_success_login(request):
+    """Process a success login attempt.
+
+    Reset failed login attempts counter for remote IP address.
+    No release IP address from banned list function, it can only be done by
+    manual modify ip bans config file.
+    """
+    remote_addr = request[KEY_REAL_IP]
+
+    # Check if ban middleware is loaded
+    if (KEY_BANNED_IPS not in request.app or
+            request.app[KEY_LOGIN_THRESHOLD] < 1):
+        return
+
+    if remote_addr in request.app[KEY_FAILED_LOGIN_ATTEMPTS] and \
+            request.app[KEY_FAILED_LOGIN_ATTEMPTS][remote_addr] > 0:
+        _LOGGER.debug('Login success, reset failed login attempts counter'
+                      ' from %s', remote_addr)
+        request.app[KEY_FAILED_LOGIN_ATTEMPTS].pop(remote_addr)
 
 
 class IpBan(object):

--- a/homeassistant/components/http/view.py
+++ b/homeassistant/components/http/view.py
@@ -12,6 +12,7 @@ from aiohttp import web
 from aiohttp.web_exceptions import HTTPUnauthorized, HTTPInternalServerError
 
 import homeassistant.remote as rem
+from homeassistant.components.http.ban import process_success_login
 from homeassistant.core import is_callback
 from homeassistant.const import CONTENT_TYPE_JSON
 
@@ -91,8 +92,11 @@ def request_handler_factory(view, handler):
 
         authenticated = request.get(KEY_AUTHENTICATED, False)
 
-        if view.requires_auth and not authenticated:
-            raise HTTPUnauthorized()
+        if view.requires_auth:
+            if authenticated:
+                await process_success_login(request)
+            else:
+                raise HTTPUnauthorized()
 
         _LOGGER.info('Serving %s to %s (auth: %s)',
                      request.path, request.get(KEY_REAL_IP), authenticated)

--- a/homeassistant/components/websocket_api.py
+++ b/homeassistant/components/websocket_api.py
@@ -26,7 +26,8 @@ from homeassistant.helpers.service import async_get_all_descriptions
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.components.http.auth import validate_password
 from homeassistant.components.http.const import KEY_AUTHENTICATED
-from homeassistant.components.http.ban import process_wrong_login
+from homeassistant.components.http.ban import process_wrong_login, \
+    process_success_login
 
 DOMAIN = 'websocket_api'
 
@@ -360,6 +361,7 @@ class ActiveConnection:
                 return wsock
 
             self.debug("Auth OK")
+            await process_success_login(request)
             await self.wsock.send_json(auth_ok_message())
 
             # ---------- AUTH PHASE OVER ----------


### PR DESCRIPTION
## Description:
Current IP Ban implementation never decrease failed login attempts counter. For example, if the `login_attempts_threshold` set to 2, and user input wrong password twice, then he input correct password and logged in. If he logout and login again, he input wrong password again, he will be lock out because the threshold reached. 

This behavior against user's expectation. Usually such failed attempts counter shall reset after a successfully login. This PR will implement similar logic, to reset the counter after success login or success websocket authentication.

This is more important for Mobile browser user on new auth system, since the access token will expire very open, there have more chance user got failed login attempts (expired access token actually). Especially on mobile browser, which often disconnect websocket, and reconnect when user reactive browser.

A lock out incident has been report by beta channel user on 0.74 beta build.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.
