### PR TITLE
Fix error when Series missing 'episodeFileCount' or 'episodeCount'

### DIFF
--- a/homeassistant/components/sensor/sonarr.py
+++ b/homeassistant/components/sensor/sonarr.py
@@ -158,8 +158,11 @@ class SonarrSensor(Entity):
                 )
         elif self.type == 'series':
             for show in self.data:
-                attributes[show['title']] = '{}/{} Episodes'.format(
-                    show['episodeFileCount'], show['episodeCount'])
+                if 'episodeFileCount' not in show or 'episodeCount' not in show:
+                    attributes[show['title']] = 'N/A'
+                else:
+                    attributes[show['title']] = '{}/{} Episodes'.format(
+                        show['episodeFileCount'], show['episodeCount'])
         elif self.type == 'status':
             attributes = self.data
         return attributes

--- a/homeassistant/components/sensor/sonarr.py
+++ b/homeassistant/components/sensor/sonarr.py
@@ -158,8 +158,8 @@ class SonarrSensor(Entity):
                 )
         elif self.type == 'series':
             for show in self.data:
-                if 'episodeFileCount' not in show 
-                or 'episodeCount' not in show:
+                if 'episodeFileCount' not in show \
+                        or 'episodeCount' not in show:
                     attributes[show['title']] = 'N/A'
                 else:
                     attributes[show['title']] = '{}/{} Episodes'.format(

--- a/homeassistant/components/sensor/sonarr.py
+++ b/homeassistant/components/sensor/sonarr.py
@@ -158,7 +158,8 @@ class SonarrSensor(Entity):
                 )
         elif self.type == 'series':
             for show in self.data:
-                if 'episodeFileCount' not in show or 'episodeCount' not in show:
+                if 'episodeFileCount' not in show 
+                or 'episodeCount' not in show:
                     attributes[show['title']] = 'N/A'
                 else:
                     attributes[show['title']] = '{}/{} Episodes'.format(


### PR DESCRIPTION
## Description:
In some cases Sonarr API will fail to return 'episodeFileCount' or 'episodeCount' of show.
This results in sensor type 'Series' fail to load the shows list and episode count.

`Traceback (most recent call last):
  File "/usr/src/app/homeassistant/helpers/entity.py", line 215, in async_update_ha_state
    device_attr = self.device_state_attributes
  File "/config/custom_components/sensor/sonarr_test.py", line 164, in device_state_attributes
    show['episodeFileCount'], show['episodeCount'])
KeyError: 'episodeFileCount`

This request adds a simple check if 'episodeFileCount' or 'episodeCount' exist and if not return 'N/A'

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**