### PR TITLE
0.79.1

### DIFF
--- a/homeassistant/components/binary_sensor/nest.py
+++ b/homeassistant/components/binary_sensor/nest.py
@@ -148,6 +148,11 @@ class NestActivityZoneSensor(NestBinarySensor):
         self._name = "{} {} activity".format(self._name, self.zone.name)
 
     @property
+    def unique_id(self):
+        """Return unique id based on camera serial and zone id."""
+        return "{}-{}".format(self.device.serial, self.zone.zone_id)
+
+    @property
     def device_class(self):
         """Return the device class of the binary sensor."""
         return 'motion'

--- a/homeassistant/components/binary_sensor/ring.py
+++ b/homeassistant/components/binary_sensor/ring.py
@@ -44,14 +44,15 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     ring = hass.data[DATA_RING]
 
     sensors = []
-    for sensor_type in config.get(CONF_MONITORED_CONDITIONS):
-        for device in ring.doorbells:
+    for device in ring.doorbells:  # ring.doorbells is doing I/O
+        for sensor_type in config[CONF_MONITORED_CONDITIONS]:
             if 'doorbell' in SENSOR_TYPES[sensor_type][1]:
                 sensors.append(RingBinarySensor(hass,
                                                 device,
                                                 sensor_type))
 
-        for device in ring.stickup_cams:
+    for device in ring.stickup_cams:  # ring.stickup_cams is doing I/O
+        for sensor_type in config[CONF_MONITORED_CONDITIONS]:
             if 'stickup_cams' in SENSOR_TYPES[sensor_type][1]:
                 sensors.append(RingBinarySensor(hass,
                                                 device,

--- a/homeassistant/components/light/isy994.py
+++ b/homeassistant/components/light/isy994.py
@@ -31,12 +31,14 @@ class ISYLightDevice(ISYDevice, Light):
     @property
     def is_on(self) -> bool:
         """Get whether the ISY994 light is on."""
+        if self.is_unknown():
+            return False
         return self.value != 0
 
     @property
     def brightness(self) -> float:
         """Get the brightness of the ISY994 light."""
-        return self.value
+        return None if self.is_unknown() else self.value
 
     def turn_off(self, **kwargs) -> None:
         """Send the turn off command to the ISY994 light device."""

--- a/homeassistant/components/sensor/ring.py
+++ b/homeassistant/components/sensor/ring.py
@@ -66,16 +66,18 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     ring = hass.data[DATA_RING]
 
     sensors = []
-    for sensor_type in config.get(CONF_MONITORED_CONDITIONS):
-        for device in ring.chimes:
+    for device in ring.chimes:  # ring.chimes is doing I/O
+        for sensor_type in config[CONF_MONITORED_CONDITIONS]:
             if 'chime' in SENSOR_TYPES[sensor_type][1]:
                 sensors.append(RingSensor(hass, device, sensor_type))
 
-        for device in ring.doorbells:
+    for device in ring.doorbells:  # ring.doorbells is doing I/O
+        for sensor_type in config[CONF_MONITORED_CONDITIONS]:
             if 'doorbell' in SENSOR_TYPES[sensor_type][1]:
                 sensors.append(RingSensor(hass, device, sensor_type))
 
-        for device in ring.stickup_cams:
+    for device in ring.stickup_cams:  # ring.stickup_cams is doing I/O
+        for sensor_type in config[CONF_MONITORED_CONDITIONS]:
             if 'stickup_cams' in SENSOR_TYPES[sensor_type][1]:
                 sensors.append(RingSensor(hass, device, sensor_type))
 

--- a/homeassistant/components/zoneminder.py
+++ b/homeassistant/components/zoneminder.py
@@ -15,7 +15,7 @@ import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['zm-py==0.0.3']
+REQUIREMENTS = ['zm-py==0.0.4']
 
 CONF_PATH_ZMS = 'path_zms'
 

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -2,7 +2,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 79
-PATCH_VERSION = '0'
+PATCH_VERSION = '1'
 __short_version__ = '{}.{}'.format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = '{}.{}'.format(__short_version__, PATCH_VERSION)
 REQUIRED_PYTHON_VER = (3, 5, 3)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1567,4 +1567,4 @@ zigpy-xbee==0.1.1
 zigpy==0.2.0
 
 # homeassistant.components.zoneminder
-zm-py==0.0.3
+zm-py==0.0.4


### PR DESCRIPTION
- Optimize Ring Sensors platform setup ([@awarecan] - [#16886]) ([binary_sensor.ring docs]) ([sensor.ring docs])
- Fix exception during history_stats startup ([@amelchio] - [#16932]) ([sensor.history_stats docs])
- Override unique_id of NestActivityZoneSensor ([@awarecan] - [#16961]) ([binary_sensor.nest docs])
- Fix ISY blocking bug ([@OverloadUT] - [#16978]) ([light.isy994 docs])
- Bump zm-py to 0.0.4 ([@rohankapoorcom] - [#16979]) ([zoneminder docs])

[#16886]: https://github.com/home-assistant/home-assistant/pull/16886
[#16932]: https://github.com/home-assistant/home-assistant/pull/16932
[#16961]: https://github.com/home-assistant/home-assistant/pull/16961
[#16978]: https://github.com/home-assistant/home-assistant/pull/16978
[#16979]: https://github.com/home-assistant/home-assistant/pull/16979
[@OverloadUT]: https://github.com/OverloadUT
[@amelchio]: https://github.com/amelchio
[@awarecan]: https://github.com/awarecan
[@rohankapoorcom]: https://github.com/rohankapoorcom
[binary_sensor.nest docs]: https://www.home-assistant.io/components/binary_sensor.nest/
[binary_sensor.ring docs]: https://www.home-assistant.io/components/binary_sensor.ring/
[light.isy994 docs]: https://www.home-assistant.io/components/light.isy994/
[sensor.history_stats docs]: https://www.home-assistant.io/components/sensor.history_stats/
[sensor.ring docs]: https://www.home-assistant.io/components/sensor.ring/
[zoneminder docs]: https://www.home-assistant.io/components/zoneminder/