### PR TITLE
Add time created to persistent notifications.

### DIFF
--- a/homeassistant/components/persistent_notification/__init__.py
+++ b/homeassistant/components/persistent_notification/__init__.py
@@ -149,7 +149,7 @@ async def async_setup(hass: HomeAssistant, config: dict) -> Awaitable[bool]:
             ATTR_NOTIFICATION_ID: notification_id,
             ATTR_STATUS: STATUS_UNREAD,
             ATTR_TITLE: title,
-            ATTR_CREATED_AT: dt_util.now(),
+            ATTR_CREATED_AT: dt_util.utcnow(),
         }
 
         hass.bus.async_fire(EVENT_PERSISTENT_NOTIFICATIONS_UPDATED)

--- a/homeassistant/components/persistent_notification/__init__.py
+++ b/homeassistant/components/persistent_notification/__init__.py
@@ -17,7 +17,9 @@ from homeassistant.loader import bind_hass
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity import async_generate_entity_id
 from homeassistant.util import slugify
+import homeassistant.util.dt as dt_util
 
+ATTR_CREATED_AT = 'created_at'
 ATTR_MESSAGE = 'message'
 ATTR_NOTIFICATION_ID = 'notification_id'
 ATTR_TITLE = 'title'
@@ -147,6 +149,7 @@ async def async_setup(hass: HomeAssistant, config: dict) -> Awaitable[bool]:
             ATTR_NOTIFICATION_ID: notification_id,
             ATTR_STATUS: STATUS_UNREAD,
             ATTR_TITLE: title,
+            ATTR_CREATED_AT: dt_util.now(),
         }
 
         hass.bus.async_fire(EVENT_PERSISTENT_NOTIFICATIONS_UPDATED)
@@ -203,8 +206,9 @@ def websocket_get_notifications(
     connection.send_message(
         websocket_api.result_message(msg['id'], [
             {
-                key: data[key] for key in (ATTR_NOTIFICATION_ID, ATTR_MESSAGE,
-                                           ATTR_STATUS, ATTR_TITLE)
+                key: data[key] for key in (ATTR_NOTIFICATION_ID,
+                                           ATTR_MESSAGE, ATTR_STATUS,
+                                           ATTR_TITLE, ATTR_CREATED_AT)
             }
             for data in hass.data[DOMAIN]['notifications'].values()
         ])

--- a/tests/components/persistent_notification/test_init.py
+++ b/tests/components/persistent_notification/test_init.py
@@ -41,6 +41,7 @@ class TestPersistentNotification:
         assert notification['status'] == pn.STATUS_UNREAD
         assert notification['message'] == 'Hello World 2'
         assert notification['title'] == '2 beers'
+        assert notification['created_at'] is not None
         notifications.clear()
 
     def test_create_notification_id(self):
@@ -174,6 +175,7 @@ async def test_ws_get_notifications(hass, hass_ws_client):
     assert notification['message'] == 'test'
     assert notification['title'] is None
     assert notification['status'] == pn.STATUS_UNREAD
+    assert notification['created_at'] is not None
 
     # Mark Read
     await hass.services.async_call(pn.DOMAIN, pn.SERVICE_MARK_READ, {


### PR DESCRIPTION
## Description:
Adds date/time `persistent_notification` was created

Related frontend PR: https://github.com/home-assistant/home-assistant-polymer/pull/1733

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
