### PR TITLE
SSL for zoneminder

### DIFF
--- a/homeassistant/components/zoneminder.py
+++ b/homeassistant/components/zoneminder.py
@@ -11,7 +11,8 @@ import requests
 import voluptuous as vol
 
 from homeassistant.const import (
-    CONF_PATH, CONF_HOST, CONF_SSL, CONF_PASSWORD, CONF_USERNAME)
+  CONF_PATH, CONF_HOST, CONF_SSL,
+  CONF_PASSWORD, CONF_USERNAME, CONF_VERIFY_SSL)
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
@@ -20,6 +21,7 @@ CONF_PATH_ZMS = 'path_zms'
 DEFAULT_PATH = '/zm/'
 DEFAULT_PATH_ZMS = '/zm/cgi-bin/nph-zms'
 DEFAULT_SSL = False
+DEFAULT_VERIFY_SSL = True
 DEFAULT_TIMEOUT = 10
 DOMAIN = 'zoneminder'
 
@@ -31,6 +33,7 @@ CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Required(CONF_HOST): cv.string,
         vol.Optional(CONF_SSL, default=DEFAULT_SSL): cv.boolean,
+        vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): cv.boolean,
         vol.Optional(CONF_PATH, default=DEFAULT_PATH): cv.string,
         # This should match PATH_ZMS in ZoneMinder settings.
         vol.Optional(CONF_PATH_ZMS, default=DEFAULT_PATH_ZMS): cv.string,
@@ -56,11 +59,14 @@ def setup(hass, config):
     username = conf.get(CONF_USERNAME, None)
     password = conf.get(CONF_PASSWORD, None)
 
+    ssl_verification = conf.get(CONF_VERIFY_SSL)
+
     ZM['server_origin'] = server_origin
     ZM['url'] = url
     ZM['username'] = username
     ZM['password'] = password
     ZM['path_zms'] = conf.get(CONF_PATH_ZMS)
+    ZM['ssl_verification'] = ssl_verification
 
     hass.data[DOMAIN] = ZM
 
@@ -77,14 +83,16 @@ def login():
     if ZM['password']:
         login_post['password'] = ZM['password']
 
-    req = requests.post(ZM['url'] + '/index.php', data=login_post)
+    req = requests.post(ZM['url'] + '/index.php', data=login_post,
+                        verify=ZM['ssl_verification'])
+
     ZM['cookies'] = req.cookies
 
     # Login calls returns a 200 response on both failure and success.
     # The only way to tell if you logged in correctly is to issue an api call.
     req = requests.get(
         ZM['url'] + 'api/host/getVersion.json', cookies=ZM['cookies'],
-        timeout=DEFAULT_TIMEOUT)
+        timeout=DEFAULT_TIMEOUT, verify=ZM['ssl_verification'])
 
     if not req.ok:
         _LOGGER.error("Connection error logging into ZoneMinder")
@@ -99,8 +107,11 @@ def _zm_request(method, api_url, data=None):
     # if the call fails.
     for _ in range(LOGIN_RETRIES):
         req = requests.request(
-            method, urljoin(ZM['url'], api_url), data=data,
-            cookies=ZM['cookies'], timeout=DEFAULT_TIMEOUT)
+            method, urljoin(ZM['url'], api_url),
+            data=data,
+            cookies=ZM['cookies'],
+            timeout=DEFAULT_TIMEOUT,
+            verify=ZM['ssl_verification'])
 
         if not req.ok:
             login()

--- a/homeassistant/components/zoneminder.py
+++ b/homeassistant/components/zoneminder.py
@@ -106,8 +106,7 @@ def _zm_request(method, api_url, data=None):
     # Since the API uses sessions that expire, sometimes we need to re-auth
     # if the call fails.
     for _ in range(LOGIN_RETRIES):
-        req = requests.request(
-            method, urljoin(ZM['url'], api_url),
+        req = requests.request(method, urljoin(ZM['url'], api_url),
             data=data,
             cookies=ZM['cookies'],
             timeout=DEFAULT_TIMEOUT,


### PR DESCRIPTION
## Description:
Added option to disable ssl verification checks for the zoneminder module 

This is a re-try of #14869 which erroneously contained other commits due to my complete lack of git skills (apologies for that).

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#5507

## Example entry for `configuration.yaml` (if applicable):
```yaml
zoneminder:
  host: 192.168.1.1:1080
  ssl: True
  verify_ssl: False
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
