### PR TITLE
Fix jewish calendar sensor with language set to english

### DIFF
--- a/homeassistant/components/sensor/jewish_calendar.py
+++ b/homeassistant/components/sensor/jewish_calendar.py
@@ -116,10 +116,14 @@ class JewishCalSensor(Entity):
                 date.get_reading(self.diaspora), hebrew=self._hebrew)
         elif self.type == 'holiday_name':
             try:
-                self._state = next(
-                    x.description[self._hebrew].long
+                description = next(
+                    x.description[self._hebrew]
                     for x in hdate.htables.HOLIDAYS
                     if x.index == date.get_holyday())
+                if not self._hebrew:
+                    self._state = description
+                else:
+                    self._state = description.long
             except StopIteration:
                 self._state = None
         elif self.type == 'holyness':

--- a/tests/components/sensor/test_jewish_calendar.py
+++ b/tests/components/sensor/test_jewish_calendar.py
@@ -95,6 +95,18 @@ class TestJewishCalenderSensor(unittest.TestCase):
                 sensor.async_update(), self.hass.loop).result()
             self.assertEqual(sensor.state, "א\' ראש השנה")
 
+    def test_jewish_calendar_sensor_holiday_name_english(self):
+        """Test Jewish calendar sensor date output in hebrew."""
+        test_time = dt(2018, 9, 10)
+        sensor = JewishCalSensor(
+            name='test', language='english', sensor_type='holiday_name',
+            latitude=self.TEST_LATITUDE, longitude=self.TEST_LONGITUDE,
+            diaspora=False)
+        with patch('homeassistant.util.dt.now', return_value=test_time):
+            run_coroutine_threadsafe(
+                sensor.async_update(), self.hass.loop).result()
+            self.assertEqual(sensor.state, "Rosh Hashana I")
+
     def test_jewish_calendar_sensor_holyness(self):
         """Test Jewish calendar sensor date output in hebrew."""
         test_time = dt(2018, 9, 10)


### PR DESCRIPTION
## Description:
This fixes the issue and adds a testcase when requesting the jewish calendar sensor to display the holiday name in english. The correct place for this should be in the external hdat library, but for the time being I'm putting it here so it doesn't break the given configuration.

**Related issue (if applicable):** fixes #16830 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
N/A

If the code communicates with devices, web services, or third-party tools: 
N/A

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
