### PR TITLE
System Monitor Sensor shows IP4 address instead of MAC address

### DIFF
--- a/homeassistant/components/sensor/systemmonitor.py
+++ b/homeassistant/components/sensor/systemmonitor.py
@@ -6,6 +6,7 @@ https://home-assistant.io/components/sensor.systemmonitor/
 """
 import logging
 import os
+import socket
 
 import voluptuous as vol
 
@@ -61,9 +62,9 @@ IO_COUNTER = {
     'packets_in': 3,
 }
 
-IF_ADDRS = {
-    'ipv4_address': 0,
-    'ipv6_address': 1,
+IF_ADDRS_FAMILY = {
+    'ipv4_address': socket.AF_INET,
+    'ipv6_address': socket.AF_INET6,
 }
 
 
@@ -165,7 +166,9 @@ class SystemMonitorSensor(Entity):
         elif self.type == 'ipv4_address' or self.type == 'ipv6_address':
             addresses = psutil.net_if_addrs()
             if self.argument in addresses:
-                self._state = addresses[self.argument][IF_ADDRS[self.type]][1]
+                for addr in addresses[self.argument]:
+                    if addr.family == IF_ADDRS_FAMILY[self.type]:
+                        self._state = addr.address
             else:
                 self._state = None
         elif self.type == 'last_boot':


### PR DESCRIPTION
## Description:
On Windows, the IP4-address is not the first item in the list of addresses. This PR adds an additional address.family checks to select the right item in the list independent from the sorting of the list.

**Related issue (if applicable):** fixes #16231 

## Checklist:
  - [x] The code change is tested and works locally. Tested on Windows 10 x64 and Linux Mint 19
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
