### PR TITLE
Add linky sensor

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -682,6 +682,7 @@ omit =
     homeassistant/components/sensor/kwb.py
     homeassistant/components/sensor/lacrosse.py
     homeassistant/components/sensor/lastfm.py
+    homeassistant/components/sensor/linky.py
     homeassistant/components/sensor/linux_battery.py
     homeassistant/components/sensor/loopenergy.py
     homeassistant/components/sensor/luftdaten.py

--- a/homeassistant/components/sensor/linky.py
+++ b/homeassistant/components/sensor/linky.py
@@ -1,0 +1,83 @@
+"""
+Support for Linky.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/sensor.linky/
+"""
+import logging
+import json
+from datetime import timedelta
+
+import voluptuous as vol
+
+from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.helpers.entity import Entity
+from homeassistant.util import Throttle
+import homeassistant.helpers.config_validation as cv
+
+REQUIREMENTS = ['pylinky==0.1.5']
+_LOGGER = logging.getLogger(__name__)
+
+SCAN_INTERVAL = timedelta(minutes=10)
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_USERNAME): cv.string,
+    vol.Required(CONF_PASSWORD): cv.string
+})
+
+
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    """Configure the platform and add the Linky sensor."""
+    username = config.get(CONF_USERNAME)
+    password = config.get(CONF_PASSWORD)
+
+    from pylinky.client import LinkyClient
+    client = LinkyClient(username, password)
+
+    devices = [LinkySensor('Linky', client)]
+    add_entities(devices, True)
+
+
+class LinkySensor(Entity):
+    """Representation of a sensor entity for Linky."""
+
+    def __init__(self, name, client):
+        """Initialize the sensor."""
+        self._name = name
+        self._client = client
+        self._state = None
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement."""
+        return 'kWh'
+
+    @Throttle(SCAN_INTERVAL)
+    def update(self):
+        """Fetch new state data for the sensor."""
+        from pylinky.client import PyLinkyError
+        try:
+            self._client.fetch_data()
+        except PyLinkyError as exp:
+            _LOGGER.error(exp)
+        except BaseException as exp:
+            _LOGGER.error(exp)
+
+        _LOGGER.debug(json.dumps(self._client.get_data(), indent=2))
+
+        if self._client.get_data():
+            # get the last past day data
+            self._state = self._client.get_data()['daily'][-2]['conso']
+        else:
+            self._state = None

--- a/homeassistant/components/sensor/linky.py
+++ b/homeassistant/components/sensor/linky.py
@@ -10,30 +10,33 @@ from datetime import timedelta
 
 import voluptuous as vol
 
-from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
+from homeassistant.const import CONF_USERNAME, CONF_PASSWORD, CONF_TIMEOUT
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['pylinky==0.1.5']
+REQUIREMENTS = ['pylinky==0.1.6']
 _LOGGER = logging.getLogger(__name__)
 
 SCAN_INTERVAL = timedelta(minutes=10)
+DEFAULT_TIMEOUT = 10
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_USERNAME): cv.string,
-    vol.Required(CONF_PASSWORD): cv.string
+    vol.Required(CONF_PASSWORD): cv.string,
+    vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int,
 })
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Configure the platform and add the Linky sensor."""
-    username = config.get(CONF_USERNAME)
-    password = config.get(CONF_PASSWORD)
+    username = config[CONF_USERNAME]
+    password = config[CONF_PASSWORD]
+    timeout = config[CONF_TIMEOUT]
 
     from pylinky.client import LinkyClient
-    client = LinkyClient(username, password)
+    client = LinkyClient(username, password, None, timeout)
 
     devices = [LinkySensor('Linky', client)]
     add_entities(devices, True)

--- a/homeassistant/components/sensor/linky.py
+++ b/homeassistant/components/sensor/linky.py
@@ -35,8 +35,14 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     password = config[CONF_PASSWORD]
     timeout = config[CONF_TIMEOUT]
 
-    from pylinky.client import LinkyClient
+    from pylinky.client import LinkyClient, PyLinkyError
     client = LinkyClient(username, password, None, timeout)
+
+    try:
+        client.fetch_data()
+    except PyLinkyError as exp:
+        _LOGGER.error(exp)
+        return
 
     devices = [LinkySensor('Linky', client)]
     add_entities(devices, True)
@@ -74,8 +80,7 @@ class LinkySensor(Entity):
             self._client.fetch_data()
         except PyLinkyError as exp:
             _LOGGER.error(exp)
-        except BaseException as exp:
-            _LOGGER.error(exp)
+            return
 
         _LOGGER.debug(json.dumps(self._client.get_data(), indent=2))
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -935,7 +935,7 @@ pylgnetcast-homeassistant==0.2.0.dev0
 pylgtv==0.1.7
 
 # homeassistant.components.sensor.linky
-pylinky==0.1.5
+pylinky==0.1.6
 
 # homeassistant.components.litejet
 pylitejet==0.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -934,6 +934,9 @@ pylgnetcast-homeassistant==0.2.0.dev0
 # homeassistant.components.notify.webostv
 pylgtv==0.1.7
 
+# homeassistant.components.sensor.linky
+pylinky==0.1.5
+
 # homeassistant.components.litejet
 pylitejet==0.1
 


### PR DESCRIPTION
## Description:
It adds a component (sensor) showing the last day consumption of your home from the Linky electric meter.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#6214

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: linky
    username: !secret linky_username
    password: !secret linky_password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
