### PR TITLE
Cast/Sonos: create config entry if manually configured

### DIFF
--- a/homeassistant/components/cast/__init__.py
+++ b/homeassistant/components/cast/__init__.py
@@ -1,4 +1,5 @@
 """Component to embed Google Cast."""
+from homeassistant import data_entry_flow
 from homeassistant.helpers import config_entry_flow
 
 
@@ -8,7 +9,14 @@ REQUIREMENTS = ['pychromecast==2.1.0']
 
 async def async_setup(hass, config):
     """Set up the Cast component."""
-    hass.data[DOMAIN] = config.get(DOMAIN, {})
+    conf = config.get(DOMAIN)
+
+    hass.data[DOMAIN] = conf or {}
+
+    if conf is not None:
+        hass.async_create_task(hass.config_entries.flow.async_init(
+            DOMAIN, source=data_entry_flow.SOURCE_IMPORT))
+
     return True
 
 

--- a/homeassistant/components/sonos/__init__.py
+++ b/homeassistant/components/sonos/__init__.py
@@ -1,4 +1,5 @@
 """Component to embed Sonos."""
+from homeassistant import data_entry_flow
 from homeassistant.helpers import config_entry_flow
 
 
@@ -8,7 +9,14 @@ REQUIREMENTS = ['SoCo==0.14']
 
 async def async_setup(hass, config):
     """Set up the Sonos component."""
-    hass.data[DOMAIN] = config.get(DOMAIN, {})
+    conf = config.get(DOMAIN)
+
+    hass.data[DOMAIN] = conf or {}
+
+    if conf is not None:
+        hass.async_create_task(hass.config_entries.flow.async_init(
+            DOMAIN, source=data_entry_flow.SOURCE_IMPORT))
+
     return True
 
 

--- a/homeassistant/helpers/config_entry_flow.py
+++ b/homeassistant/helpers/config_entry_flow.py
@@ -72,6 +72,18 @@ class DiscoveryFlowHandler(data_entry_flow.FlowHandler):
 
         return await self.async_step_confirm()
 
+    async def async_step_import(self, _):
+        """Handle a flow initialized by import."""
+        if self._async_in_progress() or self._async_current_entries():
+            return self.async_abort(
+                reason='single_instance_allowed'
+            )
+
+        return self.async_create_entry(
+            title=self._title,
+            data={},
+        )
+
     @callback
     def _async_current_entries(self):
         """Return current entries."""

--- a/tests/components/cast/test_init.py
+++ b/tests/components/cast/test_init.py
@@ -2,6 +2,7 @@
 from unittest.mock import patch
 
 from homeassistant import data_entry_flow
+from homeassistant.setup import async_setup_component
 from homeassistant.components import cast
 
 from tests.common import MockDependency, mock_coro
@@ -20,3 +21,33 @@ async def test_creating_entry_sets_up_media_player(hass):
         await hass.async_block_till_done()
 
     assert len(mock_setup.mock_calls) == 1
+
+
+async def test_configuring_cast_creates_entry(hass):
+    """Test that specifying config will create an entry."""
+    with patch('homeassistant.components.cast.async_setup_entry',
+               return_value=mock_coro(True)) as mock_setup, \
+            MockDependency('pychromecast', 'discovery'), \
+            patch('pychromecast.discovery.discover_chromecasts',
+                  return_value=True):
+        await async_setup_component(hass, cast.DOMAIN, {
+            'cast': {
+                'some_config': 'to_trigger_import'
+            }
+        })
+        await hass.async_block_till_done()
+
+    assert len(mock_setup.mock_calls) == 1
+
+
+async def test_not_configuring_cast_not_creates_entry(hass):
+    """Test that no config will not create an entry."""
+    with patch('homeassistant.components.cast.async_setup_entry',
+               return_value=mock_coro(True)) as mock_setup, \
+            MockDependency('pychromecast', 'discovery'), \
+            patch('pychromecast.discovery.discover_chromecasts',
+                  return_value=True):
+        await async_setup_component(hass, cast.DOMAIN, {})
+        await hass.async_block_till_done()
+
+    assert len(mock_setup.mock_calls) == 0

--- a/tests/components/sonos/test_init.py
+++ b/tests/components/sonos/test_init.py
@@ -2,6 +2,7 @@
 from unittest.mock import patch
 
 from homeassistant import data_entry_flow
+from homeassistant.setup import async_setup_component
 from homeassistant.components import sonos
 
 from tests.common import mock_coro
@@ -18,3 +19,29 @@ async def test_creating_entry_sets_up_media_player(hass):
         await hass.async_block_till_done()
 
     assert len(mock_setup.mock_calls) == 1
+
+
+async def test_configuring_sonos_creates_entry(hass):
+    """Test that specifying config will create an entry."""
+    with patch('homeassistant.components.sonos.async_setup_entry',
+               return_value=mock_coro(True)) as mock_setup, \
+            patch('soco.discover', return_value=True):
+        await async_setup_component(hass, sonos.DOMAIN, {
+            'sonos': {
+                'some_config': 'to_trigger_import'
+            }
+        })
+        await hass.async_block_till_done()
+
+    assert len(mock_setup.mock_calls) == 1
+
+
+async def test_not_configuring_sonos_not_creates_entry(hass):
+    """Test that no config will not create an entry."""
+    with patch('homeassistant.components.sonos.async_setup_entry',
+               return_value=mock_coro(True)) as mock_setup, \
+            patch('soco.discover', return_value=True):
+        await async_setup_component(hass, sonos.DOMAIN, {})
+        await hass.async_block_till_done()
+
+    assert len(mock_setup.mock_calls) == 0

--- a/tests/helpers/test_config_entry_flow.py
+++ b/tests/helpers/test_config_entry_flow.py
@@ -114,3 +114,24 @@ async def test_user_init_trumps_discovery(hass, flow_conf):
 
     # Discovery flow has been aborted
     assert len(hass.config_entries.flow.async_progress()) == 0
+
+
+async def test_import_no_confirmation(hass, flow_conf):
+    """Test import requires no confirmation to setup."""
+    flow = config_entries.HANDLERS['test']()
+    flow.hass = hass
+    flow_conf['discovered'] = True
+
+    result = await flow.async_step_import(None)
+    assert result['type'] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+
+
+async def test_import_single_instance(hass, flow_conf):
+    """Test import doesn't create second instance."""
+    flow = config_entries.HANDLERS['test']()
+    flow.hass = hass
+    flow_conf['discovered'] = True
+    MockConfigEntry(domain='test').add_to_hass(hass)
+
+    result = await flow.async_step_import(None)
+    assert result['type'] == data_entry_flow.RESULT_TYPE_ABORT


### PR DESCRIPTION
## Description:
If a user adds configuration for Sonos/Cast to their `configuration.yaml`, automatically create a config entry.

**Related issue (if applicable):** 
fixes #15146
fixes #15401 

CC @amelchio 

## Example entry for `configuration.yaml` (if applicable):
```yaml
sonos:
  something: here

cast:
  something: here
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
