### PR TITLE
Avoid trailing line break when sending messages

### DIFF
--- a/homeassistant/components/hangouts/hangouts_bot.py
+++ b/homeassistant/components/hangouts/hangouts_bot.py
@@ -203,16 +203,17 @@ class HangoutsBot:
 
         from hangups import ChatMessageSegment, hangouts_pb2
         messages = []
-        for segment in message:
+        for i, segment in enumerate(message):
+            if i:
+                messages.append(ChatMessageSegment('', 
+                                                   segment_type=hangouts_pb2.
+                                                   SEGMENT_TYPE_LINE_BREAK))
             if 'parse_str' in segment and segment['parse_str']:
                 messages.extend(ChatMessageSegment.from_str(segment['text']))
             else:
                 if 'parse_str' in segment:
                     del segment['parse_str']
                 messages.append(ChatMessageSegment(**segment))
-            messages.append(ChatMessageSegment('',
-                                               segment_type=hangouts_pb2.
-                                               SEGMENT_TYPE_LINE_BREAK))
 
         if not messages:
             return False

--- a/homeassistant/components/hangouts/hangouts_bot.py
+++ b/homeassistant/components/hangouts/hangouts_bot.py
@@ -205,7 +205,7 @@ class HangoutsBot:
         messages = []
         for i, segment in enumerate(message):
             if i:
-                messages.append(ChatMessageSegment('', 
+                messages.append(ChatMessageSegment('',
                                                    segment_type=hangouts_pb2.
                                                    SEGMENT_TYPE_LINE_BREAK))
             if 'parse_str' in segment and segment['parse_str']:


### PR DESCRIPTION
## Description:

Do not add line break to the end of each message sent via Hangouts
Add it only as a separator between message parts

Having line break after each short messages makes Hangouts history untidy

Messages before and after the change:

![screenshot_20180906-223357](https://user-images.githubusercontent.com/1719919/45152516-58e90380-b225-11e8-8ddd-3e85b799a4ec.png)
