### PR TITLE
Increase timeout value for async Hue bridge update

### DIFF
--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -164,7 +164,7 @@ async def async_update_items(hass, bridge, async_add_entities,
         api = bridge.api.lights
 
     try:
-        with async_timeout.timeout(4):
+        with async_timeout.timeout(30):
             await api.update()
     except (asyncio.TimeoutError, aiohue.AiohueException):
         if not bridge.available:


### PR DESCRIPTION
## Description:

Increase timeout value for async Hue bridge update to mitigate "Unable to reach bridge" errors.

**Related issue (if applicable):** fixes or mitigates #16689

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable): n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
