### PR TITLE
Add Tuya cover and scene platform

### DIFF
--- a/homeassistant/components/cover/tuya.py
+++ b/homeassistant/components/cover/tuya.py
@@ -1,0 +1,60 @@
+"""
+Support for Tuya cover.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/cover.tuya/
+"""
+from homeassistant.components.cover import (
+    CoverDevice, ENTITY_ID_FORMAT, SUPPORT_OPEN, SUPPORT_CLOSE, SUPPORT_STOP)
+from homeassistant.components.tuya import DATA_TUYA, TuyaDevice
+
+DEPENDENCIES = ['tuya']
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up Tuya cover devices."""
+    if discovery_info is None:
+        return
+    tuya = hass.data[DATA_TUYA]
+    dev_ids = discovery_info.get('dev_ids')
+    devices = []
+    for dev_id in dev_ids:
+        device = tuya.get_device_by_id(dev_id)
+        if device is None:
+            continue
+        devices.append(TuyaCover(device))
+    add_devices(devices)
+
+
+class TuyaCover(TuyaDevice, CoverDevice):
+    """Tuya cover devices."""
+
+    def __init__(self, tuya):
+        """Init tuya cover device."""
+        super().__init__(tuya)
+        self.entity_id = ENTITY_ID_FORMAT.format(tuya.object_id())
+
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+        supported_features = SUPPORT_OPEN | SUPPORT_CLOSE
+        if self.tuya.support_stop():
+            supported_features |= SUPPORT_STOP
+        return supported_features
+
+    @property
+    def is_closed(self):
+        """Return if the cover is closed or not."""
+        return None
+
+    def open_cover(self, **kwargs):
+        """Open the cover."""
+        self.tuya.open_cover()
+
+    def close_cover(self, **kwargs):
+        """Close cover."""
+        self.tuya.close_cover()
+
+    def stop_cover(self, **kwargs):
+        """Stop the cover."""
+        self.tuya.stop_cover()

--- a/homeassistant/components/scene/tuya.py
+++ b/homeassistant/components/scene/tuya.py
@@ -38,8 +38,3 @@ class TuyaScene(TuyaDevice, Scene):
     def activate(self):
         """Activate the scene."""
         self.tuya.activate()
-
-    @property
-    def should_poll(self):
-        """Scene has no data."""
-        return False

--- a/homeassistant/components/scene/tuya.py
+++ b/homeassistant/components/scene/tuya.py
@@ -1,5 +1,5 @@
 """
-Support for the Tuya devices.
+Support for the Tuya scene.
 
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/scene.tuya/

--- a/homeassistant/components/scene/tuya.py
+++ b/homeassistant/components/scene/tuya.py
@@ -1,0 +1,45 @@
+"""
+Support for the Tuya devices.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/scene.tuya/
+"""
+from homeassistant.components.scene import Scene, DOMAIN
+from homeassistant.components.tuya import DATA_TUYA, TuyaDevice
+
+DEPENDENCIES = ['tuya']
+
+ENTITY_ID_FORMAT = DOMAIN + '.{}'
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up Tuya scenes."""
+    if discovery_info is None:
+        return
+    tuya = hass.data[DATA_TUYA]
+    dev_ids = discovery_info.get('dev_ids')
+    devices = []
+    for dev_id in dev_ids:
+        device = tuya.get_device_by_id(dev_id)
+        if device is None:
+            continue
+        devices.append(TuyaScene(device))
+    add_devices(devices)
+
+
+class TuyaScene(TuyaDevice, Scene):
+    """Tuya Scene."""
+
+    def __init__(self, tuya):
+        """Init Tuya scene."""
+        super().__init__(tuya)
+        self.entity_id = ENTITY_ID_FORMAT.format(tuya.object_id())
+
+    def activate(self):
+        """Activate the scene."""
+        self.tuya.activate()
+
+    @property
+    def should_poll(self):
+        """Scene has no data."""
+        return False

--- a/homeassistant/components/tuya.py
+++ b/homeassistant/components/tuya.py
@@ -34,8 +34,10 @@ SERVICE_PULL_DEVICES = 'pull_devices'
 
 TUYA_TYPE_TO_HA = {
     'climate': 'climate',
+    'cover': 'cover',
     'fan': 'fan',
     'light': 'light',
+    'scene': 'scene',
     'switch': 'switch',
 }
 


### PR DESCRIPTION
## Description:
Add support for Tuya cover and scene. After configuring username and password and country code in Tuya component, home assistant can discover supported devices which related to user's Tuya account and control them through Tuya cloud service.
Tuya cover now support curtain.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5840


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
