### PR TITLE
Homematic cloud device update fix

### DIFF
--- a/homeassistant/components/homematicip_cloud/device.py
+++ b/homeassistant/components/homematicip_cloud/device.py
@@ -36,7 +36,7 @@ class HomematicipGenericDevice(Entity):
         """Register callbacks."""
         self._device.on_update(self._device_changed)
 
-    def _device_changed(self, json, **kwargs):
+    def _device_changed(self, *args, **kwargs):
         """Handle device state changes."""
         _LOGGER.debug("Event %s (%s)", self.name, self._device.modelType)
         self.async_schedule_update_ha_state()


### PR DESCRIPTION
## Description:
Undating a device throws an error missing a keyword argument.

**Related issue (if applicable):** fixes #17000

https://github.com/home-assistant/home-assistant/issues/17000

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

