### PR TITLE
Add weather condition code to OpenWeatherMap sensor

### DIFF
--- a/homeassistant/components/sensor/openweathermap.py
+++ b/homeassistant/components/sensor/openweathermap.py
@@ -39,6 +39,7 @@ SENSOR_TYPES = {
     'clouds': ['Cloud coverage', '%'],
     'rain': ['Rain', 'mm'],
     'snow': ['Snow', 'mm'],
+    'weather_code': ['Weather code', None],
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -177,6 +178,8 @@ class OpenWeatherMapSensor(Entity):
             if fc_data is None:
                 return
             self._state = fc_data.get_weathers()[0].get_detailed_status()
+        elif self.type == 'weather_code':
+            self._state = data.get_weather_code()
 
 
 class WeatherData:


### PR DESCRIPTION
## Description:
Add weather condition code to OpenWeatherMap Sensor. Now, you can easy create a "bad weather" trigger in the automation section. For example:

trigger:
     platform: numeric_state
     entity_id: sensor.owm_weather_code
     below: 800


**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#6468
## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
