### PR TITLE
Upgrade Adafruit-DHT to 1.3.3

### DIFF
--- a/homeassistant/components/sensor/dht.py
+++ b/homeassistant/components/sensor/dht.py
@@ -17,7 +17,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 from homeassistant.util.temperature import celsius_to_fahrenheit
 
-REQUIREMENTS = ['Adafruit_Python_DHT==1.3.2']
+REQUIREMENTS = ['Adafruit-DHT==1.3.3']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -14,6 +14,9 @@ voluptuous==0.11.1
 # homeassistant.components.nuimo_controller
 --only-binary=all nuimo==0.1.0
 
+# homeassistant.components.sensor.dht
+Adafruit-DHT==1.3.3
+
 # homeassistant.components.sensor.sht31
 Adafruit-GPIO==1.0.3
 
@@ -22,9 +25,6 @@ Adafruit-SHT31==1.0.2
 
 # homeassistant.components.bbb_gpio
 # Adafruit_BBIO==1.0.0
-
-# homeassistant.components.sensor.dht
-# Adafruit_Python_DHT==1.3.2
 
 # homeassistant.components.doorbird
 DoorBirdPy==0.1.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -15,7 +15,7 @@ voluptuous==0.11.1
 --only-binary=all nuimo==0.1.0
 
 # homeassistant.components.sensor.dht
-Adafruit-DHT==1.3.3
+# Adafruit-DHT==1.3.3
 
 # homeassistant.components.sensor.sht31
 Adafruit-GPIO==1.0.3

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -11,7 +11,7 @@ COMMENT_REQUIREMENTS = (
     'RPi.GPIO',
     'raspihats',
     'rpi-rf',
-    'Adafruit_Python_DHT',
+    'Adafruit-DHT',
     'Adafruit_BBIO',
     'fritzconnection',
     'pybluez',


### PR DESCRIPTION
The package Adafruit_Python_DHT==1.3.2 was broken and would not install, breaking DHT sensor support in Home assistant. It has since been fixed in Adafruit-DHT==1.3.3.

See: https://github.com/adafruit/Adafruit_Python_DHT/issues/99

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
