### PR TITLE
Upgrade zeroconf to 0.21.2

### DIFF
--- a/homeassistant/components/zeroconf.py
+++ b/homeassistant/components/zeroconf.py
@@ -12,7 +12,7 @@ import voluptuous as vol
 from homeassistant import util
 from homeassistant.const import (EVENT_HOMEASSISTANT_STOP, __version__)
 
-REQUIREMENTS = ['zeroconf==0.21.1']
+REQUIREMENTS = ['zeroconf==0.21.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1537,7 +1537,7 @@ youtube_dl==2018.09.10
 zengge==0.2
 
 # homeassistant.components.zeroconf
-zeroconf==0.21.1
+zeroconf==0.21.2
 
 # homeassistant.components.climate.zhong_hong
 zhong_hong_hvac==1.0.9


### PR DESCRIPTION
## Description:
Changelog: https://github.com/jstasiak/python-zeroconf/#0211

## Example entry for `configuration.yaml` (if applicable):
```yaml
zeroconf:
```

```bash
$ avahi-browse -alr
[...]
$ avahi-browse -alr
= enp0s20f0u6u1 IPv4 Home                                          _home-assistant._tcp local
   hostname = [Home._home-assistant._tcp.local]
   address = [192.168.0.241]
   port = [8123]
   txt = ["requires_api_password=false" "base_url=http://192.168.0.241:8123" "version=0.79.0.dev0"]
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
