### PR TITLE
Prevent discovered Tradfri while already configured

### DIFF
--- a/homeassistant/components/tradfri/config_flow.py
+++ b/homeassistant/components/tradfri/config_flow.py
@@ -77,6 +77,12 @@ class FlowHandler(config_entries.ConfigFlow):
 
     async def async_step_discovery(self, user_input):
         """Handle discovery."""
+        for entry in self._async_current_entries():
+            if entry.data[CONF_HOST] == user_input['host']:
+                return self.async_abort(
+                    reason='already_configured'
+                )
+
         self._host = user_input['host']
         return await self.async_step_auth()
 

--- a/tests/components/tradfri/test_config_flow.py
+++ b/tests/components/tradfri/test_config_flow.py
@@ -6,7 +6,7 @@ import pytest
 from homeassistant import data_entry_flow
 from homeassistant.components.tradfri import config_flow
 
-from tests.common import mock_coro
+from tests.common import mock_coro, MockConfigEntry
 
 
 @pytest.fixture
@@ -185,3 +185,35 @@ async def test_import_connection_legacy(hass, mock_gateway_info,
 
     assert len(mock_gateway_info.mock_calls) == 1
     assert len(mock_entry_setup.mock_calls) == 1
+
+
+async def test_discovery_duplicate_aborted(hass):
+    """Test a duplicate discovery host is ignored."""
+    MockConfigEntry(
+        domain='tradfri',
+        data={'host': 'some-host'}
+    ).add_to_hass(hass)
+
+    flow = await hass.config_entries.flow.async_init(
+        'tradfri', context={'source': 'discovery'}, data={
+            'host': 'some-host'
+        })
+
+    assert flow['type'] == data_entry_flow.RESULT_TYPE_ABORT
+    assert flow['reason'] == 'already_configured'
+
+
+async def test_import_duplicate_aborted(hass):
+    """Test a duplicate discovery host is ignored."""
+    MockConfigEntry(
+        domain='tradfri',
+        data={'host': 'some-host'}
+    ).add_to_hass(hass)
+
+    flow = await hass.config_entries.flow.async_init(
+        'tradfri', context={'source': 'import'}, data={
+            'host': 'some-host'
+        })
+
+    assert flow['type'] == data_entry_flow.RESULT_TYPE_ABORT
+    assert flow['reason'] == 'already_configured'

--- a/tests/components/tradfri/test_init.py
+++ b/tests/components/tradfri/test_init.py
@@ -58,7 +58,7 @@ async def test_config_json_host_not_imported(hass):
     assert len(mock_init.mock_calls) == 0
 
 
-async def test_config_yaml_host_imported(hass):
+async def test_config_json_host_imported(hass):
     """Test that we import a configured host."""
     with patch('homeassistant.components.tradfri.load_json',
                return_value={'mock-host': {'key': 'some-info'}}):

--- a/tests/components/tradfri/test_init.py
+++ b/tests/components/tradfri/test_init.py
@@ -1,0 +1,72 @@
+"""Tests for Tradfri setup."""
+from unittest.mock import patch
+
+from homeassistant.setup import async_setup_component
+
+from tests.common import MockConfigEntry
+
+
+async def test_config_yaml_host_not_imported(hass):
+    """Test that we don't import a configured host."""
+    MockConfigEntry(
+        domain='tradfri',
+        data={'host': 'mock-host'}
+    ).add_to_hass(hass)
+
+    with patch('homeassistant.components.tradfri.load_json',
+               return_value={}), \
+            patch.object(hass.config_entries.flow, 'async_init') as mock_init:
+        assert await async_setup_component(hass, 'tradfri', {
+            'tradfri': {
+                'host': 'mock-host'
+            }
+        })
+
+    assert len(mock_init.mock_calls) == 0
+
+
+async def test_config_yaml_host_imported(hass):
+    """Test that we import a configured host."""
+    with patch('homeassistant.components.tradfri.load_json',
+               return_value={}):
+        assert await async_setup_component(hass, 'tradfri', {
+            'tradfri': {
+                'host': 'mock-host'
+            }
+        })
+
+    progress = hass.config_entries.flow.async_progress()
+    assert len(progress) == 1
+    assert progress[0]['handler'] == 'tradfri'
+    assert progress[0]['context'] == {'source': 'import'}
+
+
+async def test_config_json_host_not_imported(hass):
+    """Test that we don't import a configured host."""
+    MockConfigEntry(
+        domain='tradfri',
+        data={'host': 'mock-host'}
+    ).add_to_hass(hass)
+
+    with patch('homeassistant.components.tradfri.load_json',
+               return_value={'mock-host': {'key': 'some-info'}}), \
+            patch.object(hass.config_entries.flow, 'async_init') as mock_init:
+        assert await async_setup_component(hass, 'tradfri', {
+            'tradfri': {}
+        })
+
+    assert len(mock_init.mock_calls) == 0
+
+
+async def test_config_yaml_host_imported(hass):
+    """Test that we import a configured host."""
+    with patch('homeassistant.components.tradfri.load_json',
+               return_value={'mock-host': {'key': 'some-info'}}):
+        assert await async_setup_component(hass, 'tradfri', {
+            'tradfri': {}
+        })
+
+    progress = hass.config_entries.flow.async_progress()
+    assert len(progress) == 1
+    assert progress[0]['handler'] == 'tradfri'
+    assert progress[0]['context'] == {'source': 'import'}


### PR DESCRIPTION
## Description:
Prevent Tradfri config flow from being discovered when it is already configured.

Reported by Cogneato in the chat.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
