### PR TITLE
Bugfix: Fix missing HomeMatic humidity sensor

### DIFF
--- a/homeassistant/components/homematic/__init__.py
+++ b/homeassistant/components/homematic/__init__.py
@@ -77,7 +77,7 @@ HM_DEVICE_TYPES = {
         'FillingLevel', 'ValveDrive', 'EcoLogic', 'IPThermostatWall',
         'IPSmoke', 'RFSiren', 'PresenceIP', 'IPAreaThermostat',
         'IPWeatherSensor', 'RotaryHandleSensorIP', 'IPPassageSensor',
-        'IPKeySwitchPowermeter'],
+        'IPKeySwitchPowermeter', 'IPThermostatWall230V'],
     DISCOVER_CLIMATE: [
         'Thermostat', 'ThermostatWall', 'MAXThermostat', 'ThermostatWall2',
         'MAXWallThermostat', 'IPThermostat', 'IPThermostatWall',


### PR DESCRIPTION
## Description:
The recent update of the pyhomematic dependency required a change of a class-name of a previously fully supported climate device. I forgot about the the devices humidity sensor though. This PR fixes the issue and brings back the sensor.

**Related issue (in pyhomematic, although the broken part is here):** https://github.com/danielperna84/pyhomematic/issues/163

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
