### PR TITLE
Add port configuration to Cast

### DIFF
--- a/homeassistant/components/cast/__init__.py
+++ b/homeassistant/components/cast/__init__.py
@@ -1,10 +1,29 @@
 """Component to embed Google Cast."""
+import voluptuous as vol
+
 from homeassistant import config_entries
 from homeassistant.helpers import config_entry_flow
+from homeassistant.const import CONF_HOST, CONF_PORT
+import homeassistant.helpers.config_validation as cv
 
+from .const import (
+    DOMAIN, DEFAULT_PORT, CONF_CAST_MEDIA_PLAYER, CONF_IGNORE_CEC)
 
-DOMAIN = 'cast'
 REQUIREMENTS = ['pychromecast==2.1.0']
+
+CAST_MEDIA_PLAYER_SCHEMA = vol.Schema({
+    vol.Required(CONF_HOST): vol.All(cv.string),
+    vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+    vol.Optional(CONF_IGNORE_CEC, default=[]): vol.All(cv.ensure_list,
+                                                       [cv.string])
+})
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Optional(CONF_CAST_MEDIA_PLAYER):
+            vol.All(cv.ensure_list, [CAST_MEDIA_PLAYER_SCHEMA]),
+    }),
+}, extra=vol.ALLOW_EXTRA)
 
 
 async def async_setup(hass, config):

--- a/homeassistant/components/cast/const.py
+++ b/homeassistant/components/cast/const.py
@@ -1,0 +1,6 @@
+"""Constants for the Cast component."""
+
+DOMAIN = 'cast'
+DEFAULT_PORT = 8009
+CONF_CAST_MEDIA_PLAYER = "media_player"
+CONF_IGNORE_CEC = 'ignore_cec'

--- a/homeassistant/components/media_player/cast.py
+++ b/homeassistant/components/media_player/cast.py
@@ -662,9 +662,9 @@ class CastDevice(MediaPlayerDevice):
     def media_position(self):
         """Position of current playing media in seconds."""
         if self.media_status is None or \
-            not (self.media_status.player_is_playing or
-                 self.media_status.player_is_paused or
-                 self.media_status.player_is_idle):
+            not (self.media_status.player_is_playing
+                 or self.media_status.player_is_paused
+                 or self.media_status.player_is_idle):
             return None
         return self.media_status.current_time
 

--- a/homeassistant/components/media_player/cast.py
+++ b/homeassistant/components/media_player/cast.py
@@ -57,7 +57,7 @@ SIGNAL_CAST_DISCOVERED = 'cast_discovered'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_HOST): cv.string,
-    vol.Optional(CONF_PORT): cv.port,
+    vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
     vol.Optional(CONF_IGNORE_CEC, default=[]):
         vol.All(cv.ensure_list, [cv.string])
 })
@@ -237,7 +237,7 @@ async def _async_setup_platform(hass: HomeAssistantType, config: ConfigType,
                               port=discovery_info['port'])
     elif CONF_HOST in config:
         info = ChromecastInfo(host=config[CONF_HOST],
-                              port=config[CONF_PORT])
+                              port=config.get(CONF_PORT, DEFAULT_PORT))
 
     @callback
     def async_cast_discovered(discover: ChromecastInfo) -> None:

--- a/homeassistant/components/media_player/cast.py
+++ b/homeassistant/components/media_player/cast.py
@@ -19,8 +19,8 @@ from homeassistant.components.media_player import (
     SUPPORT_PREVIOUS_TRACK, SUPPORT_STOP, SUPPORT_TURN_OFF, SUPPORT_TURN_ON,
     SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_SET, MediaPlayerDevice)
 from homeassistant.const import (
-    CONF_HOST, EVENT_HOMEASSISTANT_STOP, STATE_IDLE, STATE_OFF, STATE_PAUSED,
-    STATE_PLAYING)
+    CONF_HOST, CONF_PORT, EVENT_HOMEASSISTANT_STOP, STATE_IDLE, STATE_OFF,
+    STATE_PAUSED, STATE_PLAYING)
 from homeassistant.core import callback
 from homeassistant.exceptions import PlatformNotReady
 import homeassistant.helpers.config_validation as cv
@@ -57,8 +57,9 @@ SIGNAL_CAST_DISCOVERED = 'cast_discovered'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_HOST): cv.string,
+    vol.Optional(CONF_PORT): cv.port,
     vol.Optional(CONF_IGNORE_CEC, default=[]):
-        vol.All(cv.ensure_list, [cv.string]),
+        vol.All(cv.ensure_list, [cv.string])
 })
 
 
@@ -195,7 +196,7 @@ def _async_create_cast_device(hass: HomeAssistantType,
 
 async def async_setup_platform(hass: HomeAssistantType, config: ConfigType,
                                async_add_entities, discovery_info=None):
-    """Set up thet Cast platform.
+    """Set up the Cast platform.
 
     Deprecated.
     """
@@ -236,7 +237,7 @@ async def _async_setup_platform(hass: HomeAssistantType, config: ConfigType,
                               port=discovery_info['port'])
     elif CONF_HOST in config:
         info = ChromecastInfo(host=config[CONF_HOST],
-                              port=DEFAULT_PORT)
+                              port=config[CONF_PORT])
 
     @callback
     def async_cast_discovered(discover: ChromecastInfo) -> None:

--- a/tests/components/cast/test_init.py
+++ b/tests/components/cast/test_init.py
@@ -38,9 +38,7 @@ async def test_configuring_cast_creates_entry(hass):
             patch('pychromecast.discovery.discover_chromecasts',
                   return_value=True):
         await async_setup_component(hass, cast.DOMAIN, {
-            'cast': {
-                'some_config': 'to_trigger_import'
-            }
+            'cast': {}
         })
         await hass.async_block_till_done()
 

--- a/tests/components/media_player/test_cast.py
+++ b/tests/components/media_player/test_cast.py
@@ -215,13 +215,15 @@ async def test_normal_chromecast_not_starting_discovery(hass):
     with patch('homeassistant.components.media_player.cast.'
                '_setup_internal_discovery') as setup_discovery:
         # normal (non-group) chromecast shouldn't start discovery.
-        add_entities = await async_setup_cast(hass, {'host': 'host1'})
+        add_entities = await async_setup_cast(
+            hass, {'host': 'host1', 'port': 8009})
         await hass.async_block_till_done()
         assert add_entities.call_count == 1
         assert setup_discovery.call_count == 0
 
         # Same entity twice
-        add_entities = await async_setup_cast(hass, {'host': 'host1'})
+        add_entities = await async_setup_cast(
+            hass, {'host': 'host1', 'port': 8009})
         await hass.async_block_till_done()
         assert add_entities.call_count == 0
         assert setup_discovery.call_count == 0
@@ -246,7 +248,7 @@ async def test_normal_raises_platform_not_ready(hass):
     """Test cast platform raises PlatformNotReady if HTTP dial fails."""
     with patch('pychromecast.dial.get_device_status', return_value=None):
         with pytest.raises(PlatformNotReady):
-            await async_setup_cast(hass, {'host': 'host1'})
+            await async_setup_cast(hass, {'host': 'host1', 'port': 8009})
 
 
 async def test_replay_past_chromecasts(hass):
@@ -393,7 +395,9 @@ async def test_entry_setup_single_config(hass: HomeAssistantType):
         await cast.async_setup_entry(hass, MockConfigEntry(), None)
 
     assert len(mock_setup.mock_calls) == 1
-    assert mock_setup.mock_calls[0][1][1] == {'host': 'bla'}
+    assert mock_setup.mock_calls[0][1][1] == {
+        'host': 'bla', 'ignore_cec': [], 'port': 8009
+        }
 
 
 async def test_entry_setup_list_config(hass: HomeAssistantType):
@@ -402,7 +406,7 @@ async def test_entry_setup_list_config(hass: HomeAssistantType):
         'cast': {
             'media_player': [
                 {'host': 'bla'},
-                {'host': 'blu'},
+                {'host': 'blu', 'port': '12345'}
             ]
         }
     })
@@ -413,8 +417,12 @@ async def test_entry_setup_list_config(hass: HomeAssistantType):
         await cast.async_setup_entry(hass, MockConfigEntry(), None)
 
     assert len(mock_setup.mock_calls) == 2
-    assert mock_setup.mock_calls[0][1][1] == {'host': 'bla'}
-    assert mock_setup.mock_calls[1][1][1] == {'host': 'blu'}
+    assert mock_setup.mock_calls[0][1][1] == {
+        'host': 'bla', 'port': 8009, 'ignore_cec': []
+        }
+    assert mock_setup.mock_calls[1][1][1] == {
+        'host': 'blu', 'port': 12345, 'ignore_cec': []
+        }
 
 
 async def test_entry_setup_platform_not_ready(hass: HomeAssistantType):
@@ -434,4 +442,4 @@ async def test_entry_setup_platform_not_ready(hass: HomeAssistantType):
             await cast.async_setup_entry(hass, MockConfigEntry(), None)
 
     assert len(mock_setup.mock_calls) == 1
-    assert mock_setup.mock_calls[0][1][1] == {'host': 'bla'}
+    assert mock_setup.mock_calls[0][1][1] == {'host': 'bla', 'port': 8009}

--- a/tests/components/media_player/test_cast.py
+++ b/tests/components/media_player/test_cast.py
@@ -215,15 +215,13 @@ async def test_normal_chromecast_not_starting_discovery(hass):
     with patch('homeassistant.components.media_player.cast.'
                '_setup_internal_discovery') as setup_discovery:
         # normal (non-group) chromecast shouldn't start discovery.
-        add_entities = await async_setup_cast(
-            hass, {'host': 'host1', 'port': 8009})
+        add_entities = await async_setup_cast(hass, {'host': 'host1'})
         await hass.async_block_till_done()
         assert add_entities.call_count == 1
         assert setup_discovery.call_count == 0
 
         # Same entity twice
-        add_entities = await async_setup_cast(
-            hass, {'host': 'host1', 'port': 8009})
+        add_entities = await async_setup_cast(hass, {'host': 'host1'})
         await hass.async_block_till_done()
         assert add_entities.call_count == 0
         assert setup_discovery.call_count == 0
@@ -248,7 +246,7 @@ async def test_normal_raises_platform_not_ready(hass):
     """Test cast platform raises PlatformNotReady if HTTP dial fails."""
     with patch('pychromecast.dial.get_device_status', return_value=None):
         with pytest.raises(PlatformNotReady):
-            await async_setup_cast(hass, {'host': 'host1', 'port': 8009})
+            await async_setup_cast(hass, {'host': 'host1'})
 
 
 async def test_replay_past_chromecasts(hass):
@@ -442,4 +440,6 @@ async def test_entry_setup_platform_not_ready(hass: HomeAssistantType):
             await cast.async_setup_entry(hass, MockConfigEntry(), None)
 
     assert len(mock_setup.mock_calls) == 1
-    assert mock_setup.mock_calls[0][1][1] == {'host': 'bla', 'port': 8009}
+    assert mock_setup.mock_calls[0][1][1] == {
+        'host': 'bla', 'port': 8009, 'ignore_cec': []
+        }


### PR DESCRIPTION
## Description:
Allow to specify port manually for media_player.cast when not using discovery:

This allows for Chromecast groups to be added when running HA in another L3 subnet.
Caveat: groups will have to tracked manually.

**Related issue (if applicable):** fixes #16124 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#6070

## Example entry for `configuration.yaml` (if applicable):
```yaml
cast:
  media_player:
  - host: 192.168.1.10
    port: 42625
    name: My Chromecast Audio Group
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
