### PR TITLE
Upgrade paho-mqtt to 1.4.0

### DIFF
--- a/homeassistant/components/mqtt/config_flow.py
+++ b/homeassistant/components/mqtt/config_flow.py
@@ -5,7 +5,7 @@ import queue
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.const import CONF_USERNAME, CONF_PASSWORD, CONF_PORT
+from homeassistant.const import CONF_PASSWORD, CONF_PORT, CONF_USERNAME
 
 from .const import CONF_BROKER
 
@@ -20,14 +20,12 @@ class FlowHandler(config_entries.ConfigFlow):
     async def async_step_user(self, user_input=None):
         """Handle a flow initialized by the user."""
         if self._async_current_entries():
-            return self.async_abort(
-                reason='single_instance_allowed'
-            )
+            return self.async_abort(reason='single_instance_allowed')
 
         return await self.async_step_broker()
 
     async def async_step_broker(self, user_input=None):
-        """Confirm setup."""
+        """Confirm the setup."""
         errors = {}
 
         if user_input is not None:
@@ -37,9 +35,7 @@ class FlowHandler(config_entries.ConfigFlow):
 
             if can_connect:
                 return self.async_create_entry(
-                    title=user_input[CONF_BROKER],
-                    data=user_input
-                )
+                    title=user_input[CONF_BROKER], data=user_input)
 
             errors['base'] = 'cannot_connect'
 
@@ -50,10 +46,7 @@ class FlowHandler(config_entries.ConfigFlow):
         fields[vol.Optional(CONF_PASSWORD)] = str
 
         return self.async_show_form(
-            step_id='broker',
-            data_schema=vol.Schema(fields),
-            errors=errors,
-        )
+            step_id='broker', data_schema=vol.Schema(fields), errors=errors)
 
     async def async_step_import(self, user_input):
         """Import a config entry.
@@ -62,14 +55,9 @@ class FlowHandler(config_entries.ConfigFlow):
         Instead, we're going to rely on the values that are in config file.
         """
         if self._async_current_entries():
-            return self.async_abort(
-                reason='single_instance_allowed'
-            )
+            return self.async_abort(reason='single_instance_allowed')
 
-        return self.async_create_entry(
-            title='configuration.yaml',
-            data={}
-        )
+        return self.async_create_entry(title='configuration.yaml', data={})
 
 
 def try_connection(broker, port, username, password):

--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -9,9 +9,9 @@ import logging
 import re
 
 from homeassistant.components import mqtt
-from homeassistant.helpers.discovery import async_load_platform
-from homeassistant.const import CONF_PLATFORM
 from homeassistant.components.mqtt import CONF_STATE_TOPIC
+from homeassistant.const import CONF_PLATFORM
+from homeassistant.helpers.discovery import async_load_platform
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/mqtt/server.py
+++ b/homeassistant/components/mqtt/server.py
@@ -14,6 +14,9 @@ from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['hbmqtt==0.9.4']
+
+_LOGGER = logging.getLogger(__name__)
+
 DEPENDENCIES = ['http']
 
 # None allows custom config to be created through generate_config
@@ -26,8 +29,6 @@ HBMQTT_CONFIG_SCHEMA = vol.Any(None, vol.Schema({
         str: vol.Schema(dict)
     })
 }, extra=vol.ALLOW_EXTRA))
-
-_LOGGER = logging.getLogger(__name__)
 
 
 @asyncio.coroutine

--- a/homeassistant/components/shiftr.py
+++ b/homeassistant/components/shiftr.py
@@ -14,7 +14,7 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_STOP)
 from homeassistant.helpers import state as state_helper
 
-REQUIREMENTS = ['paho-mqtt==1.3.1']
+REQUIREMENTS = ['paho-mqtt==1.4.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -660,7 +660,7 @@ orvibo==1.1.1
 
 # homeassistant.components.mqtt
 # homeassistant.components.shiftr
-paho-mqtt==1.3.1
+paho-mqtt==1.4.0
 
 # homeassistant.components.media_player.panasonic_viera
 panasonic_viera==0.3.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -112,7 +112,7 @@ numpy==1.15.1
 
 # homeassistant.components.mqtt
 # homeassistant.components.shiftr
-paho-mqtt==1.3.1
+paho-mqtt==1.4.0
 
 # homeassistant.components.device_tracker.aruba
 # homeassistant.components.device_tracker.asuswrt


### PR DESCRIPTION
## Description:
Changelog: https://github.com/eclipse/paho.mqtt.python/blob/master/ChangeLog.txt

## Example entry for `configuration.yaml` (if applicable):

``` yaml
mqtt:
  broker: localhost
  discovery: True
```

```bash
$ mosquitto_pub -h 127.0.0.1 -p 1883 -t "homeassistant/binary_sensor/garden/config" -m '{"name": "garden", "device_class": "motion"}'
```
```bash
2018-09-18 14:02:15 INFO (MainThread) [homeassistant.core] Bus:Handling <Event platform_discovered[L]: service=load_platform.binary_sensor, platform=mqtt, discovered=name=garden, device_class=motion, platform=mqtt, state_topic=homeassistant/binary_sensor/garden/state>
2018-09-18 14:02:15 INFO (MainThread) [homeassistant.components.binary_sensor] Setting up binary_sensor.mqtt
2018-09-18 14:02:15 INFO (MainThread) [homeassistant.core] Bus:Handling <Event state_changed[L]: entity_id=binary_sensor.garden, old_state=None, new_state=<state binary_sensor.garden=off; friendly_name=garden, device_class=motion @ 2018-09-18T14:02:15.523584+02:00>>
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [x] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
