### PR TITLE
Added working support for private storage

### DIFF
--- a/homeassistant/helpers/storage.py
+++ b/homeassistant/helpers/storage.py
@@ -187,9 +187,7 @@ class Store:
             os.makedirs(os.path.dirname(path))
 
         _LOGGER.debug('Writing data for %s', self.key)
-        tmp_path = path + "__TEMP__"
-        json.save_json(tmp_path, data, self._private)
-        os.replace(tmp_path, path)
+        json.save_json(path, data, self._private)
 
     async def _async_migrate_func(self, old_version, old_data):
         """Migrate to the new version."""

--- a/homeassistant/helpers/storage.py
+++ b/homeassistant/helpers/storage.py
@@ -187,7 +187,9 @@ class Store:
             os.makedirs(os.path.dirname(path))
 
         _LOGGER.debug('Writing data for %s', self.key)
-        json.save_json(path, data, self._private)
+        tmp_path = path + "__TEMP__"
+        json.save_json(tmp_path, data, self._private)
+        os.replace(tmp_path, path)
 
     async def _async_migrate_func(self, old_version, old_data):
         """Migrate to the new version."""

--- a/homeassistant/util/json.py
+++ b/homeassistant/util/json.py
@@ -66,7 +66,7 @@ def save_json(filename: str, data: Union[List, Dict],
         if os.path.exists(tmp_filename):
             try:
                 os.remove(tmp_filename)
-            except OSError as e:
+            except OSError as err:
                 # If we are cleaning up then something else went wrong, so
                 # we should suppress likely follow-on errors in the cleanup
-                _LOGGER.error("JSON file replacement cleanup failed: %s", e)
+                _LOGGER.error("JSON replacement cleanup failed: %s", err)

--- a/homeassistant/util/json.py
+++ b/homeassistant/util/json.py
@@ -4,6 +4,7 @@ from typing import Union, List, Dict
 
 import json
 import os
+from os import O_WRONLY, O_CREAT, O_TRUNC
 
 from homeassistant.exceptions import HomeAssistantError
 
@@ -47,7 +48,9 @@ def save_json(filename: str, data: Union[List, Dict],
     """
     try:
         json_data = json.dumps(data, sort_keys=True, indent=4)
-        with open(filename, 'w', encoding='utf-8') as fdesc:
+        mode = 0o600 if private else 0o644
+        with open(os.open(filename, O_WRONLY | O_CREAT | O_TRUNC, mode),
+                  'w', encoding='utf-8') as fdesc:
             fdesc.write(json_data)
     except TypeError as error:
         _LOGGER.exception('Failed to serialize to JSON: %s',

--- a/homeassistant/util/json.py
+++ b/homeassistant/util/json.py
@@ -46,12 +46,14 @@ def save_json(filename: str, data: Union[List, Dict],
 
     Returns True on success.
     """
+    tmp_filename = filename + "__TEMP__"
     try:
         json_data = json.dumps(data, sort_keys=True, indent=4)
         mode = 0o600 if private else 0o644
-        with open(os.open(filename, O_WRONLY | O_CREAT | O_TRUNC, mode),
+        with open(os.open(tmp_filename, O_WRONLY | O_CREAT | O_TRUNC, mode),
                   'w', encoding='utf-8') as fdesc:
             fdesc.write(json_data)
+        os.replace(tmp_filename, filename)
     except TypeError as error:
         _LOGGER.exception('Failed to serialize to JSON: %s',
                           filename)
@@ -60,3 +62,11 @@ def save_json(filename: str, data: Union[List, Dict],
         _LOGGER.exception('Saving JSON file failed: %s',
                           filename)
         raise WriteError(error)
+    finally:
+        if os.path.exists(tmp_filename):
+            try:
+                os.remove(tmp_filename)
+            except OSError as e:
+                # If we are cleaning up then something else went wrong, so
+                # we should suppress likely follow-on errors in the cleanup
+                _LOGGER.error("JSON file replacement cleanup failed: %s", e)

--- a/tests/components/emulated_hue/test_init.py
+++ b/tests/components/emulated_hue/test_init.py
@@ -1,14 +1,16 @@
 """Test the Emulated Hue component."""
 import json
 
-from unittest.mock import patch, Mock, mock_open
+from unittest.mock import patch, Mock, mock_open, MagicMock
 
 from homeassistant.components.emulated_hue import Config
 
 
 def test_config_google_home_entity_id_to_number():
     """Test config adheres to the type."""
-    conf = Config(Mock(), {
+    mock_hass = Mock()
+    mock_hass.config.path = MagicMock("path", return_value="test_path")
+    conf = Config(mock_hass, {
         'type': 'google_home'
     })
 
@@ -17,29 +19,32 @@ def test_config_google_home_entity_id_to_number():
 
     with patch('homeassistant.util.json.open', mop, create=True):
         with patch('homeassistant.util.json.os.open', return_value=0):
-            number = conf.entity_id_to_number('light.test')
-            assert number == '2'
-            assert handle.write.call_count == 1
-            assert json.loads(handle.write.mock_calls[0][1][0]) == {
-                '1': 'light.test2',
-                '2': 'light.test',
-            }
+            with patch('homeassistant.util.json.os.replace'):
+                number = conf.entity_id_to_number('light.test')
+                assert number == '2'
+                assert handle.write.call_count == 1
+                assert json.loads(handle.write.mock_calls[0][1][0]) == {
+                    '1': 'light.test2',
+                    '2': 'light.test',
+                }
 
-            number = conf.entity_id_to_number('light.test')
-            assert number == '2'
-            assert handle.write.call_count == 1
+                number = conf.entity_id_to_number('light.test')
+                assert number == '2'
+                assert handle.write.call_count == 1
 
-            number = conf.entity_id_to_number('light.test2')
-            assert number == '1'
-            assert handle.write.call_count == 1
+                number = conf.entity_id_to_number('light.test2')
+                assert number == '1'
+                assert handle.write.call_count == 1
 
-            entity_id = conf.number_to_entity_id('1')
-            assert entity_id == 'light.test2'
+                entity_id = conf.number_to_entity_id('1')
+                assert entity_id == 'light.test2'
 
 
 def test_config_google_home_entity_id_to_number_altered():
     """Test config adheres to the type."""
-    conf = Config(Mock(), {
+    mock_hass = Mock()
+    mock_hass.config.path = MagicMock("path", return_value="test_path")
+    conf = Config(mock_hass, {
         'type': 'google_home'
     })
 
@@ -48,29 +53,32 @@ def test_config_google_home_entity_id_to_number_altered():
 
     with patch('homeassistant.util.json.open', mop, create=True):
         with patch('homeassistant.util.json.os.open', return_value=0):
-            number = conf.entity_id_to_number('light.test')
-            assert number == '22'
-            assert handle.write.call_count == 1
-            assert json.loads(handle.write.mock_calls[0][1][0]) == {
-                '21': 'light.test2',
-                '22': 'light.test',
-            }
+            with patch('homeassistant.util.json.os.replace'):
+                number = conf.entity_id_to_number('light.test')
+                assert number == '22'
+                assert handle.write.call_count == 1
+                assert json.loads(handle.write.mock_calls[0][1][0]) == {
+                    '21': 'light.test2',
+                    '22': 'light.test',
+                }
 
-            number = conf.entity_id_to_number('light.test')
-            assert number == '22'
-            assert handle.write.call_count == 1
+                number = conf.entity_id_to_number('light.test')
+                assert number == '22'
+                assert handle.write.call_count == 1
 
-            number = conf.entity_id_to_number('light.test2')
-            assert number == '21'
-            assert handle.write.call_count == 1
+                number = conf.entity_id_to_number('light.test2')
+                assert number == '21'
+                assert handle.write.call_count == 1
 
-            entity_id = conf.number_to_entity_id('21')
-            assert entity_id == 'light.test2'
+                entity_id = conf.number_to_entity_id('21')
+                assert entity_id == 'light.test2'
 
 
 def test_config_google_home_entity_id_to_number_empty():
     """Test config adheres to the type."""
-    conf = Config(Mock(), {
+    mock_hass = Mock()
+    mock_hass.config.path = MagicMock("path", return_value="test_path")
+    conf = Config(mock_hass, {
         'type': 'google_home'
     })
 
@@ -79,23 +87,24 @@ def test_config_google_home_entity_id_to_number_empty():
 
     with patch('homeassistant.util.json.open', mop, create=True):
         with patch('homeassistant.util.json.os.open', return_value=0):
-            number = conf.entity_id_to_number('light.test')
-            assert number == '1'
-            assert handle.write.call_count == 1
-            assert json.loads(handle.write.mock_calls[0][1][0]) == {
-                '1': 'light.test',
-            }
+            with patch('homeassistant.util.json.os.replace'):
+                number = conf.entity_id_to_number('light.test')
+                assert number == '1'
+                assert handle.write.call_count == 1
+                assert json.loads(handle.write.mock_calls[0][1][0]) == {
+                    '1': 'light.test',
+                }
 
-            number = conf.entity_id_to_number('light.test')
-            assert number == '1'
-            assert handle.write.call_count == 1
+                number = conf.entity_id_to_number('light.test')
+                assert number == '1'
+                assert handle.write.call_count == 1
 
-            number = conf.entity_id_to_number('light.test2')
-            assert number == '2'
-            assert handle.write.call_count == 2
+                number = conf.entity_id_to_number('light.test2')
+                assert number == '2'
+                assert handle.write.call_count == 2
 
-            entity_id = conf.number_to_entity_id('2')
-            assert entity_id == 'light.test2'
+                entity_id = conf.number_to_entity_id('2')
+                assert entity_id == 'light.test2'
 
 
 def test_config_alexa_entity_id_to_number():

--- a/tests/components/emulated_hue/test_init.py
+++ b/tests/components/emulated_hue/test_init.py
@@ -16,24 +16,25 @@ def test_config_google_home_entity_id_to_number():
     handle = mop()
 
     with patch('homeassistant.util.json.open', mop, create=True):
-        number = conf.entity_id_to_number('light.test')
-        assert number == '2'
-        assert handle.write.call_count == 1
-        assert json.loads(handle.write.mock_calls[0][1][0]) == {
-            '1': 'light.test2',
-            '2': 'light.test',
-        }
+        with patch('homeassistant.util.json.os.open', return_value=0):
+            number = conf.entity_id_to_number('light.test')
+            assert number == '2'
+            assert handle.write.call_count == 1
+            assert json.loads(handle.write.mock_calls[0][1][0]) == {
+                '1': 'light.test2',
+                '2': 'light.test',
+            }
 
-        number = conf.entity_id_to_number('light.test')
-        assert number == '2'
-        assert handle.write.call_count == 1
+            number = conf.entity_id_to_number('light.test')
+            assert number == '2'
+            assert handle.write.call_count == 1
 
-        number = conf.entity_id_to_number('light.test2')
-        assert number == '1'
-        assert handle.write.call_count == 1
+            number = conf.entity_id_to_number('light.test2')
+            assert number == '1'
+            assert handle.write.call_count == 1
 
-        entity_id = conf.number_to_entity_id('1')
-        assert entity_id == 'light.test2'
+            entity_id = conf.number_to_entity_id('1')
+            assert entity_id == 'light.test2'
 
 
 def test_config_google_home_entity_id_to_number_altered():
@@ -46,24 +47,25 @@ def test_config_google_home_entity_id_to_number_altered():
     handle = mop()
 
     with patch('homeassistant.util.json.open', mop, create=True):
-        number = conf.entity_id_to_number('light.test')
-        assert number == '22'
-        assert handle.write.call_count == 1
-        assert json.loads(handle.write.mock_calls[0][1][0]) == {
-            '21': 'light.test2',
-            '22': 'light.test',
-        }
+        with patch('homeassistant.util.json.os.open', return_value=0):
+            number = conf.entity_id_to_number('light.test')
+            assert number == '22'
+            assert handle.write.call_count == 1
+            assert json.loads(handle.write.mock_calls[0][1][0]) == {
+                '21': 'light.test2',
+                '22': 'light.test',
+            }
 
-        number = conf.entity_id_to_number('light.test')
-        assert number == '22'
-        assert handle.write.call_count == 1
+            number = conf.entity_id_to_number('light.test')
+            assert number == '22'
+            assert handle.write.call_count == 1
 
-        number = conf.entity_id_to_number('light.test2')
-        assert number == '21'
-        assert handle.write.call_count == 1
+            number = conf.entity_id_to_number('light.test2')
+            assert number == '21'
+            assert handle.write.call_count == 1
 
-        entity_id = conf.number_to_entity_id('21')
-        assert entity_id == 'light.test2'
+            entity_id = conf.number_to_entity_id('21')
+            assert entity_id == 'light.test2'
 
 
 def test_config_google_home_entity_id_to_number_empty():
@@ -76,23 +78,24 @@ def test_config_google_home_entity_id_to_number_empty():
     handle = mop()
 
     with patch('homeassistant.util.json.open', mop, create=True):
-        number = conf.entity_id_to_number('light.test')
-        assert number == '1'
-        assert handle.write.call_count == 1
-        assert json.loads(handle.write.mock_calls[0][1][0]) == {
-            '1': 'light.test',
-        }
+        with patch('homeassistant.util.json.os.open', return_value=0):
+            number = conf.entity_id_to_number('light.test')
+            assert number == '1'
+            assert handle.write.call_count == 1
+            assert json.loads(handle.write.mock_calls[0][1][0]) == {
+                '1': 'light.test',
+            }
 
-        number = conf.entity_id_to_number('light.test')
-        assert number == '1'
-        assert handle.write.call_count == 1
+            number = conf.entity_id_to_number('light.test')
+            assert number == '1'
+            assert handle.write.call_count == 1
 
-        number = conf.entity_id_to_number('light.test2')
-        assert number == '2'
-        assert handle.write.call_count == 2
+            number = conf.entity_id_to_number('light.test2')
+            assert number == '2'
+            assert handle.write.call_count == 2
 
-        entity_id = conf.number_to_entity_id('2')
-        assert entity_id == 'light.test2'
+            entity_id = conf.number_to_entity_id('2')
+            assert entity_id == 'light.test2'
 
 
 def test_config_alexa_entity_id_to_number():

--- a/tests/helpers/test_storage.py
+++ b/tests/helpers/test_storage.py
@@ -31,14 +31,6 @@ async def test_loading(hass, store):
     assert data == MOCK_DATA
 
 
-async def test_overwriting(hass, store):
-    """Test we can save, overwrite and reload data."""
-    await store.async_save(MOCK_DATA)
-    await store.async_save(MOCK_DATA2)
-    data = await store.async_load()
-    assert data == MOCK_DATA2
-
-
 async def test_loading_non_existing(hass, store):
     """Test we can save and load data."""
     with patch('homeassistant.util.json.open', side_effect=FileNotFoundError):

--- a/tests/helpers/test_storage.py
+++ b/tests/helpers/test_storage.py
@@ -15,6 +15,7 @@ from tests.common import async_fire_time_changed, mock_coro
 MOCK_VERSION = 1
 MOCK_KEY = 'storage-test'
 MOCK_DATA = {'hello': 'world'}
+MOCK_DATA2 = {'goodbye': 'cruel world'}
 
 
 @pytest.fixture
@@ -28,6 +29,14 @@ async def test_loading(hass, store):
     await store.async_save(MOCK_DATA)
     data = await store.async_load()
     assert data == MOCK_DATA
+
+
+async def test_overwriting(hass, store):
+    """Test we can save, overwrite and reload data."""
+    await store.async_save(MOCK_DATA)
+    await store.async_save(MOCK_DATA2)
+    data = await store.async_load()
+    assert data == MOCK_DATA2
 
 
 async def test_loading_non_existing(hass, store):

--- a/tests/util/test_json.py
+++ b/tests/util/test_json.py
@@ -21,11 +21,11 @@ class TestJSON(unittest.TestCase):
     """Test util.json save and load."""
 
     def setUp(self):
-        """Setting up for tests."""
+        """Set up for tests."""
         self.tmp_dir = mkdtemp()
 
     def tearDown(self):
-        """Cleaning up after tests."""
+        """Clean up after tests."""
         for fname in os.listdir(self.tmp_dir):
             os.remove(os.path.join(self.tmp_dir, fname))
         os.rmdir(self.tmp_dir)

--- a/tests/util/test_json.py
+++ b/tests/util/test_json.py
@@ -9,10 +9,10 @@ from homeassistant.util.json import (SerializationError,
 from homeassistant.exceptions import HomeAssistantError
 
 # Test data that can be saved as JSON
-TEST_JSON_A = {"a" : 1, "B" : "two"}
-TEST_JSON_B = {"a" : "one", "B" : 2}
+TEST_JSON_A = {"a": 1, "B": "two"}
+TEST_JSON_B = {"a": "one", "B": 2}
 # Test data that can not be saved as JSON (keys must be strings)
-TEST_BAD_OBJECT = {("A",) : 1}
+TEST_BAD_OBJECT = {("A",): 1}
 # Test data that can not be loaded as JSON
 TEST_BAD_SERIALIED = "THIS IS NOT JSON\n"
 

--- a/tests/util/test_json.py
+++ b/tests/util/test_json.py
@@ -1,0 +1,67 @@
+"""Test Home Assistant json utility functions."""
+import os
+import unittest
+import sys
+from tempfile import mkdtemp
+
+from homeassistant.util.json import (SerializationError, WriteError,
+                                     load_json, save_json)
+from homeassistant.exceptions import HomeAssistantError
+
+# Test data that can be saved as JSON
+TEST_JSON_A = {"a":1, "B":"two"}
+TEST_JSON_B = {"a":"one", "B":2}
+# Test data that can not be saved as JSON (keys must be strings)
+TEST_BAD_OBJECT = {("A",):1}
+# Test data that can not be loaded as JSON
+TEST_BAD_SERIALIED = "THIS IS NOT JSON\n"
+
+class TestJSON(unittest.TestCase):
+    """Test util.json save and load"""
+
+    def setUp(self):
+        self.tmp_dir = mkdtemp()
+
+    def tearDown(self):
+        for fname in os.listdir(self.tmp_dir):
+            os.remove(os.path.join(self.tmp_dir, fname))
+        os.rmdir(self.tmp_dir)
+        
+    def path_for(self, leaf_name):
+        return os.path.join(self.tmp_dir, leaf_name+".json")
+
+    def test_save_and_load(self):
+        fname = self.path_for("test1")
+        save_json(fname, TEST_JSON_A)
+        data = load_json(fname)
+        self.assertEqual(data, TEST_JSON_A)
+
+    # Skipped on Windows
+    @unittest.skipIf(sys.platform.startswith('win'),
+                     "private permissions not supported on Windows")
+    def test_save_and_load_private(self):
+        fname = self.path_for("test2")
+        save_json(fname, TEST_JSON_A, private=True)
+        data = load_json(fname)
+        self.assertEqual(data, TEST_JSON_A)
+        stats = os.stat(fname)
+        self.assertEqual(stats.st_mode & 0o77, 0)
+
+    def test_overwrite_and_reload(self):
+        fname = self.path_for("test3")
+        save_json(fname, TEST_JSON_A)
+        save_json(fname, TEST_JSON_B)
+        data = load_json(fname)
+        self.assertEqual(data, TEST_JSON_B)
+        
+    def test_save_bad_data(self):
+        fname = self.path_for("test4")
+        with self.assertRaises(SerializationError):
+            save_json(fname, TEST_BAD_OBJECT)
+
+    def test_load_bad_data(self):
+        fname = self.path_for("test5")
+        with open(fname, "w") as fh:
+            fh.write(TEST_BAD_SERIALIED)
+        with self.assertRaises(HomeAssistantError):
+            data = load_json(fname)

--- a/tests/util/test_json.py
+++ b/tests/util/test_json.py
@@ -18,21 +18,24 @@ TEST_BAD_SERIALIED = "THIS IS NOT JSON\n"
 
 
 class TestJSON(unittest.TestCase):
-    """Test util.json save and load"""
+    """Test util.json save and load."""
 
     def setUp(self):
+        """Setting up for tests."""
         self.tmp_dir = mkdtemp()
 
     def tearDown(self):
+        """Cleaning up after tests."""
         for fname in os.listdir(self.tmp_dir):
             os.remove(os.path.join(self.tmp_dir, fname))
         os.rmdir(self.tmp_dir)
 
-    def path_for(self, leaf_name):
+    def _path_for(self, leaf_name):
         return os.path.join(self.tmp_dir, leaf_name+".json")
 
     def test_save_and_load(self):
-        fname = self.path_for("test1")
+        """Test saving and loading back."""
+        fname = self._path_for("test1")
         save_json(fname, TEST_JSON_A)
         data = load_json(fname)
         self.assertEqual(data, TEST_JSON_A)
@@ -41,7 +44,8 @@ class TestJSON(unittest.TestCase):
     @unittest.skipIf(sys.platform.startswith('win'),
                      "private permissions not supported on Windows")
     def test_save_and_load_private(self):
-        fname = self.path_for("test2")
+        """Test we can load private files and that they are protected."""
+        fname = self._path_for("test2")
         save_json(fname, TEST_JSON_A, private=True)
         data = load_json(fname)
         self.assertEqual(data, TEST_JSON_A)
@@ -49,19 +53,22 @@ class TestJSON(unittest.TestCase):
         self.assertEqual(stats.st_mode & 0o77, 0)
 
     def test_overwrite_and_reload(self):
-        fname = self.path_for("test3")
+        """Test that we can overwrite an existing file and read back."""
+        fname = self._path_for("test3")
         save_json(fname, TEST_JSON_A)
         save_json(fname, TEST_JSON_B)
         data = load_json(fname)
         self.assertEqual(data, TEST_JSON_B)
 
     def test_save_bad_data(self):
-        fname = self.path_for("test4")
+        """Test error from trying to save unserialisable data."""
+        fname = self._path_for("test4")
         with self.assertRaises(SerializationError):
             save_json(fname, TEST_BAD_OBJECT)
 
     def test_load_bad_data(self):
-        fname = self.path_for("test5")
+        """Test error from trying to load unserialisable data."""
+        fname = self._path_for("test5")
         with open(fname, "w") as fh:
             fh.write(TEST_BAD_SERIALIED)
         with self.assertRaises(HomeAssistantError):

--- a/tests/util/test_json.py
+++ b/tests/util/test_json.py
@@ -4,17 +4,18 @@ import unittest
 import sys
 from tempfile import mkdtemp
 
-from homeassistant.util.json import (SerializationError, WriteError,
+from homeassistant.util.json import (SerializationError,
                                      load_json, save_json)
 from homeassistant.exceptions import HomeAssistantError
 
 # Test data that can be saved as JSON
-TEST_JSON_A = {"a":1, "B":"two"}
-TEST_JSON_B = {"a":"one", "B":2}
+TEST_JSON_A = {"a" : 1, "B" : "two"}
+TEST_JSON_B = {"a" : "one", "B" : 2}
 # Test data that can not be saved as JSON (keys must be strings)
-TEST_BAD_OBJECT = {("A",):1}
+TEST_BAD_OBJECT = {("A",) : 1}
 # Test data that can not be loaded as JSON
 TEST_BAD_SERIALIED = "THIS IS NOT JSON\n"
+
 
 class TestJSON(unittest.TestCase):
     """Test util.json save and load"""
@@ -26,7 +27,7 @@ class TestJSON(unittest.TestCase):
         for fname in os.listdir(self.tmp_dir):
             os.remove(os.path.join(self.tmp_dir, fname))
         os.rmdir(self.tmp_dir)
-        
+
     def path_for(self, leaf_name):
         return os.path.join(self.tmp_dir, leaf_name+".json")
 
@@ -53,7 +54,7 @@ class TestJSON(unittest.TestCase):
         save_json(fname, TEST_JSON_B)
         data = load_json(fname)
         self.assertEqual(data, TEST_JSON_B)
-        
+
     def test_save_bad_data(self):
         fname = self.path_for("test4")
         with self.assertRaises(SerializationError):
@@ -64,4 +65,4 @@ class TestJSON(unittest.TestCase):
         with open(fname, "w") as fh:
             fh.write(TEST_BAD_SERIALIED)
         with self.assertRaises(HomeAssistantError):
-            data = load_json(fname)
+            load_json(fname)


### PR DESCRIPTION
## Description:

This is a fixed version of #16878. It adds support for marking `Store` objects objects as private to prevent data exposure.

Compared to the original PR it:
* fixes the corruption bug in the original PR caused by not properly truncating the storage file when writing JSON files using `utils.json.save_json()`
* Implements atomic file replacement in the `helpers.storage.Store` class to prevent file corruption if the system crashes while writing a storage file.
* Ensures that the file permissions of existing storage files get updated if they are now marked as private and the contents is updated.
* Adds test cases to `test/helpers/test_storage.py` to test that updating an existing storage file works correctly.

**Related issue (if applicable):** fixes #16349

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** *N/A*

## Example entry for `configuration.yaml` (if applicable):
*N/A*

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. 

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) *N/A*

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]). *N/A*
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]). *N/A*
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`. *N/A*
  - [x] New files were added to `.coveragerc`. *N/A*

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works. *N/A*

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54