### PR TITLE
Remove error logging when Sonos shuffle_set is not available

### DIFF
--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -70,7 +70,7 @@ ATTR_SPEECH_ENHANCE = 'speech_enhance'
 
 ATTR_SONOS_GROUP = 'sonos_group'
 
-UPNP_ERRORS_TO_IGNORE = ['701', '711']
+UPNP_ERRORS_TO_IGNORE = ['701', '711', '712']
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_ADVERTISE_ADDR): cv.string,
@@ -833,7 +833,7 @@ class SonosDevice(MediaPlayerDevice):
         """Set volume level, range 0..1."""
         self.soco.volume = str(int(volume * 100))
 
-    @soco_error()
+    @soco_error(UPNP_ERRORS_TO_IGNORE)
     @soco_coordinator
     def set_shuffle(self, shuffle):
         """Enable/Disable shuffle mode."""


### PR DESCRIPTION

## Description:

Ignores this harmless error, for example when trying to shuffle a radio stream:
```
 Error on set_shuffle with UPnP Error 712 received: Play mode not supported from 10.23.2.16
```

**Related issue (if applicable):** mentioned [in forum](https://community.home-assistant.io/t/sonos-playmode-shuffle-toggle/29609/17)

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54