### PR TITLE
fritzdect change current_power_watt  to current_power_w

### DIFF
--- a/homeassistant/components/switch/fritzdect.py
+++ b/homeassistant/components/switch/fritzdect.py
@@ -105,7 +105,7 @@ class FritzDectSwitch(SwitchDevice):
         return attrs
 
     @property
-    def current_power_watt(self):
+    def current_power_w(self):
         """Return the current power usage in Watt."""
         try:
             return float(self.data.current_consumption)


### PR DESCRIPTION
## Description:
fritzdect change current_power_watt to current_power_w

It should be current_power_w and not current_power_watt
https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/switch/__init__.py#L133



## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
