### PR TITLE
Update developer doc links to developers.home-assistant.io

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,5 +10,5 @@ The process is straight-forward.
  - Ensure tests work.
  - Create a Pull Request against the [**dev**](https://github.com/home-assistant/home-assistant/tree/dev) branch of Home Assistant.
 
-Still interested? Then you should take a peek at the [developer documentation](https://home-assistant.io/developers/) to get more details.
+Still interested? Then you should take a peek at the [developer documentation](https://developers.home-assistant.io/) to get more details.
 

--- a/README.rst
+++ b/README.rst
@@ -21,8 +21,8 @@ Featured integrations
 
 |screenshot-components|
 
-The system is built using a modular approach so support for other devices or actions can be implemented easily. See also the `section on architecture <https://home-assistant.io/developers/architecture/>`__ and the `section on creating your own
-components <https://home-assistant.io/developers/creating_components/>`__.
+The system is built using a modular approach so support for other devices or actions can be implemented easily. See also the `section on architecture <https://developers.home-assistant.io/docs/en/architecture_index.html>`__ and the `section on creating your own
+components <https://developers.home-assistant.io/docs/en/creating_component_index.html>`__.
 
 If you run into issues while using Home Assistant or during development
 of a component, check the `Home Assistant help section <https://home-assistant.io/help/>`__ of our website for further help and information.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -19,4 +19,4 @@ Indices and tables
 * :ref:`modindex`
 * :ref:`search`
 
-.. _Home Assistant developers: https://home-assistant.io/developers/
+.. _Home Assistant developers: https://developers.home-assistant.io/

--- a/homeassistant/components/websocket_api.py
+++ b/homeassistant/components/websocket_api.py
@@ -2,7 +2,7 @@
 Websocket based API for Home Assistant.
 
 For more details about this component, please refer to the documentation at
-https://home-assistant.io/developers/websocket_api/
+https://developers.home-assistant.io/docs/external_api_websocket.html
 """
 import asyncio
 from concurrent import futures

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -115,8 +115,8 @@ IGNORE_REQ = (
     'colorama<=1',  # Windows only requirement in check_config
 )
 
-URL_PIN = ('https://home-assistant.io/developers/code_review_platform/'
-           '#1-requirements')
+URL_PIN = ('https://developers.home-assistant.io/docs/'
+           'creating_platform_code_review.html#1-requirements')
 
 
 CONSTRAINT_PATH = os.path.join(os.path.dirname(__file__),


### PR DESCRIPTION
## Description:

Update developer doc links to point directly to developers.home-assistant.io, without redirects.

## Checklist:
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
