### PR TITLE
Restore status attribute for xiaomi_vacuum

### DIFF
--- a/homeassistant/components/vacuum/__init__.py
+++ b/homeassistant/components/vacuum/__init__.py
@@ -68,11 +68,6 @@ STATE_IDLE = STATE_IDLE
 STATE_PAUSED = STATE_PAUSED
 STATE_RETURNING = 'returning'
 STATE_ERROR = 'error'
-STATE_REMOTE = 'remote controlled'
-STATE_SPOT_CLEANING = 'spot cleaning'
-STATE_GOING_TO_TARGET = 'going to target'
-STATE_UPDATING = 'updating'
-STATE_ZONED_CLEANING = 'zoned cleaning'
 
 DEFAULT_NAME = 'Vacuum cleaner robot'
 

--- a/homeassistant/components/vacuum/__init__.py
+++ b/homeassistant/components/vacuum/__init__.py
@@ -68,6 +68,11 @@ STATE_IDLE = STATE_IDLE
 STATE_PAUSED = STATE_PAUSED
 STATE_RETURNING = 'returning'
 STATE_ERROR = 'error'
+STATE_REMOTE = 'remote controlled'
+STATE_SPOT_CLEANING = 'spot cleaning'
+STATE_GOING_TO_TARGET = 'going to target'
+STATE_UPDATING = 'updating'
+STATE_ZONED_CLEANING = 'zoned cleaning'
 
 DEFAULT_NAME = 'Vacuum cleaner robot'
 

--- a/homeassistant/components/vacuum/xiaomi_miio.py
+++ b/homeassistant/components/vacuum/xiaomi_miio.py
@@ -16,7 +16,8 @@ from homeassistant.components.vacuum import (
     SUPPORT_RETURN_HOME, SUPPORT_SEND_COMMAND, SUPPORT_STOP,
     SUPPORT_STATE, SUPPORT_START, VACUUM_SERVICE_SCHEMA, StateVacuumDevice,
     STATE_CLEANING, STATE_DOCKED, STATE_PAUSED, STATE_IDLE, STATE_RETURNING,
-    STATE_ERROR)
+    STATE_ERROR, STATE_REMOTE, STATE_SPOT_CLEANING, STATE_GOING_TO_TARGET,
+    STATE_UPDATING, STATE_ZONED_CLEANING)
 from homeassistant.const import (
     ATTR_ENTITY_ID, CONF_HOST, CONF_NAME, CONF_TOKEN, STATE_OFF, STATE_ON)
 import homeassistant.helpers.config_validation as cv
@@ -60,6 +61,8 @@ ATTR_ERROR = 'error'
 ATTR_RC_DURATION = 'duration'
 ATTR_RC_ROTATION = 'rotation'
 ATTR_RC_VELOCITY = 'velocity'
+ATTR_RAW_STATE = 'state'
+ATTR_RAW_STATE_CODE = 'state_code'
 
 SERVICE_SCHEMA_REMOTE_CONTROL = VACUUM_SERVICE_SCHEMA.extend({
     vol.Optional(ATTR_RC_VELOCITY):
@@ -89,16 +92,18 @@ SUPPORT_XIAOMI = SUPPORT_STATE | SUPPORT_PAUSE | \
 STATE_CODE_TO_STATE = {
     2: STATE_IDLE,
     3: STATE_IDLE,
+    4: STATE_REMOTE,
     5: STATE_CLEANING,
     6: STATE_RETURNING,
     8: STATE_DOCKED,
     9: STATE_ERROR,
     10: STATE_PAUSED,
-    11: STATE_CLEANING,
+    11: STATE_SPOT_CLEANING,
     12: STATE_ERROR,
+    14: STATE_UPDATING,
     15: STATE_RETURNING,
-    16: STATE_CLEANING,
-    17: STATE_CLEANING,
+    16: STATE_GOING_TO_TARGET,
+    17: STATE_ZONED_CLEANING,
 }
 
 
@@ -245,6 +250,8 @@ class MiroboVacuum(StateVacuumDevice):
 
             if self.vacuum_state.got_error:
                 attrs[ATTR_ERROR] = self.vacuum_state.error
+        attrs[ATTR_RAW_STATE_CODE] = self.vacuum_state.state_code
+        attrs[ATTR_RAW_STATE] = self.vacuum_state.state
         return attrs
 
     @property

--- a/homeassistant/components/vacuum/xiaomi_miio.py
+++ b/homeassistant/components/vacuum/xiaomi_miio.py
@@ -16,8 +16,7 @@ from homeassistant.components.vacuum import (
     SUPPORT_RETURN_HOME, SUPPORT_SEND_COMMAND, SUPPORT_STOP,
     SUPPORT_STATE, SUPPORT_START, VACUUM_SERVICE_SCHEMA, StateVacuumDevice,
     STATE_CLEANING, STATE_DOCKED, STATE_PAUSED, STATE_IDLE, STATE_RETURNING,
-    STATE_ERROR, STATE_REMOTE, STATE_SPOT_CLEANING, STATE_GOING_TO_TARGET,
-    STATE_UPDATING, STATE_ZONED_CLEANING)
+    STATE_ERROR)
 from homeassistant.const import (
     ATTR_ENTITY_ID, CONF_HOST, CONF_NAME, CONF_TOKEN, STATE_OFF, STATE_ON)
 import homeassistant.helpers.config_validation as cv
@@ -61,8 +60,7 @@ ATTR_ERROR = 'error'
 ATTR_RC_DURATION = 'duration'
 ATTR_RC_ROTATION = 'rotation'
 ATTR_RC_VELOCITY = 'velocity'
-ATTR_RAW_STATE = 'state'
-ATTR_RAW_STATE_CODE = 'state_code'
+ATTR_STATUS = 'status'
 
 SERVICE_SCHEMA_REMOTE_CONTROL = VACUUM_SERVICE_SCHEMA.extend({
     vol.Optional(ATTR_RC_VELOCITY):
@@ -92,18 +90,16 @@ SUPPORT_XIAOMI = SUPPORT_STATE | SUPPORT_PAUSE | \
 STATE_CODE_TO_STATE = {
     2: STATE_IDLE,
     3: STATE_IDLE,
-    4: STATE_REMOTE,
     5: STATE_CLEANING,
     6: STATE_RETURNING,
     8: STATE_DOCKED,
     9: STATE_ERROR,
     10: STATE_PAUSED,
-    11: STATE_SPOT_CLEANING,
+    11: STATE_CLEANING,
     12: STATE_ERROR,
-    14: STATE_UPDATING,
     15: STATE_RETURNING,
-    16: STATE_GOING_TO_TARGET,
-    17: STATE_ZONED_CLEANING,
+    16: STATE_CLEANING,
+    17: STATE_CLEANING,
 }
 
 
@@ -245,13 +241,12 @@ class MiroboVacuum(StateVacuumDevice):
                     / 3600),
                 ATTR_SENSOR_DIRTY_LEFT: int(
                     self.consumable_state.sensor_dirty_left.total_seconds()
-                    / 3600)
+                    / 3600),
+                ATTR_STATUS: str(self.vacuum_state.state)
                 })
 
             if self.vacuum_state.got_error:
                 attrs[ATTR_ERROR] = self.vacuum_state.error
-        attrs[ATTR_RAW_STATE_CODE] = self.vacuum_state.state_code
-        attrs[ATTR_RAW_STATE] = self.vacuum_state.state
         return attrs
 
     @property


### PR DESCRIPTION
…cuum

## Description:
Pre [#15643](https://github.com/home-assistant/home-assistant/pull/15643) xiaomi_vacuum component provided specific states ( like "Going to target", "Zoned cleanup" ).
As a side effect of the mentioned PR, device state got simplified, having the same general string "Cleaning" for many specific actions ( like zoned cleanup, spot cleanup and going to target).
This breaks existing automation, which relies on a specific state of the device and limits the toolset for doing a complex script.
I think trying to standardize the vacuum states is a good idea, but I strongly advise against making such a change without depr. warning.

This PR contains two things related to the vacuum component:
- Added some common states, which could be used by other vacuums, like STATE_SPOT_CLEANING
- Exposed xiaomi_vacuum raw state through state and state_code attr

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
