### PR TITLE
Add Hue device info

### DIFF
--- a/homeassistant/components/hue/__init__.py
+++ b/homeassistant/components/hue/__init__.py
@@ -11,7 +11,8 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_FILENAME, CONF_HOST
-from homeassistant.helpers import aiohttp_client, config_validation as cv
+from homeassistant.helpers import (
+    aiohttp_client, config_validation as cv, device_registry as dr)
 
 from .const import DOMAIN, API_NUPNP
 from .bridge import HueBridge
@@ -132,7 +133,28 @@ async def async_setup_entry(hass, entry):
 
     bridge = HueBridge(hass, entry, allow_unreachable, allow_groups)
     hass.data[DOMAIN][host] = bridge
-    return await bridge.async_setup()
+
+    if not await bridge.async_setup():
+        return False
+
+    config = bridge.api.config
+    device_registry = await dr.async_get_registry(hass)
+    device_registry.async_get_or_create(
+        config_entry=entry.entry_id,
+        connections=[
+            (dr.CONNECTION_NETWORK_MAC, config.mac)
+        ],
+        identifiers=[
+            (DOMAIN, config.bridgeid)
+        ],
+        manufacturer='Signify',
+        name=config.name,
+        # Not yet exposed as properties in aiohue
+        model=config.raw['modelid'],
+        sw_version=config.raw['swversion'],
+    )
+
+    return True
 
 
 async def async_unload_entry(hass, entry):

--- a/homeassistant/components/hue/__init__.py
+++ b/homeassistant/components/hue/__init__.py
@@ -141,12 +141,12 @@ async def async_setup_entry(hass, entry):
     device_registry = await dr.async_get_registry(hass)
     device_registry.async_get_or_create(
         config_entry=entry.entry_id,
-        connections=[
+        connections={
             (dr.CONNECTION_NETWORK_MAC, config.mac)
-        ],
-        identifiers=[
+        },
+        identifiers={
             (DOMAIN, config.bridgeid)
-        ],
+        },
         manufacturer='Signify',
         name=config.name,
         # Not yet exposed as properties in aiohue

--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -292,9 +292,9 @@ class HueLight(Light):
             return None
 
         return {
-            'identifiers': [
+            'identifiers': {
                 (hue.DOMAIN, self.unique_id)
-            ],
+            },
             'name': self.name,
             'manufacturer': self.light.manufacturername,
             # productname added in Hue Bridge API 1.24

--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -285,6 +285,25 @@ class HueLight(Light):
         """Return the list of supported effects."""
         return [EFFECT_COLORLOOP, EFFECT_RANDOM]
 
+    @property
+    def device_info(self):
+        """Return the device info."""
+        if self.light.type in ('LightGroup', 'Room'):
+            return None
+
+        return {
+            'identifiers': [
+                (hue.DOMAIN, self.unique_id)
+            ],
+            'name': self.name,
+            'manufacturer': self.light.manufacturername,
+            # productname added in Hue Bridge API 1.24
+            # (published 03/05/2018)
+            'model': self.light.productname or self.light.modelid,
+            # Not yet exposed as properties in aiohue
+            'sw_version': self.light.raw['swversion'],
+        }
+
     async def async_turn_on(self, **kwargs):
         """Turn the specified or all lights on."""
         command = {'on': True}

--- a/tests/components/hue/test_init.py
+++ b/tests/components/hue/test_init.py
@@ -1,5 +1,5 @@
 """Test Hue setup process."""
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from homeassistant.setup import async_setup_component
 from homeassistant.components import hue
@@ -145,9 +145,21 @@ async def test_config_passed_to_config_entry(hass):
         'host': '0.0.0.0',
     })
     entry.add_to_hass(hass)
-
-    with patch.object(hue, 'HueBridge') as mock_bridge:
+    mock_registry = Mock()
+    with patch.object(hue, 'HueBridge') as mock_bridge, \
+        patch('homeassistant.helpers.device_registry.async_get_registry',
+              return_value=mock_coro(mock_registry)):
         mock_bridge.return_value.async_setup.return_value = mock_coro(True)
+        mock_bridge.return_value.api.config = Mock(
+            mac='mock-mac',
+            bridgeid='mock-bridgeid',
+            raw={
+                'modelid': 'mock-modelid',
+                'swversion': 'mock-swversion',
+            }
+        )
+        # Can't set name via kwargs
+        mock_bridge.return_value.api.config.name = 'mock-name'
         assert await async_setup_component(hass, hue.DOMAIN, {
             hue.DOMAIN: {
                 hue.CONF_BRIDGES: {
@@ -168,6 +180,21 @@ async def test_config_passed_to_config_entry(hass):
     assert p_allow_unreachable is True
     assert p_allow_groups is False
 
+    assert len(mock_registry.mock_calls) == 1
+    assert mock_registry.mock_calls[0][2] == {
+        'config_entry': entry.entry_id,
+        'connections': {
+            ('mac', 'mock-mac')
+        },
+        'identifiers': {
+            ('hue', 'mock-bridgeid')
+        },
+        'manufacturer': 'Signify',
+        'name': 'mock-name',
+        'model': 'mock-modelid',
+        'sw_version': 'mock-swversion'
+    }
+
 
 async def test_unload_entry(hass):
     """Test being able to unload an entry."""
@@ -176,8 +203,11 @@ async def test_unload_entry(hass):
     })
     entry.add_to_hass(hass)
 
-    with patch.object(hue, 'HueBridge') as mock_bridge:
+    with patch.object(hue, 'HueBridge') as mock_bridge, \
+        patch('homeassistant.helpers.device_registry.async_get_registry',
+              return_value=mock_coro(Mock())):
         mock_bridge.return_value.async_setup.return_value = mock_coro(True)
+        mock_bridge.return_value.api.config = Mock()
         assert await async_setup_component(hass, hue.DOMAIN, {}) is True
 
     assert len(mock_bridge.return_value.mock_calls) == 1


### PR DESCRIPTION
## Description:
Add Hue device info

Bridge entry

```json
{
                "config_entries": [
                    "b37fbcb15ecc4abea09989b5529b9604"
                ],
                "connections": [
                    [
                        "mac",
                        "00:17:88:1c:c4:fd"
                    ]
                ],
                "id": "90e914207bb5438082711a63031b01fb",
                "identifiers": [
                    [
                        "hue",
                        "001788AAAAAAFD"
                    ]
                ],
                "manufacturer": "Signify",
                "model": "BSB001",
                "name": "Philips hue",
                "sw_version": "01041302"
            }
```

Light entries:

```json
            {
                "config_entries": [
                    "b37fbcb15ecc4abea09989b5529b9604"
                ],
                "connections": [],
                "id": "60d4e8a0098a4bd58e7465964f133400",
                "identifiers": [
                    [
                        "hue",
                        "90:fd:9f:ff:fe:f7:AA-01"
                    ]
                ],
                "manufacturer": "IKEA of Sweden",
                "model": "TRADFRI bulb E27 CWS opal 600lm",
                "name": "Bolletje",
                "sw_version": "1.3.002"
            },
            {
                "config_entries": [
                    "b37fbcb15ecc4abea09989b5529b9604"
                ],
                "connections": [],
                "id": "1d0de4842c6d4c5ba3de3b7024b48f11",
                "identifiers": [
                    [
                        "hue",
                        "00:17:88:01:00:f5:AA-0b"
                    ]
                ],
                "manufacturer": "Philips",
                "model": "LWB004",
                "name": "Ballonetje",
                "sw_version": "5.38.2.19136"
            },
```