### PR TITLE
Add unique ID and device info to Nest camera

### DIFF
--- a/homeassistant/components/camera/nest.py
+++ b/homeassistant/components/camera/nest.py
@@ -77,7 +77,6 @@ class NestCamera(Camera):
             'name': self.device.name_long,
             'manufacturer': 'Nest Labs',
             'model': "Camera",
-            'sw_version': self.device.software_version,
         }
 
     @property

--- a/homeassistant/components/camera/nest.py
+++ b/homeassistant/components/camera/nest.py
@@ -63,6 +63,24 @@ class NestCamera(Camera):
         return self._name
 
     @property
+    def unique_id(self):
+        """Return the serial number."""
+        return self.device.device_id
+
+    @property
+    def device_info(self):
+        """Return information about the device."""
+        return {
+            'identifiers': {
+                (nest.DOMAIN, self.device.device_id)
+            },
+            'name': self.device.name_long,
+            'manufacturer': 'Nest Labs',
+            'model': "Camera",
+            'sw_version': self.device.software_version,
+        }
+
+    @property
     def should_poll(self):
         """Nest camera should poll periodically."""
         return True


### PR DESCRIPTION
## Description:
Add device info and unique ID to Nest cameras.

CC @awarecan 

