### PR TITLE
WIP Add Tilgin device_tracker support

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -476,6 +476,7 @@ omit =
     homeassistant/components/device_tracker/tado.py
     homeassistant/components/device_tracker/thomson.py
     homeassistant/components/device_tracker/tile.py
+    homeassistant/components/device_tracker/tilgen.py
     homeassistant/components/device_tracker/tomato.py
     homeassistant/components/device_tracker/tplink.py
     homeassistant/components/device_tracker/trackr.py

--- a/homeassistant/components/device_tracker/tilgin.py
+++ b/homeassistant/components/device_tracker/tilgin.py
@@ -50,6 +50,7 @@ class TilginHG238xDeviceScanner(DeviceScanner):
         self.success_init = False
 
         try:
+            _LOGGER.debug("Initialising Tilgin HG238x Device")
             self.success_init = self._check_auth()
         except:
             _LOGGER.debug("ConnectionError in TilginDeviceScanner")
@@ -67,14 +68,20 @@ class TilginHG238xDeviceScanner(DeviceScanner):
         self._authenticate()
         r = self.session.get(self.url)
         if 'You are logged in as' in r.text:
+            _LOGGER.debug("auth success")
             return True
         else:
+            _LOGGER.debug("auth failure")
             return False
 
     def _authenticate(self):
         """Extract the HMAC key and auth to the device"""
 
+        _LOGGER.debug("Starting auth")
         r = self.session.get(self.url)
+        if 'You are logged in as' in r.text:
+            _LOGGER.debug("already authenticated")
+            return
         soup = BeautifulSoup(r.content, 'html.parser')
         hmac_key = re.search('__pass\.value,\s+"(\w+?)"', soup.text).group(1)
         _LOGGER.debug("hmac_key: {}".format(hmac_key))
@@ -108,4 +115,5 @@ class TilginHG238xDeviceScanner(DeviceScanner):
             device.findAll('td')[2].text.strip(u'\u200e'): device.findAll('td')[1].text
             for device in devices if 'Active' in device.findAll('td')[0].text
         }
+        _LOGGER.debug("Found {} devices".format(len(self.last_results)))
         return True

--- a/homeassistant/components/device_tracker/tilgin.py
+++ b/homeassistant/components/device_tracker/tilgin.py
@@ -3,7 +3,6 @@ import hmac
 import logging
 import hashlib
 import requests
-from bs4 import BeautifulSoup
 
 from homeassistant.components.device_tracker import (
     DOMAIN, PLATFORM_SCHEMA, DeviceScanner)
@@ -75,6 +74,7 @@ class TilginHG238xDeviceScanner(DeviceScanner):
             return False
 
     def _authenticate(self):
+        from bs4 import BeautifulSoup
         """Extract the HMAC key and auth to the device"""
 
         _LOGGER.debug("Starting auth")
@@ -94,6 +94,7 @@ class TilginHG238xDeviceScanner(DeviceScanner):
         self.session.post(self.url, data=login_data, allow_redirects=False)
 
     def _update_info(self):
+        from bs4 import BeautifulSoup
         """Ensure the information from the TP-Link router is up to date.
         Return boolean if scanning successful.
         """

--- a/homeassistant/components/device_tracker/tilgin.py
+++ b/homeassistant/components/device_tracker/tilgin.py
@@ -73,8 +73,8 @@ class TilginHG238xDeviceScanner(DeviceScanner):
             return False
 
     def _authenticate(self):
-        from bs4 import BeautifulSoup
         """Extract the HMAC key and auth to the device"""
+        from bs4 import BeautifulSoup
 
         _LOGGER.debug("Starting auth")
         r = self.session.get(self.url + '/status/lan_clients/')
@@ -82,7 +82,7 @@ class TilginHG238xDeviceScanner(DeviceScanner):
             _LOGGER.debug("already authenticated")
             return
         soup = BeautifulSoup(r.content, 'html.parser')
-        hmac_key = re.search('__pass\.value,\s+"(\w+?)"', soup.text).group(1)
+        hmac_key = re.search(r'__pass\.value,\s+"(\w+?)"', soup.text).group(1)
         hmac_message = (self.username + self.password).encode("utf8")
 
         _LOGGER.debug("hmac_key: {}".format(hmac_key))
@@ -102,10 +102,10 @@ class TilginHG238xDeviceScanner(DeviceScanner):
         self.session.post(self.url, data=login_data, allow_redirects=False)
 
     def _update_info(self):
-        from bs4 import BeautifulSoup
         """Ensure the information from the TP-Link router is up to date.
         Return boolean if scanning successful.
         """
+        from bs4 import BeautifulSoup
 
         _LOGGER.info("Loading LAN clients...")
 

--- a/homeassistant/components/device_tracker/tilgin.py
+++ b/homeassistant/components/device_tracker/tilgin.py
@@ -96,7 +96,7 @@ class TilginHG238xDeviceScanner(DeviceScanner):
         login_data = {'__hash': hashed_login.hexdigest(),
                       '__user': self.username,
                       '__auth': 'login',
-                      '__formtok':''
+                      '__formtok': ''
                       }
 
         self.session.post(self.url, data=login_data, allow_redirects=False)

--- a/homeassistant/components/device_tracker/tilgin.py
+++ b/homeassistant/components/device_tracker/tilgin.py
@@ -12,7 +12,7 @@ import homeassistant.helpers.config_validation as cv
 
 import voluptuous as vol
 
-REQUIREMENTS = ['beautifulsoup4']
+REQUIREMENTS = ['beautifulsoup4==4.6.3']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/device_tracker/tilgin.py
+++ b/homeassistant/components/device_tracker/tilgin.py
@@ -1,5 +1,6 @@
 """
 Support for Tilgin routers.
+
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/device_tracker.tilgen/
 """
@@ -44,6 +45,7 @@ def get_scanner(hass, config):
 
 class TilginHG238xDeviceScanner(DeviceScanner):
     """Queries the router for connected devices."""
+
     def __init__(self, config):
         """Initialize the scanner."""
         self.url = 'http://{}'.format(config[CONF_HOST])
@@ -89,7 +91,7 @@ class TilginHG238xDeviceScanner(DeviceScanner):
         hmac_key = re.search(r'__pass\.value,\s+"(\w+?)"', soup.text).group(1)
         hmac_message = (self.username + self.password).encode("utf8")
 
-        _LOGGER.debug("hmac_key: {}".format(hmac_key))
+        _LOGGER.debug("hmac_key: %s", hmac_key)
 
         # Calculate the login HMAC
         hashed_login = hmac.new(bytes(hmac_key, 'ascii'),
@@ -133,8 +135,8 @@ class TilginHG238xDeviceScanner(DeviceScanner):
                 continue
             device_mac = device[2].text.strip(u'\u200e')
             device_name = device[1].text
-            _LOGGER.debug('{}: {}'.format(device_name, device_mac))
+            _LOGGER.debug('%s: %s', device_name, device_mac)
             self.last_results[device_mac] = device_name
 
-        _LOGGER.debug("Found {} devices".format(len(self.last_results)))
+        _LOGGER.debug("Found %d devices", len(self.last_results))
         return True

--- a/homeassistant/components/device_tracker/tilgin.py
+++ b/homeassistant/components/device_tracker/tilgin.py
@@ -1,0 +1,111 @@
+import re
+import hmac
+import logging
+import hashlib
+import requests
+from bs4 import BeautifulSoup
+
+from homeassistant.components.device_tracker import (
+    DOMAIN, PLATFORM_SCHEMA, DeviceScanner)
+from homeassistant.const import (
+    CONF_HOST, CONF_PASSWORD, CONF_USERNAME, HTTP_HEADER_X_REQUESTED_WITH)
+import homeassistant.helpers.config_validation as cv
+
+import voluptuous as vol
+
+REQUIREMENTS = ['beautifulsoup4']
+
+_LOGGER = logging.getLogger(__name__)
+
+HTTP_HEADER_NO_CACHE = 'no-cache'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_HOST): cv.string,
+    vol.Required(CONF_PASSWORD): cv.string,
+    vol.Required(CONF_USERNAME): cv.string
+})
+
+def get_scanner(hass, config):
+    """Validate the configuration and return a Tilgin Device Scanner."""
+
+    models = [ TilginHG238xDeviceScanner ]
+    for model_family in models:
+        scanner = model_family(config[DOMAIN])
+        if scanner.success_init:
+            return scanner
+
+    return None
+
+class TilginHG238xDeviceScanner(DeviceScanner):
+    """Queries the router for connected devices."""
+
+    def __init__(self, config):
+        """Initialize the scanner."""
+        self.url = 'http://{}'.format(config[CONF_HOST])
+        self.username = config[CONF_USERNAME]
+        self.password = config[CONF_PASSWORD]
+        self.session = requests.Session()
+
+        self.last_results = {}
+        self.success_init = False
+
+        try:
+            self.success_init = self._check_auth()
+        except:
+            _LOGGER.debug("ConnectionError in TilginDeviceScanner")
+
+    def scan_devices(self):
+        """Scan for new devices and return a list with found device IDs."""
+        self._update_info()
+        return self.last_results.keys()
+
+    def get_device_name(self, device):
+        """Get the name of the device."""
+        return self.last_results.get(device)
+
+    def _check_auth(self):
+        self._authenticate()
+        r = self.session.get(self.url)
+        if 'You are logged in as' in r.text:
+            return True
+        else:
+            return False
+
+    def _authenticate(self):
+        """Extract the HMAC key and auth to the device"""
+
+        r = self.session.get(self.url)
+        soup = BeautifulSoup(r.content, 'html.parser')
+        hmac_key = re.search('__pass\.value,\s+"(\w+?)"', soup.text).group(1)
+        _LOGGER.debug("hmac_key: {}".format(hmac_key))
+
+        # Calculate the login HMAC
+        hashed_login = hmac.new(bytes(hmac_key, 'ascii'), (self.username + self.password).encode("utf8"), hashlib.sha1)
+
+        login_data = { '__hash': hashed_login.hexdigest(), '__user': self.username, '__auth': 'login', '__formtok':''}
+
+        self.session.post(self.url, data=login_data, allow_redirects=False)
+
+    def _update_info(self):
+        """Ensure the information from the TP-Link router is up to date.
+        Return boolean if scanning successful.
+        """
+
+        _LOGGER.info("Loading LAN clients...")
+
+        r = self.session.get(self.url + '/status/lan_clients/')
+        if r.status_code == 403:
+            self._authenticate()
+            r = self.session.get(self.url + '/status/lan_clients/')
+            if r.status_code == 403:
+                return False
+
+        soup = BeautifulSoup(r.content, 'html.parser')
+        clients_html = soup.find('table', {"class": "control"})
+        devices = clients_html.findAll('tr')[1:]
+
+        self.last_results = {
+            device.findAll('td')[2].text.strip(u'\u200e'): device.findAll('td')[1].text
+            for device in devices if 'Active' in device.findAll('td')[0].text
+        }
+        return True

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -164,6 +164,7 @@ batinfo==0.4.2
 # beacontools[scan]==1.2.3
 
 # homeassistant.components.device_tracker.linksys_ap
+# homeassistant.components.device_tracker.tilgin
 # homeassistant.components.sensor.scrape
 # homeassistant.components.sensor.sytadin
 beautifulsoup4==4.6.3


### PR DESCRIPTION
## Description:
My first PR here to add device_tracker support for Tilgin HG238x devices which my ISP Hyperoptic use. The device doesn't provide SSH or Telnet so you can only pull clients by logging in and scraping the status page.

I've put this together taking inspiration from other device_trackers. Looking for feedback an guidance here.

## Example entry for `configuration.yaml` (if applicable):
```yaml
device_tracker:
  - platform: tilgin
    host: 192.168.1.1
    username: admin
    password: MrN00dles
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
