### PR TITLE
Use python slim to reduce docker build size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # When updating this file, please also update virtualization/Docker/Dockerfile.dev
 # This way, the development image and the production image are kept in sync.
 
-FROM python:3.6
+FROM python:3.6-slim
 LABEL maintainer="Paulus Schoutsen <Paulus@PaulusSchoutsen.nl>"
 
 # Uncomment any of the following lines to disable the installation.
@@ -26,8 +26,12 @@ RUN virtualization/Docker/setup_docker_prereqs
 COPY requirements_all.txt requirements_all.txt
 # Uninstall enum34 because some dependencies install it but breaks Python 3.4+.
 # See PR #8103 for more info.
-RUN pip3 install --no-cache-dir -r requirements_all.txt && \
-    pip3 install --no-cache-dir mysqlclient psycopg2 uvloop cchardet cython
+RUN apt-get update \
+   && apt-get install -y --no-install-recommends autoconf libmariadbclient-dev-compat  \
+   && pip3 install --no-cache-dir -r requirements_all.txt \
+   && pip3 install --no-cache-dir mysqlclient psycopg2 uvloop cchardet cython \
+   && apt-get remove -y autoconf libmariadbclient-dev-compat  \
+   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Copy source
 COPY . .

--- a/virtualization/Docker/Dockerfile.dev
+++ b/virtualization/Docker/Dockerfile.dev
@@ -2,7 +2,7 @@
 # Based on the production Dockerfile, but with development additions.
 # Keep this file as close as possible to the production Dockerfile, so the environments match.
 
-FROM python:3.6
+FROM python:3.6-slim
 LABEL maintainer="Paulus Schoutsen <Paulus@PaulusSchoutsen.nl>"
 
 # Uncomment any of the following lines to disable the installation.
@@ -28,8 +28,12 @@ COPY requirements_all.txt requirements_all.txt
 
 # Uninstall enum34 because some dependencies install it but breaks Python 3.4+.
 # See PR #8103 for more info.
-RUN pip3 install --no-cache-dir -r requirements_all.txt && \
-    pip3 install --no-cache-dir mysqlclient psycopg2 uvloop cchardet cython
+RUN apt-get update \
+   && apt-get install -y --no-install-recommends autoconf libmariadbclient-dev-compat  \
+   && pip3 install --no-cache-dir -r requirements_all.txt \
+   && pip3 install --no-cache-dir mysqlclient psycopg2 uvloop cchardet cython \
+   && apt-get remove -y autoconf libmariadbclient-dev-compat  \
+   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # BEGIN: Development additions
 

--- a/virtualization/Docker/scripts/tellstick
+++ b/virtualization/Docker/scripts/tellstick
@@ -9,9 +9,12 @@ PACKAGES=(
   libtelldus-core2
 )
 
+apt-get update
+apt-get install -y --no-install-recommends wget gnupg
 # Add Tellstick repository
 echo "deb http://download.telldus.com/debian/ stable main" >> /etc/apt/sources.list.d/telldus.list
 wget -qO - http://download.telldus.com/debian/telldus-public.key | apt-key add -
 
 apt-get update
+apt-get remove -y  wget
 apt-get install -y --no-install-recommends ${PACKAGES[@]}


### PR DESCRIPTION
## Description:
The current published docker image is built on top of python3.6 image and is 1.78GB. Using python3.6-slim I've got the size down to 1.47GB. 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**