### PR TITLE
Fix faulty color temp crashing google

### DIFF
--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -317,7 +317,9 @@ class ColorTemperatureTrait(_Trait):
         response = {}
 
         temp = self.state.attributes.get(light.ATTR_COLOR_TEMP)
-        if temp is not None:
+        # not checking specifically for `None` because some faulty
+        # integration might put 0 in here, raising exception.
+        if temp:
             response['color'] = {
                 'temperature':
                     color_util.color_temperature_mired_to_kelvin(temp)

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -1,4 +1,6 @@
 """Implement the Smart Home traits."""
+import logging
+
 from homeassistant.core import DOMAIN as HA_DOMAIN
 from homeassistant.components import (
     climate,
@@ -24,6 +26,8 @@ from homeassistant.util import color as color_util, temperature as temp_util
 
 from .const import ERR_VALUE_OUT_OF_RANGE
 from .helpers import SmartHomeError
+
+_LOGGER = logging.getLogger(__name__)
 
 PREFIX_TRAITS = 'action.devices.traits.'
 TRAIT_ONOFF = PREFIX_TRAITS + 'OnOff'
@@ -317,9 +321,11 @@ class ColorTemperatureTrait(_Trait):
         response = {}
 
         temp = self.state.attributes.get(light.ATTR_COLOR_TEMP)
-        # not checking specifically for `None` because some faulty
-        # integration might put 0 in here, raising exception.
-        if temp:
+        # Some faulty integrations might put 0 in here, raising exception.
+        if temp == 0:
+            _LOGGER.warning('Entity %s has incorrect color temperature %s',
+                            self.state.entity_id, temp)
+        elif temp is not None:
             response['color'] = {
                 'temperature':
                     color_util.color_temperature_mired_to_kelvin(temp)

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -457,7 +457,7 @@ async def test_color_temperature_light(hass):
     }
 
 
-async def test_color_temperature_light(hass):
+async def test_color_temperature_light_bad_temp(hass):
     """Test ColorTemperature trait support for light domain."""
     assert not trait.ColorTemperatureTrait.supported(light.DOMAIN, 0)
     assert trait.ColorTemperatureTrait.supported(light.DOMAIN,

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -457,6 +457,22 @@ async def test_color_temperature_light(hass):
     }
 
 
+async def test_color_temperature_light(hass):
+    """Test ColorTemperature trait support for light domain."""
+    assert not trait.ColorTemperatureTrait.supported(light.DOMAIN, 0)
+    assert trait.ColorTemperatureTrait.supported(light.DOMAIN,
+                                                 light.SUPPORT_COLOR_TEMP)
+
+    trt = trait.ColorTemperatureTrait(hass, State('light.bla', STATE_ON, {
+        light.ATTR_MIN_MIREDS: 200,
+        light.ATTR_COLOR_TEMP: 0,
+        light.ATTR_MAX_MIREDS: 500,
+    }))
+
+    assert trt.query_attributes() == {
+    }
+
+
 async def test_scene_scene(hass):
     """Test Scene trait support for scene domain."""
     assert trait.SceneTrait.supported(scene.DOMAIN, 0)


### PR DESCRIPTION
## Description:
Fix faulty color temp crashing Google Assistant sync

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/13381

## Example entry for `configuration.yaml` (if applicable):
```yaml
cloud:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
