### PR TITLE
Implement support for complex templates in script delays

### DIFF
--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -591,7 +591,7 @@ _SCRIPT_DELAY_SCHEMA = vol.Schema({
     vol.Optional(CONF_ALIAS): string,
     vol.Required("delay"): vol.Any(
         vol.All(time_period, positive_timedelta),
-        template)
+        template, {match_all: template_complex})
 })
 
 _SCRIPT_WAIT_TEMPLATE_SCHEMA = vol.Schema({

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -591,7 +591,7 @@ _SCRIPT_DELAY_SCHEMA = vol.Schema({
     vol.Optional(CONF_ALIAS): string,
     vol.Required("delay"): vol.Any(
         vol.All(time_period, positive_timedelta),
-        template, {match_all: template_complex})
+        template, template_complex)
 })
 
 _SCRIPT_WAIT_TEMPLATE_SCHEMA = vol.Schema({

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -99,11 +99,17 @@ class Script():
                 delay = action[CONF_DELAY]
 
                 try:
+                    import collections
                     if isinstance(delay, template.Template):
                         delay = vol.All(
                             cv.time_period,
                             cv.positive_timedelta)(
                                 delay.async_render(variables))
+                    elif isinstance(delay, collections.Mapping):
+                        delay_data = {}
+                        delay_data.update(
+                            template.render_complex(delay, variables))
+                        delay = cv.time_period(delay_data)
                 except (TemplateError, vol.Invalid) as ex:
                     _LOGGER.error("Error rendering '%s' delay template: %s",
                                   self.name, ex)

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -99,13 +99,12 @@ class Script():
                 delay = action[CONF_DELAY]
 
                 try:
-                    import collections
                     if isinstance(delay, template.Template):
                         delay = vol.All(
                             cv.time_period,
                             cv.positive_timedelta)(
                                 delay.async_render(variables))
-                    elif isinstance(delay, collections.Mapping):
+                    elif isinstance(delay, dict):
                         delay_data = {}
                         delay_data.update(
                             template.render_complex(delay, variables))

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -244,6 +244,70 @@ class TestScriptHelper(unittest.TestCase):
         assert not script_obj.is_running
         assert len(events) == 1
 
+    def test_delay_complex_template(self):
+        """Test the delay with a working complex template."""
+        event = 'test_event'
+        events = []
+
+        @callback
+        def record_event(event):
+            """Add recorded event to set."""
+            events.append(event)
+
+        self.hass.bus.listen(event, record_event)
+
+        script_obj = script.Script(self.hass, cv.SCRIPT_SCHEMA([
+            {'event': event},
+            {'delay': {
+                'seconds': '{{ 5 }}'
+            }},
+            {'event': event}]))
+
+        script_obj.run()
+        self.hass.block_till_done()
+
+        assert script_obj.is_running
+        assert script_obj.can_cancel
+        assert script_obj.last_action == event
+        assert len(events) == 1
+
+        future = dt_util.utcnow() + timedelta(seconds=5)
+        fire_time_changed(self.hass, future)
+        self.hass.block_till_done()
+
+        assert not script_obj.is_running
+        assert len(events) == 2
+
+    def test_delay_complex_invalid_template(self):
+        """Test the delay with a complex template that fails."""
+        event = 'test_event'
+        events = []
+
+        @callback
+        def record_event(event):
+            """Add recorded event to set."""
+            events.append(event)
+
+        self.hass.bus.listen(event, record_event)
+
+        script_obj = script.Script(self.hass, cv.SCRIPT_SCHEMA([
+            {'event': event},
+            {'delay': {
+                 'seconds': '{{ invalid_delay }}'
+            }},
+            {'delay': {
+                'seconds': '{{ 5 }}'
+            }},
+            {'event': event}]))
+
+        with mock.patch.object(script, '_LOGGER') as mock_logger:
+            script_obj.run()
+            self.hass.block_till_done()
+            assert mock_logger.error.called
+
+        assert not script_obj.is_running
+        assert len(events) == 1
+
     def test_cancel_while_delay(self):
         """Test the cancelling while the delay is present."""
         event = 'test_event'


### PR DESCRIPTION
## Description:

This is related to previous pull requests (#16401, #16432).

There is currently no way to do complex templates in the `delay` call in a script (or automation). This means that the following syntax is valid:

```yaml
- delay: "00:00:{{ (((states('input_number.speed') | float) / 2) * 1000) | int }}"
- delay:
    seconds: 5
```

But the following syntax is invalid:
```yaml
- delay:
    seconds: "{{ (((states('input_number.speed') | float) / 2) * 1000) | int }}"
```

**Why is this relevant?**

- Consistency - it's weird that I can use a template when providing a time string but not when providing a dict.
- There is currently no way to specify a dynamic number of milliseconds or days (though the standard delay syntax will allow you to [specify static numbers for them](https://www.home-assistant.io/docs/scripts/#delay))

I've already tried updating the time string to support milliseconds (#16401), and was suggested to use the dictionary approach (which allows milliseconds, but not template strings). I then tried creating a `delay_template` (#16432) but was told that delay already supports templates.

It seems then, that the only approach left is to the allow `delay` to support complex templates, allowing a dictionary of templates to be passed in. This allows using templates to provide: milliseconds, seconds, minutes, hours, and days and makes the two different ways of specifying delays equal (in that they both support using templates or not).

@balloob I hope this makes sense and if not, can you provide some guidance on how to move forward with this?

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#6224

## Example entry for `configuration.yaml` (if applicable):
```yaml
- delay:
    seconds: "{{ (((states('input_number.speed') | float) / 2) * 1000) | int }}"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
