### PR TITLE
Moved econet from climate to water heater

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -432,7 +432,6 @@ omit =
     homeassistant/components/camera/xeoma.py
     homeassistant/components/camera/xiaomi.py
     homeassistant/components/camera/yi.py
-    homeassistant/components/climate/econet.py
     homeassistant/components/climate/ephember.py
     homeassistant/components/climate/eq3btsmart.py
     homeassistant/components/climate/flexit.py
@@ -840,6 +839,7 @@ omit =
     homeassistant/components/tts/picotts.py
     homeassistant/components/vacuum/mqtt.py
     homeassistant/components/vacuum/roomba.py
+    homeassistant/components/water_heater/econet.py
     homeassistant/components/watson_iot.py
     homeassistant/components/weather/bom.py
     homeassistant/components/weather/buienradar.py

--- a/homeassistant/components/climate/services.yaml
+++ b/homeassistant/components/climate/services.yaml
@@ -123,26 +123,6 @@ nuheat_resume_program:
       description: Name(s) of entities to change.
       example: 'climate.kitchen'
 
-econet_add_vacation:
-  description: Add a vacation to your water heater.
-  fields:
-    entity_id:
-      description: Name(s) of entities to change.
-      example: 'climate.water_heater'
-    start_date:
-      description: The timestamp of when the vacation should start. (Optional, defaults to now)
-      example: 1513186320
-    end_date:
-      description: The timestamp of when the vacation should end.
-      example: 1513445520
-
-econet_delete_vacation:
-  description: Delete your existing vacation from your water heater.
-  fields:
-    entity_id:
-      description: Name(s) of entities to change.
-      example: 'climate.water_heater'
-
 sensibo_assume_state:
   description: Set Sensibo device to external state.
   fields:

--- a/homeassistant/components/water_heater/econet.py
+++ b/homeassistant/components/water_heater/econet.py
@@ -2,17 +2,17 @@
 Support for Rheem EcoNet water heaters.
 
 For more details about this platform, please refer to the documentation at
-https://home-assistant.io/components/climate.econet/
+https://home-assistant.io/components/water_heater.econet/
 """
 import datetime
 import logging
 
 import voluptuous as vol
 
-from homeassistant.components.climate import (
+from homeassistant.components.water_heater import (
     DOMAIN, PLATFORM_SCHEMA, STATE_ECO, STATE_ELECTRIC, STATE_GAS,
     STATE_HEAT_PUMP, STATE_HIGH_DEMAND, STATE_OFF, STATE_PERFORMANCE,
-    SUPPORT_OPERATION_MODE, SUPPORT_TARGET_TEMPERATURE, ClimateDevice)
+    SUPPORT_OPERATION_MODE, SUPPORT_TARGET_TEMPERATURE, WaterHeaterDevice)
 from homeassistant.const import (
     ATTR_ENTITY_ID, ATTR_TEMPERATURE, CONF_PASSWORD, CONF_USERNAME,
     TEMP_FAHRENHEIT)
@@ -109,7 +109,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                            schema=DELETE_VACATION_SCHEMA)
 
 
-class EcoNetWaterHeater(ClimateDevice):
+class EcoNetWaterHeater(WaterHeaterDevice):
     """Representation of an EcoNet water heater."""
 
     def __init__(self, water_heater):

--- a/homeassistant/components/water_heater/services.yaml
+++ b/homeassistant/components/water_heater/services.yaml
@@ -9,6 +9,7 @@ set_away_mode:
     away_mode:
       description: New value of away mode.
       example: true
+
 set_temperature:
   description: Set target temperature of water_heater device.
   fields:
@@ -18,6 +19,7 @@ set_temperature:
     temperature:
       description: New target temperature for water heater.
       example: 25
+
 set_operation_mode:
   description: Set operation mode for water_heater device.
   fields:
@@ -27,3 +29,23 @@ set_operation_mode:
     operation_mode:
       description: New value of operation mode.
       example: eco
+
+econet_add_vacation:
+  description: Add a vacation to your water heater.
+  fields:
+    entity_id:
+      description: Name(s) of entities to change.
+      example: 'water_heater.econet'
+    start_date:
+      description: The timestamp of when the vacation should start. (Optional, defaults to now)
+      example: 1513186320
+    end_date:
+      description: The timestamp of when the vacation should end.
+      example: 1513445520
+
+econet_delete_vacation:
+  description: Delete your existing vacation from your water heater.
+  fields:
+    entity_id:
+      description: Name(s) of entities to change.
+      example: 'water_heater.econet'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -860,6 +860,7 @@ pydukeenergy==0.0.6
 pyebox==1.1.4
 
 # homeassistant.components.climate.econet
+# homeassistant.components.water_heater.econet
 pyeconet==0.0.6
 
 # homeassistant.components.switch.edimax

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -859,7 +859,6 @@ pydukeenergy==0.0.6
 # homeassistant.components.sensor.ebox
 pyebox==1.1.4
 
-# homeassistant.components.climate.econet
 # homeassistant.components.water_heater.econet
 pyeconet==0.0.6
 


### PR DESCRIPTION
## Description:
This PR moves econet water heaters to the new water_heater component added with https://github.com/home-assistant/home-assistant/pull/17058

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#6676

## Example entry for `configuration.yaml` (if applicable):
```yaml
water_heater:
  - platform: econet
    username: test@test.com
    password: test1234
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
