### PR TITLE
History csv

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -73,6 +73,8 @@ omit =
     homeassistant/components/comfoconnect.py
     homeassistant/components/*/comfoconnect.py
 
+    homeassistant/components/csv.py
+
     homeassistant/components/daikin.py
     homeassistant/components/*/daikin.py
 

--- a/homeassistant/components/csv.py
+++ b/homeassistant/components/csv.py
@@ -1,0 +1,195 @@
+"""
+Exports events as CSV file.
+
+Component that records all events as lines in a CSV file.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/csv/
+"""
+import concurrent.futures
+import logging
+import queue
+import threading
+import os
+from typing import Dict
+
+import asyncio
+import voluptuous as vol
+
+from homeassistant.const import (
+    ATTR_ENTITY_ID, CONF_DOMAINS, CONF_ENTITIES, CONF_EXCLUDE, CONF_INCLUDE,
+    EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP,
+    EVENT_STATE_CHANGED, STATE_UNAVAILABLE, STATE_UNKNOWN)
+from homeassistant.core import CoreState, HomeAssistant, callback
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entityfilter import generate_filter
+from homeassistant.helpers.typing import ConfigType
+
+REQUIREMENTS = []
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = 'csv'
+
+CONF_DATA_DIR = 'data_dir'
+CONF_SEPARATOR = 'separator'
+
+FILTER_SCHEMA = vol.Schema({
+    vol.Optional(CONF_EXCLUDE, default={}): vol.Schema({
+        vol.Optional(CONF_DOMAINS): vol.All(cv.ensure_list, [cv.string]),
+        vol.Optional(CONF_ENTITIES): cv.entity_ids,
+    }),
+    vol.Optional(CONF_INCLUDE, default={}): vol.Schema({
+        vol.Optional(CONF_DOMAINS): vol.All(cv.ensure_list, [cv.string]),
+        vol.Optional(CONF_ENTITIES): cv.entity_ids,
+    })
+})
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: FILTER_SCHEMA.extend({
+        vol.Required(CONF_DATA_DIR): cv.string,
+        vol.Optional(CONF_SEPARATOR, default=','): cv.string,
+    })
+}, extra=vol.ALLOW_EXTRA)
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the recorder."""
+    conf = config.get(DOMAIN, {})
+    data_dir = conf.get(CONF_DATA_DIR)
+    separator = conf.get(CONF_SEPARATOR)
+    include = conf.get(CONF_INCLUDE, {})
+    exclude = conf.get(CONF_EXCLUDE, {})
+
+    if not os.path.isdir(data_dir):
+        _LOGGER.error("Value of '%s' does not point to an existing directory: "
+                      "%s", CONF_DATA_DIR, data_dir)
+        return False
+
+    instance = hass.data[DOMAIN] = Csv(hass=hass, data_dir=data_dir,
+                                       include=include, exclude=exclude,
+                                       separator=separator)
+    instance.async_initialize()
+    instance.start()
+
+    return True
+
+
+class Csv(threading.Thread):
+    """Thread that writes to the file."""
+
+    def __init__(self, hass: HomeAssistant, data_dir: str,
+                 include: Dict, exclude: Dict, separator: str) -> None:
+        """Initialize the recorder."""
+        threading.Thread.__init__(self, name='CSV')
+        self.hass = hass
+        self.data_dir = data_dir
+        self.separator = separator
+        self.queue = queue.Queue()
+        self.async_db_ready = asyncio.Future(loop=hass.loop)
+
+        self.entity_filter = generate_filter(
+            include.get(CONF_DOMAINS, []), include.get(CONF_ENTITIES, []),
+            exclude.get(CONF_DOMAINS, []), exclude.get(CONF_ENTITIES, []))
+
+    @callback
+    def async_initialize(self):
+        """Initialize the thread."""
+        self.hass.bus.async_listen(EVENT_STATE_CHANGED, self.event_listener)
+
+    @callback
+    def event_listener(self, event):
+        """Listen for new events."""
+        if _LOGGER.isEnabledFor(logging.DEBUG) and event is not None:
+            _LOGGER.debug("Got new event: %s",
+                          event.data.get(ATTR_ENTITY_ID))
+        self.queue.put(event)
+
+    def block_till_done(self):
+        """Block till all events processed."""
+        self.queue.join()
+
+    def run(self):
+        """Start processing events."""
+        shutdown_task = object()
+        hass_started = concurrent.futures.Future()
+
+        @callback
+        def register():
+            """Post connection initialize."""
+            def shutdown(event):
+                """Shut down the Recorder."""
+                if not hass_started.done():
+                    hass_started.set_result(shutdown_task)
+                self.queue.put(None)
+                self.join()
+
+            self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, shutdown)
+
+            if self.hass.state == CoreState.running:
+                hass_started.set_result(None)
+            else:
+                @callback
+                def notify_hass_started(event):
+                    """Notify that hass has started."""
+                    hass_started.set_result(None)
+
+                self.hass.bus.async_listen_once(
+                    EVENT_HOMEASSISTANT_START, notify_hass_started)
+
+        self.hass.add_job(register)
+        result = hass_started.result()
+
+        # If shutdown happened before Home Assistant finished starting
+        if result is shutdown_task:
+            return
+
+        while True:
+            event = self.queue.get()
+
+            if event is None:
+                self.queue.task_done()
+                return
+
+            entity_id = event.data.get(ATTR_ENTITY_ID)
+            if entity_id is not None:
+                if not self.entity_filter(entity_id):
+                    if _LOGGER.isEnabledFor(logging.DEBUG):
+                        _LOGGER.debug(
+                            "Ignoring event because it is excluded: %s",
+                            entity_id)
+                    self.queue.task_done()
+                    continue
+
+            new_state = event.data.get('new_state')
+            if new_state is None or new_state.state in (
+                    STATE_UNKNOWN, '', STATE_UNAVAILABLE):
+                if _LOGGER.isEnabledFor(logging.DEBUG):
+                    _LOGGER.debug("Ignoring event because state is n.a.: %s",
+                                  entity_id)
+                self.queue.task_done()
+                continue
+
+            origin = event.origin
+            time_fired = event.time_fired
+            file_name = 'events_' + time_fired.strftime("%Y-%m-%d") + '.csv'
+            file_path = os.path.join(self.data_dir, file_name)
+
+            try:
+                with open(file_path, 'a') as csv_file:
+                    line = "{}{}{}{}{}{}{}\n".format(entity_id,
+                                                     self.separator,
+                                                     time_fired.isoformat(),
+                                                     self.separator,
+                                                     origin,
+                                                     self.separator,
+                                                     new_state.state)
+                    csv_file.write(line)
+                    csv_file.flush()
+                    if _LOGGER.isEnabledFor(logging.DEBUG):
+                        _LOGGER.debug("Written line: %s", line.rstrip())
+            except IOError as err:
+                _LOGGER.error("Failed to write to file %s: %s",
+                              file_path, err)
+
+            self.queue.task_done()

--- a/tests/components/test_csv.py
+++ b/tests/components/test_csv.py
@@ -1,0 +1,120 @@
+"""The tests for the csv component."""
+import datetime
+import os
+import tempfile
+
+import unittest
+from unittest import mock
+
+import homeassistant.components.csv as csvcomp
+from homeassistant.setup import setup_component
+from tests.common import get_test_home_assistant
+
+
+class TestCsv(unittest.TestCase):
+    """Test the csv component."""
+
+    def setUp(self):
+        """Set up things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+        self.handler_method = None
+        self.hass.bus.listen = mock.Mock()
+
+    def tearDown(self):
+        """Clear data."""
+        self.hass.stop()
+
+    def test_setup_minimal_config(self):
+        """Test the setup with minimal configuration."""
+        with tempfile.TemporaryDirectory() as tempdirname:
+            config = {
+                'csv': {
+                    'data_dir': tempdirname
+                }
+            }
+            assert setup_component(self.hass, csvcomp.DOMAIN, config)
+
+    def test_setup_full_config(self):
+        """Test the setup with full configuration."""
+        with tempfile.TemporaryDirectory() as tempdirname:
+            config = {
+                'csv': {
+                    'data_dir': tempdirname,
+                    'include': {
+                        'entities': [
+                            'sensor.include'
+                        ],
+                        'domains': [
+                            'sun'
+                        ]
+                    },
+                    'exclude': {
+                        'entities': [
+                            'sensor.exclude'
+                        ],
+                        'domains': [
+                            'weather'
+                        ]
+                    }
+                }
+            }
+            assert setup_component(self.hass, csvcomp.DOMAIN, config)
+
+    def test_lines_written(self):
+        """Test that csv file gets created and filled."""
+        with tempfile.TemporaryDirectory() as tempdir:
+            config = {
+                'csv': {
+                    'data_dir': tempdir
+                }
+            }
+            assert setup_component(self.hass, csvcomp.DOMAIN, config)
+
+            self.hass.states.set('sensor.temperature', 10)
+
+            self.hass.block_till_done()
+            self.hass.data[csvcomp.DOMAIN].block_till_done()
+
+            now = datetime.datetime.now()
+            file_name = 'events_' + now.strftime("%Y-%m-%d") + '.csv'
+            path = os.path.join(tempdir, file_name)
+            self.assertTrue(os.path.isfile(path))
+
+            line_found = False
+            with open(path, 'r') as file:
+                for line in file:
+                    if "sensor.temperature" in line and "10" in line:
+                        line_found = True
+            self.assertTrue(line_found)
+
+            self.hass.block_till_done()
+
+    def test_lines_written_separator(self):
+        """Test that csv file gets created and filled."""
+        with tempfile.TemporaryDirectory() as tempdir:
+            config = {
+                'csv': {
+                    'data_dir': tempdir,
+                    'separator': ';'
+                }
+            }
+            assert setup_component(self.hass, csvcomp.DOMAIN, config)
+
+            self.hass.states.set('sensor.temperature', 10)
+
+            self.hass.block_till_done()
+            self.hass.data[csvcomp.DOMAIN].block_till_done()
+
+            now = datetime.datetime.now()
+            file_name = 'events_' + now.strftime("%Y-%m-%d") + '.csv'
+            path = os.path.join(tempdir, file_name)
+            self.assertTrue(os.path.isfile(path))
+
+            line_found = False
+            with open(path, 'r') as file:
+                for line in file:
+                    if "sensor.temperature;" in line and "10" in line:
+                        line_found = True
+            self.assertTrue(line_found)
+
+            self.hass.block_till_done()


### PR DESCRIPTION
## Description:
This pull request provides a ``csv``component that stores all state changes (events) inside CSV files (one per day) inside a configurable directory. Optionally one can configure to gzip the CSV files for past days and/or remove files that are older than a configurable amount of days.

As shown in [this](https://community.home-assistant.io/t/export-history-to-csv/46901) feature request, there is a need to store data as simple text files to make it available to third party applications or just to archive the data for later analysis/usage. Although it is currently possible to use the ``file notification`` component to achieve a similar purpose, the ``csv`` component is easier to use (just a list of entities/domains instead of a template which can get very long) and writes all files immediately when the events was fired and not only every x minutes or so. Beyond that old files can be gzipped and/or removed. Additionally it is easier than exporting the data from the sqlite database on a regular basis.

**Related issue (if applicable):** n/a

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
csv:
  data_dir: '/home/homeassistant/data_dir'
  separator: ','
  gzip: True
  purge_keep_days: 365
  include:
    entities:
      - entity_to_include
    domains:
      - domain_to_include
  exclude:
    entities:
      - entitiy_to_exclude
    domains:
      - domain_to_exclude
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
