### PR TITLE
_send_packet() improvement

### DIFF
--- a/homeassistant/components/switch/broadlink.py
+++ b/homeassistant/components/switch/broadlink.py
@@ -123,7 +123,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         packets = call.data.get('packet', [])
         repeat = call.data.get('repeat')
         delay = call.data.get('delay')
-        for times in range(0, repeat):
+        for _ in range(0, repeat):
             for packet in packets:
                 for retry in range(DEFAULT_RETRY):
                     try:

--- a/homeassistant/components/switch/broadlink.py
+++ b/homeassistant/components/switch/broadlink.py
@@ -69,8 +69,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 SEND_PACKET_SCHEMA = vol.Schema({
     vol.Required('packet'): cv.ensure_list,
-    vol.Optional('repeat'): cv.positive_int,
-    vol.Optional('delay'): cv.small_float
+    vol.Optional('repeat', default=1): cv.positive_int,
+    vol.Optional('delay', default=0): cv.small_float
 })
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -119,28 +119,30 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     def _send_packet(call):
         """Send a packet."""
         packets = call.data.get('packet', [])
-        repeat = call.data.get('repeat', 1)
-        delay = call.data.get('delay', 0)
+        repeat = call.data.get('repeat')
+        delay = call.data.get('delay')
         if repeat == 0:
             return
-        else:
-            for i in range(0, repeat):
-                for packet in packets:
-                    for retry in range(DEFAULT_RETRY):
+        for i in range(0, repeat):
+            for packet in packets:
+                for retry in range(DEFAULT_RETRY):
+                    try:
+                        extra = len(packet) % 4
+                        if extra > 0:
+                            packet = packet + ('=' * (4 - extra))
+                        payload = b64decode(packet)
+                        yield from hass.async_add_job(
+                            broadlink_device.send_data, payload)
+                        yield from asyncio.sleep(delay)
+                        break
+                    except (socket.timeout, ValueError):
                         try:
-                            extra = len(packet) % 4
-                            if extra > 0:
-                                packet = packet + ('=' * (4 - extra))
-                            payload = b64decode(packet)
-                            yield from hass.async_add_job(broadlink_device.send_data, payload)
-                            yield from asyncio.sleep(delay)
-                            break
-                        except (socket.timeout, ValueError):
-                            try:
-                                yield from hass.async_add_job(broadlink_device.auth)
-                            except socket.timeout:
-                                if retry == DEFAULT_RETRY-1:
-                                    _LOGGER.error("Failed to send packet to device")
+                            yield from hass.async_add_job(
+                                broadlink_device.auth)
+                        except socket.timeout:
+                            if retry == DEFAULT_RETRY-1:
+                                _LOGGER.error(
+                                    "Failed to send packet to device")
 
     def _get_mp1_slot_name(switch_friendly_name, slot):
         """Get slot name."""

--- a/homeassistant/components/switch/broadlink.py
+++ b/homeassistant/components/switch/broadlink.py
@@ -1,5 +1,6 @@
 """
 Support for Broadlink RM devices.
+
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/switch.broadlink/
 """
@@ -73,6 +74,7 @@ SEND_PACKET_SCHEMA = vol.Schema({
     vol.Optional('delay', default=0): cv.small_float
 })
 
+
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Broadlink switches."""
     import broadlink
@@ -121,9 +123,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         packets = call.data.get('packet', [])
         repeat = call.data.get('repeat')
         delay = call.data.get('delay')
-        if repeat == 0:
-            return
-        for i in range(0, repeat):
+        for x in range(0, repeat):
             for packet in packets:
                 for retry in range(DEFAULT_RETRY):
                     try:

--- a/homeassistant/components/switch/broadlink.py
+++ b/homeassistant/components/switch/broadlink.py
@@ -123,7 +123,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         packets = call.data.get('packet', [])
         repeat = call.data.get('repeat')
         delay = call.data.get('delay')
-        for x in range(0, repeat):
+        for times in range(0, repeat):
             for packet in packets:
                 for retry in range(DEFAULT_RETRY):
                     try:


### PR DESCRIPTION
## Description

This enhancement allows you to specify the number of times a packet should be sent and the delay between one send and another. Useful for controlling TV volume.


## Example entry for _configuration.yaml_:
```
script:
    enhanced_send_packet:
        sequence:
            - service: switch.broadlink_send_packet_192_168_0_100
              data:
                  packet: 'JgAaAB8bHxs8Gx8bHxseHB4cHjk6HR4cHhweAA0FAAAAAAAAAAAAAAAAAAA=='
                  repeat: 5
                  delay: 0.2
```
The above script will send the packet 5 times with a 0.2s delay between one send and another. I'm currently using this enhancement to control the volume of my TV with a slider.
This is my first pull request and I didn't have time to learn about the process of documentation yet, so I apologize for not providing one. Peace.