### PR TITLE
Pylint 2 useless-return fixes

### DIFF
--- a/homeassistant/components/climate/heatmiser.py
+++ b/homeassistant/components/climate/heatmiser.py
@@ -50,7 +50,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             HeatmiserV3Thermostat(
                 heatmiser, tstat.get(CONF_ID), tstat.get(CONF_NAME), serport)
             ])
-    return
 
 
 class HeatmiserV3Thermostat(ClimateDevice):

--- a/homeassistant/components/cloud/iot.py
+++ b/homeassistant/components/cloud/iot.py
@@ -253,5 +253,3 @@ def async_handle_cloud(hass, cloud, payload):
                       payload['reason'])
     else:
         _LOGGER.warning("Received unknown cloud action: %s", action)
-
-    return None

--- a/homeassistant/components/fan/comfoconnect.py
+++ b/homeassistant/components/fan/comfoconnect.py
@@ -31,7 +31,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     ccb = hass.data[DOMAIN]
 
     add_devices([ComfoConnectFan(hass, name=ccb.name, ccb=ccb)], True)
-    return
 
 
 class ComfoConnectFan(FanEntity):

--- a/homeassistant/components/mailgun.py
+++ b/homeassistant/components/mailgun.py
@@ -48,4 +48,3 @@ class MailgunReceiveMessageView(HomeAssistantView):
         hass = request.app['hass']
         data = yield from request.post()
         hass.bus.async_fire(MESSAGE_RECEIVED, dict(data))
-        return

--- a/homeassistant/components/notify/xmpp.py
+++ b/homeassistant/components/notify/xmpp.py
@@ -110,6 +110,5 @@ def send_message(sender, password, recipient, use_tls,
         def discard_ssl_invalid_cert(event):
             """Do nothing if ssl certificate is invalid."""
             _LOGGER.info('Ignoring invalid ssl certificate as requested.')
-            return
 
     SendNotificationBot()

--- a/homeassistant/components/sensor/fritzbox_callmonitor.py
+++ b/homeassistant/components/sensor/fritzbox_callmonitor.py
@@ -187,7 +187,6 @@ class FritzBoxCallMonitor:
                 line = response.split("\n", 1)[0]
                 self._parse(line)
                 time.sleep(1)
-        return
 
     def _parse(self, line):
         """Parse the call information and set the sensor states."""

--- a/homeassistant/components/sensor/modem_callerid.py
+++ b/homeassistant/components/sensor/modem_callerid.py
@@ -95,7 +95,6 @@ class ModemCalleridSensor(Entity):
         if self.modem:
             self.modem.close()
             self.modem = None
-        return
 
     def _incomingcallcallback(self, newstate):
         """Handle new states."""
@@ -117,4 +116,3 @@ class ModemCalleridSensor(Entity):
         elif newstate == self.modem.STATE_IDLE:
             self._state = STATE_IDLE
             self.schedule_update_ha_state()
-        return

--- a/homeassistant/monkey_patch.py
+++ b/homeassistant/monkey_patch.py
@@ -57,7 +57,6 @@ def disable_c_asyncio() -> None:
         def __init__(self, path_entry: str) -> None:
             if path_entry != self.PATH_TRIGGER:
                 raise ImportError()
-            return
 
         def find_module(self, fullname: str, path: Any = None) -> None:
             """Find a module."""
@@ -65,7 +64,6 @@ def disable_c_asyncio() -> None:
                 # We lint in Py35, exception is introduced in Py36
                 # pylint: disable=undefined-variable
                 raise ModuleNotFoundError()  # type: ignore # noqa
-            return None
 
     sys.path_hooks.append(AsyncioImportFinder)
     sys.path.insert(0, AsyncioImportFinder.PATH_TRIGGER)

--- a/homeassistant/util/async_.py
+++ b/homeassistant/util/async_.py
@@ -156,7 +156,6 @@ def fire_coroutine_threadsafe(coro: Coroutine,
         ensure_future(coro, loop=loop)
 
     loop.call_soon_threadsafe(callback)
-    return
 
 
 def run_callback_threadsafe(loop: AbstractEventLoop, callback: Callable,


### PR DESCRIPTION
## Description:

Pylint 2 useless-return fixes (a majority subset of them, rest will be handled and explained in the upcoming pylint 2 upgrade PR). I think this will be the last PR submitted separately before the actual upgrade.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
