### PR TITLE
Remove warning on script delay

### DIFF
--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -1,6 +1,7 @@
 """Helpers to execute scripts."""
 
 import logging
+from contextlib import suppress
 from itertools import islice
 from typing import Optional, Sequence
 
@@ -95,10 +96,8 @@ class Script():
                 def async_script_delay(now):
                     """Handle delay."""
                     # pylint: disable=cell-var-from-loop
-                    try:
+                    with suppress(ValueError):
                         self._async_listener.remove(unsub)
-                    except ValueError:
-                        pass
 
                     self.hass.async_create_task(
                         self.async_run(variables, context))
@@ -244,10 +243,8 @@ class Script():
         @callback
         def async_script_timeout(now):
             """Call after timeout is retrieve."""
-            try:
+            with suppress(ValueError):
                 self._async_listener.remove(unsub)
-            except ValueError:
-                pass
 
             # Check if we want to continue to execute
             # the script after the timeout

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -95,7 +95,11 @@ class Script():
                 def async_script_delay(now):
                     """Handle delay."""
                     # pylint: disable=cell-var-from-loop
-                    self._async_remove_listener()
+                    try:
+                        self._async_listener.remove(unsub)
+                    except ValueError:
+                        pass
+
                     self.hass.async_create_task(
                         self.async_run(variables, context))
 
@@ -240,7 +244,10 @@ class Script():
         @callback
         def async_script_timeout(now):
             """Call after timeout is retrieve."""
-            self._async_remove_listener()
+            try:
+                self._async_listener.remove(unsub)
+            except ValueError:
+                pass
 
             # Check if we want to continue to execute
             # the script after the timeout


### PR DESCRIPTION
## Description:

This is another attempt at the fix in #16923.

Apparently I got confused by the naming. The `_async_remove_listener()` helper actually does more than just `remove()` the listener. The result is (harmless) warnings about double timer unsubscribes for script delays.

This reworked fix just ignores the exception that could happen if a script is turned on/off right as its timer expires.

**Related issue (if applicable):** fixes #17204

## Example entry for `configuration.yaml` (if applicable):
```yaml
script:
 vdr_ambilight_off:
    sequence:
      - service: switch.turn_off
        entity_id: switch.433_hyperion
      - delay: '00:00:02'
      - service: shell_command.easyvdr_off
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
