### PR TITLE
Upgrade mypy to 0.620

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -126,7 +126,7 @@ class HomeAssistant:
         else:
             self.loop = loop or asyncio.get_event_loop()
 
-        executor_opts = {'max_workers': None}
+        executor_opts = {'max_workers': None}  # type: Dict[str, Any]
         if sys.version_info[:2] >= (3, 6):
             executor_opts['thread_name_prefix'] = 'SyncWorker'
 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,7 +6,7 @@ coveralls==1.2.0
 flake8-docstrings==1.0.3
 flake8==3.5
 mock-open==1.3.1
-mypy==0.610
+mypy==0.620
 pydocstyle==1.1.1
 pylint==1.9.2
 pytest-aiohttp==0.3.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -7,7 +7,7 @@ coveralls==1.2.0
 flake8-docstrings==1.0.3
 flake8==3.5
 mock-open==1.3.1
-mypy==0.610
+mypy==0.620
 pydocstyle==1.1.1
 pylint==1.9.2
 pytest-aiohttp==0.3.0


### PR DESCRIPTION
## Description:

Upgrades mypy to 0.620. There's some oddity related to the change in homeassistant.core, but anyway this seems to at least get past the error, and I don't think it's incorrect in any way.

**Related issue (if applicable):** https://github.com/python/mypy/issues/5382

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**