### PR TITLE
Config entry update data

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -379,7 +379,8 @@ class ConfigEntries:
                                            CONN_CLASS_UNKNOWN))
             for entry in config['entries']]
 
-    async def async_update_entry(self, entry, data):
+    @callback
+    def async_update_entry(self, entry, *, data):
         """Update a config entry."""
         entry.data = data
         self._async_schedule_save()

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -379,6 +379,11 @@ class ConfigEntries:
                                            CONN_CLASS_UNKNOWN))
             for entry in config['entries']]
 
+    async def async_update_entry(self, entry, data):
+        """Update a config entry."""
+        entry.data = data
+        self._async_schedule_save()
+
     async def async_forward_entry_setup(self, entry, component):
         """Forward the setup of an entry to a different component.
 

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -315,3 +315,20 @@ async def test_loading_default_config(hass):
         await manager.async_load()
 
     assert len(manager.async_entries()) == 0
+
+
+async def test_updating_entry_data(manager):
+    """Test that we can update an entry data."""
+    entry = MockConfigEntry(
+        domain='test',
+        data={'first': True},
+    )
+    entry.add_to_manager(manager)
+
+    manager.async_update_entry(entry, data={
+        'second': True
+    })
+
+    assert entry.data == {
+        'second': True
+    }


### PR DESCRIPTION
## Description:
Allow updating the data of a config entry. This will make it possible to use it for integrations that need to refresh access tokens.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
