### PR TITLE
Make ENTITY_ID_PATTERN not accept uppercase letters

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -63,7 +63,7 @@ DOMAIN = 'homeassistant'
 SERVICE_CALL_LIMIT = 10  # seconds
 
 # Pattern for validating entity IDs (format: <domain>.<entity>)
-ENTITY_ID_PATTERN = re.compile(r"^(\w+)\.(\w+)$")
+ENTITY_ID_PATTERN = re.compile(r"^([a-z0-9_]+)\.([a-z0-9_]+)$")
 
 # How long to wait till things that run on startup have to finish.
 TIMEOUT_EVENT_START = 15


### PR DESCRIPTION
## Description:
HASS isn't meant to allow uppercase characters in entity names, but the `ENTITY_ID_PATTERN` allows them. This PR changes the regex accordingly to not allow them.

**Related issue (if applicable):** fixes #14227

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
