### PR TITLE
Replace pbkdf2 with bcrypt

### DIFF
--- a/homeassistant/auth/providers/homeassistant.py
+++ b/homeassistant/auth/providers/homeassistant.py
@@ -90,8 +90,10 @@ class Data:
                            dummy)
             raise InvalidAuth
 
-        # NOTE: not sure why this isn't utf-8... boo loose typing!
-        user_hash = base64.b64decode(found['password']).decode('ISO-8859-1')
+        # NOTE: this fails but works with ISO-8859-1, which doesn't
+        # seem right since we're storing as utf-8 and the data is base64...
+        # leaving this for someone who's smarter than me.
+        user_hash = base64.b64decode(found['password']).decode()
 
         # if the hash is not a bcrypt hash...
         # provide a transparant upgrade for old pbkdf2 hash format

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -2,6 +2,7 @@ aiohttp==3.4.0
 astral==1.6.1
 async_timeout==3.0.0
 attrs==18.1.0
+bcrypt==3.1.4
 certifi>=2018.04.16
 jinja2>=2.10
 PyJWT==1.6.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3,6 +3,7 @@ aiohttp==3.4.0
 astral==1.6.1
 async_timeout==3.0.0
 attrs==18.1.0
+bcrypt==3.1.4
 certifi>=2018.04.16
 jinja2>=2.10
 PyJWT==1.6.4

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ REQUIRES = [
     'astral==1.6.1',
     'async_timeout==3.0.0',
     'attrs==18.1.0',
+    'bcrypt==3.1.4',
     'certifi>=2018.04.16',
     'jinja2>=2.10',
     'PyJWT==1.6.4',

--- a/tests/auth/providers/test_homeassistant.py
+++ b/tests/auth/providers/test_homeassistant.py
@@ -170,6 +170,10 @@ async def test_pbkdf2_to_bcrypt_hash_upgrade(hass_storage, hass):
     data = hass_auth.Data(hass)
     await data.async_load()
 
+    # Make sure invalid legacy passwords fail
+    with pytest.raises(hass_auth.InvalidAuth):
+        data.validate_login('legacyuser', 'wine')
+
     # verify the correct (pbkdf2) password successfuly authenticates the user
     data.validate_login('legacyuser', 'beer')
 

--- a/tests/auth/providers/test_homeassistant.py
+++ b/tests/auth/providers/test_homeassistant.py
@@ -170,10 +170,6 @@ async def test_pbkdf2_to_bcrypt_hash_upgrade(hass_storage, hass):
     data = hass_auth.Data(hass)
     await data.async_load()
 
-    # Make sure invalid legacy passwords fail
-    with pytest.raises(hass_auth.InvalidAuth):
-        data.validate_login('legacyuser', 'wine')
-
     # verify the correct (pbkdf2) password successfuly authenticates the user
     data.validate_login('legacyuser', 'beer')
 
@@ -184,3 +180,41 @@ async def test_pbkdf2_to_bcrypt_hash_upgrade(hass_storage, hass):
             or user_hash.startswith(b'$2b$')
             or user_hash.startswith(b'$2x$')
             or user_hash.startswith(b'$2y$'))
+
+
+async def test_pbkdf2_to_bcrypt_hash_upgrade_with_incorrect_pass(hass_storage,
+                                                                 hass):
+    """Test migrating user from pbkdf2 hash to bcrypt hash."""
+    hass_storage[hass_auth.STORAGE_KEY] = {
+        'version': hass_auth.STORAGE_VERSION,
+        'key': hass_auth.STORAGE_KEY,
+        'data': {
+            'salt': '09c52f0b120eaa7dea5f73f9a9b985f3d493b30a08f3f2945ef613'
+                    '0b08e6a3ea',
+            'users': [
+                {
+                    'password': 'L5PAbehB8LAQI2Ixu+d+PDNJKmljqLnBcYWYw35onC/8D'
+                                'BM1SpvT6A8ZFael5+deCt+s+43J08IcztnguouHSw==',
+                    'username': 'legacyuser'
+                }
+            ]
+        },
+    }
+    data = hass_auth.Data(hass)
+    await data.async_load()
+
+    orig_user_hash = base64.b64decode(
+        hass_storage[hass_auth.STORAGE_KEY]['data']['users'][0]['password'])
+
+    # Make sure invalid legacy passwords fail
+    with pytest.raises(hass_auth.InvalidAuth):
+        data.validate_login('legacyuser', 'wine')
+
+    # Make sure we don't change the password/hash when password is incorrect
+    with pytest.raises(hass_auth.InvalidAuth):
+        data.validate_login('legacyuser', 'wine')
+
+    same_user_hash = base64.b64decode(
+        hass_storage[hass_auth.STORAGE_KEY]['data']['users'][0]['password'])
+
+    assert orig_user_hash == same_user_hash

--- a/tests/auth/providers/test_homeassistant.py
+++ b/tests/auth/providers/test_homeassistant.py
@@ -152,15 +152,13 @@ async def test_new_hashes_are_bcrypt(data, hass):
 async def test_pbkdf2_to_bcrypt_hash_upgrade(data, hass):
     data.add_auth('legacyuser', 'user-pass')
     # overwrite with pbkdf2 hash
-    data.salt = b'testingsalt'  # simulates legacy salt
+    # NOTE: this needs to be wired into the underlying structure
+    # ...or something.
     found = None
     for user in data.users:
         if user['username'] == 'legacyuser':
             found = user
     assert found is not None
-
-    # NOTE: this needs to be wired into the underlying structure
-    # ...or something.
     found['password'] = data.legacy_hash_password(
         'testtest', True).decode()
 

--- a/tests/auth/providers/test_homeassistant.py
+++ b/tests/auth/providers/test_homeassistant.py
@@ -171,7 +171,8 @@ async def test_pbkdf2_to_bcrypt_hash_upgrade(hass_storage, hass):
     await data.async_load()
 
     # verify the correct (pbkdf2) password successfuly authenticates the user
-    data.validate_login('legacyuser', 'beer')
+    await hass.async_add_executor_job(
+        data.validate_login, 'legacyuser', 'beer')
 
     # ...and that the hashes are now bcrypt hashes
     user_hash = base64.b64decode(
@@ -208,11 +209,13 @@ async def test_pbkdf2_to_bcrypt_hash_upgrade_with_incorrect_pass(hass_storage,
 
     # Make sure invalid legacy passwords fail
     with pytest.raises(hass_auth.InvalidAuth):
-        data.validate_login('legacyuser', 'wine')
+        await hass.async_add_executor_job(
+            data.validate_login, 'legacyuser', 'wine')
 
     # Make sure we don't change the password/hash when password is incorrect
     with pytest.raises(hass_auth.InvalidAuth):
-        data.validate_login('legacyuser', 'wine')
+        await hass.async_add_executor_job(
+            data.validate_login, 'legacyuser', 'wine')
 
     same_user_hash = base64.b64decode(
         hass_storage[hass_auth.STORAGE_KEY]['data']['users'][0]['password'])


### PR DESCRIPTION
## Description:
bcrypt isn't inherently better than pbkdf2, but everything "just works"
out of the box.

  * the hash verification routine now only computes one hash per call
  * a per-user salt is built into the hash as opposed to the current
  global salt
  * bcrypt.checkpw() is immune to timing attacks regardless of input
  * hash strength is a function of real time benchmarks and a
  "difficulty" level, meaning we won't have to ever update the iteration
  count

Note that I haven't tested this code myself. Also, this won't be a clean upgrade for current "beta" users, not sure how that should be handled.

## Example entry for `configuration.yaml` (if applicable):
```yaml
auth_providers:
  - type: homeassistant
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
