### PR TITLE
Improve precision of timer ticks

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1256,4 +1256,5 @@ def _async_create_timer(hass: HomeAssistant) -> None:
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, stop_timer)
 
     _LOGGER.info("Timer:starting")
-    fire_time_event(monotonic())
+    slp_seconds = 1 - (dt_util.utcnow().microsecond / 10**6)
+    hass.loop.call_later(slp_seconds, lambda: fire_time_event(monotonic()))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -862,21 +862,29 @@ def test_create_timer(mock_monotonic, loop):
 
     with patch.object(ha, 'callback', mock_callback), \
             patch('homeassistant.core.dt_util.utcnow',
-                  return_value=sentinel.mock_date):
+                  return_value=datetime(2018, 12, 31, 3, 4, 5, 333333)):
         ha._async_create_timer(hass)
+
+    assert len(hass.loop.call_later.mock_calls) == 1
+    slp_seconds, action = hass.loop.call_later.mock_calls[0][1]
+    assert abs(slp_seconds - 0.666667) < 0.001
+
+    with patch('homeassistant.core.dt_util.utcnow',
+               return_value=sentinel.mock_date):
+        action()
 
         assert len(funcs) == 2
         fire_time_event, stop_timer = funcs
 
     assert len(hass.bus.async_listen_once.mock_calls) == 1
     assert len(hass.bus.async_fire.mock_calls) == 1
-    assert len(hass.loop.call_later.mock_calls) == 1
+    assert len(hass.loop.call_later.mock_calls) == 2
 
     event_type, callback = hass.bus.async_listen_once.mock_calls[0][1]
     assert event_type == EVENT_HOMEASSISTANT_STOP
     assert callback is stop_timer
 
-    slp_seconds, callback, nxt = hass.loop.call_later.mock_calls[0][1]
+    slp_seconds, callback, nxt = hass.loop.call_later.mock_calls[1][1]
     assert abs(slp_seconds - 0.9) < 0.001
     assert callback is fire_time_event
     assert abs(nxt - 11.2) < 0.001
@@ -901,15 +909,21 @@ def test_timer_out_of_sync(mock_monotonic, loop):
 
     with patch.object(ha, 'callback', mock_callback), \
             patch('homeassistant.core.dt_util.utcnow',
-                  return_value=sentinel.mock_date):
+                  return_value=datetime(2018, 12, 31, 3, 4, 5, 333333)):
         ha._async_create_timer(hass)
+
+    _, action = hass.loop.call_later.mock_calls[0][1]
+
+    with patch('homeassistant.core.dt_util.utcnow',
+               return_value=sentinel.mock_date):
+        action()
 
         assert len(funcs) == 2
         fire_time_event, stop_timer = funcs
 
-    assert len(hass.loop.call_later.mock_calls) == 1
+    assert len(hass.loop.call_later.mock_calls) == 2
 
-    slp_seconds, callback, nxt = hass.loop.call_later.mock_calls[0][1]
+    slp_seconds, callback, nxt = hass.loop.call_later.mock_calls[1][1]
     assert slp_seconds == 1
     assert callback is fire_time_event
     assert abs(nxt - 12.3) < 0.001


### PR DESCRIPTION
## Description:

The timer tries to tick a whole number of seconds since it was started. Thus, if it is started very close to a second rolling over, many ticks will fire on the wrong second. This is because we are usually a little bit late with scheduled tasks. I added a log statement to show this.

```
2018-07-29 09:27:16 [...] Timer tick 2018-07-29 07:27:16.998479+00:00
2018-07-29 09:27:18 [...] Timer tick 2018-07-29 07:27:18.000322+00:00 <-- :17
2018-07-29 09:27:18 [...] Timer tick 2018-07-29 07:27:18.995209+00:00
2018-07-29 09:27:20 [...] Timer tick 2018-07-29 07:27:20.000136+00:00 <-- :19
2018-07-29 09:27:21 [...] Timer tick 2018-07-29 07:27:21.000139+00:00 <-- :20
2018-07-29 09:27:22 [...] Timer tick 2018-07-29 07:27:22.000105+00:00 <-- :21
2018-07-29 09:27:22 [...] Timer tick 2018-07-29 07:27:22.999665+00:00
```

To help avoid these double and missed ticks, this PR delays the first tick until a second rolls over. This means that we can be almost one second late and still work as expected.

This is just an improvement, more complete fixes are discussed in home-assistant/architecture#50.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.
