### PR TITLE
Fix switch.zoneminder name

### DIFF
--- a/homeassistant/components/switch/zoneminder.py
+++ b/homeassistant/components/switch/zoneminder.py
@@ -57,7 +57,7 @@ class ZMSwitchMonitors(SwitchDevice):
     @property
     def name(self):
         """Return the name of the switch."""
-        return '{}\'s State'.format(self._monitor.name)
+        return '{} State'.format(self._monitor.name)
 
     def update(self):
         """Update the switch value."""


### PR DESCRIPTION
## Description:
In https://github.com/home-assistant/home-assistant/pull/16527#discussion_r221494061 I accidentally changed the entity name for switch.zoneminder.

This was released in 0.79 and was not listed as a **breaking change**. We should put this in the next hotfix and announce the accidental breaking change (and the fact that this will also be a breaking change) if anyone has changed anything using the entity names from this platform.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
