### PR TITLE
Set InsteonEntity name to be combo of description and address.

### DIFF
--- a/homeassistant/components/insteon/__init__.py
+++ b/homeassistant/components/insteon/__init__.py
@@ -10,12 +10,12 @@ from typing import Dict
 
 import voluptuous as vol
 
-from homeassistant.core import callback
+import homeassistant.helpers.config_validation as cv
 from homeassistant.const import (CONF_PORT, EVENT_HOMEASSISTANT_STOP,
                                  CONF_PLATFORM,
                                  CONF_ENTITY_ID,
                                  CONF_HOST)
-import homeassistant.helpers.config_validation as cv
+from homeassistant.core import callback
 from homeassistant.helpers import discovery
 from homeassistant.helpers.entity import Entity
 
@@ -447,10 +447,10 @@ Descriptor = collections.namedtuple('Descriptor',
 
 
 class DescriptorMapper:
-    """Maps the Device, State, and Group to a descriptive label function
-     for a grouped devices instance."""
+    """Maps the Device, State, and Group to a descriptive label function."""
 
     def __init__(self):
+        """Load up device map db"""
         from insteonplm.devices.dimmableLightingControl import \
             DimmableLightingControl_2475F, \
             DimmableLightingControl_2334_222_6, \
@@ -597,7 +597,6 @@ class InsteonEntity(Entity):
     @property
     def name(self):
         """Return the name of the node (used for Entity_ID)."""
-
         # Set a base description
         description = self._insteon_device.description
         if self._insteon_device.description is None:
@@ -655,7 +654,7 @@ class InsteonEntity(Entity):
         self.print_aldb()
 
     def _get_label(self):
-        """ Get the device label for grouped devices"""
+        """ Get the device label for grouped devices."""
         descriptor_mapper = DescriptorMapper()
 
         def def_group_label(device):

--- a/homeassistant/components/insteon/__init__.py
+++ b/homeassistant/components/insteon/__init__.py
@@ -575,7 +575,8 @@ class DescriptorMapper:
 
     def __init__(self):
         from insteonplm.devices.dimmableLightingControl import \
-            DimmableLightingControl_2475F, DimmableLightingControl_2334_222_6, \
+            DimmableLightingControl_2475F, \
+            DimmableLightingControl_2334_222_6, \
             DimmableLightingControl_2334_222_8
         from insteonplm.states.dimmable import DimmableSwitch_Fan, \
             DimmableSwitch, DimmableKeypadA

--- a/homeassistant/components/insteon/__init__.py
+++ b/homeassistant/components/insteon/__init__.py
@@ -656,9 +656,8 @@ class InsteonEntity(Entity):
 
     def _get_label(self):
         """ Get the device label for grouped devices"""
-
         descriptor_mapper = DescriptorMapper()
-        
+
         def def_group_label(device):
             return 'Group {:d}'.format(device.group)
 

--- a/homeassistant/components/insteon/__init__.py
+++ b/homeassistant/components/insteon/__init__.py
@@ -563,8 +563,6 @@ class DescriptorMapper:
 class InsteonEntity(Entity):
     """INSTEON abstract base entity."""
 
-    descriptor_mapper = DescriptorMapper()
-
     def __init__(self, device, state_key):
         """Initialize the INSTEON binary sensor."""
         self._insteon_device_state = device.states[state_key]
@@ -659,13 +657,15 @@ class InsteonEntity(Entity):
     def _get_label(self):
         """ Get the device label for grouped devices"""
 
+        descriptor_mapper = DescriptorMapper()
+        
         def def_group_label(device):
             return 'Group {:d}'.format(device.group)
 
         def empty_label(device):
             return ''
 
-        label_func = InsteonEntity.descriptor_mapper[
+        label_func = descriptor_mapper[
             [self._insteon_device, self._insteon_device_state,
              self._insteon_device_state.group]]
         if label_func is None:

--- a/homeassistant/components/insteon/__init__.py
+++ b/homeassistant/components/insteon/__init__.py
@@ -535,15 +535,6 @@ class InsteonEntity(Entity):
         """All-Link Database loaded for the device."""
         self.print_aldb()
 
-    def _generate_network_address(self):
-        """Get the formatted network address for the device."""
-        if self._insteon_device_state.group == 0x01:
-            addr = self._insteon_device.id
-        else:
-            addr = '{:s}_{:d}'.format(self._insteon_device.id,
-                                      self._insteon_device_state.group)
-        return addr
-
     def _get_label(self):
         """ Get the device label for grouped devices"""
 

--- a/homeassistant/components/insteon/__init__.py
+++ b/homeassistant/components/insteon/__init__.py
@@ -538,10 +538,10 @@ class InsteonEntity(Entity):
     def _get_label(self):
         """ Get the device label for grouped devices"""
 
-        def def_group_label(d):
-            return 'Group {:d}'.format(d.group)
+        def def_group_label(device):
+            return 'Group {:d}'.format(device.group)
 
-        def empty_label(d):
+        def empty_label(device):
             return ''
 
         label_func = DESCRIPTOR_MAPPER[
@@ -581,14 +581,27 @@ class DescriptorMapper:
         from insteonplm.states.onOff import OpenClosedRelay, OnOffKeypad, \
             OnOffSwitch_OutletTop, OnOffSwitch_OutletBottom
 
-        def button_6_label(d): return \
-            {1: 'Main', 3: 'Button A', 4: 'Button B', 5: 'Button C',
-             6: 'Button D', 7: 'Button E'}[d.group]
+        def button_6_label(device):
+            return {
+                1: 'Main',
+                3: 'Button A',
+                4: 'Button B',
+                5: 'Button C',
+                6: 'Button D',
+                7: 'Button E'
+            }[device.group]
 
-        def button_8_label(d): return \
-            {1: 'Main', 2: 'Button B', 3: 'Button C', 4: 'Button D',
-             5: 'Button E', 6: 'Button F', 7: 'Button G', 8: 'Button H'}[
-                d.group]
+        def button_8_label(device):
+            return {
+                1: 'Main',
+                2: 'Button B',
+                3: 'Button C',
+                4: 'Button D',
+                5: 'Button E',
+                6: 'Button F',
+                7: 'Button G',
+                8: 'Button H'
+            }[device.group]
 
         self.name_maps = [
             # FanLinc
@@ -653,12 +666,12 @@ class DescriptorMapper:
                     and isinstance(state, name_map.state) \
                     and group == name_map.group:
                 descriptor = name_map.descriptor
-
-            if not descriptor:
-                for name_map in self.name_maps:
-                    if isinstance(device, name_map.device) \
-                            and isinstance(state, name_map.state):
-                        descriptor = name_map.descriptor
+                
+        if not descriptor:
+            for name_map in self.name_maps:
+                if isinstance(device, name_map.device) \
+                        and isinstance(state, name_map.state):
+                    descriptor = name_map.descriptor
         return descriptor
 
 

--- a/homeassistant/components/insteon/__init__.py
+++ b/homeassistant/components/insteon/__init__.py
@@ -450,7 +450,7 @@ class DescriptorMapper:
     """Maps the Device, State, and Group to a descriptive label function."""
 
     def __init__(self):
-        """Load up device map db"""
+        """Load up device map db."""
         from insteonplm.devices.dimmableLightingControl import \
             DimmableLightingControl_2475F, \
             DimmableLightingControl_2334_222_6, \
@@ -654,7 +654,7 @@ class InsteonEntity(Entity):
         self.print_aldb()
 
     def _get_label(self):
-        """ Get the device label for grouped devices."""
+        """Get the device label for grouped devices."""
         descriptor_mapper = DescriptorMapper()
 
         def def_group_label(device):

--- a/homeassistant/components/insteon/__init__.py
+++ b/homeassistant/components/insteon/__init__.py
@@ -468,22 +468,17 @@ class InsteonEntity(Entity):
     @property
     def unique_id(self) -> str:
         """Return a unique ID."""
-        if self._insteon_device_state.group == 0x01:
-            uid = self._insteon_device.id
-        else:
-            uid = '{:s}_{:d}'.format(self._insteon_device.id,
-                                     self._insteon_device_state.group)
-        return uid
+        return self._generate_network_address()
 
     @property
     def name(self):
         """Return the name of the node (used for Entity_ID)."""
-        name = ''
-        if self._insteon_device_state.group == 0x01:
-            name = self._insteon_device.id
+        addr = self._generate_network_address()
+        if self._insteon_device.description is None:
+            name = addr
         else:
-            name = '{:s}_{:d}'.format(self._insteon_device.id,
-                                      self._insteon_device_state.group)
+            name = '{:s} {:s}'.format(self._insteon_device.description,
+                                      addr)
         return name
 
     @property
@@ -525,6 +520,15 @@ class InsteonEntity(Entity):
     def _aldb_loaded(self):
         """All-Link Database loaded for the device."""
         self.print_aldb()
+
+    def _generate_network_address(self):
+        """Get the formatted network address for the device."""
+        if self._insteon_device_state.group == 0x01:
+            addr = self._insteon_device.id
+        else:
+            addr = '{:s}_{:d}'.format(self._insteon_device.id,
+                                      self._insteon_device_state.group)
+        return addr
 
 
 def print_aldb_to_log(aldb):

--- a/homeassistant/components/insteon/__init__.py
+++ b/homeassistant/components/insteon/__init__.py
@@ -91,7 +91,7 @@ CONF_DEVICE_OVERRIDE_SCHEMA = vol.All(
         vol.Optional(CONF_FIRMWARE): cv.byte,
         vol.Optional(CONF_PRODUCT_KEY): cv.byte,
         vol.Optional(CONF_PLATFORM): cv.string,
-        }))
+    }))
 
 CONF_X10_SCHEMA = vol.All(
     vol.Schema({
@@ -146,6 +146,45 @@ PRINT_ALDB_SCHEMA = vol.Schema({
 X10_HOUSECODE_SCHEMA = vol.Schema({
     vol.Required(SRV_HOUSECODE): vol.In(HOUSECODES),
     })
+
+STATE_NAME_LABEL_MAP = {
+    'keypadButtonA': 'Button A',
+    'keypadButtonB': 'Button B',
+    'keypadButtonC': 'Button C',
+    'keypadButtonD': 'Button D',
+    'keypadButtonE': 'Button E',
+    'keypadButtonF': 'Button F',
+    'keypadButtonG': 'Button G',
+    'keypadButtonH': 'Button H',
+    'keypadButtonMain': 'Main',
+    'onOffButtonA': 'Button A',
+    'onOffButtonB': 'Button B',
+    'onOffButtonC': 'Button C',
+    'onOffButtonD': 'Button D',
+    'onOffButtonE': 'Button E',
+    'onOffButtonF': 'Button F',
+    'onOffButtonG': 'Button G',
+    'onOffButtonH': 'Button H',
+    'onOffButtonMain': 'Main',
+    'fanOnLevel': 'Fan',
+    'lightOnLevel': 'Light',
+    'coolSetPoint': 'Cool Set',
+    'heatSetPoint': 'HeatSet',
+    'statusReport': 'Status',
+    'generalSensor': 'Sensor',
+    'motionSensor': 'Motion',
+    'lightSensor': 'Light',
+    'batterySensor': 'Battery',
+    'dryLeakSensor': 'Dry',
+    'wetLeakSensor': 'Wet',
+    'heartbeatLeakSensor': 'Heartbeat',
+    'openClosedRelay': 'Relay',
+    'openClosedSensor': 'Sensor',
+    'lightOnOff': 'Light',
+    'outletTopOnOff': 'Top',
+    'outletBottomOnOff': 'Bottom',
+    'coverOpenLevel': 'Cover',
+}
 
 
 async def async_setup(hass, config):
@@ -441,125 +480,6 @@ class IPDB:
         return None
 
 
-# Descriptor Label Tuple
-Descriptor = collections.namedtuple('Descriptor',
-                                    'device state group descriptor')
-
-
-class DescriptorMapper:
-    """Maps the Device, State, and Group to a descriptive label function."""
-
-    def __init__(self):
-        """Load up device map db."""
-        from insteonplm.devices.dimmableLightingControl import \
-            DimmableLightingControl_2475F, \
-            DimmableLightingControl_2334_222_6, \
-            DimmableLightingControl_2334_222_8
-        from insteonplm.states.dimmable import DimmableSwitch_Fan, \
-            DimmableSwitch, DimmableKeypadA
-        from insteonplm.devices.sensorsActuators import SensorsActuators_2450
-        from insteonplm.devices.securityHealthSafety import \
-            SecurityHealthSafety_2842_222, SecurityHealthSafety_2852_222
-        from insteonplm.devices.switchedLightingControl import \
-            SwitchedLightingControl_2663_222
-        from insteonplm.states.sensor import IoLincSensor, OnOffSensor, \
-            LeakSensorDryWet, LeakSensorHeartbeat
-        from insteonplm.states.onOff import OpenClosedRelay, OnOffKeypad, \
-            OnOffSwitch_OutletTop, OnOffSwitch_OutletBottom
-
-        def button_6_label(device):
-            return {
-                1: 'Main',
-                3: 'Button A',
-                4: 'Button B',
-                5: 'Button C',
-                6: 'Button D',
-                7: 'Button E'
-            }[device.group]
-
-        def button_8_label(device):
-            return {
-                1: 'Main',
-                2: 'Button B',
-                3: 'Button C',
-                4: 'Button D',
-                5: 'Button E',
-                6: 'Button F',
-                7: 'Button G',
-                8: 'Button H'
-            }[device.group]
-
-        self.name_maps = [
-            # FanLinc
-            Descriptor(DimmableLightingControl_2475F, DimmableSwitch, 0x01,
-                       lambda d: 'Light'),
-            Descriptor(DimmableLightingControl_2475F, DimmableSwitch_Fan, 0x02,
-                       lambda d: 'Fan'),
-            # I/O Linc
-            Descriptor(SensorsActuators_2450, OpenClosedRelay, 0x01,
-                       lambda d: 'Relay'),
-            Descriptor(SensorsActuators_2450, IoLincSensor, 0x02,
-                       lambda d: 'Sensor'),
-
-            # Keypads
-            Descriptor(DimmableLightingControl_2334_222_6, OnOffKeypad,
-                       None, button_6_label),
-            Descriptor(DimmableLightingControl_2334_222_6, DimmableKeypadA,
-                       None, button_6_label),
-            Descriptor(DimmableLightingControl_2334_222_8, OnOffKeypad,
-                       None, button_8_label),
-            Descriptor(DimmableLightingControl_2334_222_8, DimmableKeypadA,
-                       None, button_8_label),
-
-            # Moton Sensor model 2842-222.
-            Descriptor(SecurityHealthSafety_2842_222, OnOffSensor,
-                       0x01, lambda d: 'Motion'),
-            Descriptor(SecurityHealthSafety_2842_222, OnOffSensor,
-                       0x02, lambda d: 'Light'),
-            Descriptor(SecurityHealthSafety_2842_222, OnOffSensor,
-                       0x03, lambda d: 'Battery'),
-
-            # Water Leak Sensor model 2852-222.
-            Descriptor(SecurityHealthSafety_2852_222, LeakSensorDryWet,
-                       0x01, lambda d: 'Dry'),
-            Descriptor(SecurityHealthSafety_2852_222, LeakSensorDryWet,
-                       0x02, lambda d: 'Wet'),
-            Descriptor(SecurityHealthSafety_2852_222, LeakSensorHeartbeat,
-                       0x04, lambda d: 'Heartbeat'),
-
-            # On/Off outlet model 2663-222 Switched Lighting Control
-            Descriptor(SwitchedLightingControl_2663_222, OnOffSwitch_OutletTop,
-                       0x01, lambda d: 'Top'),
-            Descriptor(SwitchedLightingControl_2663_222,
-                       OnOffSwitch_OutletBottom, 0x02, lambda d: 'Bottom'),
-        ]
-
-    def __len__(self):
-        """Return the number of Entity Descriptors mapped."""
-        return len(self.name_maps)
-
-    def __iter__(self):
-        """Itterate through the Entity Descriptors."""
-        for namemap in self.name_maps:
-            yield namemap
-
-    def __getitem__(self, key):
-        """Return a Entity Descriptors."""
-        device, state, group = key
-        descriptor = None
-        for name_map in self.name_maps:
-            if isinstance(device, name_map.device) \
-                    and isinstance(state, name_map.state) \
-                    and group == name_map.group:
-                descriptor = name_map.descriptor
-        if not descriptor:
-            for name_map in self.name_maps:
-                if isinstance(device, name_map.device) \
-                        and isinstance(state, name_map.state):
-                    descriptor = name_map.descriptor
-        return descriptor
-
-
 class InsteonEntity(Entity):
     """INSTEON abstract base entity."""
 
@@ -655,23 +575,13 @@ class InsteonEntity(Entity):
 
     def _get_label(self):
         """Get the device label for grouped devices."""
-        descriptor_mapper = DescriptorMapper()
-
-        def def_group_label(device):
-            return 'Group {:d}'.format(device.group)
-
-        def empty_label(device):
-            return ''
-
-        label_func = descriptor_mapper[
-            [self._insteon_device, self._insteon_device_state,
-             self._insteon_device_state.group]]
-        if label_func is None:
-            if len(self._insteon_device.states) > 1:
-                label_func = def_group_label
+        label = ''
+        if len(self._insteon_device.states) > 1:
+            if self._insteon_device_state.name in STATE_NAME_LABEL_MAP:
+                label = STATE_NAME_LABEL_MAP[self._insteon_device_state.name]
             else:
-                label_func = empty_label
-        return format(label_func(self))
+                label = 'Group {:d}'.format(self.group)
+        return label
 
 
 def print_aldb_to_log(aldb):

--- a/homeassistant/components/insteon/__init__.py
+++ b/homeassistant/components/insteon/__init__.py
@@ -666,7 +666,6 @@ class DescriptorMapper:
                     and isinstance(state, name_map.state) \
                     and group == name_map.group:
                 descriptor = name_map.descriptor
-                
         if not descriptor:
             for name_map in self.name_maps:
                 if isinstance(device, name_map.device) \


### PR DESCRIPTION

## Description:
The Insteon initial entity_id is currently only the unique address of the Insteon device.  This adds the device description to the name to allow easier identification

ie "LampLinc Dimmer 26453a" or "Keypad Dimmer 291abb_2"

Cleans up the unique_id so there is no duplicated code

**Related issue (if applicable):** fixes #17194 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable): NA

## Example entry for `configuration.yaml` (if applicable):
```yaml
insteon:
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
