### PR TITLE
Device Registry Support for iOS Sensors

### DIFF
--- a/homeassistant/components/sensor/ios.py
+++ b/homeassistant/components/sensor/ios.py
@@ -4,9 +4,13 @@ Support for Home Assistant iOS app sensors.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/ecosystem/ios/
 """
+import logging
+
 from homeassistant.components import ios
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.icon import icon_for_battery_level
+
+_LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = ['ios']
 
@@ -45,6 +49,21 @@ class IOSSensor(Entity):
         self.type = sensor_type
         self._state = None
         self._unit_of_measurement = SENSOR_TYPES[sensor_type][1]
+
+    
+    @property
+    def device_info(self):
+        """Return information about the device."""
+        return {
+            'identifiers': {
+                (ios.DOMAIN, self._device[ios.ATTR_DEVICE][ios.ATTR_DEVICE_PERMANENT_ID]),
+            },
+            'name': self._device[ios.ATTR_DEVICE][ios.ATTR_DEVICE_NAME],
+            'manufacturer': 'Apple',
+            'model': self._device[ios.ATTR_DEVICE][ios.ATTR_DEVICE_TYPE],
+            'sw_version': self._device[ios.ATTR_DEVICE][ios.ATTR_DEVICE_SYSTEM_VERSION],
+        }
+    
 
     @property
     def name(self):

--- a/homeassistant/components/sensor/ios.py
+++ b/homeassistant/components/sensor/ios.py
@@ -46,7 +46,6 @@ class IOSSensor(Entity):
         self._state = None
         self._unit_of_measurement = SENSOR_TYPES[sensor_type][1]
 
-    
     @property
     def device_info(self):
         """Return information about the device."""
@@ -60,7 +59,6 @@ class IOSSensor(Entity):
             'sw_version': self._device[ios.ATTR_DEVICE][ios.ATTR_DEVICE_SYSTEM_VERSION],
         }
     
-
     @property
     def name(self):
         """Return the name of the iOS sensor."""

--- a/homeassistant/components/sensor/ios.py
+++ b/homeassistant/components/sensor/ios.py
@@ -51,14 +51,14 @@ class IOSSensor(Entity):
         """Return information about the device."""
         return {
             'identifiers': {
-                (ios.DOMAIN, self._device[ios.ATTR_DEVICE]
-                                         [ios.ATTR_DEVICE_PERMANENT_ID]),
+                (ios.DOMAIN,
+                 self._device[ios.ATTR_DEVICE][ios.ATTR_DEVICE_PERMANENT_ID]),
             },
             'name': self._device[ios.ATTR_DEVICE][ios.ATTR_DEVICE_NAME],
             'manufacturer': 'Apple',
             'model': self._device[ios.ATTR_DEVICE][ios.ATTR_DEVICE_TYPE],
-            'sw_version': self._device[ios.ATTR_DEVICE]
-                                      [ios.ATTR_DEVICE_SYSTEM_VERSION],
+            'sw_version':
+            self._device[ios.ATTR_DEVICE][ios.ATTR_DEVICE_SYSTEM_VERSION],
         }
 
     @property

--- a/homeassistant/components/sensor/ios.py
+++ b/homeassistant/components/sensor/ios.py
@@ -4,13 +4,9 @@ Support for Home Assistant iOS app sensors.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/ecosystem/ios/
 """
-import logging
-
 from homeassistant.components import ios
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.icon import icon_for_battery_level
-
-_LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = ['ios']
 

--- a/homeassistant/components/sensor/ios.py
+++ b/homeassistant/components/sensor/ios.py
@@ -51,14 +51,16 @@ class IOSSensor(Entity):
         """Return information about the device."""
         return {
             'identifiers': {
-                (ios.DOMAIN, self._device[ios.ATTR_DEVICE][ios.ATTR_DEVICE_PERMANENT_ID]),
+                (ios.DOMAIN, self._device[ios.ATTR_DEVICE]
+                                         [ios.ATTR_DEVICE_PERMANENT_ID]),
             },
             'name': self._device[ios.ATTR_DEVICE][ios.ATTR_DEVICE_NAME],
             'manufacturer': 'Apple',
             'model': self._device[ios.ATTR_DEVICE][ios.ATTR_DEVICE_TYPE],
-            'sw_version': self._device[ios.ATTR_DEVICE][ios.ATTR_DEVICE_SYSTEM_VERSION],
+            'sw_version': self._device[ios.ATTR_DEVICE]
+                                      [ios.ATTR_DEVICE_SYSTEM_VERSION],
         }
-    
+
     @property
     def name(self):
         """Return the name of the iOS sensor."""


### PR DESCRIPTION
## Description:
Adds device registry support for the iOS sensors (battery level and charging state)

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
N/A
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
