### PR TITLE
Add support for revoking refresh tokens

### DIFF
--- a/homeassistant/auth/__init__.py
+++ b/homeassistant/auth/__init__.py
@@ -202,6 +202,12 @@ class AuthManager:
         """Get refresh token by token."""
         return await self._store.async_get_refresh_token_by_token(token)
 
+    async def async_remove_refresh_token(self,
+                                         refresh_token: models.RefreshToken) \
+            -> None:
+        """Delete a refresh token."""
+        await self._store.async_remove_refresh_token(refresh_token)
+
     @callback
     def async_create_access_token(self,
                                   refresh_token: models.RefreshToken) -> str:
@@ -215,7 +221,7 @@ class AuthManager:
 
     async def async_validate_access_token(
             self, token: str) -> Optional[models.RefreshToken]:
-        """Return if an access token is valid."""
+        """Return refresh token if an access token is valid."""
         try:
             unverif_claims = jwt.decode(token, verify=False)
         except jwt.InvalidTokenError:

--- a/homeassistant/auth/auth_store.py
+++ b/homeassistant/auth/auth_store.py
@@ -139,6 +139,10 @@ class AuthStore:
     async def async_remove_refresh_token(
             self, refresh_token: models.RefreshToken) -> None:
         """Remove a refresh token."""
+        if self._users is None:
+            await self._async_load()
+            assert self._users is not None
+
         for user in self._users.values():
             if user.refresh_tokens.pop(refresh_token.id, None):
                 break

--- a/homeassistant/auth/auth_store.py
+++ b/homeassistant/auth/auth_store.py
@@ -136,6 +136,15 @@ class AuthStore:
         self._async_schedule_save()
         return refresh_token
 
+    async def async_remove_refresh_token(
+            self, refresh_token: models.RefreshToken) -> None:
+        """Remove a refresh token."""
+        for user in self._users.values():
+            if user.refresh_tokens.pop(refresh_token.id, None):
+                break
+
+        self._async_schedule_save()
+
     async def async_get_refresh_token(
             self, token_id: str) -> Optional[models.RefreshToken]:
         """Get refresh token by id."""

--- a/homeassistant/auth/auth_store.py
+++ b/homeassistant/auth/auth_store.py
@@ -145,9 +145,8 @@ class AuthStore:
 
         for user in self._users.values():
             if user.refresh_tokens.pop(refresh_token.id, None):
+                self._async_schedule_save()
                 break
-
-        self._async_schedule_save()
 
     async def async_get_refresh_token(
             self, token_id: str) -> Optional[models.RefreshToken]:

--- a/homeassistant/components/auth/__init__.py
+++ b/homeassistant/components/auth/__init__.py
@@ -45,17 +45,15 @@ a limited expiration.
     "token_type": "Bearer"
 }
 
-### Revoking a refresh token
+## Revoking a refresh token
 
-Grant type refresh_token also supports revoking a refresh token. To revoke,
-pass action=revoke with your request. Response code will ALWAYS be 200.
+It is also possible to revoke a refresh token and all access tokens that have
+ever been granted by that refresh token. Response code will ALWAYS be 200.
 
 {
-    "grant_type": "refresh_token",
-    "refresh_token": "IJKLMNOPQRST",
+    "token": "IJKLMNOPQRST",
     "action": "revoke"
 }
-
 
 """
 import logging

--- a/homeassistant/components/auth/__init__.py
+++ b/homeassistant/components/auth/__init__.py
@@ -141,8 +141,9 @@ class GrantTokenView(HomeAssistantView):
         action = data.get('action')
         if action == 'revoke':
             return web.Response(status=200)
+
         # We only support no action or action=revoke
-        elif action is not None:
+        if action is not None:
             return self.json({
                 'error': 'invalid_request',
                 'error_description': 'Invalid action',

--- a/tests/auth/test_init.py
+++ b/tests/auth/test_init.py
@@ -281,3 +281,20 @@ async def test_cannot_deactive_owner(mock_hass):
 
     with pytest.raises(ValueError):
         await manager.async_deactivate_user(owner)
+
+
+async def test_remove_refresh_token(mock_hass):
+    """Test that we can remove a refresh token."""
+    manager = await auth.auth_manager_from_config(mock_hass, [])
+    user = MockUser().add_to_auth_manager(manager)
+    refresh_token = await manager.async_create_refresh_token(user, CLIENT_ID)
+    access_token = manager.async_create_access_token(refresh_token)
+
+    await manager.async_remove_refresh_token(refresh_token)
+
+    assert (
+        await manager.async_get_refresh_token(refresh_token.id) is None
+    )
+    assert (
+        await manager.async_validate_access_token(access_token) is None
+    )

--- a/tests/components/auth/test_init.py
+++ b/tests/components/auth/test_init.py
@@ -248,9 +248,7 @@ async def test_revoking_refresh_token(hass, aiohttp_client):
 
     # Revoke refresh token
     resp = await client.post('/auth/token', data={
-        'client_id': CLIENT_ID,
-        'grant_type': 'refresh_token',
-        'refresh_token': refresh_token.token,
+        'token': refresh_token.token,
         'action': 'revoke',
     })
     assert resp.status == 200
@@ -269,32 +267,3 @@ async def test_revoking_refresh_token(hass, aiohttp_client):
     })
 
     assert resp.status == 400
-
-
-async def test_revoking_refresh_token_invalid_client_id(hass, aiohttp_client):
-    """Test that we can revoke refresh tokens."""
-    client = await async_setup_auth(hass, aiohttp_client)
-    user = await hass.auth.async_create_user('Test User')
-    refresh_token = await hass.auth.async_create_refresh_token(user, CLIENT_ID)
-    access_token = hass.auth.async_create_access_token(refresh_token)
-
-    # Revoke refresh token
-    resp = await client.post('/auth/token', data={
-        'client_id': 'something else',
-        'grant_type': 'refresh_token',
-        'refresh_token': refresh_token.token,
-        'action': 'revoke',
-    })
-    # Response is ALWAYS 200
-    assert resp.status == 200
-
-    # Token should not have been revoked
-    assert (
-        await hass.auth.async_get_refresh_token(refresh_token.id) is not None
-    )
-
-    # Existing access tokens should still work
-    assert (
-        await hass.auth.async_validate_access_token(access_token)
-        is not None
-    )

--- a/tests/components/auth/test_init.py
+++ b/tests/components/auth/test_init.py
@@ -224,3 +224,77 @@ async def test_refresh_token_different_client_id(hass, aiohttp_client):
         await hass.auth.async_validate_access_token(tokens['access_token'])
         is not None
     )
+
+
+async def test_revoking_refresh_token(hass, aiohttp_client):
+    """Test that we can revoke refresh tokens."""
+    client = await async_setup_auth(hass, aiohttp_client)
+    user = await hass.auth.async_create_user('Test User')
+    refresh_token = await hass.auth.async_create_refresh_token(user, CLIENT_ID)
+
+    # Test that we can create an access token
+    resp = await client.post('/auth/token', data={
+        'client_id': CLIENT_ID,
+        'grant_type': 'refresh_token',
+        'refresh_token': refresh_token.token,
+    })
+
+    assert resp.status == 200
+    tokens = await resp.json()
+    assert (
+        await hass.auth.async_validate_access_token(tokens['access_token'])
+        is not None
+    )
+
+    # Revoke refresh token
+    resp = await client.post('/auth/token', data={
+        'client_id': CLIENT_ID,
+        'grant_type': 'refresh_token',
+        'refresh_token': refresh_token.token,
+        'action': 'revoke',
+    })
+    assert resp.status == 200
+
+    # Old access token should be no longer valid
+    assert (
+        await hass.auth.async_validate_access_token(tokens['access_token'])
+        is None
+    )
+
+    # Test that we no longer can create an access token
+    resp = await client.post('/auth/token', data={
+        'client_id': CLIENT_ID,
+        'grant_type': 'refresh_token',
+        'refresh_token': refresh_token.token,
+    })
+
+    assert resp.status == 400
+
+
+async def test_revoking_refresh_token_invalid_client_id(hass, aiohttp_client):
+    """Test that we can revoke refresh tokens."""
+    client = await async_setup_auth(hass, aiohttp_client)
+    user = await hass.auth.async_create_user('Test User')
+    refresh_token = await hass.auth.async_create_refresh_token(user, CLIENT_ID)
+    access_token = hass.auth.async_create_access_token(refresh_token)
+
+    # Revoke refresh token
+    resp = await client.post('/auth/token', data={
+        'client_id': 'something else',
+        'grant_type': 'refresh_token',
+        'refresh_token': refresh_token.token,
+        'action': 'revoke',
+    })
+    # Response is ALWAYS 200
+    assert resp.status == 200
+
+    # Token should not have been revoked
+    assert (
+        await hass.auth.async_get_refresh_token(refresh_token.id) is not None
+    )
+
+    # Existing access tokens should still work
+    assert (
+        await hass.auth.async_validate_access_token(access_token)
+        is not None
+    )


### PR DESCRIPTION
## Description:
Add a refresh token revoke endpoint. This will cancel a refresh token and all related access tokens.

```
POST /auth/token

action=revoke&token=REFRESH_TOKEN
```

Related RFC:

 - [RFC 7009 - OAuth 2.0 Token Revocation](https://tools.ietf.org/html/rfc7009)
 - [IndieAuth - 6.5.3: Token Revocation](https://indieauth.spec.indieweb.org/#token-revocation)

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** https://github.com/home-assistant/developers.home-assistant/pull/73

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
