### PR TITLE
Replace api_password in Camera.Push

### DIFF
--- a/homeassistant/components/camera/push.py
+++ b/homeassistant/components/camera/push.py
@@ -43,7 +43,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_TIMEOUT, default=timedelta(seconds=5)): vol.All(
         cv.time_period, cv.positive_timedelta),
     vol.Optional(CONF_IMAGE_FIELD, default='image'): cv.string,
-    vol.Required(CONF_TOKEN): vol.All(cv.string, vol.Length(min=8)),
+    vol.Optional(CONF_TOKEN): vol.All(cv.string, vol.Length(min=8)),
 })
 
 
@@ -91,8 +91,9 @@ class CameraPushReceiver(HomeAssistantView):
                          request.query.get('token') == _camera.token)
 
         if not authenticated:
-            return self.json_message('Invalid token for {}'.format(entity_id),
-                                     HTTP_UNAUTHORIZED)
+            return self.json_message(
+                'Invalid authorization credentials for {}'.format(entity_id),
+                HTTP_UNAUTHORIZED)
 
         try:
             data = await request.post()

--- a/homeassistant/components/camera/push.py
+++ b/homeassistant/components/camera/push.py
@@ -13,8 +13,10 @@ import voluptuous as vol
 from homeassistant.components.camera import Camera, PLATFORM_SCHEMA,\
     STATE_IDLE, STATE_RECORDING
 from homeassistant.core import callback
-from homeassistant.components.http.view import HomeAssistantView
-from homeassistant.const import CONF_NAME, CONF_TIMEOUT, HTTP_BAD_REQUEST
+from homeassistant.components.http.view import KEY_AUTHENTICATED,\
+    HomeAssistantView
+from homeassistant.const import CONF_NAME, CONF_TIMEOUT,\
+    HTTP_NOT_FOUND, HTTP_UNAUTHORIZED, HTTP_BAD_REQUEST
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.event import async_track_point_in_utc_time
 import homeassistant.util.dt as dt_util
@@ -25,11 +27,13 @@ DEPENDENCIES = ['http']
 
 CONF_BUFFER_SIZE = 'buffer'
 CONF_IMAGE_FIELD = 'field'
+CONF_TOKEN = 'token'
 
 DEFAULT_NAME = "Push Camera"
 
 ATTR_FILENAME = 'filename'
 ATTR_LAST_TRIP = 'last_trip'
+ATTR_TOKEN = 'token'
 
 PUSH_CAMERA_DATA = 'push_camera'
 
@@ -39,6 +43,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_TIMEOUT, default=timedelta(seconds=5)): vol.All(
         cv.time_period, cv.positive_timedelta),
     vol.Optional(CONF_IMAGE_FIELD, default='image'): cv.string,
+    vol.Required(CONF_TOKEN): vol.All(cv.string, vol.Length(min=8)),
 })
 
 
@@ -50,7 +55,8 @@ async def async_setup_platform(hass, config, async_add_entities,
 
     cameras = [PushCamera(config[CONF_NAME],
                           config[CONF_BUFFER_SIZE],
-                          config[CONF_TIMEOUT])]
+                          config[CONF_TIMEOUT],
+                          config[CONF_TOKEN])]
 
     hass.http.register_view(CameraPushReceiver(hass,
                                                config[CONF_IMAGE_FIELD]))
@@ -63,6 +69,7 @@ class CameraPushReceiver(HomeAssistantView):
 
     url = "/api/camera_push/{entity_id}"
     name = 'api:camera_push:camera_entity'
+    requires_auth = False
 
     def __init__(self, hass, image_field):
         """Initialize CameraPushReceiver with camera entity."""
@@ -75,8 +82,17 @@ class CameraPushReceiver(HomeAssistantView):
 
         if _camera is None:
             _LOGGER.error("Unknown %s", entity_id)
+            status = HTTP_NOT_FOUND if request[KEY_AUTHENTICATED]\
+                else HTTP_UNAUTHORIZED
             return self.json_message('Unknown {}'.format(entity_id),
-                                     HTTP_BAD_REQUEST)
+                                     status)
+
+        authenticated = (request[KEY_AUTHENTICATED] or
+                         request.query.get('token') == _camera.token)
+
+        if not authenticated:
+            return self.json_message('Invalid token for {}'.format(entity_id),
+                                     HTTP_UNAUTHORIZED)
 
         try:
             data = await request.post()
@@ -95,7 +111,7 @@ class CameraPushReceiver(HomeAssistantView):
 class PushCamera(Camera):
     """The representation of a Push camera."""
 
-    def __init__(self, name, buffer_size, timeout):
+    def __init__(self, name, buffer_size, timeout, token):
         """Initialize push camera component."""
         super().__init__()
         self._name = name
@@ -106,6 +122,7 @@ class PushCamera(Camera):
         self._timeout = timeout
         self.queue = deque([], buffer_size)
         self._current_image = None
+        self.token = token
 
     async def async_added_to_hass(self):
         """Call when entity is added to hass."""
@@ -168,5 +185,6 @@ class PushCamera(Camera):
             name: value for name, value in (
                 (ATTR_LAST_TRIP, self._last_trip),
                 (ATTR_FILENAME, self._filename),
+                (ATTR_TOKEN, self.token),
             ) if value is not None
         }

--- a/homeassistant/components/camera/push.py
+++ b/homeassistant/components/camera/push.py
@@ -87,6 +87,8 @@ class CameraPushReceiver(HomeAssistantView):
             return self.json_message('Unknown {}'.format(entity_id),
                                      status)
 
+        # Supports HA authentication and token based
+        # when token has been configured
         authenticated = (request[KEY_AUTHENTICATED] or
                          (_camera.token is not None and
                           request.query.get('token') == _camera.token))

--- a/homeassistant/components/camera/push.py
+++ b/homeassistant/components/camera/push.py
@@ -56,7 +56,7 @@ async def async_setup_platform(hass, config, async_add_entities,
     cameras = [PushCamera(config[CONF_NAME],
                           config[CONF_BUFFER_SIZE],
                           config[CONF_TIMEOUT],
-                          config[CONF_TOKEN])]
+                          config.get(CONF_TOKEN))]
 
     hass.http.register_view(CameraPushReceiver(hass,
                                                config[CONF_IMAGE_FIELD]))
@@ -88,7 +88,8 @@ class CameraPushReceiver(HomeAssistantView):
                                      status)
 
         authenticated = (request[KEY_AUTHENTICATED] or
-                         request.query.get('token') == _camera.token)
+                         (_camera.token is not None and
+                          request.query.get('token') == _camera.token))
 
         if not authenticated:
             return self.json_message(

--- a/tests/components/camera/test_push.py
+++ b/tests/components/camera/test_push.py
@@ -54,7 +54,8 @@ async def test_cases_with_no_auth(aioclient_mock, hass, aiohttp_client):
         data=files)
     assert resp.status == 200
 
-async def test_cases_with_no_auth_no_token(aioclient_mock, hass, aiohttp_client):
+
+async def test_no_auth_no_token(aioclient_mock, hass, aiohttp_client):
     """Test cases where aiohttp_client is not auth."""
     await async_setup_component(hass, 'camera', {
         'camera': {
@@ -76,7 +77,7 @@ async def test_cases_with_no_auth_no_token(aioclient_mock, hass, aiohttp_client)
     resp = await client.post(
         '/api/camera_push/camera.config_test?token=12345678',
         data=files)
-    assert resp.status == 401 
+    assert resp.status == 401
 
 
 async def test_posting_url(hass, aiohttp_client):

--- a/tests/components/camera/test_push.py
+++ b/tests/components/camera/test_push.py
@@ -54,6 +54,30 @@ async def test_cases_with_no_auth(aioclient_mock, hass, aiohttp_client):
         data=files)
     assert resp.status == 200
 
+async def test_cases_with_no_auth_no_token(aioclient_mock, hass, aiohttp_client):
+    """Test cases where aiohttp_client is not auth."""
+    await async_setup_component(hass, 'camera', {
+        'camera': {
+            'platform': 'push',
+            'name': 'config_test',
+        }})
+
+    setup_auth(hass.http.app, [], True, api_password=None)
+    client = await aiohttp_client(hass.http.app)
+
+    # no token
+    files = {'image': io.BytesIO(b'fake')}
+    resp = await client.post('/api/camera_push/camera.config_test',
+                             data=files)
+    assert resp.status == 401
+
+    # fake token
+    files = {'image': io.BytesIO(b'fake')}
+    resp = await client.post(
+        '/api/camera_push/camera.config_test?token=12345678',
+        data=files)
+    assert resp.status == 401 
+
 
 async def test_posting_url(hass, aiohttp_client):
     """Test that posting to api endpoint works."""


### PR DESCRIPTION
## Description:

Remove api_password, and changes to using access_token/user provided token accordingly to https://github.com/home-assistant/home-assistant/issues/15376#issuecomment-417373618

This is a **breaking change** for most users pushing camera images through cURL scripts

**Related issue (if applicable):** #15376

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#6130

## Example entry for `configuration.yaml` (if applicable):
```yaml
camera:
  - platform: push
    name: cam1
    timeout: 10
    cache: 5
    token: 12345678
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54