### PR TITLE
Bump Enphase_Envoy dependency for older models support

### DIFF
--- a/homeassistant/components/sensor/enphase_envoy.py
+++ b/homeassistant/components/sensor/enphase_envoy.py
@@ -14,7 +14,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.const import (CONF_IP_ADDRESS, CONF_MONITORED_CONDITIONS)
 
 
-REQUIREMENTS = ['envoy_reader==0.2']
+REQUIREMENTS = ['envoy_reader==0.3']
 _LOGGER = logging.getLogger(__name__)
 
 SENSORS = {

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -324,7 +324,7 @@ enocean==0.40
 # envirophat==0.0.6
 
 # homeassistant.components.sensor.enphase_envoy
-envoy_reader==0.2
+envoy_reader==0.3
 
 # homeassistant.components.sensor.season
 ephem==3.7.6.0


### PR DESCRIPTION
## Description:
The envoy_reader from PyPi has been updated to fix support for older models. See https://github.com/jesserizzo/envoy_reader/pull/3

**Related issue (if applicable):** fixes #16210 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#6404



## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
