### PR TITLE
Changing z-wave brightness calculation to respect 0x01 and 0x02 byte values

### DIFF
--- a/homeassistant/components/light/zwave.py
+++ b/homeassistant/components/light/zwave.py
@@ -64,7 +64,7 @@ def brightness_state(value):
 
 
 def byte_to_zwave_brightness(value):
-    """Converts brightness in 0-255 scale to 0-99 scale.
+    """Convert brightness in 0-255 scale to 0-99 scale.
 
     `value` -- (int) Brightness byte value from 0-255.
     """

--- a/homeassistant/components/light/zwave.py
+++ b/homeassistant/components/light/zwave.py
@@ -62,6 +62,15 @@ def brightness_state(value):
         return round((value.data / 99) * 255), STATE_ON
     return 0, STATE_OFF
 
+def byte_to_zwave_brightness(value):
+    """
+    Converts brightness in 0-255 scale to 0-99 scale.
+
+    `value` -- (int) Brightness byte value from 0-255.
+    """
+    if value > 0:
+        return max(1, int((value / 255) * 99))
+    return 0
 
 def ct_to_hs(temp):
     """Convert color temperature (mireds) to hs."""
@@ -187,7 +196,7 @@ class ZwaveDimmer(zwave.ZWaveDeviceEntity, Light):
         # brightness. Level 255 means to set it to previous value.
         if ATTR_BRIGHTNESS in kwargs:
             self._brightness = kwargs[ATTR_BRIGHTNESS]
-            brightness = int((self._brightness / 255) * 99)
+            brightness = byte_to_zwave_brightness(self._brightness)
         else:
             brightness = 255
 

--- a/homeassistant/components/light/zwave.py
+++ b/homeassistant/components/light/zwave.py
@@ -62,6 +62,7 @@ def brightness_state(value):
         return round((value.data / 99) * 255), STATE_ON
     return 0, STATE_OFF
 
+
 def byte_to_zwave_brightness(value):
     """
     Converts brightness in 0-255 scale to 0-99 scale.
@@ -71,6 +72,7 @@ def byte_to_zwave_brightness(value):
     if value > 0:
         return max(1, int((value / 255) * 99))
     return 0
+
 
 def ct_to_hs(temp):
     """Convert color temperature (mireds) to hs."""

--- a/homeassistant/components/light/zwave.py
+++ b/homeassistant/components/light/zwave.py
@@ -64,8 +64,7 @@ def brightness_state(value):
 
 
 def byte_to_zwave_brightness(value):
-    """
-    Converts brightness in 0-255 scale to 0-99 scale.
+    """Converts brightness in 0-255 scale to 0-99 scale.
 
     `value` -- (int) Brightness byte value from 0-255.
     """

--- a/tests/components/light/test_zwave.py
+++ b/tests/components/light/test_zwave.py
@@ -105,6 +105,21 @@ def test_dimmer_turn_on(mock_openzwave):
         assert entity_id == device.entity_id
 
 
+def test_dimmer_min_brightness(mock_openzwave):
+    """Test turning on a dimmable Z-Wave light to its minimum brightness"""
+    node = MockNode()
+    value = MockValue(data=0, node=node)
+    values = MockLightValues(primary=value)
+    device = zwave.get_device(node=node, values=values, node_config={})
+
+    assert not device.is_on
+
+    device.turn_on(**{ATTR_BRIGHTNESS: 1})
+
+    assert device.is_on
+    assert device.brightness == 1
+
+
 def test_dimmer_transitions(mock_openzwave):
     """Test dimming transition on a dimmable Z-Wave light."""
     node = MockNode()

--- a/tests/components/light/test_zwave.py
+++ b/tests/components/light/test_zwave.py
@@ -106,7 +106,7 @@ def test_dimmer_turn_on(mock_openzwave):
 
 
 def test_dimmer_min_brightness(mock_openzwave):
-    """Test turning on a dimmable Z-Wave light to its minimum brightness"""
+    """Test turning on a dimmable Z-Wave light to its minimum brightness."""
     node = MockNode()
     value = MockValue(data=0, node=node)
     values = MockLightValues(primary=value)
@@ -118,6 +118,11 @@ def test_dimmer_min_brightness(mock_openzwave):
 
     assert device.is_on
     assert device.brightness == 1
+
+    device.turn_on(**{ATTR_BRIGHTNESS: 0})
+
+    assert device.is_on
+    assert device.brightness == 0
 
 
 def test_dimmer_transitions(mock_openzwave):


### PR DESCRIPTION
## Description:
Changing z-wave brightness calculation to respect 0x01 and 0x02 byte values

**Related issue (if applicable):** fixes #16406 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable): n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
