### PR TITLE
Vacuum component: start_pause to individual start and pause commands.

### DIFF
--- a/homeassistant/components/vacuum/services.yaml
+++ b/homeassistant/components/vacuum/services.yaml
@@ -35,6 +35,20 @@ start_pause:
       description: Name of the vacuum entity.
       example: 'vacuum.xiaomi_vacuum_cleaner'
 
+start:
+  description: Start or resume the cleaning task.
+  fields:
+    entity_id:
+      description: Name of the vacuum entity.
+      example: 'vacuum.xiaomi_vacuum_cleaner'
+
+pause:
+  description: Pause the cleaning task.
+  fields:
+    entity_id:
+      description: Name of the vacuum entity.
+      example: 'vacuum.xiaomi_vacuum_cleaner'
+
 return_to_base:
   description: Tell the vacuum cleaner to return to its dock.
   fields:

--- a/tests/components/vacuum/test_demo.py
+++ b/tests/components/vacuum/test_demo.py
@@ -83,7 +83,7 @@ class TestVacuumDemo(unittest.TestCase):
         self.assertEqual(STATE_OFF, state.state)
 
         state = self.hass.states.get(ENTITY_VACUUM_STATE)
-        self.assertEqual(5244, state.attributes.get(ATTR_SUPPORTED_FEATURES))
+        self.assertEqual(13436, state.attributes.get(ATTR_SUPPORTED_FEATURES))
         self.assertEqual(STATE_DOCKED, state.state)
         self.assertEqual(100, state.attributes.get(ATTR_BATTERY_LEVEL))
         self.assertEqual("medium", state.attributes.get(ATTR_FAN_SPEED))
@@ -158,12 +158,12 @@ class TestVacuumDemo(unittest.TestCase):
         self.assertIn("spot", state.attributes.get(ATTR_STATUS))
         self.assertEqual(STATE_ON, state.state)
 
-        vacuum.start_pause(self.hass, ENTITY_VACUUM_STATE)
+        vacuum.start(self.hass, ENTITY_VACUUM_STATE)
         self.hass.block_till_done()
         state = self.hass.states.get(ENTITY_VACUUM_STATE)
         self.assertEqual(STATE_CLEANING, state.state)
 
-        vacuum.start_pause(self.hass, ENTITY_VACUUM_STATE)
+        vacuum.pause(self.hass, ENTITY_VACUUM_STATE)
         self.hass.block_till_done()
         state = self.hass.states.get(ENTITY_VACUUM_STATE)
         self.assertEqual(STATE_PAUSED, state.state)

--- a/tests/components/vacuum/test_demo.py
+++ b/tests/components/vacuum/test_demo.py
@@ -247,6 +247,23 @@ class TestVacuumDemo(unittest.TestCase):
         self.assertNotIn("spot", state.attributes.get(ATTR_STATUS))
         self.assertEqual(STATE_OFF, state.state)
 
+        # VacuumDevice should not support start and pause methods.
+        self.hass.states.set(ENTITY_VACUUM_COMPLETE, STATE_ON)
+        self.hass.block_till_done()
+        self.assertTrue(vacuum.is_on(self.hass, ENTITY_VACUUM_COMPLETE))
+
+        vacuum.pause(self.hass, ENTITY_VACUUM_COMPLETE)
+        self.hass.block_till_done()
+        self.assertTrue(vacuum.is_on(self.hass, ENTITY_VACUUM_COMPLETE))
+
+        self.hass.states.set(ENTITY_VACUUM_COMPLETE, STATE_OFF)
+        self.hass.block_till_done()
+        self.assertFalse(vacuum.is_on(self.hass, ENTITY_VACUUM_COMPLETE))
+
+        vacuum.start(self.hass, ENTITY_VACUUM_COMPLETE)
+        self.hass.block_till_done()
+        self.assertFalse(vacuum.is_on(self.hass, ENTITY_VACUUM_COMPLETE))
+
         # StateVacuumDevice does not support on/off
         vacuum.turn_on(self.hass, entity_id=ENTITY_VACUUM_STATE)
         self.hass.block_till_done()


### PR DESCRIPTION
## Description:
First of all I'm not sure if I have done this correctly, as this PR has been build on top of: https://github.com/home-assistant/home-assistant/pull/15573 (and requires that PR to be merged first i think). If these changes should be a part of that PR, let me know and I'll change it.

This PR updates the Vacuum component and all current platform to use individual start and pause commands instead of start_pause, as agreed upon here: https://github.com/home-assistant/architecture/issues/29

Frontend changes: https://github.com/home-assistant/home-assistant-polymer/pull/1532

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5941

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
