### PR TITLE
Enable BMW component to be unit system aware

### DIFF
--- a/homeassistant/components/binary_sensor/bmw_connected_drive.py
+++ b/homeassistant/components/binary_sensor/bmw_connected_drive.py
@@ -68,8 +68,6 @@ class BMWConnectedDriveSensor(BinarySensorDevice):
         self._sensor_name = sensor_name
         self._device_class = device_class
         self._state = None
-        # self._unit_system = unit_system
-        # self._unit_system = self.hass.config.units
 
     @property
     def should_poll(self) -> bool:

--- a/homeassistant/components/binary_sensor/bmw_connected_drive.py
+++ b/homeassistant/components/binary_sensor/bmw_connected_drive.py
@@ -191,7 +191,7 @@ class BMWConnectedDriveSensor(BinarySensorDevice):
         if report.due_distance is not None:
             distance = round(unit_system.length(report.due_distance,
                                                 LENGTH_KILOMETERS))
-            result['{} distance'.format(service_type)] =  '{} {}'.format(
+            result['{} distance'.format(service_type)] = '{} {}'.format(
                 distance, unit_system.length_unit)
         return result
 

--- a/homeassistant/components/bmw_connected_drive/__init__.py
+++ b/homeassistant/components/bmw_connected_drive/__init__.py
@@ -9,9 +9,7 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.const import (CONF_USERNAME, CONF_PASSWORD,
-                                 CONF_UNIT_SYSTEM_METRIC,
-                                 CONF_UNIT_SYSTEM_IMPERIAL)
+from homeassistant.const import (CONF_USERNAME, CONF_PASSWORD)
 from homeassistant.helpers import discovery
 from homeassistant.helpers.event import track_utc_time_change
 import homeassistant.helpers.config_validation as cv
@@ -87,15 +85,11 @@ def setup_account(account_config: dict, hass, name: str) \
     password = account_config[CONF_PASSWORD]
     region = account_config[CONF_REGION]
     read_only = account_config[CONF_READ_ONLY]
-
-    if hass.config.units.is_imperial:
-        unit_system = CONF_UNIT_SYSTEM_IMPERIAL
-    else:
-        unit_system = CONF_UNIT_SYSTEM_METRIC
+    # unit_system = hass.config.units
 
     _LOGGER.debug('Adding new account %s', name)
     cd_account = BMWConnectedDriveAccount(username, password, region, name,
-                                          read_only, unit_system)
+                                          read_only)#, unit_system)
 
     def execute_service(call):
         """Execute a service for a vehicle.
@@ -133,8 +127,10 @@ def setup_account(account_config: dict, hass, name: str) \
 class BMWConnectedDriveAccount:
     """Representation of a BMW vehicle."""
 
+    # def __init__(self, username: str, password: str, region_str: str,
+    #              name: str, read_only, unit_system) -> None:
     def __init__(self, username: str, password: str, region_str: str,
-                 name: str, read_only, unit_system) -> None:
+                 name: str, read_only) -> None:
         """Constructor."""
         from bimmer_connected.account import ConnectedDriveAccount
         from bimmer_connected.country_selector import get_region_from_name
@@ -144,7 +140,7 @@ class BMWConnectedDriveAccount:
         self.read_only = read_only
         self.account = ConnectedDriveAccount(username, password, region)
         self.name = name
-        self.unit_system = unit_system
+        # self.unit_system = unit_system
         self._update_listeners = []
 
     def update(self, *_):

--- a/homeassistant/components/bmw_connected_drive/__init__.py
+++ b/homeassistant/components/bmw_connected_drive/__init__.py
@@ -89,7 +89,7 @@ def setup_account(account_config: dict, hass, name: str) \
 
     _LOGGER.debug('Adding new account %s', name)
     cd_account = BMWConnectedDriveAccount(username, password, region, name,
-                                          read_only)#, unit_system)
+                                          read_only)
 
     def execute_service(call):
         """Execute a service for a vehicle.

--- a/homeassistant/components/bmw_connected_drive/__init__.py
+++ b/homeassistant/components/bmw_connected_drive/__init__.py
@@ -10,7 +10,7 @@ import logging
 import voluptuous as vol
 
 from homeassistant.const import (CONF_USERNAME, CONF_PASSWORD,
-                                 CONF_UNIT_SYSTEM, CONF_UNIT_SYSTEM_METRIC,
+                                 CONF_UNIT_SYSTEM_METRIC,
                                  CONF_UNIT_SYSTEM_IMPERIAL)
 from homeassistant.helpers import discovery
 from homeassistant.helpers.event import track_utc_time_change

--- a/homeassistant/components/bmw_connected_drive/__init__.py
+++ b/homeassistant/components/bmw_connected_drive/__init__.py
@@ -30,8 +30,6 @@ ACCOUNT_SCHEMA = vol.Schema({
     vol.Required(CONF_PASSWORD): cv.string,
     vol.Required(CONF_REGION): vol.Any('north_america', 'china',
                                        'rest_of_world'),
-    vol.Optional(CONF_UNIT_SYSTEM): vol.Any(CONF_UNIT_SYSTEM_METRIC,
-                                            CONF_UNIT_SYSTEM_IMPERIAL),
     vol.Optional(CONF_READ_ONLY, default=False): cv.boolean,
 })
 
@@ -90,9 +88,7 @@ def setup_account(account_config: dict, hass, name: str) \
     region = account_config[CONF_REGION]
     read_only = account_config[CONF_READ_ONLY]
 
-    if account_config.get(CONF_UNIT_SYSTEM):
-        unit_system = account_config[CONF_UNIT_SYSTEM]
-    elif hass.config.units.is_imperial:
+    if hass.config.units.is_imperial:
         unit_system = CONF_UNIT_SYSTEM_IMPERIAL
     else:
         unit_system = CONF_UNIT_SYSTEM_METRIC

--- a/homeassistant/components/bmw_connected_drive/__init__.py
+++ b/homeassistant/components/bmw_connected_drive/__init__.py
@@ -30,7 +30,8 @@ ACCOUNT_SCHEMA = vol.Schema({
     vol.Required(CONF_PASSWORD): cv.string,
     vol.Required(CONF_REGION): vol.Any('north_america', 'china',
                                        'rest_of_world'),
-    vol.Optional(CONF_UNIT_SYSTEM): vol.Any('metric', 'imperial'),
+    vol.Optional(CONF_UNIT_SYSTEM): vol.Any(CONF_UNIT_SYSTEM_METRIC,
+                                            CONF_UNIT_SYSTEM_IMPERIAL),
     vol.Optional(CONF_READ_ONLY, default=False): cv.boolean,
 })
 

--- a/homeassistant/components/bmw_connected_drive/__init__.py
+++ b/homeassistant/components/bmw_connected_drive/__init__.py
@@ -85,7 +85,6 @@ def setup_account(account_config: dict, hass, name: str) \
     password = account_config[CONF_PASSWORD]
     region = account_config[CONF_REGION]
     read_only = account_config[CONF_READ_ONLY]
-    # unit_system = hass.config.units
 
     _LOGGER.debug('Adding new account %s', name)
     cd_account = BMWConnectedDriveAccount(username, password, region, name,
@@ -127,8 +126,6 @@ def setup_account(account_config: dict, hass, name: str) \
 class BMWConnectedDriveAccount:
     """Representation of a BMW vehicle."""
 
-    # def __init__(self, username: str, password: str, region_str: str,
-    #              name: str, read_only, unit_system) -> None:
     def __init__(self, username: str, password: str, region_str: str,
                  name: str, read_only) -> None:
         """Constructor."""
@@ -140,7 +137,6 @@ class BMWConnectedDriveAccount:
         self.read_only = read_only
         self.account = ConnectedDriveAccount(username, password, region)
         self.name = name
-        # self.unit_system = unit_system
         self._update_listeners = []
 
     def update(self, *_):

--- a/homeassistant/components/sensor/bmw_connected_drive.py
+++ b/homeassistant/components/sensor/bmw_connected_drive.py
@@ -161,4 +161,3 @@ class BMWConnectedDriveSensor(Entity):
         Show latest data after startup.
         """
         self._account.add_update_listener(self.update_callback)
-        

--- a/homeassistant/components/sensor/bmw_connected_drive.py
+++ b/homeassistant/components/sensor/bmw_connected_drive.py
@@ -9,22 +9,37 @@ import logging
 from homeassistant.components.bmw_connected_drive import DOMAIN as BMW_DOMAIN
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.icon import icon_for_battery_level
+from homeassistant.const import (CONF_UNIT_SYSTEM_IMPERIAL, VOLUME_LITERS,
+                                 VOLUME_GALLONS, LENGTH_KILOMETERS,
+                                 LENGTH_MILES)
+from homeassistant.util.volume import liter_to_gallon
+from homeassistant.util.distance import convert
 
 DEPENDENCIES = ['bmw_connected_drive']
 
 _LOGGER = logging.getLogger(__name__)
 
-ATTR_TO_HA = {
-    'mileage': ['mdi:speedometer', 'km'],
-    'remaining_range_total': ['mdi:ruler', 'km'],
-    'remaining_range_electric': ['mdi:ruler', 'km'],
-    'remaining_range_fuel': ['mdi:ruler', 'km'],
-    'max_range_electric': ['mdi:ruler', 'km'],
-    'remaining_fuel': ['mdi:gas-station', 'l'],
+ATTR_TO_HA_METRIC = {
+    'mileage': ['mdi:speedometer', LENGTH_KILOMETERS],
+    'remaining_range_total': ['mdi:ruler', LENGTH_KILOMETERS],
+    'remaining_range_electric': ['mdi:ruler', LENGTH_KILOMETERS],
+    'remaining_range_fuel': ['mdi:ruler', LENGTH_KILOMETERS],
+    'max_range_electric': ['mdi:ruler', LENGTH_KILOMETERS],
+    'remaining_fuel': ['mdi:gas-station', VOLUME_LITERS],
     'charging_time_remaining': ['mdi:update', 'h'],
     'charging_status': ['mdi:battery-charging', None]
 }
 
+ATTR_TO_HA_IMPERIAL = {
+    'mileage': ['mdi:speedometer', LENGTH_MILES],
+    'remaining_range_total': ['mdi:ruler', LENGTH_MILES],
+    'remaining_range_electric': ['mdi:ruler', LENGTH_MILES],
+    'remaining_range_fuel': ['mdi:ruler', LENGTH_MILES],
+    'max_range_electric': ['mdi:ruler', LENGTH_MILES],
+    'remaining_fuel': ['mdi:gas-station', VOLUME_GALLONS],
+    'charging_time_remaining': ['mdi:update', 'h'],
+    'charging_status': ['mdi:battery-charging', None]
+}
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the BMW sensors."""
@@ -33,12 +48,18 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                   ', '.join([a.name for a in accounts]))
     devices = []
     for account in accounts:
+        if account.unit_system == CONF_UNIT_SYSTEM_IMPERIAL:
+            attribute_info = ATTR_TO_HA_IMPERIAL
+        else:
+            attribute_info = ATTR_TO_HA_METRIC
         for vehicle in account.account.vehicles:
             for attribute_name in vehicle.drive_train_attributes:
                 device = BMWConnectedDriveSensor(account, vehicle,
-                                                 attribute_name)
+                                                 attribute_name,
+                                                 attribute_info)
                 devices.append(device)
-            device = BMWConnectedDriveSensor(account, vehicle, 'mileage')
+            device = BMWConnectedDriveSensor(account, vehicle, 'mileage',
+                                             attribute_info)
             devices.append(device)
     add_entities(devices, True)
 
@@ -46,7 +67,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class BMWConnectedDriveSensor(Entity):
     """Representation of a BMW vehicle sensor."""
 
-    def __init__(self, account, vehicle, attribute: str):
+    def __init__(self, account, vehicle, attribute: str, attribute_info):
         """Constructor."""
         self._vehicle = vehicle
         self._account = account
@@ -54,6 +75,7 @@ class BMWConnectedDriveSensor(Entity):
         self._state = None
         self._name = '{} {}'.format(self._vehicle.name, self._attribute)
         self._unique_id = '{}-{}'.format(self._vehicle.vin, self._attribute)
+        self._attribute_info = attribute_info
 
     @property
     def should_poll(self) -> bool:
@@ -85,7 +107,7 @@ class BMWConnectedDriveSensor(Entity):
             return icon_for_battery_level(
                 battery_level=vehicle_state.charging_level_hv,
                 charging=charging_state)
-        icon, _ = ATTR_TO_HA.get(self._attribute, [None, None])
+        icon, _ = self._attribute_info.get(self._attribute, [None, None])
         return icon
 
     @property
@@ -100,7 +122,7 @@ class BMWConnectedDriveSensor(Entity):
     @property
     def unit_of_measurement(self) -> str:
         """Get the unit of measurement."""
-        _, unit = ATTR_TO_HA.get(self._attribute, [None, None])
+        _, unit = self._attribute_info.get(self._attribute, [None, None])
         return unit
 
     @property
@@ -116,6 +138,13 @@ class BMWConnectedDriveSensor(Entity):
         vehicle_state = self._vehicle.state
         if self._attribute == 'charging_status':
             self._state = getattr(vehicle_state, self._attribute).value
+        elif self.unit_of_measurement == VOLUME_GALLONS:
+            self._state = round(liter_to_gallon(getattr(vehicle_state,
+                                                  self._attribute)))
+        elif self.unit_of_measurement == LENGTH_MILES:
+            value = getattr(vehicle_state, self._attribute)
+            self._state = round(convert(value, LENGTH_KILOMETERS,
+                                        LENGTH_MILES))
         else:
             self._state = getattr(vehicle_state, self._attribute)
 

--- a/homeassistant/components/sensor/bmw_connected_drive.py
+++ b/homeassistant/components/sensor/bmw_connected_drive.py
@@ -100,8 +100,8 @@ class BMWConnectedDriveSensor(Entity):
         """Icon to use in the frontend, if any."""
         from bimmer_connected.state import ChargingState
         vehicle_state = self._vehicle.state
-        charging_state = vehicle_state.charging_status in \
-                         [ChargingState.CHARGING]
+        charging_state = vehicle_state.charging_status in [
+            ChargingState.CHARGING]
 
         if self._attribute == 'charging_level_hv':
             return icon_for_battery_level(

--- a/homeassistant/components/sensor/bmw_connected_drive.py
+++ b/homeassistant/components/sensor/bmw_connected_drive.py
@@ -41,6 +41,7 @@ ATTR_TO_HA_IMPERIAL = {
     'charging_status': ['mdi:battery-charging', None]
 }
 
+
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the BMW sensors."""
     accounts = hass.data[BMW_DOMAIN]
@@ -140,7 +141,7 @@ class BMWConnectedDriveSensor(Entity):
             self._state = getattr(vehicle_state, self._attribute).value
         elif self.unit_of_measurement == VOLUME_GALLONS:
             self._state = round(liter_to_gallon(getattr(vehicle_state,
-                                                  self._attribute)))
+                                                        self._attribute)))
         elif self.unit_of_measurement == LENGTH_MILES:
             value = getattr(vehicle_state, self._attribute)
             self._state = round(convert(value, LENGTH_KILOMETERS,

--- a/homeassistant/util/unit_system.py
+++ b/homeassistant/util/unit_system.py
@@ -91,6 +91,11 @@ class UnitSystem:
         """Determine if this is the metric unit system."""
         return self.name == CONF_UNIT_SYSTEM_METRIC
 
+    @property
+    def is_imperial(self) -> bool:
+        """Determine if this is the imperial unit system."""
+        return self.name == CONF_UNIT_SYSTEM_IMPERIAL
+
     def temperature(self, temperature: float, from_unit: str) -> float:
         """Convert the given temperature to this unit system."""
         if not isinstance(temperature, Number):

--- a/homeassistant/util/unit_system.py
+++ b/homeassistant/util/unit_system.py
@@ -13,6 +13,7 @@ from homeassistant.const import (
     TEMPERATURE, UNIT_NOT_RECOGNIZED_TEMPLATE)
 from homeassistant.util import temperature as temperature_util
 from homeassistant.util import distance as distance_util
+from homeassistant.util import volume as volume_util
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -91,11 +92,6 @@ class UnitSystem:
         """Determine if this is the metric unit system."""
         return self.name == CONF_UNIT_SYSTEM_METRIC
 
-    @property
-    def is_imperial(self) -> bool:
-        """Determine if this is the imperial unit system."""
-        return self.name == CONF_UNIT_SYSTEM_IMPERIAL
-
     def temperature(self, temperature: float, from_unit: str) -> float:
         """Convert the given temperature to this unit system."""
         if not isinstance(temperature, Number):
@@ -112,6 +108,13 @@ class UnitSystem:
 
         return distance_util.convert(length, from_unit,
                                      self.length_unit)
+
+    def volume(self, volume: Optional[float], from_unit: str) -> float:
+        """Convert the given volume to this unit system."""
+        if not isinstance(volume, Number):
+            raise TypeError('{} is not a numeric value.'.format(str(volume)))
+
+        return volume_util.convert(volume, from_unit, self.volume_unit)
 
     def as_dict(self) -> dict:
         """Convert the unit system to a dictionary."""

--- a/homeassistant/util/volume.py
+++ b/homeassistant/util/volume.py
@@ -36,7 +36,12 @@ def convert(volume: float, from_unit: str, to_unit: str) -> float:
     if from_unit == to_unit:
         return volume
 
+    result = volume
+    
     if from_unit == VOLUME_LITERS and to_unit == VOLUME_GALLONS:
-        return __liter_to_gallon(volume)
+        result = __liter_to_gallon(volume)
     elif from_unit == VOLUME_GALLONS and to_unit == VOLUME_LITERS:
-        return __gallon_to_liter(volume)
+        result = __gallon_to_liter(volume)
+
+    return result
+

--- a/homeassistant/util/volume.py
+++ b/homeassistant/util/volume.py
@@ -1,0 +1,9 @@
+"""Volume conversion util functions."""
+
+def liter_to_gallon(liter: float) -> float:
+    """Convert a volume measurement in Liter to Gallon."""
+    return liter * .2642
+
+def gallon_to_liter(gallon: float) -> float:
+    """Convert a volume measurement in Gallon to Liter."""
+    return gallon * 3.785

--- a/homeassistant/util/volume.py
+++ b/homeassistant/util/volume.py
@@ -1,8 +1,10 @@
 """Volume conversion util functions."""
 
+
 def liter_to_gallon(liter: float) -> float:
     """Convert a volume measurement in Liter to Gallon."""
     return liter * .2642
+
 
 def gallon_to_liter(gallon: float) -> float:
     """Convert a volume measurement in Gallon to Liter."""

--- a/homeassistant/util/volume.py
+++ b/homeassistant/util/volume.py
@@ -37,11 +37,9 @@ def convert(volume: float, from_unit: str, to_unit: str) -> float:
         return volume
 
     result = volume
-    
     if from_unit == VOLUME_LITERS and to_unit == VOLUME_GALLONS:
         result = __liter_to_gallon(volume)
     elif from_unit == VOLUME_GALLONS and to_unit == VOLUME_LITERS:
         result = __gallon_to_liter(volume)
 
     return result
-

--- a/homeassistant/util/volume.py
+++ b/homeassistant/util/volume.py
@@ -1,11 +1,42 @@
 """Volume conversion util functions."""
 
+import logging
+from numbers import Number
+from homeassistant.const import (VOLUME_LITERS, VOLUME_MILLILITERS,
+                                 VOLUME_GALLONS, VOLUME_FLUID_OUNCE,
+                                 VOLUME, UNIT_NOT_RECOGNIZED_TEMPLATE)
 
-def liter_to_gallon(liter: float) -> float:
+_LOGGER = logging.getLogger(__name__)
+
+VALID_UNITS = [VOLUME_LITERS, VOLUME_MILLILITERS, VOLUME_GALLONS,
+               VOLUME_FLUID_OUNCE]
+
+
+def __liter_to_gallon(liter: float) -> float:
     """Convert a volume measurement in Liter to Gallon."""
     return liter * .2642
 
 
-def gallon_to_liter(gallon: float) -> float:
+def __gallon_to_liter(gallon: float) -> float:
     """Convert a volume measurement in Gallon to Liter."""
     return gallon * 3.785
+
+
+def convert(volume: float, from_unit: str, to_unit: str) -> float:
+    """Convert a temperature from one unit to another."""
+    if from_unit not in VALID_UNITS:
+        raise ValueError(UNIT_NOT_RECOGNIZED_TEMPLATE.format(from_unit,
+                                                             VOLUME))
+    if to_unit not in VALID_UNITS:
+        raise ValueError(UNIT_NOT_RECOGNIZED_TEMPLATE.format(to_unit, VOLUME))
+
+    if not isinstance(volume, Number):
+        raise TypeError('{} is not of numeric type'.format(volume))
+
+    if from_unit == to_unit:
+        return volume
+
+    if from_unit == VOLUME_LITERS and to_unit == VOLUME_GALLONS:
+        return __liter_to_gallon(volume)
+    elif from_unit == VOLUME_GALLONS and to_unit == VOLUME_LITERS:
+        return __gallon_to_liter(volume)

--- a/tests/util/test_volume.py
+++ b/tests/util/test_volume.py
@@ -1,0 +1,49 @@
+"""Test homeassistant volume utility functions."""
+
+import unittest
+import homeassistant.util.volume as volume_util
+from homeassistant.const import (VOLUME_LITERS, VOLUME_MILLILITERS,
+                                 VOLUME_GALLONS, VOLUME_FLUID_OUNCE)
+
+INVALID_SYMBOL = 'bob'
+VALID_SYMBOL = VOLUME_LITERS
+
+
+class TestVolumeUtil(unittest.TestCase):
+    """Test the volume utility functions."""
+
+    def test_convert_same_unit(self):
+        """Test conversion from any unit to same unit."""
+        self.assertEqual(2, volume_util.convert(2, VOLUME_LITERS,
+                                                VOLUME_LITERS))
+        self.assertEqual(3, volume_util.convert(3, VOLUME_MILLILITERS,
+                                                VOLUME_MILLILITERS))
+        self.assertEqual(4, volume_util.convert(4, VOLUME_GALLONS,
+                                                VOLUME_GALLONS))
+        self.assertEqual(5, volume_util.convert(5, VOLUME_FLUID_OUNCE,
+                                                VOLUME_FLUID_OUNCE))
+
+    def test_convert_invalid_unit(self):
+        """Test exception is thrown for invalid units."""
+        with self.assertRaises(ValueError):
+            volume_util.convert(5, INVALID_SYMBOL, VALID_SYMBOL)
+
+        with self.assertRaises(ValueError):
+            volume_util.convert(5, VALID_SYMBOL, INVALID_SYMBOL)
+
+    def test_convert_nonnumeric_value(self):
+        """Test exception is thrown for nonnumeric type."""
+        with self.assertRaises(TypeError):
+            volume_util.convert('a', VOLUME_GALLONS, VOLUME_LITERS)
+
+    def test_convert_from_liters(self):
+        """Test conversion from liters to other units."""
+        liters = 5
+        self.assertEqual(volume_util.convert(liters, VOLUME_LITERS,
+                                             VOLUME_GALLONS), 1.321)
+
+    def test_convert_from_gallons(self):
+        """Test conversion from gallons to other units."""
+        gallons = 5
+        self.assertEqual(volume_util.convert(gallons, VOLUME_GALLONS,
+                                             VOLUME_LITERS), 18.925)


### PR DESCRIPTION
## Description:
Allow BMW component to convert units to imperial or metric depending on what is passed in to the HA config's `unit_system`.

## Example entry for `configuration.yaml` (if applicable):
```yaml
homeassistant:
  unit_system: imperial

bmw_connected_drive:
  name:
    username: user_email
    password: user_password
    region: north_america
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**