### PR TITLE
Correct wemo static device discovery issue.

### DIFF
--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -124,14 +124,14 @@ def setup(hass, config):
             _LOGGER.error(
                 'Unable to get description url for %s',
                 '{}:{}'.format(host, port) if port else host)
-            return False
+            continue
 
         try:
             device = pywemo.discovery.device_from_description(url, None)
         except (requests.exceptions.ConnectionError,
                 requests.exceptions.Timeout) as err:
             _LOGGER.error('Unable to access %s (%s)', url, err)
-            return False
+            continue
 
         devices.append((url, device))
 


### PR DESCRIPTION
A recent change caused an issue if a single static wemo device is offline and could not be reached, then the whole component would not initialize (and therefore all other wemo devices are not added).

## Description:

As described in the comments of the latest release blog:

mnl​1121
If you have a Wemo switch unplugged and explicitly set each Wemo switch in your config, none of your wemo plugs will work. It throws an error about not being able to find the one and then none work. I have 3 wemo switches and sometimes I unplug one. Previous HA versions never had a problem, now they do.




**Related issue (if applicable):** fixes #

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
