### PR TITLE
Fix mysensors connection task blocking setup

### DIFF
--- a/homeassistant/components/mysensors/gateway.py
+++ b/homeassistant/components/mysensors/gateway.py
@@ -186,12 +186,16 @@ def _discover_mysensors_platform(hass, platform, new_devices):
 
 async def _gw_start(hass, gateway):
     """Start the gateway."""
+    # Don't use hass.async_create_task to avoid holding up setup indefinitely.
+    connect_task = hass.loop.create_task(gateway.start())
+
     @callback
     def gw_stop(event):
         """Trigger to stop the gateway."""
         hass.async_add_job(gateway.stop())
+        if not connect_task.cancelled():
+            connect_task.cancel()
 
-    await gateway.start()
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, gw_stop)
     if gateway.device == 'mqtt':
         # Gatways connected via mqtt doesn't send gateway ready message.

--- a/homeassistant/components/mysensors/gateway.py
+++ b/homeassistant/components/mysensors/gateway.py
@@ -193,7 +193,7 @@ async def _gw_start(hass, gateway):
     def gw_stop(event):
         """Trigger to stop the gateway."""
         hass.async_add_job(gateway.stop())
-        if not connect_task.cancelled():
+        if not connect_task.done():
             connect_task.cancel()
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, gw_stop)


### PR DESCRIPTION
## Description:
* Schedule the connection task without having the core track the task to avoid blocking setup, if the connection don't succeed.
* Cancel the connection task, if not cancelled already, when home assistant stops.

**Related issue (if applicable):**
fixes #15894 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**