### PR TITLE
Fix race between script delay and turn_off

### DIFF
--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -95,7 +95,7 @@ class Script():
                 def async_script_delay(now):
                     """Handle delay."""
                     # pylint: disable=cell-var-from-loop
-                    self._async_listener.remove(unsub)
+                    self._async_remove_listener()
                     self.hass.async_create_task(
                         self.async_run(variables, context))
 
@@ -240,7 +240,7 @@ class Script():
         @callback
         def async_script_timeout(now):
             """Call after timeout is retrieve."""
-            self._async_listener.remove(unsub)
+            self._async_remove_listener()
 
             # Check if we want to continue to execute
             # the script after the timeout


### PR DESCRIPTION
## Description:

We already had a helper method that will only unsubscribe existing listeners; however, it was not used consistently.

```
2018-09-27 18:16:01 ERROR (MainThread) [homeassistant.core] Error doing job: Exception in callback <function async_track_point_in_utc_time.<locals>.point_in_time_listener at 0x10c2312f0>
Traceback (most recent call last):
  File "uvloop/cbhandles.pyx", line 66, in uvloop.loop.Handle._run
  File "/Users/am/home-assistant/homeassistant/helpers/event.py", line 210, in point_in_time_listener
    hass.async_run_job(action, now)
  File "/Users/am/home-assistant/homeassistant/core.py", line 327, in async_run_job
    target(*args)
  File "/Users/am/home-assistant/homeassistant/helpers/script.py", line 98, in async_script_delay
    self._async_listener.remove(unsub)
ValueError: list.remove(x): x not in list
```

## Example entry for `configuration.yaml` (if applicable):
```yaml
automation:
  trigger:
    - platform: state
      entity_id: script.sleep
  action:
    - service: script.toggle
      entity_id: script.sleep

script:
  sleep:
    sequence:
      - delay:
          milliseconds: 1
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
