### PR TITLE
Fix the sabnzbd component api error

### DIFF
--- a/homeassistant/components/sabnzbd.py
+++ b/homeassistant/components/sabnzbd.py
@@ -19,7 +19,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.util.json import load_json, save_json
 
-REQUIREMENTS = ['pysabnzbd==1.0.1']
+REQUIREMENTS = ['pysabnzbd==1.1.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sabnzbd.py
+++ b/homeassistant/components/sabnzbd.py
@@ -15,6 +15,7 @@ from homeassistant.const import (
     CONF_HOST, CONF_API_KEY, CONF_NAME, CONF_PORT, CONF_SENSORS, CONF_SSL)
 from homeassistant.core import callback
 from homeassistant.helpers import discovery
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.util.json import load_json, save_json
@@ -102,7 +103,8 @@ async def async_configure_sabnzbd(hass, config, use_ssl, name=DEFAULT_NAME,
                                         hass.config.path(CONFIG_FILE))
         api_key = conf.get(base_url, {}).get(CONF_API_KEY, '')
 
-    sab_api = SabnzbdApi(base_url, api_key)
+    sab_api = SabnzbdApi(base_url, api_key,
+                         session=async_get_clientsession(hass))
     if await async_check_sabnzbd(sab_api):
         async_setup_sabnzbd(hass, sab_api, config, name)
     else:
@@ -188,7 +190,8 @@ def async_request_configuration(hass, config, host):
     async def async_configuration_callback(data):
         """Handle configuration changes."""
         api_key = data.get(CONF_API_KEY)
-        sab_api = SabnzbdApi(host, api_key)
+        sab_api = SabnzbdApi(host, api_key,
+                             session=async_get_clientsession(hass))
         if not await async_check_sabnzbd(sab_api):
             return
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1046,7 +1046,7 @@ pyqwikswitch==0.8
 pyrainbird==0.1.6
 
 # homeassistant.components.sabnzbd
-pysabnzbd==1.0.1
+pysabnzbd==1.1.0
 
 # homeassistant.components.climate.sensibo
 pysensibo==1.0.3


### PR DESCRIPTION
Fixes an error that was caused when communicating with the sabnzbd API due to the fact that the path was not specified.

## Description:

When trying to connect to a sabnzbd instance, homeassistant was trying to connect to a bogus url namely `http://hostname:8080//api` when it should be attempting to hit `http://hostname:8080/sabnzbd/api`. This is because [pysabnzbd expects a `web_root` parameter](https://github.com/jeradM/pysabnzbd/blob/master/pysabnzbd/__init__.py#L8) that defaults to `''` (which seems silly to me... going to submit another PR for that too). Since the web root used by sabnzbd is `/sabnzbd/` we need to pass that to the library for it to connect correctly.

This PR fixes the functionality so that the API (and by extension component) now works.

**Related issue:** partially fixes #13767 (only the last comment)

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

