### PR TITLE
Fixed 'on_startup() takes 0 positional arguments but 1 was given'

### DIFF
--- a/homeassistant/components/sensor/miflora.py
+++ b/homeassistant/components/sensor/miflora.py
@@ -106,7 +106,7 @@ class MiFloraSensor(Entity):
     async def async_added_to_hass(self):
         """Set initial state."""
         @callback
-        def on_startup():
+        def on_startup(_):
             self.async_schedule_update_ha_state(True)
 
         self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, on_startup)


### PR DESCRIPTION
## Description:
Small fix related to unexisting argument error.

**Related issue (if applicable):** fixes #17217
