### PR TITLE
Zha switch schedule update state

### DIFF
--- a/homeassistant/components/switch/zha.py
+++ b/homeassistant/components/switch/zha.py
@@ -44,7 +44,10 @@ class Switch(zha.Entity, SwitchDevice):
 
     def attribute_updated(self, attribute, value):
         """Handle attribute update from device."""
-        _LOGGER.debug("Attribute updated: %s %s %s", self, attribute, value)
+        cluster = self._endpoint.on_off
+        attr_name = cluster.attributes.get(attribute, [attribute])[0]
+        _LOGGER.debug("%s: Attribute '%s' on cluster '%s' updated to %s",
+                      self.entity_id, attr_name, cluster.ep_attribute, value)
         if attribute == self.value_attribute:
             self._state = value
             self.async_schedule_update_ha_state()
@@ -65,9 +68,11 @@ class Switch(zha.Entity, SwitchDevice):
         """Turn the entity on."""
         from zigpy.exceptions import DeliveryError
         try:
-            await self._endpoint.on_off.on()
+            res = await self._endpoint.on_off.on()
+            _LOGGER.debug("%s: turned 'on': %s", self.entity_id, res[1])
         except DeliveryError as ex:
-            _LOGGER.error("Unable to turn the switch on: %s", ex)
+            _LOGGER.error("%s: Unable to turn the switch on: %s",
+                          self.entity_id, ex)
             return
 
         self._state = 1
@@ -77,9 +82,11 @@ class Switch(zha.Entity, SwitchDevice):
         """Turn the entity off."""
         from zigpy.exceptions import DeliveryError
         try:
-            await self._endpoint.on_off.off()
+            res = await self._endpoint.on_off.off()
+            _LOGGER.debug("%s: turned 'off': %s", self.entity_id, res[1])
         except DeliveryError as ex:
-            _LOGGER.error("Unable to turn the switch off: %s", ex)
+            _LOGGER.error("%s: Unable to turn the switch off: %s",
+                          self.entity_id, ex)
             return
 
         self._state = 0

--- a/homeassistant/components/switch/zha.py
+++ b/homeassistant/components/switch/zha.py
@@ -71,6 +71,7 @@ class Switch(zha.Entity, SwitchDevice):
             return
 
         self._state = 1
+        self.async_schedule_update_ha_state()
 
     async def async_turn_off(self, **kwargs):
         """Turn the entity off."""
@@ -82,6 +83,7 @@ class Switch(zha.Entity, SwitchDevice):
             return
 
         self._state = 0
+        self.async_schedule_update_ha_state()
 
     async def async_update(self):
         """Retrieve latest state."""


### PR DESCRIPTION
## Description:
switch.zha is a non-polled entity `should_poll = False` so whenever the switch is successfully turned on or off, it should schedule state update, otherwise the state wouldn't be updated in the UI

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
