### PR TITLE
Increase travis tox timeout to 40 min

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ cache:
     - $HOME/.cache/pip
 install: pip install -U tox coveralls
 language: python
-script: travis_wait 30 tox --develop
+script: travis_wait 40 tox --develop
 services:
   - docker
 before_deploy:


### PR DESCRIPTION
## Description:
https://github.com/home-assistant/home-assistant/pull/15947 adds pandas which seems to make us go beyond 30 min for the travis pylint job. 30 min is our current travis tox timeout. This PR increases that to 40 min.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**