### PR TITLE
Catch possible errors from tradfri

### DIFF
--- a/homeassistant/components/tradfri/config_flow.py
+++ b/homeassistant/components/tradfri/config_flow.py
@@ -169,7 +169,8 @@ async def get_gateway_info(hass, host, identity, key):
         api = factory.request
         gateway = Gateway()
         gateway_info_result = await api(gateway.get_gateway_info())
-    except RequestError:
+    except (OSError, RequestError):
+        # We're also catching OSError as PyTradfri doesn't catch that one yet
         raise AuthError('cannot_connect')
 
     return {

--- a/homeassistant/components/tradfri/config_flow.py
+++ b/homeassistant/components/tradfri/config_flow.py
@@ -171,6 +171,7 @@ async def get_gateway_info(hass, host, identity, key):
         gateway_info_result = await api(gateway.get_gateway_info())
     except (OSError, RequestError):
         # We're also catching OSError as PyTradfri doesn't catch that one yet
+        # Upstream PR: https://github.com/ggravlingen/pytradfri/pull/189
         raise AuthError('cannot_connect')
 
     return {


### PR DESCRIPTION
## Description:
Looks like aiocoap can also raise an OSError. This should be caught in PyTradfri but until that is fixed upstream, let's catch it.

**Related issue (if applicable):** fixes #17008
