### PR TITLE
Update radiotherm to 1.4.1

### DIFF
--- a/homeassistant/components/climate/radiotherm.py
+++ b/homeassistant/components/climate/radiotherm.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
     CONF_HOST, TEMP_FAHRENHEIT, ATTR_TEMPERATURE, PRECISION_HALVES)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['radiotherm==1.3']
+REQUIREMENTS = ['radiotherm==1.4.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1201,7 +1201,7 @@ qnapstats==0.2.6
 rachiopy==0.1.3
 
 # homeassistant.components.climate.radiotherm
-radiotherm==1.3
+radiotherm==1.4.1
 
 # homeassistant.components.raincloud
 raincloudy==0.0.5


### PR DESCRIPTION
## Description:

Updates radiotherm to use version 1.4.1

*

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**



[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
