### PR TITLE
Fix Ecovacs vacuums showing "None" for name

### DIFF
--- a/homeassistant/components/ecovacs.py
+++ b/homeassistant/components/ecovacs.py
@@ -59,8 +59,9 @@ def setup(hass, config):
     _LOGGER.debug("Ecobot devices: %s", devices)
 
     for device in devices:
-        _LOGGER.info("Discovered Ecovacs device on account: %s",
-                     device['nick'])
+        _LOGGER.info(
+            "Discovered Ecovacs device on account: %s with nickname %s",
+            device['did'], device['nick'])
         vacbot = VacBot(ecovacs_api.uid,
                         ecovacs_api.REALM,
                         ecovacs_api.resource,
@@ -74,7 +75,7 @@ def setup(hass, config):
         """Shut down open connections to Ecovacs XMPP server."""
         for device in hass.data[ECOVACS_DEVICES]:
             _LOGGER.info("Shutting down connection to Ecovacs device %s",
-                         device.vacuum['nick'])
+                         device.vacuum['did'])
             device.disconnect()
 
     # Listen for HA stop to disconnect.

--- a/homeassistant/components/vacuum/ecovacs.py
+++ b/homeassistant/components/vacuum/ecovacs.py
@@ -43,9 +43,9 @@ class EcovacsVacuum(VacuumDevice):
         """Initialize the Ecovacs Vacuum."""
         self.device = device
         self.device.connect_and_wait_until_ready()
-        try:
+        if self.device.vacuum.get('nick', None) is not None:
             self._name = '{}'.format(self.device.vacuum['nick'])
-        except KeyError:
+        else:
             # In case there is no nickname defined, use the device id
             self._name = '{}'.format(self.device.vacuum['did'])
 


### PR DESCRIPTION
## Description:
Some users had their vacuums set to the name "None" which was an error. Now it'll be set to the device ID.

Was previously checking for a missing key, when should have been checking for the value being None

**Related issue (if applicable):** fixes #16584 (at least part of it)

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** none


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
