### PR TITLE
Add Python 3.7 classifier

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,7 @@ classifier =
     Operating System :: OS Independent
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
     Topic :: Home Automation
 
 [tool:pytest]


### PR DESCRIPTION
## Description:

https://www.home-assistant.io/docs/installation/ says 3.5.3 or later, so I suppose we should add 3.7 here too.

## Checklist:
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**