### PR TITLE
zha: Bump to zigpy 0.2.0/bellows 0.7.0

### DIFF
--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -16,8 +16,8 @@ from homeassistant.helpers import discovery, entity
 from homeassistant.util import slugify
 
 REQUIREMENTS = [
-    'bellows==0.6.0',
-    'zigpy==0.1.0',
+    'bellows==0.7.0',
+    'zigpy==0.2.0',
     'zigpy-xbee==0.1.1',
 ]
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -168,7 +168,7 @@ batinfo==0.4.2
 beautifulsoup4==4.6.3
 
 # homeassistant.components.zha
-bellows==0.6.0
+bellows==0.7.0
 
 # homeassistant.components.bmw_connected_drive
 bimmer_connected==0.5.1
@@ -1530,4 +1530,4 @@ ziggo-mediabox-xl==1.0.0
 zigpy-xbee==0.1.1
 
 # homeassistant.components.zha
-zigpy==0.1.0
+zigpy==0.2.0


### PR DESCRIPTION
## Description:

zigpy:
 - Python 3.7 support
 - Add support for King of Fans
 - Improvements around cached attribute reading
 - Misc other fixes and improvements

bellows:
 - Python 3.7 support
 - Fix issue where commands may fail after some time (https://github.com/zigpy/bellows/issues/124)
 - CLI fixes
 - Improved protocol handling

**Related issue (if applicable):** Fixes: #16380, partial #15479

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
