### PR TITLE
Split out storage delay save

### DIFF
--- a/homeassistant/auth/auth_store.py
+++ b/homeassistant/auth/auth_store.py
@@ -228,6 +228,8 @@ class AuthStore:
     @callback
     def _data_to_save(self) -> Dict:
         """Return the data to store."""
+        assert self._users is not None
+
         users = [
             {
                 'id': user.id,

--- a/homeassistant/auth/auth_store.py
+++ b/homeassistant/auth/auth_store.py
@@ -218,6 +218,7 @@ class AuthStore:
 
         self._users = users
 
+    @callback
     def _async_schedule_save(self) -> None:
         """Save users."""
         if self._users is None:

--- a/homeassistant/auth/auth_store.py
+++ b/homeassistant/auth/auth_store.py
@@ -5,7 +5,7 @@ from logging import getLogger
 from typing import Any, Dict, List, Optional  # noqa: F401
 import hmac
 
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.util import dt as dt_util
 
 from . import models
@@ -32,7 +32,7 @@ class AuthStore:
     async def async_get_users(self) -> List[models.User]:
         """Retrieve all users."""
         if self._users is None:
-            await self.async_load()
+            await self._async_load()
             assert self._users is not None
 
         return list(self._users.values())
@@ -40,7 +40,7 @@ class AuthStore:
     async def async_get_user(self, user_id: str) -> Optional[models.User]:
         """Retrieve a user by id."""
         if self._users is None:
-            await self.async_load()
+            await self._async_load()
             assert self._users is not None
 
         return self._users.get(user_id)
@@ -52,7 +52,7 @@ class AuthStore:
             credentials: Optional[models.Credentials] = None) -> models.User:
         """Create a new user."""
         if self._users is None:
-            await self.async_load()
+            await self._async_load()
             assert self._users is not None
 
         kwargs = {
@@ -73,7 +73,7 @@ class AuthStore:
         self._users[new_user.id] = new_user
 
         if credentials is None:
-            await self.async_save()
+            self._async_schedule_save()
             return new_user
 
         # Saving is done inside the link.
@@ -84,33 +84,33 @@ class AuthStore:
                               credentials: models.Credentials) -> None:
         """Add credentials to an existing user."""
         user.credentials.append(credentials)
-        await self.async_save()
+        self._async_schedule_save()
         credentials.is_new = False
 
     async def async_remove_user(self, user: models.User) -> None:
         """Remove a user."""
         if self._users is None:
-            await self.async_load()
+            await self._async_load()
             assert self._users is not None
 
         self._users.pop(user.id)
-        await self.async_save()
+        self._async_schedule_save()
 
     async def async_activate_user(self, user: models.User) -> None:
         """Activate a user."""
         user.is_active = True
-        await self.async_save()
+        self._async_schedule_save()
 
     async def async_deactivate_user(self, user: models.User) -> None:
         """Activate a user."""
         user.is_active = False
-        await self.async_save()
+        self._async_schedule_save()
 
     async def async_remove_credentials(
             self, credentials: models.Credentials) -> None:
         """Remove credentials."""
         if self._users is None:
-            await self.async_load()
+            await self._async_load()
             assert self._users is not None
 
         for user in self._users.values():
@@ -125,7 +125,7 @@ class AuthStore:
                 user.credentials.pop(found)
                 break
 
-        await self.async_save()
+        self._async_schedule_save()
 
     async def async_create_refresh_token(
             self, user: models.User, client_id: Optional[str] = None) \
@@ -133,14 +133,14 @@ class AuthStore:
         """Create a new token for a user."""
         refresh_token = models.RefreshToken(user=user, client_id=client_id)
         user.refresh_tokens[refresh_token.id] = refresh_token
-        await self.async_save()
+        self._async_schedule_save()
         return refresh_token
 
     async def async_get_refresh_token(
             self, token_id: str) -> Optional[models.RefreshToken]:
         """Get refresh token by id."""
         if self._users is None:
-            await self.async_load()
+            await self._async_load()
             assert self._users is not None
 
         for user in self._users.values():
@@ -154,7 +154,7 @@ class AuthStore:
             self, token: str) -> Optional[models.RefreshToken]:
         """Get refresh token by token."""
         if self._users is None:
-            await self.async_load()
+            await self._async_load()
             assert self._users is not None
 
         found = None
@@ -166,7 +166,7 @@ class AuthStore:
 
         return found
 
-    async def async_load(self) -> None:
+    async def _async_load(self) -> None:
         """Load the users."""
         data = await self._store.async_load()
 
@@ -218,12 +218,16 @@ class AuthStore:
 
         self._users = users
 
-    async def async_save(self) -> None:
+    def _async_schedule_save(self) -> None:
         """Save users."""
         if self._users is None:
-            await self.async_load()
-            assert self._users is not None
+            return
 
+        self._store.async_delay_save(self._data_to_save, 1)
+
+    @callback
+    def _data_to_save(self) -> Dict:
+        """Return the data to store."""
         users = [
             {
                 'id': user.id,
@@ -262,10 +266,8 @@ class AuthStore:
             for refresh_token in user.refresh_tokens.values()
         ]
 
-        data = {
+        return {
             'users': users,
             'credentials': credentials,
             'refresh_tokens': refresh_tokens,
         }
-
-        await self._store.async_save(data, delay=1)

--- a/tests/helpers/test_storage.py
+++ b/tests/helpers/test_storage.py
@@ -56,7 +56,7 @@ async def test_loading_parallel(hass, store, hass_storage, caplog):
 
 async def test_saving_with_delay(hass, store, hass_storage):
     """Test saving data after a delay."""
-    await store.async_save(MOCK_DATA, delay=1)
+    store.async_delay_save(lambda: MOCK_DATA, 1)
     assert store.key not in hass_storage
 
     async_fire_time_changed(hass, dt.utcnow() + timedelta(seconds=1))
@@ -71,7 +71,7 @@ async def test_saving_with_delay(hass, store, hass_storage):
 async def test_saving_on_stop(hass, hass_storage):
     """Test delayed saves trigger when we quit Home Assistant."""
     store = storage.Store(hass, MOCK_VERSION, MOCK_KEY)
-    await store.async_save(MOCK_DATA, delay=1)
+    store.async_delay_save(lambda: MOCK_DATA, 1)
     assert store.key not in hass_storage
 
     hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
@@ -92,7 +92,7 @@ async def test_loading_while_delay(hass, store, hass_storage):
         'data': {'delay': 'no'},
     }
 
-    await store.async_delay_save(lambda: {'delay': 'yes'}, 1)
+    store.async_delay_save(lambda: {'delay': 'yes'}, 1)
     assert hass_storage[store.key] == {
         'version': MOCK_VERSION,
         'key': MOCK_KEY,
@@ -105,7 +105,7 @@ async def test_loading_while_delay(hass, store, hass_storage):
 
 async def test_writing_while_writing_delay(hass, store, hass_storage):
     """Test a write while a write with delay is active."""
-    await store.async_delay_save(lambda: {'delay': 'yes'}, 1)
+    store.async_delay_save(lambda: {'delay': 'yes'}, 1)
     assert store.key not in hass_storage
     await store.async_save({'delay': 'no'})
     assert hass_storage[store.key] == {

--- a/tests/helpers/test_storage.py
+++ b/tests/helpers/test_storage.py
@@ -92,7 +92,7 @@ async def test_loading_while_delay(hass, store, hass_storage):
         'data': {'delay': 'no'},
     }
 
-    await store.async_save({'delay': 'yes'}, delay=1)
+    await store.async_delay_save(lambda: {'delay': 'yes'}, 1)
     assert hass_storage[store.key] == {
         'version': MOCK_VERSION,
         'key': MOCK_KEY,
@@ -105,7 +105,7 @@ async def test_loading_while_delay(hass, store, hass_storage):
 
 async def test_writing_while_writing_delay(hass, store, hass_storage):
     """Test a write while a write with delay is active."""
-    await store.async_save({'delay': 'yes'}, delay=1)
+    await store.async_delay_save(lambda: {'delay': 'yes'}, 1)
     assert store.key not in hass_storage
     await store.async_save({'delay': 'no'})
     assert hass_storage[store.key] == {


### PR DESCRIPTION
## Description:
Split up storage save in a delay_save (callback) and a save method. `delay_save` takes a function to postpone generating the data. This avoids generating data when we're going to delay writing and might not ever write the passed in object.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
