### PR TITLE
Avoid insecure pycryptodome

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -13,6 +13,8 @@ pyyaml>=3.13,<4
 requests==2.19.1
 voluptuous==0.11.5
 
+pycryptodome>=3.6.6
+
 # Breaks Python 3.6 and is not needed for our supported Python versions
 enum34==1000000000.0.0
 

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -124,6 +124,8 @@ URL_PIN = ('https://home-assistant.io/developers/code_review_platform/'
 CONSTRAINT_PATH = os.path.join(os.path.dirname(__file__),
                                '../homeassistant/package_constraints.txt')
 CONSTRAINT_BASE = """
+pycryptodome>=3.6.6
+
 # Breaks Python 3.6 and is not needed for our supported Python versions
 enum34==1000000000.0.0
 


### PR DESCRIPTION
## Description:
PyCryptodome < 3.6.6 has [a vulnerability](https://www.cvedetails.com/cve/CVE-2018-15560/). Although not used directly by Home Assistant, it is used by some of our dependencies. This will make sure that we don't install vulnerable versions.
