### PR TITLE
Generic Thermostat: add support for climate.turn_on/climate.turn_off

### DIFF
--- a/homeassistant/components/climate/generic_thermostat.py
+++ b/homeassistant/components/climate/generic_thermostat.py
@@ -252,11 +252,11 @@ class GenericThermostat(ClimateDevice):
         self.schedule_update_ha_state()
 
     async def async_turn_on(self):
-        """Turn thermostat on"""
+        """Turn thermostat on."""
         await self.async_set_operation_mode(self.operation_list[0])
 
     async def async_turn_off(self):
-        """Turn thermostat off"""
+        """Turn thermostat off."""
         await self.async_set_operation_mode(STATE_OFF)
 
     async def async_set_temperature(self, **kwargs):

--- a/homeassistant/components/climate/generic_thermostat.py
+++ b/homeassistant/components/climate/generic_thermostat.py
@@ -251,6 +251,14 @@ class GenericThermostat(ClimateDevice):
         # Ensure we update the current operation after changing the mode
         self.schedule_update_ha_state()
 
+    async def async_turn_on(self):
+        """Turn thermostat on"""
+        await self.async_set_operation_mode(self.operation_list[0])
+
+    async def async_turn_off(self):
+        """Turn thermostat off"""
+        await self.async_set_operation_mode(STATE_OFF)
+
     async def async_set_temperature(self, **kwargs):
         """Set new target temperature."""
         temperature = kwargs.get(ATTR_TEMPERATURE)

--- a/tests/components/climate/test_generic_thermostat.py
+++ b/tests/components/climate/test_generic_thermostat.py
@@ -22,6 +22,7 @@ from homeassistant import loader
 from homeassistant.util.unit_system import METRIC_SYSTEM
 from homeassistant.util.async_ import run_coroutine_threadsafe
 from homeassistant.components import climate, input_boolean, switch
+from homeassistant.components.climate import STATE_HEAT, STATE_COOL
 import homeassistant.components as comps
 from tests.common import (assert_setup_component, get_test_home_assistant,
                           mock_restore_cache)
@@ -922,6 +923,89 @@ class TestClimateGenericThermostatKeepAlive(unittest.TestCase):
 
         self.hass.services.register(ha.DOMAIN, SERVICE_TURN_ON, log_call)
         self.hass.services.register(ha.DOMAIN, SERVICE_TURN_OFF, log_call)
+
+
+class TestClimateGenericThermostatTurnOnOff(unittest.TestCase):
+    """Test the Generic Thermostat."""
+    HEAT_ENTITY = 'climate.test_heat'
+    COOL_ENTITY = 'climate.test_cool'
+
+    def setUp(self):  # pylint: disable=invalid-name
+        """Set up things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+        assert setup_component(self.hass, climate.DOMAIN, {'climate': [
+            {
+                'platform': 'generic_thermostat',
+                'name': 'test_heat',
+                'heater': ENT_SWITCH,
+                'target_sensor': ENT_SENSOR
+            },
+            {
+                'platform': 'generic_thermostat',
+                'name': 'test_cool',
+                'heater': ENT_SWITCH,
+                'ac_mode': True,
+                'target_sensor': ENT_SENSOR
+            }
+        ]})
+
+    def tearDown(self):  # pylint: disable=invalid-name
+        """Stop down everything that was started."""
+        self.hass.stop()
+
+    def test_turn_on_when_off(self):
+        """Test if climate.turn_on turns on a turned off device."""
+        climate.set_operation_mode(self.hass, STATE_OFF)
+        self.hass.block_till_done()
+        self.hass.services.call('climate', SERVICE_TURN_ON)
+        self.hass.block_till_done()
+        state_heat = self.hass.states.get(self.HEAT_ENTITY)
+        state_cool = self.hass.states.get(self.COOL_ENTITY)
+        self.assertEqual(STATE_HEAT,
+                         state_heat.attributes.get('operation_mode'))
+        self.assertEqual(STATE_COOL,
+                         state_cool.attributes.get('operation_mode'))
+
+    def test_turn_on_when_on(self):
+        """Test if climate.turn_on does nothing to a turned on device."""
+        climate.set_operation_mode(self.hass, STATE_HEAT, self.HEAT_ENTITY)
+        climate.set_operation_mode(self.hass, STATE_COOL, self.COOL_ENTITY)
+        self.hass.block_till_done()
+        self.hass.services.call('climate', SERVICE_TURN_ON)
+        self.hass.block_till_done()
+        state_heat = self.hass.states.get(self.HEAT_ENTITY)
+        state_cool = self.hass.states.get(self.COOL_ENTITY)
+        self.assertEqual(STATE_HEAT,
+                         state_heat.attributes.get('operation_mode'))
+        self.assertEqual(STATE_COOL,
+                         state_cool.attributes.get('operation_mode'))
+
+    def test_turn_off_when_on(self):
+        """Test if climate.turn_off turns off a turned on device."""
+        climate.set_operation_mode(self.hass, STATE_HEAT, self.HEAT_ENTITY)
+        climate.set_operation_mode(self.hass, STATE_COOL, self.COOL_ENTITY)
+        self.hass.block_till_done()
+        self.hass.services.call('climate', SERVICE_TURN_OFF)
+        self.hass.block_till_done()
+        state_heat = self.hass.states.get(self.HEAT_ENTITY)
+        state_cool = self.hass.states.get(self.COOL_ENTITY)
+        self.assertEqual(STATE_OFF,
+                         state_heat.attributes.get('operation_mode'))
+        self.assertEqual(STATE_OFF,
+                         state_cool.attributes.get('operation_mode'))
+
+    def test_turn_off_when_off(self):
+        """Test if climate.turn_off does nothing to a turned off device."""
+        climate.set_operation_mode(self.hass, STATE_OFF)
+        self.hass.block_till_done()
+        self.hass.services.call('climate', SERVICE_TURN_OFF)
+        self.hass.block_till_done()
+        state_heat = self.hass.states.get(self.HEAT_ENTITY)
+        state_cool = self.hass.states.get(self.COOL_ENTITY)
+        self.assertEqual(STATE_OFF,
+                         state_heat.attributes.get('operation_mode'))
+        self.assertEqual(STATE_OFF,
+                         state_cool.attributes.get('operation_mode'))
 
 
 @asyncio.coroutine

--- a/tests/components/climate/test_generic_thermostat.py
+++ b/tests/components/climate/test_generic_thermostat.py
@@ -926,8 +926,8 @@ class TestClimateGenericThermostatKeepAlive(unittest.TestCase):
 
 
 class TestClimateGenericThermostatTurnOnOff(unittest.TestCase):
-
     """Test the Generic Thermostat."""
+
     HEAT_ENTITY = 'climate.test_heat'
     COOL_ENTITY = 'climate.test_cool'
 

--- a/tests/components/climate/test_generic_thermostat.py
+++ b/tests/components/climate/test_generic_thermostat.py
@@ -926,6 +926,7 @@ class TestClimateGenericThermostatKeepAlive(unittest.TestCase):
 
 
 class TestClimateGenericThermostatTurnOnOff(unittest.TestCase):
+
     """Test the Generic Thermostat."""
     HEAT_ENTITY = 'climate.test_heat'
     COOL_ENTITY = 'climate.test_cool'


### PR DESCRIPTION
## Description:

Added support for turning a `generic_thermostat` device on and off via `climate.turn_on` and `climate.turn_off` services. This makes certain automations a lot easier to write.

Turning it on would be a bit ambiguous (and require looking up its state prior to being turned off), but luckily, it currently supports only a single operation mode in addition to OFF: either COOL or HEAT. So the `async_turn_on` method simply switches the operation mode to the first mode in the operation_list, which is, by definition, the only supported mode.

In the future, if support for multiple modes is added (as has been attempted before, with an AUTO mode), the logic will have to be revised.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
