### PR TITLE
Add support for zha custom cluster mappings

### DIFF
--- a/homeassistant/components/sensor/zha.py
+++ b/homeassistant/components/sensor/zha.py
@@ -37,7 +37,7 @@ async def make_sensor(discovery_info):
     from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
     in_clusters = discovery_info['in_clusters']
     if 'sub_component' in discovery_info:
-        sensor = globals()[discovery_info['sub_component']](**discovery_info)
+        sensor = discovery_info['sub_component'](**discovery_info)
     elif RelativeHumidity.cluster_id in in_clusters:
         sensor = RelativeHumiditySensor(**discovery_info)
     elif TemperatureMeasurement.cluster_id in in_clusters:

--- a/homeassistant/components/sensor/zha.py
+++ b/homeassistant/components/sensor/zha.py
@@ -36,7 +36,9 @@ async def make_sensor(discovery_info):
     from zigpy.zcl.clusters.smartenergy import Metering
     from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
     in_clusters = discovery_info['in_clusters']
-    if RelativeHumidity.cluster_id in in_clusters:
+    if 'sub_component' in discovery_info:
+        sensor = globals()[discovery_info['sub_component']](**discovery_info)
+    elif RelativeHumidity.cluster_id in in_clusters:
         sensor = RelativeHumiditySensor(**discovery_info)
     elif TemperatureMeasurement.cluster_id in in_clusters:
         sensor = TemperatureSensor(**discovery_info)

--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -274,13 +274,21 @@ class ApplicationListener:
                                              device_classes, discovery_attr,
                                              is_new_join):
         """Try to set up an entity from a "bare" cluster."""
+        import homeassistant.components.zha.const as zha_const
         if cluster.cluster_id in profile_clusters:
             return
 
-        component = None
+        component = sub_component = None
         for cluster_type, candidate_component in device_classes.items():
             if isinstance(cluster, cluster_type):
                 component = candidate_component
+                break
+
+        for signature, comp in zha_const.CUSTOM_CLUSTER_MAPPINGS.items():
+            if (isinstance(endpoint.device, signature[0]) and
+                    cluster.cluster_id == signature[1]):
+                component = comp[0]
+                sub_component = comp[1]
                 break
 
         if component is None:
@@ -299,6 +307,8 @@ class ApplicationListener:
             'entity_suffix': '_{}'.format(cluster.cluster_id),
         }
         discovery_info[discovery_attr] = {cluster.cluster_id: cluster}
+        if sub_component:
+            discovery_info.update({'sub_component': sub_component})
         self._hass.data[DISCOVERY_KEY][cluster_key] = discovery_info
 
         await discovery.async_load_platform(

--- a/homeassistant/components/zha/const.py
+++ b/homeassistant/components/zha/const.py
@@ -15,6 +15,7 @@ def populate_data():
     """
     from zigpy import zcl, quirks
     from zigpy.profiles import PROFILES, zha, zll
+    from homeassistant.components.sensor import zha as sensor_zha
 
     DEVICE_CLASS[zha.PROFILE_ID] = {
         zha.DeviceType.ON_OFF_SWITCH: 'binary_sensor',
@@ -62,7 +63,7 @@ def populate_data():
     # A map of device/cluster to component/sub-component
     CUSTOM_CLUSTER_MAPPINGS.update({
         (quirks.smartthings.SmartthingsTemperatureHumiditySensor, 64581):
-            ('sensor', 'RelativeHumiditySensor')
+            ('sensor', sensor_zha.RelativeHumiditySensor)
     })
 
     # A map of hass components to all Zigbee clusters it could use

--- a/homeassistant/components/zha/const.py
+++ b/homeassistant/components/zha/const.py
@@ -3,6 +3,7 @@
 DEVICE_CLASS = {}
 SINGLE_INPUT_CLUSTER_DEVICE_CLASS = {}
 SINGLE_OUTPUT_CLUSTER_DEVICE_CLASS = {}
+CUSTOM_CLUSTER_MAPPINGS = {}
 COMPONENT_CLUSTERS = {}
 
 
@@ -12,7 +13,7 @@ def populate_data():
     These cannot be module level, as importing bellows must be done in a
     in a function.
     """
-    from zigpy import zcl
+    from zigpy import zcl, quirks
     from zigpy.profiles import PROFILES, zha, zll
 
     DEVICE_CLASS[zha.PROFILE_ID] = {
@@ -56,6 +57,12 @@ def populate_data():
     })
     SINGLE_OUTPUT_CLUSTER_DEVICE_CLASS.update({
         zcl.clusters.general.OnOff: 'binary_sensor',
+    })
+
+    # A map of device/cluster to component/sub-component
+    CUSTOM_CLUSTER_MAPPINGS.update({
+        (quirks.smartthings.SmartthingsTemperatureHumiditySensor, 64581):
+            ('sensor', 'RelativeHumiditySensor')
     })
 
     # A map of hass components to all Zigbee clusters it could use


### PR DESCRIPTION
## Description:

Add support for mapping clusters to specific components. There are two use-cases I can think of where this is necessary:

- In case a manufacturer specific cluster is used, eg. SmartThings Temp/Humidity sensor
- There is not always a clear 1:1 mapping between a zigbee cluster and HA platform, eg. OnOff cluster, which could be used by a remote device, but also a binary_sensor like the Xiaomi Door sensor

This PR will add support for humidity measurement with the SmartThings Temp/Humidity sensor.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

