### PR TITLE
XMPP async

### DIFF
--- a/homeassistant/components/notify/xmpp.py
+++ b/homeassistant/components/notify/xmpp.py
@@ -44,15 +44,8 @@ async def async_get_service(hass, config, discovery_info=None):
 class XmppNotificationService(BaseNotificationService):
     """Implement the notification service for Jabber (XMPP)."""
 
-    def __init__(self,
-                 sender,
-                 resource,
-                 password,
-                 recipient,
-                 tls,
-                 verify,
-                 room,
-                 loop):
+    def __init__(self, sender, resource, password,
+                 recipient, tls, verify, room, loop):
         """Initialize the service."""
         self._loop = loop
         self._sender = sender

--- a/homeassistant/components/notify/xmpp.py
+++ b/homeassistant/components/notify/xmpp.py
@@ -77,7 +77,7 @@ async def async_send_message(sender, password, recipient, use_tls,
 
         def __init__(self):
             """Initialize the Jabber Bot."""
-            super(SendNotificationBot, self).__init__(sender, password)
+            super().__init__(sender, password)
 
             # need hass.loop!!
             self.loop = loop

--- a/homeassistant/components/notify/xmpp.py
+++ b/homeassistant/components/notify/xmpp.py
@@ -14,10 +14,22 @@ from homeassistant.components.notify import (
 from homeassistant.const import (
     CONF_PASSWORD, CONF_SENDER, CONF_RECIPIENT, CONF_ROOM)
 
-REQUIREMENTS = ['sleekxmpp==1.3.2',
+REQUIREMENTS = ['aioxmpp==0.10.1',
+                'lxml==4.2.5',
+                'sortedcollections==1.0.1',
+                'tzlocal==1.5.1',
+                'pyOpenSSL==18.0.0',
+                #'pyasn1==0.4.4',
+                #'pyasn1-modules==0.2.2',
+                'aiosasl==0.3.1',
+                'multidict==4.4.2',
+                'aioopenssl==0.4.0',
+                ##
+                'sleekxmpp==1.3.2',
                 'dnspython3==1.15.0',
                 'pyasn1==0.3.7',
-                'pyasn1-modules==0.1.5']
+                'pyasn1-modules==0.1.5'
+                ]
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/notify/xmpp.py
+++ b/homeassistant/components/notify/xmpp.py
@@ -64,13 +64,14 @@ class XmppNotificationService(BaseNotificationService):
         data = '{}: {}'.format(title, message) if title else message
 
         # TODO allow /home-assistant part of the resource to be configured
-        await async_send_message('{}/home-assistant'.format(self._sender),
-                     self._password, self._recipient, self._tls,
-                     self._verify, self._room, self._loop, data)
+        await async_send_message(
+            '{}/home-assistant'.format(self._sender),
+            self._password, self._recipient, self._tls,
+            self._verify, self._room, self._loop, data)
 
 
 async def async_send_message(sender, password, recipient, use_tls,
-                 verify_certificate, room, loop, message):
+                             verify_certificate, room, loop, message):
     """Send a message over XMPP."""
     import slixmpp
 
@@ -85,7 +86,7 @@ async def async_send_message(sender, password, recipient, use_tls,
             # need hass.loop!!
             self.loop = loop
 
-            self.force_starttls = use_tls  # NOT optional will be forced TODO docs
+            self.force_starttls = use_tls
             self.use_ipv6 = False
             self.add_event_handler(
                 'failed_auth', self.disconnect_on_login_fail)

--- a/homeassistant/components/notify/xmpp.py
+++ b/homeassistant/components/notify/xmpp.py
@@ -4,35 +4,20 @@ Jabber (XMPP) notification service.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/notify.xmpp/
 """
-import asyncio
 import logging
-from datetime import timedelta
 
 import voluptuous as vol
+
 import homeassistant.helpers.config_validation as cv
-from homeassistant.core import callback
 from homeassistant.components.notify import (
     ATTR_TITLE, ATTR_TITLE_DEFAULT, PLATFORM_SCHEMA, BaseNotificationService)
 from homeassistant.const import (
     CONF_PASSWORD, CONF_SENDER, CONF_RECIPIENT, CONF_ROOM)
 
-
-REQUIREMENTS = ['aioxmpp==0.10.1',
-                'lxml==4.2.5',
-                'sortedcollections==1.0.1',
-                'tzlocal==1.5.1',
-                'pyOpenSSL==18.0.0',
-                'pyasn1==0.4.4',
-                'pyasn1-modules==0.2.2',
-                'aiosasl==0.3.1',
-                'multidict==4.4.2',
-                'aioopenssl==0.4.0',
-                ##
-                #'sleekxmpp==1.3.2',
-                #'dnspython3==1.15.0',
-                #'pyasn1==0.3.7',
-                #'pyasn1-modules==0.1.5'
-                ]
+REQUIREMENTS = ['sleekxmpp==1.3.2',
+                'dnspython3==1.15.0',
+                'pyasn1==0.3.7',
+                'pyasn1-modules==0.1.5']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -48,24 +33,20 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_ROOM, default=''): cv.string,
 })
 
-# not 'async def' but @callback because of:
-# https://developers.home-assistant.io/docs/en/asyncio_categorizing_functions.html#why-even-have-callbacks
-#@callback
-# FIXXXXXME
-async def async_get_service(hass, config, discovery_info=None):
+
+def get_service(hass, config, discovery_info=None):
     """Get the Jabber (XMPP) notification service."""
     return XmppNotificationService(
         config.get(CONF_SENDER), config.get(CONF_PASSWORD),
         config.get(CONF_RECIPIENT), config.get(CONF_TLS),
-        config.get(CONF_VERIFY), config.get(CONF_ROOM), hass.loop)
+        config.get(CONF_VERIFY), config.get(CONF_ROOM))
+
 
 class XmppNotificationService(BaseNotificationService):
     """Implement the notification service for Jabber (XMPP)."""
 
-    def __init__(
-            self, sender, password, recipient, tls, verify, room, loop):
+    def __init__(self, sender, password, recipient, tls, verify, room):
         """Initialize the service."""
-        self._loop = loop
         self._sender = sender
         self._password = password
         self._recipient = recipient
@@ -73,51 +54,61 @@ class XmppNotificationService(BaseNotificationService):
         self._verify = verify
         self._room = room
 
-    async def async_send_message(self, message="", **kwargs):
+    def send_message(self, message="", **kwargs):
         """Send a message to a user."""
         title = kwargs.get(ATTR_TITLE, ATTR_TITLE_DEFAULT)
         data = '{}: {}'.format(title, message) if title else message
-        _LOGGER.debug("before return async_send_message")
 
-        return async_send_message('{}/home-assistant'.format(self._sender),
+        send_message('{}/home-assistant'.format(self._sender),
                      self._password, self._recipient, self._tls,
-                     self._verify, self._room, self._loop, data)
+                     self._verify, self._room, data)
 
 
-async def async_send_message(sender, password, recipient, use_tls,
-                 verify_certificate, room, loop, message):
+def send_message(sender, password, recipient, use_tls,
+                 verify_certificate, room, message):
     """Send a message over XMPP."""
-    import aioxmpp
+    import sleekxmpp
 
-    class SendNotificationBot(aioxmpp.PresenceManagedClient):
+    class SendNotificationBot(sleekxmpp.ClientXMPP):
         """Service for sending Jabber (XMPP) messages."""
 
         def __init__(self):
             """Initialize the Jabber Bot."""
-            _LOGGER.debug("init of aioxmpp version {}".format(aioxmpp.__version__))
-            super(SendNotificationBot, self).__init__(
-                aioxmpp.JID.fromstr(sender),
-                aioxmpp.make_security_layer(password),
-                negotiation_timeout=timedelta(seconds=10),
-                loop=loop,
-            )
-            # FIXXXXXME MUC for room
-            self.start()
+            super(SendNotificationBot, self).__init__(sender, password)
 
-        async def start(self):
+            self.use_tls = use_tls
+            self.use_ipv6 = False
+            self.add_event_handler('failed_auth', self.check_credentials)
+            self.add_event_handler('session_start', self.start)
+            if room:
+                self.register_plugin('xep_0045')  # MUC
+            if not verify_certificate:
+                self.add_event_handler('ssl_invalid_cert',
+                                       self.discard_ssl_invalid_cert)
+
+            self.connect(use_tls=self.use_tls, use_ssl=False)
+            self.process()
+
+        def start(self, event):
             """Start the communication and sends the message."""
-            super(SendNotificationBot, self).start()
-            async with self.connected() as stream:
-                await asyncio.sleep(10)
-                msg = aioxmpp.Message(
-                    to=recipient,
-                    type_=aioxmpp.MessageType.CHAT,
-                      )
-                # None is for "default language"
-                msg.body[None] = message
+            self.send_presence()
+            self.get_roster()
 
-                await self.send(msg)
-            # FIXXXXXXXME join room
-            self.stop()
+            if room:
+                _LOGGER.debug("Joining room %s.", room)
+                self.plugin['xep_0045'].joinMUC(room, sender, wait=True)
+                self.send_message(mto=room, mbody=message, mtype='groupchat')
+            else:
+                self.send_message(mto=recipient, mbody=message, mtype='chat')
+            self.disconnect(wait=True)
+
+        def check_credentials(self, event):
+            """Disconnect from the server if credentials are invalid."""
+            self.disconnect()
+
+        @staticmethod
+        def discard_ssl_invalid_cert(event):
+            """Do nothing if ssl certificate is invalid."""
+            _LOGGER.info('Ignoring invalid ssl certificate as requested.')
 
     SendNotificationBot()

--- a/homeassistant/components/notify/xmpp.py
+++ b/homeassistant/components/notify/xmpp.py
@@ -101,7 +101,7 @@ async def async_send_message(sender, password, recipient, use_tls,
             self.get_roster()
             self.send_presence()
             if room:
-                _LOGGER.debug("Joining room %s.", room)
+                _LOGGER.debug("Joining room %s", room)
                 self.plugin['xep_0045'].join_muc(room, sender, wait=True)
                 self.send_message(mto=room, mbody=message, mtype='groupchat')
             else:
@@ -110,12 +110,12 @@ async def async_send_message(sender, password, recipient, use_tls,
 
         def disconnect_on_login_fail(self, event):
             """Disconnect from the server if credentials are invalid."""
-            _LOGGER.warning('Login failed.')
+            _LOGGER.warning('Login failed')
             self.disconnect()
 
         @staticmethod
         def discard_ssl_invalid_cert(event):
             """Do nothing if ssl certificate is invalid."""
-            _LOGGER.info('Ignoring invalid ssl certificate as requested.')
+            _LOGGER.info('Ignoring invalid ssl certificate as requested')
 
     SendNotificationBot()

--- a/homeassistant/components/notify/xmpp.py
+++ b/homeassistant/components/notify/xmpp.py
@@ -14,10 +14,7 @@ from homeassistant.components.notify import (
 from homeassistant.const import (
     CONF_PASSWORD, CONF_SENDER, CONF_RECIPIENT, CONF_ROOM)
 
-REQUIREMENTS = ['slixmpp==1.4.0',
-                'aiodns==1.1.1',
-                'pyasn1==0.3.7',
-                'pyasn1-modules==0.1.5']
+REQUIREMENTS = ['slixmpp==1.4.0']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -36,7 +33,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 async def async_get_service(hass, config, discovery_info=None):
     """Get the Jabber (XMPP) notification service."""
-    _LOGGER.debug("async_get_service")
     return XmppNotificationService(
         config.get(CONF_SENDER), config.get(CONF_PASSWORD),
         config.get(CONF_RECIPIENT), config.get(CONF_TLS),
@@ -55,15 +51,13 @@ class XmppNotificationService(BaseNotificationService):
         self._tls = tls
         self._verify = verify
         self._room = room
-        _LOGGER.debug("XmppNotificationService __init__")
 
     async def async_send_message(self, message="", **kwargs):
         """Send a message to a user."""
-        _LOGGER.debug("XmppNotificationService async_send_message 1")
         title = kwargs.get(ATTR_TITLE, ATTR_TITLE_DEFAULT)
         data = '{}: {}'.format(title, message) if title else message
 
-        # TODO allow /home-assistant part of the resource to be configured
+        # MAYBE allow /home-assistant part of the resource to be configured
         await async_send_message(
             '{}/home-assistant'.format(self._sender),
             self._password, self._recipient, self._tls,
@@ -81,7 +75,6 @@ async def async_send_message(sender, password, recipient, use_tls,
         def __init__(self):
             """Initialize the Jabber Bot."""
             super(SendNotificationBot, self).__init__(sender, password)
-            _LOGGER.debug("async_send_message SendNotificationBot __init__")
 
             # need hass.loop!!
             self.loop = loop
@@ -98,16 +91,12 @@ async def async_send_message(sender, password, recipient, use_tls,
                 self.add_event_handler('ssl_invalid_cert',
                                        self.discard_ssl_invalid_cert)
 
-            _LOGGER.debug("before connect")
             self.connect(force_starttls=self.force_starttls, use_ssl=False)
 
         def start(self, event):
             """Start the communication and sends the message."""
-            _LOGGER.debug("event handler callback called on start")
-
             self.get_roster()
             self.send_presence()
-            _LOGGER.debug("sender {}, message: {}".format(sender, message))
             if room:
                 _LOGGER.debug("Joining room %s.", room)
                 self.plugin['xep_0045'].join_muc(room, sender, wait=True)
@@ -118,8 +107,7 @@ async def async_send_message(sender, password, recipient, use_tls,
 
         def disconnect_on_login_fail(self, event):
             """Disconnect from the server if credentials are invalid."""
-            _LOGGER.debug("event handler callback called "
-                          "on disconnect on login fail")
+            _LOGGER.warning('Login failed.')
             self.disconnect()
 
         @staticmethod

--- a/homeassistant/components/notify/xmpp.py
+++ b/homeassistant/components/notify/xmpp.py
@@ -91,7 +91,7 @@ async def async_send_message(sender, password, recipient, use_tls,
             self.add_event_handler(
                 'failed_auth', self.disconnect_on_login_fail)
             self.add_event_handler('session_start', self.start)
-            # TODO test room
+
             if room:
                 self.register_plugin('xep_0045')  # MUC
             if not verify_certificate:
@@ -105,8 +105,8 @@ async def async_send_message(sender, password, recipient, use_tls,
             """Start the communication and sends the message."""
             _LOGGER.debug("event handler callback called on start")
 
-            self.send_presence()
             self.get_roster()
+            self.send_presence()
             _LOGGER.debug("sender {}, message: {}".format(sender, message))
             if room:
                 _LOGGER.debug("Joining room %s.", room)
@@ -125,8 +125,6 @@ async def async_send_message(sender, password, recipient, use_tls,
         @staticmethod
         def discard_ssl_invalid_cert(event):
             """Do nothing if ssl certificate is invalid."""
-            _LOGGER.debug("event handler callback called "
-                          "on discard_ssl_invalid_cert")
             _LOGGER.info('Ignoring invalid ssl certificate as requested.')
 
     SendNotificationBot()

--- a/homeassistant/components/notify/xmpp.py
+++ b/homeassistant/components/notify/xmpp.py
@@ -4,31 +4,34 @@ Jabber (XMPP) notification service.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/notify.xmpp/
 """
+import asyncio
 import logging
+from datetime import timedelta
 
 import voluptuous as vol
-
 import homeassistant.helpers.config_validation as cv
+from homeassistant.core import callback
 from homeassistant.components.notify import (
     ATTR_TITLE, ATTR_TITLE_DEFAULT, PLATFORM_SCHEMA, BaseNotificationService)
 from homeassistant.const import (
     CONF_PASSWORD, CONF_SENDER, CONF_RECIPIENT, CONF_ROOM)
+
 
 REQUIREMENTS = ['aioxmpp==0.10.1',
                 'lxml==4.2.5',
                 'sortedcollections==1.0.1',
                 'tzlocal==1.5.1',
                 'pyOpenSSL==18.0.0',
-                #'pyasn1==0.4.4',
-                #'pyasn1-modules==0.2.2',
+                'pyasn1==0.4.4',
+                'pyasn1-modules==0.2.2',
                 'aiosasl==0.3.1',
                 'multidict==4.4.2',
                 'aioopenssl==0.4.0',
                 ##
-                'sleekxmpp==1.3.2',
-                'dnspython3==1.15.0',
-                'pyasn1==0.3.7',
-                'pyasn1-modules==0.1.5'
+                #'sleekxmpp==1.3.2',
+                #'dnspython3==1.15.0',
+                #'pyasn1==0.3.7',
+                #'pyasn1-modules==0.1.5'
                 ]
 
 _LOGGER = logging.getLogger(__name__)
@@ -45,20 +48,24 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_ROOM, default=''): cv.string,
 })
 
-
-def get_service(hass, config, discovery_info=None):
+# not 'async def' but @callback because of:
+# https://developers.home-assistant.io/docs/en/asyncio_categorizing_functions.html#why-even-have-callbacks
+#@callback
+# FIXXXXXME
+async def async_get_service(hass, config, discovery_info=None):
     """Get the Jabber (XMPP) notification service."""
     return XmppNotificationService(
         config.get(CONF_SENDER), config.get(CONF_PASSWORD),
         config.get(CONF_RECIPIENT), config.get(CONF_TLS),
-        config.get(CONF_VERIFY), config.get(CONF_ROOM))
-
+        config.get(CONF_VERIFY), config.get(CONF_ROOM), hass.loop)
 
 class XmppNotificationService(BaseNotificationService):
     """Implement the notification service for Jabber (XMPP)."""
 
-    def __init__(self, sender, password, recipient, tls, verify, room):
+    def __init__(
+            self, sender, password, recipient, tls, verify, room, loop):
         """Initialize the service."""
+        self._loop = loop
         self._sender = sender
         self._password = password
         self._recipient = recipient
@@ -66,61 +73,51 @@ class XmppNotificationService(BaseNotificationService):
         self._verify = verify
         self._room = room
 
-    def send_message(self, message="", **kwargs):
+    async def async_send_message(self, message="", **kwargs):
         """Send a message to a user."""
         title = kwargs.get(ATTR_TITLE, ATTR_TITLE_DEFAULT)
         data = '{}: {}'.format(title, message) if title else message
+        _LOGGER.debug("before return async_send_message")
 
-        send_message('{}/home-assistant'.format(self._sender),
+        return async_send_message('{}/home-assistant'.format(self._sender),
                      self._password, self._recipient, self._tls,
-                     self._verify, self._room, data)
+                     self._verify, self._room, self._loop, data)
 
 
-def send_message(sender, password, recipient, use_tls,
-                 verify_certificate, room, message):
+async def async_send_message(sender, password, recipient, use_tls,
+                 verify_certificate, room, loop, message):
     """Send a message over XMPP."""
-    import sleekxmpp
+    import aioxmpp
 
-    class SendNotificationBot(sleekxmpp.ClientXMPP):
+    class SendNotificationBot(aioxmpp.PresenceManagedClient):
         """Service for sending Jabber (XMPP) messages."""
 
         def __init__(self):
             """Initialize the Jabber Bot."""
-            super(SendNotificationBot, self).__init__(sender, password)
+            _LOGGER.debug("init of aioxmpp version {}".format(aioxmpp.__version__))
+            super(SendNotificationBot, self).__init__(
+                aioxmpp.JID.fromstr(sender),
+                aioxmpp.make_security_layer(password),
+                negotiation_timeout=timedelta(seconds=10),
+                loop=loop,
+            )
+            # FIXXXXXME MUC for room
+            self.start()
 
-            self.use_tls = use_tls
-            self.use_ipv6 = False
-            self.add_event_handler('failed_auth', self.check_credentials)
-            self.add_event_handler('session_start', self.start)
-            if room:
-                self.register_plugin('xep_0045')  # MUC
-            if not verify_certificate:
-                self.add_event_handler('ssl_invalid_cert',
-                                       self.discard_ssl_invalid_cert)
-
-            self.connect(use_tls=self.use_tls, use_ssl=False)
-            self.process()
-
-        def start(self, event):
+        async def start(self):
             """Start the communication and sends the message."""
-            self.send_presence()
-            self.get_roster()
+            super(SendNotificationBot, self).start()
+            async with self.connected() as stream:
+                await asyncio.sleep(10)
+                msg = aioxmpp.Message(
+                    to=recipient,
+                    type_=aioxmpp.MessageType.CHAT,
+                      )
+                # None is for "default language"
+                msg.body[None] = message
 
-            if room:
-                _LOGGER.debug("Joining room %s.", room)
-                self.plugin['xep_0045'].joinMUC(room, sender, wait=True)
-                self.send_message(mto=room, mbody=message, mtype='groupchat')
-            else:
-                self.send_message(mto=recipient, mbody=message, mtype='chat')
-            self.disconnect(wait=True)
-
-        def check_credentials(self, event):
-            """Disconnect from the server if credentials are invalid."""
-            self.disconnect()
-
-        @staticmethod
-        def discard_ssl_invalid_cert(event):
-            """Do nothing if ssl certificate is invalid."""
-            _LOGGER.info('Ignoring invalid ssl certificate as requested.')
+                await self.send(msg)
+            # FIXXXXXXXME join room
+            self.stop()
 
     SendNotificationBot()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -87,6 +87,7 @@ afsapi==0.0.4
 # homeassistant.components.device_tracker.automatic
 aioautomatic==0.6.5
 
+# homeassistant.components.notify.xmpp
 # homeassistant.components.sensor.dnsip
 aiodns==1.1.1
 
@@ -298,9 +299,6 @@ distro==1.3.0
 
 # homeassistant.components.switch.digitalloggers
 dlipower==0.7.165
-
-# homeassistant.components.notify.xmpp
-dnspython3==1.15.0
 
 # homeassistant.components.sensor.dovado
 dovado==0.4.1
@@ -1349,11 +1347,11 @@ skybellpy==0.1.2
 # homeassistant.components.notify.slack
 slacker==0.9.65
 
-# homeassistant.components.notify.xmpp
-sleekxmpp==1.3.2
-
 # homeassistant.components.sleepiq
 sleepyq==0.6
+
+# homeassistant.components.notify.xmpp
+slixmpp==1.4.0
 
 # homeassistant.components.smappee
 smappy==0.2.16

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -87,7 +87,6 @@ afsapi==0.0.4
 # homeassistant.components.device_tracker.automatic
 aioautomatic==0.6.5
 
-# homeassistant.components.notify.xmpp
 # homeassistant.components.sensor.dnsip
 aiodns==1.1.1
 
@@ -791,12 +790,6 @@ pyalarmdotcom==0.3.2
 
 # homeassistant.components.arlo
 pyarlo==0.2.0
-
-# homeassistant.components.notify.xmpp
-pyasn1-modules==0.1.5
-
-# homeassistant.components.notify.xmpp
-pyasn1==0.3.7
 
 # homeassistant.components.netatmo
 pyatmo==1.2


### PR DESCRIPTION
## Description:

Move notify.XMPP from sleekxmpp to slixmpp to allow async functionality.

- adds `resource` config option: lets users define the [resource](https://wiki.xmpp.org/web/Jabber_Resources) part of the sender address. see example below.
- adds support for TLSv1.1 and TLSv1.2

**Related issue (if applicable):** fixes #17005 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#6640

## Example entry for `configuration.yaml` (if applicable):
```yaml
# Example configuration.yaml entry
notify:
  - name: NOTIFIER_NAME
    platform: xmpp
    sender: YOUR_JID
    password: YOUR_JABBER_ACCOUNT_PASSWORD
    recipient: YOUR_RECIPIENT
    room: roomXY@server.jabber.example.com  # (option)
    resource: HA-lakehouse  # (option)
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
