### PR TITLE
Fix upnp by adding defaults

### DIFF
--- a/homeassistant/components/upnp/config_flow.py
+++ b/homeassistant/components/upnp/config_flow.py
@@ -125,8 +125,8 @@ class UpnpFlowHandler(data_entry_flow.FlowHandler):
             data_schema=vol.Schema(
                 OrderedDict([
                     (vol.Required('name'), vol.In(names)),
-                    (vol.Optional('enable_sensors'), bool),
-                    (vol.Optional('enable_port_mapping'), bool),
+                    (vol.Optional('enable_sensors', default=False), bool),
+                    (vol.Optional('enable_port_mapping', default=False), bool),
                 ])
             ))
 


### PR DESCRIPTION
## Description:
Fix for #17229, settings defaults for user-input

**Related issue (if applicable):** fixes #17229

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** -

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
