### PR TITLE
Update SoCo to 0.16

### DIFF
--- a/homeassistant/components/sonos/__init__.py
+++ b/homeassistant/components/sonos/__init__.py
@@ -4,7 +4,7 @@ from homeassistant.helpers import config_entry_flow
 
 
 DOMAIN = 'sonos'
-REQUIREMENTS = ['SoCo==0.14']
+REQUIREMENTS = ['SoCo==0.16']
 
 
 async def async_setup(hass, config):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -57,7 +57,7 @@ PyXiaomiGateway==0.9.5
 RtmAPI==0.7.0
 
 # homeassistant.components.sonos
-SoCo==0.14
+SoCo==0.16
 
 # homeassistant.components.sensor.travisci
 TravisPy==0.3.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -25,7 +25,7 @@ HAP-python==2.2.2
 PyJWT==1.6.0
 
 # homeassistant.components.sonos
-SoCo==0.14
+SoCo==0.16
 
 # homeassistant.components.device_tracker.automatic
 aioautomatic==0.6.5


### PR DESCRIPTION
## Description:

This updates SoCo to 0.16 and removes a few workarounds that are hopefully no longer needed. It also re-introduces `advertise_addr` that was removed in #13225 but is now supported by SoCo.

**Related issue (if applicable):** fixes #13413

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
sonos:
  media_player:
    advertise_addr: 192.168.2.42
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54