### PR TITLE
Add Carbon Monoxide HomeKit Sensor

### DIFF
--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -22,9 +22,9 @@ from homeassistant.util import get_local_ip
 from homeassistant.util.decorator import Registry
 from .const import (
     BRIDGE_NAME, CONF_AUTO_START, CONF_ENTITY_CONFIG, CONF_FEATURE_LIST,
-    CONF_FILTER, DEFAULT_AUTO_START, DEFAULT_PORT, DEVICE_CLASS_CO2,
-    DEVICE_CLASS_PM25, DOMAIN, HOMEKIT_FILE, SERVICE_HOMEKIT_START,
-    TYPE_OUTLET, TYPE_SWITCH)
+    CONF_FILTER, DEFAULT_AUTO_START, DEFAULT_PORT, DEVICE_CLASS_CO,
+    DEVICE_CLASS_CO2, DEVICE_CLASS_PM25, DOMAIN, HOMEKIT_FILE,
+    SERVICE_HOMEKIT_START, TYPE_OUTLET, TYPE_SWITCH)
 from .util import (
     show_setup_message, validate_entity_config, validate_media_player_features)
 
@@ -150,6 +150,8 @@ def get_accessory(hass, driver, state, aid, config):
         elif device_class == DEVICE_CLASS_PM25 \
                 or DEVICE_CLASS_PM25 in state.entity_id:
             a_type = 'AirQualitySensor'
+        elif device_class == DEVICE_CLASS_CO:
+            a_type = 'CarbonMonoxideSensor'
         elif device_class == DEVICE_CLASS_CO2 \
                 or DEVICE_CLASS_CO2 in state.entity_id:
             a_type = 'CarbonDioxideSensor'

--- a/homeassistant/components/homekit/const.py
+++ b/homeassistant/components/homekit/const.py
@@ -69,6 +69,8 @@ CHAR_CARBON_DIOXIDE_DETECTED = 'CarbonDioxideDetected'
 CHAR_CARBON_DIOXIDE_LEVEL = 'CarbonDioxideLevel'
 CHAR_CARBON_DIOXIDE_PEAK_LEVEL = 'CarbonDioxidePeakLevel'
 CHAR_CARBON_MONOXIDE_DETECTED = 'CarbonMonoxideDetected'
+CHAR_CARBON_MONOXIDE_LEVEL = 'CarbonMonoxideLevel'
+CHAR_CARBON_MONOXIDE_PEAK_LEVEL = 'CarbonMonoxidePeakLevel'
 CHAR_CHARGING_STATE = 'ChargingState'
 CHAR_COLOR_TEMPERATURE = 'ColorTemperature'
 CHAR_CONTACT_SENSOR_STATE = 'ContactSensorState'
@@ -114,6 +116,7 @@ PROP_MIN_VALUE = 'minValue'
 PROP_CELSIUS = {'minValue': -273, 'maxValue': 999}
 
 # #### Device Classes ####
+DEVICE_CLASS_CO = 'co'
 DEVICE_CLASS_CO2 = 'co2'
 DEVICE_CLASS_DOOR = 'door'
 DEVICE_CLASS_GARAGE_DOOR = 'garage_door'
@@ -125,3 +128,7 @@ DEVICE_CLASS_OPENING = 'opening'
 DEVICE_CLASS_PM25 = 'pm25'
 DEVICE_CLASS_SMOKE = 'smoke'
 DEVICE_CLASS_WINDOW = 'window'
+
+# #### Thresholds ####
+THRESHOLD_CO = 25
+THRESHOLD_CO2 = 1000

--- a/homeassistant/components/homekit/type_sensors.py
+++ b/homeassistant/components/homekit/type_sensors.py
@@ -13,6 +13,7 @@ from .const import (
     CHAR_AIR_PARTICULATE_DENSITY, CHAR_AIR_QUALITY,
     CHAR_CARBON_DIOXIDE_DETECTED, CHAR_CARBON_DIOXIDE_LEVEL,
     CHAR_CARBON_DIOXIDE_PEAK_LEVEL, CHAR_CARBON_MONOXIDE_DETECTED,
+    CHAR_CARBON_MONOXIDE_LEVEL, CHAR_CARBON_MONOXIDE_PEAK_LEVEL,
     CHAR_CONTACT_SENSOR_STATE, CHAR_CURRENT_AMBIENT_LIGHT_LEVEL,
     CHAR_CURRENT_HUMIDITY, CHAR_CURRENT_TEMPERATURE, CHAR_LEAK_DETECTED,
     CHAR_MOTION_DETECTED, CHAR_OCCUPANCY_DETECTED, CHAR_SMOKE_DETECTED,
@@ -23,7 +24,7 @@ from .const import (
     SERV_CARBON_DIOXIDE_SENSOR, SERV_CARBON_MONOXIDE_SENSOR,
     SERV_CONTACT_SENSOR, SERV_HUMIDITY_SENSOR, SERV_LEAK_SENSOR,
     SERV_LIGHT_SENSOR, SERV_MOTION_SENSOR, SERV_OCCUPANCY_SENSOR,
-    SERV_SMOKE_SENSOR, SERV_TEMPERATURE_SENSOR)
+    SERV_SMOKE_SENSOR, SERV_TEMPERATURE_SENSOR, THRESHOLD_CO, THRESHOLD_CO2)
 from .util import (
     convert_to_float, temperature_to_homekit, density_to_air_quality)
 
@@ -114,6 +115,34 @@ class AirQualitySensor(HomeAccessory):
             _LOGGER.debug('%s: Set to %d', self.entity_id, density)
 
 
+@TYPES.register('CarbonMonoxideSensor')
+class CarbonMonoxideSensor(HomeAccessory):
+    """Generate a CarbonMonoxidSensor accessory as CO sensor."""
+
+    def __init__(self, *args):
+        """Initialize a CarbonMonoxideSensor accessory object."""
+        super().__init__(*args, category=CATEGORY_SENSOR)
+
+        serv_co = self.add_preload_service(SERV_CARBON_MONOXIDE_SENSOR, [
+            CHAR_CARBON_MONOXIDE_LEVEL, CHAR_CARBON_MONOXIDE_PEAK_LEVEL])
+        self.char_level = serv_co.configure_char(
+            CHAR_CARBON_MONOXIDE_LEVEL, value=0)
+        self.char_peak = serv_co.configure_char(
+            CHAR_CARBON_MONOXIDE_PEAK_LEVEL, value=0)
+        self.char_detected = serv_co.configure_char(
+            CHAR_CARBON_MONOXIDE_DETECTED, value=0)
+
+    def update_state(self, new_state):
+        """Update accessory after state change."""
+        value = convert_to_float(new_state.state)
+        if value:
+            self.char_level.set_value(value)
+            if value > self.char_peak.value:
+                self.char_peak.set_value(value)
+            self.char_detected.set_value(value > THRESHOLD_CO)
+            _LOGGER.debug('%s: Set to %d', self.entity_id, value)
+
+
 @TYPES.register('CarbonDioxideSensor')
 class CarbonDioxideSensor(HomeAccessory):
     """Generate a CarbonDioxideSensor accessory as CO2 sensor."""
@@ -124,7 +153,7 @@ class CarbonDioxideSensor(HomeAccessory):
 
         serv_co2 = self.add_preload_service(SERV_CARBON_DIOXIDE_SENSOR, [
             CHAR_CARBON_DIOXIDE_LEVEL, CHAR_CARBON_DIOXIDE_PEAK_LEVEL])
-        self.char_co2 = serv_co2.configure_char(
+        self.char_level = serv_co2.configure_char(
             CHAR_CARBON_DIOXIDE_LEVEL, value=0)
         self.char_peak = serv_co2.configure_char(
             CHAR_CARBON_DIOXIDE_PEAK_LEVEL, value=0)
@@ -133,13 +162,13 @@ class CarbonDioxideSensor(HomeAccessory):
 
     def update_state(self, new_state):
         """Update accessory after state change."""
-        co2 = convert_to_float(new_state.state)
-        if co2:
-            self.char_co2.set_value(co2)
-            if co2 > self.char_peak.value:
-                self.char_peak.set_value(co2)
-            self.char_detected.set_value(co2 > 1000)
-            _LOGGER.debug('%s: Set to %d', self.entity_id, co2)
+        value = convert_to_float(new_state.state)
+        if value:
+            self.char_level.set_value(value)
+            if value > self.char_peak.value:
+                self.char_peak.set_value(value)
+            self.char_detected.set_value(value > THRESHOLD_CO2)
+            _LOGGER.debug('%s: Set to %d', self.entity_id, value)
 
 
 @TYPES.register('LightSensor')

--- a/tests/components/homekit/test_get_accessories.py
+++ b/tests/components/homekit/test_get_accessories.py
@@ -106,6 +106,8 @@ def test_type_covers(type_name, entity_id, state, attrs):
     ('AirQualitySensor', 'sensor.air_quality_pm25', '40', {}),
     ('AirQualitySensor', 'sensor.air_quality', '40',
      {ATTR_DEVICE_CLASS: 'pm25'}),
+    ('CarbonMonoxideSensor', 'sensor.airmeter', '2',
+     {ATTR_DEVICE_CLASS: 'co'}),
     ('CarbonDioxideSensor', 'sensor.airmeter_co2', '500', {}),
     ('CarbonDioxideSensor', 'sensor.airmeter', '500',
      {ATTR_DEVICE_CLASS: 'co2'}),


### PR DESCRIPTION
## Description:
Add support for Carbon Monoxide Sensors in HomeKit as well as small cleanups. The sensor must have the `co` device_class to be mapped correctly. Either handled through HA or set manually in the `customize` section. I decided not to add entity_id mapping, since this would create conflicts with `co2` sensors.

**Feature Request:** https://community.home-assistant.io/t/carbon-monoxide-sensor-support/68969

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#6300

## Example entry for `configuration.yaml` (if applicable):
```yaml
homeassistant:
  customize:
    sensor.carbon_monoxide:
      device_class: 'co'

homekit:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)
  - [x] Tests have been added to verify that the new code works.