### PR TITLE
Add forgiving add column

### DIFF
--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -136,7 +136,6 @@ def _add_columns(engine, table_name, columns_def):
         # Some engines support adding all columns at once,
         # this error is when they dont'
         _LOGGER.info('Unable to use quick column add. Adding 1 by 1.')
-        pass
 
     for column_def in columns_def:
         try:

--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -117,7 +117,13 @@ def _drop_index(engine, table_name, index_name):
 def _add_columns(engine, table_name, columns_def):
     """Add columns to a table."""
     from sqlalchemy import text
-    from sqlalchemy.exc import SQLAlchemyError
+    from sqlalchemy.exc import OperationalError
+
+    _LOGGER.info("Adding columns %s to table %s. Note: this can take several "
+                 "minutes on large databases and slow computers. Please "
+                 "be patient!",
+                 ', '.join(column.split(' ')[0] for column in columns_def),
+                 table_name)
 
     columns_def = ['ADD COLUMN {}'.format(col_def) for col_def in columns_def]
 
@@ -126,13 +132,23 @@ def _add_columns(engine, table_name, columns_def):
             table=table_name,
             columns_def=', '.join(columns_def))))
         return
-    except SQLAlchemyError:
+    except OperationalError:
+        # Some engines support adding all columns at once,
+        # this error is when they dont'
+        _LOGGER.info('Unable to use quick column add. Adding 1 by 1.')
         pass
 
     for column_def in columns_def:
-        engine.execute(text("ALTER TABLE {table} {column_def}".format(
-            table=table_name,
-            column_def=column_def)))
+        try:
+            engine.execute(text("ALTER TABLE {table} {column_def}".format(
+                table=table_name,
+                column_def=column_def)))
+        except OperationalError as err:
+            if 'duplicate' not in str(err).lower():
+                raise
+
+            _LOGGER.warning('Column %s already exists on %s, continueing',
+                            column_def.split(' ')[0], table_name)
 
 
 def _apply_update(engine, new_version, old_version):


### PR DESCRIPTION
## Description:
This makes the add column migration forgiving. It means that it will continue execution if the column already exists. Because of different engines, I am unable to detect using a classname. Instead checking for the string 'duplicate'.

This should help with the instances that accidentally got killed by Hass.io or when people stopped Home Assistant while it is migrating.

This is a stop-gap solution, in the future I want the recorder to run migrations in the background or in an onboarding step.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
