### PR TITLE
Bump zm-py up to 0.0.2

### DIFF
--- a/homeassistant/components/zoneminder.py
+++ b/homeassistant/components/zoneminder.py
@@ -15,7 +15,7 @@ import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['zm-py==0.0.1']
+REQUIREMENTS = ['zm-py==0.0.2']
 
 CONF_PATH_ZMS = 'path_zms'
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1561,4 +1561,4 @@ zigpy-xbee==0.1.1
 zigpy==0.2.0
 
 # homeassistant.components.zoneminder
-zm-py==0.0.1
+zm-py==0.0.2


### PR DESCRIPTION
## Description:

zm-py 0.0.1 has some incompatibilities with python 3.5 due to type hinted variables. This is fixed in zm-py 0.0.2.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
