### PR TITLE
Try to fix coveralls unstable result

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
       env: TOXENV=typing
     - python: "3.5.3"
       env: TOXENV=cov
+      after_success: coveralls
     - python: "3.6"
       env: TOXENV=py36
     - python: "3.7"
@@ -45,4 +46,3 @@ deploy:
   on:
     branch: dev
     condition: $TOXENV = lint
-after_success: coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,6 @@ matrix:
       env: TOXENV=typing
     - python: "3.5.3"
       env: TOXENV=cov
-      after_success: coveralls
-    - python: "3.5.3"
-      env: TOXENV=py35
     - python: "3.6"
       env: TOXENV=py36
     - python: "3.7"
@@ -48,3 +45,4 @@ deploy:
   on:
     branch: dev
     condition: $TOXENV = lint
+after_success: coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ matrix:
     - python: "3.5.3"
       env: TOXENV=typing
     - python: "3.5.3"
+      env: TOXENV=cov
+      after_success: coveralls
+    - python: "3.5.3"
       env: TOXENV=py35
     - python: "3.6"
       env: TOXENV=py36
@@ -45,4 +48,3 @@ deploy:
   on:
     branch: dev
     condition: $TOXENV = lint
-after_success: coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,24 @@
 [tox]
-envlist = py35, py36, py37, py38, lint, pylint, typing
+envlist = py35, py36, py37, py38, lint, pylint, typing, cov
 skip_missing_interpreters = True
 
 [testenv]
+setenv =
+    PYTHONPATH = {toxinidir}:{toxinidir}/homeassistant
+; both temper-python and XBee modules have utf8 in their README files
+; which get read in from setup.py. If we don't force our locale to a
+; utf8 one, tox's env is reset. And the install of these 2 packages
+; fail.
+whitelist_externals = /usr/bin/env
+install_command = /usr/bin/env LANG=C.UTF-8 pip install {opts} {packages}
+commands =
+     pytest --timeout=9 --duration=10 {posargs}
+deps =
+     -r{toxinidir}/requirements_test_all.txt
+     -c{toxinidir}/homeassistant/package_constraints.txt
+
+[testenv:cov]
+basepython = {env:PYTHON3_PATH:python3}
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/homeassistant
 ; both temper-python and XBee modules have utf8 in their README files


### PR DESCRIPTION
## Description:
https://coveralls.io/ gave us lots of false negative result. This PR created a new tox environment `cov`, and only generate code coverage for this environment, and only upload code coverage report to coveralls.io if `cov` travis build job success. So that we will have only one job per build data in coveralls.io. 

This config seems let coveralls.io reports stable results:
![image](https://user-images.githubusercontent.com/7366491/43618403-d7baf0f2-967c-11e8-9f35-94e2ad2b53d5.png)

Above screenshot has 3 build results with exactly same source code, the top and bottom has only one job in each build, but the middle one has multiple jobs, only one job reports code coverage. So you will see coveralls.io still gave us false negative result.

https://coveralls.io/builds/18303942 is the build on the top in the screenshot for your reference.
https://coveralls.io/builds/18303647 is the build in the middle

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
