### PR TITLE
Homekit controller reconnect

### DIFF
--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -227,6 +227,10 @@ def async_call_later(hass, delay, action):
         hass, action, dt_util.utcnow() + timedelta(seconds=delay))
 
 
+call_later = threaded_listener_factory(
+    async_call_later)
+
+
 @callback
 @bind_hass
 def async_track_time_interval(hass, action, interval):


### PR DESCRIPTION
## Description:
This PR updates the homekit controller component so that it attempts to reconnect when the connection to a device is lost. This allows the component to recover after an intermittent network issue.

I've also added a threaded `call_later` helper, since that variant seemed to be missing. I can split that commit to a separate PR if necessary, or I can remove it if I'm overlooking some reason we don't need this.