### PR TITLE
Add confirmation to Cast/Sonos/iOS config entries

### DIFF
--- a/homeassistant/helpers/config_entry_flow.py
+++ b/homeassistant/helpers/config_entry_flow.py
@@ -31,38 +31,52 @@ class DiscoveryFlowHandler(config_entries.ConfigFlow):
                 reason='single_instance_allowed'
             )
 
-        # Get current discovered entries.
-        in_progress = self._async_in_progress()
+        if self.context and self.context.get('source') != \
+                config_entries.SOURCE_DISCOVERY:
+            # Get current discovered entries.
+            in_progress = self._async_in_progress()
 
-        has_devices = in_progress
-        if not has_devices:
-            has_devices = await self.hass.async_add_job(
-                self._discovery_function, self.hass)
+            has_devices = in_progress
+            if not has_devices:
+                has_devices = await self.hass.async_add_job(
+                    self._discovery_function, self.hass)
 
-        if not has_devices:
-            return self.async_abort(
-                reason='no_devices_found'
+            if not has_devices:
+                return self.async_abort(
+                    reason='no_devices_found'
+                )
+
+        return await self.async_step_confirm()
+
+    async def async_step_confirm(self, user_input=None):
+        """Confirm setup."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id='confirm',
             )
 
-        # Cancel the discovered one.
-        for flow in in_progress:
-            self.hass.config_entries.flow.async_abort(flow['flow_id'])
+        if self.context and self.context.get('source') != \
+                config_entries.SOURCE_DISCOVERY:
+            # Get current discovered entries.
+            in_progress = self._async_in_progress()
+
+            has_devices = in_progress
+            if not has_devices:
+                has_devices = await self.hass.async_add_job(
+                    self._discovery_function, self.hass)
+
+            if not has_devices:
+                return self.async_abort(
+                    reason='no_devices_found'
+                )
+
+            # Cancel the discovered one.
+            for flow in in_progress:
+                self.hass.config_entries.flow.async_abort(flow['flow_id'])
 
         return self.async_create_entry(
             title=self._title,
             data={},
-        )
-
-    async def async_step_confirm(self, user_input=None):
-        """Confirm setup."""
-        if user_input is not None:
-            return self.async_create_entry(
-                title=self._title,
-                data={},
-            )
-
-        return self.async_show_form(
-            step_id='confirm',
         )
 
     async def async_step_discovery(self, discovery_info):

--- a/homeassistant/helpers/config_entry_flow.py
+++ b/homeassistant/helpers/config_entry_flow.py
@@ -31,21 +31,6 @@ class DiscoveryFlowHandler(config_entries.ConfigFlow):
                 reason='single_instance_allowed'
             )
 
-        if self.context and self.context.get('source') != \
-                config_entries.SOURCE_DISCOVERY:
-            # Get current discovered entries.
-            in_progress = self._async_in_progress()
-
-            has_devices = in_progress
-            if not has_devices:
-                has_devices = await self.hass.async_add_job(
-                    self._discovery_function, self.hass)
-
-            if not has_devices:
-                return self.async_abort(
-                    reason='no_devices_found'
-                )
-
         return await self.async_step_confirm()
 
     async def async_step_confirm(self, user_input=None):

--- a/tests/components/cast/test_init.py
+++ b/tests/components/cast/test_init.py
@@ -17,6 +17,12 @@ async def test_creating_entry_sets_up_media_player(hass):
                   return_value=True):
         result = await hass.config_entries.flow.async_init(
             cast.DOMAIN, context={'source': config_entries.SOURCE_USER})
+
+        # Confirmation form
+        assert result['type'] == data_entry_flow.RESULT_TYPE_FORM
+
+        result = await hass.config_entries.flow.async_configure(
+            result['flow_id'], {})
         assert result['type'] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
 
         await hass.async_block_till_done()

--- a/tests/components/ios/test_init.py
+++ b/tests/components/ios/test_init.py
@@ -30,6 +30,12 @@ async def test_creating_entry_sets_up_sensor(hass):
                return_value=mock_coro(True)) as mock_setup:
         result = await hass.config_entries.flow.async_init(
             ios.DOMAIN, context={'source': config_entries.SOURCE_USER})
+
+        # Confirmation form
+        assert result['type'] == data_entry_flow.RESULT_TYPE_FORM
+
+        result = await hass.config_entries.flow.async_configure(
+            result['flow_id'], {})
         assert result['type'] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
 
         await hass.async_block_till_done()

--- a/tests/components/sonos/test_init.py
+++ b/tests/components/sonos/test_init.py
@@ -15,6 +15,12 @@ async def test_creating_entry_sets_up_media_player(hass):
             patch('pysonos.discover', return_value=True):
         result = await hass.config_entries.flow.async_init(
             sonos.DOMAIN, context={'source': config_entries.SOURCE_USER})
+
+        # Confirmation form
+        assert result['type'] == data_entry_flow.RESULT_TYPE_FORM
+
+        result = await hass.config_entries.flow.async_configure(
+            result['flow_id'], {})
         assert result['type'] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
 
         await hass.async_block_till_done()


### PR DESCRIPTION
## Description:
Adds confirmation step to config entries Cast, Sonos and iOS. Old behavior was a "Success!" message when clicking configure.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
