### PR TITLE
Install fritzbox component dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ COPY requirements_all.txt requirements_all.txt
 # See PR #8103 for more info.
 RUN pip3 install --no-cache-dir -r requirements_all.txt && \
     pip3 install --no-cache-dir mysqlclient psycopg2 uvloop cchardet cython && \
-    pip3 install `grep fritzconnection== requirements_all.txt  | sed -e 's/# //'`
+    pip3 install --no-cache-dir `grep fritzconnection== requirements_all.txt  | sed -e 's/# //'`
 
 # Copy source
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,8 @@ COPY requirements_all.txt requirements_all.txt
 # Uninstall enum34 because some dependencies install it but breaks Python 3.4+.
 # See PR #8103 for more info.
 RUN pip3 install --no-cache-dir -r requirements_all.txt && \
-    pip3 install --no-cache-dir mysqlclient psycopg2 uvloop cchardet cython
+    pip3 install --no-cache-dir mysqlclient psycopg2 uvloop cchardet cython && \
+    pip3 install `grep fritzconnection== requirements_all.txt  | sed -e 's/# //'`
 
 # Copy source
 COPY . .

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -355,7 +355,7 @@ freesms==0.1.2
 # homeassistant.components.device_tracker.fritz
 # homeassistant.components.sensor.fritzbox_callmonitor
 # homeassistant.components.sensor.fritzbox_netmonitor
-# fritzconnection==0.6.5
+fritzconnection==0.6.5
 
 # homeassistant.components.switch.fritzdect
 fritzhome==1.0.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -355,7 +355,7 @@ freesms==0.1.2
 # homeassistant.components.device_tracker.fritz
 # homeassistant.components.sensor.fritzbox_callmonitor
 # homeassistant.components.sensor.fritzbox_netmonitor
-fritzconnection==0.6.5
+# fritzconnection==0.6.5
 
 # homeassistant.components.switch.fritzdect
 fritzhome==1.0.4

--- a/virtualization/Docker/setup_docker_prereqs
+++ b/virtualization/Docker/setup_docker_prereqs
@@ -37,6 +37,8 @@ PACKAGES_DEV=(
   cmake
   git
   swig
+  # homeassistant.components.sensor.fritzbox_callmonitor
+  libxml2-dev libxslt-dev zlib1g-dev
 )
 
 # Install packages

--- a/virtualization/Docker/setup_docker_prereqs
+++ b/virtualization/Docker/setup_docker_prereqs
@@ -30,6 +30,10 @@ PACKAGES=(
   ffmpeg
   # homeassistant.components.sensor.iperf3
   iperf3
+  # homeassistant.components.device_tracker.fritz
+  # homeassistant.components.sensor.fritzbox_callmonitor
+  # homeassistant.components.sensor.fritzbox_netmonitor
+  libxml2-dev libxslt-dev zlib1g-dev
 )
 
 # Required debian packages for building dependencies
@@ -37,8 +41,6 @@ PACKAGES_DEV=(
   cmake
   git
   swig
-  # homeassistant.components.sensor.fritzbox_callmonitor
-  libxml2-dev libxslt-dev zlib1g-dev
 )
 
 # Install packages


### PR DESCRIPTION
This should fix #15359 running the components under docker.

## Description:


**Related issue (if applicable):** fixes #15359

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: fritzbox_callmonitor
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
