### PR TITLE
homematic: Add homematic.put_paramset service

### DIFF
--- a/homeassistant/components/homematic/__init__.py
+++ b/homeassistant/components/homematic/__init__.py
@@ -48,6 +48,8 @@ ATTR_MESSAGE = 'message'
 ATTR_MODE = 'mode'
 ATTR_TIME = 'time'
 ATTR_UNIQUE_ID = 'unique_id'
+ATTR_PARAMSET_KEY = 'paramset_key'
+ATTR_PARAMSET = 'paramset'
 
 EVENT_KEYPRESS = 'homematic.keypress'
 EVENT_IMPULSE = 'homematic.impulse'
@@ -58,6 +60,7 @@ SERVICE_RECONNECT = 'reconnect'
 SERVICE_SET_VARIABLE_VALUE = 'set_variable_value'
 SERVICE_SET_DEVICE_VALUE = 'set_device_value'
 SERVICE_SET_INSTALL_MODE = 'set_install_mode'
+SERVICE_PUT_PARAMSET = 'put_paramset'
 
 HM_DEVICE_TYPES = {
     DISCOVER_SWITCHES: [
@@ -232,6 +235,13 @@ SCHEMA_SERVICE_SET_INSTALL_MODE = vol.Schema({
     vol.Optional(ATTR_ADDRESS): vol.All(cv.string, vol.Upper),
 })
 
+SCHEMA_SERVICE_PUT_PARAMSET = vol.Schema({
+    vol.Required(ATTR_INTERFACE): cv.string,
+    vol.Required(ATTR_ADDRESS): vol.All(cv.string, vol.Upper),
+    vol.Required(ATTR_PARAMSET_KEY): vol.All(cv.string, vol.Upper),
+    vol.Required(ATTR_PARAMSET): dict,
+})
+
 
 @bind_hass
 def virtualkey(hass, address, channel, param, interface=None):
@@ -269,6 +279,19 @@ def set_device_value(hass, address, channel, param, value, interface=None):
     }
 
     hass.services.call(DOMAIN, SERVICE_SET_DEVICE_VALUE, data)
+
+
+@bind_hass
+def put_paramset(hass, interface, address, paramset_key, paramset):
+    """Call putParamset XML-RPC method of supplied interface."""
+    data = {
+        ATTR_INTERFACE: interface,
+        ATTR_ADDRESS: address,
+        ATTR_PARAMSET_KEY: paramset_key,
+        ATTR_PARAMSET: paramset,
+    }
+
+    hass.services.call(DOMAIN, SERVICE_PUT_PARAMSET, data)
 
 
 @bind_hass
@@ -438,6 +461,26 @@ def setup(hass, config):
     hass.services.register(
         DOMAIN, SERVICE_SET_INSTALL_MODE, _service_handle_install_mode,
         schema=SCHEMA_SERVICE_SET_INSTALL_MODE)
+
+    def _service_put_paramset(service):
+        """Service to call the putParamset method on a HomeMatic connection."""
+        interface = service.data.get(ATTR_INTERFACE)
+        address = service.data.get(ATTR_ADDRESS)
+        paramset_key = service.data.get(ATTR_PARAMSET_KEY)
+        # When passing in the paramset from a YAML file we get an OrderedDict
+        # here instead of a dict, so add this explicit cast.
+        # The service schema makes sure that this cast works.
+        paramset = dict(service.data.get(ATTR_PARAMSET))
+
+        _LOGGER.debug(
+            "Calling putParamset: %s, %s, %s, %s",
+            interface, address, paramset_key, paramset
+        )
+        homematic.putParamset(interface, address, paramset_key, paramset)
+
+    hass.services.register(
+        DOMAIN, SERVICE_PUT_PARAMSET, _service_put_paramset,
+        schema=SCHEMA_SERVICE_PUT_PARAMSET)
 
     return True
 

--- a/homeassistant/components/homematic/services.yaml
+++ b/homeassistant/components/homematic/services.yaml
@@ -66,3 +66,20 @@ set_install_mode:
     address:
       description: (Optional) Address of homematic device or BidCoS-RF to learn
       example: LEQ3948571
+
+put_paramset:
+  description: Call to putParamset in the RPC XML interface
+  fields:
+    interface:
+      description: The interfaces name from the config
+      example: wireless
+    address:
+      description: Address of Homematic device
+      example: LEQ3948571
+    paramset_key:
+      description: The paramset_key argument to putParamset
+      example: MASTER
+    paramset:
+      description: A paramset dictionary
+      example: '{"WEEK_PROGRAM_POINTER": 1}'
+


### PR DESCRIPTION
The service enables access to an advanced part of the Homematic XML-RPC
API. This allows users to use features, which are not directly exposed
by device attributes. For instance this service can be used to set the
WEEK_PROGRAM_POINTER for some Homematic thermostat devices.

## Description:
**Related issue (if applicable):** danielperna84/pyhomematic#139

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#6032

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)
