### PR TITLE
Add option to disable specific integrations

### DIFF
--- a/homeassistant/components/alexa/smart_home.py
+++ b/homeassistant/components/alexa/smart_home.py
@@ -1529,3 +1529,8 @@ async def async_api_reportstate(hass, config, request, context, entity):
         name='StateReport',
         context={'properties': properties}
     )
+
+
+def turned_off_response(message):
+    """Return a device turned off response."""
+    return api_error(message[API_DIRECTIVE], error_type='BRIDGE_UNREACHABLE')

--- a/homeassistant/components/cloud/iot.py
+++ b/homeassistant/components/cloud/iot.py
@@ -227,6 +227,9 @@ def async_handle_message(hass, cloud, handler_name, payload):
 @asyncio.coroutine
 def async_handle_alexa(hass, cloud, payload):
     """Handle an incoming IoT message for Alexa."""
+    if not cloud.alexa_enabled:
+        return alexa.turned_off_response(payload)
+
     result = yield from alexa.async_handle_message(
         hass, cloud.alexa_config, payload)
     return result
@@ -236,6 +239,9 @@ def async_handle_alexa(hass, cloud, payload):
 @asyncio.coroutine
 def async_handle_google_actions(hass, cloud, payload):
     """Handle an incoming IoT message for Google Actions."""
+    if not cloud.google_enabled:
+        return ga.turned_off_response(payload)
+
     result = yield from ga.async_handle_message(
         hass, cloud.gactions_config, payload)
     return result

--- a/homeassistant/components/google_assistant/smart_home.py
+++ b/homeassistant/components/google_assistant/smart_home.py
@@ -324,3 +324,11 @@ async def handle_devices_execute(hass, config, payload):
         })
 
     return {'commands': final_results}
+
+
+def turned_off_response(message):
+    """Return a device turned off response."""
+    return {
+        'requestId': message.get('requestId'),
+        'payload': {'errorCode': 'deviceTurnedOff'}
+    }

--- a/tests/components/cloud/__init__.py
+++ b/tests/components/cloud/__init__.py
@@ -1,1 +1,32 @@
 """Tests for the cloud component."""
+from unittest.mock import patch
+from homeassistant.setup import async_setup_component
+from homeassistant.components import cloud
+
+from jose import jwt
+
+from tests.common import mock_coro
+
+
+def mock_cloud(hass, config={}):
+    """Mock cloud."""
+    with patch('homeassistant.components.cloud.Cloud.async_start',
+               return_value=mock_coro()):
+        assert hass.loop.run_until_complete(async_setup_component(
+            hass, cloud.DOMAIN, {
+                'cloud': config
+            }))
+
+    hass.data[cloud.DOMAIN]._decode_claims = \
+        lambda token: jwt.get_unverified_claims(token)
+
+
+def mock_cloud_prefs(hass, prefs={}):
+    """Fixture for cloud component."""
+    prefs_to_set = {
+        cloud.STORAGE_ENABLE_ALEXA: True,
+        cloud.STORAGE_ENABLE_GOOGLE: True,
+    }
+    prefs_to_set.update(prefs)
+    hass.data[cloud.DOMAIN]._prefs = prefs_to_set
+    return prefs_to_set

--- a/tests/components/cloud/conftest.py
+++ b/tests/components/cloud/conftest.py
@@ -9,5 +9,3 @@ def mock_cloud_fixture(hass):
     """Fixture for cloud component."""
     mock_cloud(hass)
     return mock_cloud_prefs(hass)
-
-

--- a/tests/components/cloud/conftest.py
+++ b/tests/components/cloud/conftest.py
@@ -1,0 +1,13 @@
+"""Fixtures for cloud tests."""
+import pytest
+
+from . import mock_cloud, mock_cloud_prefs
+
+
+@pytest.fixture
+def mock_cloud_fixture(hass):
+    """Fixture for cloud component."""
+    mock_cloud(hass)
+    return mock_cloud_prefs(hass)
+
+

--- a/tests/components/cloud/test_init.py
+++ b/tests/components/cloud/test_init.py
@@ -141,9 +141,9 @@ def test_write_user_info():
 
 
 @asyncio.coroutine
-def test_subscription_expired():
+def test_subscription_expired(hass):
     """Test subscription being expired."""
-    cl = cloud.Cloud(None, cloud.MODE_DEV, None, None)
+    cl = cloud.Cloud(hass, cloud.MODE_DEV, None, None)
     token_val = {
         'custom:sub-exp': '2017-11-13'
     }
@@ -154,9 +154,9 @@ def test_subscription_expired():
 
 
 @asyncio.coroutine
-def test_subscription_not_expired():
+def test_subscription_not_expired(hass):
     """Test subscription not being expired."""
-    cl = cloud.Cloud(None, cloud.MODE_DEV, None, None)
+    cl = cloud.Cloud(hass, cloud.MODE_DEV, None, None)
     token_val = {
         'custom:sub-exp': '2017-11-13'
     }


### PR DESCRIPTION
## Description:
Add options to disable the Alexa or Google Assistant integration via the websocket UI.

## Example entry for `configuration.yaml` (if applicable):
```yaml
cloud:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
