### PR TITLE
Enhance sun component

### DIFF
--- a/homeassistant/components/sun.py
+++ b/homeassistant/components/sun.py
@@ -9,8 +9,8 @@ import logging
 from datetime import timedelta
 import voluptuous as vol
 
-from homeassistant.const import (CONF_ELEVATION, CONF_MONITORED_CONDITIONS,
-        CONF_SCAN_INTERVAL)
+from homeassistant.const import (
+    CONF_ELEVATION, CONF_MONITORED_CONDITIONS, CONF_SCAN_INTERVAL)
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
@@ -45,12 +45,13 @@ STATE_ATTR_SUNSET = 'sunset'
 STATE_ATTR_DAYLIGHT = 'daylight'
 STATE_ATTR_PREV_DAYLIGHT = 'prev_daylight'
 STATE_ATTR_NEXT_DAYLIGHT = 'next_daylight'
-DEFAULT_STATE_ATTRS = [STATE_ATTR_AZIMUTH, STATE_ATTR_ELEVATION,
-        STATE_ATTR_NEXT_DAWN, STATE_ATTR_NEXT_DUSK, STATE_ATTR_NEXT_MIDNIGHT,
-        STATE_ATTR_NEXT_NOON, STATE_ATTR_NEXT_RISING, STATE_ATTR_NEXT_SETTING]
-OPTIONAL_STATE_ATTRS = [STATE_ATTR_SUNRISE, STATE_ATTR_SUNSET,
-        STATE_ATTR_DAYLIGHT, STATE_ATTR_PREV_DAYLIGHT,
-        STATE_ATTR_NEXT_DAYLIGHT]
+DEFAULT_STATE_ATTRS = [
+    STATE_ATTR_AZIMUTH, STATE_ATTR_ELEVATION, STATE_ATTR_NEXT_DAWN,
+    STATE_ATTR_NEXT_DUSK, STATE_ATTR_NEXT_MIDNIGHT, STATE_ATTR_NEXT_NOON,
+    STATE_ATTR_NEXT_RISING, STATE_ATTR_NEXT_SETTING]
+OPTIONAL_STATE_ATTRS = [
+    STATE_ATTR_SUNRISE, STATE_ATTR_SUNSET, STATE_ATTR_DAYLIGHT,
+    STATE_ATTR_PREV_DAYLIGHT, STATE_ATTR_NEXT_DAYLIGHT]
 STATE_ATTRS = DEFAULT_STATE_ATTRS + OPTIONAL_STATE_ATTRS
 
 CONFIG_SCHEMA = vol.Schema({
@@ -58,8 +59,9 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(CONF_MONITORED_CONDITIONS, default=DEFAULT_STATE_ATTRS):
             vol.All(cv.ensure_list, [vol.In(STATE_ATTRS)]),
         vol.Optional(CONF_SCAN_INTERVAL):
-            vol.All(cv.time_period, vol.Clamp(min=MIN_SCAN_INTERVAL))})},
-    extra=vol.ALLOW_EXTRA)
+            vol.All(cv.time_period, vol.Clamp(min=MIN_SCAN_INTERVAL))
+        })
+}, extra=vol.ALLOW_EXTRA)
 
 
 @asyncio.coroutine
@@ -88,8 +90,8 @@ class Sun(Entity):
         self.hass = hass
         self.location = location
         # Initialize values for attributes to be reported.
-        for a in self._monitored_condtions:
-            setattr(self, a, None)
+        for attr in self._monitored_condtions:
+            setattr(self, attr, None)
         # Make sure STATE_ATTR_NEXT_RISING & STATE_ATTR_NEXT_SETTING are
         # defined since they are used to calculate state. Initialize them.
         setattr(self, STATE_ATTR_NEXT_RISING, None)
@@ -127,25 +129,25 @@ class Sun(Entity):
     def state_attributes(self):
         """Return the state attributes of the sun."""
         attrs = {}
-        for a in [STATE_ATTR_NEXT_DAWN,
-                  STATE_ATTR_NEXT_DUSK,
-                  STATE_ATTR_NEXT_MIDNIGHT,
-                  STATE_ATTR_NEXT_NOON,
-                  STATE_ATTR_NEXT_RISING,
-                  STATE_ATTR_NEXT_SETTING,
-                  STATE_ATTR_SUNRISE,
-                  STATE_ATTR_SUNSET]:
-            if a in self._monitored_condtions:
-                attrs[a] = getattr(self, a).isoformat()
-        for a in [STATE_ATTR_ELEVATION,
-                  STATE_ATTR_AZIMUTH]:
-            if a in self._monitored_condtions:
-                attrs[a] = round(getattr(self, a), 2)
-        for a in [STATE_ATTR_DAYLIGHT,
-                  STATE_ATTR_PREV_DAYLIGHT,
-                  STATE_ATTR_NEXT_DAYLIGHT]:
-            if a in self._monitored_condtions:
-                attrs[a] = getattr(self, a)
+        for attr in [STATE_ATTR_NEXT_DAWN,
+                     STATE_ATTR_NEXT_DUSK,
+                     STATE_ATTR_NEXT_MIDNIGHT,
+                     STATE_ATTR_NEXT_NOON,
+                     STATE_ATTR_NEXT_RISING,
+                     STATE_ATTR_NEXT_SETTING,
+                     STATE_ATTR_SUNRISE,
+                     STATE_ATTR_SUNSET]:
+            if attr in self._monitored_condtions:
+                attrs[attr] = getattr(self, attr).isoformat()
+        for attr in [STATE_ATTR_ELEVATION,
+                     STATE_ATTR_AZIMUTH]:
+            if attr in self._monitored_condtions:
+                attrs[attr] = round(getattr(self, attr), 2)
+        for attr in [STATE_ATTR_DAYLIGHT,
+                     STATE_ATTR_PREV_DAYLIGHT,
+                     STATE_ATTR_NEXT_DAYLIGHT]:
+            if attr in self._monitored_condtions:
+                attrs[attr] = getattr(self, attr)
         return attrs
 
     @property
@@ -157,21 +159,21 @@ class Sun(Entity):
                        getattr(self, STATE_ATTR_NEXT_SETTING)]
         # Only need to update remaining properties if they will be reported
         # in attributes.
-        for a in [STATE_ATTR_NEXT_DAWN,
-                  STATE_ATTR_NEXT_DUSK,
-                  STATE_ATTR_NEXT_MIDNIGHT,
-                  STATE_ATTR_NEXT_NOON]:
-            if a in self._monitored_condtions:
-                next_events.append(getattr(self, a))
+        for attr in [STATE_ATTR_NEXT_DAWN,
+                     STATE_ATTR_NEXT_DUSK,
+                     STATE_ATTR_NEXT_MIDNIGHT,
+                     STATE_ATTR_NEXT_NOON]:
+            if attr in self._monitored_condtions:
+                next_events.append(getattr(self, attr))
         # For sunrise, sunset and daylights, update at next "real" midnight
         # (as opposed to next_midnight, which is solar midnight.) But subtract
         # one second because point_in_time_listener() will add one.
-        if any(a in self._monitored_condtions for a in
-                (STATE_ATTR_SUNRISE, STATE_ATTR_SUNSET,
-                        STATE_ATTR_DAYLIGHT, STATE_ATTR_PREV_DAYLIGHT,
-                        STATE_ATTR_NEXT_DAYLIGHT)):
+        if any(attr in self._monitored_condtions for attr in
+               [STATE_ATTR_SUNRISE, STATE_ATTR_SUNSET,
+                STATE_ATTR_DAYLIGHT, STATE_ATTR_PREV_DAYLIGHT,
+                STATE_ATTR_NEXT_DAYLIGHT]):
             midnight = dt_util.start_of_local_day(
-                    dt_util.now() + timedelta(days=1))
+                dt_util.now() + timedelta(days=1))
             next_events.append(dt_util.as_utc(midnight) - timedelta(seconds=1))
         return min(next_events)
 
@@ -180,28 +182,31 @@ class Sun(Entity):
         """Update the attributes containing solar events."""
         # Always need to update next_rising and next_setting so state can be
         # determined.
-        for a, e in [(STATE_ATTR_NEXT_RISING, 'sunrise'),
-                     (STATE_ATTR_NEXT_SETTING, 'sunset')]:
-            setattr(self, a, get_astral_event_next(self.hass, e, utc_time))
+        for attr, event in [(STATE_ATTR_NEXT_RISING, 'sunrise'),
+                            (STATE_ATTR_NEXT_SETTING, 'sunset')]:
+            setattr(self, attr,
+                    get_astral_event_next(self.hass, event, utc_time))
         # Only need to update remaining properties if they will be reported
         # in attributes.
-        for a, e in [(STATE_ATTR_NEXT_DAWN, 'dawn'),
-                     (STATE_ATTR_NEXT_DUSK, 'dusk'),
-                     (STATE_ATTR_NEXT_MIDNIGHT, 'solar_midnight'),
-                     (STATE_ATTR_NEXT_NOON, 'solar_noon')]:
-            if a in self._monitored_condtions:
-                setattr(self, a, get_astral_event_next(self.hass, e, utc_time))
-        for a, e in [(STATE_ATTR_SUNRISE, 'sunrise'),
-                     (STATE_ATTR_SUNSET, 'sunset')]:
-            if a in self._monitored_condtions:
-                setattr(self, a, get_astral_event_date(self.hass, e, utc_time))
-        for a, d in [(STATE_ATTR_DAYLIGHT, 0),
-                     (STATE_ATTR_PREV_DAYLIGHT, -1),
-                     (STATE_ATTR_NEXT_DAYLIGHT, 1)]:
-            if a in self._monitored_condtions:
-                dl = get_astral_event_date(self.hass, 'daylight',
-                        utc_time+timedelta(days=d))
-                setattr(self, a, (dl[1]-dl[0]).total_seconds())
+        for attr, event in [(STATE_ATTR_NEXT_DAWN, 'dawn'),
+                            (STATE_ATTR_NEXT_DUSK, 'dusk'),
+                            (STATE_ATTR_NEXT_MIDNIGHT, 'solar_midnight'),
+                            (STATE_ATTR_NEXT_NOON, 'solar_noon')]:
+            if attr in self._monitored_condtions:
+                setattr(self, attr,
+                        get_astral_event_next(self.hass, event, utc_time))
+        for attr, event in [(STATE_ATTR_SUNRISE, 'sunrise'),
+                            (STATE_ATTR_SUNSET, 'sunset')]:
+            if attr in self._monitored_condtions:
+                setattr(self, attr,
+                        get_astral_event_date(self.hass, event, utc_time))
+        for attr, delta in [(STATE_ATTR_DAYLIGHT, 0),
+                            (STATE_ATTR_PREV_DAYLIGHT, -1),
+                            (STATE_ATTR_NEXT_DAYLIGHT, 1)]:
+            if attr in self._monitored_condtions:
+                daylight = get_astral_event_date(
+                    self.hass, 'daylight', utc_time+timedelta(days=delta))
+                setattr(self, attr, (daylight[1]-daylight[0]).total_seconds())
 
     @callback
     def update_sun_position(self, utc_time):

--- a/homeassistant/components/sun.py
+++ b/homeassistant/components/sun.py
@@ -7,14 +7,18 @@ https://home-assistant.io/components/sun/
 import asyncio
 import logging
 from datetime import timedelta
+import voluptuous as vol
 
-from homeassistant.const import CONF_ELEVATION
+from homeassistant.const import (CONF_ELEVATION, CONF_MONITORED_CONDITIONS,
+    CONF_SCAN_INTERVAL)
 from homeassistant.core import callback
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import (
-    async_track_point_in_utc_time, async_track_utc_time_change)
+    async_track_point_in_utc_time, async_track_utc_time_change,
+    async_track_time_interval)
 from homeassistant.helpers.sun import (
-    get_astral_location, get_astral_event_next)
+    get_astral_location, get_astral_event_next, get_astral_event_date)
 from homeassistant.util import dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
@@ -22,6 +26,8 @@ _LOGGER = logging.getLogger(__name__)
 DOMAIN = 'sun'
 
 ENTITY_ID = 'sun.sun'
+
+MIN_SCAN_INTERVAL = timedelta(minutes=1)
 
 STATE_ABOVE_HORIZON = 'above_horizon'
 STATE_BELOW_HORIZON = 'below_horizon'
@@ -34,7 +40,25 @@ STATE_ATTR_NEXT_MIDNIGHT = 'next_midnight'
 STATE_ATTR_NEXT_NOON = 'next_noon'
 STATE_ATTR_NEXT_RISING = 'next_rising'
 STATE_ATTR_NEXT_SETTING = 'next_setting'
+STATE_ATTR_SUNRISE = 'sunrise'
+STATE_ATTR_SUNSET = 'sunset'
+STATE_ATTR_DAYLIGHT = 'daylight'
+STATE_ATTR_PREV_DAYLIGHT = 'prev_daylight'
+STATE_ATTR_NEXT_DAYLIGHT = 'next_daylight'
+DEFAULT_STATE_ATTRS = [STATE_ATTR_AZIMUTH, STATE_ATTR_ELEVATION,
+    STATE_ATTR_NEXT_DAWN, STATE_ATTR_NEXT_DUSK, STATE_ATTR_NEXT_MIDNIGHT,
+    STATE_ATTR_NEXT_NOON, STATE_ATTR_NEXT_RISING, STATE_ATTR_NEXT_SETTING]
+OPTIONAL_STATE_ATTRS = [STATE_ATTR_SUNRISE, STATE_ATTR_SUNSET,
+    STATE_ATTR_DAYLIGHT, STATE_ATTR_PREV_DAYLIGHT, STATE_ATTR_NEXT_DAYLIGHT]
+STATE_ATTRS = DEFAULT_STATE_ATTRS + OPTIONAL_STATE_ATTRS
 
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Optional(CONF_MONITORED_CONDITIONS, default=DEFAULT_STATE_ATTRS):
+            vol.All(cv.ensure_list, [vol.In(STATE_ATTRS)]),
+        vol.Optional(CONF_SCAN_INTERVAL):
+            vol.All(cv.time_period, vol.Clamp(min=MIN_SCAN_INTERVAL))})},
+    extra=vol.ALLOW_EXTRA)
 
 @asyncio.coroutine
 def async_setup(hass, config):
@@ -44,7 +68,7 @@ def async_setup(hass, config):
             "Elevation is now configured in home assistant core. "
             "See https://home-assistant.io/docs/configuration/basic/")
 
-    sun = Sun(hass, get_astral_location(hass))
+    sun = Sun(hass, get_astral_location(hass), config[DOMAIN])
     sun.point_in_time_listener(dt_util.utcnow())
 
     return True
@@ -55,16 +79,33 @@ class Sun(Entity):
 
     entity_id = ENTITY_ID
 
-    def __init__(self, hass, location):
+    def __init__(self, hass, location, config):
         """Initialize the sun."""
+        self._monitored_condtions = config[CONF_MONITORED_CONDITIONS]
+        scan_interval = config.get(CONF_SCAN_INTERVAL)
         self.hass = hass
         self.location = location
-        self._state = self.next_rising = self.next_setting = None
-        self.next_dawn = self.next_dusk = None
-        self.next_midnight = self.next_noon = None
-        self.solar_elevation = self.solar_azimuth = None
+        # Initialize values for attributes to be reported.
+        for a in self._monitored_condtions:
+            setattr(self, a, None)
+        # Make sure STATE_ATTR_NEXT_RISING & STATE_ATTR_NEXT_SETTING are
+        # defined since they are used to calculate state. Initialize them.
+        setattr(self, STATE_ATTR_NEXT_RISING, None)
+        setattr(self, STATE_ATTR_NEXT_SETTING, None)
+        self._state = None
+        self._update_position = (
+            STATE_ATTR_AZIMUTH in self._monitored_condtions or
+            STATE_ATTR_ELEVATION in self._monitored_condtions)
 
-        async_track_utc_time_change(hass, self.timer_update, second=30)
+        if self._update_position:
+            if scan_interval:
+                async_track_time_interval(hass, self.timer_update,
+                                          scan_interval)
+            else:
+                # If scan_interval not specified, use old method of updating
+                # once a minute on the half minute (i.e., now == xx:xx:30.)
+                async_track_utc_time_change(hass, self.timer_update,
+                                            second=30)
 
     @property
     def name(self):
@@ -74,7 +115,8 @@ class Sun(Entity):
     @property
     def state(self):
         """Return the state of the sun."""
-        if self.next_rising > self.next_setting:
+        if (getattr(self, STATE_ATTR_NEXT_RISING) >
+                getattr(self, STATE_ATTR_NEXT_SETTING)):
             return STATE_ABOVE_HORIZON
 
         return STATE_BELOW_HORIZON
@@ -82,49 +124,95 @@ class Sun(Entity):
     @property
     def state_attributes(self):
         """Return the state attributes of the sun."""
-        return {
-            STATE_ATTR_NEXT_DAWN: self.next_dawn.isoformat(),
-            STATE_ATTR_NEXT_DUSK: self.next_dusk.isoformat(),
-            STATE_ATTR_NEXT_MIDNIGHT: self.next_midnight.isoformat(),
-            STATE_ATTR_NEXT_NOON: self.next_noon.isoformat(),
-            STATE_ATTR_NEXT_RISING: self.next_rising.isoformat(),
-            STATE_ATTR_NEXT_SETTING: self.next_setting.isoformat(),
-            STATE_ATTR_ELEVATION: round(self.solar_elevation, 2),
-            STATE_ATTR_AZIMUTH: round(self.solar_azimuth, 2)
-        }
+        attrs = {}
+        for a in [STATE_ATTR_NEXT_DAWN,
+                  STATE_ATTR_NEXT_DUSK,
+                  STATE_ATTR_NEXT_MIDNIGHT,
+                  STATE_ATTR_NEXT_NOON,
+                  STATE_ATTR_NEXT_RISING,
+                  STATE_ATTR_NEXT_SETTING,
+                  STATE_ATTR_SUNRISE,
+                  STATE_ATTR_SUNSET]:
+            if a in self._monitored_condtions:
+                attrs[a] = getattr(self, a).isoformat()
+        for a in [STATE_ATTR_ELEVATION,
+                  STATE_ATTR_AZIMUTH]:
+            if a in self._monitored_condtions:
+                attrs[a] = round(getattr(self, a), 2)
+        for a in [STATE_ATTR_DAYLIGHT,
+                  STATE_ATTR_PREV_DAYLIGHT,
+                  STATE_ATTR_NEXT_DAYLIGHT]:
+            if a in self._monitored_condtions:
+                attrs[a] = getattr(self, a)
+        return attrs
 
     @property
     def next_change(self):
         """Datetime when the next change to the state is."""
-        return min(self.next_dawn, self.next_dusk, self.next_midnight,
-                   self.next_noon, self.next_rising, self.next_setting)
+        # Always need to update next rising and next setting so state can be
+        # determined.
+        next_events = [getattr(self, STATE_ATTR_NEXT_RISING),
+                       getattr(self, STATE_ATTR_NEXT_SETTING)]
+        # Only need to update remaining properties if they will be reported
+        # in attributes.
+        for a in [STATE_ATTR_NEXT_DAWN,
+                  STATE_ATTR_NEXT_DUSK,
+                  STATE_ATTR_NEXT_MIDNIGHT,
+                  STATE_ATTR_NEXT_NOON]:
+            if a in self._monitored_condtions:
+                next_events.append(getattr(self, a))
+        # For sunrise, sunset and daylights, update at next "real" midnight
+        # (as opposed to next_midnight, which is solar midnight.) But subtract
+        # one second because point_in_time_listener() will add one.
+        if any(a in self._monitored_condtions for a in
+                   (STATE_ATTR_SUNRISE, STATE_ATTR_SUNSET,
+                    STATE_ATTR_DAYLIGHT, STATE_ATTR_PREV_DAYLIGHT,
+                    STATE_ATTR_NEXT_DAYLIGHT)):
+            next_events.append(dt_util.as_utc(dt_util.start_of_local_day(
+            dt_util.now()+timedelta(days=1))-timedelta(seconds=1)))
+        return min(next_events)
 
     @callback
-    def update_as_of(self, utc_point_in_time):
+    def update_as_of(self, utc_time):
         """Update the attributes containing solar events."""
-        self.next_dawn = get_astral_event_next(
-            self.hass, 'dawn', utc_point_in_time)
-        self.next_dusk = get_astral_event_next(
-            self.hass, 'dusk', utc_point_in_time)
-        self.next_midnight = get_astral_event_next(
-            self.hass, 'solar_midnight', utc_point_in_time)
-        self.next_noon = get_astral_event_next(
-            self.hass, 'solar_noon', utc_point_in_time)
-        self.next_rising = get_astral_event_next(
-            self.hass, 'sunrise', utc_point_in_time)
-        self.next_setting = get_astral_event_next(
-            self.hass, 'sunset', utc_point_in_time)
+        # Always need to update next_rising and next_setting so state can be
+        # determined.
+        for a, e in [(STATE_ATTR_NEXT_RISING, 'sunrise'),
+                     (STATE_ATTR_NEXT_SETTING, 'sunset')]:
+            setattr(self, a, get_astral_event_next(self.hass, e, utc_time))
+        # Only need to update remaining properties if they will be reported
+        # in attributes.
+        for a, e in [(STATE_ATTR_NEXT_DAWN, 'dawn'),
+                     (STATE_ATTR_NEXT_DUSK, 'dusk'),
+                     (STATE_ATTR_NEXT_MIDNIGHT, 'solar_midnight'),
+                     (STATE_ATTR_NEXT_NOON, 'solar_noon')]:
+            if a in self._monitored_condtions:
+                setattr(self, a, get_astral_event_next(self.hass, e, utc_time))
+        for a, e in [(STATE_ATTR_SUNRISE, 'sunrise'),
+                     (STATE_ATTR_SUNSET, 'sunset')]:
+            if a in self._monitored_condtions:
+                setattr(self, a, get_astral_event_date(self.hass, e, utc_time))
+        for a, d in [(STATE_ATTR_DAYLIGHT, 0),
+                     (STATE_ATTR_PREV_DAYLIGHT, -1),
+                     (STATE_ATTR_NEXT_DAYLIGHT, 1)]:
+            if a in self._monitored_condtions:
+                dl = get_astral_event_date(self.hass, 'daylight',
+                    utc_time+timedelta(days=d))
+                setattr(self, a, (dl[1]-dl[0]).total_seconds())
 
     @callback
-    def update_sun_position(self, utc_point_in_time):
+    def update_sun_position(self, utc_time):
         """Calculate the position of the sun."""
-        self.solar_azimuth = self.location.solar_azimuth(utc_point_in_time)
-        self.solar_elevation = self.location.solar_elevation(utc_point_in_time)
+        setattr(self, STATE_ATTR_AZIMUTH,
+            self.location.solar_azimuth(utc_time))
+        setattr(self, STATE_ATTR_ELEVATION,
+            self.location.solar_elevation(utc_time))
 
     @callback
     def point_in_time_listener(self, now):
         """Run when the state of the sun has changed."""
-        self.update_sun_position(now)
+        if self._update_position:
+            self.update_sun_position(now)
         self.update_as_of(now)
         self.async_schedule_update_ha_state()
 

--- a/homeassistant/components/sun.py
+++ b/homeassistant/components/sun.py
@@ -60,7 +60,7 @@ CONFIG_SCHEMA = vol.Schema({
             vol.All(cv.ensure_list, [vol.In(STATE_ATTRS)]),
         vol.Optional(CONF_SCAN_INTERVAL):
             vol.All(cv.time_period, vol.Clamp(min=MIN_SCAN_INTERVAL))
-        })
+        }, extra=vol.ALLOW_EXTRA)
 }, extra=vol.ALLOW_EXTRA)
 
 

--- a/homeassistant/components/sun.py
+++ b/homeassistant/components/sun.py
@@ -10,7 +10,7 @@ from datetime import timedelta
 import voluptuous as vol
 
 from homeassistant.const import (CONF_ELEVATION, CONF_MONITORED_CONDITIONS,
-    CONF_SCAN_INTERVAL)
+        CONF_SCAN_INTERVAL)
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
@@ -46,10 +46,11 @@ STATE_ATTR_DAYLIGHT = 'daylight'
 STATE_ATTR_PREV_DAYLIGHT = 'prev_daylight'
 STATE_ATTR_NEXT_DAYLIGHT = 'next_daylight'
 DEFAULT_STATE_ATTRS = [STATE_ATTR_AZIMUTH, STATE_ATTR_ELEVATION,
-    STATE_ATTR_NEXT_DAWN, STATE_ATTR_NEXT_DUSK, STATE_ATTR_NEXT_MIDNIGHT,
-    STATE_ATTR_NEXT_NOON, STATE_ATTR_NEXT_RISING, STATE_ATTR_NEXT_SETTING]
+        STATE_ATTR_NEXT_DAWN, STATE_ATTR_NEXT_DUSK, STATE_ATTR_NEXT_MIDNIGHT,
+        STATE_ATTR_NEXT_NOON, STATE_ATTR_NEXT_RISING, STATE_ATTR_NEXT_SETTING]
 OPTIONAL_STATE_ATTRS = [STATE_ATTR_SUNRISE, STATE_ATTR_SUNSET,
-    STATE_ATTR_DAYLIGHT, STATE_ATTR_PREV_DAYLIGHT, STATE_ATTR_NEXT_DAYLIGHT]
+        STATE_ATTR_DAYLIGHT, STATE_ATTR_PREV_DAYLIGHT,
+        STATE_ATTR_NEXT_DAYLIGHT]
 STATE_ATTRS = DEFAULT_STATE_ATTRS + OPTIONAL_STATE_ATTRS
 
 CONFIG_SCHEMA = vol.Schema({
@@ -59,6 +60,7 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(CONF_SCAN_INTERVAL):
             vol.All(cv.time_period, vol.Clamp(min=MIN_SCAN_INTERVAL))})},
     extra=vol.ALLOW_EXTRA)
+
 
 @asyncio.coroutine
 def async_setup(hass, config):
@@ -165,11 +167,12 @@ class Sun(Entity):
         # (as opposed to next_midnight, which is solar midnight.) But subtract
         # one second because point_in_time_listener() will add one.
         if any(a in self._monitored_condtions for a in
-                   (STATE_ATTR_SUNRISE, STATE_ATTR_SUNSET,
-                    STATE_ATTR_DAYLIGHT, STATE_ATTR_PREV_DAYLIGHT,
-                    STATE_ATTR_NEXT_DAYLIGHT)):
-            next_events.append(dt_util.as_utc(dt_util.start_of_local_day(
-            dt_util.now()+timedelta(days=1))-timedelta(seconds=1)))
+                (STATE_ATTR_SUNRISE, STATE_ATTR_SUNSET,
+                        STATE_ATTR_DAYLIGHT, STATE_ATTR_PREV_DAYLIGHT,
+                        STATE_ATTR_NEXT_DAYLIGHT)):
+            midnight = dt_util.start_of_local_day(
+                    dt_util.now() + timedelta(days=1))
+            next_events.append(dt_util.as_utc(midnight) - timedelta(seconds=1))
         return min(next_events)
 
     @callback
@@ -197,16 +200,16 @@ class Sun(Entity):
                      (STATE_ATTR_NEXT_DAYLIGHT, 1)]:
             if a in self._monitored_condtions:
                 dl = get_astral_event_date(self.hass, 'daylight',
-                    utc_time+timedelta(days=d))
+                        utc_time+timedelta(days=d))
                 setattr(self, a, (dl[1]-dl[0]).total_seconds())
 
     @callback
     def update_sun_position(self, utc_time):
         """Calculate the position of the sun."""
         setattr(self, STATE_ATTR_AZIMUTH,
-            self.location.solar_azimuth(utc_time))
+                self.location.solar_azimuth(utc_time))
         setattr(self, STATE_ATTR_ELEVATION,
-            self.location.solar_elevation(utc_time))
+                self.location.solar_elevation(utc_time))
 
     @callback
     def point_in_time_listener(self, now):


### PR DESCRIPTION
## Description:
This pull request proposes some useful enhancements to the sun component. Without any configuration changes the new component will function exactly as the current component, so it is fully backward compatible, and hence is not a "breaking change."

The first change is to add some new, optional attributes - specifically daylight, next_daylight, prev_daylight, sunrise and sunset.

The sunrise and sunset attributes are particularly useful for paralleling the existing sun conditions in template code. Unfortunately the existing next_rising and next_setting attributes do not work well in this scenario because they change as soon as sunrise and sunset are passed, respectively. The new attributes stay constant throughout the day (only updating at midnight local), so they can be used effectively in templates.

The next change allows optional selection of which attributes the sun component maintains via a new monitored_conditions configuration parameter. The default is to maintain the original set of attributes. Since the component must update at each maintained attribute/event, if only a subset of the attributes are of interest to the user, there is really no need to take time to update the component for a data point the user does not use. This can be particularly useful if the user does not use or need azimuth and elevation, since these attributes are updated every minute.

Which leads to the next change, the addition of an optional scan_interval configuration parameter. If azimuth and/or elevation are being used, then this parameter controls how often they are updated. The default is to implement the existing behavior. If specified the rate at which these attributes are updated can be reduced, resulting in a potentially significant reduction in corresponding state_changed events. Of course, if azimuth and elevation are not used or needed, then all of the corresponding, frequent updates can be eliminated entirely.

To these ends the following, specific changes were implemented:

Add monitored_conditions config item to specify which attributes to maintain. (next_rising and next_setting will always be maintained.) If monitored_conditions is not specified then original set of attributes will be maintained. For elevation and azimuth, add scan_interval (minimum of one minute.) Add optional new attributes daylight, next_daylight, prev_daylight, sunrise & sunset, all of which will be updated at midnight local.

Additional background and discussion can be found [here](https://community.home-assistant.io/t/hours-of-daylight/59422) and [here](https://community.home-assistant.io/t/sensor-sunrise-and-sensor-sunset-in-sync-for-todays-date/63191/2).

**Related issue (if applicable):** none

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#6053

## Example entry for `configuration.yaml` (if applicable):
```yaml
sun:
  monitored_conditions:
    - elevation
    - sunrise
    - sunset
  scan_interval:
    minutes: 10
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
