### PR TITLE
Handle netgear_lte connection errors

### DIFF
--- a/homeassistant/components/notify/netgear_lte.py
+++ b/homeassistant/components/notify/netgear_lte.py
@@ -4,6 +4,8 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/notify.netgear_lte/
 """
 
+import logging
+
 import voluptuous as vol
 import attr
 
@@ -17,6 +19,8 @@ from ..netgear_lte import DATA_KEY
 
 DEPENDENCIES = ['netgear_lte']
 
+_LOGGER = logging.getLogger(__name__)
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_HOST): cv.string,
     vol.Required(ATTR_TARGET): vol.All(cv.ensure_list, [cv.string]),
@@ -25,21 +29,29 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 async def async_get_service(hass, config, discovery_info=None):
     """Get the notification service."""
-    modem_data = hass.data[DATA_KEY].get_modem_data(config)
-    phone = config.get(ATTR_TARGET)
-    return NetgearNotifyService(modem_data, phone)
+    return NetgearNotifyService(hass, config)
 
 
 @attr.s
 class NetgearNotifyService(BaseNotificationService):
     """Implementation of a notification service."""
 
-    modem_data = attr.ib()
-    phone = attr.ib()
+    hass = attr.ib()
+    config = attr.ib()
 
     async def async_send_message(self, message="", **kwargs):
         """Send a message to a user."""
-        targets = kwargs.get(ATTR_TARGET, self.phone)
+        modem_data = self.hass.data[DATA_KEY].get_modem_data(self.config)
+        if not modem_data:
+            _LOGGER.error("No modem available")
+            return
+
+        phone = self.config.get(ATTR_TARGET)
+        targets = kwargs.get(ATTR_TARGET, phone)
         if targets and message:
             for target in targets:
-                await self.modem_data.modem.sms(target, message)
+                import eternalegypt
+                try:
+                    await modem_data.modem.sms(target, message)
+                except eternalegypt.Error:
+                    _LOGGER.error("Unable to send to %s", target)

--- a/homeassistant/components/sensor/netgear_lte.py
+++ b/homeassistant/components/sensor/netgear_lte.py
@@ -9,6 +9,7 @@ import attr
 
 from homeassistant.const import CONF_HOST, CONF_SENSORS
 from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 
@@ -30,6 +31,9 @@ async def async_setup_platform(
         hass, config, async_add_entities, discovery_info):
     """Set up Netgear LTE sensor devices."""
     modem_data = hass.data[DATA_KEY].get_modem_data(config)
+
+    if not modem_data:
+        raise PlatformNotReady
 
     sensors = []
     for sensor_type in config[CONF_SENSORS]:
@@ -88,4 +92,7 @@ class UsageSensor(LTESensor):
     @property
     def state(self):
         """Return the state of the sensor."""
+        if self.modem_data.usage is None:
+            return None
+
         return round(self.modem_data.usage / 1024**2, 1)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -333,7 +333,7 @@ ephem==3.7.6.0
 epson-projector==0.1.3
 
 # homeassistant.components.netgear_lte
-eternalegypt==0.0.3
+eternalegypt==0.0.5
 
 # homeassistant.components.keyboard_remote
 # evdev==0.6.1


### PR DESCRIPTION
## Description:

This upgrades netgear_lte to use eternalegypt 0.0.5 which will raise `eternalegypt.Error` on connection errors (connection lost, expired session, etc.).

The recovery strategy is to just keep trying because eternalegypt itself will attempt to do a new login.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
