### PR TITLE
fix error message for cv.matches_regex

### DIFF
--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -92,7 +92,7 @@ def matches_regex(regex):
 
         if not regex.match(value):
             raise vol.Invalid('value {} does not match regular expression {}'
-                              .format(regex.pattern, value))
+                              .format(value, regex.pattern))
 
         return value
     return validator


### PR DESCRIPTION
## Description:
Fixes the error message for `cv.matches_regex` so that it reads correctly.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**