### PR TITLE
Reverse out change #14234 BOM Weather throttle fix

### DIFF
--- a/homeassistant/components/sensor/bom.py
+++ b/homeassistant/components/sensor/bom.py
@@ -220,23 +220,32 @@ class BOMCurrentData:
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
-        # Get the latest data from BOM, check if it is > 35 minutes since the last reading came in.
-        # The readings are timestamped on the hour/half hour and the data generally refreshes 35 minutes after that.
-        # You don't want to just throttle for 35 mins as that doesn't take into account how far you currently are from the last reading time.
+        """Get the latest data from BOM.
+
+        Check if it is > 35 minutes since the last reading came in.
+        The readings are timestamped on the hour/half hour and the
+        data generally refreshes 35 minutes after that.
+        You don't want to just throttle for 35 mins as that doesn't take
+        into account how far you currently are from the last reading time.
+        """
         if self._lastupdate != 0 and \
             ((datetime.datetime.now() - self._lastupdate) <
              datetime.timedelta(minutes=35)):
             _LOGGER.debug(
                 "BOM was updated %s minutes ago, skipping update as"
-                " < 35 minutes, Now: %s, LastUpdate: %s", (datetime.datetime.now() - self._lastupdate), datetime.datetime.now(), self._lastupdate)
+                " < 35 minutes, Now: %s, LastUpdate: %s",
+                (datetime.datetime.now() - self._lastupdate),
+                datetime.datetime.now(), self._lastupdate)
             return self._lastupdate
 
         try:
             result = requests.get(self._build_url(), timeout=10).json()
             self._data = result['observations']['data']
-            
-            # set lastupdate using self._data[0] as the first element in the array is the latest date in the json
-            self._lastupdate = datetime.datetime.strptime(str(self._data[0]['local_date_time_full']), '%Y%m%d%H%M%S') 
+
+            # set lastupdate using self._data[0] as the first element in the
+            # array is the latest date in the json
+            self._lastupdate = datetime.datetime.strptime(
+                str(self._data[0]['local_date_time_full']), '%Y%m%d%H%M%S')
             return self._lastupdate
 
         except ValueError as err:

--- a/homeassistant/components/sensor/bom.py
+++ b/homeassistant/components/sensor/bom.py
@@ -39,7 +39,8 @@ CONF_STATION = 'station'
 CONF_ZONE_ID = 'zone_id'
 CONF_WMO_ID = 'wmo_id'
 
-MIN_TIME_BETWEEN_UPDATES = datetime.timedelta(minutes=35)
+MIN_TIME_BETWEEN_UPDATES = datetime.timedelta(seconds=60)
+LAST_UPDATE = 0
 
 SENSOR_TYPES = {
     'wmo': ['wmo', None],
@@ -188,6 +189,7 @@ class BOMCurrentData:
         self._hass = hass
         self._zone_id, self._wmo_id = station_id.split('.')
         self._data = None
+        self._lastupdate = LAST_UPDATE
 
     def _build_url(self):
         """Build the URL for the requests."""
@@ -211,17 +213,32 @@ class BOMCurrentData:
         for the latest value that is not `-`.
 
         Iterators are used in this method to avoid iterating needlessly
-        iterating through the entire BOM provided dataset.
+        through the entire BOM provided dataset.
         """
         condition_readings = (entry[condition] for entry in self._data)
         return next((x for x in condition_readings if x != '-'), None)
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
-        """Get the latest data from BOM."""
+        # Get the latest data from BOM, check if it is > 35 minutes since the last reading came in.
+        # The readings are timestamped on the hour/half hour and the data generally refreshes 35 minutes after that.
+        # You don't want to just throttle for 35 mins as that doesn't take into account how far you currently are from the last reading time.
+        if self._lastupdate != 0 and \
+            ((datetime.datetime.now() - self._lastupdate) <
+             datetime.timedelta(minutes=35)):
+            _LOGGER.debug(
+                "BOM was updated %s minutes ago, skipping update as"
+                " < 35 minutes, Now: %s, LastUpdate: %s", (datetime.datetime.now() - self._lastupdate), datetime.datetime.now(), self._lastupdate)
+            return self._lastupdate
+
         try:
             result = requests.get(self._build_url(), timeout=10).json()
             self._data = result['observations']['data']
+            
+            # set lastupdate using self._data[0] as the first element in the array is the latest date in the json
+            self._lastupdate = datetime.datetime.strptime(str(self._data[0]['local_date_time_full']), '%Y%m%d%H%M%S') 
+            return self._lastupdate
+
         except ValueError as err:
             _LOGGER.error("Check BOM %s", err.args)
             self._data = None


### PR DESCRIPTION
## Description:
On May 1, 2018, OttoWinter suggested a change in https://github.com/home-assistant/home-assistant/pull/14042#discussion_r185224704 that then became #14234 


@nickw444 made the change in PR #14234 to throttle every 35 minutes but this causes the time the sensor is read to be decoupled from the time of the actual reading becoming available in the JSON file.

e.g. 
6:45 HA started, BOM sensor started, sensor waits 35 mins
7:20 BOM sensor gets 7:00 reading, waits 35 mins <-- this one is 15 minutes after reading was in JSON (7:05)
7:55 BOM sensor gets 7:30 reading, waits 35 mins <-- this one is 20 minutes late
8:30 BOM sensor gets 8:00 reading, waits 35 mins <-- this one is 25 minutes late
9:05 BOM sensor gets 8:30 reading, waits 35 mins <-- this one is 30 minutes late
9:40 BOM sensor gets 9:30 reading, waits 35 mins <-- back on track time-wise, if a little late
etc

The readings get more and more 'late' until they flick over back to being reasonable then creep out again. The original logic kept it locked to the last reading time + 35 mins which is when we'd expect a new reading in or soon after.

This change takes the latest code base and puts back the previous logic that kept the sensor readings in sync with the new data coming in.

It also tidies a comment by removing the word iterating where it had been used twice.

**Related issue (if applicable):** reverts #14234

## Example entry for `configuration.yaml` (if applicable):
```yaml
weather:
  - platform: bom
    station: IDN60901.94767
sensor:
  - platform: bom
    station: IDN60901.94767
    name: Sydney
    monitored_conditions:
      - apparent_t
      - cloud
      - cloud_base_m
      - cloud_oktas
      - cloud_type_id
      - cloud_type
      - delta_t
      - local_date_time
      - local_date_time_full
      - gust_kmh
      - gust_kt
      - air_temp
      - dewpt
      - press
      - press_qnh
      - press_msl
      - press_tend
      - rain_trace
      - rel_hum
      - sea_state
      - swell_dir_worded
      - swell_height
      - swell_period
      - vis_km
      - weather
      - wind_dir
      - wind_spd_kmh
      - wind_spd_kt
```

## Checklist:
  - [x] The code change is tested and works locally. Tested using tests in #14042
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
