### PR TITLE
Add Tuya cover state

### DIFF
--- a/homeassistant/components/cover/tuya.py
+++ b/homeassistant/components/cover/tuya.py
@@ -47,9 +47,9 @@ class TuyaCover(TuyaDevice, CoverDevice):
         """Return if the cover is closed or not."""
         state = self.tuya.state()
         if state == 1:
-            return True
-        elif state == 2:
             return False
+        elif state == 2:
+            return True
         else:
             return None
 

--- a/homeassistant/components/cover/tuya.py
+++ b/homeassistant/components/cover/tuya.py
@@ -48,7 +48,7 @@ class TuyaCover(TuyaDevice, CoverDevice):
         state = self.tuya.state()
         if state == 1:
             return False
-        elif state == 2:
+        if state == 2:
             return True
         return None
 

--- a/homeassistant/components/cover/tuya.py
+++ b/homeassistant/components/cover/tuya.py
@@ -50,8 +50,7 @@ class TuyaCover(TuyaDevice, CoverDevice):
             return False
         elif state == 2:
             return True
-        else:
-            return None
+        return None
 
     def open_cover(self, **kwargs):
         """Open the cover."""

--- a/homeassistant/components/cover/tuya.py
+++ b/homeassistant/components/cover/tuya.py
@@ -45,7 +45,13 @@ class TuyaCover(TuyaDevice, CoverDevice):
     @property
     def is_closed(self):
         """Return if the cover is closed or not."""
-        return None
+        state = self.tuya.state()
+        if state == 1:
+            return True
+        elif state == 2:
+            return False
+        else:
+            return None
 
     def open_cover(self, **kwargs):
         """Open the cover."""


### PR DESCRIPTION
## Description:
Add cover state. 
We can know the cover is open or closed. But we don't know the specific position when it is paused. 



## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
