### PR TITLE
Add update service to Google Travel Sensor

### DIFF
--- a/homeassistant/components/sensor/google_travel_time.py
+++ b/homeassistant/components/sensor/google_travel_time.py
@@ -128,7 +128,7 @@ def setup_platform(hass, config, add_entities_callback, discovery_info=None):
 
     # Wait until start event is sent to load this component.
     hass.bus.listen_once(EVENT_HOMEASSISTANT_START, run_setup)
-    hass.services.register(DOMAIN, 'update_google_travel_sensor', update)
+    hass.services.register(DOMAIN, 'google_travel_sensor_update', update)
 
 
 class GoogleTravelTimeSensor(Entity):

--- a/homeassistant/components/sensor/google_travel_time.py
+++ b/homeassistant/components/sensor/google_travel_time.py
@@ -93,6 +93,7 @@ def setup_platform(hass, config, add_entities_callback, discovery_info=None):
             options['units'] = hass.config.units.name
         if DATA_KEY not in hass.data:
             hass.data[DATA_KEY] = []
+            hass.services.register(DOMAIN, 'google_travel_sensor_update', update)
 
         travel_mode = config.get(CONF_TRAVEL_MODE)
         mode = options.get(CONF_MODE)
@@ -128,8 +129,6 @@ def setup_platform(hass, config, add_entities_callback, discovery_info=None):
 
     # Wait until start event is sent to load this component.
     hass.bus.listen_once(EVENT_HOMEASSISTANT_START, run_setup)
-    hass.services.register(DOMAIN, 'google_travel_sensor_update', update)
-
 
 class GoogleTravelTimeSensor(Entity):
     """Representation of a Google travel time sensor."""

--- a/homeassistant/components/sensor/google_travel_time.py
+++ b/homeassistant/components/sensor/google_travel_time.py
@@ -10,7 +10,7 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.components.sensor import DOMAIN, PLATFORM_SCHEMA
 from homeassistant.helpers.entity import Entity
 from homeassistant.const import (
     CONF_API_KEY, CONF_NAME, EVENT_HOMEASSISTANT_START, ATTR_LATITUDE,
@@ -68,6 +68,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 TRACKABLE_DOMAINS = ['device_tracker', 'sensor', 'zone']
+DATA_KEY = 'google_travel_time'
 
 
 def convert_time_to_utc(timestr):
@@ -90,6 +91,8 @@ def setup_platform(hass, config, add_entities_callback, discovery_info=None):
 
         if options.get('units') is None:
             options['units'] = hass.config.units.name
+        if DATA_KEY not in hass.data:
+            hass.data[DATA_KEY] = []
 
         travel_mode = config.get(CONF_TRAVEL_MODE)
         mode = options.get(CONF_MODE)
@@ -110,12 +113,22 @@ def setup_platform(hass, config, add_entities_callback, discovery_info=None):
 
         sensor = GoogleTravelTimeSensor(
             hass, name, api_key, origin, destination, options)
+        hass.data[DATA_KEY].append(sensor)
 
         if sensor.valid_api_connection:
             add_entities_callback([sensor])
 
+    def update(service):
+        """Update service for manual updates."""
+        entity_id = service.data.get('entity_id')
+        for sensor in hass.data[DATA_KEY]:
+            if sensor.entity_id == entity_id:
+                sensor.update(no_throttle=True)
+                sensor.schedule_update_ha_state()
+
     # Wait until start event is sent to load this component.
     hass.bus.listen_once(EVENT_HOMEASSISTANT_START, run_setup)
+    hass.services.register(DOMAIN, 'update_google_travel_sensor', update)
 
 
 class GoogleTravelTimeSensor(Entity):

--- a/homeassistant/components/sensor/google_travel_time.py
+++ b/homeassistant/components/sensor/google_travel_time.py
@@ -93,7 +93,8 @@ def setup_platform(hass, config, add_entities_callback, discovery_info=None):
             options['units'] = hass.config.units.name
         if DATA_KEY not in hass.data:
             hass.data[DATA_KEY] = []
-            hass.services.register(DOMAIN, 'google_travel_sensor_update', update)
+            hass.services.register(
+                DOMAIN, 'google_travel_sensor_update', update)
 
         travel_mode = config.get(CONF_TRAVEL_MODE)
         mode = options.get(CONF_MODE)
@@ -129,6 +130,7 @@ def setup_platform(hass, config, add_entities_callback, discovery_info=None):
 
     # Wait until start event is sent to load this component.
     hass.bus.listen_once(EVENT_HOMEASSISTANT_START, run_setup)
+
 
 class GoogleTravelTimeSensor(Entity):
     """Representation of a Google travel time sensor."""


### PR DESCRIPTION
## Description:
Google limited the number of API calls. Limiting the the number of calls using `scan_interval` (as suggested in the docs) is very inefficient. Instead, this PR creates a service call that can be used to update the sensor on demand. 

**Related issue (if applicable):** fixes #14250

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#6474

So, if you want to update one of the sensors every 2 minutes on weekday mornings, you can use an automation like:

```yaml
- id: update_morning_commute_sensor
  alias: "Commute - Update morning commute sensor"
  initial_state: 'on'
  trigger:
    - platform: time
      minutes: '/2'
      seconds: 00
  condition:
    - condition: time
      after: '08:00:00'
      before: '11:00:00'
    - condition: time
      weekday:
        - mon
        - tue
        - wed
        - thu
        - fri
    - condition: state
      entity_id: device_tracker.meta_alok
      state: 'home'
  action:
    - service: sensor.google_travel_sensor_update
      entity_id: sensor.morning_commute
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)