### PR TITLE
Add support for Tahoma Lighting Receiver on/off io

### DIFF
--- a/homeassistant/components/switch/tahoma.py
+++ b/homeassistant/components/switch/tahoma.py
@@ -82,10 +82,10 @@ class TahomaSwitch(TahomaDevice, SwitchDevice):
         _LOGGER.debug("Turn off: %s", self._name)
         if self.tahoma_device.type == 'rts:GarageDoor4TRTSComponent':
             return
-        else:
-            self.apply_action('off')
-            self._skip_update = True
-            self._state = STATE_OFF
+
+        self.apply_action('off')
+        self._skip_update = True
+        self._state = STATE_OFF
 
     def toggle(self, **kwargs):
         """Click the switch."""

--- a/homeassistant/components/switch/tahoma.py
+++ b/homeassistant/components/switch/tahoma.py
@@ -12,10 +12,17 @@ import logging
 from homeassistant.components.switch import SwitchDevice
 from homeassistant.components.tahoma import (
     DOMAIN as TAHOMA_DOMAIN, TahomaDevice)
+from homeassistant.const import (STATE_OFF, STATE_ON)
 
 DEPENDENCIES = ['tahoma']
 
 _LOGGER = logging.getLogger(__name__)
+
+ATTR_RSSI_LEVEL = 'rssi_level'
+ATTR_STATUS = 'status'
+ATTR_LOCK_TIMER = 'priority_lock_timer'
+ATTR_LOCK_LEVEL = 'priority_lock_level'
+ATTR_LOCK_ORIG = 'priority_lock_originator'
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -30,6 +37,27 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class TahomaSwitch(TahomaDevice, SwitchDevice):
     """Representation a Tahoma Switch."""
 
+    def __init__(self, tahoma_device, controller):
+        """Initialize the switch."""
+        super().__init__(tahoma_device, controller)
+        self._state = STATE_OFF
+        self._skip_update = False
+
+    def update(self):
+        """Update method."""
+        # Postpone the immediate state check for changes that take time.
+        if self._skip_update:
+            self._skip_update = False
+            return
+
+        self.controller.get_states([self.tahoma_device])
+        if self.tahoma_device.type == 'io:OnOffLightIOComponent':
+            if self.tahoma_device.active_states['core:OnOffState'] == 'on':
+                self._state = STATE_ON
+            else:
+                self._state = STATE_OFF
+        _LOGGER.debug("Update %s, state: %s", self._name, self._state)
+
     @property
     def device_class(self):
         """Return the class of the device."""
@@ -39,7 +67,23 @@ class TahomaSwitch(TahomaDevice, SwitchDevice):
 
     def turn_on(self, **kwargs):
         """Send the on command."""
-        self.toggle()
+        _LOGGER.debug("Turn on: %s", self._name)
+        if self.tahoma_device.type == 'rts:GarageDoor4TRTSComponent':
+            self.toggle()
+        else:
+            self.apply_action('on')
+            self._skip_update = True
+            self._state = STATE_ON
+
+    def turn_off(self, **kwargs):
+        """Send the off command."""
+        _LOGGER.debug("Turn off: %s", self._name)
+        if self.tahoma_device.type == 'rts:GarageDoor4TRTSComponent':
+            return
+        else:
+            self.apply_action('off')
+            self._skip_update = True
+            self._state = STATE_OFF
 
     def toggle(self, **kwargs):
         """Click the switch."""
@@ -48,4 +92,33 @@ class TahomaSwitch(TahomaDevice, SwitchDevice):
     @property
     def is_on(self):
         """Get whether the switch is in on state."""
-        return False
+        if self.tahoma_device.type == 'rts:GarageDoor4TRTSComponent':
+            return False
+        return bool(self._state == STATE_ON)
+
+    @property
+    def device_state_attributes(self):
+        """Return the device state attributes."""
+        attr = {}
+        super_attr = super().device_state_attributes
+        if super_attr is not None:
+            attr.update(super_attr)
+
+        if 'core:RSSILevelState' in self.tahoma_device.active_states:
+            attr[ATTR_RSSI_LEVEL] = \
+                self.tahoma_device.active_states['core:RSSILevelState']
+        if 'core:StatusState' in self.tahoma_device.active_states:
+            attr[ATTR_STATUS] = \
+                self.tahoma_device.active_states['core:StatusState']
+        if 'core:PriorityLockTimerState' in self.tahoma_device.active_states:
+            attr[ATTR_LOCK_TIMER] = \
+                self.tahoma_device.active_states['core:PriorityLockTimerState']
+        if 'io:PriorityLockLevelState' in self.tahoma_device.active_states:
+            attr[ATTR_LOCK_LEVEL] = \
+                self.tahoma_device.active_states['io:PriorityLockLevelState']
+        if 'io:PriorityLockOriginatorState' in \
+                self.tahoma_device.active_states:
+            attr[ATTR_LOCK_ORIG] = \
+                self.tahoma_device.active_states[
+                    'io:PriorityLockOriginatorState']
+        return attr

--- a/homeassistant/components/tahoma.py
+++ b/homeassistant/components/tahoma.py
@@ -50,6 +50,7 @@ TAHOMA_TYPES = {
     'io:WindowOpenerVeluxIOComponent': 'cover',
     'io:LightIOSystemSensor': 'sensor',
     'rts:GarageDoor4TRTSComponent': 'switch',
+    'io:OnOffLightIOComponent': 'switch',
     'rtds:RTDSSmokeSensor': 'smoke',
 }
 


### PR DESCRIPTION
## Description:
Add support for [Tahoma Lighting Receiver on/off io](https://www.somfy.de/produkte/1822423/lighting-receiver-on-off-io)


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`.

If user exposed functionality or configuration variables are added/changed:
  - No additional documentation required

If the code communicates with devices, web services, or third-party tools:
  - No new dependencies.
  - No new files.

If the code does not interact with devices:
  - Does interact with devices