### PR TITLE
aiohttp.ClientSession gets proxy information from HTTP_PROXY/HTTPS_PROXY

### DIFF
--- a/homeassistant/helpers/aiohttp_client.py
+++ b/homeassistant/helpers/aiohttp_client.py
@@ -56,6 +56,7 @@ def async_create_clientsession(hass, verify_ssl=True, auto_cleanup=True,
     clientsession = aiohttp.ClientSession(
         loop=hass.loop,
         connector=connector,
+        trust_env=True,
         headers={USER_AGENT: SERVER_SOFTWARE},
         **kwargs
     )


### PR DESCRIPTION
## Description:

Currently the instance of ``aiohttp.ClientSession`` returned by ``async_create_clientsession()`` does not take the environment variables HTTP_PROXY and HTTPS_PROXY into account. This PR resolves this by setting the option ``trust_env`` to ``True`` (see https://docs.aiohttp.org/en/stable/client_reference.html).

**Related issue (if applicable):** No issue available.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** No issue available.

## Example entry for `configuration.yaml` (if applicable):
n.a.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
