### PR TITLE
Manual IP & port configuration for Konnected devices

### DIFF
--- a/homeassistant/components/konnected.py
+++ b/homeassistant/components/konnected.py
@@ -85,7 +85,7 @@ CONFIG_SCHEMA = vol.Schema(
                 vol.Optional(CONF_SWITCHES): vol.All(
                     cv.ensure_list, [_SWITCH_SCHEMA]),
                 vol.Optional(CONF_HOST): cv.string,
-                vol.Optional(CONF_PORT): cv.positive_int,
+                vol.Optional(CONF_PORT): cv.port,
                 vol.Optional(CONF_BLINK): cv.boolean,
                 vol.Optional(CONF_DISCOVERY): cv.boolean,
             }],
@@ -130,9 +130,8 @@ async def async_setup(hass, config):
 
     def manual_discovery(event):
         """Init devices on the network with manually assigned addresses."""
-        specified = list(filter(  # list of devices where host and port is set
-            lambda dev: dev.get(CONF_HOST) and dev.get(CONF_PORT),
-            cfg.get(CONF_DEVICES)))
+        specified = [dev for dev in cfg.get(CONF_DEVICES) if
+                     dev.get(CONF_HOST) and dev.get(CONF_PORT)]
 
         while specified:
             for dev in specified:
@@ -148,10 +147,10 @@ async def async_setup(hass, config):
                         discovered.setup()
                         specified.remove(dev)
                     else:
-                        _LOGGER.err("""
-                            Konnected device %s was manually configured, but
-                            its mac address is not found in configuration.yaml
-                        """, discovered.device_id)
+                        _LOGGER.error("Konnected device %s was manually "
+                                      "configured, but its mac address is not "
+                                      "found in configuration.yaml",
+                                      discovered.device_id)
                 except konnected.Client.ClientError as err:
                     _LOGGER.error(err)
                     time.sleep(10)  # try again in 10 seconds

--- a/homeassistant/components/konnected.py
+++ b/homeassistant/components/konnected.py
@@ -9,7 +9,6 @@ import hmac
 import json
 import time
 import voluptuous as vol
-import konnected
 
 from aiohttp.hdrs import AUTHORIZATION
 from aiohttp.web import Request, Response
@@ -104,6 +103,8 @@ SIGNAL_SENSOR_UPDATE = 'konnected.{}.update'
 
 async def async_setup(hass, config):
     """Set up the Konnected platform."""
+    import konnected
+
     cfg = config.get(DOMAIN)
     if cfg is None:
         cfg = {}
@@ -254,6 +255,7 @@ class DiscoveredDevice:
         self.host = host
         self.port = port
 
+        import konnected
         self.client = konnected.Client(host, str(port))
         self.status = self.client.get_status()
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -528,7 +528,7 @@ keyrings.alt==3.1
 kiwiki-client==0.1.1
 
 # homeassistant.components.konnected
-konnected==0.1.2
+konnected==0.1.3
 
 # homeassistant.components.eufy
 lakeside==0.10

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -528,7 +528,7 @@ keyrings.alt==3.1
 kiwiki-client==0.1.1
 
 # homeassistant.components.konnected
-konnected==0.1.3
+konnected==0.1.4
 
 # homeassistant.components.eufy
 lakeside==0.10


### PR DESCRIPTION
## Description:
Allows manual configuration of Konnected devices by specifying `host` and `port` configs. This enables you to not rely on discovery to set up Konnected devices -- useful for advanced networks where devices are not on the same subnet and improves reliability/recovery after a reboot.

Also adds a new `discovery` boolean config to turn off discovery (on the device) if desired. This makes it more secure and also reduces memory overhead on the ESP8266.

Adds a `blink` boolean config to disable the blue LED blink on success.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation:** https://github.com/home-assistant/home-assistant.io/pull/6493

## Example entry for `configuration.yaml` (if applicable):
```yaml
konnected:
  access_token: REPLACE_ME_WITH_A_RANDOM_STRING
  devices:
    - id: 438a388bcd53
      host: 192.168.86.201
      port: 17604
      discovery: false
      blink: false
      binary_sensors:
        - zone: 1
          type: door
      switches:
        - zone: out
    - id: 8bcd53438a38
      binary_sensors:
        - pin: 2
          type: door
      switches:
        - pin: 5
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
