### PR TITLE
Add Entur departure information sensor

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -700,7 +700,6 @@ omit =
     homeassistant/components/sensor/eliqonline.py
     homeassistant/components/sensor/emoncms.py
     homeassistant/components/sensor/enphase_envoy.py
-    homeassistant/components/sensor/entur_public_transport.py
     homeassistant/components/sensor/envirophat.py
     homeassistant/components/sensor/etherscan.py
     homeassistant/components/sensor/fastdotcom.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -700,6 +700,7 @@ omit =
     homeassistant/components/sensor/eliqonline.py
     homeassistant/components/sensor/emoncms.py
     homeassistant/components/sensor/enphase_envoy.py
+    homeassistant/components/sensor/entur_public_transport.py
     homeassistant/components/sensor/envirophat.py
     homeassistant/components/sensor/etherscan.py
     homeassistant/components/sensor/fastdotcom.py

--- a/homeassistant/components/sensor/entur_public_transport.py
+++ b/homeassistant/components/sensor/entur_public_transport.py
@@ -34,18 +34,18 @@ DEFAULT_NAME = 'Entur'
 DEFAULT_ICON_KEY = 'bus'
 
 ICONS = {
-    'bus': 'mdi:bus',
     'air': 'mdi:airplane',
+    'bus': 'mdi:bus',
+    'rail': 'mdi:train',
     'water': 'mdi:ferry',
-    'rail': 'mdi:train'
 }
 
 SCAN_INTERVAL = timedelta(minutes=1)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_STOP_IDS): vol.All(cv.ensure_list, [cv.string]),
-    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_EXPAND_PLATFORMS, default=True): cv.boolean,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_SHOW_ON_MAP, default=False): cv.boolean,
 })
 
@@ -68,19 +68,16 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Entur public transport sensor."""
     from enturclient import EnturPublicTransportData
     from enturclient.consts import CONF_NAME as API_NAME
-    stop_ids = config.get(CONF_STOP_IDS)
+
     expand = config.get(CONF_EXPAND_PLATFORMS)
-    show_on_map = config.get(CONF_SHOW_ON_MAP)
     name = config.get(CONF_NAME)
+    show_on_map = config.get(CONF_SHOW_ON_MAP)
+    stop_ids = config.get(CONF_STOP_IDS)
 
     stops = [s for s in stop_ids if "StopPlace" in s]
     quays = [s for s in stop_ids if "Quay" in s]
 
-    data = EnturPublicTransportData(
-        API_CLIENT_NAME,
-        stops,
-        quays,
-        expand)
+    data = EnturPublicTransportData(API_CLIENT_NAME, stops, quays, expand)
     data.update()
 
     proxy = EnturProxy(data)
@@ -102,7 +99,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class EnturProxy:
     """Proxy for the Entur client.
 
-    Ensure throttle to not hit rate limiting on api.
+    Ensure throttle to not hit rate limiting on the API.
     """
 
     def __init__(self, api):
@@ -122,13 +119,11 @@ class EnturProxy:
 class EnturPublicTransportSensor(Entity):
     """Implementation of a Entur public transport sensor."""
 
-    def __init__(self,
-                 api: EnturProxy,
-                 name: str,
-                 stop: str,
-                 show_on_map: bool):
+    def __init__(
+            self, api: EnturProxy, name: str, stop: str, show_on_map: bool):
         """Initialize the sensor."""
         from enturclient.consts import ATTR_STOP_ID
+
         self.api = api
         self._stop = stop
         self._show_on_map = show_on_map
@@ -138,7 +133,7 @@ class EnturPublicTransportSensor(Entity):
         self._icon = ICONS[DEFAULT_ICON_KEY]
         self._attributes = {
             ATTR_ATTRIBUTION: CONF_ATTRIBUTION,
-            ATTR_STOP_ID: self._stop
+            ATTR_STOP_ID: self._stop,
         }
 
     @property
@@ -171,6 +166,7 @@ class EnturPublicTransportSensor(Entity):
         from enturclient.consts import (
             ATTR, ATTR_EXPECTED_AT, ATTR_NEXT_UP_AT, CONF_LOCATION,
             CONF_LATITUDE as LAT, CONF_LONGITUDE as LONG, CONF_TRANSPORT_MODE)
+
         self.api.update()
 
         self._data = self.api.get_stop_info(self._stop)

--- a/homeassistant/components/sensor/entur_public_transport.py
+++ b/homeassistant/components/sensor/entur_public_transport.py
@@ -1,6 +1,5 @@
 """
-Support for realtime information about public transport departures
-in Norway from Entur.
+Real-time information about public transport departures in Norway.
 
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.entur_public_transport/
@@ -92,13 +91,13 @@ ATTR_ROUTE = 'Route'
 ATTR_EXPECTED_IN = 'Due in'
 ATTR_EXPECTED_AT = 'Due at'
 ATTR_DELAY = 'Delay'
-ATTR_REALTIME = 'Realtime'
+ATTR_REALTIME = 'Real-time'
 
 ATTR_NEXT_UP_ROUTE = 'Next departure route'
 ATTR_NEXT_UP_IN = 'Next departure in'
 ATTR_NEXT_UP_AT = 'Next departure at'
 ATTR_NEXT_UP_DELAY = 'Next departure delay'
-ATTR_NEXT_UP_REALTIME = 'Next departure is realtime'
+ATTR_NEXT_UP_REALTIME = 'Next departure is real-time'
 
 CONF_ATTRIBUTION = "Data provided by entur.org under NLOD."
 CONF_STOP_IDS = 'stop_ids'
@@ -166,7 +165,6 @@ class PublicTransportData:
 
     def __init__(self, stops: list, quays: list):
         """Initialize the data object."""
-
         self.stops = stops
         self.stops_string = "\"" + "\",\"".join(stops) + "\""
         self.quays = quays
@@ -199,7 +197,6 @@ class PublicTransportData:
     @Throttle(SCAN_INTERVAL)
     def update(self) -> None:
         """Get the latest data from api.entur.org."""
-
         query = self.template.substitute(
             stops=self.stops_string,
             quays=self.quays_string,
@@ -234,6 +231,7 @@ class PublicTransportData:
                 self._process_place(quey)
 
     def _process_place(self, place_dict: dict) -> None:
+        """Extracts information from place dictionary."""
         place_id = place_dict['id']
         info = {ATTR_STOP_ID: place_id,
                 CONF_NAME: place_dict['name']}
@@ -264,7 +262,7 @@ class EnturPublicTransportSensor(Entity):
     """Implementation of a Entur public transport sensor."""
 
     def __init__(self, data: PublicTransportData, stop: str):
-        """Initialize the sensor"""
+        """Initialize the sensor."""
         self.data = data
         self._stop = stop
         self._times = {ATTR_STOP_ID: 'Unknown',

--- a/homeassistant/components/sensor/entur_public_transport.py
+++ b/homeassistant/components/sensor/entur_public_transport.py
@@ -1,5 +1,5 @@
 """
-Support for realtime information about public transport departures 
+Support for realtime information about public transport departures
 in Norway from Entur.
 
 For more details about this platform, please refer to the documentation at
@@ -26,8 +26,8 @@ _GRAPHQL_STOP_TEMPLATE = """
     id
     name
     estimatedCalls(
-        startTime: \"$time\", 
-        timeRange: 72100, 
+        startTime: \"$time\",
+        timeRange: 72100,
         numberOfDepartures: 2) {
       realtime
       aimedArrivalTime
@@ -58,8 +58,8 @@ _GRAPHQL_QUAY_TEMPLATE = """
     id
     name
     estimatedCalls(
-        startTime: \"$time\", 
-        timeRange: 72100, 
+        startTime: \"$time\",
+        timeRange: 72100,
         numberOfDepartures: 2) {
       realtime
       aimedArrivalTime
@@ -116,7 +116,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 def due_in_minutes(timestamp: str) -> str:
     """Get the time in minutes from a timestamp.
 
-    The timestamp should be in the format 
+    The timestamp should be in the format
     year-month-yearThour:minute:second+timezone
     """
     if timestamp is None:
@@ -130,7 +130,7 @@ def due_in_minutes(timestamp: str) -> str:
 def time_diff_in_minutes(timestamp1: str, timestamp2: str) -> str:
     """Get the time in minutes from a timestamp.
 
-    The timestamp should be in the format 
+    The timestamp should be in the format
     year-month-yearThour:minute:second+timezone
     """
     if timestamp1 is None:

--- a/homeassistant/components/sensor/entur_public_transport.py
+++ b/homeassistant/components/sensor/entur_public_transport.py
@@ -231,7 +231,7 @@ class PublicTransportData:
                 self._process_place(quey)
 
     def _process_place(self, place_dict: dict) -> None:
-        """Extracts information from place dictionary."""
+        """Extract travel information from place dictionary."""
         place_id = place_dict['id']
         info = {ATTR_STOP_ID: place_id,
                 CONF_NAME: place_dict['name']}

--- a/homeassistant/components/sensor/entur_public_transport.py
+++ b/homeassistant/components/sensor/entur_public_transport.py
@@ -1,5 +1,6 @@
 """
-Support for realtime information about public transport departures in Norway from Entur.
+Support for realtime information about public transport departures 
+in Norway from Entur.
 
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.entur_public_transport/
@@ -24,7 +25,10 @@ _GRAPHQL_STOP_TEMPLATE = """
   stopPlaces(ids: [$stops]) {
     id
     name
-    estimatedCalls(startTime: \"$time\", timeRange: 72100, numberOfDepartures: 2) {
+    estimatedCalls(
+        startTime: \"$time\", 
+        timeRange: 72100, 
+        numberOfDepartures: 2) {
       realtime
       aimedArrivalTime
       aimedDepartureTime
@@ -53,7 +57,10 @@ _GRAPHQL_QUAY_TEMPLATE = """
   quays(ids:[$quays]) {
     id
     name
-    estimatedCalls(startTime: \"$time\", timeRange: 72100, numberOfDepartures: 2) {
+    estimatedCalls(
+        startTime: \"$time\", 
+        timeRange: 72100, 
+        numberOfDepartures: 2) {
       realtime
       aimedArrivalTime
       aimedDepartureTime
@@ -109,7 +116,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 def due_in_minutes(timestamp: str) -> str:
     """Get the time in minutes from a timestamp.
 
-    The timestamp should be in the format year-month-yearThour:minute:second+timezone
+    The timestamp should be in the format 
+    year-month-yearThour:minute:second+timezone
     """
     if timestamp is None:
         return 'Unknown'
@@ -122,7 +130,8 @@ def due_in_minutes(timestamp: str) -> str:
 def time_diff_in_minutes(timestamp1: str, timestamp2: str) -> str:
     """Get the time in minutes from a timestamp.
 
-    The timestamp should be in the format year-month-yearThour:minute:second+timezone
+    The timestamp should be in the format 
+    year-month-yearThour:minute:second+timezone
     """
     if timestamp1 is None:
         return 'Unknown'
@@ -289,7 +298,8 @@ class EnturPublicTransportSensor(Entity):
 
                 ATTR_ROUTE: self._times[ATTR_ROUTE],
                 ATTR_DELAY: self._times[ATTR_DELAY],
-                ATTR_EXPECTED_IN: due_in_minutes(self._times[ATTR_EXPECTED_AT]),
+                ATTR_EXPECTED_IN: due_in_minutes(
+                    self._times[ATTR_EXPECTED_AT]),
                 ATTR_EXPECTED_AT: self._times[ATTR_EXPECTED_AT],
                 ATTR_REALTIME: self._times[ATTR_REALTIME],
 

--- a/homeassistant/components/sensor/entur_public_transport.py
+++ b/homeassistant/components/sensor/entur_public_transport.py
@@ -1,0 +1,322 @@
+"""
+Support for realtime information about public transport departures in Norway from Entur.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.entur_public_transport/
+"""
+from datetime import datetime, timedelta
+import logging
+from string import Template
+
+import requests
+import voluptuous as vol
+
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import ATTR_ATTRIBUTION, CONF_NAME
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import Entity
+from homeassistant.util import Throttle
+import homeassistant.util.dt as dt_util
+
+_LOGGER = logging.getLogger(__name__)
+_RESOURCE = 'https://api.entur.org/journeyplanner/2.0/index/graphql'
+_GRAPHQL_STOP_TEMPLATE = """
+  stopPlaces(ids: [$stops]) {
+    id
+    name
+    estimatedCalls(startTime: \"$time\", timeRange: 72100, numberOfDepartures: 2) {
+      realtime
+      aimedArrivalTime
+      aimedDepartureTime
+      expectedArrivalTime
+      expectedDepartureTime
+      requestStop
+      notices {
+        text
+      }
+      destinationDisplay {
+        frontText
+      }
+      serviceJourney {
+        journeyPattern {
+          line {
+            id
+            name
+            transportMode
+          }
+        }
+      }
+    }
+  }
+"""
+_GRAPHQL_QUAY_TEMPLATE = """
+  quays(ids:[$quays]) {
+    id
+    name
+    estimatedCalls(startTime: \"$time\", timeRange: 72100, numberOfDepartures: 2) {
+      realtime
+      aimedArrivalTime
+      aimedDepartureTime
+      expectedArrivalTime
+      expectedDepartureTime
+      requestStop
+      notices {
+        text
+      }
+      destinationDisplay {
+        frontText
+      }
+      serviceJourney {
+        journeyPattern {
+          line {
+            id
+            name
+            transportMode
+          }
+        }
+      }
+    }
+  }
+"""
+
+ATTR_STOP_ID = 'Stop ID'
+
+ATTR_ROUTE = 'Route'
+ATTR_EXPECTED_IN = 'Due in'
+ATTR_EXPECTED_AT = 'Due at'
+ATTR_DELAY = 'Delay'
+ATTR_REALTIME = 'Realtime'
+
+ATTR_NEXT_UP_ROUTE = 'Next departure route'
+ATTR_NEXT_UP_IN = 'Next departure in'
+ATTR_NEXT_UP_AT = 'Next departure at'
+ATTR_NEXT_UP_DELAY = 'Next departure delay'
+ATTR_NEXT_UP_REALTIME = 'Next departure is realtime'
+
+CONF_ATTRIBUTION = "Data provided by entur.org under NLOD."
+CONF_STOP_IDS = 'stop_ids'
+
+ICON = 'mdi:bus'
+
+SCAN_INTERVAL = timedelta(minutes=1)
+TIME_STR_FORMAT = '%H:%M'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_STOP_IDS): vol.All(cv.ensure_list, [cv.string]),
+})
+
+
+def due_in_minutes(timestamp: str) -> str:
+    """Get the time in minutes from a timestamp.
+
+    The timestamp should be in the format year-month-yearThour:minute:second+timezone
+    """
+    if timestamp is None:
+        return 'Unknown'
+    diff = datetime.strptime(
+        timestamp, "%Y-%m-%dT%H:%M:%S%z") - dt_util.now()
+
+    return str(int(diff.total_seconds() / 60))
+
+
+def time_diff_in_minutes(timestamp1: str, timestamp2: str) -> str:
+    """Get the time in minutes from a timestamp.
+
+    The timestamp should be in the format year-month-yearThour:minute:second+timezone
+    """
+    if timestamp1 is None:
+        return 'Unknown'
+    if timestamp2 is None:
+        return 'Unknown'
+
+    time1 = datetime.strptime(timestamp1, "%Y-%m-%dT%H:%M:%S%z")
+    time2 = datetime.strptime(timestamp2, "%Y-%m-%dT%H:%M:%S%z")
+    diff = time1 - time2
+
+    return str(int(diff.total_seconds() / 60))
+
+
+def setup_platform(hass, config, add_entities, discovery_info=None) -> None:
+    """Set up the Dublin public transport sensor."""
+    stop_ids = config.get(CONF_STOP_IDS)
+
+    stops = [s for s in stop_ids if "StopPlace" in s]
+    quays = [s for s in stop_ids if "Quay" in s]
+
+    data = PublicTransportData(stops, quays)
+    data.update()
+    entities = []
+    for item in stop_ids:
+        entities.append(EnturPublicTransportSensor(data, item))
+
+    add_entities(entities, True)
+
+
+class PublicTransportData:
+    """The Class for handling the data retrieval."""
+
+    def __init__(self, stops: list, quays: list):
+        """Initialize the data object."""
+
+        self.stops = stops
+        self.stops_string = "\"" + "\",\"".join(stops) + "\""
+        self.quays = quays
+        self.quays_string = "\"" + "\",\"".join(quays) + "\""
+
+        self.info = {}
+        for item in stops:
+            self.info[item] = {ATTR_STOP_ID: 'Unknown',
+                               CONF_NAME: item,
+                               ATTR_EXPECTED_AT: 'Unknown',
+                               ATTR_REALTIME: 'Unknown',
+                               ATTR_ROUTE: 'Unknown',
+                               ATTR_DELAY: 'Unknown'}
+        for item in quays:
+            self.info[item] = {ATTR_STOP_ID: 'Unknown',
+                               CONF_NAME: item,
+                               ATTR_EXPECTED_AT: 'Unknown',
+                               ATTR_REALTIME: 'Unknown',
+                               ATTR_ROUTE: 'Unknown',
+                               ATTR_DELAY: 'Unknown'}
+
+        self.template_string = "{\n"
+        if len(self.stops) > 0:
+            self.template_string += _GRAPHQL_STOP_TEMPLATE
+        if len(self.quays) > 0:
+            self.template_string += _GRAPHQL_QUAY_TEMPLATE
+        self.template_string += "}"
+        self.template = Template(self.template_string)
+
+    @Throttle(SCAN_INTERVAL)
+    def update(self) -> None:
+        """Get the latest data from api.entur.org."""
+
+        query = self.template.substitute(
+            stops=self.stops_string,
+            quays=self.quays_string,
+            time=datetime.utcnow().strftime("%Y-%m-%dT%XZ"))
+        headers = {'ET-Client-Name': 'home-assistant'}
+        response = requests.post(
+            _RESOURCE,
+            json={"query": query},
+            timeout=10,
+            headers=headers)
+
+        if response.status_code != 200:
+            _LOGGER.warning(
+                "Got non success http code from entur api: %s",
+                response.status_code)
+            return
+
+        result = response.json()
+
+        if 'errors' in result:
+            _LOGGER.warning(
+                "Got error from entur api: %s",
+                str(result['errors']))
+            return
+
+        if 'stopPlaces' in result['data']:
+            for stop in result['data']['stopPlaces']:
+                self._process_place(stop)
+
+        if 'quays' in result['data']:
+            for quey in result['data']['quays']:
+                self._process_place(quey)
+
+    def _process_place(self, place_dict: dict) -> None:
+        place_id = place_dict['id']
+        info = {ATTR_STOP_ID: place_id,
+                CONF_NAME: place_dict['name']}
+        if len(place_dict['estimatedCalls']) > 0:
+            call = place_dict['estimatedCalls'][0]
+            info[ATTR_EXPECTED_AT] = call['expectedDepartureTime']
+            info[ATTR_REALTIME] = call['realtime']
+            info[ATTR_ROUTE] = \
+                call['serviceJourney']['journeyPattern']['line']['name'] \
+                + " " + call['destinationDisplay']['frontText']
+            info[ATTR_DELAY] = time_diff_in_minutes(
+                call['expectedDepartureTime'],
+                call['aimedDepartureTime'])
+        if len(place_dict['estimatedCalls']) > 1:
+            call = place_dict['estimatedCalls'][1]
+            info[ATTR_NEXT_UP_AT] = call['expectedDepartureTime']
+            info[ATTR_NEXT_UP_REALTIME] = call['realtime']
+            info[ATTR_NEXT_UP_ROUTE] = \
+                call['serviceJourney']['journeyPattern']['line']['name'] \
+                + " " + call['destinationDisplay']['frontText']
+            info[ATTR_NEXT_UP_DELAY] = time_diff_in_minutes(
+                call['expectedDepartureTime'],
+                call['aimedDepartureTime'])
+        self.info[place_id] = info
+
+
+class EnturPublicTransportSensor(Entity):
+    """Implementation of a Entur public transport sensor."""
+
+    def __init__(self, data: PublicTransportData, stop: str):
+        """Initialize the sensor"""
+        self.data = data
+        self._stop = stop
+        self._times = {ATTR_STOP_ID: 'Unknown',
+                       CONF_NAME: stop,
+                       ATTR_EXPECTED_AT: 'Unknown',
+                       ATTR_REALTIME: 'Unknown',
+                       ATTR_ROUTE: 'Unknown',
+                       ATTR_DELAY: 'Unknown'}
+        self._state = 'Unknown'
+        try:
+            self._name = "Entur " + data.info[stop][CONF_NAME] + " Departures"
+        except TypeError:
+            self._name = stop
+
+    @property
+    def name(self) -> str:
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def state(self) -> str:
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def device_state_attributes(self) -> dict:
+        """Return the state attributes."""
+        if self._times is not None:
+            return {
+                ATTR_STOP_ID: self._stop,
+
+                ATTR_ROUTE: self._times[ATTR_ROUTE],
+                ATTR_DELAY: self._times[ATTR_DELAY],
+                ATTR_EXPECTED_IN: due_in_minutes(self._times[ATTR_EXPECTED_AT]),
+                ATTR_EXPECTED_AT: self._times[ATTR_EXPECTED_AT],
+                ATTR_REALTIME: self._times[ATTR_REALTIME],
+
+                ATTR_NEXT_UP_ROUTE: self._times[ATTR_NEXT_UP_ROUTE],
+                ATTR_NEXT_UP_DELAY: self._times[ATTR_NEXT_UP_DELAY],
+                ATTR_NEXT_UP_IN: due_in_minutes(self._times[ATTR_NEXT_UP_AT]),
+                ATTR_NEXT_UP_AT: self._times[ATTR_NEXT_UP_AT],
+                ATTR_NEXT_UP_REALTIME: self._times[ATTR_NEXT_UP_REALTIME],
+
+                ATTR_ATTRIBUTION: CONF_ATTRIBUTION
+            }
+
+    @property
+    def unit_of_measurement(self) -> str:
+        """Return the unit this state is expressed in."""
+        return 'min'
+
+    @property
+    def icon(self) -> str:
+        """Icon to use in the frontend."""
+        return ICON
+
+    def update(self) -> None:
+        """Get the latest data and update the states."""
+        self.data.update()
+        self._times = self.data.info[self._stop]
+        try:
+            self._state = due_in_minutes(self._times[ATTR_EXPECTED_AT])
+        except TypeError:
+            pass

--- a/homeassistant/components/sensor/entur_public_transport.py
+++ b/homeassistant/components/sensor/entur_public_transport.py
@@ -19,7 +19,7 @@ from homeassistant.util import Throttle
 import homeassistant.util.dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
-_RESOURCE = 'https://api.entur.org/journeyplanner/2.0/index/graphql'
+RESOURCE = 'https://api.entur.org/journeyplanner/2.0/index/graphql'
 _GRAPHQL_STOP_TEMPLATE = """
   stopPlaces(ids: [$stops]) {
     id
@@ -144,7 +144,7 @@ def time_diff_in_minutes(timestamp1: str, timestamp2: str) -> str:
     return str(int(diff.total_seconds() / 60))
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None) -> None:
+def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Dublin public transport sensor."""
     stop_ids = config.get(CONF_STOP_IDS)
 
@@ -203,7 +203,7 @@ class PublicTransportData:
             time=datetime.utcnow().strftime("%Y-%m-%dT%XZ"))
         headers = {'ET-Client-Name': 'home-assistant'}
         response = requests.post(
-            _RESOURCE,
+            RESOURCE,
             json={"query": query},
             timeout=10,
             headers=headers)
@@ -231,12 +231,11 @@ class PublicTransportData:
                 self._process_place(quey)
 
     def _process_place(self, place_dict: dict) -> None:
-        """Extract travel information from place dictionary."""
+        """Extract information from place dictionary."""
         place_id = place_dict['id']
         info = {ATTR_STOP_ID: place_id,
                 CONF_NAME: place_dict['name']}
-        number_of_calls = len(place_dict['estimatedCalls'])
-        if number_of_calls > 0:
+        if place_dict['estimatedCalls']:
             call = place_dict['estimatedCalls'][0]
             info[ATTR_EXPECTED_AT] = call['expectedDepartureTime']
             info[ATTR_REALTIME] = call['realtime']
@@ -246,7 +245,7 @@ class PublicTransportData:
             info[ATTR_DELAY] = time_diff_in_minutes(
                 call['expectedDepartureTime'],
                 call['aimedDepartureTime'])
-        if number_of_calls > 1:
+        if len(place_dict['estimatedCalls']) > 1:
             call = place_dict['estimatedCalls'][1]
             info[ATTR_NEXT_UP_AT] = call['expectedDepartureTime']
             info[ATTR_NEXT_UP_REALTIME] = call['realtime']

--- a/homeassistant/components/sensor/entur_public_transport.py
+++ b/homeassistant/components/sensor/entur_public_transport.py
@@ -6,109 +6,37 @@ https://home-assistant.io/components/sensor.entur_public_transport/
 """
 from datetime import datetime, timedelta
 import logging
-from string import Template
 
-import requests
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import ATTR_ATTRIBUTION, CONF_NAME
+from homeassistant.const import (
+    ATTR_ATTRIBUTION, CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 import homeassistant.util.dt as dt_util
 
+REQUIREMENTS = ['enturclient==0.1.0']
+
 _LOGGER = logging.getLogger(__name__)
-RESOURCE = 'https://api.entur.org/journeyplanner/2.0/index/graphql'
-_GRAPHQL_STOP_TEMPLATE = """
-  stopPlaces(ids: [$stops]) {
-    id
-    name
-    estimatedCalls(
-        startTime: \"$time\",
-        timeRange: 72100,
-        numberOfDepartures: 2) {
-      realtime
-      aimedArrivalTime
-      aimedDepartureTime
-      expectedArrivalTime
-      expectedDepartureTime
-      requestStop
-      notices {
-        text
-      }
-      destinationDisplay {
-        frontText
-      }
-      serviceJourney {
-        journeyPattern {
-          line {
-            id
-            name
-            transportMode
-          }
-        }
-      }
-    }
-  }
-"""
-_GRAPHQL_QUAY_TEMPLATE = """
-  quays(ids:[$quays]) {
-    id
-    name
-    estimatedCalls(
-        startTime: \"$time\",
-        timeRange: 72100,
-        numberOfDepartures: 2) {
-      realtime
-      aimedArrivalTime
-      aimedDepartureTime
-      expectedArrivalTime
-      expectedDepartureTime
-      requestStop
-      notices {
-        text
-      }
-      destinationDisplay {
-        frontText
-      }
-      serviceJourney {
-        journeyPattern {
-          line {
-            id
-            name
-            transportMode
-          }
-        }
-      }
-    }
-  }
-"""
 
-ATTR_STOP_ID = 'Stop ID'
+ATTR_EXPECTED_IN = 'due_in'
+ATTR_NEXT_UP_IN = 'next_due_in'
 
-ATTR_ROUTE = 'Route'
-ATTR_EXPECTED_IN = 'Due in'
-ATTR_EXPECTED_AT = 'Due at'
-ATTR_DELAY = 'Delay'
-ATTR_REALTIME = 'Real-time'
+UNKNOWN = 'Unknown'
 
-ATTR_NEXT_UP_ROUTE = 'Next departure route'
-ATTR_NEXT_UP_IN = 'Next departure in'
-ATTR_NEXT_UP_AT = 'Next departure at'
-ATTR_NEXT_UP_DELAY = 'Next departure delay'
-ATTR_NEXT_UP_REALTIME = 'Next departure is real-time'
+API_CLIENT_ID = 'private-development-smarthome'
 
 CONF_ATTRIBUTION = "Data provided by entur.org under NLOD."
 CONF_STOP_IDS = 'stop_ids'
-
-ICON = 'mdi:bus'
+CONF_EXPAND_PLATFORMS = 'expand_platforms'
 
 SCAN_INTERVAL = timedelta(minutes=1)
-TIME_STR_FORMAT = '%H:%M'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_STOP_IDS): vol.All(cv.ensure_list, [cv.string]),
+    vol.Optional(CONF_EXPAND_PLATFORMS, default=True): cv.boolean,
 })
 
 
@@ -119,163 +47,74 @@ def due_in_minutes(timestamp: str) -> str:
     year-month-yearThour:minute:second+timezone
     """
     if timestamp is None:
-        return 'Unknown'
+        return UNKNOWN
     diff = datetime.strptime(
         timestamp, "%Y-%m-%dT%H:%M:%S%z") - dt_util.now()
 
     return str(int(diff.total_seconds() / 60))
 
 
-def time_diff_in_minutes(timestamp1: str, timestamp2: str) -> str:
-    """Get the time in minutes from a timestamp.
-
-    The timestamp should be in the format
-    year-month-yearThour:minute:second+timezone
-    """
-    if timestamp1 is None:
-        return 'Unknown'
-    if timestamp2 is None:
-        return 'Unknown'
-
-    time1 = datetime.strptime(timestamp1, "%Y-%m-%dT%H:%M:%S%z")
-    time2 = datetime.strptime(timestamp2, "%Y-%m-%dT%H:%M:%S%z")
-    diff = time1 - time2
-
-    return str(int(diff.total_seconds() / 60))
-
-
 def setup_platform(hass, config, add_entities, discovery_info=None):
-    """Set up the Dublin public transport sensor."""
+    """Set up the Entur public transport sensor."""
+    from enturclient import EnturPublicTransportData
     stop_ids = config.get(CONF_STOP_IDS)
+    expand = config.get(CONF_EXPAND_PLATFORMS)
 
     stops = [s for s in stop_ids if "StopPlace" in s]
     quays = [s for s in stop_ids if "Quay" in s]
 
-    data = PublicTransportData(stops, quays)
+    data = EnturPublicTransportData(
+        API_CLIENT_ID,
+        stops,
+        quays,
+        expand)
+
     data.update()
     entities = []
-    for item in stop_ids:
-        entities.append(EnturPublicTransportSensor(data, item))
+    for item in data.all_stop_places_quays():
+        entities.append(EnturPublicTransportSensor(EnturProxy(data), item))
 
     add_entities(entities, True)
 
 
-class PublicTransportData:
-    """The Class for handling the data retrieval."""
+class EnturProxy:
+    """Proxy for the Entur client.
 
-    def __init__(self, stops: list, quays: list):
-        """Initialize the data object."""
-        self.stops = stops
-        self.stops_string = "\"" + "\",\"".join(stops) + "\""
-        self.quays = quays
-        self.quays_string = "\"" + "\",\"".join(quays) + "\""
+    Ensure throttle to not hit rate limiting on api.
+    """
 
-        self.info = {}
-        for item in stops:
-            self.info[item] = {ATTR_STOP_ID: 'Unknown',
-                               CONF_NAME: item,
-                               ATTR_EXPECTED_AT: 'Unknown',
-                               ATTR_REALTIME: 'Unknown',
-                               ATTR_ROUTE: 'Unknown',
-                               ATTR_DELAY: 'Unknown'}
-        for item in quays:
-            self.info[item] = {ATTR_STOP_ID: 'Unknown',
-                               CONF_NAME: item,
-                               ATTR_EXPECTED_AT: 'Unknown',
-                               ATTR_REALTIME: 'Unknown',
-                               ATTR_ROUTE: 'Unknown',
-                               ATTR_DELAY: 'Unknown'}
-
-        self.template_string = "{\n"
-        if self.stops:
-            self.template_string += _GRAPHQL_STOP_TEMPLATE
-        if self.quays:
-            self.template_string += _GRAPHQL_QUAY_TEMPLATE
-        self.template_string += "}"
-        self.template = Template(self.template_string)
+    def __init__(self, data):
+        """Initialize the proxy."""
+        self._data = data
 
     @Throttle(SCAN_INTERVAL)
     def update(self) -> None:
-        """Get the latest data from api.entur.org."""
-        query = self.template.substitute(
-            stops=self.stops_string,
-            quays=self.quays_string,
-            time=datetime.utcnow().strftime("%Y-%m-%dT%XZ"))
-        headers = {'ET-Client-Name': 'home-assistant'}
-        response = requests.post(
-            RESOURCE,
-            json={"query": query},
-            timeout=10,
-            headers=headers)
+        """Update data in client."""
+        self._data.update()
 
-        if response.status_code != 200:
-            _LOGGER.warning(
-                "Got non success http code from entur api: %s",
-                response.status_code)
-            return
-
-        result = response.json()
-
-        if 'errors' in result:
-            _LOGGER.warning(
-                "Got error from entur api: %s",
-                str(result['errors']))
-            return
-
-        if 'stopPlaces' in result['data']:
-            for stop in result['data']['stopPlaces']:
-                self._process_place(stop)
-
-        if 'quays' in result['data']:
-            for quey in result['data']['quays']:
-                self._process_place(quey)
-
-    def _process_place(self, place_dict: dict) -> None:
-        """Extract information from place dictionary."""
-        place_id = place_dict['id']
-        info = {ATTR_STOP_ID: place_id,
-                CONF_NAME: place_dict['name']}
-        if place_dict['estimatedCalls']:
-            call = place_dict['estimatedCalls'][0]
-            info[ATTR_EXPECTED_AT] = call['expectedDepartureTime']
-            info[ATTR_REALTIME] = call['realtime']
-            info[ATTR_ROUTE] = \
-                call['serviceJourney']['journeyPattern']['line']['name'] \
-                + " " + call['destinationDisplay']['frontText']
-            info[ATTR_DELAY] = time_diff_in_minutes(
-                call['expectedDepartureTime'],
-                call['aimedDepartureTime'])
-        if len(place_dict['estimatedCalls']) > 1:
-            call = place_dict['estimatedCalls'][1]
-            info[ATTR_NEXT_UP_AT] = call['expectedDepartureTime']
-            info[ATTR_NEXT_UP_REALTIME] = call['realtime']
-            info[ATTR_NEXT_UP_ROUTE] = \
-                call['serviceJourney']['journeyPattern']['line']['name'] \
-                + " " + call['destinationDisplay']['frontText']
-            info[ATTR_NEXT_UP_DELAY] = time_diff_in_minutes(
-                call['expectedDepartureTime'],
-                call['aimedDepartureTime'])
-        self.info[place_id] = info
+    def get_stop_info(self, stop_id: str) -> dict:
+        """Get info about specific stop place."""
+        return self._data.get_stop_info(stop_id)
 
 
 class EnturPublicTransportSensor(Entity):
     """Implementation of a Entur public transport sensor."""
 
-    def __init__(self, data: PublicTransportData, stop: str):
+    def __init__(self, data: EnturProxy, stop: str):
         """Initialize the sensor."""
+        from enturclient.consts import (
+            ATTR_STOP_ID, ATTR_EXPECTED_AT, ATTR_NEXT_UP_AT)
         self.data = data
         self._stop = stop
-        self._times = {ATTR_STOP_ID: 'Unknown',
+        self._times = {ATTR_STOP_ID: UNKNOWN,
                        CONF_NAME: stop,
-                       ATTR_EXPECTED_AT: 'Unknown',
-                       ATTR_REALTIME: 'Unknown',
-                       ATTR_ROUTE: 'Unknown',
-                       ATTR_DELAY: 'Unknown'}
-        self._state = 'Unknown'
+                       ATTR_EXPECTED_AT: UNKNOWN,
+                       ATTR_NEXT_UP_AT: UNKNOWN}
+        self._state = UNKNOWN
         try:
-            self._name = "Entur " + data.info[stop][CONF_NAME] + " Departures"
+            self._name = "Entur " + data.get_stop_info(stop)[CONF_NAME]
         except TypeError:
-            self._name = stop
+            self._name = "Entur " + stop
 
     @property
     def name(self) -> str:
@@ -285,30 +124,31 @@ class EnturPublicTransportSensor(Entity):
     @property
     def state(self) -> str:
         """Return the state of the sensor."""
-        return self._state
+        from enturclient.consts import ATTR, ATTR_EXPECTED_AT
+        try:
+            return due_in_minutes(
+                self._times[ATTR][ATTR_EXPECTED_AT])
+        except TypeError:
+            return UNKNOWN
 
     @property
     def device_state_attributes(self) -> dict:
         """Return the state attributes."""
+        from enturclient.consts import (
+            CONF_LOCATION, ATTR, ATTR_NEXT_UP_AT,
+            ATTR_STOP_ID, ATTR_EXPECTED_AT)
         if self._times is not None:
-            return {
-                ATTR_STOP_ID: self._stop,
-
-                ATTR_ROUTE: self._times[ATTR_ROUTE],
-                ATTR_DELAY: self._times[ATTR_DELAY],
-                ATTR_EXPECTED_IN: due_in_minutes(
-                    self._times[ATTR_EXPECTED_AT]),
-                ATTR_EXPECTED_AT: self._times[ATTR_EXPECTED_AT],
-                ATTR_REALTIME: self._times[ATTR_REALTIME],
-
-                ATTR_NEXT_UP_ROUTE: self._times[ATTR_NEXT_UP_ROUTE],
-                ATTR_NEXT_UP_DELAY: self._times[ATTR_NEXT_UP_DELAY],
-                ATTR_NEXT_UP_IN: due_in_minutes(self._times[ATTR_NEXT_UP_AT]),
-                ATTR_NEXT_UP_AT: self._times[ATTR_NEXT_UP_AT],
-                ATTR_NEXT_UP_REALTIME: self._times[ATTR_NEXT_UP_REALTIME],
-
-                ATTR_ATTRIBUTION: CONF_ATTRIBUTION
-            }
+            attr = self._times[ATTR]
+            attr[ATTR_NEXT_UP_IN] = due_in_minutes(attr[ATTR_NEXT_UP_AT])
+            attr[ATTR_EXPECTED_IN] = due_in_minutes(attr[ATTR_EXPECTED_AT])
+            attr[ATTR_STOP_ID] = self._times[ATTR_STOP_ID]
+            attr[ATTR_ATTRIBUTION] = CONF_ATTRIBUTION
+            if CONF_LOCATION in self._times:
+                attr[CONF_LATITUDE] = \
+                    self._times[CONF_LOCATION][CONF_LATITUDE]
+                attr[CONF_LONGITUDE] = \
+                    self._times[CONF_LOCATION][CONF_LONGITUDE]
+            return attr
 
     @property
     def unit_of_measurement(self) -> str:
@@ -318,13 +158,19 @@ class EnturPublicTransportSensor(Entity):
     @property
     def icon(self) -> str:
         """Icon to use in the frontend."""
-        return ICON
+        from enturclient.consts import CONF_TRANSPORT_MODE
+        if self._times[CONF_TRANSPORT_MODE] == 'bus':
+            return 'mdi:bus'
+        if self._times[CONF_TRANSPORT_MODE] == 'rail':
+            return 'mdi:train'
+        if self._times[CONF_TRANSPORT_MODE] == 'water':
+            return 'mdi:ferry'
+        if self._times[CONF_TRANSPORT_MODE] == 'air':
+            return 'mdi:airplane'
+
+        return 'mdi:bus'
 
     def update(self) -> None:
         """Get the latest data and update the states."""
         self.data.update()
-        self._times = self.data.info[self._stop]
-        try:
-            self._state = due_in_minutes(self._times[ATTR_EXPECTED_AT])
-        except TypeError:
-            pass
+        self._times = self.data.get_stop_info(self._stop)

--- a/homeassistant/components/sensor/entur_public_transport.py
+++ b/homeassistant/components/sensor/entur_public_transport.py
@@ -187,9 +187,9 @@ class PublicTransportData:
                                ATTR_DELAY: 'Unknown'}
 
         self.template_string = "{\n"
-        if len(self.stops) > 0:
+        if self.stops:
             self.template_string += _GRAPHQL_STOP_TEMPLATE
-        if len(self.quays) > 0:
+        if self.quays:
             self.template_string += _GRAPHQL_QUAY_TEMPLATE
         self.template_string += "}"
         self.template = Template(self.template_string)
@@ -235,7 +235,8 @@ class PublicTransportData:
         place_id = place_dict['id']
         info = {ATTR_STOP_ID: place_id,
                 CONF_NAME: place_dict['name']}
-        if len(place_dict['estimatedCalls']) > 0:
+        number_of_calls = len(place_dict['estimatedCalls'])
+        if number_of_calls > 0:
             call = place_dict['estimatedCalls'][0]
             info[ATTR_EXPECTED_AT] = call['expectedDepartureTime']
             info[ATTR_REALTIME] = call['realtime']
@@ -245,7 +246,7 @@ class PublicTransportData:
             info[ATTR_DELAY] = time_diff_in_minutes(
                 call['expectedDepartureTime'],
                 call['aimedDepartureTime'])
-        if len(place_dict['estimatedCalls']) > 1:
+        if number_of_calls > 1:
             call = place_dict['estimatedCalls'][1]
             info[ATTR_NEXT_UP_AT] = call['expectedDepartureTime']
             info[ATTR_NEXT_UP_REALTIME] = call['realtime']

--- a/homeassistant/components/sensor/entur_public_transport.py
+++ b/homeassistant/components/sensor/entur_public_transport.py
@@ -31,6 +31,14 @@ CONF_STOP_IDS = 'stop_ids'
 CONF_EXPAND_PLATFORMS = 'expand_platforms'
 
 DEFAULT_NAME = 'Entur'
+DEFAULT_ICON_KEY = 'bus'
+
+ICONS = {
+    'bus': 'mdi:bus',
+    'air': 'mdi:airplane',
+    'water': 'mdi:ferry',
+    'rail': 'mdi:train'
+}
 
 SCAN_INTERVAL = timedelta(minutes=1)
 
@@ -114,15 +122,6 @@ class EnturProxy:
 class EnturPublicTransportSensor(Entity):
     """Implementation of a Entur public transport sensor."""
 
-    ICONS = {
-        'bus': 'mdi:bus',
-        'air': 'mdi:airplane',
-        'water': 'mdi:ferry',
-        'rail': 'mdi:train'
-    }
-
-    DEFAULT_ICON_KEY = 'bus'
-
     def __init__(self,
                  api: EnturProxy,
                  name: str,
@@ -136,7 +135,7 @@ class EnturPublicTransportSensor(Entity):
         self._name = name
         self._data = None
         self._state = None
-        self._icon = self.ICONS[self.DEFAULT_ICON_KEY]
+        self._icon = ICONS[DEFAULT_ICON_KEY]
         self._attributes = {
             ATTR_ATTRIBUTION: CONF_ATTRIBUTION,
             ATTR_STOP_ID: self._stop
@@ -194,6 +193,5 @@ class EnturPublicTransportSensor(Entity):
             else:
                 self._state = None
 
-            self._icon = self.ICONS.get(
-                self._data[CONF_TRANSPORT_MODE],
-                self.ICONS[self.DEFAULT_ICON_KEY])
+            self._icon = ICONS.get(
+                self._data[CONF_TRANSPORT_MODE], ICONS[DEFAULT_ICON_KEY])

--- a/homeassistant/components/sensor/entur_public_transport.py
+++ b/homeassistant/components/sensor/entur_public_transport.py
@@ -26,7 +26,7 @@ ATTR_NEXT_UP_IN = 'next_due_in'
 
 UNKNOWN = 'Unknown'
 
-API_CLIENT_ID = 'private-development-smarthome'
+API_CLIENT_ID = 'home-assistant'
 
 CONF_ATTRIBUTION = "Data provided by entur.org under NLOD."
 CONF_STOP_IDS = 'stop_ids'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -338,6 +338,9 @@ elkm1-lib==0.7.12
 # homeassistant.components.enocean
 enocean==0.40
 
+# homeassistant.components.sensor.entur_public_transport
+enturclient==0.1.0
+
 # homeassistant.components.sensor.envirophat
 # envirophat==0.0.6
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -58,6 +58,9 @@ defusedxml==0.5.0
 # homeassistant.components.sensor.dsmr
 dsmr_parser==0.12
 
+# homeassistant.components.sensor.entur_public_transport
+enturclient==0.1.0
+
 # homeassistant.components.sensor.season
 ephem==3.7.6.0
 

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -46,6 +46,7 @@ TEST_REQUIREMENTS = (
     'coinmarketcap',
     'defusedxml',
     'dsmr_parser',
+    'enturclient',
     'ephem',
     'evohomeclient',
     'feedparser',

--- a/tests/components/sensor/test_entur_public_transport.py
+++ b/tests/components/sensor/test_entur_public_transport.py
@@ -3,10 +3,12 @@ from datetime import datetime
 import unittest
 from unittest.mock import patch
 
+from enturclient.api import RESOURCE
+from enturclient.consts import ATTR_EXPECTED_AT, ATTR_ROUTE, ATTR_STOP_ID
 import requests_mock
 
 from homeassistant.components.sensor.entur_public_transport import (
-    ATTR_EXPECTED_AT, ATTR_ROUTE, ATTR_STOP_ID, CONF_STOP_IDS, RESOURCE)
+    CONF_EXPAND_PLATFORMS, CONF_STOP_IDS)
 from homeassistant.setup import setup_component
 import homeassistant.util.dt as dt_util
 
@@ -14,6 +16,7 @@ from tests.common import get_test_home_assistant, load_fixture
 
 VALID_CONFIG = {
     'platform': 'entur_public_transport',
+    CONF_EXPAND_PLATFORMS: False,
     CONF_STOP_IDS: [
         'NSR:StopPlace:548',
         'NSR:Quay:48550',
@@ -48,17 +51,17 @@ class TestEnturPublicTransportSensor(unittest.TestCase):
         self.assertTrue(
             setup_component(self.hass, 'sensor', {'sensor': self.config}))
 
-        state = self.hass.states.get('sensor.entur_bergen_stasjon_departures')
+        state = self.hass.states.get('sensor.entur_bergen_stasjon')
         assert state.state == '28'
         assert state.attributes.get(ATTR_STOP_ID) == 'NSR:StopPlace:548'
-        assert state.attributes.get(ATTR_ROUTE) == "Vossabanen Bergen"
+        assert state.attributes.get(ATTR_ROUTE) == "59 Bergen"
         assert state.attributes.get(ATTR_EXPECTED_AT) \
             == '2018-10-10T09:28:00+0200'
 
-        state = self.hass.states.get('sensor.entur_fiskepiren_departures')
+        state = self.hass.states.get('sensor.entur_fiskepiren_platform_2')
         assert state.state == '0'
         assert state.attributes.get(ATTR_STOP_ID) == 'NSR:Quay:48550'
         assert state.attributes.get(ATTR_ROUTE) \
-            == "Flybussen Stavanger Airport via Forum"
+            == "5 Stavanger Airport via Forum"
         assert state.attributes.get(ATTR_EXPECTED_AT) \
             == '2018-10-10T09:00:00+0200'

--- a/tests/components/sensor/test_entur_public_transport.py
+++ b/tests/components/sensor/test_entur_public_transport.py
@@ -1,4 +1,4 @@
-"""The tests for the tube_state platform."""
+"""The tests for the entur platform."""
 from datetime import datetime
 import unittest
 from unittest.mock import patch
@@ -28,7 +28,7 @@ TEST_TIMESTAMP = datetime(2018, 10, 10, 7, tzinfo=dt_util.UTC)
 
 
 class TestEnturPublicTransportSensor(unittest.TestCase):
-    """Test the tube_state platform."""
+    """Test the entur platform."""
 
     def setUp(self):
         """Initialize values for this testcase class."""

--- a/tests/components/sensor/test_entur_public_transport.py
+++ b/tests/components/sensor/test_entur_public_transport.py
@@ -33,7 +33,6 @@ class TestEnturPublicTransportSensor(unittest.TestCase):
     def setUp(self):
         """Initialize values for this testcase class."""
         self.hass = get_test_home_assistant()
-        self.config = VALID_CONFIG
 
     def tearDown(self):
         """Stop everything that was started."""
@@ -49,7 +48,7 @@ class TestEnturPublicTransportSensor(unittest.TestCase):
                       text=load_fixture(FIXTURE_FILE),
                       status_code=200)
         self.assertTrue(
-            setup_component(self.hass, 'sensor', {'sensor': self.config}))
+            setup_component(self.hass, 'sensor', {'sensor': VALID_CONFIG}))
 
         state = self.hass.states.get('sensor.entur_bergen_stasjon')
         assert state.state == '28'

--- a/tests/components/sensor/test_entur_public_transport.py
+++ b/tests/components/sensor/test_entur_public_transport.py
@@ -1,0 +1,64 @@
+"""The tests for the tube_state platform."""
+from datetime import datetime
+import unittest
+from unittest.mock import patch
+
+import requests_mock
+
+from homeassistant.components.sensor.entur_public_transport import (
+    ATTR_EXPECTED_AT, ATTR_ROUTE, ATTR_STOP_ID, CONF_STOP_IDS, RESOURCE)
+from homeassistant.setup import setup_component
+import homeassistant.util.dt as dt_util
+
+from tests.common import get_test_home_assistant, load_fixture
+
+VALID_CONFIG = {
+    'platform': 'entur_public_transport',
+    CONF_STOP_IDS: [
+        'NSR:StopPlace:548',
+        'NSR:Quay:48550',
+    ]
+}
+
+FIXTURE_FILE = 'entur_public_transport.json'
+TEST_TIMESTAMP = datetime(2018, 10, 10, 7, tzinfo=dt_util.UTC)
+
+
+class TestEnturPublicTransportSensor(unittest.TestCase):
+    """Test the tube_state platform."""
+
+    def setUp(self):
+        """Initialize values for this testcase class."""
+        self.hass = get_test_home_assistant()
+        self.config = VALID_CONFIG
+
+    def tearDown(self):
+        """Stop everything that was started."""
+        self.hass.stop()
+
+    @requests_mock.Mocker()
+    @patch(
+        'homeassistant.components.sensor.entur_public_transport.dt_util.now',
+        return_value=TEST_TIMESTAMP)
+    def test_setup(self, mock_req, mock_patch):
+        """Test for correct sensor setup with state and proper attributes."""
+        mock_req.post(RESOURCE,
+                      text=load_fixture(FIXTURE_FILE),
+                      status_code=200)
+        self.assertTrue(
+            setup_component(self.hass, 'sensor', {'sensor': self.config}))
+
+        state = self.hass.states.get('sensor.entur_bergen_stasjon_departures')
+        assert state.state == '28'
+        assert state.attributes.get(ATTR_STOP_ID) == 'NSR:StopPlace:548'
+        assert state.attributes.get(ATTR_ROUTE) == "Vossabanen Bergen"
+        assert state.attributes.get(ATTR_EXPECTED_AT) \
+            == '2018-10-10T09:28:00+0200'
+
+        state = self.hass.states.get('sensor.entur_fiskepiren_departures')
+        assert state.state == '0'
+        assert state.attributes.get(ATTR_STOP_ID) == 'NSR:Quay:48550'
+        assert state.attributes.get(ATTR_ROUTE) \
+            == "Flybussen Stavanger Airport via Forum"
+        assert state.attributes.get(ATTR_EXPECTED_AT) \
+            == '2018-10-10T09:00:00+0200'

--- a/tests/fixtures/entur_public_transport.json
+++ b/tests/fixtures/entur_public_transport.json
@@ -21,7 +21,8 @@
                 "line": {
                   "id": "NSB:Line:45",
                   "name": "Vossabanen",
-                  "transportMode": "rail"
+                  "transportMode": "rail",
+                  "publicCode": "59"
                 }
               }
             }
@@ -42,7 +43,8 @@
                 "line": {
                   "id": "NSB:Line:45",
                   "name": "Vossabanen",
-                  "transportMode": "rail"
+                  "transportMode": "rail",
+                  "publicCode": "58"
                 }
               }
             }
@@ -54,6 +56,9 @@
       {
         "id": "NSR:Quay:48550",
         "name": "Fiskepiren",
+        "publicCode": "2",
+        "latitude": 59.960904,
+        "longitude": 10.882942,
         "estimatedCalls": [
           {
             "realtime": false,
@@ -71,7 +76,8 @@
                 "line": {
                   "id": "KOL:Line:2900_234",
                   "name": "Flybussen",
-                  "transportMode": "bus"
+                  "transportMode": "bus",
+                  "publicCode": "5"
                 }
               }
             }
@@ -92,7 +98,8 @@
                 "line": {
                   "id": "KOL:Line:1000_234",
                   "name": "1",
-                  "transportMode": "bus"
+                  "transportMode": "bus",
+                  "publicCode": "1"
                 }
               }
             }

--- a/tests/fixtures/entur_public_transport.json
+++ b/tests/fixtures/entur_public_transport.json
@@ -1,0 +1,104 @@
+{
+  "data": {
+    "stopPlaces": [
+      {
+        "id": "NSR:StopPlace:548",
+        "name": "Bergen stasjon",
+        "estimatedCalls": [
+          {
+            "realtime": false,
+            "aimedArrivalTime": "2018-10-10T09:28:00+0200",
+            "aimedDepartureTime": "2018-10-10T09:28:00+0200",
+            "expectedArrivalTime": "2018-10-10T09:28:00+0200",
+            "expectedDepartureTime": "2018-10-10T09:28:00+0200",
+            "requestStop": false,
+            "notices": [],
+            "destinationDisplay": {
+              "frontText": "Bergen"
+            },
+            "serviceJourney": {
+              "journeyPattern": {
+                "line": {
+                  "id": "NSB:Line:45",
+                  "name": "Vossabanen",
+                  "transportMode": "rail"
+                }
+              }
+            }
+          },
+          {
+            "realtime": false,
+            "aimedArrivalTime": "2018-10-10T09:35:00+0200",
+            "aimedDepartureTime": "2018-10-10T09:35:00+0200",
+            "expectedArrivalTime": "2018-10-10T09:35:00+0200",
+            "expectedDepartureTime": "2018-10-10T09:35:00+0200",
+            "requestStop": false,
+            "notices": [],
+            "destinationDisplay": {
+              "frontText": "Arna"
+            },
+            "serviceJourney": {
+              "journeyPattern": {
+                "line": {
+                  "id": "NSB:Line:45",
+                  "name": "Vossabanen",
+                  "transportMode": "rail"
+                }
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "quays": [
+      {
+        "id": "NSR:Quay:48550",
+        "name": "Fiskepiren",
+        "estimatedCalls": [
+          {
+            "realtime": false,
+            "aimedArrivalTime": "2018-10-10T09:00:00+0200",
+            "aimedDepartureTime": "2018-10-10T09:00:00+0200",
+            "expectedArrivalTime": "2018-10-10T09:00:00+0200",
+            "expectedDepartureTime": "2018-10-10T09:00:00+0200",
+            "requestStop": false,
+            "notices": [],
+            "destinationDisplay": {
+              "frontText": "Stavanger Airport via Forum"
+            },
+            "serviceJourney": {
+              "journeyPattern": {
+                "line": {
+                  "id": "KOL:Line:2900_234",
+                  "name": "Flybussen",
+                  "transportMode": "bus"
+                }
+              }
+            }
+          },
+          {
+            "realtime": false,
+            "aimedArrivalTime": "2018-10-10T09:06:00+0200",
+            "aimedDepartureTime": "2018-10-10T09:06:00+0200",
+            "expectedArrivalTime": "2018-10-10T09:06:00+0200",
+            "expectedDepartureTime": "2018-10-10T09:06:00+0200",
+            "requestStop": false,
+            "notices": [],
+            "destinationDisplay": {
+              "frontText": "Stavanger"
+            },
+            "serviceJourney": {
+              "journeyPattern": {
+                "line": {
+                  "id": "KOL:Line:1000_234",
+                  "name": "1",
+                  "transportMode": "bus"
+                }
+              }
+            }
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Description:

Adding support for realtime departure information about public transport in Norway. Fetches timing information from the open api of entur once a minute to show how long before next bus, ferry, train or similar is leaving the station. 

Long time user of home assistant here, and in the spirit of hacktoberfest i wanted to give a bit back to this awesome project! So first time contributing here and first time writing something proper in python, so be gentle with me. If something is not 100% correctly done or similar, its probably because I don't know better, and any tips are welcome! 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation:** home-assistant/home-assistant.io#6643

## Example entry for `configuration.yaml`:
```yaml
# Example configuration.yaml entry
sensor:
  - platform: entur_public_transport
    stop_ids:
      - 'NSR:StopPlace:548'   # Bergen train station
      - 'NSR:StopPlace:737'   # Trondheim airport
      - 'NSR:StopPlace:5850'  # Grorud T bus stop
      - 'NSR:StopPlace:58652' # Mortavika ferry 
      - 'NSR:StopPlace:27639' # Sør-Hidle quay 
      - 'NSR:Quay:48550'      # Fiskepiren bus stop platform 1
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
