### PR TITLE
Allow split component definitions in packages

### DIFF
--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -171,7 +171,7 @@ def _no_duplicate_auth_mfa_module(configs: Sequence[Dict[str, Any]]) \
 
 PACKAGES_CONFIG_SCHEMA = vol.Schema({
     cv.slug: vol.Schema(  # Package names are slugs
-        {cv.slug: vol.Any(dict, list, None)})  # Only slugs for component names
+        {cv.string: vol.Any(dict, list, None)})  # Component configuration
 })
 
 CUSTOMIZE_DICT_SCHEMA = vol.Schema({
@@ -662,7 +662,10 @@ def merge_packages_config(hass: HomeAssistant, config: Dict, packages: Dict,
         for comp_name, comp_conf in pack_conf.items():
             if comp_name == CONF_CORE:
                 continue
-            component = get_component(hass, comp_name)
+            # If component name is given with a trailing description, remove it
+            # when looking for component
+            domain = comp_name.split(' ')[0]
+            component = get_component(hass, domain)
 
             if component is None:
                 _log_pkg_error(pack_name, comp_name, config, "does not exist")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -965,3 +965,21 @@ async def test_disallowed_duplicated_auth_mfa_module_config(hass):
     }
     with pytest.raises(Invalid):
         await config_util.async_process_ha_core_config(hass, core_config)
+
+
+def test_merge_split_component_definition(hass):
+    """Test components with trailing description in packages are merged."""
+    packages = {
+        'pack_1': {'light one': {'l1': None}},
+        'pack_2': {'light two': {'l2': None},
+                   'light three': {'l3': None}},
+    }
+    config = {
+        config_util.CONF_CORE: {config_util.CONF_PACKAGES: packages},
+    }
+    config_util.merge_packages_config(hass, config, packages)
+
+    assert len(config) == 4
+    assert len(config['light one']) == 1
+    assert len(config['light two']) == 1
+    assert len(config['light three']) == 1


### PR DESCRIPTION
## Description:
Two different configuration styles are described in
https://www.home-assistant.io/docs/configuration/devices/#style-2-list-each-device-separately

But only one is allowed in packages according to
https://www.home-assistant.io/docs/configuration/packages/

This change allows "Style 2" configuration in packages.

**Related issue:**  N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#6075

## Example entry for `configuration.yaml` (if applicable):
```yaml
homeassistant:
  packages: !include dir_named packages
```

`packages/my_package.yaml`
```yaml
sensor first:
  - platform: template
    sensors:
      my_sensor_1:
        value_template: 1

sensor second:
  - platform: template
    sensors:
      my_sensor_2:
        value_template: 2
```

## Checklist:
  - [X] The code change is tested and works locally.
  
- [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
