### PR TITLE
Keep the repeat mode when setting Sonos shuffle mode

### DIFF
--- a/homeassistant/components/media_player/sonos.py
+++ b/homeassistant/components/media_player/sonos.py
@@ -342,7 +342,7 @@ class SonosDevice(MediaPlayerDevice):
         self._model = None
         self._player_volume = None
         self._player_muted = None
-        self._play_mode = None
+        self._shuffle = None
         self._name = None
         self._coordinator = None
         self._sonos_group = None
@@ -439,7 +439,7 @@ class SonosDevice(MediaPlayerDevice):
         speaker_info = self.soco.get_speaker_info(True)
         self._name = speaker_info['zone_name']
         self._model = speaker_info['model_name']
-        self._play_mode = self.soco.play_mode
+        self._shuffle = self.soco.shuffle
 
         self.update_volume()
 
@@ -532,7 +532,7 @@ class SonosDevice(MediaPlayerDevice):
         if new_status == 'TRANSITIONING':
             return
 
-        self._play_mode = self.soco.play_mode
+        self._shuffle = self.soco.shuffle
 
         if self.soco.is_playing_tv:
             self.update_media_linein(SOURCE_TV)
@@ -757,7 +757,7 @@ class SonosDevice(MediaPlayerDevice):
     @soco_coordinator
     def shuffle(self):
         """Shuffling state."""
-        return 'SHUFFLE' in self._play_mode
+        return self._shuffle
 
     @property
     def media_content_type(self):
@@ -837,7 +837,7 @@ class SonosDevice(MediaPlayerDevice):
     @soco_coordinator
     def set_shuffle(self, shuffle):
         """Enable/Disable shuffle mode."""
-        self.soco.play_mode = 'SHUFFLE_NOREPEAT' if shuffle else 'NORMAL'
+        self.soco.shuffle = shuffle
 
     @soco_error()
     def mute_volume(self, mute):

--- a/tests/components/media_player/test_sonos.py
+++ b/tests/components/media_player/test_sonos.py
@@ -57,7 +57,7 @@ class SoCoMock():
         self.is_visible = True
         self.volume = 50
         self.mute = False
-        self.play_mode = 'NORMAL'
+        self.shuffle = False
         self.night_mode = False
         self.dialog_mode = False
         self.music_library = MusicLibraryMock()


### PR DESCRIPTION
## Description:

Since pysonos 0.0.3 we can use the dedicated `shuffle` property to avoid having to alter the play mode by hand. This fixes an issue where we would ignore the repeat mode when setting shuffle mode.

**Related issue (if applicable):** fixes #13984

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
