### PR TITLE
Allow MQTT discovery

### DIFF
--- a/homeassistant/components/mqtt/.translations/en.json
+++ b/homeassistant/components/mqtt/.translations/en.json
@@ -10,6 +10,7 @@
             "broker": {
                 "data": {
                     "broker": "Broker",
+                    "discovery": "Enable discovery",
                     "password": "Password",
                     "port": "Port",
                     "username": "Username"

--- a/homeassistant/components/mqtt/config_flow.py
+++ b/homeassistant/components/mqtt/config_flow.py
@@ -7,7 +7,7 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD, CONF_PORT, CONF_USERNAME
 
-from .const import CONF_BROKER
+from .const import CONF_BROKER, CONF_DISCOVERY, DEFAULT_DISCOVERY
 
 
 @config_entries.HANDLERS.register('mqtt')
@@ -44,6 +44,7 @@ class FlowHandler(config_entries.ConfigFlow):
         fields[vol.Required(CONF_PORT, default=1883)] = vol.Coerce(int)
         fields[vol.Optional(CONF_USERNAME)] = str
         fields[vol.Optional(CONF_PASSWORD)] = str
+        fields[vol.Optional(CONF_DISCOVERY, default=DEFAULT_DISCOVERY)] = bool
 
         return self.async_show_form(
             step_id='broker', data_schema=vol.Schema(fields), errors=errors)

--- a/homeassistant/components/mqtt/const.py
+++ b/homeassistant/components/mqtt/const.py
@@ -1,2 +1,4 @@
 """Constants used by multiple MQTT modules."""
 CONF_BROKER = 'broker'
+CONF_DISCOVERY = 'discovery'
+DEFAULT_DISCOVERY = False

--- a/homeassistant/components/mqtt/strings.json
+++ b/homeassistant/components/mqtt/strings.json
@@ -9,7 +9,8 @@
           "broker": "Broker",
           "port": "Port",
           "username": "Username",
-          "password": "Password"
+          "password": "Password",
+          "discovery": "Enable discovery"
         }
       }
     },

--- a/tests/components/mqtt/test_config_flow.py
+++ b/tests/components/mqtt/test_config_flow.py
@@ -41,6 +41,11 @@ async def test_user_connection_works(hass, mock_try_connection,
     )
 
     assert result['type'] == 'create_entry'
+    assert result['result'].data == {
+        'broker': '127.0.0.1',
+        'port': 1883,
+        'discovery': False,
+    }
     # Check we tried the connection
     assert len(mock_try_connection.mock_calls) == 1
     # Check config entry got setup


### PR DESCRIPTION
## Description:
Allow enabling discovery inside the MQTT config flow.

<img width="455" alt="screen shot 2018-09-25 at 10 56 21 am" src="https://user-images.githubusercontent.com/1444314/46003852-c0ba9d80-c0b1-11e8-926c-65a3e3be5533.png">


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
