### PR TITLE
Add bitwise operations as template helpers

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -580,6 +580,16 @@ def regex_findall_index(value, find='', index=0, ignorecase=False):
     return re.findall(find, value, flags)[index]
 
 
+def bitwise_and(first_value, second_value):
+    """Perform a bitwise and operation."""
+    return first_value & second_value
+
+
+def bitwise_or(first_value, second_value):
+    """Perform a bitwise or operation."""
+    return first_value | second_value
+
+
 @contextfilter
 def random_every_time(context, values):
     """Choose a random value.
@@ -617,6 +627,8 @@ ENV.filters['regex_match'] = regex_match
 ENV.filters['regex_replace'] = regex_replace
 ENV.filters['regex_search'] = regex_search
 ENV.filters['regex_findall_index'] = regex_findall_index
+ENV.filters['bitwise_and'] = bitwise_and
+ENV.filters['bitwise_or'] = bitwise_or
 ENV.globals['log'] = logarithm
 ENV.globals['sin'] = sine
 ENV.globals['cos'] = cosine

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -562,6 +562,36 @@ class TestHelpersTemplate(unittest.TestCase):
                 """, self.hass)
         self.assertEqual('LHR', tpl.render())
 
+    def test_bitwise_and(self):
+        """Test bitwise_and method."""
+        tpl = template.Template("""
+{{ 8 | bitwise_and(8) }}
+                """, self.hass)
+        self.assertEqual(str(8 & 8), tpl.render())
+        tpl = template.Template("""
+{{ 10 | bitwise_and(2) }}
+                """, self.hass)
+        self.assertEqual(str(10 & 2), tpl.render())
+        tpl = template.Template("""
+{{ 8 | bitwise_and(2) }}
+                """, self.hass)
+        self.assertEqual(str(8 & 2), tpl.render())
+
+    def test_bitwise_or(self):
+        """Test bitwise_or method."""
+        tpl = template.Template("""
+{{ 8 | bitwise_or(8) }}
+                """, self.hass)
+        self.assertEqual(str(8 | 8), tpl.render())
+        tpl = template.Template("""
+{{ 10 | bitwise_or(2) }}
+                """, self.hass)
+        self.assertEqual(str(10 | 2), tpl.render())
+        tpl = template.Template("""
+{{ 8 | bitwise_or(2) }}
+                """, self.hass)
+        self.assertEqual(str(8 | 2), tpl.render())
+
     def test_distance_function_with_1_state(self):
         """Test distance function with 1 state."""
         self.hass.states.set('test.object', 'happy', {


### PR DESCRIPTION
## Description:
Added new template filters `bitwise_and` and `bitwise_or` to make it easy to parse out the status of individual LEDs from the indicator value on a Z-Wave component.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#6352

## Example entry for `configuration.yaml` (if applicable):
```yaml
switch:
  - platform: template
    switches:
      button_1_led:
        value_template: "{{ states('sensor.scene_contrl_indicator')|int|bitwise_and(1) > 0 }}"
        turn_on:
          service: zwave.set_indicator
          data_template:
            node_id: 3
            value: "{{ states('sensor.scene_contrl_indicator')|int + 1 }}"
        turn_off:
          service: zwave.set_indicator
          data_template:
            node_id: 3
            value: "{{ states('sensor.scene_contrl_indicator')|int - 1 }}"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.
