### PR TITLE
Fix check config packages key error

### DIFF
--- a/homeassistant/scripts/check_config.py
+++ b/homeassistant/scripts/check_config.py
@@ -325,7 +325,7 @@ def check_ha_config_file(hass):
     # Merge packages
     merge_packages_config(
         hass, config, core_config.get(CONF_PACKAGES, {}), _pack_error)
-    del core_config[CONF_PACKAGES]
+    core_config.pop(CONF_PACKAGES, None)
 
     # Ensure we have no None values after merge
     for key, value in config.items():

--- a/tests/scripts/test_check_config.py
+++ b/tests/scripts/test_check_config.py
@@ -22,6 +22,12 @@ BASE_CONFIG = (
     '\n\n'
 )
 
+BAD_CORE_CONFIG = (
+    'homeassistant:\n'
+    '  unit_system: bad\n'
+    '\n\n'
+)
+
 
 def normalize_yaml_files(check_dict):
     """Remove configuration path from ['yaml_files']."""
@@ -47,6 +53,17 @@ class TestCheckConfig(unittest.TestCase):
         self.maxDiff = None  # pylint: disable=invalid-name
 
     # pylint: disable=no-self-use,invalid-name
+    @patch('os.path.isfile', return_value=True)
+    def test_bad_core_config(self, isfile_patch):
+        """Test a bad core config setup."""
+        files = {
+            YAML_CONFIG_FILE: BAD_CORE_CONFIG,
+        }
+        with patch_yaml_files(files):
+            res = check_config.check(get_test_config_dir())
+            assert res['except'].keys() == {'homeassistant'}
+            assert res['except']['homeassistant'][1] == {'unit_system': 'bad'}
+
     @patch('os.path.isfile', return_value=True)
     def test_config_platform_valid(self, isfile_patch):
         """Test a valid platform setup."""


### PR DESCRIPTION
## Description:
* The config key for packages is not present if core config validation failed. We need to do a safe dict deletion using dict.pop in the check_config script.

**Related issue (if applicable):**
The key error was reported in #13247, but this fix won't solve that issue since it's about `'whitelist_external_dirs'` and probably due to non existing dirs during check config validation.

## Example entry for `configuration.yaml` (if applicable):
```yaml
homeassistant:
  unit_system: bad
```

**Stacktrace before fix:**
```
2018-08-05 11:03:15 ERROR (MainThread) [aiohttp.server] Error handling request
Traceback (most recent call last):
  File "/home/martin/.virtualenvs/home-assistant/lib/python3.6/site-packages/aiohttp/web_protocol.py", line 378, in start
    resp = await self._request_handler(request)
  File "/home/martin/.virtualenvs/home-assistant/lib/python3.6/site-packages/aiohttp/web_app.py", line 341, in _handle
    resp = await handler(request)
  File "/home/martin/.virtualenvs/home-assistant/lib/python3.6/site-packages/aiohttp/web_middlewares.py", line 88, in impl
    return await handler(request)
  File "/home/martin/Dev/home-assistant/homeassistant/components/http/static.py", line 66, in staticresource_middleware
    return await handler(request)
  File "/home/martin/Dev/home-assistant/homeassistant/components/http/real_ip.py", line 34, in real_ip_middleware
    return await handler(request)
  File "/home/martin/Dev/home-assistant/homeassistant/components/http/ban.py", line 67, in ban_middleware
    return await handler(request)
  File "/home/martin/Dev/home-assistant/homeassistant/components/http/auth.py", line 66, in auth_middleware
    return await handler(request)
  File "/home/martin/Dev/home-assistant/homeassistant/components/http/view.py", line 113, in handle
    result = await result
  File "/home/martin/Dev/home-assistant/homeassistant/components/config/core.py", line 24, in post
    errors = yield from async_check_ha_config_file(request.app['hass'])
  File "/home/martin/Dev/home-assistant/homeassistant/config.py", line 723, in async_check_ha_config_file
    check_ha_config_file, hass)
  File "/usr/lib/python3.6/concurrent/futures/thread.py", line 56, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/home/martin/Dev/home-assistant/homeassistant/scripts/check_config.py", line 328, in check_ha_config_file
    del core_config[CONF_PACKAGES]
KeyError: 'packages'
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.