### PR TITLE
Fix upnp component l10n error

### DIFF
--- a/homeassistant/components/upnp/.translations/en.json
+++ b/homeassistant/components/upnp/.translations/en.json
@@ -1,25 +1,23 @@
 {
     "config": {
-        "title": "UPnP/IGD",
+        "abort": {
+            "already_configured": "UPnP/IGD is already configured",
+            "no_devices_discovered": "No UPnP/IGDs discovered",
+            "no_sensors_or_port_mapping": "Enable at least sensors or port mapping"
+        },
         "step": {
             "init": {
                 "title": "UPnP/IGD"
             },
             "user": {
-                "title": "Configuration options for the UPnP/IGD",
-                "data":{
-                    "igd": "UPnP/IGD",
+                "data": {
+                    "enable_port_mapping": "Enable port mapping for Home Assistant",
                     "enable_sensors": "Add traffic sensors",
-                    "enable_port_mapping": "Enable port mapping for Home Assistant"
-                }
+                    "igd": "UPnP/IGD"
+                },
+                "title": "Configuration options for the UPnP/IGD"
             }
         },
-        "error": {
-        },
-        "abort": {
-            "no_devices_discovered": "No UPnP/IGDs discovered",
-            "already_configured": "UPnP/IGD is already configured",
-            "no_sensors_or_port_mapping": "Enable at least sensors or port mapping"
-        }
+        "title": "UPnP/IGD"
     }
 }

--- a/homeassistant/components/upnp/strings.json
+++ b/homeassistant/components/upnp/strings.json
@@ -14,8 +14,6 @@
                 }
             }
         },
-        "error": {
-        },
         "abort": {
             "no_devices_discovered": "No UPnP/IGDs discovered",
             "already_configured": "UPnP/IGD is already configured",


### PR DESCRIPTION
## Description:
Remove unused `error` field from strings.json, fixes
![image](https://user-images.githubusercontent.com/7366491/46473620-a493bc00-c795-11e8-8fd3-efa7b58eba68.png)



**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
