### PR TITLE
Make it easier for auth to consume newer formats

### DIFF
--- a/homeassistant/auth/models.py
+++ b/homeassistant/auth/models.py
@@ -19,19 +19,19 @@ class User:
     """A user."""
 
     name = attr.ib(type=str)  # type: Optional[str]
-    id = attr.ib(type=str, default=attr.Factory(lambda: uuid.uuid4().hex))
+    id = attr.ib(type=str, factory=lambda: uuid.uuid4().hex)
     is_owner = attr.ib(type=bool, default=False)
     is_active = attr.ib(type=bool, default=False)
     system_generated = attr.ib(type=bool, default=False)
 
     # List of credentials of a user.
     credentials = attr.ib(
-        type=list, default=attr.Factory(list), cmp=False
+        type=list, factory=list, cmp=False
     )  # type: List[Credentials]
 
     # Tokens associated with a user.
     refresh_tokens = attr.ib(
-        type=dict, default=attr.Factory(dict), cmp=False
+        type=dict, factory=dict, cmp=False
     )  # type: Dict[str, RefreshToken]
 
 
@@ -48,12 +48,10 @@ class RefreshToken:
                          validator=attr.validators.in_((
                              TOKEN_TYPE_NORMAL, TOKEN_TYPE_SYSTEM,
                              TOKEN_TYPE_LONG_LIVED_ACCESS_TOKEN)))
-    id = attr.ib(type=str, default=attr.Factory(lambda: uuid.uuid4().hex))
-    created_at = attr.ib(type=datetime, default=attr.Factory(dt_util.utcnow))
-    token = attr.ib(type=str,
-                    default=attr.Factory(lambda: generate_secret(64)))
-    jwt_key = attr.ib(type=str,
-                      default=attr.Factory(lambda: generate_secret(64)))
+    id = attr.ib(type=str, factory=lambda: uuid.uuid4().hex)
+    created_at = attr.ib(type=datetime, factory=dt_util.utcnow)
+    token = attr.ib(type=str, factory=lambda: generate_secret(64))
+    jwt_key = attr.ib(type=str, factory=lambda: generate_secret(64))
 
     last_used_at = attr.ib(type=Optional[datetime], default=None)
     last_used_ip = attr.ib(type=Optional[str], default=None)
@@ -69,7 +67,7 @@ class Credentials:
     # Allow the auth provider to store data to represent their auth.
     data = attr.ib(type=dict)
 
-    id = attr.ib(type=str, default=attr.Factory(lambda: uuid.uuid4().hex))
+    id = attr.ib(type=str, factory=lambda: uuid.uuid4().hex)
     is_new = attr.ib(type=bool, default=True)
 
 

--- a/homeassistant/helpers/storage.py
+++ b/homeassistant/helpers/storage.py
@@ -2,7 +2,7 @@
 import asyncio
 import logging
 import os
-from typing import Dict, Optional, Callable
+from typing import Dict, Optional, Callable, Any
 
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import callback
@@ -63,7 +63,7 @@ class Store:
         """Return the config path."""
         return self.hass.config.path(STORAGE_DIR, self.key)
 
-    async def async_load(self):
+    async def async_load(self) -> Optional[Dict[str, Any]]:
         """Load data.
 
         If the expected version does not match the given version, the migrate

--- a/tests/common.py
+++ b/tests/common.py
@@ -392,7 +392,7 @@ def ensure_auth_manager_loaded(auth_mgr):
     """Ensure an auth manager is considered loaded."""
     store = auth_mgr._store
     if store._users is None:
-        store._users = OrderedDict()
+        store._set_defaults()
 
 
 class MockModule:


### PR DESCRIPTION
## Description:
Some cleanups and making it easier for auth to consume newer versions of the auth storage in case we need to be backwards compatible.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
