### PR TITLE
Upgrade keyring to 15.1.0

### DIFF
--- a/homeassistant/scripts/keyring.py
+++ b/homeassistant/scripts/keyring.py
@@ -5,7 +5,7 @@ import os
 
 from homeassistant.util.yaml import _SECRET_NAMESPACE
 
-REQUIREMENTS = ['keyring==15.0.0', 'keyrings.alt==3.1']
+REQUIREMENTS = ['keyring==15.1.0', 'keyrings.alt==3.1']
 
 
 def run(args):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -507,7 +507,7 @@ jsonrpc-async==0.6
 jsonrpc-websocket==0.6
 
 # homeassistant.scripts.keyring
-keyring==15.0.0
+keyring==15.1.0
 
 # homeassistant.scripts.keyring
 keyrings.alt==3.1


### PR DESCRIPTION
## Description:
Changelog: https://github.com/jaraco/keyring/blob/master/CHANGES.rst#1510

```bash
(home-assistant) [fab@test123 home-assistant]$ hass --script keyring get http
INFO:homeassistant.util.package:Attempting install of keyring==15.1.0
INFO:homeassistant.util.package:Attempting install of keyrings.alt==3.1
Secret http=test123
(home-assistant) [fab@test123 home-assistant]$ hass --script keyring set http
INFO:homeassistant.util.package:Attempting install of keyring==15.1.0
INFO:homeassistant.util.package:Attempting install of keyrings.alt==3.1
Please enter the secret for http: 
Secret http set successfully
(home-assistant) [fab@test123 home-assistant]$ hass --script keyring get http
INFO:homeassistant.util.package:Attempting install of keyring==15.1.0
INFO:homeassistant.util.package:Attempting install of keyrings.alt==3.1
Secret http=homeassistant
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
