### PR TITLE
Change log level to error when auth provider failed to load

### DIFF
--- a/homeassistant/auth/mfa_modules/__init__.py
+++ b/homeassistant/auth/mfa_modules/__init__.py
@@ -152,8 +152,8 @@ async def _load_mfa_module(hass: HomeAssistant, module_name: str) \
 
     try:
         module = importlib.import_module(module_path)
-    except ImportError:
-        _LOGGER.warning('Unable to find %s', module_path)
+    except ImportError as err:
+        _LOGGER.error('Unable to load mfa module %s: %s', module_name, err)
         return None
 
     if hass.config.skip_pip or not hasattr(module, 'REQUIREMENTS'):

--- a/homeassistant/auth/providers/__init__.py
+++ b/homeassistant/auth/providers/__init__.py
@@ -134,8 +134,8 @@ async def load_auth_provider_module(
     try:
         module = importlib.import_module(
             'homeassistant.auth.providers.{}'.format(provider))
-    except ImportError:
-        _LOGGER.warning('Unable to find auth provider %s', provider)
+    except ImportError as err:
+        _LOGGER.error('Unable to load auth provider %s: %s', provider, err)
         return None
 
     if hass.config.skip_pip or not hasattr(module, 'REQUIREMENTS'):


### PR DESCRIPTION
## Description:
Change log level to error when auth provider or mfa module failed to load

Failed to load auth provider may allow anonymous access  

**Related issue (if applicable):** fixes #16223

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
