### PR TITLE
Always return True from Nest setup

### DIFF
--- a/homeassistant/components/nest/__init__.py
+++ b/homeassistant/components/nest/__init__.py
@@ -93,7 +93,7 @@ async def async_nest_update_event_broker(hass, nest):
 async def async_setup(hass, config):
     """Set up Nest components."""
     if DOMAIN not in config:
-        return
+        return True
 
     conf = config[DOMAIN]
 


### PR DESCRIPTION
## Description:
Setup methods should always return a boolean value.

**Related issue (if applicable):** fixes #15765


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
