### PR TITLE
Fail fetch auth providers if onboarding required

### DIFF
--- a/homeassistant/components/auth/login_flow.py
+++ b/homeassistant/components/auth/login_flow.py
@@ -66,7 +66,7 @@ associate with an credential if "type" set to "link_user" in
     "version": 1
 }
 """
-import aiohttp.web
+from aiohttp import web
 import voluptuous as vol
 
 from homeassistant import data_entry_flow
@@ -95,11 +95,20 @@ class AuthProvidersView(HomeAssistantView):
 
     async def get(self, request):
         """Get available auth providers."""
+        hass = request.app['hass']
+
+        if not hass.components.onboarding.async_is_onboarded():
+            return self.json_message(
+                message='Onboarding not finished',
+                status_code=400,
+                message_code='onboarding_required'
+            )
+
         return self.json([{
             'name': provider.name,
             'id': provider.id,
             'type': provider.type,
-        } for provider in request.app['hass'].auth.auth_providers])
+        } for provider in hass.auth.auth_providers])
 
 
 def _prepare_result_json(result):
@@ -139,7 +148,7 @@ class LoginFlowIndexView(HomeAssistantView):
 
     async def get(self, request):
         """Do not allow index of flows in progress."""
-        return aiohttp.web.Response(status=405)
+        return web.Response(status=405)
 
     @RequestDataValidator(vol.Schema({
         vol.Required('client_id'): str,

--- a/tests/components/auth/test_login_flow.py
+++ b/tests/components/auth/test_login_flow.py
@@ -1,4 +1,6 @@
 """Tests for the login flow."""
+from unittest.mock import patch
+
 from . import async_setup_auth
 
 from tests.common import CLIENT_ID, CLIENT_REDIRECT_URI
@@ -14,6 +16,19 @@ async def test_fetch_auth_providers(hass, aiohttp_client):
         'type': 'insecure_example',
         'id': None
     }]
+
+
+async def test_fetch_auth_providers_onboarding(hass, aiohttp_client):
+    """Test fetching auth providers."""
+    client = await async_setup_auth(hass, aiohttp_client)
+    with patch('homeassistant.components.onboarding.async_is_onboarded',
+               return_value=False):
+        resp = await client.get('/auth/providers')
+    assert resp.status == 400
+    assert await resp.json() == {
+        'message': 'Onboarding not finished',
+        'code': 'onboarding_required',
+    }
 
 
 async def test_cannot_get_flows_in_progress(hass, aiohttp_client):


### PR DESCRIPTION
## Description:
Fail when fetching auth providers if onboarding is required. This will allow us to redirect users from the authorize page.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
