### PR TITLE
Smarty

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -276,6 +276,9 @@ omit =
     homeassistant/components/smappee.py
     homeassistant/components/*/smappee.py
 
+    homeassistant/components/smarty.py
+    homeassistant/components/*/smarty.py
+
     homeassistant/components/sonos/__init__.py
     homeassistant/components/*/sonos.py
 

--- a/homeassistant/components/fan/smarty.py
+++ b/homeassistant/components/fan/smarty.py
@@ -1,0 +1,145 @@
+"""
+Platform to control a Salda Smarty XP/XV ventilation unit.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/fan.smarty/
+"""
+import logging
+
+from homeassistant.core import callback
+from homeassistant.components.fan import (
+    SPEED_HIGH, SPEED_LOW, SPEED_MEDIUM, SPEED_OFF, SUPPORT_SET_SPEED,
+    FanEntity)
+from homeassistant.components.smarty import (
+    DATA_SMARTY, Smarty, SIGNAL_UPDATE_SMARTY)
+from homeassistant.const import (STATE_OFF, STATE_ON)
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+
+DEPENDENCIES = ['smarty']
+
+_LOGGER = logging.getLogger(__name__)
+
+SPEED_LIST = [SPEED_OFF, SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH]
+
+SPEED_MAPPING = {
+    0: SPEED_OFF,
+    1: SPEED_LOW,
+    2: SPEED_MEDIUM,
+    3: SPEED_HIGH
+}
+
+SPEED_TO_MODE = {
+    SPEED_OFF: 0,
+    SPEED_LOW: 1,
+    SPEED_MEDIUM: 2,
+    SPEED_HIGH: 3
+}
+
+
+async def async_setup_platform(hass, config,
+                               async_add_devices, discovery_info=None):
+    """Set up the Smarty Fan Platform."""
+    smarty = hass.data[DATA_SMARTY]
+
+    async_add_devices([SmartyFan(smarty.name, smarty)])
+
+
+class SmartyFan(FanEntity):
+    """Representation of a Smarty Fan."""
+
+    def __init__(self, name: str, smarty: Smarty):
+        """Initialize the entity."""
+        self._name = name
+        self._speed = SPEED_OFF
+        self._state = None
+        self._smarty = smarty
+
+    @property
+    def should_poll(self) -> bool:
+        """Do not poll."""
+        return False
+
+    @property
+    def name(self):
+        """Return the name of the fan."""
+        return self._name
+
+    @property
+    def icon(self):
+        """Return the icon to use in the frontend."""
+        return 'mdi:air-conditioner'
+
+    @property
+    def supported_features(self):
+        """Return the list of supported features."""
+        return SUPPORT_SET_SPEED
+
+    @property
+    def speed_list(self) -> list:
+        """List of available fan modes."""
+        return SPEED_LIST
+
+    @property
+    def is_on(self):
+        """Return state of the fan."""
+        return self._state == STATE_ON
+
+    @property
+    def speed(self) -> str:
+        """Return speed of the fan."""
+        return self._speed
+
+    def turn_on(self, speed: str = None, **kwargs):
+        """Turn on the fan."""
+        _LOGGER.debug('Turning on fan.')
+        if speed is None:
+            speed = SPEED_MEDIUM
+        self.set_speed(speed)
+        if speed == SPEED_OFF:
+            self._state = STATE_OFF
+        else:
+            self._state = STATE_ON
+
+    def turn_off(self, **kwargs):
+        """Turn off the fan."""
+        _LOGGER.debug('Turning off fan.')
+        self.set_speed(SPEED_OFF)
+        self._state = STATE_OFF
+
+    def set_speed(self, speed: str) -> None:
+        """Set fan speed."""
+        _LOGGER.debug('Changing fan speed to %s.', speed)
+        if speed in SPEED_LIST:
+            mode = SPEED_TO_MODE.get(speed)
+            _LOGGER.debug('Mode is %s', mode)
+            self._smarty.set_fan_mode(mode)
+            self._speed = speed
+
+        self.schedule_update_ha_state()
+
+    async def async_added_to_hass(self):
+        """Call to update fan."""
+        async_dispatcher_connect(self.hass,
+                                 SIGNAL_UPDATE_SMARTY,
+                                 self._update_callback)
+
+    @callback
+    def _update_callback(self):
+        """Call update method."""
+        self.async_schedule_update_ha_state(True)
+
+    def update(self) -> None:
+        """Update state."""
+        _LOGGER.debug('Updating state')
+        result = self._smarty.get_fan_mode()
+        try:
+            self._speed = SPEED_MAPPING[result]
+            _LOGGER.debug('Speed/Mode is %s/%s', self._speed, result)
+            if self._speed == SPEED_OFF:
+                self._state = STATE_OFF
+            else:
+                self._state = STATE_ON
+        except KeyError:
+            _LOGGER.debug('Cannot update. Speed/State %s/%s',
+                          self._speed, self._state)
+            self._state = None

--- a/homeassistant/components/sensor/smarty.py
+++ b/homeassistant/components/sensor/smarty.py
@@ -1,0 +1,107 @@
+"""
+Support for Salda Smarty XP/XV Ventilation Unit Sensors.
+
+For more details about this component, please refer to the documentation at:
+https://home-assistant.io/components/sensor.smarty/
+"""
+import logging
+
+from homeassistant.core import callback
+from homeassistant.components.smarty import (
+    DATA_SMARTY, Smarty, SIGNAL_UPDATE_SMARTY)
+from homeassistant.const import (
+    TEMP_CELSIUS, DEVICE_CLASS_TEMPERATURE,
+    STATE_UNKNOWN)
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity import Entity
+
+DEPENDENCIES = ['smarty']
+
+_LOGGER = logging.getLogger(__name__)
+
+DEVICE_CLASS_RPM = 'rpm'
+RPM = 'rpm'
+
+
+async def async_setup_platform(hass, config, async_add_devices,
+                               discovery_info=None):
+    """Set up the Smarty Sensor Platform."""
+    smarty = hass.data[DATA_SMARTY]
+
+    sensors = [SmartySensor(smarty.name + " Supply Air",
+                            'IR_SUPPLY_AIR_TEMPERATURE',
+                            DEVICE_CLASS_TEMPERATURE, TEMP_CELSIUS,
+                            smarty),
+               SmartySensor(smarty.name + " Extract Air",
+                            'IR_EXTRACT_AIR_TEMPERATURE',
+                            DEVICE_CLASS_TEMPERATURE, TEMP_CELSIUS,
+                            smarty),
+               SmartySensor(smarty.name + ' Outdoor Air',
+                            'IR_OUTDOOR_AIR_TEMPERATURE',
+                            DEVICE_CLASS_TEMPERATURE, TEMP_CELSIUS,
+                            smarty),
+               SmartySensor(smarty.name + ' Supply Fan Speed',
+                            'IR_SUPPLY_FAN_SPEED_RPM',
+                            DEVICE_CLASS_RPM, RPM,
+                            smarty),
+               SmartySensor(smarty.name + ' Extract Fan Speed',
+                            'IR_EXTRACT_FAN_SPEED_RPM',
+                            DEVICE_CLASS_RPM, RPM,
+                            smarty)]
+
+    async_add_devices(sensors)
+
+
+class SmartySensor(Entity):
+    """Representation of a Smarty Sensor."""
+
+    def __init__(self, name: str, sensor_type: str, device_class: str,
+                 unit_of_measurement: str, smarty: Smarty):
+        """Initialize the entity."""
+        self._name = name
+        self._sensor_type = sensor_type
+        self._state = STATE_UNKNOWN
+        self._device_class = device_class
+        self._unit_of_measurement = unit_of_measurement
+        self._smarty = smarty
+
+    @property
+    def should_poll(self) -> bool:
+        """Do not poll."""
+        return False
+
+    @property
+    def device_class(self):
+        """Return the device class of the sensor."""
+        return self._device_class
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit this state is expressed in."""
+        return self._unit_of_measurement
+
+    async def async_added_to_hass(self):
+        """Call to update fan."""
+        async_dispatcher_connect(self.hass,
+                                 SIGNAL_UPDATE_SMARTY,
+                                 self._update_callback)
+
+    @callback
+    def _update_callback(self):
+        """Call update method."""
+        self.async_schedule_update_ha_state(True)
+
+    def update(self) -> None:
+        """Update state."""
+        _LOGGER.debug('Updating sensor %s', self._sensor_type)
+        self._state = self._smarty.get_sensor(self._sensor_type)

--- a/homeassistant/components/smarty.py
+++ b/homeassistant/components/smarty.py
@@ -1,0 +1,220 @@
+"""
+Support to control a Salda Smarty XP/XV ventilation unit.
+
+For more details about this component, please refer to the documentation at:
+https://home-assistant.io/components/smarty/
+
+MCB 1.21 Modbus Table:
+http://salda.lt/mcb/downloads/doc/MCB%201.21%20Modbus%20table%202018-05-03.xlsx
+"""
+
+from datetime import timedelta
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components import modbus
+from homeassistant.const import (CONF_NAME, CONF_SLAVE, TEMP_CELSIUS)
+from homeassistant.helpers import discovery
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.dispatcher import dispatcher_send
+from homeassistant.helpers.event import track_time_interval
+
+DEPENDENCIES = ['modbus']
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = 'smarty'
+DATA_SMARTY = 'smarty'
+
+CONFIG_SCHEMA = vol.Schema(
+    {
+        DOMAIN: vol.Schema({
+            vol.Required(CONF_SLAVE): cv.positive_int,
+            vol.Optional(CONF_NAME, default='Smarty'): cv.string
+        }),
+    },
+    extra=vol.ALLOW_EXTRA)
+
+RPM = 'rpm'
+SIGNAL_UPDATE_SMARTY = 'smarty_update'
+
+INPUT_REGS = {
+    'IR_CURRENT_SYSTEM_STATE': {
+        'ADDR': 1,
+        'NAME': 'Current system state',
+        'MULTIPLIER': 1,
+        'STATE': {
+            0: 'Stand-by',
+            1: 'Building protection',
+            2: 'Economy',
+            3: 'Comfort',
+            4: 'Emergency run',
+            5: 'Preparing',
+            6: 'Opening dampers',
+            7: 'Boost',
+            8: 'Cooling heaters',
+            9: 'Closing dampers',
+            10: 'Night Cooling',
+            11: 'Critical alarm',
+            12: 'Fire alarm',
+            13: 'Heat exchanger frost protection',
+            14: 'Change filters',
+            15: 'Room RH 3 days average is lower than 30%. Limiting speed',
+            16: 'DX cooler defrosting',
+            17: 'Fire damper testing'
+        },
+        'UNIT_OF_MESUREMENT': None
+    },
+    'IR_CURRENT_SYSTEM_MODE': {
+        'ADDR': 15,
+        'NAME': 'Current system mode',
+        'MULTIPLIER': 1,
+        'STATE': {
+            0: 'Stand-by',
+            1: 'Building protection',
+            2: 'Economy',
+            3: 'Comfort',
+            4: 'Boost'
+        },
+        'UNIT_OF_MESUREMENT': None
+    },
+    'IR_SUPPLY_AIR_TEMPERATURE': {
+        'ADDR': 18,
+        'NAME': 'T1-Supply air temperature',
+        'MULTIPLIER': 0.1,
+        'STATE': {},
+        'UNIT_OF_MESUREMENT': TEMP_CELSIUS
+    },
+    'IR_EXTRACT_AIR_TEMPERATURE': {
+        'ADDR': 19,
+        'NAME': 'T2-Extract air temperature',
+        'MULTIPLIER': 0.1,
+        'STATE': {},
+        'UNIT_OF_MESUREMENT': TEMP_CELSIUS
+    },
+    'IR_OUTDOOR_AIR_TEMPERATURE': {
+        'ADDR': 21,
+        'NAME': 'Outdoor air temperature',
+        'MULTIPLIER': 0.1,
+        'STATE': {},
+        'UNIT_OF_MESUREMENT': TEMP_CELSIUS
+    },
+    'IR_SUPPLY_FAN_SPEED_RPM': {
+        'ADDR': 55,
+        'NAME': 'Supply fan spreed RPM',
+        'MULTIPLIER': 1,
+        'STATE': {},
+        'UNIT_OF_MESUREMENT': RPM
+    },
+    'IR_EXTRACT_FAN_SPEED_RPM': {
+        'ADDR': 56,
+        'NAME': 'Extract fan spreed RPM',
+        'MULTIPLIER': 1,
+        'STATE': {},
+        'UNIT_OF_MESUREMENT': RPM
+    }
+}
+
+HOLDING_REGS = {
+    'HR_USER_CONFIG_CURRENT_SYSTEM_MODE': {
+        'ADDR': 1,
+        'NAME': 'Current system mode',
+        'STATE': {
+            'Stand-by': 0,
+            'Building protection': 1,
+            'Economy': 2,
+            'Confort': 3
+        }
+    }
+}
+
+
+def setup(hass, config):
+    """Set up the smarty environment."""
+    conf = config[DOMAIN]
+
+    name = conf.get(CONF_NAME)
+    modbus_slave = conf.get(CONF_SLAVE)
+
+    _LOGGER.debug("name: %s, modbus_slave: %s", name, modbus_slave)
+
+    smarty = Smarty(hass, name, modbus_slave)
+    hass.data[DATA_SMARTY] = smarty
+
+    # Load platforms
+    discovery.load_platform(hass, 'fan', DOMAIN, {}, config)
+    discovery.load_platform(hass, 'sensor', DOMAIN, {}, config)
+
+    def poll_device_update(event_time):
+        """Update Smarty device."""
+        _LOGGER.debug("Updating Smarty device...")
+        smarty.update()
+        dispatcher_send(hass, SIGNAL_UPDATE_SMARTY)
+
+    track_time_interval(hass, poll_device_update, timedelta(seconds=30))
+
+    return True
+
+
+class Smarty:
+    """Representation of a Smarty Ventilation Unit."""
+
+    def __init__(self, hass, name, modbus_slave):
+        """Initialize the Smarty Ventilation Unit."""
+        self.data = {}
+        self.name = name
+        self.hass = hass
+        self._modbus_slave = modbus_slave
+        self._holding_registers = []
+        self._coils = []
+        self._discrete_inputs = []
+        self._input_registers = []
+
+    def update(self):
+        """Update registers."""
+        from pymodbus.exceptions import ConnectionException
+        try:
+            result = modbus.HUB.read_holding_registers(unit=self._modbus_slave,
+                                                       address=1,
+                                                       count=37)
+            self._holding_registers = result.registers
+            _LOGGER.debug('Holding Registers: %s', self._holding_registers)
+
+            # it cannot read all 132 registers at once
+            result1 = modbus.HUB.read_input_registers(unit=self._modbus_slave,
+                                                      address=1,
+                                                      count=66)
+            result2 = modbus.HUB.read_input_registers(unit=self._modbus_slave,
+                                                      address=67,
+                                                      count=66)
+            self._input_registers = result1.registers + result2.registers
+            _LOGGER.debug('Input Registers: %s', self._input_registers)
+        except AttributeError:
+            _LOGGER.error('No valid response from modbus slave %s',
+                          self._modbus_slave)
+        except ConnectionException:
+            _LOGGER.error('Cannot connect to Smarty. Modbus Unreacheable.')
+
+    def get_fan_mode(self):
+        """Get Current System Mode."""
+        addr = HOLDING_REGS['HR_USER_CONFIG_CURRENT_SYSTEM_MODE']['ADDR']
+        return self._holding_registers[addr - 1]
+
+    def set_fan_mode(self, mode):
+        """Set Current System Mode."""
+        from pymodbus.exceptions import ConnectionException
+        _LOGGER.debug('Set System Mode to : %s', mode)
+        try:
+            addr = HOLDING_REGS['HR_USER_CONFIG_CURRENT_SYSTEM_MODE']['ADDR']
+            modbus.HUB.write_register(self._modbus_slave, addr, mode)
+        except ConnectionException:
+            _LOGGER.error('Cannot connect to Smarty. Modbus Unreacheable.')
+
+    def get_sensor(self, sensor_type):
+        """Get a sensor value."""
+        addr = INPUT_REGS[sensor_type]['ADDR']
+        multiplier = INPUT_REGS[sensor_type]['MULTIPLIER']
+        result = round(self._input_registers[addr - 1] * multiplier, 2)
+        _LOGGER.debug('Get Sensor result: %s', result)
+        return result


### PR DESCRIPTION
## Description:
Initial support for [Salda Smarty 2X/3X/4X P/V Ventilation Unit](http://www.salda.lt/en/products/category/compact-counter-flow-units)

This is my first PR ever. Beginner with python/git/etc... Please let me something is not the right way
 done.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here> PR: https://github.com/home-assistant/home-assistant.io/pull/6086

## Example entry for `configuration.yaml` (if applicable):
```yaml
modbus:
  type: tcp
  host: 10.10.10.10
  port: 502

smarty:
  name: Smarty 3X
  slave: 1
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) 

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
