### PR TITLE
Better handling of Yi camera being disconnected

### DIFF
--- a/homeassistant/components/camera/yi.py
+++ b/homeassistant/components/camera/yi.py
@@ -133,11 +133,12 @@ class YiCamera(Camera):
         """Generate an HTTP MJPEG stream from the camera."""
         from haffmpeg import CameraMjpeg
 
-        stream = CameraMjpeg(self._manager.binary, loop=self.hass.loop)
-        await stream.open_camera(
-            self._last_url, extra_cmd=self._extra_arguments)
+        if self._is_on:
+            stream = CameraMjpeg(self._manager.binary, loop=self.hass.loop)
+            await stream.open_camera(
+                self._last_url, extra_cmd=self._extra_arguments)
 
-        await async_aiohttp_proxy_stream(
-            self.hass, request, stream,
-            'multipart/x-mixed-replace;boundary=ffserver')
-        await stream.close()
+            await async_aiohttp_proxy_stream(
+                self.hass, request, stream,
+                'multipart/x-mixed-replace;boundary=ffserver')
+            await stream.close()

--- a/homeassistant/components/camera/yi.py
+++ b/homeassistant/components/camera/yi.py
@@ -107,10 +107,7 @@ class YiCamera(Camera):
                 return None
 
             await ftp.quit()
-
-            if not self._is_on:
-                self._is_on = True
-
+            self._is_on = True
             return 'ftp://{0}:{1}@{2}:{3}{4}/{5}/{6}'.format(
                 self.user, self.passwd, self.host, self.port, self.path,
                 latest_dir, videos[-1])


### PR DESCRIPTION
## Description:
Implements `is_on` property and handles FFmpeg exceptions if the camera is offline.

**Related issue (if applicable):**
fixes #15691

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):**
N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
camera:
  - platform: yi
    name: Camera
    host: 192.168.1.10
    password: mypassword123
    ffmpeg_arguments: "-vf scale=800:450"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  ~- [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)~

If the code communicates with devices, web services, or third-party tools:
  ~- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).~
  ~- [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).~
  ~- [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.~
  ~- [ ] New files were added to `.coveragerc`.~

If the code does not interact with devices:
  ~- [ ] Tests have been added to verify that the new code works.~

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
