### PR TITLE
Make pylint report non-LF linefeeds per the style guidelines

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -42,5 +42,8 @@ reports=no
 ignored-classes=_CountingAttr
 generated-members=botocore.errorfactory
 
+[FORMAT]
+expected-line-ending-format=LF
+
 [EXCEPTIONS]
 overgeneral-exceptions=Exception,HomeAssistantError


### PR DESCRIPTION
## Description:

Makes https://developers.home-assistant.io/docs/en/maintenance.html#line-separator kind of obsolete.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
