### PR TITLE
Add device tracking for the BT Smart Hub router

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -33,7 +33,6 @@ omit =
 
     homeassistant/components/arduino.py
     homeassistant/components/*/arduino.py
-
     homeassistant/components/bmw_connected_drive/*.py
     homeassistant/components/*/bmw_connected_drive.py
 
@@ -461,6 +460,7 @@ omit =
     homeassistant/components/device_tracker/bluetooth_le_tracker.py
     homeassistant/components/device_tracker/bluetooth_tracker.py
     homeassistant/components/device_tracker/bt_home_hub_5.py
+    homeassistant/components/device_tracker/bt_smarthub.py
     homeassistant/components/device_tracker/cisco_ios.py
     homeassistant/components/device_tracker/ddwrt.py
     homeassistant/components/device_tracker/freebox.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -33,6 +33,7 @@ omit =
 
     homeassistant/components/arduino.py
     homeassistant/components/*/arduino.py
+    
     homeassistant/components/bmw_connected_drive/*.py
     homeassistant/components/*/bmw_connected_drive.py
 

--- a/.coveragerc
+++ b/.coveragerc
@@ -33,7 +33,7 @@ omit =
 
     homeassistant/components/arduino.py
     homeassistant/components/*/arduino.py
-    
+
     homeassistant/components/bmw_connected_drive/*.py
     homeassistant/components/*/bmw_connected_drive.py
 

--- a/homeassistant/components/device_tracker/bt_smarthub.py
+++ b/homeassistant/components/device_tracker/bt_smarthub.py
@@ -9,8 +9,8 @@ import logging
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
-from homeassistant.components.device_tracker import (
-  DOMAIN, PLATFORM_SCHEMA, DeviceScanner)
+from homeassistant.components.device_tracker import (DOMAIN, 
+                                                     PLATFORM_SCHEMA, DeviceScanner)
 from homeassistant.const import CONF_HOST
 
 REQUIREMENTS = ['btsmarthub_devicelist==0.1.1']

--- a/homeassistant/components/device_tracker/bt_smarthub.py
+++ b/homeassistant/components/device_tracker/bt_smarthub.py
@@ -9,8 +9,8 @@ import logging
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
-from homeassistant.components.device_tracker import (DOMAIN, PLATFORM_SCHEMA,
-                                                     DeviceScanner)
+from homeassistant.components.device_tracker import (
+  DOMAIN, PLATFORM_SCHEMA, DeviceScanner)
 from homeassistant.const import CONF_HOST
 
 REQUIREMENTS = ['btsmarthub_devicelist==0.1.1']
@@ -25,7 +25,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 
 def get_scanner(hass, config):
-    """Return a BT SmartHub scanner if successful."""
+    """Return a BT Smart Hub scanner if successful."""
     scanner = BTSmartHubScanner(config[DOMAIN])
 
     return scanner if scanner.success_init else None
@@ -36,7 +36,7 @@ class BTSmartHubScanner(DeviceScanner):
 
     def __init__(self, config):
         """Initialise the scanner."""
-        _LOGGER.info("Initialising BT Smart Hub")
+        _LOGGER.debug("Initialising BT Smart Hub")
         self.host = config[CONF_HOST]
         self.last_results = {}
         self.success_init = False
@@ -63,7 +63,7 @@ class BTSmartHubScanner(DeviceScanner):
         return None
 
     def _update_info(self):
-        """Ensure the information from the BT Home Hub 5 is up to date."""
+        """Ensure the information from the BT Smart Hub is up to date."""
         if not self.success_init:
             return
 
@@ -77,7 +77,7 @@ class BTSmartHubScanner(DeviceScanner):
         self.last_results = clients
 
     def get_bt_smarthub_data(self):
-        """Retrieve data from BT Smarthub and return parsed result."""
+        """Retrieve data from BT Smart Hub and return parsed result."""
         import btsmarthub_devicelist
         # Request data from bt smarthub into a list of dicts.
         data = btsmarthub_devicelist.get_devicelist(

--- a/homeassistant/components/device_tracker/bt_smarthub.py
+++ b/homeassistant/components/device_tracker/bt_smarthub.py
@@ -9,8 +9,8 @@ import logging
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
-from homeassistant.components.device_tracker import (DOMAIN, 
-                                                     PLATFORM_SCHEMA, DeviceScanner)
+from homeassistant.components.device_tracker import (
+    DOMAIN, PLATFORM_SCHEMA, DeviceScanner)
 from homeassistant.const import CONF_HOST
 
 REQUIREMENTS = ['btsmarthub_devicelist==0.1.1']

--- a/homeassistant/components/device_tracker/bt_smarthub.py
+++ b/homeassistant/components/device_tracker/bt_smarthub.py
@@ -59,22 +59,19 @@ class BTSmartHubScanner(DeviceScanner):
         return None
 
     def _update_info(self):
-        """Ensure the information from the BT Home Hub 5 is up to date.
-
-        Return boolean if scanning successful.
-        """
+        """Ensure the information from the BT Home Hub 5 is up to date."""
         if not self.success_init:
-            return False
+            return
 
         _LOGGER.info("Scanning")
         data = self.get_bt_smarthub_data()
         if not data:
             _LOGGER.warning("Error scanning devices")
-            return False
+            return
 
         clients = [client for client in data.values()]
         self.last_results = clients
-        return True
+        return
 
     def get_bt_smarthub_data(self):
         """Retrieve data from BT Smarthub and return parsed result."""

--- a/homeassistant/components/device_tracker/bt_smarthub.py
+++ b/homeassistant/components/device_tracker/bt_smarthub.py
@@ -1,6 +1,8 @@
 """
-Support for BT Smart Hub.
+Support for BT Smart Hub (Sometimes referred to as BT Home Hub 6).
 
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/device_tracker.bt_smarthub/
 """
 import logging
 
@@ -34,7 +36,6 @@ class BTSmartHubScanner(DeviceScanner):
 
     def __init__(self, config):
         """Initialise the scanner."""
-
         _LOGGER.info("Initialising BT Smart Hub")
         self.host = config[CONF_HOST]
         self.last_results = {}
@@ -46,11 +47,10 @@ class BTSmartHubScanner(DeviceScanner):
     def scan_devices(self):
         """Scan for new devices and return a list with found device IDs."""
         self._update_info()
-
         return [client['mac'] for client in self.last_results]
 
     def get_device_name(self, device):
-
+        """Return the name of the given device or None if we don't know."""
         if not self.last_results:
             return None
         for client in self.last_results:
@@ -60,7 +60,7 @@ class BTSmartHubScanner(DeviceScanner):
 
     def _update_info(self):
         """Ensure the information from the BT Home Hub 5 is up to date.
-         Return boolean if scanning successful
+        Return boolean if scanning successful
         """
         if not self.success_init:
             return False

--- a/homeassistant/components/device_tracker/bt_smarthub.py
+++ b/homeassistant/components/device_tracker/bt_smarthub.py
@@ -39,6 +39,7 @@ class BTSmartHubScanner(DeviceScanner):
         _LOGGER.info("Initialising BT Smart Hub")
         self.host = config[CONF_HOST]
         self.last_results = {}
+        self.success_init = False
 
         # Test the router is accessible
         data = self.get_bt_smarthub_data()

--- a/homeassistant/components/device_tracker/bt_smarthub.py
+++ b/homeassistant/components/device_tracker/bt_smarthub.py
@@ -79,7 +79,8 @@ class BTSmartHubScanner(DeviceScanner):
         """Retrieve data from BT Smarthub and return parsed result"""
         import btsmarthub_devicelist
         """Request data from bt smarthub into a list of dicts"""
-        data = btsmarthub_devicelist.get_devicelist(router_ip=self.host, only_active_devices=True)
+        data = btsmarthub_devicelist.get_devicelist(
+          router_ip=self.host, only_active_devices=True)
         """Renaming keys from parsed result"""
         devices = {}
         for device in data:

--- a/homeassistant/components/device_tracker/bt_smarthub.py
+++ b/homeassistant/components/device_tracker/bt_smarthub.py
@@ -91,6 +91,6 @@ class BTSmartHubScanner(DeviceScanner):
                     'host': device['UserHostName'],
                     'status': device['Active']
                 }
-            except:
+            except KeyError:
                 pass
         return devices

--- a/homeassistant/components/device_tracker/bt_smarthub.py
+++ b/homeassistant/components/device_tracker/bt_smarthub.py
@@ -1,0 +1,95 @@
+"""
+Support for BT Smart Hub.
+
+"""
+import logging
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.device_tracker import (DOMAIN, PLATFORM_SCHEMA,
+                                                     DeviceScanner)
+from homeassistant.const import CONF_HOST
+
+REQUIREMENTS = ['btsmarthub_devicelist==0.1.1']
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_DEFAULT_IP = '192.168.1.254'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_HOST, default=CONF_DEFAULT_IP): cv.string,
+})
+
+
+def get_scanner(hass, config):
+    """Return a BT SmartHub scanner if successful."""
+    scanner = BTSmartHubScanner(config[DOMAIN])
+
+    return scanner if scanner.success_init else None
+
+
+class BTSmartHubScanner(DeviceScanner):
+    """This class queries a BT Smart Hub."""
+
+    def __init__(self, config):
+        """Initialise the scanner."""
+
+        _LOGGER.info("Initialising BT Smart Hub")
+        self.host = config[CONF_HOST]
+        self.last_results = {}
+
+        # Test the router is accessible
+        data = self.get_bt_smarthub_data()
+        self.success_init = data is not None
+
+    def scan_devices(self):
+        """Scan for new devices and return a list with found device IDs."""
+        self._update_info()
+
+        return [client['mac'] for client in self.last_results]
+
+    def get_device_name(self, device):
+
+        if not self.last_results:
+            return None
+        for client in self.last_results:
+            if client['mac'] == device:
+                return client['host']
+        return None
+
+    def _update_info(self):
+        """Ensure the information from the BT Home Hub 5 is up to date.
+         Return boolean if scanning successful
+        """
+        if not self.success_init:
+            return False
+
+        _LOGGER.info("Scanning")
+        data = self.get_bt_smarthub_data()
+        if not data:
+            _LOGGER.warning("Error scanning devices")
+            return False
+
+        clients = [client for client in data.values()]
+        self.last_results = clients
+        return True
+
+    def get_bt_smarthub_data(self):
+        """Retrieve data from BT Smarthub and return parsed result"""
+        import btsmarthub_devicelist
+        """Request data from bt smarthub into a list of dicts"""
+        data = btsmarthub_devicelist.get_devicelist(router_ip=self.host, only_active_devices=True)
+        """Renaming keys from parsed result"""
+        devices = {}
+        for device in data:
+            try:
+                devices[device['UserHostName']] = {
+                    'ip': device['IPAddress'],
+                    'mac': device['PhysAddress'],
+                    'host': device['UserHostName'],
+                    'status': device['Active']
+                }
+            except (KeyError, 'no'):
+                pass
+        return devices

--- a/homeassistant/components/device_tracker/bt_smarthub.py
+++ b/homeassistant/components/device_tracker/bt_smarthub.py
@@ -25,17 +25,17 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 
 def get_scanner(hass, config):
-    """Return a BT SmartHub scanner if successful."""
+    #Return a BT SmartHub scanner if successful.
     scanner = BTSmartHubScanner(config[DOMAIN])
 
     return scanner if scanner.success_init else None
 
 
 class BTSmartHubScanner(DeviceScanner):
-    """This class queries a BT Smart Hub."""
+    #This class queries a BT Smart Hub.
 
     def __init__(self, config):
-        """Initialise the scanner."""
+        #Initialise the scanner.
         _LOGGER.info("Initialising BT Smart Hub")
         self.host = config[CONF_HOST]
         self.last_results = {}
@@ -45,12 +45,12 @@ class BTSmartHubScanner(DeviceScanner):
         self.success_init = data is not None
 
     def scan_devices(self):
-        """Scan for new devices and return a list with found device IDs."""
+        #Scan for new devices and return a list with found device IDs.
         self._update_info()
         return [client['mac'] for client in self.last_results]
 
     def get_device_name(self, device):
-        """Return the name of the given device or None if we don't know."""
+        #Return the name of the given device or None if we don't know.
         if not self.last_results:
             return None
         for client in self.last_results:
@@ -59,9 +59,8 @@ class BTSmartHubScanner(DeviceScanner):
         return None
 
     def _update_info(self):
-        """Ensure the information from the BT Home Hub 5 is up to date.
-        Return boolean if scanning successful
-        """
+        #Ensure the information from the BT Home Hub 5 is up to date.
+        #Return boolean if scanning successful
         if not self.success_init:
             return False
 
@@ -76,12 +75,12 @@ class BTSmartHubScanner(DeviceScanner):
         return True
 
     def get_bt_smarthub_data(self):
-        """Retrieve data from BT Smarthub and return parsed result"""
+        #Retrieve data from BT Smarthub and return parsed result
         import btsmarthub_devicelist
-        """Request data from bt smarthub into a list of dicts"""
+        #Request data from bt smarthub into a list of dicts
         data = btsmarthub_devicelist.get_devicelist(
-          router_ip=self.host, only_active_devices=True)
-        """Renaming keys from parsed result"""
+            router_ip=self.host, only_active_devices=True)
+        #Renaming keys from parsed result
         devices = {}
         for device in data:
             try:

--- a/homeassistant/components/device_tracker/bt_smarthub.py
+++ b/homeassistant/components/device_tracker/bt_smarthub.py
@@ -90,6 +90,6 @@ class BTSmartHubScanner(DeviceScanner):
                     'host': device['UserHostName'],
                     'status': device['Active']
                 }
-            except (KeyError, 'no'):
+            except:
                 pass
         return devices

--- a/homeassistant/components/device_tracker/bt_smarthub.py
+++ b/homeassistant/components/device_tracker/bt_smarthub.py
@@ -25,7 +25,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 
 def get_scanner(hass, config):
-    #Return a BT SmartHub scanner if successful.
+    """Return a BT SmartHub scanner if successful."""
     scanner = BTSmartHubScanner(config[DOMAIN])
 
     return scanner if scanner.success_init else None
@@ -60,7 +60,9 @@ class BTSmartHubScanner(DeviceScanner):
 
     def _update_info(self):
         """Ensure the information from the BT Home Hub 5 is up to date.
-        Return boolean if scanning successful."""
+        
+        Return boolean if scanning successful.
+        """
         if not self.success_init:
             return False
 

--- a/homeassistant/components/device_tracker/bt_smarthub.py
+++ b/homeassistant/components/device_tracker/bt_smarthub.py
@@ -32,10 +32,10 @@ def get_scanner(hass, config):
 
 
 class BTSmartHubScanner(DeviceScanner):
-    # This class queries a BT Smart Hub.
+    """This class queries a BT Smart Hub."""
 
     def __init__(self, config):
-        # Initialise the scanner.
+        """Initialise the scanner."""
         _LOGGER.info("Initialising BT Smart Hub")
         self.host = config[CONF_HOST]
         self.last_results = {}
@@ -45,12 +45,12 @@ class BTSmartHubScanner(DeviceScanner):
         self.success_init = data is not None
 
     def scan_devices(self):
-        # Scan for new devices and return a list with found device IDs.
+        """Scan for new devices and return a list with found device IDs."""
         self._update_info()
         return [client['mac'] for client in self.last_results]
 
     def get_device_name(self, device):
-        #Return the name of the given device or None if we don't know.
+        """Return the name of the given device or None if we don't know."""
         if not self.last_results:
             return None
         for client in self.last_results:
@@ -59,8 +59,8 @@ class BTSmartHubScanner(DeviceScanner):
         return None
 
     def _update_info(self):
-        # Ensure the information from the BT Home Hub 5 is up to date.
-        # Return boolean if scanning successful.
+        """Ensure the information from the BT Home Hub 5 is up to date.
+        Return boolean if scanning successful."""
         if not self.success_init:
             return False
 
@@ -75,7 +75,7 @@ class BTSmartHubScanner(DeviceScanner):
         return True
 
     def get_bt_smarthub_data(self):
-        # Retrieve data from BT Smarthub and return parsed result.
+        """Retrieve data from BT Smarthub and return parsed result."""
         import btsmarthub_devicelist
         # Request data from bt smarthub into a list of dicts.
         data = btsmarthub_devicelist.get_devicelist(

--- a/homeassistant/components/device_tracker/bt_smarthub.py
+++ b/homeassistant/components/device_tracker/bt_smarthub.py
@@ -43,9 +43,9 @@ class BTSmartHubScanner(DeviceScanner):
         # Test the router is accessible
         data = self.get_bt_smarthub_data()
         if data:
-          self.success_init = True
+            self.success_init = True
         else:
-          _LOGGER.info("Failed to connect to %s", self.host)
+            _LOGGER.info("Failed to connect to %s", self.host)
 
     def scan_devices(self):
         """Scan for new devices and return a list with found device IDs."""

--- a/homeassistant/components/device_tracker/bt_smarthub.py
+++ b/homeassistant/components/device_tracker/bt_smarthub.py
@@ -60,7 +60,7 @@ class BTSmartHubScanner(DeviceScanner):
 
     def _update_info(self):
         """Ensure the information from the BT Home Hub 5 is up to date.
-        
+
         Return boolean if scanning successful.
         """
         if not self.success_init:

--- a/homeassistant/components/device_tracker/bt_smarthub.py
+++ b/homeassistant/components/device_tracker/bt_smarthub.py
@@ -94,4 +94,6 @@ class BTSmartHubScanner(DeviceScanner):
                 }
             except KeyError:
                 pass
+        if devices == {}:
+            return None
         return devices

--- a/homeassistant/components/device_tracker/bt_smarthub.py
+++ b/homeassistant/components/device_tracker/bt_smarthub.py
@@ -42,7 +42,10 @@ class BTSmartHubScanner(DeviceScanner):
 
         # Test the router is accessible
         data = self.get_bt_smarthub_data()
-        self.success_init = data is not None
+        if data:
+          self.success_init = True
+        else:
+          _LOGGER.info("Failed to connect to %s", self.host)
 
     def scan_devices(self):
         """Scan for new devices and return a list with found device IDs."""
@@ -71,7 +74,6 @@ class BTSmartHubScanner(DeviceScanner):
 
         clients = [client for client in data.values()]
         self.last_results = clients
-        return
 
     def get_bt_smarthub_data(self):
         """Retrieve data from BT Smarthub and return parsed result."""
@@ -91,6 +93,4 @@ class BTSmartHubScanner(DeviceScanner):
                 }
             except KeyError:
                 pass
-        if devices == {}:
-            return None
         return devices

--- a/homeassistant/components/device_tracker/bt_smarthub.py
+++ b/homeassistant/components/device_tracker/bt_smarthub.py
@@ -32,10 +32,10 @@ def get_scanner(hass, config):
 
 
 class BTSmartHubScanner(DeviceScanner):
-    #This class queries a BT Smart Hub.
+    # This class queries a BT Smart Hub.
 
     def __init__(self, config):
-        #Initialise the scanner.
+        # Initialise the scanner.
         _LOGGER.info("Initialising BT Smart Hub")
         self.host = config[CONF_HOST]
         self.last_results = {}
@@ -45,7 +45,7 @@ class BTSmartHubScanner(DeviceScanner):
         self.success_init = data is not None
 
     def scan_devices(self):
-        #Scan for new devices and return a list with found device IDs.
+        # Scan for new devices and return a list with found device IDs.
         self._update_info()
         return [client['mac'] for client in self.last_results]
 
@@ -59,8 +59,8 @@ class BTSmartHubScanner(DeviceScanner):
         return None
 
     def _update_info(self):
-        #Ensure the information from the BT Home Hub 5 is up to date.
-        #Return boolean if scanning successful
+        # Ensure the information from the BT Home Hub 5 is up to date.
+        # Return boolean if scanning successful.
         if not self.success_init:
             return False
 
@@ -75,12 +75,12 @@ class BTSmartHubScanner(DeviceScanner):
         return True
 
     def get_bt_smarthub_data(self):
-        #Retrieve data from BT Smarthub and return parsed result
+        # Retrieve data from BT Smarthub and return parsed result.
         import btsmarthub_devicelist
-        #Request data from bt smarthub into a list of dicts
+        # Request data from bt smarthub into a list of dicts.
         data = btsmarthub_devicelist.get_devicelist(
             router_ip=self.host, only_active_devices=True)
-        #Renaming keys from parsed result
+        # Renaming keys from parsed result.
         devices = {}
         for device in data:
             try:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -221,6 +221,9 @@ bt_proximity==0.1.2
 # homeassistant.components.device_tracker.bt_home_hub_5
 bthomehub5-devicelist==0.1.1
 
+# homeassistant.components.device_tracker.bt_smarthub
+btsmarthub_devicelist==0.1.1
+
 # homeassistant.components.sensor.buienradar
 # homeassistant.components.weather.buienradar
 buienradar==0.91


### PR DESCRIPTION
## Description:
Added support for device tracking for the BT Smart Hub router (UK). Might it be sensible to collect this with the bt_home_hub_5 component in some way - perhaps to share a page on home-assistant.io ?



**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#6528

## Example entry for `configuration.yaml` (if applicable):
```yaml
# Example configuration.yaml entry
device_tracker:
  - platform: bt_smarthub
    host: 192.168.1.254
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
