### PR TITLE
Xiaomi Vacuum: keep error state active after erroring

### DIFF
--- a/homeassistant/components/vacuum/xiaomi_miio.py
+++ b/homeassistant/components/vacuum/xiaomi_miio.py
@@ -179,7 +179,8 @@ class MiroboVacuum(StateVacuumDevice):
     def state(self):
         """Return the status of the vacuum cleaner."""
         if self.vacuum_state is not None:
-            # We can have an error even when the state code does not indicate it (anymore).
+            # The vacuum reverts back to an idle state after erroring out.
+            # We want to keep returning an error until it has been cleared.
             if self.vacuum_state.got_error:
                 return STATE_ERROR
             try:

--- a/homeassistant/components/vacuum/xiaomi_miio.py
+++ b/homeassistant/components/vacuum/xiaomi_miio.py
@@ -179,6 +179,9 @@ class MiroboVacuum(StateVacuumDevice):
     def state(self):
         """Return the status of the vacuum cleaner."""
         if self.vacuum_state is not None:
+            # We can have an error even when the state code does not indicate it (anymore).
+            if self.vacuum_state.got_error:
+                return STATE_ERROR
             try:
                 return STATE_CODE_TO_STATE[int(self.vacuum_state.state_code)]
             except KeyError:


### PR DESCRIPTION
## Description:
The vacuum returns back to an idle state after erroring, making it seem that there's no error anymore.
This will change this behaviour to keep the error state active.
A new python-miio release (with https://github.com/rytilahti/python-miio/pull/379) is required for this to work.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
