### PR TITLE
Update based upon forum post

### DIFF
--- a/homeassistant/components/device_tracker/ping.py
+++ b/homeassistant/components/device_tracker/ping.py
@@ -38,7 +38,7 @@ class Host:
         self.dev_id = dev_id
         self._count = config[CONF_PING_COUNT]
         if sys.platform == 'win32':
-            self._ping_cmd = ['ping', '-n 1', '-w', '1000', self.ip_address]
+            self._ping_cmd = ['ping', '-n', '1', '-w', '1000', self.ip_address]
         else:
             self._ping_cmd = ['ping', '-n', '-q', '-c1', '-W1',
                               self.ip_address]


### PR DESCRIPTION
Based upon [this post](https://community.home-assistant.io/t/device-tracker-ping-on-windows-not-working-solved/61474/3) it looks like we've found why people couldn't get the ping tracker working on Windows.

NB: I cannot test this locally, I have zero developer capabilities.
