### PR TITLE
Fix invalid state

### DIFF
--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -225,6 +225,9 @@ ATTR_ID = 'id'
 # Name
 ATTR_NAME = 'name'
 
+# Data for a SERVICE_EXECUTED event
+ATTR_SERVICE_CALL_ID = 'service_call_id'
+
 # Contains one string or a list of strings, each being an entity id
 ATTR_ENTITY_ID = 'entity_id'
 

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1064,6 +1064,7 @@ class ServiceRegistry:
             """Handle an executed service."""
             if event.data[ATTR_SERVICE_CALL_ID] == call_id:
                 fut.set_result(True)
+                unsub()
 
         unsub = self._hass.bus.async_listen(
             EVENT_SERVICE_EXECUTED, service_executed)
@@ -1073,7 +1074,8 @@ class ServiceRegistry:
 
         done, _ = await asyncio.wait([fut], timeout=SERVICE_CALL_LIMIT)
         success = bool(done)
-        unsub()
+        if not success:
+            unsub()
         return success
 
     async def _event_to_service_call(self, event: Event) -> None:

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -904,7 +904,6 @@ class ServiceRegistry:
         self._services = {}  # type: Dict[str, Dict[str, Service]]
         self._hass = hass
         self._async_unsub_call_event = None  # type: Optional[CALLBACK_TYPE]
-        self._call_id = 0
 
     @property
     def services(self) -> Dict[str, Dict[str, Service]]:
@@ -1043,8 +1042,7 @@ class ServiceRegistry:
         This method is a coroutine.
         """
         context = context or Context()
-        self._call_id += 1
-        call_id = self._call_id
+        call_id = uuid.uuid4().hex
         event_data = {
             ATTR_DOMAIN: domain.lower(),
             ATTR_SERVICE: service.lower(),

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -20,7 +20,8 @@ from homeassistant.util.unit_system import (METRIC_SYSTEM)
 from homeassistant.const import (
     __version__, EVENT_STATE_CHANGED, ATTR_FRIENDLY_NAME, CONF_UNIT_SYSTEM,
     ATTR_NOW, EVENT_TIME_CHANGED, EVENT_HOMEASSISTANT_STOP,
-    EVENT_HOMEASSISTANT_CLOSE, EVENT_SERVICE_REGISTERED, EVENT_SERVICE_REMOVED)
+    EVENT_HOMEASSISTANT_CLOSE, EVENT_SERVICE_REGISTERED, EVENT_SERVICE_REMOVED,
+    EVENT_SERVICE_EXECUTED)
 
 from tests.common import get_test_home_assistant, async_mock_service
 
@@ -978,13 +979,18 @@ async def test_service_executed_with_subservices(hass):
     async def handle_outer(call):
         """Handle outer service call."""
         calls.append(call)
-        await hass.services.async_call('test', 'inner', blocking=True,
-                                       context=call.context)
+        call1 = hass.services.async_call('test', 'inner', blocking=True,
+                                         context=call.context)
+        call2 = hass.services.async_call('test', 'inner', blocking=True,
+                                         context=call.context)
+        await asyncio.wait([call1, call2])
         calls.append(call)
 
     hass.services.async_register('test', 'outer', handle_outer)
 
     await hass.services.async_call('test', 'outer', blocking=True)
 
-    assert len(calls) == 3
-    assert [call.service for call in calls] == ['outer', 'inner', 'outer']
+    assert len(calls) == 4
+    assert [call.service for call in calls] == [
+        'outer', 'inner', 'inner', 'outer']
+    assert len(hass.bus.async_listeners().get(EVENT_SERVICE_EXECUTED, [])) == 0


### PR DESCRIPTION
## Description:
In #15674 we started checking if a service was done by comparing context. This was an incorrect assumption as context has to propagate. So when we added that in #16415, the service executed handler could be called twice.

This fixes it by restoring unique call IDs for service calls.

**Related issue (if applicable):** fixes #16544

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
