### PR TITLE
Update aiohttp to version 3.4.0.

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -1,4 +1,4 @@
-aiohttp==3.3.2
+aiohttp==3.4.0
 astral==1.6.1
 async_timeout==3.0.0
 attrs==18.1.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1,5 +1,5 @@
 # Home Assistant core
-aiohttp==3.3.2
+aiohttp==3.4.0
 astral==1.6.1
 async_timeout==3.0.0
 attrs==18.1.0

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ PROJECT_URLS = {
 PACKAGES = find_packages(exclude=['tests', 'tests.*'])
 
 REQUIRES = [
-    'aiohttp==3.3.2',
+    'aiohttp==3.4.0',
     'astral==1.6.1',
     'async_timeout==3.0.0',
     'attrs==18.1.0',


### PR DESCRIPTION
## Description:

Update to aiohttp version 3.4.0

**Related issue (if applicable):** fixes https://github.com/aio-libs/aiohttp/issues/3208

## Why this is important

I discovered this problem when interacting with a device I'm aiming on integrating. 

The aiohttp client, which in turn relies on nodejs/http-parser, messes up the TCP ACK packets and results in a bunch of TCP errors after sending a HTTP message when the header is split between TCP packets.

This might not always be visible, however it does result in a bunch of extra network traffic. In my particular case it was visible because the device didn't change states if the TCP connection didn't close properly (which seems to be a bug to me, but anyhow).

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
