### PR TITLE
Fix decora_wifi residences

### DIFF
--- a/homeassistant/components/light/decora_wifi.py
+++ b/homeassistant/components/light/decora_wifi.py
@@ -62,7 +62,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         all_switches = []
         for permission in perms:
             if permission.residentialAccountId is not None:
-                acct = ResidentialAccount(session, permission.residentialAccountId)
+                acct = ResidentialAccount(
+                    session, permission.residentialAccountId)
                 for residence in acct.get_residences():
                     for switch in residence.get_iot_switches():
                         all_switches.append(switch)

--- a/homeassistant/components/light/decora_wifi.py
+++ b/homeassistant/components/light/decora_wifi.py
@@ -61,7 +61,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         perms = session.user.get_residential_permissions()
         all_switches = []
         for permission in perms:
-            if permission.residentailAccountId is not None:
+            if permission.residentialAccountId is not None:
                 acct = ResidentialAccount(session, permission.residentialAccountId)
                 for residence in acct.get_residences():
                     for switch in residence.get_iot_switches():

--- a/homeassistant/components/light/decora_wifi.py
+++ b/homeassistant/components/light/decora_wifi.py
@@ -40,6 +40,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     from decora_wifi import DecoraWiFiSession
     from decora_wifi.models.person import Person
     from decora_wifi.models.residential_account import ResidentialAccount
+    from decora_wifi.models.residence import Residence
 
     email = config.get(CONF_USERNAME)
     password = config.get(CONF_PASSWORD)
@@ -60,8 +61,13 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         perms = session.user.get_residential_permissions()
         all_switches = []
         for permission in perms:
-            acct = ResidentialAccount(session, permission.residentialAccountId)
-            for residence in acct.get_residences():
+            if permission.residentailAccountId is not None:
+                acct = ResidentialAccount(session, permission.residentialAccountId)
+                for residence in acct.get_residences():
+                    for switch in residence.get_iot_switches():
+                        all_switches.append(switch)
+            elif permission.residenceId is not None:
+                residence = Residence(session, permission.residenceId)
                 for switch in residence.get_iot_switches():
                     all_switches.append(switch)
 


### PR DESCRIPTION
## Description:

Fix loading of `decora_wifi` lights for residences that are not owned by the account ( see https://github.com/tlyakhov/python-decora_wifi/pull/8 for more details). This makes decora_wifi work correctly with my myLeviton account.

Just a bug fix; no new dependencies or documentation updates needed.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**