### PR TITLE
BMW Connected drive: option to disable the services

### DIFF
--- a/homeassistant/components/bmw_connected_drive/__init__.py
+++ b/homeassistant/components/bmw_connected_drive/__init__.py
@@ -20,8 +20,7 @@ _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = 'bmw_connected_drive'
 CONF_REGION = 'region'
-CONF_ENABLE_SERVICES = 'serviceenabled'
-
+CONF_ENABLE_SERVICES = 'services'
 ATTR_VIN = 'vin'
 
 ACCOUNT_SCHEMA = vol.Schema({
@@ -85,10 +84,9 @@ def setup_account(account_config: dict, hass, name: str) \
     username = account_config[CONF_USERNAME]
     password = account_config[CONF_PASSWORD]
     region = account_config[CONF_REGION]
-    services_enabled = account_config[CONF_ENABLE_SERVICES]
-		
+    enable_services = account_config[CONF_ENABLE_SERVICES]
     _LOGGER.debug('Adding new account %s', name)
-    cd_account = BMWConnectedDriveAccount(username, password, region, name,services_enabled)
+    cd_account = BMWConnectedDriveAccount(username, password, region, name,enable_services)
 
     def execute_service(call):
         """Execute a service for a vehicle.
@@ -104,7 +102,7 @@ def setup_account(account_config: dict, hass, name: str) \
         function_name = _SERVICE_MAP[call.service]
         function_call = getattr(vehicle.remote_services, function_name)
         function_call()
-    if services_enabled:
+    if enable_services:
         # register the remote services
         for service in _SERVICE_MAP:
             hass.services.register(
@@ -127,14 +125,14 @@ class BMWConnectedDriveAccount:
     """Representation of a BMW vehicle."""
 
     def __init__(self, username: str, password: str, region_str: str,
-                 name: str, services_enabled=True) -> None:
+                 name: str, enable_services=True) -> None:
         """Constructor."""
         from bimmer_connected.account import ConnectedDriveAccount
         from bimmer_connected.country_selector import get_region_from_name
 
         region = get_region_from_name(region_str)
 
-        self.services_enabled = services_enabled
+        self.enable_services = enable_services
         self.account = ConnectedDriveAccount(username, password, region)
         self.name = name
         self._update_listeners = []

--- a/homeassistant/components/bmw_connected_drive/__init__.py
+++ b/homeassistant/components/bmw_connected_drive/__init__.py
@@ -86,7 +86,7 @@ def setup_account(account_config: dict, hass, name: str) \
     region = account_config[CONF_REGION]
     enable_services = account_config[CONF_ENABLE_SERVICES]
     _LOGGER.debug('Adding new account %s', name)
-    cd_account = BMWConnectedDriveAccount(username, password, region, name, 
+    cd_account = BMWConnectedDriveAccount(username, password, region, name,
                                           enable_services)
 
     def execute_service(call):

--- a/homeassistant/components/bmw_connected_drive/__init__.py
+++ b/homeassistant/components/bmw_connected_drive/__init__.py
@@ -86,7 +86,7 @@ def setup_account(account_config: dict, hass, name: str) \
     region = account_config[CONF_REGION]
     enable_services = account_config[CONF_ENABLE_SERVICES]
     _LOGGER.debug('Adding new account %s', name)
-    cd_account = BMWConnectedDriveAccount(username, password, region, name,enable_services)
+    cd_account = BMWConnectedDriveAccount(username, password, region, name, enable_services)
 
     def execute_service(call):
         """Execute a service for a vehicle.

--- a/homeassistant/components/bmw_connected_drive/__init__.py
+++ b/homeassistant/components/bmw_connected_drive/__init__.py
@@ -20,6 +20,8 @@ _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = 'bmw_connected_drive'
 CONF_REGION = 'region'
+CONF_ENABLE_SERVICES = 'serviceenabled'
+
 ATTR_VIN = 'vin'
 
 ACCOUNT_SCHEMA = vol.Schema({
@@ -27,6 +29,7 @@ ACCOUNT_SCHEMA = vol.Schema({
     vol.Required(CONF_PASSWORD): cv.string,
     vol.Required(CONF_REGION): vol.Any('north_america', 'china',
                                        'rest_of_world'),
+    vol.Optional(CONF_ENABLE_SERVICES, default=True): cv.boolean,
 })
 
 CONFIG_SCHEMA = vol.Schema({
@@ -82,8 +85,10 @@ def setup_account(account_config: dict, hass, name: str) \
     username = account_config[CONF_USERNAME]
     password = account_config[CONF_PASSWORD]
     region = account_config[CONF_REGION]
+    services_enabled = account_config[CONF_ENABLE_SERVICES]
+		
     _LOGGER.debug('Adding new account %s', name)
-    cd_account = BMWConnectedDriveAccount(username, password, region, name)
+    cd_account = BMWConnectedDriveAccount(username, password, region, name,services_enabled)
 
     def execute_service(call):
         """Execute a service for a vehicle.
@@ -99,13 +104,13 @@ def setup_account(account_config: dict, hass, name: str) \
         function_name = _SERVICE_MAP[call.service]
         function_call = getattr(vehicle.remote_services, function_name)
         function_call()
-
-    # register the remote services
-    for service in _SERVICE_MAP:
-        hass.services.register(
-            DOMAIN, service,
-            execute_service,
-            schema=SERVICE_SCHEMA)
+    if services_enabled:
+        # register the remote services
+        for service in _SERVICE_MAP:
+            hass.services.register(
+                DOMAIN, service,
+                execute_service,
+                schema=SERVICE_SCHEMA)
 
     # update every UPDATE_INTERVAL minutes, starting now
     # this should even out the load on the servers
@@ -122,13 +127,14 @@ class BMWConnectedDriveAccount:
     """Representation of a BMW vehicle."""
 
     def __init__(self, username: str, password: str, region_str: str,
-                 name: str) -> None:
+                 name: str, services_enabled=True) -> None:
         """Constructor."""
         from bimmer_connected.account import ConnectedDriveAccount
         from bimmer_connected.country_selector import get_region_from_name
 
         region = get_region_from_name(region_str)
 
+        self.services_enabled = services_enabled
         self.account = ConnectedDriveAccount(username, password, region)
         self.name = name
         self._update_listeners = []

--- a/homeassistant/components/bmw_connected_drive/__init__.py
+++ b/homeassistant/components/bmw_connected_drive/__init__.py
@@ -86,7 +86,8 @@ def setup_account(account_config: dict, hass, name: str) \
     region = account_config[CONF_REGION]
     enable_services = account_config[CONF_ENABLE_SERVICES]
     _LOGGER.debug('Adding new account %s', name)
-    cd_account = BMWConnectedDriveAccount(username, password, region, name, enable_services)
+    cd_account = BMWConnectedDriveAccount(username, password, region, name,
+                                       enable_services)
 
     def execute_service(call):
         """Execute a service for a vehicle.

--- a/homeassistant/components/bmw_connected_drive/__init__.py
+++ b/homeassistant/components/bmw_connected_drive/__init__.py
@@ -85,7 +85,6 @@ def setup_account(account_config: dict, hass, name: str) \
     password = account_config[CONF_PASSWORD]
     region = account_config[CONF_REGION]
     enable_services = account_config[CONF_ENABLE_SERVICES]
-    
     _LOGGER.debug('Adding new account %s', name)
     cd_account = BMWConnectedDriveAccount(username, password, region, name,enable_services)
 

--- a/homeassistant/components/bmw_connected_drive/__init__.py
+++ b/homeassistant/components/bmw_connected_drive/__init__.py
@@ -86,8 +86,8 @@ def setup_account(account_config: dict, hass, name: str) \
     region = account_config[CONF_REGION]
     enable_services = account_config[CONF_ENABLE_SERVICES]
     _LOGGER.debug('Adding new account %s', name)
-    cd_account = BMWConnectedDriveAccount(username, password, region, name,
-                                       enable_services)
+    cd_account = BMWConnectedDriveAccount(username, password, region, name, 
+                                          enable_services)
 
     def execute_service(call):
         """Execute a service for a vehicle.

--- a/homeassistant/components/bmw_connected_drive/__init__.py
+++ b/homeassistant/components/bmw_connected_drive/__init__.py
@@ -85,6 +85,7 @@ def setup_account(account_config: dict, hass, name: str) \
     password = account_config[CONF_PASSWORD]
     region = account_config[CONF_REGION]
     enable_services = account_config[CONF_ENABLE_SERVICES]
+    
     _LOGGER.debug('Adding new account %s', name)
     cd_account = BMWConnectedDriveAccount(username, password, region, name,enable_services)
 

--- a/homeassistant/components/lock/bmw_connected_drive.py
+++ b/homeassistant/components/lock/bmw_connected_drive.py
@@ -23,7 +23,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                   ', '.join([a.name for a in accounts]))
     devices = []
     for account in accounts:
-        if account.enable_services:
+        if not account.read_only:
             for vehicle in account.account.vehicles:
                 device = BMWLock(account, vehicle, 'lock', 'BMW lock')
                 devices.append(device)

--- a/homeassistant/components/lock/bmw_connected_drive.py
+++ b/homeassistant/components/lock/bmw_connected_drive.py
@@ -23,7 +23,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                   ', '.join([a.name for a in accounts]))
     devices = []
     for account in accounts:
-        if account.services_enabled:
+        if account.enable_services:
             for vehicle in account.account.vehicles:
                 device = BMWLock(account, vehicle, 'lock', 'BMW lock')
                 devices.append(device)

--- a/homeassistant/components/lock/bmw_connected_drive.py
+++ b/homeassistant/components/lock/bmw_connected_drive.py
@@ -23,9 +23,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
                   ', '.join([a.name for a in accounts]))
     devices = []
     for account in accounts:
-        for vehicle in account.account.vehicles:
-            device = BMWLock(account, vehicle, 'lock', 'BMW lock')
-            devices.append(device)
+        if account.services_enabled:
+            for vehicle in account.account.vehicles:
+                device = BMWLock(account, vehicle, 'lock', 'BMW lock')
+                devices.append(device)
     add_devices(devices, True)
 
 


### PR DESCRIPTION
## Description:
I dont want to expose the services of my car to HA. The services"light turn on", "unlock" etc. should be disabled for security reasons. This PR adds an option to disable the services and lock

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#6024

## Example entry for `configuration.yaml` (if applicable):
```yaml
bmw_connected_drive:
  name:
    username: !secret bmw_username
    password: !secret bmw_password
    region: !secret bmw_region
    services: false
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
