### PR TITLE
Added resolve_state to template distance function

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -367,18 +367,9 @@ class TemplateMethods:
 
         while to_process:
             value = to_process.pop(0)
+            point_state = self._resolve_state(value)
 
-            if isinstance(value, State):
-                latitude = value.attributes.get(ATTR_LATITUDE)
-                longitude = value.attributes.get(ATTR_LONGITUDE)
-
-                if latitude is None or longitude is None:
-                    _LOGGER.warning(
-                        "Distance:State does not contains a location: %s",
-                        value)
-                    return None
-
-            else:
+            if point_state is None:
                 # We expect this and next value to be lat&lng
                 if not to_process:
                     _LOGGER.warning(
@@ -393,6 +384,22 @@ class TemplateMethods:
                 if latitude is None or longitude is None:
                     _LOGGER.warning("Distance:Unable to process latitude and "
                                     "longitude: %s, %s", value, value_2)
+                    return None
+
+            else:
+                if not loc_helper.has_location(point_state):
+                    _LOGGER.warning(
+                        "distance:State does not contain valid location: %s",
+                        point_state)
+                    return None
+
+                latitude = point_state.attributes.get(ATTR_LATITUDE)
+                longitude = point_state.attributes.get(ATTR_LONGITUDE)
+
+                if latitude is None or longitude is None:
+                    _LOGGER.warning(
+                        "Distance:State does not contains a location: %s",
+                        value)
                     return None
 
             locations.append((latitude, longitude))

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -682,6 +682,32 @@ class TestHelpersTemplate(unittest.TestCase):
             'None',
             tpl.render())
 
+    def test_distance_function_with_2_entity_ids(self):
+        """Test distance function with 2 entity ids."""
+        self.hass.states.set('test.object', 'happy', {
+            'latitude': 32.87336,
+            'longitude': -117.22943,
+        })
+        self.hass.states.set('test.object_2', 'happy', {
+            'latitude': self.hass.config.latitude,
+            'longitude': self.hass.config.longitude,
+        })
+        tpl = template.Template(
+            '{{ distance("test.object", "test.object_2") | round }}',
+            self.hass)
+        self.assertEqual('187', tpl.render())
+
+    def test_distance_function_with_1_entity_1_coord(self):
+        """Test distance function with 1 entity_id and 1 coord."""
+        self.hass.states.set('test.object', 'happy', {
+            'latitude': self.hass.config.latitude,
+            'longitude': self.hass.config.longitude,
+        })
+        tpl = template.Template(
+            '{{ distance("test.object", "32.87336", "-117.22943") | round }}',
+            self.hass)
+        self.assertEqual('187', tpl.render())
+
     def test_closest_function_home_vs_domain(self):
         """Test closest function home vs domain."""
         self.hass.states.set('test_domain.object', 'happy', {


### PR DESCRIPTION
## Description:
_resolve_state was already used in the "closest" function, to allow for states and entity ids.
Added tests for the "new" functionality.

**Related issue (if applicable):** fixes #17178

## Example template:
```
{{ distance('device_tracker.anne_therese', 'device_tracker.paulus') }}
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
