### PR TITLE
Add connection class to config flows and config entries

### DIFF
--- a/homeassistant/components/cast/__init__.py
+++ b/homeassistant/components/cast/__init__.py
@@ -35,4 +35,5 @@ async def _async_has_devices(hass):
 
 
 config_entry_flow.register_discovery_flow(
-    DOMAIN, 'Google Cast', _async_has_devices)
+    DOMAIN, 'Google Cast', _async_has_devices,
+    config_entries.CONN_CLASS_LOCAL_PUSH)

--- a/homeassistant/components/config/config_entries.py
+++ b/homeassistant/components/config/config_entries.py
@@ -54,6 +54,7 @@ class ConfigManagerEntryIndexView(HomeAssistantView):
             'title': entry.title,
             'source': entry.source,
             'state': entry.state,
+            'connection_class': entry.connection_class,
         } for entry in hass.config_entries.async_entries()])
 
 

--- a/homeassistant/components/deconz/config_flow.py
+++ b/homeassistant/components/deconz/config_flow.py
@@ -2,7 +2,7 @@
 
 import voluptuous as vol
 
-from homeassistant import config_entries, data_entry_flow
+from homeassistant import config_entries
 from homeassistant.core import callback
 from homeassistant.const import CONF_API_KEY, CONF_HOST, CONF_PORT
 from homeassistant.helpers import aiohttp_client
@@ -23,10 +23,11 @@ def configured_hosts(hass):
 
 
 @config_entries.HANDLERS.register(DOMAIN)
-class DeconzFlowHandler(data_entry_flow.FlowHandler):
+class DeconzFlowHandler(config_entries.ConfigFlow):
     """Handle a deCONZ config flow."""
 
     VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_PUSH
 
     def __init__(self):
         """Initialize the deCONZ config flow."""

--- a/homeassistant/components/hangouts/config_flow.py
+++ b/homeassistant/components/hangouts/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow to configure Google Hangouts."""
 import voluptuous as vol
 
-from homeassistant import config_entries, data_entry_flow
+from homeassistant import config_entries
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from homeassistant.core import callback
 
@@ -19,10 +19,11 @@ def configured_hangouts(hass):
 
 
 @config_entries.HANDLERS.register(HANGOUTS_DOMAIN)
-class HangoutsFlowHandler(data_entry_flow.FlowHandler):
+class HangoutsFlowHandler(config_entries.ConfigFlow):
     """Config flow Google Hangouts."""
 
     VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_PUSH
 
     def __init__(self):
         """Initialize Google Hangouts config flow."""

--- a/homeassistant/components/homematicip_cloud/config_flow.py
+++ b/homeassistant/components/homematicip_cloud/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow to configure the HomematicIP Cloud component."""
 import voluptuous as vol
 
-from homeassistant import config_entries, data_entry_flow
+from homeassistant import config_entries
 from homeassistant.core import callback
 
 from .const import DOMAIN as HMIPC_DOMAIN
@@ -18,10 +18,11 @@ def configured_haps(hass):
 
 
 @config_entries.HANDLERS.register(HMIPC_DOMAIN)
-class HomematicipCloudFlowHandler(data_entry_flow.FlowHandler):
+class HomematicipCloudFlowHandler(config_entries.ConfigFlow):
     """Config flow for the HomematicIP Cloud component."""
 
     VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_PUSH
 
     def __init__(self):
         """Initialize HomematicIP Cloud config flow."""

--- a/homeassistant/components/hue/config_flow.py
+++ b/homeassistant/components/hue/config_flow.py
@@ -6,7 +6,7 @@ import os
 import async_timeout
 import voluptuous as vol
 
-from homeassistant import config_entries, data_entry_flow
+from homeassistant import config_entries
 from homeassistant.core import callback
 from homeassistant.helpers import aiohttp_client
 
@@ -41,10 +41,11 @@ def _find_username_from_config(hass, filename):
 
 
 @config_entries.HANDLERS.register(DOMAIN)
-class HueFlowHandler(data_entry_flow.FlowHandler):
+class HueFlowHandler(config_entries.ConfigFlow):
     """Handle a Hue config flow."""
 
     VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
 
     def __init__(self):
         """Initialize the Hue flow."""

--- a/homeassistant/components/ios/__init__.py
+++ b/homeassistant/components/ios/__init__.py
@@ -293,4 +293,5 @@ class iOSIdentifyDeviceView(HomeAssistantView):
 
 
 config_entry_flow.register_discovery_flow(
-    DOMAIN, 'Home Assistant iOS', lambda *_: True)
+    DOMAIN, 'Home Assistant iOS', lambda *_: True,
+    config_entries.CONN_CLASS_CLOUD_PUSH)

--- a/homeassistant/components/mqtt/config_flow.py
+++ b/homeassistant/components/mqtt/config_flow.py
@@ -15,6 +15,7 @@ class FlowHandler(config_entries.ConfigFlow):
     """Handle a config flow."""
 
     VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_PUSH
 
     async def async_step_user(self, user_input=None):
         """Handle a flow initialized by the user."""

--- a/homeassistant/components/nest/config_flow.py
+++ b/homeassistant/components/nest/config_flow.py
@@ -7,7 +7,7 @@ import os
 import async_timeout
 import voluptuous as vol
 
-from homeassistant import config_entries, data_entry_flow
+from homeassistant import config_entries
 from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.util.json import load_json
@@ -49,10 +49,11 @@ class CodeInvalid(NestAuthError):
 
 
 @config_entries.HANDLERS.register(DOMAIN)
-class NestFlowHandler(data_entry_flow.FlowHandler):
+class NestFlowHandler(config_entries.ConfigFlow):
     """Handle a Nest config flow."""
 
     VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_PUSH
 
     def __init__(self):
         """Initialize the Nest config flow."""

--- a/homeassistant/components/openuv/config_flow.py
+++ b/homeassistant/components/openuv/config_flow.py
@@ -4,7 +4,7 @@ from collections import OrderedDict
 
 import voluptuous as vol
 
-from homeassistant import config_entries, data_entry_flow
+from homeassistant import config_entries
 from homeassistant.core import callback
 from homeassistant.const import (
     CONF_API_KEY, CONF_ELEVATION, CONF_LATITUDE, CONF_LONGITUDE)
@@ -23,10 +23,11 @@ def configured_instances(hass):
 
 
 @config_entries.HANDLERS.register(DOMAIN)
-class OpenUvFlowHandler(data_entry_flow.FlowHandler):
+class OpenUvFlowHandler(config_entries.ConfigFlow):
     """Handle an OpenUV config flow."""
 
     VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
 
     def __init__(self):
         """Initialize the config flow."""

--- a/homeassistant/components/sonos/__init__.py
+++ b/homeassistant/components/sonos/__init__.py
@@ -34,4 +34,5 @@ async def _async_has_devices(hass):
     return await hass.async_add_executor_job(soco.discover)
 
 
-config_entry_flow.register_discovery_flow(DOMAIN, 'Sonos', _async_has_devices)
+config_entry_flow.register_discovery_flow(
+    DOMAIN, 'Sonos', _async_has_devices, config_entries.CONN_CLASS_LOCAL_PUSH)

--- a/homeassistant/components/zone/config_flow.py
+++ b/homeassistant/components/zone/config_flow.py
@@ -3,7 +3,7 @@
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
-from homeassistant import config_entries, data_entry_flow
+from homeassistant import config_entries
 from homeassistant.const import (
     CONF_NAME, CONF_LATITUDE, CONF_LONGITUDE, CONF_ICON, CONF_RADIUS)
 from homeassistant.core import callback
@@ -20,7 +20,7 @@ def configured_zones(hass):
 
 
 @config_entries.HANDLERS.register(DOMAIN)
-class ZoneFlowHandler(data_entry_flow.FlowHandler):
+class ZoneFlowHandler(config_entries.ConfigFlow):
     """Zone config flow."""
 
     VERSION = 1

--- a/tests/common.py
+++ b/tests/common.py
@@ -550,14 +550,16 @@ class MockConfigEntry(config_entries.ConfigEntry):
 
     def __init__(self, *, domain='test', data=None, version=0, entry_id=None,
                  source=config_entries.SOURCE_USER, title='Mock Title',
-                 state=None):
+                 state=None,
+                 connection_class=config_entries.CONN_CLASS_UNKNOWN):
         """Initialize a mock config entry."""
         kwargs = {
             'entry_id': entry_id or 'mock-id',
             'domain': domain,
             'data': data or {},
             'version': version,
-            'title': title
+            'title': title,
+            'connection_class': connection_class,
         }
         if source is not None:
             kwargs['source'] = source

--- a/tests/components/binary_sensor/test_deconz.py
+++ b/tests/components/binary_sensor/test_deconz.py
@@ -42,7 +42,8 @@ async def setup_bridge(hass, data, allow_clip_sensor=True):
     hass.data[deconz.DATA_DECONZ_ID] = {}
     config_entry = config_entries.ConfigEntry(
         1, deconz.DOMAIN, 'Mock Title',
-        {'host': 'mock-host', 'allow_clip_sensor': allow_clip_sensor}, 'test')
+        {'host': 'mock-host', 'allow_clip_sensor': allow_clip_sensor}, 'test',
+        config_entries.CONN_CLASS_LOCAL_PUSH)
     await hass.config_entries.async_forward_entry_setup(
         config_entry, 'binary_sensor')
     # To flush out the service call to update the group

--- a/tests/components/config/test_config_entries.py
+++ b/tests/components/config/test_config_entries.py
@@ -9,7 +9,6 @@ import voluptuous as vol
 
 from homeassistant import config_entries as core_ce
 from homeassistant.config_entries import HANDLERS
-from homeassistant.data_entry_flow import FlowHandler
 from homeassistant.setup import async_setup_component
 from homeassistant.components.config import config_entries
 from homeassistant.loader import set_component
@@ -37,13 +36,15 @@ def test_get_entries(hass, client):
     MockConfigEntry(
        domain='comp',
        title='Test 1',
-       source='bla'
+       source='bla',
+       connection_class=core_ce.CONN_CLASS_LOCAL_POLL,
     ).add_to_hass(hass)
     MockConfigEntry(
        domain='comp2',
        title='Test 2',
        source='bla2',
        state=core_ce.ENTRY_STATE_LOADED,
+       connection_class=core_ce.CONN_CLASS_ASSUMED,
     ).add_to_hass(hass)
     resp = yield from client.get('/api/config/config_entries/entry')
     assert resp.status == 200
@@ -55,13 +56,15 @@ def test_get_entries(hass, client):
             'domain': 'comp',
             'title': 'Test 1',
             'source': 'bla',
-            'state': 'not_loaded'
+            'state': 'not_loaded',
+            'connection_class': 'local_poll',
         },
         {
             'domain': 'comp2',
             'title': 'Test 2',
             'source': 'bla2',
             'state': 'loaded',
+            'connection_class': 'assumed',
         },
     ]
 
@@ -100,7 +103,7 @@ def test_available_flows(hass, client):
 @asyncio.coroutine
 def test_initialize_flow(hass, client):
     """Test we can initialize a flow."""
-    class TestFlow(FlowHandler):
+    class TestFlow(core_ce.ConfigFlow):
         @asyncio.coroutine
         def async_step_user(self, user_input=None):
             schema = OrderedDict()
@@ -155,7 +158,7 @@ def test_initialize_flow(hass, client):
 @asyncio.coroutine
 def test_abort(hass, client):
     """Test a flow that aborts."""
-    class TestFlow(FlowHandler):
+    class TestFlow(core_ce.ConfigFlow):
         @asyncio.coroutine
         def async_step_user(self, user_input=None):
             return self.async_abort(reason='bla')
@@ -181,7 +184,7 @@ def test_create_account(hass, client):
         hass, 'test',
         MockModule('test', async_setup_entry=mock_coro_func(True)))
 
-    class TestFlow(FlowHandler):
+    class TestFlow(core_ce.ConfigFlow):
         VERSION = 1
 
         @asyncio.coroutine
@@ -213,7 +216,7 @@ def test_two_step_flow(hass, client):
         hass, 'test',
         MockModule('test', async_setup_entry=mock_coro_func(True)))
 
-    class TestFlow(FlowHandler):
+    class TestFlow(core_ce.ConfigFlow):
         VERSION = 1
 
         @asyncio.coroutine
@@ -269,7 +272,7 @@ def test_two_step_flow(hass, client):
 @asyncio.coroutine
 def test_get_progress_index(hass, client):
     """Test querying for the flows that are in progress."""
-    class TestFlow(FlowHandler):
+    class TestFlow(core_ce.ConfigFlow):
         VERSION = 5
 
         @asyncio.coroutine
@@ -301,7 +304,7 @@ def test_get_progress_index(hass, client):
 @asyncio.coroutine
 def test_get_progress_flow(hass, client):
     """Test we can query the API for same result as we get from init a flow."""
-    class TestFlow(FlowHandler):
+    class TestFlow(core_ce.ConfigFlow):
         @asyncio.coroutine
         def async_step_user(self, user_input=None):
             schema = OrderedDict()

--- a/tests/components/light/test_deconz.py
+++ b/tests/components/light/test_deconz.py
@@ -64,7 +64,7 @@ async def setup_bridge(hass, data, allow_deconz_groups=True):
     config_entry = config_entries.ConfigEntry(
         1, deconz.DOMAIN, 'Mock Title',
         {'host': 'mock-host', 'allow_deconz_groups': allow_deconz_groups},
-        'test')
+        'test', config_entries.CONN_CLASS_LOCAL_PUSH)
     await hass.config_entries.async_forward_entry_setup(config_entry, 'light')
     # To flush out the service call to update the group
     await hass.async_block_till_done()

--- a/tests/components/light/test_hue.py
+++ b/tests/components/light/test_hue.py
@@ -199,7 +199,7 @@ async def setup_bridge(hass, mock_bridge):
     hass.data[hue.DOMAIN] = {'mock-host': mock_bridge}
     config_entry = config_entries.ConfigEntry(1, hue.DOMAIN, 'Mock Title', {
         'host': 'mock-host'
-    }, 'test')
+    }, 'test', config_entries.CONN_CLASS_LOCAL_POLL)
     await hass.config_entries.async_forward_entry_setup(config_entry, 'light')
     # To flush out the service call to update the group
     await hass.async_block_till_done()

--- a/tests/components/scene/test_deconz.py
+++ b/tests/components/scene/test_deconz.py
@@ -36,7 +36,8 @@ async def setup_bridge(hass, data):
     hass.data[deconz.DATA_DECONZ_UNSUB] = []
     hass.data[deconz.DATA_DECONZ_ID] = {}
     config_entry = config_entries.ConfigEntry(
-        1, deconz.DOMAIN, 'Mock Title', {'host': 'mock-host'}, 'test')
+        1, deconz.DOMAIN, 'Mock Title', {'host': 'mock-host'}, 'test',
+        config_entries.CONN_CLASS_LOCAL_PUSH)
     await hass.config_entries.async_forward_entry_setup(config_entry, 'scene')
     # To flush out the service call to update the group
     await hass.async_block_till_done()

--- a/tests/components/sensor/test_deconz.py
+++ b/tests/components/sensor/test_deconz.py
@@ -58,7 +58,8 @@ async def setup_bridge(hass, data, allow_clip_sensor=True):
     hass.data[deconz.DATA_DECONZ_ID] = {}
     config_entry = config_entries.ConfigEntry(
         1, deconz.DOMAIN, 'Mock Title',
-        {'host': 'mock-host', 'allow_clip_sensor': allow_clip_sensor}, 'test')
+        {'host': 'mock-host', 'allow_clip_sensor': allow_clip_sensor}, 'test',
+        config_entries.CONN_CLASS_LOCAL_PUSH)
     await hass.config_entries.async_forward_entry_setup(config_entry, 'sensor')
     # To flush out the service call to update the group
     await hass.async_block_till_done()

--- a/tests/components/switch/test_deconz.py
+++ b/tests/components/switch/test_deconz.py
@@ -54,7 +54,8 @@ async def setup_bridge(hass, data):
     hass.data[deconz.DATA_DECONZ_UNSUB] = []
     hass.data[deconz.DATA_DECONZ_ID] = {}
     config_entry = config_entries.ConfigEntry(
-        1, deconz.DOMAIN, 'Mock Title', {'host': 'mock-host'}, 'test')
+        1, deconz.DOMAIN, 'Mock Title', {'host': 'mock-host'}, 'test',
+        config_entries.CONN_CLASS_LOCAL_PUSH)
     await hass.config_entries.async_forward_entry_setup(config_entry, 'switch')
     # To flush out the service call to update the group
     await hass.async_block_till_done()

--- a/tests/helpers/test_config_entry_flow.py
+++ b/tests/helpers/test_config_entry_flow.py
@@ -21,7 +21,8 @@ def flow_conf(hass):
 
     with patch.dict(config_entries.HANDLERS):
         config_entry_flow.register_discovery_flow(
-            'test', 'Test', has_discovered_devices)
+            'test', 'Test', has_discovered_devices,
+            config_entries.CONN_CLASS_LOCAL_POLL)
         yield handler_conf
 
 

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -103,7 +103,7 @@ def test_add_entry_calls_setup_entry(hass, manager):
         hass, 'comp',
         MockModule('comp', async_setup_entry=mock_setup_entry))
 
-    class TestFlow(data_entry_flow.FlowHandler):
+    class TestFlow(config_entries.ConfigFlow):
 
         VERSION = 1
 
@@ -159,8 +159,9 @@ async def test_saving_and_loading(hass):
         hass, 'test',
         MockModule('test', async_setup_entry=lambda *args: mock_coro(True)))
 
-    class TestFlow(data_entry_flow.FlowHandler):
+    class TestFlow(config_entries.ConfigFlow):
         VERSION = 5
+        CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
 
         @asyncio.coroutine
         def async_step_user(self, user_input=None):
@@ -175,8 +176,9 @@ async def test_saving_and_loading(hass):
         await hass.config_entries.flow.async_init(
             'test', context={'source': config_entries.SOURCE_USER})
 
-    class Test2Flow(data_entry_flow.FlowHandler):
+    class Test2Flow(config_entries.ConfigFlow):
         VERSION = 3
+        CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_PUSH
 
         @asyncio.coroutine
         def async_step_user(self, user_input=None):
@@ -209,6 +211,7 @@ async def test_saving_and_loading(hass):
         assert orig.title == loaded.title
         assert orig.data == loaded.data
         assert orig.source == loaded.source
+        assert orig.connection_class == loaded.connection_class
 
 
 async def test_forward_entry_sets_up_component(hass):
@@ -252,7 +255,7 @@ async def test_discovery_notification(hass):
     loader.set_component(hass, 'test', MockModule('test'))
     await async_setup_component(hass, 'persistent_notification', {})
 
-    class TestFlow(data_entry_flow.FlowHandler):
+    class TestFlow(config_entries.ConfigFlow):
         VERSION = 5
 
         async def async_step_discovery(self, user_input=None):
@@ -289,7 +292,7 @@ async def test_discovery_notification_not_created(hass):
     loader.set_component(hass, 'test', MockModule('test'))
     await async_setup_component(hass, 'persistent_notification', {})
 
-    class TestFlow(data_entry_flow.FlowHandler):
+    class TestFlow(config_entries.ConfigFlow):
         VERSION = 5
 
         async def async_step_discovery(self, user_input=None):


### PR DESCRIPTION
## Description:
Add a [connection class](https://www.home-assistant.io/blog/2016/02/12/classifying-the-internet-of-things/) to config flows, to be stored in the config entries.

This will allow us to show in the UI how the integration works.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
