### PR TITLE
Update Vagrant Windows support

### DIFF
--- a/virtualization/vagrant/Vagrantfile
+++ b/virtualization/vagrant/Vagrantfile
@@ -15,6 +15,8 @@ Vagrant.configure(2) do |config|
   end
   config.vm.provider :hyperv do |h, override|
     override.vm.box = "generic/debian9"
+    override.vm.hostname = "contrib-stretch"
+    h.vmname = "home-assistant"
     h.cpus = 2
     h.memory = 1024
     h.maxmemory = 1024

--- a/virtualization/vagrant/Vagrantfile
+++ b/virtualization/vagrant/Vagrantfile
@@ -13,4 +13,10 @@ Vagrant.configure(2) do |config|
     vb.cpus = 2
     vb.customize ['modifyvm', :id, '--memory', '1024']
   end
+  config.vm.provider :hyperv do |h, override|
+    override.vm.box = "generic/debian9"
+    h.cpus = 2
+    h.memory = 1024
+    h.maxmemory = 1024
+  end
 end

--- a/virtualization/vagrant/provision.bat
+++ b/virtualization/vagrant/provision.bat
@@ -1,0 +1,50 @@
+@echo off
+call:main %*
+goto:eof
+
+:usage
+echo.############################################################
+echo.
+echo.Use `./provision.bat` to interact with HASS. E.g:
+echo.
+echo.- setup the environment: `./provision.sh start`
+echo.- restart HASS process: `./provision.sh restart`
+echo.- run test suit: `./provision.sh tests`
+echo.- destroy the host and start anew: `./provision.sh recreate`
+echo.
+echo.Official documentation at https://home-assistant.io/docs/installation/vagrant/
+echo.
+echo.############################################################'
+goto:eof
+
+:main
+if "%*"=="setup" (
+    if exist setup_done del setup_done
+    vagrant up --provision
+    echo $null >> setup_done
+) else (
+if "%*"=="tests" (
+    echo $null >> run_tests
+    vagrant provision
+) else (
+if "%*"=="restart" (
+    echo $null >> restart
+    vagrant provision
+) else (
+if "%*"=="start" (
+    vagrant up --provision
+) else (
+if "%*"=="stop" (
+    vagrant halt
+) else (
+if "%*"=="destroy" (
+    vagrant destroy -f
+) else (
+if "%*"=="recreate" (
+    if exist setup_done del setup_done
+    if exist restart del restart
+    vagrant destroy -f
+    vagrant up --provision
+) else (
+    call:usage
+)))))))

--- a/virtualization/vagrant/provision.bat
+++ b/virtualization/vagrant/provision.bat
@@ -7,10 +7,10 @@ echo.############################################################
 echo.
 echo.Use `./provision.bat` to interact with HASS. E.g:
 echo.
-echo.- setup the environment: `./provision.sh start`
-echo.- restart HASS process: `./provision.sh restart`
-echo.- run test suit: `./provision.sh tests`
-echo.- destroy the host and start anew: `./provision.sh recreate`
+echo.- setup the environment: `./provision.bat start`
+echo.- restart HASS process: `./provision.bat restart`
+echo.- run test suit: `./provision.bat tests`
+echo.- destroy the host and start anew: `./provision.bat recreate`
 echo.
 echo.Official documentation at https://home-assistant.io/docs/installation/vagrant/
 echo.
@@ -21,14 +21,14 @@ goto:eof
 if "%*"=="setup" (
     if exist setup_done del setup_done
     vagrant up --provision
-    echo $null >> setup_done
+    copy /y nul setup_done
 ) else (
 if "%*"=="tests" (
-    echo $null >> run_tests
+    copy /y nul run_tests
     vagrant provision
 ) else (
 if "%*"=="restart" (
-    echo $null >> restart
+    copy /y nul restart
     vagrant provision
 ) else (
 if "%*"=="start" (

--- a/virtualization/vagrant/provision.sh
+++ b/virtualization/vagrant/provision.sh
@@ -76,6 +76,10 @@ run_tests() {
     rsync -a --delete \
         --exclude='*.tox' \
         --exclude='*.git' \
+        --exclude='.vagrant' \
+        --exclude='lib64' \
+        --exclude='bin/python' \
+        --exclude='bin/python3' \
         /home-assistant/ /home-assistant-tests/
     cd /home-assistant-tests && tox || true
     echo '############################################################'


### PR DESCRIPTION
## Description:

Using Vagrant on Windows is limited, to start with the shell script will not work in `PowerShell`.
This PR has the following contributions (somewhat related, so they are currently in the same PR):
- Add `provision.bat` for use on Windows, with basic functionality from `provision.sh` for provisioning.
- Update `Vagrantfile` to support Hyper-V as provider. To run Docker on Windows, Hyper-V support is needed, but enabling Hyper-V disables the use of Virtualbox.
- Update `provision.sh` to:
  - exclude `.vagrant` folder when running tests - saves diskspace.
  - exclude `lib64`, `bin/python`, `bin/python3` when running tests - files already deleted caused errors on Windows.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#6589

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
