### PR TITLE
Adds support for routers implementing IGDv2

### DIFF
--- a/homeassistant/components/upnp.py
+++ b/homeassistant/components/upnp.py
@@ -119,7 +119,8 @@ async def async_setup(hass, config):
             await service.add_port_mapping(internal, external, host, 'TCP',
                                            desc='Home Assistant')
             registered.append(external)
-            _LOGGER.debug("external %s -> %s @ %s", external, internal, host)
+            _LOGGER.debug("Mapping external TCP port %s -> %s @ %s",
+                          external, internal, host)
         except UpnpSoapError as error:
             _LOGGER.error(error)
             hass.components.persistent_notification.create(

--- a/homeassistant/components/upnp.py
+++ b/homeassistant/components/upnp.py
@@ -15,7 +15,7 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import discovery
 from homeassistant.util import get_local_ip
 
-REQUIREMENTS = ['pyupnp-async==0.1.0.2']
+REQUIREMENTS = ['pyupnp-async==0.1.1.0']
 DEPENDENCIES = ['http']
 
 _LOGGER = logging.getLogger(__name__)
@@ -37,6 +37,7 @@ NOTIFICATION_TITLE = 'UPnP Setup'
 IGD_DEVICE = 'urn:schemas-upnp-org:device:InternetGatewayDevice:1'
 PPP_SERVICE = 'urn:schemas-upnp-org:service:WANPPPConnection:1'
 IP_SERVICE = 'urn:schemas-upnp-org:service:WANIPConnection:1'
+IP_SERVICE2 = 'urn:schemas-upnp-org:service:WANIPConnection:2'
 CIC_SERVICE = 'urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1'
 
 UNITS = {
@@ -48,7 +49,7 @@ UNITS = {
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
-        vol.Optional(CONF_ENABLE_PORT_MAPPING, default=True): cv.boolean,
+        vol.Optional(CONF_ENABLE_PORT_MAPPING, default=False): cv.boolean,
         vol.Optional(CONF_UNITS, default="MBytes"): vol.In(UNITS),
         vol.Optional(CONF_LOCAL_IP): vol.All(ip_address, cv.string),
         vol.Optional(CONF_PORTS):
@@ -86,8 +87,10 @@ async def async_setup(hass, config):
                 service = device.find_first_service(PPP_SERVICE)
             if _service['serviceType'] == IP_SERVICE:
                 service = device.find_first_service(IP_SERVICE)
+            if _service['serviceType'] == IP_SERVICE2:
+                service = device.find_first_service(IP_SERVICE2)
             if _service['serviceType'] == CIC_SERVICE:
-                unit = config.get(CONF_UNITS)
+                unit = config[CONF_UNITS]
                 hass.async_create_task(discovery.async_load_platform(
                     hass, 'sensor', DOMAIN, {'unit': unit}, config))
     except UpnpSoapError as error:
@@ -98,7 +101,7 @@ async def async_setup(hass, config):
         _LOGGER.warning("Could not find any UPnP IGD")
         return False
 
-    port_mapping = config.get(CONF_ENABLE_PORT_MAPPING)
+    port_mapping = config[CONF_ENABLE_PORT_MAPPING]
     if not port_mapping:
         return True
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1167,7 +1167,7 @@ pytradfri[async]==5.5.1
 pyunifi==2.13
 
 # homeassistant.components.upnp
-pyupnp-async==0.1.0.2
+pyupnp-async==0.1.1.0
 
 # homeassistant.components.binary_sensor.uptimerobot
 pyuptimerobot==0.0.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -171,7 +171,7 @@ pytradfri[async]==5.5.1
 pyunifi==2.13
 
 # homeassistant.components.upnp
-pyupnp-async==0.1.0.2
+pyupnp-async==0.1.1.0
 
 # homeassistant.components.notify.html5
 pywebpush==1.6.0

--- a/tests/components/test_upnp.py
+++ b/tests/components/test_upnp.py
@@ -102,7 +102,8 @@ async def test_setup_succeeds_if_specify_ip(hass, mock_msearch_first):
                return_value='127.0.0.1'):
         result = await async_setup_component(hass, 'upnp', {
             'upnp': {
-                'local_ip': '192.168.0.10'
+                'local_ip': '192.168.0.10',
+                'port_mapping': 'True'
             }
         })
 
@@ -118,7 +119,9 @@ async def test_no_config_maps_hass_local_to_remote_port(hass,
                                                         mock_msearch_first):
     """Test by default we map local to remote port."""
     result = await async_setup_component(hass, 'upnp', {
-        'upnp': {}
+        'upnp': {
+                'port_mapping': 'True'
+        }
     })
 
     assert result
@@ -134,6 +137,7 @@ async def test_map_hass_to_remote_port(hass,
     """Test mapping hass to remote port."""
     result = await async_setup_component(hass, 'upnp', {
         'upnp': {
+            'port_mapping': 'True',
             'ports': {
                 'hass': 1000
             }
@@ -157,6 +161,7 @@ async def test_map_internal_to_remote_ports(hass,
 
     result = await async_setup_component(hass, 'upnp', {
         'upnp': {
+            'port_mapping': 'True',
             'ports': ports
         }
     })


### PR DESCRIPTION
## Description:

Adds support for routers using IGDv2. (new PR after #16034 branch borked) 

During this PR also noticed the documentation did not match implementation in an unsafe way: port mapping was ON by default instead of OFF (as in the documentation). This might have a breaking change effect.

**Related issue (if applicable):** fixes #15793

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
upnp:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54