### PR TITLE
Fix mpd timeout error

### DIFF
--- a/homeassistant/components/media_player/mpd.py
+++ b/homeassistant/components/media_player/mpd.py
@@ -79,7 +79,7 @@ class MpdDevice(MediaPlayerDevice):
 
         # set up MPD client
         self._client = mpd.MPDClient()
-        self._client.timeout = 60
+        self._client.timeout = 30
         self._client.idletimeout = None
 
     def _connect(self):

--- a/homeassistant/components/media_player/mpd.py
+++ b/homeassistant/components/media_player/mpd.py
@@ -79,7 +79,7 @@ class MpdDevice(MediaPlayerDevice):
 
         # set up MPD client
         self._client = mpd.MPDClient()
-        self._client.timeout = 5
+        self._client.timeout = 60
         self._client.idletimeout = None
 
     def _connect(self):


### PR DESCRIPTION
## Description:

Increase mpd client timeout to default mpd connection timeout (60s).

**Related issue (if applicable):** fixes #17253

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
