### PR TITLE
Add zwave.network_complete_some_dead event

### DIFF
--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -362,7 +362,7 @@ async def async_setup(hass, config):
     dispatcher.connect(
         network_complete, ZWaveNetwork.SIGNAL_ALL_NODES_QUERIED, weak=False)
     dispatcher.connect(
-        network_complete_some_dead, 
+        network_complete_some_dead,
         ZWaveNetwork.SIGNAL_ALL_NODES_QUERIED_SOME_DEAD, weak=False)
 
     def add_node(service):

--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -265,7 +265,8 @@ async def async_setup(hass, config):
                                     ZWaveNetwork.SIGNAL_NODE_EVENT,
                                     ZWaveNetwork.SIGNAL_AWAKE_NODES_QUERIED,
                                     ZWaveNetwork.SIGNAL_ALL_NODES_QUERIED,
-                                    ZWaveNetwork.SIGNAL_ALL_NODES_QUERIED_SOME_DEAD):
+                                    ZWaveNetwork
+                                    .SIGNAL_ALL_NODES_QUERIED_SOME_DEAD):
                 pprint(_obj_to_dict(value))
 
             print("")
@@ -361,7 +362,8 @@ async def async_setup(hass, config):
     dispatcher.connect(
         network_complete, ZWaveNetwork.SIGNAL_ALL_NODES_QUERIED, weak=False)
     dispatcher.connect(
-        network_complete_some_dead, ZWaveNetwork.SIGNAL_ALL_NODES_QUERIED_SOME_DEAD, weak=False)
+        network_complete_some_dead, 
+        ZWaveNetwork.SIGNAL_ALL_NODES_QUERIED_SOME_DEAD, weak=False)
 
     def add_node(service):
         """Switch into inclusion mode."""

--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -264,7 +264,8 @@ async def async_setup(hass, config):
                                     ZWaveNetwork.SIGNAL_SCENE_EVENT,
                                     ZWaveNetwork.SIGNAL_NODE_EVENT,
                                     ZWaveNetwork.SIGNAL_AWAKE_NODES_QUERIED,
-                                    ZWaveNetwork.SIGNAL_ALL_NODES_QUERIED):
+                                    ZWaveNetwork.SIGNAL_ALL_NODES_QUERIED
+                                    ZWaveNetwork.SIGNAL_ALL_NODES_QUERIED_SOME_DEAD):
                 pprint(_obj_to_dict(value))
 
             print("")
@@ -345,6 +346,12 @@ async def async_setup(hass, config):
                      "have been queried")
         hass.bus.fire(const.EVENT_NETWORK_COMPLETE)
 
+    def network_complete_some_dead():
+        """Handle the querying of all nodes on network."""
+        _LOGGER.info("Z-Wave network is complete. All nodes on the network "
+                     "have been queried, but some node ar mark dead")
+        hass.bus.fire(const.EVENT_NETWORK_COMPLETE_SOME_DEAD)
+
     dispatcher.connect(
         value_added, ZWaveNetwork.SIGNAL_VALUE_ADDED, weak=False)
     dispatcher.connect(
@@ -353,6 +360,8 @@ async def async_setup(hass, config):
         network_ready, ZWaveNetwork.SIGNAL_AWAKE_NODES_QUERIED, weak=False)
     dispatcher.connect(
         network_complete, ZWaveNetwork.SIGNAL_ALL_NODES_QUERIED, weak=False)
+    dispatcher.connect(
+        network_complete_some_dead, ZWaveNetwork.SIGNAL_ALL_NODES_QUERIED_SOME_DEAD, weak=False)
 
     def add_node(service):
         """Switch into inclusion mode."""

--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -264,7 +264,7 @@ async def async_setup(hass, config):
                                     ZWaveNetwork.SIGNAL_SCENE_EVENT,
                                     ZWaveNetwork.SIGNAL_NODE_EVENT,
                                     ZWaveNetwork.SIGNAL_AWAKE_NODES_QUERIED,
-                                    ZWaveNetwork.SIGNAL_ALL_NODES_QUERIED
+                                    ZWaveNetwork.SIGNAL_ALL_NODES_QUERIED,
                                     ZWaveNetwork.SIGNAL_ALL_NODES_QUERIED_SOME_DEAD):
                 pprint(_obj_to_dict(value))
 

--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -349,7 +349,7 @@ async def async_setup(hass, config):
     def network_complete_some_dead():
         """Handle the querying of all nodes on network."""
         _LOGGER.info("Z-Wave network is complete. All nodes on the network "
-                     "have been queried, but some node ar mark dead")
+                     "have been queried, but some node are marked dead")
         hass.bus.fire(const.EVENT_NETWORK_COMPLETE_SOME_DEAD)
 
     dispatcher.connect(

--- a/homeassistant/components/zwave/const.py
+++ b/homeassistant/components/zwave/const.py
@@ -58,6 +58,7 @@ EVENT_SCENE_ACTIVATED = "zwave.scene_activated"
 EVENT_NODE_EVENT = "zwave.node_event"
 EVENT_NETWORK_READY = "zwave.network_ready"
 EVENT_NETWORK_COMPLETE = "zwave.network_complete"
+EVENT_NETWORK_COMPLETE_SOME_DEAD = "zwave.network_complete_some_dead"
 EVENT_NETWORK_START = "zwave.network_start"
 EVENT_NETWORK_STOP = "zwave.network_stop"
 

--- a/tests/components/zwave/test_init.py
+++ b/tests/components/zwave/test_init.py
@@ -460,7 +460,7 @@ def test_network_complete(hass, mock_openzwave):
 
 @asyncio.coroutine
 def test_network_complete_some_dead(hass, mock_openzwave):
-    """Test Node network complete event."""
+    """Test Node network complete some dead event."""
     mock_receivers = []
 
     def mock_connect(receiver, signal, *args, **kwargs):
@@ -477,7 +477,7 @@ def test_network_complete_some_dead(hass, mock_openzwave):
     def listener(event):
         events.append(event)
 
-    hass.bus.async_listen(const.EVENT_NETWORK_COMPLETE, listener)
+    hass.bus.async_listen(const.EVENT_NETWORK_COMPLETE_SOME_DEAD, listener)
 
     hass.async_add_job(mock_receivers[0])
     yield from hass.async_block_till_done()

--- a/tests/components/zwave/test_init.py
+++ b/tests/components/zwave/test_init.py
@@ -464,7 +464,7 @@ def test_network_complete_some_dead(hass, mock_openzwave):
     mock_receivers = []
 
     def mock_connect(receiver, signal, *args, **kwargs):
-        if signal == MockNetwork.SIGNAL_AWAKE_NODES_QUERIED_SOME_DEAD:
+        if signal == MockNetwork.SIGNAL_ALL_NODES_QUERIED_SOME_DEAD:
             mock_receivers.append(receiver)
 
     with patch('pydispatch.dispatcher.connect', new=mock_connect):
@@ -477,7 +477,7 @@ def test_network_complete_some_dead(hass, mock_openzwave):
     def listener(event):
         events.append(event)
 
-    hass.bus.async_listen(const.EVENT_NETWORK_READY, listener)
+    hass.bus.async_listen(const.EVENT_NETWORK_COMPLETE, listener)
 
     hass.async_add_job(mock_receivers[0])
     yield from hass.async_block_till_done()

--- a/tests/components/zwave/test_init.py
+++ b/tests/components/zwave/test_init.py
@@ -457,6 +457,31 @@ def test_network_complete(hass, mock_openzwave):
 
     assert len(events) == 1
 
+@asyncio.coroutine
+def test_network_complete_some_dead(hass, mock_openzwave):
+    """Test Node network complete event."""
+    mock_receivers = []
+
+    def mock_connect(receiver, signal, *args, **kwargs):
+        if signal == MockNetwork.SIGNAL_AWAKE_NODES_QUERIED_SOME_DEAD:
+            mock_receivers.append(receiver)
+
+    with patch('pydispatch.dispatcher.connect', new=mock_connect):
+        yield from async_setup_component(hass, 'zwave', {'zwave': {}})
+
+    assert len(mock_receivers) == 1
+
+    events = []
+
+    def listener(event):
+        events.append(event)
+
+    hass.bus.async_listen(const.EVENT_NETWORK_READY, listener)
+
+    hass.async_add_job(mock_receivers[0])
+    yield from hass.async_block_till_done()
+
+    assert len(events) == 1    
 
 class TestZWaveDeviceEntityValues(unittest.TestCase):
     """Tests for the ZWaveDeviceEntityValues helper."""

--- a/tests/components/zwave/test_init.py
+++ b/tests/components/zwave/test_init.py
@@ -457,6 +457,7 @@ def test_network_complete(hass, mock_openzwave):
 
     assert len(events) == 1
 
+
 @asyncio.coroutine
 def test_network_complete_some_dead(hass, mock_openzwave):
     """Test Node network complete event."""
@@ -481,7 +482,8 @@ def test_network_complete_some_dead(hass, mock_openzwave):
     hass.async_add_job(mock_receivers[0])
     yield from hass.async_block_till_done()
 
-    assert len(events) == 1    
+    assert len(events) == 1
+
 
 class TestZWaveDeviceEntityValues(unittest.TestCase):
     """Tests for the ZWaveDeviceEntityValues helper."""

--- a/tests/mock/zwave.py
+++ b/tests/mock/zwave.py
@@ -88,7 +88,8 @@ class MockNetwork(MagicMock):
     SIGNAL_NODE_QUERIES_COMPLETE = 'mock_NodeQueriesComplete'
     SIGNAL_AWAKE_NODES_QUERIED = 'mock_AwakeNodesQueried'
     SIGNAL_ALL_NODES_QUERIED = 'mock_AllNodesQueried'
-    SIGNAL_ALL_NODES_QUERIED_SOME_DEAD = 'mock_AllNodesQueriedSomeDead'
+    SIGNAL_ALL_NODES_QUERIED_SOME_DEAD = \
+        'mock_AllNodesQueriedSomeDead'
     SIGNAL_MSG_COMPLETE = 'mock_MsgComplete'
     SIGNAL_NOTIFICATION = 'mock_Notification'
     SIGNAL_CONTROLLER_COMMAND = 'mock_ControllerCommand'


### PR DESCRIPTION
## Description:
Add zwave.network_complete_some_dead event so you can trigger some on this event, like homekit.start.

**Related issue (if applicable):** fixes #16750

## Example entry for `configuration.yaml` (if applicable):
```yaml
  - alias: 'Zwave ready or complete'
    trigger:
      - platform: event
        event_type: zwave.network_ready
      - platform: event
        event_type: zwave.network_complete
      - platform: event
        event_type: zwave.network_complete_some_dead
    action:
      - service: persistent_notification.create
        data:
          message: "zwave ready or something"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
