### PR TITLE
Make states look nicer in frontend for Vacuum component

### DIFF
--- a/homeassistant/components/vacuum/__init__.py
+++ b/homeassistant/components/vacuum/__init__.py
@@ -62,12 +62,12 @@ VACUUM_SEND_COMMAND_SERVICE_SCHEMA = VACUUM_SERVICE_SCHEMA.extend({
     vol.Optional(ATTR_PARAMS): vol.Any(dict, cv.ensure_list),
 })
 
-STATE_CLEANING = 'cleaning'
-STATE_DOCKED = 'docked'
+STATE_CLEANING = 'Cleaning'
+STATE_DOCKED = 'Docked'
 STATE_IDLE = STATE_IDLE
 STATE_PAUSED = STATE_PAUSED
-STATE_RETURNING = 'returning'
-STATE_ERROR = 'error'
+STATE_RETURNING = 'Returning to dock'
+STATE_ERROR = 'Error'
 
 DEFAULT_NAME = 'Vacuum cleaner robot'
 


### PR DESCRIPTION
## Description:
Earlier the vacuum reported its status in plain english into home assistant, when the change in 0.77 took place it looks a lot more boring in the frontend.

With this change, states of the vacuum looks nicer in the frontend.

Is this change possible, or does it need to be lowercase and no spaces?