### PR TITLE
Avoid error when feedreader is in debug log mode and RSS entry comes without title and pubDate

### DIFF
--- a/homeassistant/components/feedreader.py
+++ b/homeassistant/components/feedreader.py
@@ -143,7 +143,7 @@ class FeedManager:
         else:
             self._has_published_parsed = False
             _LOGGER.debug("No published_parsed info available for entry %s",
-                          entry.title)
+                          entry)
         entry.update({'feed_url': self._url})
         self._hass.bus.fire(self._event_type, entry)
 
@@ -164,7 +164,7 @@ class FeedManager:
                 self._update_and_fire_entry(entry)
                 new_entries = True
             else:
-                _LOGGER.debug("Entry %s already processed", entry.title)
+                _LOGGER.debug("Entry %s already processed", entry)
         if not new_entries:
             self._log_no_entries()
         self._firstrun = False

--- a/tests/components/test_feedreader.py
+++ b/tests/components/test_feedreader.py
@@ -160,11 +160,11 @@ class TestFeedreaderComponent(unittest.TestCase):
         manager, events = self.setup_manager(feed_data, max_entries=5)
         assert len(events) == 5
 
-    def test_feed_without_publication_date(self):
-        """Test simple feed with entry without publication date."""
+    def test_feed_without_publication_date_and_title(self):
+        """Test simple feed with entry without publication date and title."""
         feed_data = load_fixture('feedreader3.xml')
         manager, events = self.setup_manager(feed_data)
-        assert len(events) == 2
+        assert len(events) == 3
 
     def test_feed_invalid_data(self):
         """Test feed with invalid data."""

--- a/tests/fixtures/feedreader3.xml
+++ b/tests/fixtures/feedreader3.xml
@@ -21,6 +21,11 @@
             <link>http://www.example.com/link/2</link>
             <guid isPermaLink="false">GUID 2</guid>
         </item>
+        <item>
+            <description>Description 3</description>
+            <link>http://www.example.com/link/3</link>
+            <guid isPermaLink="false">GUID 3</guid>
+        </item>
 
     </channel>
 </rss>


### PR DESCRIPTION
## Description:
Under rare circumstance an uncaught error is produced and the affected RSS entry is discarded: when the `feedreader` component is in `debug` log mode, and at least one entry in the RSS feed does not contain a `title` and does not contain a `pubDate` tag.

In this case an error like the following is logged (the following comes from a `tox` test run):
```
core.py                    110 ERROR    Error doing job: Future exception was never retrieved
Traceback (most recent call last):
  File "/Users/username/home-assistant/home-assistant/.tox/py36/lib/python3.6/site-packages/feedparser.py", line 398, in __getattr__
    return self.__getitem__(key)
  File "/Users/username/home-assistant/home-assistant/.tox/py36/lib/python3.6/site-packages/feedparser.py", line 356, in __getitem__
    return dict.__getitem__(self, key)
KeyError: 'title'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/Cellar/python/3.6.4_4/Frameworks/Python.framework/Versions/3.6/lib/python3.6/concurrent/futures/thread.py", line 56, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/Users/username/home-assistant/home-assistant/homeassistant/components/feedreader.py", line 74, in <lambda>
    EVENT_HOMEASSISTANT_START, lambda _: self._update())
  File "/Users/username/home-assistant/home-assistant/homeassistant/components/feedreader.py", line 119, in _update
    self._publish_new_entries()
  File "/Users/username/home-assistant/home-assistant/homeassistant/components/feedreader.py", line 164, in _publish_new_entries
    self._update_and_fire_entry(entry)
  File "/Users/username/Programming/home-assistant/home-assistant/homeassistant/components/feedreader.py", line 146, in _update_and_fire_entry
    entry.title)
  File "/Users/username/home-assistant/home-assistant/.tox/py36/lib/python3.6/site-packages/feedparser.py", line 400, in __getattr__
    raise AttributeError("object has no attribute '%s'" % key)
AttributeError: object has no attribute 'title'
```

I amended the RSS fixture for one test case to capture this issue.

**Related issue (if applicable):** n/a

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable):
```yaml
feedreader:
  urls:
    - <URL of RSS feed where entries are missing title and pubDate tag>

logger:
  default: info
  logs:
    homeassistant.components.feedreader: debug
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
