### PR TITLE
Catch exception on ZHA switch setup

### DIFF
--- a/homeassistant/components/switch/zha.py
+++ b/homeassistant/components/switch/zha.py
@@ -13,7 +13,6 @@ _LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = ['zha']
 
-
 async def async_setup_platform(hass, config, async_add_entities,
                                discovery_info=None):
     """Set up the Zigbee Home Automation switches."""
@@ -21,18 +20,22 @@ async def async_setup_platform(hass, config, async_add_entities,
     if discovery_info is None:
         return
 
+    sensor = await make_sensor(discovery_info)
+    async_add_entities([sensor], update_before_add=True)
+
+
+async def make_sensor(discovery_info):
     from zigpy.zcl.clusters.general import OnOff
-    in_clusters = discovery_info['in_clusters']
-    cluster = in_clusters[OnOff.cluster_id]
 
-    from zigpy.exceptions import DeliveryError
-    try:
+    sensor = Switch(**discovery_info)
+
+    if discovery_info['new_join']:
+        in_clusters = discovery_info['in_clusters']
+        cluster = in_clusters[OnOff.cluster_id]
         await cluster.bind()
-        await cluster.configure_reporting(0, 0, 600, 1,)
-    except DeliveryError as ex:
-        _LOGGER.error("Unable to fetch switch status: %s", ex)
+        await cluster.configure_reporting(sensor.value_attribute, 0, 600, 1)
 
-    async_add_entities([Switch(**discovery_info)], update_before_add=True)
+    return sensor
 
 
 class Switch(zha.Entity, SwitchDevice):

--- a/homeassistant/components/switch/zha.py
+++ b/homeassistant/components/switch/zha.py
@@ -13,6 +13,7 @@ _LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = ['zha']
 
+
 async def async_setup_platform(hass, config, async_add_entities,
                                discovery_info=None):
     """Set up the Zigbee Home Automation switches."""
@@ -25,6 +26,7 @@ async def async_setup_platform(hass, config, async_add_entities,
 
 
 async def make_sensor(discovery_info):
+    """Create ZHA sensors factory."""
     from zigpy.zcl.clusters.general import OnOff
 
     sensor = Switch(**discovery_info)

--- a/homeassistant/components/switch/zha.py
+++ b/homeassistant/components/switch/zha.py
@@ -24,8 +24,13 @@ async def async_setup_platform(hass, config, async_add_entities,
     from zigpy.zcl.clusters.general import OnOff
     in_clusters = discovery_info['in_clusters']
     cluster = in_clusters[OnOff.cluster_id]
-    await cluster.bind()
-    await cluster.configure_reporting(0, 0, 600, 1,)
+
+    from zigpy.exceptions import DeliveryError
+    try:
+        await cluster.bind()
+        await cluster.configure_reporting(0, 0, 600, 1,)
+    except DeliveryError as ex:
+        _LOGGER.error("Unable to fetch switch status: %s", ex)
 
     async_add_entities([Switch(**discovery_info)], update_before_add=True)
 


### PR DESCRIPTION
## Description:
HA attempts to read the device state on startup, however the devices I have, this throws and exception which means the device add never completes and the device is inoperable.

This change catches the exception so that the device will still be added regardless.

**Related issue (if applicable):** NA

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io# NA

## Example entry for `configuration.yaml` (if applicable):
NA

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
