### PR TITLE
Verisure standard config for scan interval

### DIFF
--- a/homeassistant/components/verisure.py
+++ b/homeassistant/components/verisure.py
@@ -10,8 +10,8 @@ from datetime import timedelta
 
 import voluptuous as vol
 
-from homeassistant.const import (CONF_PASSWORD, CONF_USERNAME,
-                                 EVENT_HOMEASSISTANT_STOP)
+from homeassistant.const import (CONF_PASSWORD, CONF_SCAN_INTERVAL,
+                                 CONF_USERNAME, EVENT_HOMEASSISTANT_STOP)
 from homeassistant.helpers import discovery
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
@@ -32,9 +32,11 @@ CONF_MOUSE = 'mouse'
 CONF_SMARTPLUGS = 'smartplugs'
 CONF_THERMOMETERS = 'thermometers'
 CONF_SMARTCAM = 'smartcam'
-CONF_POLLING_RATE = 'polling_rate'
 
 DOMAIN = 'verisure'
+
+MIN_SCAN_INTERVAL = timedelta(minutes=1)
+DEFAULT_SCAN_INTERVAL = timedelta(minutes=1)
 
 SERVICE_CAPTURE_SMARTCAM = 'capture_smartcam'
 
@@ -54,8 +56,8 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(CONF_SMARTPLUGS, default=True): cv.boolean,
         vol.Optional(CONF_THERMOMETERS, default=True): cv.boolean,
         vol.Optional(CONF_SMARTCAM, default=True): cv.boolean,
-        vol.Optional(CONF_POLLING_RATE, default=1): vol.All(
-            vol.Coerce(int), vol.Range(min=1)),
+        vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL): (
+            vol.All(cv.time_period, vol.Clamp(min=MIN_SCAN_INTERVAL))),
     }),
 }, extra=vol.ALLOW_EXTRA)
 
@@ -69,8 +71,8 @@ def setup(hass, config):
     import verisure
     global HUB
     HUB = VerisureHub(config[DOMAIN], verisure)
-    HUB.update_overview = Throttle(timedelta(
-        minutes=config[DOMAIN][CONF_POLLING_RATE]))(HUB.update_overview)
+    HUB.update_overview = Throttle(
+            config[DOMAIN][CONF_SCAN_INTERVAL])(HUB.update_overview)
     if not HUB.login():
         return False
     hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP,

--- a/homeassistant/components/verisure.py
+++ b/homeassistant/components/verisure.py
@@ -72,7 +72,7 @@ def setup(hass, config):
     global HUB
     HUB = VerisureHub(config[DOMAIN], verisure)
     HUB.update_overview = Throttle(
-            config[DOMAIN][CONF_SCAN_INTERVAL])(HUB.update_overview)
+        config[DOMAIN][CONF_SCAN_INTERVAL])(HUB.update_overview)
     if not HUB.login():
         return False
     hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP,


### PR DESCRIPTION
## Description:
Use standard configuration parameter names and types. 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
verisure:                                                                        
  username: ****
  password: ****
  scan_interval: 00:30:00   
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)
https://github.com/home-assistant/home-assistant.io/pull/6558