### PR TITLE
Upgrade Sphinx to 1.7.6

### DIFF
--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,3 +1,3 @@
-Sphinx==1.7.5
+Sphinx==1.7.6
 sphinx-autodoc-typehints==1.3.0
 sphinx-autodoc-annotation==1.0.post1


### PR DESCRIPTION
## Description:
Changelog: http://www.sphinx-doc.org/en/stable/changes.html

```yaml
$ make html
sphinx-build -b html -d build/doctrees   source build/html
Running Sphinx v1.7.6
WARNING: while setting up extension sphinx_autodoc_annotation: directive 'autofunction' is already registered, it will be overridden
WARNING: while setting up extension sphinx_autodoc_annotation: directive 'automethod' is already registered, it will be overridden
loading pickled environment... not yet created
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 9 source files that are out of date
updating environment: 9 added, 0 changed, 0 removed
reading sources... [100%] index                                                                                                         
/home/fab/Documents/repos/ha/home-assistant/docs/source/api/bootstrap.rst:4: WARNING: Title underline too short.
[...bunch of other error related to the auto-generation of the docs...]
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [100%] index                                                                                                          
generating indices... genindex py-modindex
writing additional pages... search
copying static files... done
copying extra files... done
dumping search index in English (code: en) ... done
dumping object inventory... done
build succeeded, 152 warnings.

The HTML pages are in build/html.

Build finished. The HTML pages are in build/html.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

