### PR TITLE
Add device info for LIFX

### DIFF
--- a/homeassistant/components/light/lifx.py
+++ b/homeassistant/components/light/lifx.py
@@ -27,6 +27,7 @@ from homeassistant.components.lifx import (
 from homeassistant.const import ATTR_ENTITY_ID, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
+import homeassistant.helpers.device_registry as dr
 from homeassistant.helpers.event import async_track_point_in_utc_time
 from homeassistant.helpers.service import extract_entity_ids
 import homeassistant.util.color as color_util
@@ -400,14 +401,22 @@ class LIFXLight(Light):
     @property
     def device_info(self):
         """Return information about the device."""
-        return {
+        info = {
             'identifiers': {
                 (LIFX_DOMAIN, self.unique_id)
             },
             'name': self.name,
-            'model': aiolifx().products.product_map.get(self.bulb.product),
+            'connections': {
+                (dr.CONNECTION_NETWORK_MAC, self.bulb.mac_addr)
+            },
             'manufacturer': 'LIFX',
         }
+
+        model = aiolifx().products.product_map.get(self.bulb.product)
+        if model is not None:
+            info['model'] = model
+
+        return info
 
     @property
     def available(self):

--- a/homeassistant/components/light/lifx.py
+++ b/homeassistant/components/light/lifx.py
@@ -398,6 +398,18 @@ class LIFXLight(Light):
         self.lock = asyncio.Lock()
 
     @property
+    def device_info(self):
+        """Return information about the device."""
+        return {
+            'identifiers': {
+                (LIFX_DOMAIN, self.unique_id)
+            },
+            'name': self.name,
+            'model': aiolifx().products.product_map.get(self.bulb.product),
+            'manufacturer': 'LIFX',
+        }
+
+    @property
     def available(self):
         """Return the availability of the bulb."""
         return self.registered


### PR DESCRIPTION
## Description:

If new models are released, this will return `'model': None` until aiolifx is updated, is that okay?

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54