### PR TITLE
Add config entry for LIFX

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -63,7 +63,6 @@ homeassistant/components/device_tracker/huawei_router.py @abmantis
 homeassistant/components/device_tracker/tile.py @bachya
 homeassistant/components/history_graph.py @andrey-git
 homeassistant/components/influx.py @fabaff
-homeassistant/components/light/lifx.py @amelchio
 homeassistant/components/light/lifx_legacy.py @amelchio
 homeassistant/components/light/tplink.py @rytilahti
 homeassistant/components/light/yeelight.py @rytilahti
@@ -179,6 +178,10 @@ homeassistant/components/knx.py @Julius2342
 homeassistant/components/*/knx.py @Julius2342
 homeassistant/components/konnected.py @heythisisnate
 homeassistant/components/*/konnected.py @heythisisnate
+
+# L
+homeassistant/components/lifx.py @amelchio
+homeassistant/components/*/lifx.py @amelchio
 
 # M
 homeassistant/components/matrix.py @tinloaf

--- a/homeassistant/components/lifx/.translations/en.json
+++ b/homeassistant/components/lifx/.translations/en.json
@@ -1,0 +1,15 @@
+{
+    "config": {
+        "abort": {
+            "no_devices_found": "No LIFX devices found on the network.",
+            "single_instance_allowed": "Only a single configuration of LIFX is possible."
+        },
+        "step": {
+            "confirm": {
+                "description": "Do you want to set up LIFX?",
+                "title": "LIFX"
+            }
+        },
+        "title": "LIFX"
+    }
+}

--- a/homeassistant/components/lifx/__init__.py
+++ b/homeassistant/components/lifx/__init__.py
@@ -1,0 +1,83 @@
+"""Component to embed LIFX."""
+import asyncio
+
+import async_timeout
+
+from homeassistant import config_entries
+from homeassistant.helpers import config_entry_flow
+
+
+DOMAIN = 'lifx'
+REQUIREMENTS = ['aiolifx==0.6.3']
+
+UDP_BROADCAST_PORT = 56700
+
+
+async def async_setup(hass, config):
+    """Set up the LIFX component."""
+    conf = config.get(DOMAIN)
+
+    hass.data[DOMAIN] = conf or {}
+
+    if conf is not None:
+        hass.async_create_task(hass.config_entries.flow.async_init(
+            DOMAIN, context={'source': config_entries.SOURCE_IMPORT}))
+
+    return True
+
+
+async def async_setup_entry(hass, entry):
+    """Set up LIFX from a config entry."""
+    hass.async_create_task(hass.config_entries.async_forward_entry_setup(
+        entry, 'light'))
+    return True
+
+
+async def _async_has_devices(hass):
+    """Return if there are devices that can be discovered."""
+    import aiolifx
+
+    manager = DiscoveryManager()
+    lifx_discovery = aiolifx.LifxDiscovery(hass.loop, manager)
+    coro = hass.loop.create_datagram_endpoint(
+        lambda: lifx_discovery,
+        local_addr=('0.0.0.0', UDP_BROADCAST_PORT))
+    hass.async_create_task(coro)
+
+    has_devices = await manager.found_devices()
+    lifx_discovery.cleanup()
+
+    return has_devices
+
+
+config_entry_flow.register_discovery_flow(
+    DOMAIN, 'LIFX', _async_has_devices, config_entries.CONN_CLASS_LOCAL_POLL)
+
+
+class DiscoveryManager:
+    """Temporary LIFX manager for discovering any bulb."""
+
+    def __init__(self):
+        """Initialize the manager."""
+        self._event = asyncio.Event()
+
+    async def found_devices(self):
+        """Return whether any device could be discovered."""
+        try:
+            async with async_timeout.timeout(2):
+                await self._event.wait()
+
+                # Let bulbs recover from the discovery
+                await asyncio.sleep(1)
+
+                return True
+        except asyncio.TimeoutError:
+            return False
+
+    def register(self, bulb):
+        """Handle aiolifx detected bulb."""
+        self._event.set()
+
+    def unregister(self, bulb):
+        """Handle aiolifx disappearing bulbs."""
+        pass

--- a/homeassistant/components/lifx/strings.json
+++ b/homeassistant/components/lifx/strings.json
@@ -1,0 +1,15 @@
+{
+  "config": {
+    "title": "LIFX",
+    "step": {
+      "confirm": {
+        "title": "LIFX",
+        "description": "Do you want to set up LIFX?"
+      }
+    },
+    "abort": {
+      "single_instance_allowed": "Only a single configuration of LIFX is possible.",
+      "no_devices_found": "No LIFX devices found on the network."
+    }
+  }
+}

--- a/homeassistant/components/light/lifx.py
+++ b/homeassistant/components/light/lifx.py
@@ -160,7 +160,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         kwargs['local_addr'] = (local_addr, 0)
     coro = hass.loop.create_datagram_endpoint(lambda: lifx_discovery, **kwargs)
 
-    hass.async_add_job(coro)
+    hass.async_create_task(coro)
 
     @callback
     def cleanup(event):
@@ -230,7 +230,7 @@ class LIFXManager:
             for light in self.service_to_entities(service):
                 if service.service == SERVICE_LIFX_SET_STATE:
                     task = light.set_state(**service.data)
-                tasks.append(self.hass.async_add_job(task))
+                tasks.append(self.hass.async_create_task(task))
             if tasks:
                 await asyncio.wait(tasks, loop=self.hass.loop)
 

--- a/homeassistant/components/light/lifx.py
+++ b/homeassistant/components/light/lifx.py
@@ -18,7 +18,7 @@ from homeassistant import util
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS, ATTR_BRIGHTNESS_PCT, ATTR_COLOR_NAME, ATTR_COLOR_TEMP,
     ATTR_EFFECT, ATTR_HS_COLOR, ATTR_KELVIN, ATTR_RGB_COLOR, ATTR_TRANSITION,
-    ATTR_XY_COLOR, COLOR_GROUP, DOMAIN as LIGHT_DOMAIN, LIGHT_TURN_ON_SCHEMA,
+    ATTR_XY_COLOR, COLOR_GROUP, DOMAIN, LIGHT_TURN_ON_SCHEMA,
     SUPPORT_BRIGHTNESS, SUPPORT_COLOR, SUPPORT_COLOR_TEMP, SUPPORT_EFFECT,
     SUPPORT_TRANSITION, VALID_BRIGHTNESS, VALID_BRIGHTNESS_PCT, Light,
     preprocess_turn_on_alternatives)
@@ -144,7 +144,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         _LOGGER.warning("The lifx platform is known to not work on Windows. "
                         "Consider using the lifx_legacy platform instead")
 
-    config = hass.data[LIFX_DOMAIN].get(LIGHT_DOMAIN, {})
+    config = hass.data[LIFX_DOMAIN].get(DOMAIN, {})
 
     lifx_manager = LIFXManager(hass, async_add_entities)
 
@@ -235,7 +235,7 @@ class LIFXManager:
                 await asyncio.wait(tasks, loop=self.hass.loop)
 
         self.hass.services.async_register(
-            LIGHT_DOMAIN, SERVICE_LIFX_SET_STATE, service_handler,
+            DOMAIN, SERVICE_LIFX_SET_STATE, service_handler,
             schema=LIFX_SET_STATE_SCHEMA)
 
     def register_effects(self):
@@ -248,15 +248,15 @@ class LIFXManager:
                     entities, service.service, **service.data)
 
         self.hass.services.async_register(
-            LIGHT_DOMAIN, SERVICE_EFFECT_PULSE, service_handler,
+            DOMAIN, SERVICE_EFFECT_PULSE, service_handler,
             schema=LIFX_EFFECT_PULSE_SCHEMA)
 
         self.hass.services.async_register(
-            LIGHT_DOMAIN, SERVICE_EFFECT_COLORLOOP, service_handler,
+            DOMAIN, SERVICE_EFFECT_COLORLOOP, service_handler,
             schema=LIFX_EFFECT_COLORLOOP_SCHEMA)
 
         self.hass.services.async_register(
-            LIGHT_DOMAIN, SERVICE_EFFECT_STOP, service_handler,
+            DOMAIN, SERVICE_EFFECT_STOP, service_handler,
             schema=LIFX_EFFECT_STOP_SCHEMA)
 
     async def start_effect(self, entities, service, **kwargs):
@@ -560,7 +560,7 @@ class LIFXLight(Light):
         data = {
             ATTR_ENTITY_ID: self.entity_id,
         }
-        await self.hass.services.async_call(LIGHT_DOMAIN, service, data)
+        await self.hass.services.async_call(DOMAIN, service, data)
 
     async def async_update(self):
         """Update bulb status."""

--- a/homeassistant/components/light/lifx.py
+++ b/homeassistant/components/light/lifx.py
@@ -32,7 +32,7 @@ import homeassistant.util.color as color_util
 
 _LOGGER = logging.getLogger(__name__)
 
-DEPENDENCIES = ('lifx',)
+DEPENDENCIES = ['lifx']
 REQUIREMENTS = ['aiolifx_effects==0.2.1']
 
 SCAN_INTERVAL = timedelta(seconds=10)

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -142,6 +142,7 @@ FLOWS = [
     'hue',
     'ifttt',
     'ios',
+    'lifx',
     'mqtt',
     'nest',
     'openuv',

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -106,7 +106,7 @@ aiohue==1.5.0
 # homeassistant.components.sensor.imap
 aioimaplib==0.7.13
 
-# homeassistant.components.light.lifx
+# homeassistant.components.lifx
 aiolifx==0.6.3
 
 # homeassistant.components.light.lifx


### PR DESCRIPTION
## Description:

This is a minimal PR to add a config entry for LIFX. I plan additional PRs for a more complete experience.

**Breaking change:** LIFX can now be configured from the integrations page in the config panel and advanced configuration is available through the `lifx:` component configuration. Configuring LIFX via light platform config no longer works.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#6565

## Example entry for `configuration.yaml` (if applicable):
```yaml
lifx:
  light:
    server: 10.0.2.14
    broadcast: 10.0.2.255
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54