### PR TITLE
Add basic support of the Philips Zhirui desk lamp (philips.light.mono1)

### DIFF
--- a/homeassistant/components/light/xiaomi_miio.py
+++ b/homeassistant/components/light/xiaomi_miio.py
@@ -39,7 +39,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
          'philips.light.zyceiling',
          'philips.light.bulb',
          'philips.light.candle',
-         'philips.light.candle2']),
+         'philips.light.candle2',
+         'philips.light.mono1']),
 })
 
 REQUIREMENTS = ['python-miio==0.4.1', 'construct==2.9.41']
@@ -155,6 +156,12 @@ async def async_setup_platform(hass, config, async_add_entities,
         from miio import PhilipsBulb
         light = PhilipsBulb(host, token)
         device = XiaomiPhilipsBulb(name, light, model, unique_id)
+        devices.append(device)
+        hass.data[DATA_KEY][host] = device
+    elif model == 'philips.light.mono1':
+        from miio import PhilipsBulb
+        light = PhilipsBulb(host, token)
+        device = XiaomiPhilipsGenericLight(name, light, model, unique_id)
         devices.append(device)
         hass.data[DATA_KEY][host] = device
     else:


### PR DESCRIPTION
## Description:

https://github.com/syssi/philipslight/issues/13

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#6619

## Example entry for `configuration.yaml` (if applicable):
```yaml
light:
  - platform: xiaomi_miio
    name: Philips desk lamp
    host: 192.168.130.67
    token: da548d86f55996413d82eea94279d2ff
    model: philips.light.mono1
```
