### PR TITLE
Add a base_url configuration setting to tts.

### DIFF
--- a/homeassistant/components/tts/__init__.py
+++ b/homeassistant/components/tts/__init__.py
@@ -48,7 +48,6 @@ CONF_BASE_URL = 'base_url'
 DEFAULT_CACHE = True
 DEFAULT_CACHE_DIR = 'tts'
 DEFAULT_TIME_MEMORY = 300
-DEFAULT_BASE_URL = ''
 DEPENDENCIES = ['http']
 DOMAIN = 'tts'
 
@@ -67,7 +66,7 @@ PLATFORM_SCHEMA = cv.PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_CACHE_DIR, default=DEFAULT_CACHE_DIR): cv.string,
     vol.Optional(CONF_TIME_MEMORY, default=DEFAULT_TIME_MEMORY):
         vol.All(vol.Coerce(int), vol.Range(min=60, max=57600)),
-    vol.Optional(CONF_BASE_URL, default=DEFAULT_BASE_URL): cv.string,
+    vol.Optional(CONF_BASE_URL): cv.string,
 })
 
 SCHEMA_SERVICE_SAY = vol.Schema({
@@ -90,10 +89,7 @@ async def async_setup(hass, config):
         use_cache = conf.get(CONF_CACHE, DEFAULT_CACHE)
         cache_dir = conf.get(CONF_CACHE_DIR, DEFAULT_CACHE_DIR)
         time_memory = conf.get(CONF_TIME_MEMORY, DEFAULT_TIME_MEMORY)
-        base_url = conf.get(CONF_BASE_URL, DEFAULT_BASE_URL)
-
-        if base_url == '':
-            base_url = hass.config.api.base_url
+        base_url = conf.get(CONF_BASE_URL) or hass.config.api.base_url
 
         await tts.async_init_cache(use_cache, cache_dir, time_memory, base_url)
     except (HomeAssistantError, KeyError) as err:
@@ -187,7 +183,7 @@ class SpeechManager:
         self.use_cache = DEFAULT_CACHE
         self.cache_dir = DEFAULT_CACHE_DIR
         self.time_memory = DEFAULT_TIME_MEMORY
-        self.base_url = DEFAULT_BASE_URL
+        self.base_url = None
         self.file_cache = {}
         self.mem_cache = {}
 

--- a/tests/components/tts/test_init.py
+++ b/tests/components/tts/test_init.py
@@ -97,10 +97,9 @@ class TestTTS:
 
         assert len(calls) == 1
         assert calls[0].data[ATTR_MEDIA_CONTENT_TYPE] == MEDIA_TYPE_MUSIC
-        assert calls[0].data[ATTR_MEDIA_CONTENT_ID].find(
-            "/api/tts_proxy/265944c108cbb00b2a621be5930513e03a0bb2cd"
-            "_en_-_demo.mp3") \
-            != -1
+        assert calls[0].data[ATTR_MEDIA_CONTENT_ID] == \
+            "{}/api/tts_proxy/265944c108cbb00b2a621be5930513e03a0bb2cd" \
+            "_en_-_demo.mp3".format(self.hass.config.api.base_url)
         assert os.path.isfile(os.path.join(
             self.default_tts_cache,
             "265944c108cbb00b2a621be5930513e03a0bb2cd_en_-_demo.mp3"))
@@ -126,10 +125,9 @@ class TestTTS:
 
         assert len(calls) == 1
         assert calls[0].data[ATTR_MEDIA_CONTENT_TYPE] == MEDIA_TYPE_MUSIC
-        assert calls[0].data[ATTR_MEDIA_CONTENT_ID].find(
-            "/api/tts_proxy/265944c108cbb00b2a621be5930513e03a0bb2cd"
-            "_de_-_demo.mp3") \
-            != -1
+        assert calls[0].data[ATTR_MEDIA_CONTENT_ID] == \
+            "{}/api/tts_proxy/265944c108cbb00b2a621be5930513e03a0bb2cd" \
+            "_de_-_demo.mp3".format(self.hass.config.api.base_url)
         assert os.path.isfile(os.path.join(
             self.default_tts_cache,
             "265944c108cbb00b2a621be5930513e03a0bb2cd_de_-_demo.mp3"))
@@ -167,10 +165,9 @@ class TestTTS:
 
         assert len(calls) == 1
         assert calls[0].data[ATTR_MEDIA_CONTENT_TYPE] == MEDIA_TYPE_MUSIC
-        assert calls[0].data[ATTR_MEDIA_CONTENT_ID].find(
-            "/api/tts_proxy/265944c108cbb00b2a621be5930513e03a0bb2cd"
-            "_de_-_demo.mp3") \
-            != -1
+        assert calls[0].data[ATTR_MEDIA_CONTENT_ID] == \
+            "{}/api/tts_proxy/265944c108cbb00b2a621be5930513e03a0bb2cd" \
+            "_de_-_demo.mp3".format(self.hass.config.api.base_url)
         assert os.path.isfile(os.path.join(
             self.default_tts_cache,
             "265944c108cbb00b2a621be5930513e03a0bb2cd_de_-_demo.mp3"))
@@ -225,10 +222,9 @@ class TestTTS:
 
         assert len(calls) == 1
         assert calls[0].data[ATTR_MEDIA_CONTENT_TYPE] == MEDIA_TYPE_MUSIC
-        assert calls[0].data[ATTR_MEDIA_CONTENT_ID].find(
-            "/api/tts_proxy/265944c108cbb00b2a621be5930513e03a0bb2cd"
-            "_de_{0}_demo.mp3".format(opt_hash)) \
-            != -1
+        assert calls[0].data[ATTR_MEDIA_CONTENT_ID] == \
+            "{}/api/tts_proxy/265944c108cbb00b2a621be5930513e03a0bb2cd" \
+            "_de_{}_demo.mp3".format(self.hass.config.api.base_url, opt_hash)
         assert os.path.isfile(os.path.join(
             self.default_tts_cache,
             "265944c108cbb00b2a621be5930513e03a0bb2cd_de_{0}_demo.mp3".format(
@@ -259,10 +255,9 @@ class TestTTS:
 
         assert len(calls) == 1
         assert calls[0].data[ATTR_MEDIA_CONTENT_TYPE] == MEDIA_TYPE_MUSIC
-        assert calls[0].data[ATTR_MEDIA_CONTENT_ID].find(
-            "/api/tts_proxy/265944c108cbb00b2a621be5930513e03a0bb2cd"
-            "_de_{0}_demo.mp3".format(opt_hash)) \
-            != -1
+        assert calls[0].data[ATTR_MEDIA_CONTENT_ID] == \
+            "{}/api/tts_proxy/265944c108cbb00b2a621be5930513e03a0bb2cd" \
+            "_de_{}_demo.mp3".format(self.hass.config.api.base_url, opt_hash)
         assert os.path.isfile(os.path.join(
             self.default_tts_cache,
             "265944c108cbb00b2a621be5930513e03a0bb2cd_de_{0}_demo.mp3".format(
@@ -297,6 +292,32 @@ class TestTTS:
             self.default_tts_cache,
             "265944c108cbb00b2a621be5930513e03a0bb2cd_de_{0}_demo.mp3".format(
                 opt_hash)))
+
+    def test_setup_component_and_test_service_with_base_url_set(self):
+        """Set up the demo platform with ``base_url`` set and call service."""
+        calls = mock_service(self.hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
+
+        config = {
+            tts.DOMAIN: {
+                'platform': 'demo',
+                'base_url': 'http://fnord',
+            }
+        }
+
+        with assert_setup_component(1, tts.DOMAIN):
+            setup_component(self.hass, tts.DOMAIN, config)
+
+        self.hass.services.call(tts.DOMAIN, 'demo_say', {
+            tts.ATTR_MESSAGE: "I person is on front of your door.",
+        })
+        self.hass.block_till_done()
+
+        assert len(calls) == 1
+        assert calls[0].data[ATTR_MEDIA_CONTENT_TYPE] == MEDIA_TYPE_MUSIC
+        assert calls[0].data[ATTR_MEDIA_CONTENT_ID] == \
+            "http://fnord" \
+            "/api/tts_proxy/265944c108cbb00b2a621be5930513e03a0bb2cd" \
+            "_en_-_demo.mp3"
 
     def test_setup_component_and_test_service_clear_cache(self):
         """Set up the demo platform and call service clear cache."""
@@ -507,10 +528,9 @@ class TestTTS:
         self.hass.block_till_done()
 
         assert len(calls) == 1
-        assert calls[0].data[ATTR_MEDIA_CONTENT_ID].find(
-            "/api/tts_proxy/265944c108cbb00b2a621be5930513e03a0bb2cd"
-            "_en_-_demo.mp3") \
-            != -1
+        assert calls[0].data[ATTR_MEDIA_CONTENT_ID] == \
+            "{}/api/tts_proxy/265944c108cbb00b2a621be5930513e03a0bb2cd" \
+            "_en_-_demo.mp3".format(self.hass.config.api.base_url)
 
     @patch('homeassistant.components.tts.demo.DemoProvider.get_tts_audio',
            return_value=(None, None))


### PR DESCRIPTION
## Description:

This adds a `base_url` configuration option for the `tts` component. For some usage scenarios, changing the `base_url` of the `http` component is not desirable. For instance, if someone is using a self-signed certificate to encrypt communications, the `say` service will not be able to play anything on a Google Home device, because the Google Home device will refuse to fetch from a `https://` url with a self-signed certificate. There's nothing that can be done on the Google Home end to fix this: you cannot install a new CA or do anything else. With the new `base_url` setting, it is possible to tell Google Home to fetch media at an `http://` address, and configure an `nginx` instance to serve only the URLs produced by `say` as `http` instead of `https`.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#6219

## Example entry for `configuration.yaml` (if applicable):

```yaml
tts:
  - platform: google
    base_url: http://192.168.0.10:8123
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)
  - [x] Tests have been added to verify that the new code works.
