### PR TITLE
Fix exception during history_stats startup

### DIFF
--- a/homeassistant/components/sensor/history_stats.py
+++ b/homeassistant/components/sensor/history_stats.py
@@ -109,7 +109,7 @@ class HistoryStatsSensor(Entity):
         self.count = None
 
         @callback
-        def start_refresh():
+        def start_refresh(*args):
             """Register state tracking."""
             @callback
             def force_refresh(*args):


### PR DESCRIPTION
## Description:

Move registration of state tracking to after `EVENT_HOMEASSISTANT_START`.

**Related issue (if applicable):** reported by @arsaboo in chat

```
Error doing job: Future exception was never retrieved
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/concurrent/futures/thread.py", line 56, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/srv/homeassistant/lib/python3.6/site-packages/homeassistant/components/sensor/history_stats.py", line 114, in force_refresh
    self.schedule_update_ha_state(True)
  File "/srv/homeassistant/lib/python3.6/site-packages/homeassistant/helpers/entity.py", line 319, in schedule_update_ha_state
    self.hass.add_job(self.async_update_ha_state(force_refresh))
AttributeError: 'NoneType' object has no attribute 'add_job'
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
