### PR TITLE
Fix ISY blocking bug

### DIFF
--- a/homeassistant/components/light/isy994.py
+++ b/homeassistant/components/light/isy994.py
@@ -31,12 +31,14 @@ class ISYLightDevice(ISYDevice, Light):
     @property
     def is_on(self) -> bool:
         """Get whether the ISY994 light is on."""
+        if self.is_unknown():
+            return False
         return self.value != 0
 
     @property
     def brightness(self) -> float:
         """Get the brightness of the ISY994 light."""
-        return self.value
+        return None if self.is_unknown() else self.value
 
     def turn_off(self, **kwargs) -> None:
         """Send the turn off command to the ISY994 light device."""


### PR DESCRIPTION
## Description:
This fix results in `is_on` returning False if the state is unknown (which was a bug in 0.79).

I also added a guard to ensure that brightness will return None if the state is unknown (see below for explanation.)

The cascading effect of this bug is interesting:
1. `is_on` was returning `True` when the state was unknown.
2. This caused brightness to be requested for unknown state lights, when in previous versions this would never happen.
3. Due to internal ways that the ISY component works, an unknown state's brightness would return `-inf` (negative infinity)
4. The JSON serializer (I presume) would then create JSON for the frontend that included `"brightness": -Infinity`, which is **invalid JSON** and would cause the frontend to entirely crash on load.

Item 4 above is evidence that we have a Core bug that passes broken JSON to the frontend if the data includes a value of `-inf`. This is presumably quite a rate occurrence as -inf is probably not used very often, but it seems like it warrants fixing anyway. It was quite challenging tracking down the root cause here!

**Related issue (if applicable):** fixes #16966

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.
