### PR TITLE
Disable assuming Optional type for values with None default

### DIFF
--- a/homeassistant/auth/providers/homeassistant.py
+++ b/homeassistant/auth/providers/homeassistant.py
@@ -215,7 +215,8 @@ class LoginFlow(data_entry_flow.FlowHandler):
         self._auth_provider = auth_provider
 
     async def async_step_init(
-            self, user_input: Dict[str, str] = None) -> Dict[str, Any]:
+            self, user_input: Optional[Dict[str, str]] = None) \
+            -> Dict[str, Any]:
         """Handle the step of the form."""
         errors = {}
 

--- a/homeassistant/auth/providers/insecure_example.py
+++ b/homeassistant/auth/providers/insecure_example.py
@@ -98,7 +98,8 @@ class LoginFlow(data_entry_flow.FlowHandler):
         self._auth_provider = auth_provider
 
     async def async_step_init(
-            self, user_input: Dict[str, str] = None) -> Dict[str, Any]:
+            self, user_input: Optional[Dict[str, str]] = None) \
+            -> Dict[str, Any]:
         """Handle the step of the form."""
         errors = {}
 

--- a/homeassistant/auth/providers/legacy_api_password.py
+++ b/homeassistant/auth/providers/legacy_api_password.py
@@ -89,7 +89,8 @@ class LoginFlow(data_entry_flow.FlowHandler):
         self._auth_provider = auth_provider
 
     async def async_step_init(
-            self, user_input: Dict[str, str] = None) -> Dict[str, Any]:
+            self, user_input: Optional[Dict[str, str]] = None) \
+            -> Dict[str, Any]:
         """Handle the step of the form."""
         errors = {}
 

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -302,7 +302,7 @@ class ConfigEntries:
         return result
 
     @callback
-    def async_entries(self, domain: str = None) -> List[ConfigEntry]:
+    def async_entries(self, domain: Optional[str] = None) -> List[ConfigEntry]:
         """Return all entries or entries for a specific domain."""
         if domain is None:
             return list(self._entries)

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -49,7 +49,8 @@ class FlowManager:
             'context': flow.context,
         } for flow in self._progress.values()]
 
-    async def async_init(self, handler: Hashable, *, context: Dict = None,
+    async def async_init(self, handler: Hashable, *,
+                         context: Optional[Dict] = None,
                          data: Any = None) -> Any:
         """Start a configuration flow."""
         flow = await self._async_create_flow(
@@ -63,7 +64,7 @@ class FlowManager:
         return await self._async_handle_step(flow, flow.init_step, data)
 
     async def async_configure(
-            self, flow_id: str, user_input: str = None) -> Any:
+            self, flow_id: str, user_input: Optional[str] = None) -> Any:
         """Continue a configuration flow."""
         flow = self._progress.get(flow_id)
 
@@ -134,8 +135,9 @@ class FlowHandler:
 
     @callback
     def async_show_form(self, *, step_id: str, data_schema: vol.Schema = None,
-                        errors: Dict = None,
-                        description_placeholders: Dict = None) -> Dict:
+                        errors: Optional[Dict] = None,
+                        description_placeholders: Optional[Dict] = None) \
+            -> Dict:
         """Return the definition of a form to gather user input."""
         return {
             'type': RESULT_TYPE_FORM,

--- a/homeassistant/remote.py
+++ b/homeassistant/remote.py
@@ -76,7 +76,7 @@ class API:
 
         return self.status == APIStatus.OK
 
-    def __call__(self, method: str, path: str, data: Dict = None,
+    def __call__(self, method: str, path: str, data: Optional[Dict] = None,
                  timeout: int = 5) -> requests.Response:
         """Make a call to the Home Assistant API."""
         if data is None:
@@ -161,7 +161,7 @@ def get_event_listeners(api: API) -> Dict:
         return {}
 
 
-def fire_event(api: API, event_type: str, data: Dict = None) -> None:
+def fire_event(api: API, event_type: str, data: Optional[Dict] = None) -> None:
     """Fire an event at remote API."""
     try:
         req = api(METH_POST, URL_API_EVENTS_EVENT.format(event_type), data)
@@ -228,7 +228,8 @@ def remove_state(api: API, entity_id: str) -> bool:
 
 
 def set_state(api: API, entity_id: str, new_state: str,
-              attributes: Dict = None, force_update: bool = False) -> bool:
+              attributes: Optional[Dict] = None, force_update: bool = False) \
+        -> bool:
     """Tell API to update state for entity_id.
 
     Return True if success.
@@ -280,7 +281,7 @@ def get_services(api: API) -> Dict:
 
 
 def call_service(api: API, domain: str, service: str,
-                 service_data: Dict = None,
+                 service_data: Optional[Dict] = None,
                  timeout: int = 5) -> None:
     """Call a service at the remote API."""
     try:

--- a/homeassistant/util/__init__.py
+++ b/homeassistant/util/__init__.py
@@ -154,7 +154,7 @@ class OrderedEnum(enum.Enum):
 class OrderedSet(MutableSet[T]):
     """Ordered set taken from http://code.activestate.com/recipes/576694/."""
 
-    def __init__(self, iterable: Iterable[T] = None) -> None:
+    def __init__(self, iterable: Optional[Iterable[T]] = None) -> None:
         """Initialize the set."""
         self.end = end = []  # type: List[Any]
         end += [None, end, end]  # sentinel node for doubly linked list
@@ -260,7 +260,7 @@ class Throttle:
     """
 
     def __init__(self, min_time: timedelta,
-                 limit_no_throttle: timedelta = None) -> None:
+                 limit_no_throttle: Optional[timedelta] = None) -> None:
         """Initialize the throttle."""
         self.min_time = min_time
         self.limit_no_throttle = limit_no_throttle

--- a/homeassistant/util/dt.py
+++ b/homeassistant/util/dt.py
@@ -53,7 +53,7 @@ def utcnow() -> dt.datetime:
     return dt.datetime.now(UTC)
 
 
-def now(time_zone: dt.tzinfo = None) -> dt.datetime:
+def now(time_zone: Optional[dt.tzinfo] = None) -> dt.datetime:
     """Get now in specified time zone."""
     return dt.datetime.now(time_zone or DEFAULT_TIME_ZONE)
 
@@ -97,8 +97,8 @@ def utc_from_timestamp(timestamp: float) -> dt.datetime:
     return UTC.localize(dt.datetime.utcfromtimestamp(timestamp))
 
 
-def start_of_local_day(dt_or_d:
-                       Union[dt.date, dt.datetime] = None) -> dt.datetime:
+def start_of_local_day(
+        dt_or_d: Union[dt.date, dt.datetime, None] = None) -> dt.datetime:
     """Return local datetime object of start of day from date or datetime."""
     if dt_or_d is None:
         date = now().date()  # type: dt.date

--- a/mypy.ini
+++ b/mypy.ini
@@ -3,6 +3,7 @@ check_untyped_defs = true
 disallow_untyped_calls = true
 follow_imports = silent
 ignore_missing_imports = true
+no_implicit_optional = true
 warn_incomplete_stub = true
 warn_redundant_casts = true
 warn_return_any = true


### PR DESCRIPTION
## Description:

It's clearer if Optionals are marked as such, and PEP 484 recommends it, so it's possible it'll become mandatory at some point:

https://www.python.org/dev/peps/pep-0484/#union-types
> Type checkers should move towards requiring the optional type to be made explicit.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
