### PR TITLE
Enable new registry rename for Insteon

### DIFF
--- a/homeassistant/components/insteon/__init__.py
+++ b/homeassistant/components/insteon/__init__.py
@@ -466,6 +466,11 @@ class InsteonEntity(Entity):
         return self._insteon_device_state.group
 
     @property
+    def unique_id(self) -> str:
+        """Return a unique ID."""
+        return self.name
+
+    @property
     def name(self):
         """Return the name of the node (used for Entity_ID)."""
         name = ''

--- a/homeassistant/components/insteon/__init__.py
+++ b/homeassistant/components/insteon/__init__.py
@@ -468,7 +468,12 @@ class InsteonEntity(Entity):
     @property
     def unique_id(self) -> str:
         """Return a unique ID."""
-        return self.name
+        if self._insteon_device_state.group == 0x01:
+            uid = self._insteon_device.id
+        else:
+            uid = '{:s}_{:d}'.format(self._insteon_device.id,
+                                     self._insteon_device_state.group)
+        return uid
 
     @property
     def name(self):


### PR DESCRIPTION
### ## Description:

This is a simple change to the **InsteonEntity** what supports the **unique_id** property in order to allow renames with the new entity registry.  

Currently the **name** returns a unique name thats used for the entity_id.  This is just being called now by the **unique_id** property in order to allow for the registry to support the rename configuration options.

**Related issue (if applicable):** fixes #17170

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** None

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed: None Needed

If the code communicates with devices, web services, or third-party tools: None Needed

If the code does not interact with devices: 
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
