### PR TITLE
Add permissions foundation

### DIFF
--- a/homeassistant/auth/auth_store.py
+++ b/homeassistant/auth/auth_store.py
@@ -10,15 +10,11 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.util import dt as dt_util
 
 from . import models
+from .permissions import DEFAULT_POLICY
 
 STORAGE_VERSION = 1
 STORAGE_KEY = 'auth'
 INITIAL_GROUP_NAME = 'All Access'
-
-DEFAULT_POLICY = {
-    # Whitelist all entities
-    'entities': True,
-}
 
 
 class AuthStore:

--- a/homeassistant/auth/models.py
+++ b/homeassistant/auth/models.py
@@ -7,6 +7,7 @@ import attr
 
 from homeassistant.util import dt as dt_util
 
+from . import permissions as perm_pkg
 from .util import generate_secret
 
 TOKEN_TYPE_NORMAL = 'normal'
@@ -19,6 +20,7 @@ class Group:
     """A group."""
 
     name = attr.ib(type=str)  # type: Optional[str]
+    policy = attr.ib(type=perm_pkg.PolicyType)
     id = attr.ib(type=str, factory=lambda: uuid.uuid4().hex)
 
 
@@ -43,6 +45,28 @@ class User:
     refresh_tokens = attr.ib(
         type=dict, factory=dict, cmp=False
     )  # type: Dict[str, RefreshToken]
+
+    _permissions = attr.ib(
+        type=perm_pkg.PolicyPermissions,
+        init=False,
+        cmp=False,
+        default=None,
+    )
+
+    @property
+    def permissions(self) -> perm_pkg.AbstractPermissions:
+        """Return permissions object for user."""
+        if self.is_owner:
+            return perm_pkg.OwnerPermissions
+
+        if self._permissions is not None:
+            return self._permissions
+
+        self._permissions = perm_pkg.PolicyPermissions(
+            perm_pkg.merge_policies([
+                group.policy for group in self.groups]))
+
+        return self._permissions
 
 
 @attr.s(slots=True)

--- a/homeassistant/auth/models.py
+++ b/homeassistant/auth/models.py
@@ -7,7 +7,7 @@ import attr
 
 from homeassistant.util import dt as dt_util
 
-from . import permissions as perm_pkg
+from . import permissions as perm_mdl
 from .util import generate_secret
 
 TOKEN_TYPE_NORMAL = 'normal'
@@ -20,7 +20,7 @@ class Group:
     """A group."""
 
     name = attr.ib(type=str)  # type: Optional[str]
-    policy = attr.ib(type=perm_pkg.PolicyType)
+    policy = attr.ib(type=perm_mdl.PolicyType)
     id = attr.ib(type=str, factory=lambda: uuid.uuid4().hex)
 
 
@@ -47,23 +47,23 @@ class User:
     )  # type: Dict[str, RefreshToken]
 
     _permissions = attr.ib(
-        type=perm_pkg.PolicyPermissions,
+        type=perm_mdl.PolicyPermissions,
         init=False,
         cmp=False,
         default=None,
     )
 
     @property
-    def permissions(self) -> perm_pkg.AbstractPermissions:
+    def permissions(self) -> perm_mdl.AbstractPermissions:
         """Return permissions object for user."""
         if self.is_owner:
-            return perm_pkg.OwnerPermissions
+            return perm_mdl.OwnerPermissions
 
         if self._permissions is not None:
             return self._permissions
 
-        self._permissions = perm_pkg.PolicyPermissions(
-            perm_pkg.merge_policies([
+        self._permissions = perm_mdl.PolicyPermissions(
+            perm_mdl.merge_policies([
                 group.policy for group in self.groups]))
 
         return self._permissions

--- a/homeassistant/auth/permissions.py
+++ b/homeassistant/auth/permissions.py
@@ -1,0 +1,226 @@
+"""Permissions for Home Assistant."""
+from typing import (  # noqa: F401
+    cast, Any, Callable, Dict, List, Mapping, Set, Tuple, Union)
+
+import voluptuous as vol
+
+from homeassistant.core import State
+
+CategoryType = Union[Mapping[str, 'CategoryType'], bool, None]
+PolicyType = Mapping[str, CategoryType]
+
+
+# Policy if user has no policy applied.
+DEFAULT_POLICY = {
+    "entities": True
+}  # type: PolicyType
+
+ENTITY_POLICY_SCHEMA = vol.Any(bool, vol.Schema({
+    vol.Optional('domains'): vol.Any(bool, vol.Schema({
+        str: bool
+    })),
+    vol.Optional('entity_ids'): vol.Any(bool, vol.Schema({
+        str: bool
+    })),
+}))
+
+POLICY_SCHEMA = vol.Schema({
+    vol.Optional('entities'): ENTITY_POLICY_SCHEMA
+})
+
+
+class AbstractPermissions:
+    """Default permissions class."""
+
+    def check_entity(self, entity_id: str, *keys: str) -> bool:
+        """Test if we can access entity."""
+        raise NotImplementedError
+
+    def filter_entities(self, entities: List[State]) -> List[State]:
+        """Filter a list of entities for what the user is allowed to see."""
+        raise NotImplementedError
+
+
+class PolicyPermissions(AbstractPermissions):
+    """Handle permissions."""
+
+    def __init__(self, policy: PolicyType) -> None:
+        """Initialize the permission class."""
+        self._policy = policy
+        self._compiled = {}  # type: Dict[str, Callable[..., bool]]
+
+    def check_entity(self, entity_id: str, *keys: str) -> bool:
+        """Test if we can access entity."""
+        func = self._policy_func('entities', _compile_entities)
+        return func(entity_id, keys)
+
+    def filter_entities(self, entities: List[State]) -> List[State]:
+        """Filter a list of entities for what the user is allowed to see."""
+        func = self._policy_func('entities', _compile_entities)
+        keys = ('read',)
+        return [entity for entity in entities if func(entity.entity_id, keys)]
+
+    def _policy_func(self, category: str,
+                     compile_func: Callable[[CategoryType], Callable]) \
+            -> Callable[..., bool]:
+        """Get a policy function."""
+        func = self._compiled.get(category)
+
+        if func:
+            return func
+
+        func = self._compiled[category] = compile_func(
+            self._policy.get(category))
+        return func
+
+    def __eq__(self, other: Any) -> bool:
+        """Equals check."""
+        # pylint: disable=protected-access
+        return (isinstance(other, PolicyPermissions) and
+                other._policy == self._policy)
+
+
+class _OwnerPermissions(AbstractPermissions):
+    """Owner permissions."""
+
+    # pylint: disable=no-self-use
+
+    def check_entity(self, entity_id: str, *keys: str) -> bool:
+        """Test if we can access entity."""
+        return True
+
+    def filter_entities(self, entities: List[State]) -> List[State]:
+        """Filter a list of entities for what the user is allowed to see."""
+        return entities
+
+
+OwnerPermissions = _OwnerPermissions()  # pylint: disable=invalid-name
+
+
+def _compile_entities(policy: CategoryType) \
+        -> Callable[[str, Tuple[str]], bool]:
+    """Compile policy into a function that tests policy."""
+    # None, Empty Dict, False
+    if not policy:
+        return lambda entity_id, keys: False
+
+    if policy is True:
+        return lambda entity_id, keys: True
+
+    assert isinstance(policy, dict)
+
+    domains = policy.get('domains')
+    entity_ids = policy.get('entity_ids')
+
+    funcs = []  # type: List[Callable[[str, Tuple[str]], Union[None, bool]]]
+
+    # The order of these functions matter. The more precise are at the top.
+    # If a function returns None, they cannot handle it.
+    # If a function returns a boolean, that's the result to return.
+
+    # Setting entity_ids to a boolean is final decision for permissions
+    # So return right away.
+    if isinstance(entity_ids, bool):
+        def apply_entity_id_policy(entity_id: str, keys: Tuple[str]) -> bool:
+            """Test if allowed entity_id."""
+            return entity_ids  # type: ignore
+
+        return apply_entity_id_policy
+
+    if entity_ids is not None:
+        def allowed_entity_id(entity_id: str, keys: Tuple[str]) \
+                -> Union[None, bool]:
+            """Test if allowed entity_id."""
+            return entity_ids.get(entity_id)  # type: ignore
+
+        funcs.append(allowed_entity_id)
+
+    if isinstance(domains, bool):
+        def allowed_domain(entity_id: str, keys: Tuple[str]) \
+                -> Union[None, bool]:
+            """Test if allowed domain."""
+            return domains
+
+        funcs.append(allowed_domain)
+
+    elif domains is not None:
+        def allowed_domain(entity_id: str, keys: Tuple[str]) \
+                -> Union[None, bool]:
+            """Test if allowed domain."""
+            domain = entity_id.split(".", 1)[0]
+            return domains.get(domain)  # type: ignore
+
+        funcs.append(allowed_domain)
+
+    if not funcs:
+        return lambda entity_id, keys: False
+
+    if len(funcs) == 1:
+        func = funcs[0]
+        return lambda entity_id, keys: func(entity_id, keys) is True
+
+    def apply_policy(entity_id: str, keys: Tuple[str]) -> bool:
+        """Apply several policies."""
+        for func in funcs:
+            result = func(entity_id, keys)
+            if result is not None:
+                return result
+        return False
+
+    return apply_policy
+
+
+def merge_policies(policies: List[PolicyType]) -> PolicyType:
+    """Merge policies."""
+    new_policy = {}  # type: Dict[str, CategoryType]
+    seen = set()  # type: Set[str]
+    for policy in policies:
+        for category in policy:
+            if category in seen:
+                continue
+            seen.add(category)
+            new_policy[category] = _merge_policies([
+                policy.get(category) for policy in policies])
+    cast(PolicyType, new_policy)
+    return new_policy
+
+
+def _merge_policies(sources: List[CategoryType]) -> CategoryType:
+    """Merge a policy."""
+    # When merging policies, the most permissive wins.
+    # This means we order it like this:
+    # True > Dict > False > None
+
+    policy = None  # type: CategoryType
+    seen = set()  # type: Set[str]
+    for source in sources:
+        if source is None:
+            continue
+        # A source that's True will always win. Shortcut return.
+        if source is True:
+            return True
+        if source is False:
+            if policy is None:
+                policy = False
+            continue
+
+        # Source is a dict
+        if policy is False or policy is None:
+            policy = {}
+
+        assert isinstance(source, dict)
+        assert isinstance(policy, dict)
+
+        for key in source:
+            if key in seen:
+                continue
+            seen.add(key)
+
+            key_sources = []
+            for src in sources:
+                if isinstance(src, dict):
+                    key_sources.append(src.get(key))
+
+            policy[key] = _merge_policies(key_sources)
+
+    return policy

--- a/homeassistant/auth/permissions.py
+++ b/homeassistant/auth/permissions.py
@@ -102,13 +102,13 @@ def _compile_entities(policy: CategoryType) \
     """Compile policy into a function that tests policy."""
     # None, Empty Dict, False
     if not policy:
-        def apply_policy_deny_all(entity_id, keys):
+        def apply_policy_deny_all(entity_id: str, keys: Tuple[str]) -> bool:
             return False
 
         return apply_policy_deny_all
 
     if policy is True:
-        def apply_policy_allow_all(entity_id, keys):
+        def apply_policy_allow_all(entity_id: str, keys: Tuple[str]) -> bool:
             return True
 
         return apply_policy_allow_all

--- a/homeassistant/auth/permissions.py
+++ b/homeassistant/auth/permissions.py
@@ -19,11 +19,11 @@ CAT_ENTITIES = 'entities'
 ENTITY_DOMAINS = 'domains'
 ENTITY_ENTITY_IDS = 'entity_ids'
 
-VALUES_SCHEMA = vol.Any(bool, vol.Schema({
-    str: bool
+VALUES_SCHEMA = vol.Any(True, vol.Schema({
+    str: True
 }))
 
-ENTITY_POLICY_SCHEMA = vol.Any(bool, vol.Schema({
+ENTITY_POLICY_SCHEMA = vol.Any(True, vol.Schema({
     vol.Optional(ENTITY_DOMAINS): VALUES_SCHEMA,
     vol.Optional(ENTITY_ENTITY_IDS): VALUES_SCHEMA,
 }))

--- a/homeassistant/auth/permissions.py
+++ b/homeassistant/auth/permissions.py
@@ -15,17 +15,21 @@ DEFAULT_POLICY = {
     "entities": True
 }  # type: PolicyType
 
+CAT_ENTITIES = 'entities'
+ENTITY_DOMAINS = 'domains'
+ENTITY_ENTITY_IDS = 'entity_ids'
+
+VALUES_SCHEMA = vol.Any(bool, vol.Schema({
+    str: bool
+}))
+
 ENTITY_POLICY_SCHEMA = vol.Any(bool, vol.Schema({
-    vol.Optional('domains'): vol.Any(bool, vol.Schema({
-        str: bool
-    })),
-    vol.Optional('entity_ids'): vol.Any(bool, vol.Schema({
-        str: bool
-    })),
+    vol.Optional(ENTITY_DOMAINS): VALUES_SCHEMA,
+    vol.Optional(ENTITY_ENTITY_IDS): VALUES_SCHEMA,
 }))
 
 POLICY_SCHEMA = vol.Schema({
-    vol.Optional('entities'): ENTITY_POLICY_SCHEMA
+    vol.Optional(CAT_ENTITIES): ENTITY_POLICY_SCHEMA
 })
 
 
@@ -51,12 +55,12 @@ class PolicyPermissions(AbstractPermissions):
 
     def check_entity(self, entity_id: str, *keys: str) -> bool:
         """Test if we can access entity."""
-        func = self._policy_func('entities', _compile_entities)
+        func = self._policy_func(CAT_ENTITIES, _compile_entities)
         return func(entity_id, keys)
 
     def filter_states(self, states: List[State]) -> List[State]:
         """Filter a list of states for what the user is allowed to see."""
-        func = self._policy_func('entities', _compile_entities)
+        func = self._policy_func(CAT_ENTITIES, _compile_entities)
         keys = ('read',)
         return [entity for entity in states if func(entity.entity_id, keys)]
 
@@ -117,8 +121,8 @@ def _compile_entities(policy: CategoryType) \
 
     assert isinstance(policy, dict)
 
-    domains = policy.get('domains')
-    entity_ids = policy.get('entity_ids')
+    domains = policy.get(ENTITY_DOMAINS)
+    entity_ids = policy.get(ENTITY_ENTITY_IDS)
 
     funcs = []  # type: List[Callable[[str, Tuple[str]], Union[None, bool]]]
 

--- a/homeassistant/auth/permissions.py
+++ b/homeassistant/auth/permissions.py
@@ -211,9 +211,8 @@ def _merge_policies(sources: List[CategoryType]) -> CategoryType:
     """Merge a policy."""
     # When merging policies, the most permissive wins.
     # This means we order it like this:
-    # False > True > Dict > None
+    # True > Dict > None
     #
-    # False: do not allow
     # True: allow everything
     # Dict: specify more granular permissions
     # None: no opinion
@@ -227,19 +226,11 @@ def _merge_policies(sources: List[CategoryType]) -> CategoryType:
         if source is None:
             continue
 
-        # A source that's False will always win. Shortcut return.
-        if source is False:
-            return False
-
+        # A source that's True will always win. Shortcut return.
         if source is True:
-            policy = True
-            continue
+            return True
 
         assert isinstance(source, dict)
-
-        # True > Dict, skipping source
-        if policy is True:
-            continue
 
         if policy is None:
             policy = {}

--- a/tests/auth/test_init.py
+++ b/tests/auth/test_init.py
@@ -289,6 +289,7 @@ async def test_saving_loading(hass, hass_storage):
     store2 = auth_store.AuthStore(hass)
     users = await store2.async_get_users()
     assert len(users) == 1
+    assert users[0].permissions == user.permissions
     assert users[0] == user
     assert len(users[0].refresh_tokens) == 2
     for r_token in users[0].refresh_tokens.values():

--- a/tests/auth/test_models.py
+++ b/tests/auth/test_models.py
@@ -1,0 +1,34 @@
+"""Tests for the auth models."""
+from homeassistant.auth import models, permissions
+
+
+def test_owner_fetching_owner_permissions():
+    """Test we fetch the owner permissions for an owner user."""
+    group = models.Group(name="Test Group", policy={})
+    owner = models.User(name="Test User", groups=[group], is_owner=True)
+    assert owner.permissions is permissions.OwnerPermissions
+
+
+def test_permissions_merged():
+    """Test we merge the groups permissions."""
+    group = models.Group(name="Test Group", policy={
+        'entities': {
+            'domains': {
+                'switch': True
+            }
+        }
+    })
+    group2 = models.Group(name="Test Group", policy={
+        'entities': {
+            'entity_ids': {
+                'light.kitchen': True
+            }
+        }
+    })
+    user = models.User(name="Test User", groups=[group, group2])
+    # Make sure we cache instance
+    assert user.permissions is user.permissions
+
+    assert user.permissions.check_entity('switch.bla') is True
+    assert user.permissions.check_entity('light.kitchen') is True
+    assert user.permissions.check_entity('light.not_kitchen') is False

--- a/tests/auth/test_permissions.py
+++ b/tests/auth/test_permissions.py
@@ -1,0 +1,246 @@
+"""Tests for the auth permission system."""
+from homeassistant.core import State
+from homeassistant.auth import permissions
+
+
+def test_entities_none():
+    """Test entity ID policy."""
+    policy = None
+    compiled = permissions._compile_entities(policy)
+    assert compiled('light.kitchen', []) is False
+
+
+def test_entities_empty():
+    """Test entity ID policy."""
+    policy = {}
+    permissions.ENTITY_POLICY_SCHEMA(policy)
+    compiled = permissions._compile_entities(policy)
+    assert compiled('light.kitchen', []) is False
+
+
+def test_entities_false():
+    """Test entity ID policy."""
+    policy = False
+    permissions.ENTITY_POLICY_SCHEMA(policy)
+    compiled = permissions._compile_entities(policy)
+    assert compiled('light.kitchen', []) is False
+
+
+def test_entities_true():
+    """Test entity ID policy."""
+    policy = True
+    permissions.ENTITY_POLICY_SCHEMA(policy)
+    compiled = permissions._compile_entities(policy)
+    assert compiled('light.kitchen', []) is True
+
+
+def test_entities_domains_true():
+    """Test entity ID policy."""
+    policy = {
+        'domains': True
+    }
+    permissions.ENTITY_POLICY_SCHEMA(policy)
+    compiled = permissions._compile_entities(policy)
+    assert compiled('light.kitchen', []) is True
+
+
+def test_entities_domains_false():
+    """Test entity ID policy."""
+    policy = {
+        'domains': False
+    }
+    permissions.ENTITY_POLICY_SCHEMA(policy)
+    compiled = permissions._compile_entities(policy)
+    assert compiled('light.kitchen', []) is False
+
+
+def test_entities_domains_domain_true():
+    """Test entity ID policy."""
+    policy = {
+        'domains': {
+            'light': True
+        }
+    }
+    permissions.ENTITY_POLICY_SCHEMA(policy)
+    compiled = permissions._compile_entities(policy)
+    assert compiled('light.kitchen', []) is True
+    assert compiled('switch.kitchen', []) is False
+
+
+def test_entities_domains_domain_false():
+    """Test entity ID policy."""
+    policy = {
+        'domains': {
+            'light': False
+        }
+    }
+    permissions.ENTITY_POLICY_SCHEMA(policy)
+    compiled = permissions._compile_entities(policy)
+    assert compiled('light.kitchen', []) is False
+    assert compiled('switch.kitchen', []) is False
+
+
+def test_entities_entity_ids_true():
+    """Test entity ID policy."""
+    policy = {
+        'entity_ids': True
+    }
+    permissions.ENTITY_POLICY_SCHEMA(policy)
+    compiled = permissions._compile_entities(policy)
+    assert compiled('light.kitchen', []) is True
+
+
+def test_entities_entity_ids_false():
+    """Test entity ID policy."""
+    policy = {
+        'entity_ids': False
+    }
+    permissions.ENTITY_POLICY_SCHEMA(policy)
+    compiled = permissions._compile_entities(policy)
+    assert compiled('light.kitchen', []) is False
+
+
+def test_entities_entity_ids_entity_id_true():
+    """Test entity ID policy."""
+    policy = {
+        'entity_ids': {
+            'light.kitchen': True
+        }
+    }
+    permissions.ENTITY_POLICY_SCHEMA(policy)
+    compiled = permissions._compile_entities(policy)
+    assert compiled('light.kitchen', []) is True
+    assert compiled('switch.kitchen', []) is False
+
+
+def test_entities_precision_order():
+    """Test entity ID policy."""
+    policy = {
+        'entity_ids': False,
+        'domains': True,
+    }
+    permissions.ENTITY_POLICY_SCHEMA(policy)
+    compiled = permissions._compile_entities(policy)
+    assert compiled('light.kitchen', []) is False
+
+
+def test_entities_entity_ids_entity_id_false():
+    """Test entity ID policy."""
+    policy = {
+        'entity_ids': {
+            'light.kitchen': False
+        }
+    }
+    permissions.ENTITY_POLICY_SCHEMA(policy)
+    compiled = permissions._compile_entities(policy)
+    assert compiled('light.kitchen', []) is False
+    assert compiled('switch.kitchen', []) is False
+
+
+def test_entities_domain_and_entity_ids():
+    """Test entity ID policy whitelist domain, decline entity."""
+    policy = {
+        'domains': {
+            'light': True,
+        },
+        'entity_ids': {
+            'light.kitchen': False
+        }
+    }
+    permissions.ENTITY_POLICY_SCHEMA(policy)
+    compiled = permissions._compile_entities(policy)
+    assert compiled('light.living_room', []) is True
+    assert compiled('light.kitchen', []) is False
+
+
+def test_policy_perm_filter_entities():
+    """Test filtering entitites."""
+    states = [
+        State('light.kitchen', 'on'),
+        State('light.living_room', 'off'),
+        State('light.balcony', 'on'),
+    ]
+    perm = permissions.PolicyPermissions({
+        'entities': {
+            'entity_ids': {
+                'light.kitchen': True,
+                'light.balcony': True,
+            }
+        }
+    })
+    filtered = perm.filter_entities(states)
+    assert len(filtered) == 2
+    assert filtered == [states[0], states[2]]
+
+
+def test_owner_permissions():
+    """Test owner permissions access all."""
+    assert permissions.OwnerPermissions.check_entity('light.kitchen')
+    states = [
+        State('light.kitchen', 'on'),
+        State('light.living_room', 'off'),
+        State('light.balcony', 'on'),
+    ]
+    assert permissions.OwnerPermissions.filter_entities(states) == states
+
+
+def test_default_policy_allow_all():
+    """Test that the default policy is to allow all entity actions."""
+    perm = permissions.PolicyPermissions(permissions.DEFAULT_POLICY)
+    assert perm.check_entity('light.kitchen')
+    states = [
+        State('light.kitchen', 'on'),
+        State('light.living_room', 'off'),
+        State('light.balcony', 'on'),
+    ]
+    assert perm.filter_entities(states) == states
+
+
+def test_merging_permissions_true_rules_all():
+    """Test merging policy with two entities."""
+    policy1 = {
+        'something_else': True,
+        'entities': {
+            'entity_ids': {
+                'light.kitchen': True,
+            }
+        }
+    }
+    policy2 = {
+        'entities': {
+            'entity_ids': True
+        }
+    }
+    assert permissions.merge_policies([policy1, policy2]) == {
+        'something_else': True,
+        'entities': {
+            'entity_ids': True
+        }
+    }
+
+
+def test_merging_permissions_multiple_subcategories():
+    """Test merging policy with two entities."""
+    policy1 = {
+        'entities': {
+            'entity_ids': {
+                'light.kitchen': True,
+            }
+        }
+    }
+    policy2 = {
+        'entities': {
+            'entity_ids': {
+                'light.kitchen': False,
+                'light.living_room': False,
+            }
+        }
+    }
+    assert permissions.merge_policies([policy1, policy2]) == {
+        'entities': {
+            'entity_ids': {
+                'light.kitchen': True,
+                'light.living_room': False,
+            }
+        }
+    }

--- a/tests/auth/test_permissions.py
+++ b/tests/auth/test_permissions.py
@@ -153,7 +153,7 @@ def test_entities_domain_and_entity_ids():
     assert compiled('light.kitchen', []) is False
 
 
-def test_policy_perm_filter_entities():
+def test_policy_perm_filter_states():
     """Test filtering entitites."""
     states = [
         State('light.kitchen', 'on'),
@@ -168,7 +168,7 @@ def test_policy_perm_filter_entities():
             }
         }
     })
-    filtered = perm.filter_entities(states)
+    filtered = perm.filter_states(states)
     assert len(filtered) == 2
     assert filtered == [states[0], states[2]]
 
@@ -181,7 +181,7 @@ def test_owner_permissions():
         State('light.living_room', 'off'),
         State('light.balcony', 'on'),
     ]
-    assert permissions.OwnerPermissions.filter_entities(states) == states
+    assert permissions.OwnerPermissions.filter_states(states) == states
 
 
 def test_default_policy_allow_all():
@@ -193,7 +193,7 @@ def test_default_policy_allow_all():
         State('light.living_room', 'off'),
         State('light.balcony', 'on'),
     ]
-    assert perm.filter_entities(states) == states
+    assert perm.filter_states(states) == states
 
 
 def test_merging_permissions_true_rules_all():

--- a/tests/auth/test_permissions.py
+++ b/tests/auth/test_permissions.py
@@ -1,4 +1,7 @@
 """Tests for the auth permission system."""
+import pytest
+import voluptuous as vol
+
 from homeassistant.core import State
 from homeassistant.auth import permissions
 
@@ -21,9 +24,8 @@ def test_entities_empty():
 def test_entities_false():
     """Test entity ID policy."""
     policy = False
-    permissions.ENTITY_POLICY_SCHEMA(policy)
-    compiled = permissions._compile_entities(policy)
-    assert compiled('light.kitchen', []) is False
+    with pytest.raises(vol.Invalid):
+        permissions.ENTITY_POLICY_SCHEMA(policy)
 
 
 def test_entities_true():
@@ -42,16 +44,6 @@ def test_entities_domains_true():
     permissions.ENTITY_POLICY_SCHEMA(policy)
     compiled = permissions._compile_entities(policy)
     assert compiled('light.kitchen', []) is True
-
-
-def test_entities_domains_false():
-    """Test entity ID policy."""
-    policy = {
-        'domains': False
-    }
-    permissions.ENTITY_POLICY_SCHEMA(policy)
-    compiled = permissions._compile_entities(policy)
-    assert compiled('light.kitchen', []) is False
 
 
 def test_entities_domains_domain_true():
@@ -74,10 +66,8 @@ def test_entities_domains_domain_false():
             'light': False
         }
     }
-    permissions.ENTITY_POLICY_SCHEMA(policy)
-    compiled = permissions._compile_entities(policy)
-    assert compiled('light.kitchen', []) is False
-    assert compiled('switch.kitchen', []) is False
+    with pytest.raises(vol.Invalid):
+        permissions.ENTITY_POLICY_SCHEMA(policy)
 
 
 def test_entities_entity_ids_true():
@@ -95,9 +85,8 @@ def test_entities_entity_ids_false():
     policy = {
         'entity_ids': False
     }
-    permissions.ENTITY_POLICY_SCHEMA(policy)
-    compiled = permissions._compile_entities(policy)
-    assert compiled('light.kitchen', []) is False
+    with pytest.raises(vol.Invalid):
+        permissions.ENTITY_POLICY_SCHEMA(policy)
 
 
 def test_entities_entity_ids_entity_id_true():
@@ -113,17 +102,6 @@ def test_entities_entity_ids_entity_id_true():
     assert compiled('switch.kitchen', []) is False
 
 
-def test_entities_precision_order():
-    """Test entity ID policy."""
-    policy = {
-        'entity_ids': False,
-        'domains': True,
-    }
-    permissions.ENTITY_POLICY_SCHEMA(policy)
-    compiled = permissions._compile_entities(policy)
-    assert compiled('light.kitchen', []) is False
-
-
 def test_entities_entity_ids_entity_id_false():
     """Test entity ID policy."""
     policy = {
@@ -131,26 +109,8 @@ def test_entities_entity_ids_entity_id_false():
             'light.kitchen': False
         }
     }
-    permissions.ENTITY_POLICY_SCHEMA(policy)
-    compiled = permissions._compile_entities(policy)
-    assert compiled('light.kitchen', []) is False
-    assert compiled('switch.kitchen', []) is False
-
-
-def test_entities_domain_and_entity_ids():
-    """Test entity ID policy whitelist domain, decline entity."""
-    policy = {
-        'domains': {
-            'light': True,
-        },
-        'entity_ids': {
-            'light.kitchen': False
-        }
-    }
-    permissions.ENTITY_POLICY_SCHEMA(policy)
-    compiled = permissions._compile_entities(policy)
-    assert compiled('light.living_room', []) is True
-    assert compiled('light.kitchen', []) is False
+    with pytest.raises(vol.Invalid):
+        permissions.ENTITY_POLICY_SCHEMA(policy)
 
 
 def test_policy_perm_filter_states():
@@ -232,14 +192,7 @@ def test_merging_permissions_multiple_subcategories():
     policy3 = {
         'entities': True
     }
-    policy4 = {
-        'entities': False
-    }
     assert permissions.merge_policies([policy1, policy2]) == policy2
     assert permissions.merge_policies([policy1, policy3]) == policy3
-    assert permissions.merge_policies([policy1, policy4]) == policy4
 
     assert permissions.merge_policies([policy2, policy3]) == policy3
-    assert permissions.merge_policies([policy2, policy4]) == policy4
-
-    assert permissions.merge_policies([policy3, policy4]) == policy4

--- a/tests/auth/test_permissions.py
+++ b/tests/auth/test_permissions.py
@@ -196,7 +196,7 @@ def test_default_policy_allow_all():
     assert perm.filter_states(states) == states
 
 
-def test_merging_permissions_true_rules_all():
+def test_merging_permissions_true_rules_dict():
     """Test merging policy with two entities."""
     policy1 = {
         'something_else': True,
@@ -222,25 +222,24 @@ def test_merging_permissions_true_rules_all():
 def test_merging_permissions_multiple_subcategories():
     """Test merging policy with two entities."""
     policy1 = {
-        'entities': {
-            'entity_ids': {
-                'light.kitchen': True,
-            }
-        }
+        'entities': None
     }
     policy2 = {
         'entities': {
-            'entity_ids': {
-                'light.kitchen': False,
-                'light.living_room': False,
-            }
+            'entity_ids': True,
         }
     }
-    assert permissions.merge_policies([policy1, policy2]) == {
-        'entities': {
-            'entity_ids': {
-                'light.kitchen': True,
-                'light.living_room': False,
-            }
-        }
+    policy3 = {
+        'entities': True
     }
+    policy4 = {
+        'entities': False
+    }
+    assert permissions.merge_policies([policy1, policy2]) == policy2
+    assert permissions.merge_policies([policy1, policy3]) == policy3
+    assert permissions.merge_policies([policy1, policy4]) == policy4
+
+    assert permissions.merge_policies([policy2, policy3]) == policy3
+    assert permissions.merge_policies([policy2, policy4]) == policy4
+
+    assert permissions.merge_policies([policy3, policy4]) == policy4

--- a/tests/common.py
+++ b/tests/common.py
@@ -348,10 +348,12 @@ def mock_device_registry(hass, mock_entries=None):
 class MockGroup(auth_models.Group):
     """Mock a group in Home Assistant."""
 
-    def __init__(self, id=None, name='Mock Group'):
+    def __init__(self, id=None, name='Mock Group',
+                 policy=auth_store.DEFAULT_POLICY):
         """Mock a group."""
         kwargs = {
-            'name': name
+            'name': name,
+            'policy': policy,
         }
         if id is not None:
             kwargs['id'] = id


### PR DESCRIPTION
~~# First need to merge [groups PR](https://github.com/home-assistant/home-assistant/pull/16935)~~
## Description:
This PR adds the foundation for permissions to Home Assistant. It's the goal to make permissions available. It's not the goal of this PR to enforce permissions.

It is based on top off the [groups PR](https://github.com/home-assistant/home-assistant/pull/16935). Until that is merged, that code will be included in the diff of this PR.

TO DO:
 - [x] Create groups that a user can be a part of (separate PR)
 - [x] Attach policies to a group
 - [x] Docs

Not going to do in this PR:
 - [ ] Filter Rest API output for states ([here](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/api.py#L177-L239))
 - [ ] Filter WebSocket API output ([here](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/websocket_api.py#L554-L561))
 - [ ] Check policy when calling services ([here](https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/helpers/service.py#L213))


**Related issue (if applicable):** fixes https://github.com/home-assistant/architecture/issues/67

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** https://github.com/home-assistant/developers.home-assistant/pull/118

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
