### PR TITLE
deCONZ - Entities are now properly unloaded with config entry

### DIFF
--- a/homeassistant/components/binary_sensor/deconz.py
+++ b/homeassistant/components/binary_sensor/deconz.py
@@ -54,6 +54,11 @@ class DeconzBinarySensor(BinarySensorDevice):
         self._sensor.register_async_callback(self.async_update_callback)
         self.hass.data[DATA_DECONZ_ID][self.entity_id] = self._sensor.deconz_id
 
+    async def async_will_remove_from_hass(self) -> None:
+        """Disconnect sensor object when removed."""
+        self._sensor.remove_callback(self.async_update_callback)
+        self._sensor = None
+
     @callback
     def async_update_callback(self, reason):
         """Update the sensor's state.

--- a/homeassistant/components/light/deconz.py
+++ b/homeassistant/components/light/deconz.py
@@ -82,6 +82,11 @@ class DeconzLight(Light):
         self._light.register_async_callback(self.async_update_callback)
         self.hass.data[DATA_DECONZ_ID][self.entity_id] = self._light.deconz_id
 
+    async def async_will_remove_from_hass(self) -> None:
+        """Disconnect light object when removed."""
+        self._light.remove_callback(self.async_update_callback)
+        self._light = None
+
     @callback
     def async_update_callback(self, reason):
         """Update the light's state."""

--- a/homeassistant/components/scene/deconz.py
+++ b/homeassistant/components/scene/deconz.py
@@ -38,6 +38,10 @@ class DeconzScene(Scene):
         """Subscribe to sensors events."""
         self.hass.data[DATA_DECONZ_ID][self.entity_id] = self._scene.deconz_id
 
+    async def async_will_remove_from_hass(self) -> None:
+        """Disconnect scene object when removed."""
+        self._scene = None
+
     async def async_activate(self):
         """Activate the scene."""
         await self._scene.async_set_state({})

--- a/homeassistant/components/sensor/deconz.py
+++ b/homeassistant/components/sensor/deconz.py
@@ -64,6 +64,11 @@ class DeconzSensor(Entity):
         self._sensor.register_async_callback(self.async_update_callback)
         self.hass.data[DATA_DECONZ_ID][self.entity_id] = self._sensor.deconz_id
 
+    async def async_will_remove_from_hass(self) -> None:
+        """Disconnect sensor object when removed."""
+        self._sensor.remove_callback(self.async_update_callback)
+        self._sensor = None
+
     @callback
     def async_update_callback(self, reason):
         """Update the sensor's state.
@@ -155,16 +160,21 @@ class DeconzSensor(Entity):
 class DeconzBattery(Entity):
     """Battery class for when a device is only represented as an event."""
 
-    def __init__(self, device):
+    def __init__(self, sensor):
         """Register dispatcher callback for update of battery state."""
-        self._device = device
-        self._name = '{} {}'.format(self._device.name, 'Battery Level')
+        self._sensor = sensor
+        self._name = '{} {}'.format(self._sensor.name, 'Battery Level')
         self._unit_of_measurement = "%"
 
     async def async_added_to_hass(self):
         """Subscribe to sensors events."""
-        self._device.register_async_callback(self.async_update_callback)
-        self.hass.data[DATA_DECONZ_ID][self.entity_id] = self._device.deconz_id
+        self._sensor.register_async_callback(self.async_update_callback)
+        self.hass.data[DATA_DECONZ_ID][self.entity_id] = self._sensor.deconz_id
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Disconnect sensor object when removed."""
+        self._sensor.remove_callback(self.async_update_callback)
+        self._sensor = None
 
     @callback
     def async_update_callback(self, reason):
@@ -175,7 +185,7 @@ class DeconzBattery(Entity):
     @property
     def state(self):
         """Return the state of the battery."""
-        return self._device.battery
+        return self._sensor.battery
 
     @property
     def name(self):
@@ -185,7 +195,7 @@ class DeconzBattery(Entity):
     @property
     def unique_id(self):
         """Return a unique identifier for the device."""
-        return self._device.uniqueid
+        return self._sensor.uniqueid
 
     @property
     def device_class(self):
@@ -206,22 +216,22 @@ class DeconzBattery(Entity):
     def device_state_attributes(self):
         """Return the state attributes of the battery."""
         attr = {
-            ATTR_EVENT_ID: slugify(self._device.name),
+            ATTR_EVENT_ID: slugify(self._sensor.name),
         }
         return attr
 
     @property
     def device_info(self):
         """Return a device description for device registry."""
-        if (self._device.uniqueid is None or
-                self._device.uniqueid.count(':') != 7):
+        if (self._sensor.uniqueid is None or
+                self._sensor.uniqueid.count(':') != 7):
             return None
-        serial = self._device.uniqueid.split('-', 1)[0]
+        serial = self._sensor.uniqueid.split('-', 1)[0]
         return {
             'connections': {(CONNECTION_ZIGBEE, serial)},
             'identifiers': {(DECONZ_DOMAIN, serial)},
-            'manufacturer': self._device.manufacturer,
-            'model': self._device.modelid,
-            'name': self._device.name,
-            'sw_version': self._device.swversion,
+            'manufacturer': self._sensor.manufacturer,
+            'model': self._sensor.modelid,
+            'name': self._sensor.name,
+            'sw_version': self._sensor.swversion,
         }

--- a/homeassistant/components/switch/deconz.py
+++ b/homeassistant/components/switch/deconz.py
@@ -55,6 +55,11 @@ class DeconzSwitch(SwitchDevice):
         self._switch.register_async_callback(self.async_update_callback)
         self.hass.data[DATA_DECONZ_ID][self.entity_id] = self._switch.deconz_id
 
+    async def async_will_remove_from_hass(self) -> None:
+        """Disconnect switch object when removed."""
+        self._switch.remove_callback(self.async_update_callback)
+        self._switch = None
+
     @callback
     def async_update_callback(self, reason):
         """Update the switch's state."""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -817,7 +817,7 @@ pycsspeechtts==1.0.2
 pydaikin==0.4
 
 # homeassistant.components.deconz
-pydeconz==44
+pydeconz==45
 
 # homeassistant.components.zwave
 pydispatcher==2.0.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -139,7 +139,7 @@ py-canary==0.5.0
 pyblackbird==0.5
 
 # homeassistant.components.deconz
-pydeconz==44
+pydeconz==45
 
 # homeassistant.components.zwave
 pydispatcher==2.0.5


### PR DESCRIPTION
## Description:
Noticed while working on unloading devices from device registry that deCONZ entities didn't unload properly.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
