### PR TITLE
Add device info Nest

### DIFF
--- a/homeassistant/components/climate/nest.py
+++ b/homeassistant/components/climate/nest.py
@@ -132,9 +132,9 @@ class NestThermostat(ClimateDevice):
     def device_info(self):
         """Return information about the device."""
         return {
-            'identifiers': [
+            'identifiers': {
                 (NEST_DOMAIN, self.device.device_id),
-            ],
+            },
             'name': self.device.name_long,
             'manufacturer': 'Nest Labs',
             'model': "Thermostat",

--- a/homeassistant/components/climate/nest.py
+++ b/homeassistant/components/climate/nest.py
@@ -8,7 +8,8 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.components.nest import DATA_NEST, SIGNAL_NEST_UPDATE
+from homeassistant.components.nest import (
+    DATA_NEST, SIGNAL_NEST_UPDATE, DOMAIN as NEST_DOMAIN)
 from homeassistant.components.climate import (
     STATE_AUTO, STATE_COOL, STATE_HEAT, STATE_ECO, ClimateDevice,
     PLATFORM_SCHEMA, ATTR_TARGET_TEMP_HIGH, ATTR_TARGET_TEMP_LOW,
@@ -126,6 +127,18 @@ class NestThermostat(ClimateDevice):
     def unique_id(self):
         """Return unique ID for this device."""
         return self.device.serial
+
+    @property
+    def device_info(self):
+        """Return information about the device."""
+        return {
+            'identifiers': [
+                (NEST_DOMAIN, self.device.device_id),
+            ],
+            'name': self.device.name_long,
+            'manufacturer': 'Nest Labs',
+            'model': "Thermostat",
+        }
 
     @property
     def name(self):


### PR DESCRIPTION
## Description:
Device info for Nest. Nest doesn't expose model names so hardcoding the thermostat to 'Thermostat'

```json
            {
                "config_entries": [
                    "d478297464ea4545adba954e9ad56478"
                ],
                "connections": [],
                "id": "792342e286a942c0ae0b265a87c8e517",
                "identifiers": [
                    [
                        "nest",
                        "RivIJMkVB1JfVZQgqEjzXn6FShUmJ0IH"
                    ]
                ],
                "manufacturer": "Nest Labs",
                "model": "Thermostat",
                "name": "Downstairs Thermostat (Virtual)",
                "sw_version": null
            }
```
