### PR TITLE
Create gitignore on version upgrade

### DIFF
--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -23,7 +23,8 @@ from homeassistant.const import (
     __version__, CONF_CUSTOMIZE, CONF_CUSTOMIZE_DOMAIN, CONF_CUSTOMIZE_GLOB,
     CONF_WHITELIST_EXTERNAL_DIRS, CONF_AUTH_PROVIDERS, CONF_TYPE,
     EVENT_HOMEASSISTANT_START)
-from homeassistant.core import callback, DOMAIN as CONF_CORE, HomeAssistant
+from homeassistant.core import (
+    callback, DOMAIN as CONF_CORE, Event, HomeAssistant)
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.loader import get_component, get_platform
 from homeassistant.util.yaml import load_yaml, SECRET_YAML
@@ -764,7 +765,7 @@ def async_notify_setup_error(
         hass, message, 'Invalid config', 'invalid_config')
 
 
-def _secure_git(hass):
+def _secure_git(hass: HomeAssistant) -> None:
     """Make sure the git repo has Home Assistant security features enabled."""
     ignore_path = hass.config.path('.gitignore')
 
@@ -782,8 +783,8 @@ def _secure_git(hass):
     if not to_add:
         return
 
-    with open(ignore_path, 'at') as fp:
-        fp.write("""
+    with open(ignore_path, 'at') as file:
+        file.write("""
 
 # Added by Home Assistant to avoid storing auth
 {}
@@ -791,7 +792,7 @@ def _secure_git(hass):
 
     # no components loaded yet, listen for start and do it then.
     @callback
-    def started(_):
+    def started(_: Event) -> None:
         """Create message when Home Assistant started."""
         message = """
 You are hosting your configuration in git but we noticed that you are not ignoring files containing authentication!

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -128,6 +128,12 @@ DEFAULT_SECRETS = """
 # Learn more at https://home-assistant.io/docs/configuration/secrets/
 http_password: welcome
 """
+GIT_IGNORE = (
+    'secrets.yaml',
+    '.storage',
+    '.cloud',
+    '.tradfri_psk.conf',
+)
 
 
 PACKAGES_CONFIG_SCHEMA = vol.Schema({
@@ -775,10 +781,7 @@ def _secure_git(hass: HomeAssistant) -> None:
     except FileNotFoundError:
         ignore_entries = set()
 
-    to_add = [entry for entry in (
-        'secrets.yaml',
-        '.storage',
-    ) if entry not in ignore_entries]
+    to_add = [entry for entry in GIT_IGNORE if entry not in ignore_entries]
 
     if not to_add:
         return

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -296,7 +296,7 @@ class TestConfig(unittest.TestCase):
     def test_remove_lib_on_upgrade(self, mock_os, mock_shutil):
         """Test removal of library on upgrade from before 0.50."""
         ha_version = '0.49.0'
-        mock_os.path.isdir = mock.Mock(return_value=True)
+        mock_os.path.isdir = mock.Mock(side_effect=[True, False])
         mock_open = mock.mock_open()
         with mock.patch('homeassistant.config.open', mock_open, create=True):
             opened_file = mock_open.return_value
@@ -306,7 +306,7 @@ class TestConfig(unittest.TestCase):
             config_util.process_ha_config_upgrade(self.hass)
             hass_path = self.hass.config.path.return_value
 
-            self.assertEqual(mock_os.path.isdir.call_count, 1)
+            self.assertEqual(mock_os.path.isdir.call_count, 2)
             self.assertEqual(
                 mock_os.path.isdir.call_args, mock.call(hass_path)
             )
@@ -830,3 +830,33 @@ async def test_disallowed_auth_provider_config(hass):
     }
     with pytest.raises(Invalid):
         await config_util.async_process_ha_core_config(hass, core_config)
+
+
+@mock.patch('homeassistant.config.os')
+@mock.patch.object(config_util, 'FILE_MIGRATION', [])
+@mock.patch('homeassistant.config.open', mock.mock_open(read_data='0.70.0'))
+def test_upgrade_calls_secure_git(mock_os, hass):
+    """Test we secure config stored in git repo's."""
+    mock_os.path.isdir = mock.Mock(return_value=True)
+
+    with mock.patch('homeassistant.config._secure_git') as mock_secure:
+        config_util.process_ha_config_upgrade(hass)
+
+    assert len(mock_secure.mock_calls) == 1
+
+
+def test_secure_git_writes_correct_entries():
+    """Test we write correct entries."""
+    hass = mock.Mock()
+
+    write_mock = mock.mock_open(read_data="""
+secrets.yaml
+""")
+
+    with mock.patch('homeassistant.config.open', write_mock):
+        config_util._secure_git(hass)
+
+    written = write_mock.mock_calls[6][1][0].split('\n')
+
+    assert 'secrets.yaml' not in written
+    assert '.storage' in written

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -853,7 +853,9 @@ def test_secure_git_writes_correct_entries():
 secrets.yaml
 """)
 
-    with mock.patch('homeassistant.config.open', write_mock):
+    with mock.patch('homeassistant.config.open', write_mock), \
+        mock.patch.object(config_util, 'GIT_IGNORE',
+                          ('secrets.yaml', '.storage')):
         config_util._secure_git(hass)
 
     written = write_mock.mock_calls[6][1][0].split('\n')


### PR DESCRIPTION
## Description:
I saw a tweet with someone sharing their config and it contained a secrets file. This is something we should actively try to avoid, as people might end up publishing their secrets to GitHub (not good!).

Whenever a user does a version upgrade, we'll check if the user is storing their config in git. If so, we're going to read the `.gitignore` file and make sure both `.storage` and `secrets.yaml` are in it. If not, we add them and add a warning to their UI.

![screen shot 2018-08-20 at 1 29 01 pm](https://user-images.githubusercontent.com/1444314/44340768-2ea5f080-a486-11e8-8dec-dc6402fe60ec.png)


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
