### PR TITLE
Use one regex for Hass.io URL check

### DIFF
--- a/homeassistant/components/hassio/http.py
+++ b/homeassistant/components/hassio/http.py
@@ -22,23 +22,24 @@ _LOGGER = logging.getLogger(__name__)
 
 X_HASSIO = 'X-HASSIO-KEY'
 
-NO_TIMEOUT = {
-    re.compile(r'^homeassistant/update$'),
-    re.compile(r'^host/update$'),
-    re.compile(r'^supervisor/update$'),
-    re.compile(r'^addons/[^/]*/update$'),
-    re.compile(r'^addons/[^/]*/install$'),
-    re.compile(r'^addons/[^/]*/rebuild$'),
-    re.compile(r'^snapshots/.*/full$'),
-    re.compile(r'^snapshots/.*/partial$'),
-    re.compile(r'^snapshots/[^/]*/upload$'),
-    re.compile(r'^snapshots/[^/]*/download$'),
-}
+NO_TIMEOUT = re.compile(
+    r'^(?:'
+    r'|homeassistant/update'
+    r'|host/update'
+    r'|supervisor/update'
+    r'|addons/[^/]+/(?:update|install|rebuild)'
+    r'|snapshots/.+/full'
+    r'|snapshots/.+/partial'
+    r'|snapshots/[^/]+/(?:upload|download)'
+    r')$'
+)
 
-NO_AUTH = {
-    re.compile(r'^app/.*$'),
-    re.compile(r'^addons/[^/]*/logo$')
-}
+NO_AUTH = re.compile(
+    r'^(?:'
+    r'|app/.*'
+    r'|addons/[^/]+/logo'
+    r')$'
+)
 
 
 class HassIOView(HomeAssistantView):
@@ -128,15 +129,13 @@ def _create_response_log(client, data):
 
 def _get_timeout(path):
     """Return timeout for a URL path."""
-    for re_path in NO_TIMEOUT:
-        if re_path.match(path):
-            return 0
+    if NO_TIMEOUT.match(path):
+        return 0
     return 300
 
 
 def _need_auth(path):
     """Return if a path need authentication."""
-    for re_path in NO_AUTH:
-        if re_path.match(path):
-            return False
+    if NO_AUTH.match(path):
+        return False
     return True

--- a/tests/components/hassio/test_http.py
+++ b/tests/components/hassio/test_http.py
@@ -36,9 +36,13 @@ def test_forward_request(hassio_client):
 
 
 @asyncio.coroutine
-def test_auth_required_forward_request(hassio_client):
+@pytest.mark.parametrize(
+    'build_type', [
+        'supervisor/info', 'homeassistant/update', 'host/info'
+    ])
+def test_auth_required_forward_request(hassio_client, build_type):
     """Test auth required for normal request."""
-    resp = yield from hassio_client.post('/api/hassio/beer')
+    resp = yield from hassio_client.post("/api/hassio/{}".format(build_type))
 
     # Check we got right response
     assert resp.status == 401


### PR DESCRIPTION
## Description:

A small optimize for slow CPU system. Instead to loop a list of regex every API call, we use on regex to check the URL path. I add also more tests to check the api access.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**