### PR TITLE
Handle exception handling websocket command

### DIFF
--- a/homeassistant/components/websocket_api.py
+++ b/homeassistant/components/websocket_api.py
@@ -40,6 +40,7 @@ ERR_ID_REUSE = 1
 ERR_INVALID_FORMAT = 2
 ERR_NOT_FOUND = 3
 ERR_UNKNOWN_COMMAND = 4
+ERR_UNKNOWN_ERROR = 5
 
 TYPE_AUTH = 'auth'
 TYPE_AUTH_INVALID = 'auth_invalid'
@@ -405,7 +406,13 @@ class ActiveConnection:
 
                 else:
                     handler, schema = handlers[msg['type']]
-                    handler(self.hass, self, schema(msg))
+                    try:
+                        handler(self.hass, self, schema(msg))
+                    except Exception:  # pylint: disable=bare-except
+                        _LOGGER.exception('Error handling message: %s', msg)
+                        self.to_write.put_nowait(error_message(
+                            cur_id, ERR_UNKNOWN_ERROR,
+                            'Unknown error.'))
 
                 last_id = cur_id
                 msg = await wsock.receive_json()

--- a/homeassistant/components/websocket_api.py
+++ b/homeassistant/components/websocket_api.py
@@ -408,7 +408,7 @@ class ActiveConnection:
                     handler, schema = handlers[msg['type']]
                     try:
                         handler(self.hass, self, schema(msg))
-                    except Exception:  # pylint: disable=bare-except
+                    except Exception:  # pylint: disable=broad-except
                         _LOGGER.exception('Error handling message: %s', msg)
                         self.to_write.put_nowait(error_message(
                             cur_id, ERR_UNKNOWN_ERROR,

--- a/tests/components/test_websocket_api.py
+++ b/tests/components/test_websocket_api.py
@@ -1,6 +1,6 @@
 """Tests for the Home Assistant Websocket API."""
 import asyncio
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 
 from aiohttp import WSMsgType
 from async_timeout import timeout
@@ -539,3 +539,21 @@ async def test_call_service_context_no_user(hass, aiohttp_client):
         assert call.service == 'test_service'
         assert call.data == {'hello': 'world'}
         assert call.context.user_id is None
+
+
+async def test_handler_failing(hass, websocket_client):
+    """Test a command that raises."""
+
+    hass.components.websocket_api.async_register_command(
+        'bla', Mock(side_effect=TypeError),
+        wapi.BASE_COMMAND_MESSAGE_SCHEMA.extend({'type': 'bla'}))
+    await websocket_client.send_json({
+        'id': 5,
+        'type': 'bla',
+    })
+
+    msg = await websocket_client.receive_json()
+    assert msg['id'] == 5
+    assert msg['type'] == wapi.TYPE_RESULT
+    assert not msg['success']
+    assert msg['error']['code'] == wapi.ERR_UNKNOWN_ERROR

--- a/tests/components/test_websocket_api.py
+++ b/tests/components/test_websocket_api.py
@@ -543,7 +543,6 @@ async def test_call_service_context_no_user(hass, aiohttp_client):
 
 async def test_handler_failing(hass, websocket_client):
     """Test a command that raises."""
-
     hass.components.websocket_api.async_register_command(
         'bla', Mock(side_effect=TypeError),
         wapi.BASE_COMMAND_MESSAGE_SCHEMA.extend({'type': 'bla'}))


### PR DESCRIPTION
## Description:
Handle when a websocket message handler is throwing an exception. Before this we would just close the connection, leading to some weird situations where frontend tries to reconnect right away -> bam close again.

**Related issue (if applicable):** @robbiet480 in chat

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
