### PR TITLE
Fix downgrade hassio cannot get refresh_token issue

### DIFF
--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -175,10 +175,14 @@ def async_setup(hass, config):
     if data is None:
         data = {}
 
+    refresh_token = None
     if 'hassio_user' in data:
         user = yield from hass.auth.async_get_user(data['hassio_user'])
-        refresh_token = list(user.refresh_tokens.values())[0]
-    else:
+        # user is None when downgrade to 0.75 prior version
+        if user:
+            refresh_token = list(user.refresh_tokens.values())[0]
+
+    if refresh_token is None:
         user = yield from hass.auth.async_create_system_user('Hass.io')
         refresh_token = yield from hass.auth.async_create_refresh_token(user)
         data['hassio_user'] = user.id

--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -178,7 +178,6 @@ def async_setup(hass, config):
     refresh_token = None
     if 'hassio_user' in data:
         user = yield from hass.auth.async_get_user(data['hassio_user'])
-        # user is None when downgrade to 0.75 prior version
         if user:
             refresh_token = list(user.refresh_tokens.values())[0]
 


### PR DESCRIPTION
## Description:
I am not sure if we need fix it. User reported in #15870, downgrade from 0.75.x to 0.74.2 will left .storage/hassio file, then it will cause upgrade to 0.75 above failed

**Related issue (if applicable):** fixes #15870 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
