### PR TITLE
Package loadable: compare case insensitive

### DIFF
--- a/homeassistant/util/package.py
+++ b/homeassistant/util/package.py
@@ -73,11 +73,13 @@ def package_loadable(package: str) -> bool:
         # This is a zip file
         req = pkg_resources.Requirement.parse(urlparse(package).fragment)
 
+    req_proj_name = req.project_name.lower()
+
     for path in sys.path:
         for dist in pkg_resources.find_distributions(path):
             # If the project name is the same, it will be the one that is
             # loaded when we import it.
-            if dist.project_name == req.project_name:
+            if dist.project_name.lower() == req_proj_name:
                 return dist in req
 
     return False

--- a/tests/util/test_package.py
+++ b/tests/util/test_package.py
@@ -239,3 +239,6 @@ def test_package_loadable_installed_twice():
 
     with patch('pkg_resources.find_distributions', side_effect=[[v2]]):
         assert package.package_loadable('hello==2.0.0')
+
+    with patch('pkg_resources.find_distributions', side_effect=[[v2]]):
+        assert package.package_loadable('Hello==2.0.0')


### PR DESCRIPTION
## Description:
Noticed in the logs on beta that it kept trying to install SQLAlchemy. Realized that the package name is SQLAlchemy but we look for sqlalchemy, so never realized it was loadable.

Found some further improvements but that's for another PR.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
