### PR TITLE
Allow changing entity ID

### DIFF
--- a/homeassistant/components/config/entity_registry.py
+++ b/homeassistant/components/config/entity_registry.py
@@ -20,6 +20,7 @@ SCHEMA_WS_UPDATE = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend({
     vol.Required('entity_id'): cv.entity_id,
     # If passed in, we update value. Passing None will remove old value.
     vol.Optional('name'): vol.Any(str, None),
+    vol.Optional('new_entity_id'): str,
 })
 
 
@@ -74,13 +75,22 @@ def websocket_update_entity(hass, connection, msg):
                 msg['id'], websocket_api.ERR_NOT_FOUND, 'Entity not found'))
             return
 
-        entry = registry.async_update_entity(
-            msg['entity_id'], name=msg['name'])
+        changes = {}
+
+        if 'name' in msg:
+            changes['name'] = msg['name']
+
+        if 'new_entity_id' in msg:
+            changes['new_entity_id'] = msg['new_entity_id']
+
+        if changes:
+            entry = registry.async_update_entity(msg['entity_id'], **changes)
+
         connection.send_message_outside(websocket_api.result_message(
             msg['id'], _entry_dict(entry)
         ))
 
-    hass.async_add_job(update_entity())
+    hass.async_create_task(update_entity())
 
 
 @callback

--- a/homeassistant/components/config/entity_registry.py
+++ b/homeassistant/components/config/entity_registry.py
@@ -83,12 +83,18 @@ def websocket_update_entity(hass, connection, msg):
         if 'new_entity_id' in msg:
             changes['new_entity_id'] = msg['new_entity_id']
 
-        if changes:
-            entry = registry.async_update_entity(msg['entity_id'], **changes)
-
-        connection.send_message_outside(websocket_api.result_message(
-            msg['id'], _entry_dict(entry)
-        ))
+        try:
+            if changes:
+                entry = registry.async_update_entity(
+                    msg['entity_id'], **changes)
+        except ValueError as err:
+            connection.send_message_outside(websocket_api.error_message(
+                msg['id'], 'invalid_info', str(err)
+            ))
+        else:
+            connection.send_message_outside(websocket_api.result_message(
+                msg['id'], _entry_dict(entry)
+            ))
 
     hass.async_create_task(update_entity())
 

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -82,6 +82,9 @@ class Entity:
     # Name in the entity registry
     registry_name = None
 
+    # Hold list for functions to call on remove.
+    _on_remove = None
+
     @property
     def should_poll(self) -> bool:
         """Return True if entity has to be polled for state.
@@ -324,8 +327,19 @@ class Entity:
             if self.parallel_updates:
                 self.parallel_updates.release()
 
+    @callback
+    def async_on_remove(self, func):
+        """Add a function to call when entity removed."""
+        if self._on_remove is None:
+            self._on_remove = []
+        self._on_remove.append(func)
+
     async def async_remove(self):
         """Remove entity from Home Assistant."""
+        if self._on_remove is not None:
+            while self._on_remove:
+                self._on_remove.pop()()
+
         if self.platform is not None:
             await self.platform.async_remove_entity(self.entity_id)
         else:

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -335,7 +335,17 @@ class Entity:
     def async_registry_updated(self, old, new):
         """Called when the entity registry has been updated."""
         self.registry_name = new.name
-        self.async_schedule_update_ha_state()
+
+        if new.entity_id == self.entity_id:
+            self.async_schedule_update_ha_state()
+            return
+
+        async def readd():
+            """Remove and add entity again."""
+            await self.async_remove()
+            await self.platform.async_add_entities([self])
+
+        self.hass.async_create_task(readd())
 
     def __eq__(self, other):
         """Return the comparison."""

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -283,7 +283,7 @@ class EntityPlatform:
 
             entity.entity_id = entry.entity_id
             entity.registry_name = entry.name
-            entry.add_update_listener(entity)
+            entity.async_on_remove(entry.add_update_listener(entity))
 
         # We won't generate an entity ID if the platform has already set one
         # We will however make sure that platform cannot pick a registered ID

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -63,8 +63,13 @@ class RegistryEntry:
         """Listen for when entry is updated.
 
         Listener: Callback function(old_entry, new_entry)
+
+        Returns function to unlisten.
         """
-        self.update_listeners.append(weakref.ref(listener))
+        weak_listener = weakref.ref(listener)
+        self.update_listeners.append(weak_listener)
+
+        return lambda: self.update_listeners.remove(weak_listener)
 
 
 class EntityRegistry:

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -400,3 +400,15 @@ def test_async_remove_no_platform(hass):
     assert len(hass.states.async_entity_ids()) == 1
     yield from ent.async_remove()
     assert len(hass.states.async_entity_ids()) == 0
+
+
+async def test_async_remove_runs_callbacks(hass):
+    """Test async_remove method when no platform set."""
+    result = []
+
+    ent = entity.Entity()
+    ent.hass = hass
+    ent.entity_id = 'test.test'
+    ent.async_on_remove(lambda: result.append(1))
+    await ent.async_remove()
+    assert len(result) == 1

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -5,6 +5,8 @@ import unittest
 from unittest.mock import patch, Mock, MagicMock
 from datetime import timedelta
 
+import pytest
+
 from homeassistant.exceptions import PlatformNotReady
 import homeassistant.loader as loader
 from homeassistant.helpers.entity import generate_entity_id
@@ -487,7 +489,7 @@ def test_registry_respect_entity_disabled(hass):
     assert hass.states.async_entity_ids() == []
 
 
-async def test_entity_registry_updates(hass):
+async def test_entity_registry_updates_name(hass):
     """Test that updates on the entity registry update platform entities."""
     registry = mock_registry(hass, {
         'test_domain.world': entity_registry.RegistryEntry(
@@ -602,3 +604,75 @@ def test_not_fails_with_adding_empty_entities_(hass):
     yield from component.async_add_entities([])
 
     assert len(hass.states.async_entity_ids()) == 0
+
+
+async def test_entity_registry_updates_entity_id(hass):
+    """Test that updates on the entity registry update platform entities."""
+    registry = mock_registry(hass, {
+        'test_domain.world': entity_registry.RegistryEntry(
+            entity_id='test_domain.world',
+            unique_id='1234',
+            # Using component.async_add_entities is equal to platform "domain"
+            platform='test_platform',
+            name='Some name'
+        )
+    })
+    platform = MockEntityPlatform(hass)
+    entity = MockEntity(unique_id='1234')
+    await platform.async_add_entities([entity])
+
+    state = hass.states.get('test_domain.world')
+    assert state is not None
+    assert state.name == 'Some name'
+
+    registry.async_update_entity('test_domain.world',
+                                 new_entity_id='test_domain.planet')
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+
+    assert hass.states.get('test_domain.world') is None
+    state = hass.states.get('test_domain.planet')
+
+
+async def test_entity_registry_updates_invalid_entity_id(hass):
+    """Test that we can't update to an invalid entity id."""
+    registry = mock_registry(hass, {
+        'test_domain.world': entity_registry.RegistryEntry(
+            entity_id='test_domain.world',
+            unique_id='1234',
+            # Using component.async_add_entities is equal to platform "domain"
+            platform='test_platform',
+            name='Some name'
+        ),
+        'test_domain.existing': entity_registry.RegistryEntry(
+            entity_id='test_domain.existing',
+            unique_id='5678',
+            platform='test_platform',
+        ),
+    })
+    platform = MockEntityPlatform(hass)
+    entity = MockEntity(unique_id='1234')
+    await platform.async_add_entities([entity])
+
+    state = hass.states.get('test_domain.world')
+    assert state is not None
+    assert state.name == 'Some name'
+
+    with pytest.raises(ValueError):
+        registry.async_update_entity('test_domain.world',
+                                     new_entity_id='test_domain.existing')
+
+    with pytest.raises(ValueError):
+        registry.async_update_entity('test_domain.world',
+                                     new_entity_id='invalid_entity_id')
+
+    with pytest.raises(ValueError):
+        registry.async_update_entity('test_domain.world',
+                                     new_entity_id='diff_domain.world')
+
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+
+    assert hass.states.get('test_domain.world') is not None
+    state = hass.states.get('invalid_entity_id') is None
+    state = hass.states.get('diff_domain.world') is None

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -631,7 +631,7 @@ async def test_entity_registry_updates_entity_id(hass):
     await hass.async_block_till_done()
 
     assert hass.states.get('test_domain.world') is None
-    state = hass.states.get('test_domain.planet')
+    assert hass.states.get('test_domain.planet') is not None
 
 
 async def test_entity_registry_updates_invalid_entity_id(hass):
@@ -674,5 +674,5 @@ async def test_entity_registry_updates_invalid_entity_id(hass):
     await hass.async_block_till_done()
 
     assert hass.states.get('test_domain.world') is not None
-    state = hass.states.get('invalid_entity_id') is None
-    state = hass.states.get('diff_domain.world') is None
+    assert hass.states.get('invalid_entity_id') is None
+    assert hass.states.get('diff_domain.world') is None


### PR DESCRIPTION
## Description:
Allow changing the entity ID of an entity without restarting Home Assistant.

To do:
 - [x] Hook it up to entity registry websocket command

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
