### PR TITLE
Revert #16874: Don't pass use_env=True

### DIFF
--- a/homeassistant/helpers/aiohttp_client.py
+++ b/homeassistant/helpers/aiohttp_client.py
@@ -56,7 +56,6 @@ def async_create_clientsession(hass, verify_ssl=True, auto_cleanup=True,
     clientsession = aiohttp.ClientSession(
         loop=hass.loop,
         connector=connector,
-        trust_env=True,
         headers={USER_AGENT: SERVER_SOFTWARE},
         **kwargs
     )


### PR DESCRIPTION
## Description:
In #16874 we added `use_env=True` to allow users to specify proxies via en variables (something that aiohttp supports). However, this is not cached inside aiohttp and it is doing I/O, triggering the following warning:

```
2018-09-26 08:10:07 WARNING (MainThread) [aiohttp.client] could't find .netrc file
```

**Related issue (if applicable):** Reported in chat by @dshokouhi 
