### PR TITLE
Remove self type hints

### DIFF
--- a/homeassistant/components/climate/honeywell.py
+++ b/homeassistant/components/climate/honeywell.py
@@ -165,7 +165,7 @@ class RoundThermostat(ClimateDevice):
         self.client.set_temperature(self._name, temperature)
 
     @property
-    def current_operation(self: ClimateDevice) -> str:
+    def current_operation(self) -> str:
         """Get the current operation of the system."""
         return getattr(self.client, ATTR_SYSTEM_MODE, None)
 
@@ -174,7 +174,7 @@ class RoundThermostat(ClimateDevice):
         """Return true if away mode is on."""
         return self._away
 
-    def set_operation_mode(self: ClimateDevice, operation_mode: str) -> None:
+    def set_operation_mode(self, operation_mode: str) -> None:
         """Set the HVAC mode for the thermostat."""
         if hasattr(self.client, ATTR_SYSTEM_MODE):
             self.client.system_mode = operation_mode
@@ -280,7 +280,7 @@ class HoneywellUSThermostat(ClimateDevice):
         return self._device.setpoint_heat
 
     @property
-    def current_operation(self: ClimateDevice) -> str:
+    def current_operation(self) -> str:
         """Return current operation ie. heat, cool, idle."""
         oper = getattr(self._device, ATTR_CURRENT_OPERATION, None)
         if oper == "off":
@@ -373,7 +373,7 @@ class HoneywellUSThermostat(ClimateDevice):
         except somecomfort.SomeComfortError:
             _LOGGER.error('Can not stop hold mode')
 
-    def set_operation_mode(self: ClimateDevice, operation_mode: str) -> None:
+    def set_operation_mode(self, operation_mode: str) -> None:
         """Set the system mode (Cool, Heat, etc)."""
         if hasattr(self._device, ATTR_SYSTEM_MODE):
             self._device.system_mode = operation_mode

--- a/homeassistant/components/fan/__init__.py
+++ b/homeassistant/components/fan/__init__.py
@@ -235,11 +235,11 @@ def async_setup(hass, config: dict):
 class FanEntity(ToggleEntity):
     """Representation of a fan."""
 
-    def set_speed(self: ToggleEntity, speed: str) -> None:
+    def set_speed(self, speed: str) -> None:
         """Set the speed of the fan."""
         raise NotImplementedError()
 
-    def async_set_speed(self: ToggleEntity, speed: str):
+    def async_set_speed(self, speed: str):
         """Set the speed of the fan.
 
         This method must be run in the event loop and returns a coroutine.
@@ -248,11 +248,11 @@ class FanEntity(ToggleEntity):
             return self.async_turn_off()
         return self.hass.async_add_job(self.set_speed, speed)
 
-    def set_direction(self: ToggleEntity, direction: str) -> None:
+    def set_direction(self, direction: str) -> None:
         """Set the direction of the fan."""
         raise NotImplementedError()
 
-    def async_set_direction(self: ToggleEntity, direction: str):
+    def async_set_direction(self, direction: str):
         """Set the direction of the fan.
 
         This method must be run in the event loop and returns a coroutine.
@@ -260,12 +260,12 @@ class FanEntity(ToggleEntity):
         return self.hass.async_add_job(self.set_direction, direction)
 
     # pylint: disable=arguments-differ
-    def turn_on(self: ToggleEntity, speed: str = None, **kwargs) -> None:
+    def turn_on(self, speed: str = None, **kwargs) -> None:
         """Turn on the fan."""
         raise NotImplementedError()
 
     # pylint: disable=arguments-differ
-    def async_turn_on(self: ToggleEntity, speed: str = None, **kwargs):
+    def async_turn_on(self, speed: str = None, **kwargs):
         """Turn on the fan.
 
         This method must be run in the event loop and returns a coroutine.
@@ -275,11 +275,11 @@ class FanEntity(ToggleEntity):
         return self.hass.async_add_job(
             ft.partial(self.turn_on, speed, **kwargs))
 
-    def oscillate(self: ToggleEntity, oscillating: bool) -> None:
+    def oscillate(self, oscillating: bool) -> None:
         """Oscillate the fan."""
         pass
 
-    def async_oscillate(self: ToggleEntity, oscillating: bool):
+    def async_oscillate(self, oscillating: bool):
         """Oscillate the fan.
 
         This method must be run in the event loop and returns a coroutine.
@@ -297,7 +297,7 @@ class FanEntity(ToggleEntity):
         return None
 
     @property
-    def speed_list(self: ToggleEntity) -> list:
+    def speed_list(self) -> list:
         """Get the list of available speeds."""
         return []
 
@@ -307,7 +307,7 @@ class FanEntity(ToggleEntity):
         return None
 
     @property
-    def state_attributes(self: ToggleEntity) -> dict:
+    def state_attributes(self) -> dict:
         """Return optional state attributes."""
         data = {}  # type: dict
 
@@ -322,6 +322,6 @@ class FanEntity(ToggleEntity):
         return data
 
     @property
-    def supported_features(self: ToggleEntity) -> int:
+    def supported_features(self) -> int:
         """Flag supported features."""
         return 0

--- a/homeassistant/components/fan/dyson.py
+++ b/homeassistant/components/fan/dyson.py
@@ -8,12 +8,11 @@ import logging
 
 import voluptuous as vol
 
+import homeassistant.helpers.config_validation as cv
 from homeassistant.components.dyson import DYSON_DEVICES
 from homeassistant.components.fan import (
     DOMAIN, SUPPORT_OSCILLATE, SUPPORT_SET_SPEED, FanEntity)
 from homeassistant.const import CONF_ENTITY_ID
-import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.entity import ToggleEntity
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/fan/dyson.py
+++ b/homeassistant/components/fan/dyson.py
@@ -100,7 +100,7 @@ class DysonPureCoolLinkDevice(FanEntity):
         """Return the display name of this fan."""
         return self._device.name
 
-    def set_speed(self: ToggleEntity, speed: str) -> None:
+    def set_speed(self, speed: str) -> None:
         """Set the speed of the fan. Never called ??."""
         from libpurecoollink.const import FanSpeed, FanMode
 
@@ -113,7 +113,7 @@ class DysonPureCoolLinkDevice(FanEntity):
             self._device.set_configuration(
                 fan_mode=FanMode.FAN, fan_speed=fan_speed)
 
-    def turn_on(self: ToggleEntity, speed: str = None, **kwargs) -> None:
+    def turn_on(self, speed: str = None, **kwargs) -> None:
         """Turn on the fan."""
         from libpurecoollink.const import FanSpeed, FanMode
 
@@ -129,14 +129,14 @@ class DysonPureCoolLinkDevice(FanEntity):
             # Speed not set, just turn on
             self._device.set_configuration(fan_mode=FanMode.FAN)
 
-    def turn_off(self: ToggleEntity, **kwargs) -> None:
+    def turn_off(self, **kwargs) -> None:
         """Turn off the fan."""
         from libpurecoollink.const import FanMode
 
         _LOGGER.debug("Turn off fan %s", self.name)
         self._device.set_configuration(fan_mode=FanMode.OFF)
 
-    def oscillate(self: ToggleEntity, oscillating: bool) -> None:
+    def oscillate(self, oscillating: bool) -> None:
         """Turn on/off oscillating."""
         from libpurecoollink.const import Oscillation
 
@@ -183,7 +183,7 @@ class DysonPureCoolLinkDevice(FanEntity):
         """Return Night mode."""
         return self._device.state.night_mode == "ON"
 
-    def night_mode(self: ToggleEntity, night_mode: bool) -> None:
+    def night_mode(self, night_mode: bool) -> None:
         """Turn fan in night mode."""
         from libpurecoollink.const import NightMode
 
@@ -198,7 +198,7 @@ class DysonPureCoolLinkDevice(FanEntity):
         """Return auto mode."""
         return self._device.state.fan_mode == "AUTO"
 
-    def auto_mode(self: ToggleEntity, auto_mode: bool) -> None:
+    def auto_mode(self, auto_mode: bool) -> None:
         """Turn fan in auto mode."""
         from libpurecoollink.const import FanMode
 
@@ -209,7 +209,7 @@ class DysonPureCoolLinkDevice(FanEntity):
             self._device.set_configuration(fan_mode=FanMode.FAN)
 
     @property
-    def speed_list(self: ToggleEntity) -> list:
+    def speed_list(self) -> list:
         """Get the list of available speeds."""
         from libpurecoollink.const import FanSpeed
 
@@ -230,6 +230,6 @@ class DysonPureCoolLinkDevice(FanEntity):
         return supported_speeds
 
     @property
-    def supported_features(self: ToggleEntity) -> int:
+    def supported_features(self) -> int:
         """Flag supported features."""
         return SUPPORT_OSCILLATE | SUPPORT_SET_SPEED

--- a/homeassistant/components/fan/insteon_local.py
+++ b/homeassistant/components/fan/insteon_local.py
@@ -7,11 +7,10 @@ https://home-assistant.io/components/fan.insteon_local/
 import logging
 from datetime import timedelta
 
+from homeassistant import util
 from homeassistant.components.fan import (
     ATTR_SPEED, SPEED_OFF, SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH,
     SUPPORT_SET_SPEED, FanEntity)
-from homeassistant.helpers.entity import ToggleEntity
-from homeassistant import util
 
 _CONFIGURING = {}
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/fan/insteon_local.py
+++ b/homeassistant/components/fan/insteon_local.py
@@ -68,7 +68,7 @@ class InsteonLocalFanDevice(FanEntity):
         return self._speed
 
     @property
-    def speed_list(self: ToggleEntity) -> list:
+    def speed_list(self) -> list:
         """Get the list of available speeds."""
         return [SPEED_OFF, SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH]
 
@@ -91,18 +91,18 @@ class InsteonLocalFanDevice(FanEntity):
         """Flag supported features."""
         return SUPPORT_INSTEON_LOCAL
 
-    def turn_on(self: ToggleEntity, speed: str = None, **kwargs) -> None:
+    def turn_on(self, speed: str = None, **kwargs) -> None:
         """Turn device on."""
         if speed is None:
             speed = kwargs.get(ATTR_SPEED, SPEED_MEDIUM)
 
         self.set_speed(speed)
 
-    def turn_off(self: ToggleEntity, **kwargs) -> None:
+    def turn_off(self, **kwargs) -> None:
         """Turn device off."""
         self.node.off()
 
-    def set_speed(self: ToggleEntity, speed: str) -> None:
+    def set_speed(self, speed: str) -> None:
         """Set the speed of the fan."""
         if self.node.on(speed):
             self._speed = speed

--- a/homeassistant/components/fan/template.py
+++ b/homeassistant/components/fan/template.py
@@ -196,7 +196,7 @@ class TemplateFan(FanEntity):
         return self._supported_features
 
     @property
-    def speed_list(self: ToggleEntity) -> list:
+    def speed_list(self) -> list:
         """Get the list of available speeds."""
         return self._speed_list
 

--- a/homeassistant/components/fan/template.py
+++ b/homeassistant/components/fan/template.py
@@ -8,21 +8,17 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.core import callback
-from homeassistant.const import (
-    CONF_FRIENDLY_NAME, CONF_VALUE_TEMPLATE, CONF_ENTITY_ID,
-    STATE_ON, STATE_OFF, MATCH_ALL, EVENT_HOMEASSISTANT_START,
-    STATE_UNKNOWN)
-
-from homeassistant.exceptions import TemplateError
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.config_validation import PLATFORM_SCHEMA
-from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.components.fan import (
     SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH, SUPPORT_SET_SPEED, SUPPORT_OSCILLATE,
     FanEntity, ATTR_SPEED, ATTR_OSCILLATING, ENTITY_ID_FORMAT,
     SUPPORT_DIRECTION, DIRECTION_FORWARD, DIRECTION_REVERSE, ATTR_DIRECTION)
-
+from homeassistant.const import (
+    CONF_FRIENDLY_NAME, CONF_VALUE_TEMPLATE, CONF_ENTITY_ID,
+    STATE_ON, STATE_OFF, MATCH_ALL, EVENT_HOMEASSISTANT_START,
+    STATE_UNKNOWN)
+from homeassistant.core import callback
+from homeassistant.exceptions import TemplateError
 from homeassistant.helpers.entity import async_generate_entity_id
 from homeassistant.helpers.script import Script
 
@@ -65,7 +61,7 @@ FAN_SCHEMA = vol.Schema({
     vol.Optional(CONF_ENTITY_ID): cv.entity_ids
 })
 
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+PLATFORM_SCHEMA = cv.PLATFORM_SCHEMA.extend({
     vol.Required(CONF_FANS): vol.Schema({cv.slug: FAN_SCHEMA}),
 })
 

--- a/homeassistant/components/fan/wink.py
+++ b/homeassistant/components/fan/wink.py
@@ -11,7 +11,6 @@ from homeassistant.components.fan import (
     SPEED_HIGH, SPEED_LOW, SPEED_MEDIUM, STATE_UNKNOWN, SUPPORT_DIRECTION,
     SUPPORT_SET_SPEED, FanEntity)
 from homeassistant.components.wink import DOMAIN, WinkDevice
-from homeassistant.helpers.entity import ToggleEntity
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/fan/wink.py
+++ b/homeassistant/components/fan/wink.py
@@ -39,19 +39,19 @@ class WinkFanDevice(WinkDevice, FanEntity):
         """Call when entity is added to hass."""
         self.hass.data[DOMAIN]['entities']['fan'].append(self)
 
-    def set_direction(self: ToggleEntity, direction: str) -> None:
+    def set_direction(self, direction: str) -> None:
         """Set the direction of the fan."""
         self.wink.set_fan_direction(direction)
 
-    def set_speed(self: ToggleEntity, speed: str) -> None:
+    def set_speed(self, speed: str) -> None:
         """Set the speed of the fan."""
         self.wink.set_state(True, speed)
 
-    def turn_on(self: ToggleEntity, speed: str = None, **kwargs) -> None:
+    def turn_on(self, speed: str = None, **kwargs) -> None:
         """Turn on the fan."""
         self.wink.set_state(True, speed)
 
-    def turn_off(self: ToggleEntity, **kwargs) -> None:
+    def turn_off(self, **kwargs) -> None:
         """Turn off the fan."""
         self.wink.set_state(False)
 
@@ -82,7 +82,7 @@ class WinkFanDevice(WinkDevice, FanEntity):
         return self.wink.current_fan_direction()
 
     @property
-    def speed_list(self: ToggleEntity) -> list:
+    def speed_list(self) -> list:
         """Get the list of available speeds."""
         wink_supported_speeds = self.wink.fan_speeds()
         supported_speeds = []
@@ -99,6 +99,6 @@ class WinkFanDevice(WinkDevice, FanEntity):
         return supported_speeds
 
     @property
-    def supported_features(self: ToggleEntity) -> int:
+    def supported_features(self) -> int:
         """Flag supported features."""
         return SUPPORTED_FEATURES

--- a/homeassistant/components/fan/zha.py
+++ b/homeassistant/components/fan/zha.py
@@ -89,7 +89,7 @@ class ZhaFan(zha.Entity, FanEntity):
         yield from self.async_set_speed(SPEED_OFF)
 
     @asyncio.coroutine
-    def async_set_speed(self: FanEntity, speed: str) -> None:
+    def async_set_speed(self, speed: str) -> None:
         """Set the speed of the fan."""
         yield from self._endpoint.fan.write_attributes({
             'fan_mode': SPEED_TO_VALUE[speed]})

--- a/homeassistant/util/__init__.py
+++ b/homeassistant/util/__init__.py
@@ -126,25 +126,25 @@ class OrderedEnum(enum.Enum):
     # https://github.com/PyCQA/pylint/issues/2306
     # pylint: disable=comparison-with-callable
 
-    def __ge__(self: ENUM_T, other: ENUM_T) -> bool:
+    def __ge__(self, other: ENUM_T) -> bool:
         """Return the greater than element."""
         if self.__class__ is other.__class__:
             return bool(self.value >= other.value)
         return NotImplemented
 
-    def __gt__(self: ENUM_T, other: ENUM_T) -> bool:
+    def __gt__(self, other: ENUM_T) -> bool:
         """Return the greater element."""
         if self.__class__ is other.__class__:
             return bool(self.value > other.value)
         return NotImplemented
 
-    def __le__(self: ENUM_T, other: ENUM_T) -> bool:
+    def __le__(self, other: ENUM_T) -> bool:
         """Return the lower than element."""
         if self.__class__ is other.__class__:
             return bool(self.value <= other.value)
         return NotImplemented
 
-    def __lt__(self: ENUM_T, other: ENUM_T) -> bool:
+    def __lt__(self, other: ENUM_T) -> bool:
         """Return the lower element."""
         if self.__class__ is other.__class__:
             return bool(self.value < other.value)

--- a/homeassistant/util/unit_system.py
+++ b/homeassistant/util/unit_system.py
@@ -65,7 +65,7 @@ def is_valid_unit(unit: str, unit_type: str) -> bool:
 class UnitSystem:
     """A container for units of measure."""
 
-    def __init__(self: object, name: str, temperature: str, length: str,
+    def __init__(self, name: str, temperature: str, length: str,
                  volume: str, mass: str) -> None:
         """Initialize the unit system object."""
         errors = \

--- a/tests/components/climate/test_honeywell.py
+++ b/tests/components/climate/test_honeywell.py
@@ -320,7 +320,7 @@ class TestHoneywellRound(unittest.TestCase):
             self.device.set_temperature.call_args, mock.call('House', 25)
         )
 
-    def test_set_operation_mode(self: unittest.TestCase) -> None:
+    def test_set_operation_mode(self) -> None:
         """Test setting the system operation."""
         self.round1.set_operation_mode('cool')
         self.assertEqual('cool', self.round1.current_operation)
@@ -384,7 +384,7 @@ class TestHoneywellUS(unittest.TestCase):
         self.assertEqual(74, self.device.setpoint_cool)
         self.assertEqual(74, self.honeywell.target_temperature)
 
-    def test_set_operation_mode(self: unittest.TestCase) -> None:
+    def test_set_operation_mode(self) -> None:
         """Test setting the operation mode."""
         self.honeywell.set_operation_mode('cool')
         self.assertEqual('cool', self.device.system_mode)


### PR DESCRIPTION
## Description:
self parameter in class method should not have type hint

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**


