### PR TITLE
Add Call Data Log platform.  Mailboxes no longer require media

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -42,6 +42,7 @@ omit =
 
     homeassistant/components/asterisk_mbox.py
     homeassistant/components/*/asterisk_mbox.py
+    homeassistant/components/*/asterisk_cdr.py
 
     homeassistant/components/august.py
     homeassistant/components/*/august.py

--- a/homeassistant/components/asterisk_mbox.py
+++ b/homeassistant/components/asterisk_mbox.py
@@ -67,7 +67,7 @@ class AsteriskData:
         async_dispatcher_connect(
             self.hass, SIGNAL_CDR_REQUEST, self._request_cdr)
         async_dispatcher_connect(
-             self.hass, SIGNAL_DISCOVER_PLATFORM, self._discover_platform)
+            self.hass, SIGNAL_DISCOVER_PLATFORM, self._discover_platform)
 
     @callback
     def _discover_platform(self, component):
@@ -89,8 +89,9 @@ class AsteriskData:
                 msg, key=lambda item: item['info']['origtime'], reverse=True)
             if not isinstance(old_messages, list):
                 async_dispatcher_send(self.hass, SIGNAL_DISCOVER_PLATFORM,
-                                DOMAIN)
-            async_dispatcher_send(self.hass, SIGNAL_MESSAGE_UPDATE, self.messages)
+                                      DOMAIN)
+            async_dispatcher_send(self.hass, SIGNAL_MESSAGE_UPDATE,
+                                  self.messages)
         elif command == CMD_MESSAGE_CDR:
             _LOGGER.info("AsteriskVM sent updated CDR list")
             self.cdr = msg['entries']

--- a/homeassistant/components/asterisk_mbox.py
+++ b/homeassistant/components/asterisk_mbox.py
@@ -66,7 +66,7 @@ class AsteriskData:
 
     @callback
     def _discover_platform(self, component):
-        logging.error("Adding mailbox")
+        _LOGGER.debug("Adding mailbox")
         self.hass.async_add_job(discovery.async_load_platform(
             self.hass, "mailbox", component, {}, self.config))
 

--- a/homeassistant/components/asterisk_mbox.py
+++ b/homeassistant/components/asterisk_mbox.py
@@ -13,7 +13,7 @@ from homeassistant.core import callback
 from homeassistant.helpers import discovery
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import (
-    async_dispatcher_connect, async_dispatcher_send)
+    async_dispatcher_send, dispatcher_connect)
 
 REQUIREMENTS = ['asterisk_mbox==0.5.0']
 
@@ -55,19 +55,19 @@ class AsteriskData:
     def __init__(self, hass, host, port, password, config):
         """Init the Asterisk data object."""
         from asterisk_mbox import Client as asteriskClient
-
         self.hass = hass
         self.config = config
-        self.client = asteriskClient(host, port, password, self.handle_data)
         self.messages = None
         self.cdr = None
 
-        async_dispatcher_connect(
+        dispatcher_connect(
             self.hass, SIGNAL_MESSAGE_REQUEST, self._request_messages)
-        async_dispatcher_connect(
+        dispatcher_connect(
             self.hass, SIGNAL_CDR_REQUEST, self._request_cdr)
-        async_dispatcher_connect(
+        dispatcher_connect(
             self.hass, SIGNAL_DISCOVER_PLATFORM, self._discover_platform)
+        # Only connect after signal connection to ensure we don't miss any
+        self.client = asteriskClient(host, port, password, self.handle_data)
 
     @callback
     def _discover_platform(self, component):

--- a/homeassistant/components/mailbox/__init__.py
+++ b/homeassistant/components/mailbox/__init__.py
@@ -64,7 +64,7 @@ async def async_setup(hass, config):
                 mailbox = await \
                     platform.async_get_handler(hass, p_config, discovery_info)
             elif hasattr(platform, 'get_handler'):
-                mailbox = await hass.async_add_job(
+                mailbox = await hass.async_add_executor_job(
                     platform.get_handler, hass, p_config, discovery_info)
             else:
                 raise HomeAssistantError("Invalid mailbox platform.")

--- a/homeassistant/components/mailbox/__init__.py
+++ b/homeassistant/components/mailbox/__init__.py
@@ -33,26 +33,24 @@ CONTENT_TYPE_NONE = 'none'
 SCAN_INTERVAL = timedelta(seconds=30)
 
 
-@asyncio.coroutine
-def async_setup(hass, config):
+async def async_setup(hass, config):
     """Track states and offer events for mailboxes."""
     mailboxes = []
-    yield from hass.components.frontend.async_register_built_in_panel(
+    await hass.components.frontend.async_register_built_in_panel(
         'mailbox', 'mailbox', 'mdi:mailbox')
     hass.http.register_view(MailboxPlatformsView(mailboxes))
     hass.http.register_view(MailboxMessageView(mailboxes))
     hass.http.register_view(MailboxMediaView(mailboxes))
     hass.http.register_view(MailboxDeleteView(mailboxes))
 
-    @asyncio.coroutine
-    def async_setup_platform(p_type, p_config=None, discovery_info=None):
+    async def async_setup_platform(p_type, p_config=None, discovery_info=None):
         """Set up a mailbox platform."""
         if p_config is None:
             p_config = {}
         if discovery_info is None:
             discovery_info = {}
 
-        platform = yield from async_prepare_setup_platform(
+        platform = await async_prepare_setup_platform(
             hass, config, DOMAIN, p_type)
 
         if platform is None:
@@ -63,10 +61,10 @@ def async_setup(hass, config):
         mailbox = None
         try:
             if hasattr(platform, 'async_get_handler'):
-                mailbox = yield from \
+                mailbox = await \
                     platform.async_get_handler(hass, p_config, discovery_info)
             elif hasattr(platform, 'get_handler'):
-                mailbox = yield from hass.async_add_job(
+                mailbox = await hass.async_add_job(
                     platform.get_handler, hass, p_config, discovery_info)
             else:
                 raise HomeAssistantError("Invalid mailbox platform.")
@@ -84,18 +82,17 @@ def async_setup(hass, config):
         mailbox_entity = MailboxEntity(mailbox)
         component = EntityComponent(
             logging.getLogger(__name__), DOMAIN, hass, SCAN_INTERVAL)
-        yield from component.async_add_entities([mailbox_entity])
+        await component.async_add_entities([mailbox_entity])
 
     setup_tasks = [async_setup_platform(p_type, p_config) for p_type, p_config
                    in config_per_platform(config, DOMAIN)]
 
     if setup_tasks:
-        yield from asyncio.wait(setup_tasks, loop=hass.loop)
+        await asyncio.wait(setup_tasks, loop=hass.loop)
 
-    @asyncio.coroutine
-    def async_platform_discovered(platform, info):
+    async def async_platform_discovered(platform, info):
         """Handle for discovered platform."""
-        yield from async_setup_platform(platform, discovery_info=info)
+        await async_setup_platform(platform, discovery_info=info)
 
     discovery.async_listen_platform(hass, DOMAIN, async_platform_discovered)
 
@@ -110,8 +107,7 @@ class MailboxEntity(Entity):
         self.mailbox = mailbox
         self.message_count = 0
 
-    @asyncio.coroutine
-    def async_added_to_hass(self):
+    async def async_added_to_hass(self):
         """Complete entity initialization."""
         @callback
         def _mailbox_updated(event):
@@ -130,10 +126,9 @@ class MailboxEntity(Entity):
         """Return the name of the entity."""
         return self.mailbox.name
 
-    @asyncio.coroutine
-    def async_update(self):
+    async def async_update(self):
         """Retrieve messages from platform."""
-        messages = yield from self.mailbox.async_get_messages()
+        messages = await self.mailbox.async_get_messages()
         self.message_count = len(messages)
 
 
@@ -164,13 +159,11 @@ class Mailbox:
         """Return if messages have attached media files."""
         return False
 
-    @asyncio.coroutine
-    def async_get_media(self, msgid):
+    async def async_get_media(self, msgid):
         """Return the media blob for the msgid."""
         raise NotImplementedError()
 
-    @asyncio.coroutine
-    def async_get_messages(self):
+    async def async_get_messages(self):
         """Return a list of the current messages."""
         raise NotImplementedError()
 
@@ -206,8 +199,7 @@ class MailboxPlatformsView(MailboxView):
     url = "/api/mailbox/platforms"
     name = "api:mailbox:platforms"
 
-    @asyncio.coroutine
-    def get(self, request):
+    async def get(self, request):
         """Retrieve list of platforms."""
         platforms = []
         for mailbox in self.mailboxes:
@@ -226,11 +218,10 @@ class MailboxMessageView(MailboxView):
     url = "/api/mailbox/messages/{platform}"
     name = "api:mailbox:messages"
 
-    @asyncio.coroutine
-    def get(self, request, platform):
+    async def get(self, request, platform):
         """Retrieve messages."""
         mailbox = self.get_mailbox(platform)
-        messages = yield from mailbox.async_get_messages()
+        messages = await mailbox.async_get_messages()
         return self.json(messages)
 
 
@@ -240,8 +231,7 @@ class MailboxDeleteView(MailboxView):
     url = "/api/mailbox/delete/{platform}/{msgid}"
     name = "api:mailbox:delete"
 
-    @asyncio.coroutine
-    def delete(self, request, platform, msgid):
+    async def delete(self, request, platform, msgid):
         """Delete items."""
         mailbox = self.get_mailbox(platform)
         mailbox.async_delete(msgid)
@@ -253,8 +243,7 @@ class MailboxMediaView(MailboxView):
     url = r"/api/mailbox/media/{platform}/{msgid}"
     name = "api:asteriskmbox:media"
 
-    @asyncio.coroutine
-    def get(self, request, platform, msgid):
+    async def get(self, request, platform, msgid):
         """Retrieve media."""
         mailbox = self.get_mailbox(platform)
 
@@ -262,7 +251,7 @@ class MailboxMediaView(MailboxView):
         with suppress(asyncio.CancelledError, asyncio.TimeoutError):
             with async_timeout.timeout(10, loop=hass.loop):
                 try:
-                    stream = yield from mailbox.async_get_media(msgid)
+                    stream = await mailbox.async_get_media(msgid)
                 except StreamError as err:
                     error_msg = "Error getting media: %s" % (err)
                     _LOGGER.error(error_msg)

--- a/homeassistant/components/mailbox/asterisk_cdr.py
+++ b/homeassistant/components/mailbox/asterisk_cdr.py
@@ -1,0 +1,61 @@
+"""
+Asterisk CDR interface.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/mailbox.asteriskvm/
+"""
+import asyncio
+import logging
+import hashlib
+import datetime
+
+from homeassistant.core import callback
+from homeassistant.components.asterisk_mbox import SIGNAL_CDR_UPDATE
+from homeassistant.components.asterisk_mbox import DOMAIN as MBOX_DOMAIN
+from homeassistant.components.mailbox import Mailbox
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+
+DEPENDENCIES = ['asterisk_mbox']
+_LOGGER = logging.getLogger(__name__)
+DOMAIN = "asterisk_cdr"
+
+
+@asyncio.coroutine
+def async_get_handler(hass, config, async_add_devices, discovery_info=None):
+    """Set up the Asterix CDR platform."""
+    return AsteriskCDR(hass, DOMAIN)
+
+
+class AsteriskCDR(Mailbox):
+    """Asterisk VM Call Data Record mailbox."""
+
+    def __init__(self, hass, name):
+        """Initialie Asterisk CDR."""
+        super().__init__(hass, name)
+        self.cdr = []
+        async_dispatcher_connect(
+            self.hass, SIGNAL_CDR_UPDATE, self._update_callback)
+
+    @callback
+    def _update_callback(self, msg):
+        """Update the message count in HA, if needed."""
+        cdr = []
+        for entry in self.hass.data[MBOX_DOMAIN].cdr:
+            timestamp = datetime.datetime.strptime(
+                entry['time'], "%Y-%m-%d %H:%M:%S").timestamp()
+            info = {
+                'origtime': timestamp,
+                'callerid': entry['callerid'],
+                'duration': entry['duration'],
+            }
+            sha = hashlib.sha256(str(entry).encode('utf-8')).hexdigest()
+            msg = "Destination: {}\nApplication: {}\n Context: {}".format(
+                entry['dest'], entry['application'], entry['context'])
+            cdr.append({'info': info, 'sha': sha, 'text': msg})
+        self.cdr = cdr
+        self.async_update()
+
+    @asyncio.coroutine
+    def async_get_messages(self):
+        """Return a list of the current messages."""
+        return self.cdr

--- a/homeassistant/components/mailbox/asterisk_cdr.py
+++ b/homeassistant/components/mailbox/asterisk_cdr.py
@@ -19,8 +19,7 @@ _LOGGER = logging.getLogger(__name__)
 DOMAIN = "asterisk_cdr"
 
 
-async def async_get_handler(hass, config, async_add_devices,
-                            discovery_info=None):
+async def async_get_handler(hass, config, discovery_info=None):
     """Set up the Asterix CDR platform."""
     return AsteriskCDR(hass, DOMAIN)
 

--- a/homeassistant/components/mailbox/asterisk_cdr.py
+++ b/homeassistant/components/mailbox/asterisk_cdr.py
@@ -2,7 +2,7 @@
 Asterisk CDR interface.
 
 For more details about this platform, please refer to the documentation at
-https://home-assistant.io/components/mailbox.asteriskvm/
+https://home-assistant.io/components/mailbox.asterisk_cdr/
 """
 import logging
 import hashlib
@@ -10,7 +10,7 @@ import datetime
 
 from homeassistant.core import callback
 from homeassistant.components.asterisk_mbox import SIGNAL_CDR_UPDATE
-from homeassistant.components.asterisk_mbox import DOMAIN
+from homeassistant.components.asterisk_mbox import DOMAIN as ASTERISK_DOMAIN
 from homeassistant.components.mailbox import Mailbox
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
@@ -43,7 +43,7 @@ class AsteriskCDR(Mailbox):
     def _build_message(self):
         """Build message structure."""
         cdr = []
-        for entry in self.hass.data[DOMAIN].cdr:
+        for entry in self.hass.data[ASTERISK_DOMAIN].cdr:
             timestamp = datetime.datetime.strptime(
                 entry['time'], "%Y-%m-%d %H:%M:%S").timestamp()
             info = {

--- a/homeassistant/components/mailbox/asterisk_cdr.py
+++ b/homeassistant/components/mailbox/asterisk_cdr.py
@@ -39,6 +39,11 @@ class AsteriskCDR(Mailbox):
     @callback
     def _update_callback(self, msg):
         """Update the message count in HA, if needed."""
+        self._build_message()
+        self.async_update()
+
+    def _build_message(self):
+        """Build message structure"""
         cdr = []
         for entry in self.hass.data[MBOX_DOMAIN].cdr:
             timestamp = datetime.datetime.strptime(
@@ -53,9 +58,10 @@ class AsteriskCDR(Mailbox):
                 entry['dest'], entry['application'], entry['context'])
             cdr.append({'info': info, 'sha': sha, 'text': msg})
         self.cdr = cdr
-        self.async_update()
 
     @asyncio.coroutine
     def async_get_messages(self):
         """Return a list of the current messages."""
+        if not self.cdr:
+            self._build_message()
         return self.cdr

--- a/homeassistant/components/mailbox/asterisk_cdr.py
+++ b/homeassistant/components/mailbox/asterisk_cdr.py
@@ -4,7 +4,6 @@ Asterisk CDR interface.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/mailbox.asteriskvm/
 """
-import asyncio
 import logging
 import hashlib
 import datetime
@@ -20,8 +19,7 @@ _LOGGER = logging.getLogger(__name__)
 DOMAIN = "asterisk_cdr"
 
 
-@asyncio.coroutine
-def async_get_handler(hass, config, async_add_devices, discovery_info=None):
+async def async_get_handler(hass, config, async_add_devices, discovery_info=None):
     """Set up the Asterix CDR platform."""
     return AsteriskCDR(hass, DOMAIN)
 
@@ -59,8 +57,7 @@ class AsteriskCDR(Mailbox):
             cdr.append({'info': info, 'sha': sha, 'text': msg})
         self.cdr = cdr
 
-    @asyncio.coroutine
-    def async_get_messages(self):
+    async def async_get_messages(self):
         """Return a list of the current messages."""
         if not self.cdr:
             self._build_message()

--- a/homeassistant/components/mailbox/asterisk_cdr.py
+++ b/homeassistant/components/mailbox/asterisk_cdr.py
@@ -29,7 +29,7 @@ class AsteriskCDR(Mailbox):
     """Asterisk VM Call Data Record mailbox."""
 
     def __init__(self, hass, name):
-        """Initialie Asterisk CDR."""
+        """Initialize Asterisk CDR."""
         super().__init__(hass, name)
         self.cdr = []
         async_dispatcher_connect(

--- a/homeassistant/components/mailbox/asterisk_cdr.py
+++ b/homeassistant/components/mailbox/asterisk_cdr.py
@@ -19,7 +19,8 @@ _LOGGER = logging.getLogger(__name__)
 DOMAIN = "asterisk_cdr"
 
 
-async def async_get_handler(hass, config, async_add_devices, discovery_info=None):
+async def async_get_handler(hass, config, async_add_devices,
+                            discovery_info=None):
     """Set up the Asterix CDR platform."""
     return AsteriskCDR(hass, DOMAIN)
 
@@ -41,7 +42,7 @@ class AsteriskCDR(Mailbox):
         self.async_update()
 
     def _build_message(self):
-        """Build message structure"""
+        """Build message structure."""
         cdr = []
         for entry in self.hass.data[MBOX_DOMAIN].cdr:
             timestamp = datetime.datetime.strptime(

--- a/homeassistant/components/mailbox/asterisk_cdr.py
+++ b/homeassistant/components/mailbox/asterisk_cdr.py
@@ -10,18 +10,18 @@ import datetime
 
 from homeassistant.core import callback
 from homeassistant.components.asterisk_mbox import SIGNAL_CDR_UPDATE
-from homeassistant.components.asterisk_mbox import DOMAIN as MBOX_DOMAIN
+from homeassistant.components.asterisk_mbox import DOMAIN
 from homeassistant.components.mailbox import Mailbox
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 DEPENDENCIES = ['asterisk_mbox']
 _LOGGER = logging.getLogger(__name__)
-DOMAIN = "asterisk_cdr"
+MAILBOX_NAME = "asterisk_cdr"
 
 
 async def async_get_handler(hass, config, discovery_info=None):
     """Set up the Asterix CDR platform."""
-    return AsteriskCDR(hass, DOMAIN)
+    return AsteriskCDR(hass, MAILBOX_NAME)
 
 
 class AsteriskCDR(Mailbox):
@@ -43,7 +43,7 @@ class AsteriskCDR(Mailbox):
     def _build_message(self):
         """Build message structure."""
         cdr = []
-        for entry in self.hass.data[MBOX_DOMAIN].cdr:
+        for entry in self.hass.data[DOMAIN].cdr:
             timestamp = datetime.datetime.strptime(
                 entry['time'], "%Y-%m-%d %H:%M:%S").timestamp()
             info = {

--- a/homeassistant/components/mailbox/asterisk_mbox.py
+++ b/homeassistant/components/mailbox/asterisk_mbox.py
@@ -46,6 +46,16 @@ class AsteriskMailbox(Mailbox):
         """Return the supported media type."""
         return CONTENT_TYPE_MPEG
 
+    @property
+    def can_delete(self):
+        """Return if messages can be deleted."""
+        return True
+
+    @property
+    def has_media(self):
+        """Return if messages have attached media files."""
+        return True
+
     @asyncio.coroutine
     def async_get_media(self, msgid):
         """Return the media blob for the msgid."""

--- a/homeassistant/components/mailbox/asterisk_mbox.py
+++ b/homeassistant/components/mailbox/asterisk_mbox.py
@@ -6,7 +6,7 @@ https://home-assistant.io/components/mailbox.asteriskvm/
 """
 import logging
 
-from homeassistant.components.asterisk_mbox import DOMAIN
+from homeassistant.components.asterisk_mbox import DOMAIN as ASTERISK_DOMAIN
 from homeassistant.components.mailbox import (
     CONTENT_TYPE_MPEG, Mailbox, StreamError)
 from homeassistant.core import callback
@@ -22,7 +22,7 @@ SIGNAL_MESSAGE_UPDATE = 'asterisk_mbox.message_updated'
 
 async def async_get_handler(hass, config, discovery_info=None):
     """Set up the Asterix VM platform."""
-    return AsteriskMailbox(hass, DOMAIN)
+    return AsteriskMailbox(hass, ASTERISK_DOMAIN)
 
 
 class AsteriskMailbox(Mailbox):
@@ -57,7 +57,7 @@ class AsteriskMailbox(Mailbox):
     async def async_get_media(self, msgid):
         """Return the media blob for the msgid."""
         from asterisk_mbox import ServerError
-        client = self.hass.data[DOMAIN].client
+        client = self.hass.data[ASTERISK_DOMAIN].client
         try:
             return client.mp3(msgid, sync=True)
         except ServerError as err:
@@ -65,11 +65,11 @@ class AsteriskMailbox(Mailbox):
 
     async def async_get_messages(self):
         """Return a list of the current messages."""
-        return self.hass.data[DOMAIN].messages
+        return self.hass.data[ASTERISK_DOMAIN].messages
 
     def async_delete(self, msgid):
         """Delete the specified messages."""
-        client = self.hass.data[DOMAIN].client
+        client = self.hass.data[ASTERISK_DOMAIN].client
         _LOGGER.info("Deleting: %s", msgid)
         client.delete(msgid)
         return True

--- a/homeassistant/components/mailbox/asterisk_mbox.py
+++ b/homeassistant/components/mailbox/asterisk_mbox.py
@@ -20,8 +20,7 @@ SIGNAL_MESSAGE_REQUEST = 'asterisk_mbox.message_request'
 SIGNAL_MESSAGE_UPDATE = 'asterisk_mbox.message_updated'
 
 
-async def async_get_handler(hass, config, async_add_entities,
-                            discovery_info=None):
+async def async_get_handler(hass, config, discovery_info=None):
     """Set up the Asterix VM platform."""
     return AsteriskMailbox(hass, DOMAIN)
 

--- a/homeassistant/components/mailbox/asterisk_mbox.py
+++ b/homeassistant/components/mailbox/asterisk_mbox.py
@@ -20,7 +20,8 @@ SIGNAL_MESSAGE_REQUEST = 'asterisk_mbox.message_request'
 SIGNAL_MESSAGE_UPDATE = 'asterisk_mbox.message_updated'
 
 
-async def async_get_handler(hass, config, async_add_entities, discovery_info=None):
+async def async_get_handler(hass, config, async_add_entities,
+                            discovery_info=None):
     """Set up the Asterix VM platform."""
     return AsteriskMailbox(hass, DOMAIN)
 

--- a/homeassistant/components/mailbox/asterisk_mbox.py
+++ b/homeassistant/components/mailbox/asterisk_mbox.py
@@ -4,7 +4,6 @@ Asterisk Voicemail interface.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/mailbox.asteriskvm/
 """
-import asyncio
 import logging
 
 from homeassistant.components.asterisk_mbox import DOMAIN
@@ -21,8 +20,7 @@ SIGNAL_MESSAGE_REQUEST = 'asterisk_mbox.message_request'
 SIGNAL_MESSAGE_UPDATE = 'asterisk_mbox.message_updated'
 
 
-@asyncio.coroutine
-def async_get_handler(hass, config, async_add_entities, discovery_info=None):
+async def async_get_handler(hass, config, async_add_entities, discovery_info=None):
     """Set up the Asterix VM platform."""
     return AsteriskMailbox(hass, DOMAIN)
 
@@ -56,8 +54,7 @@ class AsteriskMailbox(Mailbox):
         """Return if messages have attached media files."""
         return True
 
-    @asyncio.coroutine
-    def async_get_media(self, msgid):
+    async def async_get_media(self, msgid):
         """Return the media blob for the msgid."""
         from asterisk_mbox import ServerError
         client = self.hass.data[DOMAIN].client
@@ -66,8 +63,7 @@ class AsteriskMailbox(Mailbox):
         except ServerError as err:
             raise StreamError(err)
 
-    @asyncio.coroutine
-    def async_get_messages(self):
+    async def async_get_messages(self):
         """Return a list of the current messages."""
         return self.hass.data[DOMAIN].messages
 

--- a/homeassistant/components/mailbox/demo.py
+++ b/homeassistant/components/mailbox/demo.py
@@ -54,6 +54,16 @@ class DemoMailbox(Mailbox):
         """Return the supported media type."""
         return CONTENT_TYPE_MPEG
 
+    @property
+    def can_delete(self):
+        """Return if messages can be deleted."""
+        return True
+
+    @property
+    def has_media(self):
+        """Return if messages have attached media files."""
+        return True
+
     @asyncio.coroutine
     def async_get_media(self, msgid):
         """Return the media blob for the msgid."""

--- a/homeassistant/components/mailbox/demo.py
+++ b/homeassistant/components/mailbox/demo.py
@@ -14,12 +14,12 @@ from homeassistant.util import dt
 
 _LOGGER = logging.getLogger(__name__)
 
-DOMAIN = "DemoMailbox"
+MAILBOX_NAME = "DemoMailbox"
 
 
 async def async_get_handler(hass, config, discovery_info=None):
     """Set up the Demo mailbox."""
-    return DemoMailbox(hass, DOMAIN)
+    return DemoMailbox(hass, MAILBOX_NAME)
 
 
 class DemoMailbox(Mailbox):

--- a/homeassistant/components/mailbox/demo.py
+++ b/homeassistant/components/mailbox/demo.py
@@ -4,7 +4,6 @@ Asterisk Voicemail interface.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/mailbox.asteriskvm/
 """
-import asyncio
 from hashlib import sha1
 import logging
 import os
@@ -18,8 +17,7 @@ _LOGGER = logging.getLogger(__name__)
 DOMAIN = "DemoMailbox"
 
 
-@asyncio.coroutine
-def async_get_handler(hass, config, discovery_info=None):
+async def async_get_handler(hass, config, discovery_info=None):
     """Set up the Demo mailbox."""
     return DemoMailbox(hass, DOMAIN)
 
@@ -64,8 +62,7 @@ class DemoMailbox(Mailbox):
         """Return if messages have attached media files."""
         return True
 
-    @asyncio.coroutine
-    def async_get_media(self, msgid):
+    async def async_get_media(self, msgid):
         """Return the media blob for the msgid."""
         if msgid not in self._messages:
             raise StreamError("Message not found")
@@ -75,8 +72,7 @@ class DemoMailbox(Mailbox):
         with open(audio_path, 'rb') as file:
             return file.read()
 
-    @asyncio.coroutine
-    def async_get_messages(self):
+    async def async_get_messages(self):
         """Return a list of the current messages."""
         return sorted(self._messages.values(),
                       key=lambda item: item['info']['origtime'],

--- a/tests/components/mailbox/test_init.py
+++ b/tests/components/mailbox/test_init.py
@@ -29,7 +29,7 @@ def test_get_platforms_from_mailbox(mock_http_client):
     req = yield from mock_http_client.get(url)
     assert req.status == 200
     result = yield from req.json()
-    assert len(result) == 1 and "DemoMailbox" in result
+    assert len(result) == 1 and "DemoMailbox" == result[0].get('name', None)
 
 
 @asyncio.coroutine


### PR DESCRIPTION
## Description:
This patch adds the asterisk_cdr mailbox platform to view call activity.  It also makes it possible to dynamically create mailbox platforms (needed in case CDR isn't supplied by the server).  Additionally, mailboxes without media are now supported, as are read-only messages, making the mailbox platform more generic.  Lastly all asycio.coroutines have been migrated to async/await.
This pull request requires a matching frontend change

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable): https://github.com/home-assistant/home-assistant.io/pull/6264**
**Pull request in [home-assistant-polymer](https://github.com/home-assistant/home-assistant-polymer) for frontend updates: https://github.com/home-assistant/home-assistant-polymer/pull/1660**

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New files were added to `.coveragerc`.

