### PR TITLE
Fix invalid entity_config parameter HomeKit

### DIFF
--- a/homeassistant/components/homekit/util.py
+++ b/homeassistant/components/homekit/util.py
@@ -44,6 +44,9 @@ SWITCH_TYPE_SCHEMA = BASIC_INFO_SCHEMA.extend({
 
 def validate_entity_config(values):
     """Validate config entry for CONF_ENTITY."""
+    if not isinstance(values, dict):
+        raise vol.Invalid('expected a dictionary')
+
     entities = {}
     for entity_id, config in values.items():
         entity = cv.entity_id(entity_id)

--- a/tests/components/homekit/test_util.py
+++ b/tests/components/homekit/test_util.py
@@ -23,7 +23,8 @@ from tests.common import async_mock_service
 
 def test_validate_entity_config():
     """Test validate entities."""
-    configs = [{'invalid_entity_id': {}}, {'demo.test': 1},
+    configs = [None, [], 'string', 12345,
+               {'invalid_entity_id': {}}, {'demo.test': 1},
                {'demo.test': 'test'}, {'demo.test': [1, 2]},
                {'demo.test': None}, {'demo.test': {CONF_NAME: None}},
                {'media_player.test': {CONF_FEATURE_LIST: [


### PR DESCRIPTION
## Description:
Catches a small error that occurred with an invalid `HomeKit` config.


## Example of the invalid config this PR catches:
```yaml
homekit:
  entity_config:
```

The `entity_config` parameter is expected to be a dictionary.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.