### PR TITLE
Upgrade pytest to 3.7.1 and pytest-timeout to 1.3.1

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -12,6 +12,6 @@ pylint==2.0.1
 pytest-aiohttp==0.3.0
 pytest-cov==2.5.1
 pytest-sugar==0.9.1
-pytest-timeout==1.3.0
-pytest==3.6.3
+pytest-timeout==1.3.1
+pytest==3.7.1
 requests_mock==1.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -13,8 +13,8 @@ pylint==2.0.1
 pytest-aiohttp==0.3.0
 pytest-cov==2.5.1
 pytest-sugar==0.9.1
-pytest-timeout==1.3.0
-pytest==3.6.3
+pytest-timeout==1.3.1
+pytest==3.7.1
 requests_mock==1.5
 
 


### PR DESCRIPTION
## Description:

Upgrade pytest to 3.7.1 and pytest-timeout to 1.3.1.

## Checklist:
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
