### PR TITLE
Implemented tplink_lte components and notify service via SMS

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -328,6 +328,9 @@ omit =
     homeassistant/components/toon.py
     homeassistant/components/*/toon.py
 
+    homeassistant/components/tplink_lte.py
+    homeassistant/components/*/tplink_lte.py
+
     homeassistant/components/tradfri.py
     homeassistant/components/*/tradfri.py
 

--- a/homeassistant/components/notify/tplink_lte.py
+++ b/homeassistant/components/notify/tplink_lte.py
@@ -1,0 +1,57 @@
+"""TP-Link LTE platform for notify component.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/notify.tplink_lte/
+"""
+
+import logging
+
+import voluptuous as vol
+import attr
+
+from homeassistant.components.notify import (
+    BaseNotificationService, ATTR_TARGET, PLATFORM_SCHEMA)
+from homeassistant.const import CONF_HOST
+import homeassistant.helpers.config_validation as cv
+
+from ..tplink_lte import DATA_KEY
+
+
+DEPENDENCIES = ['tplink_lte']
+
+_LOGGER = logging.getLogger(__name__)
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_HOST): cv.string,
+    vol.Required(ATTR_TARGET): vol.All(cv.ensure_list, [cv.string]),
+})
+
+
+async def async_get_service(hass, config, discovery_info=None):
+    """Get the notification service."""
+    return TplinkNotifyService(hass, config)
+
+
+@attr.s
+class TplinkNotifyService(BaseNotificationService):
+    """Implementation of a notification service."""
+
+    hass = attr.ib()
+    config = attr.ib()
+
+    async def async_send_message(self, message="", **kwargs):
+        """Send a message to a user."""
+        import tp_connected
+        modem_data = self.hass.data[DATA_KEY].get_modem_data(self.config)
+        if not modem_data:
+            _LOGGER.error("No modem available")
+            return
+
+        phone = self.config.get(ATTR_TARGET)
+        targets = kwargs.get(ATTR_TARGET, phone)
+        if targets and message:
+            for target in targets:
+                try:
+                    await modem_data.modem.sms(target, message)
+                except tp_connected.Error:
+                    _LOGGER.error("Unable to send to %s", target)

--- a/homeassistant/components/notify/tplink_lte.py
+++ b/homeassistant/components/notify/tplink_lte.py
@@ -6,30 +6,23 @@ https://home-assistant.io/components/notify.tplink_lte/
 
 import logging
 
-import voluptuous as vol
 import attr
 
 from homeassistant.components.notify import (
-    BaseNotificationService, ATTR_TARGET, PLATFORM_SCHEMA)
-from homeassistant.const import CONF_HOST
-import homeassistant.helpers.config_validation as cv
+    ATTR_TARGET, BaseNotificationService)
 
 from ..tplink_lte import DATA_KEY
-
 
 DEPENDENCIES = ['tplink_lte']
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Optional(CONF_HOST): cv.string,
-    vol.Required(ATTR_TARGET): vol.All(cv.ensure_list, [cv.string]),
-})
-
 
 async def async_get_service(hass, config, discovery_info=None):
     """Get the notification service."""
-    return TplinkNotifyService(hass, config)
+    if discovery_info is None:
+        return
+    return TplinkNotifyService(hass, discovery_info)
 
 
 @attr.s
@@ -47,7 +40,7 @@ class TplinkNotifyService(BaseNotificationService):
             _LOGGER.error("No modem available")
             return
 
-        phone = self.config.get(ATTR_TARGET)
+        phone = self.config[ATTR_TARGET]
         targets = kwargs.get(ATTR_TARGET, phone)
         if targets and message:
             for target in targets:

--- a/homeassistant/components/tplink_lte.py
+++ b/homeassistant/components/tplink_lte.py
@@ -1,0 +1,109 @@
+"""
+Support for TP-Link LTE modems.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/tplink_lte/
+"""
+import asyncio
+import logging
+from datetime import timedelta
+
+import aiohttp
+import attr
+import voluptuous as vol
+
+from homeassistant.const import (
+    CONF_HOST, CONF_PASSWORD, EVENT_HOMEASSISTANT_STOP)
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.aiohttp_client import async_create_clientsession
+
+REQUIREMENTS = ['tp-connected==0.0.4']
+
+_LOGGER = logging.getLogger(__name__)
+
+MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=10)
+
+DOMAIN = 'tplink_lte'
+DATA_KEY = 'tplink_lte'
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.All(cv.ensure_list, [vol.Schema({
+        vol.Required(CONF_HOST): cv.string,
+        vol.Required(CONF_PASSWORD): cv.string,
+    })])
+}, extra=vol.ALLOW_EXTRA)
+
+
+@attr.s
+class ModemData:
+    """Class for modem state."""
+
+    modem = attr.ib()
+
+
+@attr.s
+class LTEData:
+    """Shared state."""
+
+    websession = attr.ib()
+    modem_data = attr.ib(init=False, factory=dict)
+
+    def get_modem_data(self, config):
+        """Get the requested or the only modem_data value."""
+        if CONF_HOST in config:
+            return self.modem_data.get(config[CONF_HOST])
+        if len(self.modem_data) == 1:
+            return next(iter(self.modem_data.values()))
+
+        return None
+
+
+async def async_setup(hass, config):
+    """Set up TP-Link LTE component."""
+    if DATA_KEY not in hass.data:
+        websession = async_create_clientsession(
+            hass, cookie_jar=aiohttp.CookieJar(unsafe=True))
+        hass.data[DATA_KEY] = LTEData(websession)
+
+    tasks = [_setup_lte(hass, conf) for conf in config.get(DOMAIN, [])]
+    if tasks:
+        await asyncio.wait(tasks)
+
+    return True
+
+
+async def _setup_lte(hass, lte_config, delay=0):
+    """Set up a TP-Link LTE modem."""
+    import tp_connected
+
+    try:
+        if delay:
+            await asyncio.sleep(delay)
+    except asyncio.CancelledError:
+        return
+
+    host = lte_config[CONF_HOST]
+    password = lte_config[CONF_PASSWORD]
+
+    websession = hass.data[DATA_KEY].websession
+    modem = tp_connected.Modem(hostname=host, websession=websession)
+
+    try:
+        await modem.login(password=password)
+    except asyncio.CancelledError:
+        return
+    except tp_connected.Error:
+        delay = max(15, min(2*delay, 300))
+        _LOGGER.warning("Retrying %s in %d seconds", host, delay)
+        task = hass.loop.create_task(_setup_lte(hass, lte_config, delay))
+        return
+
+    modem_data = ModemData(modem)
+    hass.data[DATA_KEY].modem_data[host] = modem_data
+
+    async def cleanup(event):
+        """Clean up resources."""
+        task.cancel()
+        await modem.logout()
+
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, cleanup)

--- a/homeassistant/components/tplink_lte.py
+++ b/homeassistant/components/tplink_lte.py
@@ -124,9 +124,7 @@ async def _login(hass, modem_data, password):
     except asyncio.CancelledError:
         return
 
-    _LOGGER.warning("Connected to %s", modem_data.host)
     modem_data.connected = True
-
     hass.data[DATA_KEY].modem_data[modem_data.host] = modem_data
 
     async def cleanup(event):
@@ -154,5 +152,6 @@ async def _retry_login(hass, modem_data, password):
 
         try:
             await _login(hass, modem_data, password)
+            _LOGGER.warning("Connected to %s", modem_data.host)
         except tp_connected.Error:
             delay = min(2*delay, 300)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1469,6 +1469,9 @@ toonlib==1.0.2
 # homeassistant.components.alarm_control_panel.totalconnect
 total_connect_client==0.18
 
+# homeassistant.components.tplink_lte
+tp-connected==0.0.4
+
 # homeassistant.components.device_tracker.tplink
 tplink==0.2.1
 


### PR DESCRIPTION
## Description:

A new component to handle TP-Link LTE routers. The only feature implemented is a notify service to send SMS trough the the router. I plan to add new features like router status and SMS inbox.

This component has a lot of similarities with the `netgear_lte` component and my code is heavily based on it. I think that the 2 components could be merged together as an abstract "LTE modem" handler. I'm going to find out where is the best place to talk about this proposal but for now I think that two separate components is the right solution.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#6485

## Example entry for `configuration.yaml` (if applicable):
```yaml
tplink_lte:
  - host: 192.168.1.1
    password: secret

notify:
  - platform: tplink_lte
    name: sms
    target: "+393405555555"
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass** 
**Tox with virtualenv seems to be broken in my local environment, I'll figure out a solution but for now I'm going to check the results on Travis**

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) 

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
