### PR TITLE
Fix message: `Updating dlna_dmr media_player took longer than the scheduled update interval 0:00:10`

### DIFF
--- a/homeassistant/components/media_player/dlna_dmr.py
+++ b/homeassistant/components/media_player/dlna_dmr.py
@@ -35,7 +35,7 @@ from homeassistant.util import get_local_ip
 DLNA_DMR_DATA = 'dlna_dmr'
 
 REQUIREMENTS = [
-    'async-upnp-client==0.12.2',
+    'async-upnp-client==0.12.3',
 ]
 
 DEFAULT_NAME = 'DLNA Digital Media Renderer'
@@ -126,7 +126,7 @@ async def async_setup_platform(hass: HomeAssistant,
         name = config.get(CONF_NAME)
     elif discovery_info is not None:
         url = discovery_info['ssdp_description']
-        name = discovery_info['name']
+        name = discovery_info.get('name')
 
     if DLNA_DMR_DATA not in hass.data:
         hass.data[DLNA_DMR_DATA] = {}

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -138,7 +138,7 @@ apns2==0.3.0
 asterisk_mbox==0.4.0
 
 # homeassistant.components.media_player.dlna_dmr
-async-upnp-client==0.12.2
+async-upnp-client==0.12.3
 
 # homeassistant.components.light.avion
 # avion==0.7


### PR DESCRIPTION
## Description:

Fix message: `Updating dlna_dmr media_player took longer than the scheduled update interval 0:00:10`

**Related issue (if applicable):** fixes #15985

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`.

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable.
  - [x] New dependencies are only imported inside functions that use them.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.
