### PR TITLE
Add default reminder for Todoist premium users

### DIFF
--- a/homeassistant/components/calendar/todoist.py
+++ b/homeassistant/components/calendar/todoist.py
@@ -232,7 +232,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             # Wait for the API to know about the task, otherwise adding
             # a reminder will fail
             task = None
-            for i in range(0, 50):
+            for _i in range(0, 50):
                 api.sync()
                 task = api.items.get(result['items'][0]['id'])
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1421,7 +1421,7 @@ thingspeak==0.4.1
 tikteck==0.4
 
 # homeassistant.components.calendar.todoist
-todoist-python==7.0.17
+todoist-python==7.0.18
 
 # homeassistant.components.toon
 toonlib==1.0.2


### PR DESCRIPTION
## Description:
Todoist Premium members have the possibility to set default reminders on any tasks that have a due time set. This happens automatically when the Todoist web UI is used, but unfortunately their sync API does not automatically add the default reminder.

This request adds this functionality to the Todoist platform.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
