### PR TITLE
Rachio component modernization

### DIFF
--- a/homeassistant/components/binary_sensor/rachio.py
+++ b/homeassistant/components/binary_sensor/rachio.py
@@ -93,6 +93,11 @@ class RachioControllerOnlineBinarySensor(RachioControllerBinarySensor):
         return "{} online".format(self._controller.name)
 
     @property
+    def unique_id(self) -> str:
+        """Return a unique id for this entity."""
+        return "{}-online".format(self._controller.controller_id)
+
+    @property
     def device_class(self) -> str:
         """Return the class of this device, from component DEVICE_CLASSES."""
         return 'connectivity'


### PR DESCRIPTION
## Description:
Some modernization to the Rachio component:
* Add `unique_id` to all rachio entities
* Add platform discovery to rachio component, removing the need to specify rachio switch and binary_sensor platforms manually
* Move config options from switch.rachio platform to the rachio component

**Related issue (if applicable):** fixes n/a

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** *pending*

## Breaking Change
The Rachio component no longer requires you to specify `switch` and `binary_sensor` platforms. These platforms will be initialized automatically by the Rachio component. For the end user, this means:
1. Remove `switch` and `binary_sensor` entries with `platform: rachio`
2. If you configured `manual_run_mins` on the `switch` platform, move that parameter to the `rachio:` component configuration.

## Example entry for `configuration.yaml` (if applicable):
```yaml
rachio:
  api_key: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
  manual_run_mins: 10
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.
