### PR TITLE
Bumped NDMS2 client library to 0.0.4 to get compatible with python 3.5

### DIFF
--- a/homeassistant/components/device_tracker/keenetic_ndms2.py
+++ b/homeassistant/components/device_tracker/keenetic_ndms2.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
     CONF_HOST, CONF_PORT, CONF_PASSWORD, CONF_USERNAME
 )
 
-REQUIREMENTS = ['ndms2_client==0.0.3']
+REQUIREMENTS = ['ndms2_client==0.0.4']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -594,7 +594,7 @@ nad_receiver==0.0.9
 nanoleaf==0.4.1
 
 # homeassistant.components.device_tracker.keenetic_ndms2
-ndms2_client==0.0.3
+ndms2_client==0.0.4
 
 # homeassistant.components.sensor.netdata
 netdata==0.1.2


### PR DESCRIPTION
## Description:

Bumped NDMS2 client library to 0.0.4 to get compatible with python 3.5

**Related issue:** fixes #16059

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

