### PR TITLE
Improve opentherm_gw state detection

### DIFF
--- a/homeassistant/components/climate/opentherm_gw.py
+++ b/homeassistant/components/climate/opentherm_gw.py
@@ -72,8 +72,9 @@ class OpenThermGateway(ClimateDevice):
         """Receive and handle a new report from the Gateway."""
         _LOGGER.debug("Received report: %s", status)
         ch_active = status.get(self.pyotgw.DATA_SLAVE_CH_ACTIVE)
+        flame_on = status.get(self.pyotgw.DATA_SLAVE_FLAME_ON)
         cooling_active = status.get(self.pyotgw.DATA_SLAVE_COOLING_ACTIVE)
-        if ch_active:
+        if ch_active and flame_on:
             self._current_operation = STATE_HEAT
         elif cooling_active:
             self._current_operation = STATE_COOL


### PR DESCRIPTION
Only show the platform in STATE_HEAT when the boiler is actually heating.

## Description:
DATA_SLAVE_CH_ACTIVE does not necessarily indicate that the boiler is actually heating. We should check that DATA_SLAVE_FLAME_ON is true as well.


**Related issue (if applicable):** N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
N/A
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - N/A

If the code communicates with devices, web services, or third-party tools:
  - No new files/dependencies

If the code does not interact with devices:
  - N/A

