### PR TITLE
Frontend component should auto load auth component

### DIFF
--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -29,7 +29,8 @@ from homeassistant.util.yaml import load_yaml
 REQUIREMENTS = ['home-assistant-frontend==20180720.0']
 
 DOMAIN = 'frontend'
-DEPENDENCIES = ['api', 'websocket_api', 'http', 'system_log', 'onboarding']
+DEPENDENCIES = ['api', 'websocket_api', 'http', 'system_log',
+                'auth', 'onboarding']
 
 CONF_THEMES = 'themes'
 CONF_EXTRA_HTML_URL = 'extra_html_url'

--- a/tests/components/frontend/test_init.py
+++ b/tests/components/frontend/test_init.py
@@ -336,3 +336,15 @@ async def test_lovelace_ui_load_err(hass, hass_ws_client):
     assert msg['type'] == wapi.TYPE_RESULT
     assert msg['success'] is False
     assert msg['error']['code'] == 'load_error'
+
+
+async def test_auth_load(mock_http_client):
+    """Test auth component loaded by default."""
+    resp = await mock_http_client.get('/auth/providers')
+    assert resp.status == 200
+
+
+async def test_onboarding_load(mock_http_client):
+    """Test onboarding component loaded by default."""
+    resp = await mock_http_client.get('/api/onboarding')
+    assert resp.status == 200


### PR DESCRIPTION
## Description:
In our current instruction, we ask user add `auth:` to configuration.yaml as one of steps to enable new auth system. However it is very easy to miss that step. Because `auth` component provides basic API support for new login process, we think `frontend` should auto load `auth` even user is not explicitly enable it in configuration

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>
Several incidents have been reported in beta channel and support channel.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
No need explicitly have `auth:` in configuration.yaml as long as `frontend:` exists.

To enable new auth system, you only need
```yaml
# Example configuration.yaml entry
homeassistant:
  auth_providers:
   - type: homeassistant
   # Uncomment next line if you want to enable legacy API password support
   # - type: legacy_api_password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

