### PR TITLE
Don't set initial values for MQTT HVAC in non-optimistic mode

### DIFF
--- a/homeassistant/components/climate/mqtt.py
+++ b/homeassistant/components/climate/mqtt.py
@@ -237,18 +237,22 @@ class MqttClimate(MqttAvailability, MqttDiscoveryUpdate, ClimateDevice):
         self._value_templates = value_templates
         self._qos = qos
         self._retain = retain
+        # set to None in non-optimistic mode
+        self._target_temperature = self._current_fan_mode = \
+            self._current_operation = self._current_swing_mode = None
         if self._topic[CONF_TEMPERATURE_STATE_TOPIC] is None:
             self._target_temperature = target_temperature
-        else:
-            self._target_temperature = None
         self._unit_of_measurement = hass.config.units.temperature_unit
         self._away = away
         self._hold = hold
         self._current_temperature = None
-        self._current_fan_mode = current_fan_mode
-        self._current_operation = current_operation
+        if self._topic[CONF_FAN_MODE_STATE_TOPIC] is None:
+            self._current_fan_mode = current_fan_mode
+        if self._topic[CONF_MODE_STATE_TOPIC] is None:
+            self._current_operation = current_operation
         self._aux = aux
-        self._current_swing_mode = current_swing_mode
+        if self._topic[CONF_SWING_MODE_STATE_TOPIC] is None:
+            self._current_swing_mode = current_swing_mode
         self._fan_list = fan_mode_list
         self._operation_list = mode_list
         self._swing_list = swing_mode_list

--- a/homeassistant/components/climate/mqtt.py
+++ b/homeassistant/components/climate/mqtt.py
@@ -237,7 +237,10 @@ class MqttClimate(MqttAvailability, MqttDiscoveryUpdate, ClimateDevice):
         self._value_templates = value_templates
         self._qos = qos
         self._retain = retain
-        self._target_temperature = target_temperature
+        if self._topic[CONF_TEMPERATURE_STATE_TOPIC] is None:
+            self._target_temperature = target_temperature
+        else:
+            self._target_temperature = None
         self._unit_of_measurement = hass.config.units.temperature_unit
         self._away = away
         self._hold = hold

--- a/tests/components/climate/test_mqtt.py
+++ b/tests/components/climate/test_mqtt.py
@@ -119,14 +119,14 @@ class TestMQTTClimate(unittest.TestCase):
         assert setup_component(self.hass, climate.DOMAIN, config)
 
         state = self.hass.states.get(ENTITY_CLIMATE)
-        self.assertEqual("off", state.attributes.get('operation_mode'))
-        self.assertEqual("off", state.state)
+        self.assertEqual(None, state.attributes.get('operation_mode'))
+        self.assertEqual("unknown", state.state)
 
         common.set_operation_mode(self.hass, "cool", ENTITY_CLIMATE)
         self.hass.block_till_done()
         state = self.hass.states.get(ENTITY_CLIMATE)
-        self.assertEqual("off", state.attributes.get('operation_mode'))
-        self.assertEqual("off", state.state)
+        self.assertEqual(None, state.attributes.get('operation_mode'))
+        self.assertEqual("unknown", state.state)
 
         fire_mqtt_message(self.hass, 'mode-state', 'cool')
         self.hass.block_till_done()
@@ -189,12 +189,12 @@ class TestMQTTClimate(unittest.TestCase):
         assert setup_component(self.hass, climate.DOMAIN, config)
 
         state = self.hass.states.get(ENTITY_CLIMATE)
-        self.assertEqual("low", state.attributes.get('fan_mode'))
+        self.assertEqual(None, state.attributes.get('fan_mode'))
 
         common.set_fan_mode(self.hass, 'high', ENTITY_CLIMATE)
         self.hass.block_till_done()
         state = self.hass.states.get(ENTITY_CLIMATE)
-        self.assertEqual("low", state.attributes.get('fan_mode'))
+        self.assertEqual(None, state.attributes.get('fan_mode'))
 
         fire_mqtt_message(self.hass, 'fan-state', 'high')
         self.hass.block_till_done()
@@ -237,12 +237,12 @@ class TestMQTTClimate(unittest.TestCase):
         assert setup_component(self.hass, climate.DOMAIN, config)
 
         state = self.hass.states.get(ENTITY_CLIMATE)
-        self.assertEqual("off", state.attributes.get('swing_mode'))
+        self.assertEqual(None, state.attributes.get('swing_mode'))
 
         common.set_swing_mode(self.hass, 'on', ENTITY_CLIMATE)
         self.hass.block_till_done()
         state = self.hass.states.get(ENTITY_CLIMATE)
-        self.assertEqual("off", state.attributes.get('swing_mode'))
+        self.assertEqual(None, state.attributes.get('swing_mode'))
 
         fire_mqtt_message(self.hass, 'swing-state', 'on')
         self.hass.block_till_done()
@@ -539,21 +539,21 @@ class TestMQTTClimate(unittest.TestCase):
 
         # Operation Mode
         state = self.hass.states.get(ENTITY_CLIMATE)
-        self.assertEqual("off", state.attributes.get('operation_mode'))
+        self.assertEqual(None, state.attributes.get('operation_mode'))
         fire_mqtt_message(self.hass, 'mode-state', '"cool"')
         self.hass.block_till_done()
         state = self.hass.states.get(ENTITY_CLIMATE)
         self.assertEqual("cool", state.attributes.get('operation_mode'))
 
         # Fan Mode
-        self.assertEqual("low", state.attributes.get('fan_mode'))
+        self.assertEqual(None, state.attributes.get('fan_mode'))
         fire_mqtt_message(self.hass, 'fan-state', '"high"')
         self.hass.block_till_done()
         state = self.hass.states.get(ENTITY_CLIMATE)
         self.assertEqual('high', state.attributes.get('fan_mode'))
 
         # Swing Mode
-        self.assertEqual("off", state.attributes.get('swing_mode'))
+        self.assertEqual(None, state.attributes.get('swing_mode'))
         fire_mqtt_message(self.hass, 'swing-state', '"on"')
         self.hass.block_till_done()
         state = self.hass.states.get(ENTITY_CLIMATE)

--- a/tests/components/climate/test_mqtt.py
+++ b/tests/components/climate/test_mqtt.py
@@ -310,14 +310,14 @@ class TestMQTTClimate(unittest.TestCase):
         assert setup_component(self.hass, climate.DOMAIN, config)
 
         state = self.hass.states.get(ENTITY_CLIMATE)
-        self.assertEqual(21, state.attributes.get('temperature'))
+        self.assertEqual(None, state.attributes.get('temperature'))
         common.set_operation_mode(self.hass, 'heat', ENTITY_CLIMATE)
         self.hass.block_till_done()
         common.set_temperature(self.hass, temperature=47,
                                entity_id=ENTITY_CLIMATE)
         self.hass.block_till_done()
         state = self.hass.states.get(ENTITY_CLIMATE)
-        self.assertEqual(21, state.attributes.get('temperature'))
+        self.assertEqual(None, state.attributes.get('temperature'))
 
         fire_mqtt_message(self.hass, 'temperature-state', '1701')
         self.hass.block_till_done()
@@ -560,7 +560,7 @@ class TestMQTTClimate(unittest.TestCase):
         self.assertEqual("on", state.attributes.get('swing_mode'))
 
         # Temperature - with valid value
-        self.assertEqual(21, state.attributes.get('temperature'))
+        self.assertEqual(None, state.attributes.get('temperature'))
         fire_mqtt_message(self.hass, 'temperature-state', '"1031"')
         self.hass.block_till_done()
         state = self.hass.states.get(ENTITY_CLIMATE)


### PR DESCRIPTION
## Description:
Fix wrong value on MQTT HVAC graph after Home Assistant restart and wrong state of other variables.

**Related issue (if applicable):** fixes #17267

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
