### PR TITLE
Command Line Sensor - json_attributes

### DIFF
--- a/homeassistant/components/sensor/command_line.py
+++ b/homeassistant/components/sensor/command_line.py
@@ -4,6 +4,7 @@ Allows to configure custom shell commands to turn a value for a sensor.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.command_line/
 """
+import collections
 import logging
 import json
 import subprocess
@@ -104,7 +105,7 @@ class CommandSensor(Entity):
             if value:
                 try:
                     json_dict = json.loads(value)
-                    if isinstance(json_dict, dict):
+                    if isinstance(json_dict, collections.Mapping):
                         attrs = {k: json_dict[k] for k in self._json_attrs
                                  if k in json_dict}
                         self._attributes = attrs

--- a/homeassistant/components/sensor/command_line.py
+++ b/homeassistant/components/sensor/command_line.py
@@ -29,7 +29,7 @@ DEFAULT_NAME = 'Command Sensor'
 
 SCAN_INTERVAL = timedelta(seconds=60)
 
-CONF_JSON_ATTRS = 'json_attributes'
+CONF_JSON_ATTRIBUTES = 'json_attributes'
 CONF_COMMAND_TIMEOUT = 'command_timeout'
 DEFAULT_TIMEOUT = 15
 
@@ -38,7 +38,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
     vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
-    vol.Optional(CONF_JSON_ATTRS, default=[]): cv.ensure_list_csv,
+    vol.Optional(CONF_JSON_ATTRIBUTES): cv.ensure_list_csv,
     vol.Optional(
         CONF_COMMAND_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int,
 })
@@ -53,18 +53,18 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     command_timeout = config.get(CONF_COMMAND_TIMEOUT)
     if value_template is not None:
         value_template.hass = hass
-    json_attrs = config.get(CONF_JSON_ATTRS)
+    json_attributes = config.get(CONF_JSON_ATTRIBUTES)
     data = CommandSensorData(hass, command, command_timeout)
 
     add_devices([CommandSensor(hass, data, name, unit, value_template,
-                               json_attrs)], True)
+                               json_attributes)], True)
 
 
 class CommandSensor(Entity):
     """Representation of a sensor that is using shell commands."""
 
     def __init__(self, hass, data, name, unit_of_measurement, value_template,
-                 json_attrs):
+                 json_attributes):
         """Initialize the sensor."""
         self._hass = hass
         self.data = data
@@ -72,7 +72,7 @@ class CommandSensor(Entity):
         self._state = None
         self._unit_of_measurement = unit_of_measurement
         self._value_template = value_template
-        self._json_attrs = json_attrs
+        self._json_attributes = json_attributes
         self._attributes = None
 
     @property
@@ -100,15 +100,15 @@ class CommandSensor(Entity):
         self.data.update()
         value = self.data.value
 
-        if self._json_attrs:
+        if self._json_attributes:
             self._attributes = {}
             if value:
                 try:
                     json_dict = json.loads(value)
                     if isinstance(json_dict, collections.Mapping):
-                        attrs = {k: json_dict[k] for k in self._json_attrs
-                                 if k in json_dict}
-                        self._attributes = attrs
+                        self._attributes = {k: json_dict[k] for k in
+                                            self._json_attributes
+                                            if k in json_dict}
                     else:
                         _LOGGER.warning("JSON result was not a dictionary")
                 except ValueError:

--- a/homeassistant/components/sensor/command_line.py
+++ b/homeassistant/components/sensor/command_line.py
@@ -112,9 +112,8 @@ class CommandSensor(Entity):
                     else:
                         _LOGGER.warning("JSON result was not a dictionary")
                 except ValueError:
-                    _LOGGER.warning("Command result could not be parsed as"
-                                    "JSON")
-                    _LOGGER.debug("Erroneous JSON: %s", value)
+                    _LOGGER.warning("Error: Could not parse command output as"
+                                    "JSON: %s", value)
             else:
                 _LOGGER.warning("Empty reply found when expecting JSON data")
 

--- a/homeassistant/components/sensor/command_line.py
+++ b/homeassistant/components/sensor/command_line.py
@@ -112,7 +112,7 @@ class CommandSensor(Entity):
                     else:
                         _LOGGER.warning("JSON result was not a dictionary")
                 except ValueError:
-                    _LOGGER.warning("Command result could not be parsed as" +
+                    _LOGGER.warning("Command result could not be parsed as"
                                     "JSON")
                     _LOGGER.debug("Erroneous JSON: %s", value)
             else:

--- a/homeassistant/components/sensor/command_line.py
+++ b/homeassistant/components/sensor/command_line.py
@@ -111,7 +111,8 @@ class CommandSensor(Entity):
                     else:
                         _LOGGER.warning("JSON result was not a dictionary")
                 except ValueError:
-                    _LOGGER.warning("Command result could not be parsed as JSON")
+                    _LOGGER.warning("Command result could not be parsed as" +
+                                    "JSON")
                     _LOGGER.debug("Erroneous JSON: %s", value)
             else:
                 _LOGGER.warning("Empty reply found when expecting JSON data")

--- a/tests/components/sensor/test_command_line.py
+++ b/tests/components/sensor/test_command_line.py
@@ -134,3 +134,26 @@ class TestCommandSensorSensor(unittest.TestCase):
         self.assertEqual({}, self.sensor.device_state_attributes)
         self.assertTrue(mock_logger.warning.called)
         self.assertTrue(mock_logger.debug.called)
+
+    def test_update_with_missing_json_attrs(self):
+        """Test attributes get extracted from a JSON result."""
+        data = command_line.CommandSensorData(
+            self.hass,
+            ('echo { \\"key\\": \\"some_json_value\\", \\"another_key\\":\
+             \\"another_json_value\\", \\"key_three\\": \\"value_three\\" }'),
+            15
+        )
+
+        self.sensor = command_line.CommandSensor(self.hass, data, 'test',
+                                                 None, None, ['key',
+                                                              'another_key',
+                                                              'key_three',
+                                                              'special_key'])
+        self.sensor.update()
+        self.assertEqual('some_json_value',
+                         self.sensor.device_state_attributes['key'])
+        self.assertEqual('another_json_value',
+                         self.sensor.device_state_attributes['another_key'])
+        self.assertEqual('value_three',
+                         self.sensor.device_state_attributes['key_three'])
+        self.assertFalse('special_key' in self.sensor.device_state_attributes)

--- a/tests/components/sensor/test_command_line.py
+++ b/tests/components/sensor/test_command_line.py
@@ -78,14 +78,22 @@ class TestCommandSensorSensor(unittest.TestCase):
         """Test attributes get extracted from a JSON result."""
         data = command_line.CommandSensorData(
             self.hass,
-            'echo { \\"key\\": \\"some_json_value\\" }', 15
+            ('echo { \\"key\\": \\"some_json_value\\", \\"another_key\\":\
+             \\"another_json_value\\", \\"key_three\\": \\"value_three\\" }'),
+            15
         )
 
         self.sensor = command_line.CommandSensor(self.hass, data, 'test',
-                                                 None, None, ['key'])
+                                                 None, None, ['key',
+                                                              'another_key',
+                                                              'key_three'])
         self.sensor.update()
         self.assertEqual('some_json_value',
                          self.sensor.device_state_attributes['key'])
+        self.assertEqual('another_json_value',
+                         self.sensor.device_state_attributes['another_key'])
+        self.assertEqual('value_three',
+                         self.sensor.device_state_attributes['key_three'])
 
     @patch('homeassistant.components.sensor.command_line._LOGGER')
     def test_update_with_json_attrs_no_data(self, mock_logger):

--- a/tests/components/sensor/test_command_line.py
+++ b/tests/components/sensor/test_command_line.py
@@ -80,7 +80,7 @@ class TestCommandSensorSensor(unittest.TestCase):
             self.hass,
             'echo { \\"key\\": \\"some_json_value\\" }', 15
         )
- 
+
         self.sensor = command_line.CommandSensor(self.hass, data, 'test',
                                                  None, None, ['key'])
         self.sensor.update()

--- a/tests/components/sensor/test_command_line.py
+++ b/tests/components/sensor/test_command_line.py
@@ -1,5 +1,6 @@
 """The tests for the Command line sensor platform."""
 import unittest
+from unittest.mock import patch
 
 from homeassistant.helpers.template import Template
 from homeassistant.components.sensor import command_line
@@ -16,6 +17,10 @@ class TestCommandSensorSensor(unittest.TestCase):
     def tearDown(self):
         """Stop everything that was started."""
         self.hass.stop()
+
+    def update_side_effect(self, data):
+        """Side effect function for mocking CommandSensorData.update()."""
+        self.commandline.data = data
 
     def test_setup(self):
         """Test sensor setup."""
@@ -46,7 +51,7 @@ class TestCommandSensorSensor(unittest.TestCase):
 
         entity = command_line.CommandSensor(
             self.hass, data, 'test', 'in',
-            Template('{{ value | multiply(0.1) }}', self.hass))
+            Template('{{ value | multiply(0.1) }}', self.hass), [])
 
         entity.update()
         self.assertEqual(5, float(entity.state))
@@ -68,3 +73,56 @@ class TestCommandSensorSensor(unittest.TestCase):
         data.update()
 
         self.assertEqual(None, data.value)
+
+    def test_update_with_json_attrs(self):
+        """Test attributes get extracted from a JSON result."""
+        data = command_line.CommandSensorData(
+            self.hass,
+            'echo { \\"key\\": \\"some_json_value\\" }', 15
+        )
+ 
+        self.sensor = command_line.CommandSensor(self.hass, data, 'test',
+                                                 None, None, ['key'])
+        self.sensor.update()
+        self.assertEqual('some_json_value',
+                         self.sensor.device_state_attributes['key'])
+
+    @patch('homeassistant.components.sensor.command_line._LOGGER')
+    def test_update_with_json_attrs_no_data(self, mock_logger):
+        """Test attributes when no JSON result fetched."""
+        data = command_line.CommandSensorData(
+            self.hass,
+            'echo ', 15
+        )
+        self.sensor = command_line.CommandSensor(self.hass, data, 'test',
+                                                 None, None, ['key'])
+        self.sensor.update()
+        self.assertEqual({}, self.sensor.device_state_attributes)
+        self.assertTrue(mock_logger.warning.called)
+
+    @patch('homeassistant.components.sensor.command_line._LOGGER')
+    def test_update_with_json_attrs_not_dict(self, mock_logger):
+        """Test attributes get extracted from a JSON result."""
+        data = command_line.CommandSensorData(
+            self.hass,
+            'echo [1, 2, 3]', 15
+        )
+        self.sensor = command_line.CommandSensor(self.hass, data, 'test',
+                                                 None, None, ['key'])
+        self.sensor.update()
+        self.assertEqual({}, self.sensor.device_state_attributes)
+        self.assertTrue(mock_logger.warning.called)
+
+    @patch('homeassistant.components.sensor.command_line._LOGGER')
+    def test_update_with_json_attrs_bad_JSON(self, mock_logger):
+        """Test attributes get extracted from a JSON result."""
+        data = command_line.CommandSensorData(
+            self.hass,
+            'echo This is text rather than JSON data.', 15
+        )
+        self.sensor = command_line.CommandSensor(self.hass, data, 'test',
+                                                 None, None, ['key'])
+        self.sensor.update()
+        self.assertEqual({}, self.sensor.device_state_attributes)
+        self.assertTrue(mock_logger.warning.called)
+        self.assertTrue(mock_logger.debug.called)

--- a/tests/components/sensor/test_command_line.py
+++ b/tests/components/sensor/test_command_line.py
@@ -157,3 +157,22 @@ class TestCommandSensorSensor(unittest.TestCase):
         self.assertEqual('value_three',
                          self.sensor.device_state_attributes['key_three'])
         self.assertFalse('special_key' in self.sensor.device_state_attributes)
+
+    def test_update_with_unnecessary_json_attrs(self):
+        """Test attributes get extracted from a JSON result."""
+        data = command_line.CommandSensorData(
+            self.hass,
+            ('echo { \\"key\\": \\"some_json_value\\", \\"another_key\\":\
+             \\"another_json_value\\", \\"key_three\\": \\"value_three\\" }'),
+            15
+        )
+
+        self.sensor = command_line.CommandSensor(self.hass, data, 'test',
+                                                 None, None, ['key',
+                                                              'another_key'])
+        self.sensor.update()
+        self.assertEqual('some_json_value',
+                         self.sensor.device_state_attributes['key'])
+        self.assertEqual('another_json_value',
+                         self.sensor.device_state_attributes['another_key'])
+        self.assertFalse('key_three' in self.sensor.device_state_attributes)

--- a/tests/components/sensor/test_command_line.py
+++ b/tests/components/sensor/test_command_line.py
@@ -133,7 +133,6 @@ class TestCommandSensorSensor(unittest.TestCase):
         self.sensor.update()
         self.assertEqual({}, self.sensor.device_state_attributes)
         self.assertTrue(mock_logger.warning.called)
-        self.assertTrue(mock_logger.debug.called)
 
     def test_update_with_missing_json_attrs(self):
         """Test attributes get extracted from a JSON result."""


### PR DESCRIPTION
## Description:
Add json_attributes support to the command line sensor (functions in the same way as for the rest component).

It's bothered me for a while that command line sensors can't have attributes, and as one already has access to value_json in command line, json_attributes didn't feel out of place.

Also, I'm completely new to python (or well, started six weeks ago) and thought this would be a simple feature to hopefully start contributing a bit more to home assistant.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5889

## Example entry for `configuration.yaml` (if applicable):
```yaml
  - platform: command_line
    command: 'python3 my_json_script.py'
    value_template: '{{ value_json.primary_value }}'
    json_attributes:
      - secondary_value
      - tertiary_value
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.