### PR TITLE
Add Verizon Fios Quantum Gateway device_tracker platform

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -472,6 +472,7 @@ omit =
     homeassistant/components/device_tracker/netgear.py
     homeassistant/components/device_tracker/nmap_tracker.py
     homeassistant/components/device_tracker/ping.py
+    homeassistant/components/device_tracker/quantum_gateway.py
     homeassistant/components/device_tracker/ritassist.py
     homeassistant/components/device_tracker/sky_hub.py
     homeassistant/components/device_tracker/snmp.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -51,6 +51,7 @@ homeassistant/components/cover/group.py @cdce8p
 homeassistant/components/cover/template.py @PhracturedBlue
 homeassistant/components/device_tracker/automatic.py @armills
 homeassistant/components/device_tracker/huawei_router.py @abmantis
+homeassistant/components/device_tracker/quantum_gateway.py @cisasteelersfan
 homeassistant/components/device_tracker/tile.py @bachya
 homeassistant/components/history_graph.py @andrey-git
 homeassistant/components/light/lifx.py @amelchio

--- a/homeassistant/components/device_tracker/quantum_gateway.py
+++ b/homeassistant/components/device_tracker/quantum_gateway.py
@@ -1,9 +1,11 @@
+"""
+Support for Verizon FiOS Quantum Gatewaysself.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/device_tracker.quantum_gateway/
+"""
 import logging
 
-import hashlib
-from http.cookies import SimpleCookie
-import json
-import requests
 import voluptuous as vol
 
 from homeassistant.components.device_tracker import (DOMAIN, PLATFORM_SCHEMA,
@@ -23,29 +25,35 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 
 def get_scanner(hass, config):
+    """Validate the configuration and return a Quantum Gateway scanner."""
     scanner = QuantumGatewayDeviceScanner(config[DOMAIN])
 
     return scanner if scanner.success_init else None
 
 
 class QuantumGatewayDeviceScanner(DeviceScanner):
+    """This class queries a Quantum Gateway."""
 
     def __init__(self, config):
+        """Initialize the scanner."""
         from quantum_gateway import QuantumGatewayScanner
-        
+
         self.host = config[CONF_HOST]
         self.password = config[CONF_PASSWORD]
-        _LOGGER.info("Initializing")
+        _LOGGER.debug("Initializing")
 
         self.quantum = QuantumGatewayScanner(self.host, self.password)
 
         self.success_init = self.quantum.success_init
 
         if not self.success_init:
-            _LOGGER.error("Unable to login to gateway. Check password and host.")
+            _LOGGER.error("Unable to login to gateway. Check password and "
+                          "host.")
 
     def scan_devices(self):
+        """Scan for new devices and return a list of found MACs."""
         return self.quantum.scan_devices()
 
     def get_device_name(self, device):
+        """Return the name of the given device or None if we don't know."""
         return self.quantum.get_device_name(device)

--- a/homeassistant/components/device_tracker/quantum_gateway.py
+++ b/homeassistant/components/device_tracker/quantum_gateway.py
@@ -6,6 +6,7 @@ https://home-assistant.io/components/device_tracker.quantum_gateway/
 """
 import logging
 
+from requests.exceptions import RequestException
 import voluptuous as vol
 
 from homeassistant.components.device_tracker import (DOMAIN, PLATFORM_SCHEMA,
@@ -45,10 +46,9 @@ class QuantumGatewayDeviceScanner(DeviceScanner):
         try:
             self.quantum = QuantumGatewayScanner(self.host, self.password)
             self.success_init = self.quantum.success_init
-        except:
+        except RequestException:
             self.success_init = False
             _LOGGER.error("Unable to connect to gateway. Check host.")
-
 
         if not self.success_init:
             _LOGGER.error("Unable to login to gateway. Check password and "
@@ -59,10 +59,9 @@ class QuantumGatewayDeviceScanner(DeviceScanner):
         connected_devices = []
         try:
             connected_devices = self.quantum.scan_devices()
-        except:
+        except RequestException:
             _LOGGER.error("Unable to scan devices. Check connection to router")
         return connected_devices
-
 
     def get_device_name(self, device):
         """Return the name of the given device or None if we don't know."""

--- a/homeassistant/components/device_tracker/quantum_gateway.py
+++ b/homeassistant/components/device_tracker/quantum_gateway.py
@@ -40,7 +40,7 @@ class QuantumGatewayDeviceScanner(DeviceScanner):
 
         self.host = config[CONF_HOST]
         self.password = config[CONF_PASSWORD]
-        _LOGGER.debug("Initializing")
+        _LOGGER.debug('Initializing')
 
         self.quantum = QuantumGatewayScanner(self.host, self.password)
 

--- a/homeassistant/components/device_tracker/quantum_gateway.py
+++ b/homeassistant/components/device_tracker/quantum_gateway.py
@@ -21,7 +21,8 @@ _LOGGER = logging.getLogger(__name__)
 DEFAULT_HOST = 'myfiosgateway.com'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string
+    vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
+    vol.Required(CONF_PASSWORD): cv.string
 })
 
 

--- a/homeassistant/components/device_tracker/quantum_gateway.py
+++ b/homeassistant/components/device_tracker/quantum_gateway.py
@@ -1,5 +1,5 @@
 """
-Support for Verizon FiOS Quantum Gatewaysself.
+Support for Verizon FiOS Quantum Gateways.
 
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/device_tracker.quantum_gateway/

--- a/homeassistant/components/device_tracker/quantum_gateway.py
+++ b/homeassistant/components/device_tracker/quantum_gateway.py
@@ -13,7 +13,7 @@ from homeassistant.components.device_tracker import (DOMAIN, PLATFORM_SCHEMA,
 from homeassistant.const import (CONF_HOST, CONF_PASSWORD)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['quantum-gateway==0.0.2']
+REQUIREMENTS = ['quantum-gateway==0.0.3']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -42,9 +42,13 @@ class QuantumGatewayDeviceScanner(DeviceScanner):
         self.password = config[CONF_PASSWORD]
         _LOGGER.debug('Initializing')
 
-        self.quantum = QuantumGatewayScanner(self.host, self.password)
+        try:
+            self.quantum = QuantumGatewayScanner(self.host, self.password)
+            self.success_init = self.quantum.success_init
+        except:
+            self.success_init = False
+            _LOGGER.error("Unable to connect to gateway. Check host.")
 
-        self.success_init = self.quantum.success_init
 
         if not self.success_init:
             _LOGGER.error("Unable to login to gateway. Check password and "
@@ -52,7 +56,13 @@ class QuantumGatewayDeviceScanner(DeviceScanner):
 
     def scan_devices(self):
         """Scan for new devices and return a list of found MACs."""
-        return self.quantum.scan_devices()
+        connected_devices = []
+        try:
+            connected_devices = self.quantum.scan_devices()
+        except:
+            _LOGGER.error("Unable to scan devices. Check connection to router")
+        return connected_devices
+
 
     def get_device_name(self, device):
         """Return the name of the given device or None if we don't know."""

--- a/homeassistant/components/device_tracker/quantum_gateway.py
+++ b/homeassistant/components/device_tracker/quantum_gateway.py
@@ -1,0 +1,51 @@
+import logging
+
+import hashlib
+from http.cookies import SimpleCookie
+import json
+import requests
+import voluptuous as vol
+
+from homeassistant.components.device_tracker import (DOMAIN, PLATFORM_SCHEMA,
+                                                     DeviceScanner)
+from homeassistant.const import (CONF_HOST, CONF_PASSWORD)
+import homeassistant.helpers.config_validation as cv
+
+REQUIREMENTS = ['quantum-gateway==0.0.2']
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_HOST = 'myfiosgateway.com'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string
+})
+
+
+def get_scanner(hass, config):
+    scanner = QuantumGatewayDeviceScanner(config[DOMAIN])
+
+    return scanner if scanner.success_init else None
+
+
+class QuantumGatewayDeviceScanner(DeviceScanner):
+
+    def __init__(self, config):
+        from quantum_gateway import QuantumGatewayScanner
+        
+        self.host = config[CONF_HOST]
+        self.password = config[CONF_PASSWORD]
+        _LOGGER.info("Initializing")
+
+        self.quantum = QuantumGatewayScanner(self.host, self.password)
+
+        self.success_init = self.quantum.success_init
+
+        if not self.success_init:
+            _LOGGER.error("Unable to login to gateway. Check password and host.")
+
+    def scan_devices(self):
+        return self.quantum.scan_devices()
+
+    def get_device_name(self, device):
+        return self.quantum.get_device_name(device)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1259,7 +1259,7 @@ pyzabbix==0.7.4
 qnapstats==0.2.7
 
 # homeassistant.components.device_tracker.quantum_gateway
-quantum-gateway==0.0.2
+quantum-gateway==0.0.3
 
 # homeassistant.components.rachio
 rachiopy==0.1.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1258,6 +1258,9 @@ pyzabbix==0.7.4
 # homeassistant.components.sensor.qnap
 qnapstats==0.2.7
 
+# homeassistant.components.device_tracker.quantum_gateway
+quantum-gateway==0.0.2
+
 # homeassistant.components.rachio
 rachiopy==0.1.3
 


### PR DESCRIPTION
## Description:
Support for a Verizon Fios Quantum Gateway. Tested on a Quantum Gateway G1100. 

Uses my quantum_gateway [library](https://github.com/cisasteelersfan/quantum_gateway) that I published to [PyPI](https://pypi.org/project/quantum-gateway/) to query the gateway.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#6396

## Example entry for `configuration.yaml` (if applicable):
```yaml
device_tracker:
  - platform: quantum_gateway
    host: 192.168.1.1
    password: YOUR_PASSWORD
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
