### PR TITLE
Remove Hue discovery on manual configuration

### DIFF
--- a/homeassistant/components/hue/__init__.py
+++ b/homeassistant/components/hue/__init__.py
@@ -12,9 +12,9 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import CONF_FILENAME, CONF_HOST
 from homeassistant.helpers import (
-    aiohttp_client, config_validation as cv, device_registry as dr)
+    config_validation as cv, device_registry as dr)
 
-from .const import DOMAIN, API_NUPNP
+from .const import DOMAIN
 from .bridge import HueBridge
 # Loading the config flow file will register the flow
 from .config_flow import configured_hosts
@@ -62,36 +62,10 @@ async def async_setup(hass, config):
     configured = configured_hosts(hass)
 
     # User has configured bridges
-    if CONF_BRIDGES in conf:
-        bridges = conf[CONF_BRIDGES]
-
-    # Component is part of config but no bridges specified, discover.
-    elif DOMAIN in config:
-        # discover from nupnp
-        websession = aiohttp_client.async_get_clientsession(hass)
-
-        async with websession.get(API_NUPNP) as req:
-            hosts = await req.json()
-
-        bridges = []
-        for entry in hosts:
-            # Filter out already configured hosts
-            if entry['internalipaddress'] in configured:
-                continue
-
-            # Run through config schema to populate defaults
-            bridges.append(BRIDGE_CONFIG_SCHEMA({
-                CONF_HOST: entry['internalipaddress'],
-                # Careful with using entry['id'] for other reasons. The
-                # value is in lowercase but is returned uppercase from hub.
-                CONF_FILENAME: '.hue_{}.conf'.format(entry['id']),
-            }))
-    else:
-        # Component not specified in config, we're loaded via discovery
-        bridges = []
-
-    if not bridges:
+    if CONF_BRIDGES not in conf:
         return True
+
+    bridges = conf[CONF_BRIDGES]
 
     for bridge_conf in bridges:
         host = bridge_conf[CONF_HOST]

--- a/tests/components/hue/test_init.py
+++ b/tests/components/hue/test_init.py
@@ -20,62 +20,6 @@ async def test_setup_with_no_config(hass):
     assert hass.data[hue.DOMAIN] == {}
 
 
-async def test_setup_with_discovery_no_known_auth(hass, aioclient_mock):
-    """Test discovering a bridge and not having known auth."""
-    aioclient_mock.get(hue.API_NUPNP, json=[
-        {
-            'internalipaddress': '0.0.0.0',
-            'id': 'abcd1234'
-        }
-    ])
-
-    with patch.object(hass, 'config_entries') as mock_config_entries, \
-            patch.object(hue, 'configured_hosts', return_value=[]):
-        mock_config_entries.flow.async_init.return_value = mock_coro()
-        assert await async_setup_component(hass, hue.DOMAIN, {
-            hue.DOMAIN: {}
-        }) is True
-
-    # Flow started for discovered bridge
-    assert len(mock_config_entries.flow.mock_calls) == 1
-    assert mock_config_entries.flow.mock_calls[0][2]['data'] == {
-        'host': '0.0.0.0',
-        'path': '.hue_abcd1234.conf',
-    }
-
-    # Config stored for domain.
-    assert hass.data[hue.DOMAIN] == {
-        '0.0.0.0': {
-            hue.CONF_HOST: '0.0.0.0',
-            hue.CONF_FILENAME: '.hue_abcd1234.conf',
-            hue.CONF_ALLOW_HUE_GROUPS: hue.DEFAULT_ALLOW_HUE_GROUPS,
-            hue.CONF_ALLOW_UNREACHABLE: hue.DEFAULT_ALLOW_UNREACHABLE,
-        }
-    }
-
-
-async def test_setup_with_discovery_known_auth(hass, aioclient_mock):
-    """Test we don't do anything if we discover already configured hub."""
-    aioclient_mock.get(hue.API_NUPNP, json=[
-        {
-            'internalipaddress': '0.0.0.0',
-            'id': 'abcd1234'
-        }
-    ])
-
-    with patch.object(hass, 'config_entries') as mock_config_entries, \
-            patch.object(hue, 'configured_hosts', return_value=['0.0.0.0']):
-        assert await async_setup_component(hass, hue.DOMAIN, {
-            hue.DOMAIN: {}
-        }) is True
-
-    # Flow started for discovered bridge
-    assert len(mock_config_entries.flow.mock_calls) == 0
-
-    # Config stored for domain.
-    assert hass.data[hue.DOMAIN] == {}
-
-
 async def test_setup_defined_hosts_known_auth(hass):
     """Test we don't initiate a config entry if config bridge is known."""
     with patch.object(hass, 'config_entries') as mock_config_entries, \


### PR DESCRIPTION
## Description:
We used to allow `hue:` to be configured in configuration.yaml without any options. This would then trigger a discovery of hubs and then set them up. When we moved to config entries, the logic changed to discover and them import them. This allowed people transitioning to import their auth.

This logic was introduced on March 30. Now it's time to sunset this behavior.

**Related issue (if applicable):** fixes #17025

## Example entry for `configuration.yaml` (if applicable):
```yaml
hue:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
