### PR TITLE
deCONZ - Add support for Xiaomi window covers

### DIFF
--- a/homeassistant/components/cover/deconz.py
+++ b/homeassistant/components/cover/deconz.py
@@ -5,8 +5,8 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/cover.deconz/
 """
 from homeassistant.components.deconz.const import (
-    COVER_TYPES, DAMPERS, DOMAIN as DATA_DECONZ, DATA_DECONZ_ID, DATA_DECONZ_UNSUB,
-    DECONZ_DOMAIN, WINDOW_COVERS)
+    COVER_TYPES, DAMPERS, DOMAIN as DATA_DECONZ, DATA_DECONZ_ID,
+    DATA_DECONZ_UNSUB, DECONZ_DOMAIN, WINDOW_COVERS)
 from homeassistant.components.cover import (
     ATTR_POSITION, CoverDevice, SUPPORT_CLOSE, SUPPORT_OPEN, SUPPORT_STOP,
     SUPPORT_SET_POSITION)
@@ -15,6 +15,8 @@ from homeassistant.helpers.device_registry import CONNECTION_ZIGBEE
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 DEPENDENCIES = ['deconz']
+
+ZIGBEE_SPEC = ['lumi.curtain']
 
 
 async def async_setup_platform(hass, config, async_add_entities,
@@ -34,7 +36,10 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         entities = []
         for light in lights:
             if light.type in COVER_TYPES:
-                entities.append(DeconzCover(light))
+                if light.modelid in ZIGBEE_SPEC:
+                    entities.append(DeconzCoverZigbeeSpec(light))
+                else:
+                    entities.append(DeconzCover(light))
         async_add_entities(entities, True)
 
     hass.data[DATA_DECONZ_UNSUB].append(
@@ -53,9 +58,6 @@ class DeconzCover(CoverDevice):
         self._features |= SUPPORT_CLOSE
         self._features |= SUPPORT_STOP
         self._features |= SUPPORT_SET_POSITION
-        self.reverse = False
-        if self._cover.modelid == "lumi.curtain":
-            self.reverse = True
 
     async def async_added_to_hass(self):
         """Subscribe to covers events."""
@@ -75,8 +77,6 @@ class DeconzCover(CoverDevice):
     @property
     def current_cover_position(self):
         """Return the current position of the cover."""
-        if self.reverse:
-            return 100 - int(self._cover.brightness / 255 * 100)
         if self.is_closed:
             return 0
         return int(self._cover.brightness / 255 * 100)
@@ -84,8 +84,6 @@ class DeconzCover(CoverDevice):
     @property
     def is_closed(self):
         """Return if the cover is closed."""
-        if self.reverse:
-            return self._cover.state
         return not self._cover.state
 
     @property
@@ -101,9 +99,9 @@ class DeconzCover(CoverDevice):
     @property
     def device_class(self):
         """Return the class of the cover."""
-        if self._cover.type == "Level controllable output":
+        if self._cover.type in DAMPERS:
             return 'damper'
-        if self._cover.type == "Window covering device":
+        if self._cover.type in WINDOW_COVERS:
             return 'window'
         return None
 
@@ -126,10 +124,7 @@ class DeconzCover(CoverDevice):
         """Move the cover to a specific position."""
         position = kwargs[ATTR_POSITION]
         data = {'on': False}
-        if self.reverse and position < 100:
-            data['on'] = True
-            data['bri'] = int((100 - position) / 100 * 255)
-        elif not self.reverse and position > 0:
+        if position > 0:
             data['on'] = True
             data['bri'] = int(position / 100 * 255)
         await self._cover.async_set_state(data)
@@ -166,3 +161,26 @@ class DeconzCover(CoverDevice):
             'sw_version': self._cover.swversion,
             'via_hub': (DECONZ_DOMAIN, bridgeid),
         }
+
+
+class DeconzCoverZigbeeSpec(DeconzCover):
+    """Zigbee spec is the inverse of how deCONZ normally reports attributes."""
+
+    @property
+    def current_cover_position(self):
+        """Return the current position of the cover."""
+        return 100 - int(self._cover.brightness / 255 * 100)
+
+    @property
+    def is_closed(self):
+        """Return if the cover is closed."""
+        return self._cover.state
+
+    async def async_set_cover_position(self, **kwargs):
+        """Move the cover to a specific position."""
+        position = kwargs[ATTR_POSITION]
+        data = {'on': False}
+        if position < 100:
+            data['on'] = True
+            data['bri'] = 255 - int(position / 100 * 255)
+        await self._cover.async_set_state(data)

--- a/homeassistant/components/cover/deconz.py
+++ b/homeassistant/components/cover/deconz.py
@@ -54,7 +54,7 @@ class DeconzCover(CoverDevice):
         self._features |= SUPPORT_STOP
         self._features |= SUPPORT_SET_POSITION
         self.reverse = False
-        if self._cover.modelid in "lumi.curtain":
+        if self._cover.modelid == "lumi.curtain":
             self.reverse = True
 
     async def async_added_to_hass(self):
@@ -128,7 +128,7 @@ class DeconzCover(CoverDevice):
         data = {'on': False}
         if self.reverse and position < 100:
             data['on'] = True
-            data['bri'] = 100 - int(position / 100 * 255)
+            data['bri'] = int((100 - position) / 100 * 255)
         elif not self.reverse and position > 0:
             data['on'] = True
             data['bri'] = int(position / 100 * 255)

--- a/homeassistant/components/cover/deconz.py
+++ b/homeassistant/components/cover/deconz.py
@@ -91,7 +91,11 @@ class DeconzCover(CoverDevice):
     @property
     def device_class(self):
         """Return the class of the cover."""
-        return 'damper'
+        if self._cover.type == "Level controllable output":
+            return 'damper'
+        if self._cover.type == "Window covering device":
+            return 'window'
+        return None
 
     @property
     def supported_features(self):

--- a/homeassistant/components/deconz/const.py
+++ b/homeassistant/components/deconz/const.py
@@ -16,8 +16,9 @@ CONF_ALLOW_DECONZ_GROUPS = 'allow_deconz_groups'
 ATTR_DARK = 'dark'
 ATTR_ON = 'on'
 
-
-COVER_TYPES = ["Level controllable output", "Window covering device"]
+DAMPERS = ["Level controllable output"]
+WINDOW_COVERS = ["Window covering device"]
+COVER_TYPES = DAMPERS + WINDOW_COVERS
 
 POWER_PLUGS = ["On/Off plug-in unit", "Smart plug"]
 SIRENS = ["Warning device"]

--- a/homeassistant/components/deconz/const.py
+++ b/homeassistant/components/deconz/const.py
@@ -16,7 +16,8 @@ CONF_ALLOW_DECONZ_GROUPS = 'allow_deconz_groups'
 ATTR_DARK = 'dark'
 ATTR_ON = 'on'
 
-COVER_TYPES = ["Level controllable output"]
+
+COVER_TYPES = ["Level controllable output", "Window covering device"]
 
 POWER_PLUGS = ["On/Off plug-in unit", "Smart plug"]
 SIRENS = ["Warning device"]

--- a/tests/components/cover/test_deconz.py
+++ b/tests/components/cover/test_deconz.py
@@ -13,13 +13,15 @@ SUPPORTED_COVERS = {
         "id": "Cover 1 id",
         "name": "Cover 1 name",
         "type": "Level controllable output",
-        "state": {}
+        "state": {},
+        "modelid": "Not zigbee spec"
     },
     "2": {
         "id": "Cover 2 id",
         "name": "Cover 2 name",
         "type": "Window covering device",
-        "state": {}
+        "state": {},
+        "modelid": "lumi.curtain"
     }
 }
 

--- a/tests/components/cover/test_deconz.py
+++ b/tests/components/cover/test_deconz.py
@@ -14,6 +14,12 @@ SUPPORTED_COVERS = {
         "name": "Cover 1 name",
         "type": "Level controllable output",
         "state": {}
+    },
+    "2": {
+        "id": "Cover 2 id",
+        "name": "Cover 2 name",
+        "type": "Window covering device",
+        "state": {}
     }
 }
 
@@ -62,7 +68,7 @@ async def test_cover(hass):
     await setup_bridge(hass, {"lights": SUPPORTED_COVERS})
     assert "cover.cover_1_name" in hass.data[deconz.DATA_DECONZ_ID]
     assert len(SUPPORTED_COVERS) == len(COVER_TYPES)
-    assert len(hass.states.async_all()) == 2
+    assert len(hass.states.async_all()) == 3
 
 
 async def test_add_new_cover(hass):


### PR DESCRIPTION
## Description:

Note that the controls are inverted if using deCONZ pre-2.05.40

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#6867


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.