### PR TITLE
Add support for P5 FutureNow light platform

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -461,6 +461,7 @@ omit =
     homeassistant/components/light/decora_wifi.py
     homeassistant/components/light/decora.py
     homeassistant/components/light/flux_led.py
+    homeassistant/components/light/futurenow.py
     homeassistant/components/light/greenwave.py
     homeassistant/components/light/hue.py
     homeassistant/components/light/hyperion.py

--- a/homeassistant/components/light/futurenow.py
+++ b/homeassistant/components/light/futurenow.py
@@ -131,10 +131,4 @@ class FutureNowLight(Light):
             return
 
         state = int(self._light.is_on())
-        if state:
-            self._state = True
-            self._brightness = to_hass_level(state)
-        else:
-            if self._dimmable:
-                self._brightness = 0
-            self._state = False
+        self._state = bool(state)

--- a/homeassistant/components/light/futurenow.py
+++ b/homeassistant/components/light/futurenow.py
@@ -6,7 +6,6 @@ https://home-assistant.io/components/light.futurenow/
 """
 
 import logging
-import time
 
 import voluptuous as vol
 
@@ -45,7 +44,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     for channel, device_config in config[CONF_DEVICES].items():
         device = {}
         device['name'] = device_config[CONF_NAME]
-        device['dimmable'] = True if device_config['dimmable'] is True else False
+        device['dimmable'] = True if device_config['dimmable'] else False
         device['channel'] = channel
         device['driver'] = config[CONF_DRIVER]
         device['host'] = config[CONF_HOST]

--- a/homeassistant/components/light/futurenow.py
+++ b/homeassistant/components/light/futurenow.py
@@ -1,0 +1,133 @@
+"""
+Support for FutureNow Ethernet unit outputs as Lights.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/light.futurenow/
+"""
+
+import logging
+import time
+import voluptuous as vol
+
+from homeassistant.const import (
+    CONF_NAME, CONF_HOST, CONF_PORT, CONF_DEVICES)
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS, SUPPORT_BRIGHTNESS, Light,
+    PLATFORM_SCHEMA)
+import homeassistant.helpers.config_validation as cv
+
+REQUIREMENTS = ['pyfnip']
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_DRIVER = 'driver'
+CONF_DRIVER_FNIP6X10AD = 'FNIP6x10ad'
+CONF_DRIVER_FNIP8X10A = 'FNIP8x10a'
+CONF_DRIVER_TYPES = [CONF_DRIVER_FNIP6X10AD, CONF_DRIVER_FNIP8X10A]
+
+DEVICE_SCHEMA = vol.Schema({
+    vol.Required(CONF_NAME): cv.string,
+    vol.Optional('dimmable'): int,
+})
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_DRIVER): vol.In(CONF_DRIVER_TYPES),
+    vol.Required(CONF_HOST): cv.string,
+    vol.Required(CONF_PORT): cv.string,
+    vol.Required(CONF_DEVICES): {cv.string: DEVICE_SCHEMA},
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    import pyfnip
+
+    lights = []
+    for channel, device_config in config[CONF_DEVICES].items():
+        device = {}
+        device['name'] = device_config[CONF_NAME]
+        device['dimmable'] = True if 'dimmable' in device_config else False
+        device['channel'] = channel
+        device['driver'] = config[CONF_DRIVER]
+        device['host'] = config[CONF_HOST]
+        device['port'] = config[CONF_PORT]
+        lights.append(FutureNowLight(device))
+
+    add_devices(lights)
+
+
+def to_futurenow_level(level):
+    """Convert the given HASS light level (0-255) to FutureNow (0-100)."""
+    return int((level * 100) / 255)
+
+
+def to_hass_level(level):
+    """Convert the given FutureNow (0-100) light level to HASS (0-255)."""
+    return int((level * 255) / 100)
+
+
+class FutureNowLight(Light):
+    """Representation of an FutureNow light."""
+
+    def __init__(self, device):
+        """Initialize the light."""
+        import pyfnip
+
+        self._name = device['name']
+        self._dimmable = device['dimmable']
+        self._channel = device['channel']
+        self._brightness = None
+        self._state = None
+
+        if device['driver'] == CONF_DRIVER_FNIP6X10AD:
+            self._light = pyfnip.FNIP6x2adOutput(device['host'], 
+                                                 device['port'], self._channel)
+        if device['driver'] == CONF_DRIVER_FNIP8X10A:
+            self._light = pyfnip.FNIP8x10aOutput(device['host'], 
+                                                 device['port'], self._channel)
+
+        """Get actual state of light."""
+        self.update()
+
+    @property
+    def name(self):
+        """Return the name of the device if any."""
+        return self._name
+
+    @property
+    def is_on(self):
+        """Return true if device is on."""
+        return self._state
+
+    @property
+    def brightness(self):
+        """Return the brightness of this light between 0..255."""
+        return self._brightness
+
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+        if self._dimmable is True:
+            return SUPPORT_BRIGHTNESS
+        return 0
+
+    def turn_on(self, **kwargs):
+        """Turn the light on."""
+        level = kwargs.get(ATTR_BRIGHTNESS, 255) if self._dimmable else 255
+        self._light.turn_on(to_futurenow_level(level))
+
+    def turn_off(self, **kwargs):
+        self._light.turn_off()
+
+    def update(self):
+        """Fetch new state data for this light."""
+        """Delay a bit until state change has fully finished."""
+        time.sleep(.500)
+
+        state = int(self._light.is_on())
+        if state > 0:
+            self._state = True
+            self._brightness = to_hass_level(state)
+        else:
+            if self._dimmable:
+                self._brightness = 0
+            self._state = False

--- a/homeassistant/components/light/futurenow.py
+++ b/homeassistant/components/light/futurenow.py
@@ -44,7 +44,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     for channel, device_config in config[CONF_DEVICES].items():
         device = {}
         device['name'] = device_config[CONF_NAME]
-        device['dimmable'] = True if device_config['dimmable'] else False
+        device['dimmable'] = device_config['dimmable']
         device['channel'] = channel
         device['driver'] = config[CONF_DRIVER]
         device['host'] = config[CONF_HOST]

--- a/homeassistant/components/light/futurenow.py
+++ b/homeassistant/components/light/futurenow.py
@@ -132,3 +132,4 @@ class FutureNowLight(Light):
 
         state = int(self._light.is_on())
         self._state = bool(state)
+        self._brightness = to_hass_level(state)

--- a/homeassistant/components/light/futurenow.py
+++ b/homeassistant/components/light/futurenow.py
@@ -16,7 +16,7 @@ from homeassistant.components.light import (
     PLATFORM_SCHEMA)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['pyfnip']
+REQUIREMENTS = ['pyfnip==0.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/light/futurenow.py
+++ b/homeassistant/components/light/futurenow.py
@@ -39,8 +39,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    import pyfnip
-
+    """Set up the light platform for each FutureNow unit."""
     lights = []
     for channel, device_config in config[CONF_DEVICES].items():
         device = {}
@@ -79,13 +78,14 @@ class FutureNowLight(Light):
         self._state = None
 
         if device['driver'] == CONF_DRIVER_FNIP6X10AD:
-            self._light = pyfnip.FNIP6x2adOutput(device['host'], 
-                                                 device['port'], self._channel)
+            self._light = pyfnip.FNIP6x2adOutput(device['host'],
+                                                 device['port'],
+                                                 self._channel)
         if device['driver'] == CONF_DRIVER_FNIP8X10A:
-            self._light = pyfnip.FNIP8x10aOutput(device['host'], 
-                                                 device['port'], self._channel)
-
-        """Get actual state of light."""
+            self._light = pyfnip.FNIP8x10aOutput(device['host'],
+                                                 device['port'],
+                                                 self._channel)
+        # Get actual state of light.
         self.update()
 
     @property
@@ -116,11 +116,12 @@ class FutureNowLight(Light):
         self._light.turn_on(to_futurenow_level(level))
 
     def turn_off(self, **kwargs):
+        """Turn the light off."""
         self._light.turn_off()
 
     def update(self):
         """Fetch new state data for this light."""
-        """Delay a bit until state change has fully finished."""
+        # Delay a bit until state change has fully finished."
         time.sleep(.500)
 
         state = int(self._light.is_on())

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -822,6 +822,9 @@ pyflexit==0.3
 # homeassistant.components.binary_sensor.flic
 pyflic-homeassistant==0.4.dev0
 
+# homeassistant.components.light.futurenow
+pyfnip==0.1
+
 # homeassistant.components.fritzbox
 pyfritzhome==0.3.7
 


### PR DESCRIPTION
## Description:
Add support for P5 FutureNow light platform

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5875

## Example entry for `configuration.yaml` (if applicable):
```yaml
light:
  - platform: futurenow
    driver: FNIP6x10ad
    host: 192.168.1.101
    port: 7078
    devices:
      5:
        name: Dimmer Channel 5
        dimmable: 1
      6:
        name: Dimmer Channel 6
        dimmable: 1
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54