### PR TITLE
Implement support for the delay_template in scripts

### DIFF
--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -594,6 +594,11 @@ _SCRIPT_DELAY_SCHEMA = vol.Schema({
         template)
 })
 
+_SCRIPT_DELAY_TEMPLATE_SCHEMA = vol.Schema({
+    vol.Optional(CONF_ALIAS): string,
+    vol.Required("delay_template"): {match_all: template_complex}
+})
+
 _SCRIPT_WAIT_TEMPLATE_SCHEMA = vol.Schema({
     vol.Optional(CONF_ALIAS): string,
     vol.Required("wait_template"): template,
@@ -604,5 +609,6 @@ _SCRIPT_WAIT_TEMPLATE_SCHEMA = vol.Schema({
 SCRIPT_SCHEMA = vol.All(
     ensure_list,
     [vol.Any(SERVICE_SCHEMA, _SCRIPT_DELAY_SCHEMA,
-             _SCRIPT_WAIT_TEMPLATE_SCHEMA, EVENT_SCHEMA, CONDITION_SCHEMA)],
+             _SCRIPT_DELAY_TEMPLATE_SCHEMA, _SCRIPT_WAIT_TEMPLATE_SCHEMA,
+             EVENT_SCHEMA, CONDITION_SCHEMA)],
 )

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -244,6 +244,70 @@ class TestScriptHelper(unittest.TestCase):
         assert not script_obj.is_running
         assert len(events) == 1
 
+    def test_delay_advanced_template(self):
+        """Test the delay_template with a working template."""
+        event = 'test_event'
+        events = []
+
+        @callback
+        def record_event(event):
+            """Add recorded event to set."""
+            events.append(event)
+
+        self.hass.bus.listen(event, record_event)
+
+        script_obj = script.Script(self.hass, cv.SCRIPT_SCHEMA([
+            {'event': event},
+            {'delay_template': {
+                'seconds': '{{ 5 }}'
+            }},
+            {'event': event}]))
+
+        script_obj.run()
+        self.hass.block_till_done()
+
+        assert script_obj.is_running
+        assert script_obj.can_cancel
+        assert script_obj.last_action == event
+        assert len(events) == 1
+
+        future = dt_util.utcnow() + timedelta(seconds=5)
+        fire_time_changed(self.hass, future)
+        self.hass.block_till_done()
+
+        assert not script_obj.is_running
+        assert len(events) == 2
+
+    def test_delay_advanced_invalid_template(self):
+        """Test the delay_template as a template that fails."""
+        event = 'test_event'
+        events = []
+
+        @callback
+        def record_event(event):
+            """Add recorded event to set."""
+            events.append(event)
+
+        self.hass.bus.listen(event, record_event)
+
+        script_obj = script.Script(self.hass, cv.SCRIPT_SCHEMA([
+            {'event': event},
+            {'delay_template': {
+                 'seconds': '{{ invalid_delay }}'
+            }},
+            {'delay_template': {
+                'seconds': '{{ 5 }}'
+            }},
+            {'event': event}]))
+
+        with mock.patch.object(script, '_LOGGER') as mock_logger:
+            script_obj.run()
+            self.hass.block_till_done()
+            assert mock_logger.error.called
+
+        assert not script_obj.is_running
+        assert len(events) == 1
+
     def test_cancel_while_delay(self):
         """Test the cancelling while the delay is present."""
         event = 'test_event'


### PR DESCRIPTION
## Description:
In #16401, I described a use case for wanting to create a `delay` with a dynamic amount of milliseconds. @balloob suggested that using the `dict` approach to building a `delay` would make sense. Unfortunately, the `delay` does not allow a template dictionary to be used.

I've implemented support for a `delay_template` in scripts (and I believe it works in automations as well).

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

I'll make the documentation changes once this approach is validated.

## Simple example for `configuration.yaml` (if applicable):
```yaml
input_number:
 random_color_loop_transition_speed:
    name: Transition Time
    initial: 1.5
    min: 1
    max: 10
    step: 0.5

script:

  random_color_loop:
    sequence:
      - service: script.turn_off
        entity_id: script.random_color_loop_control
      - delay_template:
          milliseconds: "{{ (((states('input_number.random_color_loop_transition_speed') | float) / 2) * 1000) | int }}"
      - service: script.random_color_loop_control

  random_color_loop_control:
    sequence:
      - service: script.turn_off
        entity_id: script.random_color_loop
      - delay_template:
          milliseconds: "{{ (((states('input_number.random_color_loop_transition_speed') | float) / 2) * 1000) | int }}"
      - service: script.random_color_loop
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
