### PR TITLE
Prevent legacy api password with empty password

### DIFF
--- a/homeassistant/auth/providers/legacy_api_password.py
+++ b/homeassistant/auth/providers/legacy_api_password.py
@@ -80,8 +80,8 @@ class LegacyLoginFlow(LoginFlow):
         """Handle the step of the form."""
         errors = {}
 
-        if (getattr(self.hass, 'http', None) is None or
-                not self.hass.http.api_password):
+        hass_http = getattr(self.hass, 'http', None)
+        if hass_http is None or not hass_http.api_password:
             return self.async_abort(
                 reason='no_api_password_set'
             )

--- a/homeassistant/auth/providers/legacy_api_password.py
+++ b/homeassistant/auth/providers/legacy_api_password.py
@@ -46,13 +46,6 @@ class LegacyApiPasswordAuthProvider(AuthProvider):
         """Helper to validate a username and password."""
         hass_http = getattr(self.hass, 'http', None)  # type: HomeAssistantHTTP
 
-        if not hass_http:
-            raise ValueError('http component is not loaded')
-
-        if hass_http.api_password is None:
-            raise ValueError('http component is not configured using'
-                             ' api_password')
-
         if not hmac.compare_digest(hass_http.api_password.encode('utf-8'),
                                    password.encode('utf-8')):
             raise InvalidAuthError
@@ -86,6 +79,12 @@ class LegacyLoginFlow(LoginFlow):
             -> Dict[str, Any]:
         """Handle the step of the form."""
         errors = {}
+
+        if (getattr(self.hass, 'http', None) is None or
+                not self.hass.http.api_password):
+            return self.async_abort(
+                reason='no_api_password_set'
+            )
 
         if user_input is not None:
             try:


### PR DESCRIPTION
## Description:
Abort a login flow for the legacy API password provider if the HTTP component has not been configured with an API password.

**Related issue (if applicable):** #16107

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
