### PR TITLE
Upgrade bimmer_connected to 0.5.2

### DIFF
--- a/homeassistant/components/bmw_connected_drive/__init__.py
+++ b/homeassistant/components/bmw_connected_drive/__init__.py
@@ -14,7 +14,7 @@ from homeassistant.helpers import discovery
 from homeassistant.helpers.event import track_utc_time_change
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['bimmer_connected==0.5.1']
+REQUIREMENTS = ['bimmer_connected==0.5.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -172,7 +172,7 @@ beautifulsoup4==4.6.3
 bellows==0.7.0
 
 # homeassistant.components.bmw_connected_drive
-bimmer_connected==0.5.1
+bimmer_connected==0.5.2
 
 # homeassistant.components.blink
 blinkpy==0.6.0


### PR DESCRIPTION
## Description:
The login url to the BMW server has changed causing the component to not work anymore. This PR upgrades to `bimmer_connected 0.5.2` which fixes that issue.
Changelog: https://github.com/m1n3rva/bimmer_connected/pull/85

**Related issue (if applicable):** fixes https://community.home-assistant.io/t/bmw-connecteddrive-component/39569/288

## Example entry for `configuration.yaml` (if applicable):
```yaml
bmw_connected_drive:
  name:
    username: USERNAME_BMW_CONNECTED_DRIVE
    password: PASSWORD_BMW_CONNECTED_DRIVE
    region: one of "north_america", "china" , "rest_of_world"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
