### PR TITLE
Add support for alarm_control_panel to MQTT Discovery.

### DIFF
--- a/homeassistant/components/alarm_control_panel/mqtt.py
+++ b/homeassistant/components/alarm_control_panel/mqtt.py
@@ -49,6 +49,9 @@ PLATFORM_SCHEMA = mqtt.MQTT_BASE_PLATFORM_SCHEMA.extend({
 @asyncio.coroutine
 def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up the MQTT Alarm Control Panel platform."""
+    if discovery_info is not None:
+        config = PLATFORM_SCHEMA(discovery_info)
+
     async_add_devices([MqttAlarm(
         config.get(CONF_NAME),
         config.get(CONF_STATE_TOPIC),

--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -21,7 +21,8 @@ TOPIC_MATCHER = re.compile(
 
 SUPPORTED_COMPONENTS = [
     'binary_sensor', 'camera', 'cover', 'fan',
-    'light', 'sensor', 'switch', 'lock', 'climate']
+    'light', 'sensor', 'switch', 'lock', 'climate',
+    'alarm_control_panel']
 
 ALLOWED_PLATFORMS = {
     'binary_sensor': ['mqtt'],
@@ -33,6 +34,7 @@ ALLOWED_PLATFORMS = {
     'sensor': ['mqtt'],
     'switch': ['mqtt'],
     'climate': ['mqtt'],
+    'alarm_control_panel': ['mqtt'],
 }
 
 ALREADY_DISCOVERED = 'mqtt_discovered_components'

--- a/tests/components/mqtt/test_discovery.py
+++ b/tests/components/mqtt/test_discovery.py
@@ -125,6 +125,28 @@ def test_discover_climate(hass, mqtt_mock, caplog):
 
 
 @asyncio.coroutine
+def test_discover_alarm_control_panel(hass, mqtt_mock, caplog):
+    """Test discovering an MQTT alarm control panel component."""
+    yield from async_start(hass, 'homeassistant', {})
+
+    data = (
+        '{ "name": "AlarmControlPanelTest",'
+        '  "state_topic": "test_topic",'
+        '  "command_topic": "test_topic" }'
+    )
+
+    async_fire_mqtt_message(
+        hass, 'homeassistant/alarm_control_panel/bla/config', data)
+    yield from hass.async_block_till_done()
+
+    state = hass.states.get('alarm_control_panel.AlarmControlPanelTest')
+
+    assert state is not None
+    assert state.name == 'AlarmControlPanelTest'
+    assert ('alarm_control_panel', 'bla') in hass.data[ALREADY_DISCOVERED]
+
+
+@asyncio.coroutine
 def test_discovery_incl_nodeid(hass, mqtt_mock, caplog):
     """Test sending in correct JSON with optional node_id included."""
     yield from async_start(hass, 'homeassistant', {})


### PR DESCRIPTION
## Description:
Adds support for the alarm_control_panel platform to MQTT Discovery.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.
