### PR TITLE
Take timezone into consideration when calulating Zmanim.

### DIFF
--- a/homeassistant/components/sensor/jewish_calendar.py
+++ b/homeassistant/components/sensor/jewish_calendar.py
@@ -64,7 +64,8 @@ async def async_setup_platform(
     dev = []
     for sensor_type in config[CONF_SENSORS]:
         dev.append(JewishCalSensor(
-            name, language, sensor_type, latitude, longitude, diaspora))
+            name, language, sensor_type, latitude, longitude,
+            hass.config.time_zone, diaspora))
     async_add_entities(dev, True)
 
 
@@ -72,7 +73,8 @@ class JewishCalSensor(Entity):
     """Representation of an Jewish calendar sensor."""
 
     def __init__(
-            self, name, language, sensor_type, latitude, longitude, diaspora):
+            self, name, language, sensor_type, latitude, longitude, timezone,
+            diaspora):
         """Initialize the Jewish calendar sensor."""
         self.client_name = name
         self._name = SENSOR_TYPES[sensor_type][0]
@@ -81,6 +83,7 @@ class JewishCalSensor(Entity):
         self._state = None
         self.latitude = latitude
         self.longitude = longitude
+        self.timezone = timezone
         self.diaspora = diaspora
         _LOGGER.debug("Sensor %s initialized", self.type)
 
@@ -131,7 +134,7 @@ class JewishCalSensor(Entity):
         else:
             times = hdate.Zmanim(
                 date=today, latitude=self.latitude, longitude=self.longitude,
-                hebrew=self._hebrew).zmanim
+                timezone=self.timezone, hebrew=self._hebrew).zmanim
             self._state = times[self.type].time()
 
         _LOGGER.debug("New value: %s", self._state)

--- a/tests/components/sensor/test_jewish_calendar.py
+++ b/tests/components/sensor/test_jewish_calendar.py
@@ -1,5 +1,6 @@
 """The tests for the Jewish calendar sensor platform."""
 import unittest
+from datetime import time
 from datetime import datetime as dt
 from unittest.mock import patch
 
@@ -64,7 +65,7 @@ class TestJewishCalenderSensor(unittest.TestCase):
         sensor = JewishCalSensor(
             name='test', language='english', sensor_type='date',
             latitude=self.TEST_LATITUDE, longitude=self.TEST_LONGITUDE,
-            diaspora=False)
+            timezone="UTC", diaspora=False)
         with patch('homeassistant.util.dt.now', return_value=test_time):
             run_coroutine_threadsafe(
                 sensor.async_update(),
@@ -77,7 +78,7 @@ class TestJewishCalenderSensor(unittest.TestCase):
         sensor = JewishCalSensor(
             name='test', language='hebrew', sensor_type='date',
             latitude=self.TEST_LATITUDE, longitude=self.TEST_LONGITUDE,
-            diaspora=False)
+            timezone="UTC", diaspora=False)
         with patch('homeassistant.util.dt.now', return_value=test_time):
             run_coroutine_threadsafe(
                 sensor.async_update(), self.hass.loop).result()
@@ -89,7 +90,7 @@ class TestJewishCalenderSensor(unittest.TestCase):
         sensor = JewishCalSensor(
             name='test', language='hebrew', sensor_type='holiday_name',
             latitude=self.TEST_LATITUDE, longitude=self.TEST_LONGITUDE,
-            diaspora=False)
+            timezone="UTC", diaspora=False)
         with patch('homeassistant.util.dt.now', return_value=test_time):
             run_coroutine_threadsafe(
                 sensor.async_update(), self.hass.loop).result()
@@ -101,7 +102,7 @@ class TestJewishCalenderSensor(unittest.TestCase):
         sensor = JewishCalSensor(
             name='test', language='english', sensor_type='holiday_name',
             latitude=self.TEST_LATITUDE, longitude=self.TEST_LONGITUDE,
-            diaspora=False)
+            timezone="UTC", diaspora=False)
         with patch('homeassistant.util.dt.now', return_value=test_time):
             run_coroutine_threadsafe(
                 sensor.async_update(), self.hass.loop).result()
@@ -113,7 +114,7 @@ class TestJewishCalenderSensor(unittest.TestCase):
         sensor = JewishCalSensor(
             name='test', language='hebrew', sensor_type='holyness',
             latitude=self.TEST_LATITUDE, longitude=self.TEST_LONGITUDE,
-            diaspora=False)
+            timezone="UTC", diaspora=False)
         with patch('homeassistant.util.dt.now', return_value=test_time):
             run_coroutine_threadsafe(
                 sensor.async_update(), self.hass.loop).result()
@@ -125,8 +126,32 @@ class TestJewishCalenderSensor(unittest.TestCase):
         sensor = JewishCalSensor(
             name='test', language='hebrew', sensor_type='weekly_portion',
             latitude=self.TEST_LATITUDE, longitude=self.TEST_LONGITUDE,
-            diaspora=False)
+            timezone="UTC", diaspora=False)
         with patch('homeassistant.util.dt.now', return_value=test_time):
             run_coroutine_threadsafe(
                 sensor.async_update(), self.hass.loop).result()
             self.assertEqual(sensor.state, "פרשת נצבים")
+
+    def test_jewish_calendar_sensor_first_stars_ny(self):
+        """Test Jewish calendar sensor date output in hebrew."""
+        test_time = dt(2018, 9, 8)
+        sensor = JewishCalSensor(
+            name='test', language='hebrew', sensor_type='first_stars',
+            latitude=40.7128, longitude=-74.0060,
+            timezone="America/New_York", diaspora=False)
+        with patch('homeassistant.util.dt.now', return_value=test_time):
+            run_coroutine_threadsafe(
+                sensor.async_update(), self.hass.loop).result()
+            self.assertEqual(sensor.state, time(19, 48))
+
+    def test_jewish_calendar_sensor_first_stars_jerusalem(self):
+        """Test Jewish calendar sensor date output in hebrew."""
+        test_time = dt(2018, 9, 8)
+        sensor = JewishCalSensor(
+            name='test', language='hebrew', sensor_type='first_stars',
+            latitude=self.TEST_LATITUDE, longitude=self.TEST_LONGITUDE,
+            timezone="Asia/Jerusalem", diaspora=False)
+        with patch('homeassistant.util.dt.now', return_value=test_time):
+            run_coroutine_threadsafe(
+                sensor.async_update(), self.hass.loop).result()
+            self.assertEqual(sensor.state, time(19, 21))


### PR DESCRIPTION
Partial fix for #16946

## Description:
This adds support so we take the users timezone into consideration when calculating the times.
I consider this a partial fix as the times are off by up to 10 minutes in comparison to other calculators.

**Related issue (if applicable):** fixes #16946

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable): N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
N/A

If the code communicates with devices, web services, or third-party tools:
N/A

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
