### PR TITLE
Add support for NOAA tide information (new PR)

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -684,6 +684,7 @@ omit =
     homeassistant/components/sensor/nederlandse_spoorwegen.py
     homeassistant/components/sensor/netdata.py
     homeassistant/components/sensor/neurio_energy.py
+    homeassistant/components/sensor/noaa-tides.py
     homeassistant/components/sensor/nsw_fuel_station.py
     homeassistant/components/sensor/nut.py
     homeassistant/components/sensor/nzbget.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -684,7 +684,7 @@ omit =
     homeassistant/components/sensor/nederlandse_spoorwegen.py
     homeassistant/components/sensor/netdata.py
     homeassistant/components/sensor/neurio_energy.py
-    homeassistant/components/sensor/noaa-tides.py
+    homeassistant/components/sensor/noaa_tides.py
     homeassistant/components/sensor/nsw_fuel_station.py
     homeassistant/components/sensor/nut.py
     homeassistant/components/sensor/nzbget.py

--- a/homeassistant/components/sensor/noaa_tides.py
+++ b/homeassistant/components/sensor/noaa_tides.py
@@ -1,0 +1,128 @@
+"""
+This component provides HA sensor support for the NOAA Tides and Currents API.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.noaa_tides/
+"""
+import logging
+from datetime import datetime, timedelta
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import (ATTR_ATTRIBUTION, CONF_NAME)
+from homeassistant.helpers.entity import Entity
+
+REQUIREMENTS = ['py_noaa==0.2.2']
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_STA_ID = 'station_id'
+CONF_TZ = 'timezone'
+CONF_UNITS = 'units'
+DEFAULT_ATTRIBUTION = "Data provided by NOAA"
+DEFAULT_NAME = 'NOAA Tides'
+DEFAULT_TZ = 'lst_ldt'
+
+SCAN_INTERVAL = timedelta(minutes=60)
+
+TZS = ['gmt', 'lst', 'lst_ldt']
+UNITS = ['english', 'metric']
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_STA_ID): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_TZ, default=DEFAULT_TZ): vol.In(TZS),
+    vol.Optional(CONF_UNITS): vol.In(UNITS),
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the NOAATidesAndCurrents sensor."""
+    sta = config[CONF_STA_ID]
+    name = config.get(CONF_NAME)
+    t_z = config.get(CONF_TZ)
+
+    if CONF_UNITS in config:
+        units = config[CONF_UNITS]
+    elif hass.config.units.is_metric:
+        units = UNITS[1]
+    else:
+        units = UNITS[0]
+
+    add_devices([NOAATidesAndCurrentsSensor(name, sta, t_z, units)], True)
+
+
+class NOAATidesAndCurrentsSensor(Entity):
+    """Representation of a NOAATidesAndCurrents sensor."""
+
+    def __init__(self, name, sta, t_z, units):
+        """Initialize the sensor."""
+        self._name = name
+        self._sta = sta
+        self._tz = t_z
+        self._units = units
+        self.data = None
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes of this device."""
+        attr = {ATTR_ATTRIBUTION: DEFAULT_ATTRIBUTION}
+        if self.data is not None:
+            if self.data['hi_lo'][1] == 'H':
+                attr['high_tide_time'] = \
+                    self.data.index[1].strftime('%I:%M %p')
+                attr['high_tide_height'] = self.data['predicted_wl'][1]
+                attr['low_tide_time'] = self.data.index[2].strftime('%I:%M %p')
+                attr['low_tide_height'] = self.data['predicted_wl'][2]
+            elif self.data['hi_lo'][1] == 'L':
+                attr['low_tide_time'] = self.data.index[1].strftime('%I:%M %p')
+                attr['low_tide_height'] = self.data['predicted_wl'][1]
+                attr['high_tide_time'] = \
+                    self.data.index[2].strftime('%I:%M %p')
+                attr['high_tide_height'] = self.data['predicted_wl'][2]
+        return attr
+
+    @property
+    def state(self):
+        """Return the state of the device."""
+        if self.data is not None:
+            api_time = self.data.index[0]
+            if self.data['hi_lo'][0] == 'H':
+                tidetime = api_time.strftime('%I:%M %p')
+                return "High tide at {}".format(tidetime)
+            if self.data['hi_lo'][0] == 'L':
+                tidetime = api_time.strftime('%I:%M %p')
+                return "Low tide at {}".format(tidetime)
+            return None
+        return None
+
+    def update(self):
+        """Get the latest data from NOAA Tides and Currents API."""
+        from py_noaa import coops
+        begin = datetime.now()
+        delta = timedelta(days=2)
+        end = begin + delta
+        try:
+            df_predictions = coops.get_data(
+                begin_date=begin.strftime("%Y%m%d %H:%M"),
+                end_date=end.strftime("%Y%m%d %H:%M"),
+                stationid=self._sta,
+                product="predictions",
+                datum="MLLW",
+                interval="hilo",
+                units=self._units,
+                time_zone=self._tz)
+            self.data = df_predictions.head()
+            _LOGGER.debug("Data = %s", self.data)
+            _LOGGER.debug("Recent Tide data queried with start time set to %s",
+                          begin.strftime("%m-%d-%Y %H:%M"))
+        except ValueError as err:
+            _LOGGER.error("Check NOAA Tides and Currents %s", err.args)
+            self.data = None

--- a/homeassistant/components/sensor/noaa_tides.py
+++ b/homeassistant/components/sensor/noaa_tides.py
@@ -1,17 +1,18 @@
 """
-This platform provides HA sensor support for the NOAA Tides and Currents API.
+Support for the NOAA Tides and Currents API.
 
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.noaa_tides/
 """
-import logging
 from datetime import datetime, timedelta
+import logging
 
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import (ATTR_ATTRIBUTION, CONF_NAME, CONF_UNIT_SYSTEM)
+from homeassistant.const import (
+    ATTR_ATTRIBUTION, CONF_NAME, CONF_TIME_ZONE, CONF_UNIT_SYSTEM)
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 
 REQUIREMENTS = ['py_noaa==0.3.0']
@@ -19,7 +20,7 @@ REQUIREMENTS = ['py_noaa==0.3.0']
 _LOGGER = logging.getLogger(__name__)
 
 CONF_STATION_ID = 'station_id'
-CONF_TIMEZONE = 'timezone'
+
 DEFAULT_ATTRIBUTION = "Data provided by NOAA"
 DEFAULT_NAME = 'NOAA Tides'
 DEFAULT_TIMEZONE = 'lst_ldt'
@@ -32,16 +33,16 @@ UNIT_SYSTEMS = ['english', 'metric']
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_STATION_ID): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional(CONF_TIMEZONE, default=DEFAULT_TIMEZONE): vol.In(TIMEZONES),
+    vol.Optional(CONF_TIME_ZONE, default=DEFAULT_TIMEZONE): vol.In(TIMEZONES),
     vol.Optional(CONF_UNIT_SYSTEM): vol.In(UNIT_SYSTEMS),
 })
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    """Set up the NOAATidesAndCurrents sensor."""
+    """Set up the NOAA Tides and Currents sensor."""
     station_id = config[CONF_STATION_ID]
     name = config.get(CONF_NAME)
-    timezone = config.get(CONF_TIMEZONE)
+    timezone = config.get(CONF_TIME_ZONE)
 
     if CONF_UNIT_SYSTEM in config:
         unit_system = config[CONF_UNIT_SYSTEM]
@@ -50,17 +51,18 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     else:
         unit_system = UNIT_SYSTEMS[0]
 
-    noaa_sensor = NOAATidesAndCurrentsSensor(name, station_id,
-                                             timezone, unit_system)
+    noaa_sensor = NOAATidesAndCurrentsSensor(
+        name, station_id, timezone, unit_system)
+
     noaa_sensor.update()
     if noaa_sensor.data is None:
-        _LOGGER.error("Unable to setup NOAA Tides Sensor.")
+        _LOGGER.error("Unable to setup NOAA Tides Sensor")
         return
     add_devices([noaa_sensor], True)
 
 
 class NOAATidesAndCurrentsSensor(Entity):
-    """Representation of a NOAATidesAndCurrents sensor."""
+    """Representation of a NOAA Tides and Currents sensor."""
 
     def __init__(self, name, station_id, timezone, unit_system):
         """Initialize the sensor."""
@@ -132,5 +134,5 @@ class NOAATidesAndCurrentsSensor(Entity):
             _LOGGER.debug("Recent Tide data queried with start time set to %s",
                           begin.strftime("%m-%d-%Y %H:%M"))
         except ValueError as err:
-            _LOGGER.error("Check NOAA Tides and Currents %s", err.args)
+            _LOGGER.error("Check NOAA Tides and Currents: %s", err.args)
             self.data = None

--- a/homeassistant/components/sensor/noaa_tides.py
+++ b/homeassistant/components/sensor/noaa_tides.py
@@ -113,7 +113,7 @@ class NOAATidesAndCurrentsSensor(Entity):
 
     def update(self):
         """Get the latest data from NOAA Tides and Currents API."""
-        from py_noaa import coops # pylint: disable=import-error
+        from py_noaa import coops  # pylint: disable=import-error
         begin = datetime.now()
         delta = timedelta(days=2)
         end = begin + delta

--- a/homeassistant/components/sensor/noaa_tides.py
+++ b/homeassistant/components/sensor/noaa_tides.py
@@ -54,6 +54,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                                              timezone, unit_system)
     noaa_sensor.update()
     if noaa_sensor.data is None:
+        _LOGGER.error("Unable to setup NOAA Tides Sensor.")
         return
     add_devices([noaa_sensor], True)
 
@@ -112,7 +113,7 @@ class NOAATidesAndCurrentsSensor(Entity):
 
     def update(self):
         """Get the latest data from NOAA Tides and Currents API."""
-        from py_noaa import coops
+        from py_noaa import coops # pylint: disable=import-error
         begin = datetime.now()
         delta = timedelta(days=2)
         end = begin + delta

--- a/homeassistant/components/sensor/noaa_tides.py
+++ b/homeassistant/components/sensor/noaa_tides.py
@@ -14,7 +14,7 @@ from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (ATTR_ATTRIBUTION, CONF_NAME, CONF_UNIT_SYSTEM)
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['py_noaa==0.2.2']
+REQUIREMENTS = ['py_noaa==0.3.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -740,7 +740,7 @@ pyTibber==0.4.1
 pyW215==0.6.0
 
 # homeassistant.components.sensor.noaa_tides
-# py_noaa==0.2.2
+# py_noaa==0.3.0
 
 # homeassistant.components.cover.ryobi_gdo
 py_ryobi_gdo==0.0.10

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -739,6 +739,9 @@ pyTibber==0.4.1
 # homeassistant.components.switch.dlink
 pyW215==0.6.0
 
+# homeassistant.components.sensor.noaa_tides
+py_noaa==0.2.2
+
 # homeassistant.components.cover.ryobi_gdo
 py_ryobi_gdo==0.0.10
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -740,7 +740,7 @@ pyTibber==0.4.1
 pyW215==0.6.0
 
 # homeassistant.components.sensor.noaa_tides
-py_noaa==0.2.2
+# py_noaa==0.2.2
 
 # homeassistant.components.cover.ryobi_gdo
 py_ryobi_gdo==0.0.10

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -34,6 +34,7 @@ COMMENT_REQUIREMENTS = (
     'credstash',
     'bme680',
     'homekit',
+    'py_noaa',
 )
 
 TEST_REQUIREMENTS = (


### PR DESCRIPTION
## Description:

This sensor adds support for NOAA Tide information. This is a new PR as requested in [15664](https://github.com/home-assistant/home-assistant/pull/15664)

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5881

## Example entry for `configuration.yaml` (if applicable):
```yaml
senor:
  - platform: noaa_tides
    station_id: 8721164
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
