### PR TITLE
Remove entity picture of Tuya entity

### DIFF
--- a/homeassistant/components/tuya.py
+++ b/homeassistant/components/tuya.py
@@ -143,11 +143,6 @@ class TuyaDevice(Entity):
         return self.tuya.name()
 
     @property
-    def entity_picture(self):
-        """Return the entity picture to use in the frontend, if any."""
-        return self.tuya.iconurl()
-
-    @property
     def available(self):
         """Return if the device is available."""
         return self.tuya.available()


### PR DESCRIPTION
## Description:
This removes the default entity picture for all Tuya entities. Home Assistant will provide a generic icon based on the device type. We should only use entity picture to represent people/content.

We can use the icons again in the future when we introduce devices https://github.com/home-assistant/architecture/issues/36

CC @huangyupeng

