### PR TITLE
Fix openuv.config_flow unit test

### DIFF
--- a/tests/components/openuv/test_config_flow.py
+++ b/tests/components/openuv/test_config_flow.py
@@ -26,7 +26,6 @@ async def test_duplicate_error(hass):
     assert result['errors'] == {'base': 'identifier_exists'}
 
 
-@patch('pyopenuv.util.validate_api_key', return_value=mock_coro(False))
 async def test_invalid_api_key(hass):
     """Test that an invalid API key throws an error."""
     conf = {
@@ -39,8 +38,10 @@ async def test_invalid_api_key(hass):
     flow = config_flow.OpenUvFlowHandler()
     flow.hass = hass
 
-    result = await flow.async_step_user(user_input=conf)
-    assert result['errors'] == {'base': 'invalid_api_key'}
+    with patch('pyopenuv.util.validate_api_key',
+               return_value=mock_coro(False)):
+        result = await flow.async_step_user(user_input=conf)
+        assert result['errors'] == {'base': 'invalid_api_key'}
 
 
 async def test_show_form(hass):
@@ -54,7 +55,6 @@ async def test_show_form(hass):
     assert result['step_id'] == 'user'
 
 
-@patch('pyopenuv.util.validate_api_key', return_value=mock_coro(True))
 async def test_step_import(hass):
     """Test that the import step works."""
     conf = {
@@ -64,15 +64,16 @@ async def test_step_import(hass):
     flow = config_flow.OpenUvFlowHandler()
     flow.hass = hass
 
-    result = await flow.async_step_import(import_config=conf)
+    with patch('pyopenuv.util.validate_api_key',
+               return_value=mock_coro(True)):
+        result = await flow.async_step_import(import_config=conf)
 
-    assert result['type'] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result['title'] == '{0}, {1}'.format(
-        hass.config.latitude, hass.config.longitude)
-    assert result['data'] == conf
+        assert result['type'] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result['title'] == '{0}, {1}'.format(
+            hass.config.latitude, hass.config.longitude)
+        assert result['data'] == conf
 
 
-@patch('pyopenuv.util.validate_api_key', return_value=mock_coro(True))
 async def test_step_user(hass):
     """Test that the user step works."""
     conf = {
@@ -85,9 +86,11 @@ async def test_step_user(hass):
     flow = config_flow.OpenUvFlowHandler()
     flow.hass = hass
 
-    result = await flow.async_step_user(user_input=conf)
+    with patch('pyopenuv.util.validate_api_key',
+               return_value=mock_coro(True)):
+        result = await flow.async_step_user(user_input=conf)
 
-    assert result['type'] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result['title'] == '{0}, {1}'.format(
-        conf[CONF_LATITUDE], conf[CONF_LONGITUDE])
-    assert result['data'] == conf
+        assert result['type'] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result['title'] == '{0}, {1}'.format(
+            conf[CONF_LATITUDE], conf[CONF_LONGITUDE])
+        assert result['data'] == conf


### PR DESCRIPTION
## Description:
Got warning message regarding openuv unit test
```
tests/components/openuv/test_config_flow.py::test_invalid_api_key
  /home/jason/ha/home-assistant/.tox/py36/lib/python3.6/site-packages/_pytest/python.py:196: RuntimeWarning: coroutine 'test_invalid_api_key' was never awaited
    testfunction(**testargs)

tests/components/openuv/test_config_flow.py::test_step_import
  /home/jason/ha/home-assistant/.tox/py36/lib/python3.6/site-packages/_pytest/python.py:196: RuntimeWarning: coroutine 'test_step_import' was never awaited
    testfunction(**testargs)

tests/components/openuv/test_config_flow.py::test_step_user
  /home/jason/ha/home-assistant/.tox/py36/lib/python3.6/site-packages/_pytest/python.py:196: RuntimeWarning: coroutine 'test_step_user' was never awaited
    testfunction(**testargs)

-- Docs: http://doc.pytest.org/en/latest/warnings.html
```

`@path` cannot decorate coroutine, change to `with path`

@bachya 


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

