### PR TITLE
Add auth/authorize endpoint

### DIFF
--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -249,6 +249,7 @@ async def async_setup(hass, config):
 
     index_view = IndexView(repo_path, js_version, hass.auth.active)
     hass.http.register_view(index_view)
+    hass.http.register_view(AuthorizeView(repo_path, js_version))
 
     @callback
     def async_finalize_panel(panel):
@@ -332,6 +333,35 @@ def _async_setup_themes(hass, themes):
     hass.services.async_register(
         DOMAIN, SERVICE_SET_THEME, set_theme, schema=SERVICE_SET_THEME_SCHEMA)
     hass.services.async_register(DOMAIN, SERVICE_RELOAD_THEMES, reload_themes)
+
+
+class AuthorizeView(HomeAssistantView):
+    """Serve the frontend."""
+
+    url = '/auth/authorize'
+    name = 'auth:authorize'
+    requires_auth = False
+
+    def __init__(self, repo_path, js_option):
+        """Initialize the frontend view."""
+        self.repo_path = repo_path
+        self.js_option = js_option
+
+    async def get(self, request: web.Request):
+        """Redirect to the authorize page."""
+        latest = self.repo_path is not None or \
+            _is_latest(self.js_option, request)
+
+        if latest:
+            location = '/frontend_latest/authorize.html'
+        else:
+            location = '/frontend_es5/authorize.html'
+
+        location += '?{}'.format(request.query_string)
+
+        return web.Response(status=302, headers={
+            'location': location
+        })
 
 
 class IndexView(HomeAssistantView):

--- a/tests/components/frontend/test_init.py
+++ b/tests/components/frontend/test_init.py
@@ -348,3 +348,14 @@ async def test_onboarding_load(mock_http_client):
     """Test onboarding component loaded by default."""
     resp = await mock_http_client.get('/api/onboarding')
     assert resp.status == 200
+
+
+async def test_auth_authorize(mock_http_client):
+    """Test the authorize endpoint works."""
+    resp = await mock_http_client.get('/auth/authorize?hello=world')
+    assert resp.url.query_string == 'hello=world'
+    assert resp.url.path == '/frontend_es5/authorize.html'
+
+    resp = await mock_http_client.get('/auth/authorize?latest&hello=world')
+    assert resp.url.query_string == 'latest&hello=world'
+    assert resp.url.path == '/frontend_latest/authorize.html'


### PR DESCRIPTION
## Description:
Add an `/auth/authorize` endpoint that the frontend will redirect to the right url.

This endpoint is needed so that the fact that we currently use `/frontend_es5` and `/frontend_latest` remains an implementation detail and external clients integrating with Home Assistant can just use `/auth/authorize`.

You can test it with https://github.com/home-assistant/home-assistant-js-websocket/pull/29

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
