### PR TITLE
Remove discovered MQTT sensor device when discovery topic is cleared

### DIFF
--- a/tests/components/sensor/test_mqtt.py
+++ b/tests/components/sensor/test_mqtt.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 import homeassistant.core as ha
 from homeassistant.setup import setup_component, async_setup_component
+from homeassistant.components.mqtt.discovery import async_start
 import homeassistant.components.sensor as sensor
 from homeassistant.const import EVENT_STATE_CHANGED, STATE_UNAVAILABLE
 import homeassistant.util.dt as dt_util
@@ -387,3 +388,24 @@ async def test_unique_id(hass):
     await hass.async_block_till_done()
 
     assert len(hass.states.async_all()) == 1
+
+
+async def test_discovery_removal_sensor(hass, mqtt_mock, caplog):
+    """Test removal of discovered sensor."""
+    await async_start(hass, 'homeassistant', {})
+    data = (
+        '{ "name": "Beer",'
+        '  "status_topic": "test_topic" }'
+    )
+    async_fire_mqtt_message(hass, 'homeassistant/sensor/bla/config',
+                            data)
+    await hass.async_block_till_done()
+    state = hass.states.get('sensor.beer')
+    assert state is not None
+    assert state.name == 'Beer'
+    async_fire_mqtt_message(hass, 'homeassistant/sensor/bla/config',
+                            '')
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+    state = hass.states.get('sensor.beer')
+    assert state is None


### PR DESCRIPTION
## Description:
Support removal of previously discovered MQTT sensor device when a (retained) discovery payload is cleared.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`.