### PR TITLE
Smaller steps for Sonos volume up/down

### DIFF
--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -335,7 +335,7 @@ class SonosDevice(MediaPlayerDevice):
     def __init__(self, player):
         """Initialize the Sonos device."""
         self._receives_events = False
-        self._volume_increment = 5
+        self._volume_increment = 2
         self._unique_id = player.uid
         self._player = player
         self._model = None


### PR DESCRIPTION
## Description:

This makes `volume_up`/`volume_down` match the physical up/down buttons on my Sonos.

Suggested in chat.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
