### PR TITLE
Fix return to base logic for Neato

### DIFF
--- a/homeassistant/components/vacuum/neato.py
+++ b/homeassistant/components/vacuum/neato.py
@@ -188,6 +188,8 @@ class NeatoConnectedVacuum(StateVacuumDevice):
 
     def return_to_base(self, **kwargs):
         """Set the vacuum cleaner to return to the dock."""
+        if self._clean_state == STATE_CLEANING:
+            self.robot.pause_cleaning()
         self._clean_state = STATE_RETURNING
         self.robot.send_to_base()
 


### PR DESCRIPTION
## Description:

The Neato botvac is unable to return to the base while it is cleaning, this PR now checks if the botvac is cleaning and will pause it so it can return to the base properly.  This logic was there before PR #16035 so this now makes sure the UI functions as it did in the past.

**Related issue (if applicable):** fixes #16491 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** 

n/a

## Example entry for `configuration.yaml` (if applicable):
```yaml
neato:
  username: username
  password: password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
