### PR TITLE
Add context to scripts run by templates

### DIFF
--- a/homeassistant/components/cover/template.py
+++ b/homeassistant/components/cover/template.py
@@ -278,9 +278,10 @@ class CoverTemplate(CoverDevice):
     async def async_open_cover(self, **kwargs):
         """Move the cover up."""
         if self._open_script:
-            await self._open_script.async_run()
+            await self._open_script.async_run(context=self._context)
         elif self._position_script:
-            await self._position_script.async_run({"position": 100})
+            await self._position_script.async_run(
+                {"position": 100}, context=self._context)
         if self._optimistic:
             self._position = 100
             self.async_schedule_update_ha_state()
@@ -288,9 +289,10 @@ class CoverTemplate(CoverDevice):
     async def async_close_cover(self, **kwargs):
         """Move the cover down."""
         if self._close_script:
-            await self._close_script.async_run()
+            await self._close_script.async_run(context=self._context)
         elif self._position_script:
-            await self._position_script.async_run({"position": 0})
+            await self._position_script.async_run(
+                {"position": 0}, context=self._context)
         if self._optimistic:
             self._position = 0
             self.async_schedule_update_ha_state()
@@ -298,20 +300,21 @@ class CoverTemplate(CoverDevice):
     async def async_stop_cover(self, **kwargs):
         """Fire the stop action."""
         if self._stop_script:
-            await self._stop_script.async_run()
+            await self._stop_script.async_run(context=self._context)
 
     async def async_set_cover_position(self, **kwargs):
         """Set cover position."""
         self._position = kwargs[ATTR_POSITION]
         await self._position_script.async_run(
-            {"position": self._position})
+            {"position": self._position}, context=self._context)
         if self._optimistic:
             self.async_schedule_update_ha_state()
 
     async def async_open_cover_tilt(self, **kwargs):
         """Tilt the cover open."""
         self._tilt_value = 100
-        await self._tilt_script.async_run({"tilt": self._tilt_value})
+        await self._tilt_script.async_run(
+            {"tilt": self._tilt_value}, context=self._context)
         if self._tilt_optimistic:
             self.async_schedule_update_ha_state()
 
@@ -319,14 +322,15 @@ class CoverTemplate(CoverDevice):
         """Tilt the cover closed."""
         self._tilt_value = 0
         await self._tilt_script.async_run(
-            {"tilt": self._tilt_value})
+            {"tilt": self._tilt_value}, context=self._context)
         if self._tilt_optimistic:
             self.async_schedule_update_ha_state()
 
     async def async_set_cover_tilt_position(self, **kwargs):
         """Move the cover tilt to a specific position."""
         self._tilt_value = kwargs[ATTR_TILT_POSITION]
-        await self._tilt_script.async_run({"tilt": self._tilt_value})
+        await self._tilt_script.async_run(
+            {"tilt": self._tilt_value}, context=self._context)
         if self._tilt_optimistic:
             self.async_schedule_update_ha_state()
 

--- a/homeassistant/components/fan/template.py
+++ b/homeassistant/components/fan/template.py
@@ -224,7 +224,7 @@ class TemplateFan(FanEntity):
     # pylint: disable=arguments-differ
     async def async_turn_on(self, speed: str = None) -> None:
         """Turn on the fan."""
-        await self._on_script.async_run()
+        await self._on_script.async_run(context=self._context)
         self._state = STATE_ON
 
         if speed is not None:
@@ -233,7 +233,7 @@ class TemplateFan(FanEntity):
     # pylint: disable=arguments-differ
     async def async_turn_off(self) -> None:
         """Turn off the fan."""
-        await self._off_script.async_run()
+        await self._off_script.async_run(context=self._context)
         self._state = STATE_OFF
 
     async def async_set_speed(self, speed: str) -> None:
@@ -243,7 +243,8 @@ class TemplateFan(FanEntity):
 
         if speed in self._speed_list:
             self._speed = speed
-            await self._set_speed_script.async_run({ATTR_SPEED: speed})
+            await self._set_speed_script.async_run(
+                {ATTR_SPEED: speed}, context=self._context)
         else:
             _LOGGER.error(
                 'Received invalid speed: %s. Expected: %s.',
@@ -257,7 +258,7 @@ class TemplateFan(FanEntity):
         if oscillating in _VALID_OSC:
             self._oscillating = oscillating
             await self._set_oscillating_script.async_run(
-                {ATTR_OSCILLATING: oscillating})
+                {ATTR_OSCILLATING: oscillating}, context=self._context)
         else:
             _LOGGER.error(
                 'Received invalid oscillating value: %s. Expected: %s.',
@@ -271,7 +272,7 @@ class TemplateFan(FanEntity):
         if direction in _VALID_DIRECTIONS:
             self._direction = direction
             await self._set_direction_script.async_run(
-                {ATTR_DIRECTION: direction})
+                {ATTR_DIRECTION: direction}, context=self._context)
         else:
             _LOGGER.error(
                 'Received invalid direction: %s. Expected: %s.',

--- a/homeassistant/components/light/template.py
+++ b/homeassistant/components/light/template.py
@@ -215,8 +215,8 @@ class LightTemplate(Light):
             optimistic_set = True
 
         if ATTR_BRIGHTNESS in kwargs and self._level_script:
-            self.hass.async_create_task(self._level_script.async_run(
-                {"brightness": kwargs[ATTR_BRIGHTNESS]}))
+            await self._level_script.async_run(
+                {"brightness": kwargs[ATTR_BRIGHTNESS]}, context=self._context)
         else:
             await self._on_script.async_run()
 
@@ -225,7 +225,7 @@ class LightTemplate(Light):
 
     async def async_turn_off(self, **kwargs):
         """Turn the light off."""
-        await self._off_script.async_run()
+        await self._off_script.async_run(context=self._context)
         if self._template is None:
             self._state = False
             self.async_schedule_update_ha_state()

--- a/homeassistant/components/lock/template.py
+++ b/homeassistant/components/lock/template.py
@@ -131,11 +131,11 @@ class TemplateLock(LockDevice):
         if self._optimistic:
             self._state = True
             self.async_schedule_update_ha_state()
-        await self._command_lock.async_run()
+        await self._command_lock.async_run(context=self._context)
 
     async def async_unlock(self, **kwargs):
         """Unlock the device."""
         if self._optimistic:
             self._state = False
             self.async_schedule_update_ha_state()
-        await self._command_unlock.async_run()
+        await self._command_unlock.async_run(context=self._context)

--- a/homeassistant/components/switch/template.py
+++ b/homeassistant/components/switch/template.py
@@ -151,11 +151,11 @@ class SwitchTemplate(SwitchDevice):
 
     async def async_turn_on(self, **kwargs):
         """Fire the on action."""
-        await self._on_script.async_run()
+        await self._on_script.async_run(context=self._context)
 
     async def async_turn_off(self, **kwargs):
         """Fire the off action."""
-        await self._off_script.async_run()
+        await self._off_script.async_run(context=self._context)
 
     async def async_update(self):
         """Update the state from the template."""


### PR DESCRIPTION
## Description:
Scripts run by a template entity now use the context that called the service on the template entity.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
