### PR TITLE
Switch to intermediate Mozilla cert profile

### DIFF
--- a/homeassistant/util/ssl.py
+++ b/homeassistant/util/ssl.py
@@ -13,7 +13,7 @@ def client_context() -> ssl.SSLContext:
     return context
 
 
-def server_context() -> ssl.SSLContext:
+def server_context_modern() -> ssl.SSLContext:
     """Return an SSL context following the Mozilla recommendations.
 
     TLS configuration follows the best-practice guidelines specified here:
@@ -37,4 +37,58 @@ def server_context() -> ssl.SSLContext:
         "ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:"
         "ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256"
     )
+
+    return context
+
+
+def server_context_intermediate() -> ssl.SSLContext:
+    """Return an SSL context following the Mozilla recommendations.
+
+    TLS configuration follows the best-practice guidelines specified here:
+    https://wiki.mozilla.org/Security/Server_Side_TLS
+    Intermediate guidelines are followed.
+    """
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS)  # pylint: disable=no-member
+
+    context.options |= (
+        ssl.OP_NO_SSLv2 | ssl.OP_NO_SSLv3 |
+        ssl.OP_CIPHER_SERVER_PREFERENCE
+    )
+    if hasattr(ssl, 'OP_NO_COMPRESSION'):
+        context.options |= ssl.OP_NO_COMPRESSION
+
+    context.set_ciphers(
+        "ECDHE-ECDSA-CHACHA20-POLY1305:"
+        "ECDHE-RSA-CHACHA20-POLY1305:"
+        "ECDHE-ECDSA-AES128-GCM-SHA256:"
+        "ECDHE-RSA-AES128-GCM-SHA256:"
+        "ECDHE-ECDSA-AES256-GCM-SHA384:"
+        "ECDHE-RSA-AES256-GCM-SHA384:"
+        "DHE-RSA-AES128-GCM-SHA256:"
+        "DHE-RSA-AES256-GCM-SHA384:"
+        "ECDHE-ECDSA-AES128-SHA256:"
+        "ECDHE-RSA-AES128-SHA256:"
+        "ECDHE-ECDSA-AES128-SHA:"
+        "ECDHE-RSA-AES256-SHA384:"
+        "ECDHE-RSA-AES128-SHA:"
+        "ECDHE-ECDSA-AES256-SHA384:"
+        "ECDHE-ECDSA-AES256-SHA:"
+        "ECDHE-RSA-AES256-SHA:"
+        "DHE-RSA-AES128-SHA256:"
+        "DHE-RSA-AES128-SHA:"
+        "DHE-RSA-AES256-SHA256:"
+        "DHE-RSA-AES256-SHA:"
+        "ECDHE-ECDSA-DES-CBC3-SHA:"
+        "ECDHE-RSA-DES-CBC3-SHA:"
+        "EDH-RSA-DES-CBC3-SHA:"
+        "AES128-GCM-SHA256:"
+        "AES256-GCM-SHA384:"
+        "AES128-SHA256:"
+        "AES256-SHA256:"
+        "AES128-SHA:"
+        "AES256-SHA:"
+        "DES-CBC3-SHA:"
+        "!DSS"
+    )
+
     return context

--- a/tests/components/http/test_init.py
+++ b/tests/components/http/test_init.py
@@ -1,10 +1,13 @@
 """The tests for the Home Assistant HTTP component."""
 import logging
 import unittest
+from unittest.mock import patch
 
 from homeassistant.setup import async_setup_component
 
 import homeassistant.components.http as http
+from homeassistant.util.ssl import (
+    server_context_modern, server_context_intermediate)
 
 
 class TestView(http.HomeAssistantView):
@@ -169,3 +172,56 @@ async def test_proxy_config_only_trust_proxies(hass):
             http.CONF_TRUSTED_PROXIES: ['127.0.0.1']
         }
     }) is not True
+
+
+async def test_ssl_profile_defaults_modern(hass):
+    """Test default ssl profile."""
+    assert await async_setup_component(hass, 'http', {}) is True
+
+    hass.http.ssl_certificate = 'bla'
+
+    with patch('ssl.SSLContext.load_cert_chain'), \
+        patch('homeassistant.util.ssl.server_context_modern',
+              side_effect=server_context_modern) as mock_context:
+        await hass.async_start()
+        await hass.async_block_till_done()
+
+    assert len(mock_context.mock_calls) == 1
+
+
+async def test_ssl_profile_change_intermediate(hass):
+    """Test setting ssl profile to intermediate."""
+    assert await async_setup_component(hass, 'http', {
+        'http': {
+            'ssl_profile': 'intermediate'
+        }
+    }) is True
+
+    hass.http.ssl_certificate = 'bla'
+
+    with patch('ssl.SSLContext.load_cert_chain'), \
+        patch('homeassistant.util.ssl.server_context_intermediate',
+              side_effect=server_context_intermediate) as mock_context:
+        await hass.async_start()
+        await hass.async_block_till_done()
+
+    assert len(mock_context.mock_calls) == 1
+
+
+async def test_ssl_profile_change_modern(hass):
+    """Test setting ssl profile to modern."""
+    assert await async_setup_component(hass, 'http', {
+        'http': {
+            'ssl_profile': 'modern'
+        }
+    }) is True
+
+    hass.http.ssl_certificate = 'bla'
+
+    with patch('ssl.SSLContext.load_cert_chain'), \
+        patch('homeassistant.util.ssl.server_context_modern',
+              side_effect=server_context_modern) as mock_context:
+        await hass.async_start()
+        await hass.async_block_till_done()
+
+    assert len(mock_context.mock_calls) == 1

--- a/tests/scripts/test_check_config.py
+++ b/tests/scripts/test_check_config.py
@@ -159,7 +159,9 @@ class TestCheckConfig(unittest.TestCase):
                 'login_attempts_threshold': -1,
                 'server_host': '0.0.0.0',
                 'server_port': 8123,
-                'trusted_networks': []}
+                'trusted_networks': [],
+                'ssl_profile': 'modern',
+            }
             assert res['secret_cache'] == {secrets_path: {'http_pw': 'abc123'}}
             assert res['secrets'] == {'http_pw': 'abc123'}
             assert normalize_yaml_files(res) == [


### PR DESCRIPTION
## Description:
Allow users to downgrade the SSL profile to the Mozilla Intermediate SSL profile.

Modern profile was too modern for certain integrations that interact with the Home Assistant API. Sadly, because the error happens when setting up the connection, it's not easy to figure out the source integration.

**Related issue (if applicable):** 
fixes #15538 
fixes #15579

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** https://github.com/home-assistant/home-assistant.io/pull/6013

## Example entry for `configuration.yaml` (if applicable):
```yaml
http:
  ssl_profile: intermediate
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
