### PR TITLE
Update fan.zha platform.

### DIFF
--- a/homeassistant/components/fan/zha.py
+++ b/homeassistant/components/fan/zha.py
@@ -4,7 +4,6 @@ Fans on Zigbee Home Automation networks.
 For more details on this platform, please refer to the documentation
 at https://home-assistant.io/components/fan.zha/
 """
-import asyncio
 import logging
 from homeassistant.components import zha
 from homeassistant.components.fan import (
@@ -38,9 +37,8 @@ VALUE_TO_SPEED = {i: speed for i, speed in enumerate(SPEED_LIST)}
 SPEED_TO_VALUE = {speed: i for i, speed in enumerate(SPEED_LIST)}
 
 
-@asyncio.coroutine
-def async_setup_platform(hass, config, async_add_entities,
-                         discovery_info=None):
+async def async_setup_platform(hass, config, async_add_entities,
+                               discovery_info=None):
     """Set up the Zigbee Home Automation fans."""
     discovery_info = zha.get_discovery_info(hass, discovery_info)
     if discovery_info is None:
@@ -76,34 +74,36 @@ class ZhaFan(zha.Entity, FanEntity):
             return False
         return self._state != SPEED_OFF
 
-    @asyncio.coroutine
-    def async_turn_on(self, speed: str = None, **kwargs) -> None:
+    async def async_turn_on(self, speed: str = None, **kwargs) -> None:
         """Turn the entity on."""
         if speed is None:
             speed = SPEED_MEDIUM
 
-        yield from self.async_set_speed(speed)
+        await self.async_set_speed(speed)
 
-    @asyncio.coroutine
-    def async_turn_off(self, **kwargs) -> None:
+    async def async_turn_off(self, **kwargs) -> None:
         """Turn the entity off."""
-        yield from self.async_set_speed(SPEED_OFF)
+        await self.async_set_speed(SPEED_OFF)
 
-    @asyncio.coroutine
-    def async_set_speed(self, speed: str) -> None:
+    async def async_set_speed(self, speed: str) -> None:
         """Set the speed of the fan."""
-        yield from self._endpoint.fan.write_attributes({
-            'fan_mode': SPEED_TO_VALUE[speed]})
+        from zigpy.exceptions import DeliveryError
+        try:
+            await self._endpoint.fan.write_attributes(
+                {'fan_mode': SPEED_TO_VALUE[speed]}
+            )
+        except DeliveryError as ex:
+            _LOGGER.error("%s: Could not set speed: %s", self.entity_id, ex)
+            return
 
         self._state = speed
         self.async_schedule_update_ha_state()
 
-    @asyncio.coroutine
-    def async_update(self):
+    async def async_update(self):
         """Retrieve latest state."""
-        result = yield from zha.safe_read(self._endpoint.fan, ['fan_mode'])
+        result = await zha.safe_read(self._endpoint.fan, ['fan_mode'])
         new_value = result.get('fan_mode', None)
-        self._state = VALUE_TO_SPEED.get(new_value, None)
+        self._state = VALUE_TO_SPEED.get(new_value, self._state)
 
     @property
     def should_poll(self) -> bool:

--- a/homeassistant/components/fan/zha.py
+++ b/homeassistant/components/fan/zha.py
@@ -103,7 +103,7 @@ class ZhaFan(zha.Entity, FanEntity):
         """Retrieve latest state."""
         result = await zha.safe_read(self._endpoint.fan, ['fan_mode'])
         new_value = result.get('fan_mode', None)
-        self._state = VALUE_TO_SPEED.get(new_value, self._state)
+        self._state = VALUE_TO_SPEED.get(new_value, None)
 
     @property
     def should_poll(self) -> bool:


### PR DESCRIPTION
## Description:
switch from asyncio to async def()
catch DeliveryError exceptions
keep previous state, if reading 'fan_mode' attribute fails


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**