### PR TITLE
Set a cooldown for automation

### DIFF
--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -383,25 +383,33 @@ class AutomationEntity(ToggleEntity):
             if now_triggered.year <= last_triggered.year:
                 if self._cooldown_once_per_month:
                     if now_triggered.month <= last_triggered.month:
-                        _LOGGER.debug('Automation % s on cooldown, already triggerd this
-                                      month', self._name)
+                        _LOGGER.debug(
+                            'Automation %s on cooldown, already triggerd '
+                            'this month',
+                            self._name)
                         return
                 elif self._cooldown_once_per_week:
-                    if now_triggered.isocalendar()[1]
-                    last_triggered.isocalendar()[1]:
-                        _LOGGER.debug('Automation % s on cooldown, already triggerd this
-                                      week', self._name)
+                    if now_triggered.isocalendar()[1] <= \
+                            last_triggered.isocalendar()[1]:
+                        _LOGGER.debug(
+                            'Automation %s on cooldown, already triggerd '
+                            'this week',
+                            self._name)
                         return
                 elif self._cooldown_once_per_day:
-                    if now_triggered.timetuple().tm_yday <=
-                    last_triggered.timetuple().tm_yday:
-                        _LOGGER.debug('Automation % s on cooldown, already triggerd this
-                                      day', self._name)
+                    if now_triggered.timetuple().tm_yday <= \
+                            last_triggered.timetuple().tm_yday:
+                        _LOGGER.debug(
+                            'Automation %s on cooldown, already triggerd '
+                            'this day',
+                            self._name)
                         return
                 elif self._cooldown_time is not None:
                     if now_triggered <= (last_triggered + self._cooldown_time):
-                        _LOGGER.info('Automation % s on cooldown, already triggerd
-                                     within cooldown time', self._name)
+                        _LOGGER.info(
+                            'Automation %s on cooldown, already triggerd '
+                            'within cooldown time',
+                            self._name)
                         return
         if skip_condition or self._cond_func(variables):
             yield from self._async_action(self.entity_id, variables)

--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -383,23 +383,25 @@ class AutomationEntity(ToggleEntity):
             if now_triggered.year <= last_triggered.year:
                 if self._cooldown_once_per_month:
                     if now_triggered.month <= last_triggered.month:
-                        _LOGGER.debug(
-                            'Automation %s on cooldown, already triggerd this month', self._name)
+                        _LOGGER.debug('Automation % s on cooldown, already triggerd this
+                                      month', self._name)
                         return
                 elif self._cooldown_once_per_week:
-                    if now_triggered.isocalendar()[1] <= last_triggered.isocalendar()[1]:
-                        _LOGGER.debug(
-                            'Automation %s on cooldown, already triggerd this week', self._name)
+                    if now_triggered.isocalendar()[1]
+                    last_triggered.isocalendar()[1]:
+                        _LOGGER.debug('Automation % s on cooldown, already triggerd this
+                                      week', self._name)
                         return
                 elif self._cooldown_once_per_day:
-                    if now_triggered.timetuple().tm_yday <= last_triggered.timetuple().tm_yday:
-                        _LOGGER.debug(
-                            'Automation %s on cooldown, already triggerd this day', self._name)
+                    if now_triggered.timetuple().tm_yday <=
+                    last_triggered.timetuple().tm_yday:
+                        _LOGGER.debug('Automation % s on cooldown, already triggerd this
+                                      day', self._name)
                         return
                 elif self._cooldown_time is not None:
                     if now_triggered <= (last_triggered + self._cooldown_time):
-                        _LOGGER.info(
-                            'Automation %s on cooldown, already triggerd within cooldown time', self._name)
+                        _LOGGER.info('Automation % s on cooldown, already triggerd
+                                     within cooldown time', self._name)
                         return
         if skip_condition or self._cond_func(variables):
             yield from self._async_action(self.entity_id, variables)

--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -360,7 +360,7 @@ class AutomationEntity(ToggleEntity):
         await self.async_update_ha_state()
 
     def cooldown_reset(self):
-        """Resets cooldown of the automation."""
+        """Reset cooldown of the automation."""
         self._cooldown_reset = True
 
     async def async_trigger(self, variables, skip_condition=False,

--- a/homeassistant/components/automation/services.yaml
+++ b/homeassistant/components/automation/services.yaml
@@ -30,3 +30,10 @@ trigger:
 
 reload:
   description: Reload the automation configuration.
+
+cooldown_reset:
+  description: Resets the cooldown of an automation.
+  fields:
+    entity_id:
+      description: Name of the automation to reset.
+      example: 'automation.notify_home'


### PR DESCRIPTION
Added cooldown for automations

## Description:
Ability to pause an automation for a given time after it has been triggered, so its not triggered within that timerange again (cooldown). This would have been made before with

```
- condition: template
        value_template: >-
          {{ ((as_timestamp(now()) - as_timestamp(states.automation.entity_id.attributes.last_triggered))) > 3600 }}
```

This is a lot of code and not good for the config. The entity name of the automation had to be changed also every time.

Service cooldown_reset resets the current cooldown of the automation

Closed my last PR by accident (https://github.com/home-assistant/home-assistant/pull/16228). Some changes made in this PR compared to the last one.

I need help to setup tox unit test, because i've never done that and i dont know the HA specific needs (Change time etc.)

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
automation:
  - alias: 'automation'
    cooldown:
      # Set a cooldown for 30 seconds
      time: '00:00:30'
      # Set a cooldown for the current day starting from 00:00:00 to 24:00:00
      once_per_day: true
      # Set a cooldown for the current week starting from monday to sunday
      once_per_week: true
      # Set a cooldown for the current month starting from the first to last day of the month (eg 01-31)
      once_per_month: true
    trigger:
    condition:
    action:
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
