### PR TITLE
Add new device attributes to fritzbox climate

### DIFF
--- a/homeassistant/components/climate/fritzbox.py
+++ b/homeassistant/components/climate/fritzbox.py
@@ -10,13 +10,15 @@ import requests
 
 from homeassistant.components.fritzbox import DOMAIN as FRITZBOX_DOMAIN
 from homeassistant.components.fritzbox import (
-    ATTR_STATE_DEVICE_LOCKED, ATTR_STATE_BATTERY_LOW, ATTR_STATE_LOCKED)
+    ATTR_STATE_DEVICE_LOCKED, ATTR_STATE_BATTERY_LOW, ATTR_STATE_HOLIDAY_MODE,
+    ATTR_STATE_LOCKED, ATTR_STATE_SUMMER_MODE,
+    ATTR_STATE_WINDOW_OPEN)
 from homeassistant.components.climate import (
     ATTR_OPERATION_MODE, ClimateDevice, STATE_ECO, STATE_HEAT, STATE_MANUAL,
     STATE_OFF, STATE_ON, SUPPORT_OPERATION_MODE,
     SUPPORT_TARGET_TEMPERATURE)
 from homeassistant.const import (
-    ATTR_TEMPERATURE, PRECISION_HALVES, TEMP_CELSIUS)
+    ATTR_BATTERY_LEVEL, ATTR_TEMPERATURE, PRECISION_HALVES, TEMP_CELSIUS)
 DEPENDENCIES = ['fritzbox']
 
 _LOGGER = logging.getLogger(__name__)
@@ -151,10 +153,21 @@ class FritzboxThermostat(ClimateDevice):
     def device_state_attributes(self):
         """Return the device specific state attributes."""
         attrs = {
+            ATTR_STATE_BATTERY_LOW: self._device.battery_low,
             ATTR_STATE_DEVICE_LOCKED: self._device.device_lock,
             ATTR_STATE_LOCKED: self._device.lock,
-            ATTR_STATE_BATTERY_LOW: self._device.battery_low,
         }
+
+        # the following attributes are available since fritzos 7
+        if self._device.battery_level is not None:
+            attrs[ATTR_BATTERY_LEVEL] = self._device.battery_level
+        if self._device.holiday_active is not None:
+            attrs[ATTR_STATE_HOLIDAY_MODE] = self._device.holiday_active
+        if self._device.summer_active is not None:
+            attrs[ATTR_STATE_SUMMER_MODE] = self._device.summer_active
+        if ATTR_STATE_WINDOW_OPEN is not None:
+            attrs[ATTR_STATE_WINDOW_OPEN] = self._device.window_open
+
         return attrs
 
     def update(self):

--- a/homeassistant/components/fritzbox.py
+++ b/homeassistant/components/fritzbox.py
@@ -16,7 +16,7 @@ from homeassistant.helpers import discovery
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['pyfritzhome==0.3.7']
+REQUIREMENTS = ['pyfritzhome==0.4.0']
 
 SUPPORTED_DOMAINS = ['climate', 'switch']
 

--- a/homeassistant/components/fritzbox.py
+++ b/homeassistant/components/fritzbox.py
@@ -22,9 +22,12 @@ SUPPORTED_DOMAINS = ['climate', 'switch']
 
 DOMAIN = 'fritzbox'
 
-ATTR_STATE_DEVICE_LOCKED = 'device_locked'
-ATTR_STATE_LOCKED = 'locked'
 ATTR_STATE_BATTERY_LOW = 'battery_low'
+ATTR_STATE_DEVICE_LOCKED = 'device_locked'
+ATTR_STATE_HOLIDAY_MODE = 'holiday_mode'
+ATTR_STATE_LOCKED = 'locked'
+ATTR_STATE_SUMMER_MODE = 'summer_mode'
+ATTR_STATE_WINDOW_OPEN = 'window_open'
 
 
 CONFIG_SCHEMA = vol.Schema({

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -884,7 +884,7 @@ pyflic-homeassistant==0.4.dev0
 pyfnip==0.2
 
 # homeassistant.components.fritzbox
-pyfritzhome==0.3.7
+pyfritzhome==0.4.0
 
 # homeassistant.components.ifttt
 pyfttt==0.3


### PR DESCRIPTION
With Fitz!OS 7 new parameters are introduced.

Signed-off-by: Heiko Thiery <heiko.thiery@gmail.com>

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#6398

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
