### PR TITLE
WIP: Adds Clarifai image processing

### DIFF
--- a/homeassistant/components/image_processing/clarifai_general.py
+++ b/homeassistant/components/image_processing/clarifai_general.py
@@ -68,10 +68,10 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     entities = []
     for camera in config[CONF_SOURCE]:
         entities.append(ClarifaiClassifier(
-            camera.get(CONF_NAME),
             app,
             config[CONF_CONCEPTS],
             camera[CONF_ENTITY_ID],
+            camera.get(CONF_NAME),
         ))
     add_devices(entities)
 
@@ -79,7 +79,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class ClarifaiClassifier(ImageProcessingEntity):
     """Perform a classification via Clarifai."""
 
-    def __init__(self, name, app, concepts, camera_entity):
+    def __init__(self, app, concepts, camera_entity, name=None):
         """Init with the API key."""
         model = 'general-v1.3'
         self.model = app.models.get(model)

--- a/homeassistant/components/image_processing/clarifai_general.py
+++ b/homeassistant/components/image_processing/clarifai_general.py
@@ -1,8 +1,8 @@
 """
-Component that will perform image classification via Clarifai.
+Component that will perform image classification via Clarifai general model.
 
 For more details about this platform, please refer to the documentation at
-https://home-assistant.io/components/image_processing/clarifai
+https://home-assistant.io/components/image_processing/clarifai_general
 """
 import base64
 import json
@@ -90,8 +90,8 @@ class ClarifaiClassifier(ImageProcessingEntity):
             self._name = "{} {}".format(CLASSIFIER, entity_name)
         self._concepts = concepts
         self._camera_entity = camera_entity
-        self._classifications = {}  # The dict of classifications
-        self._state = None    # The most likely classification
+        self._classifications = {}  # The dict of classifications.
+        self._state = None  # The most likely classification.
 
     def process_image(self, image):
         """Perform classification of a single image."""

--- a/homeassistant/components/image_processing/clarifai_general.py
+++ b/homeassistant/components/image_processing/clarifai_general.py
@@ -1,0 +1,143 @@
+"""
+Component that will perform image classification via Clarifai.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/image_processing/clarifai
+"""
+import base64
+import json
+import logging
+
+import voluptuous as vol
+
+from homeassistant.core import split_entity_id
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.image_processing import (
+    PLATFORM_SCHEMA, ImageProcessingEntity, CONF_SOURCE, CONF_ENTITY_ID,
+    CONF_NAME)
+
+_LOGGER = logging.getLogger(__name__)
+
+CLASSIFIER = 'Clarifai'
+CONF_API_KEY = 'api_key'
+CONF_CONCEPTS = 'concepts'
+DEFAULT_CONCEPTS = 'None'
+EVENT_MODEL_PREDICTION = 'image_processing.model_prediction'
+
+REQUIREMENTS = ['clarifai==2.2.3']
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_API_KEY): cv.string,
+    vol.Optional(CONF_CONCEPTS, default=[DEFAULT_CONCEPTS]):
+        vol.All(cv.ensure_list, [cv.string]),
+})
+
+
+def encode_image(image):
+    """base64 encode an image stream."""
+    base64_img = base64.b64encode(image)
+    return base64_img
+
+
+def parse_concepts(api_concepts):
+    """Parse the API concepts data."""
+    return {concept['name']: round(100.0*concept['value'], 2)
+            for concept in api_concepts}
+
+
+def validate_api_key(api_key):
+    """Check that an API key is valid, if yes return the app."""
+    try:
+        from clarifai.rest import ClarifaiApp, ApiError
+        app = ClarifaiApp(api_key=api_key)
+        return app
+    except ApiError as exc:
+        error = json.loads(exc.response.content)
+        _LOGGER.error(
+            "%s error: %s", CLASSIFIER, error['status']['details'])
+        return None
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the Clarifai classifier."""
+    api_key = config[CONF_API_KEY]
+    app = validate_api_key(api_key)
+    if app is None:
+        return
+
+    entities = []
+    for camera in config[CONF_SOURCE]:
+        entities.append(ClarifaiClassifier(
+            camera.get(CONF_NAME),
+            app,
+            config[CONF_CONCEPTS],
+            camera[CONF_ENTITY_ID],
+        ))
+    add_devices(entities)
+
+
+class ClarifaiClassifier(ImageProcessingEntity):
+    """Perform a classification via Clarifai."""
+
+    def __init__(self, name, app, concepts, camera_entity):
+        """Init with the API key."""
+        model = 'general-v1.3'
+        self.model = app.models.get(model)
+        if name:  # Since name is optional.
+            self._name = name
+        else:
+            entity_name = split_entity_id(camera_entity)[1]
+            self._name = "{} {}".format(CLASSIFIER, entity_name)
+        self._concepts = concepts
+        self._camera_entity = camera_entity
+        self._classifications = {}  # The dict of classifications
+        self._state = None    # The most likely classification
+
+    def process_image(self, image):
+        """Perform classification of a single image."""
+        response = self.model.predict_by_base64(encode_image(image))
+
+        if response['status']['description'] == 'Ok':
+            api_concepts = response['outputs'][0]['data']['concepts']
+            self._classifications = parse_concepts(api_concepts)
+            self._state = next(iter(self._classifications))
+            self.fire_concept_events()
+        else:
+            self._state = "Request_failed"
+            self._classifications = {}
+
+    def fire_concept_events(self):
+        """Fire an event for each concept identified."""
+        identified_concepts = self._classifications.keys() & self._concepts
+        for concept in identified_concepts:
+            self.hass.bus.fire(
+                EVENT_MODEL_PREDICTION, {
+                    CONF_ENTITY_ID: self._camera_entity,
+                    'concept': concept,
+                    })
+
+    @property
+    def device_class(self):
+        """Return the class of this device, from component DEVICE_CLASSES."""
+        return 'class'
+
+    @property
+    def camera_entity(self):
+        """Return camera entity id from process pictures."""
+        return self._camera_entity
+
+    @property
+    def state(self):
+        """Return the state of the entity."""
+        return self._state
+
+    @property
+    def state_attributes(self):
+        """Return device specific state attributes."""
+        attr = self._classifications
+        return attr
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -230,6 +230,9 @@ caldav==0.5.0
 # homeassistant.components.notify.ciscospark
 ciscosparkapi==0.4.2
 
+# homeassistant.components.image_processing.clarifai_general
+clarifai==2.2.3
+
 # homeassistant.components.coinbase
 coinbase==2.1.0
 

--- a/tests/components/image_processing/test_clarifai_general.py
+++ b/tests/components/image_processing/test_clarifai_general.py
@@ -12,12 +12,6 @@ import homeassistant.components.image_processing.clarifai_general as cg
 
 # Mock data returned by the Clarifai API.
 
-MOCK_HEALTH = {'success': True,
-               'hostname': 'b893cc4f7fd6',
-               'metadata': {'boxname': 'facebox', 'build': 'development'},
-               'errors': []}
-
-
 MOCK_NAME = 'mock_name'
 MOCK_API_KEY = '12345'
 
@@ -132,3 +126,4 @@ async def test_setup_platform_with_name(hass, mock_app):
     assert hass.states.get(named_entity_id)
     state = hass.states.get(named_entity_id)
     assert state.attributes.get(CONF_FRIENDLY_NAME) == MOCK_NAME
+

--- a/tests/components/image_processing/test_clarifai_general.py
+++ b/tests/components/image_processing/test_clarifai_general.py
@@ -1,0 +1,79 @@
+"""The tests for the clarifai_general component."""
+from unittest.mock import Mock, mock_open, patch
+
+import pytest
+import requests
+import requests_mock
+
+from homeassistant.core import callback
+from homeassistant.const import (
+    ATTR_ENTITY_ID, ATTR_NAME, CONF_FRIENDLY_NAME, CONF_PASSWORD,
+    CONF_USERNAME, CONF_IP_ADDRESS, CONF_PORT,
+    HTTP_BAD_REQUEST, HTTP_OK, HTTP_UNAUTHORIZED, STATE_UNKNOWN)
+from homeassistant.setup import async_setup_component
+import homeassistant.components.image_processing as ip
+import homeassistant.components.image_processing.clarifai_general as cg
+
+
+# Mock data returned by the Clarifai API.
+
+MOCK_HEALTH = {'success': True,
+               'hostname': 'b893cc4f7fd6',
+               'metadata': {'boxname': 'facebox', 'build': 'development'},
+               'errors': []}
+
+
+MOCK_NAME = 'mock_name'
+MOCK_API_KEY = '12345'
+
+RAW_CONCEPTS = [
+    {'id': 'ai_Q', 'name': 'dog', 'value': 0.65432, 'app_id': 'main'},
+    {'id': 'ai_c', 'name': 'cat', 'value': 0.34568, 'app_id': 'main'}
+]
+
+# Concepts data after parsing.
+PARSED_CONCEPTS = {'cat': 34.57, 'dog': 65.43}
+
+VALID_ENTITY_ID = 'image_processing.clarifai_demo_camera'
+VALID_CONFIG = {
+    ip.DOMAIN: {
+        'platform': 'clarifai_general',
+        cg.CONF_API_KEY: MOCK_API_KEY,
+        ip.CONF_SOURCE: {
+            ip.CONF_ENTITY_ID: 'camera.demo_camera'}
+        },
+    'camera': {
+        'platform': 'demo'
+        }
+    }
+
+
+@pytest.fixture
+def mock_clarifai():
+    """Return a mock camera image."""
+    with patch('clarifai.rest.ClarifaiApp') as _mock_clarifai:
+        yield _mock_clarifai
+
+
+@pytest.fixture
+def mock_image():
+    """Return a mock camera image."""
+    with patch('homeassistant.components.camera.demo.DemoCamera.camera_image',
+               return_value=b'Test') as image:
+        yield image
+
+
+def test_encode_image():
+    """Test that binary data is encoded correctly."""
+    assert cg.encode_image(b'test') == b'dGVzdA=='
+
+
+def test_parse_data():
+    """Test parsing of raw face data, and generation of matched_faces."""
+    assert cg.parse_concepts(RAW_CONCEPTS) == PARSED_CONCEPTS
+
+
+async def test_setup_platform(hass, mock_clarifai, mock_image):
+    """Set up platform with one entity."""
+    await async_setup_component(hass, ip.DOMAIN, VALID_CONFIG)
+    assert hass.states.get(VALID_ENTITY_ID)

--- a/tests/components/image_processing/test_clarifai_general.py
+++ b/tests/components/image_processing/test_clarifai_general.py
@@ -1,15 +1,10 @@
 """The tests for the clarifai_general component."""
-from unittest.mock import Mock, mock_open, patch
+from unittest.mock import patch
 
 import pytest
-import requests
-import requests_mock
 
 from homeassistant.core import callback
-from homeassistant.const import (
-    ATTR_ENTITY_ID, ATTR_NAME, CONF_FRIENDLY_NAME, CONF_PASSWORD,
-    CONF_USERNAME, CONF_IP_ADDRESS, CONF_PORT,
-    HTTP_BAD_REQUEST, HTTP_OK, HTTP_UNAUTHORIZED, STATE_UNKNOWN)
+from homeassistant.const import ATTR_ENTITY_ID, CONF_FRIENDLY_NAME
 from homeassistant.setup import async_setup_component
 import homeassistant.components.image_processing as ip
 import homeassistant.components.image_processing.clarifai_general as cg
@@ -94,10 +89,10 @@ def test_valid_api_key(mock_app):
 def test_invalid_api_key(caplog, mock_app):
     """Test that an invalid api key is caught."""
     pass
-    #from clarifai.rest import ApiError
-    #mock_app.side_effect = ApiError
-    #cg.validate_api_key(MOCK_API_KEY)
-    #assert "Clarifai error: Key not found" in caplog.text
+    # from clarifai.rest import ApiError
+    # mock_app.side_effect = ApiError
+    # cg.validate_api_key(MOCK_API_KEY)
+    # assert "Clarifai error: Key not found" in caplog.text
 
 
 async def test_setup_platform(hass, mock_app, mock_image):

--- a/tests/components/image_processing/test_clarifai_general.py
+++ b/tests/components/image_processing/test_clarifai_general.py
@@ -8,6 +8,7 @@ from homeassistant.const import ATTR_ENTITY_ID, CONF_FRIENDLY_NAME
 from homeassistant.setup import async_setup_component
 import homeassistant.components.image_processing as ip
 import homeassistant.components.image_processing.clarifai_general as cg
+from tests.common import MockDependency
 
 
 # Mock data returned by the Clarifai API.
@@ -89,12 +90,14 @@ def test_invalid_api_key(caplog, mock_app):
     # assert "Clarifai error: Key not found" in caplog.text
 
 
+@MockDependency('clarifai')
 async def test_setup_platform(hass, mock_app, mock_image):
     """Set up platform with one entity."""
     await async_setup_component(hass, ip.DOMAIN, VALID_CONFIG)
     assert hass.states.get(VALID_ENTITY_ID)
 
 
+@MockDependency('clarifai')
 async def test_process_image(hass, mock_app, mock_image, mock_response):
     """Test successful processing of an image."""
     await async_setup_component(hass, ip.DOMAIN, VALID_CONFIG)
@@ -115,6 +118,7 @@ async def test_process_image(hass, mock_app, mock_image, mock_response):
     await hass.async_block_till_done()
 
 
+@MockDependency('clarifai')
 async def test_setup_platform_with_name(hass, mock_app):
     """Set up platform with one entity and a name."""
     named_entity_id = 'image_processing.{}'.format(MOCK_NAME)

--- a/tests/components/image_processing/test_clarifai_general.py
+++ b/tests/components/image_processing/test_clarifai_general.py
@@ -49,10 +49,10 @@ VALID_CONFIG = {
 
 
 @pytest.fixture
-def mock_clarifai():
+def mock_app():
     """Return a mock camera image."""
-    with patch('clarifai.rest.ClarifaiApp') as _mock_clarifai:
-        yield _mock_clarifai
+    with patch('clarifai.rest.ClarifaiApp') as _mock_app:
+        yield _mock_app
 
 
 @pytest.fixture
@@ -73,7 +73,13 @@ def test_parse_data():
     assert cg.parse_concepts(RAW_CONCEPTS) == PARSED_CONCEPTS
 
 
-async def test_setup_platform(hass, mock_clarifai, mock_image):
+def test_validate_api_key(mock_app):
+    """Test that the api key is validated."""
+    cg.validate_api_key(MOCK_API_KEY)
+    mock_app.assert_called_with(api_key=MOCK_API_KEY)
+
+
+async def test_setup_platform(hass, mock_app, mock_image):
     """Set up platform with one entity."""
     await async_setup_component(hass, ip.DOMAIN, VALID_CONFIG)
     assert hass.states.get(VALID_ENTITY_ID)

--- a/tests/components/image_processing/test_clarifai_general.py
+++ b/tests/components/image_processing/test_clarifai_general.py
@@ -73,10 +73,19 @@ def test_parse_data():
     assert cg.parse_concepts(RAW_CONCEPTS) == PARSED_CONCEPTS
 
 
-def test_validate_api_key(mock_app):
+def test_valid_api_key(mock_app):
     """Test that the api key is validated."""
     cg.validate_api_key(MOCK_API_KEY)
     mock_app.assert_called_with(api_key=MOCK_API_KEY)
+
+
+def test_invalid_api_key(caplog, mock_app):
+    """Test that an invalid api key is caught."""
+    pass
+    #from clarifai.rest import ApiError
+    #mock_app.side_effect = ApiError
+    #cg.validate_api_key(MOCK_API_KEY)
+    #assert "Clarifai error: Key not found" in caplog.text
 
 
 async def test_setup_platform(hass, mock_app, mock_image):


### PR DESCRIPTION
## Description:
Adds [Clarifai](https://www.clarifai.com/) image processing using the [general model](https://www.clarifai.com/models/general-image-recognition-model-aaa03c23b3724a16a56b629203edc62c). The component creates an entity with a state that is the most likely concept (objects or ideas) within a camera image. The entities attributes contains a dictionary of all identified concepts and their probability (in %). A `image_processing.model_prediction` event is fired for each concept predicted by the model. To setup authentication with Clarifai, first generate an API key (YOUR_KEY) as per the [Clarifai docs](https://www.clarifai.com/developer/docs/). The [free plan](https://www.clarifai.com/pricing) allows 5000 requests per month.

## WIP
1. I'm not sure why I'm getting the test error `'homeassistant.components.image_processing.clarifai_general' is not a package
`
2. I'm not sure how to mock the `ApiError` error

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.io/pull/6284) with documentation (if applicable):** home-assistant/home-assistant.github.io#6284

## Example entry for `configuration.yaml` (if applicable):
```yaml
image_processing:
  - platform: clarifai_general
    api_key: abcd
    source:
      - entity_id: camera.local_file
    concepts:
      - dog
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
