### PR TITLE
Add unique_id to homematic_cloud

### DIFF
--- a/homeassistant/components/homematicip_cloud/device.py
+++ b/homeassistant/components/homematicip_cloud/device.py
@@ -63,6 +63,7 @@ class HomematicipGenericDevice(Entity):
 
     @property
     def unique_id(self):
+        """Return a unique ID."""
         return "{}_{}".format(self.__class__.__name__, self._device.id)
 
     @property

--- a/homeassistant/components/homematicip_cloud/device.py
+++ b/homeassistant/components/homematicip_cloud/device.py
@@ -62,6 +62,10 @@ class HomematicipGenericDevice(Entity):
         return not self._device.unreach
 
     @property
+    def unique_id(self):
+        return "{}_{}".format(self.__class__.__name__, self._device.id)
+
+    @property
     def icon(self):
         """Return the icon."""
         if hasattr(self._device, 'lowBat') and self._device.lowBat:


### PR DESCRIPTION
## Description:
Add unique_id property to homematic_cloud entities to prevent mixup of devices when hass is restarted.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>
https://github.com/home-assistant/home-assistant/issues/16794


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
