### PR TITLE
Set botvac state when offline

### DIFF
--- a/homeassistant/components/vacuum/neato.py
+++ b/homeassistant/components/vacuum/neato.py
@@ -75,6 +75,8 @@ class NeatoConnectedVacuum(StateVacuumDevice):
                 requests.exceptions.HTTPError) as ex:
             _LOGGER.warning("Neato connection error: %s", ex)
             self._state = None
+            self._clean_state = STATE_ERROR
+            self._status_state = 'Robot Offline'
             return
         _LOGGER.debug('self._state=%s', self._state)
         if self._state['state'] == 1:


### PR DESCRIPTION
## Description:

Neato has had some cloud issues lately which causes robots to randomly go offline in the Neato app.  When this happens HA see's this as a connection error.  This now sets `STATE_ERROR` and updates the attribute to let the user know the robot is offline.   This also sets the state accordingly if the battery runs out as the user will see the same error.

**Related issue (if applicable):**

N/A but several users on discord and in other issues have confirmed the same behavior.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#6340

## Example entry for `configuration.yaml` (if applicable):
```yaml
neato:
  username: username
  password: password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
