### PR TITLE
Add OpenTherm Gateway climate platform

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -411,6 +411,7 @@ omit =
     homeassistant/components/climate/honeywell.py
     homeassistant/components/climate/knx.py
     homeassistant/components/climate/oem.py
+    homeassistant/components/climate/opentherm_gw.py
     homeassistant/components/climate/proliphix.py
     homeassistant/components/climate/radiotherm.py
     homeassistant/components/climate/sensibo.py

--- a/homeassistant/components/climate/opentherm_gw.py
+++ b/homeassistant/components/climate/opentherm_gw.py
@@ -1,0 +1,187 @@
+import asyncio
+import logging
+import voluptuous as vol
+
+from homeassistant.components.climate import (
+    ATTR_CURRENT_TEMPERATURE, ATTR_MAX_TEMP, ATTR_MIN_TEMP,
+    ATTR_TARGET_TEMP_HIGH, ATTR_TARGET_TEMP_LOW, ATTR_TARGET_TEMP_STEP,
+    ClimateDevice, PLATFORM_SCHEMA, STATE_IDLE, STATE_HEAT, STATE_COOL,
+    SUPPORT_AWAY_MODE, SUPPORT_TARGET_TEMPERATURE,
+    SUPPORT_TARGET_TEMPERATURE_HIGH, SUPPORT_TARGET_TEMPERATURE_LOW,
+    SUPPORT_ON_OFF)
+from homeassistant.components.climate.modbus import CONF_PRECISION
+from homeassistant.const import (ATTR_TEMPERATURE, CONF_DEVICE, CONF_NAME,
+    PRECISION_HALVES, PRECISION_TENTHS, TEMP_CELSIUS, PRECISION_WHOLE,
+    STATE_ON, STATE_OFF)
+from homeassistant.helpers.temperature import display_temp as show_temp
+from homeassistant.util.temperature import convert as convert_temperature
+from homeassistant.helpers.entity import Entity
+import homeassistant.helpers.config_validation as cv
+
+REQUIREMENTS = ['pyotgw']
+
+CONF_FLOOR_TEMP = "floor_temperature"
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_DEVICE): cv.string,
+    vol.Optional(CONF_NAME, default="Opentherm Gateway"): cv.string,
+    vol.Optional(CONF_PRECISION): vol.In([PRECISION_TENTHS, PRECISION_HALVES,
+                                         PRECISION_WHOLE]),
+    vol.Optional(CONF_FLOOR_TEMP, default=False): cv.boolean,
+})
+
+SUPPORT_FLAGS = (SUPPORT_TARGET_TEMPERATURE)
+_LOGGER = logging.getLogger(__name__)
+
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    """Setup the opentherm_gw component."""
+    gw = opentherm_gw()
+    gw.friendly_name = config.get(CONF_NAME)
+    gw._floor_temp = config.get(CONF_FLOOR_TEMP, False)
+    gw._precision = config.get(CONF_PRECISION)
+    async_add_entities([gw])
+    await gw.connect(hass, config.get(CONF_DEVICE))
+    _LOGGER.debug("Connected to {} on {}".format(gw.friendly_name,
+                                                 config.get(CONF_DEVICE)))
+    return True
+
+class opentherm_gw(ClimateDevice):
+    """Representation of a climate device."""
+
+    def __init__(self):
+        """Initialize the sensor."""
+        import pyotgw
+        self.pyotgw = pyotgw
+        self._current_operation = STATE_IDLE
+        self._current_temperature = 0.0
+        self._target_temperature = 0.0
+
+    async def connect(self, hass, gw_path):
+        self.gw = self.pyotgw.pyotgw()
+        self.hass = hass
+        await self.gw.connect(hass.loop, gw_path)
+        self.gw.subscribe(self.receive_report)
+        return
+
+    async def receive_report(self, status):
+        _LOGGER.debug("Received report: {}".format(status))
+        ch_active = status.get(self.pyotgw.DATA_SLAVE_CH_ACTIVE)
+        cooling_active = status.get(self.pyotgw.DATA_SLAVE_COOLING_ACTIVE)
+        if ch_active:
+            self._current_operation = STATE_HEAT
+        elif cooling_active:
+            self._current_operation = STATE_COOL
+        else:
+            self._current_operation = STATE_IDLE
+        self._current_temperature = status.get(self.pyotgw.DATA_ROOM_TEMP)
+        self._target_temperature = (status.get(self.pyotgw.DATA_ROOM_SETPOINT)
+            if status.get(self.pyotgw.DATA_ROOM_SETPOINT_OVRD, 0) == 0
+            else status.get(self.pyotgw.DATA_ROOM_SETPOINT_OVRD))
+
+        if (status.get(self.pyotgw.OTGW_GPIO_A) == 5):
+            self._away_mode_a = 0
+        elif (status.get(self.pyotgw.OTGW_GPIO_A) == 6):
+            self._away_mode_a = 1
+        else:
+            self._away_mode_a = None
+        if (status.get(self.pyotgw.OTGW_GPIO_B) == 5):
+            self._away_mode_b = 0
+        elif (status.get(self.pyotgw.OTGW_GPIO_B) == 6):
+            self._away_mode_b = 1
+        else:
+            self._away_mode_b = None
+        if self._away_mode_a is not None:
+            self._away_state_a = (status.get(self.pyotgw.OTGW_GPIO_A_STATE) ==
+                                  self._away_mode_a)
+        if self._away_mode_b is not None:
+            self._away_state_b = (status.get(self.pyotgw.OTGW_GPIO_B_STATE) ==
+                                  self._away_mode_b)
+        self.hass.async_add_job(self.async_update_ha_state(True))
+
+    @property
+    def name(self):
+        return self.friendly_name
+
+    @property
+    def state(self):
+        """Return the current state."""
+        if self.is_on is False:
+            return STATE_OFF
+        if self._current_operation:
+            return self._current_operation
+        if self.is_on:
+            return STATE_ON
+        return STATE_UNKNOWN
+
+    @property
+    def precision(self):
+        """Return the precision of the system."""
+        if self._precision is not None:
+            return self._precision
+        if self.unit_of_measurement == TEMP_CELSIUS:
+            return PRECISION_HALVES
+        return PRECISION_WHOLE
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement to display."""
+        return self.hass.config.units.temperature_unit
+
+    @property
+    def temperature_unit(self):
+        """Return the unit of measurement used by the platform."""
+        return TEMP_CELSIUS
+
+    @property
+    def current_operation(self):
+        """Return current operation ie. heat, cool, idle."""
+        return self._current_operation
+
+    @property
+    def current_temperature(self):
+        """Return the current temperature."""
+        if self._floor_temp is True:
+            if self._precision == PRECISION_HALVES:
+                return int(2 * self._current_temperature) / 2
+            elif self._precision == PRECISION_TENTHS:
+                return int(10 * self._current_temperature) / 10
+        return self._current_temperature
+
+    @property
+    def target_temperature(self):
+        """Return the temperature we try to reach."""
+        return self._target_temperature
+
+    @property
+    def target_temperature_step(self):
+        """Return the supported step of target temperature."""
+        return self.precision
+
+    @property
+    def is_away_mode_on(self):
+        """Return true if away mode is on."""
+        return (getattr(self, '_away_state_a', False) or
+                getattr(self, '_away_state_b', False))
+
+    def async_set_temperature(self, **kwargs):
+        """Set new target temperature."""
+        if 'temperature' in kwargs:
+            temp = float(kwargs['temperature'])
+            return self.gw.set_target_temp(temp)
+        else:
+            return False
+
+    @property
+    def supported_features(self):
+        """Return the list of supported features."""
+        return (SUPPORT_TARGET_TEMPERATURE)
+
+    @property
+    def min_temp(self):
+        """Return the minimum temperature."""
+        return convert_temperature(1, TEMP_CELSIUS, self.temperature_unit)
+
+    @property
+    def max_temp(self):
+        """Return the maximum temperature."""
+        return convert_temperature(30, TEMP_CELSIUS, self.temperature_unit)

--- a/homeassistant/components/climate/opentherm_gw.py
+++ b/homeassistant/components/climate/opentherm_gw.py
@@ -1,6 +1,5 @@
-"""
-OpenTherm Gateway Climate component for Home Assistant
-"""
+"""OpenTherm Gateway Climate component for Home Assistant."""
+
 import logging
 import voluptuous as vol
 
@@ -31,9 +30,10 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 SUPPORT_FLAGS = (SUPPORT_TARGET_TEMPERATURE)
 _LOGGER = logging.getLogger(__name__)
 
+
 async def async_setup_platform(hass, config, async_add_entities,
                                discovery_info=None):
-    """Setup the opentherm_gw component."""
+    """Set up the opentherm_gw component."""
     gateway = OpenThermGateway()
     gateway.friendly_name = config.get(CONF_NAME)
     gateway.floor_temp = config.get(CONF_FLOOR_TEMP, False)
@@ -43,6 +43,7 @@ async def async_setup_platform(hass, config, async_add_entities,
     _LOGGER.debug("Connected to %s on %s", gateway.friendly_name,
                   config.get(CONF_DEVICE))
     return True
+
 
 class OpenThermGateway(ClimateDevice):
     """Representation of a climate device."""
@@ -64,14 +65,14 @@ class OpenThermGateway(ClimateDevice):
         self._away_state_b = False
 
     async def connect(self, hass, gw_path):
-        """Connect to the OpenTherm Gateway device at gw_path"""
+        """Connect to the OpenTherm Gateway device at gw_path."""
         self.hass = hass
         await self.gateway.connect(hass.loop, gw_path)
         self.gateway.subscribe(self.receive_report)
         return
 
     async def receive_report(self, status):
-        """Called when a new report has been received from the Gateway"""
+        """Receive and handle a new report from the Gateway."""
         _LOGGER.debug("Received report: %s", status)
         ch_active = status.get(self.pyotgw.DATA_SLAVE_CH_ACTIVE)
         cooling_active = status.get(self.pyotgw.DATA_SLAVE_COOLING_ACTIVE)
@@ -112,6 +113,7 @@ class OpenThermGateway(ClimateDevice):
 
     @property
     def name(self):
+        """Return the friendly name."""
         return self.friendly_name
 
     @property

--- a/homeassistant/components/climate/opentherm_gw.py
+++ b/homeassistant/components/climate/opentherm_gw.py
@@ -18,7 +18,7 @@ from homeassistant.const import (ATTR_TEMPERATURE, CONF_DEVICE, CONF_NAME,
                                  STATE_OFF, STATE_UNKNOWN)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['pyotgw==0.1a0']
+REQUIREMENTS = ['pyotgw==0.1b0']
 
 CONF_FLOOR_TEMP = "floor_temperature"
 CONF_PRECISION = 'precision'
@@ -84,7 +84,7 @@ class OpenThermGateway(ClimateDevice):
         else:
             self._current_operation = STATE_IDLE
         self._current_temperature = status.get(self.pyotgw.DATA_ROOM_TEMP)
-        if status.get(self.pyotgw.DATA_ROOM_SETPOINT_OVRD, 0) == 0:
+        if status.get(self.pyotgw.DATA_ROOM_SETPOINT_OVRD) == None:
             temp = status.get(self.pyotgw.DATA_ROOM_SETPOINT)
         else:
             temp = status.get(self.pyotgw.DATA_ROOM_SETPOINT_OVRD)

--- a/homeassistant/components/climate/opentherm_gw.py
+++ b/homeassistant/components/climate/opentherm_gw.py
@@ -106,7 +106,7 @@ class OpenThermGateway(ClimateDevice):
         if self._away_mode_b is not None:
             self._away_state_b = (status.get(self.pyotgw.OTGW_GPIO_B_STATE) ==
                                   self._away_mode_b)
-        self.hass.async_add_job(self.async_update_ha_state(True))
+        self.async_schedule_update_ha_state()
 
     @property
     def name(self):
@@ -121,6 +121,11 @@ class OpenThermGateway(ClimateDevice):
         if self.hass.config.units.temperature_unit == TEMP_CELSIUS:
             return PRECISION_HALVES
         return PRECISION_WHOLE
+
+    @property
+    def should_poll(self):
+        """Disable polling for this entity."""
+        return False
 
     @property
     def temperature_unit(self):
@@ -162,8 +167,9 @@ class OpenThermGateway(ClimateDevice):
         """Set new target temperature."""
         if ATTR_TEMPERATURE in kwargs:
             temp = float(kwargs[ATTR_TEMPERATURE])
-            await self.gateway.set_target_temp(temp)
-            await self.async_update_ha_state()
+            self._target_temperature = await self.gateway.set_target_temp(
+                temp)
+            self.async_schedule_update_ha_state()
 
     @property
     def supported_features(self):

--- a/homeassistant/components/climate/opentherm_gw.py
+++ b/homeassistant/components/climate/opentherm_gw.py
@@ -122,14 +122,9 @@ class OpenThermGateway(ClimateDevice):
         """Return the precision of the system."""
         if self.temp_precision is not None:
             return self.temp_precision
-        if self.unit_of_measurement == TEMP_CELSIUS:
+        if self.hass.config.units.temperature_unit == TEMP_CELSIUS:
             return PRECISION_HALVES
         return PRECISION_WHOLE
-
-    @property
-    def unit_of_measurement(self):
-        """Return the unit of measurement to display."""
-        return self.hass.config.units.temperature_unit
 
     @property
     def temperature_unit(self):

--- a/homeassistant/components/climate/opentherm_gw.py
+++ b/homeassistant/components/climate/opentherm_gw.py
@@ -62,7 +62,7 @@ class OpenThermGateway(ClimateDevice):
         self._away_state_b = False
 
     async def async_added_to_hass(self):
-        """Connect to the OpenTherm Gateway device"""
+        """Connect to the OpenTherm Gateway device."""
         await self.gateway.connect(self.hass.loop, self._device)
         self.gateway.subscribe(self.receive_report)
         _LOGGER.debug("Connected to %s on %s", self.friendly_name,

--- a/homeassistant/components/climate/opentherm_gw.py
+++ b/homeassistant/components/climate/opentherm_gw.py
@@ -14,8 +14,7 @@ from homeassistant.components.climate import (ClimateDevice, PLATFORM_SCHEMA,
                                               SUPPORT_TARGET_TEMPERATURE)
 from homeassistant.const import (ATTR_TEMPERATURE, CONF_DEVICE, CONF_NAME,
                                  PRECISION_HALVES, PRECISION_TENTHS,
-                                 TEMP_CELSIUS, PRECISION_WHOLE, STATE_ON,
-                                 STATE_OFF, STATE_UNKNOWN)
+                                 TEMP_CELSIUS, PRECISION_WHOLE)
 import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['pyotgw==0.1b0']
@@ -84,7 +83,7 @@ class OpenThermGateway(ClimateDevice):
         else:
             self._current_operation = STATE_IDLE
         self._current_temperature = status.get(self.pyotgw.DATA_ROOM_TEMP)
-        if status.get(self.pyotgw.DATA_ROOM_SETPOINT_OVRD) == None:
+        if status.get(self.pyotgw.DATA_ROOM_SETPOINT_OVRD) is None:
             temp = status.get(self.pyotgw.DATA_ROOM_SETPOINT)
         else:
             temp = status.get(self.pyotgw.DATA_ROOM_SETPOINT_OVRD)

--- a/homeassistant/components/climate/opentherm_gw.py
+++ b/homeassistant/components/climate/opentherm_gw.py
@@ -49,7 +49,7 @@ class OpenThermGateway(ClimateDevice):
         import pyotgw
         self.pyotgw = pyotgw
         self.gateway = self.pyotgw.pyotgw()
-        self._device = config.get(CONF_DEVICE)
+        self._device = config[CONF_DEVICE]
         self.friendly_name = config.get(CONF_NAME)
         self.floor_temp = config.get(CONF_FLOOR_TEMP)
         self.temp_precision = config.get(CONF_PRECISION)
@@ -80,23 +80,25 @@ class OpenThermGateway(ClimateDevice):
         else:
             self._current_operation = STATE_IDLE
         self._current_temperature = status.get(self.pyotgw.DATA_ROOM_TEMP)
-        if status.get(self.pyotgw.DATA_ROOM_SETPOINT_OVRD) is None:
+
+        temp = status.get(self.pyotgw.DATA_ROOM_SETPOINT_OVRD)
+        if temp is None:
             temp = status.get(self.pyotgw.DATA_ROOM_SETPOINT)
-        else:
-            temp = status.get(self.pyotgw.DATA_ROOM_SETPOINT_OVRD)
         self._target_temperature = temp
 
         # GPIO mode 5: 0 == Away
         # GPIO mode 6: 1 == Away
-        if status.get(self.pyotgw.OTGW_GPIO_A) == 5:
+        gpio_a_state = status.get(self.pyotgw.OTGW_GPIO_A)
+        if gpio_a_state == 5:
             self._away_mode_a = 0
-        elif status.get(self.pyotgw.OTGW_GPIO_A) == 6:
+        elif gpio_a_state == 6:
             self._away_mode_a = 1
         else:
             self._away_mode_a = None
-        if status.get(self.pyotgw.OTGW_GPIO_B) == 5:
+        gpio_b_state = status.get(self.pyotgw.OTGW_GPIO_B)
+        if gpio_b_state == 5:
             self._away_mode_b = 0
-        elif status.get(self.pyotgw.OTGW_GPIO_B) == 6:
+        elif gpio_b_state == 6:
             self._away_mode_b = 1
         else:
             self._away_mode_b = None

--- a/homeassistant/components/climate/opentherm_gw.py
+++ b/homeassistant/components/climate/opentherm_gw.py
@@ -118,17 +118,6 @@ class OpenThermGateway(ClimateDevice):
         return self.friendly_name
 
     @property
-    def state(self):
-        """Return the current state."""
-        if self.is_on is False:
-            return STATE_OFF
-        if self._current_operation:
-            return self._current_operation
-        if self.is_on:
-            return STATE_ON
-        return STATE_UNKNOWN
-
-    @property
     def precision(self):
         """Return the precision of the system."""
         if self.temp_precision is not None:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -992,6 +992,9 @@ pyopenuv==1.0.1
 # homeassistant.components.iota
 pyota==2.0.5
 
+# homeassistant.components.climate.opentherm_gw
+pyotgw==0.1a0
+
 # homeassistant.auth.mfa_modules.totp
 # homeassistant.components.sensor.otp
 pyotp==2.2.6

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -993,7 +993,7 @@ pyopenuv==1.0.1
 pyota==2.0.5
 
 # homeassistant.components.climate.opentherm_gw
-pyotgw==0.1a0
+pyotgw==0.1b0
 
 # homeassistant.auth.mfa_modules.totp
 # homeassistant.components.sensor.otp


### PR DESCRIPTION
## Description:
Add support for the [OpenTherm Gateway](http://otgw.tclcode.com).

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#6118

## Example entry for `configuration.yaml` (if applicable):
```yaml
climate:
  - platform: opentherm_gw
    device: /dev/ttyUSB0
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.i)

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
