### PR TITLE
Added warning to homekit component

### DIFF
--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -39,6 +39,8 @@ STATUS_RUNNING = 1
 STATUS_STOPPED = 2
 STATUS_WAIT = 3
 
+MAX_DEVICES = 100
+
 SWITCH_TYPES = {TYPE_OUTLET: 'Outlet',
                 TYPE_SWITCH: 'Switch'}
 
@@ -193,6 +195,7 @@ class HomeKit():
         self._filter = entity_filter
         self._config = entity_config
         self.status = STATUS_READY
+        self.devices_added = 0
 
         self.bridge = None
         self.driver = None
@@ -214,6 +217,10 @@ class HomeKit():
         """Try adding accessory to bridge if configured beforehand."""
         if not state or not self._filter(state.entity_id):
             return
+        self.devices_added += 1
+        if self.devices_added == MAX_DEVICES + 1:
+            _LOGGER.warning("More than %s devices added to homekit.",
+                            MAX_DEVICES)
         aid = generate_aid(state.entity_id)
         conf = self._config.pop(state.entity_id, {})
         acc = get_accessory(self.hass, self.driver, state, aid, conf)

--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -28,11 +28,12 @@ from .const import (
 from .util import (
     show_setup_message, validate_entity_config, validate_media_player_features)
 
-TYPES = Registry()
-MAX_DEVICES = 100
+REQUIREMENTS = ['HAP-python==2.2.2']
+
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['HAP-python==2.2.2']
+MAX_DEVICES = 100
+TYPES = Registry()
 
 # #### Driver Status ####
 STATUS_READY = 0

--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -227,10 +227,6 @@ class HomeKit():
             return
         self.status = STATUS_WAIT
 
-        if len(self.bridge.accessories) > MAX_DEVICES:
-            _LOGGER.warning("More than %s devices added to homekit.",
-                            MAX_DEVICES)
-
         # pylint: disable=unused-variable
         from . import (  # noqa F401
             type_covers, type_fans, type_lights, type_locks,
@@ -243,6 +239,10 @@ class HomeKit():
 
         if not self.driver.state.paired:
             show_setup_message(self.hass, self.driver.state.pincode)
+
+        if len(self.bridge.accessories) > MAX_DEVICES:
+            _LOGGER.warning("More than %s devices added to homekit.",
+                            MAX_DEVICES)
 
         _LOGGER.debug('Driver start')
         self.hass.add_job(self.driver.start)

--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -241,8 +241,8 @@ class HomeKit():
             show_setup_message(self.hass, self.driver.state.pincode)
 
         if len(self.bridge.accessories) > MAX_DEVICES:
-            _LOGGER.warning("More than %s devices added to homekit.",
-                            MAX_DEVICES)
+            _LOGGER.warning('You have exceeded the device limit, which ' \
+                'might cause issues. Consider using the filter option.')
 
         _LOGGER.debug('Driver start')
         self.hass.add_job(self.driver.start)

--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -241,8 +241,8 @@ class HomeKit():
             show_setup_message(self.hass, self.driver.state.pincode)
 
         if len(self.bridge.accessories) > MAX_DEVICES:
-            _LOGGER.warning('You have exceeded the device limit, which ' \
-                'might cause issues. Consider using the filter option.')
+            _LOGGER.warning('You have exceeded the device limit, which might '
+                            'cause issues. Consider using the filter option.')
 
         _LOGGER.debug('Driver start')
         self.hass.add_job(self.driver.start)

--- a/tests/components/homekit/test_homekit.py
+++ b/tests/components/homekit/test_homekit.py
@@ -1,5 +1,5 @@
 """Tests for the HomeKit component."""
-from unittest.mock import patch, ANY, Mock
+from unittest.mock import patch, ANY, Mock, MagicMock
 
 import pytest
 
@@ -173,7 +173,7 @@ async def test_homekit_start(hass, hk_driver, debounce_patcher):
     """Test HomeKit start method."""
     pin = b'123-45-678'
     homekit = HomeKit(hass, None, None, None, {}, {'cover.demo': {}})
-    homekit.bridge = 'bridge'
+    homekit.bridge = mock_bridge = MagicMock()
     homekit.driver = hk_driver
 
     hass.states.async_set('light.demo', 'on')
@@ -190,7 +190,7 @@ async def test_homekit_start(hass, hk_driver, debounce_patcher):
 
     mock_add_acc.assert_called_with(state)
     mock_setup_msg.assert_called_with(hass, pin)
-    hk_driver_add_acc.assert_called_with('bridge')
+    hk_driver_add_acc.assert_called_with(mock_bridge)
     assert hk_driver_start.called
     assert homekit.status == STATUS_RUNNING
 

--- a/tests/components/homekit/test_homekit.py
+++ b/tests/components/homekit/test_homekit.py
@@ -221,10 +221,10 @@ async def test_homekit_stop(hass):
 
 
 async def test_homekit_too_many_accessories(hass, hk_driver):
-    """Test adding too many accessories to homekit."""
+    """Test adding too many accessories to HomeKit."""
     homekit = HomeKit(hass, None, None, None, None, None)
     homekit.bridge = Mock()
-    homekit.bridge.accessories = list(range(0, MAX_DEVICES + 1))
+    homekit.bridge.accessories = range(MAX_DEVICES + 1)
     homekit.driver = hk_driver
 
     with patch('pyhap.accessory_driver.AccessoryDriver.start'), \


### PR DESCRIPTION
Homekit component has a device limit of [100 devices](https://www.home-assistant.io/components/homekit/#device-limit).

If you exceed this limit, home kit does no longer work, without any warning/error, it simply gets stuck.

A warning might help to trace this error - and avoid frustration.
