### PR TITLE
Fix chromecast disconnect

### DIFF
--- a/homeassistant/components/media_player/cast.py
+++ b/homeassistant/components/media_player/cast.py
@@ -61,8 +61,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
         vol.All(cv.ensure_list, [cv.string]),
 })
 
-CONNECTION_RETRY = 3
-CONNECTION_RETRY_WAIT = 2
+CONNECTION_RETRY = 6
+CONNECTION_RETRY_WAIT = 5
 CONNECTION_TIMEOUT = 10
 
 
@@ -124,7 +124,6 @@ def _fill_out_missing_chromecast_info(info: ChromecastInfo) -> ChromecastInfo:
 def _discover_chromecast(hass: HomeAssistantType, info: ChromecastInfo):
     if info in hass.data[KNOWN_CHROMECAST_INFO_KEY]:
         _LOGGER.debug("Discovered previous chromecast %s", info)
-        return
 
     # Either discovered completely new chromecast or a "moved" one.
     info = _fill_out_missing_chromecast_info(info)


### PR DESCRIPTION
## Description:

Overhaul the platform setup code.

Chromecast has two different way to config, zeroconf discovery or manual config the host IP. In this PR
1. Delay the start of internal discovery till HA is started
2. Auto-discovery device could be discovery again if it came back after offline, so limit the socket connection retry times
3. For all manual configured host IP, HA will create media_player device no matter the device is online or not during the system start up. The socket connection will "keep-alive", e.g. keep trying to connect to host until it connected. If the connection lost, it will keep trying to reconnect

**Related issue (if applicable):** fixes #13530 fixes #16686

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
# Either configured through configuration panel or by configuration.yaml
# configuration.yaml example
cast:
  media_player:
    - host: 192.168.1.1
    - host: 192.168.1.2
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

