### PR TITLE
Bump zm-py to 0.0.3

### DIFF
--- a/homeassistant/components/zoneminder.py
+++ b/homeassistant/components/zoneminder.py
@@ -15,7 +15,7 @@ import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['zm-py==0.0.2']
+REQUIREMENTS = ['zm-py==0.0.3']
 
 CONF_PATH_ZMS = 'path_zms'
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1567,4 +1567,4 @@ zigpy-xbee==0.1.1
 zigpy==0.2.0
 
 # homeassistant.components.zoneminder
-zm-py==0.0.2
+zm-py==0.0.3


### PR DESCRIPTION
## Description:
Bump up `zm-py` to 0.0.3 for a couple of bug fixes.

**Related issue (if applicable):** fixes #16829

Well it fixes the second problem reported in that issue, the first problem appears to be a problem with installing the library. This needs to be merged into the 0.79 beta release.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
