### PR TITLE
block external IP

### DIFF
--- a/homeassistant/components/emulated_hue/__init__.py
+++ b/homeassistant/components/emulated_hue/__init__.py
@@ -18,11 +18,12 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.deprecation import get_deprecated
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util.json import load_json, save_json
+from homeassistant.components.http import real_ip
+
 from .hue_api import (
     HueUsernameView, HueAllLightsStateView, HueOneLightStateView,
     HueOneLightChangeView, HueGroupView)
 from .upnp import DescriptionXmlView, UPNPResponderThread
-from homeassistant.components.http import real_ip
 
 DOMAIN = 'emulated_hue'
 

--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -20,6 +20,9 @@ from homeassistant.components.fan import (
     SPEED_MEDIUM, SPEED_HIGH
 )
 from homeassistant.components.http import HomeAssistantView
+from homeassistant.components.http.const import KEY_REAL_IP
+from homeassistant.util.network import is_local
+
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -46,6 +49,10 @@ class HueUsernameView(HomeAssistantView):
             return self.json_message('devicetype not specified',
                                      HTTP_BAD_REQUEST)
 
+        if not is_local(request[KEY_REAL_IP]):
+            return self.json_message('only local IPs allowed',
+                                     HTTP_BAD_REQUEST)
+
         return self.json([{'success': {'username': '12345678901234567890'}}])
 
 
@@ -63,6 +70,10 @@ class HueGroupView(HomeAssistantView):
     @core.callback
     def put(self, request, username):
         """Process a request to make the Logitech Pop working."""
+        if not is_local(request[KEY_REAL_IP]):
+            return self.json_message('only local IPs allowed',
+                                     HTTP_BAD_REQUEST)
+
         return self.json([{
             'error': {
                 'address': '/groups/0/action/scene',
@@ -86,6 +97,10 @@ class HueAllLightsStateView(HomeAssistantView):
     @core.callback
     def get(self, request, username):
         """Process a request to get the list of available lights."""
+        if not is_local(request[KEY_REAL_IP]):
+            return self.json_message('only local IPs allowed',
+                                     HTTP_BAD_REQUEST)
+
         hass = request.app['hass']
         json_response = {}
 
@@ -114,6 +129,10 @@ class HueOneLightStateView(HomeAssistantView):
     @core.callback
     def get(self, request, username, entity_id):
         """Process a request to get the state of an individual light."""
+        if not is_local(request[KEY_REAL_IP]):
+            return self.json_message('only local IPs allowed',
+                                     HTTP_BAD_REQUEST)
+
         hass = request.app['hass']
         entity_id = self.config.number_to_entity_id(entity_id)
         entity = hass.states.get(entity_id)
@@ -146,6 +165,10 @@ class HueOneLightChangeView(HomeAssistantView):
 
     async def put(self, request, username, entity_number):
         """Process a request to set the state of an individual light."""
+        if not is_local(request[KEY_REAL_IP]):
+            return self.json_message('only local IPs allowed',
+                                     HTTP_BAD_REQUEST)
+
         config = self.config
         hass = request.app['hass']
         entity_id = config.number_to_entity_id(entity_number)

--- a/tests/components/emulated_hue/test_hue_api.py
+++ b/tests/components/emulated_hue/test_hue_api.py
@@ -1,6 +1,7 @@
 """The tests for the emulated Hue component."""
 import asyncio
 import json
+from ipaddress import ip_address
 from unittest.mock import patch
 
 from aiohttp.hdrs import CONTENT_TYPE
@@ -484,3 +485,12 @@ def perform_put_light_state(hass_hue, client, entity_id, is_on,
     yield from hass_hue.async_block_till_done()
 
     return result
+
+
+async def test_external_ip_blocked(hue_client):
+    """Test external IP blocked."""
+    with patch('homeassistant.components.http.real_ip.ip_address',
+               return_value=ip_address('45.45.45.45')):
+        result = await hue_client.get('/api/username/lights')
+
+    assert result.status == 400


### PR DESCRIPTION
## Description:
I was looking for the auth issue by @awarecan to link the new webhook trigger PR #17246 when I stumbled upon #15427. I wish I had seen this earlier or that it was escalated.

Anyway, here is a PR to block all external IPs from accessing the emulated Hue APIs.

Could probably be a decorator but wanted to get this out fast.

I really hate the emulated Hue component, it's been such a source of problems.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
