### PR TITLE
Long-lived access token

### DIFF
--- a/homeassistant/auth/__init__.py
+++ b/homeassistant/auth/__init__.py
@@ -266,15 +266,9 @@ class AuthManager:
             else:
                 token_type = models.TOKEN_TYPE_NORMAL
 
-        if user.system_generated and token_type != models.TOKEN_TYPE_SYSTEM:
+        if user.system_generated != (token_type == models.TOKEN_TYPE_SYSTEM):
             raise ValueError(
                 'System generated users can only have system type '
-                'refresh tokens')
-
-        if not user.system_generated and \
-                token_type == models.TOKEN_TYPE_SYSTEM:
-            raise ValueError(
-                'Only system generated users can have system type '
                 'refresh tokens')
 
         if token_type == models.TOKEN_TYPE_NORMAL and client_id is None:

--- a/homeassistant/auth/__init__.py
+++ b/homeassistant/auth/__init__.py
@@ -284,13 +284,8 @@ class AuthManager:
                 if (token.client_name == client_name and token.token_type ==
                         models.TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN):
                     # Each client_name can only have one
-                    # long_lived_access_token type of refresh token, remove
-                    # exist refresh token, a new one will be created.
-                    # As a side effect, all previous issued long-lived access
-                    # token for this client_id will be invoked.
-                    # Continue scan all tokens in case there are multiple
-                    # long_lived_access_token type of refresh tokens.
-                    await self._store.async_remove_refresh_token(token)
+                    # long_lived_access_token type of refresh token
+                    raise ValueError('{} already exists'.format(client_name))
 
         return await self._store.async_create_refresh_token(
             user, client_id, client_name, client_icon,

--- a/homeassistant/auth/__init__.py
+++ b/homeassistant/auth/__init__.py
@@ -280,7 +280,8 @@ class AuthManager:
                 'refresh tokens')
 
         if (token_type == models.TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN and
-                client_id.lower().startswith(('http://', 'https://'))):
+                (client_id is None or client_id.lower().startswith(
+                    ('http://', 'https://')))):
             raise ValueError('Client_id is not allowed start with http:// or '
                              'https:// for long-lived access token')
 

--- a/homeassistant/auth/__init__.py
+++ b/homeassistant/auth/__init__.py
@@ -2,6 +2,7 @@
 import asyncio
 import logging
 from collections import OrderedDict
+from datetime import timedelta
 from typing import Any, Dict, List, Optional, Tuple, cast
 
 import jwt
@@ -242,8 +243,9 @@ class AuthManager:
                 modules[module_id] = module.name
         return modules
 
-    async def async_create_refresh_token(self, user: models.User,
-                                         client_id: Optional[str] = None) \
+    async def async_create_refresh_token(
+            self, user: models.User, client_id: Optional[str] = None,
+            access_token_expiration: Optional[timedelta] = None) \
             -> models.RefreshToken:
         """Create a new refresh token for a user."""
         if not user.is_active:
@@ -257,7 +259,8 @@ class AuthManager:
         if not user.system_generated and client_id is None:
             raise ValueError('Client is required to generate a refresh token.')
 
-        return await self._store.async_create_refresh_token(user, client_id)
+        return await self._store.async_create_refresh_token(
+            user, client_id, access_token_expiration)
 
     async def async_get_refresh_token(
             self, token_id: str) -> Optional[models.RefreshToken]:

--- a/homeassistant/auth/__init__.py
+++ b/homeassistant/auth/__init__.py
@@ -280,10 +280,9 @@ class AuthManager:
                 'refresh tokens')
 
         if (token_type == models.TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN and
-                (client_id is None or client_id.lower().startswith(
-                    ('http://', 'https://')))):
-            raise ValueError('Client_id is not allowed start with http:// or '
-                             'https:// for long-lived access token')
+                (client_id is None or client_name is None)):
+            raise ValueError('Client_id and client_name are both required for'
+                             ' long-lived access token')
 
         if token_type == models.TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN:
             for token in user.refresh_tokens.values():

--- a/homeassistant/auth/__init__.py
+++ b/homeassistant/auth/__init__.py
@@ -280,7 +280,7 @@ class AuthManager:
                              'token')
 
         if token_type == models.TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN:
-            for token in list(user.refresh_tokens.values()):
+            for token in user.refresh_tokens.values():
                 if (token.client_name == client_name and token.token_type ==
                         models.TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN):
                     # Each client_name can only have one

--- a/homeassistant/auth/auth_store.py
+++ b/homeassistant/auth/auth_store.py
@@ -206,6 +206,20 @@ class AuthStore:
         self._async_schedule_save()
         return refresh_token
 
+    @callback
+    def async_update_refresh_token_name(
+            self, refresh_token: models.RefreshToken,
+            client_name: Optional[str] = None,
+            client_icon: Optional[str] = None) -> models.RefreshToken:
+        """Change refresh token name and/or icon."""
+        if client_name:
+            refresh_token.client_name = client_name
+        if client_icon:
+            refresh_token.client_icon = client_icon
+
+        self._async_schedule_save()
+        return refresh_token
+
     async def _async_load(self) -> None:
         """Load the users."""
         data = await self._store.async_load()

--- a/homeassistant/auth/auth_store.py
+++ b/homeassistant/auth/auth_store.py
@@ -128,11 +128,20 @@ class AuthStore:
         self._async_schedule_save()
 
     async def async_create_refresh_token(
-            self, user: models.User, client_id: Optional[str] = None) \
+            self, user: models.User, client_id: Optional[str] = None,
+            access_token_expiration: Optional[timedelta] = None) \
             -> models.RefreshToken:
         """Create a new token for a user."""
-        refresh_token = models.RefreshToken(user=user, client_id=client_id)
+        kwargs = {
+            'user': user,
+            'client_id': client_id
+        }  # type: Dict[str, Any]
+        if access_token_expiration:
+            kwargs['access_token_expiration'] = access_token_expiration
+
+        refresh_token = models.RefreshToken(**kwargs)
         user.refresh_tokens[refresh_token.id] = refresh_token
+
         self._async_schedule_save()
         return refresh_token
 

--- a/homeassistant/auth/models.py
+++ b/homeassistant/auth/models.py
@@ -10,6 +10,10 @@ from homeassistant.util import dt as dt_util
 from .const import ACCESS_TOKEN_EXPIRATION
 from .util import generate_secret
 
+TOKEN_TYPE_NORMAL = 'normal'
+TOKEN_TYPE_SYSTEM = 'system'
+TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN = 'long_lived_access_token'
+
 
 @attr.s(slots=True)
 class User:
@@ -37,7 +41,14 @@ class RefreshToken:
     """RefreshToken for a user to grant new access tokens."""
 
     user = attr.ib(type=User)
-    client_id = attr.ib(type=str)  # type: Optional[str]
+    client_id = attr.ib(type=Optional[str])
+    client_name = attr.ib(type=Optional[str])
+    client_icon = attr.ib(type=Optional[str])
+    token_type = attr.ib(type=str, default=TOKEN_TYPE_NORMAL,
+                         validator=attr.validators.in_((
+                             TOKEN_TYPE_NORMAL, TOKEN_TYPE_SYSTEM,
+                             TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN)))
+    is_for_long_lived_access_token = attr.ib(type=bool, default=False)
     id = attr.ib(type=str, default=attr.Factory(lambda: uuid.uuid4().hex))
     created_at = attr.ib(type=datetime, default=attr.Factory(dt_util.utcnow))
     access_token_expiration = attr.ib(type=timedelta,

--- a/homeassistant/auth/models.py
+++ b/homeassistant/auth/models.py
@@ -42,8 +42,8 @@ class RefreshToken:
 
     user = attr.ib(type=User)
     client_id = attr.ib(type=Optional[str])
-    client_name = attr.ib(type=Optional[str])
-    client_icon = attr.ib(type=Optional[str])
+    client_name = attr.ib(type=Optional[str], default=None)
+    client_icon = attr.ib(type=Optional[str], default=None)
     token_type = attr.ib(type=str, default=TOKEN_TYPE_NORMAL,
                          validator=attr.validators.in_((
                              TOKEN_TYPE_NORMAL, TOKEN_TYPE_SYSTEM,

--- a/homeassistant/auth/models.py
+++ b/homeassistant/auth/models.py
@@ -7,7 +7,6 @@ import attr
 
 from homeassistant.util import dt as dt_util
 
-from .const import ACCESS_TOKEN_EXPIRATION
 from .util import generate_secret
 
 TOKEN_TYPE_NORMAL = 'normal'
@@ -42,6 +41,7 @@ class RefreshToken:
 
     user = attr.ib(type=User)
     client_id = attr.ib(type=Optional[str])
+    access_token_expiration = attr.ib(type=timedelta)
     client_name = attr.ib(type=Optional[str], default=None)
     client_icon = attr.ib(type=Optional[str], default=None)
     token_type = attr.ib(type=str, default=TOKEN_TYPE_NORMAL,
@@ -50,8 +50,6 @@ class RefreshToken:
                              TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN)))
     id = attr.ib(type=str, default=attr.Factory(lambda: uuid.uuid4().hex))
     created_at = attr.ib(type=datetime, default=attr.Factory(dt_util.utcnow))
-    access_token_expiration = attr.ib(type=timedelta,
-                                      default=ACCESS_TOKEN_EXPIRATION)
     token = attr.ib(type=str,
                     default=attr.Factory(lambda: generate_secret(64)))
     jwt_key = attr.ib(type=str,

--- a/homeassistant/auth/models.py
+++ b/homeassistant/auth/models.py
@@ -48,7 +48,6 @@ class RefreshToken:
                          validator=attr.validators.in_((
                              TOKEN_TYPE_NORMAL, TOKEN_TYPE_SYSTEM,
                              TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN)))
-    is_for_long_lived_access_token = attr.ib(type=bool, default=False)
     id = attr.ib(type=str, default=attr.Factory(lambda: uuid.uuid4().hex))
     created_at = attr.ib(type=datetime, default=attr.Factory(dt_util.utcnow))
     access_token_expiration = attr.ib(type=timedelta,

--- a/homeassistant/components/auth/__init__.py
+++ b/homeassistant/components/auth/__init__.py
@@ -104,7 +104,6 @@ Home Assistant. User need to record the token in secure place.
 {
     "id": 11,
     "type": "auth/long_lived_access_token",
-    "client_id": "gps_logger",
     "client_name": "GPS Logger",
     "client_icon": null,
     "lifespan": 365
@@ -152,9 +151,8 @@ WS_TYPE_LONG_LIVED_ACCESS_TOKEN = 'auth/long_lived_access_token'
 SCHEMA_WS_LONG_LIVED_ACCESS_TOKEN = \
     websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend({
         vol.Required('type'): WS_TYPE_LONG_LIVED_ACCESS_TOKEN,
-        vol.Required('client_id'): str,
         vol.Required('lifespan'): int,  # days
-        vol.Optional('client_name'): str,
+        vol.Required('client_name'): str,
         vol.Optional('client_icon'): str,
     })
 
@@ -433,8 +431,9 @@ def websocket_create_long_lived_access_token(
     async def async_create_long_lived_access_token(user):
         """Create or refresh a long-lived access token."""
         refresh_token = await hass.auth.async_create_refresh_token(
-            user, msg['client_id'],
-            msg.get('client_name'), msg.get('client_icon'),
+            user,
+            client_name=msg['client_name'],
+            client_icon=msg.get('client_icon'),
             token_type=TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN,
             access_token_expiration=timedelta(days=msg['lifespan']))
 

--- a/homeassistant/components/auth/__init__.py
+++ b/homeassistant/components/auth/__init__.py
@@ -12,6 +12,7 @@ be in JSON as it's more readable.
 Exchange the authorization code retrieved from the login flow for tokens.
 
 {
+    "client_id": "https://hassbian.local:8123/",
     "grant_type": "authorization_code",
     "code": "411ee2f916e648d691e937ae9344681e"
 }
@@ -32,6 +33,7 @@ token.
 Request a new access token using a refresh token.
 
 {
+    "client_id": "https://hassbian.local:8123/",
     "grant_type": "refresh_token",
     "refresh_token": "IJKLMNOPQRST"
 }
@@ -55,6 +57,68 @@ ever been granted by that refresh token. Response code will ALWAYS be 200.
     "action": "revoke"
 }
 
+# Websocket API
+
+## Get current user
+
+Send websocket command `auth/current_user` will return current user of the
+active websocket connection.
+
+{
+    "id": 10,
+    "type": "auth/current_user",
+}
+
+The result payload likes
+
+{
+    "id": 10,
+    "type": "result",
+    "success": true,
+    "result": {
+        "id": "USER_ID",
+        "name": "John Doe",
+        "is_owner': true,
+        "credentials": [
+            {
+                "auth_provider_type": "homeassistant",
+                "auth_provider_id": null
+            }
+        ],
+        "mfa_modules": [
+            {
+                "id": "totp",
+                "name": "TOTP",
+                "enabled": true,
+            }
+        ]
+    }
+}
+
+## Create or refresh long-lived access token
+
+Send websocket command `auth/long_lived_access_token` will create or refresh
+a long-lived access token for current user. Access token will not be saved in
+Home Assistant. User need to record the token in secure place.
+
+{
+    "id": 11,
+    "type": "auth/long_lived_access_token",
+    "client_id": "gps_logger",
+    "client_name": "GPS Logger",
+    "client_icon": null,
+    "lifespan": 365
+}
+
+Result will be a long-lived access token:
+
+{
+    "id": 11,
+    "type": "result",
+    "success": true,
+    "result": "ABCDEFGH"
+}
+
 """
 import logging
 import uuid
@@ -63,7 +127,8 @@ from datetime import timedelta
 from aiohttp import web
 import voluptuous as vol
 
-from homeassistant.auth.models import User, Credentials
+from homeassistant.auth.models import User, Credentials, \
+    TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN
 from homeassistant.components import websocket_api
 from homeassistant.components.http.ban import log_invalid_auth
 from homeassistant.components.http.data_validator import RequestDataValidator
@@ -83,6 +148,16 @@ SCHEMA_WS_CURRENT_USER = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend({
     vol.Required('type'): WS_TYPE_CURRENT_USER,
 })
 
+WS_TYPE_LONG_LIVED_ACCESS_TOKEN = 'auth/long_lived_access_token'
+SCHEMA_WS_LONG_LIVED_ACCESS_TOKEN = \
+    websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend({
+        vol.Required('type'): WS_TYPE_LONG_LIVED_ACCESS_TOKEN,
+        vol.Required('client_id'): str,
+        vol.Required('lifespan'): int,  # days
+        vol.Optional('client_name'): str,
+        vol.Optional('client_icon'): str,
+    })
+
 RESULT_TYPE_CREDENTIALS = 'credentials'
 RESULT_TYPE_USER = 'user'
 
@@ -99,6 +174,11 @@ async def async_setup(hass, config):
     hass.components.websocket_api.async_register_command(
         WS_TYPE_CURRENT_USER, websocket_current_user,
         SCHEMA_WS_CURRENT_USER
+    )
+    hass.components.websocket_api.async_register_command(
+        WS_TYPE_LONG_LIVED_ACCESS_TOKEN,
+        websocket_create_long_lived_access_token,
+        SCHEMA_WS_LONG_LIVED_ACCESS_TOKEN
     )
 
     await login_flow.async_setup(hass, store_result)
@@ -343,3 +423,26 @@ def websocket_current_user(
             }))
 
     hass.async_create_task(async_get_current_user(connection.user))
+
+
+@websocket_api.ws_require_user()
+@callback
+def websocket_create_long_lived_access_token(
+        hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg):
+    """Create or refresh a long-lived access token."""
+    async def async_create_long_lived_access_tokenr(user):
+        """Create or refresh a long-lived access token."""
+        refresh_token = await hass.auth.async_create_refresh_token(
+            user, msg['client_id'],
+            msg.get('client_name'), msg.get('client_icon'),
+            token_type=TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN,
+            access_token_expiration=timedelta(days=msg['lifespan']))
+
+        access_token = hass.auth.async_create_access_token(
+            refresh_token)
+
+        connection.send_message_outside(
+            websocket_api.result_message(msg['id'], access_token))
+
+    hass.async_create_task(
+        async_create_long_lived_access_tokenr(connection.user))

--- a/homeassistant/components/auth/__init__.py
+++ b/homeassistant/components/auth/__init__.py
@@ -430,7 +430,7 @@ def websocket_current_user(
 def websocket_create_long_lived_access_token(
         hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg):
     """Create or refresh a long-lived access token."""
-    async def async_create_long_lived_access_tokenr(user):
+    async def async_create_long_lived_access_token(user):
         """Create or refresh a long-lived access token."""
         refresh_token = await hass.auth.async_create_refresh_token(
             user, msg['client_id'],
@@ -445,4 +445,4 @@ def websocket_create_long_lived_access_token(
             websocket_api.result_message(msg['id'], access_token))
 
     hass.async_create_task(
-        async_create_long_lived_access_tokenr(connection.user))
+        async_create_long_lived_access_token(connection.user))

--- a/homeassistant/components/auth/__init__.py
+++ b/homeassistant/components/auth/__init__.py
@@ -95,9 +95,9 @@ The result payload likes
     }
 }
 
-## Create or refresh long-lived access token
+## Create a long-lived access token
 
-Send websocket command `auth/long_lived_access_token` will create or refresh
+Send websocket command `auth/long_lived_access_token` will create
 a long-lived access token for current user. Access token will not be saved in
 Home Assistant. User need to record the token in secure place.
 
@@ -427,9 +427,9 @@ def websocket_current_user(
 @callback
 def websocket_create_long_lived_access_token(
         hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg):
-    """Create or refresh a long-lived access token."""
+    """Create or a long-lived access token."""
     async def async_create_long_lived_access_token(user):
-        """Create or refresh a long-lived access token."""
+        """Create or a long-lived access token."""
         refresh_token = await hass.auth.async_create_refresh_token(
             user,
             client_name=msg['client_name'],

--- a/tests/auth/test_init.py
+++ b/tests/auth/test_init.py
@@ -396,25 +396,13 @@ async def test_refresh_token_type_long_lived_access_token(hass):
             user, token_type=auth_models.TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN)
 
     token = await manager.async_create_refresh_token(
-        user, client_name='GPS LOGGER',
+        user, client_name='GPS LOGGER', client_icon='mdi:home',
         token_type=auth_models.TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN)
     assert token is not None
     assert token.client_id is None
     assert token.client_name == 'GPS LOGGER'
+    assert token.client_icon == 'mdi:home'
     assert token.token_type == auth_models.TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN
-
-    new_token = await manager.async_create_refresh_token(
-        user, client_name='GPS LOGGER', client_icon='mdi:home',
-        token_type=auth_models.TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN)
-    assert new_token is not None
-    assert new_token.id != token.id
-    assert new_token.token != token.token
-    assert new_token.jwt_key != token.jwt_key
-    assert new_token.client_id is None
-    assert new_token.client_name == 'GPS LOGGER'
-    assert new_token.client_icon == 'mdi:home'
-    assert new_token.token_type == \
-        auth_models.TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN
 
 
 async def test_cannot_deactive_owner(mock_hass):
@@ -495,11 +483,22 @@ async def test_one_long_lived_access_token_per_refresh_token(mock_hass):
     rt = await manager.async_validate_access_token(access_token)
     assert rt.id == refresh_token.id
 
+    with pytest.raises(ValueError):
+        await manager.async_create_refresh_token(
+            user, client_name='GPS Logger',
+            token_type=auth_models.TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN,
+            access_token_expiration=timedelta(days=3000))
+
+    await manager.async_remove_refresh_token(refresh_token)
+    assert refresh_token.id not in user.refresh_tokens
+    rt = await manager.async_validate_access_token(access_token)
+    assert rt is None, 'Previous issued access token has been invoked'
+
     refresh_token_2 = await manager.async_create_refresh_token(
         user, client_name='GPS Logger',
         token_type=auth_models.TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN,
         access_token_expiration=timedelta(days=3000))
-    assert refresh_token.id not in user.refresh_tokens
+    assert refresh_token_2.id != refresh_token.id
     assert refresh_token_2.token_type == \
         auth_models.TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN
     access_token_2 = manager.async_create_access_token(refresh_token_2)
@@ -507,9 +506,6 @@ async def test_one_long_lived_access_token_per_refresh_token(mock_hass):
 
     assert access_token != access_token_2
     assert jwt_key != jwt_key_2
-
-    rt = await manager.async_validate_access_token(access_token)
-    assert rt is None, 'Previous issued access token has been invoked'
 
     rt = await manager.async_validate_access_token(access_token_2)
     jwt_payload = jwt.decode(

--- a/tests/auth/test_init.py
+++ b/tests/auth/test_init.py
@@ -503,12 +503,11 @@ async def test_one_long_lived_access_token_per_refresh_token(mock_hass):
 
     assert access_token != access_token_2
     assert jwt_key != jwt_key_2
-    
+
     rt = await manager.async_validate_access_token(access_token)
     assert rt is None, 'Previous issued access token has been invoked'
 
     rt = await manager.async_validate_access_token(access_token_2)
-
     jwt_payload = jwt.decode(
         access_token_2, rt.jwt_key, algorithm=['HS256'])
     assert jwt_payload['iss'] == refresh_token.id

--- a/tests/auth/test_init.py
+++ b/tests/auth/test_init.py
@@ -393,26 +393,25 @@ async def test_refresh_token_type_long_lived_access_token(hass):
 
     with pytest.raises(ValueError):
         await manager.async_create_refresh_token(
-            user, CLIENT_ID,
-            token_type=auth_models.TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN)
+            user, token_type=auth_models.TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN)
 
     token = await manager.async_create_refresh_token(
-        user, 'gps_logger', 'GPS LOGGER',
+        user, client_name='GPS LOGGER',
         token_type=auth_models.TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN)
     assert token is not None
-    assert token.client_id == 'gps_logger'
+    assert token.client_id is None
     assert token.client_name == 'GPS LOGGER'
     assert token.token_type == auth_models.TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN
 
     new_token = await manager.async_create_refresh_token(
-        user, 'gps_logger', 'GPS LOGGER 2', 'mdi:home',
+        user, client_name='GPS LOGGER', client_icon='mdi:home',
         token_type=auth_models.TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN)
     assert new_token is not None
     assert new_token.id != token.id
     assert new_token.token != token.token
     assert new_token.jwt_key != token.jwt_key
-    assert new_token.client_id == 'gps_logger'
-    assert new_token.client_name == 'GPS LOGGER 2'
+    assert new_token.client_id is None
+    assert new_token.client_name == 'GPS LOGGER'
     assert new_token.client_icon == 'mdi:home'
     assert new_token.token_type == \
         auth_models.TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN
@@ -467,7 +466,7 @@ async def test_create_long_lived_access_token(mock_hass):
     manager = await auth.auth_manager_from_config(mock_hass, [], [])
     user = MockUser().add_to_auth_manager(manager)
     refresh_token = await manager.async_create_refresh_token(
-        user, 'gps_logger', 'GPS Logger',
+        user, client_name='GPS Logger',
         token_type=auth_models.TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN,
         access_token_expiration=timedelta(days=300))
     assert refresh_token.token_type == \
@@ -485,7 +484,7 @@ async def test_one_long_lived_access_token_per_refresh_token(mock_hass):
     manager = await auth.auth_manager_from_config(mock_hass, [], [])
     user = MockUser().add_to_auth_manager(manager)
     refresh_token = await manager.async_create_refresh_token(
-        user, 'https://gps.logger.com/', 'GPS Logger',
+        user, client_name='GPS Logger',
         token_type=auth_models.TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN,
         access_token_expiration=timedelta(days=3000))
     assert refresh_token.token_type == \
@@ -497,7 +496,7 @@ async def test_one_long_lived_access_token_per_refresh_token(mock_hass):
     assert rt.id == refresh_token.id
 
     refresh_token_2 = await manager.async_create_refresh_token(
-        user, 'https://gps.logger.com/', 'GPS Logger',
+        user, client_name='GPS Logger',
         token_type=auth_models.TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN,
         access_token_expiration=timedelta(days=3000))
     assert refresh_token.id not in user.refresh_tokens

--- a/tests/auth/test_init.py
+++ b/tests/auth/test_init.py
@@ -467,7 +467,7 @@ async def test_create_long_lived_access_token(mock_hass):
     manager = await auth.auth_manager_from_config(mock_hass, [], [])
     user = MockUser().add_to_auth_manager(manager)
     refresh_token = await manager.async_create_refresh_token(
-        user, 'gps_logger',
+        user, 'gps_logger', 'GPS Logger',
         token_type=auth_models.TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN,
         access_token_expiration=timedelta(days=300))
     assert refresh_token.token_type == \
@@ -487,7 +487,7 @@ async def test_one_long_lived_access_token_per_refresh_token(mock_hass):
     manager = await auth.auth_manager_from_config(mock_hass, [], [])
     user = MockUser().add_to_auth_manager(manager)
     refresh_token = await manager.async_create_refresh_token(
-        user, 'gps_logger',
+        user, 'https://gps.logger.com/', 'GPS Logger',
         token_type=auth_models.TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN,
         access_token_expiration=timedelta(days=3000))
     assert refresh_token.token_type == \

--- a/tests/auth/test_init.py
+++ b/tests/auth/test_init.py
@@ -2,6 +2,7 @@
 from datetime import timedelta
 from unittest.mock import Mock, patch
 
+import jwt
 import pytest
 import voluptuous as vol
 
@@ -334,6 +335,7 @@ async def test_refresh_token_requires_client_for_user(hass):
     token = await manager.async_create_refresh_token(user, CLIENT_ID)
     assert token is not None
     assert token.client_id == CLIENT_ID
+    assert token.token_type == auth_models.TOKEN_TYPE_NORMAL
     # default access token expiration
     assert token.access_token_expiration == \
         auth_models.ACCESS_TOKEN_EXPIRATION
@@ -351,22 +353,69 @@ async def test_refresh_token_not_requires_client_for_system_user(hass):
     token = await manager.async_create_refresh_token(user)
     assert token is not None
     assert token.client_id is None
+    assert token.token_type == auth_models.TOKEN_TYPE_SYSTEM
 
 
 async def test_refresh_token_with_specific_access_token_expiration(hass):
     """Test create a refresh token with specific access token expiration."""
     manager = await auth.auth_manager_from_config(hass, [], [])
     user = MockUser().add_to_auth_manager(manager)
-    assert user.system_generated is False
-
-    with pytest.raises(ValueError):
-        await manager.async_create_refresh_token(user)
 
     token = await manager.async_create_refresh_token(
-        user, CLIENT_ID, timedelta(days=100))
+        user, CLIENT_ID,
+        access_token_expiration=timedelta(days=100))
     assert token is not None
     assert token.client_id == CLIENT_ID
     assert token.access_token_expiration == timedelta(days=100)
+
+
+async def test_refresh_token_type(hass):
+    """Test create a refresh token with token type."""
+    manager = await auth.auth_manager_from_config(hass, [], [])
+    user = MockUser().add_to_auth_manager(manager)
+
+    with pytest.raises(ValueError):
+        await manager.async_create_refresh_token(
+            user, CLIENT_ID, token_type=auth_models.TOKEN_TYPE_SYSTEM)
+
+    token = await manager.async_create_refresh_token(
+        user, CLIENT_ID,
+        token_type=auth_models.TOKEN_TYPE_NORMAL)
+    assert token is not None
+    assert token.client_id == CLIENT_ID
+    assert token.token_type == auth_models.TOKEN_TYPE_NORMAL
+
+
+async def test_refresh_token_type_long_lived_access_token(hass):
+    """Test create a refresh token has long-lived access token type."""
+    manager = await auth.auth_manager_from_config(hass, [], [])
+    user = MockUser().add_to_auth_manager(manager)
+
+    with pytest.raises(ValueError):
+        await manager.async_create_refresh_token(
+            user, CLIENT_ID,
+            token_type=auth_models.TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN)
+
+    token = await manager.async_create_refresh_token(
+        user, 'gps_logger', 'GPS LOGGER',
+        token_type=auth_models.TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN)
+    assert token is not None
+    assert token.client_id == 'gps_logger'
+    assert token.client_name == 'GPS LOGGER'
+    assert token.token_type == auth_models.TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN
+
+    new_token = await manager.async_create_refresh_token(
+        user, 'gps_logger', 'GPS LOGGER 2', 'mdi:home',
+        token_type=auth_models.TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN)
+    assert new_token is not None
+    assert new_token.id == token.id
+    assert new_token.token == token.token
+    assert new_token.jwt_key == token.jwt_key
+    assert new_token.client_id == 'gps_logger'
+    assert new_token.client_name == 'GPS LOGGER 2'
+    assert new_token.client_icon == 'mdi:home'
+    assert new_token.token_type == \
+        auth_models.TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN
 
 
 async def test_cannot_deactive_owner(mock_hass):
@@ -395,6 +444,76 @@ async def test_remove_refresh_token(mock_hass):
     assert (
         await manager.async_validate_access_token(access_token) is None
     )
+
+
+async def test_create_access_token(mock_hass):
+    """Test normal refresh_token's jwt_key keep same after used."""
+    manager = await auth.auth_manager_from_config(mock_hass, [], [])
+    user = MockUser().add_to_auth_manager(manager)
+    refresh_token = await manager.async_create_refresh_token(user, CLIENT_ID)
+    assert refresh_token.token_type == auth_models.TOKEN_TYPE_NORMAL
+    jwt_key = refresh_token.jwt_key
+    access_token = manager.async_create_access_token(refresh_token)
+    assert access_token is not None
+    assert refresh_token.jwt_key == jwt_key
+    jwt_payload = jwt.decode(access_token, jwt_key, algorithm=['HS256'])
+    assert jwt_payload['iss'] == refresh_token.id
+    assert jwt_payload['exp'] - jwt_payload['iat'] == \
+        timedelta(minutes=30).total_seconds()
+
+
+async def test_create_long_lived_access_token(mock_hass):
+    """Test refresh_token's jwt_key changed for long-lived access token."""
+    manager = await auth.auth_manager_from_config(mock_hass, [], [])
+    user = MockUser().add_to_auth_manager(manager)
+    refresh_token = await manager.async_create_refresh_token(
+        user, 'gps_logger',
+        token_type=auth_models.TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN,
+        access_token_expiration=timedelta(days=300))
+    assert refresh_token.token_type == \
+        auth_models.TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN
+    jwt_key = refresh_token.jwt_key
+    access_token = manager.async_create_access_token(refresh_token)
+    assert refresh_token.jwt_key != jwt_key
+    jwt_payload = jwt.decode(
+        access_token, refresh_token.jwt_key, algorithm=['HS256'])
+    assert jwt_payload['iss'] == refresh_token.id
+    assert jwt_payload['exp'] - jwt_payload['iat'] == \
+        timedelta(days=300).total_seconds()
+
+
+async def test_one_long_lived_access_token_per_refresh_token(mock_hass):
+    """Test one refresh_token can only have one long-lived access token."""
+    manager = await auth.auth_manager_from_config(mock_hass, [], [])
+    user = MockUser().add_to_auth_manager(manager)
+    refresh_token = await manager.async_create_refresh_token(
+        user, 'gps_logger',
+        token_type=auth_models.TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN,
+        access_token_expiration=timedelta(days=3000))
+    assert refresh_token.token_type == \
+        auth_models.TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN
+    access_token = manager.async_create_access_token(refresh_token)
+    jwt_key = refresh_token.jwt_key
+
+    rt = await manager.async_validate_access_token(access_token)
+    assert rt.id == refresh_token.id
+
+    access_token_2 = manager.async_create_access_token(refresh_token)
+    jwt_key_2 = refresh_token.jwt_key
+
+    assert access_token != access_token_2
+    assert jwt_key != jwt_key_2
+    
+    rt = await manager.async_validate_access_token(access_token)
+    assert rt is None, 'Previous issued access token has been invoked'
+
+    rt = await manager.async_validate_access_token(access_token_2)
+
+    jwt_payload = jwt.decode(
+        access_token_2, rt.jwt_key, algorithm=['HS256'])
+    assert jwt_payload['iss'] == refresh_token.id
+    assert jwt_payload['exp'] - jwt_payload['iat'] == \
+        timedelta(days=3000).total_seconds()
 
 
 async def test_login_with_auth_module(mock_hass):

--- a/tests/components/auth/test_init.py
+++ b/tests/components/auth/test_init.py
@@ -2,6 +2,8 @@
 from datetime import timedelta
 from unittest.mock import patch
 
+from homeassistant import const
+from homeassistant.auth import auth_manager_from_config
 from homeassistant.auth.models import Credentials
 from homeassistant.components.auth import RESULT_TYPE_USER
 from homeassistant.setup import async_setup_component
@@ -10,7 +12,8 @@ from homeassistant.components import auth
 
 from . import async_setup_auth
 
-from tests.common import CLIENT_ID, CLIENT_REDIRECT_URI, MockUser
+from tests.common import CLIENT_ID, CLIENT_REDIRECT_URI, MockUser, \
+    ensure_auth_manager_loaded
 
 
 async def test_login_new_user_and_trying_refresh_token(hass, aiohttp_client):
@@ -267,3 +270,58 @@ async def test_revoking_refresh_token(hass, aiohttp_client):
     })
 
     assert resp.status == 400
+
+
+async def test_ws_long_lived_access_token(hass, hass_ws_client):
+    """Test generate long-lived access token."""
+    hass.auth = await auth_manager_from_config(
+        hass, provider_configs=[{
+            'type': 'insecure_example',
+            'users': [{
+                'username': 'test-user',
+                'password': 'test-pass',
+                'name': 'Test Name',
+            }]
+        }], module_configs=[])
+    ensure_auth_manager_loaded(hass.auth)
+    assert await async_setup_component(hass, 'auth', {'http': {}})
+    assert await async_setup_component(hass, 'api', {'http': {}})
+
+    user = MockUser(id='mock-user').add_to_hass(hass)
+    cred = await hass.auth.auth_providers[0].async_get_or_create_credentials(
+        {'username': 'test-user'})
+    await hass.auth.async_link_user(user, cred)
+
+    ws_client = await hass_ws_client(hass, hass.auth.async_create_access_token(
+        await hass.auth.async_create_refresh_token(user, CLIENT_ID)))
+
+    # verify create long-lived access token
+    await ws_client.send_json({
+        'id': 5,
+        'type': auth.WS_TYPE_LONG_LIVED_ACCESS_TOKEN,
+        'client_id': 'gps_logger',
+        'client_name': 'GPS Logger',
+        'lifespan': 365,
+    })
+
+    result = await ws_client.receive_json()
+    assert result['success'], result
+
+    long_lived_access_token = result['result']
+    assert long_lived_access_token is not None
+
+    refresh_token = await hass.auth.async_validate_access_token(
+        long_lived_access_token)
+    assert refresh_token.client_id == 'gps_logger'
+    assert refresh_token.client_name == 'GPS Logger'
+    assert refresh_token.client_icon is None
+
+    # verify long-lived access token can be used as bearer token
+    api_client = ws_client.client
+    resp = await api_client.get(const.URL_API)
+    assert resp.status == 401
+
+    resp = await api_client.get(const.URL_API, headers={
+        'Authorization': 'Bearer {}'.format(long_lived_access_token)
+    })
+    assert resp.status == 200

--- a/tests/components/auth/test_init.py
+++ b/tests/components/auth/test_init.py
@@ -299,7 +299,6 @@ async def test_ws_long_lived_access_token(hass, hass_ws_client):
     await ws_client.send_json({
         'id': 5,
         'type': auth.WS_TYPE_LONG_LIVED_ACCESS_TOKEN,
-        'client_id': 'gps_logger',
         'client_name': 'GPS Logger',
         'lifespan': 365,
     })
@@ -312,7 +311,7 @@ async def test_ws_long_lived_access_token(hass, hass_ws_client):
 
     refresh_token = await hass.auth.async_validate_access_token(
         long_lived_access_token)
-    assert refresh_token.client_id == 'gps_logger'
+    assert refresh_token.client_id is None
     assert refresh_token.client_name == 'GPS Logger'
     assert refresh_token.client_icon is None
 

--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -34,6 +34,8 @@ def hass_ws_client(aiohttp_client):
         auth_ok = await websocket.receive_json()
         assert auth_ok['type'] == wapi.TYPE_AUTH_OK
 
+        # wrap in client
+        websocket.client = client
         return websocket
 
     return create_client


### PR DESCRIPTION
## Description:
Implement long-lived access token back end logic

- Allow create refresh_token with different access_token_expiration,
- Add client_name, client_icon fields
- Add token_type, `normal`, `system` or `long_lived_access_token`
- Each such `client_id` can only have one `long_lived_access_token` type refresh_token, each such refresh_token can only have one active access_token. 

Send websocket command `auth/long_lived_access_token` will create or refresh a long-lived access token for current user. Access token will not be saved in Home Assistant. User need to record the token in secure place.

```json
{
    "id": 11,
    "type": "auth/long_lived_access_token",
    "client_id": "gps_logger",
    "client_name": "GPS Logger",
    "client_icon": null,
    "lifespan": 365
}
```

Result will be a long-lived access token:
```json
{
    "id": 11,
    "type": "result",
    "success": true,
    "result": "ABCDEFGH"
}
```

To use access token, put it in HTTP Authorization Header, for example
```shell
curl -H "Authorization: Bearer ABCDEFGH" http://hassbian.local:8123/api
```


**Related issue (if applicable):** fixes back-end part #15195 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/developers.home-assistant#82

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.
