### PR TITLE
Update RitAssist dependency to 0.9.2

### DIFF
--- a/homeassistant/components/device_tracker/ritassist.py
+++ b/homeassistant/components/device_tracker/ritassist.py
@@ -14,7 +14,7 @@ from homeassistant.components.device_tracker import PLATFORM_SCHEMA
 from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
 from homeassistant.helpers.event import track_utc_time_change
 
-REQUIREMENTS = ['ritassist==0.5']
+REQUIREMENTS = ['ritassist==0.9.2']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -78,6 +78,10 @@ class RitAssistDeviceScanner:
             for device in devices:
                 if (not self._include or
                         device.license_plate in self._include):
+
+                    if device.active or device.current_address is None:
+                        device.get_map_details()
+
                     self._see(dev_id=device.plate_as_id,
                               gps=(device.latitude, device.longitude),
                               attributes=device.state_attributes,

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1227,7 +1227,7 @@ rflink==0.0.37
 ring_doorbell==0.2.1
 
 # homeassistant.components.device_tracker.ritassist
-ritassist==0.5
+ritassist==0.9.2
 
 # homeassistant.components.notify.rocketchat
 rocketchat-API==0.6.1


### PR DESCRIPTION
## Description:
Update RitAssist dependency to 0.9.2 so we support fetching the current maximum speed and address for a device.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#6038

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54