### PR TITLE
Create group.all_sensors

### DIFF
--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -10,6 +10,8 @@ import logging
 
 import voluptuous as vol
 
+from homeassistant.components.group import \
+        ENTITY_ID_FORMAT as GROUP_ENTITY_ID_FORMAT
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.config_validation import PLATFORM_SCHEMA  # noqa
 from homeassistant.const import (
@@ -19,6 +21,10 @@ from homeassistant.const import (
 _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = 'sensor'
+DEPENDENCIES = ['group']
+
+GROUP_NAME_ALL_SENSORS = 'all sensors'
+ENTITY_ID_ALL_SENSORS = GROUP_ENTITY_ID_FORMAT.format('all_sensors')
 
 ENTITY_ID_FORMAT = DOMAIN + '.{}'
 
@@ -36,7 +42,7 @@ DEVICE_CLASSES_SCHEMA = vol.All(vol.Lower, vol.In(DEVICE_CLASSES))
 async def async_setup(hass, config):
     """Track states and offer events for sensors."""
     component = hass.data[DOMAIN] = EntityComponent(
-        _LOGGER, DOMAIN, hass, SCAN_INTERVAL)
+        _LOGGER, DOMAIN, hass, SCAN_INTERVAL, GROUP_NAME_ALL_SENSORS)
 
     await component.async_setup(config)
     return True


### PR DESCRIPTION
## Description:

This PR enables the automatic creation of the `group.all_sensors` group like it already happens for lights, automations, etc. In my testing this does not substantially alter the standard behavior of the UI, and enables users to create custom Home views with sensors displayed in a card.

**Testing by other users  with different configurations would be strongly appreciated.**
[Development ideas taken from the Light component.](https://github.com/home-assistant/home-assistant/blob/744c27712308468270fcf8046bd62cdcaf3100dc/homeassistant/components/light/__init__.py#L33)

![example](https://user-images.githubusercontent.com/3594528/43394330-a7c1da16-93fa-11e8-9cd9-742a89b5e8d7.png)

---

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here> **TODO**

## Example entry for `configuration.yaml` (if applicable):
```yaml
customize:
  group.all_sensors:
    hidden: false

group:
  default_view:
  name: Home
  icon: mdi:home
  view: yes
  entities:
    - group.all_sensors
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **TODO**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.
