### PR TITLE
light.tplink: initialize min & max mireds only once, avoid i/o outside update

### DIFF
--- a/homeassistant/components/light/tplink.py
+++ b/homeassistant/components/light/tplink.py
@@ -66,6 +66,8 @@ class TPLinkSmartBulb(Light):
         self._brightness = None
         self._hs = None
         self._supported_features = 0
+        self._min_mireds = None
+        self._max_mireds = None
         self._emeter_params = {}
 
     @property
@@ -107,12 +109,12 @@ class TPLinkSmartBulb(Light):
     @property
     def min_mireds(self):
         """Return minimum supported color temperature."""
-        return kelvin_to_mired(self.smartbulb.valid_temperature_range[1])
+        return self._min_mireds
 
     @property
     def max_mireds(self):
         """Return maximum supported color temperature."""
-        return kelvin_to_mired(self.smartbulb.valid_temperature_range[0])
+        return self._max_mireds
 
     @property
     def color_temp(self):
@@ -195,5 +197,9 @@ class TPLinkSmartBulb(Light):
             self._supported_features += SUPPORT_BRIGHTNESS
         if self.smartbulb.is_variable_color_temp:
             self._supported_features += SUPPORT_COLOR_TEMP
+            self._min_mireds = kelvin_to_mired(
+                self.smartbulb.valid_temperature_range[0])
+            self._max_mireds = kelvin_to_mired(
+                    self.smartbulb.valid_temperature_range[1])
         if self.smartbulb.is_color:
             self._supported_features += SUPPORT_COLOR

--- a/homeassistant/components/light/tplink.py
+++ b/homeassistant/components/light/tplink.py
@@ -200,6 +200,6 @@ class TPLinkSmartBulb(Light):
             self._min_mireds = kelvin_to_mired(
                 self.smartbulb.valid_temperature_range[1])
             self._max_mireds = kelvin_to_mired(
-                    self.smartbulb.valid_temperature_range[0])
+                self.smartbulb.valid_temperature_range[0])
         if self.smartbulb.is_color:
             self._supported_features += SUPPORT_COLOR

--- a/homeassistant/components/light/tplink.py
+++ b/homeassistant/components/light/tplink.py
@@ -198,8 +198,8 @@ class TPLinkSmartBulb(Light):
         if self.smartbulb.is_variable_color_temp:
             self._supported_features += SUPPORT_COLOR_TEMP
             self._min_mireds = kelvin_to_mired(
-                self.smartbulb.valid_temperature_range[0])
+                self.smartbulb.valid_temperature_range[1])
             self._max_mireds = kelvin_to_mired(
-                    self.smartbulb.valid_temperature_range[1])
+                    self.smartbulb.valid_temperature_range[0])
         if self.smartbulb.is_color:
             self._supported_features += SUPPORT_COLOR


### PR DESCRIPTION
## Description:

Note: this also changes `min_mireds` to be the lower temperature and other way around, I suppose that was a bug in the original code.

**Related issue (if applicable):** fixes #15562

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
