### PR TITLE
Remove discovered MQTT lock device when discovery topic is cleared

### DIFF
--- a/homeassistant/components/lock/mqtt.py
+++ b/homeassistant/components/lock/mqtt.py
@@ -12,9 +12,9 @@ import voluptuous as vol
 from homeassistant.core import callback
 from homeassistant.components.lock import LockDevice
 from homeassistant.components.mqtt import (
-    CONF_AVAILABILITY_TOPIC, CONF_STATE_TOPIC, CONF_COMMAND_TOPIC,
-    CONF_PAYLOAD_AVAILABLE, CONF_PAYLOAD_NOT_AVAILABLE, CONF_QOS, CONF_RETAIN,
-    MqttAvailability)
+    ATTR_DISCOVERY_HASH, CONF_AVAILABILITY_TOPIC, CONF_STATE_TOPIC,
+    CONF_COMMAND_TOPIC, CONF_PAYLOAD_AVAILABLE, CONF_PAYLOAD_NOT_AVAILABLE,
+    CONF_QOS, CONF_RETAIN, MqttAvailability, MqttDiscoveryUpdate)
 from homeassistant.const import (
     CONF_NAME, CONF_OPTIMISTIC, CONF_VALUE_TEMPLATE)
 from homeassistant.components import mqtt
@@ -52,6 +52,10 @@ def async_setup_platform(hass, config, async_add_entities,
     if value_template is not None:
         value_template.hass = hass
 
+    discovery_hash = None
+    if discovery_info is not None and ATTR_DISCOVERY_HASH in discovery_info:
+        discovery_hash = discovery_info[ATTR_DISCOVERY_HASH]
+
     async_add_entities([MqttLock(
         config.get(CONF_NAME),
         config.get(CONF_STATE_TOPIC),
@@ -64,19 +68,22 @@ def async_setup_platform(hass, config, async_add_entities,
         value_template,
         config.get(CONF_AVAILABILITY_TOPIC),
         config.get(CONF_PAYLOAD_AVAILABLE),
-        config.get(CONF_PAYLOAD_NOT_AVAILABLE)
+        config.get(CONF_PAYLOAD_NOT_AVAILABLE),
+        discovery_hash,
     )])
 
 
-class MqttLock(MqttAvailability, LockDevice):
+class MqttLock(MqttAvailability, MqttDiscoveryUpdate, LockDevice):
     """Representation of a lock that can be toggled using MQTT."""
 
     def __init__(self, name, state_topic, command_topic, qos, retain,
                  payload_lock, payload_unlock, optimistic, value_template,
-                 availability_topic, payload_available, payload_not_available):
+                 availability_topic, payload_available, payload_not_available,
+                 discovery_hash):
         """Initialize the lock."""
-        super().__init__(availability_topic, qos, payload_available,
-                         payload_not_available)
+        MqttAvailability.__init__(self, availability_topic, qos,
+                                  payload_available, payload_not_available)
+        MqttDiscoveryUpdate.__init__(self, discovery_hash)
         self._state = False
         self._name = name
         self._state_topic = state_topic
@@ -87,11 +94,13 @@ class MqttLock(MqttAvailability, LockDevice):
         self._payload_unlock = payload_unlock
         self._optimistic = optimistic
         self._template = value_template
+        self._discovery_hash = discovery_hash
 
     @asyncio.coroutine
     def async_added_to_hass(self):
         """Subscribe to MQTT events."""
-        yield from super().async_added_to_hass()
+        yield from MqttAvailability.async_added_to_hass(self)
+        yield from MqttDiscoveryUpdate.async_added_to_hass(self)
 
         @callback
         def message_received(topic, payload, qos):


### PR DESCRIPTION
## Description:
Support removal of previously discovered MQTT lock device when a (retained) discovery payload is cleared.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`.