### PR TITLE
Fix zha MeteringSensor state - divide by 10

### DIFF
--- a/homeassistant/components/sensor/zha.py
+++ b/homeassistant/components/sensor/zha.py
@@ -187,7 +187,7 @@ class MeteringSensor(Sensor):
         if self._state is None:
             return None
 
-        return round(float(self._state))
+        return round(float(self._state) / 10, 1)
 
 
 class ElectricalMeasurementSensor(Sensor):


### PR DESCRIPTION
## Description:
zha ElectricalMeasurementSensor's state divides the value by 10 but
MeteringSensor's state does not. This causes Zigbee MeteringSensors
to show the incorrect value in HomeAssistant. Adding division by 10 to
match ElectricalMeasurementSensor and to fix MeteringSensor's output.

**Related issue (if applicable):** fixes #15958

## Checklist:
  - [X] The code change is tested and works locally.
  - [N/A (No Tests in Tox for zha.sensor)] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [N/A] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [N/A] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [N/A] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [N/A] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [N/A] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.