### PR TITLE
Guard for bad device info

### DIFF
--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -273,6 +273,7 @@ class EntityPlatform:
                 config_entry_id = None
 
             device_info = entity.device_info
+            device_id = None
 
             if config_entry_id is not None and device_info is not None:
                 processed_dev_info = {
@@ -292,9 +293,8 @@ class EntityPlatform:
 
                 device = device_registry.async_get_or_create(
                     **processed_dev_info)
-                device_id = device.id
-            else:
-                device_id = None
+                if device:
+                    device_id = device.id
 
             entry = entity_registry.async_get_or_create(
                 self.domain, self.platform_name, entity.unique_id,

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -719,6 +719,8 @@ async def test_device_info_called(hass):
     assert await entity_platform.async_setup_entry(config_entry)
     await hass.async_block_till_done()
 
+    assert len(hass.states.async_entity_ids()) == 2
+
     device = registry.async_get_device({('hue', '1234')}, set())
     assert device is not None
     assert device.identifiers == {('hue', '1234')}


### PR DESCRIPTION
## Description:
Don't raise an exception if bad device info resulted in no device.


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
