### PR TITLE
On removal, only unload config entry if loaded

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -340,7 +340,10 @@ class ConfigEntries:
         entry = self._entries.pop(found)
         self._async_schedule_save()
 
-        unloaded = await entry.async_unload(self.hass)
+        if entry.state == ENTRY_STATE_LOADED:
+            unloaded = await entry.async_unload(self.hass)
+        else:
+            unloaded = True
 
         device_registry = await \
             self.hass.helpers.device_registry.async_get_registry()

--- a/tests/components/config/test_config_entries.py
+++ b/tests/components/config/test_config_entries.py
@@ -72,7 +72,7 @@ def test_get_entries(hass, client):
 @asyncio.coroutine
 def test_remove_entry(hass, client):
     """Test removing an entry via the API."""
-    entry = MockConfigEntry(domain='demo')
+    entry = MockConfigEntry(domain='demo', state=core_ce.ENTRY_STATE_LOADED)
     entry.add_to_hass(hass)
     resp = yield from client.delete(
         '/api/config/config_entries/entry/{}'.format(entry.entry_id))


### PR DESCRIPTION
## Description:
If a config entry never loaded, do not attempt to unload when we remove it. Could happen if a config entry failed to setup.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
