### PR TITLE
Support brightness for emulated_hue covers

### DIFF
--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -325,7 +325,7 @@ def parse_hue_api_put_light_body(request_json, entity):
 
         elif (entity.domain == "script" or
               entity.domain == "media_player" or
-              entity.domain == "fan") or
+              entity.domain == "fan" or
               entity.domain == "cover"):
             # Convert 0-255 to 0-100
             level = brightness / 255 * 100

--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -20,6 +20,12 @@ from homeassistant.components.fan import (
     ATTR_SPEED, SUPPORT_SET_SPEED, SPEED_OFF, SPEED_LOW,
     SPEED_MEDIUM, SPEED_HIGH
 )
+
+from homeassistant.components.cover import (
+    ATTR_CURRENT_POSITION, ATTR_POSITION, SERVICE_SET_COVER_POSITION,
+    SUPPORT_SET_POSITION
+)
+
 from homeassistant.components.http import HomeAssistantView
 
 _LOGGER = logging.getLogger(__name__)
@@ -228,6 +234,11 @@ class HueOneLightChangeView(HomeAssistantView):
                 service = SERVICE_OPEN_COVER
             else:
                 service = SERVICE_CLOSE_COVER
+            if entity_features & SUPPORT_SET_POSITION:
+                if brightness is not None:
+                    domain = entity.domain
+                    service = SERVICE_SET_COVER_POSITION
+                    data[ATTR_POSITION] = brightness
 
         # If the requested entity is a fan, convert to speed
         elif entity.domain == "fan":
@@ -314,7 +325,8 @@ def parse_hue_api_put_light_body(request_json, entity):
 
         elif (entity.domain == "script" or
               entity.domain == "media_player" or
-              entity.domain == "fan"):
+              entity.domain == "fan") or
+              entity.domain == "cover"):
             # Convert 0-255 to 0-100
             level = brightness / 255 * 100
             brightness = round(level)
@@ -355,6 +367,9 @@ def get_entity_state(config, entity):
                 final_brightness = 170
             elif speed == SPEED_HIGH:
                 final_brightness = 255
+        elif entity.domain == "cover":
+            current_position = entity.attributes.get(ATTR_CURRENT_POSITION, 0)
+            final_brightness = round(current_position / 100 * 255)
     else:
         final_state, final_brightness = cached_state
         # Make sure brightness is valid

--- a/tests/components/emulated_hue/test_hue_api.py
+++ b/tests/components/emulated_hue/test_hue_api.py
@@ -333,14 +333,13 @@ def test_put_light_state_media_player(hass_hue, hue_client):
 
 
 @asyncio.coroutine
-
 def test_put_light_state_cover(hass_hue, hue_client):
     """Test setting cover level."""
     # close the cover first
     yield from hass_hue.services.async_call(
         cover.DOMAIN, const.SERVICE_SET_COVER_POSITION,
         {const.ATTR_ENTITY_ID: 'cover.living_room_window',
-        cover.ATTR_POSITION: 66.0}, blocking=True)
+            cover.ATTR_POSITION: 66.0}, blocking=True)
 
     # Emulated hue converts 0-100% to 0-255.
     level = 89
@@ -358,9 +357,9 @@ def test_put_light_state_cover(hass_hue, hue_client):
     living_room_window_cover = hass_hue.states.get('cover.living_room_window')
     assert living_room_window_cover.state == 'open'
     assert living_room_window_cover.attributes[
-    cover.ATTR_CURRENT_POSITION] == level
+        cover.ATTR_CURRENT_POSITION] == level
 
-
+@asyncio.coroutine
 def test_put_light_state_fan(hass_hue, hue_client):
     """Test turning on fan and setting speed."""
     # Turn the fan off first

--- a/tests/components/emulated_hue/test_hue_api.py
+++ b/tests/components/emulated_hue/test_hue_api.py
@@ -336,13 +336,11 @@ def test_put_light_state_media_player(hass_hue, hue_client):
 
 def test_put_light_state_cover(hass_hue, hue_client):
     """Test setting cover level."""
-
     # close the cover first
     yield from hass_hue.services.async_call(
         cover.DOMAIN, const.SERVICE_SET_COVER_POSITION,
         {const.ATTR_ENTITY_ID: 'cover.living_room_window',
-        cover.ATTR_POSITION: 66.0},
-        blocking=True)
+        cover.ATTR_POSITION: 66.0}, blocking=True)
 
     # Emulated hue converts 0-100% to 0-255.
     level = 89
@@ -359,7 +357,8 @@ def test_put_light_state_cover(hass_hue, hue_client):
 
     living_room_window_cover = hass_hue.states.get('cover.living_room_window')
     assert living_room_window_cover.state == 'open'
-    assert living_room_window_cover.attributes[cover.ATTR_CURRENT_POSITION] == level
+    assert living_room_window_cover.attributes[
+    cover.ATTR_CURRENT_POSITION] == level
 
 
 def test_put_light_state_fan(hass_hue, hue_client):

--- a/tests/components/emulated_hue/test_hue_api.py
+++ b/tests/components/emulated_hue/test_hue_api.py
@@ -359,6 +359,7 @@ def test_put_light_state_cover(hass_hue, hue_client):
     assert living_room_window_cover.attributes[
         cover.ATTR_CURRENT_POSITION] == level
 
+
 @asyncio.coroutine
 def test_put_light_state_fan(hass_hue, hue_client):
     """Test turning on fan and setting speed."""

--- a/tests/components/emulated_hue/test_hue_api.py
+++ b/tests/components/emulated_hue/test_hue_api.py
@@ -342,7 +342,7 @@ def test_put_light_state_cover(hass_hue, hue_client):
             cover.ATTR_POSITION: 66.0}, blocking=True)
 
     # Emulated hue converts 0-100% to 0-255.
-    level = 89
+    level = 0
     brightness = round(level * 255 / 100)
 
     cover_level_result = yield from perform_put_light_state(
@@ -353,9 +353,9 @@ def test_put_light_state_cover(hass_hue, hue_client):
 
     assert cover_level_result.status == 200
     assert len(cover_level_result_json) == 2
-
+    yield from hass_hue.async_block_till_done()
     living_room_window_cover = hass_hue.states.get('cover.living_room_window')
-    assert living_room_window_cover.state == 'open'
+    assert living_room_window_cover.state == 'closed'
     assert living_room_window_cover.attributes[
         cover.ATTR_CURRENT_POSITION] == level
 


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
