### PR TITLE
Remove discovered MQTT Switch device when discovery topic is cleared

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -92,6 +92,7 @@ ATTR_PAYLOAD = 'payload'
 ATTR_PAYLOAD_TEMPLATE = 'payload_template'
 ATTR_QOS = CONF_QOS
 ATTR_RETAIN = CONF_RETAIN
+ATTR_DISCOVERY_HASH = 'discovery_hash'
 
 MAX_RECONNECT_WAIT = 300  # seconds
 

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -858,7 +858,7 @@ class MqttDiscoveryUpdate(Entity):
             if not payload:
                 # Empty payload: Remove component
                 _LOGGER.info("Removing component: %s", self.entity_id)
-                self.hass.async_add_job(self.async_remove())
+                self.hass.async_create_task(self.async_remove())
                 del self.hass.data[ALREADY_DISCOVERED][self._discovery_hash]
                 self._remove_signal()
 

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -834,3 +834,36 @@ class MqttAvailability(Entity):
     def available(self) -> bool:
         """Return if the device is available."""
         return self._available
+
+
+class MqttDiscoveryUpdate(Entity):
+    """Mixin used to handle updated discovery message."""
+
+    def __init__(self, discovery_hash) -> None:
+        """Initialize the discovery update mixin."""
+        self._discovery_hash = discovery_hash
+        self._remove_signal = None
+
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to discovery updates."""
+        from homeassistant.helpers.dispatcher import async_dispatcher_connect
+        from homeassistant.components.mqtt.discovery import (
+            ALREADY_DISCOVERED, MQTT_DISCOVERY_UPDATED)
+
+        @callback
+        def discovery_callback(payload):
+            """Handle discovery update."""
+            _LOGGER.info("Got update for entity with hash: %s '%s'",
+                         self._discovery_hash, payload)
+            if not payload:
+                # Empty payload: Remove component
+                _LOGGER.info("Removing component: %s", self.entity_id)
+                self.hass.async_add_job(self.async_remove())
+                del self.hass.data[ALREADY_DISCOVERED][self._discovery_hash]
+                self._remove_signal()
+
+        if self._discovery_hash:
+            self._remove_signal = async_dispatcher_connect(
+                self.hass,
+                MQTT_DISCOVERY_UPDATED.format(self._discovery_hash),
+                discovery_callback)

--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -39,8 +39,8 @@ ALLOWED_PLATFORMS = {
 }
 
 ALREADY_DISCOVERED = 'mqtt_discovered_components'
-
 MQTT_DISCOVERY_UPDATED = 'mqtt_discovery_updated_{}'
+
 
 async def async_start(hass, discovery_topic, hass_config):
     """Initialize of MQTT Discovery."""

--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -9,7 +9,7 @@ import logging
 import re
 
 from homeassistant.components import mqtt
-from homeassistant.components.mqtt import CONF_STATE_TOPIC
+from homeassistant.components.mqtt import CONF_STATE_TOPIC, ATTR_DISCOVERY_HASH
 from homeassistant.const import CONF_PLATFORM
 from homeassistant.helpers.discovery import async_load_platform
 
@@ -51,47 +51,64 @@ async def async_start(hass, discovery_topic, hass_config):
 
         _prefix_topic, component, node_id, object_id = match.groups()
 
-        try:
-            payload = json.loads(payload)
-        except ValueError:
-            _LOGGER.warning("Unable to parse JSON %s: %s", object_id, payload)
-            return
-
         if component not in SUPPORTED_COMPONENTS:
             _LOGGER.warning("Component %s is not supported", component)
             return
 
-        payload = dict(payload)
-        platform = payload.get(CONF_PLATFORM, 'mqtt')
-        if platform not in ALLOWED_PLATFORMS.get(component, []):
-            _LOGGER.warning("Platform %s (component %s) is not allowed",
-                            platform, component)
-            return
-
-        payload[CONF_PLATFORM] = platform
-        if CONF_STATE_TOPIC not in payload:
-            payload[CONF_STATE_TOPIC] = '{}/{}/{}{}/state'.format(
-                discovery_topic, component, '%s/' % node_id if node_id else '',
-                object_id)
-
-        if ALREADY_DISCOVERED not in hass.data:
-            hass.data[ALREADY_DISCOVERED] = set()
-
         # If present, the node_id will be included in the discovered object id
         discovery_id = '_'.join((node_id, object_id)) if node_id else object_id
 
+        if ALREADY_DISCOVERED not in hass.data:
+            hass.data[ALREADY_DISCOVERED] = {}
+
         discovery_hash = (component, discovery_id)
-        if discovery_hash in hass.data[ALREADY_DISCOVERED]:
-            _LOGGER.info("Component has already been discovered: %s %s",
-                         component, discovery_id)
-            return
 
-        hass.data[ALREADY_DISCOVERED].add(discovery_hash)
+        if payload:
+            # Add component
+            try:
+                payload = json.loads(payload)
+            except ValueError:
+                _LOGGER.warning("Unable to parse JSON %s: %s",
+                                object_id, payload)
+                return
 
-        _LOGGER.info("Found new component: %s %s", component, discovery_id)
+            payload = dict(payload)
+            platform = payload.get(CONF_PLATFORM, 'mqtt')
+            if platform not in ALLOWED_PLATFORMS.get(component, []):
+                _LOGGER.warning("Platform %s (component %s) is not allowed",
+                                platform, component)
+                return
 
-        await async_load_platform(
-            hass, component, platform, payload, hass_config)
+            payload[CONF_PLATFORM] = platform
+            if CONF_STATE_TOPIC not in payload:
+                payload[CONF_STATE_TOPIC] = '{}/{}/{}{}/state'.format(
+                    discovery_topic, component,
+                    '%s/' % node_id if node_id else '', object_id)
+
+            if discovery_hash in hass.data[ALREADY_DISCOVERED]:
+                _LOGGER.info("Component has already been discovered: %s %s",
+                             component, discovery_id)
+                return
+
+            hass.data[ALREADY_DISCOVERED][discovery_hash] = None
+            payload[ATTR_DISCOVERY_HASH] = discovery_hash
+
+            _LOGGER.info("Found new component: %s %s", component, discovery_id)
+
+            await async_load_platform(
+                hass, component, platform, payload, hass_config)
+
+        else:
+            # Remove component
+            if discovery_hash in hass.data[ALREADY_DISCOVERED]:
+                _LOGGER.info("Removing component: %s %s",
+                             component, discovery_id)
+
+                if hass.data[ALREADY_DISCOVERED][discovery_hash] is not None:
+                    entity = hass.data[ALREADY_DISCOVERED][discovery_hash]
+                    hass.states.async_remove(entity.entity_id)
+
+                del hass.data[ALREADY_DISCOVERED][discovery_hash]
 
     await mqtt.async_subscribe(
         hass, discovery_topic + '/#', async_device_message_received, 0)


### PR DESCRIPTION
## Description:
Support removal of previously discovered device when a (retained) discovery payload is cleared.
Note1: This is item 1 from home-assistant/architecture#70
Note2: This was previously raised as #11489, so credit (if merged) goes to @Big4SMK :)

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#6276

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`.