### PR TITLE
Move git from PACKAGES_DEV to PACKAGES for Gitlab CI Sensor

### DIFF
--- a/virtualization/Docker/setup_docker_prereqs
+++ b/virtualization/Docker/setup_docker_prereqs
@@ -29,12 +29,13 @@ PACKAGES=(
   ffmpeg
   # homeassistant.components.sensor.iperf3
   iperf3
+  # homeassistant.components.sensor.gitlab_ci
+  git
 )
 
 # Required debian packages for building dependencies
 PACKAGES_DEV=(
   cmake
-  git
   swig
 )
 


### PR DESCRIPTION
## Description:
Using the upcoming Gitlab Ci Sensor it would be nice to use the 'command line' sensors. These sensors provide my local commit ID and local commit time. Read more about it here: https://old.reddit.com/r/homeassistant/comments/9m5q8k/gitlab_ci_sensor_addition_for_home_assistant/

## Checklist:
  - [x] The code change is tested and works locally.