### PR TITLE
Use posargs in tox lint env

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -49,8 +49,8 @@ deps =
      -r{toxinidir}/requirements_test.txt
 commands =
          python script/gen_requirements_all.py validate
-         flake8
-         pydocstyle homeassistant tests
+         flake8 {posargs}
+         pydocstyle {posargs:homeassistant tests}
 
 [testenv:typing]
 basepython = {env:PYTHON3_PATH:python3}


### PR DESCRIPTION
## Description:

Allows linting specified files or dirs only.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
