### PR TITLE
Fix HomeKit test

### DIFF
--- a/tests/components/homekit/test_accessories.py
+++ b/tests/components/homekit/test_accessories.py
@@ -104,6 +104,7 @@ async def test_battery_service(hass, hk_driver):
     await hass.async_block_till_done()
 
     acc = HomeAccessory(hass, hk_driver, 'Battery Service', entity_id, 2, None)
+    acc.update_state = lambda x: None
     assert acc._char_battery.value == 0
     assert acc._char_low_battery.value == 0
     assert acc._char_charging.value == 2
@@ -126,6 +127,7 @@ async def test_battery_service(hass, hk_driver):
     await hass.async_block_till_done()
 
     acc = HomeAccessory(hass, hk_driver, 'Battery Service', entity_id, 2, None)
+    acc.update_state = lambda x: None
     assert acc._char_battery.value == 0
     assert acc._char_low_battery.value == 0
     assert acc._char_charging.value == 2


### PR DESCRIPTION
## Description:
Don't raise `NotImplementedError` during test of `battery_service`

## Checklist:
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**