### PR TITLE
Add device registry to MQTT cover

### DIFF
--- a/homeassistant/components/cover/mqtt.py
+++ b/homeassistant/components/cover/mqtt.py
@@ -19,12 +19,12 @@ from homeassistant.components.cover import (
 from homeassistant.exceptions import TemplateError
 from homeassistant.const import (
     CONF_NAME, CONF_VALUE_TEMPLATE, CONF_OPTIMISTIC, STATE_OPEN,
-    STATE_CLOSED, STATE_UNKNOWN)
+    STATE_CLOSED, STATE_UNKNOWN, CONF_DEVICE)
 from homeassistant.components.mqtt import (
     ATTR_DISCOVERY_HASH, CONF_AVAILABILITY_TOPIC, CONF_STATE_TOPIC,
     CONF_COMMAND_TOPIC, CONF_PAYLOAD_AVAILABLE, CONF_PAYLOAD_NOT_AVAILABLE,
     CONF_QOS, CONF_RETAIN, valid_publish_topic, valid_subscribe_topic,
-    MqttAvailability, MqttDiscoveryUpdate)
+    MqttAvailability, MqttDiscoveryUpdate, MqttEntityDeviceInfo)
 from homeassistant.components.mqtt.discovery import MQTT_DISCOVERY_NEW
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -96,6 +96,7 @@ PLATFORM_SCHEMA = mqtt.MQTT_BASE_PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_TILT_INVERT_STATE,
                  default=DEFAULT_TILT_INVERT_STATE): cv.boolean,
     vol.Optional(CONF_UNIQUE_ID): cv.string,
+    vol.Optional(CONF_DEVICE): mqtt.MQTT_ENTITY_DEVICE_INFO_SCHEMA,
 }).extend(mqtt.MQTT_AVAILABILITY_SCHEMA.schema)
 
 
@@ -155,11 +156,13 @@ async def _async_setup_entity(hass, config, async_add_entities,
         config.get(CONF_POSITION_TOPIC),
         set_position_template,
         config.get(CONF_UNIQUE_ID),
+        config.get(CONF_DEVICE),
         discovery_hash
     )])
 
 
-class MqttCover(MqttAvailability, MqttDiscoveryUpdate, CoverDevice):
+class MqttCover(MqttAvailability, MqttDiscoveryUpdate, MqttEntityDeviceInfo,
+                CoverDevice):
     """Representation of a cover that can be controlled using MQTT."""
 
     def __init__(self, name, state_topic, command_topic, availability_topic,
@@ -169,11 +172,13 @@ class MqttCover(MqttAvailability, MqttDiscoveryUpdate, CoverDevice):
                  optimistic, value_template, tilt_open_position,
                  tilt_closed_position, tilt_min, tilt_max, tilt_optimistic,
                  tilt_invert, position_topic, set_position_template,
-                 unique_id: Optional[str], discovery_hash):
+                 unique_id: Optional[str], device_config: Optional[ConfigType],
+                 discovery_hash):
         """Initialize the cover."""
         MqttAvailability.__init__(self, availability_topic, qos,
                                   payload_available, payload_not_available)
         MqttDiscoveryUpdate.__init__(self, discovery_hash)
+        MqttEntityDeviceInfo.__init__(self, device_config)
         self._position = None
         self._state = None
         self._name = name

--- a/tests/components/cover/test_mqtt.py
+++ b/tests/components/cover/test_mqtt.py
@@ -616,7 +616,7 @@ class TestCoverMQTT(unittest.TestCase):
             'tilt-command-topic', 'tilt-status-topic', 0, False,
             'OPEN', 'CLOSE', 'OPEN', 'CLOSE', 'STOP', None, None,
             False, None, 100, 0, 0, 100, False, False, None, None, None,
-            None)
+            None, None)
 
         self.assertEqual(44, mqtt_cover.find_percentage_in_range(44))
 
@@ -627,7 +627,7 @@ class TestCoverMQTT(unittest.TestCase):
             'tilt-command-topic', 'tilt-status-topic', 0, False,
             'OPEN', 'CLOSE', 'OPEN', 'CLOSE', 'STOP', None, None,
             False, None, 180, 80, 80, 180, False, False, None, None, None,
-            None)
+            None, None)
 
         self.assertEqual(40, mqtt_cover.find_percentage_in_range(120))
 
@@ -638,7 +638,7 @@ class TestCoverMQTT(unittest.TestCase):
             'tilt-command-topic', 'tilt-status-topic', 0, False,
             'OPEN', 'CLOSE', 'OPEN', 'CLOSE', 'STOP', None, None,
             False, None, 100, 0, 0, 100, False, True, None, None, None,
-            None)
+            None, None)
 
         self.assertEqual(56, mqtt_cover.find_percentage_in_range(44))
 
@@ -649,7 +649,7 @@ class TestCoverMQTT(unittest.TestCase):
             'tilt-command-topic', 'tilt-status-topic', 0, False,
             'OPEN', 'CLOSE', 'OPEN', 'CLOSE', 'STOP', None, None,
             False, None, 180, 80, 80, 180, False, True, None, None, None,
-            None)
+            None, None)
 
         self.assertEqual(60, mqtt_cover.find_percentage_in_range(120))
 
@@ -660,7 +660,7 @@ class TestCoverMQTT(unittest.TestCase):
             'tilt-command-topic', 'tilt-status-topic', 0, False,
             'OPEN', 'CLOSE', 'OPEN', 'CLOSE', 'STOP', None, None,
             False, None, 100, 0, 0, 100, False, False, None, None, None,
-            None)
+            None, None)
 
         self.assertEqual(44, mqtt_cover.find_in_range_from_percent(44))
 
@@ -671,7 +671,7 @@ class TestCoverMQTT(unittest.TestCase):
             'tilt-command-topic', 'tilt-status-topic', 0, False,
             'OPEN', 'CLOSE', 'OPEN', 'CLOSE', 'STOP', None, None,
             False, None, 180, 80, 80, 180, False, False, None, None, None,
-            None)
+            None, None)
 
         self.assertEqual(120, mqtt_cover.find_in_range_from_percent(40))
 
@@ -682,7 +682,7 @@ class TestCoverMQTT(unittest.TestCase):
             'tilt-command-topic', 'tilt-status-topic', 0, False,
             'OPEN', 'CLOSE', 'OPEN', 'CLOSE', 'STOP', None, None,
             False, None, 100, 0, 0, 100, False, True, None, None, None,
-            None)
+            None, None)
 
         self.assertEqual(44, mqtt_cover.find_in_range_from_percent(56))
 
@@ -693,7 +693,7 @@ class TestCoverMQTT(unittest.TestCase):
             'tilt-command-topic', 'tilt-status-topic', 0, False,
             'OPEN', 'CLOSE', 'OPEN', 'CLOSE', 'STOP', None, None,
             False, None, 180, 80, 80, 180, False, True, None, None, None,
-            None)
+            None, None)
 
         self.assertEqual(120, mqtt_cover.find_in_range_from_percent(60))
 

--- a/tests/components/cover/test_mqtt.py
+++ b/tests/components/cover/test_mqtt.py
@@ -1,4 +1,5 @@
 """The tests for the MQTT cover platform."""
+import json
 import unittest
 
 from homeassistant.components import cover, mqtt
@@ -810,3 +811,42 @@ async def test_unique_id(hass):
     await hass.async_block_till_done()
 
     assert len(hass.states.async_entity_ids(cover.DOMAIN)) == 1
+
+
+async def test_entity_device_info_with_identifier(hass, mqtt_mock):
+    """Test MQTT cover device registry integration."""
+    entry = MockConfigEntry(domain=mqtt.DOMAIN)
+    entry.add_to_hass(hass)
+    await async_start(hass, 'homeassistant', {}, entry)
+    registry = await hass.helpers.device_registry.async_get_registry()
+
+    data = json.dumps({
+        'platform': 'mqtt',
+        'name': 'Test 1',
+        'state_topic': 'test-topic',
+        'command_topic': 'test-command-topic',
+        'device': {
+            'identifiers': ['helloworld'],
+            'connections': [
+                ["mac", "02:5b:26:a8:dc:12"],
+            ],
+            'manufacturer': 'Whatever',
+            'name': 'Beer',
+            'model': 'Glass',
+            'sw_version': '0.1-beta',
+        },
+        'unique_id': 'veryunique'
+    })
+    async_fire_mqtt_message(hass, 'homeassistant/cover/bla/config',
+                            data)
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+
+    device = registry.async_get_device({('mqtt', 'helloworld')}, set())
+    assert device is not None
+    assert device.identifiers == {('mqtt', 'helloworld')}
+    assert device.connections == {('mac', "02:5b:26:a8:dc:12")}
+    assert device.manufacturer == 'Whatever'
+    assert device.name == 'Beer'
+    assert device.model == 'Glass'
+    assert device.sw_version == '0.1-beta'


### PR DESCRIPTION
## Description:

Implements #16943 for `cover.mqtt`

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#6606

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.