### PR TITLE
Fix data used for logbook

### DIFF
--- a/homeassistant/components/logbook.py
+++ b/homeassistant/components/logbook.py
@@ -265,16 +265,17 @@ def humanify(hass, events):
 
             elif event.event_type == EVENT_ALEXA_SMART_HOME:
                 data = event.data
-                entity_id = data.get('entity_id')
+                entity_id = data['request'].get('entity_id')
 
                 if entity_id:
                     state = hass.states.get(entity_id)
                     name = state.name if state else entity_id
                     message = "send command {}/{} for {}".format(
-                        data['namespace'], data['name'], name)
+                        data['request']['namespace'],
+                        data['request']['name'], name)
                 else:
                     message = "send command {}/{}".format(
-                        data['namespace'], data['name'])
+                        data['request']['namespace'], data['request']['name'])
 
                 yield {
                     'when': event.time_fired,

--- a/tests/components/test_logbook.py
+++ b/tests/components/test_logbook.py
@@ -565,20 +565,20 @@ async def test_humanify_alexa_event(hass):
     })
 
     results = list(logbook.humanify(hass, [
-        ha.Event(EVENT_ALEXA_SMART_HOME, {
+        ha.Event(EVENT_ALEXA_SMART_HOME, { 'request': {
             'namespace': 'Alexa.Discovery',
             'name': 'Discover',
-        }),
-        ha.Event(EVENT_ALEXA_SMART_HOME, {
+        }}),
+        ha.Event(EVENT_ALEXA_SMART_HOME, { 'request': {
             'namespace': 'Alexa.PowerController',
             'name': 'TurnOn',
             'entity_id': 'light.kitchen'
-        }),
-        ha.Event(EVENT_ALEXA_SMART_HOME, {
+        }}),
+        ha.Event(EVENT_ALEXA_SMART_HOME, { 'request': {
             'namespace': 'Alexa.PowerController',
             'name': 'TurnOn',
             'entity_id': 'light.non_existing'
-        }),
+        }}),
 
     ]))
 

--- a/tests/components/test_logbook.py
+++ b/tests/components/test_logbook.py
@@ -565,16 +565,16 @@ async def test_humanify_alexa_event(hass):
     })
 
     results = list(logbook.humanify(hass, [
-        ha.Event(EVENT_ALEXA_SMART_HOME, { 'request': {
+        ha.Event(EVENT_ALEXA_SMART_HOME, {'request': {
             'namespace': 'Alexa.Discovery',
             'name': 'Discover',
         }}),
-        ha.Event(EVENT_ALEXA_SMART_HOME, { 'request': {
+        ha.Event(EVENT_ALEXA_SMART_HOME, {'request': {
             'namespace': 'Alexa.PowerController',
             'name': 'TurnOn',
             'entity_id': 'light.kitchen'
         }}),
-        ha.Event(EVENT_ALEXA_SMART_HOME, { 'request': {
+        ha.Event(EVENT_ALEXA_SMART_HOME, {'request': {
             'namespace': 'Alexa.PowerController',
             'name': 'TurnOn',
             'entity_id': 'light.non_existing'


### PR DESCRIPTION
## Description:
What's the use of tests if we test with the wrong data 🤷‍♂️ 

**Related issue (if applicable):** @arsaboo in the chat

## Example entry for `configuration.yaml` (if applicable):
```yaml
logbook:

# Alexa configured via HA Cloud
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
