### PR TITLE
Add a service for zoned cleaning for Xiaomi Miio vacuum

### DIFF
--- a/homeassistant/components/vacuum/services.yaml
+++ b/homeassistant/components/vacuum/services.yaml
@@ -131,3 +131,49 @@ xiaomi_remote_control_move_step:
     duration:
       description: Duration of the movement.
       example: '1500'
+
+
+xiaomi_clean_zone:
+  description: Clean a zone.
+  fields:
+    entity_id:
+      description: Name of the vacuum entity.
+      example: 'vacuum.xiaomi_vacuum_cleaner'
+    x1:
+      description: X coordinate for the first corner.
+      example: '22500'
+    x2:
+      description: X coordinate for the second corner.
+      example: '28500'
+    y1:
+      description: Y coordinate for the first corner.
+      example: '22500'
+    y2:
+      description: Y coordinate for the second corner.
+      example: '28500'
+    iterations:
+      description: Number of repetitions to clean the zone.
+      example: '1'
+
+xiaomi_clean_zones:
+  description: Clean a list of zones.
+  fields:
+    entity_id:
+      description: Name of the vacuum entity.
+      example: 'vacuum.xiaomi_vacuum_cleaner'
+    zones:
+      description: X coordinate for the first corner.
+      example: '[{"x1":"20000","x2":"21000","y1":"28000","y2":"29000","iterations":"1"},{"x1":"24000","x2":"27000","y1":"21000","y2":"23000","iterations":"2"}]'
+
+xiaomi_goto:
+  description: Send the vacuum to a coordinate.
+  fields:
+    entity_id:
+      description: Name of the vacuum entity.
+      example: 'vacuum.xiaomi_vacuum_cleaner'
+    x:
+      description: X coordinate.
+      example: '25500'
+    y:
+      description: Y coordinate.
+      example: '25500'


### PR DESCRIPTION
Added a service for zoned cleaning after some help from pnbruckner (thanks!). Tested with my Xiaomi Roborock 2.

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
