### PR TITLE
Upgrade Adafruit-DHT to 1.3.4

### DIFF
--- a/homeassistant/components/sensor/dht.py
+++ b/homeassistant/components/sensor/dht.py
@@ -17,7 +17,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 from homeassistant.util.temperature import celsius_to_fahrenheit
 
-REQUIREMENTS = ['Adafruit-DHT==1.3.3']
+REQUIREMENTS = ['Adafruit-DHT==1.3.4']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -18,7 +18,7 @@ voluptuous==0.11.5
 --only-binary=all nuimo==0.1.0
 
 # homeassistant.components.sensor.dht
-# Adafruit-DHT==1.3.3
+# Adafruit-DHT==1.3.4
 
 # homeassistant.components.sensor.sht31
 Adafruit-GPIO==1.0.3


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes [#16321](https://github.com/home-assistant/home-assistant/issues/16321)

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: dht
    sensor: AM2302
    pin: 22
    monitored_conditions:
      - temperature
      - humidity
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54

Starting home assistant after code change (sensor not connected, therfore not showing results):
```bash
2018-08-31 12:51:29 INFO (Thread-3) [homeassistant.util.package] Attempting install of Adafruit-DHT==1.3.4
2018-08-31 12:52:29 INFO (MainThread) [homeassistant.components.sensor] Setting up sensor.dht
2018-08-31 12:53:07 INFO (MainThread) [homeassistant.core] Bus:Handling <Event state_changed[L]: new_state=<state sensor.dht_sensor_humidity=unknown; friendly_name=DHT Sensor Humidity, unit_of_measurement=% @ 2018-08-31T12:53:07.663078+00:00>, old_state=None, entity_id=sensor.dht_sensor_humidity>

```