### PR TITLE
homematic: Make device avilable again when UNREACH becomes False

### DIFF
--- a/homeassistant/components/homematic/__init__.py
+++ b/homeassistant/components/homematic/__init__.py
@@ -869,7 +869,7 @@ class HMDevice(Entity):
 
         # Availability has changed
         if attribute == 'UNREACH':
-            self._available = bool(value)
+            self._available = not bool(value)
             has_changed = True
         elif not self.available:
             self._available = False


### PR DESCRIPTION
## Description:

This fixes just a minor logic issue. When `UNREACH` is `True`, then the device is unavailable.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
