### PR TITLE
Fixed Ziggo Mediabox XL media_player on / off handeling

### DIFF
--- a/homeassistant/components/media_player/ziggo_mediabox_xl.py
+++ b/homeassistant/components/media_player/ziggo_mediabox_xl.py
@@ -122,13 +122,15 @@ class ZiggoMediaboxXLDevice(MediaPlayerDevice):
 
     def turn_on(self):
         """Turn the media player on."""
-        self.send_keys(['POWER'])
-        self._state = STATE_ON
+        if self._state is STATE_OFF:
+            self.send_keys(['POWER'])
+            self._state = STATE_ON
 
     def turn_off(self):
         """Turn off media player."""
-        self.send_keys(['POWER'])
-        self._state = STATE_OFF
+        if self._state is not STATE_OFF:
+            self.send_keys(['POWER'])
+            self._state = STATE_OFF
 
     def media_play(self):
         """Send play command."""


### PR DESCRIPTION
## Description:
This adds an extra check if the Ziggo Mediabox XL is already on or off. When the device is already off it does not turn on when you send a off command.

## Issue
The Ziggo Mediabox XL turns on if you send a turn off command through an automation when the device is already turned off.

## Documentation
This does not need any documentation.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
