### PR TITLE
Remove commented out API password from default config

### DIFF
--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -75,11 +75,9 @@ frontend:
 # Enables configuration UI
 config:
 
-http:
-  # Secrets are defined in the file secrets.yaml
-  # api_password: !secret http_password
-  # Uncomment this if you are using SSL/TLS, running in Docker container, etc.
-  # base_url: example.duckdns.org:8123
+# Uncomment this if you are using SSL/TLS, running in Docker container, etc.
+# http:
+#   base_url: example.duckdns.org:8123
 
 # Checks for available updates
 # Note: This component will send some information about your system to
@@ -126,7 +124,7 @@ script: !include scripts.yaml
 DEFAULT_SECRETS = """
 # Use this file to store secrets like usernames and passwords.
 # Learn more at https://home-assistant.io/docs/configuration/secrets/
-http_password: welcome
+some_password: welcome
 """
 
 


### PR DESCRIPTION
## Description:
This removes the commented out API password from the default config. Users will now see an onboarding flow on initial boot.

