### PR TITLE
Upgrade to async_upnp_client==0.12.4

### DIFF
--- a/homeassistant/components/media_player/dlna_dmr.py
+++ b/homeassistant/components/media_player/dlna_dmr.py
@@ -35,7 +35,7 @@ from homeassistant.util import get_local_ip
 DLNA_DMR_DATA = 'dlna_dmr'
 
 REQUIREMENTS = [
-    'async-upnp-client==0.12.3',
+    'async-upnp-client==0.12.4',
 ]
 
 DEFAULT_NAME = 'DLNA Digital Media Renderer'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -138,7 +138,7 @@ apns2==0.3.0
 asterisk_mbox==0.4.0
 
 # homeassistant.components.media_player.dlna_dmr
-async-upnp-client==0.12.3
+async-upnp-client==0.12.4
 
 # homeassistant.components.light.avion
 # avion==0.7


### PR DESCRIPTION
## Description:

Fix error: AttributeError: 'VideoItem' object has no attribute 'resources'

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/16016



## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`.

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable.
  - [x] New dependencies are only imported inside functions that use them.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.
