### PR TITLE
Add recent context

### DIFF
--- a/homeassistant/components/alert.py
+++ b/homeassistant/components/alert.py
@@ -111,6 +111,7 @@ def async_setup(hass, config):
 
         for alert_id in alert_ids:
             alert = all_alerts[alert_id]
+            alert.async_set_context(service_call.context)
             if service_call.service == SERVICE_TURN_ON:
                 yield from alert.async_turn_on()
             elif service_call.service == SERVICE_TOGGLE:

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -345,6 +345,8 @@ async def async_setup(hass, config):
 
         update_tasks = []
         for light in target_lights:
+            light.async_set_context(service.context)
+
             pars = params
             if not pars:
                 pars = params.copy()
@@ -356,7 +358,7 @@ async def async_setup(hass, config):
                 continue
 
             update_tasks.append(
-                light.async_update_ha_state(True, service.context))
+                light.async_update_ha_state(True))
 
         if update_tasks:
             await asyncio.wait(update_tasks, loop=hass.loop)

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -218,13 +218,15 @@ async def _handle_service_platform_call(func, data, entities, context):
         if not entity.available:
             continue
 
+        entity.async_set_context(context)
+
         if isinstance(func, str):
             await getattr(entity, func)(**data)
         else:
             await func(entity, data)
 
         if entity.should_poll:
-            tasks.append(entity.async_update_ha_state(True, context))
+            tasks.append(entity.async_update_ha_state(True))
 
     if tasks:
         await asyncio.wait(tasks)

--- a/tests/components/test_input_boolean.py
+++ b/tests/components/test_input_boolean.py
@@ -4,7 +4,7 @@ import asyncio
 import unittest
 import logging
 
-from homeassistant.core import CoreState, State
+from homeassistant.core import CoreState, State, Context
 from homeassistant.setup import setup_component, async_setup_component
 from homeassistant.components.input_boolean import (
     DOMAIN, is_on, toggle, turn_off, turn_on, CONF_INITIAL)
@@ -158,3 +158,24 @@ def test_initial_state_overrules_restore_state(hass):
     state = hass.states.get('input_boolean.b2')
     assert state
     assert state.state == 'on'
+
+
+async def test_input_boolean_context(hass):
+    """Test that input_boolean context works."""
+    assert await async_setup_component(hass, 'input_boolean', {
+        'input_boolean': {
+            'ac': {CONF_INITIAL: True},
+        }
+    })
+
+    state = hass.states.get('input_boolean.ac')
+    assert state is not None
+
+    await hass.services.async_call('input_boolean', 'turn_off', {
+        'entity_id': state.entity_id,
+    }, True, Context(user_id='abcd'))
+
+    state2 = hass.states.get('input_boolean.ac')
+    assert state2 is not None
+    assert state.state != state2.state
+    assert state2.context.user_id == 'abcd'

--- a/tests/components/test_input_datetime.py
+++ b/tests/components/test_input_datetime.py
@@ -4,7 +4,7 @@ import asyncio
 import unittest
 import datetime
 
-from homeassistant.core import CoreState, State
+from homeassistant.core import CoreState, State, Context
 from homeassistant.setup import setup_component, async_setup_component
 from homeassistant.components.input_datetime import (
     DOMAIN, ATTR_ENTITY_ID, ATTR_DATE, ATTR_TIME, SERVICE_SET_DATETIME)
@@ -208,3 +208,27 @@ def test_restore_state(hass):
 
     state_bogus = hass.states.get('input_datetime.test_bogus_data')
     assert state_bogus.state == str(initial)
+
+
+async def test_input_datetime_context(hass):
+    """Test that input_datetime context works."""
+    assert await async_setup_component(hass, 'input_datetime', {
+        'input_datetime': {
+            'only_date': {
+                'has_date': True,
+            }
+        }
+    })
+
+    state = hass.states.get('input_datetime.only_date')
+    assert state is not None
+
+    await hass.services.async_call('input_datetime', 'set_datetime', {
+        'entity_id': state.entity_id,
+        'date': '2018-01-02'
+    }, True, Context(user_id='abcd'))
+
+    state2 = hass.states.get('input_datetime.only_date')
+    assert state2 is not None
+    assert state.state != state2.state
+    assert state2.context.user_id == 'abcd'

--- a/tests/components/test_input_number.py
+++ b/tests/components/test_input_number.py
@@ -3,7 +3,7 @@
 import asyncio
 import unittest
 
-from homeassistant.core import CoreState, State
+from homeassistant.core import CoreState, State, Context
 from homeassistant.setup import setup_component, async_setup_component
 from homeassistant.components.input_number import (
     DOMAIN, set_value, increment, decrement)
@@ -236,3 +236,27 @@ def test_no_initial_state_and_no_restore_state(hass):
     state = hass.states.get('input_number.b1')
     assert state
     assert float(state.state) == 0
+
+
+async def test_input_number_context(hass):
+    """Test that input_number context works."""
+    assert await async_setup_component(hass, 'input_number', {
+        'input_number': {
+            'b1': {
+                'min': 0,
+                'max': 100,
+            },
+        }
+    })
+
+    state = hass.states.get('input_number.b1')
+    assert state is not None
+
+    await hass.services.async_call('input_number', 'increment', {
+        'entity_id': state.entity_id,
+    }, True, Context(user_id='abcd'))
+
+    state2 = hass.states.get('input_number.b1')
+    assert state2 is not None
+    assert state.state != state2.state
+    assert state2.context.user_id == 'abcd'

--- a/tests/components/test_input_select.py
+++ b/tests/components/test_input_select.py
@@ -5,7 +5,7 @@ import unittest
 
 from tests.common import get_test_home_assistant, mock_restore_cache
 
-from homeassistant.core import State
+from homeassistant.core import State, Context
 from homeassistant.setup import setup_component, async_setup_component
 from homeassistant.components.input_select import (
     ATTR_OPTIONS, DOMAIN, SERVICE_SET_OPTIONS,
@@ -276,3 +276,30 @@ def test_initial_state_overrules_restore_state(hass):
     state = hass.states.get('input_select.s2')
     assert state
     assert state.state == 'middle option'
+
+
+async def test_input_select_context(hass):
+    """Test that input_select context works."""
+    assert await async_setup_component(hass, 'input_select', {
+        'input_select': {
+            's1': {
+                'options': [
+                    'first option',
+                    'middle option',
+                    'last option',
+                ],
+            }
+        }
+    })
+
+    state = hass.states.get('input_select.s1')
+    assert state is not None
+
+    await hass.services.async_call('input_select', 'select_next', {
+        'entity_id': state.entity_id,
+    }, True, Context(user_id='abcd'))
+
+    state2 = hass.states.get('input_select.s1')
+    assert state2 is not None
+    assert state.state != state2.state
+    assert state2.context.user_id == 'abcd'

--- a/tests/components/test_input_text.py
+++ b/tests/components/test_input_text.py
@@ -3,7 +3,7 @@
 import asyncio
 import unittest
 
-from homeassistant.core import CoreState, State
+from homeassistant.core import CoreState, State, Context
 from homeassistant.setup import setup_component, async_setup_component
 from homeassistant.components.input_text import (DOMAIN, set_value)
 
@@ -180,3 +180,27 @@ def test_no_initial_state_and_no_restore_state(hass):
     state = hass.states.get('input_text.b1')
     assert state
     assert str(state.state) == 'unknown'
+
+
+async def test_input_text_context(hass):
+    """Test that input_text context works."""
+    assert await async_setup_component(hass, 'input_text', {
+        'input_text': {
+            't1': {
+                'initial': 'bla',
+            }
+        }
+    })
+
+    state = hass.states.get('input_text.t1')
+    assert state is not None
+
+    await hass.services.async_call('input_text', 'set_value', {
+        'entity_id': state.entity_id,
+        'value': 'new_value',
+    }, True, Context(user_id='abcd'))
+
+    state2 = hass.states.get('input_text.t1')
+    assert state2 is not None
+    assert state.state != state2.state
+    assert state2.context.user_id == 'abcd'

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -1,11 +1,13 @@
 """Test the entity helper."""
 # pylint: disable=protected-access
 import asyncio
-from unittest.mock import MagicMock, patch
+from datetime import timedelta
+from unittest.mock import MagicMock, patch, PropertyMock
 
 import pytest
 
 import homeassistant.helpers.entity as entity
+from homeassistant.core import Context
 from homeassistant.const import ATTR_HIDDEN, ATTR_DEVICE_CLASS
 from homeassistant.config import DATA_CUSTOMIZE
 from homeassistant.helpers.entity_values import EntityValues
@@ -412,3 +414,32 @@ async def test_async_remove_runs_callbacks(hass):
     ent.async_on_remove(lambda: result.append(1))
     await ent.async_remove()
     assert len(result) == 1
+
+
+async def test_set_context(hass):
+    """Test setting context."""
+    context = Context()
+    ent = entity.Entity()
+    ent.hass = hass
+    ent.entity_id = 'hello.world'
+    ent.async_set_context(context)
+    await ent.async_update_ha_state()
+    assert hass.states.get('hello.world').context == context
+
+
+async def test_set_context_expired(hass):
+    """Test setting context."""
+    context = Context()
+
+    with patch.object(entity.Entity, 'context_recent_time',
+                      new_callable=PropertyMock) as recent:
+        recent.return_value = timedelta(seconds=-5)
+        ent = entity.Entity()
+        ent.hass = hass
+        ent.entity_id = 'hello.world'
+        ent.async_set_context(context)
+        await ent.async_update_ha_state()
+
+    assert hass.states.get('hello.world').context != context
+    assert ent._context is None
+    assert ent._context_set is None


### PR DESCRIPTION
## Description:
This adds a recent context to entities as discussed in https://github.com/home-assistant/architecture/issues/53

This way we'll be able to attribute state changes to the people or automation that triggered it.

~~Marked WIP as I first am going to create abstraction to handle services for entities. It's a copy paste fest and I have an idea to make it faster~~ #15991 has made this PR super easy. #15998 made it even easier.

**Related issue (if applicable):** fixes https://github.com/home-assistant/architecture/issues/53

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
