### PR TITLE
Set 'event_data' column to 64 bytes instead of 32

### DIFF
--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -10,7 +10,7 @@ PROGRESS_FILE = '.migration_progress'
 
 def migrate_schema(instance):
     """Check if the schema needs to be upgraded."""
-    from .models import SchemaChanges, SCHEMA_VERSION
+    from .models import SchemaChanges, SCHEMA_VERSION, COLUMN_EVENT_TYPE_SIZE
 
     progress_path = instance.hass.config.path(PROGRESS_FILE)
 
@@ -218,6 +218,12 @@ def _apply_update(engine, new_version, old_version):
         ])
         _create_index(engine, "states", "ix_states_context_id")
         _create_index(engine, "states", "ix_states_context_user_id")
+    elif new_version == 7:
+        _drop_index(engine, "events", "event_type")
+
+        _create_index(engine, "events", [
+            'event_type CHARACTER({})'.format(COLUMN_EVENT_TYPE_SIZE),
+        ])
     else:
         raise ValueError("No schema migration defined for version {}"
                          .format(new_version))

--- a/homeassistant/components/recorder/models.py
+++ b/homeassistant/components/recorder/models.py
@@ -17,7 +17,8 @@ from homeassistant.helpers.json import JSONEncoder
 # pylint: disable=invalid-name
 Base = declarative_base()
 
-SCHEMA_VERSION = 6
+SCHEMA_VERSION = 7
+COLUMN_EVENT_TYPE_SIZE = 64
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -27,7 +28,7 @@ class Events(Base):  # type: ignore
 
     __tablename__ = 'events'
     event_id = Column(Integer, primary_key=True)
-    event_type = Column(String(32), index=True)
+    event_type = Column(String(COLUMN_EVENT_TYPE_SIZE), index=True)
     event_data = Column(Text)
     origin = Column(String(32))
     time_fired = Column(DateTime(timezone=True), index=True)


### PR DESCRIPTION
## Description:
32 bytes is too short for some event types, enlarging the column to 64 should be fine.

fixes #16074 #15984
