### PR TITLE
Update pyhomematic to 0.1.47

### DIFF
--- a/homeassistant/components/homematic/__init__.py
+++ b/homeassistant/components/homematic/__init__.py
@@ -20,7 +20,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.loader import bind_hass
 
-REQUIREMENTS = ['pyhomematic==0.1.46']
+REQUIREMENTS = ['pyhomematic==0.1.47']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -78,7 +78,7 @@ HM_DEVICE_TYPES = {
     DISCOVER_CLIMATE: [
         'Thermostat', 'ThermostatWall', 'MAXThermostat', 'ThermostatWall2',
         'MAXWallThermostat', 'IPThermostat', 'IPThermostatWall',
-        'ThermostatGroup'],
+        'ThermostatGroup', 'IPThermostatWall230V'],
     DISCOVER_BINARY_SENSORS: [
         'ShutterContact', 'Smoke', 'SmokeV2', 'Motion', 'MotionV2',
         'MotionIP', 'RemoteMotion', 'WeatherSensor', 'TiltSensor',
@@ -103,7 +103,7 @@ HM_ATTRIBUTE_SUPPORT = {
     'LOW_BAT': ['battery', {0: 'High', 1: 'Low'}],
     'ERROR': ['sabotage', {0: 'No', 1: 'Yes'}],
     'SABOTAGE': ['sabotage', {0: 'No', 1: 'Yes'}],
-    'RSSI_DEVICE': ['rssi', {}],
+    'RSSI_PEER': ['rssi', {}],
     'VALVE_STATE': ['valve', {}],
     'BATTERY_STATE': ['battery', {}],
     'CONTROL_MODE': ['mode', {

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -876,7 +876,7 @@ pyhik==0.1.8
 pyhiveapi==0.2.14
 
 # homeassistant.components.homematic
-pyhomematic==0.1.46
+pyhomematic==0.1.47
 
 # homeassistant.components.sensor.hydroquebec
 pyhydroquebec==2.2.2


### PR DESCRIPTION
## Description:
Updating the pyhomematic library.
This update fixes the reporting of RSSI values (until now the wrong values were returned), a cosmetic bug for a thermostat (just within the logs, HmIP-BWTH) and adds support for a new HomeMatic IP remote controller (HmIP-KRCA).

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
