### PR TITLE
Update name legacy api password

### DIFF
--- a/homeassistant/auth/providers/legacy_api_password.py
+++ b/homeassistant/auth/providers/legacy_api_password.py
@@ -24,7 +24,7 @@ USER_SCHEMA = vol.Schema({
 CONFIG_SCHEMA = AUTH_PROVIDER_SCHEMA.extend({
 }, extra=vol.PREVENT_EXTRA)
 
-LEGACY_USER = 'homeassistant'
+LEGACY_USER_NAME = 'Legacy API password user'
 
 
 class InvalidAuthError(HomeAssistantError):
@@ -52,23 +52,21 @@ class LegacyApiPasswordAuthProvider(AuthProvider):
 
     async def async_get_or_create_credentials(
             self, flow_result: Dict[str, str]) -> Credentials:
-        """Return LEGACY_USER always."""
-        for credential in await self.async_credentials():
-            if credential.data['username'] == LEGACY_USER:
-                return credential
+        """Return credentials for this login."""
+        credentials = await self.async_credentials()
+        if credentials:
+            return credentials[0]
 
-        return self.async_create_credentials({
-            'username': LEGACY_USER
-        })
+        return self.async_create_credentials({})
 
     async def async_user_meta_for_credentials(
             self, credentials: Credentials) -> UserMeta:
         """
-        Set name as LEGACY_USER always.
+        Return info for the user.
 
         Will be used to populate info when creating a new user.
         """
-        return UserMeta(name=LEGACY_USER, is_active=True)
+        return UserMeta(name=LEGACY_USER_NAME, is_active=True)
 
 
 class LegacyLoginFlow(LoginFlow):

--- a/tests/auth/providers/test_legacy_api_password.py
+++ b/tests/auth/providers/test_legacy_api_password.py
@@ -33,11 +33,10 @@ def manager(hass, store, provider):
 async def test_create_new_credential(manager, provider):
     """Test that we create a new credential."""
     credentials = await provider.async_get_or_create_credentials({})
-    assert credentials.data["username"] is legacy_api_password.LEGACY_USER
     assert credentials.is_new is True
 
     user = await manager.async_get_or_create_user(credentials)
-    assert user.name == legacy_api_password.LEGACY_USER
+    assert user.name == legacy_api_password.LEGACY_USER_NAME
     assert user.is_active
 
 
@@ -46,7 +45,6 @@ async def test_only_one_credentials(manager, provider):
     credentials = await provider.async_get_or_create_credentials({})
     await manager.async_get_or_create_user(credentials)
     credentials2 = await provider.async_get_or_create_credentials({})
-    assert credentials2.data["username"] == legacy_api_password.LEGACY_USER
     assert credentials2.id == credentials.id
     assert credentials2.is_new is False
 


### PR DESCRIPTION
## Description:
It's confusing that the legacy API password user is called 'homeassistant'. This will rename it to "Legacy API password user". This will only impact new users.

CC @awarecan 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
