### PR TITLE
Account for vera devices which may not have a last_scene_time

### DIFF
--- a/homeassistant/components/sensor/vera.py
+++ b/homeassistant/components/sensor/vera.py
@@ -83,7 +83,7 @@ class VeraSensor(VeraDevice, Entity):
         elif self.vera_device.category == veraApi.CATEGORY_SCENE_CONTROLLER:
             value = self.vera_device.get_last_scene_id(True)
             time = self.vera_device.get_last_scene_time(True)
-            if time == self.last_changed_time:
+            if time != None and time == self.last_changed_time:
                 self.current_value = None
             else:
                 self.current_value = value

--- a/homeassistant/components/sensor/vera.py
+++ b/homeassistant/components/sensor/vera.py
@@ -83,7 +83,7 @@ class VeraSensor(VeraDevice, Entity):
         elif self.vera_device.category == veraApi.CATEGORY_SCENE_CONTROLLER:
             value = self.vera_device.get_last_scene_id(True)
             time = self.vera_device.get_last_scene_time(True)
-            if time != None and time == self.last_changed_time:
+            if time is not None and time == self.last_changed_time:
                 self.current_value = None
             else:
                 self.current_value = value


### PR DESCRIPTION
## Description:
Handles a case where a vera scene controller may not report a last_scene_time.  This lets the values still pass through to the sensor.