### PR TITLE
Add @rohankapoorcom to CODEOWNERS for the zoneminder platform

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -125,5 +125,7 @@ homeassistant/components/velux.py @Julius2342
 homeassistant/components/*/velux.py @Julius2342
 homeassistant/components/*/xiaomi_aqara.py @danielhiversen @syssi
 homeassistant/components/*/xiaomi_miio.py @rytilahti @syssi
+homeassistant/components/zoneminder.py @rohankapoorcom
+homeassistant/components/*/zoneminder.py @rohankapoorcom
 
 homeassistant/scripts/check_config.py @kellerza


### PR DESCRIPTION
## Description:
Adding myself to `CODEOWNERS` for the `zoneminder` platform per @MartinHjelmare's comment in https://github.com/home-assistant/home-assistant/pull/16527#issuecomment-421535979


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
