### PR TITLE
Upnp setup improvements

### DIFF
--- a/homeassistant/components/upnp.py
+++ b/homeassistant/components/upnp.py
@@ -77,6 +77,7 @@ async def async_setup(hass, config):
     service = None
     resp = await pyupnp_async.msearch_first(search_target=IGD_DEVICE)
     if not resp:
+        _LOGGER.warning("Could not find any UPnP IGD")
         return False
 
     try:
@@ -98,7 +99,7 @@ async def async_setup(hass, config):
         return False
 
     if not service:
-        _LOGGER.warning("Could not find any UPnP IGD")
+        _LOGGER.warning("Could not find UPnP service for port mapping")
         return False
 
     port_mapping = config[CONF_ENABLE_PORT_MAPPING]

--- a/homeassistant/components/upnp.py
+++ b/homeassistant/components/upnp.py
@@ -80,6 +80,7 @@ async def async_setup(hass, config):
         _LOGGER.warning("Could not find any UPnP IGD")
         return False
 
+    cic_found = False
     try:
         device = await resp.get_device()
         hass.data[DATA_UPNP] = device
@@ -91,6 +92,7 @@ async def async_setup(hass, config):
             if _service['serviceType'] == IP_SERVICE2:
                 service = device.find_first_service(IP_SERVICE2)
             if _service['serviceType'] == CIC_SERVICE:
+                cic_found = True
                 unit = config[CONF_UNITS]
                 hass.async_create_task(discovery.async_load_platform(
                     hass, 'sensor', DOMAIN, {'unit': unit}, config))
@@ -98,13 +100,13 @@ async def async_setup(hass, config):
         _LOGGER.error(error)
         return False
 
-    if not service:
-        _LOGGER.warning("Could not find UPnP service for port mapping")
-        return False
-
     port_mapping = config[CONF_ENABLE_PORT_MAPPING]
     if not port_mapping:
         return True
+
+    if not service:
+        _LOGGER.warning("Could not find UPnP service for port mapping")
+        return cic_found
 
     internal_port = hass.http.server_port
 


### PR DESCRIPTION
## Description:

See individual commit messages for more details.

I encountered these when adding a simple upnp entry with no other config to my setup. There were no upnp routers in the net, so I was greeted by a upnp setup failure message, but no further info anywhere.

Second, if configuring upnp with no further port config, I don't think it's good to report a failure if CIC services were discovered when there were no port mapping services discovered but port mapping wasn't even requested.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
