### PR TITLE
Wrong camera type & missing sensors when multiple Netatmo camera

### DIFF
--- a/homeassistant/components/netatmo.py
+++ b/homeassistant/components/netatmo.py
@@ -101,10 +101,10 @@ class CameraData:
         return self.module_names
 
     def get_camera_type(self, camera=None, home=None, cid=None):
-        """Return all module available on the API as a list."""
-        for camera_name in self.camera_names:
-            self.camera_type = self.camera_data.cameraType(camera_name)
-            return self.camera_type
+        """Return camera type for a camera, cid has preference over camera."""
+        self.camera_type = self.camera_data.cameraType(camera=camera,
+                                                       home=home, cid=cid)
+        return self.camera_type
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):


### PR DESCRIPTION
## Description:
Fixed an issue with Netatmo discovery where the camera_type (Camera Model) was incorrectly mapped for 2nd and subsequent cameras when their models were different from first camera.

The function get_camera_type was used incorrectly - it was accepting camera name as input but was not used, was always looping across all cameras and returning camera type of first camera as return string.

I suspect that a latent bug exist with another function update_event as it is using self.camera_type which is None, no change in functionality of that event updater with this PR, but has to be fixed later if binary sensors need specific events.

**Related issue (if applicable):** fixes #16331

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**