### PR TITLE
Move more MQTT platforms to config entries

### DIFF
--- a/homeassistant/components/alarm_control_panel/mqtt.py
+++ b/homeassistant/components/alarm_control_panel/mqtt.py
@@ -12,7 +12,7 @@ import voluptuous as vol
 
 from homeassistant.core import callback
 import homeassistant.components.alarm_control_panel as alarm
-from homeassistant.components import mqtt
+from homeassistant.components import mqtt, alarm_control_panel
 from homeassistant.const import (
     STATE_ALARM_ARMED_AWAY, STATE_ALARM_ARMED_HOME, STATE_ALARM_DISARMED,
     STATE_ALARM_PENDING, STATE_ALARM_TRIGGERED, STATE_UNKNOWN,
@@ -21,7 +21,10 @@ from homeassistant.components.mqtt import (
     ATTR_DISCOVERY_HASH, CONF_AVAILABILITY_TOPIC, CONF_STATE_TOPIC,
     CONF_COMMAND_TOPIC, CONF_PAYLOAD_AVAILABLE, CONF_PAYLOAD_NOT_AVAILABLE,
     CONF_QOS, CONF_RETAIN, MqttAvailability, MqttDiscoveryUpdate)
+from homeassistant.components.mqtt.discovery import MQTT_DISCOVERY_NEW
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.typing import HomeAssistantType, ConfigType
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -46,9 +49,26 @@ PLATFORM_SCHEMA = mqtt.MQTT_BASE_PLATFORM_SCHEMA.extend({
 }).extend(mqtt.MQTT_AVAILABILITY_SCHEMA.schema)
 
 
-@asyncio.coroutine
-def async_setup_platform(hass, config, async_add_entities,
-                         discovery_info=None):
+async def async_setup_platform(hass: HomeAssistantType, config: ConfigType,
+                               async_add_entities, discovery_info=None):
+    """Set up MQTT alarm control panel through configuration.yaml."""
+    await _async_setup_platform(hass, config, async_add_entities,
+                                discovery_info)
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up MQTT alarm control panel dynamically through MQTT discovery."""
+    async def async_discover(config):
+        """Discover and add an MQTT alarm control panel."""
+        await _async_setup_platform(hass, {}, async_add_entities, config)
+
+    async_dispatcher_connect(
+        hass, MQTT_DISCOVERY_NEW.format(alarm_control_panel.DOMAIN, 'mqtt'),
+        async_discover)
+
+
+async def _async_setup_platform(hass, config, async_add_entities,
+                                discovery_info=None):
     """Set up the MQTT Alarm Control Panel platform."""
     if discovery_info is not None:
         config = PLATFORM_SCHEMA(discovery_info)

--- a/homeassistant/components/binary_sensor/mqtt.py
+++ b/homeassistant/components/binary_sensor/mqtt.py
@@ -11,7 +11,7 @@ from typing import Optional
 import voluptuous as vol
 
 from homeassistant.core import callback
-from homeassistant.components import mqtt
+from homeassistant.components import mqtt, binary_sensor
 from homeassistant.components.binary_sensor import (
     BinarySensorDevice, DEVICE_CLASSES_SCHEMA)
 from homeassistant.const import (
@@ -21,7 +21,10 @@ from homeassistant.components.mqtt import (
     ATTR_DISCOVERY_HASH, CONF_STATE_TOPIC, CONF_AVAILABILITY_TOPIC,
     CONF_PAYLOAD_AVAILABLE, CONF_PAYLOAD_NOT_AVAILABLE, CONF_QOS,
     MqttAvailability, MqttDiscoveryUpdate)
+from homeassistant.components.mqtt.discovery import MQTT_DISCOVERY_NEW
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.typing import HomeAssistantType, ConfigType
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -45,9 +48,26 @@ PLATFORM_SCHEMA = mqtt.MQTT_RO_PLATFORM_SCHEMA.extend({
 }).extend(mqtt.MQTT_AVAILABILITY_SCHEMA.schema)
 
 
-@asyncio.coroutine
-def async_setup_platform(hass, config, async_add_entities,
-                         discovery_info=None):
+async def async_setup_platform(hass: HomeAssistantType, config: ConfigType,
+                               async_add_entities, discovery_info=None):
+    """Set up MQTT binary sensor through configuration.yaml."""
+    await _async_setup_platform(hass, config, async_add_entities,
+                                discovery_info)
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up MQTT binary sensor dynamically through MQTT discovery."""
+    async def async_discover(config):
+        """Discover and add a MQTT binary sensor."""
+        await _async_setup_platform(hass, {}, async_add_entities, config)
+
+    async_dispatcher_connect(
+        hass, MQTT_DISCOVERY_NEW.format(binary_sensor.DOMAIN, 'mqtt'),
+        async_discover)
+
+
+async def _async_setup_platform(hass, config, async_add_entities,
+                                discovery_info=None):
     """Set up the MQTT binary sensor."""
     if discovery_info is not None:
         config = PLATFORM_SCHEMA(discovery_info)

--- a/homeassistant/components/binary_sensor/mqtt.py
+++ b/homeassistant/components/binary_sensor/mqtt.py
@@ -51,34 +51,28 @@ PLATFORM_SCHEMA = mqtt.MQTT_RO_PLATFORM_SCHEMA.extend({
 async def async_setup_platform(hass: HomeAssistantType, config: ConfigType,
                                async_add_entities, discovery_info=None):
     """Set up MQTT binary sensor through configuration.yaml."""
-    await _async_setup_platform(hass, config, async_add_entities,
-                                discovery_info)
+    await _async_setup_entity(hass, config, async_add_entities)
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up MQTT binary sensor dynamically through MQTT discovery."""
-    async def async_discover(config):
+    async def async_discover(discovery_payload):
         """Discover and add a MQTT binary sensor."""
-        await _async_setup_platform(hass, {}, async_add_entities, config)
+        config = PLATFORM_SCHEMA(discovery_payload)
+        await _async_setup_entity(hass, config, async_add_entities,
+                                  discovery_payload[ATTR_DISCOVERY_HASH])
 
     async_dispatcher_connect(
         hass, MQTT_DISCOVERY_NEW.format(binary_sensor.DOMAIN, 'mqtt'),
         async_discover)
 
 
-async def _async_setup_platform(hass, config, async_add_entities,
-                                discovery_info=None):
+async def _async_setup_entity(hass, config, async_add_entities,
+                              discovery_hash=None):
     """Set up the MQTT binary sensor."""
-    if discovery_info is not None:
-        config = PLATFORM_SCHEMA(discovery_info)
-
     value_template = config.get(CONF_VALUE_TEMPLATE)
     if value_template is not None:
         value_template.hass = hass
-
-    discovery_hash = None
-    if discovery_info is not None and ATTR_DISCOVERY_HASH in discovery_info:
-        discovery_hash = discovery_info[ATTR_DISCOVERY_HASH]
 
     async_add_entities([MqttBinarySensor(
         config.get(CONF_NAME),

--- a/homeassistant/components/camera/mqtt.py
+++ b/homeassistant/components/camera/mqtt.py
@@ -10,10 +10,13 @@ import logging
 
 import voluptuous as vol
 
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.typing import HomeAssistantType, ConfigType
 from homeassistant.core import callback
-from homeassistant.components import mqtt
 from homeassistant.const import CONF_NAME
+from homeassistant.components import mqtt, camera
 from homeassistant.components.camera import Camera, PLATFORM_SCHEMA
+from homeassistant.components.mqtt.discovery import MQTT_DISCOVERY_NEW
 from homeassistant.helpers import config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
@@ -31,9 +34,26 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-@asyncio.coroutine
-def async_setup_platform(hass, config, async_add_entities,
-                         discovery_info=None):
+async def async_setup_platform(hass: HomeAssistantType, config: ConfigType,
+                               async_add_entities, discovery_info=None):
+    """Set up MQTT camera through configuration.yaml."""
+    await _async_setup_platform(hass, config, async_add_entities,
+                                discovery_info)
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up MQTT camera dynamically through MQTT discovery."""
+    async def async_discover(config):
+        """Discover and add a MQTT camera."""
+        await _async_setup_platform(hass, {}, async_add_entities, config)
+
+    async_dispatcher_connect(
+        hass, MQTT_DISCOVERY_NEW.format(camera.DOMAIN, 'mqtt'),
+        async_discover)
+
+
+async def _async_setup_platform(hass, config, async_add_entities,
+                                discovery_info=None):
     """Set up the MQTT Camera."""
     if discovery_info is not None:
         config = PLATFORM_SCHEMA(discovery_info)

--- a/homeassistant/components/camera/mqtt.py
+++ b/homeassistant/components/camera/mqtt.py
@@ -37,27 +37,23 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 async def async_setup_platform(hass: HomeAssistantType, config: ConfigType,
                                async_add_entities, discovery_info=None):
     """Set up MQTT camera through configuration.yaml."""
-    await _async_setup_platform(hass, config, async_add_entities,
-                                discovery_info)
+    await _async_setup_entity(hass, config, async_add_entities)
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up MQTT camera dynamically through MQTT discovery."""
-    async def async_discover(config):
+    async def async_discover(discovery_payload):
         """Discover and add a MQTT camera."""
-        await _async_setup_platform(hass, {}, async_add_entities, config)
+        config = PLATFORM_SCHEMA(discovery_payload)
+        await _async_setup_entity(hass, config, async_add_entities)
 
     async_dispatcher_connect(
         hass, MQTT_DISCOVERY_NEW.format(camera.DOMAIN, 'mqtt'),
         async_discover)
 
 
-async def _async_setup_platform(hass, config, async_add_entities,
-                                discovery_info=None):
+async def _async_setup_entity(hass, config, async_add_entities):
     """Set up the MQTT Camera."""
-    if discovery_info is not None:
-        config = PLATFORM_SCHEMA(discovery_info)
-
     async_add_entities([MqttCamera(
         config.get(CONF_NAME),
         config.get(CONF_UNIQUE_ID),

--- a/homeassistant/components/light/mqtt.py
+++ b/homeassistant/components/light/mqtt.py
@@ -108,33 +108,27 @@ PLATFORM_SCHEMA = mqtt.MQTT_RW_PLATFORM_SCHEMA.extend({
 async def async_setup_platform(hass: HomeAssistantType, config: ConfigType,
                                async_add_entities, discovery_info=None):
     """Set up MQTT light through configuration.yaml."""
-    await _async_setup_platform(hass, config, async_add_entities,
-                                discovery_info)
+    await _async_setup_entity(hass, config, async_add_entities)
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up MQTT light dynamically through MQTT discovery."""
-    async def async_discover(config):
+    async def async_discover(discovery_payload):
         """Discover and add a MQTT light."""
-        await _async_setup_platform(hass, {}, async_add_entities, config)
+        config = PLATFORM_SCHEMA(discovery_payload)
+        await _async_setup_entity(hass, config, async_add_entities,
+                                  discovery_payload[ATTR_DISCOVERY_HASH])
 
     async_dispatcher_connect(
         hass, MQTT_DISCOVERY_NEW.format(light.DOMAIN, 'mqtt'),
         async_discover)
 
 
-async def _async_setup_platform(hass, config, async_add_entities,
-                                discovery_info=None):
+async def _async_setup_entity(hass, config, async_add_entities,
+                              discovery_hash=None):
     """Set up a MQTT Light."""
-    if discovery_info is not None:
-        config = PLATFORM_SCHEMA(discovery_info)
-
     config.setdefault(
         CONF_STATE_VALUE_TEMPLATE, config.get(CONF_VALUE_TEMPLATE))
-
-    discovery_hash = None
-    if discovery_info is not None and ATTR_DISCOVERY_HASH in discovery_info:
-        discovery_hash = discovery_info[ATTR_DISCOVERY_HASH]
 
     async_add_entities([MqttLight(
         config.get(CONF_NAME),

--- a/homeassistant/components/light/mqtt.py
+++ b/homeassistant/components/light/mqtt.py
@@ -9,7 +9,7 @@ import logging
 import voluptuous as vol
 
 from homeassistant.core import callback
-from homeassistant.components import mqtt
+from homeassistant.components import mqtt, light
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS, ATTR_COLOR_TEMP, ATTR_EFFECT, ATTR_HS_COLOR,
     ATTR_WHITE_VALUE, Light, SUPPORT_BRIGHTNESS, SUPPORT_COLOR_TEMP,
@@ -22,7 +22,10 @@ from homeassistant.components.mqtt import (
     ATTR_DISCOVERY_HASH, CONF_AVAILABILITY_TOPIC, CONF_COMMAND_TOPIC,
     CONF_PAYLOAD_AVAILABLE, CONF_PAYLOAD_NOT_AVAILABLE, CONF_QOS, CONF_RETAIN,
     CONF_STATE_TOPIC, MqttAvailability, MqttDiscoveryUpdate)
+from homeassistant.components.mqtt.discovery import MQTT_DISCOVERY_NEW
 from homeassistant.helpers.restore_state import async_get_last_state
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.typing import HomeAssistantType, ConfigType
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.color as color_util
 
@@ -102,8 +105,26 @@ PLATFORM_SCHEMA = mqtt.MQTT_RW_PLATFORM_SCHEMA.extend({
 }).extend(mqtt.MQTT_AVAILABILITY_SCHEMA.schema)
 
 
-async def async_setup_platform(hass, config, async_add_entities,
-                               discovery_info=None):
+async def async_setup_platform(hass: HomeAssistantType, config: ConfigType,
+                               async_add_entities, discovery_info=None):
+    """Set up MQTT light through configuration.yaml."""
+    await _async_setup_platform(hass, config, async_add_entities,
+                                discovery_info)
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up MQTT light dynamically through MQTT discovery."""
+    async def async_discover(config):
+        """Discover and add a MQTT light."""
+        await _async_setup_platform(hass, {}, async_add_entities, config)
+
+    async_dispatcher_connect(
+        hass, MQTT_DISCOVERY_NEW.format(light.DOMAIN, 'mqtt'),
+        async_discover)
+
+
+async def _async_setup_platform(hass, config, async_add_entities,
+                                discovery_info=None):
     """Set up a MQTT Light."""
     if discovery_info is not None:
         config = PLATFORM_SCHEMA(discovery_info)

--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -40,7 +40,14 @@ ALLOWED_PLATFORMS = {
 }
 
 CONFIG_ENTRY_PLATFORMS = {
+    'binary_sensor': ['mqtt'],
+    'camera': ['mqtt'],
+    'cover': ['mqtt'],
+    'light': ['mqtt'],
     'sensor': ['mqtt'],
+    'switch': ['mqtt'],
+    'climate': ['mqtt'],
+    'alarm_control_panel': ['mqtt'],
 }
 
 ALREADY_DISCOVERED = 'mqtt_discovered_components'

--- a/homeassistant/components/sensor/mqtt.py
+++ b/homeassistant/components/sensor/mqtt.py
@@ -57,33 +57,28 @@ PLATFORM_SCHEMA = mqtt.MQTT_RO_PLATFORM_SCHEMA.extend({
 async def async_setup_platform(hass: HomeAssistantType, config: ConfigType,
                                async_add_entities, discovery_info=None):
     """Set up MQTT sensors through configuration.yaml."""
-    await _async_setup_platform(hass, config, async_add_entities,
-                                discovery_info)
+    await _async_setup_entity(hass, config, async_add_entities)
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up MQTT sensors dynamically through MQTT discovery."""
-    async def async_discover_sensor(config):
+    async def async_discover_sensor(discovery_payload):
         """Discover and add a discovered MQTT sensor."""
-        await _async_setup_platform(hass, {}, async_add_entities, config)
+        config = PLATFORM_SCHEMA(discovery_payload)
+        await _async_setup_entity(hass, config, async_add_entities,
+                                  discovery_payload[ATTR_DISCOVERY_HASH])
 
     async_dispatcher_connect(hass,
                              MQTT_DISCOVERY_NEW.format(sensor.DOMAIN, 'mqtt'),
                              async_discover_sensor)
 
 
-async def _async_setup_platform(hass: HomeAssistantType, config: ConfigType,
-                                async_add_entities, discovery_info=None):
-    if discovery_info is not None:
-        config = PLATFORM_SCHEMA(discovery_info)
-
+async def _async_setup_entity(hass: HomeAssistantType, config: ConfigType,
+                              async_add_entities, discovery_hash=None):
+    """Set up MQTT sensor."""
     value_template = config.get(CONF_VALUE_TEMPLATE)
     if value_template is not None:
         value_template.hass = hass
-
-    discovery_hash = None
-    if discovery_info is not None and ATTR_DISCOVERY_HASH in discovery_info:
-        discovery_hash = discovery_info[ATTR_DISCOVERY_HASH]
 
     async_add_entities([MqttSensor(
         config.get(CONF_NAME),

--- a/homeassistant/components/switch/mqtt.py
+++ b/homeassistant/components/switch/mqtt.py
@@ -53,34 +53,29 @@ PLATFORM_SCHEMA = mqtt.MQTT_RW_PLATFORM_SCHEMA.extend({
 async def async_setup_platform(hass: HomeAssistantType, config: ConfigType,
                                async_add_entities, discovery_info=None):
     """Set up MQTT switch through configuration.yaml."""
-    await _async_setup_platform(hass, config, async_add_entities,
-                                discovery_info)
+    await _async_setup_entity(hass, config, async_add_entities,
+                              discovery_info)
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up MQTT switch dynamically through MQTT discovery."""
-    async def async_discover(config):
+    async def async_discover(discovery_payload):
         """Discover and add a MQTT switch."""
-        await _async_setup_platform(hass, {}, async_add_entities, config)
+        config = PLATFORM_SCHEMA(discovery_payload)
+        await _async_setup_entity(hass, config, async_add_entities,
+                                  discovery_payload[ATTR_DISCOVERY_HASH])
 
     async_dispatcher_connect(
         hass, MQTT_DISCOVERY_NEW.format(switch.DOMAIN, 'mqtt'),
         async_discover)
 
 
-async def _async_setup_platform(hass, config, async_add_entities,
-                               discovery_info=None):
+async def _async_setup_entity(hass, config, async_add_entities,
+                              discovery_hash=None):
     """Set up the MQTT switch."""
-    if discovery_info is not None:
-        config = PLATFORM_SCHEMA(discovery_info)
-
     value_template = config.get(CONF_VALUE_TEMPLATE)
     if value_template is not None:
         value_template.hass = hass
-
-    discovery_hash = None
-    if discovery_info is not None and ATTR_DISCOVERY_HASH in discovery_info:
-        discovery_hash = discovery_info[ATTR_DISCOVERY_HASH]
 
     newswitch = MqttSwitch(
         config.get(CONF_NAME),

--- a/tests/components/alarm_control_panel/test_mqtt.py
+++ b/tests/components/alarm_control_panel/test_mqtt.py
@@ -6,12 +6,12 @@ from homeassistant.const import (
     STATE_ALARM_DISARMED, STATE_ALARM_ARMED_HOME, STATE_ALARM_ARMED_AWAY,
     STATE_ALARM_PENDING, STATE_ALARM_TRIGGERED, STATE_UNAVAILABLE,
     STATE_UNKNOWN)
-from homeassistant.components import alarm_control_panel
+from homeassistant.components import alarm_control_panel, mqtt
 from homeassistant.components.mqtt.discovery import async_start
 
 from tests.common import (
     mock_mqtt_component, async_fire_mqtt_message, fire_mqtt_message,
-    get_test_home_assistant, assert_setup_component)
+    get_test_home_assistant, assert_setup_component, MockConfigEntry)
 from tests.components.alarm_control_panel import common
 
 CODE = 'HELLO_CODE'
@@ -245,7 +245,8 @@ class TestAlarmControlPanelMQTT(unittest.TestCase):
 
 async def test_discovery_removal_alarm(hass, mqtt_mock, caplog):
     """Test removal of discovered alarm_control_panel."""
-    await async_start(hass, 'homeassistant', {})
+    entry = MockConfigEntry(domain=mqtt.DOMAIN)
+    await async_start(hass, 'homeassistant', {}, entry)
 
     data = (
         '{ "name": "Beer",'

--- a/tests/components/binary_sensor/test_mqtt.py
+++ b/tests/components/binary_sensor/test_mqtt.py
@@ -3,7 +3,7 @@ import unittest
 
 import homeassistant.core as ha
 from homeassistant.setup import setup_component, async_setup_component
-import homeassistant.components.binary_sensor as binary_sensor
+from homeassistant.components import binary_sensor, mqtt
 from homeassistant.components.mqtt.discovery import async_start
 
 from homeassistant.const import STATE_OFF, STATE_ON
@@ -11,7 +11,8 @@ from homeassistant.const import EVENT_STATE_CHANGED, STATE_UNAVAILABLE
 
 from tests.common import (
     get_test_home_assistant, fire_mqtt_message, async_fire_mqtt_message,
-    mock_component, mock_mqtt_component, async_mock_mqtt_component)
+    mock_component, mock_mqtt_component, async_mock_mqtt_component,
+    MockConfigEntry)
 
 
 class TestSensorMQTT(unittest.TestCase):
@@ -231,7 +232,8 @@ async def test_unique_id(hass):
 
 async def test_discovery_removal_binary_sensor(hass, mqtt_mock, caplog):
     """Test removal of discovered binary_sensor."""
-    await async_start(hass, 'homeassistant', {})
+    entry = MockConfigEntry(domain=mqtt.DOMAIN)
+    await async_start(hass, 'homeassistant', {}, entry)
     data = (
         '{ "name": "Beer",'
         '  "status_topic": "test_topic" }'

--- a/tests/components/climate/test_mqtt.py
+++ b/tests/components/climate/test_mqtt.py
@@ -6,7 +6,7 @@ from homeassistant.util.unit_system import (
     METRIC_SYSTEM
 )
 from homeassistant.setup import setup_component
-from homeassistant.components import climate
+from homeassistant.components import climate, mqtt
 from homeassistant.const import STATE_OFF, STATE_UNAVAILABLE
 from homeassistant.components.climate import (
     SUPPORT_OPERATION_MODE, SUPPORT_TARGET_TEMPERATURE,
@@ -15,7 +15,7 @@ from homeassistant.components.climate import (
 from homeassistant.components.mqtt.discovery import async_start
 from tests.common import (get_test_home_assistant, mock_mqtt_component,
                           async_fire_mqtt_message, fire_mqtt_message,
-                          mock_component)
+                          mock_component, MockConfigEntry)
 from tests.components.climate import common
 
 ENTITY_CLIMATE = 'climate.test'
@@ -656,7 +656,8 @@ class TestMQTTClimate(unittest.TestCase):
 
 async def test_discovery_removal_climate(hass, mqtt_mock, caplog):
     """Test removal of discovered climate."""
-    await async_start(hass, 'homeassistant', {})
+    entry = MockConfigEntry(domain=mqtt.DOMAIN)
+    await async_start(hass, 'homeassistant', {}, entry)
     data = (
         '{ "name": "Beer" }'
     )

--- a/tests/components/cover/test_mqtt.py
+++ b/tests/components/cover/test_mqtt.py
@@ -1,7 +1,7 @@
 """The tests for the MQTT cover platform."""
 import unittest
 
-import homeassistant.components.cover as cover
+from homeassistant.components import cover, mqtt
 from homeassistant.components.cover import (ATTR_POSITION, ATTR_TILT_POSITION)
 from homeassistant.components.cover.mqtt import MqttCover
 from homeassistant.components.mqtt.discovery import async_start
@@ -15,7 +15,7 @@ from homeassistant.setup import setup_component
 
 from tests.common import (
     get_test_home_assistant, mock_mqtt_component, async_fire_mqtt_message,
-    fire_mqtt_message)
+    fire_mqtt_message, MockConfigEntry)
 
 
 class TestCoverMQTT(unittest.TestCase):
@@ -761,7 +761,8 @@ class TestCoverMQTT(unittest.TestCase):
 
 async def test_discovery_removal_cover(hass, mqtt_mock, caplog):
     """Test removal of discovered cover."""
-    await async_start(hass, 'homeassistant', {})
+    entry = MockConfigEntry(domain=mqtt.DOMAIN)
+    await async_start(hass, 'homeassistant', {}, entry)
     data = (
         '{ "name": "Beer",'
         '  "command_topic": "test_topic" }'

--- a/tests/components/light/test_mqtt.py
+++ b/tests/components/light/test_mqtt.py
@@ -145,13 +145,13 @@ from unittest.mock import patch
 from homeassistant.setup import setup_component
 from homeassistant.const import (
     STATE_ON, STATE_OFF, STATE_UNAVAILABLE, ATTR_ASSUMED_STATE)
-import homeassistant.components.light as light
+from homeassistant.components import light, mqtt
 from homeassistant.components.mqtt.discovery import async_start
 import homeassistant.core as ha
 
 from tests.common import (
     assert_setup_component, get_test_home_assistant, mock_mqtt_component,
-    async_fire_mqtt_message, fire_mqtt_message, mock_coro)
+    async_fire_mqtt_message, fire_mqtt_message, mock_coro, MockConfigEntry)
 from tests.components.light import common
 
 
@@ -883,7 +883,8 @@ class TestLightMQTT(unittest.TestCase):
 
 async def test_discovery_removal_light(hass, mqtt_mock, caplog):
     """Test removal of discovered light."""
-    await async_start(hass, 'homeassistant', {})
+    entry = MockConfigEntry(domain=mqtt.DOMAIN)
+    await async_start(hass, 'homeassistant', {}, entry)
 
     data = (
         '{ "name": "Beer",'

--- a/tests/components/switch/test_mqtt.py
+++ b/tests/components/switch/test_mqtt.py
@@ -6,12 +6,12 @@ from homeassistant.setup import setup_component, async_setup_component
 from homeassistant.const import STATE_ON, STATE_OFF, STATE_UNAVAILABLE,\
     ATTR_ASSUMED_STATE
 import homeassistant.core as ha
-import homeassistant.components.switch as switch
+from homeassistant.components import switch, mqtt
 from homeassistant.components.mqtt.discovery import async_start
 
 from tests.common import (
     mock_mqtt_component, fire_mqtt_message, get_test_home_assistant, mock_coro,
-    async_mock_mqtt_component, async_fire_mqtt_message)
+    async_mock_mqtt_component, async_fire_mqtt_message, MockConfigEntry)
 from tests.components.switch import common
 
 
@@ -313,7 +313,8 @@ async def test_unique_id(hass):
 
 async def test_discovery_removal_switch(hass, mqtt_mock, caplog):
     """Test expansion of discovered switch."""
-    await async_start(hass, 'homeassistant', {})
+    entry = MockConfigEntry(domain=mqtt.DOMAIN)
+    await async_start(hass, 'homeassistant', {}, entry)
 
     data = (
         '{ "name": "Beer",'


### PR DESCRIPTION
## Description:

#16904, but for these new platforms:

* binary_sensor
* camera
* cover
* light
* sensor
* switch
* alarm_control_panel

`fan` and `lock` need to be dealt with later because their base classes haven't been converted to config entries yet.

## Checklist:
  - [ ] The code change is tested and works locally. It's a rather simple change, and I have tested the sensor platform quite well.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
