### PR TITLE
Add websocket commands for refresh tokens

### DIFF
--- a/homeassistant/components/auth/__init__.py
+++ b/homeassistant/components/auth/__init__.py
@@ -492,10 +492,9 @@ def websocket_delete_refresh_token(
     """Handle a delete refresh token request."""
     async def async_delete_refresh_token(user, refresh_token_id):
         """Delete a refresh token."""
-        refresh_token = await hass.auth.async_get_refresh_token(
-            refresh_token_id)
+        refresh_token = connection.user.refresh_tokens.get(refresh_token_id)
 
-        if refresh_token is None or refresh_token.user != user:
+        if refresh_token is None:
             return websocket_api.error_message(
                 msg['id'], 'invalid_token_id', 'Received invalid token')
 

--- a/homeassistant/components/auth/__init__.py
+++ b/homeassistant/components/auth/__init__.py
@@ -156,6 +156,19 @@ SCHEMA_WS_LONG_LIVED_ACCESS_TOKEN = \
         vol.Optional('client_icon'): str,
     })
 
+WS_TYPE_REFRESH_TOKENS = 'auth/refresh_tokens'
+SCHEMA_WS_REFRESH_TOKENS = \
+    websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend({
+        vol.Required('type'): WS_TYPE_REFRESH_TOKENS,
+    })
+
+WS_TYPE_DELETE_REFRESH_TOKEN = 'auth/delete_refresh_token'
+SCHEMA_WS_DELETE_REFRESH_TOKEN = \
+    websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend({
+        vol.Required('type'): WS_TYPE_DELETE_REFRESH_TOKEN,
+        vol.Required('refresh_token_id'): str,
+    })
+
 RESULT_TYPE_CREDENTIALS = 'credentials'
 RESULT_TYPE_USER = 'user'
 
@@ -177,6 +190,16 @@ async def async_setup(hass, config):
         WS_TYPE_LONG_LIVED_ACCESS_TOKEN,
         websocket_create_long_lived_access_token,
         SCHEMA_WS_LONG_LIVED_ACCESS_TOKEN
+    )
+    hass.components.websocket_api.async_register_command(
+        WS_TYPE_REFRESH_TOKENS,
+        websocket_refresh_tokens,
+        SCHEMA_WS_REFRESH_TOKENS
+    )
+    hass.components.websocket_api.async_register_command(
+        WS_TYPE_DELETE_REFRESH_TOKEN,
+        websocket_delete_refresh_token,
+        SCHEMA_WS_DELETE_REFRESH_TOKEN
     )
 
     await login_flow.async_setup(hass, store_result)
@@ -445,3 +468,41 @@ def websocket_create_long_lived_access_token(
 
     hass.async_create_task(
         async_create_long_lived_access_token(connection.user))
+
+
+@websocket_api.ws_require_user()
+@callback
+def websocket_refresh_tokens(
+        hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg):
+    """Return metadata of users refresh tokens."""
+    connection.to_write.put_nowait(websocket_api.result_message(msg['id'], [{
+        'id': refresh.id,
+        'client_id': refresh.client_id,
+        'client_name': refresh.client_name,
+        'client_icon': refresh.client_icon,
+        'type': refresh.token_type,
+        'created_at': refresh.created_at,
+    } for refresh in connection.user.refresh_tokens.values()]))
+
+
+@websocket_api.ws_require_user()
+@callback
+def websocket_delete_refresh_token(
+        hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg):
+    """Handle a delete refresh token request."""
+    async def async_delete_refresh_token(user, refresh_token_id):
+        """Delete a refresh token."""
+        refresh_token = await hass.auth.async_get_refresh_token(
+            refresh_token_id)
+
+        if refresh_token is None or refresh_token.user != user:
+            return websocket_api.error_message(
+                msg['id'], 'invalid_token_id', 'Received invalid token')
+
+        await hass.auth.async_remove_refresh_token(refresh_token)
+
+        connection.send_message_outside(
+            websocket_api.result_message(msg['id'], {}))
+
+    hass.async_create_task(
+        async_delete_refresh_token(connection.user, msg['refresh_token_id']))

--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -1,4 +1,6 @@
 """Fixtures for component testing."""
+from unittest.mock import patch
+
 import pytest
 
 from homeassistant.setup import async_setup_component
@@ -16,23 +18,37 @@ def hass_ws_client(aiohttp_client):
         assert await async_setup_component(hass, 'websocket_api')
 
         client = await aiohttp_client(hass.http.app)
-        websocket = await client.ws_connect(wapi.URL)
-        auth_resp = await websocket.receive_json()
 
-        if auth_resp['type'] == wapi.TYPE_AUTH_OK:
-            assert access_token is None, \
-                'Access token given but no auth required'
-            return websocket
+        patching = None
 
-        assert access_token is not None, 'Access token required for fixture'
+        if access_token is not None:
+            patching = patch('homeassistant.auth.AuthManager.active',
+                             return_value=True)
+            patching.start()
 
-        await websocket.send_json({
-            'type': websocket_api.TYPE_AUTH,
-            'access_token': access_token
-        })
+        try:
+            websocket = await client.ws_connect(wapi.URL)
+            auth_resp = await websocket.receive_json()
 
-        auth_ok = await websocket.receive_json()
-        assert auth_ok['type'] == wapi.TYPE_AUTH_OK
+            if auth_resp['type'] == wapi.TYPE_AUTH_OK:
+                assert access_token is None, \
+                    'Access token given but no auth required'
+                return websocket
+
+            assert access_token is not None, \
+                'Access token required for fixture'
+
+            await websocket.send_json({
+                'type': websocket_api.TYPE_AUTH,
+                'access_token': access_token
+            })
+
+            auth_ok = await websocket.receive_json()
+            assert auth_ok['type'] == wapi.TYPE_AUTH_OK
+
+        finally:
+            if patching is not None:
+                patching.stop()
 
         # wrap in client
         websocket.client = client


### PR DESCRIPTION
## Description:
Allows users to manage refresh tokens via websocket commands. Will be used from the frontend.

CC @awarecan 

**Related issue (if applicable):** #15195

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
