### PR TITLE
Run pylint with parallel jobs equal to number of cpus in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
     - python: "3.5.3"
       env: TOXENV=lint
     - python: "3.5.3"
-      env: TOXENV=pylint
+      env: TOXENV=pylint PYLINT_ARGS=--jobs=0
     - python: "3.5.3"
       env: TOXENV=typing
     - python: "3.5.3"

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,7 @@ deps =
      -r{toxinidir}/requirements_test.txt
      -c{toxinidir}/homeassistant/package_constraints.txt
 commands =
-     pylint {posargs} homeassistant
+     pylint {env:PYLINT_ARGS} {posargs:homeassistant}
 
 [testenv:lint]
 basepython = {env:PYTHON3_PATH:python3}


### PR DESCRIPTION
## Description:

Apparently number of cpus there is 2 at the moment, and this makes the pylint command (just the command, not necessarily the entire Travis job) complete ~20% faster. Before this change, it usually took a bit over 10 minutes to complete; after this a bit under 8 minutes.

Changes the handling of the pylint tox posargs in incompatible manner, but I think that's acceptable.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
