### PR TITLE
Upgrade pysonos to 0.0.2

### DIFF
--- a/homeassistant/components/sonos/__init__.py
+++ b/homeassistant/components/sonos/__init__.py
@@ -4,7 +4,7 @@ from homeassistant.helpers import config_entry_flow
 
 
 DOMAIN = 'sonos'
-REQUIREMENTS = ['pysonos==0.0.1']
+REQUIREMENTS = ['pysonos==0.0.2']
 
 
 async def async_setup(hass, config):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1058,7 +1058,7 @@ pysma==0.2
 pysnmp==4.4.5
 
 # homeassistant.components.sonos
-pysonos==0.0.1
+pysonos==0.0.2
 
 # homeassistant.components.notify.stride
 pystride==0.1.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -165,7 +165,7 @@ pyotp==2.2.6
 pyqwikswitch==0.8
 
 # homeassistant.components.sonos
-pysonos==0.0.1
+pysonos==0.0.2
 
 # homeassistant.components.sensor.darksky
 # homeassistant.components.weather.darksky


### PR DESCRIPTION
## Description:

The pysonos 0.0.2 changelog:
* Fix support for Playbar, and add for Playbase and Beam.

**Related issue (if applicable):** fixes #16661

## Checklist:
  - [ ] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54