### PR TITLE
Add monitored conditions for Unifi device_tracker

### DIFF
--- a/homeassistant/components/device_tracker/unifi.py
+++ b/homeassistant/components/device_tracker/unifi.py
@@ -31,6 +31,18 @@ DEFAULT_DETECTION_TIME = timedelta(seconds=300)
 NOTIFICATION_ID = 'unifi_notification'
 NOTIFICATION_TITLE = 'Unifi Device Tracker Setup'
 
+AVAILABLE_ATTRS = [
+    '_id', '_is_guest_by_uap', '_last_seen_by_uap', '_uptime_by_uap',
+    'ap_mac', 'assoc_time', 'authorized', 'bssid', 'bytes-r', 'ccq',
+    'channel', 'essid', 'first_seen', 'hostname', 'idletime', 'ip',
+    'is_11r', 'is_guest', 'is_wired', 'last_seen', 'latest_assoc_time',
+    'mac', 'name', 'noise', 'noted', 'oui', 'powersave_enabled',
+    'qos_policy_applied', 'radio', 'radio_proto', 'rssi', 'rx_bytes',
+    'rx_bytes-r', 'rx_packets', 'rx_rate', 'signal', 'site_id',
+    'tx_bytes', 'tx_bytes-r', 'tx_packets', 'tx_power', 'tx_rate',
+    'uptime', 'user_id', 'usergroup_id', 'vlan'
+]
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
     vol.Optional(CONF_SITE_ID, default='default'): cv.string,
@@ -42,7 +54,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_DETECTION_TIME, default=DEFAULT_DETECTION_TIME): vol.All(
         cv.time_period, cv.positive_timedelta),
     vol.Optional(CONF_MONITORED_CONDITIONS):
-        vol.All(cv.ensure_list, [cv.string]),
+        vol.All(cv.ensure_list, [vol.In(AVAILABLE_ATTRS)]),
     vol.Optional(CONF_SSID_FILTER): vol.All(cv.ensure_list, [cv.string])
 })
 


### PR DESCRIPTION
## Description:
This PR supersedes #15711 

Adds a monitored_conditions config option to the Unifi device_tracker to pick and chose what extended attributes to keep from the giant list returned by the Unifi controller. Defaults to no extra attributes.

This is technically a breaking change from the current behavior.

**Related issue (if applicable):** fixes #14745 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5977

## Example entry for `configuration.yaml` (if applicable):
```yaml
device_tracker:
  - platform: unifi
    host: 192.168.1.201
    verify_ssl: false
    username: !secret unifi_username
    password: !secret unifi_password
    monitored_conditions:
      - signal
      - mac
      - essid
    new_device_defaults:
      track_new_devices: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)
