### PR TITLE
Update trusted networks flow

### DIFF
--- a/homeassistant/auth/providers/trusted_networks.py
+++ b/homeassistant/auth/providers/trusted_networks.py
@@ -111,7 +111,6 @@ class TrustedNetworksLoginFlow(LoginFlow):
             self, user_input: Optional[Dict[str, str]] = None) \
             -> Dict[str, Any]:
         """Handle the step of the form."""
-        errors = {}
         try:
             cast(TrustedNetworksAuthProvider, self._auth_provider)\
                 .async_validate_access(self._ip_address)
@@ -127,5 +126,4 @@ class TrustedNetworksLoginFlow(LoginFlow):
         return self.async_show_form(
             step_id='init',
             data_schema=vol.Schema({'user': vol.In(self._available_users)}),
-            errors=errors,
         )

--- a/homeassistant/auth/providers/trusted_networks.py
+++ b/homeassistant/auth/providers/trusted_networks.py
@@ -117,25 +117,15 @@ class TrustedNetworksLoginFlow(LoginFlow):
                 .async_validate_access(self._ip_address)
 
         except InvalidAuthError:
-            errors['base'] = 'invalid_auth'
-            return self.async_show_form(
-                step_id='init',
-                data_schema=None,
-                errors=errors,
+            return self.async_abort(
+                reason='not_whitelisted'
             )
 
         if user_input is not None:
-            user_id = user_input['user']
-            if user_id not in self._available_users:
-                errors['base'] = 'invalid_auth'
-
-            if not errors:
-                return await self.async_finish(user_input)
-
-        schema = {'user': vol.In(self._available_users)}
+            return await self.async_finish(user_input)
 
         return self.async_show_form(
             step_id='init',
-            data_schema=vol.Schema(schema),
+            data_schema=vol.Schema({'user': vol.In(self._available_users)}),
             errors=errors,
         )

--- a/tests/auth/providers/test_trusted_networks.py
+++ b/tests/auth/providers/test_trusted_networks.py
@@ -74,16 +74,16 @@ async def test_login_flow(manager, provider):
     # trusted network didn't loaded
     flow = await provider.async_login_flow({'ip_address': '127.0.0.1'})
     step = await flow.async_step_init()
-    assert step['step_id'] == 'init'
-    assert step['errors']['base'] == 'invalid_auth'
+    assert step['type'] == 'abort'
+    assert step['reason'] == 'not_whitelisted'
 
     provider.hass.http = Mock(trusted_networks=['192.168.0.1'])
 
     # not from trusted network
     flow = await provider.async_login_flow({'ip_address': '127.0.0.1'})
     step = await flow.async_step_init()
-    assert step['step_id'] == 'init'
-    assert step['errors']['base'] == 'invalid_auth'
+    assert step['type'] == 'abort'
+    assert step['reason'] == 'not_whitelisted'
 
     # from trusted network, list users
     flow = await provider.async_login_flow({'ip_address': '192.168.0.1'})
@@ -94,11 +94,6 @@ async def test_login_flow(manager, provider):
     assert schema({'user': owner.id})
     with pytest.raises(vol.Invalid):
         assert schema({'user': 'invalid-user'})
-
-    # login with invalid user
-    step = await flow.async_step_init({'user': 'invalid-user'})
-    assert step['step_id'] == 'init'
-    assert step['errors']['base'] == 'invalid_auth'
 
     # login with valid user
     step = await flow.async_step_init({'user': user.id})


### PR DESCRIPTION
## Description:
Tweak the trusted networks flow. We should abort when we know the flow can never be successfully finished. We also don't have to check that the user is valid, as the voluptuous schema will validate that.

CC @awarecan 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
