### PR TITLE
Extracting zoneminder to a new library

### DIFF
--- a/homeassistant/components/camera/zoneminder.py
+++ b/homeassistant/components/camera/zoneminder.py
@@ -10,18 +10,16 @@ import logging
 from homeassistant.const import CONF_NAME
 from homeassistant.components.camera.mjpeg import (
     CONF_MJPEG_URL, CONF_STILL_IMAGE_URL, MjpegCamera)
-from homeassistant.components.zoneminder import DOMAIN
+from homeassistant.components.zoneminder import DOMAIN as ZONEMINDER_DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = ['zoneminder']
 
 
-@asyncio.coroutine
-def async_setup_platform(hass, config, async_add_entities,
-                         discovery_info=None):
+def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the ZoneMinder cameras."""
-    zm = hass.data[DOMAIN]
+    zm = hass.data[ZONEMINDER_DOMAIN]
 
     monitors = zm.get_monitors()
     if not monitors:
@@ -32,12 +30,7 @@ def async_setup_platform(hass, config, async_add_entities,
     for monitor in monitors:
         _LOGGER.info("Initializing camera %s", monitor.id)
         cameras.append(ZoneMinderCamera(hass, monitor))
-
-    if not cameras:
-        _LOGGER.warning("No active cameras found")
-        return
-
-    async_add_entities(cameras)
+    add_entities(cameras)
 
 
 class ZoneMinderCamera(MjpegCamera):
@@ -51,7 +44,6 @@ class ZoneMinderCamera(MjpegCamera):
             CONF_STILL_IMAGE_URL: monitor.still_image_url
         }
         super().__init__(hass, device_info)
-        self._monitor_id = monitor.id
         self._is_recording = None
         self._monitor = monitor
 
@@ -62,7 +54,7 @@ class ZoneMinderCamera(MjpegCamera):
 
     def update(self):
         """Update our recording state from the ZM API."""
-        _LOGGER.debug("Updating camera state for monitor %i", self._monitor_id)
+        _LOGGER.debug("Updating camera state for monitor %i", self._monitor.id)
         self._is_recording = self._monitor.is_recording
 
     @property

--- a/homeassistant/components/camera/zoneminder.py
+++ b/homeassistant/components/camera/zoneminder.py
@@ -10,13 +10,11 @@ import logging
 from homeassistant.const import CONF_NAME
 from homeassistant.components.camera.mjpeg import (
     CONF_MJPEG_URL, CONF_STILL_IMAGE_URL, MjpegCamera)
-
-from homeassistant.components import zoneminder
+from homeassistant.components.zoneminder import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = ['zoneminder']
-DOMAIN = 'zoneminder'
 
 
 @asyncio.coroutine

--- a/homeassistant/components/camera/zoneminder.py
+++ b/homeassistant/components/camera/zoneminder.py
@@ -55,6 +55,7 @@ class ZoneMinderCamera(MjpegCamera):
         super().__init__(hass, device_info)
         self._monitor_id = monitor.id
         self._is_recording = None
+        self._monitor = monitor
 
     @property
     def should_poll(self):
@@ -64,14 +65,7 @@ class ZoneMinderCamera(MjpegCamera):
     def update(self):
         """Update our recording state from the ZM API."""
         _LOGGER.debug("Updating camera state for monitor %i", self._monitor_id)
-        status = self.hass.data[DOMAIN].is_recording(self._monitor_id)
-
-        if status is None:
-            _LOGGER.warning("Could not get status for monitor %i",
-                            self._monitor_id)
-            return
-
-        self._is_recording = status
+        self._is_recording = self._monitor.is_recording
 
     @property
     def is_recording(self):

--- a/homeassistant/components/camera/zoneminder.py
+++ b/homeassistant/components/camera/zoneminder.py
@@ -23,11 +23,10 @@ DOMAIN = 'zoneminder'
 def async_setup_platform(hass, config, async_add_entities,
                          discovery_info=None):
     """Set up the ZoneMinder cameras."""
-    from zoneminder.zm import ZoneMinder
-    zm: ZoneMinder = hass.data[DOMAIN]
+    zm = hass.data[DOMAIN]
 
     cameras = []
-    monitors = zoneminder.get_state('api/monitors.json')
+    monitors = zoneminder.get_state(hass, 'api/monitors.json')
     if not monitors:
         _LOGGER.warning("Could not fetch monitors from ZoneMinder")
         return

--- a/homeassistant/components/camera/zoneminder.py
+++ b/homeassistant/components/camera/zoneminder.py
@@ -4,7 +4,6 @@ Support for ZoneMinder camera streaming.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/camera.zoneminder/
 """
-import asyncio
 import logging
 
 from homeassistant.const import CONF_NAME
@@ -19,9 +18,9 @@ DEPENDENCIES = ['zoneminder']
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the ZoneMinder cameras."""
-    zm = hass.data[ZONEMINDER_DOMAIN]
+    zm_client = hass.data[ZONEMINDER_DOMAIN]
 
-    monitors = zm.get_monitors()
+    monitors = zm_client.get_monitors()
     if not monitors:
         _LOGGER.warning("Could not fetch monitors from ZoneMinder")
         return

--- a/homeassistant/components/sensor/zoneminder.py
+++ b/homeassistant/components/sensor/zoneminder.py
@@ -10,9 +10,8 @@ import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.components.zoneminder import DOMAIN
+from homeassistant.components.zoneminder import DOMAIN as ZONEMINDER_DOMAIN
 from homeassistant.const import CONF_MONITORED_CONDITIONS
-from homeassistant.const import STATE_UNKNOWN
 from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)
@@ -43,7 +42,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the ZoneMinder sensor platform."""
     include_archived = config.get(CONF_INCLUDE_ARCHIVED)
 
-    zm = hass.data[DOMAIN]
+    zm = hass.data[ZONEMINDER_DOMAIN]
     monitors = zm.get_monitors()
     if not monitors:
         _LOGGER.warning('Could not fetch any monitors from ZoneMinder')
@@ -80,7 +79,7 @@ class ZMSensorMonitors(Entity):
         """Update the sensor."""
         state = self._monitor.function
         if not state:
-            self._state = STATE_UNKNOWN
+            self._state = None
         else:
             self._state = state.value
 
@@ -113,9 +112,5 @@ class ZMSensorEvents(Entity):
 
     def update(self):
         """Update the sensor."""
-        events = self._monitor.get_events(
+        self._state = self._monitor.get_events(
             self.time_period, self._include_archived)
-        if not events:
-            self._state = 0
-        else:
-            self._state = events

--- a/homeassistant/components/sensor/zoneminder.py
+++ b/homeassistant/components/sensor/zoneminder.py
@@ -42,8 +42,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the ZoneMinder sensor platform."""
     include_archived = config.get(CONF_INCLUDE_ARCHIVED)
 
-    zm = hass.data[ZONEMINDER_DOMAIN]
-    monitors = zm.get_monitors()
+    zm_client = hass.data[ZONEMINDER_DOMAIN]
+    monitors = zm_client.get_monitors()
     if not monitors:
         _LOGGER.warning('Could not fetch any monitors from ZoneMinder')
 

--- a/homeassistant/components/sensor/zoneminder.py
+++ b/homeassistant/components/sensor/zoneminder.py
@@ -45,7 +45,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     sensors = []
 
-    monitors = zoneminder.get_state('api/monitors.json')
+    monitors = zoneminder.get_state(hass, 'api/monitors.json')
     for i in monitors['monitors']:
         sensors.append(
             ZMSensorMonitors(int(i['Monitor']['Id']), i['Monitor']['Name'])
@@ -83,8 +83,8 @@ class ZMSensorMonitors(Entity):
     def update(self):
         """Update the sensor."""
         monitor = zoneminder.get_state(
-            'api/monitors/{}.json'.format(self._monitor_id)
-        )
+            self.hass, 'api/monitors/{}.json'.format(
+                self._monitor_id))
         if monitor['monitor']['Monitor']['Function'] is None:
             self._state = STATE_UNKNOWN
         else:
@@ -131,10 +131,10 @@ class ZMSensorEvents(Entity):
         if self._include_archived:
             archived_filter = ''
 
-        event = zoneminder.get_state(
-            'api/events/consoleEvents/{}{}.json'.format(date_filter,
-                                                        archived_filter)
-        )
+        event = zoneminder.get_state(self.hass,
+                                     'api/events/consoleEvents/{}{}.json'.format(
+                                         date_filter,
+                                         archived_filter))
 
         try:
             self._state = event['results'][str(self._monitor_id)]

--- a/homeassistant/components/sensor/zoneminder.py
+++ b/homeassistant/components/sensor/zoneminder.py
@@ -8,12 +8,12 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import STATE_UNKNOWN
-from homeassistant.const import CONF_MONITORED_CONDITIONS
-from homeassistant.helpers.entity import Entity
-from homeassistant.components import zoneminder
 import homeassistant.helpers.config_validation as cv
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.components.zoneminder import DOMAIN
+from homeassistant.const import CONF_MONITORED_CONDITIONS
+from homeassistant.const import STATE_UNKNOWN
+from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -43,20 +43,17 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the ZoneMinder sensor platform."""
     include_archived = config.get(CONF_INCLUDE_ARCHIVED)
 
-    sensors = []
+    zm = hass.data[DOMAIN]
+    monitors = zm.get_monitors()
+    if not monitors:
+        _LOGGER.warning('Could not fetch any monitors from ZoneMinder')
 
-    monitors = zoneminder.get_state(hass, 'api/monitors.json')
-    for i in monitors['monitors']:
-        sensors.append(
-            ZMSensorMonitors(int(i['Monitor']['Id']), i['Monitor']['Name'])
-        )
+    sensors = []
+    for monitor in monitors:
+        sensors.append(ZMSensorMonitors(monitor))
 
         for sensor in config[CONF_MONITORED_CONDITIONS]:
-            sensors.append(
-                ZMSensorEvents(int(i['Monitor']['Id']),
-                               i['Monitor']['Name'],
-                               include_archived, sensor)
-            )
+            sensors.append(ZMSensorEvents(monitor, include_archived, sensor))
 
     add_entities(sensors)
 
@@ -64,16 +61,15 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class ZMSensorMonitors(Entity):
     """Get the status of each ZoneMinder monitor."""
 
-    def __init__(self, monitor_id, monitor_name):
+    def __init__(self, monitor):
         """Initialize monitor sensor."""
-        self._monitor_id = monitor_id
-        self._monitor_name = monitor_name
-        self._state = None
+        self._monitor = monitor
+        self._state = monitor.function.value
 
     @property
     def name(self):
         """Return the name of the sensor."""
-        return '{} Status'.format(self._monitor_name)
+        return '{} Status'.format(self._monitor.name)
 
     @property
     def state(self):
@@ -82,32 +78,28 @@ class ZMSensorMonitors(Entity):
 
     def update(self):
         """Update the sensor."""
-        monitor = zoneminder.get_state(
-            self.hass, 'api/monitors/{}.json'.format(
-                self._monitor_id))
-        if monitor['monitor']['Monitor']['Function'] is None:
+        state = self._monitor.function
+        if not state:
             self._state = STATE_UNKNOWN
         else:
-            self._state = monitor['monitor']['Monitor']['Function']
+            self._state = state.value
 
 
 class ZMSensorEvents(Entity):
     """Get the number of events for each monitor."""
 
-    def __init__(self, monitor_id, monitor_name, include_archived,
-                 sensor_type):
+    def __init__(self, monitor, include_archived, sensor_type):
         """Initialize event sensor."""
-        self._monitor_id = monitor_id
-        self._monitor_name = monitor_name
+        from zoneminder.monitor import TimePeriod
+        self._monitor = monitor
         self._include_archived = include_archived
-        self._type = sensor_type
-        self._name = SENSOR_TYPES[sensor_type][0]
+        self.time_period = TimePeriod.get_time_period(sensor_type)
         self._state = None
 
     @property
     def name(self):
         """Return the name of the sensor."""
-        return '{} {}'.format(self._monitor_name, self._name)
+        return '{} {}'.format(self._monitor.name, self.time_period.title)
 
     @property
     def unit_of_measurement(self):
@@ -121,22 +113,9 @@ class ZMSensorEvents(Entity):
 
     def update(self):
         """Update the sensor."""
-        date_filter = '1%20{}'.format(self._type)
-        if self._type == 'all':
-            # The consoleEvents API uses DATE_SUB, so give it
-            # something large
-            date_filter = '100%20year'
-
-        archived_filter = '/Archived=:0'
-        if self._include_archived:
-            archived_filter = ''
-
-        event = zoneminder.get_state(self.hass,
-                                     'api/events/consoleEvents/{}{}.json'.format(
-                                         date_filter,
-                                         archived_filter))
-
-        try:
-            self._state = event['results'][str(self._monitor_id)]
-        except (TypeError, KeyError):
-            self._state = '0'
+        events = self._monitor.get_events(
+            self.time_period, self._include_archived)
+        if not events:
+            self._state = 0
+        else:
+            self._state = events

--- a/homeassistant/components/switch/zoneminder.py
+++ b/homeassistant/components/switch/zoneminder.py
@@ -29,9 +29,9 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     on_state = MonitorState(config.get(CONF_COMMAND_ON))
     off_state = MonitorState(config.get(CONF_COMMAND_OFF))
 
-    zm = hass.data[ZONEMINDER_DOMAIN]
+    zm_client = hass.data[ZONEMINDER_DOMAIN]
 
-    monitors = zm.get_monitors()
+    monitors = zm_client.get_monitors()
     if not monitors:
         _LOGGER.warning('Could not fetch monitors from ZoneMinder')
         return

--- a/homeassistant/components/switch/zoneminder.py
+++ b/homeassistant/components/switch/zoneminder.py
@@ -9,8 +9,8 @@ import logging
 import voluptuous as vol
 
 from homeassistant.components.switch import (SwitchDevice, PLATFORM_SCHEMA)
+from homeassistant.components.zoneminder import DOMAIN
 from homeassistant.const import (CONF_COMMAND_ON, CONF_COMMAND_OFF)
-from homeassistant.components import zoneminder
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
@@ -25,22 +25,20 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the ZoneMinder switch platform."""
-    on_state = config.get(CONF_COMMAND_ON)
-    off_state = config.get(CONF_COMMAND_OFF)
+    from zoneminder.monitor import MonitorState
+    on_state = MonitorState(config.get(CONF_COMMAND_ON))
+    off_state = MonitorState(config.get(CONF_COMMAND_OFF))
+
+    zm = hass.data[DOMAIN]
+
+    monitors = zm.get_monitors()
+    if not monitors:
+        _LOGGER.warning("Could not fetch monitors from ZoneMinder")
+        return
 
     switches = []
-
-    monitors = zoneminder.get_state(hass, 'api/monitors.json')
-    for i in monitors['monitors']:
-        switches.append(
-            ZMSwitchMonitors(
-                int(i['Monitor']['Id']),
-                i['Monitor']['Name'],
-                on_state,
-                off_state
-            )
-        )
-
+    for monitor in monitors:
+        switches.append(ZMSwitchMonitors(monitor, on_state, off_state))
     add_entities(switches)
 
 
@@ -49,10 +47,9 @@ class ZMSwitchMonitors(SwitchDevice):
 
     icon = 'mdi:record-rec'
 
-    def __init__(self, monitor_id, monitor_name, on_state, off_state):
+    def __init__(self, monitor, on_state, off_state):
         """Initialize the switch."""
-        self._monitor_id = monitor_id
-        self._monitor_name = monitor_name
+        self._monitor = monitor
         self._on_state = on_state
         self._off_state = off_state
         self._state = None
@@ -60,13 +57,11 @@ class ZMSwitchMonitors(SwitchDevice):
     @property
     def name(self):
         """Return the name of the switch."""
-        return "%s State" % self._monitor_name
+        return "%s State" % self._monitor.name
 
     def update(self):
         """Update the switch value."""
-        monitor = zoneminder.get_state(self.hass,
-                                       'api/monitors/%i.json' % self._monitor_id)
-        current_state = monitor['monitor']['Monitor']['Function']
+        current_state = self._monitor.function
         self._state = True if current_state == self._on_state else False
 
     @property
@@ -76,12 +71,8 @@ class ZMSwitchMonitors(SwitchDevice):
 
     def turn_on(self, **kwargs):
         """Turn the entity on."""
-        zoneminder.change_state(self.hass,
-                                'api/monitors/%i.json' % self._monitor_id,
-                                {'Monitor[Function]': self._on_state})
+        self._monitor.set_function(self._on_state)
 
     def turn_off(self, **kwargs):
         """Turn the entity off."""
-        zoneminder.change_state(self.hass,
-                                'api/monitors/%i.json' % self._monitor_id,
-                                {'Monitor[Function]': self._off_state})
+        self._monitor.set_function(self._off_state)

--- a/homeassistant/components/switch/zoneminder.py
+++ b/homeassistant/components/switch/zoneminder.py
@@ -30,7 +30,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     switches = []
 
-    monitors = zoneminder.get_state('api/monitors.json')
+    monitors = zoneminder.get_state(hass, 'api/monitors.json')
     for i in monitors['monitors']:
         switches.append(
             ZMSwitchMonitors(
@@ -64,9 +64,8 @@ class ZMSwitchMonitors(SwitchDevice):
 
     def update(self):
         """Update the switch value."""
-        monitor = zoneminder.get_state(
-            'api/monitors/%i.json' % self._monitor_id
-        )
+        monitor = zoneminder.get_state(self.hass,
+                                       'api/monitors/%i.json' % self._monitor_id)
         current_state = monitor['monitor']['Monitor']['Function']
         self._state = True if current_state == self._on_state else False
 
@@ -77,14 +76,12 @@ class ZMSwitchMonitors(SwitchDevice):
 
     def turn_on(self, **kwargs):
         """Turn the entity on."""
-        zoneminder.change_state(
-            'api/monitors/%i.json' % self._monitor_id,
-            {'Monitor[Function]': self._on_state}
-        )
+        zoneminder.change_state(self.hass,
+                                'api/monitors/%i.json' % self._monitor_id,
+                                {'Monitor[Function]': self._on_state})
 
     def turn_off(self, **kwargs):
         """Turn the entity off."""
-        zoneminder.change_state(
-            'api/monitors/%i.json' % self._monitor_id,
-            {'Monitor[Function]': self._off_state}
-        )
+        zoneminder.change_state(self.hass,
+                                'api/monitors/%i.json' % self._monitor_id,
+                                {'Monitor[Function]': self._off_state})

--- a/homeassistant/components/switch/zoneminder.py
+++ b/homeassistant/components/switch/zoneminder.py
@@ -33,7 +33,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     monitors = zm.get_monitors()
     if not monitors:
-        _LOGGER.warning("Could not fetch monitors from ZoneMinder")
+        _LOGGER.warning('Could not fetch monitors from ZoneMinder')
         return
 
     switches = []
@@ -71,8 +71,8 @@ class ZMSwitchMonitors(SwitchDevice):
 
     def turn_on(self, **kwargs):
         """Turn the entity on."""
-        self._monitor.set_function(self._on_state)
+        self._monitor.function(self._on_state)
 
     def turn_off(self, **kwargs):
         """Turn the entity off."""
-        self._monitor.set_function(self._off_state)
+        self._monitor.function(self._off_state)

--- a/homeassistant/components/switch/zoneminder.py
+++ b/homeassistant/components/switch/zoneminder.py
@@ -9,7 +9,7 @@ import logging
 import voluptuous as vol
 
 from homeassistant.components.switch import (SwitchDevice, PLATFORM_SCHEMA)
-from homeassistant.components.zoneminder import DOMAIN
+from homeassistant.components.zoneminder import DOMAIN as ZONEMINDER_DOMAIN
 from homeassistant.const import (CONF_COMMAND_ON, CONF_COMMAND_OFF)
 import homeassistant.helpers.config_validation as cv
 
@@ -29,7 +29,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     on_state = MonitorState(config.get(CONF_COMMAND_ON))
     off_state = MonitorState(config.get(CONF_COMMAND_OFF))
 
-    zm = hass.data[DOMAIN]
+    zm = hass.data[ZONEMINDER_DOMAIN]
 
     monitors = zm.get_monitors()
     if not monitors:
@@ -57,12 +57,11 @@ class ZMSwitchMonitors(SwitchDevice):
     @property
     def name(self):
         """Return the name of the switch."""
-        return "%s State" % self._monitor.name
+        return '{}\'s State'.format(self._monitor.name)
 
     def update(self):
         """Update the switch value."""
-        current_state = self._monitor.function
-        self._state = True if current_state == self._on_state else False
+        self._state = self._monitor.function == self._on_state
 
     @property
     def is_on(self):

--- a/homeassistant/components/switch/zoneminder.py
+++ b/homeassistant/components/switch/zoneminder.py
@@ -70,8 +70,8 @@ class ZMSwitchMonitors(SwitchDevice):
 
     def turn_on(self, **kwargs):
         """Turn the entity on."""
-        self._monitor.function(self._on_state)
+        self._monitor.function = self._on_state
 
     def turn_off(self, **kwargs):
         """Turn the entity off."""
-        self._monitor.function(self._off_state)
+        self._monitor.function = self._off_state

--- a/homeassistant/components/zoneminder.py
+++ b/homeassistant/components/zoneminder.py
@@ -26,8 +26,6 @@ DOMAIN = 'zoneminder'
 
 LOGIN_RETRIES = 2
 
-ZM = None
-
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Required(CONF_HOST): cv.string,
@@ -44,8 +42,6 @@ CONFIG_SCHEMA = vol.Schema({
 def setup(hass, config):
     """Set up the ZoneMinder component."""
     from zoneminder.zm import ZoneMinder
-    global ZM
-    ZM = None
 
     conf = config[DOMAIN]
     if conf[CONF_SSL]:
@@ -54,27 +50,22 @@ def setup(hass, config):
         schema = 'http'
 
     server_origin = '{}://{}'.format(schema, conf[CONF_HOST])
-    ZM = ZoneMinder(server_origin, conf.get(CONF_USERNAME, None), conf.get(CONF_PASSWORD, None),
-                    conf.get(CONF_PATH), conf.get(CONF_PATH_ZMS), conf.get(CONF_VERIFY_SSL))
+    hass.data[DOMAIN] = ZoneMinder(server_origin,
+                                   conf.get(CONF_USERNAME, None),
+                                   conf.get(CONF_PASSWORD, None),
+                                   conf.get(CONF_PATH),
+                                   conf.get(CONF_PATH_ZMS),
+                                   conf.get(CONF_VERIFY_SSL))
 
-    hass.data[DOMAIN] = ZM
-
-    return login()
-
-
-def login():
-    """Login to the ZoneMinder API."""
-    global ZM
-    return ZM.login()
+    return hass.data[DOMAIN].login()
 
 
-def get_state(api_url):
+def get_state(hass, api_url):
     """Get a state from the ZoneMinder API service."""
-    global ZM
-    return ZM._zm_request('get', api_url)
+    return hass.data[DOMAIN]._zm_request('get', api_url)
 
 
-def change_state(api_url, post_data):
-    """Update a state using the Zoneminder API."""
-    global ZM
-    return ZM._zm_request('post', api_url, data=post_data)
+def change_state(hass, api_url, post_data):
+    """Update a state using the Zoneminder API.
+    """
+    return hass.data[DOMAIN]._zm_request('post', api_url, data=post_data)

--- a/homeassistant/components/zoneminder.py
+++ b/homeassistant/components/zoneminder.py
@@ -24,8 +24,6 @@ DEFAULT_TIMEOUT = 10
 DEFAULT_VERIFY_SSL = True
 DOMAIN = 'zoneminder'
 
-LOGIN_RETRIES = 2
-
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Required(CONF_HOST): cv.string,
@@ -58,14 +56,3 @@ def setup(hass, config):
                                    conf.get(CONF_VERIFY_SSL))
 
     return hass.data[DOMAIN].login()
-
-
-def get_state(hass, api_url):
-    """Get a state from the ZoneMinder API service."""
-    return hass.data[DOMAIN]._zm_request('get', api_url)
-
-
-def change_state(hass, api_url, post_data):
-    """Update a state using the Zoneminder API.
-    """
-    return hass.data[DOMAIN]._zm_request('post', api_url, data=post_data)

--- a/homeassistant/components/zoneminder.py
+++ b/homeassistant/components/zoneminder.py
@@ -15,6 +15,8 @@ import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
+REQUIREMENTS = ['zm-py==0.0.1']
+
 CONF_PATH_ZMS = 'path_zms'
 
 DEFAULT_PATH = '/zm/'
@@ -49,8 +51,8 @@ def setup(hass, config):
 
     server_origin = '{}://{}'.format(schema, conf[CONF_HOST])
     hass.data[DOMAIN] = ZoneMinder(server_origin,
-                                   conf.get(CONF_USERNAME, None),
-                                   conf.get(CONF_PASSWORD, None),
+                                   conf.get(CONF_USERNAME),
+                                   conf.get(CONF_PASSWORD),
                                    conf.get(CONF_PATH),
                                    conf.get(CONF_PATH_ZMS),
                                    conf.get(CONF_VERIFY_SSL))

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1538,3 +1538,6 @@ zigpy-xbee==0.1.1
 
 # homeassistant.components.zha
 zigpy==0.2.0
+
+# homeassistant.components.zoneminder
+zm-py==0.0.1


### PR DESCRIPTION
## Description:
In #15324, @jantman was trying to expose the ZoneMinder run state to Home Assistant and @MartinHjelmare and @balloob asked for the device specific logic to be moved to a new pypi library before any new functionality changes be made.

I've taken a first stab at splitting out the platform with the `camera.zoneminder` component so far. I was hoping to get a quick review to confirm that I'm on the right track before I continued with migrating out `switch.zoneminder` and `sensor.zoneminder`. I have intentionally not set the `REQUIREMENTS` variable since I have not published the library yet.

I've spun up a new repo to hold the new library and have opened a PR in it for visibility: https://github.com/rohankapoorcom/zm-py/pull/2

This should not require any configuration changes (nor any documentation updates) in Home Assistant.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
