### PR TITLE
Fixes a bug with showing a subset of Pollen index conditions

### DIFF
--- a/homeassistant/components/sensor/pollen.py
+++ b/homeassistant/components/sensor/pollen.py
@@ -307,7 +307,7 @@ class PollenComData:
                     _LOGGER.error('Unable to get allergy history: %s', err)
                     self.data[TYPE_ALLERGY_HISTORIC] = {}
 
-            if all(s in self._sensor_types
+            if any(s in self._sensor_types
                    for s in [TYPE_ALLERGY_TODAY, TYPE_ALLERGY_TOMORROW,
                              TYPE_ALLERGY_YESTERDAY]):
                 try:


### PR DESCRIPTION
## Description:
Fixes a bug in the Pollen sensor where `allergy_index` sensors would show `Unavailable` unless all three conditions were monitored.

**Related issue (if applicable):** fixes #15375 and #15693

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: pollen
    zip_code: "12345"
    monitored_conditions:
      - allergy_index_today
      - allergy_index_tomorrow
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  ~- [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)~

If the code communicates with devices, web services, or third-party tools:
  ~- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).~
  ~- [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).~
  ~- [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.~
  ~- [ ] New files were added to `.coveragerc`.~

If the code does not interact with devices:
  ~- [ ] Tests have been added to verify that the new code works.~

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
