### PR TITLE
Ignore Xiaomi hub callbacks during setup

### DIFF
--- a/homeassistant/components/xiaomi_aqara.py
+++ b/homeassistant/components/xiaomi_aqara.py
@@ -218,7 +218,7 @@ class XiaomiDevice(Entity):
         self._get_from_hub = xiaomi_hub.get_from_hub
         self._device_state_attributes = {}
         self._remove_unavailability_tracker = None
-        xiaomi_hub.callbacks[self._sid].append(self._add_push_data_job)
+        self._xiaomi_hub = xiaomi_hub
         self.parse_data(device['data'], device['raw_data'])
         self.parse_voltage(device['data'])
 
@@ -236,6 +236,7 @@ class XiaomiDevice(Entity):
     @asyncio.coroutine
     def async_added_to_hass(self):
         """Start unavailability tracking."""
+        self._xiaomi_hub.callbacks[self._sid].append(self._add_push_data_job)
         self._async_track_unavailable()
 
     @property


### PR DESCRIPTION
## Description:

This is to fix the below exception. I am not sure that this is the best way?

CC @Danielhiversen 

```
2018-09-25 23:56:04 ERROR (MainThread) [homeassistant.core] Error doing job: Future exception was never retrieved
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/concurrent/futures/thread.py", line 56, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/local/lib/python3.6/site-packages/xiaomi_gateway/__init__.py", line 385, in push_data
    func(jdata, data)
  File "/usr/local/lib/python3.6/site-packages/homeassistant/components/xiaomi_aqara.py", line 234, in _add_push_data_job
    self.hass.add_job(self.push_data, *args)
AttributeError: 'NoneType' object has no attribute 'add_job'
```

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`.

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
