### PR TITLE
Bump zm-py to 0.0.4

### DIFF
--- a/homeassistant/components/zoneminder.py
+++ b/homeassistant/components/zoneminder.py
@@ -15,7 +15,7 @@ import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['zm-py==0.0.3']
+REQUIREMENTS = ['zm-py==0.0.4']
 
 CONF_PATH_ZMS = 'path_zms'
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1574,4 +1574,4 @@ zigpy-xbee==0.1.1
 zigpy==0.2.0
 
 # homeassistant.components.zoneminder
-zm-py==0.0.3
+zm-py==0.0.4


### PR DESCRIPTION
## Description:
Bump up zm-py to 0.0.4 to fix some bugs. If a hotfix is released for 0.79, this should be included in it.

**Related issue (if applicable):** fixes #16829 #16944 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
