### PR TITLE
Allow google_travel_time options to be set by entities

### DIFF
--- a/homeassistant/components/sensor/google_travel_time.py
+++ b/homeassistant/components/sensor/google_travel_time.py
@@ -142,12 +142,14 @@ class GoogleTravelTimeSensor(Entity):
             self._destination = destination
 
         # Check if mode is a trackable entity
-        if CONF_MODE in options and options[CONF_MODE].split('.', 1)[0] in TRACKABLE_DOMAINS:
+        if CONF_MODE in options \
+                and options[CONF_MODE].split('.', 1)[0] in TRACKABLE_DOMAINS:
             self._mode_entity_id = options[CONF_MODE]
         elif options[CONF_MODE] in TRAVEL_MODE:
             self._mode = options[CONF_MODE]
         else:
-            _LOGGER.warning('Invalid travel mode: {}'.format(options[CONF_MODE]))
+            _LOGGER.warning('Invalid travel mode: {}'
+                            .format(options[CONF_MODE]))
             self._mode = 'driving'  # Default
 
         import googlemaps
@@ -205,7 +207,8 @@ class GoogleTravelTimeSensor(Entity):
         """Get the latest data from Google."""
         options_copy = self._get_options_values()
 
-        if 'departure_time' not in options_copy and 'arrival_time' not in options_copy:
+        if 'departure_time' not in options_copy \
+                and 'arrival_time' not in options_copy:
             options_copy['departure_time'] = 'now'
 
         # Convert device_trackers to google friendly location

--- a/homeassistant/components/sensor/google_travel_time.py
+++ b/homeassistant/components/sensor/google_travel_time.py
@@ -148,8 +148,7 @@ class GoogleTravelTimeSensor(Entity):
         elif options[CONF_MODE] in TRAVEL_MODE:
             self._mode = options[CONF_MODE]
         else:
-            _LOGGER.warning('Invalid travel mode: {}'
-                            .format(options[CONF_MODE]))
+            _LOGGER.warning('Invalid travel mode: %s', options[CONF_MODE])
 
         # Check if arrival_time or departure_time is a trackable entity.
         # Only process one - departure time takes precedence.
@@ -250,18 +249,14 @@ class GoogleTravelTimeSensor(Entity):
                 self._mode = mode_entity.state
                 options[CONF_MODE] = mode_entity.state
             else:
-                _LOGGER.warning('Invalid travel mode: {}'.format(
-                    mode_entity.state)
-                )
+                _LOGGER.warning('Invalid travel mode: %s', mode_entity.state)
 
         if hasattr(self, '_departure_time_entity_id'):
             departure_time_entity = self._hass.states.get(
-                self._departure_time_entity_id
-            )
+                self._departure_time_entity_id)
             if ':' in departure_time_entity.state:
                 self._departure_time = convert_time_to_utc(
-                    departure_time_entity.state
-                )
+                    departure_time_entity.state)
                 options['departure_time'] = departure_time_entity.state
             else:
                 self._departure_time = int(departure_time_entity.state)
@@ -269,8 +264,7 @@ class GoogleTravelTimeSensor(Entity):
 
         elif hasattr(self, '_arrival_time_entity_id'):
             arrival_time_entity = self._hass.states.get(
-                self._arrival_time_entity_id
-            )
+                self._arrival_time_entity_id)
             if ':' in arrival_time_entity.state:
                 self._arrival_time = int(convert_time_to_utc(
                     arrival_time_entity.state


### PR DESCRIPTION
## Description:
Allow google_travel_time sensor to use sensor values in options.

**Related issue (if applicable):** fixes #11606


## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
