### PR TITLE
Add helper to determine closest match from list.

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -580,6 +580,29 @@ def regex_findall_index(value, find='', index=0, ignorecase=False):
     return re.findall(find, value, flags)[index]
 
 
+def closest_match(value, items):
+    """Find closest match using Levenstein distance."""
+    max_score = -1
+    best_match = None
+    import jellyfish
+
+    for item in items:
+        if value == item:
+            max_score = 1
+            best_match = item
+            break
+        else:
+            ratio = 1/(
+                1+jellyfish.levenshtein_distance(
+                    value.lower(), item.lower()))
+            if ratio > max_score:
+                max_score = ratio
+                best_match = item
+
+    _LOGGER.debug("Best match <%s> for <%s> in <%s>", best_match, value, list)
+    return best_match
+
+
 @contextfilter
 def random_every_time(context, values):
     """Choose a random value.
@@ -617,6 +640,8 @@ ENV.filters['regex_match'] = regex_match
 ENV.filters['regex_replace'] = regex_replace
 ENV.filters['regex_search'] = regex_search
 ENV.filters['regex_findall_index'] = regex_findall_index
+ENV.filters['regex_search'] = regex_search
+ENV.globals['closest_match'] = closest_match
 ENV.globals['log'] = logarithm
 ENV.globals['sin'] = sine
 ENV.globals['cos'] = cosine

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -11,6 +11,7 @@ pytz>=2018.04
 pyyaml>=3.13,<4
 requests==2.19.1
 voluptuous==0.11.5
+jellyfish==0.6.1
 
 # Breaks Python 3.6 and is not needed for our supported Python versions
 enum34==1000000000.0.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -12,6 +12,7 @@ pytz>=2018.04
 pyyaml>=3.13,<4
 requests==2.19.1
 voluptuous==0.11.5
+jellyfish==0.6.1
 
 # homeassistant.components.nuimo_controller
 --only-binary=all nuimo==0.1.0

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ REQUIRES = [
     'pyyaml>=3.13,<4',
     'requests==2.19.1',
     'voluptuous==0.11.5',
+    'jellyfish==0.6.1',
 ]
 
 MIN_PY_VERSION = '.'.join(map(str, hass_const.REQUIRED_PYTHON_VER))


### PR DESCRIPTION
Can be used in an intent script to choose the bezt fitting media_player source, or the best matching entity from a list if voice recognition is inperfect)

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#6069

## Example entry for `configuration.yaml` (if applicable):
```yaml
intent_script:
  set_channel_television:
    action:
      - service: media_player.play_media
        data_template:
          entity_id: media_player.lg_webos_smart_tv 
          media_content_id: "{{closest_match(channel, state_attr('media_player.lg_webos_smart_tv','channel_list'))}}"
          media_content_type: channel
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
