### PR TITLE
Add max_gps_accuracy option to Google Maps

### DIFF
--- a/homeassistant/components/device_tracker/google_maps.py
+++ b/homeassistant/components/device_tracker/google_maps.py
@@ -85,19 +85,20 @@ class GoogleMapsScanner:
                              "accuracy %s is not met: %s",
                              person.nickname, self.max_gps_accuracy,
                              person.accuracy)
-            else:
-                attrs = {
-                    ATTR_ADDRESS: person.address,
-                    ATTR_FULL_NAME: person.full_name,
-                    ATTR_ID: person.id,
-                    ATTR_LAST_SEEN: person.datetime,
-                    ATTR_NICKNAME: person.nickname,
-                }
-                self.see(
-                    dev_id=dev_id,
-                    gps=(person.latitude, person.longitude),
-                    picture=person.picture_url,
-                    source_type=SOURCE_TYPE_GPS,
-                    gps_accuracy=person.accuracy,
-                    attributes=attrs,
-                )
+                continue
+
+            attrs = {
+                ATTR_ADDRESS: person.address,
+                ATTR_FULL_NAME: person.full_name,
+                ATTR_ID: person.id,
+                ATTR_LAST_SEEN: person.datetime,
+                ATTR_NICKNAME: person.nickname,
+            }
+            self.see(
+                dev_id=dev_id,
+                gps=(person.latitude, person.longitude),
+                picture=person.picture_url,
+                source_type=SOURCE_TYPE_GPS,
+                gps_accuracy=person.accuracy,
+                attributes=attrs,
+            )

--- a/homeassistant/components/device_tracker/google_maps.py
+++ b/homeassistant/components/device_tracker/google_maps.py
@@ -21,6 +21,7 @@ REQUIREMENTS = ['locationsharinglib==2.0.7']
 
 _LOGGER = logging.getLogger(__name__)
 
+CONF_MAX_GPS_ACCURACY = 'max_gps_accuracy'
 ATTR_ADDRESS = 'address'
 ATTR_FULL_NAME = 'full_name'
 ATTR_LAST_SEEN = 'last_seen'
@@ -31,6 +32,7 @@ CREDENTIALS_FILE = '.google_maps_location_sharing.cookies'
 MIN_TIME_BETWEEN_SCANS = timedelta(seconds=30)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_MAX_GPS_ACCURACY, default=100000): vol.Coerce(float),
     vol.Required(CONF_USERNAME): cv.string,
     vol.Required(CONF_PASSWORD): cv.string,
 })
@@ -53,6 +55,7 @@ class GoogleMapsScanner:
         self.see = see
         self.username = config[CONF_USERNAME]
         self.password = config[CONF_PASSWORD]
+        self.max_gps_accuracy = config[CONF_MAX_GPS_ACCURACY]
 
         try:
             self.service = Service(self.username, self.password,
@@ -76,18 +79,25 @@ class GoogleMapsScanner:
                 _LOGGER.warning("No location(s) shared with this account")
                 return
 
-            attrs = {
-                ATTR_ADDRESS: person.address,
-                ATTR_FULL_NAME: person.full_name,
-                ATTR_ID: person.id,
-                ATTR_LAST_SEEN: person.datetime,
-                ATTR_NICKNAME: person.nickname,
-            }
-            self.see(
-                dev_id=dev_id,
-                gps=(person.latitude, person.longitude),
-                picture=person.picture_url,
-                source_type=SOURCE_TYPE_GPS,
-                gps_accuracy=person.accuracy,
-                attributes=attrs,
-            )
+            if self.max_gps_accuracy is not None and \
+                    person.accuracy > self.max_gps_accuracy:
+                _LOGGER.info("Ignoring %s update because expected GPS "
+                             "accuracy %s is not met: %s",
+                             person.nickname, self.max_gps_accuracy,
+                             person.accuracy)
+            else:
+                attrs = {
+                    ATTR_ADDRESS: person.address,
+                    ATTR_FULL_NAME: person.full_name,
+                    ATTR_ID: person.id,
+                    ATTR_LAST_SEEN: person.datetime,
+                    ATTR_NICKNAME: person.nickname,
+                }
+                self.see(
+                    dev_id=dev_id,
+                    gps=(person.latitude, person.longitude),
+                    picture=person.picture_url,
+                    source_type=SOURCE_TYPE_GPS,
+                    gps_accuracy=person.accuracy,
+                    attributes=attrs,
+                )


### PR DESCRIPTION
## Description:
Duplicates the max gps accuracy option found in the owntracks component to prevent updates with poor GPS accuracy

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5953

## Example entry for `configuration.yaml` (if applicable):
```yaml
device_tracker:
  - platform: google_maps
    username: YOUR_USERNAME
    password: YOUR_PASSWORD
    max_gps_accuracy: 100
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works. - **Existing component doesnt have tests - didnt add as didnt know how/where to start with Google Maps API or how to test the existing code**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
