### PR TITLE
Upgrade wakeonlan to 1.1.6

### DIFF
--- a/homeassistant/components/media_player/panasonic_viera.py
+++ b/homeassistant/components/media_player/panasonic_viera.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
     STATE_UNKNOWN)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['panasonic_viera==0.3.1', 'wakeonlan==1.0.0']
+REQUIREMENTS = ['panasonic_viera==0.3.1', 'wakeonlan==1.1.6']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/media_player/samsungtv.py
+++ b/homeassistant/components/media_player/samsungtv.py
@@ -24,7 +24,7 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import dt as dt_util
 
-REQUIREMENTS = ['samsungctl[websocket]==0.7.1', 'wakeonlan==1.0.0']
+REQUIREMENTS = ['samsungctl[websocket]==0.7.1', 'wakeonlan==1.1.6']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/wake_on_lan.py
+++ b/homeassistant/components/wake_on_lan.py
@@ -13,10 +13,11 @@ import voluptuous as vol
 from homeassistant.const import CONF_MAC
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['wakeonlan==1.0.0']
+REQUIREMENTS = ['wakeonlan==1.1.6']
 
-DOMAIN = "wake_on_lan"
 _LOGGER = logging.getLogger(__name__)
+
+DOMAIN = 'wake_on_lan'
 
 CONF_BROADCAST_ADDRESS = 'broadcast_address'
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1461,7 +1461,7 @@ vultr==0.1.2
 # homeassistant.components.media_player.panasonic_viera
 # homeassistant.components.media_player.samsungtv
 # homeassistant.components.switch.wake_on_lan
-wakeonlan==1.0.0
+wakeonlan==1.1.6
 
 # homeassistant.components.sensor.waqi
 waqiasync==1.0.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -222,7 +222,7 @@ vultr==0.1.2
 # homeassistant.components.media_player.panasonic_viera
 # homeassistant.components.media_player.samsungtv
 # homeassistant.components.switch.wake_on_lan
-wakeonlan==1.0.0
+wakeonlan==1.1.6
 
 # homeassistant.components.cloud
 warrant==0.6.1


### PR DESCRIPTION
## Description:
Changelog: https://github.com/remcohaszing/pywakeonlan/releases

## Example entry for `configuration.yaml` (if applicable):
```yaml
wake_on_lan:
```

Service data: 

```json
{  
   "mac":"00:30:18:cf:0f:80"
}
```
```bash
2018-09-09 10:12:11 INFO (MainThread) [homeassistant.core] Bus:Handling <Event call_service[L]: domain=wake_on_lan, service=send_magic_packet, service_data=mac=00:30:18:cf:0f:80>
2018-09-09 10:12:11 INFO (MainThread) [homeassistant.components.wake_on_lan] Send magic packet to mac 00:30:18:cf:0f:80 (broadcast: None)
2018-09-09 10:12:11 INFO (MainThread) [homeassistant.core] Bus:Handling <Event service_executed[L]>
```

Traffic dump:

![screenshot from 2018-09-09 10-23-53](https://user-images.githubusercontent.com/116184/45262629-a8445500-b41a-11e8-9303-12e23dbfbd81.png)


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
