### PR TITLE
Fix insteon Hub v1 support

### DIFF
--- a/homeassistant/components/insteon/__init__.py
+++ b/homeassistant/components/insteon/__init__.py
@@ -69,33 +69,19 @@ EVENT_BUTTON_OFF = 'insteon.button_off'
 EVENT_CONF_BUTTON = 'button'
 
 
-# Adapted from:
-# https://github.com/alecthomas/voluptuous/issues/115#issuecomment-144464666
-def set_default_port() -> Callable:
+def set_default_port(schema: Dict) -> Dict:
     """Set the default port based on the Hub version."""
-    def set_default(obj: Dict) -> Dict:
-        """Set ip_port default value based on hub_version."""
-        if not isinstance(obj, dict):
-            raise vol.Invalid('expected dictionary')
-
-        try:
-            # If the ip_port is found do nothing
-            # If it is not found (KeyError) the set the default
-            ip_port = obj[CONF_IP_PORT]
-        except KeyError:
-            try:
-                hub_version = obj[CONF_HUB_VERSION]
-                # Found hub_version but not ip_port
-                if hub_version == 1:
-                    obj[CONF_IP_PORT] = 9761
-                elif not ip_port:
-                    obj[CONF_IP_PORT] = 25105
-            except KeyError:
-                raise vol.Invalid('Schema must contain {}.'.format(
-                    CONF_HUB_VERSION))
-        return obj
-
-    return set_default
+    # If the ip_port is found do nothing
+    # If it is not found the set the default
+    ip_port = schema.get(CONF_IP_PORT)
+    if not ip_port:
+        hub_version = schema.get(CONF_HUB_VERSION)
+        # Found hub_version but not ip_port
+        if hub_version == 1:
+            schema[CONF_IP_PORT] = 9761
+        elif not ip_port:
+            schema[CONF_IP_PORT] = 25105
+    return schema
 
 
 CONF_DEVICE_OVERRIDE_SCHEMA = vol.All(
@@ -136,7 +122,7 @@ CONFIG_SCHEMA = vol.Schema({
                                              [CONF_X10_SCHEMA])
              }, extra=vol.ALLOW_EXTRA, required=True),
         cv.has_at_least_one_key(CONF_PORT, CONF_HOST),
-        set_default_port())
+        set_default_port)
     }, extra=vol.ALLOW_EXTRA)
 
 

--- a/homeassistant/components/insteon/__init__.py
+++ b/homeassistant/components/insteon/__init__.py
@@ -7,7 +7,7 @@ https://home-assistant.io/components/insteon/
 import asyncio
 import collections
 import logging
-from typing import Callable, Dict
+from typing import Dict
 
 import voluptuous as vol
 

--- a/homeassistant/components/insteon/__init__.py
+++ b/homeassistant/components/insteon/__init__.py
@@ -18,7 +18,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers import discovery
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['insteonplm==0.13.1']
+REQUIREMENTS = ['insteonplm==0.14.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/insteon/__init__.py
+++ b/homeassistant/components/insteon/__init__.py
@@ -79,7 +79,7 @@ def set_default_port(schema: Dict) -> Dict:
         # Found hub_version but not ip_port
         if hub_version == 1:
             schema[CONF_IP_PORT] = 9761
-        elif not ip_port:
+        else:
             schema[CONF_IP_PORT] = 25105
     return schema
 
@@ -109,7 +109,7 @@ CONFIG_SCHEMA = vol.Schema({
                            msg=CONF_PLM_HUB_MSG): cv.string,
              vol.Exclusive(CONF_HOST, 'plm_or_hub',
                            msg=CONF_PLM_HUB_MSG): cv.string,
-             vol.Optional(CONF_IP_PORT): int,
+             vol.Optional(CONF_IP_PORT): cv.port,
              vol.Optional(CONF_HUB_USERNAME): cv.string,
              vol.Optional(CONF_HUB_PASSWORD): cv.string,
              vol.Optional(CONF_HUB_VERSION, default=2): vol.In([1, 2]),

--- a/homeassistant/components/insteon/__init__.py
+++ b/homeassistant/components/insteon/__init__.py
@@ -78,8 +78,9 @@ def set_default_port() -> Callable:
         if not isinstance(obj, dict):
             raise vol.Invalid('expected dictionary')
 
-        ip_port = None
         try:
+            # If the ip_port is found do nothing
+            # If it is not found (KeyError) the set the default
             ip_port = obj[CONF_IP_PORT]
         except KeyError:
             try:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -482,7 +482,7 @@ ihcsdk==2.2.0
 influxdb==5.0.0
 
 # homeassistant.components.insteon
-insteonplm==0.14.1
+insteonplm==0.14.2
 
 # homeassistant.components.sensor.iperf3
 iperf3==0.1.10

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -482,7 +482,7 @@ ihcsdk==2.2.0
 influxdb==5.0.0
 
 # homeassistant.components.insteon
-insteonplm==0.13.1
+insteonplm==0.14.1
 
 # homeassistant.components.sensor.iperf3
 iperf3==0.1.10


### PR DESCRIPTION
## Description:
When insteon_local and insteon_plm were merged, support for the Insteon Hub version 1 is broken. This fixes that support.

**Related issue (if applicable):** fixes #16342 
**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#6211

## Example entry for `configuration.yaml` (if applicable):
```yaml
# Hub 2242 configuration variables
insteon:
  host: HOST
  ip_port: IP_PORT
  hub_version: 1
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
