### PR TITLE
Webhook component - pass headers to webhook handler

### DIFF
--- a/homeassistant/components/ifttt/__init__.py
+++ b/homeassistant/components/ifttt/__init__.py
@@ -78,7 +78,7 @@ async def async_setup(hass, config):
 
 async def handle_webhook(hass, webhook_id, request):
     """Handle webhook callback."""
-    body = request.text()
+    body = await request.text()
     try:
         data = json.loads(body) if body else {}
     except ValueError:

--- a/homeassistant/components/ifttt/__init__.py
+++ b/homeassistant/components/ifttt/__init__.py
@@ -9,7 +9,6 @@ import json
 import logging
 from urllib.parse import urlparse
 
-from aiohttp.web import Response
 import requests
 import voluptuous as vol
 
@@ -82,9 +81,7 @@ async def handle_webhook(hass, webhook_id, request):
     try:
         data = json.loads(body) if body else {}
     except ValueError:
-        _LOGGER.warning(
-            'Received webhook %s with invalid JSON', webhook_id)
-        return Response(status=200)
+        return None
 
     if isinstance(data, dict):
         data['webhook_id'] = webhook_id

--- a/homeassistant/components/ifttt/__init__.py
+++ b/homeassistant/components/ifttt/__init__.py
@@ -5,9 +5,11 @@ For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/ifttt/
 """
 from ipaddress import ip_address
+import json
 import logging
 from urllib.parse import urlparse
 
+from aiohttp.web import Response
 import requests
 import voluptuous as vol
 
@@ -74,8 +76,16 @@ async def async_setup(hass, config):
     return True
 
 
-async def handle_webhook(hass, webhook_id, data):
+async def handle_webhook(hass, webhook_id, request):
     """Handle webhook callback."""
+    body = request.text()
+    try:
+        data = json.loads(body) if body else {}
+    except ValueError:
+        _LOGGER.warning(
+            'Received webhook %s with invalid JSON', webhook_id)
+        return Response(status=200)
+
     if isinstance(data, dict):
         data['webhook_id'] = webhook_id
     hass.bus.async_fire(EVENT_RECEIVED, data)

--- a/homeassistant/components/webhook.py
+++ b/homeassistant/components/webhook.py
@@ -3,7 +3,6 @@
 For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/webhook/
 """
-import json
 import logging
 
 from aiohttp.web import Response
@@ -76,16 +75,8 @@ class WebhookView(HomeAssistantView):
                 'Received message for unregistered webhook %s', webhook_id)
             return Response(status=200)
 
-        body = await request.text()
         try:
-            data = json.loads(body) if body else {}
-        except ValueError:
-            _LOGGER.warning(
-                'Received webhook %s with invalid JSON', webhook_id)
-            return Response(status=200)
-
-        try:
-            response = await handler(hass, webhook_id, data, request.headers)
+            response = await handler(hass, webhook_id, request)
             if response is None:
                 response = Response(status=200)
             return response

--- a/homeassistant/components/webhook.py
+++ b/homeassistant/components/webhook.py
@@ -85,7 +85,7 @@ class WebhookView(HomeAssistantView):
             return Response(status=200)
 
         try:
-            response = await handler(hass, webhook_id, data)
+            response = await handler(hass, webhook_id, data, request.headers)
             if response is None:
                 response = Response(status=200)
             return response

--- a/tests/components/test_webhook.py
+++ b/tests/components/test_webhook.py
@@ -58,7 +58,6 @@ async def test_posting_webhook_invalid_json(hass, mock_client):
 
 async def test_posting_webhook_json(hass, mock_client):
     """Test posting a webhook with JSON data."""
-    from aiohttp.web import Request
     hooks = []
     webhook_id = hass.components.webhook.async_generate_id()
 
@@ -75,12 +74,12 @@ async def test_posting_webhook_json(hass, mock_client):
     assert len(hooks) == 1
     assert hooks[0][0] is hass
     assert hooks[0][1] == webhook_id
-    assert isinstance(hooks[0][2], Request)
+    # The line below causes PayloadAccessError
+    # assert await hooks[0][2].text() == '{\'data\':true}'
 
 
 async def test_posting_webhook_no_data(hass, mock_client):
     """Test posting a webhook with no data."""
-    from aiohttp.web import Request
     hooks = []
     webhook_id = hass.components.webhook.async_generate_id()
 
@@ -95,4 +94,4 @@ async def test_posting_webhook_no_data(hass, mock_client):
     assert len(hooks) == 1
     assert hooks[0][0] is hass
     assert hooks[0][1] == webhook_id
-    assert isinstance(hooks[0][2], Request)
+    assert await hooks[0][2].text() == ''

--- a/tests/components/test_webhook.py
+++ b/tests/components/test_webhook.py
@@ -58,6 +58,7 @@ async def test_posting_webhook_invalid_json(hass, mock_client):
 
 async def test_posting_webhook_json(hass, mock_client):
     """Test posting a webhook with JSON data."""
+    from aiohttp.web import Request
     hooks = []
     webhook_id = hass.components.webhook.async_generate_id()
 
@@ -74,13 +75,12 @@ async def test_posting_webhook_json(hass, mock_client):
     assert len(hooks) == 1
     assert hooks[0][0] is hass
     assert hooks[0][1] == webhook_id
-    assert hooks[0][2] == {
-        'data': True
-    }
+    assert isinstance(hooks[0][2], Request)
 
 
 async def test_posting_webhook_no_data(hass, mock_client):
     """Test posting a webhook with no data."""
+    from aiohttp.web import Request
     hooks = []
     webhook_id = hass.components.webhook.async_generate_id()
 
@@ -95,4 +95,4 @@ async def test_posting_webhook_no_data(hass, mock_client):
     assert len(hooks) == 1
     assert hooks[0][0] is hass
     assert hooks[0][1] == webhook_id
-    assert hooks[0][2] == {}
+    assert isinstance(hooks[0][2], Request)

--- a/tests/components/test_webhook.py
+++ b/tests/components/test_webhook.py
@@ -63,7 +63,7 @@ async def test_posting_webhook_json(hass, mock_client):
 
     async def handle(*args):
         """Handle webhook."""
-        hooks.append(args)
+        hooks.append((args[0], args[1], await args[2].text()))
 
     hass.components.webhook.async_register(webhook_id, handle)
 
@@ -74,8 +74,7 @@ async def test_posting_webhook_json(hass, mock_client):
     assert len(hooks) == 1
     assert hooks[0][0] is hass
     assert hooks[0][1] == webhook_id
-    # The line below causes PayloadAccessError
-    # assert await hooks[0][2].text() == '{\'data\':true}'
+    assert hooks[0][2] == '{"data": true}'
 
 
 async def test_posting_webhook_no_data(hass, mock_client):


### PR DESCRIPTION
## Description:
I'm suggesting to pass the headers (or the whole request object) to the webhook handler, besides the data and the `webhook_id`.

As I'm working on switching OwnTracks HTTP to use the webhooks component, I found out that the webhook component will pass to the handler only the data that is POST-ed by the OwnTracks app. The app, however, posts some necessary data as the username and the device ID as part of the headers, and the username and device ID are needed to match the device with the `known_devices.yaml` entry.

If I have access to the headers I can extract the necessary data automatically, and not require the user to create separate webhook IDs for each device they want to add.

~If this suggestion is accepted, I'll need to update the IFTTT component too.~

**Related issue (if applicable):** home-assistant/architecture/issues/80, home-assistant/home-assistant/pull/16817

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
