### PR TITLE
Netatmo public

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -682,6 +682,7 @@ omit =
     homeassistant/components/sensor/mvglive.py
     homeassistant/components/sensor/nederlandse_spoorwegen.py
     homeassistant/components/sensor/netdata.py
+    homeassistant/components/sensor/netdata_public.py
     homeassistant/components/sensor/neurio_energy.py
     homeassistant/components/sensor/nsw_fuel_station.py
     homeassistant/components/sensor/nut.py

--- a/homeassistant/components/sensor/netatmo_public.py
+++ b/homeassistant/components/sensor/netatmo_public.py
@@ -1,0 +1,160 @@
+"""
+Support for the Sensors using public Netatmo data.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.netatmo_public/.
+"""
+from datetime import timedelta
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import (CONF_NAME, CONF_TYPE)
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.entity import Entity
+from homeassistant.util import Throttle
+
+_LOGGER = logging.getLogger(__name__)
+
+DEPENDENCIES = ['netatmo']
+
+CONF_AREAS = 'areas'
+CONF_LAT_NE = 'lat_ne'
+CONF_LON_NE = 'lon_ne'
+CONF_LAT_SW = 'lat_sw'
+CONF_LON_SW = 'lon_sw'
+
+DEFAULT_NAME = 'Netatmo Public Data'
+DEFAULT_TYPE = 'max'
+SENSOR_TYPES = {'max', 'avg'}
+
+# NetAtmo Data is uploaded to server every 10 minutes
+MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=600)
+
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_AREAS): vol.All(cv.ensure_list, [
+        {
+            vol.Required(CONF_LAT_NE): cv.latitude,
+            vol.Required(CONF_LAT_SW): cv.latitude,
+            vol.Required(CONF_LON_NE): cv.longitude,
+            vol.Required(CONF_LON_SW): cv.longitude,
+            vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+            vol.Optional(CONF_TYPE, default=DEFAULT_TYPE):
+                vol.In(SENSOR_TYPES)
+        }
+    ]),
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the access to Netatmo binary sensor."""
+    netatmo = hass.components.netatmo
+
+    sensors = []
+    areas = config.get(CONF_AREAS)
+    for area_conf in areas:
+        data = NetatmoPublicData(netatmo.NETATMO_AUTH,
+                                 lat_ne=area_conf.get(CONF_LAT_NE),
+                                 lon_ne=area_conf.get(CONF_LON_NE),
+                                 lat_sw=area_conf.get(CONF_LAT_SW),
+                                 lon_sw=area_conf.get(CONF_LON_SW),
+                                 calculation=area_conf.get(CONF_TYPE))
+        sensors.append(NetatmoPublicSensor(area_conf.get(CONF_NAME), data))
+    add_devices(sensors)
+
+
+class NetatmoPublicSensor(Entity):
+    """Represent a single sensor in a Netatmo."""
+
+    def __init__(self, name, data):
+        """Initialize the sensor."""
+        self.netatmo_data = data
+        self._name = name
+        self._state = None
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def icon(self):
+        """Icon to use in the frontend."""
+        return 'mdi:weather-rainy'
+
+    @property
+    def device_class(self):
+        """Return the device class of the sensor."""
+        return None
+
+    @property
+    def state(self):
+        """Return true if binary sensor is on."""
+        return self._state
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement of this entity."""
+        return 'mm'
+
+    def update(self):
+        """Get the latest data from NetAtmo API and updates the states."""
+        self.netatmo_data.update()
+        self._state = self.netatmo_data.data
+
+
+class NetatmoPublicData(object):
+    """Get the latest data from NetAtmo."""
+
+    def __init__(self, auth, lat_ne, lon_ne, lat_sw, lon_sw, calculation):
+        """Initialize the data object."""
+        self.auth = auth
+        self.data = None
+        self.lat_ne = lat_ne
+        self.lon_ne = lon_ne
+        self.lat_sw = lat_sw
+        self.lon_sw = lon_sw
+        self.calculation = calculation
+
+    def calculate_average(self, raindata):
+        """Get the average value in the area."""
+        total = 0
+        counter = 0
+        for measure in raindata.items():
+            counter += 1
+            total += measure
+
+        if counter <= 0:
+            _LOGGER.error('Shouldn\'t have ever gotten this far')
+
+        _LOGGER.debug('Average: %d' % (total))
+
+        return total / counter
+
+    def calculate_max(self, raindata):
+        """Get the highest value in the area."""
+        key_max = max(raindata.keys(), key=(lambda k: raindata[k]))
+
+        return raindata[key_max]
+
+    @Throttle(MIN_TIME_BETWEEN_UPDATES)
+    def update(self):
+        """Request an update from the Netatmo API."""
+        import pyatmo
+        raindata = pyatmo.PublicData(self.auth,
+                                     LAT_NE=self.lat_ne,
+                                     LON_NE=self.lon_ne,
+                                     LAT_SW=self.lat_sw,
+                                     LON_SW=self.lon_sw)
+
+        if raindata.CountStationInArea() == 0:
+            _LOGGER.warning('No Rain Station available in this area.')
+        else:
+            raindata_live = raindata.getLive()
+
+            if self.calculation == 'avg':
+                self.data = self.calculate_average(raindata_live)
+            else:
+                self.data = self.calculate_max(raindata_live)

--- a/homeassistant/components/sensor/netatmo_public.py
+++ b/homeassistant/components/sensor/netatmo_public.py
@@ -134,27 +134,27 @@ class NetatmoPublicData(object):
             raindata_live = raindata.getLive()
 
             if self.calculation == 'avg':
-                self.data = self.calculate_average(raindata_live)
+                self.data = calculate_average(raindata_live)
             else:
-                self.data = self.calculate_max(raindata_live)
+                self.data = calculate_max(raindata_live)
 
-    def calculate_average(self, raindata):
-        """Get the average value in the area."""
-        total = 0
-        counter = 0
-        for measure in raindata.items():
-            counter += 1
-            total += measure
 
-        if counter <= 0:
-            _LOGGER.error('Shouldn\'t have ever gotten this far')
+def calculate_average(raindata):
+    """Get the average value in the area."""
+    total = 0
+    counter = 0
+    for measure in raindata.items():
+        counter += 1
+        total += measure
 
-        _LOGGER.debug('Average: %d' % (total))
+    if counter <= 0:
+        _LOGGER.error('Shouldn\'t have ever gotten this far')
 
-        return total / counter
+    return total / counter
 
-    def calculate_max(self, raindata):
-        """Get the highest value in the area."""
-        key_max = max(raindata.keys(), key=(lambda k: raindata[k]))
 
-        return raindata[key_max]
+def calculate_max(raindata):
+    """Get the highest value in the area."""
+    key_max = max(raindata.keys(), key=(lambda k: raindata[k]))
+
+    return raindata[key_max]

--- a/homeassistant/components/sensor/netatmo_public.py
+++ b/homeassistant/components/sensor/netatmo_public.py
@@ -128,7 +128,7 @@ class NetatmoPublicData(object):
                                      LON_NE=self.lon_ne,
                                      LAT_SW=self.lat_sw,
                                      LON_SW=self.lon_sw,
-                                     required_data_type = "rain")
+                                     required_data_type="rain")
 
         if raindata.CountStationInArea() == 0:
             _LOGGER.warning('No Rain Station available in this area.')

--- a/homeassistant/components/sensor/netatmo_public.py
+++ b/homeassistant/components/sensor/netatmo_public.py
@@ -127,7 +127,8 @@ class NetatmoPublicData(object):
                                      LAT_NE=self.lat_ne,
                                      LON_NE=self.lon_ne,
                                      LAT_SW=self.lat_sw,
-                                     LON_SW=self.lon_sw)
+                                     LON_SW=self.lon_sw,
+                                     required_data_type = "rain")
 
         if raindata.CountStationInArea() == 0:
             _LOGGER.warning('No Rain Station available in this area.')

--- a/homeassistant/components/sensor/netatmo_public.py
+++ b/homeassistant/components/sensor/netatmo_public.py
@@ -136,7 +136,6 @@ class NetatmoPublicData(object):
 
         raindata_live = raindata.getLive()
 
-        _LOGGER.error(raindata_live.values())
         if self.calculation == 'avg':
             self.data = sum(raindata_live.values()) / len(raindata_live)
         else:

--- a/homeassistant/components/sensor/netatmo_public.py
+++ b/homeassistant/components/sensor/netatmo_public.py
@@ -105,7 +105,7 @@ class NetatmoPublicSensor(Entity):
         self._state = self.netatmo_data.data
 
 
-class NetatmoPublicData(object):
+class NetatmoPublicData:
     """Get the latest data from NetAtmo."""
 
     def __init__(self, auth, lat_ne, lon_ne, lat_sw, lon_sw, calculation):


### PR DESCRIPTION
## Description:

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5893

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: netatmo_public
    areas:
      - lat_ne: 40.719
        lon_ne: -73.735
        lat_sw: 40.552
        lon_sw: -74.105
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
