### PR TITLE
Fix 0.76 beta2 hassio token issue

### DIFF
--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -178,7 +178,7 @@ def async_setup(hass, config):
     refresh_token = None
     if 'hassio_user' in data:
         user = yield from hass.auth.async_get_user(data['hassio_user'])
-        if user:
+        if user and user.refresh_tokens:
             refresh_token = list(user.refresh_tokens.values())[0]
 
     if refresh_token is None:


### PR DESCRIPTION
## Description:

Since we invalid all refresh token issued before 0.76 beta2, hassio user's refresh token will be missing.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

