### PR TITLE
Upgrade voluptuous-serialize to 2.0.0

### DIFF
--- a/homeassistant/components/config/config_entries.py
+++ b/homeassistant/components/config/config_entries.py
@@ -7,7 +7,7 @@ from homeassistant.helpers.data_entry_flow import (
     FlowManagerIndexView, FlowManagerResourceView)
 
 
-REQUIREMENTS = ['voluptuous-serialize==2']
+REQUIREMENTS = ['voluptuous-serialize==2.0.0']
 
 
 @asyncio.coroutine

--- a/homeassistant/components/config/config_entries.py
+++ b/homeassistant/components/config/config_entries.py
@@ -7,7 +7,7 @@ from homeassistant.helpers.data_entry_flow import (
     FlowManagerIndexView, FlowManagerResourceView)
 
 
-REQUIREMENTS = ['voluptuous-serialize==1']
+REQUIREMENTS = ['voluptuous-serialize==2']
 
 
 @asyncio.coroutine

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1393,7 +1393,7 @@ uvcclient==0.10.1
 venstarcolortouch==0.6
 
 # homeassistant.components.config.config_entries
-voluptuous-serialize==1
+voluptuous-serialize==2
 
 # homeassistant.components.volvooncall
 volvooncall==0.4.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1393,7 +1393,7 @@ uvcclient==0.10.1
 venstarcolortouch==0.6
 
 # homeassistant.components.config.config_entries
-voluptuous-serialize==2
+voluptuous-serialize==2.0.0
 
 # homeassistant.components.volvooncall
 volvooncall==0.4.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -206,7 +206,7 @@ statsd==3.2.1
 uvcclient==0.10.1
 
 # homeassistant.components.config.config_entries
-voluptuous-serialize==2
+voluptuous-serialize==2.0.0
 
 # homeassistant.components.vultr
 vultr==0.1.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -206,7 +206,7 @@ statsd==3.2.1
 uvcclient==0.10.1
 
 # homeassistant.components.config.config_entries
-voluptuous-serialize==1
+voluptuous-serialize==2
 
 # homeassistant.components.vultr
 vultr==0.1.2


### PR DESCRIPTION
## Description:
Need wait home-assistant/home-assistant-polymer#1529 merged first

Change log: https://github.com/balloob/voluptuous-serialize/releases/tag/2.0.0

It changes data structure feed to ha-form, need change frontend's `components/ha-form.js`.

Particularly, 
`vol.Schema({'s': vol.In(['a','b','c'])})` will be serialized to
```json
{
  "name": "s",
  "type": "select",
  "options": [
    ["a", "a"],
    ["b", "b"],
    ["c", "c"]
  ]
}
``` 

hue and deconz component's config flow used vol.In validation.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

