### PR TITLE
Fix long update 'load_power' and 'in_use' for Xiaomi Zigbee Plug

### DIFF
--- a/homeassistant/components/switch/xiaomi_aqara.py
+++ b/homeassistant/components/switch/xiaomi_aqara.py
@@ -99,6 +99,11 @@ class XiaomiGenericSwitch(XiaomiDevice, SwitchDevice):
         attrs.update(super().device_state_attributes)
         return attrs
 
+    @property
+    def should_poll(self):
+        """Return the polling state. Polling needed for zigbee plug only."""
+        return self._supports_power_consumption
+
     def turn_on(self, **kwargs):
         """Turn the switch on."""
         if self._write_to_hub(self._sid, **{self._data_key: 'on'}):
@@ -131,3 +136,8 @@ class XiaomiGenericSwitch(XiaomiDevice, SwitchDevice):
             return False
         self._state = state
         return True
+
+    def update(self):
+        """Get data from hub."""
+        _LOGGER.debug("Update data from hub: %s", self._name)
+        self._get_from_hub(self._sid)


### PR DESCRIPTION
## Description:
Default update interval (heartbeat) for Xiaomi Plug Switch is [5-8 minutes](http://docs.opencloud.aqara.cn/en/guideline/product-discription/#smart-plug).
Changes fix long updates of `in_use` and `load_power` attributes by forcing data from hub.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**