### PR TITLE
0.74.1

### DIFF
--- a/homeassistant/components/cast/__init__.py
+++ b/homeassistant/components/cast/__init__.py
@@ -1,4 +1,5 @@
 """Component to embed Google Cast."""
+from homeassistant import data_entry_flow
 from homeassistant.helpers import config_entry_flow
 
 
@@ -8,7 +9,14 @@ REQUIREMENTS = ['pychromecast==2.1.0']
 
 async def async_setup(hass, config):
     """Set up the Cast component."""
-    hass.data[DOMAIN] = config.get(DOMAIN, {})
+    conf = config.get(DOMAIN)
+
+    hass.data[DOMAIN] = conf or {}
+
+    if conf is not None:
+        hass.async_create_task(hass.config_entries.flow.async_init(
+            DOMAIN, source=data_entry_flow.SOURCE_IMPORT))
+
     return True
 
 

--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -29,7 +29,8 @@ from homeassistant.util.yaml import load_yaml
 REQUIREMENTS = ['home-assistant-frontend==20180720.0']
 
 DOMAIN = 'frontend'
-DEPENDENCIES = ['api', 'websocket_api', 'http', 'system_log', 'onboarding']
+DEPENDENCIES = ['api', 'websocket_api', 'http', 'system_log',
+                'auth', 'onboarding']
 
 CONF_THEMES = 'themes'
 CONF_EXTRA_HTML_URL = 'extra_html_url'

--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -21,9 +21,10 @@ from homeassistant.helpers.entityfilter import FILTER_SCHEMA
 from homeassistant.util import get_local_ip
 from homeassistant.util.decorator import Registry
 from .const import (
-    CONF_AUTO_START, CONF_ENTITY_CONFIG, CONF_FEATURE_LIST, CONF_FILTER,
-    DEFAULT_AUTO_START, DEFAULT_PORT, DEVICE_CLASS_CO2, DEVICE_CLASS_PM25,
-    DOMAIN, HOMEKIT_FILE, SERVICE_HOMEKIT_START, TYPE_OUTLET, TYPE_SWITCH)
+    BRIDGE_NAME, CONF_AUTO_START, CONF_ENTITY_CONFIG, CONF_FEATURE_LIST,
+    CONF_FILTER, DEFAULT_AUTO_START, DEFAULT_PORT, DEVICE_CLASS_CO2,
+    DEVICE_CLASS_PM25, DOMAIN, HOMEKIT_FILE, SERVICE_HOMEKIT_START,
+    TYPE_OUTLET, TYPE_SWITCH)
 from .util import (
     show_setup_message, validate_entity_config, validate_media_player_features)
 
@@ -43,6 +44,8 @@ SWITCH_TYPES = {TYPE_OUTLET: 'Outlet',
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.All({
+        vol.Optional(CONF_NAME, default=BRIDGE_NAME):
+            vol.All(cv.string, vol.Length(min=3, max=25)),
         vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
         vol.Optional(CONF_IP_ADDRESS):
             vol.All(ipaddress.ip_address, cv.string),
@@ -58,13 +61,15 @@ async def async_setup(hass, config):
     _LOGGER.debug('Begin setup HomeKit')
 
     conf = config[DOMAIN]
+    name = conf[CONF_NAME]
     port = conf[CONF_PORT]
     ip_address = conf.get(CONF_IP_ADDRESS)
     auto_start = conf[CONF_AUTO_START]
     entity_filter = conf[CONF_FILTER]
     entity_config = conf[CONF_ENTITY_CONFIG]
 
-    homekit = HomeKit(hass, port, ip_address, entity_filter, entity_config)
+    homekit = HomeKit(hass, name, port, ip_address, entity_filter,
+                      entity_config)
     await hass.async_add_job(homekit.setup)
 
     if auto_start:
@@ -176,9 +181,11 @@ def generate_aid(entity_id):
 class HomeKit():
     """Class to handle all actions between HomeKit and Home Assistant."""
 
-    def __init__(self, hass, port, ip_address, entity_filter, entity_config):
+    def __init__(self, hass, name, port, ip_address, entity_filter,
+                 entity_config):
         """Initialize a HomeKit object."""
         self.hass = hass
+        self._name = name
         self._port = port
         self._ip_address = ip_address
         self._filter = entity_filter
@@ -199,7 +206,7 @@ class HomeKit():
         path = self.hass.config.path(HOMEKIT_FILE)
         self.driver = HomeDriver(self.hass, address=ip_addr,
                                  port=self._port, persist_file=path)
-        self.bridge = HomeBridge(self.hass, self.driver)
+        self.bridge = HomeBridge(self.hass, self.driver, self._name)
 
     def add_bridge_accessory(self, state):
         """Try adding accessory to bridge if configured beforehand."""

--- a/homeassistant/components/homekit/accessories.py
+++ b/homeassistant/components/homekit/accessories.py
@@ -17,7 +17,7 @@ from homeassistant.helpers.event import (
 from homeassistant.util import dt as dt_util
 
 from .const import (
-    BRIDGE_MODEL, BRIDGE_NAME, BRIDGE_SERIAL_NUMBER, CHAR_BATTERY_LEVEL,
+    BRIDGE_MODEL, BRIDGE_SERIAL_NUMBER, CHAR_BATTERY_LEVEL,
     CHAR_CHARGING_STATE, CHAR_STATUS_LOW_BATTERY, DEBOUNCE_TIMEOUT,
     MANUFACTURER, SERV_BATTERY_SERVICE)
 from .util import (
@@ -141,7 +141,7 @@ class HomeAccessory(Accessory):
 class HomeBridge(Bridge):
     """Adapter class for Bridge."""
 
-    def __init__(self, hass, driver, name=BRIDGE_NAME):
+    def __init__(self, hass, driver, name):
         """Initialize a Bridge object."""
         super().__init__(driver, name)
         self.set_info_service(

--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -865,9 +865,10 @@ class SonosDevice(MediaPlayerDevice):
         """List of available input sources."""
         sources = [fav.title for fav in self._favorites]
 
-        if 'PLAY:5' in self._model or 'CONNECT' in self._model:
+        model = self._model.upper()
+        if 'PLAY:5' in model or 'CONNECT' in model:
             sources += [SOURCE_LINEIN]
-        elif 'PLAYBAR' in self._model:
+        elif 'PLAYBAR' in model:
             sources += [SOURCE_LINEIN, SOURCE_TV]
 
         return sources

--- a/homeassistant/components/sonos/__init__.py
+++ b/homeassistant/components/sonos/__init__.py
@@ -1,4 +1,5 @@
 """Component to embed Sonos."""
+from homeassistant import data_entry_flow
 from homeassistant.helpers import config_entry_flow
 
 
@@ -8,7 +9,14 @@ REQUIREMENTS = ['SoCo==0.14']
 
 async def async_setup(hass, config):
     """Set up the Sonos component."""
-    hass.data[DOMAIN] = config.get(DOMAIN, {})
+    conf = config.get(DOMAIN)
+
+    hass.data[DOMAIN] = conf or {}
+
+    if conf is not None:
+        hass.async_create_task(hass.config_entries.flow.async_init(
+            DOMAIN, source=data_entry_flow.SOURCE_IMPORT))
+
     return True
 
 

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -2,7 +2,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 74
-PATCH_VERSION = '0'
+PATCH_VERSION = '1'
 __short_version__ = '{}.{}'.format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = '{}.{}'.format(__short_version__, PATCH_VERSION)
 REQUIRED_PYTHON_VER = (3, 5, 3)

--- a/homeassistant/helpers/config_entry_flow.py
+++ b/homeassistant/helpers/config_entry_flow.py
@@ -72,6 +72,18 @@ class DiscoveryFlowHandler(data_entry_flow.FlowHandler):
 
         return await self.async_step_confirm()
 
+    async def async_step_import(self, _):
+        """Handle a flow initialized by import."""
+        if self._async_in_progress() or self._async_current_entries():
+            return self.async_abort(
+                reason='single_instance_allowed'
+            )
+
+        return self.async_create_entry(
+            title=self._title,
+            data={},
+        )
+
     @callback
     def _async_current_entries(self):
         """Return current entries."""

--- a/tests/components/cast/test_init.py
+++ b/tests/components/cast/test_init.py
@@ -2,6 +2,7 @@
 from unittest.mock import patch
 
 from homeassistant import data_entry_flow
+from homeassistant.setup import async_setup_component
 from homeassistant.components import cast
 
 from tests.common import MockDependency, mock_coro
@@ -20,3 +21,33 @@ async def test_creating_entry_sets_up_media_player(hass):
         await hass.async_block_till_done()
 
     assert len(mock_setup.mock_calls) == 1
+
+
+async def test_configuring_cast_creates_entry(hass):
+    """Test that specifying config will create an entry."""
+    with patch('homeassistant.components.cast.async_setup_entry',
+               return_value=mock_coro(True)) as mock_setup, \
+            MockDependency('pychromecast', 'discovery'), \
+            patch('pychromecast.discovery.discover_chromecasts',
+                  return_value=True):
+        await async_setup_component(hass, cast.DOMAIN, {
+            'cast': {
+                'some_config': 'to_trigger_import'
+            }
+        })
+        await hass.async_block_till_done()
+
+    assert len(mock_setup.mock_calls) == 1
+
+
+async def test_not_configuring_cast_not_creates_entry(hass):
+    """Test that no config will not create an entry."""
+    with patch('homeassistant.components.cast.async_setup_entry',
+               return_value=mock_coro(True)) as mock_setup, \
+            MockDependency('pychromecast', 'discovery'), \
+            patch('pychromecast.discovery.discover_chromecasts',
+                  return_value=True):
+        await async_setup_component(hass, cast.DOMAIN, {})
+        await hass.async_block_till_done()
+
+    assert len(mock_setup.mock_calls) == 0

--- a/tests/components/frontend/test_init.py
+++ b/tests/components/frontend/test_init.py
@@ -336,3 +336,15 @@ async def test_lovelace_ui_load_err(hass, hass_ws_client):
     assert msg['type'] == wapi.TYPE_RESULT
     assert msg['success'] is False
     assert msg['error']['code'] == 'load_error'
+
+
+async def test_auth_load(mock_http_client):
+    """Test auth component loaded by default."""
+    resp = await mock_http_client.get('/auth/providers')
+    assert resp.status == 200
+
+
+async def test_onboarding_load(mock_http_client):
+    """Test onboarding component loaded by default."""
+    resp = await mock_http_client.get('/api/onboarding')
+    assert resp.status == 200

--- a/tests/components/homekit/test_accessories.py
+++ b/tests/components/homekit/test_accessories.py
@@ -146,7 +146,7 @@ async def test_battery_service(hass, hk_driver):
 
 def test_home_bridge(hk_driver):
     """Test HomeBridge class."""
-    bridge = HomeBridge('hass', hk_driver)
+    bridge = HomeBridge('hass', hk_driver, BRIDGE_NAME)
     assert bridge.hass == 'hass'
     assert bridge.display_name == BRIDGE_NAME
     assert bridge.category == 2  # Category.BRIDGE

--- a/tests/components/sonos/test_init.py
+++ b/tests/components/sonos/test_init.py
@@ -2,6 +2,7 @@
 from unittest.mock import patch
 
 from homeassistant import data_entry_flow
+from homeassistant.setup import async_setup_component
 from homeassistant.components import sonos
 
 from tests.common import mock_coro
@@ -18,3 +19,29 @@ async def test_creating_entry_sets_up_media_player(hass):
         await hass.async_block_till_done()
 
     assert len(mock_setup.mock_calls) == 1
+
+
+async def test_configuring_sonos_creates_entry(hass):
+    """Test that specifying config will create an entry."""
+    with patch('homeassistant.components.sonos.async_setup_entry',
+               return_value=mock_coro(True)) as mock_setup, \
+            patch('soco.discover', return_value=True):
+        await async_setup_component(hass, sonos.DOMAIN, {
+            'sonos': {
+                'some_config': 'to_trigger_import'
+            }
+        })
+        await hass.async_block_till_done()
+
+    assert len(mock_setup.mock_calls) == 1
+
+
+async def test_not_configuring_sonos_not_creates_entry(hass):
+    """Test that no config will not create an entry."""
+    with patch('homeassistant.components.sonos.async_setup_entry',
+               return_value=mock_coro(True)) as mock_setup, \
+            patch('soco.discover', return_value=True):
+        await async_setup_component(hass, sonos.DOMAIN, {})
+        await hass.async_block_till_done()
+
+    assert len(mock_setup.mock_calls) == 0

--- a/tests/helpers/test_config_entry_flow.py
+++ b/tests/helpers/test_config_entry_flow.py
@@ -114,3 +114,24 @@ async def test_user_init_trumps_discovery(hass, flow_conf):
 
     # Discovery flow has been aborted
     assert len(hass.config_entries.flow.async_progress()) == 0
+
+
+async def test_import_no_confirmation(hass, flow_conf):
+    """Test import requires no confirmation to setup."""
+    flow = config_entries.HANDLERS['test']()
+    flow.hass = hass
+    flow_conf['discovered'] = True
+
+    result = await flow.async_step_import(None)
+    assert result['type'] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+
+
+async def test_import_single_instance(hass, flow_conf):
+    """Test import doesn't create second instance."""
+    flow = config_entries.HANDLERS['test']()
+    flow.hass = hass
+    flow_conf['discovered'] = True
+    MockConfigEntry(domain='test').add_to_hass(hass)
+
+    result = await flow.async_step_import(None)
+    assert result['type'] == data_entry_flow.RESULT_TYPE_ABORT


### PR DESCRIPTION
- Bugfix HomeKit name and serial_number ([@cdce8p] - [#15600]) ([homekit docs])
- Use case insensitive comparison for Sonos model check ([@amelchio] - [#15604]) ([media_player.sonos docs])
- Frontend component should auto load auth coomponent ([@awarecan] - [#15606]) ([frontend docs])
- Cast/Sonos: create config entry if manually configured ([@balloob] - [#15630]) ([cast docs]) ([sonos docs])

[#15600]: https://github.com/home-assistant/home-assistant/pull/15600
[#15604]: https://github.com/home-assistant/home-assistant/pull/15604
[#15606]: https://github.com/home-assistant/home-assistant/pull/15606
[#15630]: https://github.com/home-assistant/home-assistant/pull/15630
[@amelchio]: https://github.com/amelchio
[@awarecan]: https://github.com/awarecan
[@balloob]: https://github.com/balloob
[@cdce8p]: https://github.com/cdce8p
[cast docs]: https://www.home-assistant.io/components/cast/
[frontend docs]: https://www.home-assistant.io/components/frontend/
[homekit docs]: https://www.home-assistant.io/components/homekit/
[media_player.sonos docs]: https://www.home-assistant.io/components/media_player.sonos/
[sonos docs]: https://www.home-assistant.io/components/sonos/
