### PR TITLE
Store notifications in component. Add ws endpoint for fetching.

### DIFF
--- a/tests/components/persistent_notification/test_init.py
+++ b/tests/components/persistent_notification/test_init.py
@@ -1,5 +1,6 @@
 """The tests for the persistent notification component."""
-from homeassistant.setup import setup_component
+from homeassistant.components import websocket_api
+from homeassistant.setup import setup_component, async_setup_component
 import homeassistant.components.persistent_notification as pn
 
 from tests.common import get_test_home_assistant
@@ -20,6 +21,7 @@ class TestPersistentNotification:
     def test_create(self):
         """Test creating notification without title or notification id."""
         assert len(self.hass.states.entity_ids(pn.DOMAIN)) == 0
+        assert len(pn.PERSISTENT_NOTIFICATIONS) == 0
 
         pn.create(self.hass, 'Hello World {{ 1 + 1 }}',
                   title='{{ 1 + 1 }} beers')
@@ -27,54 +29,162 @@ class TestPersistentNotification:
 
         entity_ids = self.hass.states.entity_ids(pn.DOMAIN)
         assert len(entity_ids) == 1
+        assert len(pn.PERSISTENT_NOTIFICATIONS) == 1
 
         state = self.hass.states.get(entity_ids[0])
         assert state.state == pn.STATE
         assert state.attributes.get('message') == 'Hello World 2'
         assert state.attributes.get('title') == '2 beers'
 
+        notification = pn.PERSISTENT_NOTIFICATIONS.get(entity_ids[0])
+        assert notification['status'] == pn.STATUS_UNREAD
+        assert notification['message'] == 'Hello World 2'
+        assert notification['title'] == '2 beers'
+        pn.PERSISTENT_NOTIFICATIONS.clear()
+
     def test_create_notification_id(self):
         """Ensure overwrites existing notification with same id."""
         assert len(self.hass.states.entity_ids(pn.DOMAIN)) == 0
+        assert len(pn.PERSISTENT_NOTIFICATIONS) == 0
 
         pn.create(self.hass, 'test', notification_id='Beer 2')
         self.hass.block_till_done()
 
         assert len(self.hass.states.entity_ids()) == 1
-        state = self.hass.states.get('persistent_notification.beer_2')
+        assert len(pn.PERSISTENT_NOTIFICATIONS) == 1
+
+        entity_id = 'persistent_notification.beer_2'
+        state = self.hass.states.get(entity_id)
         assert state.attributes.get('message') == 'test'
+
+        notification = pn.PERSISTENT_NOTIFICATIONS.get(entity_id)
+        assert notification['message'] == 'test'
+        assert notification['title'] is None
 
         pn.create(self.hass, 'test 2', notification_id='Beer 2')
         self.hass.block_till_done()
 
         # We should have overwritten old one
         assert len(self.hass.states.entity_ids()) == 1
-        state = self.hass.states.get('persistent_notification.beer_2')
+        state = self.hass.states.get(entity_id)
         assert state.attributes.get('message') == 'test 2'
+
+        notification = pn.PERSISTENT_NOTIFICATIONS.get(entity_id)
+        assert notification['message'] == 'test 2'
+        pn.PERSISTENT_NOTIFICATIONS.clear()
 
     def test_create_template_error(self):
         """Ensure we output templates if contain error."""
         assert len(self.hass.states.entity_ids(pn.DOMAIN)) == 0
+        assert len(pn.PERSISTENT_NOTIFICATIONS) == 0
 
         pn.create(self.hass, '{{ message + 1 }}', '{{ title + 1 }}')
         self.hass.block_till_done()
 
         entity_ids = self.hass.states.entity_ids(pn.DOMAIN)
         assert len(entity_ids) == 1
+        assert len(pn.PERSISTENT_NOTIFICATIONS) == 1
 
         state = self.hass.states.get(entity_ids[0])
         assert state.attributes.get('message') == '{{ message + 1 }}'
         assert state.attributes.get('title') == '{{ title + 1 }}'
 
+        notification = pn.PERSISTENT_NOTIFICATIONS.get(entity_ids[0])
+        assert notification['message'] == '{{ message + 1 }}'
+        assert notification['title'] == '{{ title + 1 }}'
+        pn.PERSISTENT_NOTIFICATIONS.clear()
+
     def test_dismiss_notification(self):
         """Ensure removal of specific notification."""
         assert len(self.hass.states.entity_ids(pn.DOMAIN)) == 0
+        assert len(pn.PERSISTENT_NOTIFICATIONS) == 0
 
         pn.create(self.hass, 'test', notification_id='Beer 2')
         self.hass.block_till_done()
 
         assert len(self.hass.states.entity_ids(pn.DOMAIN)) == 1
+        assert len(pn.PERSISTENT_NOTIFICATIONS) == 1
         pn.dismiss(self.hass, notification_id='Beer 2')
         self.hass.block_till_done()
 
         assert len(self.hass.states.entity_ids(pn.DOMAIN)) == 0
+        assert len(pn.PERSISTENT_NOTIFICATIONS) == 0
+        pn.PERSISTENT_NOTIFICATIONS.clear()
+
+    def test_mark_read(self):
+        """Ensure notification is marked as Read."""
+        assert len(pn.PERSISTENT_NOTIFICATIONS) == 0
+
+        pn.create(self.hass, 'test', notification_id='Beer 2')
+        self.hass.block_till_done()
+
+        entity_id = 'persistent_notification.beer_2'
+        assert len(pn.PERSISTENT_NOTIFICATIONS) == 1
+        notification = pn.PERSISTENT_NOTIFICATIONS.get(entity_id)
+        assert notification['status'] == pn.STATUS_UNREAD
+
+        pn.mark_read(self.hass, notification_id='Beer 2')
+        self.hass.block_till_done()
+
+        assert len(pn.PERSISTENT_NOTIFICATIONS) == 1
+        notification = pn.PERSISTENT_NOTIFICATIONS.get(entity_id)
+        assert notification['status'] == pn.STATUS_READ
+        pn.PERSISTENT_NOTIFICATIONS.clear()
+
+
+async def test_ws_get_notifications(hass, hass_ws_client):
+    """Test websocket endpoint for retrieving persistent notifications."""
+    await async_setup_component(hass, pn.DOMAIN, {})
+
+    client = await hass_ws_client(hass)
+
+    await client.send_json({
+        'id': 5,
+        'type': 'persistent_notification/get'
+    })
+    msg = await client.receive_json()
+    assert msg['id'] == 5
+    assert msg['type'] == websocket_api.TYPE_RESULT
+    assert msg['success']
+    notifications = msg['result']
+    assert len(notifications) == 0
+
+    # Create
+    hass.components.persistent_notification.async_create(
+        'test', notification_id='Beer 2')
+    await client.send_json({
+        'id': 6,
+        'type': 'persistent_notification/get'
+    })
+    msg = await client.receive_json()
+    assert msg['id'] == 6
+    assert msg['type'] == websocket_api.TYPE_RESULT
+    assert msg['success']
+    notifications = msg['result']
+    assert len(notifications) == 1
+    notification = notifications[0]
+    assert notification['notification_id'] == 'Beer 2'
+    assert notification['message'] == 'test'
+    assert notification['title'] is None
+    assert notification['status'] == pn.STATUS_UNREAD
+
+    # Mark Read
+    hass.components.persistent_notification.async_mark_read('Beer 2')
+    await client.send_json({
+        'id': 7,
+        'type': 'persistent_notification/get'
+    })
+    msg = await client.receive_json()
+    notifications = msg['result']
+    assert len(notifications) == 1
+    assert notifications[0]['status'] == pn.STATUS_READ
+
+    # Dismiss
+    hass.components.persistent_notification.async_dismiss('Beer 2')
+    await client.send_json({
+        'id': 8,
+        'type': 'persistent_notification/get'
+    })
+    msg = await client.receive_json()
+    notifications = msg['result']
+    assert len(notifications) == 0


### PR DESCRIPTION
## Description:
Depends on https://github.com/home-assistant/home-assistant-polymer/pull/1649

This is initial MVP for component storage of persistent notifications. Eventually they will be removed from the state machine, but this leaves them there for now so it is not a breaking change.

**Related issue (if applicable):** fixes #15071


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
