### PR TITLE
Add binary_sensor support to RFlink

### DIFF
--- a/homeassistant/components/binary_sensor/rflink.py
+++ b/homeassistant/components/binary_sensor/rflink.py
@@ -1,0 +1,106 @@
+"""
+Support for Rflink binary sensors.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.rflink/
+"""
+import logging
+
+from homeassistant.components.binary_sensor import (
+    DEVICE_CLASSES_SCHEMA)
+from homeassistant.components.rflink import (
+    CONF_DEVICES, DATA_ENTITY_LOOKUP, DOMAIN,
+    EVENT_KEY_COMMAND, RflinkDevice, cv, vol)
+from homeassistant.const import (
+    CONF_FORCE_UPDATE, CONF_NAME, CONF_DEVICE_CLASS, CONF_PLATFORM, STATE_OFF,
+    STATE_ON)
+import homeassistant.helpers.event as evt
+
+CONF_OFF_DELAY = 'off_delay'
+DEFAULT_FORCE_UPDATE = False
+
+DEPENDENCIES = ['rflink']
+
+_LOGGER = logging.getLogger(__name__)
+
+PLATFORM_SCHEMA = vol.Schema({
+    vol.Required(CONF_PLATFORM): DOMAIN,
+    vol.Optional(CONF_DEVICES, default={}): vol.Schema({
+        cv.string: {
+            vol.Optional(CONF_NAME): cv.string,
+            vol.Optional(CONF_DEVICE_CLASS):
+                DEVICE_CLASSES_SCHEMA,
+            vol.Optional(CONF_FORCE_UPDATE, default=DEFAULT_FORCE_UPDATE):
+                cv.boolean,
+            vol.Optional(CONF_OFF_DELAY):
+                vol.All(vol.Coerce(int), vol.Range(min=0)),
+        },
+    }),
+})
+
+
+def devices_from_config(domain_config, hass=None):
+    """Parse configuration and add Rflink sensor devices."""
+    devices = []
+    for device_id, config in domain_config[CONF_DEVICES].items():
+        device = RflinkBinarySensor(device_id, hass, **config)
+        devices.append(device)
+
+        # Register entity to listen to incoming rflink events
+        hass.data[DATA_ENTITY_LOOKUP][
+            EVENT_KEY_COMMAND][device_id].append(device)
+    return devices
+
+
+async def async_setup_platform(hass, config, async_add_entities,
+                               discovery_info=None):
+    """Set up the Rflink platform."""
+    async_add_entities(devices_from_config(config, hass))
+
+
+class RflinkBinarySensor(RflinkDevice):
+    """Representation of an Rflink sensor."""
+
+    def __init__(self, device_id, hass, device_class, force_update, off_delay,
+                 **kwargs):
+        """Handle sensor specific args and super init."""
+        self._device_class = device_class
+        self._force_update = force_update
+        self._off_delay = off_delay
+        self._delay_listener = None
+        super().__init__(device_id, hass, **kwargs)
+
+    def _handle_event(self, event):
+        """Domain specific event handler."""
+        command = event['command']
+        if command == 'on':
+            self._state = True
+        elif command == 'off':
+            self._state = False
+
+        if (self._state and self._off_delay is not None):
+            def off_delay_listener(now):
+                """Switch device off after a delay."""
+                self._delay_listener = None
+                self._state = False
+                self.async_schedule_update_ha_state()
+            if self._delay_listener is not None:
+                self._delay_listener()
+            self._delay_listener = evt.async_call_later(
+                self.hass, self._off_delay, off_delay_listener)
+        self.async_schedule_update_ha_state()
+
+    @property
+    def state(self):
+        """Return the state of the binary sensor."""
+        return STATE_ON if self.is_on else STATE_OFF
+
+    @property
+    def device_class(self):
+        """Return the class of this sensor."""
+        return self._device_class
+
+    @property
+    def force_update(self):
+        """Force update."""
+        return self._force_update

--- a/homeassistant/components/binary_sensor/rflink.py
+++ b/homeassistant/components/binary_sensor/rflink.py
@@ -5,13 +5,15 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/binary_sensor.rflink/
 """
 import logging
+import voluptuous as vol
 
 from homeassistant.components.binary_sensor import (
     DEVICE_CLASSES_SCHEMA, PLATFORM_SCHEMA, BinarySensorDevice)
 from homeassistant.components.rflink import (
-    CONF_ALIASES, CONF_DEVICES, RflinkDevice, cv, vol)
+    CONF_ALIASES, CONF_DEVICES, RflinkDevice)
 from homeassistant.const import (
     CONF_FORCE_UPDATE, CONF_NAME, CONF_DEVICE_CLASS)
+import homeassistant.helpers.config_validation as cv
 import homeassistant.helpers.event as evt
 
 CONF_OFF_DELAY = 'off_delay'

--- a/homeassistant/components/binary_sensor/rflink.py
+++ b/homeassistant/components/binary_sensor/rflink.py
@@ -28,8 +28,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
             vol.Optional(CONF_DEVICE_CLASS): DEVICE_CLASSES_SCHEMA,
             vol.Optional(CONF_FORCE_UPDATE, default=DEFAULT_FORCE_UPDATE):
                 cv.boolean,
-            vol.Optional(CONF_OFF_DELAY):
-                vol.All(vol.Coerce(int), vol.Range(min=0)),
+            vol.Optional(CONF_OFF_DELAY): cv.positive_int,
             vol.Optional(CONF_ALIASES, default=[]):
                 vol.All(cv.ensure_list, [cv.string]),
         })

--- a/homeassistant/components/binary_sensor/rflink.py
+++ b/homeassistant/components/binary_sensor/rflink.py
@@ -5,6 +5,7 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/binary_sensor.rflink/
 """
 import logging
+
 import voluptuous as vol
 
 from homeassistant.components.binary_sensor import (

--- a/homeassistant/components/rflink.py
+++ b/homeassistant/components/rflink.py
@@ -120,7 +120,6 @@ async def async_setup(hass, config):
     }
     hass.data[DATA_ENTITY_GROUP_LOOKUP] = {
         EVENT_KEY_COMMAND: defaultdict(list),
-        EVENT_KEY_SENSOR: defaultdict(list),
     }
 
     # Allow platform to specify function to register new unknown devices

--- a/homeassistant/components/sensor/rflink.py
+++ b/homeassistant/components/sensor/rflink.py
@@ -2,7 +2,7 @@
 Support for Rflink sensors.
 
 For more details about this platform, please refer to the documentation at
-https://home-assistant.io/components/light.rflink/
+https://home-assistant.io/components/sensor.rflink/
 """
 import logging
 

--- a/tests/components/binary_sensor/test_rflink.py
+++ b/tests/components/binary_sensor/test_rflink.py
@@ -1,0 +1,161 @@
+"""Test for RFlink sensor components.
+
+Test setup of rflink sensor component/platform. Verify manual and
+automatic sensor creation.
+
+"""
+
+import asyncio
+from datetime import timedelta
+
+from ..test_rflink import mock_rflink
+from homeassistant.components.rflink import (
+    CONF_RECONNECT_INTERVAL)
+
+import homeassistant.core as ha
+from homeassistant.const import (
+    EVENT_STATE_CHANGED, STATE_ON, STATE_OFF, STATE_UNAVAILABLE)
+import homeassistant.util.dt as dt_util
+
+from tests.common import async_fire_time_changed
+
+DOMAIN = 'binary_sensor'
+
+CONFIG = {
+    'rflink': {
+        'port': '/dev/ttyABC0',
+        'ignore_devices': ['ignore_wildcard_*', 'ignore_sensor'],
+    },
+    DOMAIN: {
+        'platform': 'rflink',
+        'devices': {
+            'test': {
+                'name': 'test',
+                'device_class': 'door',
+            },
+            'test2': {
+                'name': 'test2',
+                'device_class': 'motion',
+                'off_delay': 30,
+                'force_update': True,
+            },
+        },
+    },
+}
+
+
+@asyncio.coroutine
+def test_default_setup(hass, monkeypatch):
+    """Test all basic functionality of the rflink sensor component."""
+    # setup mocking rflink module
+    event_callback, create, _, disconnect_callback = yield from mock_rflink(
+        hass, CONFIG, DOMAIN, monkeypatch)
+
+    # make sure arguments are passed
+    assert create.call_args_list[0][1]['ignore']
+
+    # test default state of sensor loaded from config
+    config_sensor = hass.states.get('binary_sensor.test')
+    assert config_sensor
+    assert config_sensor.state == STATE_OFF
+    assert config_sensor.attributes['device_class'] == 'door'
+
+    # test event for config sensor
+    event_callback({
+        'id': 'test',
+        'command': 'on',
+    })
+    yield from hass.async_block_till_done()
+
+    assert hass.states.get('binary_sensor.test').state == STATE_ON
+
+    # test event for config sensor
+    event_callback({
+        'id': 'test',
+        'command': 'off',
+    })
+    yield from hass.async_block_till_done()
+
+    assert hass.states.get('binary_sensor.test').state == STATE_OFF
+
+
+@asyncio.coroutine
+def test_entity_availability(hass, monkeypatch):
+    """If Rflink device is disconnected, entities should become unavailable."""
+    # Make sure Rflink mock does not 'recover' to quickly from the
+    # disconnect or else the unavailability cannot be measured
+    config = CONFIG
+    failures = [True, True]
+    config[CONF_RECONNECT_INTERVAL] = 60
+
+    # Create platform and entities
+    event_callback, create, _, disconnect_callback = yield from mock_rflink(
+        hass, config, DOMAIN, monkeypatch, failures=failures)
+
+    # Entities are available by default
+    assert hass.states.get('binary_sensor.test').state == STATE_OFF
+
+    # Mock a disconnect of the Rflink device
+    disconnect_callback()
+
+    # Wait for dispatch events to propagate
+    yield from hass.async_block_till_done()
+
+    # Entity should be unavailable
+    assert hass.states.get('binary_sensor.test').state == STATE_UNAVAILABLE
+
+    # Reconnect the Rflink device
+    disconnect_callback()
+
+    # Wait for dispatch events to propagate
+    yield from hass.async_block_till_done()
+
+    # Entities should be available again
+    assert hass.states.get('binary_sensor.test').state == STATE_OFF
+
+
+@asyncio.coroutine
+def test_off_delay(hass, monkeypatch):
+    """Test off_delay option."""
+    # setup mocking rflink module
+    event_callback, create, _, disconnect_callback = yield from mock_rflink(
+        hass, CONFIG, DOMAIN, monkeypatch)
+
+    # make sure arguments are passed
+    assert create.call_args_list[0][1]['ignore']
+
+    events = []
+
+    @ha.callback
+    def callback(event):
+        """Verify event got called."""
+        events.append(event)
+
+    hass.bus.async_listen(EVENT_STATE_CHANGED, callback)
+
+    # turn on sensor
+    event_callback({
+        'id': 'test2',
+        'command': 'on',
+    })
+    yield from hass.async_block_till_done()
+    state = hass.states.get('binary_sensor.test2')
+    assert state.state == STATE_ON
+    assert len(events) == 1
+
+    # turn on sensor again
+    event_callback({
+        'id': 'test2',
+        'command': 'on',
+    })
+    yield from hass.async_block_till_done()
+    state = hass.states.get('binary_sensor.test2')
+    assert state.state == STATE_ON
+    assert len(events) == 2
+
+    # fake time change and verify sensor sent a single off event
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=30))
+    yield from hass.async_block_till_done()
+    state = hass.states.get('binary_sensor.test2')
+    assert state.state == STATE_OFF
+    assert len(events) == 3


### PR DESCRIPTION
## Description:
Add RFLink support for binary_sensor

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation:** home-assistant/home-assistant.io#6519

## Example entry for `configuration.yaml` (if applicable):
```yaml
binary_sensor:
   - platform: rflink
     devices:
       pt2262_00174754_0:
         name: PIR Entrance
         device_class: motion
         off_delay: 5
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)