### PR TITLE
Fixes an AirVisual bug where response data is missing

### DIFF
--- a/homeassistant/components/sensor/airvisual.py
+++ b/homeassistant/components/sensor/airvisual.py
@@ -281,7 +281,7 @@ class AirVisualData:
             _LOGGER.debug("New data retrieved: %s", resp)
 
             self.pollution_info = resp['current']['pollution']
-        except AirVisualError as err:
+        except (KeyError, AirVisualError) as err:
             if self.city and self.state and self.country:
                 location = (self.city, self.state, self.country)
             else:


### PR DESCRIPTION
## Description:
"Fixes" #16639 (in that an error is logged instead of an uncaught exception bubbling up).

**Related issue (if applicable):** fixes #16639

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: airvisual
    api_key: <API_KEY>
    monitored_conditions:
      - us
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  ~- [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)~

If the code communicates with devices, web services, or third-party tools:
  ~- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).~
  ~- [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).~
  ~- [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.~
  ~- [ ] New files were added to `.coveragerc`.~

If the code does not interact with devices:
  ~- [ ] Tests have been added to verify that the new code works.~

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
