### PR TITLE
Fix Min/Max Kelvin color temp attribute for Google

### DIFF
--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -304,10 +304,12 @@ class ColorTemperatureTrait(_Trait):
     def sync_attributes(self):
         """Return color temperature attributes for a sync request."""
         attrs = self.state.attributes
+        # Max Kelvin is Min Mireds K = 1000000 / mireds
+        # Min Kevin is Max Mireds K = 1000000 / mireds
         return {
-            'temperatureMinK': color_util.color_temperature_mired_to_kelvin(
-                attrs.get(light.ATTR_MIN_MIREDS)),
             'temperatureMaxK': color_util.color_temperature_mired_to_kelvin(
+                attrs.get(light.ATTR_MIN_MIREDS)),
+            'temperatureMinK': color_util.color_temperature_mired_to_kelvin(
                 attrs.get(light.ATTR_MAX_MIREDS)),
         }
 

--- a/tests/components/google_assistant/test_smart_home.py
+++ b/tests/components/google_assistant/test_smart_home.py
@@ -74,8 +74,8 @@ async def test_sync_message(hass):
                 'willReportState': False,
                 'attributes': {
                     'colorModel': 'rgb',
-                    'temperatureMinK': 6535,
-                    'temperatureMaxK': 2000,
+                    'temperatureMinK': 2000,
+                    'temperatureMaxK': 6535,
                 },
                 'roomHint': 'Living Room'
             }]

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -414,8 +414,8 @@ async def test_color_temperature_light(hass):
     }))
 
     assert trt.sync_attributes() == {
-        'temperatureMinK': 5000,
-        'temperatureMaxK': 2000,
+        'temperatureMinK': 2000,
+        'temperatureMaxK': 5000,
     }
 
     assert trt.query_attributes() == {


### PR DESCRIPTION
Max Kelvin is actually Min Mireds and vice-versa. K = 1000000 / mireds

## Description:
When the refactor for google_assistant and some additional color_util changes were done, there was an oversight in the reported Kelvin attribute for Google Assistant. The maximum kelvin is actually the minimum mireds and vice-versa. This caused the color temperature for white to skew towards super warm when utilizing Google Assistant. This PR fixes this.

**Related issue (if applicable):** fixes #14364

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
