### PR TITLE
Add pymssql as a requirment so state can be saved in MS Sql

### DIFF
--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -34,7 +34,7 @@ from . import migration, purge
 from .const import DATA_INSTANCE
 from .util import session_scope
 
-REQUIREMENTS = ['sqlalchemy==1.2.11','pymssql==2.1.4']
+REQUIREMENTS = ['sqlalchemy==1.2.11', 'pymssql==2.1.4']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -34,7 +34,7 @@ from . import migration, purge
 from .const import DATA_INSTANCE
 from .util import session_scope
 
-REQUIREMENTS = ['sqlalchemy==1.2.11']
+REQUIREMENTS = ['sqlalchemy==1.2.11','pymssql==2.1.4']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1399,6 +1399,7 @@ spotipy-homeassistant==2.4.4.dev1
 # homeassistant.scripts.db_migrator
 # homeassistant.components.sensor.sql
 sqlalchemy==1.2.11
+pymssql==2.1.4
 
 # homeassistant.components.sensor.starlingbank
 starlingbank==1.2


### PR DESCRIPTION
## Description:
MS Sql currently can't be used by the recorder if you use a docker image as the python requirment hasn't been added.

## Checklist:
  - [x] The code change is tested and works locally. 

I can't get the script `script/gen_requirements_all.py` to run locally, but this is an issue with my build environment, the changes I manually made to requirments_all.txt does add the missing requirement when I build the docker image, and the image works fine.

  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)
If we add this I will need to update this: https://www.home-assistant.io/components/recorder/#ms-sql-server to remove the message about adding this missing requirement. I want this change checked first.

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
This was done manually as I couldn't get the script to run in my dev environment
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
