### PR TITLE
Allow no movement in vamera.onvif_ptz service

### DIFF
--- a/homeassistant/components/camera/onvif.py
+++ b/homeassistant/components/camera/onvif.py
@@ -46,6 +46,7 @@ DIR_LEFT = "LEFT"
 DIR_RIGHT = "RIGHT"
 ZOOM_OUT = "ZOOM_OUT"
 ZOOM_IN = "ZOOM_IN"
+PTZ_NONE = "NONE"
 
 SERVICE_PTZ = "onvif_ptz"
 
@@ -65,9 +66,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 SERVICE_PTZ_SCHEMA = vol.Schema({
     ATTR_ENTITY_ID: cv.entity_ids,
-    ATTR_PAN: vol.In([DIR_LEFT, DIR_RIGHT]),
-    ATTR_TILT: vol.In([DIR_UP, DIR_DOWN]),
-    ATTR_ZOOM: vol.In([ZOOM_OUT, ZOOM_IN])
+    ATTR_PAN: vol.In([DIR_LEFT, DIR_RIGHT, PTZ_NONE]),
+    ATTR_TILT: vol.In([DIR_UP, DIR_DOWN, PTZ_NONE]),
+    ATTR_ZOOM: vol.In([ZOOM_OUT, ZOOM_IN, PTZ_NONE])
 })
 
 


### PR DESCRIPTION
## Description:
The service `camera.onvif_ptz` which controlls the pan/tilt/zoom of onvif cameras take the arguments `pan`, `tilt`, and `zoom`, which can be `LEFT/RIGHT`, `UP/DOWN` and `ZOOM_IN/ZOOM_OUT` respectively.

This change adds the optional value `NONE` to each of the arguments. This makes it much more easy to use the service with templates. Since arguments cannot be left blank (but can be left out entirely), there was previously no way to choose *not to* pan, tilt or zoom via e.g `data_template`.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#6431

## Example entry for `configuration.yaml` (if applicable):
```yaml
script:
  camera_ptz:
    sequence:
      - service: camera.onvif_ptz
        data_template:
          entity_id: "{{ entity_id }}"
          pan: >
            {{ {'left':'LEFT', 'right':'RIGHT', 'up':'NONE', 'down':'NONE'}[dir] }}
          tilt: >
            {{ {'left':'NONE', 'right':'NONE', 'up':'UP', 'down':'DOWN'}[dir] }}
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
