### PR TITLE
Pin crypto

### DIFF
--- a/homeassistant/components/notify/html5.py
+++ b/homeassistant/components/notify/html5.py
@@ -26,7 +26,7 @@ from homeassistant.const import (
 from homeassistant.helpers import config_validation as cv
 from homeassistant.util import ensure_unique_string
 
-REQUIREMENTS = ['pywebpush==1.6.0', 'PyJWT==1.6.0']
+REQUIREMENTS = ['pywebpush==1.6.0']
 
 DEPENDENCIES = ['frontend']
 

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -5,6 +5,7 @@ attrs==18.1.0
 certifi>=2018.04.16
 jinja2>=2.10
 PyJWT==1.6.4
+cryptography==2.3.1
 pip>=8.0.3
 pytz>=2018.04
 pyyaml>=3.13,<4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -6,6 +6,7 @@ attrs==18.1.0
 certifi>=2018.04.16
 jinja2>=2.10
 PyJWT==1.6.4
+cryptography==2.3.1
 pip>=8.0.3
 pytz>=2018.04
 pyyaml>=3.13,<4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -40,9 +40,6 @@ Mastodon.py==1.3.1
 # homeassistant.components.isy994
 PyISY==1.1.0
 
-# homeassistant.components.notify.html5
-PyJWT==1.6.0
-
 # homeassistant.components.sensor.mvglive
 PyMVGLive==1.1.4
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -21,9 +21,6 @@ requests_mock==1.5.2
 # homeassistant.components.homekit
 HAP-python==2.2.2
 
-# homeassistant.components.notify.html5
-PyJWT==1.6.0
-
 # homeassistant.components.sensor.rmvtransport
 PyRMVtransport==0.0.7
 

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,8 @@ REQUIRES = [
     'certifi>=2018.04.16',
     'jinja2>=2.10',
     'PyJWT==1.6.4',
+    # PyJWT has loose dependency. We want the latest one.
+    'cryptography==2.3.1',
     'pip>=8.0.3',
     'pytz>=2018.04',
     'pyyaml>=3.13,<4',


### PR DESCRIPTION
## Description:
From comment by @pvizeli 

We should pin `cryptography` so that PyJWT loose dependency can't break all of a sudden.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
