### PR TITLE
bugfix:XiaomiDoorSensor deson't update state

### DIFF
--- a/homeassistant/components/binary_sensor/xiaomi_aqara.py
+++ b/homeassistant/components/binary_sensor/xiaomi_aqara.py
@@ -199,6 +199,7 @@ class XiaomiDoorSensor(XiaomiBinarySensor):
         self._open_since = 0
         XiaomiBinarySensor.__init__(self, device, 'Door Window Sensor',
                                     xiaomi_hub, data_key, 'opening')
+        self._should_poll = True
 
     @property
     def device_state_attributes(self):


### PR DESCRIPTION
Aqara Door Sensor（having illumination） doesn't notify it's state when state changes. Beside, if all the devices under binary_sensor.xiaomi_aqara platform initial "should_poll" property with "False", HA will not in initial a update task for this platform. In these cases, the door sensor can't update state. So it's necessary to initial "should_poll" property with "True".

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
