### PR TITLE
Upgrade Mastodon.py to 1.3.1

### DIFF
--- a/homeassistant/components/notify/mastodon.py
+++ b/homeassistant/components/notify/mastodon.py
@@ -13,7 +13,7 @@ from homeassistant.components.notify import (
 from homeassistant.const import CONF_ACCESS_TOKEN
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['Mastodon.py==1.3.0']
+REQUIREMENTS = ['Mastodon.py==1.3.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -33,7 +33,7 @@ DoorBirdPy==0.1.3
 HAP-python==2.2.2
 
 # homeassistant.components.notify.mastodon
-Mastodon.py==1.3.0
+Mastodon.py==1.3.1
 
 # homeassistant.components.isy994
 PyISY==1.1.0


### PR DESCRIPTION
## Description:
Changelog: https://github.com/halcy/Mastodon.py/blob/master/CHANGELOG.rst#v131

## Example entry for `configuration.yaml` (if applicable):
``` yaml
notify:
  - platform: mastodon
    name: mastodon
    access_token: !secret mastodon_access_token
    client_id: !secret mastodon_client_id
    client_secret: !secret mastodon_client_secret
```

Message sent with "Call Service"

``` json
{
  "message": "The sun is {% if is_state('sun.sun', 'above_horizon') %}up{% else %}down{% endif %}! Update Mastodon.py for #HomeAssistant"
}
```

:smile: -> [:m:](https://mastodon.social/@fabaff/100470414582046620/)

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
