### PR TITLE
Add timeout and fix oscillations on Samsung TV component

### DIFF
--- a/homeassistant/components/media_player/samsungtv.py
+++ b/homeassistant/components/media_player/samsungtv.py
@@ -124,20 +124,15 @@ class SamsungTVDevice(MediaPlayerDevice):
 
     def update(self):
         """Update state of device."""
-        count = 3  # number of echo requests
         if sys.platform == 'win32':
             timeout_arg = '-w {}000'.format(self._config['timeout'])
-            count_arg = '-n {}'.format(count)
-
             _ping_cmd = [
-                'ping', count_arg, timeout_arg, self._config['host']]
+                'ping', '-n 3', timeout_arg, self._config['host']]
         else:
             timeout_arg = '-W{}'.format(self._config['timeout'])
-            count_arg = '-c{}'.format(count)
-
             _ping_cmd = [
                 'ping', '-n', '-q',
-                count_arg, timeout_arg, self._config['host']]
+                '-c3', timeout_arg, self._config['host']]
 
         ping = subprocess.Popen(
             _ping_cmd,

--- a/homeassistant/components/media_player/samsungtv.py
+++ b/homeassistant/components/media_player/samsungtv.py
@@ -124,19 +124,20 @@ class SamsungTVDevice(MediaPlayerDevice):
 
     def update(self):
         """Update state of device."""
-        count = 3
+        count = 3  # number of echo requests
         if sys.platform == 'win32':
+            timeout_arg = '-w {}000'.format(self._config['timeout'])
+            count_arg = '-n {}'.format(count)
+
             _ping_cmd = [
-                'ping', f'-n {count}', '-w',
-                f"{self._config['timeout']}000",
-                self._config['host']
-            ]
+                'ping', count_arg, timeout_arg, self._config['host']]
         else:
+            timeout_arg = '-W{}'.format(self._config['timeout'])
+            count_arg = '-c{}'.format(count)
+
             _ping_cmd = [
-                'ping', '-n', '-q', f'-c{count}',
-                f"-W{self._config['timeout']}",
-                self._config['host']
-            ]
+                'ping', '-n', '-q',
+                count_arg, timeout_arg, self._config['host']]
 
         ping = subprocess.Popen(
             _ping_cmd,

--- a/homeassistant/components/media_player/samsungtv.py
+++ b/homeassistant/components/media_player/samsungtv.py
@@ -124,11 +124,19 @@ class SamsungTVDevice(MediaPlayerDevice):
 
     def update(self):
         """Update state of device."""
+        count = 3
         if sys.platform == 'win32':
-            _ping_cmd = ['ping', '-n 1', '-w', '1000', self._config['host']]
+            _ping_cmd = [
+                'ping', f'-n {count}', '-w',
+                f"{self._config['timeout']}000",
+                self._config['host']
+            ]
         else:
-            _ping_cmd = ['ping', '-n', '-q', '-c1', '-W1',
-                         self._config['host']]
+            _ping_cmd = [
+                'ping', '-n', '-q', f'-c{count}',
+                f"-W{self._config['timeout']}",
+                self._config['host']
+            ]
 
         ping = subprocess.Popen(
             _ping_cmd,

--- a/tests/components/media_player/test_samsungtv.py
+++ b/tests/components/media_player/test_samsungtv.py
@@ -138,8 +138,9 @@ class TestSamsungTv(unittest.TestCase):
         ping.returncode = 0
         self.device.update()
         expected_timeout = self.device._config['timeout']
+        timeout_arg = '-W{}'.format(expected_timeout)
         ping_command = [
-            'ping', '-n', '-q', '-c3', f'-W{expected_timeout}', 'fake']
+            'ping', '-n', '-q', '-c3', timeout_arg, 'fake']
         expected_call = call(ping_command, stderr=-3, stdout=-1)
         self.assertEqual(mocked_popen.call_args, expected_call)
         self.assertEqual(STATE_ON, self.device._state)

--- a/tests/components/media_player/test_samsungtv.py
+++ b/tests/components/media_player/test_samsungtv.py
@@ -128,6 +128,22 @@ class TestSamsungTv(unittest.TestCase):
         self.device.update()
         self.assertEqual(STATE_OFF, self.device._state)
 
+    @mock.patch(
+        'homeassistant.components.media_player.samsungtv.subprocess.Popen'
+    )
+    def test_timeout(self, mocked_popen):
+        """Test timeout use."""
+        ping = mock.Mock()
+        mocked_popen.return_value = ping
+        ping.returncode = 0
+        self.device.update()
+        expected_timeout = self.device._config['timeout']
+        ping_command = [
+            'ping', '-n', '-q', '-c3', f'-W{expected_timeout}', 'fake']
+        expected_call = call(ping_command, stderr=-3, stdout=-1)
+        self.assertEqual(mocked_popen.call_args, expected_call)
+        self.assertEqual(STATE_ON, self.device._state)
+
     def test_send_key(self):
         """Test for send key."""
         self.device.send_key('KEY_POWER')


### PR DESCRIPTION
## Description:

Add timeout to ping command and send 3 echo requests instead of one. Those modifications fixes the flapping problem in Samsung TVs. Before that, even when the TV was ON the status has been changed between ON and OFF, causing few problems with automations (like lights on and off from nowhere).

Tested with HA 0.79.2 and Samsung TV UEMU6199UXZG.

**Related issue (if applicable):** fixes #12604 and #16446 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** not applicable

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
