### PR TITLE
Fix MQTT discovery

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -524,12 +524,8 @@ async def async_setup_entry(hass, entry):
         schema=MQTT_PUBLISH_SCHEMA)
 
     if conf.get(CONF_DISCOVERY):
-        async def async_setup_discovery(event):
-            await _async_setup_discovery(
-                hass, conf, hass.data[DATA_MQTT_HASS_CONFIG])
-
-        hass.bus.async_listen_once(
-            EVENT_HOMEASSISTANT_START, async_setup_discovery)
+        await _async_setup_discovery(
+            hass, conf, hass.data[DATA_MQTT_HASS_CONFIG])
 
     return True
 

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -21,7 +21,7 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import (
     CONF_PASSWORD, CONF_PAYLOAD, CONF_PORT, CONF_PROTOCOL, CONF_USERNAME,
-    CONF_VALUE_TEMPLATE, EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP)
+    CONF_VALUE_TEMPLATE, EVENT_HOMEASSISTANT_STOP)
 from homeassistant.core import Event, ServiceCall, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv


### PR DESCRIPTION
## Description:
When we moved MQTT to a config entry, we initially didn't port discovery. So to avoid discovery trying to configure itself before the server was connected, we had it initialize on HA START event. Now that discovery is part of the config entry, this is no longer necessary. Bonus: now it actually starts discovery when the MQTT config entry is created, instead of relying on a reboot.

**Related issue (if applicable):** via chat @dshokouhi 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
