### PR TITLE
Add all EntityComponent instances to hass.data

### DIFF
--- a/homeassistant/components/alarm_control_panel/__init__.py
+++ b/homeassistant/components/alarm_control_panel/__init__.py
@@ -18,6 +18,8 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_component import EntityComponent
 
+_LOGGER = logging.getLogger(__name__)
+
 DOMAIN = 'alarm_control_panel'
 SCAN_INTERVAL = timedelta(seconds=30)
 ATTR_CHANGED_BY = 'changed_by'
@@ -32,8 +34,7 @@ ALARM_SERVICE_SCHEMA = vol.Schema({
 
 async def async_setup(hass, config):
     """Track states and offer events for sensors."""
-    component = hass.data[DOMAIN] = EntityComponent(
-        logging.getLogger(__name__), DOMAIN, hass, SCAN_INTERVAL)
+    component = EntityComponent(_LOGGER, DOMAIN, hass, SCAN_INTERVAL)
 
     await component.async_setup(config)
 

--- a/homeassistant/components/binary_sensor/__init__.py
+++ b/homeassistant/components/binary_sensor/__init__.py
@@ -15,6 +15,8 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.const import (STATE_ON, STATE_OFF)
 from homeassistant.helpers.config_validation import PLATFORM_SCHEMA  # noqa
 
+_LOGGER = logging.getLogger(__name__)
+
 DOMAIN = 'binary_sensor'
 SCAN_INTERVAL = timedelta(seconds=30)
 
@@ -50,8 +52,7 @@ DEVICE_CLASSES_SCHEMA = vol.All(vol.Lower, vol.In(DEVICE_CLASSES))
 
 async def async_setup(hass, config):
     """Track states and offer events for binary sensors."""
-    component = hass.data[DOMAIN] = EntityComponent(
-        logging.getLogger(__name__), DOMAIN, hass, SCAN_INTERVAL)
+    component = EntityComponent(_LOGGER, DOMAIN, hass, SCAN_INTERVAL)
 
     await component.async_setup(config)
     return True

--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -166,8 +166,7 @@ def _get_camera_from_entity_id(hass, entity_id):
 
 async def async_setup(hass, config):
     """Set up the camera component."""
-    component = hass.data[DOMAIN] = \
-        EntityComponent(_LOGGER, DOMAIN, hass, SCAN_INTERVAL)
+    component = EntityComponent(_LOGGER, DOMAIN, hass, SCAN_INTERVAL)
 
     hass.http.register_view(CameraImageView(component))
     hass.http.register_view(CameraMjpegStream(component))

--- a/homeassistant/components/climate/__init__.py
+++ b/homeassistant/components/climate/__init__.py
@@ -143,8 +143,7 @@ SET_SWING_MODE_SCHEMA = vol.Schema({
 
 async def async_setup(hass, config):
     """Set up climate devices."""
-    component = hass.data[DOMAIN] = \
-        EntityComponent(_LOGGER, DOMAIN, hass, SCAN_INTERVAL)
+    component = EntityComponent(_LOGGER, DOMAIN, hass, SCAN_INTERVAL)
     await component.async_setup(config)
 
     component.async_register_entity_service(

--- a/homeassistant/components/cover/__init__.py
+++ b/homeassistant/components/cover/__init__.py
@@ -83,7 +83,7 @@ def is_closed(hass, entity_id=None):
 
 async def async_setup(hass, config):
     """Track states and offer events for covers."""
-    component = hass.data[DOMAIN] = EntityComponent(
+    component = EntityComponent(
         _LOGGER, DOMAIN, hass, SCAN_INTERVAL, GROUP_NAME_ALL_COVERS)
 
     await component.async_setup(config)

--- a/homeassistant/components/fan/__init__.py
+++ b/homeassistant/components/fan/__init__.py
@@ -99,7 +99,7 @@ def is_on(hass, entity_id: str = None) -> bool:
 
 async def async_setup(hass, config: dict):
     """Expose fan control via statemachine and services."""
-    component = hass.data[DOMAIN] = EntityComponent(
+    component = EntityComponent(
         _LOGGER, DOMAIN, hass, SCAN_INTERVAL, GROUP_NAME_ALL_FANS)
 
     await component.async_setup(config)

--- a/homeassistant/components/group/__init__.py
+++ b/homeassistant/components/group/__init__.py
@@ -184,7 +184,7 @@ async def async_setup(hass, config):
     component = hass.data.get(DOMAIN)
 
     if component is None:
-        component = hass.data[DOMAIN] = EntityComponent(_LOGGER, DOMAIN, hass)
+        component = EntityComponent(_LOGGER, DOMAIN, hass)
 
     await _async_process_config(hass, config, component)
 
@@ -378,8 +378,7 @@ class Group(Entity):
         component = hass.data.get(DOMAIN)
 
         if component is None:
-            component = hass.data[DOMAIN] = \
-                EntityComponent(_LOGGER, DOMAIN, hass)
+            component = EntityComponent(_LOGGER, DOMAIN, hass)
 
         await component.async_add_entities([group], True)
 

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -238,7 +238,7 @@ class SetIntentHandler(intent.IntentHandler):
 
 async def async_setup(hass, config):
     """Expose light control via state machine and services."""
-    component = hass.data[DOMAIN] = EntityComponent(
+    component = EntityComponent(
         _LOGGER, DOMAIN, hass, SCAN_INTERVAL, GROUP_NAME_ALL_LIGHTS)
     await component.async_setup(config)
 

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -201,8 +201,7 @@ SCHEMA_WEBSOCKET_GET_THUMBNAIL = \
 
 async def async_setup(hass, config):
     """Track states and offer events for media_players."""
-    component = hass.data[DOMAIN] = EntityComponent(
-        logging.getLogger(__name__), DOMAIN, hass, SCAN_INTERVAL)
+    component = EntityComponent(_LOGGER, DOMAIN, hass, SCAN_INTERVAL)
 
     hass.components.websocket_api.async_register_command(
         WS_TYPE_MEDIA_PLAYER_THUMBNAIL, websocket_handle_thumbnail,

--- a/homeassistant/components/scene/__init__.py
+++ b/homeassistant/components/scene/__init__.py
@@ -17,6 +17,8 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.state import HASS_DOMAIN
 
+_LOGGER = logging.getLogger(__name__)
+
 DOMAIN = 'scene'
 STATE = 'scening'
 STATES = 'states'
@@ -62,8 +64,7 @@ SCENE_SERVICE_SCHEMA = vol.Schema({
 
 async def async_setup(hass, config):
     """Set up the scenes."""
-    logger = logging.getLogger(__name__)
-    component = hass.data[DOMAIN] = EntityComponent(logger, DOMAIN, hass)
+    component = EntityComponent(_LOGGER, DOMAIN, hass)
 
     await component.async_setup(config)
 

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -36,8 +36,7 @@ DEVICE_CLASSES_SCHEMA = vol.All(vol.Lower, vol.In(DEVICE_CLASSES))
 
 async def async_setup(hass, config):
     """Track states and offer events for sensors."""
-    component = hass.data[DOMAIN] = EntityComponent(
-        _LOGGER, DOMAIN, hass, SCAN_INTERVAL)
+    component = EntityComponent(_LOGGER, DOMAIN, hass, SCAN_INTERVAL)
 
     await component.async_setup(config)
     return True

--- a/homeassistant/components/switch/__init__.py
+++ b/homeassistant/components/switch/__init__.py
@@ -19,6 +19,8 @@ from homeassistant.const import (
     ATTR_ENTITY_ID)
 from homeassistant.components import group
 
+_LOGGER = logging.getLogger(__name__)
+
 DOMAIN = 'switch'
 DEPENDENCIES = ['group']
 SCAN_INTERVAL = timedelta(seconds=30)
@@ -42,8 +44,6 @@ SWITCH_SERVICE_SCHEMA = vol.Schema({
     vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
 })
 
-_LOGGER = logging.getLogger(__name__)
-
 
 @bind_hass
 def is_on(hass, entity_id=None):
@@ -57,7 +57,7 @@ def is_on(hass, entity_id=None):
 
 async def async_setup(hass, config):
     """Track states and offer events for switches."""
-    component = hass.data[DOMAIN] = EntityComponent(
+    component = EntityComponent(
         _LOGGER, DOMAIN, hass, SCAN_INTERVAL, GROUP_NAME_ALL_SWITCHES)
     await component.async_setup(config)
 

--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -31,6 +31,7 @@ class EntityComponent:
     def __init__(self, logger, domain, hass,
                  scan_interval=DEFAULT_SCAN_INTERVAL, group_name=None):
         """Initialize an entity component."""
+        hass.data[domain] = self
         self.logger = logger
         self.hass = hass
         self.domain = domain

--- a/tests/helpers/test_entity_component.py
+++ b/tests/helpers/test_entity_component.py
@@ -415,3 +415,9 @@ async def test_unload_entry_fails_if_never_loaded(hass):
 
     with pytest.raises(ValueError):
         await component.async_unload_entry(entry)
+
+
+async def test_add_component_to_hass_data(hass):
+    """Test that component is added to hass data during initialization."""
+    component = EntityComponent(_LOGGER, DOMAIN, hass)
+    assert hass.data.get(DOMAIN) == component


### PR DESCRIPTION
## Description:
Until now each component that uses the `EntityComponent` helper class is responsible to handle adding it's instance to `hass.data`. That leaves many others not to do so, since it might have been missed.

To change that I propose to let the `EntityComponent` class handle this during the initialization via `hass.data[domain] = self`.

I intent to start working on an experimental component reload service similar to `reload_core_config` for which it would be useful to have access to each `EntityComponent` instance and its `async_prepare_reload` method.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.