### PR TITLE
Add configuration for extra Unifi device_tracker attributes

### DIFF
--- a/homeassistant/components/device_tracker/unifi.py
+++ b/homeassistant/components/device_tracker/unifi.py
@@ -21,12 +21,14 @@ _LOGGER = logging.getLogger(__name__)
 CONF_PORT = 'port'
 CONF_SITE_ID = 'site_id'
 CONF_DETECTION_TIME = 'detection_time'
+CONF_EXTRA_ATTRIBUTES = 'extra_attributes'
 CONF_SSID_FILTER = 'ssid_filter'
 
 DEFAULT_HOST = 'localhost'
 DEFAULT_PORT = 8443
 DEFAULT_VERIFY_SSL = True
 DEFAULT_DETECTION_TIME = timedelta(seconds=300)
+DEFAULT_EXTRA_ATTRIBUTES = False
 
 NOTIFICATION_ID = 'unifi_notification'
 NOTIFICATION_TITLE = 'Unifi Device Tracker Setup'
@@ -41,6 +43,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
         cv.boolean, cv.isfile),
     vol.Optional(CONF_DETECTION_TIME, default=DEFAULT_DETECTION_TIME): vol.All(
         cv.time_period, cv.positive_timedelta),
+    vol.Optional(CONF_EXTRA_ATTRIBUTES, default=DEFAULT_EXTRA_ATTRIBUTES):
+        cv.boolean,
     vol.Optional(CONF_SSID_FILTER): vol.All(cv.ensure_list, [cv.string])
 })
 
@@ -56,6 +60,7 @@ def get_scanner(hass, config):
     port = config[DOMAIN].get(CONF_PORT)
     verify_ssl = config[DOMAIN].get(CONF_VERIFY_SSL)
     detection_time = config[DOMAIN].get(CONF_DETECTION_TIME)
+    extra_attributes = config[DOMAIN].get(CONF_EXTRA_ATTRIBUTES)
     ssid_filter = config[DOMAIN].get(CONF_SSID_FILTER)
 
     try:
@@ -72,18 +77,19 @@ def get_scanner(hass, config):
             notification_id=NOTIFICATION_ID)
         return False
 
-    return UnifiScanner(ctrl, detection_time, ssid_filter)
+    return UnifiScanner(ctrl, detection_time, ssid_filter, extra_attributes)
 
 
 class UnifiScanner(DeviceScanner):
     """Provide device_tracker support from Unifi WAP client data."""
 
     def __init__(self, controller, detection_time: timedelta,
-                 ssid_filter) -> None:
+                 ssid_filter, extra_attributes) -> None:
         """Initialize the scanner."""
         self._detection_time = detection_time
         self._controller = controller
         self._ssid_filter = ssid_filter
+        self._extra_attributes = extra_attributes
         self._update()
 
     def _update(self):
@@ -125,6 +131,9 @@ class UnifiScanner(DeviceScanner):
 
     def get_extra_attributes(self, device):
         """Return the extra attributes of the device."""
-        client = self._clients.get(device, {})
-        _LOGGER.debug("Device mac %s attributes %s", device, client)
-        return client
+        if (self._extra_attributes):
+            client = self._clients.get(device, {})
+            _LOGGER.debug("Device mac %s attributes %s", device, client)
+            return client
+        else:
+            return dict()

--- a/homeassistant/components/device_tracker/unifi.py
+++ b/homeassistant/components/device_tracker/unifi.py
@@ -131,9 +131,9 @@ class UnifiScanner(DeviceScanner):
 
     def get_extra_attributes(self, device):
         """Return the extra attributes of the device."""
-        if (self._extra_attributes):
-            client = self._clients.get(device, {})
-            _LOGGER.debug("Device mac %s attributes %s", device, client)
-            return client
-        else:
-            return dict()
+        if not self._extra_attributes:
+            return {}
+
+        client = self._clients.get(device, {})
+        _LOGGER.debug("Device mac %s attributes %s", device, client)
+        return client

--- a/tests/components/device_tracker/test_unifi.py
+++ b/tests/components/device_tracker/test_unifi.py
@@ -205,7 +205,7 @@ def test_scan_devices_filtered():
     ssid_filter = ['foonet', 'barnet']
     ctrl.get_clients.return_value = fake_clients
     scanner = unifi.UnifiScanner(ctrl, DEFAULT_DETECTION_TIME, ssid_filter,
-        False)
+                                 False)
     assert set(scanner.scan_devices()) == set(['123', '234', '890'])
 
 

--- a/tests/components/device_tracker/test_unifi.py
+++ b/tests/components/device_tracker/test_unifi.py
@@ -54,7 +54,8 @@ def test_config_valid_verify_ssl(hass, mock_scanner, mock_ctrl):
     assert mock_scanner.call_count == 1
     assert mock_scanner.call_args == mock.call(mock_ctrl.return_value,
                                                DEFAULT_DETECTION_TIME,
-                                               None)
+                                               None,
+                                               False)
 
 
 def test_config_minimal(hass, mock_scanner, mock_ctrl):
@@ -76,7 +77,8 @@ def test_config_minimal(hass, mock_scanner, mock_ctrl):
     assert mock_scanner.call_count == 1
     assert mock_scanner.call_args == mock.call(mock_ctrl.return_value,
                                                DEFAULT_DETECTION_TIME,
-                                               None)
+                                               None,
+                                               False)
 
 
 def test_config_full(hass, mock_scanner, mock_ctrl):
@@ -91,6 +93,7 @@ def test_config_full(hass, mock_scanner, mock_ctrl):
             'port': 123,
             'site_id': 'abcdef01',
             'detection_time': 300,
+            'extra_attributes': True
         })
     }
     result = unifi.get_scanner(hass, config)
@@ -103,7 +106,8 @@ def test_config_full(hass, mock_scanner, mock_ctrl):
     assert mock_scanner.call_count == 1
     assert mock_scanner.call_args == mock.call(mock_ctrl.return_value,
                                                DEFAULT_DETECTION_TIME,
-                                               None)
+                                               None,
+                                               True)
 
 
 def test_config_error():
@@ -157,7 +161,7 @@ def test_scanner_update():
          'last_seen': dt_util.as_timestamp(dt_util.utcnow())},
     ]
     ctrl.get_clients.return_value = fake_clients
-    unifi.UnifiScanner(ctrl, DEFAULT_DETECTION_TIME, None)
+    unifi.UnifiScanner(ctrl, DEFAULT_DETECTION_TIME, None, False)
     assert ctrl.get_clients.call_count == 1
     assert ctrl.get_clients.call_args == mock.call()
 
@@ -167,7 +171,7 @@ def test_scanner_update_error():
     ctrl = mock.MagicMock()
     ctrl.get_clients.side_effect = APIError(
         '/', 500, 'foo', {}, None)
-    unifi.UnifiScanner(ctrl, DEFAULT_DETECTION_TIME, None)
+    unifi.UnifiScanner(ctrl, DEFAULT_DETECTION_TIME, None, False)
 
 
 def test_scan_devices():
@@ -180,7 +184,7 @@ def test_scan_devices():
          'last_seen': dt_util.as_timestamp(dt_util.utcnow())},
     ]
     ctrl.get_clients.return_value = fake_clients
-    scanner = unifi.UnifiScanner(ctrl, DEFAULT_DETECTION_TIME, None)
+    scanner = unifi.UnifiScanner(ctrl, DEFAULT_DETECTION_TIME, None, False)
     assert set(scanner.scan_devices()) == set(['123', '234'])
 
 
@@ -200,7 +204,8 @@ def test_scan_devices_filtered():
 
     ssid_filter = ['foonet', 'barnet']
     ctrl.get_clients.return_value = fake_clients
-    scanner = unifi.UnifiScanner(ctrl, DEFAULT_DETECTION_TIME, ssid_filter)
+    scanner = unifi.UnifiScanner(ctrl, DEFAULT_DETECTION_TIME, ssid_filter,
+        False)
     assert set(scanner.scan_devices()) == set(['123', '234', '890'])
 
 
@@ -221,7 +226,7 @@ def test_get_device_name():
          'last_seen': '1504786810'},
     ]
     ctrl.get_clients.return_value = fake_clients
-    scanner = unifi.UnifiScanner(ctrl, DEFAULT_DETECTION_TIME, None)
+    scanner = unifi.UnifiScanner(ctrl, DEFAULT_DETECTION_TIME, None, False)
     assert scanner.get_device_name('123') == 'foobar'
     assert scanner.get_device_name('234') == 'Nice Name'
     assert scanner.get_device_name('456') is None


### PR DESCRIPTION
## Description:
The Unifi device tracker adds a lot of extra attributes to devices, such as rx/tx rates, rx/tx bytes, signal strength, etc. which cause a lot of extra state changed events to be fired and logged in the database. This update adds a configuration option, `extra_attributes`, defaulting to False (disabled). This is technically a breaking change since it defaults to false.

This is my first time working with tests, so I'm not sure I updated the test_unify.py file correctly.

**Related issue (if applicable):** fixes #14745

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5921

## Example entry for `configuration.yaml` (if applicable):
```yaml
device_tracker:
  - platform: unifi
    host: 192.168.1.201
    verify_ssl: false
    username: !secret unifi_username
    password: !secret unifi_password
    extra_attributes: true
    new_device_defaults:
      track_new_devices: false
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
