### PR TITLE
Fix arlo intilization when no base station available

### DIFF
--- a/homeassistant/components/arlo.py
+++ b/homeassistant/components/arlo.py
@@ -63,7 +63,7 @@ def setup(hass, config):
 
         if arlo_base_station is not None:
             arlo_base_station.refresh_rate = scan_interval.total_seconds()
-        elif len(arlo.cameras) == 0:
+        elif not arlo.cameras == 0:
             _LOGGER.error("No camera or base station available.")
             return False
 

--- a/homeassistant/components/arlo.py
+++ b/homeassistant/components/arlo.py
@@ -63,7 +63,7 @@ def setup(hass, config):
 
         if arlo_base_station is not None:
             arlo_base_station.refresh_rate = scan_interval.total_seconds()
-        elif not arlo.cameras == 0:
+        elif not arlo.cameras:
             _LOGGER.error("No camera or base station available.")
             return False
 

--- a/homeassistant/components/arlo.py
+++ b/homeassistant/components/arlo.py
@@ -61,10 +61,12 @@ def setup(hass, config):
         arlo_base_station = next((
             station for station in arlo.base_stations), None)
 
-        if arlo_base_station is None:
+        if arlo_base_station is not None:
+            arlo_base_station.refresh_rate = scan_interval.total_seconds()
+        elif len(arlo.cameras) == 0:
+            _LOGGER.error("No camera or base station available.")
             return False
 
-        arlo_base_station.refresh_rate = scan_interval.total_seconds()
         hass.data[DATA_ARLO] = arlo
 
     except (ConnectTimeout, HTTPError) as ex:

--- a/homeassistant/components/arlo.py
+++ b/homeassistant/components/arlo.py
@@ -64,7 +64,7 @@ def setup(hass, config):
         if arlo_base_station is not None:
             arlo_base_station.refresh_rate = scan_interval.total_seconds()
         elif not arlo.cameras:
-            _LOGGER.error("No camera or base station available.")
+            _LOGGER.error("No Arlo camera or base station available.")
             return False
 
         hass.data[DATA_ARLO] = arlo


### PR DESCRIPTION
## Description:
Currently arlo component always check if base station is included in PyArlo return object. However, in case user does not allow full control of base station, or only cameras are available, arlo initialization will fail. This diff should fix it.

**Related issue (if applicable):** #15026 

## Cases tested:
  - When both base station and cameras are available, Arlo plugin should work.
  - When only cameras are available (no base station return), Arlo cameras should still work.
  - When no cameras or base station are returned, an error message `No camera or base station available.` was shown in the log.

