### PR TITLE
Make rmvtransport async

### DIFF
--- a/homeassistant/components/sensor/rmvtransport.py
+++ b/homeassistant/components/sensor/rmvtransport.py
@@ -15,7 +15,6 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (CONF_NAME, ATTR_ATTRIBUTION)
 from homeassistant.util import Throttle
-from homeassistant.exceptions import PlatformNotReady
 
 REQUIREMENTS = ['PyRMVtransport==0.1.1']
 

--- a/homeassistant/components/sensor/rmvtransport.py
+++ b/homeassistant/components/sensor/rmvtransport.py
@@ -17,7 +17,7 @@ from homeassistant.const import (CONF_NAME, ATTR_ATTRIBUTION)
 from homeassistant.util import Throttle
 from homeassistant.exceptions import PlatformNotReady
 
-REQUIREMENTS = ['PyRMVtransport==0.1']
+REQUIREMENTS = ['PyRMVtransport==0.1.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sensor/rmvtransport.py
+++ b/homeassistant/components/sensor/rmvtransport.py
@@ -16,7 +16,7 @@ from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (CONF_NAME, ATTR_ATTRIBUTION)
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['PyRMVtransport==0.1.1']
+REQUIREMENTS = ['PyRMVtransport==0.1.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sensor/rmvtransport.py
+++ b/homeassistant/components/sensor/rmvtransport.py
@@ -95,7 +95,6 @@ class RMVDepartureSensor(Entity):
     def __init__(self, session, station, destinations, directions, lines,
                  products, time_offset, max_journeys, name):
         """Initialize the sensor."""
-        self._session = session
         self._station = station
         self._name = name
         self._state = None
@@ -168,7 +167,6 @@ class RMVDepartureData:
         """Initialize the sensor."""
         from RMVtransport import RMVtransport
 
-        self._session = session
         self.station = None
         self._station_id = station_id
         self._destinations = destinations
@@ -177,7 +175,7 @@ class RMVDepartureData:
         self._products = products
         self._time_offset = time_offset
         self._max_journeys = max_journeys
-        self.rmv = RMVtransport(self._session)
+        self.rmv = RMVtransport(session)
         self.departures = []
 
     @Throttle(SCAN_INTERVAL)

--- a/homeassistant/components/sensor/rmvtransport.py
+++ b/homeassistant/components/sensor/rmvtransport.py
@@ -105,9 +105,6 @@ class RMVDepartureSensor(Entity):
                                      max_journeys)
         self._icon = ICONS[None]
 
-        if self.data is None:
-            raise PlatformNotReady
-
     @property
     def name(self):
         """Return the name of the sensor."""

--- a/homeassistant/components/sensor/rmvtransport.py
+++ b/homeassistant/components/sensor/rmvtransport.py
@@ -78,7 +78,6 @@ async def async_setup_platform(hass, config, async_add_entities,
     for next_departure in config.get(CONF_NEXT_DEPARTURE):
         sensors.append(
             RMVDepartureSensor(
-                hass.loop,
                 session,
                 next_departure[CONF_STATION],
                 next_departure.get(CONF_DESTINATIONS),
@@ -94,15 +93,14 @@ async def async_setup_platform(hass, config, async_add_entities,
 class RMVDepartureSensor(Entity):
     """Implementation of an RMV departure sensor."""
 
-    def __init__(self, loop, session, station, destinations, directions,
-                 lines, products, time_offset, max_journeys, name):
+    def __init__(self, session, station, destinations, directions, lines,
+                 products, time_offset, max_journeys, name):
         """Initialize the sensor."""
-        self._loop = loop
         self._session = session
         self._station = station
         self._name = name
         self._state = None
-        self.data = RMVDepartureData(loop, session, station, destinations,
+        self.data = RMVDepartureData(session, station, destinations,
                                      directions, lines, products, time_offset,
                                      max_journeys)
         self._icon = ICONS[None]
@@ -169,12 +167,11 @@ class RMVDepartureSensor(Entity):
 class RMVDepartureData:
     """Pull data from the opendata.rmv.de web page."""
 
-    def __init__(self, loop, session, station_id, destinations, directions,
-                 lines, products, time_offset, max_journeys):
+    def __init__(self, session, station_id, destinations, directions, lines,
+                 products, time_offset, max_journeys):
         """Initialize the sensor."""
         from RMVtransport import RMVtransport
 
-        self._loop = loop
         self._session = session
         self.station = None
         self._station_id = station_id
@@ -184,7 +181,7 @@ class RMVDepartureData:
         self._products = products
         self._time_offset = time_offset
         self._max_journeys = max_journeys
-        self.rmv = RMVtransport(self._loop, self._session)
+        self.rmv = RMVtransport(self._session)
         self.departures = []
 
     @Throttle(SCAN_INTERVAL)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -52,7 +52,7 @@ PyMata==2.14
 PyQRCode==1.2.1
 
 # homeassistant.components.sensor.rmvtransport
-PyRMVtransport==0.1.2
+PyRMVtransport==0.1.3
 
 # homeassistant.components.switch.switchbot
 PySwitchbot==0.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -52,7 +52,7 @@ PyMata==2.14
 PyQRCode==1.2.1
 
 # homeassistant.components.sensor.rmvtransport
-PyRMVtransport==0.1
+PyRMVtransport==0.1.1
 
 # homeassistant.components.switch.switchbot
 PySwitchbot==0.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -52,7 +52,7 @@ PyMata==2.14
 PyQRCode==1.2.1
 
 # homeassistant.components.sensor.rmvtransport
-PyRMVtransport==0.1.1
+PyRMVtransport==0.1.2
 
 # homeassistant.components.switch.switchbot
 PySwitchbot==0.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -22,7 +22,7 @@ requests_mock==1.5.2
 HAP-python==2.2.2
 
 # homeassistant.components.sensor.rmvtransport
-PyRMVtransport==0.1
+PyRMVtransport==0.1.1
 
 # homeassistant.components.notify.yessssms
 YesssSMS==0.2.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -22,7 +22,7 @@ requests_mock==1.5.2
 HAP-python==2.2.2
 
 # homeassistant.components.sensor.rmvtransport
-PyRMVtransport==0.1.2
+PyRMVtransport==0.1.3
 
 # homeassistant.components.notify.yessssms
 YesssSMS==0.2.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -22,7 +22,7 @@ requests_mock==1.5.2
 HAP-python==2.2.2
 
 # homeassistant.components.sensor.rmvtransport
-PyRMVtransport==0.1.1
+PyRMVtransport==0.1.2
 
 # homeassistant.components.notify.yessssms
 YesssSMS==0.2.3

--- a/tests/components/sensor/test_rmvtransport.py
+++ b/tests/components/sensor/test_rmvtransport.py
@@ -101,7 +101,7 @@ def get_departures_mock():
 
 
 def get_no_departures_mock():
-    """Mock rmvtransport departures loading."""
+    """Mock empty rmvtransport departures loading."""
     data = {'station': 'Frankfurt (Main) Hauptbahnhof',
             'stationId': '3000010',
             'filter': '11111111111',

--- a/tests/components/sensor/test_rmvtransport.py
+++ b/tests/components/sensor/test_rmvtransport.py
@@ -1,11 +1,10 @@
 """The tests for the rmvtransport platform."""
 import datetime
 from unittest.mock import patch
+import pytest
 
-# from homeassistant.components.sensor import rmvtransport
 from homeassistant.setup import async_setup_component
 
-import pytest
 from tests.common import mock_coro
 
 
@@ -46,7 +45,7 @@ VALID_CONFIG_DEST = {'sensor': {
         ]}}
 
 
-def get_departuresMock():  # pylint: disable=invalid-name
+def get_departures_mock():
     """Mock rmvtransport departures loading."""
     data = {'station': 'Frankfurt (Main) Hauptbahnhof',
             'stationId': '3000010', 'filter': '11111111111', 'journeys': [
@@ -101,7 +100,7 @@ def get_departuresMock():  # pylint: disable=invalid-name
     return data
 
 
-def get_no_departuresMock():  # pylint: disable=invalid-name
+def get_no_departures_mock():
     """Mock rmvtransport departures loading."""
     data = {'station': 'Frankfurt (Main) Hauptbahnhof',
             'stationId': '3000010',
@@ -110,7 +109,7 @@ def get_no_departuresMock():  # pylint: disable=invalid-name
     return data
 
 
-def get_errDeparturesMock():  # pylint: disable=invalid-name
+def get_err_departures_mock():
     """Mock rmvtransport departures erroneous loading."""
     raise ValueError
 
@@ -118,7 +117,7 @@ def get_errDeparturesMock():  # pylint: disable=invalid-name
 async def test_rmvtransport_min_config(hass):
     """Test minimal rmvtransport configuration."""
     with patch('RMVtransport.RMVtransport.get_departures',
-               return_value=mock_coro(get_departuresMock())):
+               return_value=mock_coro(get_departures_mock())):
         assert await async_setup_component(hass, 'sensor',
                                            VALID_CONFIG_MINIMAL) is True
 
@@ -137,7 +136,7 @@ async def test_rmvtransport_min_config(hass):
 async def test_rmvtransport_name_config(hass):
     """Test custom name configuration."""
     with patch('RMVtransport.RMVtransport.get_departures',
-               return_value=mock_coro(get_departuresMock())):
+               return_value=mock_coro(get_departures_mock())):
         assert await async_setup_component(hass, 'sensor', VALID_CONFIG_NAME)
 
     state = hass.states.get('sensor.my_station')
@@ -148,14 +147,14 @@ async def test_rmvtransport_name_config(hass):
 async def test_rmvtransport_err_config(hass):
     """Test erroneous rmvtransport configuration."""
     with patch('RMVtransport.RMVtransport.get_departures',
-               return_value=mock_coro(get_errDeparturesMock())):
+               return_value=mock_coro(get_err_departures_mock())):
         await async_setup_component(hass, 'sensor', VALID_CONFIG_MINIMAL)
 
 
 async def test_rmvtransport_misc_config(hass):
     """Test misc configuration."""
     with patch('RMVtransport.RMVtransport.get_departures',
-               return_value=mock_coro(get_departuresMock())):
+               return_value=mock_coro(get_departures_mock())):
         assert await async_setup_component(hass, 'sensor', VALID_CONFIG_MISC)
 
     state = hass.states.get('sensor.frankfurt_main_hauptbahnhof')
@@ -166,7 +165,7 @@ async def test_rmvtransport_misc_config(hass):
 async def test_rmvtransport_dest_config(hass):
     """Test misc configuration."""
     with patch('RMVtransport.RMVtransport.get_departures',
-               return_value=mock_coro(get_departuresMock())):
+               return_value=mock_coro(get_departures_mock())):
         assert await async_setup_component(hass, 'sensor', VALID_CONFIG_DEST)
 
     state = hass.states.get('sensor.frankfurt_main_hauptbahnhof')
@@ -182,7 +181,7 @@ async def test_rmvtransport_dest_config(hass):
 async def test_rmvtransport_no_departures(hass):
     """Test misc configuration."""
     with patch('RMVtransport.RMVtransport.get_departures',
-               return_value=mock_coro(get_no_departuresMock())):
+               return_value=mock_coro(get_no_departures_mock())):
         assert await async_setup_component(hass, 'sensor',
                                            VALID_CONFIG_MINIMAL)
 

--- a/tests/components/sensor/test_rmvtransport.py
+++ b/tests/components/sensor/test_rmvtransport.py
@@ -1,7 +1,6 @@
 """The tests for the rmvtransport platform."""
 import datetime
 from unittest.mock import patch
-import pytest
 
 from homeassistant.setup import async_setup_component
 

--- a/tests/components/sensor/test_rmvtransport.py
+++ b/tests/components/sensor/test_rmvtransport.py
@@ -1,6 +1,5 @@
 """The tests for the rmvtransport platform."""
 import asyncio
-import logging
 import unittest
 from unittest.mock import patch
 import datetime

--- a/tests/components/sensor/test_rmvtransport.py
+++ b/tests/components/sensor/test_rmvtransport.py
@@ -4,8 +4,7 @@ import unittest
 from unittest.mock import patch
 import datetime
 
-from homeassistant.setup import setup_component
-from homeassistant.bootstrap import async_setup_component
+from homeassistant.setup import async_setup_component
 
 from tests.common import assert_setup_component
 from tests.common import get_test_home_assistant

--- a/tests/components/sensor/test_rmvtransport.py
+++ b/tests/components/sensor/test_rmvtransport.py
@@ -1,10 +1,14 @@
 """The tests for the rmvtransport platform."""
+import asyncio
+import logging
 import unittest
 from unittest.mock import patch
 import datetime
 
 from homeassistant.setup import setup_component
+from homeassistant.bootstrap import async_setup_component
 
+from tests.common import assert_setup_component
 from tests.common import get_test_home_assistant
 
 VALID_CONFIG_MINIMAL = {'sensor': {'platform': 'rmvtransport',
@@ -117,12 +121,22 @@ class TestRMVtransportSensor(unittest.TestCase):
         """Stop everything that was started."""
         self.hass.stop()
 
+    @asyncio.coroutine
     @patch('RMVtransport.RMVtransport.get_departures',
            side_effect=get_departuresMock)
     def test_rmvtransport_min_config(self, mock_get_departures):
         """Test minimal rmvtransport configuration."""
-        assert setup_component(self.hass, 'sensor', VALID_CONFIG_MINIMAL)
+        with assert_setup_component(1):
+            yield from async_setup_component(self.hass,
+                                             'sensor',
+                                             VALID_CONFIG_MINIMAL)
+
         state = self.hass.states.get('sensor.frankfurt_main_hauptbahnhof')
+        assert state.state == '0'
+
+        yield from self.hass.async_block_till_done()
+        state = self.hass.states.get('sensor.frankfurt_main_hauptbahnhof')
+
         self.assertEqual(state.state, '7')
         self.assertEqual(state.attributes['departure_time'],
                          datetime.datetime(2018, 8, 6, 14, 21))
@@ -134,36 +148,60 @@ class TestRMVtransportSensor(unittest.TestCase):
         self.assertEqual(state.attributes['friendly_name'],
                          'Frankfurt (Main) Hauptbahnhof')
 
+    @asyncio.coroutine
     @patch('RMVtransport.RMVtransport.get_departures',
            side_effect=get_departuresMock)
     def test_rmvtransport_name_config(self, mock_get_departures):
         """Test custom name configuration."""
-        assert setup_component(self.hass, 'sensor', VALID_CONFIG_NAME)
+        with assert_setup_component(1):
+            yield from async_setup_component(self.hass,
+                                             'sensor',
+                                             VALID_CONFIG_NAME)
+
         state = self.hass.states.get('sensor.my_station')
         self.assertEqual(state.attributes['friendly_name'], 'My Station')
 
+    @asyncio.coroutine
     @patch('RMVtransport.RMVtransport.get_departures',
            side_effect=get_errDeparturesMock)
     def test_rmvtransport_err_config(self, mock_get_departures):
         """Test erroneous rmvtransport configuration."""
-        assert setup_component(self.hass, 'sensor', VALID_CONFIG_MINIMAL)
+        with assert_setup_component(1):
+            yield from async_setup_component(self.hass,
+                                             'sensor',
+                                             VALID_CONFIG_MINIMAL)
 
+    @asyncio.coroutine
     @patch('RMVtransport.RMVtransport.get_departures',
            side_effect=get_departuresMock)
     def test_rmvtransport_misc_config(self, mock_get_departures):
         """Test misc configuration."""
-        assert setup_component(self.hass, 'sensor', VALID_CONFIG_MISC)
+        with assert_setup_component(1):
+            yield from async_setup_component(self.hass,
+                                             'sensor',
+                                             VALID_CONFIG_MISC)
+
         state = self.hass.states.get('sensor.frankfurt_main_hauptbahnhof')
         self.assertEqual(state.attributes['friendly_name'],
                          'Frankfurt (Main) Hauptbahnhof')
         self.assertEqual(state.attributes['line'], 21)
 
+    @asyncio.coroutine
     @patch('RMVtransport.RMVtransport.get_departures',
            side_effect=get_departuresMock)
     def test_rmvtransport_dest_config(self, mock_get_departures):
         """Test misc configuration."""
-        assert setup_component(self.hass, 'sensor', VALID_CONFIG_DEST)
+        with assert_setup_component(1):
+            yield from async_setup_component(self.hass,
+                                             'sensor',
+                                             VALID_CONFIG_DEST)
+
         state = self.hass.states.get('sensor.frankfurt_main_hauptbahnhof')
+        assert state.state == '0'
+
+        yield from self.hass.async_block_till_done()
+        state = self.hass.states.get('sensor.frankfurt_main_hauptbahnhof')
+
         self.assertEqual(state.state, '11')
         self.assertEqual(state.attributes['direction'],
                          'Frankfurt (Main) Hugo-Junkers-Straße/Schleife')

--- a/tests/components/sensor/test_rmvtransport.py
+++ b/tests/components/sensor/test_rmvtransport.py
@@ -101,17 +101,12 @@ def get_departures_mock():
 
 
 def get_no_departures_mock():
-    """Mock empty rmvtransport departures loading."""
+    """Mock no departures in results."""
     data = {'station': 'Frankfurt (Main) Hauptbahnhof',
             'stationId': '3000010',
             'filter': '11111111111',
             'journeys': []}
     return data
-
-
-def get_err_departures_mock():
-    """Mock rmvtransport departures erroneous loading."""
-    raise ValueError
 
 
 async def test_rmvtransport_min_config(hass):
@@ -141,14 +136,6 @@ async def test_rmvtransport_name_config(hass):
 
     state = hass.states.get('sensor.my_station')
     assert state.attributes['friendly_name'] == 'My Station'
-
-
-@pytest.mark.xfail(raises=ValueError)
-async def test_rmvtransport_err_config(hass):
-    """Test erroneous rmvtransport configuration."""
-    with patch('RMVtransport.RMVtransport.get_departures',
-               return_value=mock_coro(get_err_departures_mock())):
-        await async_setup_component(hass, 'sensor', VALID_CONFIG_MINIMAL)
 
 
 async def test_rmvtransport_misc_config(hass):

--- a/tests/components/sensor/test_rmvtransport.py
+++ b/tests/components/sensor/test_rmvtransport.py
@@ -163,7 +163,7 @@ async def test_rmvtransport_misc_config(hass):
 
 
 async def test_rmvtransport_dest_config(hass):
-    """Test misc configuration."""
+    """Test destination configuration."""
     with patch('RMVtransport.RMVtransport.get_departures',
                return_value=mock_coro(get_departures_mock())):
         assert await async_setup_component(hass, 'sensor', VALID_CONFIG_DEST)
@@ -179,7 +179,7 @@ async def test_rmvtransport_dest_config(hass):
 
 
 async def test_rmvtransport_no_departures(hass):
-    """Test misc configuration."""
+    """Test for no departures."""
     with patch('RMVtransport.RMVtransport.get_departures',
                return_value=mock_coro(get_no_departures_mock())):
         assert await async_setup_component(hass, 'sensor',


### PR DESCRIPTION
## Description:
Refactor the component along with the upstream module to use asyncio .

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#6646

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54