### PR TITLE
Change auth warning

### DIFF
--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -200,18 +200,10 @@ class HomeAssistantHTTP:
         if is_ban_enabled:
             setup_bans(hass, app, login_threshold)
 
-        if hass.auth.active:
-            if hass.auth.support_legacy:
-                _LOGGER.warning("Experimental auth api enabled and "
-                                "legacy_api_password support enabled. Please "
-                                "use access_token instead api_password, "
-                                "although you can still use legacy "
-                                "api_password")
-            else:
-                _LOGGER.warning("Experimental auth api enabled. Please use "
-                                "access_token instead api_password.")
-        elif api_password is None:
-            _LOGGER.warning("You have been advised to set http.api_password.")
+        if hass.auth.active and hass.auth.support_legacy:
+            _LOGGER.warning(
+                "legacy_api_password support has been enabled. If you don't"
+                "require it, remove the 'api_password' from your http config.")
 
         setup_auth(app, trusted_networks, hass.auth.active,
                    support_legacy=hass.auth.support_legacy,

--- a/homeassistant/components/http/auth.py
+++ b/homeassistant/components/http/auth.py
@@ -32,7 +32,7 @@ def setup_auth(app, trusted_networks, use_auth,
             if request.path not in old_auth_warning:
                 _LOGGER.log(
                     logging.INFO if support_legacy else logging.WARNING,
-                    'Please change to use bearer token access %s from %s',
+                    'You need to use a bearer token to access %s from %s',
                     request.path, request[KEY_REAL_IP])
                 old_auth_warning.add(request.path)
 


### PR DESCRIPTION
## Description:
Removes most warnings related to auth. It will now only give a warning if new auth is enabled (always) and the legacy API password auth provider has been enabled. It will include instructions on how to disable it.
