### PR TITLE
Add basic support for Tradfri switches

### DIFF
--- a/homeassistant/components/sensor/tradfri.py
+++ b/homeassistant/components/sensor/tradfri.py
@@ -26,7 +26,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     devices_commands = await api(gateway.get_devices())
     all_devices = await api(devices_commands)
-    devices = (dev for dev in all_devices if not dev.has_light_control)
+    devices = (dev for dev in all_devices if not dev.has_light_control and
+               not dev.has_socket_control)
     async_add_entities(TradfriDevice(device, api) for device in devices)
 
 

--- a/homeassistant/components/switch/tradfri.py
+++ b/homeassistant/components/switch/tradfri.py
@@ -7,10 +7,7 @@ https://home-assistant.io/components/switch.tradfri/
 import logging
 
 from homeassistant.core import callback
-from homeassistant.components.switch import (
-    SwitchDevice,
-    PLATFORM_SCHEMA
-)
+from homeassistant.components.switch import SwitchDevice
 from homeassistant.components.tradfri import (
     KEY_GATEWAY, KEY_API, DOMAIN as TRADFRI_DOMAIN)
 from homeassistant.components.tradfri.const import (

--- a/homeassistant/components/switch/tradfri.py
+++ b/homeassistant/components/switch/tradfri.py
@@ -1,0 +1,142 @@
+"""
+Support for the IKEA Tradfri platform.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/switch.tradfri/
+"""
+import logging
+
+from homeassistant.core import callback
+from homeassistant.components.switch import (
+    SwitchDevice,
+    PLATFORM_SCHEMA as SWITCH_PLATFORM_SCHEMA
+)
+from homeassistant.components.tradfri import (
+    KEY_GATEWAY, KEY_API, DOMAIN as TRADFRI_DOMAIN)
+from homeassistant.components.tradfri.const import (
+    CONF_GATEWAY_ID)
+
+_LOGGER = logging.getLogger(__name__)
+
+DEPENDENCIES = ['tradfri']
+PLATFORM_SCHEMA = SWITCH_PLATFORM_SCHEMA
+IKEA = 'IKEA of Sweden'
+TRADFRI_SWITCH_MANAGER = 'Tradfri Switch Manager'
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Load Tradfri switchs based on a config entry."""
+    gateway_id = config_entry.data[CONF_GATEWAY_ID]
+    api = hass.data[KEY_API][config_entry.entry_id]
+    gateway = hass.data[KEY_GATEWAY][config_entry.entry_id]
+
+    devices_commands = await api(gateway.get_devices())
+    devices = await api(devices_commands)
+    switches = [dev for dev in devices if dev.has_socket_control]
+    if switches:
+        async_add_entities(
+            TradfriSwitch(switch, api, gateway_id) for switch in switches)
+
+
+class TradfriSwitch(SwitchDevice):
+    """The platform class required by Home Assistant."""
+
+    def __init__(self, switch, api, gateway_id):
+        """Initialize a switch."""
+        self._api = api
+        self._unique_id = "switch-{}-{}".format(gateway_id, switch.id)
+        self._switch = None
+        self._socket_control = None
+        self._switch_data = None
+        self._name = None
+        self._available = True
+        self._gateway_id = gateway_id
+
+        self._refresh(switch)
+
+    @property
+    def unique_id(self):
+        """Return unique ID for switch."""
+        return self._unique_id
+
+    @property
+    def device_info(self):
+        """Return the device info."""
+        info = self._switch.device_info
+
+        return {
+            'identifiers': {
+                (TRADFRI_DOMAIN, self._switch.id)
+            },
+            'name': self._name,
+            'manufacturer': info.manufacturer,
+            'model': info.model_number,
+            'sw_version': info.firmware_version,
+            'via_hub': (TRADFRI_DOMAIN, self._gateway_id),
+        }
+
+    async def async_added_to_hass(self):
+        """Start thread when added to hass."""
+        self._async_start_observe()
+
+    @property
+    def available(self):
+        """Return True if entity is available."""
+        return self._available
+
+    @property
+    def should_poll(self):
+        """No polling needed for tradfri switch."""
+        return False
+
+    @property
+    def name(self):
+        """Return the display name of this switch."""
+        return self._name
+
+    @property
+    def is_on(self):
+        """Return true if switch is on."""
+        return self._switch_data.state
+
+    async def async_turn_off(self, **kwargs):
+        """Instruct the switch to turn off."""
+        await self._api(self._socket_control.set_state(False))
+
+    async def async_turn_on(self, **kwargs):
+        """Instruct the switch to turn on."""
+        await self._api(self._socket_control.set_state(True))
+
+    @callback
+    def _async_start_observe(self, exc=None):
+        """Start observation of switch."""
+        # pylint: disable=import-error
+        from pytradfri.error import PytradfriError
+        if exc:
+            _LOGGER.warning("Observation failed for %s", self._name,
+                            exc_info=exc)
+
+        try:
+            cmd = self._switch.observe(callback=self._observe_update,
+                                       err_callback=self._async_start_observe,
+                                       duration=0)
+            self.hass.async_add_job(self._api(cmd))
+        except PytradfriError as err:
+            _LOGGER.warning("Observation failed, trying again", exc_info=err)
+            self._async_start_observe()
+
+    def _refresh(self, switch):
+        """Refresh the switch data."""
+        self._switch = switch
+
+        # Caching of switchControl and switch object
+        self._available = switch.reachable
+        self._socket_control = switch.socket_control
+        self._switch_data = switch.socket_control.sockets[0]
+        self._name = switch.name
+
+    @callback
+    def _observe_update(self, tradfri_device):
+        """Receive new state data for this switch."""
+        self._refresh(tradfri_device)
+        self.async_schedule_update_ha_state()

--- a/homeassistant/components/switch/tradfri.py
+++ b/homeassistant/components/switch/tradfri.py
@@ -106,7 +106,6 @@ class TradfriSwitch(SwitchDevice):
     @callback
     def _async_start_observe(self, exc=None):
         """Start observation of switch."""
-        # pylint: disable=import-error
         from pytradfri.error import PytradfriError
         if exc:
             _LOGGER.warning("Observation failed for %s", self._name,

--- a/homeassistant/components/switch/tradfri.py
+++ b/homeassistant/components/switch/tradfri.py
@@ -43,7 +43,7 @@ class TradfriSwitch(SwitchDevice):
     def __init__(self, switch, api, gateway_id):
         """Initialize a switch."""
         self._api = api
-        self._unique_id = "switch-{}-{}".format(gateway_id, switch.id)
+        self._unique_id = "{}-{}".format(gateway_id, switch.id)
         self._switch = None
         self._socket_control = None
         self._switch_data = None

--- a/homeassistant/components/switch/tradfri.py
+++ b/homeassistant/components/switch/tradfri.py
@@ -21,7 +21,7 @@ TRADFRI_SWITCH_MANAGER = 'Tradfri Switch Manager'
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
-    """Load Tradfri switchs based on a config entry."""
+    """Load Tradfri switches based on a config entry."""
     gateway_id = config_entry.data[CONF_GATEWAY_ID]
     api = hass.data[KEY_API][config_entry.entry_id]
     gateway = hass.data[KEY_GATEWAY][config_entry.entry_id]

--- a/homeassistant/components/switch/tradfri.py
+++ b/homeassistant/components/switch/tradfri.py
@@ -119,7 +119,7 @@ class TradfriSwitch(SwitchDevice):
             cmd = self._switch.observe(callback=self._observe_update,
                                        err_callback=self._async_start_observe,
                                        duration=0)
-            self.hass.async_add_job(self._api(cmd))
+            self.hass.async_create_task(self._api(cmd))
         except PytradfriError as err:
             _LOGGER.warning("Observation failed, trying again", exc_info=err)
             self._async_start_observe()

--- a/homeassistant/components/switch/tradfri.py
+++ b/homeassistant/components/switch/tradfri.py
@@ -9,7 +9,7 @@ import logging
 from homeassistant.core import callback
 from homeassistant.components.switch import (
     SwitchDevice,
-    PLATFORM_SCHEMA as SWITCH_PLATFORM_SCHEMA
+    PLATFORM_SCHEMA
 )
 from homeassistant.components.tradfri import (
     KEY_GATEWAY, KEY_API, DOMAIN as TRADFRI_DOMAIN)
@@ -19,7 +19,6 @@ from homeassistant.components.tradfri.const import (
 _LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = ['tradfri']
-PLATFORM_SCHEMA = SWITCH_PLATFORM_SCHEMA
 IKEA = 'IKEA of Sweden'
 TRADFRI_SWITCH_MANAGER = 'Tradfri Switch Manager'
 

--- a/homeassistant/components/tradfri/__init__.py
+++ b/homeassistant/components/tradfri/__init__.py
@@ -119,8 +119,8 @@ async def async_setup_entry(hass, entry):
     hass.async_create_task(hass.config_entries.async_forward_entry_setup(
         entry, 'sensor'
     ))
-#    hass.async_create_task(hass.config_entries.async_forward_entry_setup(
-#        entry, 'switch'
-#    ))
+    hass.async_create_task(hass.config_entries.async_forward_entry_setup(
+        entry, 'switch'
+    ))
 
     return True

--- a/homeassistant/components/tradfri/__init__.py
+++ b/homeassistant/components/tradfri/__init__.py
@@ -17,7 +17,7 @@ from .const import (
 
 from . import config_flow  # noqa  pylint_disable=unused-import
 
-REQUIREMENTS = ['pytradfri[async]==5.5.1']
+REQUIREMENTS = ['pytradfri[async]==5.6.0']
 
 DOMAIN = 'tradfri'
 CONFIG_FILE = '.tradfri_psk.conf'
@@ -119,5 +119,8 @@ async def async_setup_entry(hass, entry):
     hass.async_create_task(hass.config_entries.async_forward_entry_setup(
         entry, 'sensor'
     ))
+#    hass.async_create_task(hass.config_entries.async_forward_entry_setup(
+#        entry, 'switch'
+#    ))
 
     return True

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1214,7 +1214,7 @@ pytouchline==0.7
 pytrackr==0.0.5
 
 # homeassistant.components.tradfri
-pytradfri[async]==5.5.1
+pytradfri[async]==5.6.0
 
 # homeassistant.components.sensor.trafikverket_weatherstation
 pytrafikverket==0.1.5.8

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -189,7 +189,7 @@ python-nest==4.0.3
 pythonwhois==2.4.3
 
 # homeassistant.components.tradfri
-pytradfri[async]==5.5.1
+pytradfri[async]==5.6.0
 
 # homeassistant.components.device_tracker.unifi
 pyunifi==2.13


### PR DESCRIPTION
## Description:
IKEA has released new wall switches. Support was added to pytradfri in 5.6.0 and the purpose of this PR is to add support to Home Assistant.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>
Fixes #16608

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#6392

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
