### PR TITLE
Add optional "all" parameter for groups

### DIFF
--- a/homeassistant/components/group/__init__.py
+++ b/homeassistant/components/group/__init__.py
@@ -227,7 +227,7 @@ async def async_setup(hass, config):
                 object_id=object_id,
                 entity_ids=entity_ids,
                 user_defined=False,
-                mode=service.data.get(ATTR_ALL)
+                mode=service.data.get(ATTR_ALL),
                 **extra_arg
             )
             return

--- a/homeassistant/components/group/__init__.py
+++ b/homeassistant/components/group/__init__.py
@@ -570,9 +570,10 @@ class Group(Entity):
         if gr_on is None:
             return
 
+        # pylint: disable=too-many-boolean-expressions
         if tr_state is None or ((gr_state == gr_on and
                                  tr_state.state == gr_off) or
-                                 (gr_state == gr_off and
+                                (gr_state == gr_off and
                                  tr_state.state == gr_on) or
                                 tr_state.state not in (gr_on, gr_off)):
             if states is None:

--- a/homeassistant/components/group/services.yaml
+++ b/homeassistant/components/group/services.yaml
@@ -40,6 +40,9 @@ set:
     add_entities:
       description: List of members they will change on group listening.
       example: domain.entity_id1, domain.entity_id2
+    mode:
+      description: Set the on/off-mode of the group.
+      example: all
 
 remove:
   description: Remove a user group.

--- a/homeassistant/components/group/services.yaml
+++ b/homeassistant/components/group/services.yaml
@@ -41,7 +41,7 @@ set:
       description: List of members they will change on group listening.
       example: domain.entity_id1, domain.entity_id2
     all:
-      description: Set the on/off-mode of the group.
+      description: Enable this option if the group should only turn on when all entities are on.
       example: True
 
 remove:

--- a/homeassistant/components/group/services.yaml
+++ b/homeassistant/components/group/services.yaml
@@ -40,9 +40,9 @@ set:
     add_entities:
       description: List of members they will change on group listening.
       example: domain.entity_id1, domain.entity_id2
-    mode:
+    all:
       description: Set the on/off-mode of the group.
-      example: all
+      example: True
 
 remove:
   description: Remove a user group.

--- a/tests/components/group/test_init.py
+++ b/tests/components/group/test_init.py
@@ -109,10 +109,7 @@ class TestComponentsGroup(unittest.TestCase):
         self.assertEqual(STATE_ON, group_state.state)
 
     def test_allgroup_stays_off_if_all_are_off_and_one_turns_on(self):
-        """
-        Test if group with all: true stays off if all devices were turned off
-        and one turns on.
-        """
+        """group with all: true, stay off if one device turns on."""
         self.hass.states.set('light.Bowl', STATE_OFF)
         self.hass.states.set('light.Ceiling', STATE_OFF)
         test_group = group.Group.create_group(
@@ -127,9 +124,7 @@ class TestComponentsGroup(unittest.TestCase):
         self.assertEqual(STATE_OFF, group_state.state)
 
     def test_allgroup_turn_on_if_last_turns_on(self):
-        """
-        Test if group with all: true turns on if last off-device turns on.
-        """
+        """group with all: true, turn on if all devices are on."""
         self.hass.states.set('light.Bowl', STATE_ON)
         self.hass.states.set('light.Ceiling', STATE_OFF)
         test_group = group.Group.create_group(

--- a/tests/components/group/test_init.py
+++ b/tests/components/group/test_init.py
@@ -109,7 +109,7 @@ class TestComponentsGroup(unittest.TestCase):
         self.assertEqual(STATE_ON, group_state.state)
 
     def test_allgroup_stays_off_if_all_are_off_and_one_turns_on(self):
-        """group with all: true, stay off if one device turns on."""
+        """Group with all: true, stay off if one device turns on."""
         self.hass.states.set('light.Bowl', STATE_OFF)
         self.hass.states.set('light.Ceiling', STATE_OFF)
         test_group = group.Group.create_group(
@@ -124,7 +124,7 @@ class TestComponentsGroup(unittest.TestCase):
         self.assertEqual(STATE_OFF, group_state.state)
 
     def test_allgroup_turn_on_if_last_turns_on(self):
-        """group with all: true, turn on if all devices are on."""
+        """Group with all: true, turn on if all devices are on."""
         self.hass.states.set('light.Bowl', STATE_ON)
         self.hass.states.set('light.Ceiling', STATE_OFF)
         test_group = group.Group.create_group(

--- a/tests/components/group/test_init.py
+++ b/tests/components/group/test_init.py
@@ -108,6 +108,41 @@ class TestComponentsGroup(unittest.TestCase):
         group_state = self.hass.states.get(test_group.entity_id)
         self.assertEqual(STATE_ON, group_state.state)
 
+    def test_allgroup_stays_off_if_all_are_off_and_one_turns_on(self):
+        """
+        Test if group with all: true stays off if all devices were turned off
+        and one turns on.
+        """
+        self.hass.states.set('light.Bowl', STATE_OFF)
+        self.hass.states.set('light.Ceiling', STATE_OFF)
+        test_group = group.Group.create_group(
+            self.hass, 'init_group', ['light.Bowl', 'light.Ceiling'], False,
+            mode=True)
+
+        # Turn one on
+        self.hass.states.set('light.Ceiling', STATE_ON)
+        self.hass.block_till_done()
+
+        group_state = self.hass.states.get(test_group.entity_id)
+        self.assertEqual(STATE_OFF, group_state.state)
+
+    def test_allgroup_turn_on_if_last_turns_on(self):
+        """
+        Test if group with all: true turns on if all last off device turns on.
+        """
+        self.hass.states.set('light.Bowl', STATE_ON)
+        self.hass.states.set('light.Ceiling', STATE_OFF)
+        test_group = group.Group.create_group(
+            self.hass, 'init_group', ['light.Bowl', 'light.Ceiling'], False,
+            mode=True)
+
+        # Turn one on
+        self.hass.states.set('light.Ceiling', STATE_ON)
+        self.hass.block_till_done()
+
+        group_state = self.hass.states.get(test_group.entity_id)
+        self.assertEqual(STATE_ON, group_state.state)
+
     def test_is_on(self):
         """Test is_on method."""
         self.hass.states.set('light.Bowl', STATE_ON)

--- a/tests/components/group/test_init.py
+++ b/tests/components/group/test_init.py
@@ -128,7 +128,7 @@ class TestComponentsGroup(unittest.TestCase):
 
     def test_allgroup_turn_on_if_last_turns_on(self):
         """
-        Test if group with all: true turns on if all last off device turns on.
+        Test if group with all: true turns on if last off-device turns on.
         """
         self.hass.states.set('light.Bowl', STATE_ON)
         self.hass.states.set('light.Ceiling', STATE_OFF)


### PR DESCRIPTION
## Description:
The current way groups work as per the [documentation](https://www.home-assistant.io/components/group/#group-behavior)
> When __any__ member of a group is `on` then the group will also be `on`. 

This may usually be what people expect. I do believe though, that there are cases where a groups state should only turn to `on` if __all__ entities are `on`. I myself once wanted that, forgot what it was though and probably ended up using some workaround.
One simple example would be monitoring if a group of devices is `on`. Like: Notify me if not all devices of a particular group are `on` (alarm system or whatever). If one node goes down, the whole group is considered down. It's pretty straightforward to build an automation based on that single state of the group instead of writing templates or creating helper-entities.

~~Marked es WIP because I want to gather opinions on this before I start with the tests and update the documentation~~
Essentially this PR keeps using [any](https://docs.python.org/3/library/functions.html#any) as the default, but overrides that if [all](https://docs.python.org/3/library/functions.html#all) is set to `true`.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#6557

## Example entry for `configuration.yaml` (if applicable):
```yaml
group:
  # Current implementation, group is on when at least one entity is on
  normal:
    name: normal
    entities:
      - input_boolean.bool1
      - input_boolean.bool2
      - input_boolean.bool3
  # New mode: group is on when all entities are on
  inverted:
    name: inverted
    all: true
    entities:
      - input_boolean.bool1
      - input_boolean.bool2
      - input_boolean.bool3
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
