### PR TITLE
Implement delay between press and release for remotes

### DIFF
--- a/homeassistant/components/remote/__init__.py
+++ b/homeassistant/components/remote/__init__.py
@@ -27,6 +27,7 @@ ATTR_COMMAND = 'command'
 ATTR_DEVICE = 'device'
 ATTR_NUM_REPEATS = 'num_repeats'
 ATTR_DELAY_SECS = 'delay_secs'
+ATTR_HOLD_SECS = 'hold_secs'
 
 DOMAIN = 'remote'
 DEPENDENCIES = ['group']
@@ -44,6 +45,7 @@ SERVICE_SYNC = 'sync'
 
 DEFAULT_NUM_REPEATS = 1
 DEFAULT_DELAY_SECS = 0.4
+DEFAULT_HOLD_SECS = 0
 
 REMOTE_SERVICE_SCHEMA = vol.Schema({
     vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
@@ -59,6 +61,7 @@ REMOTE_SERVICE_SEND_COMMAND_SCHEMA = REMOTE_SERVICE_SCHEMA.extend({
     vol.Optional(
         ATTR_NUM_REPEATS, default=DEFAULT_NUM_REPEATS): cv.positive_int,
     vol.Optional(ATTR_DELAY_SECS): vol.Coerce(float),
+    vol.Optional(ATTR_HOLD_SECS, default=DEFAULT_HOLD_SECS): vol.Coerce(float),
 })
 
 

--- a/homeassistant/components/remote/harmony.py
+++ b/homeassistant/components/remote/harmony.py
@@ -216,11 +216,11 @@ class HarmonyRemote(remote.RemoteDevice):
             _LOGGER.error("Missing required argument: device")
             return
 
-        _LOGGER.debug("Sending commands to device %s", device)
         num_repeats = kwargs.get(ATTR_NUM_REPEATS)
         delay_secs = kwargs.get(ATTR_DELAY_SECS, self._delay_secs)
         hold_secs = kwargs.get(ATTR_HOLD_SECS)
-        _LOGGER.debug("Sending command to device %s", device)
+        _LOGGER.debug("Sending commands to device %s holding for %s seconds",
+                      device, hold_secs)
 
         for _ in range(num_repeats):
             for command in commands:

--- a/homeassistant/components/remote/harmony.py
+++ b/homeassistant/components/remote/harmony.py
@@ -220,7 +220,7 @@ class HarmonyRemote(remote.RemoteDevice):
         num_repeats = kwargs.get(ATTR_NUM_REPEATS)
         delay_secs = kwargs.get(ATTR_DELAY_SECS, self._delay_secs)
         hold_secs = kwargs.get(ATTR_HOLD_SECS)
-        _LOGGER.debug("Sending command to device %s, device)
+        _LOGGER.debug("Sending command to device %s", device)
 
         for _ in range(num_repeats):
             for command in commands:

--- a/homeassistant/components/remote/services.yaml
+++ b/homeassistant/components/remote/services.yaml
@@ -42,6 +42,10 @@ send_command:
     delay_secs:
       description: An optional value that specifies that number of seconds you want to wait in between repeated commands. If not specified, the default of 0.4 seconds will be used.
       example: '0.75'
+    hold_secs:
+      description: An optional value that specifies that number of seconds you want to have it held before the release is send. If not specified, the release will be send immediately after the press.
+      example: '2.5'
+      
 
 harmony_sync:
   description: Syncs the remote's configuration.

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -917,7 +917,7 @@ pygogogate2==0.1.1
 pygtfs-homeassistant==0.1.3.dev0
 
 # homeassistant.components.remote.harmony
-pyharmony==1.0.20
+pyharmony==1.0.21
 
 # homeassistant.components.binary_sensor.hikvision
 pyhik==0.1.8

--- a/tests/components/remote/common.py
+++ b/tests/components/remote/common.py
@@ -5,7 +5,7 @@ components. Instead call the service directly.
 """
 from homeassistant.components.remote import (
     ATTR_ACTIVITY, ATTR_COMMAND, ATTR_DELAY_SECS, ATTR_DEVICE,
-    ATTR_NUM_REPEATS, DOMAIN, SERVICE_SEND_COMMAND)
+    ATTR_HOLD_SECS, ATTR_NUM_REPEATS, DOMAIN, SERVICE_SEND_COMMAND)
 from homeassistant.const import (
     ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON)
 from homeassistant.loader import bind_hass
@@ -37,7 +37,7 @@ def turn_off(hass, activity=None, entity_id=None):
 
 @bind_hass
 def send_command(hass, command, entity_id=None, device=None,
-                 num_repeats=None, delay_secs=None):
+                 num_repeats=None, delay_secs=None, hold_secs=None):
     """Send a command to a device."""
     data = {ATTR_COMMAND: command}
     if entity_id:
@@ -51,5 +51,8 @@ def send_command(hass, command, entity_id=None, device=None,
 
     if delay_secs:
         data[ATTR_DELAY_SECS] = delay_secs
+
+    if hold_secs:
+        data[ATTR_HOLD_SECS] = hold_secs
 
     hass.services.call(DOMAIN, SERVICE_SEND_COMMAND, data)

--- a/tests/components/remote/test_init.py
+++ b/tests/components/remote/test_init.py
@@ -83,7 +83,7 @@ class TestRemote(unittest.TestCase):
         common.send_command(
             self.hass, entity_id='entity_id_val',
             device='test_device', command=['test_command'],
-            num_repeats='4', delay_secs='0.6')
+            num_repeats='4', delay_secs='0.6', hold_secs='5')
 
         self.hass.block_till_done()
 


### PR DESCRIPTION
## Description:

Implement the capability for remotes to are able to suppor this to have a delay between press and release.

For example, for Harmony remotes there is a press followed by a release. This change would allow to specify a delay between the press and delay and thus similating if the user would be pressing the button on their remote for longer.

This does change the schema for the remote platform, more specifically the REMOTE_SERVICE_SEND_COMMAND_SCHEMA to add an optional parameter to identify how long the "button" should be held.

Further, this also required a change in pyharmony.py to implement this delay for Harmony remotes. A PR for pyharmony was already submitted and awaiting a merge, resulting in an increase of the version level for the pyharmony requirement.

Architecture issue https://github.com/home-assistant/architecture/issues/90 has been opened for this change as well.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
