### PR TITLE
remove hangouts.users state, simplifies hangouts.conversations

### DIFF
--- a/homeassistant/components/hangouts/hangouts_bot.py
+++ b/homeassistant/components/hangouts/hangouts_bot.py
@@ -195,23 +195,15 @@ class HangoutsBot:
         import hangups
         self._user_list, self._conversation_list = \
             (await hangups.build_user_conversation_list(self._client))
-        users = {}
         conversations = {}
-        for user in self._user_list.get_all():
-            users[str(user.id_.chat_id)] = {'full_name': user.full_name,
-                                            'is_self': user.is_self}
-
-        for conv in self._conversation_list.get_all():
-            users_in_conversation = {}
+        for i, conv in enumerate(self._conversation_list.get_all()):
+            users_in_conversation = []
             for user in conv.users:
-                users_in_conversation[str(user.id_.chat_id)] = \
-                    {'full_name': user.full_name, 'is_self': user.is_self}
-            conversations[str(conv.id_)] = \
-                {'name': conv.name, 'users': users_in_conversation}
+                users_in_conversation.append(user.full_name)
+            conversations[str(i)] = {'id': str(conv.id_),
+                                     'name': conv.name,
+                                     'users': users_in_conversation}
 
-        self.hass.states.async_set("{}.users".format(DOMAIN),
-                                   len(self._user_list.get_all()),
-                                   attributes=users)
         self.hass.states.async_set("{}.conversations".format(DOMAIN),
                                    len(self._conversation_list.get_all()),
                                    attributes=conversations)


### PR DESCRIPTION
## Description:

removes the `hangouts.users` state, it is nice to read for devs, but completely useless for users and confusing.
simplifies the hangouts.conversations, its reduced to the the id and name and a list of usernames of the conversation.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
