### PR TITLE
WIP: Add support for playing media by commandline

### DIFF
--- a/homeassistant/components/media_player/shell_player.py
+++ b/homeassistant/components/media_player/shell_player.py
@@ -1,5 +1,7 @@
 """
-Support for playing media by shell command
+Support for playing media by shell command.
+
+See documentation TODO
 """
 import asyncio
 import logging
@@ -28,9 +30,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 
 async def async_setup_platform(hass, config, async_add_devices,
-                                discovery_info=None):
+                               discovery_info=None):
     """Set up the Shell Player platform."""
-
     if discovery_info is not None:
         return
 
@@ -47,10 +48,12 @@ class ShellPlayer(MediaPlayerDevice):
         """Initialize the Shell player."""
         self._name = name
         self._cmd = cmd
+        self._prog = None
+        self._args = None
+        self._args_compiled = None
 
     async def async_added_to_hass(self):
         """Prepare arguments."""
-
         if ' ' not in self._cmd:
             self._prog = self._cmd
             self._args = None
@@ -76,7 +79,6 @@ class ShellPlayer(MediaPlayerDevice):
 
     async def async_play_media(self, media_type, media_id, **kwargs):
         """Support changing a channel."""
-
         if media_type != MEDIA_TYPE_MUSIC:
             _LOGGER.error('Unsupported media type')
             return
@@ -97,10 +99,10 @@ class ShellPlayer(MediaPlayerDevice):
 
             # pylint: disable=no-member
             await asyncio.subprocess.create_subprocess_shell(
-                    self._cmd,
-                    loop=self.hass.loop,
-                    stdin=None
-                    )
+                self._cmd,
+                loop=self.hass.loop,
+                stdin=None
+                )
         else:
             # Template used. Break into list and use create_subprocess_exec
             # (which uses shell=False) for security
@@ -109,7 +111,7 @@ class ShellPlayer(MediaPlayerDevice):
             _LOGGER.info("Executing template: %s", rendered_args)
             # pylint: disable=no-member
             await asyncio.subprocess.create_subprocess_exec(
-                    *shlexed_cmd,
-                    loop=self.hass.loop,
-                    stdin=None
-                    )
+                *shlexed_cmd,
+                loop=self.hass.loop,
+                stdin=None
+                )

--- a/homeassistant/components/media_player/shell_player.py
+++ b/homeassistant/components/media_player/shell_player.py
@@ -1,0 +1,112 @@
+"""
+Support for playing media by shell command
+"""
+import asyncio
+import logging
+import shlex
+
+import voluptuous as vol
+
+from homeassistant.components.media_player import (
+    SUPPORT_PLAY, SUPPORT_PLAY_MEDIA,
+    MediaPlayerDevice, PLATFORM_SCHEMA, MEDIA_TYPE_MUSIC)
+from homeassistant.const import ( CONF_COMMAND, CONF_NAME, STATE_ON)
+from homeassistant.exceptions import TemplateError
+from homeassistant.helpers import config_validation as cv, template
+
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_NAME = 'Shell player'
+
+SUPPORT_FEATURES = SUPPORT_PLAY | SUPPORT_PLAY_MEDIA
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_COMMAND): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+})
+
+
+async def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+    """Set up the Shell Player platform."""
+
+    if discovery_info is not None:
+        return
+
+    shell_command = config.get(CONF_COMMAND)
+    name = config.get(CONF_NAME)
+
+    async_add_devices([ShellPlayer(shell_command, name)])
+
+class ShellPlayer(MediaPlayerDevice):
+    """Representation of a Shell player."""
+
+    def __init__(self, cmd, name):
+        """Initialize the Shell player."""
+        self._name = name
+        self._cmd = cmd
+
+    async def async_added_to_hass(self):
+        """Prepare arguments."""
+
+        if ' ' not in self._cmd:
+            self._prog = self._cmd
+            self._args = None
+            self._args_compiled = None
+        else:
+            self._prog, self._args = self._cmd.split(' ', 1)
+            self._args_compiled = template.Template(self._args, self.hass)
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the device."""
+        return STATE_ON
+
+    @property
+    def supported_features(self):
+        """Flag media player features that are supported."""
+        return SUPPORT_FEATURES
+
+    async def async_play_media(self, media_type, media_id, **kwargs):
+        """Support changing a channel."""
+
+        if media_type != MEDIA_TYPE_MUSIC:
+            _LOGGER.error('Unsupported media type')
+            return
+
+        if self._args_compiled:
+            try:
+                rendered_args = self._args_compiled.async_render({'media_id':media_id})
+            except TemplateError as ex:
+                _LOGGER.exception("Error rendering command template: %s", ex)
+                return
+
+        if rendered_args == self._args:
+            # No template used. default behavior
+
+            _LOGGER.info("Executing: %s", self._cmd)
+
+            # pylint: disable=no-member
+            await asyncio.subprocess.create_subprocess_shell(
+                    self._cmd,
+                    loop=self.hass.loop,
+                    stdin=None
+                    )
+        else:
+            # Template used. Break into list and use create_subprocess_exec
+            # (which uses shell=False) for security
+            shlexed_cmd = [self._prog] + shlex.split(rendered_args)
+
+            _LOGGER.info("Executing template: %s", rendered_args)
+            # pylint: disable=no-member
+            await asyncio.subprocess.create_subprocess_exec(
+                    *shlexed_cmd,
+                    loop=self.hass.loop,
+                    stdin=None
+                    )
+

--- a/homeassistant/components/media_player/shell_player.py
+++ b/homeassistant/components/media_player/shell_player.py
@@ -10,7 +10,7 @@ import voluptuous as vol
 from homeassistant.components.media_player import (
     SUPPORT_PLAY, SUPPORT_PLAY_MEDIA,
     MediaPlayerDevice, PLATFORM_SCHEMA, MEDIA_TYPE_MUSIC)
-from homeassistant.const import ( CONF_COMMAND, CONF_NAME, STATE_ON)
+from homeassistant.const import (CONF_COMMAND, CONF_NAME, STATE_ON)
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers import config_validation as cv, template
 
@@ -27,7 +27,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-async def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_devices,
+                                discovery_info=None):
     """Set up the Shell Player platform."""
 
     if discovery_info is not None:
@@ -37,6 +38,7 @@ async def async_setup_platform(hass, config, async_add_devices, discovery_info=N
     name = config.get(CONF_NAME)
 
     async_add_devices([ShellPlayer(shell_command, name)])
+
 
 class ShellPlayer(MediaPlayerDevice):
     """Representation of a Shell player."""
@@ -81,7 +83,9 @@ class ShellPlayer(MediaPlayerDevice):
 
         if self._args_compiled:
             try:
-                rendered_args = self._args_compiled.async_render({'media_id':media_id})
+                rendered_args = self._args_compiled.async_render(
+                    {'media_id': media_id}
+                    )
             except TemplateError as ex:
                 _LOGGER.exception("Error rendering command template: %s", ex)
                 return
@@ -109,4 +113,3 @@ class ShellPlayer(MediaPlayerDevice):
                     loop=self.hass.loop,
                     stdin=None
                     )
-


### PR DESCRIPTION
Hi all,
are you interested in this shell_player? Should I continue with documentation, etc?

Best regards
Jarek


This patch add media_player.shell_player

Config example:
```yaml
media_player:
    - platform: shell_player
      name: play_media
      command: play -q {{ media_id }}
```

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
