### PR TITLE
Fix some unhandled exceptions due to missing null checks

### DIFF
--- a/homeassistant/components/cover/isy994.py
+++ b/homeassistant/components/cover/isy994.py
@@ -44,6 +44,8 @@ class ISYCoverDevice(ISYDevice, CoverDevice):
     @property
     def current_cover_position(self) -> int:
         """Return the current cover position."""
+        if self.is_unknown() or self.value is None:
+            return None
         return sorted((0, self.value, 100))[1]
 
     @property

--- a/homeassistant/components/light/isy994.py
+++ b/homeassistant/components/light/isy994.py
@@ -31,7 +31,7 @@ class ISYLightDevice(ISYDevice, Light):
     @property
     def is_on(self) -> bool:
         """Get whether the ISY994 light is on."""
-        return self.value > 0
+        return self.value != 0
 
     @property
     def brightness(self) -> float:


### PR DESCRIPTION
## Description:
Fixed a couple cases that would produce errors when the ISY node status was None or `-inf`.

**Related issue (if applicable):** fixes #9384


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
