### PR TITLE
Tplink device tracker error

### DIFF
--- a/homeassistant/components/device_tracker/tplink.py
+++ b/homeassistant/components/device_tracker/tplink.py
@@ -52,9 +52,13 @@ def get_scanner(hass, config):
             TplinkDeviceScanner, Tplink5DeviceScanner, Tplink4DeviceScanner,
             Tplink3DeviceScanner, Tplink2DeviceScanner, Tplink1DeviceScanner
     ]:
-        scanner = cls(config[DOMAIN])
-        if scanner.success_init:
-            return scanner
+        try:
+            scanner = cls(config[DOMAIN])
+            if scanner.success_init:
+                return scanner
+        except:
+            _LOGGER.warn("Error in TpLink scanner " + cls.__name__)
+            pass
 
     return None
 

--- a/homeassistant/components/device_tracker/tplink.py
+++ b/homeassistant/components/device_tracker/tplink.py
@@ -56,7 +56,7 @@ def get_scanner(hass, config):
             scanner = cls(config[DOMAIN])
             if scanner.success_init:
                 return scanner
-        except:
+        except Exception:
             _LOGGER.warn("Error in TpLink scanner " + cls.__name__)
             pass
 

--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -175,10 +175,13 @@ def async_setup(hass, config):
     if data is None:
         data = {}
 
+    refresh_token = None
     if 'hassio_user' in data:
         user = yield from hass.auth.async_get_user(data['hassio_user'])
-        refresh_token = list(user.refresh_tokens.values())[0]
-    else:
+        if user:
+            refresh_token = list(user.refresh_tokens.values())[0]
+
+    if refresh_token is None:
         user = yield from hass.auth.async_create_system_user('Hass.io')
         refresh_token = yield from hass.auth.async_create_refresh_token(user)
         data['hassio_user'] = user.id

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -2,7 +2,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 75
-PATCH_VERSION = '2'
+PATCH_VERSION = '3'
 __short_version__ = '{}.{}'.format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = '{}.{}'.format(__short_version__, PATCH_VERSION)
 REQUIRED_PYTHON_VER = (3, 5, 3)


### PR DESCRIPTION
I am a Software developer (C#/NodeJS) and this is my first ever fix for Python code.
I have a TPLink EAP245 Access Point which when I configured the device_tracker was causing a `Error setting up platform tplink` log entry.  On further investigation it seems that the code tries a number of scanners in order to try to get the user list.  In my case the scanner that works is the second in the list but it never gets there due to an exception in the first.

My fix is to log any errors but just `pass` so that the next scanner can have a try.
I've run the tests and they all pass locally.

