### PR TITLE
update python-velbus library version

### DIFF
--- a/homeassistant/components/velbus.py
+++ b/homeassistant/components/velbus.py
@@ -12,7 +12,7 @@ from homeassistant.const import EVENT_HOMEASSISTANT_STOP, CONF_PORT
 from homeassistant.helpers.discovery import load_platform
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['python-velbus==2.0.17']
+REQUIREMENTS = ['python-velbus==2.0.18']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1134,7 +1134,7 @@ python-telegram-bot==10.1.0
 python-twitch==1.3.0
 
 # homeassistant.components.velbus
-python-velbus==2.0.17
+python-velbus==2.0.18
 
 # homeassistant.components.media_player.vlc
 python-vlc==1.1.2


### PR DESCRIPTION
## Description:

This pull request updates the python-velbus library version to 2.0.18. The issue was that the 2.0.17 version did not contain the correct package definition in setup.py file which resulted in a modules directory not being installed and velbus failing on home assistant.
