### PR TITLE
Update to EnvoyReader 0.2, support for more hardware

### DIFF
--- a/homeassistant/components/sensor/enphase_envoy.py
+++ b/homeassistant/components/sensor/enphase_envoy.py
@@ -14,7 +14,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.const import (CONF_IP_ADDRESS, CONF_MONITORED_CONDITIONS)
 
 
-REQUIREMENTS = ['envoy_reader==0.1']
+REQUIREMENTS = ['envoy_reader==0.2']
 _LOGGER = logging.getLogger(__name__)
 
 SENSORS = {

--- a/homeassistant/components/sensor/enphase_envoy.py
+++ b/homeassistant/components/sensor/enphase_envoy.py
@@ -20,32 +20,34 @@ _LOGGER = logging.getLogger(__name__)
 SENSORS = {
     "production": ("Envoy Current Energy Production", 'W'),
     "daily_production": ("Envoy Today's Energy Production", "Wh"),
-    "7_days_production": ("Envoy Last Seven Days Energy Production", "Wh"),
+    "seven_days_production": ("Envoy Last Seven Days Energy Production", "Wh"),
     "lifetime_production": ("Envoy Lifetime Energy Production", "Wh"),
     "consumption": ("Envoy Current Energy Consumption", "W"),
     "daily_consumption": ("Envoy Today's Energy Consumption", "Wh"),
-    "7_days_consumption": ("Envoy Last Seven Days Energy Consumption", "Wh"),
+    "seven_days_consumption": ("Envoy Last Seven Days Energy Consumption",
+                               "Wh"),
     "lifetime_consumption": ("Envoy Lifetime Energy Consumption", "Wh")
     }
 
 
 ICON = 'mdi:flash'
+CONST_DEFAULT_HOST = "envoy"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Optional(CONF_IP_ADDRESS, default="envoy"): cv.string,
+    vol.Optional(CONF_IP_ADDRESS, default=CONST_DEFAULT_HOST): cv.string,
     vol.Optional(CONF_MONITORED_CONDITIONS, default=list(SENSORS)):
         vol.All(cv.ensure_list, [vol.In(list(SENSORS))])})
 
 
-def setup_platform(hass, config, add_devices, discovery_info=None):
+def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Enphase Envoy sensor."""
     ip_address = config[CONF_IP_ADDRESS]
     monitored_conditions = config[CONF_MONITORED_CONDITIONS]
 
     # Iterate through the list of sensors
     for condition in monitored_conditions:
-        add_devices([Envoy(ip_address, condition, SENSORS[condition][0],
-                           SENSORS[condition][1])], True)
+        add_entities([Envoy(ip_address, condition, SENSORS[condition][0],
+                            SENSORS[condition][1])], True)
 
 
 class Envoy(Entity):
@@ -83,21 +85,4 @@ class Envoy(Entity):
         """Get the energy production data from the Enphase Envoy."""
         from envoy_reader import EnvoyReader
 
-        if self._type == "production":
-            self._state = EnvoyReader(self._ip_address).production()
-        elif self._type == "daily_production":
-            self._state = EnvoyReader(self._ip_address).daily_production()
-        elif self._type == "7_days_production":
-            self._state = EnvoyReader(self._ip_address).seven_days_production()
-        elif self._type == "lifetime_production":
-            self._state = EnvoyReader(self._ip_address).lifetime_production()
-
-        elif self._type == "consumption":
-            self._state = EnvoyReader(self._ip_address).consumption()
-        elif self._type == "daily_consumption":
-            self._state = EnvoyReader(self._ip_address).daily_consumption()
-        elif self._type == "7_days_consumption":
-            self._state = (EnvoyReader(self._ip_address)
-                           .seven_days_consumption())
-        elif self._type == "lifetime_consumption":
-            self._state = EnvoyReader(self._ip_address).lifetime_consumption()
+        self._state = getattr(EnvoyReader(self._ip_address), self._type)()

--- a/homeassistant/components/sensor/enphase_envoy.py
+++ b/homeassistant/components/sensor/enphase_envoy.py
@@ -37,12 +37,10 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
         vol.All(cv.ensure_list, [vol.In(list(SENSORS))])})
 
 
-
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Enphase Envoy sensor."""
     ip_address = config[CONF_IP_ADDRESS]
     monitored_conditions = config[CONF_MONITORED_CONDITIONS]
-
 
     # Iterate through the list of sensors
     for condition in monitored_conditions:
@@ -99,6 +97,7 @@ class Envoy(Entity):
         elif self._type == "daily_consumption":
             self._state = EnvoyReader(self._ip_address).daily_consumption()
         elif self._type == "7_days_consumption":
-            self._state = EnvoyReader(self._ip_address).seven_days_consumption()
+            self._state = EnvoyReader(self._ip_address).
+            seven_days_consumption()
         elif self._type == "lifetime_consumption":
-            self._state =EnvoyReader(self._ip_address).lifetime_consumption()
+            self._state = EnvoyReader(self._ip_address).lifetime_consumption()

--- a/homeassistant/components/sensor/enphase_envoy.py
+++ b/homeassistant/components/sensor/enphase_envoy.py
@@ -97,7 +97,7 @@ class Envoy(Entity):
         elif self._type == "daily_consumption":
             self._state = EnvoyReader(self._ip_address).daily_consumption()
         elif self._type == "7_days_consumption":
-            self._state = EnvoyReader(self._ip_address).
-            seven_days_consumption()
+            self._state = (EnvoyReader(self._ip_address)
+                           .seven_days_consumption())
         elif self._type == "lifetime_consumption":
             self._state = EnvoyReader(self._ip_address).lifetime_consumption()

--- a/homeassistant/components/sensor/enphase_envoy.py
+++ b/homeassistant/components/sensor/enphase_envoy.py
@@ -30,11 +30,9 @@ SENSORS = {
 
 
 ICON = 'mdi:flash'
-CONF_ENVOY_MODEL = "envoy_model"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_IP_ADDRESS, default="envoy"): cv.string,
-    vol.Optional(CONF_ENVOY_MODEL, default="unknown"): cv.string,
     vol.Optional(CONF_MONITORED_CONDITIONS, default=list(SENSORS)):
         vol.All(cv.ensure_list, [vol.In(list(SENSORS))])})
 
@@ -44,24 +42,23 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Enphase Envoy sensor."""
     ip_address = config[CONF_IP_ADDRESS]
     monitored_conditions = config[CONF_MONITORED_CONDITIONS]
-    envoy_model = config[CONF_ENVOY_MODEL]
+
 
     # Iterate through the list of sensors
     for condition in monitored_conditions:
         add_devices([Envoy(ip_address, condition, SENSORS[condition][0],
-                           SENSORS[condition][1], envoy_model)], True)
+                           SENSORS[condition][1])], True)
 
 
 class Envoy(Entity):
     """Implementation of the Enphase Envoy sensors."""
 
-    def __init__(self, ip_address, sensor_type, name, unit, envoy_model):
+    def __init__(self, ip_address, sensor_type, name, unit):
         """Initialize the sensor."""
         self._ip_address = ip_address
         self._name = name
         self._unit_of_measurement = unit
         self._type = sensor_type
-        self._envoy_model = envoy_model
         self._state = None
 
     @property
@@ -89,19 +86,19 @@ class Envoy(Entity):
         from envoy_reader import EnvoyReader
 
         if self._type == "production":
-            self._state = EnvoyReader(self._ip_address, self._envoy_model).production()
+            self._state = EnvoyReader(self._ip_address).production()
         elif self._type == "daily_production":
-            self._state = EnvoyReader(self._ip_address, self._envoy_model).daily_production()
+            self._state = EnvoyReader(self._ip_address).daily_production()
         elif self._type == "7_days_production":
-            self._state = EnvoyReader(self._ip_address, self._envoy_model).seven_days_production()
+            self._state = EnvoyReader(self._ip_address).seven_days_production()
         elif self._type == "lifetime_production":
-            self._state = EnvoyReader(self._ip_address, self._envoy_model).lifetime_production()
+            self._state = EnvoyReader(self._ip_address).lifetime_production()
 
         elif self._type == "consumption":
-            self._state = EnvoyReader(self._ip_address, self._envoy_model).consumption()
+            self._state = EnvoyReader(self._ip_address).consumption()
         elif self._type == "daily_consumption":
-            self._state = EnvoyReader(self._ip_address, self._envoy_model).daily_consumption()
+            self._state = EnvoyReader(self._ip_address).daily_consumption()
         elif self._type == "7_days_consumption":
-            self._state = EnvoyReader(self._ip_address, self._envoy_model).seven_days_consumption()
+            self._state = EnvoyReader(self._ip_address).seven_days_consumption()
         elif self._type == "lifetime_consumption":
-            self._state =EnvoyReader(self._ip_address, self._envoy_model).lifetime_consumption()
+            self._state =EnvoyReader(self._ip_address).lifetime_consumption()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -317,7 +317,7 @@ enocean==0.40
 # envirophat==0.0.6
 
 # homeassistant.components.sensor.enphase_envoy
-envoy_reader==0.1
+envoy_reader==0.2
 
 # homeassistant.components.sensor.season
 ephem==3.7.6.0


### PR DESCRIPTION
## Description:


**Related issue (if applicable):**
fixes #16210, fixes #16137

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#6088

**Breaking Change**: Change keys in monitored_conditions from `7_days_production` and `7_days_consumption` to `seven_days_production` and `seven_days_consumption`

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: enphase_envoy
    ip_address: LOCAL_IP_FOR_ENVOY
    monitored_conditions:
      - production
      - consumption
      - lifetime_production
      - lifetime_consumption
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
