### PR TITLE
Add away mode support for fritzhome climate

### DIFF
--- a/homeassistant/components/climate/fritzbox.py
+++ b/homeassistant/components/climate/fritzbox.py
@@ -25,6 +25,8 @@ _LOGGER = logging.getLogger(__name__)
 
 SUPPORT_FLAGS = (SUPPORT_TARGET_TEMPERATURE | SUPPORT_OPERATION_MODE)
 
+STATE_AWAY = 'away'
+
 OPERATION_LIST = [STATE_HEAT, STATE_ECO, STATE_OFF, STATE_ON]
 
 MIN_TEMPERATURE = 8
@@ -113,6 +115,8 @@ class FritzboxThermostat(ClimateDevice):
     @property
     def current_operation(self):
         """Return the current operation mode."""
+        if self._device.holiday_active:
+            return STATE_AWAY
         if self._target_temperature == ON_API_TEMPERATURE:
             return STATE_ON
         if self._target_temperature == OFF_API_TEMPERATURE:

--- a/tests/components/climate/test_fritzbox.py
+++ b/tests/components/climate/test_fritzbox.py
@@ -22,6 +22,8 @@ class TestFritzboxClimate(unittest.TestCase):
         self.device.device_lock = True
         self.device.lock = False
         self.device.battery_low = True
+        self.device.summer_active = False
+        self.device.holiday_active = False
         self.device.set_target_temperature = Mock()
         self.device.update = Mock()
         mock_fritz = Mock()


### PR DESCRIPTION
Signed-off-by: Heiko Thiery <heiko.thiery@gmail.com>

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
