### PR TITLE
Deprecate remote.api

### DIFF
--- a/homeassistant/remote.py
+++ b/homeassistant/remote.py
@@ -48,6 +48,7 @@ class API:
                  port: Optional[int] = SERVER_PORT,
                  use_ssl: bool = False) -> None:
         """Init the API."""
+        _LOGGER.warning('This class is deprecated and will be removed in 0.77')
         self.host = host
         self.port = port
         self.api_password = api_password


### PR DESCRIPTION
## Description:
Deprecate the REST API helpers in remote package. They are not compatible with new auth system and I don't want to spend time in making them compatible.

Removing them in 0.77.

Blog post here https://developers.home-assistant.io/blog/2018/08/13/deprecating-remote-package.html