### PR TITLE
fix aiohttp InvalidURL exception when fetching media player image

### DIFF
--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -16,6 +16,7 @@ from random import SystemRandom
 from aiohttp import web
 from aiohttp.hdrs import CONTENT_TYPE, CACHE_CONTROL
 import async_timeout
+from urllib.parse import urlparse
 import voluptuous as vol
 
 from homeassistant.core import callback
@@ -955,6 +956,9 @@ async def _async_fetch_image(hass, url):
     """
     cache_images = ENTITY_IMAGE_CACHE[CACHE_IMAGES]
     cache_maxsize = ENTITY_IMAGE_CACHE[CACHE_MAXSIZE]
+
+    if urlparse(url).hostname is None:
+        url = hass.config.api.base_url + url
 
     if url not in cache_images:
         cache_images[url] = {CACHE_LOCK: asyncio.Lock(loop=hass.loop)}

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -6,17 +6,17 @@ https://home-assistant.io/components/media_player/
 """
 import asyncio
 import base64
+import collections
 from datetime import timedelta
 import functools as ft
-import collections
 import hashlib
 import logging
 from random import SystemRandom
+from urllib.parse import urlparse
 
 from aiohttp import web
 from aiohttp.hdrs import CONTENT_TYPE, CACHE_CONTROL
 import async_timeout
-from urllib.parse import urlparse
 import voluptuous as vol
 
 from homeassistant.core import callback


### PR DESCRIPTION
## Description:

`aiohttp` is raising InvalidURL exceptions when accessing to media player thumbnails.

The first call for the HA proxy (`/api/media_player_proxy/media_player.kodi?token=...&cache=...`)
is receiving relative urls that are failing. Second call to `_async_fetch_image` has an absolute url and works ok.

This is a simple fix to precede the `base_url` when hostname is None:

```python
if urlparse(url).hostname is None:
    url = hass.config.api.base_url + url
```


**Related issue (if applicable):** fixes #14782, [home-assistant-polymer/#1224](https://github.com/home-assistant/home-assistant-polymer/issues/1224) and errors like: 
```text
2018-07-20 13:03:34 ERROR (MainThread) [homeassistant.core] Error doing job: Task exception was never retrieved
Traceback (most recent call last):
  File "/Users/uge/Dropbox/PYTHON/PYPROJECTS/contrib/home-assistant/homeassistant/components/media_player/__init__.py", line 1048, in send_image
    data, content_type = await player.async_get_media_image()
  File "/Users/uge/Dropbox/PYTHON/PYPROJECTS/contrib/home-assistant/homeassistant/components/media_player/__init__.py", line 547, in async_get_media_image
    return await _async_fetch_image(self.hass, url)
  File "/Users/uge/Dropbox/PYTHON/PYPROJECTS/contrib/home-assistant/homeassistant/components/media_player/__init__.py", line 980, in _async_fetch_image
    response = await websession.get(url)
  File "/usr/local/lib/python3.6/site-packages/aiohttp/client.py", line 357, in _request
    ssl=ssl, proxy_headers=proxy_headers, traces=traces)
  File "/usr/local/lib/python3.6/site-packages/aiohttp/client_reqrep.py", line 223, in __init__
    self.update_host(url)
  File "/usr/local/lib/python3.6/site-packages/aiohttp/client_reqrep.py", line 274, in update_host
    raise InvalidURL(url)
aiohttp.client_exceptions.InvalidURL: /api/media_player_proxy/media_player.kodi?token=d32ebe4cd1c8e856c921270d12f9e5f841b417ed4af7eb6c2f91e1b6f763a65a&cache=243d7cb96fb9b43b
```


## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  - platform: universal
    name: TV
    children:
      - media_player.roku
```
or 
```yaml
media_player:
- platform: kodi
  host: !secret kodi_host
  port: !secret kodi_port
  username: !secret kodi_user
  password: !secret kodi_pw
  enable_websocket: true
  timeout: 10
```

## Checklist:
  - [X] The code change is tested and works locally.