### PR TITLE
Tweak MFA login flow

### DIFF
--- a/homeassistant/auth/mfa_modules/totp.py
+++ b/homeassistant/auth/mfa_modules/totp.py
@@ -137,7 +137,7 @@ class TotpAuthModule(MultiFactorAuthModule):
             await self._async_load()
 
         # user_input has been validate in caller
-        # set INPUT_FIELD_CODE as vol.Require is not user friendly
+        # set INPUT_FIELD_CODE as vol.Required is not user friendly
         return await self.hass.async_add_executor_job(
             self._validate_2fa, user_id, user_input.get(INPUT_FIELD_CODE, ''))
 

--- a/homeassistant/auth/mfa_modules/totp.py
+++ b/homeassistant/auth/mfa_modules/totp.py
@@ -137,8 +137,9 @@ class TotpAuthModule(MultiFactorAuthModule):
             await self._async_load()
 
         # user_input has been validate in caller
+        # set INPUT_FIELD_CODE as vol.Require is not user friendly
         return await self.hass.async_add_executor_job(
-            self._validate_2fa, user_id, user_input[INPUT_FIELD_CODE])
+            self._validate_2fa, user_id, user_input.get(INPUT_FIELD_CODE, ''))
 
     def _validate_2fa(self, user_id: str, code: str) -> bool:
         """Validate two factor authentication code."""

--- a/tests/auth/mfa_modules/test_insecure_example.py
+++ b/tests/auth/mfa_modules/test_insecure_example.py
@@ -119,7 +119,7 @@ async def test_login(hass):
     result = await hass.auth.login_flow.async_configure(
         result['flow_id'], {'pin': 'invalid-code'})
     assert result['type'] == data_entry_flow.RESULT_TYPE_FORM
-    assert result['errors']['base'] == 'invalid_auth'
+    assert result['errors']['base'] == 'invalid_code'
 
     result = await hass.auth.login_flow.async_configure(
         result['flow_id'], {'pin': '123456'})

--- a/tests/auth/mfa_modules/test_totp.py
+++ b/tests/auth/mfa_modules/test_totp.py
@@ -121,7 +121,7 @@ async def test_login_flow_validates_mfa(hass):
             result['flow_id'], {'code': 'invalid-code'})
         assert result['type'] == data_entry_flow.RESULT_TYPE_FORM
         assert result['step_id'] == 'mfa'
-        assert result['errors']['base'] == 'invalid_auth'
+        assert result['errors']['base'] == 'invalid_code'
 
     with patch('pyotp.TOTP.verify', return_value=True):
         result = await hass.auth.login_flow.async_configure(

--- a/tests/auth/test_init.py
+++ b/tests/auth/test_init.py
@@ -428,10 +428,10 @@ async def test_login_with_auth_module(mock_hass):
         'pin': 'invalid-pin',
     })
 
-    # Invalid auth error
+    # Invalid code error
     assert step['type'] == data_entry_flow.RESULT_TYPE_FORM
     assert step['step_id'] == 'mfa'
-    assert step['errors'] == {'base': 'invalid_auth'}
+    assert step['errors'] == {'base': 'invalid_code'}
 
     step = await manager.login_flow.async_configure(step['flow_id'], {
         'pin': 'test-pin',
@@ -571,18 +571,9 @@ async def test_auth_module_expired_session(mock_hass):
         step = await manager.login_flow.async_configure(step['flow_id'], {
             'pin': 'test-pin',
         })
-        # Invalid auth due session timeout
-        assert step['type'] == data_entry_flow.RESULT_TYPE_FORM
-        assert step['step_id'] == 'mfa'
-        assert step['errors']['base'] == 'login_expired'
-
-        # The second try will fail as well
-        step = await manager.login_flow.async_configure(step['flow_id'], {
-            'pin': 'test-pin',
-        })
-        assert step['type'] == data_entry_flow.RESULT_TYPE_FORM
-        assert step['step_id'] == 'mfa'
-        assert step['errors']['base'] == 'login_expired'
+        # login flow abort due session timeout
+        assert step['type'] == data_entry_flow.RESULT_TYPE_ABORT
+        assert step['reason'] == 'login_expired'
 
 
 async def test_enable_mfa_for_user(hass, hass_storage):


### PR DESCRIPTION
## Description:
Tweak MFA login flow for better user experience. Front end home-assistant/home-assistant-polymer#1608

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

