### PR TITLE
Upgrade pytest to 3.8.0 and pytest-timeout to 1.3.2

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -12,6 +12,6 @@ pylint==2.1.1
 pytest-aiohttp==0.3.0
 pytest-cov==2.5.1
 pytest-sugar==0.9.1
-pytest-timeout==1.3.1
-pytest==3.7.2
+pytest-timeout==1.3.2
+pytest==3.8.0
 requests_mock==1.5.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -13,8 +13,8 @@ pylint==2.1.1
 pytest-aiohttp==0.3.0
 pytest-cov==2.5.1
 pytest-sugar==0.9.1
-pytest-timeout==1.3.1
-pytest==3.7.2
+pytest-timeout==1.3.2
+pytest==3.8.0
 requests_mock==1.5.2
 
 


### PR DESCRIPTION
## Description:

Upgrade pytest to 3.8.0 and pytest-timeout to 1.3.2.

https://docs.pytest.org/en/latest/changelog.html#pytest-3-8-0-2018-09-05
https://bitbucket.org/pytest-dev/pytest-timeout/src#rst-header-changelog

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
