### PR TITLE
Use only_cache parameter in zha remotes

### DIFF
--- a/homeassistant/components/binary_sensor/zha.py
+++ b/homeassistant/components/binary_sensor/zha.py
@@ -253,5 +253,9 @@ class Remote(zha.Entity, BinarySensorDevice):
         """Retrieve latest state."""
         from zigpy.zcl.clusters.general import OnOff
         result = await zha.safe_read(
-            self._endpoint.out_clusters[OnOff.cluster_id], ['on_off'])
+            self._endpoint.out_clusters[OnOff.cluster_id],
+            ['on_off'],
+            allow_cache=False,
+            only_cache=(not self._initialized)
+        )
         self._state = result.get('on_off', self._state)


### PR DESCRIPTION
## Description:

Use only_cache option for state restoration for zha remotes.

**Related issue (if applicable):** fixes #16553 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

