### PR TITLE
Tweak MQTT error message for 0.76 release

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -354,11 +354,11 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
         if (conf.get(CONF_PASSWORD) is None and
                 config.get('http') is not None and
                 config['http'].get('api_password') is not None):
-            _LOGGER.error("Starting from 0.77, embedded MQTT broker doesn't"
-                          " use api_password as default password any more."
-                          " Please set password configuration. See https://"
-                          "home-assistant.io/docs/mqtt/broker#embedded-broker"
-                          " for details")
+            _LOGGER.error(
+                "Starting from release 0.76, the embedded MQTT broker does not"
+                " use api_password as default password anymore. Please set"
+                " password configuration. See https://home-assistant.io/docs/"
+                "mqtt/broker#embedded-broker for details")
             return False
 
         broker_config = await _async_setup_server(hass, config)


### PR DESCRIPTION
## Description:
#15929 backport to 0.76 release, need update error message

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#6020

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

