### PR TITLE
Rework chromecast fix

### DIFF
--- a/homeassistant/components/media_player/cast.py
+++ b/homeassistant/components/media_player/cast.py
@@ -120,6 +120,7 @@ def _fill_out_missing_chromecast_info(info: ChromecastInfo) -> ChromecastInfo:
 def _discover_chromecast(hass: HomeAssistantType, info: ChromecastInfo):
     if info in hass.data[KNOWN_CHROMECAST_INFO_KEY]:
         _LOGGER.debug("Discovered previous chromecast %s", info)
+        return
 
     # Either discovered completely new chromecast or a "moved" one.
     info = _fill_out_missing_chromecast_info(info)
@@ -201,8 +202,9 @@ async def async_setup_platform(hass: HomeAssistantType, config: ConfigType,
     _LOGGER.warning(
         'Setting configuration for Cast via platform is deprecated. '
         'Configure via Cast component instead.')
-    await _async_setup_platform(
-        hass, config, async_add_entities, discovery_info)
+    if not await _async_setup_platform(
+            hass, config, async_add_entities, discovery_info):
+        raise PlatformNotReady
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):

--- a/homeassistant/components/media_player/cast.py
+++ b/homeassistant/components/media_player/cast.py
@@ -266,11 +266,6 @@ async def _async_setup_platform(hass: HomeAssistantType, config: ConfigType,
         if info.friendly_name is None:
             _LOGGER.debug("Cannot retrieve detail information for chromecast"
                           " %s, the device may not online", info)
-            #if not hass.is_running:
-                # We don't want to block system setup
-                # If hass.is_running is True, means we are in the retry setup,
-                # create an unavailable device and open a socket to keep listen
-                # configured host
             remove_handler()
             return False
 

--- a/homeassistant/components/media_player/cast.py
+++ b/homeassistant/components/media_player/cast.py
@@ -266,13 +266,13 @@ async def _async_setup_platform(hass: HomeAssistantType, config: ConfigType,
         if info.friendly_name is None:
             _LOGGER.debug("Cannot retrieve detail information for chromecast"
                           " %s, the device may not online", info)
-            if not hass.is_running:
+            #if not hass.is_running:
                 # We don't want to block system setup
                 # If hass.is_running is True, means we are in the retry setup,
                 # create an unavailable device and open a socket to keep listen
                 # configured host
-                remove_handler()
-                return False
+            remove_handler()
+            return False
 
         hass.async_add_job(_discover_chromecast, hass, info)
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -609,16 +609,18 @@ def patch_yaml_files(files_dict, endswith=True):
     return patch.object(yaml, 'open', mock_open_f, create=True)
 
 
-def mock_coro(return_value=None):
-    """Return a coro that returns a value."""
-    return mock_coro_func(return_value)()
+def mock_coro(return_value=None, exception=None):
+    """Return a coro that returns a value or raise an exception."""
+    return mock_coro_func(return_value, exception)()
 
 
-def mock_coro_func(return_value=None):
+def mock_coro_func(return_value=None, exception=None):
     """Return a method to create a coro function that returns a value."""
     @asyncio.coroutine
     def coro(*args, **kwargs):
         """Fake coroutine."""
+        if exception:
+            raise exception
         return return_value
 
     return coro

--- a/tests/components/media_player/test_cast.py
+++ b/tests/components/media_player/test_cast.py
@@ -2,7 +2,7 @@
 # pylint: disable=protected-access
 import asyncio
 from typing import Optional
-from unittest.mock import patch, MagicMock, Mock
+from unittest.mock import patch, MagicMock, Mock, PropertyMock
 from uuid import UUID
 
 import attr
@@ -245,8 +245,11 @@ async def test_normal_chromecast_not_starting_discovery(hass):
 async def test_normal_raises_platform_not_ready(hass):
     """Test cast platform raises PlatformNotReady if HTTP dial fails."""
     with patch('pychromecast.dial.get_device_status', return_value=None):
-        with pytest.raises(PlatformNotReady):
-            await async_setup_cast(hass, {'host': 'host1'})
+        with patch('homeassistant.core.HomeAssistant.is_running',
+                   new_callable=PropertyMock,
+                   return_value=False):
+            with pytest.raises(PlatformNotReady):
+                await async_setup_cast(hass, {'host': 'host1'})
 
 
 async def test_replay_past_chromecasts(hass):
@@ -370,7 +373,7 @@ async def test_entry_setup_no_config(hass: HomeAssistantType):
 
     with patch(
         'homeassistant.components.media_player.cast._async_setup_platform',
-            return_value=mock_coro()) as mock_setup:
+            return_value=mock_coro(True)) as mock_setup:
         await cast.async_setup_entry(hass, MockConfigEntry(), None)
 
     assert len(mock_setup.mock_calls) == 1
@@ -389,7 +392,7 @@ async def test_entry_setup_single_config(hass: HomeAssistantType):
 
     with patch(
         'homeassistant.components.media_player.cast._async_setup_platform',
-            return_value=mock_coro()) as mock_setup:
+            return_value=mock_coro(True)) as mock_setup:
         await cast.async_setup_entry(hass, MockConfigEntry(), None)
 
     assert len(mock_setup.mock_calls) == 1
@@ -409,7 +412,7 @@ async def test_entry_setup_list_config(hass: HomeAssistantType):
 
     with patch(
         'homeassistant.components.media_player.cast._async_setup_platform',
-            return_value=mock_coro()) as mock_setup:
+            return_value=mock_coro(True)) as mock_setup:
         await cast.async_setup_entry(hass, MockConfigEntry(), None)
 
     assert len(mock_setup.mock_calls) == 2

--- a/tests/components/media_player/test_cast.py
+++ b/tests/components/media_player/test_cast.py
@@ -245,11 +245,8 @@ async def test_normal_chromecast_not_starting_discovery(hass):
 async def test_normal_raises_platform_not_ready(hass):
     """Test cast platform raises PlatformNotReady if HTTP dial fails."""
     with patch('pychromecast.dial.get_device_status', return_value=None):
-        with patch('homeassistant.core.HomeAssistant.is_running',
-                   new_callable=PropertyMock,
-                   return_value=False):
-            with pytest.raises(PlatformNotReady):
-                await async_setup_cast(hass, {'host': 'host1'})
+        with pytest.raises(PlatformNotReady):
+            await async_setup_cast(hass, {'host': 'host1'})
 
 
 async def test_replay_past_chromecasts(hass):

--- a/tests/components/media_player/test_cast.py
+++ b/tests/components/media_player/test_cast.py
@@ -429,7 +429,7 @@ async def test_entry_setup_platform_not_ready(hass: HomeAssistantType):
 
     with patch(
         'homeassistant.components.media_player.cast._async_setup_platform',
-            return_value=mock_coro(exception=PlatformNotReady)) as mock_setup:
+            return_value=mock_coro(exception=Exception)) as mock_setup:
         with pytest.raises(PlatformNotReady):
             await cast.async_setup_entry(hass, MockConfigEntry(), None)
 

--- a/tests/components/media_player/test_cast.py
+++ b/tests/components/media_player/test_cast.py
@@ -2,7 +2,7 @@
 # pylint: disable=protected-access
 import asyncio
 from typing import Optional
-from unittest.mock import patch, MagicMock, Mock, PropertyMock
+from unittest.mock import patch, MagicMock, Mock
 from uuid import UUID
 
 import attr

--- a/tests/components/media_player/test_cast.py
+++ b/tests/components/media_player/test_cast.py
@@ -370,7 +370,7 @@ async def test_entry_setup_no_config(hass: HomeAssistantType):
 
     with patch(
         'homeassistant.components.media_player.cast._async_setup_platform',
-            return_value=mock_coro(True)) as mock_setup:
+            return_value=mock_coro()) as mock_setup:
         await cast.async_setup_entry(hass, MockConfigEntry(), None)
 
     assert len(mock_setup.mock_calls) == 1
@@ -389,7 +389,7 @@ async def test_entry_setup_single_config(hass: HomeAssistantType):
 
     with patch(
         'homeassistant.components.media_player.cast._async_setup_platform',
-            return_value=mock_coro(True)) as mock_setup:
+            return_value=mock_coro()) as mock_setup:
         await cast.async_setup_entry(hass, MockConfigEntry(), None)
 
     assert len(mock_setup.mock_calls) == 1
@@ -409,9 +409,29 @@ async def test_entry_setup_list_config(hass: HomeAssistantType):
 
     with patch(
         'homeassistant.components.media_player.cast._async_setup_platform',
-            return_value=mock_coro(True)) as mock_setup:
+            return_value=mock_coro()) as mock_setup:
         await cast.async_setup_entry(hass, MockConfigEntry(), None)
 
     assert len(mock_setup.mock_calls) == 2
     assert mock_setup.mock_calls[0][1][1] == {'host': 'bla'}
     assert mock_setup.mock_calls[1][1][1] == {'host': 'blu'}
+
+
+async def test_entry_setup_platform_not_ready(hass: HomeAssistantType):
+    """Test failed setting up entry will raise PlatformNotReady."""
+    await async_setup_component(hass, 'cast', {
+        'cast': {
+            'media_player': {
+                'host': 'bla'
+            }
+        }
+    })
+
+    with patch(
+        'homeassistant.components.media_player.cast._async_setup_platform',
+            return_value=mock_coro(exception=PlatformNotReady)) as mock_setup:
+        with pytest.raises(PlatformNotReady):
+            await cast.async_setup_entry(hass, MockConfigEntry(), None)
+
+    assert len(mock_setup.mock_calls) == 1
+    assert mock_setup.mock_calls[0][1][1] == {'host': 'bla'}


### PR DESCRIPTION
## Description:

Revert the change of #16471.

Fix the usage of PlatformNotReady exception to resolve startup hang up issue.

If user configured cast by host IP address and one of chromedevice is not online during the startup, a PlatformNotReady exception will allow system start up continue and a platform setup task will be retried later.

This PR will revert chromecast connection/re-connection and discovery logic back to 0.77, but fix the issue in previous release that if device is not online during the system startup, it won't be connected even it came back later.


**Related issue (if applicable):** fixes #16686

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

