### PR TITLE
Send headers with REST switch GET request

### DIFF
--- a/homeassistant/components/switch/rest.py
+++ b/homeassistant/components/switch/rest.py
@@ -170,7 +170,8 @@ class RestSwitch(SwitchDevice):
         websession = async_get_clientsession(hass)
 
         with async_timeout.timeout(self._timeout, loop=hass.loop):
-            req = await websession.get(self._resource, auth=self._auth)
+            req = await websession.get(self._resource, auth=self._auth,
+                                       headers=self._headers)
             text = await req.text()
 
         if self._is_on_template is not None:


### PR DESCRIPTION
## Description:
I am integrating with a REST API that requires the headers to be sent for the GET requests as well as the PUT/POST requests, otherwise authentication fails. At the moment, because this component does not send the headers with the GET request, it fails setup, so this change sends the headers with the GET requests also.

## Example entry for `configuration.yaml` (if applicable):
```yaml
switch:
  - platform: rest
    resource: https://api.example.com/switch
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**





[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
