### PR TITLE
Bump pyeconet

### DIFF
--- a/homeassistant/components/climate/econet.py
+++ b/homeassistant/components/climate/econet.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
     TEMP_FAHRENHEIT)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['pyeconet==0.0.5']
+REQUIREMENTS = ['pyeconet==0.0.6']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -822,7 +822,7 @@ pydukeenergy==0.0.6
 pyebox==1.1.4
 
 # homeassistant.components.climate.econet
-pyeconet==0.0.5
+pyeconet==0.0.6
 
 # homeassistant.components.switch.edimax
 pyedimax==0.1


### PR DESCRIPTION
## Description:
A user in the forums reported an issue with EcoNet. Mode changes use to be performed on the device, and now they must be sent to a new endpoint. This pyeconet version addresses the API change.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
