### PR TITLE
Upgrade qnapstats to 0.2.7

### DIFF
--- a/homeassistant/components/sensor/qnap.py
+++ b/homeassistant/components/sensor/qnap.py
@@ -17,7 +17,7 @@ from homeassistant.const import (
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['qnapstats==0.2.6']
+REQUIREMENTS = ['qnapstats==0.2.7']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -173,7 +173,7 @@ class QNAPStatsAPI:
 
         protocol = "https" if config.get(CONF_SSL) else "http"
         self._api = QNAPStats(
-            protocol + "://" + config.get(CONF_HOST),
+            '{}://{}'.format(protocol, config.get(CONF_HOST)),
             config.get(CONF_PORT),
             config.get(CONF_USERNAME),
             config.get(CONF_PASSWORD),

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1217,7 +1217,7 @@ pyxeoma==1.4.0
 pyzabbix==0.7.4
 
 # homeassistant.components.sensor.qnap
-qnapstats==0.2.6
+qnapstats==0.2.7
 
 # homeassistant.components.rachio
 rachiopy==0.1.3


### PR DESCRIPTION
## Description:
Changelog: https://github.com/colinodell/python-qnapstats/releases/tag/0.2.7

Related issue (if applicable): partial #15479

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: qnap
    host:192.168.1.6
    username: !secret qnap_user
    password: !secret qnap_pass
    monitored_conditions:
      - status
      - cpu_usage
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
 

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
