### PR TITLE
Add "Aux Heat" 

### DIFF
--- a/homeassistant/components/alarm_control_panel/totalconnect.py
+++ b/homeassistant/components/alarm_control_panel/totalconnect.py
@@ -17,16 +17,19 @@ from homeassistant.const import (
     STATE_ALARM_ARMING, STATE_ALARM_DISARMING, STATE_UNKNOWN, CONF_NAME,
     STATE_ALARM_ARMED_CUSTOM_BYPASS)
 
-
-REQUIREMENTS = ['total_connect_client==0.18']
+REQUIREMENTS = ['total_connect_client==0.19']
 
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_NAME = 'Total Connect'
+DEFAULT_USERCODE = '-1'
+
+CONF_USERCODE = 'usercode'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_PASSWORD): cv.string,
     vol.Required(CONF_USERNAME): cv.string,
+    vol.Optional(CONF_USERCODE, default=DEFAULT_USERCODE): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 })
 
@@ -36,15 +39,16 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     name = config.get(CONF_NAME)
     username = config.get(CONF_USERNAME)
     password = config.get(CONF_PASSWORD)
+    usercode = config.get(CONF_USERCODE)
 
-    total_connect = TotalConnect(name, username, password)
+    total_connect = TotalConnect(name, username, password, usercode)
     add_entities([total_connect], True)
 
 
 class TotalConnect(alarm.AlarmControlPanel):
     """Represent an TotalConnect status."""
 
-    def __init__(self, name, username, password):
+    def __init__(self, name, username, password, usercode):
         """Initialize the TotalConnect status."""
         from total_connect_client import TotalConnectClient
 
@@ -52,9 +56,10 @@ class TotalConnect(alarm.AlarmControlPanel):
         self._name = name
         self._username = username
         self._password = password
+        self._usercode = usercode
         self._state = STATE_UNKNOWN
         self._client = TotalConnectClient.TotalConnectClient(
-            username, password)
+            username, password, usercode)
 
     @property
     def name(self):

--- a/homeassistant/components/climate/zwave.py
+++ b/homeassistant/components/climate/zwave.py
@@ -7,7 +7,7 @@ https://home-assistant.io/components/climate.zwave/
 # Because we do not compile openzwave on CI
 import logging
 from homeassistant.components.climate import (
-    DOMAIN, ClimateDevice, STATE_AUTO, STATE_COOL, STATE_HEAT,
+    DOMAIN, ClimateDevice, STATE_AUTO, STATE_COOL, STATE_HEAT, STATE_HEAT_PUMP,
     SUPPORT_TARGET_TEMPERATURE, SUPPORT_FAN_MODE,
     SUPPORT_OPERATION_MODE, SUPPORT_SWING_MODE)
 from homeassistant.components.zwave import ZWaveDeviceEntity
@@ -39,6 +39,7 @@ STATE_MAPPINGS = {
     'Heat (Default)': STATE_HEAT,
     'Cool': STATE_COOL,
     'Auto': STATE_AUTO,
+    'Aux Heat': STATE_HEAT_PUMP,
 }
 
 


### PR DESCRIPTION

## Description:

GoControl GC-TBZ48 has a mode called "Aux Heat" for heat pumps and this pull request adds it to the fix described in issue #13158

**Related issue (if applicable):** fixes #13158

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [n/a] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [n/a ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [n/a ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [n/a ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
