### PR TITLE
Support old tradfri config format

### DIFF
--- a/homeassistant/components/tradfri/config_flow.py
+++ b/homeassistant/components/tradfri/config_flow.py
@@ -95,7 +95,9 @@ class FlowHandler(config_entries.ConfigFlow):
 
         try:
             data = await get_gateway_info(
-                self.hass, user_input['host'], user_input['identity'],
+                self.hass, user_input['host'],
+                # Old config format had a fixed identity
+                user_input.get('identity', 'homeassistant'),
                 user_input['key'])
 
             data[CONF_IMPORT_GROUPS] = user_input[CONF_IMPORT_GROUPS]

--- a/tests/components/tradfri/test_config_flow.py
+++ b/tests/components/tradfri/test_config_flow.py
@@ -154,3 +154,34 @@ async def test_import_connection(hass, mock_gateway_info, mock_entry_setup):
 
     assert len(mock_gateway_info.mock_calls) == 1
     assert len(mock_entry_setup.mock_calls) == 1
+
+
+async def test_import_connection_legacy(hass, mock_gateway_info,
+                                        mock_entry_setup):
+    """Test a connection via import."""
+    mock_gateway_info.side_effect = \
+        lambda hass, host, identity, key: mock_coro({
+            'host': host,
+            'identity': identity,
+            'key': key,
+            'gateway_id': 'mock-gateway'
+        })
+
+    result = await hass.config_entries.flow.async_init(
+        'tradfri', context={'source': 'import'}, data={
+            'host': '123.123.123.123',
+            'key': 'mock-key',
+            'import_groups': True
+        })
+
+    assert result['type'] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result['result'].data == {
+        'host': '123.123.123.123',
+        'gateway_id': 'mock-gateway',
+        'identity': 'homeassistant',
+        'key': 'mock-key',
+        'import_groups': True
+    }
+
+    assert len(mock_gateway_info.mock_calls) == 1
+    assert len(mock_entry_setup.mock_calls) == 1


### PR DESCRIPTION
## Description:
Old Tradfri format had a fixed identitiy of 'homeassistant'. This adds support for it.

**Related issue (if applicable):** Reported by @cgtobi via Discord

```
Error doing job: Task exception was never retrieved

Traceback (most recent call last):
  File "/srv/homeassistant/lib/python3.6/site-packages/homeassistant/data_entry_flow.py", line 64, in async_init
    return await self._async_handle_step(flow, flow.init_step, data)
  File "/srv/homeassistant/lib/python3.6/site-packages/homeassistant/data_entry_flow.py", line 98, in _async_handle_step
    result = await getattr(flow, method)(user_input)  # type: Dict
  File "/srv/homeassistant/lib/python3.6/site-packages/homeassistant/components/tradfri/config_flow.py", line 98, in async_step_import
    self.hass, user_input['host'], user_input['identity'],
KeyError: 'identity'
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
