### PR TITLE
Streamline log messages

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -477,7 +477,7 @@ class EventBus:
         event = Event(event_type, event_data, origin, None, context)
 
         if event_type != EVENT_TIME_CHANGED:
-            _LOGGER.info("Bus:Handling %s", event)
+            _LOGGER.debug("Bus:Handling %s", event)
 
         if not listeners:
             return

--- a/tests/components/zwave/test_init.py
+++ b/tests/components/zwave/test_init.py
@@ -1180,7 +1180,7 @@ class TestZWaveServices(unittest.TestCase):
 
         self.zwave_network.nodes = {14: node}
 
-        with self.assertLogs(level='INFO') as mock_logger:
+        with self.assertLogs(level='DEBUG') as mock_logger:
             self.hass.services.call('zwave', 'print_node', {
                 const.ATTR_NODE_ID: 14
             })


### PR DESCRIPTION
## Description:
The logfile grows around 1M/hour (on my instance) with a large part of the messages being this INFO "Bus:Handling". I propose changing the message to debug message to reduce the file size and to help streamline reading of logs.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
