### PR TITLE
Revert file mode write_json

### DIFF
--- a/homeassistant/util/json.py
+++ b/homeassistant/util/json.py
@@ -47,9 +47,7 @@ def save_json(filename: str, data: Union[List, Dict],
     """
     try:
         json_data = json.dumps(data, sort_keys=True, indent=4)
-        mode = 0o600 if private else 0o644
-        with open(os.open(filename, os.O_WRONLY | os.O_CREAT, mode),
-                  'w', encoding='utf-8') as fdesc:
+        with open(filename, 'w', encoding='utf-8') as fdesc:
             fdesc.write(json_data)
     except TypeError as error:
         _LOGGER.exception('Failed to serialize to JSON: %s',


### PR DESCRIPTION
## Description:
The change in #16878 caused two writes to the file being mixed up and not being valid JSON, breaking Home Assistant.

It's something with a file handlers that are getting mixed up. I was unable to fix it quickly (was playing with doing `os.write` and `os.close`) so going to revert the writing part. Will leave the private boolean passing so that a proper solution can be re-applied.



**Related issue (if applicable):** fixes #16878
