### PR TITLE
Upgrade brunt package

### DIFF
--- a/homeassistant/components/cover/brunt.py
+++ b/homeassistant/components/cover/brunt.py
@@ -18,7 +18,7 @@ from homeassistant.components.cover import (
 )
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['brunt==0.1.2']
+REQUIREMENTS = ['brunt==0.1.3']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -205,7 +205,7 @@ braviarc-homeassistant==0.3.7.dev0
 broadlink==0.9.0
 
 # homeassistant.components.cover.brunt
-brunt==0.1.2
+brunt==0.1.3
 
 # homeassistant.components.device_tracker.bluetooth_tracker
 bt_proximity==0.1.2


### PR DESCRIPTION
## Description:
Small fix in the sdk package that caused errors when using HA with Python before 3.6 (specifically f-strings). Fixes #16001

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
