### PR TITLE
Fixed Temperature for HMIP-WeatherStation Plus/Basic

### DIFF
--- a/homeassistant/components/homematic/__init__.py
+++ b/homeassistant/components/homematic/__init__.py
@@ -97,7 +97,9 @@ HM_IGNORE_DISCOVERY_NODE = [
 ]
 
 HM_IGNORE_DISCOVERY_NODE_EXCEPTIONS = {
-    'ACTUAL_TEMPERATURE': ['IPAreaThermostat', 'IPWeatherSensor'],
+    'ACTUAL_TEMPERATURE': [
+        'IPAreaThermostat', 'IPWeatherSensor',
+        'IPWeatherSensorPlus', 'IPWeatherSensorBasic'],
 }
 
 HM_ATTRIBUTE_SUPPORT = {


### PR DESCRIPTION
## Description:
 Adding Classes 'IPWeatherSensorPlus' and 'IPWeatherSensorBasic' to HM_IGNORE_DISCOVERY_NODE_EXCEPTIONS to fix missing Temperatur for those devices.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**