### PR TITLE
Upgrade pyvera to 0.2.44

### DIFF
--- a/homeassistant/components/vera.py
+++ b/homeassistant/components/vera.py
@@ -19,7 +19,7 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_STOP, CONF_LIGHTS, CONF_EXCLUDE)
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['pyvera==0.2.43']
+REQUIREMENTS = ['pyvera==0.2.44']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1147,7 +1147,7 @@ pyuptimerobot==0.0.5
 # pyuserinput==0.1.11
 
 # homeassistant.components.vera
-pyvera==0.2.43
+pyvera==0.2.44
 
 # homeassistant.components.switch.vesync
 pyvesync==0.1.1


### PR DESCRIPTION
## Description:

Upgrade pyvera to fix support for remotes: https://community.home-assistant.io/t/add-vera-remote-control-component/59200/3