### PR TITLE
Fix fan_init test

### DIFF
--- a/tests/components/fan/__init__.py
+++ b/tests/components/fan/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for fan platforms."""

--- a/tests/components/fan/test_init.py
+++ b/tests/components/fan/test_init.py
@@ -26,13 +26,14 @@ class TestFanEntity(unittest.TestCase):
 
     def test_fanentity(self):
         """Test fan entity methods."""
-        self.assertIsNone(self.fan.state)
+        self.assertEqual('on', self.fan.state)
         self.assertEqual(0, len(self.fan.speed_list))
         self.assertEqual(0, self.fan.supported_features)
-        self.assertEqual({}, self.fan.state_attributes)
+        self.assertEqual({'speed_list': []}, self.fan.state_attributes)
         # Test set_speed not required
-        self.fan.set_speed()
-        self.fan.oscillate()
+        self.fan.oscillate(True)
+        with self.assertRaises(NotImplementedError):
+            self.fan.set_speed('slow')
         with self.assertRaises(NotImplementedError):
             self.fan.turn_on()
         with self.assertRaises(NotImplementedError):


### PR DESCRIPTION
## Description:
Renamed `tests/components/fan/__init__.py` to `fan/test_init.py`, since it includes a test for the base FanEntity. Also updated it to conform with the current fan model.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**