### PR TITLE
Adding support for RTDSContactSensor and RTDSMotionSensor in Tahoma … (RTS Alarms sensors and contacts for Somfy Protexiom alarms)

### DIFF
--- a/homeassistant/components/sensor/tahoma.py
+++ b/homeassistant/components/sensor/tahoma.py
@@ -17,7 +17,7 @@ DEPENDENCIES = ['tahoma']
 
 _LOGGER = logging.getLogger(__name__)
 
-SCAN_INTERVAL = timedelta(seconds=60)
+SCAN_INTERVAL = timedelta(seconds=10)
 
 ATTR_RSSI_LEVEL = 'rssi_level'
 
@@ -56,6 +56,10 @@ class TahomaSensor(TahomaDevice, Entity):
             return 'lx'
         if self.tahoma_device.type == 'Humidity Sensor':
             return '%'
+        if self.tahoma_device.type == 'rtds:RTDSContactSensor':
+            return None
+        if self.tahoma_device.type == 'rtds:RTDSMotionSensor':
+            return None
 
     def update(self):
         """Update the state."""
@@ -63,12 +67,23 @@ class TahomaSensor(TahomaDevice, Entity):
         if self.tahoma_device.type == 'io:LightIOSystemSensor':
             self.current_value = self.tahoma_device.active_states[
                 'core:LuminanceState']
+            self._available = bool(self.tahoma_device.active_states.get(
+                'core:StatusState') == 'available')
+
         if self.tahoma_device.type == 'io:SomfyContactIOSystemSensor':
             self.current_value = self.tahoma_device.active_states[
                 'core:ContactState']
+            self._available = bool(self.tahoma_device.active_states.get(
+                'core:StatusState') == 'available')
+        if self.tahoma_device.type == 'rtds:RTDSContactSensor':
+            self.current_value = self.tahoma_device.active_states[
+                'core:ContactState']
+            self._available = True
+        if self.tahoma_device.type == 'rtds:RTDSMotionSensor':
+            self.current_value = self.tahoma_device.active_states[
+                'core:OccupancyState']
+            self._available = True
 
-        self._available = bool(self.tahoma_device.active_states.get(
-            'core:StatusState') == 'available')
 
         _LOGGER.debug("Update %s, value: %d", self._name, self.current_value)
 

--- a/homeassistant/components/sensor/tahoma.py
+++ b/homeassistant/components/sensor/tahoma.py
@@ -17,7 +17,7 @@ DEPENDENCIES = ['tahoma']
 
 _LOGGER = logging.getLogger(__name__)
 
-SCAN_INTERVAL = timedelta(seconds=10)
+SCAN_INTERVAL = timedelta(seconds=60)
 
 ATTR_RSSI_LEVEL = 'rssi_level'
 
@@ -69,7 +69,6 @@ class TahomaSensor(TahomaDevice, Entity):
                 'core:LuminanceState']
             self._available = bool(self.tahoma_device.active_states.get(
                 'core:StatusState') == 'available')
-
         if self.tahoma_device.type == 'io:SomfyContactIOSystemSensor':
             self.current_value = self.tahoma_device.active_states[
                 'core:ContactState']
@@ -83,7 +82,6 @@ class TahomaSensor(TahomaDevice, Entity):
             self.current_value = self.tahoma_device.active_states[
                 'core:OccupancyState']
             self._available = True
-
 
         _LOGGER.debug("Update %s, value: %d", self._name, self.current_value)
 

--- a/homeassistant/components/tahoma.py
+++ b/homeassistant/components/tahoma.py
@@ -54,6 +54,8 @@ TAHOMA_TYPES = {
     'io:HorizontalAwningIOComponent': 'cover',
     'io:OnOffLightIOComponent': 'switch',
     'rtds:RTDSSmokeSensor': 'smoke',
+    'rtds:RTDSContactSensor': 'sensor',
+    'rtds:RTDSMotionSensor': 'sensor'
 }
 
 


### PR DESCRIPTION
Tahoma component:

## Description:
This commit update the list of supported devices, adding 2 new Somfy devices (1 presence sensor and 1 contact sensor)

The way of managing the flag "available" has been changed in order to well manage the  "available" flag for the 2 new sensors (not  located on the same place than the other tahoma device in the device structure).

Tested using true tahoma and sensors on my RPI 2 + Hassbian.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
