### PR TITLE
On-demand update of swiss public transport sensor 

### DIFF
--- a/homeassistant/components/sensor/swiss_public_transport.py
+++ b/homeassistant/components/sensor/swiss_public_transport.py
@@ -16,7 +16,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 import homeassistant.util.dt as dt_util
 
-REQUIREMENTS = ['python_opendata_transport==0.1.3']
+REQUIREMENTS = ['python_opendata_transport==0.1.4']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sensor/swiss_public_transport.py
+++ b/homeassistant/components/sensor/swiss_public_transport.py
@@ -80,6 +80,7 @@ class SwissPublicTransportSensor(Entity):
         self._name = name
         self._from = start
         self._to = destination
+        self._remaining_time = ""
 
     @property
     def name(self):
@@ -98,7 +99,7 @@ class SwissPublicTransportSensor(Entity):
         if self._opendata is None:
             return
 
-        remaining_time = dt_util.parse_datetime(
+        self._remaining_time = dt_util.parse_datetime(
             self._opendata.connections[0]['departure']) -\
             dt_util.as_local(dt_util.utcnow())
 
@@ -111,7 +112,7 @@ class SwissPublicTransportSensor(Entity):
             ATTR_DEPARTURE_TIME2: self._opendata.connections[2]['departure'],
             ATTR_START: self._opendata.from_name,
             ATTR_TARGET: self._opendata.to_name,
-            ATTR_REMAINING_TIME: '{}'.format(remaining_time),
+            ATTR_REMAINING_TIME: '{}'.format(self._remaining_time),
             ATTR_ATTRIBUTION: CONF_ATTRIBUTION,
         }
         return attr
@@ -126,6 +127,7 @@ class SwissPublicTransportSensor(Entity):
         from opendata_transport.exceptions import OpendataTransportError
 
         try:
-            await self._opendata.async_get_data()
+            if self._remaining_time.total_seconds()<0:
+                await self._opendata.async_get_data()
         except OpendataTransportError:
             _LOGGER.error("Unable to retrieve data from transport.opendata.ch")

--- a/homeassistant/components/sensor/swiss_public_transport.py
+++ b/homeassistant/components/sensor/swiss_public_transport.py
@@ -127,7 +127,7 @@ class SwissPublicTransportSensor(Entity):
         from opendata_transport.exceptions import OpendataTransportError
 
         try:
-            if self._remaining_time.total_seconds()<0:
+            if self._remaining_time.total_seconds() < 0:
                 await self._opendata.async_get_data()
         except OpendataTransportError:
             _LOGGER.error("Unable to retrieve data from transport.opendata.ch")

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1170,7 +1170,7 @@ python-vlc==1.1.2
 python-wink==1.10.1
 
 # homeassistant.components.sensor.swiss_public_transport
-python_opendata_transport==0.1.3
+python_opendata_transport==0.1.4
 
 # homeassistant.components.zwave
 python_openzwave==0.4.9


### PR DESCRIPTION
## Description:
Changing Swiss Public Transport sensor to update it's values only when required (only after the train has crossed)

**Related issue (if applicable):** fixes #9012
(Linking to old issue as the issue has not dissapeared completely and this pull request is extension of previous fix to change it from 90 seconds to on-demand)
Closes  fabaff/python-opendata-transport#3

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
