### PR TITLE
Add support for discrete states to MyQ cover

### DIFF
--- a/homeassistant/components/cover/myq.py
+++ b/homeassistant/components/cover/myq.py
@@ -21,6 +21,12 @@ _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_NAME = 'myq'
 
+MYQ_TO_HASS = {
+    'closed': STATE_CLOSED,
+    'closing': STATE_CLOSING,
+    'opening': STATE_OPENING
+}
+
 NOTIFICATION_ID = 'myq_notification'
 NOTIFICATION_TITLE = 'MyQ Cover Setup'
 
@@ -89,17 +95,17 @@ class MyQDevice(CoverDevice):
     @property
     def is_closed(self):
         """Return true if cover is closed, else False."""
-        return self._status == STATE_CLOSED
+        return MYQ_TO_HASS[self._status] == STATE_CLOSED
 
     @property
     def is_closing(self):
         """Return if the cover is closing or not."""
-        return self._status == STATE_CLOSING
+        return MYQ_TO_HASS[self._status] == STATE_CLOSING
 
     @property
     def is_opening(self):
         """Return if the cover is opening or not."""
-        return self._status == STATE_OPENING
+        return MYQ_TO_HASS[self._status] == STATE_OPENING
 
     def close_cover(self, **kwargs):
         """Issue close command to cover."""

--- a/homeassistant/components/cover/myq.py
+++ b/homeassistant/components/cover/myq.py
@@ -8,12 +8,14 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.components.cover import CoverDevice
+from homeassistant.components.cover import (
+    CoverDevice, SUPPORT_CLOSE, SUPPORT_OPEN)
 from homeassistant.const import (
-    CONF_USERNAME, CONF_PASSWORD, CONF_TYPE, STATE_CLOSED)
+    CONF_PASSWORD, CONF_TYPE, CONF_USERNAME, STATE_CLOSED, STATE_CLOSING,
+    STATE_OPENING)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['pymyq==0.0.11']
+REQUIREMENTS = ['pymyq==0.0.15']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -89,6 +91,16 @@ class MyQDevice(CoverDevice):
         """Return true if cover is closed, else False."""
         return self._status == STATE_CLOSED
 
+    @property
+    def is_closing(self):
+        """Return if the cover is closing or not."""
+        return self._status == STATE_CLOSING
+
+    @property
+    def is_opening(self):
+        """Return if the cover is opening or not."""
+        return self._status == STATE_OPENING
+
     def close_cover(self, **kwargs):
         """Issue close command to cover."""
         self.myq.close_device(self.device_id)
@@ -96,6 +108,11 @@ class MyQDevice(CoverDevice):
     def open_cover(self, **kwargs):
         """Issue open command to cover."""
         self.myq.open_device(self.device_id)
+
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+        return SUPPORT_OPEN | SUPPORT_CLOSE
 
     def update(self):
         """Update status of cover."""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -961,7 +961,7 @@ pymonoprice==0.3
 pymusiccast==0.1.6
 
 # homeassistant.components.cover.myq
-pymyq==0.0.11
+pymyq==0.0.15
 
 # homeassistant.components.mysensors
 pymysensors==0.17.0


### PR DESCRIPTION
## Description:
- Update dependency to latest release
- Add discrete state support for `closing` and `opening`
- Update `supported_features` to reflect actual condition (MyQ does not support `stop_cover`)

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
N/A
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54