### PR TITLE
Update August component to use py-august:0.6.0

### DIFF
--- a/homeassistant/components/august.py
+++ b/homeassistant/components/august.py
@@ -21,7 +21,7 @@ _LOGGER = logging.getLogger(__name__)
 
 _CONFIGURING = {}
 
-REQUIREMENTS = ['py-august==0.4.0']
+REQUIREMENTS = ['py-august==0.6.0']
 
 DEFAULT_TIMEOUT = 10
 ACTIVITY_FETCH_LIMIT = 10

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -706,7 +706,7 @@ pushetta==1.0.15
 pwmled==1.2.1
 
 # homeassistant.components.august
-py-august==0.4.0
+py-august==0.6.0
 
 # homeassistant.components.canary
 py-canary==0.5.0


### PR DESCRIPTION
## Description:
August component is throwing errors due to expired August API key being used. This PR upgrades August component to use py-august:0.6.0 which contains new API key.

**Related issue (if applicable):** fixes #15880 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
