### PR TITLE
Tibber component and notify

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -313,6 +313,9 @@ omit =
 
     homeassistant/components/*/thinkingcleaner.py
 
+    homeassistant/components/tibber/*
+    homeassistant/components/*/tibber.py
+
     homeassistant/components/toon.py
     homeassistant/components/*/toon.py
 
@@ -769,7 +772,6 @@ omit =
     homeassistant/components/sensor/tank_utility.py
     homeassistant/components/sensor/ted5000.py
     homeassistant/components/sensor/temper.py
-    homeassistant/components/sensor/tibber.py
     homeassistant/components/sensor/time_date.py
     homeassistant/components/sensor/torque.py
     homeassistant/components/sensor/trafikverket_weatherstation.py

--- a/homeassistant/components/notify/tibber.py
+++ b/homeassistant/components/notify/tibber.py
@@ -15,7 +15,7 @@ from homeassistant.components.tibber import DOMAIN as TIBBER_DOMAIN
 _LOGGER = logging.getLogger(__name__)
 
 
-def get_service(hass, config, discovery_info=None):
+async def async_get_service(hass, config, discovery_info=None):
     """Get the Tibber notification service."""
     tibber_connection = hass.data[TIBBER_DOMAIN]
     return TibberNotificationService(tibber_connection.send_notification)

--- a/homeassistant/components/notify/tibber.py
+++ b/homeassistant/components/notify/tibber.py
@@ -1,0 +1,37 @@
+"""
+Pushbullet platform for notify component.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/notify.tibber/
+"""
+import asyncio
+import logging
+
+from homeassistant.components.notify import (
+    ATTR_TITLE, ATTR_TITLE_DEFAULT, BaseNotificationService)
+from homeassistant.components.tibber import DOMAIN
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def get_service(hass, config, discovery_info=None):
+    """Get the Pushbullet notification service."""
+    tibber_connection = hass.data[DOMAIN]
+    return TibberNotificationService(tibber_connection.send_notification)
+
+
+class TibberNotificationService(BaseNotificationService):
+    """Implement the notification service for Tibber."""
+
+    def __init__(self, notify):
+        """Initialize the service."""
+        self._notify = notify
+
+    async def async_send_message(self, message=None, **kwargs):
+        """Send a message to Tibber devices."""
+        title = kwargs.get(ATTR_TITLE, ATTR_TITLE_DEFAULT)
+        try:
+            await self._notify(title=title, message=message)
+        except asyncio.TimeoutError:
+            _LOGGER.error("Timeout sending message with Tibber.")

--- a/homeassistant/components/notify/tibber.py
+++ b/homeassistant/components/notify/tibber.py
@@ -1,5 +1,5 @@
 """
-Pushbullet platform for notify component.
+Tibber platform for notify component.
 
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/notify.tibber/
@@ -9,15 +9,15 @@ import logging
 
 from homeassistant.components.notify import (
     ATTR_TITLE, ATTR_TITLE_DEFAULT, BaseNotificationService)
-from homeassistant.components.tibber import DOMAIN
+from homeassistant.components.tibber import DOMAIN as TIBBER_DOMAIN
 
 
 _LOGGER = logging.getLogger(__name__)
 
 
 def get_service(hass, config, discovery_info=None):
-    """Get the Pushbullet notification service."""
-    tibber_connection = hass.data[DOMAIN]
+    """Get the Tibber notification service."""
+    tibber_connection = hass.data[TIBBER_DOMAIN]
     return TibberNotificationService(tibber_connection.send_notification)
 
 
@@ -34,4 +34,4 @@ class TibberNotificationService(BaseNotificationService):
         try:
             await self._notify(title=title, message=message)
         except asyncio.TimeoutError:
-            _LOGGER.error("Timeout sending message with Tibber.")
+            _LOGGER.error("Timeout sending message with Tibber")

--- a/homeassistant/components/sensor/tibber.py
+++ b/homeassistant/components/sensor/tibber.py
@@ -11,7 +11,7 @@ import logging
 from datetime import timedelta
 import aiohttp
 
-from homeassistant.components.tibber import DOMAIN
+from homeassistant.components.tibber import DOMAIN as TIBBER_DOMAIN
 from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import dt as dt_util
@@ -28,11 +28,12 @@ MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=5)
 async def async_setup_platform(hass, config, async_add_entities,
                                discovery_info=None):
     """Set up the Tibber sensor."""
-    tibber_connection = hass.data.get(DOMAIN)
-    if tibber_connection is None:
+    if discovery_info is None:
         _LOGGER.error("Tibber sensor configuration has changed."
                       " Check https://home-assistant.io/components/tibber/")
         return
+
+    tibber_connection = hass.data.get(TIBBER_DOMAIN)
 
     try:
         dev = []

--- a/homeassistant/components/sensor/tibber.py
+++ b/homeassistant/components/sensor/tibber.py
@@ -10,24 +10,14 @@ import logging
 
 from datetime import timedelta
 import aiohttp
-import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
-from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import EVENT_HOMEASSISTANT_STOP, CONF_ACCESS_TOKEN
+from homeassistant.components.tibber import DOMAIN
 from homeassistant.exceptions import PlatformNotReady
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import dt as dt_util
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['pyTibber==0.6.0']
-
 _LOGGER = logging.getLogger(__name__)
-
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_ACCESS_TOKEN): cv.string
-})
 
 ICON = 'mdi:currency-usd'
 ICON_RT = 'mdi:power-plug'
@@ -38,16 +28,13 @@ MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=5)
 async def async_setup_platform(hass, config, async_add_entities,
                                discovery_info=None):
     """Set up the Tibber sensor."""
-    import tibber
-    tibber_connection = tibber.Tibber(config[CONF_ACCESS_TOKEN],
-                                      websession=async_get_clientsession(hass))
-
-    async def _close(*_):
-        await tibber_connection.rt_disconnect()
-    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _close)
+    tibber_connection = hass.data.get(DOMAIN)
+    if tibber_connection is None:
+        _LOGGER.error("Tibber sensor configuration has changed."
+                      " Check https://home-assistant.io/components/tibber/")
+        return
 
     try:
-        await tibber_connection.update_info()
         dev = []
         for home in tibber_connection.get_homes():
             await home.update_info()

--- a/homeassistant/components/tibber/__init__.py
+++ b/homeassistant/components/tibber/__init__.py
@@ -15,7 +15,7 @@ from homeassistant.const import EVENT_HOMEASSISTANT_STOP, CONF_ACCESS_TOKEN, CON
 from homeassistant.helpers import discovery
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-REQUIREMENTS = ['pyTibber==0.7.0']
+REQUIREMENTS = ['pyTibber==0.7.1']
 
 DOMAIN = 'tibber'
 

--- a/homeassistant/components/tibber/__init__.py
+++ b/homeassistant/components/tibber/__init__.py
@@ -38,7 +38,7 @@ async def async_setup(hass, config):
                                       websession=async_get_clientsession(hass))
     hass.data[DOMAIN] = tibber_connection
 
-    async def _close(*_):
+    async def _close(event):
         await tibber_connection.rt_disconnect()
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _close)

--- a/homeassistant/components/tibber/__init__.py
+++ b/homeassistant/components/tibber/__init__.py
@@ -5,15 +5,14 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/tibber/
 """
 import asyncio
-
 import logging
 
 import aiohttp
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers import discovery
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP, CONF_ACCESS_TOKEN, CONF_NAME
+from homeassistant.helpers import discovery
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 REQUIREMENTS = ['pyTibber==0.7.0']

--- a/homeassistant/components/tibber/__init__.py
+++ b/homeassistant/components/tibber/__init__.py
@@ -16,7 +16,7 @@ from homeassistant.const import (EVENT_HOMEASSISTANT_STOP, CONF_ACCESS_TOKEN,
 from homeassistant.helpers import discovery
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-REQUIREMENTS = ['pyTibber==0.7.1']
+REQUIREMENTS = ['pyTibber==0.7.2']
 
 DOMAIN = 'tibber'
 
@@ -50,6 +50,6 @@ async def async_setup(hass, config):
 
     for component in ['sensor', 'notify']:
         discovery.load_platform(hass, component, DOMAIN,
-                                {CONF_NAME: DOMAIN}, conf)
+                                {CONF_NAME: DOMAIN}, config)
 
     return True

--- a/homeassistant/components/tibber/__init__.py
+++ b/homeassistant/components/tibber/__init__.py
@@ -1,0 +1,54 @@
+"""
+Support for Tibber.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/tibber/
+"""
+import asyncio
+
+import logging
+
+import aiohttp
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers import discovery
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP, CONF_ACCESS_TOKEN, CONF_NAME
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+REQUIREMENTS = ['pyTibber==0.6.0']
+
+DOMAIN = 'tibber'
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_ACCESS_TOKEN): cv.string,
+    })
+}, extra=vol.ALLOW_EXTRA)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup(hass, config):
+    """Set up the Tibber component."""
+    conf = config.get(DOMAIN)
+
+    import tibber
+    tibber_connection = tibber.Tibber(conf[CONF_ACCESS_TOKEN],
+                                      websession=async_get_clientsession(hass))
+    hass.data[DOMAIN] = tibber_connection
+
+    async def _close(*_):
+        await tibber_connection.rt_disconnect()
+
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _close)
+
+    try:
+        await tibber_connection.update_info()
+    except (asyncio.TimeoutError, aiohttp.ClientError):
+        return False
+
+    for component in ['sensor', 'notify']:
+        discovery.load_platform(hass, component, DOMAIN, {CONF_NAME: DOMAIN}, conf)
+
+    return True

--- a/homeassistant/components/tibber/__init__.py
+++ b/homeassistant/components/tibber/__init__.py
@@ -16,7 +16,7 @@ from homeassistant.helpers import discovery
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP, CONF_ACCESS_TOKEN, CONF_NAME
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-REQUIREMENTS = ['pyTibber==0.6.0']
+REQUIREMENTS = ['pyTibber==0.7.0']
 
 DOMAIN = 'tibber'
 

--- a/homeassistant/components/tibber/__init__.py
+++ b/homeassistant/components/tibber/__init__.py
@@ -11,7 +11,8 @@ import aiohttp
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
-from homeassistant.const import EVENT_HOMEASSISTANT_STOP, CONF_ACCESS_TOKEN, CONF_NAME
+from homeassistant.const import (EVENT_HOMEASSISTANT_STOP, CONF_ACCESS_TOKEN,
+                                 CONF_NAME)
 from homeassistant.helpers import discovery
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
@@ -48,6 +49,7 @@ async def async_setup(hass, config):
         return False
 
     for component in ['sensor', 'notify']:
-        discovery.load_platform(hass, component, DOMAIN, {CONF_NAME: DOMAIN}, conf)
+        discovery.load_platform(hass, component, DOMAIN,
+                                {CONF_NAME: DOMAIN}, conf)
 
     return True

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -764,8 +764,8 @@ pyRFXtrx==0.23
 # homeassistant.components.switch.switchmate
 pySwitchmate==0.4.1
 
-# homeassistant.components.sensor.tibber
-pyTibber==0.6.0
+# homeassistant.components.tibber
+pyTibber==0.7.0
 
 # homeassistant.components.switch.dlink
 pyW215==0.6.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -765,7 +765,7 @@ pyRFXtrx==0.23
 pySwitchmate==0.4.1
 
 # homeassistant.components.tibber
-pyTibber==0.7.1
+pyTibber==0.7.2
 
 # homeassistant.components.switch.dlink
 pyW215==0.6.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -765,7 +765,7 @@ pyRFXtrx==0.23
 pySwitchmate==0.4.1
 
 # homeassistant.components.tibber
-pyTibber==0.7.0
+pyTibber==0.7.1
 
 # homeassistant.components.switch.dlink
 pyW215==0.6.0


### PR DESCRIPTION
## Description:
Move Tibber to a separate component.
Make a Tibber notify service

Breaking change: Tibber can not be configured as a sensor anymore.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
tibber:
  access_token: d11a43897efa4cf478afd659d6c8b7117da9e33b38232fd454b0e9f28af98012
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
