### PR TITLE
Implement correct state for RFlink cover

### DIFF
--- a/homeassistant/components/cover/rflink.py
+++ b/homeassistant/components/cover/rflink.py
@@ -109,7 +109,7 @@ class RflinkCover(RflinkCommand, CoverDevice):
 
     @property
     def assumed_state(self):
-        """return True because covers can be stopped midway"""
+        """Return True because covers can be stopped midway"""
         return True
 
     def async_close_cover(self, **kwargs):

--- a/homeassistant/components/cover/rflink.py
+++ b/homeassistant/components/cover/rflink.py
@@ -92,9 +92,9 @@ class RflinkCover(RflinkCommand, CoverDevice):
         self.cancel_queued_send_commands()
 
         command = event['command']
-        if command in ['on', 'allon']:
+        if command in ['on', 'allon', 'down']:
             self._state = True
-        elif command in ['off', 'alloff']:
+        elif command in ['off', 'alloff', 'up']:
             self._state = False
 
     @property
@@ -105,7 +105,12 @@ class RflinkCover(RflinkCommand, CoverDevice):
     @property
     def is_closed(self):
         """Return if the cover is closed."""
-        return None
+        return self._state
+
+    @property
+    def assumed_state(self):
+        """return True because covers can be stopped midway"""
+        return True
 
     def async_close_cover(self, **kwargs):
         """Turn the device close."""

--- a/homeassistant/components/cover/rflink.py
+++ b/homeassistant/components/cover/rflink.py
@@ -92,9 +92,9 @@ class RflinkCover(RflinkCommand, CoverDevice):
         self.cancel_queued_send_commands()
 
         command = event['command']
-        if command in ['on', 'allon', 'down']:
+        if command in ['on', 'allon', 'up']:
             self._state = True
-        elif command in ['off', 'alloff', 'up']:
+        elif command in ['off', 'alloff', 'down']:
             self._state = False
 
     @property
@@ -105,7 +105,7 @@ class RflinkCover(RflinkCommand, CoverDevice):
     @property
     def is_closed(self):
         """Return if the cover is closed."""
-        return self._state
+        return not self._state
 
     @property
     def assumed_state(self):

--- a/homeassistant/components/cover/rflink.py
+++ b/homeassistant/components/cover/rflink.py
@@ -109,7 +109,7 @@ class RflinkCover(RflinkCommand, CoverDevice):
 
     @property
     def assumed_state(self):
-        """Return True because covers can be stopped midway"""
+        """Return True because covers can be stopped midway."""
         return True
 
     def async_close_cover(self, **kwargs):


### PR DESCRIPTION
## Description:

This implements a very simple state for the rflink covers as currently that is just not working.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
