### PR TITLE
Bring back brightness-slider for MQTT RGB light

### DIFF
--- a/homeassistant/components/light/mqtt.py
+++ b/homeassistant/components/light/mqtt.py
@@ -201,7 +201,8 @@ class MqttLight(MqttAvailability, Light):
         self._white_value = None
         self._supported_features = 0
         self._supported_features |= (
-            topic[CONF_RGB_COMMAND_TOPIC] is not None and SUPPORT_COLOR and SUPPORT_BRIGHTNESS)
+            topic[CONF_RGB_COMMAND_TOPIC] is not None and 
+            SUPPORT_COLOR and SUPPORT_BRIGHTNESS)
         self._supported_features |= (
             topic[CONF_BRIGHTNESS_COMMAND_TOPIC] is not None and
             SUPPORT_BRIGHTNESS)

--- a/homeassistant/components/light/mqtt.py
+++ b/homeassistant/components/light/mqtt.py
@@ -201,7 +201,7 @@ class MqttLight(MqttAvailability, Light):
         self._white_value = None
         self._supported_features = 0
         self._supported_features |= (
-            topic[CONF_RGB_COMMAND_TOPIC] is not None and SUPPORT_COLOR)
+            topic[CONF_RGB_COMMAND_TOPIC] is not None and SUPPORT_COLOR and SUPPORT_BRIGHTNESS)
         self._supported_features |= (
             topic[CONF_BRIGHTNESS_COMMAND_TOPIC] is not None and
             SUPPORT_BRIGHTNESS)

--- a/homeassistant/components/light/mqtt.py
+++ b/homeassistant/components/light/mqtt.py
@@ -201,7 +201,7 @@ class MqttLight(MqttAvailability, Light):
         self._white_value = None
         self._supported_features = 0
         self._supported_features |= (
-            topic[CONF_RGB_COMMAND_TOPIC] is not None and 
+            topic[CONF_RGB_COMMAND_TOPIC] is not None and
             SUPPORT_COLOR and SUPPORT_BRIGHTNESS)
         self._supported_features |= (
             topic[CONF_BRIGHTNESS_COMMAND_TOPIC] is not None and


### PR DESCRIPTION
Add back support of brightness-slider for color (RGB) light without external brightness topic, as where you have RGB value you also have brightness calculated

## Description: 
After 0.72 PR  #15053 brightness slider disappeared making RGB lights with MQTT uncontrollable in terms of brightness. Software (like Tasmota) which doesn't support additional brightness topic, after enabling it, made light go 100% brightness all the time. 

**Related issue (if applicable):** fixes #15964

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#n/a

## Example entry for `configuration.yaml` (if applicable):
n/a

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
