### PR TITLE
Add configurable host for bbox routers

### DIFF
--- a/homeassistant/components/device_tracker/bbox.py
+++ b/homeassistant/components/device_tracker/bbox.py
@@ -4,17 +4,28 @@ Support for French FAI Bouygues Bbox routers.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/device_tracker.bbox/
 """
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.device_tracker import (
+    PLATFORM_SCHEMA, CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL, DOMAIN, DeviceScanner)
+from homeassistant.const import CONF_HOST
+
 from collections import namedtuple
 import logging
 from datetime import timedelta
 
 import homeassistant.util.dt as dt_util
-from homeassistant.components.device_tracker import DOMAIN, DeviceScanner
 from homeassistant.util import Throttle
 
 REQUIREMENTS = ['pybbox==0.0.5-alpha']
 
 _LOGGER = logging.getLogger(__name__)
+
+PLATFORM_SCHEMA = vol.All(
+    PLATFORM_SCHEMA.extend({
+        vol.Optional(CONF_HOST, default='192.168.1.254'): cv.string
+    }))
 
 MIN_TIME_BETWEEN_SCANS = timedelta(seconds=60)
 
@@ -33,6 +44,9 @@ class BboxDeviceScanner(DeviceScanner):
     """This class scans for devices connected to the bbox."""
 
     def __init__(self, config):
+        """Get host from config."""
+        self.host = config[CONF_HOST]
+
         """Initialize the scanner."""
         self.last_results = []  # type: List[Device]
 
@@ -64,7 +78,7 @@ class BboxDeviceScanner(DeviceScanner):
 
         import pybbox
 
-        box = pybbox.Bbox()
+        box = pybbox.Bbox(ip=self.host)
         result = box.get_all_connected_devices()
 
         now = dt_util.now()

--- a/homeassistant/components/device_tracker/bbox.py
+++ b/homeassistant/components/device_tracker/bbox.py
@@ -4,16 +4,17 @@ Support for French FAI Bouygues Bbox routers.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/device_tracker.bbox/
 """
+
+from collections import namedtuple
+import logging
+from datetime import timedelta
+
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.device_tracker import (
     PLATFORM_SCHEMA, DOMAIN, DeviceScanner)
 from homeassistant.const import CONF_HOST
-
-from collections import namedtuple
-import logging
-from datetime import timedelta
 
 import homeassistant.util.dt as dt_util
 from homeassistant.util import Throttle

--- a/homeassistant/components/device_tracker/bbox.py
+++ b/homeassistant/components/device_tracker/bbox.py
@@ -4,31 +4,30 @@ Support for French FAI Bouygues Bbox routers.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/device_tracker.bbox/
 """
-
 from collections import namedtuple
-import logging
 from datetime import timedelta
+import logging
 
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.components.device_tracker import (
-    PLATFORM_SCHEMA, DOMAIN, DeviceScanner)
+    DOMAIN, PLATFORM_SCHEMA, DeviceScanner)
 from homeassistant.const import CONF_HOST
-
-import homeassistant.util.dt as dt_util
+import homeassistant.helpers.config_validation as cv
 from homeassistant.util import Throttle
+import homeassistant.util.dt as dt_util
 
 REQUIREMENTS = ['pybbox==0.0.5-alpha']
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORM_SCHEMA = vol.All(
-    PLATFORM_SCHEMA.extend({
-        vol.Optional(CONF_HOST, default='192.168.1.254'): cv.string
-    }))
+DEFAULT_HOST = '192.168.1.254'
 
 MIN_TIME_BETWEEN_SCANS = timedelta(seconds=60)
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
+})
 
 
 def get_scanner(hass, config):

--- a/homeassistant/components/device_tracker/bbox.py
+++ b/homeassistant/components/device_tracker/bbox.py
@@ -8,7 +8,7 @@ import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.device_tracker import (
-    PLATFORM_SCHEMA, CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL, DOMAIN, DeviceScanner)
+    PLATFORM_SCHEMA, DOMAIN, DeviceScanner)
 from homeassistant.const import CONF_HOST
 
 from collections import namedtuple


### PR DESCRIPTION
Add configurable host for bbox router running on non-default IP addresses.

## Description:
The current implementation only supports bbox routers running on 192.168.1.254. I added a configuration entry to set the router IP address.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#6333

## Example entry for `configuration.yaml` (if applicable):
```yaml
device_tracker:
  - platform: bbox
    host: 192.168.1.1
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [N/A] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [N/A] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [N/A] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [N/A] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [N/A] Tests have been added to verify that the new code works.
