### PR TITLE
Fix envisalink reconnect

### DIFF
--- a/homeassistant/components/envisalink.py
+++ b/homeassistant/components/envisalink.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
-REQUIREMENTS = ['pyenvisalink==2.2']
+REQUIREMENTS = ['pyenvisalink==2.3']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -111,20 +111,23 @@ def async_setup(hass, config):
     def login_fail_callback(data):
         """Handle when the evl rejects our login."""
         _LOGGER.error("The Envisalink rejected your credentials")
-        sync_connect.set_result(False)
+        if not sync_connect.done():
+            sync_connect.set_result(False)
 
     @callback
     def connection_fail_callback(data):
         """Network failure callback."""
         _LOGGER.error("Could not establish a connection with the Envisalink")
-        sync_connect.set_result(False)
+        if not sync_connect.done():
+            sync_connect.set_result(False)
 
     @callback
     def connection_success_callback(data):
         """Handle a successful connection."""
         _LOGGER.info("Established a connection with the Envisalink")
-        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, stop_envisalink)
-        sync_connect.set_result(True)
+        if not sync_connect.done():
+            hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, stop_envisalink)
+            sync_connect.set_result(True)
 
     @callback
     def zones_updated_callback(data):

--- a/homeassistant/components/envisalink.py
+++ b/homeassistant/components/envisalink.py
@@ -126,7 +126,8 @@ def async_setup(hass, config):
         """Handle a successful connection."""
         _LOGGER.info("Established a connection with the Envisalink")
         if not sync_connect.done():
-            hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, stop_envisalink)
+            hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP,
+                                       stop_envisalink)
             sync_connect.set_result(True)
 
     @callback

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -814,7 +814,7 @@ pyeight==0.0.9
 pyemby==1.5
 
 # homeassistant.components.envisalink
-pyenvisalink==2.2
+pyenvisalink==2.3
 
 # homeassistant.components.climate.ephember
 pyephember==0.1.1


### PR DESCRIPTION
## Description:
People have been reporting reoccurring errors when a connectivity loss to the envisalink device occurs.  The component in HA was assuming the only time a connection will occur is upon initial start-up, when in reality it can also occur upon connection fail/reconnection.  This additional logic fixes that.

**Related issue (if applicable):** fixes #15407 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
N/A
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
