### PR TITLE
Trim RGB state list

### DIFF
--- a/homeassistant/components/light/mqtt.py
+++ b/homeassistant/components/light/mqtt.py
@@ -295,7 +295,7 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, Light):
                 _LOGGER.debug("Ignoring empty rgb message from '%s'", topic)
                 return
 
-            rgb = [int(val) for val in payload.split(',')]
+            rgb = [int(val) for val in payload.split(',')][0:3]
             self._hs = color_util.color_RGB_to_hs(*rgb)
             self.async_schedule_update_ha_state()
 


### PR DESCRIPTION
## Description:
Trim RGB state list to three items.
The purpose is to make it simple to handle a multi-channel RGBWW color value such as this: "Color":"0,255,0,0,0"