### PR TITLE
Fix unique_id of NestActivityZoneSensor

### DIFF
--- a/homeassistant/components/binary_sensor/nest.py
+++ b/homeassistant/components/binary_sensor/nest.py
@@ -148,6 +148,11 @@ class NestActivityZoneSensor(NestBinarySensor):
         self._name = "{} {} activity".format(self._name, self.zone.name)
 
     @property
+    def unique_id(self):
+        """Return unique id based on camera serial and zone id."""
+        return "{}-{}".format(self.device.serial, self.zone.zone_id)
+
+    @property
     def device_class(self):
         """Return the device class of the binary sensor."""
         return 'motion'


### PR DESCRIPTION
## Description:

`unique_id` of NestActivityZoneSensor should include `zone_id` 

**Note:**
If you have met problem in 0.79 because you have multiple activity zone in one camera, you will get one "Unavailable" entity under integration overview page. Unfortunately there is no easy way to delete that from UI for now. You can use one of following method to remove it
- modify `[YOUR_CONFIG_FOLDER]/.storage/core.entity_registry` file, to remove the "Unavailable" entity 
- delete `[YOUR_CONFIG_FOLDER]/.storage/core.entity_registry` file


**Related issue (if applicable):** fixes #16945

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

