### PR TITLE
Add verify ssl to generic camera

### DIFF
--- a/homeassistant/components/camera/generic.py
+++ b/homeassistant/components/camera/generic.py
@@ -15,7 +15,7 @@ import voluptuous as vol
 
 from homeassistant.const import (
     CONF_NAME, CONF_USERNAME, CONF_PASSWORD, CONF_AUTHENTICATION,
-    HTTP_BASIC_AUTHENTICATION, HTTP_DIGEST_AUTHENTICATION)
+    HTTP_BASIC_AUTHENTICATION, HTTP_DIGEST_AUTHENTICATION, CONF_VERIFY_SSL)
 from homeassistant.exceptions import TemplateError
 from homeassistant.components.camera import (
     PLATFORM_SCHEMA, DEFAULT_CONTENT_TYPE, Camera)
@@ -42,6 +42,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_USERNAME): cv.string,
     vol.Optional(CONF_CONTENT_TYPE, default=DEFAULT_CONTENT_TYPE): cv.string,
     vol.Optional(CONF_FRAMERATE, default=2): cv.positive_int,
+    vol.Optional(CONF_VERIFY_SSL, default=True): cv.boolean,
 })
 
 
@@ -65,6 +66,7 @@ class GenericCamera(Camera):
         self._limit_refetch = device_info[CONF_LIMIT_REFETCH_TO_URL_CHANGE]
         self._frame_interval = 1 / device_info[CONF_FRAMERATE]
         self.content_type = device_info[CONF_CONTENT_TYPE]
+        self.verify_ssl = device_info[CONF_VERIFY_SSL]
 
         username = device_info.get(CONF_USERNAME)
         password = device_info.get(CONF_PASSWORD)
@@ -108,7 +110,7 @@ class GenericCamera(Camera):
             def fetch():
                 """Read image from a URL."""
                 try:
-                    response = requests.get(url, timeout=10, auth=self._auth)
+                    response = requests.get(url, timeout=10, auth=self._auth, verify=self.verify_ssl)
                     return response.content
                 except requests.exceptions.RequestException as error:
                     _LOGGER.error("Error getting camera image: %s", error)
@@ -119,7 +121,7 @@ class GenericCamera(Camera):
         # async
         else:
             try:
-                websession = async_get_clientsession(self.hass)
+                websession = async_get_clientsession(self.hass, verify_ssl=self.verify_ssl)
                 with async_timeout.timeout(10, loop=self.hass.loop):
                     response = yield from websession.get(
                         url, auth=self._auth)

--- a/homeassistant/components/camera/generic.py
+++ b/homeassistant/components/camera/generic.py
@@ -110,7 +110,8 @@ class GenericCamera(Camera):
             def fetch():
                 """Read image from a URL."""
                 try:
-                    response = requests.get(url, timeout=10, auth=self._auth, verify=self.verify_ssl)
+                    response = requests.get(url, timeout=10, auth=self._auth,
+                                            verify=self.verify_ssl)
                     return response.content
                 except requests.exceptions.RequestException as error:
                     _LOGGER.error("Error getting camera image: %s", error)
@@ -121,7 +122,8 @@ class GenericCamera(Camera):
         # async
         else:
             try:
-                websession = async_get_clientsession(self.hass, verify_ssl=self.verify_ssl)
+                websession = async_get_clientsession(
+                    self.hass, verify_ssl=self.verify_ssl)
                 with async_timeout.timeout(10, loop=self.hass.loop):
                     response = yield from websession.get(
                         url, auth=self._auth)

--- a/tests/components/camera/test_generic.py
+++ b/tests/components/camera/test_generic.py
@@ -33,6 +33,50 @@ def test_fetching_url(aioclient_mock, hass, aiohttp_client):
 
 
 @asyncio.coroutine
+def test_fetching_url_without_ssl_verification(aioclient_mock, hass, aiohttp_client):
+    """Test that it fetches the given url when ssl verify is off."""
+    aioclient_mock.get('https://example.com', text='hello world')
+
+    yield from async_setup_component(hass, 'camera', {
+        'camera': {
+            'name': 'config_test',
+            'platform': 'generic',
+            'still_image_url': 'https://example.com',
+            'username': 'user',
+            'password': 'pass',
+            'verify_ssl': 'false',
+        }})
+
+    client = yield from aiohttp_client(hass.http.app)
+
+    resp = yield from client.get('/api/camera_proxy/camera.config_test')
+
+    assert resp.status == 200
+
+
+@asyncio.coroutine
+def test_fetching_url_with_ssl_verification(aioclient_mock, hass, aiohttp_client):
+    """Test that it fetches the given url when ssl verify is explicitly on."""
+    aioclient_mock.get('https://example.com', text='hello world')
+
+    yield from async_setup_component(hass, 'camera', {
+        'camera': {
+            'name': 'config_test',
+            'platform': 'generic',
+            'still_image_url': 'https://example.com',
+            'username': 'user',
+            'password': 'pass',
+            'verify_ssl': 'true',
+        }})
+
+    client = yield from aiohttp_client(hass.http.app)
+
+    resp = yield from client.get('/api/camera_proxy/camera.config_test')
+
+    assert resp.status == 200
+
+
+@asyncio.coroutine
 def test_limit_refetch(aioclient_mock, hass, aiohttp_client):
     """Test that it fetches the given url."""
     aioclient_mock.get('http://example.com/5a', text='hello world')

--- a/tests/components/camera/test_generic.py
+++ b/tests/components/camera/test_generic.py
@@ -1,5 +1,6 @@
 """The tests for generic camera component."""
 import asyncio
+
 from unittest import mock
 
 from homeassistant.setup import async_setup_component
@@ -33,7 +34,7 @@ def test_fetching_url(aioclient_mock, hass, aiohttp_client):
 
 
 @asyncio.coroutine
-def test_fetching_url_without_ssl_verification(aioclient_mock, hass, aiohttp_client):
+def test_fetching_without_verify_ssl(aioclient_mock, hass, aiohttp_client):
     """Test that it fetches the given url when ssl verify is off."""
     aioclient_mock.get('https://example.com', text='hello world')
 
@@ -55,7 +56,7 @@ def test_fetching_url_without_ssl_verification(aioclient_mock, hass, aiohttp_cli
 
 
 @asyncio.coroutine
-def test_fetching_url_with_ssl_verification(aioclient_mock, hass, aiohttp_client):
+def test_fetching_url_with_verify_ssl(aioclient_mock, hass, aiohttp_client):
     """Test that it fetches the given url when ssl verify is explicitly on."""
     aioclient_mock.get('https://example.com', text='hello world')
 


### PR DESCRIPTION
## Add verify_ssl option to generic camera:

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#6005

## Example entry for `configuration.yaml` (if applicable):
```yaml
- platform: generic
  name: Camera Snapshot
  still_image_url: !secret camera_image_url
  verify_ssl: False
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. 

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

