### PR TITLE
Upgrade zeroconf to 0.21.0

### DIFF
--- a/homeassistant/components/zeroconf.py
+++ b/homeassistant/components/zeroconf.py
@@ -12,7 +12,7 @@ import voluptuous as vol
 from homeassistant import util
 from homeassistant.const import (EVENT_HOMEASSISTANT_STOP, __version__)
 
-REQUIREMENTS = ['zeroconf==0.20.0']
+REQUIREMENTS = ['zeroconf==0.21.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1531,7 +1531,7 @@ youtube_dl==2018.09.10
 zengge==0.2
 
 # homeassistant.components.zeroconf
-zeroconf==0.20.0
+zeroconf==0.21.0
 
 # homeassistant.components.climate.zhong_hong
 zhong_hong_hvac==1.0.9


### PR DESCRIPTION
## Description:
New zeroconf release which fixes a quirk where external services announce themselves with invalid names.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.