### PR TITLE
Upgrade netdisco to 2.1.0

### DIFF
--- a/homeassistant/components/discovery.py
+++ b/homeassistant/components/discovery.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.event import async_track_point_in_utc_time
 from homeassistant.helpers.discovery import async_load_platform, async_discover
 import homeassistant.util.dt as dt_util
 
-REQUIREMENTS = ['netdisco==2.0.0']
+REQUIREMENTS = ['netdisco==2.1.0']
 
 DOMAIN = 'discovery'
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -619,7 +619,7 @@ ndms2_client==0.0.4
 netdata==0.1.2
 
 # homeassistant.components.discovery
-netdisco==2.0.0
+netdisco==2.1.0
 
 # homeassistant.components.sensor.neurio_energy
 neurio==0.3.1


### PR DESCRIPTION
## Description:

Changelog: https://github.com/home-assistant/netdisco/releases/tag/2.1.0

- Ensure N301 player ignored by yamaha discovery as not supported (home-assistant/netdisco#207) @vrih
- Misc cleanups (home-assistant/netdisco#208) @scop
- Add UPnP/IGD discoverable (home-assistant/netdisco#210) @StevenLooman
- Fix igd module docstring (home-assistant/netdisco#212) @scop
- Remove netifaces lib reference (home-assistant/netdisco#215) @awarecan
- Remove broken GDMDiscoverable.info_from_entry (home-assistant/netdisco#209) @scop
- Include tests in PyPI tarball (home-assistant/netdisco#205) @dotlambda 
 

**Related issue (if applicable):** fixes #16678

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

