### PR TITLE
Allows multiple Netdata elements per group

### DIFF
--- a/homeassistant/components/sensor/netdata.py
+++ b/homeassistant/components/sensor/netdata.py
@@ -24,6 +24,7 @@ _LOGGER = logging.getLogger(__name__)
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=1)
 
+CONF_GROUP = 'group'
 CONF_ELEMENT = 'element'
 
 DEFAULT_HOST = 'localhost'
@@ -33,9 +34,9 @@ DEFAULT_PORT = 19999
 DEFAULT_ICON = 'mdi:desktop-classic'
 
 RESOURCE_SCHEMA = vol.Any({
+    vol.Required(CONF_GROUP): cv.string,
     vol.Required(CONF_ELEMENT): cv.string,
     vol.Optional(CONF_ICON, default=DEFAULT_ICON): cv.icon,
-    vol.Optional(CONF_NAME): cv.string,
 })
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -65,16 +66,14 @@ async def async_setup_platform(
 
     dev = []
     for entry, data in resources.items():
-        sensor = entry
+        icon = data.get(CONF_ICON)
+        sensor = data[CONF_GROUP]
         element = data[CONF_ELEMENT]
-        sensor_name = icon = None
+        sensor_name = entry
         try:
             resource_data = netdata.api.metrics[sensor]
             unit = '%' if resource_data['units'] == 'percentage' else \
                 resource_data['units']
-            if data is not None:
-                sensor_name = data.get(CONF_NAME)
-                icon = data.get(CONF_ICON)
         except KeyError:
             _LOGGER.error("Sensor is not available: %s", sensor)
             continue

--- a/homeassistant/components/sensor/netdata.py
+++ b/homeassistant/components/sensor/netdata.py
@@ -24,7 +24,7 @@ _LOGGER = logging.getLogger(__name__)
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=1)
 
-CONF_GROUP = 'data_group'
+CONF_DATA_GROUP = 'data_group'
 CONF_ELEMENT = 'element'
 
 DEFAULT_HOST = 'localhost'
@@ -34,7 +34,7 @@ DEFAULT_PORT = 19999
 DEFAULT_ICON = 'mdi:desktop-classic'
 
 RESOURCE_SCHEMA = vol.Any({
-    vol.Required(CONF_GROUP): cv.string,
+    vol.Required(CONF_DATA_GROUP): cv.string,
     vol.Required(CONF_ELEMENT): cv.string,
     vol.Optional(CONF_ICON, default=DEFAULT_ICON): cv.icon,
 })
@@ -66,8 +66,8 @@ async def async_setup_platform(
 
     dev = []
     for entry, data in resources.items():
-        icon = data.get(CONF_ICON)
-        sensor = data[CONF_GROUP]
+        icon = data[CONF_ICON]
+        sensor = data[CONF_DATA_GROUP]
         element = data[CONF_ELEMENT]
         sensor_name = entry
         try:

--- a/homeassistant/components/sensor/netdata.py
+++ b/homeassistant/components/sensor/netdata.py
@@ -24,7 +24,7 @@ _LOGGER = logging.getLogger(__name__)
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=1)
 
-CONF_GROUP = 'group'
+CONF_GROUP = 'data_group'
 CONF_ELEMENT = 'element'
 
 DEFAULT_HOST = 'localhost'


### PR DESCRIPTION
## Description:

Current Netdata component sensor configuration syntax only allows for one element per group.
This is an issue as this it is often needed to manage two different element at the same time, eg: download and upload for one network interface.

**Related issue (if applicable):** ref #14897 Called for a PR on that particular issue.

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#6296

## Example entry for `configuration.yaml` (if applicable):

Current syntax:

```yaml
sensor:
  - platform: netdata
    resources:
      snmp_router.bandwidth_eth0:
        element: in
        icon: mdi:download
        name: Download
       snmp_router.bandwidth_eth0:
         element: out
         icon: mdi:upload
         name: Upload
```
Doesn't work because of the duplicated  `snmp_router.bandwidth_eth0` key.

New syntax:

```yaml
sensor:
  - platform: netdata
    host: 192.168.1.89
    resources:    
      Download:
        data_group: snmp_router.bandwidth_eth0
        element: in
        icon: mdi:download
      Upload:
        data_group: snmp_router.bandwidth_eth0
        element: out
        icon: mdi:upload
```

The previous `name` option is now mandatory and used as the key. As the name is used as part of the friendly name of the sensor, I'm not 100% sure if this is the right way to do it and I would like confirmation on that point.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54