### PR TITLE
Delegate mqtt topic match validation to the paho mqtt client

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -13,7 +13,6 @@ import os
 import socket
 import time
 import ssl
-import re
 import requests.certs
 import attr
 
@@ -726,23 +725,14 @@ def _raise_on_error(result_code: int) -> None:
 
 def _match_topic(subscription: str, topic: str) -> bool:
     """Test if topic matches subscription."""
-    reg_ex_parts = []  # type: List[str]
-    suffix = ""
-    if subscription.endswith('#'):
-        subscription = subscription[:-2]
-        suffix = "(.*)"
-    sub_parts = subscription.split('/')
-    for sub_part in sub_parts:
-        if sub_part == "+":
-            reg_ex_parts.append(r"([^\/]+)")
-        else:
-            reg_ex_parts.append(re.escape(sub_part))
-
-    reg_ex = "^" + (r'\/'.join(reg_ex_parts)) + suffix + "$"
-
-    reg = re.compile(reg_ex)
-
-    return reg.match(topic) is not None
+    import paho.mqtt.matcher as matcher
+    matcher = matcher.MQTTMatcher()
+    matcher[subscription] = True
+    try:
+        next(matcher.iter_match(topic))
+        return True
+    except StopIteration:
+        return False
 
 
 class MqttAvailability(Entity):

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -725,8 +725,8 @@ def _raise_on_error(result_code: int) -> None:
 
 def _match_topic(subscription: str, topic: str) -> bool:
     """Test if topic matches subscription."""
-    import paho.mqtt.matcher as matcher
-    matcher = matcher.MQTTMatcher()
+    from paho.mqtt.matcher import MQTTMatcher
+    matcher = MQTTMatcher()
     matcher[subscription] = True
     try:
         next(matcher.iter_match(topic))

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -277,6 +277,15 @@ class TestMQTTCallbacks(unittest.TestCase):
         self.hass.block_till_done()
         self.assertEqual(0, len(self.calls))
 
+    def test_subscribe_topic_level_wildcard_root_topic_no_subtree_match(self):
+        """Test the subscription of wildcard topics."""
+        mqtt.subscribe(self.hass, 'test-topic/#', self.record_calls)
+
+        fire_mqtt_message(self.hass, 'test-topic-123', 'test-payload')
+
+        self.hass.block_till_done()
+        self.assertEqual(0, len(self.calls))
+
     def test_subscribe_topic_subtree_wildcard_subtree_topic(self):
         """Test the subscription of wildcard topics."""
         mqtt.subscribe(self.hass, 'test-topic/#', self.record_calls)


### PR DESCRIPTION
## Description:

- Added an additional unit test which exposes the bug @kevinkk525 reported in #16354.

- Rather than adding additional logic to the `_match_topic` function in HA, and since it already uses the paho-mqtt client, I delegated the match functionality to the paho-mqtt matcher.

**Related issue (if applicable):** fixes #16354

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.
