### PR TITLE
Handle netatmo exception

### DIFF
--- a/homeassistant/components/sensor/netatmo.py
+++ b/homeassistant/components/sensor/netatmo.py
@@ -317,7 +317,11 @@ class NetAtmoData:
 
         try:
             import pyatmo
-            self.station_data = pyatmo.WeatherStationData(self.auth)
+            try:
+                self.station_data = pyatmo.WeatherStationData(self.auth)
+            except TypeError:
+                _LOGGER.error("Failed to connect to NetAtmo")
+                return  # finally statement will be executed
 
             if self.station is not None:
                 self.data = self.station_data.lastData(


### PR DESCRIPTION
## Description:
Handle netatmo exception when connection issue

The netatmo library will throw a TypeError when HA fails to connect to the netatmo server.


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

