### PR TITLE
HomeMatic: Enable entity registry

### DIFF
--- a/homeassistant/components/homematic/__init__.py
+++ b/homeassistant/components/homematic/__init__.py
@@ -743,7 +743,9 @@ class HMDevice(Entity):
     @property
     def unique_id(self):
         """Return unique ID. HomeMatic entity IDs are unique by default."""
-        return self._name
+        if self._address in self._name:
+            return self._name.replace(" ", "_")
+        return None
 
     @property
     def should_poll(self):

--- a/homeassistant/components/homematic/__init__.py
+++ b/homeassistant/components/homematic/__init__.py
@@ -47,6 +47,7 @@ ATTR_ERRORCODE = 'error'
 ATTR_MESSAGE = 'message'
 ATTR_MODE = 'mode'
 ATTR_TIME = 'time'
+ATTR_UNIQUE_ID = 'unique_id'
 
 EVENT_KEYPRESS = 'homematic.keypress'
 EVENT_IMPULSE = 'homematic.impulse'
@@ -173,6 +174,7 @@ DEVICE_SCHEMA = vol.Schema({
     vol.Required(ATTR_INTERFACE): cv.string,
     vol.Optional(ATTR_CHANNEL, default=1): vol.Coerce(int),
     vol.Optional(ATTR_PARAM): cv.string,
+    vol.Optional(ATTR_UNIQUE_ID): cv.string,
 })
 
 CONFIG_SCHEMA = vol.Schema({
@@ -530,8 +532,12 @@ def _get_devices(hass, discovery_type, keys, interface):
             _LOGGER.debug("%s: Handling %s: %s: %s",
                           discovery_type, key, param, channels)
             for channel in channels:
-                name = _create_ha_name(
+                name = _create_ha_id(
                     name=device.NAME, channel=channel, param=param,
+                    count=len(channels)
+                )
+                unique_id = _create_ha_id(
+                    name=key, channel=channel, param=param,
                     count=len(channels)
                 )
                 device_dict = {
@@ -539,7 +545,8 @@ def _get_devices(hass, discovery_type, keys, interface):
                     ATTR_ADDRESS: key,
                     ATTR_INTERFACE: interface,
                     ATTR_NAME: name,
-                    ATTR_CHANNEL: channel
+                    ATTR_CHANNEL: channel,
+                    ATTR_UNIQUE_ID: unique_id
                 }
                 if param is not None:
                     device_dict[ATTR_PARAM] = param
@@ -554,7 +561,7 @@ def _get_devices(hass, discovery_type, keys, interface):
     return device_arr
 
 
-def _create_ha_name(name, channel, param, count):
+def _create_ha_id(name, channel, param, count):
     """Generate a unique entity id."""
     # HMDevice is a simple device
     if count == 1 and param is None:
@@ -725,6 +732,7 @@ class HMDevice(Entity):
         self._interface = config.get(ATTR_INTERFACE)
         self._channel = config.get(ATTR_CHANNEL)
         self._state = config.get(ATTR_PARAM)
+        self._unique_id = config.get(ATTR_UNIQUE_ID)
         self._data = {}
         self._homematic = None
         self._hmdevice = None
@@ -743,9 +751,7 @@ class HMDevice(Entity):
     @property
     def unique_id(self):
         """Return unique ID. HomeMatic entity IDs are unique by default."""
-        if self._address in self._name:
-            return self._name.replace(" ", "_")
-        return None
+        return self._unique_id.replace(" ", "_")
 
     @property
     def should_poll(self):

--- a/homeassistant/components/homematic/__init__.py
+++ b/homeassistant/components/homematic/__init__.py
@@ -741,6 +741,11 @@ class HMDevice(Entity):
         yield from self.hass.async_add_job(self.link_homematic)
 
     @property
+    def unique_id(self):
+        """Return unique ID. HomeMatic entity IDs are unique by default."""
+        return self._name
+
+    @property
     def should_poll(self):
         """Return false. HomeMatic states are pushed by the XML-RPC Server."""
         return False


### PR DESCRIPTION
## Description:
Enabeling support for the entity registry. The entity IDs the HomeMatic component creates by default are uniqe and for every device always the same entity will be generated. This also works when the option to generate userfriendly entity IDs is being used. The entity ID can change though when using the userfriendly names (when the friendly name is changed in the hub-device). This will generate an entry in the registry that becomes stale.
The clean approach would be to disable the possibility the generate userfriendly names altogether. But as far as I know quite a few users are using this option, and removing support for that would break these configurations fundamentally. The way it is implemented looks acceptable to me since only a subset of the HomeMatic users would be affected by stale entries.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
