### PR TITLE
Fix auth for hass.io 

### DIFF
--- a/homeassistant/components/hassio/auth.py
+++ b/homeassistant/components/hassio/auth.py
@@ -4,8 +4,7 @@ from ipaddress import ip_address
 import os
 
 from aiohttp import web
-from aiohttp.web_exceptions import (
-    HTTPForbidden, HTTPNotFound, HTTPUnauthorized)
+from aiohttp.web_exceptions import HTTPForbidden, HTTPNotFound
 import voluptuous as vol
 
 from homeassistant.core import callback
@@ -72,4 +71,4 @@ class HassIOAuth(HomeAssistantView):
         try:
             await provider.async_validate_login(username, password)
         except HomeAssistantError:
-            raise HTTPUnauthorized() from None
+            raise HTTPForbidden() from None

--- a/tests/components/hassio/test_auth.py
+++ b/tests/components/hassio/test_auth.py
@@ -50,7 +50,7 @@ async def test_login_error(hass, hassio_client):
         )
 
         # Check we got right response
-        assert resp.status == 400
+        assert resp.status == 403
         mock_login.assert_called_with("test", "123456")
 
 

--- a/tests/components/hassio/test_auth.py
+++ b/tests/components/hassio/test_auth.py
@@ -50,7 +50,7 @@ async def test_login_error(hass, hassio_client):
         )
 
         # Check we got right response
-        assert resp.status == 401
+        assert resp.status == 400
         mock_login.assert_called_with("test", "123456")
 
 


### PR DESCRIPTION
## Description:

401 is used by API for token handling, I move it to 403