### PR TITLE
Inconsistent entity_id when multiple sensors

### DIFF
--- a/homeassistant/components/sensor/dnsip.py
+++ b/homeassistant/components/sensor/dnsip.py
@@ -89,7 +89,8 @@ class WanIpSensor(Entity):
     @asyncio.coroutine
     def async_update(self):
         """Get the current DNS IP address for hostname."""
-        response = yield from self.resolver.query(self.hostname, self.querytype)
+        response = yield from self.resolver.query(self.hostname, 
+                                                  self.querytype)
         if response:
             self._state = response[0].host
         else:

--- a/homeassistant/components/sensor/dnsip.py
+++ b/homeassistant/components/sensor/dnsip.py
@@ -89,7 +89,7 @@ class WanIpSensor(Entity):
     @asyncio.coroutine
     def async_update(self):
         """Get the current DNS IP address for hostname."""
-        response = yield from self.resolver.query(self.hostname, 
+        response = yield from self.resolver.query(self.hostname,
                                                   self.querytype)
         if response:
             self._state = response[0].host

--- a/homeassistant/components/sensor/dnsip.py
+++ b/homeassistant/components/sensor/dnsip.py
@@ -19,11 +19,13 @@ REQUIREMENTS = ['aiodns==1.1.1']
 
 _LOGGER = logging.getLogger(__name__)
 
+CONF_NAME = 'name'
 CONF_HOSTNAME = 'hostname'
 CONF_RESOLVER = 'resolver'
 CONF_RESOLVER_IPV6 = 'resolver_ipv6'
 CONF_IPV6 = 'ipv6'
 
+DEFAULT_NAME = 'myip'
 DEFAULT_HOSTNAME = 'myip.opendns.com'
 DEFAULT_RESOLVER = '208.67.222.222'
 DEFAULT_RESOLVER_IPV6 = '2620:0:ccc::2'
@@ -32,6 +34,7 @@ DEFAULT_IPV6 = False
 SCAN_INTERVAL = timedelta(seconds=120)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_NAME): cv.string,
     vol.Optional(CONF_HOSTNAME, default=DEFAULT_HOSTNAME): cv.string,
     vol.Optional(CONF_RESOLVER, default=DEFAULT_RESOLVER): cv.string,
     vol.Optional(CONF_RESOLVER_IPV6, default=DEFAULT_RESOLVER_IPV6): cv.string,
@@ -40,28 +43,34 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 
 @asyncio.coroutine
-def async_setup_platform(hass, config, async_add_entities,
-                         discovery_info=None):
+def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up the DNS IP sensor."""
     hostname = config.get(CONF_HOSTNAME)
+    name = config.get(CONF_NAME)
+    if not name:
+        if hostname == DEFAULT_HOSTNAME:
+            name = DEFAULT_NAME
+        else:
+            name = hostname
     ipv6 = config.get(CONF_IPV6)
     if ipv6:
         resolver = config.get(CONF_RESOLVER_IPV6)
     else:
         resolver = config.get(CONF_RESOLVER)
 
-    async_add_entities([WanIpSensor(
-        hass, hostname, resolver, ipv6)], True)
+    async_add_devices([WanIpSensor(
+        hass, name, hostname, resolver, ipv6)], True)
 
 
 class WanIpSensor(Entity):
     """Implementation of a DNS IP sensor."""
 
-    def __init__(self, hass, hostname, resolver, ipv6):
+    def __init__(self, hass, name, hostname, resolver, ipv6):
         """Initialize the sensor."""
         import aiodns
         self.hass = hass
-        self._name = hostname
+        self._name = name
+        self.hostname = hostname
         self.resolver = aiodns.DNSResolver(loop=self.hass.loop)
         self.resolver.nameservers = [resolver]
         self.querytype = 'AAAA' if ipv6 else 'A'
@@ -80,7 +89,7 @@ class WanIpSensor(Entity):
     @asyncio.coroutine
     def async_update(self):
         """Get the current DNS IP address for hostname."""
-        response = yield from self.resolver.query(self._name, self.querytype)
+        response = yield from self.resolver.query(self.hostname, self.querytype)
         if response:
             self._state = response[0].host
         else:


### PR DESCRIPTION
I am submitting a change to fix a [bug](https://github.com/home-assistant/home-assistant/issues/16204) for when there are several sensors for the same hostname. 

## Description:

For example I want to track my IPv4 and IPv6 address. It creates two entities that regularly switch ids based on the order they get initialized.

To fix this I comform to the way other componnents have addressed the issue by adding an optional `name` attribute.

**Related issue (if applicable):** fixes #16204

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: dnsip
    name: ipv4_pub
  - platform: dnsip
    name: ipv6_pub
    ipv6: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
