### PR TITLE
Allow milliseconds to be used in time period strings

### DIFF
--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -25,7 +25,8 @@ from homeassistant.helpers import template as template_helper
 
 # pylint: disable=invalid-name
 
-TIME_PERIOD_ERROR = "offset {} should be format 'HH:MM' or 'HH:MM:SS'"
+TIME_PERIOD_ERROR = \
+    "offset {} should be format 'HH:MM' or 'HH:MM:SS' or 'HH:MM:SS:SSS'"
 
 # Home Assistant types
 byte = vol.All(vol.Coerce(int), vol.Range(min=0, max=255))
@@ -267,12 +268,17 @@ def time_period_str(value: str) -> timedelta:
     if len(parsed) == 2:
         hour, minute = parsed
         second = 0
+        millisecond = 0
     elif len(parsed) == 3:
         hour, minute, second = parsed
+        millisecond = 0
+    elif len(parsed) == 4:
+        hour, minute, second, millisecond = parsed
     else:
         raise vol.Invalid(TIME_PERIOD_ERROR.format(value))
 
-    offset = timedelta(hours=hour, minutes=minute, seconds=second)
+    offset = timedelta(hours=hour, minutes=minute, seconds=second,
+                       milliseconds=millisecond)
 
     if negative_offset:
         offset *= -1

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -279,7 +279,8 @@ def test_time_period():
             schema(value)
 
     options = (
-        '8:20', '23:59', '-8:20', '-23:59:59', '-48:00', {'minutes': 5}, 1, '5', '12:34:56:78'
+        '8:20', '23:59', '-8:20', '-23:59:59', '-48:00', {'minutes': 5}, 1,
+        '5', '12:34:56:78'
     )
     for value in options:
         schema(value)

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -270,7 +270,7 @@ def test_time_period():
     schema = vol.Schema(cv.time_period)
 
     options = (
-        None, '', 'hello:world', '12:', '12:34:56:78',
+        None, '', 'hello:world', '12:', '12:34:56:78:00',
         {}, {'wrong_key': -10}
     )
     for value in options:
@@ -279,7 +279,7 @@ def test_time_period():
             schema(value)
 
     options = (
-        '8:20', '23:59', '-8:20', '-23:59:59', '-48:00', {'minutes': 5}, 1, '5'
+        '8:20', '23:59', '-8:20', '-23:59:59', '-48:00', {'minutes': 5}, 1, '5', '12:34:56:78'
     )
     for value in options:
         schema(value)


### PR DESCRIPTION
## Description:
Time period strings currently do not allow the use of anything besides hours, minutes, and seconds. This pull request adds milliseconds.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#6190

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
