### PR TITLE
Bump sucks (Ecovacs) lib to 0.9.3

### DIFF
--- a/homeassistant/components/ecovacs.py
+++ b/homeassistant/components/ecovacs.py
@@ -15,7 +15,7 @@ from homeassistant.helpers import discovery
 from homeassistant.const import CONF_USERNAME, CONF_PASSWORD, \
     EVENT_HOMEASSISTANT_STOP
 
-REQUIREMENTS = ['sucks==0.9.1']
+REQUIREMENTS = ['sucks==0.9.3']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/vacuum/ecovacs.py
+++ b/homeassistant/components/vacuum/ecovacs.py
@@ -189,10 +189,6 @@ class EcovacsVacuum(VacuumDevice):
 
         for key, val in self.device.components.items():
             attr_name = ATTR_COMPONENT_PREFIX + key
-            data[attr_name] = int(val * 100 / 0.2777778)
-            # The above calculation includes a fix for a bug in sucks 0.9.1
-            # When sucks 0.9.2+ is released, it should be changed to the
-            # following:
-            # data[attr_name] = int(val * 100)
+            data[attr_name] = int(val * 100)
 
         return data

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1385,7 +1385,7 @@ statsd==3.2.1
 steamodd==4.21
 
 # homeassistant.components.ecovacs
-sucks==0.9.1
+sucks==0.9.3
 
 # homeassistant.components.camera.onvif
 suds-passworddigest-homeassistant==0.1.2a0.dev0


### PR DESCRIPTION
## Description:
Bump the `sucks` lib to 0.9.3. This is the library for the Ecovacs component.

This includes a major fix that will unblock a large cohort of users who woulds get the 1004 auth error.

**Related issue (if applicable):**

* fixes #16641
* fixes #16315

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** n/a


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
