### PR TITLE
Tuya fix login problem and add login platform param

### DIFF
--- a/homeassistant/components/tuya.py
+++ b/homeassistant/components/tuya.py
@@ -10,14 +10,14 @@ import voluptuous as vol
 
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
-from homeassistant.const import (CONF_USERNAME, CONF_PASSWORD)
+from homeassistant.const import (CONF_USERNAME, CONF_PASSWORD, CONF_PLATFORM)
 from homeassistant.helpers import discovery
 from homeassistant.helpers.dispatcher import (
     dispatcher_send, async_dispatcher_connect)
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import track_time_interval
 
-REQUIREMENTS = ['tuyapy==0.1.2']
+REQUIREMENTS = ['tuyapy==0.1.3']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -45,7 +45,8 @@ CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Required(CONF_PASSWORD): cv.string,
         vol.Required(CONF_USERNAME): cv.string,
-        vol.Required(CONF_COUNTRYCODE): cv.string
+        vol.Required(CONF_COUNTRYCODE): cv.string,
+        vol.Optional(CONF_PLATFORM, default='tuya'): cv.string,
     })
 }, extra=vol.ALLOW_EXTRA)
 
@@ -58,9 +59,10 @@ def setup(hass, config):
     username = config[DOMAIN][CONF_USERNAME]
     password = config[DOMAIN][CONF_PASSWORD]
     country_code = config[DOMAIN][CONF_COUNTRYCODE]
+    platform = config[DOMAIN][CONF_PLATFORM]
 
     hass.data[DATA_TUYA] = tuya
-    tuya.init(username, password, country_code)
+    tuya.init(username, password, country_code, platform)
     hass.data[DOMAIN] = {
         'entities': {}
     }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1392,7 +1392,7 @@ tplink==0.2.1
 transmissionrpc==0.11
 
 # homeassistant.components.tuya
-tuyapy==0.1.2
+tuyapy==0.1.3
 
 # homeassistant.components.twilio
 twilio==5.7.0


### PR DESCRIPTION
## Description:
1. add platform param to distinguish accounts from different apps. Default is tuya.
2. fix a bug which may cause login failed.
3. add the error reason while login failed. 

**Related issue (if applicable):** fixes #15613 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#6048

## Example entry for `configuration.yaml` (if applicable):
```yaml
tuya:
  username: phone or email@example.com
  password: accountpassword
  country_code: 1
  platform: 'smart_life' or 'tuya'
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
