### PR TITLE
Make sure use_x_forward_for and trusted_proxies must config together

### DIFF
--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -66,8 +66,8 @@ HTTP_SCHEMA = vol.Schema({
     vol.Optional(CONF_SSL_KEY): cv.isfile,
     vol.Optional(CONF_CORS_ORIGINS, default=[]):
         vol.All(cv.ensure_list, [cv.string]),
-    vol.Optional(CONF_USE_X_FORWARDED_FOR, default=False): cv.boolean,
-    vol.Optional(CONF_TRUSTED_PROXIES, default=[]):
+    vol.Inclusive(CONF_USE_X_FORWARDED_FOR, 'proxy'): cv.boolean,
+    vol.Inclusive(CONF_TRUSTED_PROXIES, 'proxy'):
         vol.All(cv.ensure_list, [ip_network]),
     vol.Optional(CONF_TRUSTED_NETWORKS, default=[]):
         vol.All(cv.ensure_list, [ip_network]),
@@ -96,8 +96,8 @@ async def async_setup(hass, config):
     ssl_peer_certificate = conf.get(CONF_SSL_PEER_CERTIFICATE)
     ssl_key = conf.get(CONF_SSL_KEY)
     cors_origins = conf[CONF_CORS_ORIGINS]
-    use_x_forwarded_for = conf[CONF_USE_X_FORWARDED_FOR]
-    trusted_proxies = conf[CONF_TRUSTED_PROXIES]
+    use_x_forwarded_for = conf.get(CONF_USE_X_FORWARDED_FOR, False)
+    trusted_proxies = conf.get(CONF_TRUSTED_PROXIES, [])
     trusted_networks = conf[CONF_TRUSTED_NETWORKS]
     is_ban_enabled = conf[CONF_IP_BAN_ENABLED]
     login_threshold = conf[CONF_LOGIN_ATTEMPTS_THRESHOLD]

--- a/tests/components/http/test_init.py
+++ b/tests/components/http/test_init.py
@@ -96,3 +96,31 @@ async def test_not_log_password(hass, aiohttp_client, caplog):
     # Ensure we don't log API passwords
     assert '/api/' in logs
     assert 'some-pass' not in logs
+
+
+async def test_proxy_config(hass):
+    """Test use_x_forwarded_for must config together with trusted_proxies."""
+    assert await async_setup_component(hass, 'http', {
+        'http': {
+            http.CONF_USE_X_FORWARDED_FOR: True,
+            http.CONF_TRUSTED_PROXIES: ['127.0.0.1']
+        }
+    }) is True
+
+
+async def test_proxy_config_only_use_xff(hass):
+    """Test use_x_forwarded_for must config together with trusted_proxies."""
+    assert await async_setup_component(hass, 'http', {
+        'http': {
+            http.CONF_USE_X_FORWARDED_FOR: True
+        }
+    }) is not True
+
+
+async def test_proxy_config_only_trust_proxies(hass):
+    """Test use_x_forwarded_for must config together with trusted_proxies."""
+    assert await async_setup_component(hass, 'http', {
+        'http': {
+            http.CONF_TRUSTED_PROXIES: ['127.0.0.1']
+        }
+    }) is not True

--- a/tests/scripts/test_check_config.py
+++ b/tests/scripts/test_check_config.py
@@ -159,9 +159,7 @@ class TestCheckConfig(unittest.TestCase):
                 'login_attempts_threshold': -1,
                 'server_host': '0.0.0.0',
                 'server_port': 8123,
-                'trusted_networks': [],
-                'trusted_proxies': [],
-                'use_x_forwarded_for': False}
+                'trusted_networks': []}
             assert res['secret_cache'] == {secrets_path: {'http_pw': 'abc123'}}
             assert res['secrets'] == {'http_pw': 'abc123'}
             assert normalize_yaml_files(res) == [


### PR DESCRIPTION
## Description:
Per `http` component document and PR #15204
> `use_x_forwarded_for` (Optional): Enable parsing of the X-Forwarded-For header, passing on the client’s correct IP address in proxied setups. You must also whitelist trusted proxies using the `trusted_proxies` setting below for this to work. 

However, we don't have config validation against this requirement.

This PR added config validation to make sure these two options are configured together

**Related issue (if applicable):** fixes #15544

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

