### PR TITLE
Updated georss_client to 0.3

### DIFF
--- a/homeassistant/components/sensor/geo_rss_events.py
+++ b/homeassistant/components/sensor/geo_rss_events.py
@@ -19,7 +19,7 @@ from homeassistant.const import (
     STATE_UNKNOWN, CONF_UNIT_OF_MEASUREMENT, CONF_NAME, CONF_RADIUS, CONF_URL)
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['georss_client==0.1']
+REQUIREMENTS = ['georss_client==0.3']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -401,7 +401,7 @@ geizhals==0.0.7
 geojson_client==0.1
 
 # homeassistant.components.sensor.geo_rss_events
-georss_client==0.1
+georss_client==0.3
 
 # homeassistant.components.sensor.gitter
 gitterpy==0.1.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -72,7 +72,7 @@ gTTS-token==1.1.2
 geojson_client==0.1
 
 # homeassistant.components.sensor.geo_rss_events
-georss_client==0.1
+georss_client==0.3
 
 # homeassistant.components.ffmpeg
 ha-ffmpeg==1.9


### PR DESCRIPTION
## Description:
Updating `georss_client` library to version 0.3 to fix an issue where the external RSS feed contains an entry that does not contain any geo location information.
In the new version of this library an entry without geo location information is simply ignored without affecting the correct processing of any other entries in the feed.

**Related issue (if applicable):** fixes #17233

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: geo_rss_events
    name: CAL FIRE Incidents
    url: http://cdfdata.fire.ca.gov/incidents/rss.xml
    radius: 100.0
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
