### PR TITLE
Fix auth redirect

### DIFF
--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -344,11 +344,12 @@ class AuthorizeView(HomeAssistantView):
             _is_latest(self.js_option, request)
 
         if latest:
-            location = '/frontend_latest/authorize.html'
+            base = 'frontend_latest'
         else:
-            location = '/frontend_es5/authorize.html'
+            base = 'frontend_es5'
 
-        location += '?{}'.format(request.query_string)
+        location = "/{}/authorize.html{}".format(
+            base, str(request.url.relative())[15:])
 
         return web.Response(status=302, headers={
             'location': location

--- a/tests/components/frontend/test_init.py
+++ b/tests/components/frontend/test_init.py
@@ -309,8 +309,3 @@ async def test_auth_authorize(mock_http_client):
     assert str(resp.url.relative()) == (
         '/frontend_latest/authorize.html?latest&response_type=code&client_id='
         'https://localhost/&redirect_uri=https://localhost/&state=123%23456')
-
-
-    # resp = await mock_http_client.get('/auth/authorize?latest&hello=world#yoyo')
-    # assert resp.url.raw_query_string == 'latest&hello=world#yoyo'
-    # assert resp.url.path == '/frontend_latest/authorize.html'

--- a/tests/components/frontend/test_init.py
+++ b/tests/components/frontend/test_init.py
@@ -294,10 +294,23 @@ async def test_onboarding_load(mock_http_client):
 
 async def test_auth_authorize(mock_http_client):
     """Test the authorize endpoint works."""
-    resp = await mock_http_client.get('/auth/authorize?hello=world')
-    assert resp.url.query_string == 'hello=world'
-    assert resp.url.path == '/frontend_es5/authorize.html'
+    resp = await mock_http_client.get(
+        '/auth/authorize?response_type=code&client_id=https://localhost/&'
+        'redirect_uri=https://localhost/&state=123%23456')
 
-    resp = await mock_http_client.get('/auth/authorize?latest&hello=world')
-    assert resp.url.query_string == 'latest&hello=world'
-    assert resp.url.path == '/frontend_latest/authorize.html'
+    assert str(resp.url.relative()) == (
+        '/frontend_es5/authorize.html?response_type=code&client_id='
+        'https://localhost/&redirect_uri=https://localhost/&state=123%23456')
+
+    resp = await mock_http_client.get(
+        '/auth/authorize?latest&response_type=code&client_id='
+        'https://localhost/&redirect_uri=https://localhost/&state=123%23456')
+
+    assert str(resp.url.relative()) == (
+        '/frontend_latest/authorize.html?latest&response_type=code&client_id='
+        'https://localhost/&redirect_uri=https://localhost/&state=123%23456')
+
+
+    # resp = await mock_http_client.get('/auth/authorize?latest&hello=world#yoyo')
+    # assert resp.url.raw_query_string == 'latest&hello=world#yoyo'
+    # assert resp.url.path == '/frontend_latest/authorize.html'


### PR DESCRIPTION
## Description:

Fix found by @awarecan 

**Related issue (if applicable):** fixes #16888

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
