### PR TITLE
Add unique_id to MQTT Light

### DIFF
--- a/homeassistant/components/light/mqtt.py
+++ b/homeassistant/components/light/mqtt.py
@@ -400,7 +400,7 @@ class MqttLight(MqttAvailability, Light):
     def unique_id(self):
         """Return a unique ID."""
         return self._unique_id
-    
+
     @property
     def is_on(self):
         """Return true if device is on."""

--- a/homeassistant/components/light/mqtt.py
+++ b/homeassistant/components/light/mqtt.py
@@ -54,6 +54,7 @@ CONF_WHITE_VALUE_SCALE = 'white_value_scale'
 CONF_WHITE_VALUE_STATE_TOPIC = 'white_value_state_topic'
 CONF_WHITE_VALUE_TEMPLATE = 'white_value_template'
 CONF_ON_COMMAND_TYPE = 'on_command_type'
+CONF_UNIQUE_ID = 'unique_id'
 
 DEFAULT_BRIGHTNESS_SCALE = 255
 DEFAULT_NAME = 'MQTT Light'
@@ -79,6 +80,7 @@ PLATFORM_SCHEMA = mqtt.MQTT_RW_PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_EFFECT_STATE_TOPIC): mqtt.valid_subscribe_topic,
     vol.Optional(CONF_EFFECT_VALUE_TEMPLATE): cv.template,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_UNIQUE_ID): cv.string,
     vol.Optional(CONF_OPTIMISTIC, default=DEFAULT_OPTIMISTIC): cv.boolean,
     vol.Optional(CONF_PAYLOAD_OFF, default=DEFAULT_PAYLOAD_OFF): cv.string,
     vol.Optional(CONF_PAYLOAD_ON, default=DEFAULT_PAYLOAD_ON): cv.string,
@@ -111,6 +113,7 @@ async def async_setup_platform(hass, config, async_add_entities,
 
     async_add_entities([MqttLight(
         config.get(CONF_NAME),
+        config.get(CONF_UNIQUE_ID),
         config.get(CONF_EFFECT_LIST),
         {
             key: config.get(key) for key in (
@@ -159,14 +162,15 @@ async def async_setup_platform(hass, config, async_add_entities,
 class MqttLight(MqttAvailability, Light):
     """Representation of a MQTT light."""
 
-    def __init__(self, name, effect_list, topic, templates, qos,
-                 retain, payload, optimistic, brightness_scale,
+    def __init__(self, name, unique_id, effect_list, topic, templates,
+                 qos, retain, payload, optimistic, brightness_scale,
                  white_value_scale, on_command_type, availability_topic,
                  payload_available, payload_not_available):
         """Initialize MQTT light."""
         super().__init__(availability_topic, qos, payload_available,
                          payload_not_available)
         self._name = name
+        self._unique_id = unique_id
         self._effect_list = effect_list
         self._topic = topic
         self._qos = qos
@@ -392,6 +396,11 @@ class MqttLight(MqttAvailability, Light):
         """Return the name of the device if any."""
         return self._name
 
+    @property
+    def unique_id(self):
+        """Return a unique ID."""
+        return self._unique_id
+    
     @property
     def is_on(self):
         """Return true if device is on."""


### PR DESCRIPTION
## Description:
Add unique_id to MQTT Light

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#6121
## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
