### PR TITLE
Device and entity registry remove config entry on unload

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -247,6 +247,14 @@ class ConfigEntry:
                               component.DOMAIN)
                 result = False
 
+            device_registry = await \
+                hass.helpers.device_registry.async_get_registry()
+            device_registry.async_clear_config_entry(self.entry_id)
+
+            entity_registry = await \
+                hass.helpers.entity_registry.async_get_registry()
+            entity_registry.async_clear_config_entry(self.entry_id)
+
             return result
         except Exception:  # pylint: disable=broad-except
             _LOGGER.exception('Error unloading entry %s for %s',

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -247,14 +247,6 @@ class ConfigEntry:
                               component.DOMAIN)
                 result = False
 
-            device_registry = await \
-                hass.helpers.device_registry.async_get_registry()
-            device_registry.async_clear_config_entry(self.entry_id)
-
-            entity_registry = await \
-                hass.helpers.entity_registry.async_get_registry()
-            entity_registry.async_clear_config_entry(self.entry_id)
-
             return result
         except Exception:  # pylint: disable=broad-except
             _LOGGER.exception('Error unloading entry %s for %s',
@@ -332,6 +324,14 @@ class ConfigEntries:
         self._async_schedule_save()
 
         unloaded = await entry.async_unload(self.hass)
+
+        device_registry = await \
+            self.hass.helpers.device_registry.async_get_registry()
+        device_registry.async_clear_config_entry(entry_id)
+
+        entity_registry = await \
+            self.hass.helpers.entity_registry.async_get_registry()
+        entity_registry.async_clear_config_entry(entry_id)
 
         return {
             'require_restart': not unloaded

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -348,6 +348,7 @@ class EntityPlatform:
 
         This method must be run in the event loop.
         """
+        print('async reset')
         if self._async_cancel_retry_setup is not None:
             self._async_cancel_retry_setup()
             self._async_cancel_retry_setup = None

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -348,7 +348,6 @@ class EntityPlatform:
 
         This method must be run in the event loop.
         """
-        print('async reset')
         if self._async_cancel_retry_setup is not None:
             self._async_cancel_retry_setup()
             self._async_cancel_retry_setup = None
@@ -379,6 +378,20 @@ class EntityPlatform:
     async def _async_remove_entity(self, entity_id):
         """Remove entity id from platform."""
         entity = self.entities.pop(entity_id)
+
+        if entity.unique_id is not None:
+
+            entity_registry = await \
+                self.hass.helpers.entity_registry.async_get_registry()
+
+            device_id = None
+            if entity_id in entity_registry.entities:
+                device_id = entity_registry.entities[entity_id].device_id
+
+            if device_id is not None:
+                device_registry = await \
+                    self.hass.helpers.device_registry.async_get_registry()
+                device_registry.async_remove_device(device_id)
 
         if hasattr(entity, 'async_will_remove_from_hass'):
             await entity.async_will_remove_from_hass()

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -379,20 +379,6 @@ class EntityPlatform:
         """Remove entity id from platform."""
         entity = self.entities.pop(entity_id)
 
-        if entity.unique_id is not None:
-
-            entity_registry = await \
-                self.hass.helpers.entity_registry.async_get_registry()
-
-            device_id = None
-            if entity_id in entity_registry.entities:
-                device_id = entity_registry.entities[entity_id].device_id
-
-            if device_id is not None:
-                device_registry = await \
-                    self.hass.helpers.device_registry.async_get_registry()
-                device_registry.async_remove_device(device_id)
-
         if hasattr(entity, 'async_will_remove_from_hass'):
             await entity.async_will_remove_from_hass()
 

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -257,7 +257,6 @@ class EntityRegistry:
             if config_entry == entry.config_entry_id:
                 entry.config_entry_id = None
                 self.async_schedule_save()
-                print(entry)
 
 
 @bind_hass

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -31,7 +31,7 @@ STORAGE_VERSION = 1
 STORAGE_KEY = 'core.entity_registry'
 
 
-@attr.s(slots=True, frozen=True)
+@attr.s(slots=True)
 class RegistryEntry:
     """Entity Registry Entry."""
 
@@ -249,6 +249,15 @@ class EntityRegistry:
         ]
 
         return data
+
+    @callback
+    def async_clear_config_entry(self, config_entry):
+        """Clear config entry from registry entries."""
+        for entry in self.entities.values():
+            if config_entry == entry.config_entry_id:
+                entry.config_entry_id = None
+                self.async_schedule_save()
+                print(entry)
 
 
 @bind_hass

--- a/tests/helpers/test_entity_registry.py
+++ b/tests/helpers/test_entity_registry.py
@@ -192,7 +192,7 @@ async def test_removing_config_entry_id(registry):
         'light', 'hue', '5678', config_entry_id='mock-id-1')
     assert entry.config_entry_id == 'mock-id-1'
     registry.async_clear_config_entry('mock-id-1')
-    assert entry.config_entry_id == None
+    assert entry.config_entry_id is None
 
 
 async def test_migration(hass):

--- a/tests/helpers/test_entity_registry.py
+++ b/tests/helpers/test_entity_registry.py
@@ -186,6 +186,15 @@ async def test_updating_config_entry_id(registry):
     assert entry2.config_entry_id == 'mock-id-2'
 
 
+async def test_removing_config_entry_id(registry):
+    """Test that we update config entry id in registry."""
+    entry = registry.async_get_or_create(
+        'light', 'hue', '5678', config_entry_id='mock-id-1')
+    assert entry.config_entry_id == 'mock-id-1'
+    registry.async_clear_config_entry('mock-id-1')
+    assert entry.config_entry_id == None
+
+
 async def test_migration(hass):
     """Test migration from old data to new."""
     old_conf = {


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
