### PR TITLE
Fix MQTT certificates

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -426,24 +426,21 @@ async def async_setup_entry(hass, entry):
     keepalive = conf[CONF_KEEPALIVE]
     username = conf.get(CONF_USERNAME)
     password = conf.get(CONF_PASSWORD)
+    certificate = conf.get(CONF_CERTIFICATE)
     client_key = conf.get(CONF_CLIENT_KEY)
     client_cert = conf.get(CONF_CLIENT_CERT)
     tls_insecure = conf.get(CONF_TLS_INSECURE)
     protocol = conf[CONF_PROTOCOL]
 
     # For cloudmqtt.com, secured connection, auto fill in certificate
-    if (conf.get(CONF_CERTIFICATE) is None and
-            19999 < conf[CONF_PORT] < 30000 and
-            conf[CONF_BROKER].endswith('.cloudmqtt.com')):
+    if (certificate is None and 19999 < conf[CONF_PORT] < 30000 and
+            broker.endswith('.cloudmqtt.com')):
         certificate = os.path.join(
             os.path.dirname(__file__), 'addtrustexternalcaroot.crt')
 
     # When the certificate is set to auto, use bundled certs from requests
-    elif conf.get(CONF_CERTIFICATE) == 'auto':
+    elif certificate == 'auto':
         certificate = requests.certs.where()
-
-    else:
-        certificate = None
 
     if CONF_WILL_MESSAGE in conf:
         will_message = Message(**conf[CONF_WILL_MESSAGE])


### PR DESCRIPTION
## Description:
Fix loading MQTT certificates

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/16964

## Example entry for `configuration.yaml` (if applicable):
```yaml
mqtt:
  broker: localhost
  port: 8883
  username: USERNAME
  password: PASSWORD
  tls_insecure: true
  certificate: PATH_TO_MQTT_SERVER_CERTIFICATE
```
