### PR TITLE
Add Current UV Level to list of conditions of openuv

### DIFF
--- a/homeassistant/components/openuv.py
+++ b/homeassistant/components/openuv.py
@@ -37,6 +37,7 @@ TOPIC_UPDATE = '{0}_data_update'.format(DOMAIN)
 
 TYPE_CURRENT_OZONE_LEVEL = 'current_ozone_level'
 TYPE_CURRENT_UV_INDEX = 'current_uv_index'
+TYPE_CURRENT_UV_LEVEL = 'current_uv_level'
 TYPE_MAX_UV_INDEX = 'max_uv_index'
 TYPE_PROTECTION_WINDOW = 'uv_protection_window'
 TYPE_SAFE_EXPOSURE_TIME_1 = 'safe_exposure_time_type_1'
@@ -59,6 +60,7 @@ SENSORS = {
     TYPE_CURRENT_OZONE_LEVEL: (
         'Current Ozone Level', 'mdi:vector-triangle', 'du'),
     TYPE_CURRENT_UV_INDEX: ('Current UV Index', 'mdi:weather-sunny', 'index'),
+    TYPE_CURRENT_UV_LEVEL: ('Current UV Level', 'mdi:weather-sunny', None),
     TYPE_MAX_UV_INDEX: ('Max UV Index', 'mdi:weather-sunny', 'index'),
     TYPE_SAFE_EXPOSURE_TIME_1: (
         'Skin Type 1 Safe Exposure Time', 'mdi:timer', 'minutes'),

--- a/homeassistant/components/sensor/openuv.py
+++ b/homeassistant/components/sensor/openuv.py
@@ -11,10 +11,10 @@ from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.components.openuv import (
     DATA_UV, DOMAIN, SENSORS, TOPIC_UPDATE, TYPE_CURRENT_OZONE_LEVEL,
-    TYPE_CURRENT_UV_INDEX, TYPE_MAX_UV_INDEX, TYPE_SAFE_EXPOSURE_TIME_1,
-    TYPE_SAFE_EXPOSURE_TIME_2, TYPE_SAFE_EXPOSURE_TIME_3,
-    TYPE_SAFE_EXPOSURE_TIME_4, TYPE_SAFE_EXPOSURE_TIME_5,
-    TYPE_SAFE_EXPOSURE_TIME_6, OpenUvEntity)
+    TYPE_CURRENT_UV_INDEX, TYPE_CURRENT_UV_LEVEL, TYPE_MAX_UV_INDEX,
+    TYPE_SAFE_EXPOSURE_TIME_1, TYPE_SAFE_EXPOSURE_TIME_2,
+    TYPE_SAFE_EXPOSURE_TIME_3, TYPE_SAFE_EXPOSURE_TIME_4,
+    TYPE_SAFE_EXPOSURE_TIME_5, TYPE_SAFE_EXPOSURE_TIME_6, OpenUvEntity)
 from homeassistant.util.dt import as_local, parse_datetime
 
 DEPENDENCIES = ['openuv']
@@ -30,6 +30,12 @@ EXPOSURE_TYPE_MAP = {
     TYPE_SAFE_EXPOSURE_TIME_5: 'st5',
     TYPE_SAFE_EXPOSURE_TIME_6: 'st6'
 }
+
+UV_LEVEL_EXTREME = "Extreme"
+UV_LEVEL_VHIGH = "Very High"
+UV_LEVEL_HIGH = "High"
+UV_LEVEL_MODERATE = "Moderate"
+UV_LEVEL_LOW = "Low"
 
 
 async def async_setup_platform(
@@ -105,6 +111,17 @@ class OpenUvSensor(OpenUvEntity):
             self._state = data['ozone']
         elif self._sensor_type == TYPE_CURRENT_UV_INDEX:
             self._state = data['uv']
+        elif self._sensor_type == TYPE_CURRENT_UV_LEVEL:
+            if data['uv'] >= 11:
+                self._state = UV_LEVEL_EXTREME
+            elif data['uv'] >= 8:
+                self._state = UV_LEVEL_VHIGH
+            elif data['uv'] >= 6:
+                self._state = UV_LEVEL_HIGH
+            elif data['uv'] >= 3:
+                self._state = UV_LEVEL_MODERATE
+            else:
+                self._state = UV_LEVEL_LOW
         elif self._sensor_type == TYPE_MAX_UV_INDEX:
             self._state = data['uv_max']
             self._attrs.update({


### PR DESCRIPTION
## Description:

Add Current UV Level to list of conditions, which is calculated from current UV index, based on [UV Index Levels & Colors](https://www.openuv.io/kb/uv-index-levels-colors).

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#6041

## Example entry for `configuration.yaml` (if applicable):
```yaml
openuv:
  sensors:
    monitored_conditions:
      - current_uv_level
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)