### PR TITLE
Add sous_vide component and Anova platform

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -749,6 +749,7 @@ omit =
     homeassistant/components/sensor/zamg.py
     homeassistant/components/sensor/zestimate.py
     homeassistant/components/shiftr.py
+    homeassistant/components/sous_vide/anova.py
     homeassistant/components/spc.py
     homeassistant/components/switch/acer_projector.py
     homeassistant/components/switch/anel_pwrctrl.py

--- a/homeassistant/components/alexa/smart_home.py
+++ b/homeassistant/components/alexa/smart_home.py
@@ -417,7 +417,8 @@ class _AlexaThermostatController(_AlexaInterface):
     def properties_supported(self):
         properties = []
         supported = self.entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
-        if supported & climate.SUPPORT_TARGET_TEMPERATURE:
+        if supported & climate.SUPPORT_TARGET_TEMPERATURE or \
+                self.entity.domain == sous_vide.DOMAIN:
             properties.append({'name': 'targetSetpoint'})
         if supported & climate.SUPPORT_TARGET_TEMPERATURE_LOW:
             properties.append({'name': 'lowerSetpoint'})
@@ -624,9 +625,9 @@ class _SousVideCapabilities(_AlexaEntity):
         return [_DisplayCategory.MICROWAVE]
 
     def interfaces(self):
-        yield _AlexaPowerController(self.entity)
-        yield _AlexaThermostatController(self.entity)
         yield _AlexaTemperatureSensor(self.entity)
+        yield _AlexaThermostatController(self.entity)
+        yield _AlexaPowerController(self.entity)
 
 
 class _Cause:
@@ -1492,7 +1493,7 @@ async def async_api_set_thermostat_mode(hass, config, request, entity):
     mode = request[API_PAYLOAD]['thermostatMode']
     mode = mode if isinstance(mode, str) else mode['value']
 
-    operation_list = entity.attributes.get(climate.ATTR_OPERATION_LIST)
+    operation_list = entity.attributes.get(climate.ATTR_OPERATION_LIST, [])
     ha_mode = next(
         (k for k, v in API_THERMOSTAT_MODES.items() if v == mode),
         None

--- a/homeassistant/components/google_assistant/const.py
+++ b/homeassistant/components/google_assistant/const.py
@@ -17,13 +17,15 @@ CONF_ROOM_HINT = 'room'
 
 DEFAULT_EXPOSE_BY_DEFAULT = True
 DEFAULT_EXPOSED_DOMAINS = [
-    'switch', 'light', 'group', 'media_player', 'fan', 'cover', 'climate'
+    'switch', 'light', 'group', 'media_player', 'fan', 'cover', 'climate',
+    'sous_vide'
 ]
 CLIMATE_MODE_HEATCOOL = 'heatcool'
 CLIMATE_SUPPORTED_MODES = {'heat', 'cool', 'off', 'on', CLIMATE_MODE_HEATCOOL}
 
 PREFIX_TYPES = 'action.devices.types.'
 TYPE_LIGHT = PREFIX_TYPES + 'LIGHT'
+TYPE_OVEN = PREFIX_TYPES + 'OVEN'
 TYPE_SWITCH = PREFIX_TYPES + 'SWITCH'
 TYPE_SCENE = PREFIX_TYPES + 'SCENE'
 TYPE_THERMOSTAT = PREFIX_TYPES + 'THERMOSTAT'

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -4,8 +4,8 @@ from homeassistant.components import (
     script, sous_vide, switch)
 from homeassistant.const import (
     ATTR_ENTITY_ID, ATTR_MEASUREMENT_PRECISION, ATTR_TEMPERATURE,
-    ATTR_UNIT_OF_MEASUREMENT, SERVICE_SET_TEMPERATURE, SERVICE_TURN_OFF,
-    SERVICE_TURN_ON, STATE_OFF, TEMP_CELSIUS, TEMP_FAHRENHEIT)
+    ATTR_UNIT_OF_MEASUREMENT, SERVICE_TURN_OFF, SERVICE_TURN_ON, STATE_OFF,
+    TEMP_CELSIUS, TEMP_FAHRENHEIT)
 from homeassistant.core import DOMAIN as HA_DOMAIN
 from homeassistant.util import color as color_util
 from homeassistant.util import temperature as temp_util
@@ -397,7 +397,8 @@ class TemperatureControlTrait(_Trait):
         min_temp = self.state.attributes.get(climate.ATTR_MIN_TEMP, 10.0)
         max_temp = self.state.attributes.get(climate.ATTR_MAX_TEMP, 10.0)
         unit = self.state.attributes[ATTR_UNIT_OF_MEASUREMENT]
-        precision = self.state.attributes.get(ATTR_MEASUREMENT_PRECISION, 1.0)
+        precision = self.state.attributes.get(
+            ATTR_MEASUREMENT_PRECISION, 1.0)
 
         return {
             'temperatureRange': {
@@ -444,7 +445,7 @@ class TemperatureControlTrait(_Trait):
                                                                      max_temp))
 
             await hass.services.async_call(
-                sous_vide.DOMAIN, SERVICE_SET_TEMPERATURE, {
+                sous_vide.DOMAIN, climate.SERVICE_SET_TEMPERATURE, {
                     ATTR_ENTITY_ID: self.state.entity_id,
                     climate.ATTR_TEMPERATURE: temp
                 }, blocking=True)

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -3,9 +3,9 @@ from homeassistant.components import (
     climate, cover, fan, group, input_boolean, light, media_player, scene,
     script, sous_vide, switch)
 from homeassistant.const import (
-    ATTR_ENTITY_ID, ATTR_MEASUREMENT_PRECISION, ATTR_TEMPERATURE,
-    ATTR_UNIT_OF_MEASUREMENT, SERVICE_TURN_OFF, SERVICE_TURN_ON, STATE_OFF,
-    TEMP_CELSIUS, TEMP_FAHRENHEIT)
+    ATTR_ENTITY_ID, ATTR_TEMPERATURE, ATTR_UNIT_OF_MEASUREMENT,
+    SERVICE_TURN_OFF, SERVICE_TURN_ON, STATE_OFF, TEMP_CELSIUS,
+    TEMP_FAHRENHEIT)
 from homeassistant.core import DOMAIN as HA_DOMAIN
 from homeassistant.util import color as color_util
 from homeassistant.util import temperature as temp_util
@@ -398,7 +398,7 @@ class TemperatureControlTrait(_Trait):
         max_temp = self.state.attributes.get(climate.ATTR_MAX_TEMP, 10.0)
         unit = self.state.attributes[ATTR_UNIT_OF_MEASUREMENT]
         precision = self.state.attributes.get(
-            ATTR_MEASUREMENT_PRECISION, 1.0)
+            sous_vide.ATTR_MEASUREMENT_PRECISION, 1.0)
 
         return {
             'temperatureRange': {
@@ -419,11 +419,11 @@ class TemperatureControlTrait(_Trait):
             climate.ATTR_CURRENT_TEMPERATURE)
         if current_temp is not None:
             response['temperatureAmbientCelsius'] = \
-                round(temp_util.convert(current_temp, unit, TEMP_CELSIUS), 2)
+                round(temp_util.convert(current_temp, unit, TEMP_CELSIUS), 1)
         target_temp = self.state.attributes.get(ATTR_TEMPERATURE)
         if target_temp is not None:
             response['temperatureSetpointCelsius'] = round(
-                temp_util.convert(target_temp, unit, TEMP_CELSIUS), 2)
+                temp_util.convert(target_temp, unit, TEMP_CELSIUS), 1)
 
         return response
 

--- a/homeassistant/components/sous_vide/__init__.py
+++ b/homeassistant/components/sous_vide/__init__.py
@@ -1,0 +1,124 @@
+"""
+Support for sous-vide machines.
+
+For more details about this platform, please refer to the documentation
+https://home-assistant.io/components/sousvide
+"""
+import logging
+from datetime import timedelta
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.const import (
+    ATTR_CURRENT_TEMPERATURE, ATTR_ENTITY_ID, ATTR_MAX_TEMP,
+    ATTR_MEASUREMENT_PRECISION, ATTR_MIN_TEMP, ATTR_OPERATION_MODE,
+    ATTR_TEMPERATURE, ATTR_UNIT_OF_MEASUREMENT, SERVICE_SET_TEMPERATURE,
+    SERVICE_TURN_OFF, SERVICE_TURN_ON, STATE_HEAT, STATE_OFF)
+from homeassistant.helpers.entity import ToggleEntity
+from homeassistant.helpers.entity_component import EntityComponent
+from homeassistant.helpers.temperature import display_temp as show_temp
+
+LOGGER = logging.getLogger(__name__)
+DOMAIN = 'sous_vide'
+GROUP_NAME_SOUS_VIDE = 'all sous-vide cookers'
+SCAN_INTERVAL = timedelta(seconds=15)
+
+SERVICE_SCHEMA = vol.Schema({
+    vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
+})
+SET_TEMPERATURE_SCHEMA = SERVICE_SCHEMA.extend({
+    vol.Required(ATTR_TEMPERATURE): vol.Coerce(float),
+})
+
+SERVICE_TO_METHOD = {
+    SERVICE_TURN_ON: {'method': 'turn_on'},
+    SERVICE_TURN_OFF: {'method': 'turn_off'},
+    SERVICE_SET_TEMPERATURE: {'method': 'set_temp',
+                              'schema': SET_TEMPERATURE_SCHEMA},
+}
+
+
+def setup(hass, config):
+    """Perform setup for the component."""
+    component = EntityComponent(
+        LOGGER, DOMAIN, hass, SCAN_INTERVAL, GROUP_NAME_SOUS_VIDE)
+    component.setup(config)
+
+    def handle_sous_vide_service(service):
+        """Callback for handling service invocations."""
+        method = SERVICE_TO_METHOD[service.service]
+        target_sous_vide_machines = component.async_extract_from_service(
+            service)
+        params = service.data.copy()
+        params.pop(ATTR_ENTITY_ID, None)
+
+        for sous_vide_machine in target_sous_vide_machines:
+            getattr(sous_vide_machine, method["method"])(**params)
+            hass.async_add_job(sous_vide_machine.async_update_ha_state)
+
+    for service in SERVICE_TO_METHOD:
+        schema = SERVICE_TO_METHOD[service].get('schema', SERVICE_SCHEMA)
+        hass.services.register(
+            DOMAIN, service, handle_sous_vide_service, schema=schema)
+
+    return True
+
+
+class SousVideEntity(ToggleEntity):
+    """Representation of a sous-vide device."""
+
+    @property
+    def icon(self):
+        """Return the icon to use in the frontend."""
+        return 'mdi:oil-temperature'
+
+    @property
+    def precision(self):
+        """Return the precision of the device's measurements."""
+
+    @property
+    def temperature_unit(self):
+        """Return the unit of measurement used by the device."""
+
+    @property
+    def current_temperature(self) -> float:
+        """Return the device's current temperature."""
+
+    @property
+    def target_temperature(self) -> float:
+        """Return the device's target temperature."""
+
+    @property
+    def min_temperature(self) -> float:
+        """Return the device's minimum temperature."""
+
+    @property
+    def max_temperature(self) -> float:
+        """Return the device's maximum temperature."""
+
+    @property
+    def state_attributes(self):
+        """Return the state attributes of the device."""
+        return {
+            ATTR_CURRENT_TEMPERATURE: show_temp(
+                self.hass, self.current_temperature, self.unit_of_measurement,
+                self.precision),
+            ATTR_MIN_TEMP: show_temp(
+                self.hass, self.min_temperature, self.unit_of_measurement,
+                self.precision),
+            ATTR_MAX_TEMP: show_temp(
+                self.hass, self.max_temperature, self.unit_of_measurement,
+                self.precision),
+            ATTR_TEMPERATURE: show_temp(
+                self.hass, self.target_temperature, self.unit_of_measurement,
+                self.precision),
+            ATTR_UNIT_OF_MEASUREMENT: self.unit_of_measurement,
+            ATTR_MEASUREMENT_PRECISION: self.precision,
+            ATTR_OPERATION_MODE:
+                STATE_OFF if self.state == STATE_OFF else STATE_HEAT,
+        }
+
+    def set_temp(self, temperature=None) -> None:
+        """Set the target temperature of the device."""
+        raise NotImplementedError()

--- a/homeassistant/components/sous_vide/__init__.py
+++ b/homeassistant/components/sous_vide/__init__.py
@@ -10,11 +10,10 @@ from datetime import timedelta
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
+from homeassistant.components import climate
 from homeassistant.const import (
-    ATTR_CURRENT_TEMPERATURE, ATTR_ENTITY_ID, ATTR_MAX_TEMP,
-    ATTR_MEASUREMENT_PRECISION, ATTR_MIN_TEMP, ATTR_OPERATION_MODE,
-    ATTR_TEMPERATURE, ATTR_UNIT_OF_MEASUREMENT, SERVICE_SET_TEMPERATURE,
-    SERVICE_TURN_OFF, SERVICE_TURN_ON, STATE_HEAT, STATE_OFF)
+    ATTR_ENTITY_ID, ATTR_MEASUREMENT_PRECISION, ATTR_TEMPERATURE,
+    ATTR_UNIT_OF_MEASUREMENT, SERVICE_TURN_OFF, SERVICE_TURN_ON, STATE_OFF)
 from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.temperature import display_temp as show_temp
@@ -34,8 +33,8 @@ SET_TEMPERATURE_SCHEMA = SERVICE_SCHEMA.extend({
 SERVICE_TO_METHOD = {
     SERVICE_TURN_ON: {'method': 'turn_on'},
     SERVICE_TURN_OFF: {'method': 'turn_off'},
-    SERVICE_SET_TEMPERATURE: {'method': 'set_temp',
-                              'schema': SET_TEMPERATURE_SCHEMA},
+    climate.SERVICE_SET_TEMPERATURE: {'method': 'set_temp',
+                                      'schema': SET_TEMPERATURE_SCHEMA},
 }
 
 
@@ -101,13 +100,13 @@ class SousVideEntity(ToggleEntity):
     def state_attributes(self):
         """Return the state attributes of the device."""
         return {
-            ATTR_CURRENT_TEMPERATURE: show_temp(
+            climate.ATTR_CURRENT_TEMPERATURE: show_temp(
                 self.hass, self.current_temperature, self.unit_of_measurement,
                 self.precision),
-            ATTR_MIN_TEMP: show_temp(
+            climate.ATTR_MIN_TEMP: show_temp(
                 self.hass, self.min_temperature, self.unit_of_measurement,
                 self.precision),
-            ATTR_MAX_TEMP: show_temp(
+            climate.ATTR_MAX_TEMP: show_temp(
                 self.hass, self.max_temperature, self.unit_of_measurement,
                 self.precision),
             ATTR_TEMPERATURE: show_temp(
@@ -115,8 +114,8 @@ class SousVideEntity(ToggleEntity):
                 self.precision),
             ATTR_UNIT_OF_MEASUREMENT: self.unit_of_measurement,
             ATTR_MEASUREMENT_PRECISION: self.precision,
-            ATTR_OPERATION_MODE:
-                STATE_OFF if self.state == STATE_OFF else STATE_HEAT,
+            climate.ATTR_OPERATION_MODE:
+                STATE_OFF if self.state == STATE_OFF else climate.STATE_HEAT,
         }
 
     def set_temp(self, temperature=None) -> None:

--- a/homeassistant/components/sous_vide/anova.py
+++ b/homeassistant/components/sous_vide/anova.py
@@ -1,0 +1,162 @@
+"""Support for Anova sous-vide machines.
+
+For more details about this platform, please refer to the documentation
+https://home-assistant.io/components/sousvide.anova/
+"""
+import logging
+
+from homeassistant.components.sous_vide import SousVideEntity
+from homeassistant.const import (
+    CONF_MAC, CONF_NAME, PRECISION_TENTHS, STATE_OFF, STATE_ON, STATE_PROBLEM,
+    STATE_UNKNOWN, TEMP_CELSIUS, TEMP_FAHRENHEIT)
+from homeassistant.util import temperature as temp_util
+
+REQUIREMENTS = ['btlewrap==0.0.2']
+
+_LOGGER = logging.getLogger(__name__)
+
+CHANDLE_ANOVA = 0x25  # BTLE characteristic handle for interacting with Anova.
+NOTIFICATION_TIMEOUT = 1.0  # Notification wait timeout in seconds.
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Perform setup for the platform."""
+    import btlewrap
+
+    backends = btlewrap.available_backends()
+    if not backends:
+        _LOGGER.error('No available Bluetooth backends.')
+        return
+
+    backend = backends[0]  # Any available backend works.
+    _LOGGER.debug('Using the %s Bluetooth backend.', backend.__name__)
+
+    name = config[CONF_NAME]
+    mac = config[CONF_MAC]
+    entity = AnovaEntity(name, mac, backend)
+    add_devices([entity])
+
+
+class AnovaEntity(SousVideEntity):
+    """Representation of an Anova Sous-Vide cooker."""
+    # pylint: disable=too-many-instance-attributes
+    _temp = 0
+    _target_temp = 0
+    _unit = TEMP_CELSIUS
+    _state = STATE_UNKNOWN
+    _last_notification = None
+
+    def __init__(self, name, mac, backend):
+        """Create a new instance of AnovaEntity."""
+        from btlewrap.base import BluetoothInterface
+
+        self._name = name
+        self._mac = mac
+        self._bt_interface = BluetoothInterface(backend)
+
+    @property
+    def name(self):
+        """Return the name of the cooker."""
+        return self._name
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement of the cooker."""
+        return self._unit
+
+    @property
+    def is_on(self) -> bool:
+        """Return True if the cooker is on."""
+        return self._state == STATE_ON
+
+    @property
+    def precision(self):
+        """Return the precision of the cooker's temperature measurement."""
+        # 1/10 of a degree precision is hardcoded in the Anova.
+        return PRECISION_TENTHS
+
+    @property
+    def current_temperature(self) -> float:
+        """Return the cooker's current temperature."""
+        return self._temp
+
+    @property
+    def target_temperature(self) -> float:
+        """Return the cooker's target temperature."""
+        return self._target_temp
+
+    @property
+    def min_temperature(self) -> float:
+        """Return the minimum target temperature of the cooker."""
+        # 0C min temp is hardcoded in the Anova.
+        return round(temp_util.convert(0, TEMP_CELSIUS, self._unit), 2)
+
+    @property
+    def max_temperature(self) -> float:
+        """Return the maximum target temperature of the cooker."""
+        # 100C max temp is hardcoded in the Anova.
+        return round(temp_util.convert(100, TEMP_CELSIUS, self._unit), 2)
+
+    def turn_on(self, **kwargs) -> None:
+        """Turn the cooker on (starts cooking."""
+        self.send_btle_command('start')
+        self._state = STATE_ON
+
+    def turn_off(self, **kwargs) -> None:
+        """Turn the cooker off (stops cooking)."""
+        self.send_btle_command('stop')
+        self._state = STATE_OFF
+
+    def set_temp(self, temperature=None) -> None:
+        """Set the target temperature of the cooker."""
+        if temperature is not None:
+            self.send_btle_command('set temp {}'.format(temperature))
+            self._target_temp = temperature
+
+    def update(self):
+        """Fetch state from the device."""
+        status = self.send_btle_command('status', True)
+        if status == 'running':
+            self._state = STATE_ON
+        elif status == 'stopped':
+            self._state = STATE_OFF
+        elif status in ('low water', 'heater error', 'power interrupt error'):
+            self._state = STATE_PROBLEM
+        else:
+            self._state = STATE_UNKNOWN
+
+        self._temp = float(self.send_btle_command('read temp', True) or 0)
+        self._target_temp = float(
+            self.send_btle_command('read set temp', True) or 0)
+
+        unit = self.send_btle_command('read unit', True) or ''
+        self._unit = TEMP_CELSIUS if unit == 'c' else TEMP_FAHRENHEIT
+
+    def send_btle_command(self, command, read_response=False):
+        """Send a BTLE command."""
+        from btlewrap.base import BluetoothBackendException
+
+        _LOGGER.debug("Sending command %s", command)
+        command = "{0}\r".format(command)
+        try:
+            with self._bt_interface.connect(self._mac) as conn:
+                conn.write_handle(  # pylint: disable=no-member
+                    CHANDLE_ANOVA, bytes(command, 'UTF-8'))
+                if read_response:
+                    _LOGGER.debug("Waiting for response")
+                    if conn.wait_for_notification(  # pylint: disable=no-member
+                            CHANDLE_ANOVA, self, NOTIFICATION_TIMEOUT):
+                        _LOGGER.debug("Got response: %s",
+                                      self._last_notification)
+                        return self._last_notification
+        except BluetoothBackendException:
+            _LOGGER.debug('Command failed, couldnt connect')
+            return None
+        return None
+
+    def handleNotification(self, handle, raw_data):
+        """ Callback to handle BTLE notifications."""
+        if raw_data is None:
+            return
+
+        self._last_notification = raw_data.strip().decode("UTF-8")

--- a/homeassistant/components/sous_vide/anova.py
+++ b/homeassistant/components/sous_vide/anova.py
@@ -1,4 +1,5 @@
-"""Support for Anova sous-vide machines.
+"""
+Support for Anova sous-vide machines.
 
 For more details about this platform, please refer to the documentation
 https://home-assistant.io/components/sousvide.anova/
@@ -33,13 +34,12 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     name = config[CONF_NAME]
     mac = config[CONF_MAC]
-    entity = AnovaEntity(name, mac, backend)
-    add_devices([entity])
+    add_devices([AnovaEntity(name, mac, backend)], True)
 
 
-class AnovaEntity(SousVideEntity):
-    """Representation of an Anova Sous-Vide cooker."""
-    # pylint: disable=too-many-instance-attributes
+class AnovaEntity(SousVideEntity):  # pylint: disable=too-many-instance-attributes; # noqa: E501
+    """Representation of an Anova sous-vide cooker."""
+
     _temp = 0
     _target_temp = 0
     _unit = TEMP_CELSIUS
@@ -154,8 +154,8 @@ class AnovaEntity(SousVideEntity):
             return None
         return None
 
-    def handleNotification(self, handle, raw_data):
-        """ Callback to handle BTLE notifications."""
+    def handleNotification(self, handle, raw_data):  # pylint: disable=invalid-name; # noqa: E501
+        """Callback to handle BTLE notifications."""
         if raw_data is None:
             return
 

--- a/homeassistant/components/sous_vide/demo.py
+++ b/homeassistant/components/sous_vide/demo.py
@@ -1,0 +1,98 @@
+"""
+Support for Anova sous-vide machines.
+
+For more details about this platform, please refer to the documentation
+https://home-assistant.io/components/demo/
+"""
+import logging
+import random
+
+from homeassistant.components.sous_vide import SousVideDevice
+from homeassistant.const import (
+    PRECISION_TENTHS, STATE_OFF, STATE_ON, TEMP_CELSIUS)
+from homeassistant.util import temperature as temp_util
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Perform setup for the platform."""
+    add_devices([DemoSousVideDevice('Sous_Vide')])
+
+
+class DemoSousVideDevice(SousVideDevice):  # pylint: disable=too-many-instance-attributes; # noqa: E501
+    """Representation of an demo sous-vide cooker."""
+
+    _temp = 20
+    _target_temp = 60
+    _unit = TEMP_CELSIUS
+    _state = STATE_OFF
+
+    def __init__(self, name):
+        """Create a new instance of AnovaEntity."""
+        self._name = name
+
+    @property
+    def name(self):
+        """Return the name of the cooker."""
+        return self._name
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement of the cooker."""
+        return self._unit
+
+    @property
+    def is_on(self) -> bool:
+        """Return True if the cooker is on."""
+        return self._state == STATE_ON
+
+    @property
+    def precision(self):
+        """Return the precision of the cooker's temperature measurement."""
+        return PRECISION_TENTHS
+
+    @property
+    def current_temperature(self) -> float:
+        """Return the cooker's current temperature."""
+        return self._temp
+
+    @property
+    def target_temperature(self) -> float:
+        """Return the cooker's target temperature."""
+        return self._target_temp
+
+    @property
+    def min_temperature(self) -> float:
+        """Return the minimum target temperature of the cooker."""
+        return round(temp_util.convert(15, TEMP_CELSIUS, self._unit), 2)
+
+    @property
+    def max_temperature(self) -> float:
+        """Return the maximum target temperature of the cooker."""
+        return round(temp_util.convert(90, TEMP_CELSIUS, self._unit), 2)
+
+    def turn_on(self, **kwargs) -> None:
+        """Turn the cooker on (starts cooking."""
+        self._state = STATE_ON
+
+    def turn_off(self, **kwargs) -> None:
+        """Turn the cooker off (stops cooking)."""
+        self._state = STATE_OFF
+
+    def set_temp(self, temperature=None) -> None:
+        """Set the target temperature of the cooker."""
+        if temperature is not None:
+            self._target_temp = max(
+                min(temperature, self.max_temperature), self.min_temperature)
+
+    def update(self):
+        """Fetch state from the device."""
+
+        # Simulate heating and cooling
+        if self._state == STATE_ON:
+            self._temp = min(self._temp + random.uniform(0.5, 2.0),
+                             self.target_temperature)
+        else:
+            self._temp = max(self._temp - random.uniform(0.25, 1.0),
+                             self.min_temperature)

--- a/homeassistant/components/sous_vide/demo.py
+++ b/homeassistant/components/sous_vide/demo.py
@@ -7,7 +7,7 @@ https://home-assistant.io/components/demo/
 import logging
 import random
 
-from homeassistant.components.sous_vide import SousVideDevice
+from homeassistant.components.sous_vide import SousVideEntity
 from homeassistant.const import (
     PRECISION_TENTHS, STATE_OFF, STATE_ON, TEMP_CELSIUS)
 from homeassistant.util import temperature as temp_util
@@ -17,10 +17,10 @@ _LOGGER = logging.getLogger(__name__)
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Perform setup for the platform."""
-    add_devices([DemoSousVideDevice('Sous_Vide')])
+    add_devices([DemoSousVideEntity('Sous_Vide')])
 
 
-class DemoSousVideDevice(SousVideDevice):  # pylint: disable=too-many-instance-attributes; # noqa: E501
+class DemoSousVideEntity(SousVideEntity):  # pylint: disable=too-many-instance-attributes; # noqa: E501
     """Representation of an demo sous-vide cooker."""
 
     _temp = 20
@@ -88,7 +88,6 @@ class DemoSousVideDevice(SousVideDevice):  # pylint: disable=too-many-instance-a
 
     def update(self):
         """Fetch state from the device."""
-
         # Simulate heating and cooling
         if self._state == STATE_ON:
             self._temp = min(self._temp + random.uniform(0.5, 2.0),

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -300,9 +300,6 @@ ATTR_DEVICE_CLASS = 'device_class'
 # Temperature attribute
 ATTR_TEMPERATURE = 'temperature'
 
-# Precision that a measurement is taken at
-ATTR_MEASUREMENT_PRECISION = 'measurement_precision'
-
 # #### UNITS OF MEASUREMENT ####
 # Temperature units
 TEMP_CELSIUS = '°C'

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -300,6 +300,9 @@ ATTR_DEVICE_CLASS = 'device_class'
 # Temperature attribute
 ATTR_TEMPERATURE = 'temperature'
 
+# Precision that a measurement is taken at
+ATTR_MEASUREMENT_PRECISION = 'measurement_precision'
+
 # #### UNITS OF MEASUREMENT ####
 # Temperature units
 TEMP_CELSIUS = '°C'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -205,6 +205,9 @@ brunt==0.1.2
 # homeassistant.components.device_tracker.bluetooth_tracker
 bt_proximity==0.1.2
 
+# homeassistant.components.sous_vide.anova
+btlewrap==0.0.2
+
 # homeassistant.components.sensor.buienradar
 # homeassistant.components.weather.buienradar
 buienradar==0.91

--- a/tests/components/sous_vide/__init__.py
+++ b/tests/components/sous_vide/__init__.py
@@ -1,0 +1,1 @@
+"""The tests for sous-vide platforms."""

--- a/tests/components/sous_vide/test_demo.py
+++ b/tests/components/sous_vide/test_demo.py
@@ -1,0 +1,127 @@
+"""The tests for the Demo sous-vide platform."""
+from unittest.mock import MagicMock
+
+import pytest
+from homeassistant.components import climate, sous_vide
+from homeassistant.components.sous_vide import demo
+from homeassistant.components.sous_vide.demo import DemoSousVideEntity
+from homeassistant.const import (
+    ATTR_TEMPERATURE, ATTR_UNIT_OF_MEASUREMENT, STATE_OFF, TEMP_CELSIUS)
+from homeassistant.helpers.temperature import display_temp
+from homeassistant.setup import setup_component
+from homeassistant.util import temperature
+from homeassistant.util.unit_system import IMPERIAL_SYSTEM, METRIC_SYSTEM
+from tests.common import assert_setup_component, get_test_home_assistant
+
+DEMO_ENTITY_ID = "{}.{}".format(sous_vide.DOMAIN, demo.DEMO_ENTITY_NAME)
+
+
+@pytest.fixture(scope="module",
+                params=[IMPERIAL_SYSTEM, METRIC_SYSTEM])
+def mock_hass(request):
+    """Create a mock homeassistant for unit testing."""
+    # TODO: This introduces extra coupling to the implementation details of
+    # HomeAssistant, Config, and Units.  Refactor display_temp to to a Units
+    # to fix this.
+    converting_hass = MagicMock()
+    converting_hass.config = MagicMock()
+    converting_hass.config.units = request.param
+    return converting_hass
+
+
+@pytest.fixture(scope="module",
+                params=[IMPERIAL_SYSTEM, METRIC_SYSTEM])
+def hass(request):
+    """Create a homeassistant for integration testing."""
+    hass_obj = get_test_home_assistant()
+    hass_obj.config.units = request.param
+    request.addfinalizer(hass_obj.stop)
+    return hass_obj
+
+
+@pytest.fixture(scope="module",
+                params=[IMPERIAL_SYSTEM, METRIC_SYSTEM])
+def demo_entity(request, mock_hass):
+    """Create a demo sous-vide entity for testing."""
+    entity = DemoSousVideEntity(name=demo.DEMO_ENTITY_NAME,
+                                unit=request.param.temperature_unit)
+    entity.hass = mock_hass  # Entity uses internally for conversions.
+
+    return entity
+
+
+@pytest.fixture
+def component_setup(hass):
+    """Initialize a demo sous-vide platform."""
+    with assert_setup_component(1):
+        assert setup_component(hass, sous_vide.DOMAIN, {
+            sous_vide.DOMAIN: {
+                'platform': 'demo'
+            }
+        })
+
+
+def test_default_state(demo_entity):
+    """Test setup_platform with the default state."""
+    assert demo_entity
+    assert demo_entity.name == demo.DEMO_ENTITY_NAME
+    assert demo_entity.state == STATE_OFF
+    assert not demo_entity.is_on
+
+    # Test is paramtetized by these.
+    assert demo_entity.unit_of_measurement == \
+        demo_entity.state_attributes[ATTR_UNIT_OF_MEASUREMENT]
+    assert demo_entity.precision == \
+        demo_entity.state_attributes[sous_vide.ATTR_MEASUREMENT_PRECISION]
+
+    # Test conversions.
+    assert demo_entity.min_temperature == temperature.convert(
+        demo.DEFAULT_MIN_TEMP_IN_C, TEMP_CELSIUS,
+        demo_entity.unit_of_measurement)
+    assert demo_entity.state_attributes[climate.ATTR_MIN_TEMP] == \
+        demo_entity.convert_to_display_temp(demo_entity.min_temperature)
+    assert demo_entity.max_temperature == temperature.convert(
+        demo.DEFAULT_MAX_TEMP_IN_C, TEMP_CELSIUS,
+        demo_entity.unit_of_measurement)
+    assert demo_entity.state_attributes[climate.ATTR_MAX_TEMP] == \
+        demo_entity.convert_to_display_temp(demo_entity.max_temperature)
+    assert demo_entity.current_temperature == temperature.convert(
+        demo.DEFAULT_CURRENT_TEMP_IN_C, TEMP_CELSIUS,
+        demo_entity.unit_of_measurement)
+    assert demo_entity.state_attributes[climate.ATTR_CURRENT_TEMPERATURE] == \
+        demo_entity.convert_to_display_temp(demo_entity.current_temperature)
+    assert demo_entity.target_temperature == temperature.convert(
+        demo.DEFAULT_TARGET_TEMP_IN_C, TEMP_CELSIUS,
+        demo_entity.unit_of_measurement)
+    assert demo_entity.state_attributes[ATTR_TEMPERATURE] == \
+        demo_entity.convert_to_display_temp(demo_entity.target_temperature)
+
+
+def test_setup_platform_default_state(hass, component_setup):
+    """Test setup_platform with the default state."""
+    demo_entity_state = hass.states.get(DEMO_ENTITY_ID)
+    assert demo_entity_state is not None
+    assert demo_entity_state.name == demo.DEMO_ENTITY_NAME
+    assert demo_entity_state.state == STATE_OFF
+
+    # Test is parameterized by these.
+    demo_entity_unit = \
+        demo_entity_state.attributes[ATTR_UNIT_OF_MEASUREMENT]
+    demo_entity_precision = \
+        demo_entity_state.attributes[sous_vide.ATTR_MEASUREMENT_PRECISION]
+    assert demo_entity_unit == demo.DEFAULT_UNIT
+    assert demo_entity_precision == demo.DEFAULT_PRECISION
+
+    # Test conversions.
+    assert demo_entity_state.attributes[climate.ATTR_MIN_TEMP] == \
+        display_temp(hass, demo.DEFAULT_MIN_TEMP_IN_C,
+                     demo_entity_unit, demo_entity_precision)
+    assert demo_entity_state.attributes[climate.ATTR_MAX_TEMP] == \
+        display_temp(hass, demo.DEFAULT_MAX_TEMP_IN_C,
+                     demo_entity_unit, demo_entity_precision)
+    assert demo_entity_state.attributes[climate.ATTR_CURRENT_TEMPERATURE] == \
+        display_temp(hass, demo.DEFAULT_CURRENT_TEMP_IN_C,
+                     demo_entity_unit, demo_entity_precision)
+    assert demo_entity_state.attributes[climate.ATTR_TEMPERATURE] == \
+        display_temp(hass, demo.DEFAULT_TARGET_TEMP_IN_C,
+                     demo_entity_unit, demo_entity_precision)


### PR DESCRIPTION
## Description:
Architecture issue here:  https://github.com/home-assistant/architecture/issues/51

Add a basic component for smart sous-vide cookers along with Google Assistant and Alexa support.

First platform is for the Anova Precision Cooker using BTLE.

This sous_vide component re-uses a lot of the constants from climate like STATE_HEAT, ATTR_TEMPERATURE, etc. I am also working on another component for coffee makers that re-uses some of these constants as well.  The first commit moves all of the relevant constants into homeassistant.const.

**Related issue (if applicable):** 
No issues, some people have created workarounds in the community like here:  https://community.home-assistant.io/t/anova-sous-vide-control-over-mqtt/48146

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5924

## Example entry for `configuration.yaml` (if applicable):
```yaml

alexa:
  smart_home:
    filter:
      include_domains:
        - sous_vide

google_assistant:
  exposed_domains:
    - sous_vide

sous_vide:
 - platform: anova
   name: Big Blue
   mac: 11:22:33:44:55:66
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
