### PR TITLE
Update smappy library version

### DIFF
--- a/homeassistant/components/smappee.py
+++ b/homeassistant/components/smappee.py
@@ -16,7 +16,7 @@ from homeassistant.util import Throttle
 from homeassistant.helpers.discovery import load_platform
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['smappy==0.2.15']
+REQUIREMENTS = ['smappy==0.2.16']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1256,7 +1256,7 @@ sleekxmpp==1.3.2
 sleepyq==0.6
 
 # homeassistant.components.smappee
-smappy==0.2.15
+smappy==0.2.16
 
 # homeassistant.components.raspihats
 # homeassistant.components.sensor.bh1750


### PR DESCRIPTION
## Description:

Updated the version of the used smappy library to 0.2.16 as been released on pypi.org.

**Breaking change:**
The updated library shows the temperature as degrees Celsius instead of centi degrees Celsius.

- https://pypi.org/project/smappy/
- https://github.com/EnergieID/smappy

I tested it on my local instance.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
