### PR TITLE
Add exception handling to dnsip sensor

### DIFF
--- a/homeassistant/components/sensor/dnsip.py
+++ b/homeassistant/components/sensor/dnsip.py
@@ -91,7 +91,7 @@ class WanIpSensor(Entity):
         try:
             response = await self.resolver.query(self.hostname,
                                                  self.querytype)
-        except self.aiodns.error.DNSError as err:
+        except DNSError as err:
             _LOGGER.warning("Exception while resolving host: %s", err)
             response = None
         if response:

--- a/homeassistant/components/sensor/dnsip.py
+++ b/homeassistant/components/sensor/dnsip.py
@@ -67,11 +67,10 @@ class WanIpSensor(Entity):
     def __init__(self, hass, name, hostname, resolver, ipv6):
         """Initialize the sensor."""
         import aiodns
-        self.aiodns = aiodns
         self.hass = hass
         self._name = name
         self.hostname = hostname
-        self.resolver = self.aiodns.DNSResolver(loop=self.hass.loop)
+        self.resolver = aiodns.DNSResolver(loop=self.hass.loop)
         self.resolver.nameservers = [resolver]
         self.querytype = 'AAAA' if ipv6 else 'A'
         self._state = STATE_UNKNOWN
@@ -88,6 +87,7 @@ class WanIpSensor(Entity):
 
     async def async_update(self):
         """Get the current DNS IP address for hostname."""
+        from aiodns.error import DNSError
         try:
             response = await self.resolver.query(self.hostname,
                                                  self.querytype)


### PR DESCRIPTION
## Description:
Currently a DNS lookup failure (for whatever reason) results in the traceback in the HASS log. With this exception handling only a warning with the corresponding error-message gets logged.
Additionally in the case of a lookup error the state of the sensor gets set to `STATE_UNKNOWN`. This is in some way a __breaking change__. Currently the sensor just keeps the previous value. So automations based on the sensor could always expect a valid IP. The upside though is, that now an automation could check if the state is unknown (for time X), which possibly indicates that the whole network is _offline_ or some other DNS related error is present which needs to be acted on. So in terms of monitoring I see this as an improvement.

I kind of dislike what I've done with `self.aiodns`. Any suggestion how else I could make the exception class available in the update method?

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
