### PR TITLE
Workaround for http startup failed caused by cors_allowed_origins

### DIFF
--- a/homeassistant/components/http/cors.py
+++ b/homeassistant/components/http/cors.py
@@ -1,5 +1,5 @@
 """Provide cors support for the HTTP component."""
-
+import logging
 
 from aiohttp.hdrs import ACCEPT, ORIGIN, CONTENT_TYPE
 
@@ -13,6 +13,8 @@ from homeassistant.core import callback
 ALLOWED_CORS_HEADERS = [
     ORIGIN, ACCEPT, HTTP_HEADER_X_REQUESTED_WITH, CONTENT_TYPE,
     HTTP_HEADER_HA_AUTH]
+
+_LOGGER = logging.getLogger(__name__)
 
 
 @callback
@@ -50,7 +52,11 @@ def setup_cors(app, origins):
                 route = route.resource
             if route in cors_added:
                 continue
-            cors.add(route)
-            cors_added.add(route)
+            try:
+                cors.add(route)
+                cors_added.add(route)
+            except ValueError as error:
+                _LOGGER.debug('Allow CORS for route %s failed: %s',
+                              route, error)
 
     app.on_startup.append(cors_startup)


### PR DESCRIPTION
## Description:
A workaround to fix http start failed issue.
We need find a better solution to coordinate cors and auth module. 

**Related issue (if applicable):** fixes #15659 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
http:
  api_password: some_password
  cors_allowed_origins:
    - https://google.com
    - https://home-assistant.io
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

