### PR TITLE
Add context to other entity components

### DIFF
--- a/homeassistant/components/alarm_control_panel/__init__.py
+++ b/homeassistant/components/alarm_control_panel/__init__.py
@@ -141,7 +141,8 @@ def async_setup(hass, config):
 
             if not alarm.should_poll:
                 continue
-            update_tasks.append(alarm.async_update_ha_state(True))
+            update_tasks.append(
+                alarm.async_update_ha_state(True, service.context))
 
         if update_tasks:
             yield from asyncio.wait(update_tasks, loop=hass.loop)

--- a/homeassistant/components/counter/__init__.py
+++ b/homeassistant/components/counter/__init__.py
@@ -125,7 +125,8 @@ async def async_setup(hass, config):
         elif service.service == SERVICE_RESET:
             attr = 'async_reset'
 
-        tasks = [getattr(counter, attr)() for counter in target_counters]
+        tasks = [getattr(counter, attr)(service.context)
+                 for counter in target_counters]
         if tasks:
             await asyncio.wait(tasks, loop=hass.loop)
 
@@ -188,17 +189,17 @@ class Counter(Entity):
         state = await async_get_last_state(self.hass, self.entity_id)
         self._state = state and state.state == state
 
-    async def async_decrement(self):
+    async def async_decrement(self, context):
         """Decrement the counter."""
         self._state -= self._step
-        await self.async_update_ha_state()
+        await self.async_update_ha_state(context=context)
 
-    async def async_increment(self):
+    async def async_increment(self, context):
         """Increment a counter."""
         self._state += self._step
-        await self.async_update_ha_state()
+        await self.async_update_ha_state(context=context)
 
-    async def async_reset(self):
+    async def async_reset(self, context):
         """Reset a counter."""
         self._state = self._initial
-        await self.async_update_ha_state()
+        await self.async_update_ha_state(context=context)

--- a/homeassistant/components/cover/__init__.py
+++ b/homeassistant/components/cover/__init__.py
@@ -174,7 +174,8 @@ async def async_setup(hass, config):
             await getattr(cover, method['method'])(**params)
             if not cover.should_poll:
                 continue
-            update_tasks.append(cover.async_update_ha_state(True))
+            update_tasks.append(
+                cover.async_update_ha_state(True, service.context))
 
         if update_tasks:
             await asyncio.wait(update_tasks, loop=hass.loop)

--- a/homeassistant/components/fan/__init__.py
+++ b/homeassistant/components/fan/__init__.py
@@ -219,7 +219,8 @@ def async_setup(hass, config: dict):
             yield from getattr(fan, method['method'])(**params)
             if not fan.should_poll:
                 continue
-            update_tasks.append(fan.async_update_ha_state(True))
+            update_tasks.append(
+                fan.async_update_ha_state(True, service.context))
 
         if update_tasks:
             yield from asyncio.wait(update_tasks, loop=hass.loop)

--- a/homeassistant/components/input_boolean.py
+++ b/homeassistant/components/input_boolean.py
@@ -95,7 +95,8 @@ async def async_setup(hass, config):
         else:
             attr = 'async_toggle'
 
-        tasks = [getattr(input_b, attr)() for input_b in target_inputs]
+        tasks = [getattr(input_b, attr)(context=service.context)
+                 for input_b in target_inputs]
         if tasks:
             await asyncio.wait(tasks, loop=hass.loop)
 
@@ -155,9 +156,9 @@ class InputBoolean(ToggleEntity):
     async def async_turn_on(self, **kwargs):
         """Turn the entity on."""
         self._state = True
-        await self.async_update_ha_state()
+        await self.async_update_ha_state(context=kwargs.get('context'))
 
     async def async_turn_off(self, **kwargs):
         """Turn the entity off."""
         self._state = False
-        await self.async_update_ha_state()
+        await self.async_update_ha_state(context=kwargs.get('context'))

--- a/homeassistant/components/input_datetime.py
+++ b/homeassistant/components/input_datetime.py
@@ -97,7 +97,8 @@ def async_setup(hass, config):
                               str(call.data))
                 continue
 
-            tasks.append(input_datetime.async_set_datetime(date, time))
+            tasks.append(
+                input_datetime.async_set_datetime(date, time, call.context))
 
         if tasks:
             yield from asyncio.wait(tasks, loop=hass.loop)
@@ -214,7 +215,7 @@ class InputDatetime(Entity):
         return attrs
 
     @asyncio.coroutine
-    def async_set_datetime(self, date_val, time_val):
+    def async_set_datetime(self, date_val, time_val, context):
         """Set a new date / time."""
         if self._has_date and self._has_time and date_val and time_val:
             self._current_datetime = datetime.datetime.combine(date_val,
@@ -224,4 +225,4 @@ class InputDatetime(Entity):
         if self._has_time and not self._has_date and time_val:
             self._current_datetime = time_val
 
-        yield from self.async_update_ha_state()
+        yield from self.async_update_ha_state(context=context)

--- a/homeassistant/components/input_number.py
+++ b/homeassistant/components/input_number.py
@@ -151,6 +151,7 @@ def async_setup(hass, config):
         method = SERVICE_TO_METHOD.get(service.service)
         params = service.data.copy()
         params.pop(ATTR_ENTITY_ID, None)
+        params['context'] = service.context
 
         # call method
         update_tasks = []
@@ -238,7 +239,7 @@ class InputNumber(Entity):
             self._current_value = self._minimum
 
     @asyncio.coroutine
-    def async_set_value(self, value):
+    def async_set_value(self, value, context):
         """Set new value."""
         num_value = float(value)
         if num_value < self._minimum or num_value > self._maximum:
@@ -246,10 +247,10 @@ class InputNumber(Entity):
                             num_value, self._minimum, self._maximum)
             return
         self._current_value = num_value
-        yield from self.async_update_ha_state()
+        yield from self.async_update_ha_state(context=context)
 
     @asyncio.coroutine
-    def async_increment(self):
+    def async_increment(self, context):
         """Increment value."""
         new_value = self._current_value + self._step
         if new_value > self._maximum:
@@ -257,10 +258,10 @@ class InputNumber(Entity):
                             new_value, self._minimum, self._maximum)
             return
         self._current_value = new_value
-        yield from self.async_update_ha_state()
+        yield from self.async_update_ha_state(context=context)
 
     @asyncio.coroutine
-    def async_decrement(self):
+    def async_decrement(self, context):
         """Decrement value."""
         new_value = self._current_value - self._step
         if new_value < self._minimum:
@@ -268,4 +269,4 @@ class InputNumber(Entity):
                             new_value, self._minimum, self._maximum)
             return
         self._current_value = new_value
-        yield from self.async_update_ha_state()
+        yield from self.async_update_ha_state(context=context)

--- a/homeassistant/components/input_select.py
+++ b/homeassistant/components/input_select.py
@@ -134,7 +134,8 @@ def async_setup(hass, config):
         """Handle a calls to the input select option service."""
         target_inputs = component.async_extract_from_service(call)
 
-        tasks = [input_select.async_select_option(call.data[ATTR_OPTION])
+        tasks = [input_select.async_select_option(call.data[ATTR_OPTION],
+                                                  call.context)
                  for input_select in target_inputs]
         if tasks:
             yield from asyncio.wait(tasks, loop=hass.loop)
@@ -148,7 +149,7 @@ def async_setup(hass, config):
         """Handle a calls to the input select next service."""
         target_inputs = component.async_extract_from_service(call)
 
-        tasks = [input_select.async_offset_index(1)
+        tasks = [input_select.async_offset_index(1, call.context)
                  for input_select in target_inputs]
         if tasks:
             yield from asyncio.wait(tasks, loop=hass.loop)
@@ -162,7 +163,7 @@ def async_setup(hass, config):
         """Handle a calls to the input select previous service."""
         target_inputs = component.async_extract_from_service(call)
 
-        tasks = [input_select.async_offset_index(-1)
+        tasks = [input_select.async_offset_index(-1, call.context)
                  for input_select in target_inputs]
         if tasks:
             yield from asyncio.wait(tasks, loop=hass.loop)
@@ -176,7 +177,8 @@ def async_setup(hass, config):
         """Handle a calls to the set options service."""
         target_inputs = component.async_extract_from_service(call)
 
-        tasks = [input_select.async_set_options(call.data[ATTR_OPTIONS])
+        tasks = [input_select.async_set_options(call.data[ATTR_OPTIONS],
+                                                call.context)
                  for input_select in target_inputs]
         if tasks:
             yield from asyncio.wait(tasks, loop=hass.loop)
@@ -240,26 +242,26 @@ class InputSelect(Entity):
         }
 
     @asyncio.coroutine
-    def async_select_option(self, option):
+    def async_select_option(self, option, context):
         """Select new option."""
         if option not in self._options:
             _LOGGER.warning('Invalid option: %s (possible options: %s)',
                             option, ', '.join(self._options))
             return
         self._current_option = option
-        yield from self.async_update_ha_state()
+        yield from self.async_update_ha_state(context=context)
 
     @asyncio.coroutine
-    def async_offset_index(self, offset):
+    def async_offset_index(self, offset, context):
         """Offset current index."""
         current_index = self._options.index(self._current_option)
         new_index = (current_index + offset) % len(self._options)
         self._current_option = self._options[new_index]
-        yield from self.async_update_ha_state()
+        yield from self.async_update_ha_state(context=context)
 
     @asyncio.coroutine
-    def async_set_options(self, options):
+    def async_set_options(self, options, context):
         """Set options."""
         self._current_option = options[0]
         self._options = options
-        yield from self.async_update_ha_state()
+        yield from self.async_update_ha_state(context=context)

--- a/homeassistant/components/input_text.py
+++ b/homeassistant/components/input_text.py
@@ -112,7 +112,8 @@ def async_setup(hass, config):
         """Handle a calls to the input box services."""
         target_inputs = component.async_extract_from_service(call)
 
-        tasks = [input_text.async_set_value(call.data[ATTR_VALUE])
+        tasks = [input_text.async_set_value(call.data[ATTR_VALUE],
+                                            call.context)
                  for input_text in target_inputs]
         if tasks:
             yield from asyncio.wait(tasks, loop=hass.loop)
@@ -190,11 +191,11 @@ class InputText(Entity):
             self._current_value = value
 
     @asyncio.coroutine
-    def async_set_value(self, value):
+    def async_set_value(self, value, context):
         """Select new value."""
         if len(value) < self._minimum or len(value) > self._maximum:
             _LOGGER.warning("Invalid value: %s (length range %s - %s)",
                             value, self._minimum, self._maximum)
             return
         self._current_value = value
-        yield from self.async_update_ha_state()
+        yield from self.async_update_ha_state(context=context)

--- a/homeassistant/components/lock/__init__.py
+++ b/homeassistant/components/lock/__init__.py
@@ -119,7 +119,8 @@ def async_setup(hass, config):
 
             if not entity.should_poll:
                 continue
-            update_tasks.append(entity.async_update_ha_state(True))
+            update_tasks.append(
+                entity.async_update_ha_state(True, service.context))
 
         if update_tasks:
             yield from asyncio.wait(update_tasks, loop=hass.loop)

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -442,7 +442,8 @@ async def async_setup(hass, config):
             await getattr(player, method['method'])(**params)
             if not player.should_poll:
                 continue
-            update_tasks.append(player.async_update_ha_state(True))
+            update_tasks.append(
+                player.async_update_ha_state(True, service.context))
 
         if update_tasks:
             await asyncio.wait(update_tasks, loop=hass.loop)

--- a/homeassistant/components/vacuum/__init__.py
+++ b/homeassistant/components/vacuum/__init__.py
@@ -220,7 +220,8 @@ def async_setup(hass, config):
             yield from getattr(vacuum, method['method'])(**params)
             if not vacuum.should_poll:
                 continue
-            update_tasks.append(vacuum.async_update_ha_state(True))
+            update_tasks.append(
+                vacuum.async_update_ha_state(True, service.context))
 
         if update_tasks:
             yield from asyncio.wait(update_tasks, loop=hass.loop)

--- a/tests/components/test_input_boolean.py
+++ b/tests/components/test_input_boolean.py
@@ -4,7 +4,7 @@ import asyncio
 import unittest
 import logging
 
-from homeassistant.core import CoreState, State
+from homeassistant.core import CoreState, State, Context
 from homeassistant.setup import setup_component, async_setup_component
 from homeassistant.components.input_boolean import (
     DOMAIN, is_on, toggle, turn_off, turn_on, CONF_INITIAL)
@@ -158,3 +158,24 @@ def test_initial_state_overrules_restore_state(hass):
     state = hass.states.get('input_boolean.b2')
     assert state
     assert state.state == 'on'
+
+
+async def test_input_boolean_context(hass):
+    """Test that input_boolean context works."""
+    assert await async_setup_component(hass, 'input_boolean', {
+        'input_boolean': {
+            'ac': {CONF_INITIAL: True},
+        }
+    })
+
+    state = hass.states.get('input_boolean.ac')
+    assert state is not None
+
+    await hass.services.async_call('input_boolean', 'turn_off', {
+        'entity_id': state.entity_id,
+    }, True, Context(user_id='abcd'))
+
+    state2 = hass.states.get('input_boolean.ac')
+    assert state2 is not None
+    assert state.state != state2.state
+    assert state2.context.user_id == 'abcd'

--- a/tests/components/test_input_number.py
+++ b/tests/components/test_input_number.py
@@ -3,7 +3,7 @@
 import asyncio
 import unittest
 
-from homeassistant.core import CoreState, State
+from homeassistant.core import CoreState, State, Context
 from homeassistant.setup import setup_component, async_setup_component
 from homeassistant.components.input_number import (
     DOMAIN, set_value, increment, decrement)
@@ -236,3 +236,27 @@ def test_no_initial_state_and_no_restore_state(hass):
     state = hass.states.get('input_number.b1')
     assert state
     assert float(state.state) == 0
+
+
+async def test_input_number_context(hass):
+    """Test that input_number context works."""
+    assert await async_setup_component(hass, 'input_number', {
+        'input_number': {
+            'b1': {
+                'min': 0,
+                'max': 100,
+            },
+        }
+    })
+
+    state = hass.states.get('input_number.b1')
+    assert state is not None
+
+    await hass.services.async_call('input_number', 'increment', {
+        'entity_id': state.entity_id,
+    }, True, Context(user_id='abcd'))
+
+    state2 = hass.states.get('input_number.b1')
+    assert state2 is not None
+    assert state.state != state2.state
+    assert state2.context.user_id == 'abcd'

--- a/tests/components/test_input_select.py
+++ b/tests/components/test_input_select.py
@@ -5,7 +5,7 @@ import unittest
 
 from tests.common import get_test_home_assistant, mock_restore_cache
 
-from homeassistant.core import State
+from homeassistant.core import State, Context
 from homeassistant.setup import setup_component, async_setup_component
 from homeassistant.components.input_select import (
     ATTR_OPTIONS, DOMAIN, SERVICE_SET_OPTIONS,
@@ -276,3 +276,30 @@ def test_initial_state_overrules_restore_state(hass):
     state = hass.states.get('input_select.s2')
     assert state
     assert state.state == 'middle option'
+
+
+async def test_input_select_context(hass):
+    """Test that input_select context works."""
+    assert await async_setup_component(hass, 'input_select', {
+        'input_select': {
+            's1': {
+                'options': [
+                    'first option',
+                    'middle option',
+                    'last option',
+                ],
+            }
+        }
+    })
+
+    state = hass.states.get('input_select.s1')
+    assert state is not None
+
+    await hass.services.async_call('input_select', 'select_next', {
+        'entity_id': state.entity_id,
+    }, True, Context(user_id='abcd'))
+
+    state2 = hass.states.get('input_select.s1')
+    assert state2 is not None
+    assert state.state != state2.state
+    assert state2.context.user_id == 'abcd'

--- a/tests/components/test_input_text.py
+++ b/tests/components/test_input_text.py
@@ -3,7 +3,7 @@
 import asyncio
 import unittest
 
-from homeassistant.core import CoreState, State
+from homeassistant.core import CoreState, State, Context
 from homeassistant.setup import setup_component, async_setup_component
 from homeassistant.components.input_text import (DOMAIN, set_value)
 
@@ -180,3 +180,27 @@ def test_no_initial_state_and_no_restore_state(hass):
     state = hass.states.get('input_text.b1')
     assert state
     assert str(state.state) == 'unknown'
+
+
+async def test_input_text_context(hass):
+    """Test that input_text context works."""
+    assert await async_setup_component(hass, 'input_text', {
+        'input_text': {
+            't1': {
+                'initial': 'bla',
+            }
+        }
+    })
+
+    state = hass.states.get('input_text.t1')
+    assert state is not None
+
+    await hass.services.async_call('input_text', 'set_value', {
+        'entity_id': state.entity_id,
+        'value': 'new_value',
+    }, True, Context(user_id='abcd'))
+
+    state2 = hass.states.get('input_text.t1')
+    assert state2 is not None
+    assert state.state != state2.state
+    assert state2.context.user_id == 'abcd'


### PR DESCRIPTION
## Description:
This adds context propagation to the other entity components.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
