### PR TITLE
Follow changes to netdisco, separating DLNA into DLNA_DMS and DLNA_DMR

### DIFF
--- a/homeassistant/components/discovery.py
+++ b/homeassistant/components/discovery.py
@@ -85,7 +85,7 @@ SERVICE_HANDLERS = {
     'volumio': ('media_player', 'volumio'),
     'nanoleaf_aurora': ('light', 'nanoleaf_aurora'),
     'freebox': ('device_tracker', 'freebox'),
-    'DLNA_DMR': ('media_player', 'dlna_dmr'),
+    'dlna_dmr': ('media_player', 'dlna_dmr'),
 }
 
 OPTIONAL_SERVICE_HANDLERS = {

--- a/homeassistant/components/discovery.py
+++ b/homeassistant/components/discovery.py
@@ -85,7 +85,7 @@ SERVICE_HANDLERS = {
     'volumio': ('media_player', 'volumio'),
     'nanoleaf_aurora': ('light', 'nanoleaf_aurora'),
     'freebox': ('device_tracker', 'freebox'),
-    'DLNA': ('media_player', 'dlna_dmr')
+    'DLNA_DMR': ('media_player', 'dlna_dmr'),
 }
 
 OPTIONAL_SERVICE_HANDLERS = {

--- a/homeassistant/components/media_player/dlna_dmr.py
+++ b/homeassistant/components/media_player/dlna_dmr.py
@@ -67,11 +67,6 @@ HOME_ASSISTANT_UPNP_MIME_TYPE_MAPPING = {
     'channel': 'video/*',
     'playlist': 'playlist/*',
 }
-UPNP_DEVICE_MEDIA_RENDERER = [
-    'urn:schemas-upnp-org:device:MediaRenderer:1',
-    'urn:schemas-upnp-org:device:MediaRenderer:2',
-    'urn:schemas-upnp-org:device:MediaRenderer:3',
-]
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -126,15 +121,6 @@ async def async_setup_platform(hass: HomeAssistant,
                                async_add_devices,
                                discovery_info=None):
     """Set up DLNA DMR platform."""
-    # ensure this is a DLNA DMR device, if found via discovery
-    if discovery_info and \
-       'upnp_device_type' in discovery_info and \
-       discovery_info['upnp_device_type'] not in UPNP_DEVICE_MEDIA_RENDERER:
-        _LOGGER.debug('Device is not a MediaRenderer: %s, device_type: %s',
-                      discovery_info.get('ssdp_description'),
-                      discovery_info['upnp_device_type'])
-        return
-
     if config.get(CONF_URL) is not None:
         url = config[CONF_URL]
         name = config.get(CONF_NAME)


### PR DESCRIPTION
## Description:

Follow netdisco changes where discovery of DLNA has been separated into DLNA_DMS and DLNA_DMR devices.

As a result, there is no longer the need to check if the discovered device is actually a DMR device.

Note that I have not changed the netdisco version-dependency.

**Related issue (if applicable):** https://github.com/home-assistant/netdisco/pull/204

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** -

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

