### PR TITLE
Add support for Shelly switch

### DIFF
--- a/homeassistant/components/switch/shelly.py
+++ b/homeassistant/components/switch/shelly.py
@@ -118,3 +118,4 @@ class ShellySwitch(SwitchDevice):
         """Turn the device off."""
         if self._switch('off'):
             self._state = False
+            

--- a/homeassistant/components/switch/shelly.py
+++ b/homeassistant/components/switch/shelly.py
@@ -78,17 +78,6 @@ class ShellySwitch(SwitchDevice):
         except requests.RequestException as error:
             _LOGGER.error("Switching failed: " + error)
 
-    def _query_state(self):
-        """Query switch state."""
-        _LOGGER.info("Querying state from: %s", self._url)
-
-        try:
-            req = requests.get('{}'.format(self._url),
-                               auth=self._auth, timeout=5)
-            return req.json()['ison'] == True
-        except requests.RequestException as error:
-            _LOGGER.error("State query failed: " + error)
-
     @property
     def should_poll(self):
         """Return the polling state."""
@@ -106,7 +95,13 @@ class ShellySwitch(SwitchDevice):
 
     def update(self):
         """Update device state."""
-        self._state = self._query_state()
+        _LOGGER.info("Querying state from: %s", self._url)
+        try:
+            req = requests.get('{}'.format(self._url),
+                               auth=self._auth, timeout=5)
+            self._state = req.json()['ison']
+        except requests.RequestException as error:
+            _LOGGER.error("State query failed: " + error)
 
     def turn_on(self, **kwargs):
         """Turn the device on."""

--- a/homeassistant/components/switch/shelly.py
+++ b/homeassistant/components/switch/shelly.py
@@ -1,0 +1,120 @@
+"""
+Support for The Shelly Wifi switch.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/switch.shelly/
+"""
+import logging
+
+import requests
+import voluptuous as vol
+
+from homeassistant.components.switch import SwitchDevice, PLATFORM_SCHEMA
+from homeassistant.const import (
+    CONF_HOST, CONF_NAME, CONF_PATH,
+    CONF_USERNAME, CONF_PASSWORD, CONF_SWITCHES)
+import homeassistant.helpers.config_validation as cv
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_PATH = "/relay/0"
+
+SWITCH_SCHEMA = vol.Schema({
+    vol.Required(CONF_HOST): cv.string,
+    vol.Optional(CONF_NAME): cv.string,
+    vol.Optional(CONF_PATH, default=DEFAULT_PATH): cv.string,
+    vol.Optional(CONF_USERNAME): cv.string,
+    vol.Optional(CONF_PASSWORD): cv.string,
+})
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_SWITCHES): vol.Schema({cv.slug: SWITCH_SCHEMA}),
+})
+
+
+def setup_platform(hass, config, add_devices_callback, discovery_info=None):
+    """Set up Shelly Wifi switches."""
+    switches = config.get('switches', {})
+    devices = []
+
+    for dev_name, properties in switches.items():
+        devices.append(
+            ShellySwitch(
+                hass,
+                properties.get(CONF_NAME, dev_name),
+                properties.get(CONF_HOST, None),
+                properties.get(CONF_PATH, DEFAULT_PATH),
+                properties.get(CONF_USERNAME, None),
+                properties.get(CONF_PASSWORD)))
+
+    add_devices_callback(devices)
+
+
+class ShellySwitch(SwitchDevice):
+    """Representation of a Shelly Wifi switch."""
+
+    def __init__(self, hass, name, host, path, user, passwd):
+        """Initialize the device."""
+        self._hass = hass
+        self._name = name
+        self._state = False
+        self._url = 'http://{}{}'.format(host, path)
+        if user is not None:
+            self._auth = (user, passwd)
+        else:
+            self._auth = None
+
+    def _switch(self, newstate):
+        """Switch on or off."""
+        _LOGGER.info("Switching to state: %s", newstate)
+
+        try:
+            req = requests.get('{}?turn={}'.format(self._url, newstate),
+                               auth=self._auth, timeout=5)
+            result = req.status_code
+            if result == 200:
+                return True
+            else:
+                return False
+        except requests.RequestException as error:
+            _LOGGER.error("Switching failed: " + error)
+
+    def _query_state(self):
+        """Query switch state."""
+        _LOGGER.info("Querying state from: %s", self._url)
+
+        try:
+            req = requests.get('{}'.format(self._url),
+                               auth=self._auth, timeout=5)
+            return req.json()['ison'] == True
+        except requests.RequestException as error:
+            _LOGGER.error("State query failed: " + error)
+
+    @property
+    def should_poll(self):
+        """Return the polling state."""
+        return True
+
+    @property
+    def name(self):
+        """Return the name of the switch."""
+        return self._name
+
+    @property
+    def is_on(self):
+        """Return true if device is on."""
+        return self._state
+
+    def update(self):
+        """Update device state."""
+        self._state = self._query_state()
+
+    def turn_on(self, **kwargs):
+        """Turn the device on."""
+        if self._switch('on'):
+            self._state = True
+
+    def turn_off(self, **kwargs):
+        """Turn the device off."""
+        if self._switch('off'):
+            self._state = False

--- a/homeassistant/components/switch/shelly.py
+++ b/homeassistant/components/switch/shelly.py
@@ -86,7 +86,8 @@ class ShellySwitch(SwitchDevice):
         try:
             req = requests.get('{}'.format(self._url),
                                auth=self._auth, timeout=5)
-            return req.json()['ison'] == True
+            isOn = req.json()['ison']
+            return isOn
         except requests.RequestException as error:
             _LOGGER.error("State query failed: " + error)
 

--- a/homeassistant/components/switch/shelly.py
+++ b/homeassistant/components/switch/shelly.py
@@ -71,10 +71,7 @@ class ShellySwitch(SwitchDevice):
             req = requests.get('{}?turn={}'.format(self._url, newstate),
                                auth=self._auth, timeout=5)
             result = req.status_code
-            if result == 200:
-                return True
-            else:
-                return False
+            return bool(result == 200)
         except requests.RequestException as error:
             _LOGGER.error("Switching failed: %s", error)
 

--- a/homeassistant/components/switch/shelly.py
+++ b/homeassistant/components/switch/shelly.py
@@ -34,10 +34,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 def setup_platform(hass, config, add_devices_callback, discovery_info=None):
     """Set up Shelly Wifi switches."""
-    switches = config.get('switches', {})
     devices = []
 
-    for dev_name, properties in switches.items():
+    for dev_name, properties in config[CONF_SWITCHES].items():
         devices.append(
             ShellySwitch(
                 hass,

--- a/homeassistant/components/switch/shelly.py
+++ b/homeassistant/components/switch/shelly.py
@@ -76,7 +76,7 @@ class ShellySwitch(SwitchDevice):
             else:
                 return False
         except requests.RequestException as error:
-            _LOGGER.debug("Switching failed: %s", error)
+            _LOGGER.error("Switching failed: %s", error)
 
     @property
     def should_poll(self):

--- a/homeassistant/components/switch/shelly.py
+++ b/homeassistant/components/switch/shelly.py
@@ -76,7 +76,7 @@ class ShellySwitch(SwitchDevice):
             else:
                 return False
         except requests.RequestException as error:
-            _LOGGER.error("Switching failed: " + error)
+            _LOGGER.debug("Switching failed: %s", error)
 
     @property
     def should_poll(self):
@@ -95,13 +95,13 @@ class ShellySwitch(SwitchDevice):
 
     def update(self):
         """Update device state."""
-        _LOGGER.info("Querying state from: %s", self._url)
+        _LOGGER.debug("Querying state from: %s", self._url)
         try:
             req = requests.get('{}'.format(self._url),
                                auth=self._auth, timeout=5)
             self._state = req.json()['ison']
         except requests.RequestException as error:
-            _LOGGER.error("State query failed: " + error)
+            _LOGGER.error("State query failed: %s ", error)
 
     def turn_on(self, **kwargs):
         """Turn the device on."""


### PR DESCRIPTION
## Description:
Support the Shelly 1 and Shelly 2 Switches

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#6110

## Example entry for `configuration.yaml` (if applicable):
```yaml
switch:
  - platform: shelly
    switches:
      living_room_light:
        host: 10.0.0.219
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54