### PR TITLE
Nest: Fix doing async from sync

### DIFF
--- a/homeassistant/components/nest/__init__.py
+++ b/homeassistant/components/nest/__init__.py
@@ -4,10 +4,10 @@ Support for Nest devices.
 For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/nest/
 """
-from concurrent.futures import ThreadPoolExecutor
 import logging
 import socket
 from datetime import datetime, timedelta
+import threading
 
 import voluptuous as vol
 
@@ -16,8 +16,9 @@ from homeassistant.const import (
     CONF_STRUCTURE, CONF_FILENAME, CONF_BINARY_SENSORS, CONF_SENSORS,
     CONF_MONITORED_CONDITIONS,
     EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP)
+from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.dispatcher import async_dispatcher_send, \
+from homeassistant.helpers.dispatcher import dispatcher_send, \
     async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
 
@@ -71,24 +72,25 @@ CONFIG_SCHEMA = vol.Schema({
 }, extra=vol.ALLOW_EXTRA)
 
 
-async def async_nest_update_event_broker(hass, nest):
+def nest_update_event_broker(hass, nest):
     """
     Dispatch SIGNAL_NEST_UPDATE to devices when nest stream API received data.
 
-    nest.update_event.wait will block the thread in most of time,
-    so specific an executor to save default thread pool.
+    Runs in its own thread.
     """
     _LOGGER.debug("listening nest.update_event")
-    with ThreadPoolExecutor(max_workers=1) as executor:
-        while True:
-            await hass.loop.run_in_executor(executor, nest.update_event.wait)
-            if hass.is_running:
-                nest.update_event.clear()
-                _LOGGER.debug("dispatching nest data update")
-                async_dispatcher_send(hass, SIGNAL_NEST_UPDATE)
-            else:
-                _LOGGER.debug("stop listening nest.update_event")
-                return
+
+    while hass.is_running:
+        nest.update_event.wait()
+
+        if not hass.is_running:
+            break
+
+        nest.update_event.clear()
+        _LOGGER.debug("dispatching nest data update")
+        dispatcher_send(hass, SIGNAL_NEST_UPDATE)
+
+    _LOGGER.debug("stop listening nest.update_event")
 
 
 async def async_setup(hass, config):
@@ -167,16 +169,21 @@ async def async_setup_entry(hass, entry):
     hass.services.async_register(
         DOMAIN, 'set_mode', set_mode, schema=AWAY_SCHEMA)
 
+    @callback
     def start_up(event):
         """Start Nest update event listener."""
-        hass.async_add_job(async_nest_update_event_broker, hass, nest)
+        threading.Thread(
+            name='Nest update listener',
+            target=nest_update_event_broker,
+            args=(hass, nest)
+        ).start()
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, start_up)
 
+    @callback
     def shut_down(event):
         """Stop Nest update event listener."""
-        if nest:
-            nest.update_event.set()
+        nest.update_event.set()
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, shut_down)
 


### PR DESCRIPTION
## Description:
Nest was calling an async method from a sync context. This fixes it.

Instead of creating an executor pool, I also tweaked it to just use a thread. Less overhead.

I'm also a bit surprised that this didn't used to block startup as it creates a task in the startup phase, which means that it will be caught in the `async_block_till_done()` that we execute in that phase. People using Nest should have seen this error:

> Something is blocking Home Assistant from wrapping up the startup phase.

That issue has been fixed now.

However, I do see a very slow redirect from Nest to their actual stream endpoint. And as this happens during setup, it slows all of startup. 

```
2018-08-16 10:55:38 DEBUG (SyncWorker_3) [nest.nest] >> STREAM https://developer-api.nest.com/
                    …ALMOST A MINUTE PASSES…
2018-08-16 10:56:40 DEBUG (SyncWorker_3) [nest.nest] << 307
2018-08-16 10:56:40 DEBUG (SyncWorker_3) [nest.nest] >> STREAM https://firebase-apiserver29-tah01-iad01.dapi.production.nest.com:9553/
2018-08-16 10:57:40 DEBUG (SyncWorker_3) [nest.nest] << 200
```

CC @awarecan 

**Related issue (if applicable):** https://github.com/home-assistant/home-assistant/issues/13494#issuecomment-413406157

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
