### PR TITLE
Forgiving add index in migration

### DIFF
--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -57,6 +57,7 @@ def _create_index(engine, table_name, index_name):
     within the table definition described in the models
     """
     from sqlalchemy import Table
+    from sqlalchemy.exc import OperationalError
     from . import models
 
     table = Table(table_name, models.Base.metadata)
@@ -67,7 +68,15 @@ def _create_index(engine, table_name, index_name):
     _LOGGER.info("Adding index `%s` to database. Note: this can take several "
                  "minutes on large databases and slow computers. Please "
                  "be patient!", index_name)
-    index.create(engine)
+    try:
+        index.create(engine)
+    except OperationalError as err:
+        if 'already exists' not in str(err).lower():
+            raise
+
+        _LOGGER.warning('Index %s already exists on %s, continueing',
+                        index_name, table_name)
+
     _LOGGER.debug("Finished creating %s", index_name)
 
 

--- a/tests/components/recorder/test_migrate.py
+++ b/tests/components/recorder/test_migrate.py
@@ -80,3 +80,13 @@ def test_forgiving_add_column():
     migration._add_columns(engine, 'hello', [
         'context_id CHARACTER(36)',
     ])
+
+
+def test_forgiving_add_index():
+    """Test that add index will continue if index exists."""
+    engine = create_engine(
+        'sqlite://',
+        poolclass=StaticPool
+    )
+    models.Base.metadata.create_all(engine)
+    migration._create_index(engine, "states", "ix_states_context_id")


### PR DESCRIPTION
## Description:
Part deux of making migrations easier to finish if the user has accidentally canceled one midway through: if index already exists, continue.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
