### PR TITLE
Add group foundation

### DIFF
--- a/homeassistant/auth/__init__.py
+++ b/homeassistant/auth/__init__.py
@@ -130,13 +130,16 @@ class AuthManager:
             name=name,
             system_generated=True,
             is_active=True,
+            groups=[],
         )
 
     async def async_create_user(self, name: str) -> models.User:
         """Create a user."""
+        group = (await self._store.async_get_groups())[0]
         kwargs = {
             'name': name,
             'is_active': True,
+            'groups': [group]
         }  # type: Dict[str, Any]
 
         if await self._user_should_be_owner():

--- a/homeassistant/auth/auth_store.py
+++ b/homeassistant/auth/auth_store.py
@@ -13,6 +13,7 @@ from . import models
 
 STORAGE_VERSION = 1
 STORAGE_KEY = 'auth'
+INITIAL_GROUP_NAME = 'All Access'
 
 
 class AuthStore:
@@ -28,8 +29,17 @@ class AuthStore:
         """Initialize the auth store."""
         self.hass = hass
         self._users = None  # type: Optional[Dict[str, models.User]]
+        self._groups = None  # type: Optional[Dict[str, models.Group]]
         self._store = hass.helpers.storage.Store(STORAGE_VERSION, STORAGE_KEY,
                                                  private=True)
+
+    async def async_get_groups(self) -> List[models.Group]:
+        """Retrieve all users."""
+        if self._groups is None:
+            await self._async_load()
+            assert self._groups is not None
+
+        return list(self._groups.values())
 
     async def async_get_users(self) -> List[models.User]:
         """Retrieve all users."""
@@ -51,14 +61,20 @@ class AuthStore:
             self, name: Optional[str], is_owner: Optional[bool] = None,
             is_active: Optional[bool] = None,
             system_generated: Optional[bool] = None,
-            credentials: Optional[models.Credentials] = None) -> models.User:
+            credentials: Optional[models.Credentials] = None,
+            groups: Optional[List[models.Group]] = None) -> models.User:
         """Create a new user."""
         if self._users is None:
             await self._async_load()
-            assert self._users is not None
+
+        assert self._users is not None
+        assert self._groups is not None
 
         kwargs = {
-            'name': name
+            'name': name,
+            # Until we get group management, we just put everyone in the
+            # same group.
+            'groups': groups or [],
         }  # type: Dict[str, Any]
 
         if is_owner is not None:
@@ -219,19 +235,36 @@ class AuthStore:
             return
 
         users = OrderedDict()  # type: Dict[str, models.User]
+        groups = OrderedDict()  # type: Dict[str, models.Group]
 
         # When creating objects we mention each attribute explicetely. This
         # prevents crashing if user rolls back HA version after a new property
         # was added.
 
+        for group_dict in data.get('groups', []):
+            groups[group_dict['id']] = models.Group(
+                name=group_dict['name'],
+                id=group_dict['id'],
+            )
+
+        migrate_group = None
+
+        if not groups:
+            migrate_group = models.Group(name=INITIAL_GROUP_NAME)
+            groups[migrate_group.id] = migrate_group
+
         for user_dict in data['users']:
             users[user_dict['id']] = models.User(
                 name=user_dict['name'],
+                groups=[groups[group_id] for group_id
+                        in user_dict.get('group_ids', [])],
                 id=user_dict['id'],
                 is_owner=user_dict['is_owner'],
                 is_active=user_dict['is_active'],
                 system_generated=user_dict['system_generated'],
             )
+            if migrate_group is not None and not user_dict['system_generated']:
+                users[user_dict['id']].groups = [migrate_group]
 
         for cred_dict in data['credentials']:
             users[cred_dict['user_id']].credentials.append(models.Credentials(
@@ -286,6 +319,7 @@ class AuthStore:
             )
             users[rt_dict['user_id']].refresh_tokens[token.id] = token
 
+        self._groups = groups
         self._users = users
 
     @callback
@@ -300,16 +334,26 @@ class AuthStore:
     def _data_to_save(self) -> Dict:
         """Return the data to store."""
         assert self._users is not None
+        assert self._groups is not None
 
         users = [
             {
                 'id': user.id,
+                'group_ids': [group.id for group in user.groups],
                 'is_owner': user.is_owner,
                 'is_active': user.is_active,
                 'name': user.name,
                 'system_generated': user.system_generated,
             }
             for user in self._users.values()
+        ]
+
+        groups = [
+            {
+                'name': group.name,
+                'id': group.id,
+            }
+            for group in self._groups.values()
         ]
 
         credentials = [
@@ -348,6 +392,7 @@ class AuthStore:
 
         return {
             'users': users,
+            'groups': groups,
             'credentials': credentials,
             'refresh_tokens': refresh_tokens,
         }
@@ -355,3 +400,11 @@ class AuthStore:
     def _set_defaults(self) -> None:
         """Set default values for auth store."""
         self._users = OrderedDict()  # type: Dict[str, models.User]
+
+        # Add default group
+        all_access_group = models.Group(name=INITIAL_GROUP_NAME)
+
+        groups = OrderedDict()  # type: Dict[str, models.Group]
+        groups[all_access_group.id] = all_access_group
+
+        self._groups = groups

--- a/homeassistant/auth/models.py
+++ b/homeassistant/auth/models.py
@@ -15,6 +15,14 @@ TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN = 'long_lived_access_token'
 
 
 @attr.s(slots=True)
+class Group:
+    """A group."""
+
+    name = attr.ib(type=str)  # type: Optional[str]
+    id = attr.ib(type=str, factory=lambda: uuid.uuid4().hex)
+
+
+@attr.s(slots=True)
 class User:
     """A user."""
 
@@ -23,6 +31,8 @@ class User:
     is_owner = attr.ib(type=bool, default=False)
     is_active = attr.ib(type=bool, default=False)
     system_generated = attr.ib(type=bool, default=False)
+
+    groups = attr.ib(type=List, factory=list, cmp=False)  # type: List[Group]
 
     # List of credentials of a user.
     credentials = attr.ib(

--- a/homeassistant/components/config/auth.py
+++ b/homeassistant/components/config/auth.py
@@ -92,6 +92,7 @@ def _user_info(user):
         'is_owner': user.is_owner,
         'is_active': user.is_active,
         'system_generated': user.system_generated,
+        'group_ids': [group.id for group in user.groups],
         'credentials': [
             {
                 'type': c.auth_provider_type,

--- a/tests/auth/test_auth_store.py
+++ b/tests/auth/test_auth_store.py
@@ -1,0 +1,82 @@
+"""Tests for the auth store."""
+from homeassistant.auth import auth_store
+
+
+async def test_loading_old_data_format(hass, hass_storage):
+    """Test we correctly load an old data format."""
+    hass_storage[auth_store.STORAGE_KEY] = {
+        'version': 1,
+        'data': {
+            'credentials': [],
+            'users': [
+                {
+                    "id": "user-id",
+                    "is_active": True,
+                    "is_owner": True,
+                    "name": "Paulus",
+                    "system_generated": False,
+                },
+                {
+                    "id": "system-id",
+                    "is_active": True,
+                    "is_owner": True,
+                    "name": "Hass.io",
+                    "system_generated": True,
+                }
+            ],
+            "refresh_tokens": [
+                {
+                    "access_token_expiration": 1800.0,
+                    "client_id": "http://localhost:8123/",
+                    "created_at": "2018-10-03T13:43:19.774637+00:00",
+                    "id": "user-token-id",
+                    "jwt_key": "some-key",
+                    "last_used_at": "2018-10-03T13:43:19.774712+00:00",
+                    "token": "some-token",
+                    "user_id": "user-id"
+                },
+                {
+                    "access_token_expiration": 1800.0,
+                    "client_id": None,
+                    "created_at": "2018-10-03T13:43:19.774637+00:00",
+                    "id": "system-token-id",
+                    "jwt_key": "some-key",
+                    "last_used_at": "2018-10-03T13:43:19.774712+00:00",
+                    "token": "some-token",
+                    "user_id": "system-id"
+                },
+                {
+                    "access_token_expiration": 1800.0,
+                    "client_id": "http://localhost:8123/",
+                    "created_at": "2018-10-03T13:43:19.774637+00:00",
+                    "id": "hidden-because-no-jwt-id",
+                    "last_used_at": "2018-10-03T13:43:19.774712+00:00",
+                    "token": "some-token",
+                    "user_id": "user-id"
+                },
+            ]
+        }
+    }
+
+    store = auth_store.AuthStore(hass)
+    groups = await store.async_get_groups()
+    assert len(groups) == 1
+    group = groups[0]
+    assert group.name == "All Access"
+
+    users = await store.async_get_users()
+    assert len(users) == 2
+
+    owner, system = users
+
+    assert owner.system_generated is False
+    assert owner.groups == [group]
+    assert len(owner.refresh_tokens) == 1
+    owner_token = list(owner.refresh_tokens.values())[0]
+    assert owner_token.id == 'user-token-id'
+
+    assert system.system_generated is True
+    assert system.groups == []
+    assert len(system.refresh_tokens) == 1
+    system_token = list(system.refresh_tokens.values())[0]
+    assert system_token.id == 'system-token-id'

--- a/tests/common.py
+++ b/tests/common.py
@@ -345,17 +345,42 @@ def mock_device_registry(hass, mock_entries=None):
     return registry
 
 
+class MockGroup(auth_models.Group):
+    """Mock a group in Home Assistant."""
+
+    def __init__(self, id=None, name='Mock Group'):
+        """Mock a group."""
+        kwargs = {
+            'name': name
+        }
+        if id is not None:
+            kwargs['id'] = id
+
+        super().__init__(**kwargs)
+
+    def add_to_hass(self, hass):
+        """Test helper to add entry to hass."""
+        return self.add_to_auth_manager(hass.auth)
+
+    def add_to_auth_manager(self, auth_mgr):
+        """Test helper to add entry to hass."""
+        ensure_auth_manager_loaded(auth_mgr)
+        auth_mgr._store._groups[self.id] = self
+        return self
+
+
 class MockUser(auth_models.User):
     """Mock a user in Home Assistant."""
 
     def __init__(self, id=None, is_owner=False, is_active=True,
-                 name='Mock User', system_generated=False):
+                 name='Mock User', system_generated=False, groups=None):
         """Initialize mock user."""
         kwargs = {
             'is_owner': is_owner,
             'is_active': is_active,
             'name': name,
             'system_generated': system_generated,
+            'groups': groups or [],
         }
         if id is not None:
             kwargs['id'] = id


### PR DESCRIPTION
# Don't merge until after beta 0.80 has been cut.

## Description:
This adds the bare minimal foundation for groups. 
Does not add editing of groups, creation of groups, API to fetch groups.

Because it requires a migration of the auth storage, I am also fixing the data to no longer have to do backwards compat checks during normal load.

Architecture issue: https://github.com/home-assistant/architecture/issues/87

Things to note:
 - We are creating one group called "All Access"
 - All non-system generated users will be added to the "All Access" group
 - A new user that is created will also be added to this group
 - ~~This PR includes a migration for the auth storage. This means that users will be unable to rollback to 79 from 80.~~ No longer includes migration

**Related issue (if applicable):** For #16890 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** TODO dev docs update

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
