### PR TITLE
Add unique_id to netgear_lte sensors

### DIFF
--- a/homeassistant/components/netgear_lte.py
+++ b/homeassistant/components/netgear_lte.py
@@ -17,7 +17,7 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['eternalegypt==0.0.2']
+REQUIREMENTS = ['eternalegypt==0.0.3']
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=10)
 
@@ -37,6 +37,7 @@ class ModemData:
     """Class for modem state."""
 
     modem = attr.ib()
+    serial_number = attr.ib(init=False)
     unread_count = attr.ib(init=False)
     usage = attr.ib(init=False)
 
@@ -44,6 +45,7 @@ class ModemData:
     async def async_update(self):
         """Call the API to update the data."""
         information = await self.modem.information()
+        self.serial_number = information.serial_number
         self.unread_count = sum(1 for x in information.sms if x.unread)
         self.usage = information.usage
 

--- a/homeassistant/components/sensor/netgear_lte.py
+++ b/homeassistant/components/sensor/netgear_lte.py
@@ -32,11 +32,11 @@ async def async_setup_platform(
     modem_data = hass.data[DATA_KEY].get_modem_data(config)
 
     sensors = []
-    for sensortype in config[CONF_SENSORS]:
-        if sensortype == SENSOR_SMS:
-            sensors.append(SMSSensor(modem_data))
-        elif sensortype == SENSOR_USAGE:
-            sensors.append(UsageSensor(modem_data))
+    for sensor_type in config[CONF_SENSORS]:
+        if sensor_type == SENSOR_SMS:
+            sensors.append(SMSSensor(modem_data, sensor_type))
+        elif sensor_type == SENSOR_USAGE:
+            sensors.append(UsageSensor(modem_data, sensor_type))
 
     async_add_devices(sensors, True)
 
@@ -46,10 +46,16 @@ class LTESensor(Entity):
     """Data usage sensor entity."""
 
     modem_data = attr.ib()
+    sensor_type = attr.ib()
 
     async def async_update(self):
         """Update state."""
         await self.modem_data.async_update()
+
+    @property
+    def unique_id(self):
+        """Return a unique ID like 'usage_5TG365AB0078V'."""
+        return "{}_{}".format(self.sensor_type, self.modem_data.serial_number)
 
 
 class SMSSensor(LTESensor):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -309,7 +309,7 @@ ephem==3.7.6.0
 epson-projector==0.1.3
 
 # homeassistant.components.netgear_lte
-eternalegypt==0.0.2
+eternalegypt==0.0.3
 
 # homeassistant.components.keyboard_remote
 # evdev==0.6.1


### PR DESCRIPTION
## Description:

This uses the modem serial number for a unique ID (available from eternalegypt 0.0.3).

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
