### PR TITLE
Make FutureNow light remember last brightness when turning on

### DIFF
--- a/homeassistant/components/light/futurenow.py
+++ b/homeassistant/components/light/futurenow.py
@@ -16,7 +16,7 @@ from homeassistant.components.light import (
     PLATFORM_SCHEMA)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['pyfnip==0.1']
+REQUIREMENTS = ['pyfnip==0.2']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -77,7 +77,6 @@ class FutureNowLight(Light):
         self._brightness = None
         self._last_brightness = 255
         self._state = None
-        self._skip_update = False
 
         if device['driver'] == CONF_DRIVER_FNIP6X10AD:
             self._light = pyfnip.FNIP6x2adOutput(device['host'],
@@ -114,25 +113,15 @@ class FutureNowLight(Light):
         """Turn the light on."""
         level = kwargs.get(ATTR_BRIGHTNESS, self._last_brightness) if self._dimmable else 255
         self._light.turn_on(to_futurenow_level(level))
-        self._brightness = level
-        self._state = True
-        self._skip_update = True
 
     def turn_off(self, **kwargs):
         """Turn the light off."""
         self._light.turn_off()
-        self._brightness = 0
-        self._state = False
-        self._skip_update = True
         if self._brightness:
             self._last_brightness = self._brightness
 
     def update(self):
         """Fetch new state data for this light."""
-        if self._skip_update:
-            self._skip_update = False
-            return
-
         state = int(self._light.is_on())
         self._state = bool(state)
         self._brightness = to_hass_level(state)

--- a/homeassistant/components/light/futurenow.py
+++ b/homeassistant/components/light/futurenow.py
@@ -75,6 +75,7 @@ class FutureNowLight(Light):
         self._dimmable = device['dimmable']
         self._channel = device['channel']
         self._brightness = None
+        self._last_brightness = 255
         self._state = None
         self._skip_update = False
 
@@ -111,7 +112,7 @@ class FutureNowLight(Light):
 
     def turn_on(self, **kwargs):
         """Turn the light on."""
-        level = kwargs.get(ATTR_BRIGHTNESS, 255) if self._dimmable else 255
+        level = kwargs.get(ATTR_BRIGHTNESS, self._last_brightness) if self._dimmable else 255
         self._light.turn_on(to_futurenow_level(level))
         self._brightness = level
         self._state = True
@@ -123,6 +124,8 @@ class FutureNowLight(Light):
         self._brightness = 0
         self._state = False
         self._skip_update = True
+        if self._brightness:
+            self._last_brightness = self._brightness
 
     def update(self):
         """Fetch new state data for this light."""

--- a/homeassistant/components/light/futurenow.py
+++ b/homeassistant/components/light/futurenow.py
@@ -111,7 +111,10 @@ class FutureNowLight(Light):
 
     def turn_on(self, **kwargs):
         """Turn the light on."""
-        level = kwargs.get(ATTR_BRIGHTNESS, self._last_brightness) if self._dimmable else 255
+        if self._dimmable:
+            level = kwargs.get(ATTR_BRIGHTNESS, self._last_brightness)
+        else:
+            level = 255
         self._light.turn_on(to_futurenow_level(level))
 
     def turn_off(self, **kwargs):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -829,7 +829,7 @@ pyflexit==0.3
 pyflic-homeassistant==0.4.dev0
 
 # homeassistant.components.light.futurenow
-pyfnip==0.1
+pyfnip==0.2
 
 # homeassistant.components.fritzbox
 pyfritzhome==0.3.7


### PR DESCRIPTION
## Description:
* Use previously stored brightness when turning on light. This is mostly useful with HomeKit, since it calls turn_on and brightness changes as two separate calls.
* Removed manually handled states because newer library can return states reliably when update() is called.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
