### PR TITLE
0.78.3

### DIFF
--- a/homeassistant/components/tts/google.py
+++ b/homeassistant/components/tts/google.py
@@ -17,7 +17,7 @@ import yarl
 from homeassistant.components.tts import CONF_LANG, PLATFORM_SCHEMA, Provider
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-REQUIREMENTS = ['gTTS-token==1.1.1']
+REQUIREMENTS = ['gTTS-token==1.1.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -2,7 +2,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 78
-PATCH_VERSION = '2'
+PATCH_VERSION = '3'
 __short_version__ = '{}.{}'.format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = '{}.{}'.format(__short_version__, PATCH_VERSION)
 REQUIRED_PYTHON_VER = (3, 5, 3)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -383,7 +383,7 @@ freesms==0.1.2
 fritzhome==1.0.4
 
 # homeassistant.components.tts.google
-gTTS-token==1.1.1
+gTTS-token==1.1.2
 
 # homeassistant.components.sensor.gearbest
 gearbest_parser==1.0.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -66,7 +66,7 @@ feedparser==5.2.1
 foobot_async==0.3.1
 
 # homeassistant.components.tts.google
-gTTS-token==1.1.1
+gTTS-token==1.1.2
 
 # homeassistant.components.ffmpeg
 ha-ffmpeg==1.9


### PR DESCRIPTION
- Bump gtts-token to 1.1.2 ([@edif30] - [#16775]) ([tts docs])

[#16537]: https://github.com/home-assistant/home-assistant/pull/16537
[#16775]: https://github.com/home-assistant/home-assistant/pull/16775
[@edif30]: https://github.com/edif30
[@frenck]: https://github.com/frenck
[tts docs]: https://www.home-assistant.io/components/tts/