### PR TITLE
Enable auth by default 🙈

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -87,9 +87,11 @@ async def async_from_config_dict(config: Dict[str, Any],
                              log_no_color)
 
     core_config = config.get(core.DOMAIN, {})
+    has_api_password = bool(config.get('http', {}).get('api_password'))
 
     try:
-        await conf_util.async_process_ha_core_config(hass, core_config)
+        await conf_util.async_process_ha_core_config(
+            hass, core_config, has_api_password)
     except vol.Invalid as ex:
         conf_util.async_log_exception(ex, 'homeassistant', core_config, hass)
         return None

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -87,7 +87,7 @@ async def async_from_config_dict(config: Dict[str, Any],
                              log_no_color)
 
     core_config = config.get(core.DOMAIN, {})
-    has_api_password = bool(config.get('http', {}).get('api_password'))
+    has_api_password = bool((config.get('http') or {}).get('api_password'))
 
     try:
         await conf_util.async_process_ha_core_config(

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -426,10 +426,10 @@ async def async_process_ha_core_config(
             if has_api_password:
                 auth_conf.append({'type': 'legacy_api_password'})
 
-        hass.auth = await auth.auth_manager_from_config(
+        setattr(hass, 'auth', await auth.auth_manager_from_config(
             hass,
             auth_conf,
-            config.get(CONF_AUTH_MFA_MODULES, []))
+            config.get(CONF_AUTH_MFA_MODULES, [])))
 
     hac = hass.config
 

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -49,6 +49,10 @@ FILE_MIGRATION = (
     ('ios.conf', '.ios.conf'),
 )
 
+DEFAULT_AUTH_PROVIDERS = [
+    {'type': 'homeassistant'},
+    {'type': 'legacy_api_password'},
+]
 DEFAULT_CORE_CONFIG = (
     # Tuples (attribute, default, auto detect property, description)
     (CONF_NAME, 'Home', None, 'Name of the location where Home Assistant is '
@@ -162,7 +166,7 @@ CORE_CONFIG_SCHEMA = CUSTOMIZE_CONFIG_SCHEMA.extend({
         # pylint: disable=no-value-for-parameter
         vol.All(cv.ensure_list, [vol.IsDir()]),
     vol.Optional(CONF_PACKAGES, default={}): PACKAGES_CONFIG_SCHEMA,
-    vol.Optional(CONF_AUTH_PROVIDERS):
+    vol.Optional(CONF_AUTH_PROVIDERS, default=DEFAULT_AUTH_PROVIDERS):
         vol.All(cv.ensure_list,
                 [auth_providers.AUTH_PROVIDER_SCHEMA.extend({
                     CONF_TYPE: vol.NotIn(['insecure_example'],

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -812,6 +812,47 @@ async def test_auth_provider_config(hass):
     await config_util.async_process_ha_core_config(hass, core_config)
 
     assert len(hass.auth.auth_providers) == 2
+    assert hass.auth.auth_providers[0].type == 'homeassistant'
+    assert hass.auth.auth_providers[1].type == 'legacy_api_password'
+    assert hass.auth.active is True
+
+
+async def test_auth_provider_config_default(hass):
+    """Test loading default auth provider config."""
+    core_config = {
+        'latitude': 60,
+        'longitude': 50,
+        'elevation': 25,
+        'name': 'Huis',
+        CONF_UNIT_SYSTEM: CONF_UNIT_SYSTEM_IMPERIAL,
+        'time_zone': 'GMT',
+    }
+    if hasattr(hass, 'auth'):
+        del hass.auth
+    await config_util.async_process_ha_core_config(hass, core_config)
+
+    assert len(hass.auth.auth_providers) == 1
+    assert hass.auth.auth_providers[0].type == 'homeassistant'
+    assert hass.auth.active is True
+
+
+async def test_auth_provider_config_default_api_password(hass):
+    """Test loading default auth provider config with api password."""
+    core_config = {
+        'latitude': 60,
+        'longitude': 50,
+        'elevation': 25,
+        'name': 'Huis',
+        CONF_UNIT_SYSTEM: CONF_UNIT_SYSTEM_IMPERIAL,
+        'time_zone': 'GMT',
+    }
+    if hasattr(hass, 'auth'):
+        del hass.auth
+    await config_util.async_process_ha_core_config(hass, core_config, True)
+
+    assert len(hass.auth.auth_providers) == 2
+    assert hass.auth.auth_providers[0].type == 'homeassistant'
+    assert hass.auth.auth_providers[1].type == 'legacy_api_password'
     assert hass.auth.active is True
 
 


### PR DESCRIPTION
## Description:
This enabled the new authentication system by default. This will enable both the Home Assistant local auth provider and the Legacy API password auth provider. New users will be routed via an onboarding flow on initial boot to create a new user. This new user will be owner and is able to add more users.

**Breaking change:** It is no longer possible to use Home Assistant without authentication. To allow users to log in without entering a username or password, you can configure the [trusted networks auth provider](#). If you were using another application to provide authentication, like NGINX, configure it to set the header `x-ha-access: <API PASSWORD>` on each request. In the future, this header will be replaced with a header containing a long lived access token (#15195).

(I don't use these platforms like NGINX, would be nice if people would contribute config examples)

**Related issue (if applicable):** #15703

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
