### PR TITLE
Allow only_cache parameter in zha.safe_read()

### DIFF
--- a/homeassistant/components/binary_sensor/zha.py
+++ b/homeassistant/components/binary_sensor/zha.py
@@ -98,6 +98,7 @@ class BinarySensor(zha.Entity, BinarySensorDevice):
         """Initialize the ZHA binary sensor."""
         super().__init__(**kwargs)
         self._device_class = device_class
+        self._only_cache = True
         from zigpy.zcl.clusters.security import IasZone
         self._ias_zone_cluster = self._in_clusters[IasZone.cluster_id]
 
@@ -135,8 +136,10 @@ class BinarySensor(zha.Entity, BinarySensorDevice):
 
         result = await zha.safe_read(self._endpoint.ias_zone,
                                      ['zone_status'],
-                                     allow_cache=False)
+                                     allow_cache=False,
+                                     only_cache=self._only_cache)
         state = result.get('zone_status', self._state)
+        self._only_cache = False
         if isinstance(state, (int, uint16_t)):
             self._state = result.get('zone_status', self._state) & 3
 

--- a/homeassistant/components/binary_sensor/zha.py
+++ b/homeassistant/components/binary_sensor/zha.py
@@ -98,7 +98,6 @@ class BinarySensor(zha.Entity, BinarySensorDevice):
         """Initialize the ZHA binary sensor."""
         super().__init__(**kwargs)
         self._device_class = device_class
-        self._only_cache = True
         from zigpy.zcl.clusters.security import IasZone
         self._ias_zone_cluster = self._in_clusters[IasZone.cluster_id]
 
@@ -137,9 +136,8 @@ class BinarySensor(zha.Entity, BinarySensorDevice):
         result = await zha.safe_read(self._endpoint.ias_zone,
                                      ['zone_status'],
                                      allow_cache=False,
-                                     only_cache=self._only_cache)
+                                     only_cache=(not self._initialized))
         state = result.get('zone_status', self._state)
-        self._only_cache = False
         if isinstance(state, (int, uint16_t)):
             self._state = result.get('zone_status', self._state) & 3
 

--- a/homeassistant/components/fan/zha.py
+++ b/homeassistant/components/fan/zha.py
@@ -52,6 +52,11 @@ class ZhaFan(zha.Entity, FanEntity):
 
     _domain = DOMAIN
 
+    def __init__(self, **kwargs):
+        """Initiliaze ZHA fan."""
+        super().__init__(**kwargs)
+        self._only_cache = True
+
     @property
     def supported_features(self) -> int:
         """Flag supported features."""
@@ -101,9 +106,12 @@ class ZhaFan(zha.Entity, FanEntity):
 
     async def async_update(self):
         """Retrieve latest state."""
-        result = await zha.safe_read(self._endpoint.fan, ['fan_mode'])
+        result = await zha.safe_read(self._endpoint.fan, ['fan_mode'],
+                                     allow_cache=False,
+                                     only_cache=self._only_cache)
         new_value = result.get('fan_mode', None)
         self._state = VALUE_TO_SPEED.get(new_value, None)
+        self._only_cache = False
 
     @property
     def should_poll(self) -> bool:

--- a/homeassistant/components/fan/zha.py
+++ b/homeassistant/components/fan/zha.py
@@ -52,11 +52,6 @@ class ZhaFan(zha.Entity, FanEntity):
 
     _domain = DOMAIN
 
-    def __init__(self, **kwargs):
-        """Initiliaze ZHA fan."""
-        super().__init__(**kwargs)
-        self._only_cache = True
-
     @property
     def supported_features(self) -> int:
         """Flag supported features."""
@@ -108,10 +103,9 @@ class ZhaFan(zha.Entity, FanEntity):
         """Retrieve latest state."""
         result = await zha.safe_read(self._endpoint.fan, ['fan_mode'],
                                      allow_cache=False,
-                                     only_cache=self._only_cache)
+                                     only_cache=(not self._initialized))
         new_value = result.get('fan_mode', None)
         self._state = VALUE_TO_SPEED.get(new_value, None)
-        self._only_cache = False
 
     @property
     def should_poll(self) -> bool:

--- a/homeassistant/components/light/zha.py
+++ b/homeassistant/components/light/zha.py
@@ -57,7 +57,6 @@ class Light(zha.Entity, light.Light):
         self._color_temp = None
         self._hs_color = None
         self._brightness = None
-        self._only_cache = True
 
         import zigpy.zcl.clusters as zcl_clusters
         if zcl_clusters.general.LevelControl.cluster_id in self._in_clusters:
@@ -157,22 +156,21 @@ class Light(zha.Entity, light.Light):
         """Retrieve latest state."""
         result = await zha.safe_read(self._endpoint.on_off, ['on_off'],
                                      allow_cache=False,
-                                     only_cache=self._only_cache)
+                                     only_cache=(not self._initialized))
         self._state = result.get('on_off', self._state)
 
         if self._supported_features & light.SUPPORT_BRIGHTNESS:
             result = await zha.safe_read(self._endpoint.level,
                                          ['current_level'],
                                          allow_cache=False,
-                                         only_cache=self._only_cache)
+                                         only_cache=(not self._initialized))
             self._brightness = result.get('current_level', self._brightness)
 
         if self._supported_features & light.SUPPORT_COLOR_TEMP:
             result = await zha.safe_read(self._endpoint.light_color,
                                          ['color_temperature'],
                                          allow_cache=False,
-                                         only_cache=self._only_cache)
-
+                                         only_cache=(not self._initialized))
             self._color_temp = result.get('color_temperature',
                                           self._color_temp)
 
@@ -180,12 +178,11 @@ class Light(zha.Entity, light.Light):
             result = await zha.safe_read(self._endpoint.light_color,
                                          ['current_x', 'current_y'],
                                          allow_cache=False,
-                                         only_cache=self._only_cache)
+                                         only_cache=(not self._initialized))
             if 'current_x' in result and 'current_y' in result:
                 xy_color = (round(result['current_x']/65535, 3),
                             round(result['current_y']/65535, 3))
                 self._hs_color = color_util.color_xy_to_hs(*xy_color)
-        self._only_cache = False
 
     @property
     def should_poll(self) -> bool:

--- a/homeassistant/components/light/zha.py
+++ b/homeassistant/components/light/zha.py
@@ -57,6 +57,7 @@ class Light(zha.Entity, light.Light):
         self._color_temp = None
         self._hs_color = None
         self._brightness = None
+        self._only_cache = True
 
         import zigpy.zcl.clusters as zcl_clusters
         if zcl_clusters.general.LevelControl.cluster_id in self._in_clusters:
@@ -154,27 +155,37 @@ class Light(zha.Entity, light.Light):
 
     async def async_update(self):
         """Retrieve latest state."""
-        result = await zha.safe_read(self._endpoint.on_off, ['on_off'])
+        result = await zha.safe_read(self._endpoint.on_off, ['on_off'],
+                                     allow_cache=False,
+                                     only_cache=self._only_cache)
         self._state = result.get('on_off', self._state)
 
         if self._supported_features & light.SUPPORT_BRIGHTNESS:
             result = await zha.safe_read(self._endpoint.level,
-                                         ['current_level'])
+                                         ['current_level'],
+                                         allow_cache=False,
+                                         only_cache=self._only_cache)
             self._brightness = result.get('current_level', self._brightness)
 
         if self._supported_features & light.SUPPORT_COLOR_TEMP:
             result = await zha.safe_read(self._endpoint.light_color,
-                                         ['color_temperature'])
+                                         ['color_temperature'],
+                                         allow_cache=False,
+                                         only_cache=self._only_cache)
+
             self._color_temp = result.get('color_temperature',
                                           self._color_temp)
 
         if self._supported_features & light.SUPPORT_COLOR:
             result = await zha.safe_read(self._endpoint.light_color,
-                                         ['current_x', 'current_y'])
+                                         ['current_x', 'current_y'],
+                                         allow_cache=False,
+                                         only_cache=self._only_cache)
             if 'current_x' in result and 'current_y' in result:
                 xy_color = (round(result['current_x']/65535, 3),
                             round(result['current_y']/65535, 3))
                 self._hs_color = color_util.color_xy_to_hs(*xy_color)
+        self._only_cache = False
 
     @property
     def should_poll(self) -> bool:

--- a/homeassistant/components/sensor/zha.py
+++ b/homeassistant/components/sensor/zha.py
@@ -72,6 +72,11 @@ class Sensor(zha.Entity):
     value_attribute = 0
     min_reportable_change = 1
 
+    def __init__(self, **kwargs):
+        """Initialize generic ZHA sensor."""
+        super().__init__(**kwargs)
+        self._only_cache = True
+
     @property
     def should_poll(self) -> bool:
         """State gets pushed from device."""
@@ -95,9 +100,12 @@ class Sensor(zha.Entity):
         """Retrieve latest state."""
         result = await zha.safe_read(
             list(self._in_clusters.values())[0],
-            [self.value_attribute]
+            [self.value_attribute],
+            allow_cache=False,
+            only_cache=self._only_cache
         )
         self._state = result.get(self.value_attribute, self._state)
+        self._only_cache = False
 
 
 class TemperatureSensor(Sensor):
@@ -226,5 +234,6 @@ class ElectricalMeasurementSensor(Sensor):
         result = await zha.safe_read(
             self._endpoint.electrical_measurement,
             ['active_power'],
-            allow_cache=False)
+            allow_cache=False, only_cache=self._only_cache)
         self._state = result.get('active_power', self._state)
+        self._only_cache = False

--- a/homeassistant/components/sensor/zha.py
+++ b/homeassistant/components/sensor/zha.py
@@ -72,11 +72,6 @@ class Sensor(zha.Entity):
     value_attribute = 0
     min_reportable_change = 1
 
-    def __init__(self, **kwargs):
-        """Initialize generic ZHA sensor."""
-        super().__init__(**kwargs)
-        self._only_cache = True
-
     @property
     def should_poll(self) -> bool:
         """State gets pushed from device."""
@@ -102,10 +97,9 @@ class Sensor(zha.Entity):
             list(self._in_clusters.values())[0],
             [self.value_attribute],
             allow_cache=False,
-            only_cache=self._only_cache
+            only_cache=(not self._initialized)
         )
         self._state = result.get(self.value_attribute, self._state)
-        self._only_cache = False
 
 
 class TemperatureSensor(Sensor):
@@ -232,8 +226,6 @@ class ElectricalMeasurementSensor(Sensor):
         _LOGGER.debug("%s async_update", self.entity_id)
 
         result = await zha.safe_read(
-            self._endpoint.electrical_measurement,
-            ['active_power'],
-            allow_cache=False, only_cache=self._only_cache)
+            self._endpoint.electrical_measurement, ['active_power'],
+            allow_cache=False, only_cache=(not self._initialized))
         self._state = result.get('active_power', self._state)
-        self._only_cache = False

--- a/homeassistant/components/switch/zha.py
+++ b/homeassistant/components/switch/zha.py
@@ -36,6 +36,11 @@ class Switch(zha.Entity, SwitchDevice):
     _domain = DOMAIN
     value_attribute = 0
 
+    def __init__(self, **kwargs):
+        """Initialize ZHA switch."""
+        super().__init__(**kwargs)
+        self._only_cache = True
+
     def attribute_updated(self, attribute, value):
         """Handle attribute update from device."""
         _LOGGER.debug("Attribute updated: %s %s %s", self, attribute, value)
@@ -80,5 +85,8 @@ class Switch(zha.Entity, SwitchDevice):
     async def async_update(self):
         """Retrieve latest state."""
         result = await zha.safe_read(self._endpoint.on_off,
-                                     ['on_off'])
+                                     ['on_off'],
+                                     allow_cache=False,
+                                     only_cache=self._only_cache)
         self._state = result.get('on_off', self._state)
+        self._only_cache = False

--- a/homeassistant/components/switch/zha.py
+++ b/homeassistant/components/switch/zha.py
@@ -36,11 +36,6 @@ class Switch(zha.Entity, SwitchDevice):
     _domain = DOMAIN
     value_attribute = 0
 
-    def __init__(self, **kwargs):
-        """Initialize ZHA switch."""
-        super().__init__(**kwargs)
-        self._only_cache = True
-
     def attribute_updated(self, attribute, value):
         """Handle attribute update from device."""
         _LOGGER.debug("Attribute updated: %s %s %s", self, attribute, value)
@@ -87,6 +82,5 @@ class Switch(zha.Entity, SwitchDevice):
         result = await zha.safe_read(self._endpoint.on_off,
                                      ['on_off'],
                                      allow_cache=False,
-                                     only_cache=self._only_cache)
+                                     only_cache=(not self._initialized))
         self._state = result.get('on_off', self._state)
-        self._only_cache = False

--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -384,7 +384,7 @@ def get_discovery_info(hass, discovery_info):
     return all_discovery_info.get(discovery_key, None)
 
 
-async def safe_read(cluster, attributes, allow_cache=True):
+async def safe_read(cluster, attributes, allow_cache=True, only_cache=False):
     """Swallow all exceptions from network read.
 
     If we throw during initialization, setup fails. Rather have an entity that
@@ -395,6 +395,7 @@ async def safe_read(cluster, attributes, allow_cache=True):
         result, _ = await cluster.read_attributes(
             attributes,
             allow_cache=allow_cache,
+            only_cache=only_cache
         )
         return result
     except Exception:  # pylint: disable=broad-except

--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -336,6 +336,7 @@ class Entity(entity.Entity):
         self._in_listeners = {}
         self._out_listeners = {}
 
+        self._initialized = False
         application_listener.register_entity(ieee, self)
 
     async def async_added_to_hass(self):
@@ -347,6 +348,8 @@ class Entity(entity.Entity):
             cluster.add_listener(self._in_listeners.get(cluster_id, self))
         for cluster_id, cluster in self._out_clusters.items():
             cluster.add_listener(self._out_listeners.get(cluster_id, self))
+
+        self._initialized = True
 
     @property
     def unique_id(self) -> str:


### PR DESCRIPTION
## Description:
zigpy 0.2.0 allows [`only_cache=True`](https://github.com/zigpy/zigpy/pull/69) parameter to Cluster.read_attribute() method. 
This PR would allow "cache only" reads for status restoration for components with `update_before_add=True` so it won't generate extra spike in Zigbee network traffic during HA restarts.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
