### PR TITLE
Default load trusted_network auth provider if configured trusted networks

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -88,10 +88,12 @@ async def async_from_config_dict(config: Dict[str, Any],
 
     core_config = config.get(core.DOMAIN, {})
     has_api_password = bool((config.get('http') or {}).get('api_password'))
+    has_trusted_networks = bool((config.get('http') or {})
+                                .get('trusted_networks'))
 
     try:
         await conf_util.async_process_ha_core_config(
-            hass, core_config, has_api_password)
+            hass, core_config, has_api_password, has_trusted_networks)
     except vol.Invalid as ex:
         conf_util.async_log_exception(ex, 'homeassistant', core_config, hass)
         return None

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -406,7 +406,8 @@ def _format_config_error(ex: vol.Invalid, domain: str, config: Dict) -> str:
 
 async def async_process_ha_core_config(
         hass: HomeAssistant, config: Dict,
-        has_api_password: bool = False) -> None:
+        has_api_password: bool = False,
+        has_trusted_networks: bool = False) -> None:
     """Process the [homeassistant] section from the configuration.
 
     This method is a coroutine.
@@ -423,6 +424,8 @@ async def async_process_ha_core_config(
             ]
             if has_api_password:
                 auth_conf.append({'type': 'legacy_api_password'})
+            if has_trusted_networks:
+                auth_conf.append({'type': 'trusted_networks'})
 
         setattr(hass, 'auth', await auth.auth_manager_from_config(
             hass,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -856,6 +856,27 @@ async def test_auth_provider_config_default_api_password(hass):
     assert hass.auth.active is True
 
 
+async def test_auth_provider_config_default_trusted_networks(hass):
+    """Test loading default auth provider config with trusted networks."""
+    core_config = {
+        'latitude': 60,
+        'longitude': 50,
+        'elevation': 25,
+        'name': 'Huis',
+        CONF_UNIT_SYSTEM: CONF_UNIT_SYSTEM_IMPERIAL,
+        'time_zone': 'GMT',
+    }
+    if hasattr(hass, 'auth'):
+        del hass.auth
+    await config_util.async_process_ha_core_config(hass, core_config,
+                                                   has_trusted_networks=True)
+
+    assert len(hass.auth.auth_providers) == 2
+    assert hass.auth.auth_providers[0].type == 'homeassistant'
+    assert hass.auth.auth_providers[1].type == 'trusted_networks'
+    assert hass.auth.active is True
+
+
 async def test_disallowed_auth_provider_config(hass):
     """Test loading insecure example auth provider is disallowed."""
     core_config = {


### PR DESCRIPTION
## Description:
Default load trusted_network auth provider if user configured trusted networks

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
