### PR TITLE
Tweak log level for bearer token warning

### DIFF
--- a/homeassistant/components/http/auth.py
+++ b/homeassistant/components/http/auth.py
@@ -30,8 +30,10 @@ def setup_auth(app, trusted_networks, use_auth,
         if use_auth and (HTTP_HEADER_HA_AUTH in request.headers or
                          DATA_API_PASSWORD in request.query):
             if request.path not in old_auth_warning:
-                _LOGGER.warning('Please change to use bearer token access %s',
-                                request.path)
+                _LOGGER.log(
+                    logging.INFO if support_legacy else logging.WARNING,
+                    'Please change to use bearer token access %s from %s',
+                    request.path, request[KEY_REAL_IP])
                 old_auth_warning.add(request.path)
 
         legacy_auth = (not use_auth or support_legacy) and api_password


### PR DESCRIPTION
## Description:
Only log warning when user enabled new auth, disabled api_password, but still have integrations use old api_password access home-assistant. Log info if user still enabled api_password.

Still looking for better wording.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
