### PR TITLE
Change to call_service async_stop non-blocking to allow service call finish

### DIFF
--- a/homeassistant/components/__init__.py
+++ b/homeassistant/components/__init__.py
@@ -15,7 +15,6 @@ from typing import Awaitable
 import homeassistant.core as ha
 import homeassistant.config as conf_util
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.service import extract_entity_ids
 from homeassistant.helpers import intent
 from homeassistant.const import (
@@ -169,7 +168,7 @@ def async_setup(hass: ha.HomeAssistant, config: dict) -> Awaitable[bool]:
     def async_handle_core_service(call):
         """Service handler for handling core services."""
         if call.service == SERVICE_HOMEASSISTANT_STOP:
-            async_call_later(hass, 0, hass.async_stop())
+            hass.async_create_task(hass.async_stop())
             return
 
         try:
@@ -185,7 +184,7 @@ def async_setup(hass: ha.HomeAssistant, config: dict) -> Awaitable[bool]:
             return
 
         if call.service == SERVICE_HOMEASSISTANT_RESTART:
-            async_call_later(hass, 0, hass.async_stop(RESTART_EXIT_CODE))
+            hass.async_create_task(hass.async_stop(RESTART_EXIT_CODE))
 
     hass.services.async_register(
         ha.DOMAIN, SERVICE_HOMEASSISTANT_STOP, async_handle_core_service)

--- a/homeassistant/components/__init__.py
+++ b/homeassistant/components/__init__.py
@@ -15,6 +15,7 @@ from typing import Awaitable
 import homeassistant.core as ha
 import homeassistant.config as conf_util
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.service import extract_entity_ids
 from homeassistant.helpers import intent
 from homeassistant.const import (
@@ -168,7 +169,7 @@ def async_setup(hass: ha.HomeAssistant, config: dict) -> Awaitable[bool]:
     def async_handle_core_service(call):
         """Service handler for handling core services."""
         if call.service == SERVICE_HOMEASSISTANT_STOP:
-            hass.async_create_task(hass.async_stop())
+            async_call_later(hass, 0, hass.async_stop())
             return
 
         try:
@@ -184,7 +185,7 @@ def async_setup(hass: ha.HomeAssistant, config: dict) -> Awaitable[bool]:
             return
 
         if call.service == SERVICE_HOMEASSISTANT_RESTART:
-            hass.async_create_task(hass.async_stop(RESTART_EXIT_CODE))
+            async_call_later(hass, 0, hass.async_stop(RESTART_EXIT_CODE))
 
     hass.services.async_register(
         ha.DOMAIN, SERVICE_HOMEASSISTANT_STOP, async_handle_core_service)

--- a/homeassistant/components/websocket_api.py
+++ b/homeassistant/components/websocket_api.py
@@ -519,8 +519,12 @@ def handle_call_service(hass, connection, msg):
     """
     async def call_service_helper(msg):
         """Call a service and fire complete message."""
+        blocking = True
+        if (msg['domain'] == 'homeassistant' and
+                msg['service'] in ['restart', 'stop']):
+            blocking = False
         await hass.services.async_call(
-            msg['domain'], msg['service'], msg.get('service_data'), True,
+            msg['domain'], msg['service'], msg.get('service_data'), blocking,
             connection.context(msg))
         connection.send_message_outside(result_message(msg['id']))
 


### PR DESCRIPTION
## Description:

Click RESTART or STOP in Configuration -> General -> Server Management works, but the frontend display a service call failed message
![image](https://user-images.githubusercontent.com/7366491/43624864-c9a8627a-969e-11e8-93ee-ba2fe17c4944.png)

Change websocket_api call `restart` and `stop` service in non-blocking way will allow service call return success, frontend display likes
![image](https://user-images.githubusercontent.com/7366491/43624998-5b5a1a24-969f-11e8-8409-f7fbc9b9dd0f.png)

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

