### PR TITLE
Downgrade netatmo warning-level log to info-level

### DIFF
--- a/homeassistant/components/sensor/netatmo.py
+++ b/homeassistant/components/sensor/netatmo.py
@@ -340,7 +340,7 @@ class NetAtmoData:
                         # Never hammer the NetAtmo API more than
                         # twice per update interval
                         newinterval = NETATMO_UPDATE_INTERVAL / 2
-                    _LOGGER.warning(
+                    _LOGGER.info(
                         "NetAtmo refresh interval reset to %d seconds",
                         newinterval)
             else:


### PR DESCRIPTION
## Description:

This mini-PR changes a recently-added log to info level, as the content of the log is not problematic.

**Related issue (if applicable):** fixes #15618

## Example entry for `configuration.yaml` N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
