### PR TITLE
Expand IP control support for older Pioneer receivers

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@
 
 **Related issue (if applicable):** fixes #<home-assistant issue number goes here>
 
-**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>
+**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>
 
 ## Example entry for `configuration.yaml` (if applicable):
 ```yaml
@@ -15,7 +15,7 @@
   - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
 
 If user exposed functionality or configuration variables are added/changed:
-  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)
+  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)
 
 If the code communicates with devices, web services, or third-party tools:
   - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).

--- a/homeassistant/components/media_player/pioneer.py
+++ b/homeassistant/components/media_player/pioneer.py
@@ -97,9 +97,11 @@ class PioneerDevice(MediaPlayerDevice):
                 # If inputs were defined via inputs, set them up now.
                 # These need to be set before 'update' gets called.
                 self._inputs = inputs
-                for k, v in self._inputs.items():
-                    self._source_number_to_name[str(k).zfill(2)] = v[CONF_NAME]
-                    self._source_name_to_number[v[CONF_NAME]] = str(k).zfill(2)
+                for key, val in self._inputs.items():
+                    self._source_number_to_name[str(key).zfill(2)] = \
+                        val[CONF_NAME]
+                    self._source_name_to_number[val[CONF_NAME]] = \
+                        str(key).zfill(2)
 
         self._pwstate = self._poweredoff
 
@@ -189,7 +191,7 @@ class PioneerDevice(MediaPlayerDevice):
                     source_list = result[3:]
                     for i in range(MAX_SOURCE_NUMBERS):
                         if source_list[i] != '0':
-                            _LOGGER.debug("Found input: %0.2d" % i)
+                            _LOGGER.debug("Found input: %0.2d", i)
                             source_name = "Input " + str(i).zfill(2)
                             source_number = str(i).zfill(2)
 

--- a/homeassistant/components/media_player/pioneer.py
+++ b/homeassistant/components/media_player/pioneer.py
@@ -81,6 +81,7 @@ class PioneerDevice(MediaPlayerDevice):
         self._mode = mode
         self._poweredon = POWERED_ON
         self._poweredoff = POWERED_OFF_STD
+        self._maxvolume = MAX_VOLUME_STD
         self._volume = 0
         self._muted = False
         self._selected_source = ''
@@ -89,6 +90,7 @@ class PioneerDevice(MediaPlayerDevice):
 
         if self._mode == 'basic':
             self._poweredoff = POWERED_OFF_BASIC
+            self._maxvolume = MAX_VOLUME_BASIC
             if zones:
                 # If inputs were defined via zones, set them up now.
                 # These need to be set before 'update' gets called.
@@ -152,12 +154,8 @@ class PioneerDevice(MediaPlayerDevice):
             self._pwstate = pwstate
 
         volume_str = self.telnet_request(telnet, "?V", "VOL")
-        if self._mode == "basic":
-            self._volume = int(volume_str[3:]) / MAX_VOLUME_BASIC \
-                if volume_str else None
-        else:
-            self._volume = int(volume_str[3:]) / MAX_VOLUME_STD \
-                if volume_str else None
+        self._volume = int(volume_str[3:]) / self._maxvolume \
+            if volume_str else None
 
         muted_value = self.telnet_request(telnet, "?M", "MUT")
         self._muted = (muted_value == "MUT0") if muted_value else None

--- a/homeassistant/components/media_player/pioneer.py
+++ b/homeassistant/components/media_player/pioneer.py
@@ -24,7 +24,7 @@ _LOGGER = logging.getLogger(__name__)
 DEFAULT_NAME = 'Pioneer AVR'
 DEFAULT_PORT = 23   # telnet default. Some Pioneer AVRs use 8102
 DEFAULT_TIMEOUT = None
-DEFAULT_MODE = None # Use "basic" for older receivers.
+DEFAULT_MODE = None   # Use "basic" for older receivers.
 
 SUPPORT_PIONEER = SUPPORT_PAUSE | SUPPORT_VOLUME_SET | SUPPORT_VOLUME_MUTE | \
                   SUPPORT_TURN_ON | SUPPORT_TURN_OFF | \
@@ -95,7 +95,7 @@ class PioneerDevice(MediaPlayerDevice):
                 # If inputs were defined via zones, set them up now.
                 # These need to be set before 'update' gets called.
                 self._zones = zones
-                for k,v in self._zones.items():
+                for k, v in self._zones.items():
                     self._source_number_to_name[str(k).zfill(2)] = v[CONF_NAME]
                     self._source_name_to_number[v[CONF_NAME]] = str(k).zfill(2)
 
@@ -191,8 +191,10 @@ class PioneerDevice(MediaPlayerDevice):
                             source_name = "Input " + str(i).zfill(2)
                             source_number = str(i).zfill(2)
 
-                            self._source_name_to_number[source_name] = source_number
-                            self._source_number_to_name[source_number] = source_name
+                            self._source_name_to_number[source_name] = \
+                                source_number
+                            self._source_number_to_name[source_number] = \
+                                source_name
 
         source_number = self.telnet_request(telnet, "?F", "FN")
 
@@ -268,7 +270,8 @@ class PioneerDevice(MediaPlayerDevice):
     def set_volume_level(self, volume):
         """Set volume level, range 0..1."""
         # 60dB max
-        self.telnet_command(str(round(volume * MAX_VOLUME)).zfill(3) + "VL")
+        self.telnet_command(
+            str(round(volume * self._maxvolume)).zfill(3) + "VL")
 
     def mute_volume(self, mute):
         """Mute (true) or unmute (false) media player."""

--- a/homeassistant/components/media_player/pioneer.py
+++ b/homeassistant/components/media_player/pioneer.py
@@ -240,9 +240,10 @@ class PioneerDevice(MediaPlayerDevice):
     def supported_features(self):
         """Flag media player features that are supported."""
         if self._mode == "basic":
-            return SUPPORT_PIONEER_BASIC
+            return_val = SUPPORT_PIONEER_BASIC
         else:
-            return SUPPORT_PIONEER
+            return_val = SUPPORT_PIONEER
+        return return_val
 
     @property
     def source(self):

--- a/homeassistant/components/media_player/pioneer.py
+++ b/homeassistant/components/media_player/pioneer.py
@@ -15,8 +15,8 @@ from homeassistant.components.media_player import (
     SUPPORT_TURN_OFF, SUPPORT_TURN_ON, SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_SET,
     SUPPORT_VOLUME_STEP, MediaPlayerDevice)
 from homeassistant.const import (
-    CONF_HOST, CONF_MODE, CONF_NAME, CONF_PORT, CONF_TIMEOUT, CONF_ZONE,
-    STATE_OFF, STATE_ON, STATE_UNKNOWN)
+    CONF_HOST, CONF_MODE, CONF_NAME, CONF_PORT, CONF_TIMEOUT, STATE_OFF,
+    STATE_ON, STATE_UNKNOWN)
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION
## Description:
Support additional Pioneer receivers that do not work with the existing platform.  This includes at least VSX-822/1022 and presumably other pre-2013 devices.

To activate the new functionality, there are additional parameters that need to be passed, so it should not impact existing installations.
- mode: basic
- optional 'input' list of input names

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  - platform: pioneer
    host: 192.168.x.x
    port: 8102
    mode: basic
    input:
      01:
        name: "CD"
      02:
        name: "Tuner"
      06:
        name: "PC"
      49:
        name: "XBox 360"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
