### PR TITLE
Make google_maps last_seen attribute a timezone aware datetime in UTC

### DIFF
--- a/homeassistant/components/device_tracker/google_maps.py
+++ b/homeassistant/components/device_tracker/google_maps.py
@@ -15,7 +15,7 @@ from homeassistant.const import ATTR_ID, CONF_PASSWORD, CONF_USERNAME
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import track_time_interval
 from homeassistant.helpers.typing import ConfigType
-from homeassistant.util import slugify
+from homeassistant.util import slugify, dt as dt_util
 
 REQUIREMENTS = ['locationsharinglib==2.0.11']
 
@@ -92,7 +92,7 @@ class GoogleMapsScanner:
                 ATTR_ADDRESS: person.address,
                 ATTR_FULL_NAME: person.full_name,
                 ATTR_ID: person.id,
-                ATTR_LAST_SEEN: person.datetime,
+                ATTR_LAST_SEEN: dt_util.as_utc(person.datetime),
                 ATTR_NICKNAME: person.nickname,
             }
             self.see(


### PR DESCRIPTION
## Description:
The last_seen attribute was a datetime in the local timezone but with no tzinfo (i.e., a "naive" datetime.) When state changes occurred it would be printed incorrectly in homeassistant.log because homeassistant.util.dt.as_local assumes any datetime without tzinfo is UTC. Also most, if not all, datetime attributes are timezone aware in UTC. So use homeassistant.util.dt.as_utc (which assumes a naive datetime is local) to convert last_seen to a timezone aware datetime in UTC.

**Related issue (if applicable):** fixes #16341

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
