### PR TITLE
Ignore min_cycle_duration when manually controlling the thermostat.

### DIFF
--- a/homeassistant/components/climate/generic_thermostat.py
+++ b/homeassistant/components/climate/generic_thermostat.py
@@ -232,11 +232,11 @@ class GenericThermostat(ClimateDevice):
         if operation_mode == STATE_HEAT:
             self._current_operation = STATE_HEAT
             self._enabled = True
-            await self._async_control_heating()
+            await self._async_control_heating(force=True)
         elif operation_mode == STATE_COOL:
             self._current_operation = STATE_COOL
             self._enabled = True
-            await self._async_control_heating()
+            await self._async_control_heating(force=True)
         elif operation_mode == STATE_OFF:
             self._current_operation = STATE_OFF
             self._enabled = False
@@ -262,7 +262,7 @@ class GenericThermostat(ClimateDevice):
         if temperature is None:
             return
         self._target_temp = temperature
-        await self._async_control_heating()
+        await self._async_control_heating(force=True)
         await self.async_update_ha_state()
 
     @property
@@ -307,7 +307,7 @@ class GenericThermostat(ClimateDevice):
         except ValueError as ex:
             _LOGGER.error("Unable to update from sensor: %s", ex)
 
-    async def _async_control_heating(self, time=None):
+    async def _async_control_heating(self, time=None, force=False):
         """Check if we need to turn heating on or off."""
         async with self._temp_lock:
             if not self._active and None not in (self._cur_temp,
@@ -320,16 +320,21 @@ class GenericThermostat(ClimateDevice):
             if not self._active or not self._enabled:
                 return
 
-            if self.min_cycle_duration:
-                if self._is_device_active:
-                    current_state = STATE_ON
-                else:
-                    current_state = STATE_OFF
-                long_enough = condition.state(
-                    self.hass, self.heater_entity_id, current_state,
-                    self.min_cycle_duration)
-                if not long_enough:
-                    return
+            if not force and time is None:
+                # If the `force` argument is True, we
+                # ignore `min_cycle_duration`.
+                # If the `time` argument is not none, we were invoked for
+                # keep-alive purposes, and `min_cycle_duration` is irrelevant.
+                if self.min_cycle_duration:    
+                    if self._is_device_active:
+                        current_state = STATE_ON
+                    else:
+                        current_state = STATE_OFF
+                    long_enough = condition.state(
+                        self.hass, self.heater_entity_id, current_state,
+                        self.min_cycle_duration)
+                    if not long_enough:
+                        return
 
             too_cold = \
                 self._target_temp - self._cur_temp >= self._cold_tolerance
@@ -383,12 +388,12 @@ class GenericThermostat(ClimateDevice):
         self._is_away = True
         self._saved_target_temp = self._target_temp
         self._target_temp = self._away_temp
-        await self._async_control_heating()
+        await self._async_control_heating(force=True)
         await self.async_update_ha_state()
 
     async def async_turn_away_mode_off(self):
         """Turn away off."""
         self._is_away = False
         self._target_temp = self._saved_target_temp
-        await self._async_control_heating()
+        await self._async_control_heating(force=True)
         await self.async_update_ha_state()

--- a/homeassistant/components/climate/generic_thermostat.py
+++ b/homeassistant/components/climate/generic_thermostat.py
@@ -325,7 +325,7 @@ class GenericThermostat(ClimateDevice):
                 # ignore `min_cycle_duration`.
                 # If the `time` argument is not none, we were invoked for
                 # keep-alive purposes, and `min_cycle_duration` is irrelevant.
-                if self.min_cycle_duration:    
+                if self.min_cycle_duration:
                     if self._is_device_active:
                         current_state = STATE_ON
                     else:

--- a/tests/components/climate/test_generic_thermostat.py
+++ b/tests/components/climate/test_generic_thermostat.py
@@ -609,12 +609,12 @@ class TestClimateGenericThermostatACModeMinCycle(unittest.TestCase):
     def test_mode_change_ac_trigger_off_not_long_enough(self):
         """Test if mode change turns ac off despite minimum cycle."""
         self._setup_switch(True)
-        climate.set_temperature(self.hass, 30)
+        common.set_temperature(self.hass, 30)
         self.hass.block_till_done()
         self._setup_sensor(25)
         self.hass.block_till_done()
         self.assertEqual(0, len(self.calls))
-        climate.set_operation_mode(self.hass, climate.STATE_OFF)
+        common.set_operation_mode(self.hass, climate.STATE_OFF)
         self.hass.block_till_done()
         self.assertEqual(1, len(self.calls))
         call = self.calls[0]
@@ -625,12 +625,12 @@ class TestClimateGenericThermostatACModeMinCycle(unittest.TestCase):
     def test_mode_change_ac_trigger_on_not_long_enough(self):
         """Test if mode change turns ac on despite minimum cycle."""
         self._setup_switch(False)
-        climate.set_temperature(self.hass, 25)
+        common.set_temperature(self.hass, 25)
         self.hass.block_till_done()
         self._setup_sensor(30)
         self.hass.block_till_done()
         self.assertEqual(0, len(self.calls))
-        climate.set_operation_mode(self.hass, climate.STATE_HEAT)
+        common.set_operation_mode(self.hass, climate.STATE_HEAT)
         self.hass.block_till_done()
         self.assertEqual(1, len(self.calls))
         call = self.calls[0]
@@ -732,12 +732,12 @@ class TestClimateGenericThermostatMinCycle(unittest.TestCase):
     def test_mode_change_heater_trigger_off_not_long_enough(self):
         """Test if mode change turns heater off despite minimum cycle."""
         self._setup_switch(True)
-        climate.set_temperature(self.hass, 25)
+        common.set_temperature(self.hass, 25)
         self.hass.block_till_done()
         self._setup_sensor(30)
         self.hass.block_till_done()
         self.assertEqual(0, len(self.calls))
-        climate.set_operation_mode(self.hass, climate.STATE_OFF)
+        common.set_operation_mode(self.hass, climate.STATE_OFF)
         self.hass.block_till_done()
         self.assertEqual(1, len(self.calls))
         call = self.calls[0]
@@ -748,12 +748,12 @@ class TestClimateGenericThermostatMinCycle(unittest.TestCase):
     def test_mode_change_heater_trigger_on_not_long_enough(self):
         """Test if mode change turns heater on despite minimum cycle."""
         self._setup_switch(False)
-        climate.set_temperature(self.hass, 30)
+        common.set_temperature(self.hass, 30)
         self.hass.block_till_done()
         self._setup_sensor(25)
         self.hass.block_till_done()
         self.assertEqual(0, len(self.calls))
-        climate.set_operation_mode(self.hass, climate.STATE_HEAT)
+        common.set_operation_mode(self.hass, climate.STATE_HEAT)
         self.hass.block_till_done()
         self.assertEqual(1, len(self.calls))
         call = self.calls[0]

--- a/tests/components/climate/test_generic_thermostat.py
+++ b/tests/components/climate/test_generic_thermostat.py
@@ -731,6 +731,7 @@ class TestClimateGenericThermostatACKeepAlive(unittest.TestCase):
             'target_temp': 25,
             'target_sensor': ENT_SENSOR,
             'ac_mode': True,
+            'min_cycle_duration': datetime.timedelta(minutes=15),
             'keep_alive': datetime.timedelta(minutes=10)
         }})
 
@@ -821,6 +822,7 @@ class TestClimateGenericThermostatKeepAlive(unittest.TestCase):
             'target_temp': 25,
             'heater': ENT_SWITCH,
             'target_sensor': ENT_SENSOR,
+            'min_cycle_duration': datetime.timedelta(minutes=15),
             'keep_alive': datetime.timedelta(minutes=10)
         }})
 

--- a/tests/components/climate/test_generic_thermostat.py
+++ b/tests/components/climate/test_generic_thermostat.py
@@ -606,6 +606,38 @@ class TestClimateGenericThermostatACModeMinCycle(unittest.TestCase):
         self.assertEqual(SERVICE_TURN_OFF, call.service)
         self.assertEqual(ENT_SWITCH, call.data['entity_id'])
 
+    def test_mode_change_ac_trigger_off_not_long_enough(self):
+        """Test if mode change turns ac off despite minimum cycle."""
+        self._setup_switch(True)
+        climate.set_temperature(self.hass, 30)
+        self.hass.block_till_done()
+        self._setup_sensor(25)
+        self.hass.block_till_done()
+        self.assertEqual(0, len(self.calls))
+        climate.set_operation_mode(self.hass, climate.STATE_OFF)
+        self.hass.block_till_done()
+        self.assertEqual(1, len(self.calls))
+        call = self.calls[0]
+        self.assertEqual('homeassistant', call.domain)
+        self.assertEqual(SERVICE_TURN_OFF, call.service)
+        self.assertEqual(ENT_SWITCH, call.data['entity_id'])
+
+    def test_mode_change_ac_trigger_on_not_long_enough(self):
+        """Test if mode change turns ac on despite minimum cycle."""
+        self._setup_switch(False)
+        climate.set_temperature(self.hass, 25)
+        self.hass.block_till_done()
+        self._setup_sensor(30)
+        self.hass.block_till_done()
+        self.assertEqual(0, len(self.calls))
+        climate.set_operation_mode(self.hass, climate.STATE_HEAT)
+        self.hass.block_till_done()
+        self.assertEqual(1, len(self.calls))
+        call = self.calls[0]
+        self.assertEqual('homeassistant', call.domain)
+        self.assertEqual(SERVICE_TURN_ON, call.service)
+        self.assertEqual(ENT_SWITCH, call.data['entity_id'])
+
     def _setup_sensor(self, temp):
         """Set up the test sensor."""
         self.hass.states.set(ENT_SENSOR, temp)
@@ -695,6 +727,38 @@ class TestClimateGenericThermostatMinCycle(unittest.TestCase):
         call = self.calls[0]
         self.assertEqual('homeassistant', call.domain)
         self.assertEqual(SERVICE_TURN_OFF, call.service)
+        self.assertEqual(ENT_SWITCH, call.data['entity_id'])
+
+    def test_mode_change_heater_trigger_off_not_long_enough(self):
+        """Test if mode change turns heater off despite minimum cycle."""
+        self._setup_switch(True)
+        climate.set_temperature(self.hass, 25)
+        self.hass.block_till_done()
+        self._setup_sensor(30)
+        self.hass.block_till_done()
+        self.assertEqual(0, len(self.calls))
+        climate.set_operation_mode(self.hass, climate.STATE_OFF)
+        self.hass.block_till_done()
+        self.assertEqual(1, len(self.calls))
+        call = self.calls[0]
+        self.assertEqual('homeassistant', call.domain)
+        self.assertEqual(SERVICE_TURN_OFF, call.service)
+        self.assertEqual(ENT_SWITCH, call.data['entity_id'])
+
+    def test_mode_change_heater_trigger_on_not_long_enough(self):
+        """Test if mode change turns heater on despite minimum cycle."""
+        self._setup_switch(False)
+        climate.set_temperature(self.hass, 30)
+        self.hass.block_till_done()
+        self._setup_sensor(25)
+        self.hass.block_till_done()
+        self.assertEqual(0, len(self.calls))
+        climate.set_operation_mode(self.hass, climate.STATE_HEAT)
+        self.hass.block_till_done()
+        self.assertEqual(1, len(self.calls))
+        call = self.calls[0]
+        self.assertEqual('homeassistant', call.domain)
+        self.assertEqual(SERVICE_TURN_ON, call.service)
         self.assertEqual(ENT_SWITCH, call.data['entity_id'])
 
     def _setup_sensor(self, temp):


### PR DESCRIPTION
## Description:

The purpose of `min_cycle_duration` is to avoid the A/C engine from stopping and starting too frequently due to quick changes in the thermostat's sensor temperature. On top of being potentially harmful to the engine, this kind of frequent starting and stopping can be irritating to the user of the thermostat.

However, there's no reason to use this protection when the user actively engages the thermostat. Specifically, when the user actively sets the mode or changes the temperature, the expectation is for the thermostat to start working immediately.

This PR changes the behavior accordingly.

Additionally, the recent fix for the keep-alive race condition introduced a bug where the keep-alive action wouldn't run during the `min_cycle_duration` period. This PR fixes that bug, as well.

Though not directly related, both changes are fixed in practice with one line of code (and several lines of comments) in the `async_control_heating` method. Furthermore, the PR is still very small. Therefore, I hope it's OK it's a single PR, and not split in two.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
