### PR TITLE
Mind the unit system (fixes #16819)

### DIFF
--- a/homeassistant/components/weather/openweathermap.py
+++ b/homeassistant/components/weather/openweathermap.py
@@ -130,6 +130,9 @@ class OpenWeatherMapWeather(WeatherEntity):
     @property
     def wind_speed(self):
         """Return the wind speed."""
+        if self.hass.config.units.name == 'imperial':
+            return round(self.data.get_wind().get('speed') * 2.24, 2)
+
         return round(self.data.get_wind().get('speed') * 3.6, 2)
 
     @property


### PR DESCRIPTION
## Description:
The platform was always showing the wind as `km/h`.

**Related issue (if applicable):** fixes #16819

## Example entry for `configuration.yaml` (if applicable):
```yaml
homeassistant:
  [...]
  unit_system: imperial
weather:
  - platform: openweathermap
    api_key: !secret owm_api
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

