### PR TITLE
Throttle unavailability warnings for tplink light/switch

### DIFF
--- a/homeassistant/components/light/tplink.py
+++ b/homeassistant/components/light/tplink.py
@@ -140,8 +140,6 @@ class TPLinkSmartBulb(Light):
         """Update the TP-Link Bulb's state."""
         from pyHS100 import SmartDeviceException
         try:
-            self._available = True
-
             if self._supported_features == 0:
                 self.get_features()
 
@@ -182,9 +180,13 @@ class TPLinkSmartBulb(Light):
                     # device returned no daily/monthly history
                     pass
 
+            self._available = True
+
         except (SmartDeviceException, OSError) as ex:
-            _LOGGER.warning("Could not read state for %s: %s", self._name, ex)
-            self._available = False
+            if self._available:
+                _LOGGER.warning(
+                    "Could not read state for %s: %s", self._name, ex)
+                self._available = False
 
     @property
     def supported_features(self):

--- a/homeassistant/components/switch/tplink.py
+++ b/homeassistant/components/switch/tplink.py
@@ -87,8 +87,6 @@ class SmartPlugSwitch(SwitchDevice):
         """Update the TP-Link switch's state."""
         from pyHS100 import SmartDeviceException
         try:
-            self._available = True
-
             self._state = self.smartplug.state == \
                 self.smartplug.SWITCH_STATE_ON
 
@@ -121,6 +119,10 @@ class SmartPlugSwitch(SwitchDevice):
                     # Device returned no daily history
                     pass
 
+            self._available = True
+
         except (SmartDeviceException, OSError) as ex:
-            _LOGGER.warning("Could not read state for %s: %s", self.name, ex)
-            self._available = False
+            if self._available:
+                _LOGGER.warning(
+                    "Could not read state for %s: %s", self.name, ex)
+                self._available = False


### PR DESCRIPTION
## Description:

After this change, a disconnected device will only log a single warning and not one for each `update`:

```
2018-07-21 10:56:45 WARNING (SyncWorker_10) [homeassistant.components.switch.tplink] Could not read state for TP-Link Switch: Communication error
2018-07-21 10:57:15 WARNING (SyncWorker_14) [homeassistant.components.switch.tplink] Could not read state for TP-Link Switch: Communication error
2018-07-21 10:57:47 WARNING (SyncWorker_19) [homeassistant.components.switch.tplink] Could not read state for TP-Link Switch: Communication error
```

I only have the switch, so the light change is not tested.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
