### PR TITLE
Add listener for OnAVStart and OnAVChange

### DIFF
--- a/homeassistant/components/media_player/kodi.py
+++ b/homeassistant/components/media_player/kodi.py
@@ -310,6 +310,8 @@ class KodiDevice(MediaPlayerDevice):
             # Register notification listeners
             self._ws_server.Player.OnPause = self.async_on_speed_event
             self._ws_server.Player.OnPlay = self.async_on_speed_event
+            self._ws_server.Player.OnAVStart = self.async_on_speed_event
+            self._ws_server.Player.OnAVChange = self.async_on_speed_event
             self._ws_server.Player.OnResume = self.async_on_speed_event
             self._ws_server.Player.OnSpeedChanged = self.async_on_speed_event
             self._ws_server.Player.OnStop = self.async_on_stop


### PR DESCRIPTION
With Kodi 18, OnPlay is called before an item actually started playing.
For this OnAVStart and OnAVChange have been introduced.

## Description:


~**Related issue (if applicable):** fixes #<home-assistant issue number goes here>~

~**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>~

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - ~[ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)~

If the code communicates with devices, web services, or third-party tools:
  - ~[ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).~
  - ~[ ] New dependencies are only imported inside functions that use them ([example][ex-import]).~
  - ~[ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.~
  - ~[ ] New files were added to `.coveragerc`.~

If the code does not interact with devices:
  - ~[ ] Tests have been added to verify that the new code works.~

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
