### PR TITLE
Import collections abstract base classes from collections.abc

### DIFF
--- a/homeassistant/components/google_assistant/smart_home.py
+++ b/homeassistant/components/google_assistant/smart_home.py
@@ -1,5 +1,5 @@
 """Support for Google Assistant Smart Home API."""
-import collections
+from collections.abc import Mapping
 from itertools import product
 import logging
 
@@ -50,7 +50,7 @@ DOMAIN_TO_GOOGLE_TYPES = {
 def deep_update(target, source):
     """Update a nested dictionary with another nested dictionary."""
     for key, value in source.items():
-        if isinstance(value, collections.Mapping):
+        if isinstance(value, Mapping):
             target[key] = deep_update(target.get(key, {}), value)
         else:
             target[key] = value

--- a/homeassistant/components/notify/group.py
+++ b/homeassistant/components/notify/group.py
@@ -5,7 +5,7 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/notify.group/
 """
 import asyncio
-import collections
+from collections.abc import Mapping
 from copy import deepcopy
 import logging
 import voluptuous as vol
@@ -33,7 +33,7 @@ def update(input_dict, update_source):
     Async friendly.
     """
     for key, val in update_source.items():
-        if isinstance(val, collections.Mapping):
+        if isinstance(val, Mapping):
             recurse = update(input_dict.get(key, {}), val)
             input_dict[key] = recurse
         else:


### PR DESCRIPTION
## Description:

Accessing them directly through collections is deprecated since 3.7, and
will no longer work in 3.8. https://docs.python.org/3.7/library/collections.html

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
