### PR TITLE
Add retry limit for chromecast connection

### DIFF
--- a/homeassistant/components/media_player/cast.py
+++ b/homeassistant/components/media_player/cast.py
@@ -61,6 +61,10 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
                                                        [cv.string])
 })
 
+CONNECTION_RETRY = 3
+CONNECTION_RETRY_WAIT = 2
+CONNECTION_TIMEOUT = 10
+
 
 @attr.s(slots=True, frozen=True)
 class ChromecastInfo:
@@ -368,15 +372,13 @@ class CastDevice(MediaPlayerDevice):
                 return
             await self._async_disconnect()
 
-        # Failed connection will unfortunately never raise an exception, it
-        # will instead just try connecting indefinitely.
         # pylint: disable=protected-access
         _LOGGER.debug("Connecting to cast device %s", cast_info)
         chromecast = await self.hass.async_add_job(
             pychromecast._get_chromecast_from_host, (
                 cast_info.host, cast_info.port, cast_info.uuid,
                 cast_info.model_name, cast_info.friendly_name
-            ))
+            ), CONNECTION_RETRY, CONNECTION_RETRY_WAIT, CONNECTION_TIMEOUT)
         self._chromecast = chromecast
         self._status_listener = CastStatusListener(self, chromecast)
         # Initialise connection status as connected because we can only


### PR DESCRIPTION
## Description:

Connect to chromecast fail will block whole HA startup

`_get_chromecast_from_host` method accept `tries`, `retry_wait`, `timeout` and `blocking` parameters. But above code doesn't provided any one of them. `timeout` default is 30s, and tries default is **`infinite`**.

I don't have chromecast, need someone help to test this PR

**Related issue (if applicable):** fixes #14956 

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
