### PR TITLE
MyQ Open State Fix

### DIFF
--- a/homeassistant/components/cover/myq.py
+++ b/homeassistant/components/cover/myq.py
@@ -99,11 +99,6 @@ class MyQDevice(CoverDevice):
         return MYQ_TO_HASS[self._status] == STATE_CLOSED
 
     @property
-    def is_open(self):
-        """Return true if cover is open, else False."""
-        return MYQ_TO_HASS[self._status] == STATE_OPEN
-
-    @property
     def is_closing(self):
         """Return if the cover is closing or not."""
         return MYQ_TO_HASS[self._status] == STATE_CLOSING

--- a/homeassistant/components/cover/myq.py
+++ b/homeassistant/components/cover/myq.py
@@ -11,8 +11,8 @@ import voluptuous as vol
 from homeassistant.components.cover import (
     CoverDevice, SUPPORT_CLOSE, SUPPORT_OPEN)
 from homeassistant.const import (
-    CONF_PASSWORD, CONF_TYPE, CONF_USERNAME, STATE_CLOSED, STATE_OPEN, STATE_CLOSING,
-    STATE_OPENING)
+    CONF_PASSWORD, CONF_TYPE, CONF_USERNAME, STATE_CLOSED, STATE_OPEN,
+    STATE_CLOSING, STATE_OPENING)
 import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['pymyq==0.0.15']

--- a/homeassistant/components/cover/myq.py
+++ b/homeassistant/components/cover/myq.py
@@ -11,7 +11,7 @@ import voluptuous as vol
 from homeassistant.components.cover import (
     CoverDevice, SUPPORT_CLOSE, SUPPORT_OPEN)
 from homeassistant.const import (
-    CONF_PASSWORD, CONF_TYPE, CONF_USERNAME, STATE_CLOSED, STATE_CLOSING,
+    CONF_PASSWORD, CONF_TYPE, CONF_USERNAME, STATE_CLOSED, STATE_OPEN, STATE_CLOSING,
     STATE_OPENING)
 import homeassistant.helpers.config_validation as cv
 
@@ -23,6 +23,7 @@ DEFAULT_NAME = 'myq'
 
 MYQ_TO_HASS = {
     'closed': STATE_CLOSED,
+    'open': STATE_OPEN,
     'closing': STATE_CLOSING,
     'opening': STATE_OPENING
 }
@@ -96,6 +97,11 @@ class MyQDevice(CoverDevice):
     def is_closed(self):
         """Return true if cover is closed, else False."""
         return MYQ_TO_HASS[self._status] == STATE_CLOSED
+
+    @property
+    def is_open(self):
+        """Return true if cover is open, else False."""
+        return MYQ_TO_HASS[self._status] == STATE_OPEN
 
     @property
     def is_closing(self):


### PR DESCRIPTION
Fixes issues with MyQ reporting an open state

## Description:
This resolves an issue with the last change to represent discrete status of the door position caused an issue with it reporting the door status as open.  This is a break fix as any automation relying on the state of the cover to be open would fail.

**Related issue (if applicable):** fixes #16680 (and potentially #16783)

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
NA
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54