### PR TITLE
Add notify platforms to loaded components

### DIFF
--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -156,6 +156,8 @@ def async_setup(hass, config):
             DOMAIN, platform_name_slug, async_notify_message,
             schema=NOTIFY_SERVICE_SCHEMA)
 
+        hass.config.components.add('{}.{}'.format(DOMAIN, p_type))
+
         return True
 
     setup_tasks = [async_setup_platform(p_type, p_config) for p_type, p_config


### PR DESCRIPTION
## Description:
Notify platforms were not stored in `hass.config.components` to indicate that they got loaded. However, updated push notifications code in the frontend did assume this was the case.

Fixes https://github.com/home-assistant/home-assistant/issues/16055
Fixes home-assistant/home-assistant-polymer#1582

## Example entry for `configuration.yaml` (if applicable):
```yaml
notify:
  platform: html5
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
