### PR TITLE
Use Proactor loop in Windows

### DIFF
--- a/homeassistant/util/async_.py
+++ b/homeassistant/util/async_.py
@@ -2,6 +2,7 @@
 import concurrent.futures
 import threading
 import logging
+import sys
 from asyncio import coroutines
 from asyncio.events import AbstractEventLoop
 from asyncio.futures import Future

--- a/homeassistant/util/async_.py
+++ b/homeassistant/util/async_.py
@@ -22,7 +22,10 @@ except AttributeError:
 
     def asyncio_run(main: Awaitable[_T], *, debug: bool = False) -> _T:
         """Minimal re-implementation of asyncio.run (since 3.7)."""
-        loop = asyncio.new_event_loop()
+        if sys.platform == 'win32':
+            loop = asyncio.ProactorEventLoop()
+        else:
+            loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
         loop.set_debug(debug)
         try:


### PR DESCRIPTION
## Description:

The customize `asyncio.run` implementation didn't use `ProactorEventLoop` for Windows platform.

CC @smurfix

**Related issue (if applicable):** fixes #16998

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
