### PR TITLE
Add Zoneminder run state sensor and service

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -385,7 +385,7 @@ omit =
     homeassistant/components/zigbee.py
     homeassistant/components/*/zigbee.py
 
-    homeassistant/components/zoneminder.py
+    homeassistant/components/zoneminder/*
     homeassistant/components/*/zoneminder.py
 
     homeassistant/components/tuya.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -233,7 +233,7 @@ homeassistant/components/*/xiaomi_aqara.py @danielhiversen @syssi
 homeassistant/components/*/xiaomi_miio.py @rytilahti @syssi
 
 # Z
-homeassistant/components/zoneminder.py @rohankapoorcom
+homeassistant/components/zoneminder/ @rohankapoorcom
 homeassistant/components/*/zoneminder.py @rohankapoorcom
 
 # Other code

--- a/homeassistant/components/sensor/zoneminder.py
+++ b/homeassistant/components/sensor/zoneminder.py
@@ -54,6 +54,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         for sensor in config[CONF_MONITORED_CONDITIONS]:
             sensors.append(ZMSensorEvents(monitor, include_archived, sensor))
 
+    sensors.append(ZMSensorRunState(zm_client))
     add_entities(sensors)
 
 
@@ -114,3 +115,26 @@ class ZMSensorEvents(Entity):
         """Update the sensor."""
         self._state = self._monitor.get_events(
             self.time_period, self._include_archived)
+
+
+class ZMSensorRunState(Entity):
+    """Get the ZoneMinder run state."""
+
+    def __init__(self, client):
+        """Initialize run state sensor."""
+        self._state = None
+        self._client = client
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return 'Run State'
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    def update(self):
+        """Update the sensor."""
+        self._state = self._client.get_active_state()

--- a/homeassistant/components/zoneminder/__init__.py
+++ b/homeassistant/components/zoneminder/__init__.py
@@ -10,12 +10,12 @@ import voluptuous as vol
 
 from homeassistant.const import (
     CONF_HOST, CONF_PASSWORD, CONF_PATH, CONF_SSL, CONF_USERNAME,
-    CONF_VERIFY_SSL)
+    CONF_VERIFY_SSL, ATTR_NAME)
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['zm-py==0.0.5']
+REQUIREMENTS = ['zm-py==0.1.0']
 
 CONF_PATH_ZMS = 'path_zms'
 
@@ -38,6 +38,11 @@ CONFIG_SCHEMA = vol.Schema({
     })
 }, extra=vol.ALLOW_EXTRA)
 
+SERVICE_SET_RUN_STATE = 'set_run_state'
+SET_RUN_STATE_SCHEMA = vol.Schema({
+    vol.Required(ATTR_NAME): cv.string
+})
+
 
 def setup(hass, config):
     """Set up the ZoneMinder component."""
@@ -56,5 +61,14 @@ def setup(hass, config):
                                    conf.get(CONF_PATH),
                                    conf.get(CONF_PATH_ZMS),
                                    conf.get(CONF_VERIFY_SSL))
+
+    def set_active_state(call):
+        """Set the ZoneMinder run state to the given state name."""
+        return hass.data[DOMAIN].set_active_state(call.data[ATTR_NAME])
+
+    hass.services.register(
+        DOMAIN, SERVICE_SET_RUN_STATE, set_active_state,
+        schema=SET_RUN_STATE_SCHEMA
+    )
 
     return hass.data[DOMAIN].login()

--- a/homeassistant/components/zoneminder/services.yaml
+++ b/homeassistant/components/zoneminder/services.yaml
@@ -1,0 +1,6 @@
+set_run_state:
+  description: Set the ZoneMinder run state
+  fields:
+    name:
+      description: The string name of the ZoneMinder run state to set as active.
+      example: 'Home'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1594,4 +1594,4 @@ zigpy-xbee==0.1.1
 zigpy==0.2.0
 
 # homeassistant.components.zoneminder
-zm-py==0.0.5
+zm-py==0.1.0


### PR DESCRIPTION
## Description:

I've re-implemented @jantman's original PR for ZoneMinder run states using my new zm-py library. Quoting from #15324:

> One of the core concepts of ZoneMinder is run states, named sets of monitor states for each of ZoneMinder's cameras. This is an internal construct of ZoneMinder that's user-editable and exposed over the API, and is commonly used very similarly to burgular alarm states (i.e. run states of "Home", "Away", and "Disarmed" each map to different settings for different cameras). It's exposed prominently in the ZoneMinder UI and far more deeply integrated with ZoneMinder than controlling individual cameras ad-hoc (as the zoneminder component currently does with switches, which is effectively incompatible with run states).

> This PR adds a sensor for the current run state and a set_run_state service to update the run state. This will allow users to write automations that query manipulate zoneminder run state (i.e. set state to "Away" when presence is lost or when an alarm is armed).

> It should be noted that while the list of possible run states is available from ZoneMinder's API, there doesn't appear to be any way to use that in hass (see my related RFC for that, home-assistant/architecture#43 ).

The relevant code in zm-py is in https://github.com/rohankapoorcom/zm-py/pull/18 if you'd like to reference it. That still needs to be merged/published and the version bumped before this can be merged, but I wanted to get some thoughts on this first.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#6564

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
