### PR TITLE
Remove discovered MQTT cover device when discovery topic is cleared

### DIFF
--- a/homeassistant/components/cover/mqtt.py
+++ b/homeassistant/components/cover/mqtt.py
@@ -20,9 +20,10 @@ from homeassistant.const import (
     CONF_NAME, CONF_VALUE_TEMPLATE, CONF_OPTIMISTIC, STATE_OPEN,
     STATE_CLOSED, STATE_UNKNOWN)
 from homeassistant.components.mqtt import (
-    CONF_AVAILABILITY_TOPIC, CONF_STATE_TOPIC, CONF_COMMAND_TOPIC,
-    CONF_PAYLOAD_AVAILABLE, CONF_PAYLOAD_NOT_AVAILABLE, CONF_QOS, CONF_RETAIN,
-    valid_publish_topic, valid_subscribe_topic, MqttAvailability)
+    ATTR_DISCOVERY_HASH, CONF_AVAILABILITY_TOPIC, CONF_STATE_TOPIC,
+    CONF_COMMAND_TOPIC, CONF_PAYLOAD_AVAILABLE, CONF_PAYLOAD_NOT_AVAILABLE,
+    CONF_QOS, CONF_RETAIN, valid_publish_topic, valid_subscribe_topic,
+    MqttAvailability, MqttDiscoveryUpdate)
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
@@ -105,6 +106,10 @@ async def async_setup_platform(hass, config, async_add_entities,
     if set_position_template is not None:
         set_position_template.hass = hass
 
+    discovery_hash = None
+    if discovery_info is not None and ATTR_DISCOVERY_HASH in discovery_info:
+        discovery_hash = discovery_info[ATTR_DISCOVERY_HASH]
+
     async_add_entities([MqttCover(
         config.get(CONF_NAME),
         config.get(CONF_STATE_TOPIC),
@@ -131,10 +136,11 @@ async def async_setup_platform(hass, config, async_add_entities,
         config.get(CONF_TILT_INVERT_STATE),
         config.get(CONF_POSITION_TOPIC),
         set_position_template,
+        discovery_hash,
     )])
 
 
-class MqttCover(MqttAvailability, CoverDevice):
+class MqttCover(MqttAvailability, MqttDiscoveryUpdate, CoverDevice):
     """Representation of a cover that can be controlled using MQTT."""
 
     def __init__(self, name, state_topic, command_topic, availability_topic,
@@ -143,10 +149,12 @@ class MqttCover(MqttAvailability, CoverDevice):
                  payload_stop, payload_available, payload_not_available,
                  optimistic, value_template, tilt_open_position,
                  tilt_closed_position, tilt_min, tilt_max, tilt_optimistic,
-                 tilt_invert, position_topic, set_position_template):
+                 tilt_invert, position_topic, set_position_template,
+                 discovery_hash):
         """Initialize the cover."""
-        super().__init__(availability_topic, qos, payload_available,
-                         payload_not_available)
+        MqttAvailability.__init__(self, availability_topic, qos,
+                                  payload_available, payload_not_available)
+        MqttDiscoveryUpdate.__init__(self, discovery_hash)
         self._position = None
         self._state = None
         self._name = name
@@ -172,10 +180,12 @@ class MqttCover(MqttAvailability, CoverDevice):
         self._tilt_invert = tilt_invert
         self._position_topic = position_topic
         self._set_position_template = set_position_template
+        self._discovery_hash = discovery_hash
 
     async def async_added_to_hass(self):
         """Subscribe MQTT events."""
-        await super().async_added_to_hass()
+        await MqttAvailability.async_added_to_hass(self)
+        await MqttDiscoveryUpdate.async_added_to_hass(self)
 
         @callback
         def tilt_updated(topic, payload, qos):


### PR DESCRIPTION
## Description:
Support removal of previously discovered MQTT cover device when a (retained) discovery payload is cleared.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`.