### PR TITLE
Fix mqtt light brightness slider

### DIFF
--- a/homeassistant/components/light/mqtt.py
+++ b/homeassistant/components/light/mqtt.py
@@ -235,6 +235,8 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, Light):
         self._supported_features |= (
             topic[CONF_RGB_COMMAND_TOPIC] is not None and SUPPORT_COLOR)
         self._supported_features |= (
+            topic[CONF_RGB_COMMAND_TOPIC] is not None and SUPPORT_BRIGHTNESS)
+        self._supported_features |= (
             topic[CONF_BRIGHTNESS_COMMAND_TOPIC] is not None and
             SUPPORT_BRIGHTNESS)
         self._supported_features |= (

--- a/homeassistant/components/light/mqtt.py
+++ b/homeassistant/components/light/mqtt.py
@@ -327,6 +327,10 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, Light):
 
             rgb = [int(val) for val in payload.split(',')]
             self._hs = color_util.color_RGB_to_hs(*rgb)
+            if self._topic[CONF_BRIGHTNESS_STATE_TOPIC] is None:
+                percent_bright = \
+                    float(color_util.color_RGB_to_hsv(*rgb)[2]) / 100.0
+                self._brightness = int(percent_bright * 255)
             self.async_schedule_update_ha_state()
 
         if self._topic[CONF_RGB_STATE_TOPIC] is not None:

--- a/homeassistant/components/light/mqtt.py
+++ b/homeassistant/components/light/mqtt.py
@@ -233,9 +233,8 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, Light):
         self._white_value = None
         self._supported_features = 0
         self._supported_features |= (
-            topic[CONF_RGB_COMMAND_TOPIC] is not None and SUPPORT_COLOR)
-        self._supported_features |= (
-            topic[CONF_RGB_COMMAND_TOPIC] is not None and SUPPORT_BRIGHTNESS)
+            topic[CONF_RGB_COMMAND_TOPIC] is not None and
+            (SUPPORT_COLOR | SUPPORT_BRIGHTNESS))
         self._supported_features |= (
             topic[CONF_BRIGHTNESS_COMMAND_TOPIC] is not None and
             SUPPORT_BRIGHTNESS)
@@ -622,7 +621,7 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, Light):
             if self._optimistic_brightness:
                 self._brightness = kwargs[ATTR_BRIGHTNESS]
                 should_update = True
-        elif ATTR_BRIGHTNESS in kwargs and \
+        elif ATTR_BRIGHTNESS in kwargs and ATTR_HS_COLOR not in kwargs and\
                 self._topic[CONF_RGB_COMMAND_TOPIC] is not None:
             rgb = color_util.color_hsv_to_RGB(
                 self._hs[0], self._hs[1], kwargs[ATTR_BRIGHTNESS] / 255 * 100)

--- a/homeassistant/components/light/mqtt.py
+++ b/homeassistant/components/light/mqtt.py
@@ -211,7 +211,11 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, Light):
         self._optimistic_rgb = \
             optimistic or topic[CONF_RGB_STATE_TOPIC] is None
         self._optimistic_brightness = (
-            optimistic or topic[CONF_BRIGHTNESS_STATE_TOPIC] is None)
+            optimistic or
+            (topic[CONF_BRIGHTNESS_COMMAND_TOPIC] is not None and
+             topic[CONF_BRIGHTNESS_STATE_TOPIC] is None) or
+            (topic[CONF_BRIGHTNESS_COMMAND_TOPIC] is None and
+             topic[CONF_RGB_STATE_TOPIC] is None))
         self._optimistic_color_temp = (
             optimistic or topic[CONF_COLOR_TEMP_STATE_TOPIC] is None)
         self._optimistic_effect = (

--- a/homeassistant/components/light/mqtt.py
+++ b/homeassistant/components/light/mqtt.py
@@ -618,6 +618,27 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, Light):
             if self._optimistic_brightness:
                 self._brightness = kwargs[ATTR_BRIGHTNESS]
                 should_update = True
+        elif ATTR_BRIGHTNESS in kwargs and \
+                self._topic[CONF_RGB_COMMAND_TOPIC] is not None:
+            rgb = color_util.color_hsv_to_RGB(
+                self._hs[0], self._hs[1], kwargs[ATTR_BRIGHTNESS] / 255 * 100)
+            tpl = self._templates[CONF_RGB_COMMAND_TEMPLATE]
+            if tpl:
+                rgb_color_str = tpl.async_render({
+                    'red': rgb[0],
+                    'green': rgb[1],
+                    'blue': rgb[2],
+                })
+            else:
+                rgb_color_str = '{},{},{}'.format(*rgb)
+
+            mqtt.async_publish(
+                self.hass, self._topic[CONF_RGB_COMMAND_TOPIC],
+                rgb_color_str, self._qos, self._retain)
+
+            if self._optimistic_brightness:
+                self._brightness = kwargs[ATTR_BRIGHTNESS]
+                should_update = True
 
         if ATTR_COLOR_TEMP in kwargs and \
            self._topic[CONF_COLOR_TEMP_COMMAND_TOPIC] is not None:


### PR DESCRIPTION
## Description:

RGB scaling should not be calculated when you set an mqtt brightness topic (IE you want to send a 'set the brightness to 50%' command directly), in which case a 'go red' and a 'set brightness to 50%' topic should both be sent.

If you don't set a brightness topic, the brightness slider should still appear in homeassistant, but the RGB values will be scaled and sent through to the RGB topic.

This has not been happening, the brightness slider wasn't showing, and RGB updates were only storing the colour, not the brightness.  This PR fixes the issue.

**Related issue (if applicable):** fixes #15964

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**