### PR TITLE
Add and restore context in recorder [MIGRATION]

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -423,7 +423,8 @@ class Event:
                 self.event_type == other.event_type and
                 self.data == other.data and
                 self.origin == other.origin and
-                self.time_fired == other.time_fired)
+                self.time_fired == other.time_fired and
+                self.context == other.context)
 
 
 class EventBus:
@@ -695,7 +696,8 @@ class State:
         return (self.__class__ == other.__class__ and  # type: ignore
                 self.entity_id == other.entity_id and
                 self.state == other.state and
-                self.attributes == other.attributes)
+                self.attributes == other.attributes and
+                self.context == other.context)
 
     def __repr__(self) -> str:
         """Return the representation of the states."""

--- a/tests/common.py
+++ b/tests/common.py
@@ -266,7 +266,7 @@ def mock_state_change_event(hass, new_state, old_state=None):
     if old_state:
         event_data['old_state'] = old_state
 
-    hass.bus.fire(EVENT_STATE_CHANGED, event_data)
+    hass.bus.fire(EVENT_STATE_CHANGED, event_data, context=new_state.context)
 
 
 @asyncio.coroutine

--- a/tests/components/recorder/test_models.py
+++ b/tests/components/recorder/test_models.py
@@ -60,7 +60,7 @@ class TestStates(unittest.TestCase):
             'entity_id': 'sensor.temperature',
             'old_state': None,
             'new_state': state,
-        })
+        }, context=state.context)
         assert state == States.from_event(event).to_native()
 
     def test_from_event_to_delete_state(self):

--- a/tests/components/test_history.py
+++ b/tests/components/test_history.py
@@ -83,9 +83,10 @@ class TestComponentHistory(unittest.TestCase):
             self.wait_recording_done()
 
         # Get states returns everything before POINT
-        self.assertEqual(states,
-                         sorted(history.get_states(self.hass, future),
-                                key=lambda state: state.entity_id))
+        for state1, state2 in zip(
+                states, sorted(history.get_states(self.hass, future),
+                               key=lambda state: state.entity_id)):
+            assert state1 == state2
 
         # Test get_state here because we have a DB setup
         self.assertEqual(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -246,8 +246,9 @@ class TestEvent(unittest.TestCase):
         """Test events."""
         now = dt_util.utcnow()
         data = {'some': 'attr'}
+        context = ha.Context()
         event1, event2 = [
-            ha.Event('some_type', data, time_fired=now)
+            ha.Event('some_type', data, time_fired=now, context=context)
             for _ in range(2)
         ]
 


### PR DESCRIPTION
## Description:
This stores context in the database and restores it when being retrieved.

This requires a migration and might take long. I added a new migration step "add columns". For MySql it will try to add all columns at once, for SQLite it will need to do 1 at a time.

CC @OverloadUT 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
