### PR TITLE
Daikin Climate - Better integration with Climate base component

### DIFF
--- a/homeassistant/components/climate/daikin.py
+++ b/homeassistant/components/climate/daikin.py
@@ -84,7 +84,7 @@ class DaikinClimate(ClimateDevice):
         self._api = api
         self._force_refresh = False
         self._list = {
-            ATTR_OPERATION_MODE: list(DAIKIN_TO_HA_STATE),
+            ATTR_OPERATION_MODE: list(HA_STATE_TO_DAIKIN),
             ATTR_FAN_MODE: list(
                 map(
                     str.title,
@@ -143,8 +143,7 @@ class DaikinClimate(ClimateDevice):
         elif key == ATTR_OPERATION_MODE:
             # Daikin can return also internal states auto-1 or auto-7
             # and we need to translate them as AUTO
-            daikin_mode = re.sub(
-                '[^a-z]', '', self._api.device.represent(daikin_attr)[1])
+            daikin_mode = re.sub('[^a-z]', '', self._api.device.represent(daikin_attr)[1])
             
             ha_mode = DAIKIN_TO_HA_STATE.get(daikin_mode)
             value = ha_mode

--- a/homeassistant/components/climate/daikin.py
+++ b/homeassistant/components/climate/daikin.py
@@ -150,12 +150,12 @@ class DaikinClimate(ClimateDevice):
                 '',
                 self._api.device.represent(daikin_attr)[1]
             )
-            
+
             daikin_op_mode = DAIKIN_TO_HA_STATE[tmp_value]
             if daikin_op_mode is not None:
                 value = DAIKIN_TO_HA_STATE.get(daikin_op_mode)
             else:
-                value = tmp_value 
+                value = tmp_value
 
         if value is None:
             _LOGGER.error("Invalid value requested for key %s", key)

--- a/homeassistant/components/climate/daikin.py
+++ b/homeassistant/components/climate/daikin.py
@@ -143,8 +143,9 @@ class DaikinClimate(ClimateDevice):
         elif key == ATTR_OPERATION_MODE:
             # Daikin can return also internal states auto-1 or auto-7
             # and we need to translate them as AUTO
-            daikin_mode = re.sub('[^a-z]', '',
-               self._api.device.represent(daikin_attr)[1])
+            daikin_mode = re.sub(
+                '[^a-z]', '',
+                self._api.device.represent(daikin_attr)[1])
             ha_mode = DAIKIN_TO_HA_STATE.get(daikin_mode)
             value = ha_mode
 

--- a/homeassistant/components/climate/daikin.py
+++ b/homeassistant/components/climate/daikin.py
@@ -84,9 +84,7 @@ class DaikinClimate(ClimateDevice):
         self._api = api
         self._force_refresh = False
         self._list = {
-            ATTR_OPERATION_MODE: list(
-                map(str, set(DAIKIN_TO_HA_STATE.values()))
-            ),
+            ATTR_OPERATION_MODE: list(DAIKIN_TO_HA_STATE),
             ATTR_FAN_MODE: list(
                 map(
                     str.title,
@@ -145,17 +143,11 @@ class DaikinClimate(ClimateDevice):
         elif key == ATTR_OPERATION_MODE:
             # Daikin can return also internal states auto-1 or auto-7
             # and we need to translate them as AUTO
-            tmp_value = re.sub(
-                '[^a-z]',
-                '',
-                self._api.device.represent(daikin_attr)[1]
-            )
-
-            daikin_op_mode = DAIKIN_TO_HA_STATE[tmp_value]
-            if daikin_op_mode is not None:
-                value = DAIKIN_TO_HA_STATE.get(daikin_op_mode)
-            else:
-                value = tmp_value
+            daikin_mode = re.sub(
+                '[^a-z]','',self._api.device.represent(daikin_attr)[1])
+            
+            ha_mode = DAIKIN_TO_HA_STATE.get(daikin_mode)
+            value = ha_mode
 
         if value is None:
             _LOGGER.error("Invalid value requested for key %s", key)
@@ -183,7 +175,7 @@ class DaikinClimate(ClimateDevice):
             daikin_attr = HA_ATTR_TO_DAIKIN.get(attr)
             if daikin_attr is not None:
                 if value in self._list[attr]:
-                    values[daikin_attr] = value.lower()
+                    values[daikin_attr] = HA_STATE_TO_DAIKIN[value];
                 else:
                     _LOGGER.error("Invalid value %s for %s", attr, value)
 

--- a/homeassistant/components/climate/daikin.py
+++ b/homeassistant/components/climate/daikin.py
@@ -40,6 +40,15 @@ HA_STATE_TO_DAIKIN = {
     STATE_OFF: 'off',
 }
 
+DAIKIN_TO_HA_STATE = {
+    'fan': STATE_FAN_ONLY,
+    'dry': STATE_DRY,
+    'cool': STATE_COOL,
+    'hot': STATE_HEAT,
+    'auto': STATE_AUTO,
+    'off': STATE_OFF,
+}
+
 HA_ATTR_TO_DAIKIN = {
     ATTR_OPERATION_MODE: 'mode',
     ATTR_FAN_MODE: 'f_rate',
@@ -76,7 +85,7 @@ class DaikinClimate(ClimateDevice):
         self._force_refresh = False
         self._list = {
             ATTR_OPERATION_MODE: list(
-                map(str.title, set(HA_STATE_TO_DAIKIN.values()))
+                map(str, set(DAIKIN_TO_HA_STATE.values()))
             ),
             ATTR_FAN_MODE: list(
                 map(
@@ -136,11 +145,17 @@ class DaikinClimate(ClimateDevice):
         elif key == ATTR_OPERATION_MODE:
             # Daikin can return also internal states auto-1 or auto-7
             # and we need to translate them as AUTO
-            value = re.sub(
+            tmp_value = re.sub(
                 '[^a-z]',
                 '',
                 self._api.device.represent(daikin_attr)[1]
-            ).title()
+            )
+            
+            daikin_op_mode = DAIKIN_TO_HA_STATE[tmp_value]
+            if daikin_op_mode is not None:
+                value = DAIKIN_TO_HA_STATE.get(daikin_op_mode)
+            else:
+                value = tmp_value 
 
         if value is None:
             _LOGGER.error("Invalid value requested for key %s", key)

--- a/homeassistant/components/climate/daikin.py
+++ b/homeassistant/components/climate/daikin.py
@@ -144,7 +144,6 @@ class DaikinClimate(ClimateDevice):
             # Daikin can return also internal states auto-1 or auto-7
             # and we need to translate them as AUTO
             daikin_mode = re.sub('[^a-z]', '', self._api.device.represent(daikin_attr)[1])
-            
             ha_mode = DAIKIN_TO_HA_STATE.get(daikin_mode)
             value = ha_mode
 

--- a/homeassistant/components/climate/daikin.py
+++ b/homeassistant/components/climate/daikin.py
@@ -182,7 +182,7 @@ class DaikinClimate(ClimateDevice):
 
             daikin_attr = HA_ATTR_TO_DAIKIN.get(attr)
             if daikin_attr is not None:
-                if value.title() in self._list[attr]:
+                if value in self._list[attr]:
                     values[daikin_attr] = value.lower()
                 else:
                     _LOGGER.error("Invalid value %s for %s", attr, value)

--- a/homeassistant/components/climate/daikin.py
+++ b/homeassistant/components/climate/daikin.py
@@ -143,7 +143,8 @@ class DaikinClimate(ClimateDevice):
         elif key == ATTR_OPERATION_MODE:
             # Daikin can return also internal states auto-1 or auto-7
             # and we need to translate them as AUTO
-            daikin_mode = re.sub('[^a-z]', '', self._api.device.represent(daikin_attr)[1])
+            daikin_mode = re.sub('[^a-z]', '',
+               self._api.device.represent(daikin_attr)[1])
             ha_mode = DAIKIN_TO_HA_STATE.get(daikin_mode)
             value = ha_mode
 

--- a/homeassistant/components/climate/daikin.py
+++ b/homeassistant/components/climate/daikin.py
@@ -144,7 +144,7 @@ class DaikinClimate(ClimateDevice):
             # Daikin can return also internal states auto-1 or auto-7
             # and we need to translate them as AUTO
             daikin_mode = re.sub(
-                '[^a-z]','',self._api.device.represent(daikin_attr)[1])
+                '[^a-z]', '', self._api.device.represent(daikin_attr)[1])
             
             ha_mode = DAIKIN_TO_HA_STATE.get(daikin_mode)
             value = ha_mode
@@ -175,7 +175,7 @@ class DaikinClimate(ClimateDevice):
             daikin_attr = HA_ATTR_TO_DAIKIN.get(attr)
             if daikin_attr is not None:
                 if value in self._list[attr]:
-                    values[daikin_attr] = HA_STATE_TO_DAIKIN[value];
+                    values[daikin_attr] = HA_STATE_TO_DAIKIN[value]
                 else:
                     _LOGGER.error("Invalid value %s for %s", attr, value)
 


### PR DESCRIPTION
## Description:
I made some modification do the Daikin Climate Component in order to better integrate the Daikin AC interface with the base Climate Component.
Improved functionality are: 

- Support for localization for Operation Mode

- Support for Homekit Integration (if the AC is turned On, now the status is updated in Homekit)
 
## Breaking Changes
In order to support localization for Operation Mode, now the available options for this field are changed according to:

_old version / new version (english only)_

- Fan | Fan Only
- Dry | Dry
- Cool | Cool
- Hot | Heat
- Auto | Auto
- Off | Off

For other languages, the new version is used according to the translated version.