### PR TITLE
Update xiaomi_miio.py

### DIFF
--- a/homeassistant/components/vacuum/xiaomi_miio.py
+++ b/homeassistant/components/vacuum/xiaomi_miio.py
@@ -40,10 +40,11 @@ SERVICE_START_REMOTE_CONTROL = 'xiaomi_remote_control_start'
 SERVICE_STOP_REMOTE_CONTROL = 'xiaomi_remote_control_stop'
 
 FAN_SPEEDS = {
-    'Quiet': 38,
-    'Balanced': 60,
-    'Turbo': 77,
-    'Max': 90}
+    'Quiet': 101,
+    'Balanced': 102,
+    'Turbo': 103,
+    'Max': 104,
+    'Mop': 105}
 
 ATTR_CLEANING_TIME = 'cleaning_time'
 ATTR_DO_NOT_DISTURB = 'do_not_disturb'


### PR DESCRIPTION
## Description:
Update fanspeeds to reflect values that Mi Home app is sending to the vacuum
Tested on Roborock S50, I've set the fanspeed in the app and checked the value with mirobo

Quiet
Fanspeed: 101 %

Balanced
Fanspeed: 102 %

Turbo
Fanspeed: 103 %

MAX
Fanspeed: 104 %

Mop
Fanspeed: 105 %

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.