### PR TITLE
Save disabled_by in entity registry

### DIFF
--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -240,7 +240,7 @@ class EntityRegistry:
                 'unique_id': entry.unique_id,
                 'platform': entry.platform,
                 'name': entry.name,
-                'disabled_by': entry.disabled_by
+                'disabled_by': entry.disabled_by,
             } for entry in self.entities.values()
         ]
 

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -240,6 +240,7 @@ class EntityRegistry:
                 'unique_id': entry.unique_id,
                 'platform': entry.platform,
                 'name': entry.name,
+                'disabled_by': entry.disabled_by
             } for entry in self.entities.values()
         ]
 


### PR DESCRIPTION
## Description:
The entity registry supports a `disabled_by` field to exclude entities from being processed. When the entity_registry is automatically generated/updated by HA, the `disabled_by` field was not included and would be stripped out.

**Related issue (if applicable):** fixes #13643

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

