### PR TITLE
Add Elk-M1 switch and scene platforms

### DIFF
--- a/homeassistant/components/alarm_control_panel/elkm1.py
+++ b/homeassistant/components/alarm_control_panel/elkm1.py
@@ -89,7 +89,7 @@ class ElkArea(ElkEntity, alarm.AlarmControlPanel):
 
     def __init__(self, element, elk, elk_data):
         """Initialize Area as Alarm Control Panel."""
-        super().__init__('alarm_control_panel', element, elk, elk_data)
+        super().__init__(element, elk, elk_data)
         self._changed_by_entity_id = ''
         self._state = None
 

--- a/homeassistant/components/elkm1/__init__.py
+++ b/homeassistant/components/elkm1/__init__.py
@@ -35,7 +35,7 @@ CONF_ENABLED = 'enabled'
 
 _LOGGER = logging.getLogger(__name__)
 
-SUPPORTED_DOMAINS = ['alarm_control_panel', 'light']
+SUPPORTED_DOMAINS = ['alarm_control_panel', 'light', 'switch']
 
 
 def _host_validator(config):
@@ -197,7 +197,7 @@ class ElkEntity(Entity):
         return attrs
 
     def _element_changed(self, element, changeset):
-        raise NotImplementedError()
+        pass
 
     @callback
     def _element_callback(self, element, changeset):

--- a/homeassistant/components/elkm1/__init__.py
+++ b/homeassistant/components/elkm1/__init__.py
@@ -35,7 +35,7 @@ CONF_ENABLED = 'enabled'
 
 _LOGGER = logging.getLogger(__name__)
 
-SUPPORTED_DOMAINS = ['alarm_control_panel', 'light', 'switch']
+SUPPORTED_DOMAINS = ['alarm_control_panel', 'light', 'scene', 'switch']
 
 
 def _host_validator(config):
@@ -157,7 +157,7 @@ def create_elk_entities(hass, elk_elements, element_type, class_, entities):
 class ElkEntity(Entity):
     """Base class for all Elk entities."""
 
-    def __init__(self, platform, element, elk, elk_data):
+    def __init__(self, element, elk, elk_data):
         """Initialize the base of all Elk devices."""
         self._elk = elk
         self._element = element

--- a/homeassistant/components/light/elkm1.py
+++ b/homeassistant/components/light/elkm1.py
@@ -28,7 +28,7 @@ class ElkLight(ElkEntity, Light):
 
     def __init__(self, element, elk, elk_data):
         """Initialize light."""
-        super().__init__('light', element, elk, elk_data)
+        super().__init__(element, elk, elk_data)
         self._brightness = self._element.status
 
     @property

--- a/homeassistant/components/scene/elkm1.py
+++ b/homeassistant/components/scene/elkm1.py
@@ -1,5 +1,5 @@
 """
-Support for control of ElkM1 outputs (relays) and tasks ("macros).
+Support for control of ElkM1 tasks ("macros").
 
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/switch.elkm1/
@@ -8,7 +8,7 @@ https://home-assistant.io/components/switch.elkm1/
 
 from homeassistant.components.elkm1 import (
     DOMAIN as ELK_DOMAIN, ElkEntity, create_elk_entities)
-from homeassistant.components.switch import SwitchDevice
+from homeassistant.components.scene import Scene
 
 DEPENDENCIES = [ELK_DOMAIN]
 
@@ -19,26 +19,17 @@ async def async_setup_platform(hass, config, async_add_entities,
     if discovery_info is None:
         return
     elk = hass.data[ELK_DOMAIN]['elk']
-    entities = create_elk_entities(hass, elk.outputs, 'output', ElkOutput, [])
+    entities = create_elk_entities(hass, elk.tasks, 'task', ElkTask, [])
     async_add_entities(entities, True)
 
 
-class ElkOutput(ElkEntity, SwitchDevice):
-    """Elk output as switch."""
+class ElkTask(ElkEntity, Scene):
+    """Elk-M1 task as scene."""
 
     def __init__(self, element, elk, elk_data):
         """Initialize output."""
         super().__init__(element, elk, elk_data)
 
-    @property
-    def is_on(self) -> bool:
-        """Get the current output status."""
-        return self._element.output_on
-
-    async def async_turn_on(self, **kwargs):
-        """Turn on the output."""
-        self._element.turn_on(0)
-
-    async def async_turn_off(self, **kwargs):
-        """Turn off the output."""
-        self._element.turn_off()
+    async def async_activate(self, **kwargs):
+        """Activate the task."""
+        self._element.activate()

--- a/homeassistant/components/scene/elkm1.py
+++ b/homeassistant/components/scene/elkm1.py
@@ -2,7 +2,7 @@
 Support for control of ElkM1 tasks ("macros").
 
 For more details about this platform, please refer to the documentation at
-https://home-assistant.io/components/switch.elkm1/
+https://home-assistant.io/components/sensor.elkm1/
 """
 
 
@@ -15,7 +15,7 @@ DEPENDENCIES = [ELK_DOMAIN]
 
 async def async_setup_platform(hass, config, async_add_entities,
                                discovery_info=None):
-    """Create the Elk-M1 switch platform."""
+    """Create the Elk-M1 sensor platform."""
     if discovery_info is None:
         return
     elk = hass.data[ELK_DOMAIN]['elk']

--- a/homeassistant/components/scene/elkm1.py
+++ b/homeassistant/components/scene/elkm1.py
@@ -26,10 +26,6 @@ async def async_setup_platform(hass, config, async_add_entities,
 class ElkTask(ElkEntity, Scene):
     """Elk-M1 task as scene."""
 
-    def __init__(self, element, elk, elk_data):
-        """Initialize output."""
-        super().__init__(element, elk, elk_data)
-
-    async def async_activate(self, **kwargs):
+    async def async_activate(self):
         """Activate the task."""
         self._element.activate()

--- a/homeassistant/components/scene/elkm1.py
+++ b/homeassistant/components/scene/elkm1.py
@@ -2,7 +2,7 @@
 Support for control of ElkM1 tasks ("macros").
 
 For more details about this platform, please refer to the documentation at
-https://home-assistant.io/components/sensor.elkm1/
+https://home-assistant.io/components/scene.elkm1/
 """
 
 
@@ -15,7 +15,7 @@ DEPENDENCIES = [ELK_DOMAIN]
 
 async def async_setup_platform(hass, config, async_add_entities,
                                discovery_info=None):
-    """Create the Elk-M1 sensor platform."""
+    """Create the Elk-M1 scene platform."""
     if discovery_info is None:
         return
     elk = hass.data[ELK_DOMAIN]['elk']

--- a/homeassistant/components/switch/elkm1.py
+++ b/homeassistant/components/switch/elkm1.py
@@ -15,7 +15,7 @@ DEPENDENCIES = [ELK_DOMAIN]
 
 async def async_setup_platform(hass, config, async_add_entities,
                                discovery_info=None):
-    """Setup the Elk switch platform."""
+    """Set up the Elk switch platform."""
     if discovery_info is None:
         return
     elk = hass.data[ELK_DOMAIN]['elk']

--- a/homeassistant/components/switch/elkm1.py
+++ b/homeassistant/components/switch/elkm1.py
@@ -15,7 +15,7 @@ DEPENDENCIES = [ELK_DOMAIN]
 
 async def async_setup_platform(hass, config, async_add_entities,
                                discovery_info=None):
-    """Set up the Elk switch platform."""
+    """Create the Elk-M1 switch platform."""
     if discovery_info is None:
         return
     elk = hass.data[ELK_DOMAIN]['elk']

--- a/homeassistant/components/switch/elkm1.py
+++ b/homeassistant/components/switch/elkm1.py
@@ -1,0 +1,88 @@
+"""
+Support for control of ElkM1 outputs (relays) and tasks ("macros).
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/switch.elkm1/
+"""
+
+from homeassistant.helpers.entity import ToggleEntity
+
+from homeassistant.components.elkm1 import (
+    DOMAIN as ELK_DOMAIN, ElkEntity, create_elk_entities)
+
+DEPENDENCIES = [ELK_DOMAIN]
+
+
+async def async_setup_platform(hass, config, async_add_entities,
+                               discovery_info=None):
+    """Setup the Elk switch platform."""
+    if discovery_info is None:
+        return
+    elk = hass.data[ELK_DOMAIN]['elk']
+    entities = create_elk_entities(hass, elk.tasks, 'task', ElkTask, [])
+    entities = create_elk_entities(
+        hass, elk.outputs, 'output', ElkOutput, entities)
+    async_add_entities(entities, True)
+
+
+class ElkOutput(ElkEntity, ToggleEntity):
+    """Elk Output as Toggle Switch."""
+
+    def __init__(self, element, elk, elk_data):
+        """Initialize output."""
+        super().__init__('switch', element, elk, elk_data)
+
+    @property
+    def icon(self):
+        """Icon to use in the frontend."""
+        return 'mdi:toggle-switch'
+
+    @property
+    def is_on(self) -> bool:
+        """Get the current output status."""
+        return self._element.output_on
+
+    async def async_turn_on(self, **kwargs):
+        """Turn on the output."""
+        self._element.turn_on(0)
+
+    async def async_turn_off(self, **kwargs):
+        """Turn off the output."""
+        self._element.turn_off()
+
+
+class ElkTask(ElkEntity, ToggleEntity):
+    """Elk Output as Toggle Switch."""
+
+    def __init__(self, element, elk, elk_data):
+        """Initialize output."""
+        super().__init__('switch', element, elk, elk_data)
+
+    @property
+    def icon(self):
+        """Icon to use in the frontend."""
+        return 'mdi:toggle-switch'
+
+    @property
+    def device_state_attributes(self):
+        """Attributes of the task."""
+        attrs = self.initial_attrs()
+        attrs['last_change'] = self._element.last_change
+        return attrs
+
+    @property
+    def is_on(self) -> bool:
+        """Get the task status."""
+        return False
+
+    async def async_turn_on(self, **kwargs):
+        """Activate the task."""
+        self._element.activate()
+
+    async def async_turn_off(self, **kwargs):
+        """Turn off the task.
+
+        Tasks aren't actually never turned "on", they are just
+        triggered, so their state is always off.
+        """
+        pass

--- a/homeassistant/components/switch/elkm1.py
+++ b/homeassistant/components/switch/elkm1.py
@@ -26,10 +26,6 @@ async def async_setup_platform(hass, config, async_add_entities,
 class ElkOutput(ElkEntity, SwitchDevice):
     """Elk output as switch."""
 
-    def __init__(self, element, elk, elk_data):
-        """Initialize output."""
-        super().__init__(element, elk, elk_data)
-
     @property
     def is_on(self) -> bool:
         """Get the current output status."""

--- a/homeassistant/components/switch/elkm1.py
+++ b/homeassistant/components/switch/elkm1.py
@@ -1,5 +1,5 @@
 """
-Support for control of ElkM1 outputs (relays) and tasks ("macros).
+Support for control of ElkM1 outputs (relays).
 
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/switch.elkm1/


### PR DESCRIPTION
## Description:
Add switch platform for Elk-M1.

See: https://github.com/home-assistant/home-assistant/pull/16952 for component PR.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#6613

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
