### PR TITLE
Remove unused legacy test helper methods

### DIFF
--- a/tests/components/camera/common.py
+++ b/tests/components/camera/common.py
@@ -4,8 +4,7 @@ All containing methods are legacy helpers that should not be used by new
 components. Instead call the service directly.
 """
 from homeassistant.components.camera import (
-    ATTR_FILENAME, DOMAIN, SERVICE_DISABLE_MOTION, SERVICE_ENABLE_MOTION,
-    SERVICE_SNAPSHOT)
+    ATTR_FILENAME, DOMAIN, SERVICE_ENABLE_MOTION, SERVICE_SNAPSHOT)
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF, \
     SERVICE_TURN_ON
 from homeassistant.core import callback
@@ -13,22 +12,10 @@ from homeassistant.loader import bind_hass
 
 
 @bind_hass
-def turn_off(hass, entity_id=None):
-    """Turn off camera."""
-    hass.add_job(async_turn_off, hass, entity_id)
-
-
-@bind_hass
 async def async_turn_off(hass, entity_id=None):
     """Turn off camera."""
     data = {ATTR_ENTITY_ID: entity_id} if entity_id else {}
     await hass.services.async_call(DOMAIN, SERVICE_TURN_OFF, data)
-
-
-@bind_hass
-def turn_on(hass, entity_id=None):
-    """Turn on camera."""
-    hass.add_job(async_turn_on, hass, entity_id)
 
 
 @bind_hass
@@ -47,14 +34,6 @@ def enable_motion_detection(hass, entity_id=None):
     data = {ATTR_ENTITY_ID: entity_id} if entity_id else None
     hass.async_add_job(hass.services.async_call(
         DOMAIN, SERVICE_ENABLE_MOTION, data))
-
-
-@bind_hass
-def disable_motion_detection(hass, entity_id=None):
-    """Disable Motion Detection."""
-    data = {ATTR_ENTITY_ID: entity_id} if entity_id else None
-    hass.async_add_job(hass.services.async_call(
-        DOMAIN, SERVICE_DISABLE_MOTION, data))
 
 
 @bind_hass

--- a/tests/components/fan/common.py
+++ b/tests/components/fan/common.py
@@ -7,7 +7,7 @@ from homeassistant.components.fan import (
     ATTR_DIRECTION, ATTR_SPEED, ATTR_OSCILLATING, DOMAIN,
     SERVICE_OSCILLATE, SERVICE_SET_DIRECTION, SERVICE_SET_SPEED)
 from homeassistant.const import (
-    ATTR_ENTITY_ID, SERVICE_TURN_ON, SERVICE_TOGGLE, SERVICE_TURN_OFF)
+    ATTR_ENTITY_ID, SERVICE_TURN_ON, SERVICE_TURN_OFF)
 from homeassistant.loader import bind_hass
 
 
@@ -30,16 +30,6 @@ def turn_off(hass, entity_id: str = None) -> None:
     data = {ATTR_ENTITY_ID: entity_id} if entity_id else {}
 
     hass.services.call(DOMAIN, SERVICE_TURN_OFF, data)
-
-
-@bind_hass
-def toggle(hass, entity_id: str = None) -> None:
-    """Toggle all or specified fans."""
-    data = {
-        ATTR_ENTITY_ID: entity_id
-    }
-
-    hass.services.call(DOMAIN, SERVICE_TOGGLE, data)
 
 
 @bind_hass

--- a/tests/components/test_input_select.py
+++ b/tests/components/test_input_select.py
@@ -49,18 +49,6 @@ def select_previous(hass, entity_id):
     })
 
 
-@bind_hass
-def set_options(hass, entity_id, options):
-    """Set options of input_select.
-
-    This is a legacy helper method. Do not use it for new tests.
-    """
-    hass.services.call(DOMAIN, SERVICE_SET_OPTIONS, {
-        ATTR_ENTITY_ID: entity_id,
-        ATTR_OPTIONS: options,
-    })
-
-
 class TestInputSelect(unittest.TestCase):
     """Test the input select component."""
 


### PR DESCRIPTION
## Description:
Removes some of the legacy helper methods introduced with #16863 and #16879 since they aren't needed. This does **NOT** include any breaking changes.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**