### PR TITLE
WIP: Add basic suggestion component

### DIFF
--- a/homeassistant/components/suggestions/__init__.py
+++ b/homeassistant/components/suggestions/__init__.py
@@ -1,0 +1,101 @@
+"""Component to make suggestions on next actions."""
+from collections import Counter
+from datetime import timedelta
+import json
+import logging
+from time import monotonic
+from pprint import pprint
+
+from homeassistant.const import (
+    EVENT_CALL_SERVICE, ATTR_SERVICE_DATA, ATTR_ENTITY_ID)
+from homeassistant.components.recorder.util import session_scope
+from homeassistant.util import dt as dt_util
+
+DOMAIN = 'suggestions'
+
+DEPENDENCIES = ('recorder',)
+
+NUM_RESULTS = 5
+
+KEY_MORNING = 'morning'
+KEY_AFTERNOON = 'afternoon'
+KEY_EVENING = 'evening'
+KEY_NIGHT = 'night'
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup(hass, config):
+    """Initialize the suggestion component."""
+    await hass.components.recorder.wait_connection_ready()
+    results = await hass.async_add_executor_job(_generate_suggestion, hass)
+    pprint(results)
+    return True
+
+
+def _generate_suggestion(hass):
+    """Generate suggestions.
+
+    Create a dictionary with entity suggestions for time period
+    of the day.
+    """
+    from homeassistant.components.recorder.models import Events
+    start = monotonic()
+    results = {
+        KEY_MORNING: Counter(),
+        KEY_AFTERNOON: Counter(),
+        KEY_EVENING: Counter(),
+        KEY_NIGHT: Counter(),
+    }
+
+    week_ago = dt_util.utcnow() - timedelta(days=7)
+
+    with session_scope(hass=hass) as session:
+        query = (
+            session.query(Events)
+            .order_by(Events.time_fired)
+            .filter(Events.time_fired > week_ago)
+        )
+
+        # Whenever we see a service call for activating a scene or a script,
+        # we don't want to count the services called as result from activating.
+        # We track that by keeping a context blacklist.
+        context_seen = set()
+        for event in query.yield_per(500):
+            entity_ids = None
+
+            if event.context_id in context_seen:
+                continue
+
+            if event.event_type == EVENT_CALL_SERVICE:
+                data = json.loads(event.event_data).get(ATTR_SERVICE_DATA, {})
+                entity_ids = data.get(ATTR_ENTITY_ID)
+                if entity_ids is not None and not isinstance(entity_ids, list):
+                    entity_ids = [entity_ids]
+
+                context_seen.add(event.context_id)
+
+            if entity_ids is not None:
+                period = _period_from_datetime(
+                    dt_util.as_local(event.time_fired))
+                for entity_id in entity_ids:
+                    results[period][entity_id] += 1
+
+    _LOGGER.info('Generated suggestions in %.3f seconds', monotonic() - start)
+
+    return {
+        period: [entity_id for entity_id, count
+                 in period_results.most_common(NUM_RESULTS)]
+        for period, period_results in results.items()
+    }
+
+
+def _period_from_datetime(date):
+    """Convert time to a period key."""
+    if date.hour < 6:
+        return KEY_NIGHT
+    if date.hour < 12:
+        return KEY_MORNING
+    if date.hour < 18:
+        return KEY_AFTERNOON
+    return KEY_EVENING

--- a/homeassistant/components/suggestions/__init__.py
+++ b/homeassistant/components/suggestions/__init__.py
@@ -29,6 +29,11 @@ async def async_setup(hass, config):
     """Initialize the suggestion component."""
     await hass.components.recorder.wait_connection_ready()
     results = await hass.async_add_executor_job(_generate_suggestion, hass)
+
+    hass.components.persistent_notification.async_create(
+        '\n'.join('- {}:\n{}'.format(key, '\n'.join('  - {}'.format(value)
+                                     for value in values))
+                  for key, values in results.items()))
     pprint(results)
     return True
 

--- a/tests/common_recorder.py
+++ b/tests/common_recorder.py
@@ -15,11 +15,14 @@ class MockEvent(models.Events):
 
     def __init__(self, event_type, event_data={}, origin='LOCAL',
                  time_fired=None, created=None, context_id=None,
-                 context_user_id=None, event_id=None):
+                 context_user_id=None, event_id=None, event_data_raw=None):
         """Initialize the mock event."""
         global event_id_gen
 
-        event_data = json.dumps(event_data)
+        if event_data_raw is not None:
+            event_data = event_data_raw
+        else:
+            event_data = json.dumps(event_data)
 
         if event_id is None:
             event_id_gen += 1

--- a/tests/common_recorder.py
+++ b/tests/common_recorder.py
@@ -1,0 +1,42 @@
+"""Common test utils for working with recorder component."""
+from datetime import datetime
+from uuid import uuid4
+
+import json
+
+from homeassistant.components.recorder import models
+
+
+event_id_gen = 0
+
+
+class MockEvent(models.Events):
+    """Mock a recorder event."""
+
+    def __init__(self, event_type, event_data={}, origin='LOCAL',
+                 time_fired=None, created=None, context_id=None,
+                 context_user_id=None, event_id=None):
+        """Initialize the mock event."""
+        global event_id_gen
+
+        event_data = json.dumps(event_data)
+
+        if event_id is None:
+            event_id_gen += 1
+            event_id = event_id_gen
+        if time_fired is None:
+            time_fired = datetime.utcnow()
+        if created is None:
+            created = time_fired
+        if context_id is None:
+            context_id = uuid4().hex
+
+        super()
+        self.event_id = 1
+        self.event_type = event_type
+        self.event_data = event_data
+        self.origin = origin
+        self.time_fired = time_fired
+        self.created = created
+        self.context_id = context_id
+        self.context_user_id = context_user_id

--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -1,5 +1,4 @@
 """Fixtures for component testing."""
-from itertools import islice
 from unittest.mock import Mock, patch
 from contextlib import contextmanager
 

--- a/tests/components/suggestions/__init__.py
+++ b/tests/components/suggestions/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the suggestions component."""

--- a/tests/components/suggestions/test_init.py
+++ b/tests/components/suggestions/test_init.py
@@ -1,0 +1,64 @@
+"""Tests for the init."""
+from homeassistant.const import (
+    EVENT_CALL_SERVICE, ATTR_SERVICE_DATA, ATTR_ENTITY_ID)
+from homeassistant.components.suggestions import _generate_suggestion
+from homeassistant.util import dt as dt_util
+
+from tests.common_recorder import MockEvent
+
+NIGHT = dt_util.now().replace(hour=2)
+MORNING = dt_util.now().replace(hour=8)
+AFTERNOON = dt_util.now().replace(hour=14)
+EVENING = dt_util.now().replace(hour=20)
+
+
+def _mock_service(entity_id, time_fired, context_id=None):
+    """Create a mock service event."""
+    return MockEvent(
+        event_type=EVENT_CALL_SERVICE,
+        event_data={
+            ATTR_SERVICE_DATA: {
+                ATTR_ENTITY_ID: entity_id
+            }
+        },
+        time_fired=time_fired,
+        context_id=context_id
+    )
+
+
+def test_suggestions_call_service(hass, mock_recorder_results):
+    """Test call service entities being translated."""
+    mock_recorder_results.extend([
+        _mock_service('light.night', NIGHT),
+        _mock_service('light.morning', MORNING),
+        _mock_service('light.afternoon', AFTERNOON),
+        _mock_service('light.evening', EVENING),
+    ])
+    suggestions = _generate_suggestion(hass)
+    assert suggestions['night'] == ['light.night']
+    assert suggestions['morning'] == ['light.morning']
+    assert suggestions['afternoon'] == ['light.afternoon']
+    assert suggestions['evening'] == ['light.evening']
+
+
+def test_ignoring_subsequent_context_id(hass, mock_recorder_results):
+    """Test we ignore service calls as result of scene or script."""
+    context_id = 'morning-script-context'
+    mock_recorder_results.extend([
+        _mock_service('script.morning', MORNING, context_id=context_id),
+        _mock_service('light.kitchen', MORNING, context_id=context_id),
+        _mock_service('cover.kitchen', MORNING, context_id=context_id),
+    ])
+    suggestions = _generate_suggestion(hass)
+    assert suggestions['morning'] == ['script.morning']
+
+
+def test_popular_first(hass, mock_recorder_results):
+    """Test call service entities being translated."""
+    mock_recorder_results.extend([
+        _mock_service('cover.kitchen', MORNING),
+        _mock_service('light.kitchen', MORNING),
+        _mock_service('light.kitchen', MORNING),
+    ])
+    suggestions = _generate_suggestion(hass)
+    assert suggestions['morning'] == ['light.kitchen', 'cover.kitchen']

--- a/tests/components/suggestions/test_init.py
+++ b/tests/components/suggestions/test_init.py
@@ -10,6 +10,12 @@ NIGHT = dt_util.now().replace(hour=2)
 MORNING = dt_util.now().replace(hour=8)
 AFTERNOON = dt_util.now().replace(hour=14)
 EVENING = dt_util.now().replace(hour=20)
+EMPTY = {
+    'morning': [],
+    'afternoon': [],
+    'evening': [],
+    'night': [],
+}
 
 
 def _mock_service(entity_id, time_fired, context_id=None):
@@ -62,3 +68,25 @@ def test_popular_first(hass, mock_recorder_results):
     ])
     suggestions = _generate_suggestion(hass)
     assert suggestions['morning'] == ['light.kitchen', 'cover.kitchen']
+
+
+def test_bad_services(hass, mock_recorder_results):
+    """Test service with bad data."""
+    mock_recorder_results.append(
+        MockEvent(
+            event_type=EVENT_CALL_SERVICE,
+            event_data_raw='invalid json',
+        )
+    )
+    # Should not raise
+    assert _generate_suggestion(hass) == EMPTY
+
+    mock_recorder_results.clear()
+    mock_recorder_results.append(
+        MockEvent(
+            event_type=EVENT_CALL_SERVICE,
+            event_data={},
+        )
+    )
+    # Should not raise
+    assert _generate_suggestion(hass) == EMPTY


### PR DESCRIPTION
## Description:
Preview of a suggestions component I'm working on. Goal of this component is to provide suggestions to the user on which entities are popular to interact with during a specific period of time. Will be used to power a new lovelace card 😎 

This is the initial implementation and so very limited on purpose. Eventually we can start taking users into account and the location of the users (once we have a component that binds users to device trackers).

Can be heavy to generate, so plan is to generate it once a day.

It's smart enough to ignore any service call that results from another service call (ie I call a script that turns on 5 lights, only the script will show in popular list)


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
