### PR TITLE
MJPEG Camera Log Filter Fixes

### DIFF
--- a/homeassistant/components/camera/mjpeg.py
+++ b/homeassistant/components/camera/mjpeg.py
@@ -44,6 +44,14 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 async def async_setup_platform(hass, config, async_add_entities,
                                discovery_info=None):
     """Set up a MJPEG IP Camera."""
+    # Filter header errors from urllib3 due to a urllib3 bug
+    urllib3_logger = logging.getLogger("urllib3.connectionpool")
+    if not any(isinstance(x, NoHeaderErrorFilter)
+       for x in urllib3_logger.filters):
+        urllib3_logger.addFilter(
+            NoHeaderErrorFilter()
+        )
+
     if discovery_info:
         config = PLATFORM_SCHEMA(discovery_info)
     async_add_entities([MjpegCamera(config)])
@@ -73,10 +81,6 @@ class MjpegCamera(Camera):
         self._password = device_info.get(CONF_PASSWORD)
         self._mjpeg_url = device_info[CONF_MJPEG_URL]
         self._still_image_url = device_info.get(CONF_STILL_IMAGE_URL)
-
-        logging.getLogger("urllib3.connectionpool").addFilter(
-            NoHeaderErrorFilter()
-        )
 
         self._auth = None
         if self._username and self._password:

--- a/homeassistant/components/camera/mjpeg.py
+++ b/homeassistant/components/camera/mjpeg.py
@@ -47,7 +47,7 @@ async def async_setup_platform(hass, config, async_add_entities,
     # Filter header errors from urllib3 due to a urllib3 bug
     urllib3_logger = logging.getLogger("urllib3.connectionpool")
     if not any(isinstance(x, NoHeaderErrorFilter)
-       for x in urllib3_logger.filters):
+               for x in urllib3_logger.filters):
         urllib3_logger.addFilter(
             NoHeaderErrorFilter()
         )


### PR DESCRIPTION
## Description:
Address comments brought up by balloob in #17042 after it was merged.

Moved the addFilter function to setup_platform and added a check to make sure it only gets added once, instead of getting duplicated for every mjpeg camera in the system.

**Related issue (if applicable):** fN/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
camera:
  - platform: mjpeg
    name: Driveway Cam
    mjpeg_url: !secret driveway_cam
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**