### PR TITLE
Suppress urllib3 error for mjpeg camera

### DIFF
--- a/homeassistant/components/camera/mjpeg.py
+++ b/homeassistant/components/camera/mjpeg.py
@@ -74,6 +74,10 @@ class MjpegCamera(Camera):
         self._mjpeg_url = device_info[CONF_MJPEG_URL]
         self._still_image_url = device_info.get(CONF_STILL_IMAGE_URL)
 
+        logging.getLogger("urllib3.connectionpool").addFilter(
+            NoHeaderErrorFilter()
+        )
+
         self._auth = None
         if self._username and self._password:
             if self._authentication == HTTP_BASIC_AUTHENTICATION:
@@ -139,3 +143,11 @@ class MjpegCamera(Camera):
     def name(self):
         """Return the name of this camera."""
         return self._name
+
+
+class NoHeaderErrorFilter(logging.Filter):
+    """Filter out urllib3 Header Parsing Errors due to a urllib3 bug."""
+
+    def filter(self, record):
+        """Filter out Header Parsing Errors."""
+        return "Failed to parse headers" not in record.getMessage()


### PR DESCRIPTION
## Description:
This suppresses the `Failed to parse headers [StartBoundaryNotFoundDefect(), MultipartInvariantViolationDefect()], unparsed data: ''` warning caused by a [2 year old issue](https://github.com/shazow/urllib3/issues/800) in urllib3. This warning would get logged approximately every 10s when the camera image was refreshed on the frontend.

**Related issue (if applicable):** fixes #3683

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#home-assistant/home-assistant#17042

## Example entry for `configuration.yaml` (if applicable):
```yaml
camera:
  - platform: mjpeg
    name: Driveway Cam
    mjpeg_url: !secret driveway_cam
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
