### PR TITLE
Get user after login flow finished

### DIFF
--- a/homeassistant/components/auth/__init__.py
+++ b/homeassistant/components/auth/__init__.py
@@ -227,7 +227,7 @@ class LinkUserView(HomeAssistantView):
         credentials = self._retrieve_credentials(
             data['client_id'], RESULT_TYPE_CREDENTIALS, data['code'])
 
-        if credentials is None or not isinstance(credentials, Credentials):
+        if credentials is None:
             return self.json_message('Invalid code', status_code=400)
 
         await hass.auth.async_link_user(user, credentials)

--- a/tests/components/auth/test_init.py
+++ b/tests/components/auth/test_init.py
@@ -74,9 +74,9 @@ async def test_login_new_user_and_trying_refresh_token(hass, aiohttp_client):
     assert resp.status == 200
 
 
-def test_credential_store_expiration():
-    """Test that the credential store will not return expired tokens."""
-    store, retrieve = auth._create_cred_store()
+def test_auth_code_store_expiration():
+    """Test that the auth code store will not return expired tokens."""
+    store, retrieve = auth._create_auth_code_store()
     client_id = 'bla'
     credentials = 'creds'
     now = utcnow()

--- a/tests/components/auth/test_init.py
+++ b/tests/components/auth/test_init.py
@@ -3,13 +3,14 @@ from datetime import timedelta
 from unittest.mock import patch
 
 from homeassistant.auth.models import Credentials
+from homeassistant.components.auth import RESULT_TYPE_USER
 from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
 from homeassistant.components import auth
 
 from . import async_setup_auth
 
-from tests.common import CLIENT_ID, CLIENT_REDIRECT_URI
+from tests.common import CLIENT_ID, CLIENT_REDIRECT_URI, MockUser
 
 
 async def test_login_new_user_and_trying_refresh_token(hass, aiohttp_client):
@@ -78,22 +79,22 @@ def test_auth_code_store_expiration():
     """Test that the auth code store will not return expired tokens."""
     store, retrieve = auth._create_auth_code_store()
     client_id = 'bla'
-    credentials = 'creds'
+    user = MockUser(id='mock_user')
     now = utcnow()
 
     with patch('homeassistant.util.dt.utcnow', return_value=now):
-        code = store(client_id, credentials)
+        code = store(client_id, user)
 
     with patch('homeassistant.util.dt.utcnow',
                return_value=now + timedelta(minutes=10)):
-        assert retrieve(client_id, code) is None
+        assert retrieve(client_id, RESULT_TYPE_USER, code) is None
 
     with patch('homeassistant.util.dt.utcnow', return_value=now):
-        code = store(client_id, credentials)
+        code = store(client_id, user)
 
     with patch('homeassistant.util.dt.utcnow',
                return_value=now + timedelta(minutes=9, seconds=59)):
-        assert retrieve(client_id, code) == credentials
+        assert retrieve(client_id, RESULT_TYPE_USER, code) == user
 
 
 async def test_ws_current_user(hass, hass_ws_client, hass_access_token):

--- a/tests/components/auth/test_init_link_user.py
+++ b/tests/components/auth/test_init_link_user.py
@@ -32,9 +32,9 @@ async def async_get_code(hass, aiohttp_client):
     # Now authenticate with the 2nd flow
     resp = await client.post('/auth/login_flow', json={
         'client_id': CLIENT_ID,
-        'credential_only': True,
         'handler': ['insecure_example', '2nd auth'],
         'redirect_uri': CLIENT_REDIRECT_URI,
+        'type': 'link_user',
     })
     assert resp.status == 200
     step = await resp.json()

--- a/tests/components/auth/test_init_link_user.py
+++ b/tests/components/auth/test_init_link_user.py
@@ -32,6 +32,7 @@ async def async_get_code(hass, aiohttp_client):
     # Now authenticate with the 2nd flow
     resp = await client.post('/auth/login_flow', json={
         'client_id': CLIENT_ID,
+        'credential_only': True,
         'handler': ['insecure_example', '2nd auth'],
         'redirect_uri': CLIENT_REDIRECT_URI,
     })


### PR DESCRIPTION
## Description:
Change to get or create a user after login flow finished, saved it in memory and return auth_code for future usage. In case you still want to use previous behavior, i.e. get a credential after long flow finished, you can pass in a parameter `credential_only` as True when calling `/auth/login_flow`. 

It is not a breaking change as it changed internal implementation. The optional usage is designed for "link user" feature which has not been implemented in front end yet.

This change is need for MFA implementation.


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.
