### PR TITLE
Make async_track_time_change smarter

### DIFF
--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -367,6 +367,7 @@ def async_track_utc_time_change(hass, action,
         # Prevent "can't compare offset-naive and offset-aware" errors,
         # let's make everything timezone-aware
         if now.tzinfo is None:
+            # pylint: disable=no-value-for-parameter
             now = pytz.UTC.localize(now)
 
         if last_now is None or now < last_now:

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -370,11 +370,7 @@ def async_track_utc_time_change(hass, action,
 
         if next_time <= now:
             hass.async_run_job(action, event.data[ATTR_NOW])
-            base = now
-            if next_time == now:
-                # Make sure not to trigger on duplicate times
-                base = now + timedelta(seconds=1)
-            calculate_next(base)
+            calculate_next(now + timedelta(seconds=1))
 
     return hass.bus.async_listen(EVENT_TIME_CHANGED,
                                  pattern_time_change_listener)

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -2,8 +2,6 @@
 from datetime import timedelta
 import functools as ft
 
-import pytz
-
 from homeassistant.loader import bind_hass
 from homeassistant.helpers.sun import get_astral_event_next
 from ..core import HomeAssistant, callback
@@ -363,12 +361,6 @@ def async_track_utc_time_change(hass, action,
         nonlocal next_time, last_now
 
         now = event.data[ATTR_NOW]
-
-        # Prevent "can't compare offset-naive and offset-aware" errors,
-        # let's make everything timezone-aware
-        if now.tzinfo is None:
-            # pylint: disable=no-value-for-parameter
-            now = pytz.UTC.localize(now)
 
         if last_now is None or now < last_now:
             # Time rolled back or next time not yet calculated

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -352,7 +352,7 @@ def async_track_utc_time_change(hass, action,
             matching_hours)
 
     # Make sure rolling back the clock doesn't prevent the timer from
-    # triggering
+    # triggering.
     last_now = None
 
     @callback
@@ -372,6 +372,9 @@ def async_track_utc_time_change(hass, action,
             hass.async_run_job(action, event.data[ATTR_NOW])
             calculate_next(now + timedelta(seconds=1))
 
+    # We can't use async_track_point_in_utc_time here because it would
+    # break in the case that the system time abruptly jumps backwards.
+    # Our custom last_now logic takes care of resolving that scenario.
     return hass.bus.async_listen(EVENT_TIME_CHANGED,
                                  pattern_time_change_listener)
 

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -2,6 +2,8 @@
 from datetime import timedelta
 import functools as ft
 
+import pytz
+
 from homeassistant.loader import bind_hass
 from homeassistant.helpers.sun import get_astral_event_next
 from ..core import HomeAssistant, callback
@@ -322,13 +324,13 @@ track_sunset = threaded_listener_factory(async_track_sunset)
 
 @callback
 @bind_hass
-def async_track_utc_time_change(hass, action, year=None, month=None, day=None,
+def async_track_utc_time_change(hass, action,
                                 hour=None, minute=None, second=None,
                                 local=False):
     """Add a listener that will fire if time matches a pattern."""
     # We do not have to wrap the function with time pattern matching logic
     # if no pattern given
-    if all(val is None for val in (year, month, day, hour, minute, second)):
+    if all(val is None for val in (hour, minute, second)):
         @callback
         def time_change_listener(event):
             """Fire every time event that comes in."""
@@ -336,23 +338,50 @@ def async_track_utc_time_change(hass, action, year=None, month=None, day=None,
 
         return hass.bus.async_listen(EVENT_TIME_CHANGED, time_change_listener)
 
-    pmp = _process_time_match
-    year, month, day = pmp(year), pmp(month), pmp(day)
-    hour, minute, second = pmp(hour), pmp(minute), pmp(second)
+    matching_seconds = _parse_time_expression(second, 0, 59)
+    matching_minutes = _parse_time_expression(minute, 0, 59)
+    matching_hours = _parse_time_expression(hour, 0, 23)
+
+    next_time = None
+
+    def calculate_next(now):
+        """Calculate and set the next time the trigger should fire."""
+        nonlocal next_time
+
+        localized_now = dt_util.as_local(now) if local else now
+        next_time = _find_next_time_expression_time(
+            localized_now, matching_seconds, matching_minutes,
+            matching_hours)
+
+    # Make sure rolling back the clock doesn't prevent the timer from
+    # triggering
+    last_now = None
 
     @callback
     def pattern_time_change_listener(event):
         """Listen for matching time_changed events."""
+        nonlocal next_time, last_now
+
         now = event.data[ATTR_NOW]
 
-        if local:
-            now = dt_util.as_local(now)
+        # Prevent "can't compare offset-naive and offset-aware" errors,
+        # let's make everything timezone-aware
+        if now.tzinfo is None:
+            now = pytz.UTC.localize(now)
 
-        # pylint: disable=too-many-boolean-expressions
-        if second(now.second) and minute(now.minute) and hour(now.hour) and \
-           day(now.day) and month(now.month) and year(now.year):
+        if last_now is None or now < last_now:
+            # Time rolled back or next time not yet calculated
+            calculate_next(now)
 
-            hass.async_run_job(action, now)
+        last_now = now
+
+        if next_time <= now:
+            hass.async_run_job(action, event.data[ATTR_NOW])
+            base = now
+            if next_time == now:
+                # Make sure not to trigger on duplicate times
+                base = now + timedelta(seconds=1)
+            calculate_next(base)
 
     return hass.bus.async_listen(EVENT_TIME_CHANGED,
                                  pattern_time_change_listener)
@@ -363,11 +392,10 @@ track_utc_time_change = threaded_listener_factory(async_track_utc_time_change)
 
 @callback
 @bind_hass
-def async_track_time_change(hass, action, year=None, month=None, day=None,
-                            hour=None, minute=None, second=None):
+def async_track_time_change(hass, action, hour=None, minute=None, second=None):
     """Add a listener that will fire if UTC time matches a pattern."""
-    return async_track_utc_time_change(hass, action, year, month, day, hour,
-                                       minute, second, local=True)
+    return async_track_utc_time_change(hass, action, hour, minute, second,
+                                       local=True)
 
 
 track_time_change = threaded_listener_factory(async_track_time_change)
@@ -385,17 +413,104 @@ def _process_state_match(parameter):
     return lambda state: state in parameter
 
 
-def _process_time_match(parameter):
-    """Wrap parameter in a tuple if it is not one and returns it."""
+def _parse_time_expression(parameter, min_value, max_value):
+    """Parse the time expression part and return a list of times to match."""
     if parameter is None or parameter == MATCH_ALL:
-        return lambda _: True
-
-    if isinstance(parameter, str) and parameter.startswith('/'):
+        res = [x for x in range(min_value, max_value + 1)]
+    elif isinstance(parameter, str) and parameter.startswith('/'):
         parameter = float(parameter[1:])
-        return lambda time: time % parameter == 0
+        res = [x for x in range(min_value, max_value + 1)
+               if x % parameter == 0]
+    elif not hasattr(parameter, '__iter__'):
+        res = [int(parameter)]
+    else:
+        res = list(sorted(int(x) for x in parameter))
 
-    if isinstance(parameter, str) or not hasattr(parameter, '__iter__'):
-        return lambda time: time == parameter
+    for x in res:
+        if x < min_value or x > max_value:
+            raise ValueError(
+                "Time expression '{}': parameter {} out of range ({} to {})"
+                "".format(parameter, x, min_value, max_value)
+            )
 
-    parameter = tuple(parameter)
-    return lambda time: time in parameter
+    return res
+
+
+def _find_next_time_expression_time(now, seconds, minutes, hours):
+    """Find the next datetime from now for which the time expression matches.
+
+    The algorithm looks at each time unit separately and tries to find the
+    next one that matches for each. If any of them would roll over, all
+    time units below that are reset to the first matching value.
+
+    Timezones are also handled (the tzinfo of the now object is used), inluding
+    daylight saving time.
+    """
+    if not seconds or not minutes or not hours:
+        raise ValueError("Cannot find a next time: Time expression never "
+                         "matches!")
+
+    # Copy now
+    result = now.replace()
+
+    # Match next second
+    next_second = next((x for x in seconds if x >= result.second), None)
+    if next_second is None:
+        # No second to match in this minute. Roll-over to next minute.
+        next_second = seconds[0]
+        result += timedelta(minutes=1)
+
+    result = result.replace(second=next_second)
+
+    # Match next minute
+    next_minute = next((x for x in minutes if x >= result.minute), None)
+    if next_minute != result.minute:
+        # We're in the next minute. Seconds needs to be reset.
+        result = result.replace(second=seconds[0])
+
+    if next_minute is None:
+        # No minute to match in this hour. Roll-over to next hour.
+        next_minute = minutes[0]
+        result += timedelta(hours=1)
+
+    result = result.replace(minute=next_minute)
+
+    # Match next hour
+    next_hour = next((x for x in hours if x >= result.hour), None)
+    if next_hour != result.hour:
+        # We're in the next hour. Seconds+minutes needs to be reset.
+        result.replace(second=seconds[0], minute=minutes[0])
+
+    if next_hour is None:
+        # No minute to match in this day. Roll-over to next day.
+        next_hour = hours[0]
+        result += timedelta(days=1)
+
+    result = result.replace(hour=next_hour)
+
+    # Now we need to handle timezones. We will make this datetime object
+    # "naive" first and then re-convert it to the target timezone.
+    # This is so that we can call pytz's localize and handle DST changes.
+    tz = result.tzinfo
+    result = result.replace(tzinfo=None)
+
+    try:
+        result = tz.localize(result, is_dst=None)
+    except pytz.AmbiguousTimeError:
+        # This happens when we're leaving daylight saving time and local
+        # clocks are rolled back. In this case, we want to trigger
+        # on both the DST and non-DST time. So when "now" is in the DST
+        # use the DST-on time, and if not, use the DST-off time.
+        use_dst = bool(now.dst())
+        result = tz.localize(result, is_dst=use_dst)
+    except pytz.NonExistentTimeError:
+        # This happens when we're entering daylight saving time and local
+        # clocks are rolled forward, thus there are local times that do
+        # not exist. In this case, we want to trigger on the next time
+        # that *does* exist.
+        # In the worst case, this will run through all the seconds in the
+        # time shift, but that's max 3600 operations for once per year
+        result = result.replace(tzinfo=tz) + timedelta(seconds=1)
+        return _find_next_time_expression_time(result, seconds, minutes, hours)
+
+    return result

--- a/homeassistant/util/dt.py
+++ b/homeassistant/util/dt.py
@@ -306,7 +306,7 @@ def find_next_time_expression_time(now, seconds, minutes, hours):
 
     result = result.replace(hour=next_hour)
 
-    if result.tzinfo is None or result.tzinfo is pytz.UTC:
+    if result.tzinfo is None:
         return result
 
     # Now we need to handle timezones. We will make this datetime object

--- a/homeassistant/util/dt.py
+++ b/homeassistant/util/dt.py
@@ -1,8 +1,8 @@
 """Helper methods to handle the time in Home Assistant."""
 import datetime as dt
 import re
-from typing import Any, Union, Optional, Tuple, \
-    List, cast, Dict  # noqa pylint: disable=unused-import
+from typing import (Any, Union, Optional,  # noqa pylint: disable=unused-import
+                    Tuple, List, cast, Dict)
 
 import pytz
 import pytz.exceptions as pytzexceptions

--- a/homeassistant/util/dt.py
+++ b/homeassistant/util/dt.py
@@ -6,6 +6,8 @@ from typing import Any, Dict, Union, Optional, Tuple  # noqa pylint: disable=unu
 import pytz
 import pytz.exceptions as pytzexceptions
 
+from homeassistant.const import MATCH_ALL
+
 DATE_STR_FORMAT = "%Y-%m-%d"
 UTC = pytz.utc
 DEFAULT_TIME_ZONE = pytz.utc  # type: dt.tzinfo
@@ -209,3 +211,155 @@ def get_age(date: dt.datetime) -> str:
         return formatn(minute, 'minute')
 
     return formatn(second, 'second')
+
+
+def parse_time_expression(parameter, min_value, max_value):
+    """Parse the time expression part and return a list of times to match."""
+    if parameter is None or parameter == MATCH_ALL:
+        res = [x for x in range(min_value, max_value + 1)]
+    elif isinstance(parameter, str) and parameter.startswith('/'):
+        parameter = float(parameter[1:])
+        res = [x for x in range(min_value, max_value + 1)
+               if x % parameter == 0]
+    elif not hasattr(parameter, '__iter__'):
+        res = [int(parameter)]
+    else:
+        res = list(sorted(int(x) for x in parameter))
+
+    for val in res:
+        if val < min_value or val > max_value:
+            raise ValueError(
+                "Time expression '{}': parameter {} out of range ({} to {})"
+                "".format(parameter, val, min_value, max_value)
+            )
+
+    return res
+
+
+# pylint: disable=redefined-outer-name
+def find_next_time_expression_time(now, seconds, minutes, hours):
+    """Find the next datetime from now for which the time expression matches.
+
+    The algorithm looks at each time unit separately and tries to find the
+    next one that matches for each. If any of them would roll over, all
+    time units below that are reset to the first matching value.
+
+    Timezones are also handled (the tzinfo of the now object is used),
+    including daylight saving time.
+    """
+    if not seconds or not minutes or not hours:
+        raise ValueError("Cannot find a next time: Time expression never "
+                         "matches!")
+
+    def _lower_bound(arr, cmp):
+        """Return the first value in arr greater or equal to cmp.
+
+        Return None if no such value exists.
+        """
+        left = 0
+        right = len(arr)
+        while left < right:
+            mid = (left + right) // 2
+            if arr[mid] < cmp:
+                left = mid + 1
+            else:
+                right = mid
+
+        if left == len(arr):
+            return None
+        return arr[left]
+
+    result = now.replace(microsecond=0)
+
+    # Match next second
+    next_second = _lower_bound(seconds, result.second)
+    if next_second is None:
+        # No second to match in this minute. Roll-over to next minute.
+        next_second = seconds[0]
+        result += dt.timedelta(minutes=1)
+
+    result = result.replace(second=next_second)
+
+    # Match next minute
+    next_minute = _lower_bound(minutes, result.minute)
+    if next_minute != result.minute:
+        # We're in the next minute. Seconds needs to be reset.
+        result = result.replace(second=seconds[0])
+
+    if next_minute is None:
+        # No minute to match in this hour. Roll-over to next hour.
+        next_minute = minutes[0]
+        result += dt.timedelta(hours=1)
+
+    result = result.replace(minute=next_minute)
+
+    # Match next hour
+    next_hour = _lower_bound(hours, result.hour)
+    if next_hour != result.hour:
+        # We're in the next hour. Seconds+minutes needs to be reset.
+        result.replace(second=seconds[0], minute=minutes[0])
+
+    if next_hour is None:
+        # No minute to match in this day. Roll-over to next day.
+        next_hour = hours[0]
+        result += dt.timedelta(days=1)
+
+    result = result.replace(hour=next_hour)
+
+    if result.tzinfo is None or result.tzinfo is pytz.UTC:
+        return result
+
+    # Now we need to handle timezones. We will make this datetime object
+    # "naive" first and then re-convert it to the target timezone.
+    # This is so that we can call pytz's localize and handle DST changes.
+    tzinfo = result.tzinfo
+    result = result.replace(tzinfo=None)
+
+    try:
+        result = tzinfo.localize(result, is_dst=None)
+    except pytz.AmbiguousTimeError:
+        # This happens when we're leaving daylight saving time and local
+        # clocks are rolled back. In this case, we want to trigger
+        # on both the DST and non-DST time. So when "now" is in the DST
+        # use the DST-on time, and if not, use the DST-off time.
+        use_dst = bool(now.dst())
+        result = tzinfo.localize(result, is_dst=use_dst)
+    except pytz.NonExistentTimeError:
+        # This happens when we're entering daylight saving time and local
+        # clocks are rolled forward, thus there are local times that do
+        # not exist. In this case, we want to trigger on the next time
+        # that *does* exist.
+        # In the worst case, this will run through all the seconds in the
+        # time shift, but that's max 3600 operations for once per year
+        result = result.replace(tzinfo=tzinfo) + dt.timedelta(seconds=1)
+        return find_next_time_expression_time(result, seconds, minutes, hours)
+
+    if result.dst() >= now.dst():
+        return result
+
+    # Another edge-case when leaving DST:
+    # When now is in DST and ambiguous *and* the next trigger time we *should*
+    # trigger is ambiguous and outside DST, the excepts above won't catch it.
+    # For example: if triggering on 2:30 and now is 28.10.2018 2:30 (in DST)
+    # we should trigger next on 28.10.2018 2:30 (out of DST), but our
+    # algorithm above would produce 29.10.2018 2:30 (out of DST)
+
+    # Step 1: Check if now is ambiguous
+    try:
+        tzinfo.localize(now.replace(tzinfo=None), is_dst=None)
+        return result
+    except pytz.AmbiguousTimeError:
+        pass
+
+    # Step 2: Check if result of (now - DST) is ambiguous.
+    check = now - now.dst()
+    check_result = find_next_time_expression_time(
+        check, seconds, minutes, hours)
+    try:
+        tzinfo.localize(check_result.replace(tzinfo=None), is_dst=None)
+        return result
+    except pytz.AmbiguousTimeError:
+        pass
+
+    # OK, edge case does apply. We must override the DST to DST-off
+    return tzinfo.localize(check_result.replace(tzinfo=None), is_dst=False)

--- a/tests/common.py
+++ b/tests/common.py
@@ -251,7 +251,7 @@ fire_mqtt_message = threadsafe_callback_factory(async_fire_mqtt_message)
 @ha.callback
 def async_fire_time_changed(hass, time):
     """Fire a time changes event."""
-    hass.bus.async_fire(EVENT_TIME_CHANGED, {'now': time})
+    hass.bus.async_fire(EVENT_TIME_CHANGED, {'now': date_util.as_utc(time)})
 
 
 fire_time_changed = threadsafe_callback_factory(async_fire_time_changed)

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -526,12 +526,31 @@ class TestEventHelpers(unittest.TestCase):
         """Send a time changed event."""
         self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {ha.ATTR_NOW: now})
 
+
+class TestTrackTimeChange(unittest.TestCase):
+    """Test track time change methods."""
+
+    def setUp(self):
+        """Set up the tests."""
+        self.orig_default_time_zone = dt_util.DEFAULT_TIME_ZONE
+        self.hass = get_test_home_assistant()
+
+    def tearDown(self):
+        """Stop everything that was started."""
+        dt_util.set_default_time_zone(self.orig_default_time_zone)
+        self.hass.stop()
+
+    def _send_time_changed(self, now):
+        """Send a time changed event."""
+        self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {ha.ATTR_NOW: now})
+
     def test_periodic_task_minute(self):
         """Test periodic tasks per minute."""
         specific_runs = []
 
         unsub = track_utc_time_change(
-            self.hass, lambda x: specific_runs.append(1), minute='/5')
+            self.hass, lambda x: specific_runs.append(1), minute='/5',
+            second=0)
 
         self._send_time_changed(datetime(2014, 5, 24, 12, 0, 0))
         self.hass.block_till_done()
@@ -556,7 +575,8 @@ class TestEventHelpers(unittest.TestCase):
         specific_runs = []
 
         unsub = track_utc_time_change(
-            self.hass, lambda x: specific_runs.append(1), hour='/2')
+            self.hass, lambda x: specific_runs.append(1), hour='/2',
+            minute=0, second=0)
 
         self._send_time_changed(datetime(2014, 5, 24, 22, 0, 0))
         self.hass.block_till_done()
@@ -566,7 +586,7 @@ class TestEventHelpers(unittest.TestCase):
         self.hass.block_till_done()
         self.assertEqual(1, len(specific_runs))
 
-        self._send_time_changed(datetime(2014, 5, 24, 0, 0, 0))
+        self._send_time_changed(datetime(2014, 5, 25, 0, 0, 0))
         self.hass.block_till_done()
         self.assertEqual(2, len(specific_runs))
 
@@ -584,67 +604,137 @@ class TestEventHelpers(unittest.TestCase):
         self.hass.block_till_done()
         self.assertEqual(3, len(specific_runs))
 
-    def test_periodic_task_day(self):
-        """Test periodic tasks per day."""
-        specific_runs = []
-
-        unsub = track_utc_time_change(
-            self.hass, lambda x: specific_runs.append(1), day='/2')
-
-        self._send_time_changed(datetime(2014, 5, 2, 0, 0, 0))
-        self.hass.block_till_done()
-        self.assertEqual(1, len(specific_runs))
-
-        self._send_time_changed(datetime(2014, 5, 3, 12, 0, 0))
-        self.hass.block_till_done()
-        self.assertEqual(1, len(specific_runs))
-
-        self._send_time_changed(datetime(2014, 5, 4, 0, 0, 0))
-        self.hass.block_till_done()
-        self.assertEqual(2, len(specific_runs))
-
-        unsub()
-
-        self._send_time_changed(datetime(2014, 5, 4, 0, 0, 0))
-        self.hass.block_till_done()
-        self.assertEqual(2, len(specific_runs))
-
-    def test_periodic_task_year(self):
-        """Test periodic tasks per year."""
-        specific_runs = []
-
-        unsub = track_utc_time_change(
-            self.hass, lambda x: specific_runs.append(1), year='/2')
-
-        self._send_time_changed(datetime(2014, 5, 2, 0, 0, 0))
-        self.hass.block_till_done()
-        self.assertEqual(1, len(specific_runs))
-
-        self._send_time_changed(datetime(2015, 5, 2, 0, 0, 0))
-        self.hass.block_till_done()
-        self.assertEqual(1, len(specific_runs))
-
-        self._send_time_changed(datetime(2016, 5, 2, 0, 0, 0))
-        self.hass.block_till_done()
-        self.assertEqual(2, len(specific_runs))
-
-        unsub()
-
-        self._send_time_changed(datetime(2016, 5, 2, 0, 0, 0))
-        self.hass.block_till_done()
-        self.assertEqual(2, len(specific_runs))
-
     def test_periodic_task_wrong_input(self):
         """Test periodic tasks with wrong input."""
         specific_runs = []
 
         with pytest.raises(ValueError):
             track_utc_time_change(
-                self.hass, lambda x: specific_runs.append(1), year='/two')
+                self.hass, lambda x: specific_runs.append(1), hour='/two')
 
         self._send_time_changed(datetime(2014, 5, 2, 0, 0, 0))
         self.hass.block_till_done()
         self.assertEqual(0, len(specific_runs))
+
+    def test_periodic_task_clock_rollback(self):
+        """Test periodic tasks with the time rolling backwards."""
+        specific_runs = []
+
+        unsub = track_utc_time_change(
+            self.hass, lambda x: specific_runs.append(1), hour='/2', minute=0,
+            second=0)
+
+        self._send_time_changed(datetime(2014, 5, 24, 22, 0, 0))
+        self.hass.block_till_done()
+        self.assertEqual(1, len(specific_runs))
+
+        self._send_time_changed(datetime(2014, 5, 24, 23, 0, 0))
+        self.hass.block_till_done()
+        self.assertEqual(1, len(specific_runs))
+
+        self._send_time_changed(datetime(2014, 5, 24, 22, 0, 0))
+        self.hass.block_till_done()
+        self.assertEqual(2, len(specific_runs))
+
+        self._send_time_changed(datetime(2014, 5, 24, 0, 0, 0))
+        self.hass.block_till_done()
+        self.assertEqual(3, len(specific_runs))
+
+        self._send_time_changed(datetime(2014, 5, 25, 2, 0, 0))
+        self.hass.block_till_done()
+        self.assertEqual(4, len(specific_runs))
+
+        unsub()
+
+        self._send_time_changed(datetime(2014, 5, 25, 2, 0, 0))
+        self.hass.block_till_done()
+        self.assertEqual(4, len(specific_runs))
+
+    def test_periodic_task_duplicate_time(self):
+        """Test periodic tasks not triggering on duplicate time."""
+        specific_runs = []
+
+        unsub = track_utc_time_change(
+            self.hass, lambda x: specific_runs.append(1), hour='/2', minute=0,
+            second=0)
+
+        self._send_time_changed(datetime(2014, 5, 24, 22, 0, 0))
+        self.hass.block_till_done()
+        self.assertEqual(1, len(specific_runs))
+
+        self._send_time_changed(datetime(2014, 5, 24, 22, 0, 0))
+        self.hass.block_till_done()
+        self.assertEqual(1, len(specific_runs))
+
+        self._send_time_changed(datetime(2014, 5, 25, 0, 0, 0))
+        self.hass.block_till_done()
+        self.assertEqual(2, len(specific_runs))
+
+        unsub()
+
+    def test_periodic_task_entering_dst(self):
+        """Test periodic task behavior when entering dst."""
+        tz = dt_util.get_time_zone('Europe/Vienna')
+        dt_util.set_default_time_zone(tz)
+        specific_runs = []
+
+        unsub = track_time_change(
+            self.hass, lambda x: specific_runs.append(1), hour=2, minute=30,
+            second=0)
+
+        self._send_time_changed(
+            tz.localize(datetime(2018, 3, 25, 1, 50, 0)))
+        self.hass.block_till_done()
+        self.assertEqual(0, len(specific_runs))
+
+        self._send_time_changed(
+            tz.localize(datetime(2018, 3, 25, 3, 50, 0)))
+        self.hass.block_till_done()
+        self.assertEqual(0, len(specific_runs))
+
+        self._send_time_changed(
+            tz.localize(datetime(2018, 3, 26, 1, 50, 0)))
+        self.hass.block_till_done()
+        self.assertEqual(0, len(specific_runs))
+
+        self._send_time_changed(
+            tz.localize(datetime(2018, 3, 26, 2, 50, 0)))
+        self.hass.block_till_done()
+        self.assertEqual(1, len(specific_runs))
+
+        unsub()
+
+    def test_periodic_task_leaving_dst(self):
+        """Test periodic task behavior when leaving dst."""
+        tz = dt_util.get_time_zone('Europe/Vienna')
+        dt_util.set_default_time_zone(tz)
+        specific_runs = []
+
+        unsub = track_time_change(
+            self.hass, lambda x: specific_runs.append(1), hour=2, minute=30,
+            second=0)
+
+        self._send_time_changed(
+            tz.localize(datetime(2018, 10, 28, 2, 5, 0), is_dst=False))
+        self.hass.block_till_done()
+        self.assertEqual(0, len(specific_runs))
+
+        self._send_time_changed(
+            tz.localize(datetime(2018, 10, 28, 2, 55, 0), is_dst=False))
+        self.hass.block_till_done()
+        self.assertEqual(1, len(specific_runs))
+
+        self._send_time_changed(
+            tz.localize(datetime(2018, 10, 28, 2, 5, 0), is_dst=True))
+        self.hass.block_till_done()
+        self.assertEqual(1, len(specific_runs))
+
+        self._send_time_changed(
+            tz.localize(datetime(2018, 10, 28, 2, 55, 0), is_dst=True))
+        self.hass.block_till_done()
+        self.assertEqual(2, len(specific_runs))
+
+        unsub()
 
     def test_call_later(self):
         """Test calling an action later."""

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -85,38 +85,6 @@ class TestEventHelpers(unittest.TestCase):
         self.hass.block_till_done()
         self.assertEqual(2, len(runs))
 
-    def test_track_time_change(self):
-        """Test tracking time change."""
-        wildcard_runs = []
-        specific_runs = []
-
-        unsub = track_time_change(self.hass, lambda x: wildcard_runs.append(1))
-        unsub_utc = track_utc_time_change(
-            self.hass, lambda x: specific_runs.append(1), second=[0, 30])
-
-        self._send_time_changed(datetime(2014, 5, 24, 12, 0, 0))
-        self.hass.block_till_done()
-        self.assertEqual(1, len(specific_runs))
-        self.assertEqual(1, len(wildcard_runs))
-
-        self._send_time_changed(datetime(2014, 5, 24, 12, 0, 15))
-        self.hass.block_till_done()
-        self.assertEqual(1, len(specific_runs))
-        self.assertEqual(2, len(wildcard_runs))
-
-        self._send_time_changed(datetime(2014, 5, 24, 12, 0, 30))
-        self.hass.block_till_done()
-        self.assertEqual(2, len(specific_runs))
-        self.assertEqual(3, len(wildcard_runs))
-
-        unsub()
-        unsub_utc()
-
-        self._send_time_changed(datetime(2014, 5, 24, 12, 0, 30))
-        self.hass.block_till_done()
-        self.assertEqual(2, len(specific_runs))
-        self.assertEqual(3, len(wildcard_runs))
-
     def test_track_state_change(self):
         """Test track_state_change."""
         # 2 lists to track how often our callbacks get called
@@ -543,6 +511,39 @@ class TestTrackTimeChange(unittest.TestCase):
     def _send_time_changed(self, now):
         """Send a time changed event."""
         self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {ha.ATTR_NOW: now})
+
+    def test_track_time_change(self):
+        """Test tracking time change."""
+        wildcard_runs = []
+        specific_runs = []
+
+        unsub = track_time_change(self.hass,
+                                  lambda x: wildcard_runs.append(1))
+        unsub_utc = track_utc_time_change(
+            self.hass, lambda x: specific_runs.append(1), second=[0, 30])
+
+        self._send_time_changed(datetime(2014, 5, 24, 12, 0, 0))
+        self.hass.block_till_done()
+        self.assertEqual(1, len(specific_runs))
+        self.assertEqual(1, len(wildcard_runs))
+
+        self._send_time_changed(datetime(2014, 5, 24, 12, 0, 15))
+        self.hass.block_till_done()
+        self.assertEqual(1, len(specific_runs))
+        self.assertEqual(2, len(wildcard_runs))
+
+        self._send_time_changed(datetime(2014, 5, 24, 12, 0, 30))
+        self.hass.block_till_done()
+        self.assertEqual(2, len(specific_runs))
+        self.assertEqual(3, len(wildcard_runs))
+
+        unsub()
+        unsub_utc()
+
+        self._send_time_changed(datetime(2014, 5, 24, 12, 0, 30))
+        self.hass.block_till_done()
+        self.assertEqual(2, len(specific_runs))
+        self.assertEqual(3, len(wildcard_runs))
 
     def test_periodic_task_minute(self):
         """Test periodic tasks per minute."""


### PR DESCRIPTION
## Description:

Implement algorithm from https://github.com/home-assistant/architecture/issues/88 into events base.

This will enable:

 * Better scheduling as in https://github.com/home-assistant/architecture/issues/50
 * More features from cron expressions. Namely the use of offsets for steps (`5/10`), the use of lists and ranges (`0,5,8-24`). I'm planning to copy some of [esphomeyaml's parser code](https://github.com/OttoWinter/esphomeyaml/blob/master/esphomeyaml/components/time/__init__.py#L122-L248) to here.
 * `day_of_week` for time triggers.

This does not:

 * Make `async_track_time_change` more efficient. Or at least not much. The listener still fires for each second.

This does:

 * Fix situations when the timer got out of sync and some time triggers wouldn't fire. For example if I have a time trigger at 02:30 in the morning but the timer for some reason didn't fire events between 02:28 and 02:32
 * Remove the `day`, `month` and `year` kwargs from `async_track_utc_time_change`. They can be re-added later but they weren't used anywhere except for the tests.

Questions:

 * `event.py` might not be the best place for  `_find_next_time_expression_time` as it doesn't have too much to do with events. Should I move it to `dt.py`?

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
