### PR TITLE
Still update template sensor on startup

### DIFF
--- a/homeassistant/components/sensor/template.py
+++ b/homeassistant/components/sensor/template.py
@@ -137,10 +137,6 @@ class SensorTemplate(Entity):
 
     async def async_added_to_hass(self):
         """Register callbacks."""
-        # We don't render on every update
-        if self._entities == MATCH_ALL:
-            return
-
         @callback
         def template_sensor_state_listener(entity, old_state, new_state):
             """Handle device state changes."""
@@ -149,8 +145,10 @@ class SensorTemplate(Entity):
         @callback
         def template_sensor_startup(event):
             """Update template on startup."""
-            async_track_state_change(
-                self.hass, self._entities, template_sensor_state_listener)
+            if self._entities != MATCH_ALL:
+                # Track state change only for valid templates
+                async_track_state_change(
+                    self.hass, self._entities, template_sensor_state_listener)
 
             self.async_schedule_update_ha_state(True)
 


### PR DESCRIPTION
## Description:
When a template sensor has an invalid template, still update at startup.

Idea by @Anonym-tsk in https://github.com/home-assistant/home-assistant/pull/17288/files

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
