### PR TITLE
OpenUV: Fixed unhandled exception with missing protection window data

### DIFF
--- a/homeassistant/components/binary_sensor/openuv.py
+++ b/homeassistant/components/binary_sensor/openuv.py
@@ -93,7 +93,11 @@ class OpenUvBinarySensor(OpenUvEntity, BinarySensorDevice):
 
     async def async_update(self):
         """Update the state."""
-        data = self.openuv.data[DATA_PROTECTION_WINDOW]['result']
+        data = self.openuv.data[DATA_PROTECTION_WINDOW]
+
+        if not data:
+            return
+
         if self._sensor_type == TYPE_PROTECTION_WINDOW:
             self._state = parse_datetime(
                 data['from_time']) <= utcnow() <= parse_datetime(

--- a/homeassistant/components/openuv/__init__.py
+++ b/homeassistant/components/openuv/__init__.py
@@ -212,8 +212,15 @@ class OpenUV:
     async def async_update(self):
         """Update sensor/binary sensor data."""
         if TYPE_PROTECTION_WINDOW in self.binary_sensor_conditions:
-            data = await self.client.uv_protection_window()
-            self.data[DATA_PROTECTION_WINDOW] = data
+            resp = await self.client.uv_protection_window()
+            data = resp['result']
+
+            if data.get('from_time') and data.get('to_time'):
+                self.data[DATA_PROTECTION_WINDOW] = data
+            else:
+                _LOGGER.error(
+                    'No valid protection window data for this location')
+                self.data[DATA_PROTECTION_WINDOW] = {}
 
         if any(c in self.sensor_conditions for c in SENSORS):
             data = await self.client.uv_index()


### PR DESCRIPTION
## Description:
Properly catches and logs an error when OpenUV fails to return protection window information for a latitude/longitude.

**Related issue (if applicable):** fixes #16875

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
openuv:
  api_key: <OPENUV API KEY>
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  ~- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)~

If the code communicates with devices, web services, or third-party tools:
  ~- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).~
  ~- [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).~
  ~- [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.~
  ~- [ ] New files were added to `.coveragerc`.~

If the code does not interact with devices:
  ~- [ ] Tests have been added to verify that the new code works.~

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
