### PR TITLE
Fix bug where momentary switch with activation low does not reset

### DIFF
--- a/homeassistant/components/switch/konnected.py
+++ b/homeassistant/components/switch/konnected.py
@@ -83,7 +83,7 @@ class KonnectedSwitch(ToggleEntity):
 
             if self._momentary and resp.get(ATTR_STATE) != -1:
                 # Immediately set the state back off for momentary switches
-                self._set_state(self._boolean_state(False))
+                self._set_state(False)
 
     def turn_off(self, **kwargs):
         """Send a command to turn off the switch."""


### PR DESCRIPTION
## Description:
Fixes bug where momentary switches with `low` activation would not reset their state in HA after actuation.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
