### PR TITLE
Add battery warning, rssi level and availability check to Tahoma sensor

### DIFF
--- a/homeassistant/components/sensor/tahoma.py
+++ b/homeassistant/components/sensor/tahoma.py
@@ -11,12 +11,15 @@ from datetime import timedelta
 from homeassistant.helpers.entity import Entity
 from homeassistant.components.tahoma import (
     DOMAIN as TAHOMA_DOMAIN, TahomaDevice)
+from homeassistant.const import ATTR_BATTERY_LEVEL
 
 DEPENDENCIES = ['tahoma']
 
 _LOGGER = logging.getLogger(__name__)
 
-SCAN_INTERVAL = timedelta(seconds=10)
+SCAN_INTERVAL = timedelta(seconds=60)
+
+ATTR_RSSI_LEVEL = 'rssi_level'
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
@@ -34,6 +37,7 @@ class TahomaSensor(TahomaDevice, Entity):
     def __init__(self, tahoma_device, controller):
         """Initialize the sensor."""
         self.current_value = None
+        self._available = False
         super().__init__(tahoma_device, controller)
 
     @property
@@ -62,3 +66,29 @@ class TahomaSensor(TahomaDevice, Entity):
         if self.tahoma_device.type == 'io:SomfyContactIOSystemSensor':
             self.current_value = self.tahoma_device.active_states[
                 'core:ContactState']
+
+        self._available = bool(self.tahoma_device.active_states.get(
+            'core:StatusState') == 'available')
+
+        _LOGGER.debug("Update %s, value: %d", self._name, self.current_value)
+
+    @property
+    def device_state_attributes(self):
+        """Return the device state attributes."""
+        attr = {}
+        super_attr = super().device_state_attributes
+        if super_attr is not None:
+            attr.update(super_attr)
+
+        if 'core:RSSILevelState' in self.tahoma_device.active_states:
+            attr[ATTR_RSSI_LEVEL] = \
+                self.tahoma_device.active_states['core:RSSILevelState']
+        if 'core:SensorDefectState' in self.tahoma_device.active_states:
+            attr[ATTR_BATTERY_LEVEL] = \
+                self.tahoma_device.active_states['core:SensorDefectState']
+        return attr
+
+    @property
+    def available(self):
+        """Return True if entity is available."""
+        return self._available


### PR DESCRIPTION
## Description:
Add battery warning, rssi level and availability check to Tahoma sensor. Increased the sensor poll time form 10 to 60 seconds.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - No change

If the code communicates with devices, web services, or third-party tools:
  - No new dependencies.
  - No new files were added to `.coveragerc`.

If the code does not interact with devices:
  - Does interact with devices.