### PR TITLE
Upgrade aiolifx_effects to 0.2.0

### DIFF
--- a/homeassistant/components/light/lifx.py
+++ b/homeassistant/components/light/lifx.py
@@ -30,7 +30,7 @@ import homeassistant.util.color as color_util
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['aiolifx==0.6.3', 'aiolifx_effects==0.1.2']
+REQUIREMENTS = ['aiolifx==0.6.3', 'aiolifx_effects==0.2.0']
 
 UDP_BROADCAST_PORT = 56700
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -110,7 +110,7 @@ aioimaplib==0.7.13
 aiolifx==0.6.3
 
 # homeassistant.components.light.lifx
-aiolifx_effects==0.1.2
+aiolifx_effects==0.2.0
 
 # homeassistant.components.scene.hunterdouglas_powerview
 aiopvapi==1.5.4


### PR DESCRIPTION
## Description:

This fixes a rare race that could happen when a new effect was started just as the previous one was stopping.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
