### PR TITLE
Handle exception from pillow in camera proxy

### DIFF
--- a/homeassistant/components/camera/proxy.py
+++ b/homeassistant/components/camera/proxy.py
@@ -64,7 +64,10 @@ def _resize_image(image, opts):
     quality = opts.quality or DEFAULT_QUALITY
     new_width = opts.max_width
 
-    img = Image.open(io.BytesIO(image))
+    try:
+        img = Image.open(io.BytesIO(image))
+    except IOError:
+        return image
     imgfmt = str(img.format)
     if imgfmt not in ('PNG', 'JPEG'):
         _LOGGER.debug("Image is of unsupported type: %s", imgfmt)


### PR DESCRIPTION
## Description:
This fixes an issue where the camera returns an invalid image (404 for example) which gets passed to the camera proxy.  When loading the image into Pillow, it generates an exception which wasn't being handled.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
