### PR TITLE
Increasing python-websockets' version number

### DIFF
--- a/homeassistant/components/media_player/webostv.py
+++ b/homeassistant/components/media_player/webostv.py
@@ -26,7 +26,7 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.script import Script
 
-REQUIREMENTS = ['pylgtv==0.1.7', 'websockets==3.2']
+REQUIREMENTS = ['pylgtv==0.1.7', 'websockets==6.0']
 
 _CONFIGURING = {}  # type: Dict[str, str]
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/spc.py
+++ b/homeassistant/components/spc.py
@@ -20,7 +20,7 @@ from homeassistant.const import (
 from homeassistant.helpers import discovery
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['websockets==3.2']
+REQUIREMENTS = ['websockets==6.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1480,7 +1480,7 @@ websocket-client==0.37.0
 
 # homeassistant.components.spc
 # homeassistant.components.media_player.webostv
-websockets==3.2
+websockets==6.0
 
 # homeassistant.components.wirelesstag
 wirelesstagpy==0.3.0


### PR DESCRIPTION
## Description:

The webostv module has stopped working since the Python 3.6 -> 3.7 upgrade. Log showed an exception in the websockets module.

Dependency for websockets in the `REQUIREMENTS` variable has been updated. Websockets 3.2 (former version) doesn't run on Python 3.7, because it defines `async` which became a reserved keyword.

Webostv module is working again.

**Related issue (if applicable):** n/a

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  - platform: webostv
    host: LGwebOSTV.lan
    timeout: 7
    filename: webostv.conf
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed: no