### PR TITLE
MyQ cover return unknown state if not available

### DIFF
--- a/homeassistant/components/cover/myq.py
+++ b/homeassistant/components/cover/myq.py
@@ -21,16 +21,11 @@ _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_NAME = 'myq'
 
-STATE_STOPPED = 'stopped'
-STATE_TRANSITION = 'transition'
-
 MYQ_TO_HASS = {
     'closed': STATE_CLOSED,
     'closing': STATE_CLOSING,
     'open': STATE_OPEN,
-    'opening': STATE_OPENING,
-    'stopped': STATE_STOPPED,
-    'transition': STATE_TRANSITION
+    'opening': STATE_OPENING
 }
 
 NOTIFICATION_ID = 'myq_notification'
@@ -101,6 +96,8 @@ class MyQDevice(CoverDevice):
     @property
     def is_closed(self):
         """Return true if cover is closed, else False."""
+        if self._status in [None, False]:
+            return None
         return MYQ_TO_HASS.get(self._status) == STATE_CLOSED
 
     @property
@@ -133,4 +130,4 @@ class MyQDevice(CoverDevice):
 
     def update(self):
         """Update status of cover."""
-        self._status = MYQ_TO_HASS.get(self.myq.get_status(self.device_id))
+        self._status = self.myq.get_status(self.device_id)

--- a/homeassistant/components/cover/myq.py
+++ b/homeassistant/components/cover/myq.py
@@ -12,7 +12,7 @@ from homeassistant.components.cover import (
     CoverDevice, SUPPORT_CLOSE, SUPPORT_OPEN)
 from homeassistant.const import (
     CONF_PASSWORD, CONF_TYPE, CONF_USERNAME, STATE_CLOSED, STATE_CLOSING,
-    STATE_OPEN, STATE_OPENING, STATE_UNKNOWN)
+    STATE_OPEN, STATE_OPENING)
 import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['pymyq==0.0.15']
@@ -30,8 +30,7 @@ MYQ_TO_HASS = {
     'open': STATE_OPEN,
     'opening': STATE_OPENING,
     'stopped': STATE_STOPPED,
-    'transition': STATE_TRANSITION,
-    'unknown': STATE_UNKNOWN
+    'transition': STATE_TRANSITION
 }
 
 NOTIFICATION_ID = 'myq_notification'
@@ -82,7 +81,7 @@ class MyQDevice(CoverDevice):
         self.myq = myq
         self.device_id = device['deviceid']
         self._name = device['name']
-        self._status = STATE_CLOSED
+        self._status = None
 
     @property
     def device_class(self):
@@ -102,17 +101,17 @@ class MyQDevice(CoverDevice):
     @property
     def is_closed(self):
         """Return true if cover is closed, else False."""
-        return MYQ_TO_HASS[self._status] == STATE_CLOSED
+        return MYQ_TO_HASS.get(self._status) == STATE_CLOSED
 
     @property
     def is_closing(self):
         """Return if the cover is closing or not."""
-        return MYQ_TO_HASS[self._status] == STATE_CLOSING
+        return MYQ_TO_HASS.get(self._status) == STATE_CLOSING
 
     @property
     def is_opening(self):
         """Return if the cover is opening or not."""
-        return MYQ_TO_HASS[self._status] == STATE_OPENING
+        return MYQ_TO_HASS.get(self._status) == STATE_OPENING
 
     def close_cover(self, **kwargs):
         """Issue close command to cover."""
@@ -134,6 +133,4 @@ class MyQDevice(CoverDevice):
 
     def update(self):
         """Update status of cover."""
-        status = self.myq.get_status(self.device_id)
-        if status in MYQ_TO_HASS:
-            self._status = status
+        self._status = MYQ_TO_HASS.get(self.myq.get_status(self.device_id))

--- a/homeassistant/components/cover/myq.py
+++ b/homeassistant/components/cover/myq.py
@@ -11,8 +11,8 @@ import voluptuous as vol
 from homeassistant.components.cover import (
     CoverDevice, SUPPORT_CLOSE, SUPPORT_OPEN)
 from homeassistant.const import (
-    CONF_PASSWORD, CONF_TYPE, CONF_USERNAME, STATE_CLOSED, STATE_OPEN,
-    STATE_CLOSING, STATE_OPENING)
+    CONF_PASSWORD, CONF_TYPE, CONF_USERNAME, STATE_CLOSED, STATE_CLOSING,
+    STATE_OPEN, STATE_OPENING, STATE_UNKNOWN)
 import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['pymyq==0.0.15']
@@ -21,11 +21,17 @@ _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_NAME = 'myq'
 
+STATE_STOPPED = 'stopped'
+STATE_TRANSITION = 'transition'
+
 MYQ_TO_HASS = {
     'closed': STATE_CLOSED,
-    'open': STATE_OPEN,
     'closing': STATE_CLOSING,
-    'opening': STATE_OPENING
+    'open': STATE_OPEN,
+    'opening': STATE_OPENING,
+    'stopped': STATE_STOPPED,
+    'transition': STATE_TRANSITION,
+    'unknown': STATE_UNKNOWN
 }
 
 NOTIFICATION_ID = 'myq_notification'
@@ -128,4 +134,6 @@ class MyQDevice(CoverDevice):
 
     def update(self):
         """Update status of cover."""
-        self._status = self.myq.get_status(self.device_id)
+        status = self.myq.get_status(self.device_id)
+        if status in MYQ_TO_HASS:
+            self._status = status


### PR DESCRIPTION
## Description:
- Change default state to `None` rather than assume `STATE_CLOSED`
- Return `STATE_UNKNOWN` if unable to update status
- Minor format update to sort alphabetically

**Related issue (if applicable):** related to, but doesn't directly fix #16885

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
N/A
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
