### PR TITLE
WIP: Allow multiple pushover notifiers

### DIFF
--- a/homeassistant/components/notify/pushover.py
+++ b/homeassistant/components/notify/pushover.py
@@ -14,7 +14,7 @@ from homeassistant.components.notify import (
 from homeassistant.const import CONF_API_KEY
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['python-pushover==0.3']
+REQUIREMENTS = ['python-pushover==0.5']
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -28,14 +28,8 @@ PLATFORM_SCHEMA = cv.PLATFORM_SCHEMA.extend({
 
 def get_service(hass, config, discovery_info=None):
     """Get the Pushover notification service."""
-    from pushover import InitError
-
-    try:
-        return PushoverNotificationService(
-            config[CONF_USER_KEY], config[CONF_API_KEY])
-    except InitError:
-        _LOGGER.error("Wrong API key supplied")
-        return None
+    return PushoverNotificationService(
+        config[CONF_USER_KEY], config[CONF_API_KEY])
 
 
 class PushoverNotificationService(BaseNotificationService):
@@ -44,10 +38,7 @@ class PushoverNotificationService(BaseNotificationService):
     def __init__(self, user_key, api_token):
         """Initialize the service."""
         from pushover import Client
-        self._user_key = user_key
-        self._api_token = api_token
-        self.pushover = Client(
-            self._user_key, api_token=self._api_token)
+        self.pushover = Client(user_key, api_token=api_token)
 
     def send_message(self, message='', **kwargs):
         """Send a message to a user."""

--- a/homeassistant/components/notify/pushover.py
+++ b/homeassistant/components/notify/pushover.py
@@ -14,7 +14,8 @@ from homeassistant.components.notify import (
 from homeassistant.const import CONF_API_KEY
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['python-pushover==0.5']
+REQUIREMENTS = ['https://github.com/amelchio/python-pushover/archive/'
+                'local-token.zip#python-pushover==0.5']
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1069,7 +1069,7 @@ python-nest==4.0.3
 python-nmap==0.6.1
 
 # homeassistant.components.notify.pushover
-python-pushover==0.3
+python-pushover==0.5
 
 # homeassistant.components.sensor.ripple
 python-ripple-api==0.0.3


### PR DESCRIPTION
## Description:

*If you want to test this, copy [this file](https://raw.githubusercontent.com/amelchio/home-assistant/multiple-notify-pushover/homeassistant/components/notify/pushover.py) to your `<config>/custom_components/notify/pushover.py` and restart Home Assistant. Remove that file again once this PR is merged.*

This PR updates python-pushover to a version that fixes #11641.

The `InitError` exception has been renamed but I am just removing it from our code since Voluptuous will ensure the `api_key` is always specified. I am also removing a few attributes that were never accessed.

Pending Thibauth/python-pushover#27

**Related issue (if applicable):** fixes #11641

## Example entry for `configuration.yaml` (if applicable):
```yaml
notify:
 - name: pushoversecurity
   platform: pushover
   api_key: a7wt2i...
   user_key: upr9e...

 - name: pushoverhome
   platform: pushover
   api_key: ae5fi...
   user_key: upr9e...
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54