### PR TITLE
Add STATE_AUTO support to generic_thermostat

### DIFF
--- a/homeassistant/components/climate/generic_thermostat.py
+++ b/homeassistant/components/climate/generic_thermostat.py
@@ -231,7 +231,14 @@ class GenericThermostat(ClimateDevice):
 
     async def async_set_operation_mode(self, operation_mode):
         """Set operation mode."""
-        if operation_mode == STATE_HEAT:
+        if operation_mode == STATE_AUTO:
+            if not self.ac_mode:
+                self._current_operation = STATE_HEAT
+            else:
+                self._current_operation = STATE_COOL
+            self._enabled = True
+            self._async_control_heating()
+        elif operation_mode == STATE_HEAT:
             self._current_operation = STATE_HEAT
             self._enabled = True
             self._async_control_heating()


### PR DESCRIPTION
## Description:
I reeeaaally don't know if this is the right way to do this. And I've never ever developed anything with python. But it solved my issue.. 😅
If this is totally wrong pls close this pr right away.. :D 


Siri will put the state to AUTO if you say "turn on my ac", but the generic thermostat doesn't support STATE_AUTO, so it will take the command and switch to STATE_HEAT or STATE_COOL (ac mode).

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5916

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: rest
    resource: http://192.168.178.20/api/xxxxxxxxxxxxxxxxxxxxxx/sensors/10
    value_template: '{{ value_json.state.temperature | float / 100 }}'
    unit_of_measurement: °C
    name: 'Living Room Temperature'

switch:
  - platform: broadlink
    host: !secret ip_broadlink
    mac: !secret mac_broadlink
    timeout: 2
    switches:
      ac:
        friendly_name: "Klimaanlage"
        command_on: 'JgBIAAABKJMUEBETFBARNxETExERNxETFBARExMREjYRNxEUExARExM2ExASEhMRExESExMQETcTNRM2EzUTEBITFBAREhMSEwANBQ=='
        command_off: 'JgBIAAABL5UWEBYRFhAWMxgQFhEWNBQTFhAWERYRFTUWNBYQFhEWERY0FBIWERYRFRIVNRQSFhEWNBUSFTQWNRYQFRIVNRYQFQANBQ=='

climate:
  - platform: generic_thermostat
    name: Klimaanlage
    heater: switch.ac
    target_sensor: sensor.living_room_temperature
    min_temp: 18
    max_temp: 27
    ac_mode: True
    away_temp: 29

homekit:
  filter:
    include_domains:
      - climate
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54