### PR TITLE
Added error handling for sense API timeouts

### DIFF
--- a/homeassistant/components/sensor/sense.py
+++ b/homeassistant/components/sensor/sense.py
@@ -67,8 +67,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Sense sensor."""
     from sense_energy import Senseable
-    from requests import ReadTimeout
-    from websocket import WebSocketTimeoutException
 
     username = config.get(CONF_EMAIL)
     password = config.get(CONF_PASSWORD)
@@ -141,6 +139,8 @@ class Sense(Entity):
 
     def update(self):
         """Get the latest data, update state."""
+        from requests import ReadTimeout
+        from websocket import WebSocketTimeoutException
         try:
             self.update_sensor()
         except (WebSocketTimeoutException, ReadTimeout):

--- a/homeassistant/components/sensor/sense.py
+++ b/homeassistant/components/sensor/sense.py
@@ -6,6 +6,8 @@ https://home-assistant.io/components/sensor.sense/
 """
 import logging
 from datetime import timedelta
+from requests import ReadTimeout
+from websocket import WebSocketTimeoutException
 
 import voluptuous as vol
 
@@ -139,7 +141,11 @@ class Sense(Entity):
 
     def update(self):
         """Get the latest data, update state."""
-        self.update_sensor()
+        try:
+            self.update_sensor()
+        except (WebSocketTimeoutException, ReadTimeout):
+            _LOGGER.error("Timeout retrieving data")
+            return
 
         if self._sensor_type == ACTIVE_TYPE:
             if self._is_production:

--- a/homeassistant/components/sensor/sense.py
+++ b/homeassistant/components/sensor/sense.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['sense_energy==0.3.1']
+REQUIREMENTS = ['sense_energy==0.4.1']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -139,11 +139,10 @@ class Sense(Entity):
 
     def update(self):
         """Get the latest data, update state."""
-        from requests import ReadTimeout
-        from websocket import WebSocketTimeoutException
+        from sense_energy import SenseAPITimeoutException
         try:
             self.update_sensor()
-        except (WebSocketTimeoutException, ReadTimeout):
+        except SenseAPITimeoutException:
             _LOGGER.error("Timeout retrieving data")
             return
 

--- a/homeassistant/components/sensor/sense.py
+++ b/homeassistant/components/sensor/sense.py
@@ -6,8 +6,6 @@ https://home-assistant.io/components/sensor.sense/
 """
 import logging
 from datetime import timedelta
-from requests import ReadTimeout
-from websocket import WebSocketTimeoutException
 
 import voluptuous as vol
 
@@ -69,6 +67,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Sense sensor."""
     from sense_energy import Senseable
+    from requests import ReadTimeout
+    from websocket import WebSocketTimeoutException
 
     username = config.get(CONF_EMAIL)
     password = config.get(CONF_PASSWORD)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1244,7 +1244,7 @@ sendgrid==5.4.1
 sense-hat==2.2.0
 
 # homeassistant.components.sensor.sense
-sense_energy==0.3.1
+sense_energy==0.4.1
 
 # homeassistant.components.media_player.aquostv
 sharp_aquos_rc==0.3.2


### PR DESCRIPTION
## Description:
The sense API will occasionally take a long time to respond to requests which generates a long exception message in the logs


## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

