### PR TITLE
Added expire_after for MQTT binary sensor

### DIFF
--- a/tests/components/binary_sensor/test_mqtt.py
+++ b/tests/components/binary_sensor/test_mqtt.py
@@ -1,9 +1,13 @@
 """The tests for the  MQTT binary sensor platform."""
 import unittest
 
+from datetime import timedelta, datetime
+from unittest.mock import patch
+
 import homeassistant.core as ha
 from homeassistant.setup import setup_component
 import homeassistant.components.binary_sensor as binary_sensor
+import homeassistant.util.dt as dt_util
 
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.const import EVENT_STATE_CHANGED, STATE_UNAVAILABLE
@@ -48,6 +52,69 @@ class TestSensorMQTT(unittest.TestCase):
         self.hass.block_till_done()
         state = self.hass.states.get('binary_sensor.test')
         self.assertEqual(STATE_OFF, state.state)
+
+    @patch('homeassistant.core.dt_util.utcnow')
+    def test_setting_sensor_value_expires(self, mock_utcnow):
+        """Test the expiration of the value."""
+        mock_component(self.hass, 'mqtt')
+        assert setup_component(self.hass, binary_sensor.DOMAIN, {
+            binary_sensor.DOMAIN: {
+                'platform': 'mqtt',
+                'name': 'test',
+                'state_topic': 'test-topic',
+                'payload_on': 'ON',
+                'expire_after': '4',
+                'force_update': True
+            }
+        })
+
+        state = self.hass.states.get('binary_sensor.test')
+        self.assertEqual('off', state.state)
+
+        now = datetime(2018, 8, 20, 1, tzinfo=dt_util.UTC)
+        mock_utcnow.return_value = now
+        fire_mqtt_message(self.hass, 'test-topic', 'ON')
+        self.hass.block_till_done()
+
+        # Value was set correctly.
+        state = self.hass.states.get('binary_sensor.test')
+        self.assertEqual('on', state.state)
+
+        # Time jump +3s
+        now = now + timedelta(seconds=3)
+        self._send_time_changed(now)
+        self.hass.block_till_done()
+
+        # Value is not yet expired
+        state = self.hass.states.get('binary_sensor.test')
+        self.assertEqual('on', state.state)
+
+        # Next message resets timer
+        mock_utcnow.return_value = now
+        fire_mqtt_message(self.hass, 'test-topic', 'ON')
+        self.hass.block_till_done()
+
+        # Value was updated correctly.
+        state = self.hass.states.get('binary_sensor.test')
+        self.assertEqual('on', state.state)
+
+        # Time jump +3s
+        now = now + timedelta(seconds=3)
+        self._send_time_changed(now)
+        self.hass.block_till_done()
+
+        # Value is not yet expired
+        state = self.hass.states.get('binary_sensor.test')
+        self.assertEqual('on', state.state)
+
+        # Time jump +2s
+        now = now + timedelta(seconds=2)
+        self._send_time_changed(now)
+        self.hass.block_till_done()
+
+        # Value is expired now
+        state = self.hass.states.get('binary_sensor.test')
+        self.assertEqual('off', state.state)
 
     def test_valid_device_class(self):
         """Test the setting of a valid sensor class."""
@@ -223,3 +290,7 @@ class TestSensorMQTT(unittest.TestCase):
         fire_mqtt_message(self.hass, 'test-topic', 'ON')
         self.hass.block_till_done()
         self.assertEqual(2, len(events))
+
+    def _send_time_changed(self, now):
+        """Send a time changed event."""
+        self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {ha.ATTR_NOW: now})


### PR DESCRIPTION
## Description:

This adds `expire_after` configuration for MQTT binary sensor.
The UC for that is to provide simple setup for presence sensors that send only when presence is detected.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#6055

## Example entry for `configuration.yaml` (if applicable):
```yaml
binary_sensor:
  - platform: mqtt
    state_topic: "home-assistant/window/contact"
    payload_on: "DETECTED"
    expire_after: 30
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

