### PR TITLE
Added lumitek/ankuoo recswitch component

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -793,6 +793,7 @@ omit =
     homeassistant/components/switch/pulseaudio_loopback.py
     homeassistant/components/switch/rainbird.py
     homeassistant/components/switch/rest.py
+    homeassistant/components/switch/recswitch.py
     homeassistant/components/switch/rpi_rf.py
     homeassistant/components/switch/snmp.py
     homeassistant/components/switch/switchbot.py

--- a/homeassistant/components/switch/recswitch.py
+++ b/homeassistant/components/switch/recswitch.py
@@ -55,14 +55,9 @@ class RecSwitchSwitch(SwitchDevice):
         self.gpio_state = False
         self.device = device
         self.device_name = device_name
-        self.device.report_gpio_change = None
         self.mac_address = mac_address
         if not self.device_name:
             self.device_name = DEFAULT_NAME.format(self.mac_address)
-
-    async def async_added_to_hass(self):
-        """Assign callback for gpio change notification."""
-        self.device.report_gpio_change = self.report_gpio_change
 
     @property
     def unique_id(self):
@@ -104,8 +99,3 @@ class RecSwitchSwitch(SwitchDevice):
             self.gpio_state = ret.state
         except RSNetworkError as error:
             _LOGGER.error('Reading status from %s: %r', self.name, error)
-
-    async def report_gpio_change(self, ret):
-        """Callback on switch status change."""
-        self.gpio_state = ret.state
-        self.async_schedule_update_ha_state()

--- a/homeassistant/components/switch/recswitch.py
+++ b/homeassistant/components/switch/recswitch.py
@@ -16,7 +16,7 @@ import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['pyrecswitch==1.0.1']
+REQUIREMENTS = ['pyrecswitch==1.0.2']
 
 DEFAULT_NAME = 'RecSwitch {0}'
 

--- a/homeassistant/components/switch/recswitch.py
+++ b/homeassistant/components/switch/recswitch.py
@@ -34,8 +34,8 @@ async def async_setup_platform(hass, config, async_add_entities,
     """Set up the device."""
     from pyrecswitch import RSNetwork
 
-    host = config.get(CONF_HOST)
-    mac_address = config.get(CONF_MAC)
+    host = config[CONF_HOST]
+    mac_address = config[CONF_MAC]
     device_name = config.get(CONF_NAME)
 
     if not hass.data.get(DATA_RSN):
@@ -51,7 +51,7 @@ class RecSwitchSwitch(SwitchDevice):
     """Representation of a recswitch device."""
 
     def __init__(self, device, device_name, mac_address):
-        """Initialize an recswitch device."""
+        """Initialize a recswitch device."""
         self.gpio_state = False
         self.device = device
         self.device_name = device_name

--- a/homeassistant/components/switch/recswitch.py
+++ b/homeassistant/components/switch/recswitch.py
@@ -93,8 +93,8 @@ class RecSwitchSwitch(SwitchDevice):
         try:
             ret = await self.device.set_gpio_status(status)
             self.gpio_state = ret.state
-        except RSNetworkError as e:
-            _LOGGER.error('Setting status to {}: {!r}'.format(self.name, e))
+        except RSNetworkError as error:
+            _LOGGER.error('Setting status to %s: %r', self.name, error)
 
     async def async_update(self):
         """Update the current switch status."""
@@ -102,8 +102,8 @@ class RecSwitchSwitch(SwitchDevice):
         try:
             ret = await self.device.get_gpio_status()
             self.gpio_state = ret.state
-        except RSNetworkError as e:
-            _LOGGER.error('Reading status from {}: {!r}'.format(self.name, e))
+        except RSNetworkError as error:
+            _LOGGER.error('Reading status from %s: %r', self.name, error)
 
     async def report_gpio_change(self, ret):
         """Callback on switch status change."""

--- a/homeassistant/components/switch/recswitch.py
+++ b/homeassistant/components/switch/recswitch.py
@@ -1,0 +1,111 @@
+"""
+Support for Ankuoo RecSwitch MS6126 devices.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/switch.recswitch/
+"""
+
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components.switch import PLATFORM_SCHEMA, SwitchDevice
+from homeassistant.const import CONF_HOST, CONF_MAC, CONF_NAME
+import homeassistant.helpers.config_validation as cv
+
+
+_LOGGER = logging.getLogger(__name__)
+
+REQUIREMENTS = ['pyrecswitch==1.0.1']
+
+DEFAULT_NAME = 'RecSwitch {0}'
+
+DATA_RSN = 'RSN'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_HOST): cv.string,
+    vol.Required(CONF_MAC): vol.All(cv.string, vol.Upper),
+    vol.Optional(CONF_NAME): cv.string,
+})
+
+
+async def async_setup_platform(hass, config, async_add_entities,
+                               discovery_info=None):
+    """Set up the device."""
+    from pyrecswitch import RSNetwork
+
+    host = config.get(CONF_HOST)
+    mac_address = config.get(CONF_MAC)
+    device_name = config.get(CONF_NAME)
+
+    if not hass.data.get(DATA_RSN):
+        hass.data[DATA_RSN] = RSNetwork()
+        job = hass.data[DATA_RSN].create_datagram_endpoint(loop=hass.loop)
+        hass.async_create_task(job)
+
+    device = hass.data[DATA_RSN].register_device(mac_address, host)
+    async_add_entities([RecSwitchSwitch(device, device_name, mac_address)])
+
+
+class RecSwitchSwitch(SwitchDevice):
+    """Representation of a recswitch device."""
+
+    def __init__(self, device, device_name, mac_address):
+        """Initialize an recswitch device."""
+        self.gpio_state = False
+        self.device = device
+        self.device_name = device_name
+        self.device.report_gpio_change = None
+        self.mac_address = mac_address
+        if not self.device_name:
+            self.device_name = DEFAULT_NAME.format(self.mac_address)
+
+    async def async_added_to_hass(self):
+        """Assign callback for gpio change notification."""
+        self.device.report_gpio_change = self.report_gpio_change
+
+    @property
+    def unique_id(self):
+        """Return the switch unique ID."""
+        return self.mac_address
+
+    @property
+    def name(self):
+        """Return the switch name."""
+        return self.device_name
+
+    @property
+    def is_on(self):
+        """Return true if switch is on."""
+        return self.gpio_state
+
+    async def async_turn_on(self, **kwargs):
+        """Turn on the switch."""
+        await self.async_set_gpio_status(True)
+
+    async def async_turn_off(self, **kwargs):
+        """Turn off the switch."""
+        await self.async_set_gpio_status(False)
+
+    async def async_set_gpio_status(self, status):
+        """Set the switch status."""
+        from pyrecswitch import RSNetworkError
+        try:
+            ret = await self.device.set_gpio_status(status)
+            self.gpio_state = ret.state
+        except RSNetworkError as e:
+            _LOGGER.error('Setting status to {}: {!r}'.format(self.name, e))
+
+    async def async_update(self):
+        """Update the current switch status."""
+        from pyrecswitch import RSNetworkError
+        try:
+            ret = await self.device.get_gpio_status()
+            self.gpio_state = ret.state
+        except RSNetworkError as e:
+            _LOGGER.error('Reading status from {}: {!r}'.format(self.name, e))
+
+    async def report_gpio_change(self, ret):
+        """Callback on switch status change."""
+        self.gpio_state = ret.state
+        self.async_schedule_update_ha_state()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1021,6 +1021,9 @@ pyqwikswitch==0.8
 # homeassistant.components.rainbird
 pyrainbird==0.1.6
 
+# homeassistant.components.switch.recswitch
+pyrecswitch==1.0.1
+
 # homeassistant.components.sabnzbd
 pysabnzbd==1.0.1
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1022,7 +1022,7 @@ pyqwikswitch==0.8
 pyrainbird==0.1.6
 
 # homeassistant.components.switch.recswitch
-pyrecswitch==1.0.1
+pyrecswitch==1.0.2
 
 # homeassistant.components.sabnzbd
 pysabnzbd==1.0.1


### PR DESCRIPTION
## Description:
Added support for lumitek/ankuoo recswitch to homeassistant. 
the device is known as:
* Ankuoo MS6126 / 
* Ankuoo REC 4800009
* Lumitek CSW201 NEO WiFi Control module

Searching on the web it look like the device is made by lumitek and branded and sold on amazon by ankuoo: 
* [Lumitek](http://www.lumitek.cn/en/productsd.php?gid=0&pid=1093)
* [Amazon](https://www.amazon.it/MODULO-INTERRUTTORE-WIRELESS-INCASSO-ANDROID/dp/B00FB8M22K/ref=sr_1_1?ie=UTF8&qid=1533049096&sr=8-1&keywords=ANKUOO)
* [Jaycar](https://www.jaycar.com.au/240v-mains-wi-fi-wireless-switch-module-with-app/p/MS6126)

The chipset inside the device should be the HF-LPB100.
* [Hi Flying](http://www.hi-flying.com/index.php?route=product/product/show&product_id=113)

Home Assistant Support has been discussed and requested in this thread:
* https://community.home-assistant.io/t/is-this-wifi-switch-supported-ankuoo-ms6126/51342
* https://community.home-assistant.io/t/community-hass-io-add-on-google-assistant-webserver-broadcast-messages-without-interrupting-music/37274/330
* https://github.com/home-assistant/home-assistant/issues/831 not sure about these.. look like my device but really not sure

## Example entry for `configuration.yaml`:
```yaml
switch01:
  - platform: recswitch
    name: Garden Lights
    host: 192.168.X.X
    mac: 'F0:FE:6B:XX:XX:XX'
```
 **Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** [home-assistant/home-assistant.io#6548](https://github.com/home-assistant/home-assistant.io/pull/6548)

  - [X]  Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] New dependencies have been added to the `REQUIREMENTS` variable.
  - [X] New dependencies are only imported inside functions that use them.
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.