### PR TITLE
SnmpSensor: Fix async_update 

### DIFF
--- a/homeassistant/components/sensor/snmp.py
+++ b/homeassistant/components/sensor/snmp.py
@@ -182,7 +182,7 @@ class SnmpSensor(Entity):
         if value is None:
             value = STATE_UNKNOWN
         elif self._value_template is not None:
-            value = self._value_template.render_with_possible_json_value(
+            value = self._value_template.async_render_with_possible_json_value(
                 value, STATE_UNKNOWN)
 
         self._state = value


### PR DESCRIPTION
HA refused to start if value_template was used in configuration of snmp sensor.

Bugfix provided by @awarecan.

**Related issue:** fixes #16679

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`.