### PR TITLE
Add valve level to HmIP thermostat attributes

### DIFF
--- a/homeassistant/components/homematic/__init__.py
+++ b/homeassistant/components/homematic/__init__.py
@@ -110,6 +110,7 @@ HM_ATTRIBUTE_SUPPORT = {
     'RSSI_PEER': ['rssi', {}],
     'RSSI_DEVICE': ['rssi', {}],
     'VALVE_STATE': ['valve', {}],
+    'LEVEL': ['level', {}],
     'BATTERY_STATE': ['battery', {}],
     'CONTROL_MODE': ['mode', {
         0: 'Auto',


### PR DESCRIPTION
## Description:
Add valve level to HmIP thermostat attributes so that it can be used in sensors to display the number and degree of valve openings.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**