### PR TITLE
Add unique_id to MQTT cover

### DIFF
--- a/homeassistant/components/cover/mqtt.py
+++ b/homeassistant/components/cover/mqtt.py
@@ -5,6 +5,7 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/cover.mqtt/
 """
 import logging
+from typing import Optional
 
 import voluptuous as vol
 
@@ -49,6 +50,7 @@ CONF_TILT_MIN = 'tilt_min'
 CONF_TILT_MAX = 'tilt_max'
 CONF_TILT_STATE_OPTIMISTIC = 'tilt_optimistic'
 CONF_TILT_INVERT_STATE = 'tilt_invert_state'
+CONF_UNIQUE_ID = 'unique_id'
 
 DEFAULT_NAME = 'MQTT Cover'
 DEFAULT_PAYLOAD_OPEN = 'OPEN'
@@ -93,6 +95,7 @@ PLATFORM_SCHEMA = mqtt.MQTT_BASE_PLATFORM_SCHEMA.extend({
                  default=DEFAULT_TILT_OPTIMISTIC): cv.boolean,
     vol.Optional(CONF_TILT_INVERT_STATE,
                  default=DEFAULT_TILT_INVERT_STATE): cv.boolean,
+    vol.Optional(CONF_UNIQUE_ID): cv.string,
 }).extend(mqtt.MQTT_AVAILABILITY_SCHEMA.schema)
 
 
@@ -151,6 +154,7 @@ async def _async_setup_entity(hass, config, async_add_entities,
         config.get(CONF_TILT_INVERT_STATE),
         config.get(CONF_POSITION_TOPIC),
         set_position_template,
+        config.get(CONF_UNIQUE_ID),
         discovery_hash
     )])
 
@@ -165,7 +169,7 @@ class MqttCover(MqttAvailability, MqttDiscoveryUpdate, CoverDevice):
                  optimistic, value_template, tilt_open_position,
                  tilt_closed_position, tilt_min, tilt_max, tilt_optimistic,
                  tilt_invert, position_topic, set_position_template,
-                 discovery_hash):
+                 unique_id: Optional[str], discovery_hash):
         """Initialize the cover."""
         MqttAvailability.__init__(self, availability_topic, qos,
                                   payload_available, payload_not_available)
@@ -195,6 +199,7 @@ class MqttCover(MqttAvailability, MqttDiscoveryUpdate, CoverDevice):
         self._tilt_invert = tilt_invert
         self._position_topic = position_topic
         self._set_position_template = set_position_template
+        self._unique_id = unique_id
         self._discovery_hash = discovery_hash
 
     async def async_added_to_hass(self):
@@ -412,3 +417,8 @@ class MqttCover(MqttAvailability, MqttDiscoveryUpdate, CoverDevice):
         if self._tilt_invert:
             position = self._tilt_max - position + offset
         return position
+
+    @property
+    def unique_id(self):
+        """Return a unique ID."""
+        return self._unique_id

--- a/tests/components/cover/test_mqtt.py
+++ b/tests/components/cover/test_mqtt.py
@@ -614,7 +614,8 @@ class TestCoverMQTT(unittest.TestCase):
             'cover.test', 'state-topic', 'command-topic', None,
             'tilt-command-topic', 'tilt-status-topic', 0, False,
             'OPEN', 'CLOSE', 'OPEN', 'CLOSE', 'STOP', None, None,
-            False, None, 100, 0, 0, 100, False, False, None, None, None)
+            False, None, 100, 0, 0, 100, False, False, None, None, None,
+            None)
 
         self.assertEqual(44, mqtt_cover.find_percentage_in_range(44))
 
@@ -624,7 +625,8 @@ class TestCoverMQTT(unittest.TestCase):
             'cover.test', 'state-topic', 'command-topic', None,
             'tilt-command-topic', 'tilt-status-topic', 0, False,
             'OPEN', 'CLOSE', 'OPEN', 'CLOSE', 'STOP', None, None,
-            False, None, 180, 80, 80, 180, False, False, None, None, None)
+            False, None, 180, 80, 80, 180, False, False, None, None, None,
+            None)
 
         self.assertEqual(40, mqtt_cover.find_percentage_in_range(120))
 
@@ -634,7 +636,8 @@ class TestCoverMQTT(unittest.TestCase):
             'cover.test', 'state-topic', 'command-topic', None,
             'tilt-command-topic', 'tilt-status-topic', 0, False,
             'OPEN', 'CLOSE', 'OPEN', 'CLOSE', 'STOP', None, None,
-            False, None, 100, 0, 0, 100, False, True, None, None, None)
+            False, None, 100, 0, 0, 100, False, True, None, None, None,
+            None)
 
         self.assertEqual(56, mqtt_cover.find_percentage_in_range(44))
 
@@ -644,7 +647,8 @@ class TestCoverMQTT(unittest.TestCase):
             'cover.test', 'state-topic', 'command-topic', None,
             'tilt-command-topic', 'tilt-status-topic', 0, False,
             'OPEN', 'CLOSE', 'OPEN', 'CLOSE', 'STOP', None, None,
-            False, None, 180, 80, 80, 180, False, True, None, None, None)
+            False, None, 180, 80, 80, 180, False, True, None, None, None,
+            None)
 
         self.assertEqual(60, mqtt_cover.find_percentage_in_range(120))
 
@@ -654,7 +658,8 @@ class TestCoverMQTT(unittest.TestCase):
             'cover.test', 'state-topic', 'command-topic', None,
             'tilt-command-topic', 'tilt-status-topic', 0, False,
             'OPEN', 'CLOSE', 'OPEN', 'CLOSE', 'STOP', None, None,
-            False, None, 100, 0, 0, 100, False, False, None, None, None)
+            False, None, 100, 0, 0, 100, False, False, None, None, None,
+            None)
 
         self.assertEqual(44, mqtt_cover.find_in_range_from_percent(44))
 
@@ -664,7 +669,8 @@ class TestCoverMQTT(unittest.TestCase):
             'cover.test', 'state-topic', 'command-topic', None,
             'tilt-command-topic', 'tilt-status-topic', 0, False,
             'OPEN', 'CLOSE', 'OPEN', 'CLOSE', 'STOP', None, None,
-            False, None, 180, 80, 80, 180, False, False, None, None, None)
+            False, None, 180, 80, 80, 180, False, False, None, None, None,
+            None)
 
         self.assertEqual(120, mqtt_cover.find_in_range_from_percent(40))
 
@@ -674,7 +680,8 @@ class TestCoverMQTT(unittest.TestCase):
             'cover.test', 'state-topic', 'command-topic', None,
             'tilt-command-topic', 'tilt-status-topic', 0, False,
             'OPEN', 'CLOSE', 'OPEN', 'CLOSE', 'STOP', None, None,
-            False, None, 100, 0, 0, 100, False, True, None, None, None)
+            False, None, 100, 0, 0, 100, False, True, None, None, None,
+            None)
 
         self.assertEqual(44, mqtt_cover.find_in_range_from_percent(56))
 
@@ -684,7 +691,8 @@ class TestCoverMQTT(unittest.TestCase):
             'cover.test', 'state-topic', 'command-topic', None,
             'tilt-command-topic', 'tilt-status-topic', 0, False,
             'OPEN', 'CLOSE', 'OPEN', 'CLOSE', 'STOP', None, None,
-            False, None, 180, 80, 80, 180, False, True, None, None, None)
+            False, None, 180, 80, 80, 180, False, True, None, None, None,
+            None)
 
         self.assertEqual(120, mqtt_cover.find_in_range_from_percent(60))
 


### PR DESCRIPTION
## Description:

Add unique_id to MQTT cover. See #16949

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#6373

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.
