### PR TITLE
0.79.3

### DIFF
--- a/homeassistant/__main__.py
+++ b/homeassistant/__main__.py
@@ -28,6 +28,7 @@ def set_loop() -> None:
 
     if sys.platform == 'win32':
         if hasattr(asyncio, 'WindowsProactorEventLoopPolicy'):
+            # pylint: disable=no-member
             policy = asyncio.WindowsProactorEventLoopPolicy()
         else:
             class ProactorPolicy(BaseDefaultEventLoopPolicy):

--- a/homeassistant/__main__.py
+++ b/homeassistant/__main__.py
@@ -22,16 +22,30 @@ from homeassistant.const import (
 def set_loop() -> None:
     """Attempt to use uvloop."""
     import asyncio
+    from asyncio.events import BaseDefaultEventLoopPolicy
+
+    policy = None
 
     if sys.platform == 'win32':
-        asyncio.set_event_loop(asyncio.ProactorEventLoop())
+        if hasattr(asyncio, 'WindowsProactorEventLoopPolicy'):
+            policy = asyncio.WindowsProactorEventLoopPolicy()
+        else:
+            class ProactorPolicy(BaseDefaultEventLoopPolicy):
+                """Event loop policy to create proactor loops."""
+
+                _loop_factory = asyncio.ProactorEventLoop
+
+            policy = ProactorPolicy()
     else:
         try:
             import uvloop
         except ImportError:
             pass
         else:
-            asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+            policy = uvloop.EventLoopPolicy()
+
+    if policy is not None:
+        asyncio.set_event_loop_policy(policy)
 
 
 def validate_python() -> None:

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -2,7 +2,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 79
-PATCH_VERSION = '2'
+PATCH_VERSION = '3'
 __short_version__ = '{}.{}'.format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = '{}.{}'.format(__short_version__, PATCH_VERSION)
 REQUIRED_PYTHON_VER = (3, 5, 3)

--- a/homeassistant/util/async_.py
+++ b/homeassistant/util/async_.py
@@ -2,7 +2,6 @@
 import concurrent.futures
 import threading
 import logging
-import sys
 from asyncio import coroutines
 from asyncio.events import AbstractEventLoop
 from asyncio.futures import Future
@@ -23,10 +22,7 @@ except AttributeError:
 
     def asyncio_run(main: Awaitable[_T], *, debug: bool = False) -> _T:
         """Minimal re-implementation of asyncio.run (since 3.7)."""
-        if sys.platform == 'win32':
-            loop = asyncio.ProactorEventLoop()
-        else:
-            loop = asyncio.new_event_loop()
+        loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
         loop.set_debug(debug)
         try:

--- a/homeassistant/util/async_.py
+++ b/homeassistant/util/async_.py
@@ -2,6 +2,7 @@
 import concurrent.futures
 import threading
 import logging
+import sys
 from asyncio import coroutines
 from asyncio.events import AbstractEventLoop
 from asyncio.futures import Future
@@ -22,7 +23,10 @@ except AttributeError:
 
     def asyncio_run(main: Awaitable[_T], *, debug: bool = False) -> _T:
         """Minimal re-implementation of asyncio.run (since 3.7)."""
-        loop = asyncio.new_event_loop()
+        if sys.platform == 'win32':
+            loop = asyncio.ProactorEventLoop()
+        else:
+            loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
         loop.set_debug(debug)
         try:


### PR DESCRIPTION
- Use correct event loop on Windows, fixing SSL and Subprocess requests. (#16737, #17066 - @awarecan, @balloob)