### PR TITLE
Remove remote.API from core.Config

### DIFF
--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -8,6 +8,7 @@ from ipaddress import ip_network
 import logging
 import os
 import ssl
+from typing import Optional
 
 from aiohttp import web
 from aiohttp.web_exceptions import HTTPMovedPermanently
@@ -15,7 +16,6 @@ import voluptuous as vol
 
 from homeassistant.const import (
     EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP, SERVER_PORT)
-from homeassistant.core import ApiConfig
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util as hass_util
 from homeassistant.util.logging import HideSensitiveDataFilter
@@ -80,6 +80,28 @@ HTTP_SCHEMA = vol.Schema({
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: HTTP_SCHEMA,
 }, extra=vol.ALLOW_EXTRA)
+
+
+class ApiConfig:
+    """Configuration settings for API server."""
+
+    def __init__(self, host: str, port: Optional[int] = SERVER_PORT,
+                 use_ssl: bool = False,
+                 api_password: Optional[str] = None) -> None:
+        """Initialize a new API config object."""
+        self.host = host
+        self.port = port
+        self.api_password = api_password
+
+        if host.startswith(("http://", "https://")):
+            self.base_url = host
+        elif use_ssl:
+            self.base_url = "https://{}".format(host)
+        else:
+            self.base_url = "http://{}".format(host)
+
+        if port is not None:
+            self.base_url += ':{}'.format(port)
 
 
 async def async_setup(hass, config):

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -15,8 +15,8 @@ import voluptuous as vol
 
 from homeassistant.const import (
     EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP, SERVER_PORT)
+from homeassistant.core import ApiConfig
 import homeassistant.helpers.config_validation as cv
-import homeassistant.remote as rem
 import homeassistant.util as hass_util
 from homeassistant.util.logging import HideSensitiveDataFilter
 from homeassistant.util import ssl as ssl_util
@@ -146,8 +146,8 @@ async def async_setup(hass, config):
         host = hass_util.get_local_ip()
         port = server_port
 
-    hass.config.api = rem.API(host, api_password, port,
-                              ssl_certificate is not None)
+    hass.config.api = ApiConfig(host, port, ssl_certificate is not None,
+                                api_password)
 
     return True
 

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -34,7 +34,7 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP,
     EVENT_SERVICE_EXECUTED, EVENT_SERVICE_REGISTERED, EVENT_STATE_CHANGED,
     EVENT_TIME_CHANGED, MATCH_ALL, EVENT_HOMEASSISTANT_CLOSE,
-    EVENT_SERVICE_REMOVED, __version__)
+    EVENT_SERVICE_REMOVED, SERVER_PORT, __version__)
 from homeassistant import loader
 from homeassistant.exceptions import (
     HomeAssistantError, InvalidEntityFormatError, InvalidStateError)
@@ -1127,6 +1127,28 @@ class ServiceRegistry:
             _LOGGER.exception('Error executing service %s', service_call)
 
 
+class ApiConfig:
+    """Configuration settings for API server."""
+
+    def __init__(self, host: str, port: Optional[int] = SERVER_PORT,
+                 use_ssl: bool = False,
+                 api_password: Optional[str] = None) -> None:
+        """Initialize a new API config object."""
+        self.host = host
+        self.port = port
+        self.api_password = api_password
+
+        if host.startswith(("http://", "https://")):
+            self.base_url = host
+        elif use_ssl:
+            self.base_url = "https://{}".format(host)
+        else:
+            self.base_url = "http://{}".format(host)
+
+        if port is not None:
+            self.base_url += ':{}'.format(port)
+
+
 class Config:
     """Configuration settings for Home Assistant."""
 
@@ -1145,8 +1167,8 @@ class Config:
         # List of loaded components
         self.components = set()  # type: set
 
-        # Remote.API object pointing at local API
-        self.api = None
+        # API (HTTP) server configuration
+        self.api = None  # type: Optional[ApiConfig]
 
         # Directory that holds the configuration
         self.config_dir = None  # type: Optional[str]

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -34,7 +34,7 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP,
     EVENT_SERVICE_EXECUTED, EVENT_SERVICE_REGISTERED, EVENT_STATE_CHANGED,
     EVENT_TIME_CHANGED, MATCH_ALL, EVENT_HOMEASSISTANT_CLOSE,
-    EVENT_SERVICE_REMOVED, SERVER_PORT, __version__)
+    EVENT_SERVICE_REMOVED, __version__)
 from homeassistant import loader
 from homeassistant.exceptions import (
     HomeAssistantError, InvalidEntityFormatError, InvalidStateError)
@@ -1127,28 +1127,6 @@ class ServiceRegistry:
             _LOGGER.exception('Error executing service %s', service_call)
 
 
-class ApiConfig:
-    """Configuration settings for API server."""
-
-    def __init__(self, host: str, port: Optional[int] = SERVER_PORT,
-                 use_ssl: bool = False,
-                 api_password: Optional[str] = None) -> None:
-        """Initialize a new API config object."""
-        self.host = host
-        self.port = port
-        self.api_password = api_password
-
-        if host.startswith(("http://", "https://")):
-            self.base_url = host
-        elif use_ssl:
-            self.base_url = "https://{}".format(host)
-        else:
-            self.base_url = "http://{}".format(host)
-
-        if port is not None:
-            self.base_url += ':{}'.format(port)
-
-
 class Config:
     """Configuration settings for Home Assistant."""
 
@@ -1168,7 +1146,7 @@ class Config:
         self.components = set()  # type: set
 
         # API (HTTP) server configuration
-        self.api = None  # type: Optional[ApiConfig]
+        self.api = None  # type: Optional[Any]
 
         # Directory that holds the configuration
         self.config_dir = None  # type: Optional[str]

--- a/tests/components/http/test_init.py
+++ b/tests/components/http/test_init.py
@@ -1,5 +1,6 @@
 """The tests for the Home Assistant HTTP component."""
 import logging
+import unittest
 
 from homeassistant.setup import async_setup_component
 
@@ -31,6 +32,50 @@ async def test_registering_view_while_running(hass, aiohttp_client,
     await hass.async_start()
     # This raises a RuntimeError if app is frozen
     hass.http.register_view(TestView)
+
+
+class TestApiConfig(unittest.TestCase):
+    """Test API configuration methods."""
+
+    def test_api_base_url_with_domain(hass):
+        """Test setting API URL with domain."""
+        api_config = http.ApiConfig('example.com')
+        assert api_config.base_url == 'http://example.com:8123'
+
+    def test_api_base_url_with_ip(hass):
+        """Test setting API URL with IP."""
+        api_config = http.ApiConfig('1.1.1.1')
+        assert api_config.base_url == 'http://1.1.1.1:8123'
+
+    def test_api_base_url_with_ip_and_port(hass):
+        """Test setting API URL with IP and port."""
+        api_config = http.ApiConfig('1.1.1.1', 8124)
+        assert api_config.base_url == 'http://1.1.1.1:8124'
+
+    def test_api_base_url_with_protocol(hass):
+        """Test setting API URL with protocol."""
+        api_config = http.ApiConfig('https://example.com')
+        assert api_config.base_url == 'https://example.com:8123'
+
+    def test_api_base_url_with_protocol_and_port(hass):
+        """Test setting API URL with protocol and port."""
+        api_config = http.ApiConfig('https://example.com', 433)
+        assert api_config.base_url == 'https://example.com:433'
+
+    def test_api_base_url_with_ssl_enable(hass):
+        """Test setting API URL with use_ssl enabled."""
+        api_config = http.ApiConfig('example.com', use_ssl=True)
+        assert api_config.base_url == 'https://example.com:8123'
+
+    def test_api_base_url_with_ssl_enable_and_port(hass):
+        """Test setting API URL with use_ssl enabled and port."""
+        api_config = http.ApiConfig('1.1.1.1', use_ssl=True, port=8888)
+        assert api_config.base_url == 'https://1.1.1.1:8888'
+
+    def test_api_base_url_with_protocol_and_ssl_enable(hass):
+        """Test setting API URL with specific protocol and use_ssl enabled."""
+        api_config = http.ApiConfig('http://example.com', use_ssl=True)
+        assert api_config.base_url == 'http://example.com:8123'
 
 
 async def test_api_base_url_with_domain(hass):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -846,6 +846,50 @@ class TestConfig(unittest.TestCase):
                 self.config.is_allowed_path(None)
 
 
+class TestApiConfig(unittest.TestCase):
+    """Test API configuration methods."""
+
+    def test_api_base_url_with_domain(hass):
+        """Test setting API URL with domain."""
+        api_config = ha.ApiConfig('example.com')
+        assert api_config.base_url == 'http://example.com:8123'
+
+    def test_api_base_url_with_ip(hass):
+        """Test setting API URL with IP."""
+        api_config = ha.ApiConfig('1.1.1.1')
+        assert api_config.base_url == 'http://1.1.1.1:8123'
+
+    def test_api_base_url_with_ip_and_port(hass):
+        """Test setting API URL with IP and port."""
+        api_config = ha.ApiConfig('1.1.1.1', 8124)
+        assert api_config.base_url == 'http://1.1.1.1:8124'
+
+    def test_api_base_url_with_protocol(hass):
+        """Test setting API URL with protocol."""
+        api_config = ha.ApiConfig('https://example.com')
+        assert api_config.base_url == 'https://example.com:8123'
+
+    def test_api_base_url_with_protocol_and_port(hass):
+        """Test setting API URL with protocol and port."""
+        api_config = ha.ApiConfig('https://example.com', 433)
+        assert api_config.base_url == 'https://example.com:433'
+
+    def test_api_base_url_with_ssl_enable(hass):
+        """Test setting API URL with use_ssl enabled."""
+        api_config = ha.ApiConfig('example.com', use_ssl=True)
+        assert api_config.base_url == 'https://example.com:8123'
+
+    def test_api_base_url_with_ssl_enable_and_port(hass):
+        """Test setting API URL with use_ssl enabled and port."""
+        api_config = ha.ApiConfig('1.1.1.1', use_ssl=True, port=8888)
+        assert api_config.base_url == 'https://1.1.1.1:8888'
+
+    def test_api_base_url_with_protocol_and_ssl_enable(hass):
+        """Test setting API URL with specific protocol and use_ssl enabled."""
+        api_config = ha.ApiConfig('http://example.com', use_ssl=True)
+        assert api_config.base_url == 'http://example.com:8123'
+
+
 @patch('homeassistant.core.monotonic')
 def test_create_timer(mock_monotonic, loop):
     """Test create timer."""

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -846,50 +846,6 @@ class TestConfig(unittest.TestCase):
                 self.config.is_allowed_path(None)
 
 
-class TestApiConfig(unittest.TestCase):
-    """Test API configuration methods."""
-
-    def test_api_base_url_with_domain(hass):
-        """Test setting API URL with domain."""
-        api_config = ha.ApiConfig('example.com')
-        assert api_config.base_url == 'http://example.com:8123'
-
-    def test_api_base_url_with_ip(hass):
-        """Test setting API URL with IP."""
-        api_config = ha.ApiConfig('1.1.1.1')
-        assert api_config.base_url == 'http://1.1.1.1:8123'
-
-    def test_api_base_url_with_ip_and_port(hass):
-        """Test setting API URL with IP and port."""
-        api_config = ha.ApiConfig('1.1.1.1', 8124)
-        assert api_config.base_url == 'http://1.1.1.1:8124'
-
-    def test_api_base_url_with_protocol(hass):
-        """Test setting API URL with protocol."""
-        api_config = ha.ApiConfig('https://example.com')
-        assert api_config.base_url == 'https://example.com:8123'
-
-    def test_api_base_url_with_protocol_and_port(hass):
-        """Test setting API URL with protocol and port."""
-        api_config = ha.ApiConfig('https://example.com', 433)
-        assert api_config.base_url == 'https://example.com:433'
-
-    def test_api_base_url_with_ssl_enable(hass):
-        """Test setting API URL with use_ssl enabled."""
-        api_config = ha.ApiConfig('example.com', use_ssl=True)
-        assert api_config.base_url == 'https://example.com:8123'
-
-    def test_api_base_url_with_ssl_enable_and_port(hass):
-        """Test setting API URL with use_ssl enabled and port."""
-        api_config = ha.ApiConfig('1.1.1.1', use_ssl=True, port=8888)
-        assert api_config.base_url == 'https://1.1.1.1:8888'
-
-    def test_api_base_url_with_protocol_and_ssl_enable(hass):
-        """Test setting API URL with specific protocol and use_ssl enabled."""
-        api_config = ha.ApiConfig('http://example.com', use_ssl=True)
-        assert api_config.base_url == 'http://example.com:8123'
-
-
 @patch('homeassistant.core.monotonic')
 def test_create_timer(mock_monotonic, loop):
     """Test create timer."""


### PR DESCRIPTION
## Description:

Use `http.ApiConfig` to replace `remote.API` in `hass.config.api`

This is the first step to get rid of Remote API (remote.py). hass.config.api is a Remote API instance, however current code base use a simply storage of `http` component's configuration, such as `base_url` and `api_password`. It is unnecessary and inappropriate to have a Remote API instance in Config. 

**Breaking change**
It would not break any official component, but may break custom components if they rely on `hass.config.api`

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

