### PR TITLE
Fix aiohttp connection reset errors

### DIFF
--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -301,27 +301,21 @@ class Camera(Entity):
 
         last_image = None
 
-        try:
-            while True:
-                img_bytes = await self.async_camera_image()
-                if not img_bytes:
-                    break
+        while True:
+            img_bytes = await self.async_camera_image()
+            if not img_bytes:
+                break
 
-                if img_bytes and img_bytes != last_image:
+            if img_bytes and img_bytes != last_image:
+                await write_to_mjpeg_stream(img_bytes)
+
+                # Chrome seems to always ignore first picture,
+                # print it twice.
+                if last_image is None:
                     await write_to_mjpeg_stream(img_bytes)
+                last_image = img_bytes
 
-                    # Chrome seems to always ignore first picture,
-                    # print it twice.
-                    if last_image is None:
-                        await write_to_mjpeg_stream(img_bytes)
-
-                    last_image = img_bytes
-
-                await asyncio.sleep(interval)
-
-        except asyncio.CancelledError:
-            _LOGGER.debug("Stream closed by frontend.")
-            pass
+            await asyncio.sleep(interval)
 
         return response
 

--- a/homeassistant/components/camera/ffmpeg.py
+++ b/homeassistant/components/camera/ffmpeg.py
@@ -73,7 +73,7 @@ class FFmpegCamera(Camera):
             return await async_aiohttp_proxy_stream(
                 self.hass, request, stream,
                 'multipart/x-mixed-replace;boundary=ffserver')
-        finaly:
+        finally:
             await stream.close()
 
     @property

--- a/homeassistant/components/camera/ffmpeg.py
+++ b/homeassistant/components/camera/ffmpeg.py
@@ -69,10 +69,12 @@ class FFmpegCamera(Camera):
         yield from stream.open_camera(
             self._input, extra_cmd=self._extra_arguments)
 
-        return await async_aiohttp_proxy_stream(
-            self.hass, request, stream,
-            'multipart/x-mixed-replace;boundary=ffserver')
-        yield from stream.close()
+        try:
+            return await async_aiohttp_proxy_stream(
+                self.hass, request, stream,
+                'multipart/x-mixed-replace;boundary=ffserver')
+        finaly:
+            await stream.close()
 
     @property
     def name(self):

--- a/homeassistant/components/camera/ffmpeg.py
+++ b/homeassistant/components/camera/ffmpeg.py
@@ -29,8 +29,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-@asyncio.coroutine
-def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_devices,
+                               discovery_info=None):
     """Set up a FFmpeg camera."""
     if not hass.data[DATA_FFMPEG].async_run_test(config.get(CONF_INPUT)):
         return
@@ -49,24 +49,22 @@ class FFmpegCamera(Camera):
         self._input = config.get(CONF_INPUT)
         self._extra_arguments = config.get(CONF_EXTRA_ARGUMENTS)
 
-    @asyncio.coroutine
-    def async_camera_image(self):
+    async def async_camera_image(self):
         """Return a still image response from the camera."""
         from haffmpeg import ImageFrame, IMAGE_JPEG
         ffmpeg = ImageFrame(self._manager.binary, loop=self.hass.loop)
 
-        image = yield from asyncio.shield(ffmpeg.get_image(
+        image = await asyncio.shield(ffmpeg.get_image(
             self._input, output_format=IMAGE_JPEG,
             extra_cmd=self._extra_arguments), loop=self.hass.loop)
         return image
 
-    @asyncio.coroutine
-    def handle_async_mjpeg_stream(self, request):
+    async def handle_async_mjpeg_stream(self, request):
         """Generate an HTTP MJPEG stream from the camera."""
         from haffmpeg import CameraMjpeg
 
         stream = CameraMjpeg(self._manager.binary, loop=self.hass.loop)
-        yield from stream.open_camera(
+        await stream.open_camera(
             self._input, extra_cmd=self._extra_arguments)
 
         try:

--- a/homeassistant/components/camera/ffmpeg.py
+++ b/homeassistant/components/camera/ffmpeg.py
@@ -69,7 +69,7 @@ class FFmpegCamera(Camera):
         yield from stream.open_camera(
             self._input, extra_cmd=self._extra_arguments)
 
-        yield from async_aiohttp_proxy_stream(
+        return await async_aiohttp_proxy_stream(
             self.hass, request, stream,
             'multipart/x-mixed-replace;boundary=ffserver')
         yield from stream.close()

--- a/homeassistant/components/camera/mjpeg.py
+++ b/homeassistant/components/camera/mjpeg.py
@@ -135,7 +135,7 @@ class MjpegCamera(Camera):
         websession = async_get_clientsession(self.hass)
         stream_coro = websession.get(self._mjpeg_url, auth=self._auth)
 
-        yield from async_aiohttp_proxy_web(self.hass, request, stream_coro)
+        return yield from async_aiohttp_proxy_web(self.hass, request, stream_coro)
 
     @property
     def name(self):

--- a/homeassistant/components/camera/mjpeg.py
+++ b/homeassistant/components/camera/mjpeg.py
@@ -135,7 +135,7 @@ class MjpegCamera(Camera):
         websession = async_get_clientsession(self.hass)
         stream_coro = websession.get(self._mjpeg_url, auth=self._auth)
 
-        return yield from async_aiohttp_proxy_web(self.hass, request, stream_coro)
+        return await async_aiohttp_proxy_web(self.hass, request, stream_coro)
 
     @property
     def name(self):

--- a/homeassistant/components/camera/mjpeg.py
+++ b/homeassistant/components/camera/mjpeg.py
@@ -123,12 +123,11 @@ class MjpegCamera(Camera):
         with closing(req) as response:
             return extract_image_from_mjpeg(response.iter_content(102400))
 
-    @asyncio.coroutine
-    def handle_async_mjpeg_stream(self, request):
+    async def handle_async_mjpeg_stream(self, request):
         """Generate an HTTP MJPEG stream from the camera."""
         # aiohttp don't support DigestAuth -> Fallback
         if self._authentication == HTTP_DIGEST_AUTHENTICATION:
-            yield from super().handle_async_mjpeg_stream(request)
+            await super().handle_async_mjpeg_stream(request)
             return
 
         # connect to stream

--- a/homeassistant/components/camera/proxy.py
+++ b/homeassistant/components/camera/proxy.py
@@ -192,7 +192,7 @@ class ProxyCamera(Camera):
 
         if not self._stream_opts:
             await async_aiohttp_proxy_web(self.hass, request, stream_coro)
-            return
+            return aiohttp.web.HTTPBadRequest()
 
         response = aiohttp.web.StreamResponse()
         response.content_type = ('multipart/x-mixed-replace; '
@@ -232,12 +232,8 @@ class ProxyCamera(Camera):
         except asyncio.CancelledError:
             _LOGGER.debug("Stream closed by frontend.")
             req.close()
-            response = None
-            raise
 
-        finally:
-            if response is not None:
-                await response.write_eof()
+        return response
 
     @property
     def name(self):

--- a/homeassistant/components/camera/proxy.py
+++ b/homeassistant/components/camera/proxy.py
@@ -191,7 +191,8 @@ class ProxyCamera(Camera):
         stream_coro = websession.get(url, headers=self._headers)
 
         if not self._stream_opts:
-            return await async_aiohttp_proxy_web(self.hass, request, stream_coro)
+            return await async_aiohttp_proxy_web(
+                self.hass, request, stream_coro)
 
         response = aiohttp.web.StreamResponse()
         response.content_type = ('multipart/x-mixed-replace; '
@@ -228,8 +229,7 @@ class ProxyCamera(Camera):
                         _resize_image, image, self._stream_opts)
                     await write(image)
                     data = data[jpg_end + 2:]
-        except asyncio.CancelledError:
-            _LOGGER.debug("Stream closed by frontend.")
+        finally:
             req.close()
 
         return response

--- a/homeassistant/components/camera/proxy.py
+++ b/homeassistant/components/camera/proxy.py
@@ -191,8 +191,7 @@ class ProxyCamera(Camera):
         stream_coro = websession.get(url, headers=self._headers)
 
         if not self._stream_opts:
-            await async_aiohttp_proxy_web(self.hass, request, stream_coro)
-            return aiohttp.web.HTTPBadRequest()
+            return await async_aiohttp_proxy_web(self.hass, request, stream_coro)
 
         response = aiohttp.web.StreamResponse()
         response.content_type = ('multipart/x-mixed-replace; '

--- a/homeassistant/helpers/aiohttp_client.py
+++ b/homeassistant/helpers/aiohttp_client.py
@@ -120,6 +120,7 @@ async def async_aiohttp_proxy_stream(hass, request, stream, content_type,
 
     return response
 
+
 @callback
 def _async_register_clientsession_shutdown(hass, clientsession):
     """Register ClientSession close on Home Assistant shutdown.

--- a/homeassistant/helpers/aiohttp_client.py
+++ b/homeassistant/helpers/aiohttp_client.py
@@ -119,6 +119,7 @@ async def async_aiohttp_proxy_stream(hass, request, stream, content_type,
         # Something went wrong fetching data, closed connection
         pass
 
+    return response
 
 @callback
 def _async_register_clientsession_shutdown(hass, clientsession):

--- a/homeassistant/helpers/aiohttp_client.py
+++ b/homeassistant/helpers/aiohttp_client.py
@@ -66,10 +66,9 @@ def async_create_clientsession(hass, verify_ssl=True, auto_cleanup=True,
     return clientsession
 
 
-@asyncio.coroutine
 @bind_hass
-def async_aiohttp_proxy_web(hass, request, web_coro, buffer_size=102400,
-                            timeout=10):
+async def async_aiohttp_proxy_web(hass, request, web_coro,
+                                  buffer_size=102400, timeout=10):
     """Stream websession request to aiohttp web response."""
     try:
         with async_timeout.timeout(timeout, loop=hass.loop):

--- a/homeassistant/helpers/aiohttp_client.py
+++ b/homeassistant/helpers/aiohttp_client.py
@@ -115,7 +115,7 @@ async def async_aiohttp_proxy_stream(hass, request, stream, content_type,
                 break
             await response.write(data)
 
-    except (asyncio.CancelledError, asyncio.TimeoutError, aiohttp.ClientError):
+    except (asyncio.TimeoutError, aiohttp.ClientError):
         # Something went wrong fetching data, closed connection
         pass
 

--- a/homeassistant/helpers/aiohttp_client.py
+++ b/homeassistant/helpers/aiohttp_client.py
@@ -73,7 +73,7 @@ def async_aiohttp_proxy_web(hass, request, web_coro, buffer_size=102400,
     """Stream websession request to aiohttp web response."""
     try:
         with async_timeout.timeout(timeout, loop=hass.loop):
-            req = yield from web_coro
+            req = await web_coro
 
     except asyncio.CancelledError:
         # The user cancelled the request
@@ -88,7 +88,7 @@ def async_aiohttp_proxy_web(hass, request, web_coro, buffer_size=102400,
         raise HTTPBadGateway() from err
 
     try:
-        yield from async_aiohttp_proxy_stream(
+        return await async_aiohttp_proxy_stream(
             hass,
             request,
             req.content,

--- a/homeassistant/helpers/aiohttp_client.py
+++ b/homeassistant/helpers/aiohttp_client.py
@@ -112,17 +112,11 @@ async def async_aiohttp_proxy_stream(hass, request, stream, content_type,
                 data = await stream.read(buffer_size)
 
             if not data:
-                await response.write_eof()
                 break
-
             await response.write(data)
 
-    except (asyncio.TimeoutError, aiohttp.ClientError):
-        # Something went wrong fetching data, close connection gracefully
-        await response.write_eof()
-
-    except asyncio.CancelledError:
-        # The user closed the connection
+    except (asyncio.CancelledError, asyncio.TimeoutError, aiohttp.ClientError):
+        # Something went wrong fetching data, closed connection
         pass
 
 


### PR DESCRIPTION
## Description:

With aiohttp >= 3, the write_eof should be not called from us anymore.
https://docs.aiohttp.org/en/stable/web_reference.html#aiohttp.web.StreamResponse.write_eof

Next, after we create a StreamResponse, we need raise http errors and not create new Response. We need also return the StreamResponse to aiohttp after we don't use it.

Real fix: #15028

This fix also a lot of memory leaks.