### PR TITLE
Fix miflora connection errors during platform setup

### DIFF
--- a/homeassistant/components/sensor/miflora.py
+++ b/homeassistant/components/sensor/miflora.py
@@ -83,6 +83,13 @@ async def async_setup_platform(hass, config, async_add_entities,
         devs.append(MiFloraSensor(
             poller, parameter, name, unit, force_update, median))
 
+    @callback
+    def on_ha_start(_):
+        for dev in devs:
+            dev.async_schedule_update_ha_state(True)
+
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, on_ha_start)
+
     async_add_entities(devs)
 
 
@@ -102,14 +109,6 @@ class MiFloraSensor(Entity):
         # single outliers, while  median of 5 will filter double outliers
         # Use median_count = 1 if no filtering is required.
         self.median_count = median
-
-    async def async_added_to_hass(self):
-        """Set initial state."""
-        @callback
-        def on_startup():
-            self.async_schedule_update_ha_state(True)
-
-        self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, on_startup)
 
     @property
     def name(self):

--- a/homeassistant/components/sensor/miflora.py
+++ b/homeassistant/components/sensor/miflora.py
@@ -4,16 +4,13 @@ Support for Xiaomi Mi Flora BLE plant sensor.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.miflora/
 """
-import asyncio
 from datetime import timedelta
 import logging
 import voluptuous as vol
-import async_timeout
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
-from homeassistant.exceptions import PlatformNotReady
 from homeassistant.const import (
     CONF_FORCE_UPDATE, CONF_MONITORED_CONDITIONS, CONF_NAME, CONF_MAC,
     CONF_SCAN_INTERVAL, EVENT_HOMEASSISTANT_START)

--- a/homeassistant/components/sensor/miflora.py
+++ b/homeassistant/components/sensor/miflora.py
@@ -16,8 +16,8 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.exceptions import PlatformNotReady
 from homeassistant.const import (
     CONF_FORCE_UPDATE, CONF_MONITORED_CONDITIONS, CONF_NAME, CONF_MAC,
-    CONF_SCAN_INTERVAL)
-
+    CONF_SCAN_INTERVAL, EVENT_HOMEASSISTANT_START)
+from homeassistant.core import callback
 
 REQUIREMENTS = ['miflora==0.4.0']
 
@@ -75,13 +75,6 @@ async def async_setup_platform(hass, config, async_add_entities,
 
     devs = []
 
-    try:
-        with async_timeout.timeout(9):
-            await hass.async_add_executor_job(poller.fill_cache)
-    except asyncio.TimeoutError:
-        _LOGGER.error('Unable to connect to %s', config.get(CONF_MAC))
-        raise PlatformNotReady
-
     for parameter in config[CONF_MONITORED_CONDITIONS]:
         name = SENSOR_TYPES[parameter][0]
         unit = SENSOR_TYPES[parameter][1]
@@ -93,7 +86,7 @@ async def async_setup_platform(hass, config, async_add_entities,
         devs.append(MiFloraSensor(
             poller, parameter, name, unit, force_update, median))
 
-    async_add_entities(devs, update_before_add=True)
+    async_add_entities(devs)
 
 
 class MiFloraSensor(Entity):
@@ -112,6 +105,14 @@ class MiFloraSensor(Entity):
         # single outliers, while  median of 5 will filter double outliers
         # Use median_count = 1 if no filtering is required.
         self.median_count = median
+
+    async def async_added_to_hass(self):
+        """Set initial state."""
+        @callback
+        def on_startup():
+            self.async_schedule_update_ha_state(True)
+
+        self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, on_startup)
 
     @property
     def name(self):

--- a/homeassistant/components/sensor/miflora.py
+++ b/homeassistant/components/sensor/miflora.py
@@ -83,13 +83,6 @@ async def async_setup_platform(hass, config, async_add_entities,
         devs.append(MiFloraSensor(
             poller, parameter, name, unit, force_update, median))
 
-    @callback
-    def on_ha_start(_):
-        for dev in devs:
-            dev.async_schedule_update_ha_state(True)
-
-    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, on_ha_start)
-
     async_add_entities(devs)
 
 
@@ -109,6 +102,14 @@ class MiFloraSensor(Entity):
         # single outliers, while  median of 5 will filter double outliers
         # Use median_count = 1 if no filtering is required.
         self.median_count = median
+
+    async def async_added_to_hass(self):
+        """Set initial state."""
+        @callback
+        def on_startup():
+            self.async_schedule_update_ha_state(True)
+
+        self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, on_startup)
 
     @property
     def name(self):


### PR DESCRIPTION
## Description:
When user has multiple miflora devices, we can't connect to them during platforms setup, because it takes several seconds to connect to each device and we can't do it concurrently because of locks in `btlewrap` (https://github.com/ChristianKuehnel/btlewrap/blob/master/btlewrap/base.py#L42) library.
I will remove a code which makes a connection on platform setup. This will lead to 2 problems:
-  first values will appear in 20 minutes (when first `update` will be called by HA).  We can handle it by triggering `async_schedule_update_ha_state()` right after HA start.
- we won't know if everything is ok with device during HA startup. It's impossible to handle this case, we will leave w/o it.

**Related issue (if applicable):** fixes #16700 
