### PR TITLE
Clear device state attributes if update from feed fails for geo_rss_events sensor

### DIFF
--- a/homeassistant/components/sensor/geo_rss_events.py
+++ b/homeassistant/components/sensor/geo_rss_events.py
@@ -145,3 +145,4 @@ class GeoRssServiceSensor(Entity):
             # If no events were found due to an error then just set state to
             # zero.
             self._state = 0
+            self._state_attributes = {}

--- a/tests/components/sensor/test_geo_rss_events.py
+++ b/tests/components/sensor/test_geo_rss_events.py
@@ -123,6 +123,10 @@ class TestGeoRssServiceUpdater(unittest.TestCase):
                 assert len(all_states) == 1
                 state = self.hass.states.get("sensor.event_service_any")
                 assert int(state.state) == 0
+                assert state.attributes == {
+                    ATTR_FRIENDLY_NAME: "Event Service Any",
+                    ATTR_UNIT_OF_MEASUREMENT: "Events",
+                    ATTR_ICON: "mdi:alert"}
 
     @mock.patch('georss_client.generic_feed.GenericFeed')
     def test_setup_with_categories(self, mock_feed):


### PR DESCRIPTION
## Description:
In the case where a feed becomes unavailable, the state is set to `0` (same as before the refactoring in version 0.80), but the device state attributes are not cleared.
This change will fix this and clear the device state attributes if the update from the external feed fails. A test case has been amended to test this behaviour.

**Related issue (if applicable):** n/a

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable): n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
