### PR TITLE
Clear deps if running Docker and upgrading from pre-77

### DIFF
--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -352,8 +352,17 @@ def process_ha_config_upgrade(hass: HomeAssistant) -> None:
     _LOGGER.info("Upgrading configuration directory from %s to %s",
                  conf_version, __version__)
 
-    if LooseVersion(conf_version) < LooseVersion('0.50'):
-        # 0.50 introduced persistent deps dir.
+    cur_version = LooseVersion(conf_version)
+
+    if (
+            # 0.50 introduced persistent deps dir.
+            cur_version < LooseVersion('0.50')
+            or
+            # 0.75.1 didn't update requirements_all when updating frontend
+            # Resulted in Docker version installing frontend 20180804.0 in deps
+            os.path.isfile('/.dockerenv') and
+            cur_version < LooseVersion('0.77.0')
+    ):
         lib_path = hass.config.path('deps')
         if os.path.isdir(lib_path):
             shutil.rmtree(lib_path)


### PR DESCRIPTION
## Description:
Clear dependencies installed in Docker for any version upgrading to 0.77.

Background: #16120

It's not strictly necessary, as #16121 will fix the issue observed in #16120. However, by not cleaning it, it means that Docker users will have to download an additional 14MB (the size of the frontend package) on each version upgrade. That sucks.

We're doing a one time clear of all dependencies stored in the config folder for Docker based installs. 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
