### PR TITLE
Return if refresh token is current used one in WS API

### DIFF
--- a/homeassistant/components/auth/__init__.py
+++ b/homeassistant/components/auth/__init__.py
@@ -475,6 +475,7 @@ def websocket_create_long_lived_access_token(
 def websocket_refresh_tokens(
         hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg):
     """Return metadata of users refresh tokens."""
+    current_id = connection.request.get('refresh_token_id')
     connection.to_write.put_nowait(websocket_api.result_message(msg['id'], [{
         'id': refresh.id,
         'client_id': refresh.client_id,
@@ -482,6 +483,7 @@ def websocket_refresh_tokens(
         'client_icon': refresh.client_icon,
         'type': refresh.token_type,
         'created_at': refresh.created_at,
+        'is_current': refresh.id == current_id,
     } for refresh in connection.user.refresh_tokens.values()]))
 
 

--- a/homeassistant/components/websocket_api.py
+++ b/homeassistant/components/websocket_api.py
@@ -360,6 +360,7 @@ class ActiveConnection:
                     authenticated = refresh_token is not None
                     if authenticated:
                         request['hass_user'] = refresh_token.user
+                        request['refresh_token_id'] = refresh_token.id
 
                 elif ((not self.hass.auth.active or
                        self.hass.auth.support_legacy) and

--- a/tests/components/auth/test_init.py
+++ b/tests/components/auth/test_init.py
@@ -320,6 +320,7 @@ async def test_ws_refresh_tokens(hass, hass_ws_client, hass_access_token):
     assert token['client_name'] == refresh_token.client_name
     assert token['client_icon'] == refresh_token.client_icon
     assert token['created_at'] == refresh_token.created_at.isoformat()
+    assert token['is_current'] is True
 
 
 async def test_ws_delete_refresh_token(hass, hass_ws_client,


### PR DESCRIPTION
## Description:

Return if refresh token is current used one in WS API, so that user can avoid delete current used refresh token.


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.
