### PR TITLE
Disable currently unsupported Hue Entertainment Areas

### DIFF
--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -187,6 +187,11 @@ async def async_update_items(hass, bridge, async_add_devices,
 
     for item_id in api:
         if item_id not in current:
+
+            # filter out entertainment groups unless they are used for sth.
+            if api[item_id].type == 'Entertainment':
+                break
+
             current[item_id] = HueLight(
                 api[item_id], request_bridge_update, bridge, is_group)
 


### PR DESCRIPTION
## Description:
Philips introduced the so called "Entertainment Areas" feature a few weeks or month ago. In the Hue API, these are handled as a group, similar to "Room"-groups and "LightGroups". If a "Entertainment Area" is called like a "Room"-group (which makes sense and is used by users this way), the Hue platform will generate two identical entities. (same Entity ID with incr. number, same behaviour) Others also had this issue already with HA (https://github.com/home-assistant/home-assistant/issues/12969).

Unless HA differentiate between entertainment areas and other hue group types, maybe its appropriate to exclude the "Entertainment Areas"? I do not see any use case for them currently. Grouping of any kind is/can be done with the "Room" or "LightGroup" group-type (see https://developers.meethue.com/documentation/groups-api#214_notes) and there is no support in HA (also no PR or issue) for the special "Entertainment Area" features which differentiates them from the other hue group-types.


**Related issue (if applicable):** -

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** -


## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
