### PR TITLE
More isort preparations

### DIFF
--- a/homeassistant/components/binary_sensor/zwave.py
+++ b/homeassistant/components/binary_sensor/zwave.py
@@ -9,8 +9,8 @@ import datetime
 import homeassistant.util.dt as dt_util
 from homeassistant.helpers.event import track_point_in_time
 from homeassistant.components import zwave
-from homeassistant.components.zwave import workaround
-from homeassistant.components.zwave import async_setup_platform  # noqa pylint: disable=unused-import
+from homeassistant.components.zwave import (  # noqa pylint: disable=unused-import
+    async_setup_platform, workaround)
 from homeassistant.components.binary_sensor import (
     DOMAIN,
     BinarySensorDevice)

--- a/homeassistant/components/climate/zwave.py
+++ b/homeassistant/components/climate/zwave.py
@@ -10,8 +10,8 @@ from homeassistant.components.climate import (
     DOMAIN, ClimateDevice, STATE_AUTO, STATE_COOL, STATE_HEAT,
     SUPPORT_TARGET_TEMPERATURE, SUPPORT_FAN_MODE,
     SUPPORT_OPERATION_MODE, SUPPORT_SWING_MODE)
-from homeassistant.components.zwave import ZWaveDeviceEntity
-from homeassistant.components.zwave import async_setup_platform  # noqa pylint: disable=unused-import
+from homeassistant.components.zwave import (  # noqa pylint: disable=unused-import
+    ZWaveDeviceEntity, async_setup_platform)
 from homeassistant.const import (
     STATE_OFF, TEMP_CELSIUS, TEMP_FAHRENHEIT, ATTR_TEMPERATURE)
 

--- a/homeassistant/components/cover/zwave.py
+++ b/homeassistant/components/cover/zwave.py
@@ -9,10 +9,9 @@ https://home-assistant.io/components/cover.zwave/
 import logging
 from homeassistant.components.cover import (
     DOMAIN, SUPPORT_OPEN, SUPPORT_CLOSE, ATTR_POSITION)
-from homeassistant.components.zwave import ZWaveDeviceEntity
 from homeassistant.components import zwave
-from homeassistant.components.zwave import async_setup_platform  # noqa pylint: disable=unused-import
-from homeassistant.components.zwave import workaround
+from homeassistant.components.zwave import (  # noqa pylint: disable=unused-import
+    ZWaveDeviceEntity, async_setup_platform, workaround)
 from homeassistant.components.cover import CoverDevice
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/ios/__init__.py
+++ b/homeassistant/components/ios/__init__.py
@@ -9,7 +9,6 @@ import logging
 import datetime
 
 import voluptuous as vol
-# from voluptuous.humanize import humanize_error
 
 from homeassistant import config_entries
 from homeassistant.components.http import HomeAssistantView
@@ -274,8 +273,9 @@ class iOSIdentifyDeviceView(HomeAssistantView):
         # try:
         #     data = IDENTIFY_SCHEMA(req_data)
         # except vol.Invalid as ex:
-        #     return self.json_message(humanize_error(request.json, ex),
-        #                              HTTP_BAD_REQUEST)
+        #     return self.json_message(
+        #         vol.humanize.humanize_error(request.json, ex),
+        #         HTTP_BAD_REQUEST)
 
         data[ATTR_LAST_SEEN_AT] = datetime.datetime.now().isoformat()
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,3 +33,8 @@ not_skip = __init__.py
 # will group `import x` and `from x import` of the same module.
 force_sort_within_sections = true
 sections = FUTURE,STDLIB,INBETWEENS,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
+default_section = THIRDPARTY
+known_first_party = homeassistant,tests
+forced_separate = tests
+combine_as_imports = true
+use_parentheses = true


### PR DESCRIPTION
## Description:

Per https://developers.home-assistant.io/docs/en/development_guidelines.html#ordering-of-imports, this contains a run of isort over the entire source tree. Included are some isort configuration examples, and flake8-isort is added so further non-orderings can be caught automatically.

The whole patch is quite a giant one, but the vast majority of it is the result of running isort; it is in one commit that does nothing but that, and the 4 other commits should be easier to review.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.