### PR TITLE
Fix frontend requirements after bump

### DIFF
--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -424,7 +424,7 @@ hole==0.3.0
 holidays==0.9.5
 
 # homeassistant.components.frontend
-home-assistant-frontend==20180803.0
+home-assistant-frontend==20180804.0
 
 # homeassistant.components.homekit_controller
 # homekit==0.10

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -81,7 +81,7 @@ hbmqtt==0.9.2
 holidays==0.9.5
 
 # homeassistant.components.frontend
-home-assistant-frontend==20180803.0
+home-assistant-frontend==20180804.0
 
 # homeassistant.components.homematicip_cloud
 homematicip==0.9.8


### PR DESCRIPTION
## Description:
The requirements files weren't updated when the frontend was bumped to 20180804.0:
https://github.com/home-assistant/home-assistant/commit/0c7d46927e7bc66719f1436ab17c3d3166fc7132

  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
