### PR TITLE
Add support for 2 Tahoma IO awning covers

### DIFF
--- a/homeassistant/components/cover/tahoma.py
+++ b/homeassistant/components/cover/tahoma.py
@@ -213,11 +213,17 @@ class TahomaCover(TahomaDevice, CoverDevice):
 
     def open_cover(self, **kwargs):
         """Open the cover."""
-        self.apply_action('open')
+        if self.tahoma_device.type == 'io:HorizontalAwningIOComponent':
+            self.apply_action('close')
+        else:
+            self.apply_action('open')
 
     def close_cover(self, **kwargs):
         """Close the cover."""
-        self.apply_action('close')
+        if self.tahoma_device.type == 'io:HorizontalAwningIOComponent':
+            self.apply_action('open')
+        else:
+            self.apply_action('close')
 
     def stop_cover(self, **kwargs):
         """Stop the cover."""

--- a/homeassistant/components/cover/tahoma.py
+++ b/homeassistant/components/cover/tahoma.py
@@ -239,8 +239,9 @@ class TahomaCover(TahomaDevice, CoverDevice):
                  'rts:BlindRTSComponent'):
             self.apply_action('my')
         elif self.tahoma_device.type in \
-                ('io:VerticalExteriorAwningIOComponent',
-                 'io:HorizontalAwningIOComponent'):
+                ('io:HorizontalAwningIOComponent',
+                 'io:RollerShutterGenericIOComponent',
+                 'io:VerticalExteriorAwningIOComponent'):
             self.apply_action('stop')
         else:
             self.apply_action('stopIdentify')

--- a/homeassistant/components/cover/tahoma.py
+++ b/homeassistant/components/cover/tahoma.py
@@ -14,6 +14,15 @@ DEPENDENCIES = ['tahoma']
 
 _LOGGER = logging.getLogger(__name__)
 
+ATTR_CLOSURE = 'closure'
+ATTR_MEM_POS = 'memorized_position'
+ATTR_RSSI_LEVEL = 'rssi_level'
+ATTR_OPEN_CLOSE = 'open_close'
+ATTR_STATUS = 'status'
+ATTR_LOCK_TIMER = 'priority_lock_timer'
+ATTR_LOCK_LEVEL = 'priority_lock_level'
+ATTR_LOCK_ORIG = 'priority_lock_originator'
+
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Tahoma covers."""
@@ -27,27 +36,84 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class TahomaCover(TahomaDevice, CoverDevice):
     """Representation a Tahoma Cover."""
 
+    def __init__(self, tahoma_device, controller):
+        """Initialize the device."""
+        super().__init__(tahoma_device, controller)
+
+        self._closure = 0
+        # 100 equals open
+        self._position = 100
+        self._closed = False
+        self._icon = None
+        # Can be 0 and bigger
+        self._lock_timer = 0
+        # Can be 'comfortLevel1'
+        self._lock_level = None
+        # Can be 'wind'
+        self._lock_originator = None
+
     def update(self):
         """Update method."""
         self.controller.get_states([self.tahoma_device])
 
+        if 'core:ClosureState' in self.tahoma_device.active_states:
+            self._closure = \
+                self.tahoma_device.active_states['core:ClosureState']
+        else:
+            self._closure = None
+        if 'core:PriorityLockTimerState' in self.tahoma_device.active_states:
+            self._lock_timer = \
+                self.tahoma_device.active_states['core:PriorityLockTimerState']
+        else:
+            self._lock_timer = None
+        if 'io:PriorityLockLevelState' in self.tahoma_device.active_states:
+            self._lock_level = \
+                self.tahoma_device.active_states['io:PriorityLockLevelState']
+        else:
+            self._lock_level = None
+        if 'io:PriorityLockOriginatorState' in \
+                self.tahoma_device.active_states:
+            self._lock_originator = \
+                self.tahoma_device.active_states[
+                    'io:PriorityLockOriginatorState']
+        else:
+            self._lock_originator = None
+
+        # Define which icon to use
+        if self._lock_timer > 0:
+            if self._lock_originator == 'wind':
+                self._icon = 'mdi:weather-windy'
+            else:
+                self._icon = 'mdi:lock-alert'
+        else:
+            self._icon = None
+
+        # Define current position.
+        #   _position: 0 is closed, 100 is fully open.
+        #   'core:ClosureState': 100 is closed, 0 is fully open.
+        if 'core:ClosureState' in self.tahoma_device.active_states:
+            self._position = 100 - \
+                self.tahoma_device.active_states['core:ClosureState']
+            if self._position <= 5:
+                self._position = 0
+            if self._position >= 95:
+                self._position = 100
+            self._closed = self._position == 0
+        else:
+            self._position = None
+            if 'core:OpenClosedState' in self.tahoma_device.active_states:
+                self._closed = \
+                    self.tahoma_device.active_states['core:OpenClosedState']\
+                    == 'closed'
+            else:
+                self._closed = False
+
+        _LOGGER.debug("Update %s, position: %d", self._name, self._position)
+
     @property
     def current_cover_position(self):
-        """
-        Return current position of cover.
-
-        0 is closed, 100 is fully open.
-        """
-        try:
-            position = 100 - \
-                self.tahoma_device.active_states['core:ClosureState']
-            if position <= 5:
-                return 0
-            if position >= 95:
-                return 100
-            return position
-        except KeyError:
-            return None
+        """Return current position of cover."""
+        return self._position
 
     def set_cover_position(self, **kwargs):
         """Move the cover to a specific position."""
@@ -56,8 +122,7 @@ class TahomaCover(TahomaDevice, CoverDevice):
     @property
     def is_closed(self):
         """Return if the cover is closed."""
-        if self.current_cover_position is not None:
-            return self.current_cover_position == 0
+        return self._closed
 
     @property
     def device_class(self):
@@ -66,13 +131,56 @@ class TahomaCover(TahomaDevice, CoverDevice):
             return 'window'
         return None
 
+    @property
+    def device_state_attributes(self):
+        """Return the device state attributes."""
+        attr = {}
+        super_attr = super().device_state_attributes
+        if super_attr is not None:
+            attr.update(super_attr)
+
+        if self._closure is not None:
+            attr[ATTR_CLOSURE] = self._closure
+        if 'core:Memorized1PositionState' in self.tahoma_device.active_states:
+            attr[ATTR_MEM_POS] = self.tahoma_device.active_states[
+                'core:Memorized1PositionState']
+        if 'core:RSSILevelState' in self.tahoma_device.active_states:
+            attr[ATTR_RSSI_LEVEL] = self.tahoma_device.active_states[
+                'core:RSSILevelState']
+        if 'core:OpenClosedState' in self.tahoma_device.active_states:
+            attr[ATTR_OPEN_CLOSE] = self.tahoma_device.active_states[
+                'core:OpenClosedState']
+        if 'core:StatusState' in self.tahoma_device.active_states:
+            attr[ATTR_STATUS] = self.tahoma_device.active_states[
+                'core:StatusState']
+        if self._lock_timer is not None:
+            attr[ATTR_LOCK_TIMER] = self._lock_timer
+        if self._lock_level is not None:
+            attr[ATTR_LOCK_LEVEL] = self._lock_level
+        if self._lock_originator is not None:
+            attr[ATTR_LOCK_ORIG] = self._lock_originator
+        return attr
+
+    @property
+    def icon(self):
+        """Return the icon to use in the frontend, if any."""
+        return self._icon
+
     def open_cover(self, **kwargs):
         """Open the cover."""
-        self.apply_action('open')
+        if self.tahoma_device.type == 'io:HorizontalAwningIOComponent':
+            # The commands open and close seem to be reversed.
+            self.apply_action('close')
+        else:
+            self.apply_action('open')
 
     def close_cover(self, **kwargs):
         """Close the cover."""
-        self.apply_action('close')
+        if self.tahoma_device.type == 'io:HorizontalAwningIOComponent':
+            # The commands open and close seem to be reversed.
+            self.apply_action('open')
+        else:
+            self.apply_action('close')
 
     def stop_cover(self, **kwargs):
         """Stop the cover."""
@@ -87,5 +195,9 @@ class TahomaCover(TahomaDevice, CoverDevice):
                  'rts:ExteriorVenetianBlindRTSComponent',
                  'rts:BlindRTSComponent'):
             self.apply_action('my')
+        elif self.tahoma_device.type in \
+                ('io:VerticalExteriorAwningIOComponent',
+                 'io:HorizontalAwningIOComponent'):
+            self.apply_action('stop')
         else:
             self.apply_action('stopIdentify')

--- a/homeassistant/components/cover/tahoma.py
+++ b/homeassistant/components/cover/tahoma.py
@@ -16,14 +16,10 @@ DEPENDENCIES = ['tahoma']
 
 _LOGGER = logging.getLogger(__name__)
 
-ATTR_CLOSURE = 'closure'
 ATTR_MEM_POS = 'memorized_position'
 ATTR_RSSI_LEVEL = 'rssi_level'
-ATTR_OPEN_CLOSE = 'open_close'
-ATTR_STATUS = 'status'
 ATTR_LOCK_START_TS = 'lock_start_ts'
 ATTR_LOCK_END_TS = 'lock_end_ts'
-ATTR_LOCK_TIMER = 'lock_timer'
 ATTR_LOCK_LEVEL = 'lock_level'
 ATTR_LOCK_ORIG = 'lock_originator'
 
@@ -180,22 +176,11 @@ class TahomaCover(TahomaDevice, CoverDevice):
         if super_attr is not None:
             attr.update(super_attr)
 
-        if self._closure is not None:
-            attr[ATTR_CLOSURE] = self._closure
         if 'core:Memorized1PositionState' in self.tahoma_device.active_states:
             attr[ATTR_MEM_POS] = self.tahoma_device.active_states[
                 'core:Memorized1PositionState']
         if self._rssi_level is not None:
             attr[ATTR_RSSI_LEVEL] = self._rssi_level
-        if 'core:OpenClosedState' in self.tahoma_device.active_states:
-            attr[ATTR_OPEN_CLOSE] = self.tahoma_device.active_states[
-                'core:OpenClosedState']
-        # Can be 'available', 'unavailable'
-        if 'core:StatusState' in self.tahoma_device.active_states:
-            attr[ATTR_STATUS] = self.tahoma_device.active_states[
-                'core:StatusState']
-        if self._lock_timer > 0:
-            attr[ATTR_LOCK_TIMER] = self._lock_timer
         if self._lock_start_ts is not None:
             attr[ATTR_LOCK_START_TS] = self._lock_start_ts.isoformat()
         if self._lock_end_ts is not None:

--- a/homeassistant/components/cover/tahoma.py
+++ b/homeassistant/components/cover/tahoma.py
@@ -63,15 +63,12 @@ class TahomaCover(TahomaDevice, CoverDevice):
         self.controller.get_states([self.tahoma_device])
 
         # For vertical covers
-        if 'core:ClosureState' in self.tahoma_device.active_states:
-            self._closure = \
-                self.tahoma_device.active_states['core:ClosureState']
+        self._closure = self.tahoma_device.active_states.get(
+            'core:ClosureState')
         # For horizontal covers
-        elif 'core:DeploymentState' in self.tahoma_device.active_states:
-            self._closure = \
-                self.tahoma_device.active_states['core:DeploymentState']
-        else:
-            self._closure = None
+        if self._closure is None:
+            self._closure = self.tahoma_device.active_states.get(
+                'core:DeploymentState')
 
         # For all, if available
         if 'core:PriorityLockTimerState' in self.tahoma_device.active_states:
@@ -97,25 +94,14 @@ class TahomaCover(TahomaDevice, CoverDevice):
             self._lock_start_ts = None
             self._lock_end_ts = None
 
-        if 'io:PriorityLockLevelState' in self.tahoma_device.active_states:
-            self._lock_level = \
-                self.tahoma_device.active_states['io:PriorityLockLevelState']
-        else:
-            self._lock_level = None
+        self._lock_level = self.tahoma_device.active_states.get(
+            'io:PriorityLockLevelState')
 
-        if 'io:PriorityLockOriginatorState' in \
-                self.tahoma_device.active_states:
-            self._lock_originator = \
-                self.tahoma_device.active_states[
-                    'io:PriorityLockOriginatorState']
-        else:
-            self._lock_originator = None
+        self._lock_originator = self.tahoma_device.active_states.get(
+            'io:PriorityLockOriginatorState')
 
-        if 'core:RSSILevelState' in self.tahoma_device.active_states:
-            self._rssi_level = self.tahoma_device.active_states[
-                'core:RSSILevelState']
-        else:
-            self._rssi_level = None
+        self._rssi_level = self.tahoma_device.active_states.get(
+            'core:RSSILevelState')
 
         # Define which icon to use
         if self._lock_timer > 0:

--- a/homeassistant/components/tahoma.py
+++ b/homeassistant/components/tahoma.py
@@ -50,6 +50,8 @@ TAHOMA_TYPES = {
     'io:WindowOpenerVeluxIOComponent': 'cover',
     'io:LightIOSystemSensor': 'sensor',
     'rts:GarageDoor4TRTSComponent': 'switch',
+    'io:VerticalExteriorAwningIOComponent': 'cover',
+    'io:HorizontalAwningIOComponent': 'cover',
     'rtds:RTDSSmokeSensor': 'smoke',
 }
 


### PR DESCRIPTION
## Description:
Add support for 2 Tahoma IO awning covers:
  - io:VerticalExteriorAwningIOComponent
  - io:HorizontalAwningIOComponent

Fixed stop action for:
  - io:RollerShutterGenericIOComponent

In detail the following has been done:
  - created init method
  - moved data collection into the update method
  - introduction of device attributes
  - added two timestamps as attributes for priority lock of the covers, eg. in case of wind (timestamp instead of timer as suggested by ballob)
  - kept backward compatibility, eg. position handling <= 5 or >= 95 (was there since beginning)
  - inverse up/down actions for horizontal awning component
  - added stop actions
  - added special icon for the locked case

**Related issue (if applicable):** fixes #13965

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable):
n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`.

If user exposed functionality or configuration variables are added/changed:
  - No documentation added/updated

If the code communicates with devices, web services, or third-party tools:
  - No new dependencies.
  - No new files.

If the code does not interact with devices:
  - Code does interact with device.