### PR TITLE
Fix device telldus

### DIFF
--- a/homeassistant/components/tellduslive.py
+++ b/homeassistant/components/tellduslive.py
@@ -287,7 +287,6 @@ class TelldusLiveEntity(Entity):
         self._id = device_id
         self._client = hass.data[DOMAIN]
         self._client.entities.append(self)
-        self.device = self._client.device(device_id)
         self._name = self.device.name
         _LOGGER.debug('Created device %s', self)
 


### PR DESCRIPTION
## Description:
Reported on Discord:

```
Traceback (most recent call last):
  File "/usr/src/app/homeassistant/helpers/entity_platform.py", line 128, in _async_setup_platform
    SLOW_SETUP_MAX_WAIT, loop=hass.loop)
  File "/usr/local/lib/python3.6/asyncio/tasks.py", line 358, in wait_for
    return fut.result()
  File "/usr/local/lib/python3.6/concurrent/futures/thread.py", line 56, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/src/app/homeassistant/components/sensor/tellduslive.py", line 51, in setup_platform
    add_entities(TelldusLiveSensor(hass, sensor) for sensor in discovery_info)
  File "/usr/src/app/homeassistant/helpers/entity_platform.py", line 174, in _schedule_add_entities
    self._async_schedule_add_entities, list(new_entities),
  File "/usr/src/app/homeassistant/components/sensor/tellduslive.py", line 51, in <genexpr>
    add_entities(TelldusLiveSensor(hass, sensor) for sensor in discovery_info)
  File "/usr/src/app/homeassistant/components/tellduslive.py", line 290, in __init__
    self.device = self._client.device(device_id)
AttributeError: can't set attribute
```

When we reverted part of #15980 in #16209, one piece was not correctly reverted. This changes it.

CC @Kane610 