### PR TITLE
Log raw result of configure_reporting() command.

### DIFF
--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -433,9 +433,9 @@ async def configure_reporting(entity_id, cluster, attr, skip_bind=False,
         res = await cluster.configure_reporting(attr, min_report,
                                                 max_report, reportable_change)
         _LOGGER.debug(
-            "%s: reporting '%s' attr on '%s' cluster: %d/%d/%d: Status: %s",
+            "%s: reporting '%s' attr on '%s' cluster: %d/%d/%d: Result: '%s'",
             entity_id, attr_name, cluster_name, min_report, max_report,
-            reportable_change, res[0][0].status
+            reportable_change, res
         )
     except DeliveryError as ex:
         _LOGGER.debug(


### PR DESCRIPTION
## Description:
This is an update to [PR #16487](https://github.com/home-assistant/home-assistant/pull/16487)
Xiaomi devices do not support ZCL configure_reporting command and instead of returning a `ConfigureReportingResponse` record they just fail with `UNSUPPORTED_GENERAL_COMMAND` so debug logging fails to parse result correctly.  Instead we'll print the string representation of the whole response.

@damarco can you please retry this PR and let me know if it fixes your issue?

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

