### PR TITLE
Clean up MjpegCamera by removing unnused hass object in __init__

### DIFF
--- a/homeassistant/components/camera/axis.py
+++ b/homeassistant/components/camera/axis.py
@@ -50,7 +50,7 @@ class AxisCamera(MjpegCamera):
 
     def __init__(self, hass, config, port):
         """Initialize Axis Communications camera component."""
-        super().__init__(hass, config)
+        super().__init__(config)
         self.port = port
         dispatcher_connect(
             hass, DOMAIN + '_' + config[CONF_NAME] + '_new_ip', self._new_ip)

--- a/homeassistant/components/camera/mjpeg.py
+++ b/homeassistant/components/camera/mjpeg.py
@@ -47,7 +47,7 @@ def async_setup_platform(hass, config, async_add_entities,
     """Set up a MJPEG IP Camera."""
     if discovery_info:
         config = PLATFORM_SCHEMA(discovery_info)
-    async_add_entities([MjpegCamera(hass, config)])
+    async_add_entities([MjpegCamera(config)])
 
 
 def extract_image_from_mjpeg(stream):
@@ -65,7 +65,7 @@ def extract_image_from_mjpeg(stream):
 class MjpegCamera(Camera):
     """An implementation of an IP camera that is reachable over a URL."""
 
-    def __init__(self, hass, device_info):
+    def __init__(self, device_info):
         """Initialize a MJPEG camera."""
         super().__init__()
         self._name = device_info.get(CONF_NAME)

--- a/homeassistant/components/camera/zoneminder.py
+++ b/homeassistant/components/camera/zoneminder.py
@@ -28,21 +28,21 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     cameras = []
     for monitor in monitors:
         _LOGGER.info("Initializing camera %s", monitor.id)
-        cameras.append(ZoneMinderCamera(hass, monitor))
+        cameras.append(ZoneMinderCamera(monitor))
     add_entities(cameras)
 
 
 class ZoneMinderCamera(MjpegCamera):
     """Representation of a ZoneMinder Monitor Stream."""
 
-    def __init__(self, hass, monitor):
+    def __init__(self, monitor):
         """Initialize as a subclass of MjpegCamera."""
         device_info = {
             CONF_NAME: monitor.name,
             CONF_MJPEG_URL: monitor.mjpeg_image_url,
             CONF_STILL_IMAGE_URL: monitor.still_image_url
         }
-        super().__init__(hass, device_info)
+        super().__init__(device_info)
         self._is_recording = None
         self._monitor = monitor
 


### PR DESCRIPTION
## Description:
Clean up the MjpegCamera component (and all subclasses) to not pass `hass` into the `__init__` method since it is not used. This was noticed by @MartinHjelmare in https://github.com/home-assistant/home-assistant/pull/16527#discussion_r217644675

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
