### PR TITLE
Add other wemo motion sensor identifier

### DIFF
--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -27,6 +27,7 @@ WEMO_MODEL_DISPATCH = {
     'LightSwitch': 'switch',
     'Maker':   'switch',
     'Sensor':  'binary_sensor',
+    'Motion': 'binary_sensor',
     'Socket':  'switch'
 }
 

--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -26,8 +26,8 @@ WEMO_MODEL_DISPATCH = {
     'Insight': 'switch',
     'LightSwitch': 'switch',
     'Maker':   'switch',
-    'Sensor':  'binary_sensor',
     'Motion': 'binary_sensor',
+    'Sensor':  'binary_sensor',
     'Socket':  'switch'
 }
 


### PR DESCRIPTION
## Description:
Simply adds another identifier for motion sensors, now that the detection code has been updated.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
