### PR TITLE
Remove discovered MQTT alarm_control_panel device when discovery topic is cleared.

### DIFF
--- a/tests/components/mqtt/test_discovery.py
+++ b/tests/components/mqtt/test_discovery.py
@@ -209,3 +209,28 @@ def test_discovery_removal(hass, mqtt_mock, caplog):
 
     state = hass.states.get('switch.beer')
     assert state is None
+
+
+@asyncio.coroutine
+def test_discovery_removal_alarm(hass, mqtt_mock, caplog):
+    """Test removal of discovered alarm_control_panel."""
+    yield from async_start(hass, 'homeassistant', {})
+    data = (
+        '{ "name": "Beer",'
+        '  "status_topic": "test_topic",'
+        '  "command_topic": "test_topic" }'
+    )
+    async_fire_mqtt_message(hass,
+                            'homeassistant/alarm_control_panel/bla/config',
+                            data)
+    yield from hass.async_block_till_done()
+    state = hass.states.get('alarm_control_panel.beer')
+    assert state is not None
+    assert state.name == 'Beer'
+    async_fire_mqtt_message(hass,
+                            'homeassistant/alarm_control_panel/bla/config',
+                            '')
+    yield from hass.async_block_till_done()
+    yield from hass.async_block_till_done()
+    state = hass.states.get('alarm_control_panel.beer')
+    assert state is None


### PR DESCRIPTION
## Description:
Support removal of previously discovered MQTT alarm_control_panel when a (retained) discovery payload is cleared.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`.