### PR TITLE
Refactor zha/async_device_initialized()

### DIFF
--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -179,8 +179,6 @@ class ApplicationListener:
             if endpoint_id == 0:  # ZDO
                 continue
 
-            discovered_info = await _discover_endpoint_info(endpoint)
-
             component = None
             profile_clusters = ([], [])
             device_key = "{}-{}".format(device.ieee, endpoint_id)
@@ -212,10 +210,11 @@ class ApplicationListener:
                     'endpoint': endpoint,
                     'in_clusters': {c.cluster_id: c for c in in_clusters},
                     'out_clusters': {c.cluster_id: c for c in out_clusters},
+                    'manufacturer': endpoint.manufacturer,
+                    'model': endpoint.model,
                     'new_join': join,
                     'unique_id': device_key,
                 }
-                discovery_info.update(discovered_info)
                 self._hass.data[DISCOVERY_KEY][device_key] = discovery_info
 
                 await discovery.async_load_platform(
@@ -234,7 +233,6 @@ class ApplicationListener:
                     device_key,
                     zha_const.SINGLE_INPUT_CLUSTER_DEVICE_CLASS,
                     'in_clusters',
-                    discovered_info,
                     join,
                 )
 
@@ -246,7 +244,6 @@ class ApplicationListener:
                     device_key,
                     zha_const.SINGLE_OUTPUT_CLUSTER_DEVICE_CLASS,
                     'out_clusters',
-                    discovered_info,
                     join,
                 )
 
@@ -257,7 +254,7 @@ class ApplicationListener:
     async def _attempt_single_cluster_device(self, endpoint, cluster,
                                              profile_clusters, device_key,
                                              device_classes, discovery_attr,
-                                             entity_info, is_new_join):
+                                             is_new_join):
         """Try to set up an entity from a "bare" cluster."""
         if cluster.cluster_id in profile_clusters:
             return
@@ -277,12 +274,13 @@ class ApplicationListener:
             'endpoint': endpoint,
             'in_clusters': {},
             'out_clusters': {},
+            'manufacturer': endpoint.manufacturer,
+            'model': endpoint.model,
             'new_join': is_new_join,
             'unique_id': cluster_key,
             'entity_suffix': '_{}'.format(cluster.cluster_id),
         }
         discovery_info[discovery_attr] = {cluster.cluster_id: cluster}
-        discovery_info.update(entity_info)
         self._hass.data[DISCOVERY_KEY][cluster_key] = discovery_info
 
         await discovery.async_load_platform(
@@ -367,40 +365,6 @@ class Entity(entity.Entity):
     def zdo_command(self, tsn, command_id, args):
         """Handle a ZDO command received on this cluster."""
         pass
-
-
-async def _discover_endpoint_info(endpoint):
-    """Find some basic information about an endpoint."""
-    extra_info = {
-        'manufacturer': None,
-        'model': None,
-    }
-    if 0 not in endpoint.in_clusters:
-        return extra_info
-
-    async def read(attributes):
-        """Read attributes and update extra_info convenience function."""
-        result, _ = await endpoint.in_clusters[0].read_attributes(
-            attributes,
-            allow_cache=True,
-        )
-        extra_info.update(result)
-
-    await read(['manufacturer', 'model'])
-    if extra_info['manufacturer'] is None or extra_info['model'] is None:
-        # Some devices fail at returning multiple results. Attempt separately.
-        await read(['manufacturer'])
-        await read(['model'])
-
-    for key, value in extra_info.items():
-        if isinstance(value, bytes):
-            try:
-                extra_info[key] = value.decode('ascii').strip()
-            except UnicodeDecodeError:
-                # Unsure what the best behaviour here is. Unset the key?
-                pass
-
-    return extra_info
 
 
 def get_discovery_info(hass, discovery_info):


### PR DESCRIPTION
## Description:
Leverage endpoint.model and endpoint.manufacturer properties instead of reading manufacturer/model attributes.

Zigpy [PR#56](https://github.com/zigpy/zigpy/pull/56) stores manufacturer and model information as endpoint attributes. No need to read those, so no need for _discovery_endpoint_info() method.


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

