### PR TITLE
Bump python-lakeside dependency

### DIFF
--- a/homeassistant/components/eufy.py
+++ b/homeassistant/components/eufy.py
@@ -15,7 +15,7 @@ from homeassistant.helpers import discovery
 import homeassistant.helpers.config_validation as cv
 
 
-REQUIREMENTS = ['lakeside==0.7']
+REQUIREMENTS = ['lakeside==0.10']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -498,7 +498,7 @@ kiwiki-client==0.1.1
 konnected==0.1.2
 
 # homeassistant.components.eufy
-lakeside==0.7
+lakeside==0.10
 
 # homeassistant.components.device_tracker.owntracks
 # homeassistant.components.device_tracker.owntracks_http


### PR DESCRIPTION
This should fix https://github.com/home-assistant/home-assistant/issues/15374

**Related issue (if applicable):** fixes #15374 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
