### PR TITLE
Snips: Added special slot values, session_id and slotname_raw

### DIFF
--- a/homeassistant/components/snips.py
+++ b/homeassistant/components/snips.py
@@ -132,7 +132,7 @@ async def async_setup(hass, config):
         for slot in request.get('slots', []):
             slots[slot['slotName']] = {'value': resolve_slot_values(slot)}
             slots['{}_raw'.format(slot['slotName'])] = {
-                                                    'value': slot['rawValue']}
+                'value': slot['rawValue']}
         slots['site_id'] = {'value': request.get('siteId')}
         slots['session_id'] = {'value': request.get('sessionId')}
         slots['probability'] = {'value': request['intent']['probability']}

--- a/homeassistant/components/snips.py
+++ b/homeassistant/components/snips.py
@@ -131,7 +131,10 @@ async def async_setup(hass, config):
         slots = {}
         for slot in request.get('slots', []):
             slots[slot['slotName']] = {'value': resolve_slot_values(slot)}
+            slots['{}_raw'.format(slot['slotName'])] = {
+                                                    'value': slot['rawValue']}
         slots['site_id'] = {'value': request.get('siteId')}
+        slots['session_id'] = {'value': request.get('sessionId')}
         slots['probability'] = {'value': request['intent']['probability']}
 
         try:

--- a/tests/components/test_snips.py
+++ b/tests/components/test_snips.py
@@ -93,6 +93,8 @@ async def test_snips_intent(hass, mqtt_mock):
     assert result
     payload = """
     {
+        "siteId": "default",
+        "sessionId": "1234567890ABCDEF",
         "input": "turn the lights green",
         "intent": {
             "intentName": "Lights",
@@ -104,7 +106,8 @@ async def test_snips_intent(hass, mqtt_mock):
                 "value": {
                     "kind": "Custom",
                     "value": "green"
-                }
+                },
+                "rawValue": "green"
             }
         ]
     }
@@ -119,9 +122,12 @@ async def test_snips_intent(hass, mqtt_mock):
     intent = intents[0]
     assert intent.platform == 'snips'
     assert intent.intent_type == 'Lights'
+    assert intent
     assert intent.slots == {'light_color': {'value': 'green'},
+                            'light_color_raw': {'value': 'green'},
                             'probability': {'value': 1},
-                            'site_id': {'value': None}}
+                            'site_id': {'value': 'default'},
+                            'session_id': {'value': '1234567890ABCDEF'}}
     assert intent.text_input == 'turn the lights green'
 
 
@@ -147,7 +153,8 @@ async def test_snips_service_intent(hass, mqtt_mock):
                 "value": {
                     "kind": "Custom",
                     "value": "kitchen"
-                }
+                },
+                "rawValue": "green"
             }
         ]
     }
@@ -217,7 +224,9 @@ async def test_snips_intent_with_duration(hass, mqtt_mock):
     assert intent.intent_type == 'SetTimer'
     assert intent.slots == {'probability': {'value': 1},
                             'site_id': {'value': None},
-                            'timer_duration': {'value': 300}}
+                            'session_id': {'value': None},
+                            'timer_duration': {'value': 300},
+                            'timer_duration_raw': {'value': 'five minutes'}}
 
 
 async def test_intent_speech_response(hass, mqtt_mock):


### PR DESCRIPTION
## Description:

Added special slot values, session_id and slotname_raw

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#6078

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
