### PR TITLE
Telegram_bot polling support proxy_url and proxy_params (Fix #15746)

### DIFF
--- a/homeassistant/components/telegram_bot/__init__.py
+++ b/homeassistant/components/telegram_bot/__init__.py
@@ -311,10 +311,11 @@ def initialize_bot(p_config):
     proxy_url = p_config.get(CONF_PROXY_URL)
     proxy_params = p_config.get(CONF_PROXY_PARAMS)
 
-    request = None
     if proxy_url is not None:
-        request = Request(proxy_url=proxy_url,
+        request = Request(con_pool_size=4, proxy_url=proxy_url,
                           urllib3_proxy_kwargs=proxy_params)
+    else:
+        request = Request(con_pool_size=4)
     return Bot(token=api_key, request=request)
 
 

--- a/homeassistant/components/telegram_bot/polling.py
+++ b/homeassistant/components/telegram_bot/polling.py
@@ -62,7 +62,6 @@ def message_handler(cb):
     from telegram import Update
     from telegram.ext import Handler
 
-
     class MessageHandler(Handler):
         """Telegram bot message handler"""
 

--- a/homeassistant/components/telegram_bot/polling.py
+++ b/homeassistant/components/telegram_bot/polling.py
@@ -5,12 +5,7 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/telegram_bot.polling/
 """
 import asyncio
-from asyncio.futures import CancelledError
 import logging
-
-import async_timeout
-from aiohttp.client_exceptions import ClientError
-from aiohttp.hdrs import CONNECTION, KEEP_ALIVE
 
 from homeassistant.components.telegram_bot import (
     initialize_bot,
@@ -19,19 +14,14 @@ from homeassistant.components.telegram_bot import (
 from homeassistant.const import (
     EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP)
 from homeassistant.core import callback
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from telegram import Update
+from telegram.ext import (Updater, Handler)
+from telegram.error import (TelegramError, TimedOut, NetworkError, RetryAfter)
 
 _LOGGER = logging.getLogger(__name__)
 
 PLATFORM_SCHEMA = TELEGRAM_PLATFORM_SCHEMA
-RETRY_SLEEP = 10
-
-
-class WrongHttpStatus(Exception):
-    """Thrown when a wrong http status is received."""
-
-    pass
-
 
 @asyncio.coroutine
 def async_setup_platform(hass, config):
@@ -55,73 +45,53 @@ def async_setup_platform(hass, config):
     return True
 
 
+class MessageHandler(Handler):
+    """Telegram bot message handler"""
+
+    def __init__(self, callback):
+        super(MessageHandler, self).__init__(callback)
+
+    def check_update(self, update):
+        return isinstance(update, Update)
+
+    def handle_update(self, update, dispatcher):
+        optional_args = self.collect_optional_args(dispatcher, update)
+        return self.callback(dispatcher.bot, update, **optional_args)
+
+
 class TelegramPoll(BaseTelegramBotEntity):
     """Asyncio telegram incoming message handler."""
 
     def __init__(self, bot, hass, allowed_chat_ids):
         """Initialize the polling instance."""
         BaseTelegramBotEntity.__init__(self, hass, allowed_chat_ids)
-        self.update_id = 0
-        self.websession = async_get_clientsession(hass)
-        self.update_url = '{0}/getUpdates'.format(bot.base_url)
-        self.polling_task = None  # The actual polling task.
-        self.timeout = 15  # async post timeout
-        # Polling timeout should always be less than async post timeout.
-        self.post_data = {'timeout': self.timeout - 5}
+
+        self.updater = Updater(bot=bot, workers=4)  # updater
+        self.dispatcher = self.updater.dispatcher  # dispatcher
+
+        self.dispatcher.add_handler(MessageHandler(self.process_update))
+        self.dispatcher.add_error_handler(self.process_error)
 
     def start_polling(self):
         """Start the polling task."""
-        self.polling_task = self.hass.async_add_job(self.check_incoming())
+        self.updater.start_polling()
 
     def stop_polling(self):
         """Stop the polling task."""
-        self.polling_task.cancel()
+        self.updater.stop()
 
-    @asyncio.coroutine
-    def get_updates(self, offset):
-        """Bypass the default long polling method to enable asyncio."""
-        resp = None
-        if offset:
-            self.post_data['offset'] = offset
-        try:
-            with async_timeout.timeout(self.timeout, loop=self.hass.loop):
-                resp = yield from self.websession.post(
-                    self.update_url, data=self.post_data,
-                    headers={CONNECTION: KEEP_ALIVE}
-                )
-            if resp.status == 200:
-                _json = yield from resp.json()
-                return _json
-            raise WrongHttpStatus('wrong status {}'.format(resp.status))
-        finally:
-            if resp is not None:
-                yield from resp.release()
+    @callback
+    def process_update(self, bot, update):
+        self.process_message(update.to_dict())
 
-    @asyncio.coroutine
-    def check_incoming(self):
-        """Continuously check for incoming telegram messages."""
+    @callback
+    def process_error(self, bot, update, error):
         try:
-            while True:
-                try:
-                    _updates = yield from self.get_updates(self.update_id)
-                except (WrongHttpStatus, ClientError) as err:
-                    # WrongHttpStatus: Non-200 status code.
-                    # Occurs at times (mainly 502) and recovers
-                    # automatically. Pause for a while before retrying.
-                    _LOGGER.error(err)
-                    yield from asyncio.sleep(RETRY_SLEEP)
-                except (asyncio.TimeoutError, ValueError):
-                    # Long polling timeout. Nothing serious.
-                    # Json error. Just retry for the next message.
-                    pass
-                else:
-                    # no exception raised. update received data.
-                    _updates = _updates.get('result')
-                    if _updates is None:
-                        _LOGGER.error("Incorrect result received.")
-                    else:
-                        for update in _updates:
-                            self.update_id = update['update_id'] + 1
-                            self.process_message(update)
-        except CancelledError:
-            _LOGGER.debug("Stopping Telegram polling bot")
+            raise error
+        except (TimedOut, NetworkError, RetryAfter):
+            # Long polling timeout or connection problem. Nothing serious.
+            pass
+        except TelegramError:
+            _LOGGER.error('Update "%s" caused error "%s"', update, error)
+            pass
+        return

--- a/homeassistant/components/telegram_bot/polling.py
+++ b/homeassistant/components/telegram_bot/polling.py
@@ -57,17 +57,17 @@ def process_error(bot, update, error):
         _LOGGER.error('Update "%s" caused error "%s"', update, error)
 
 
-def message_handler(cb):
-    """Creates messages handler."""
+def message_handler(handler):
+    """Create messages handler."""
     from telegram import Update
     from telegram.ext import Handler
 
     class MessageHandler(Handler):
-        """Telegram bot message handler"""
+        """Telegram bot message handler."""
 
         def __init__(self):
             """Initialize the messages handler instance."""
-            super(MessageHandler, self).__init__(cb)
+            super(MessageHandler, self).__init__(handler)
 
         def check_update(self, update):
             """Check is update valid."""

--- a/homeassistant/components/telegram_bot/polling.py
+++ b/homeassistant/components/telegram_bot/polling.py
@@ -42,7 +42,6 @@ def async_setup_platform(hass, config):
     return True
 
 
-@callback
 def process_error(bot, update, error):
     """Telegram bot error handler."""
     from telegram.error import (

--- a/homeassistant/components/telegram_bot/polling.py
+++ b/homeassistant/components/telegram_bot/polling.py
@@ -66,7 +66,7 @@ def message_handler(handler):
 
         def __init__(self):
             """Initialize the messages handler instance."""
-            super(MessageHandler, self).__init__(handler)
+            super().__init__(handler)
 
         def check_update(self, update):
             """Check is update valid."""

--- a/homeassistant/components/telegram_bot/polling.py
+++ b/homeassistant/components/telegram_bot/polling.py
@@ -19,6 +19,7 @@ _LOGGER = logging.getLogger(__name__)
 
 PLATFORM_SCHEMA = TELEGRAM_PLATFORM_SCHEMA
 
+
 @asyncio.coroutine
 def async_setup_platform(hass, config):
     """Set up the Telegram polling platform."""
@@ -40,10 +41,12 @@ def async_setup_platform(hass, config):
 
     return True
 
+
 @callback
 def process_error(bot, update, error):
     """Telegram bot error handler."""
-    from telegram.error import (TelegramError, TimedOut, NetworkError, RetryAfter)
+    from telegram.error import (
+        TelegramError, TimedOut, NetworkError, RetryAfter)
 
     try:
         raise error
@@ -53,10 +56,12 @@ def process_error(bot, update, error):
     except TelegramError:
         _LOGGER.error('Update "%s" caused error "%s"', update, error)
 
+
 def message_handler(cb):
     """Creates messages handler."""
     from telegram import Update
     from telegram.ext import Handler
+
 
     class MessageHandler(Handler):
         """Telegram bot message handler"""


### PR DESCRIPTION
## Description:
Telegram bots polling component did not support proxy.

**Related issue (if applicable):** fixes #15746

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
