### PR TITLE
Adding source attribute to geo location platforms

### DIFF
--- a/homeassistant/components/geo_location/__init__.py
+++ b/homeassistant/components/geo_location/__init__.py
@@ -11,7 +11,7 @@ import logging
 from datetime import timedelta
 from typing import Optional
 
-from homeassistant.const import ATTR_LATITUDE, ATTR_LONGITUDE, ATTR_SOURCE
+from homeassistant.const import ATTR_LATITUDE, ATTR_LONGITUDE
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.config_validation import PLATFORM_SCHEMA  # noqa
@@ -19,6 +19,7 @@ from homeassistant.helpers.config_validation import PLATFORM_SCHEMA  # noqa
 _LOGGER = logging.getLogger(__name__)
 
 ATTR_DISTANCE = 'distance'
+ATTR_SOURCE = 'source'
 DOMAIN = 'geo_location'
 ENTITY_ID_FORMAT = DOMAIN + '.{}'
 GROUP_NAME_ALL_EVENTS = 'All Geo Location Events'
@@ -44,9 +45,9 @@ class GeoLocationEvent(Entity):
         return None
 
     @property
-    def source(self) -> Optional[str]:
+    def source(self) -> str:
         """Return source value of this external event."""
-        return None
+        raise NotImplementedError
 
     @property
     def distance(self) -> Optional[float]:

--- a/homeassistant/components/geo_location/__init__.py
+++ b/homeassistant/components/geo_location/__init__.py
@@ -11,7 +11,7 @@ import logging
 from datetime import timedelta
 from typing import Optional
 
-from homeassistant.const import ATTR_LATITUDE, ATTR_LONGITUDE
+from homeassistant.const import ATTR_LATITUDE, ATTR_LONGITUDE, ATTR_SOURCE
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.config_validation import PLATFORM_SCHEMA  # noqa
@@ -44,6 +44,11 @@ class GeoLocationEvent(Entity):
         return None
 
     @property
+    def source(self) -> Optional[str]:
+        """Return source value of this external event."""
+        return None
+
+    @property
     def distance(self) -> Optional[float]:
         """Return distance value of this external event."""
         return None
@@ -66,4 +71,6 @@ class GeoLocationEvent(Entity):
             data[ATTR_LATITUDE] = round(self.latitude, 5)
         if self.longitude is not None:
             data[ATTR_LONGITUDE] = round(self.longitude, 5)
+        if self.source is not None:
+            data[ATTR_SOURCE] = self.source
         return data

--- a/homeassistant/components/geo_location/demo.py
+++ b/homeassistant/components/geo_location/demo.py
@@ -26,6 +26,8 @@ EVENT_NAMES = ["Bushfire", "Hazard Reduction", "Grass Fire", "Burn off",
                "Cyclone", "Waterspout", "Dust Storm", "Blizzard", "Ice Storm",
                "Earthquake", "Tsunami"]
 
+SOURCE = 'demo'
+
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Demo geo locations."""
@@ -99,6 +101,11 @@ class DemoGeoLocationEvent(GeoLocationEvent):
         self._latitude = latitude
         self._longitude = longitude
         self._unit_of_measurement = unit_of_measurement
+
+    @property
+    def source(self) -> str:
+        """Return source value of this external event."""
+        return SOURCE
 
     @property
     def name(self) -> Optional[str]:

--- a/homeassistant/components/geo_location/geo_json_events.py
+++ b/homeassistant/components/geo_location/geo_json_events.py
@@ -31,6 +31,7 @@ DEFAULT_RADIUS_IN_KM = 20.0
 DEFAULT_UNIT_OF_MEASUREMENT = "km"
 
 SCAN_INTERVAL = timedelta(minutes=5)
+SOURCE = 'geo_json_events'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_URL): cv.string,
@@ -161,6 +162,11 @@ class GeoJsonLocationEvent(GeoLocationEvent):
         self._latitude = feed_entry.coordinates[0]
         self._longitude = feed_entry.coordinates[1]
         self.external_id = feed_entry.external_id
+
+    @property
+    def source(self) -> str:
+        """Return source value of this external event."""
+        return SOURCE
 
     @property
     def name(self) -> Optional[str]:

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -297,6 +297,9 @@ ATTR_STATE = 'state'
 
 ATTR_OPTION = 'option'
 
+# For entities which have a source they want to specify.
+ATTR_SOURCE = 'source'
+
 # Bitfield of supported component features for the entity
 ATTR_SUPPORTED_FEATURES = 'supported_features'
 

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -297,9 +297,6 @@ ATTR_STATE = 'state'
 
 ATTR_OPTION = 'option'
 
-# For entities which have a source they want to specify.
-ATTR_SOURCE = 'source'
-
 # Bitfield of supported component features for the entity
 ATTR_SUPPORTED_FEATURES = 'supported_features'
 

--- a/tests/components/geo_location/test_geo_json_events.py
+++ b/tests/components/geo_location/test_geo_json_events.py
@@ -4,11 +4,12 @@ from unittest import mock
 from unittest.mock import patch, MagicMock
 
 from homeassistant.components import geo_location
+from homeassistant.components.geo_location import ATTR_SOURCE
 from homeassistant.components.geo_location.geo_json_events import \
     SCAN_INTERVAL, ATTR_EXTERNAL_ID
 from homeassistant.const import CONF_URL, EVENT_HOMEASSISTANT_START, \
     CONF_RADIUS, ATTR_LATITUDE, ATTR_LONGITUDE, ATTR_FRIENDLY_NAME, \
-    ATTR_UNIT_OF_MEASUREMENT, ATTR_SOURCE
+    ATTR_UNIT_OF_MEASUREMENT
 from homeassistant.setup import setup_component
 from tests.common import get_test_home_assistant, assert_setup_component, \
     fire_time_changed

--- a/tests/components/geo_location/test_geo_json_events.py
+++ b/tests/components/geo_location/test_geo_json_events.py
@@ -8,7 +8,7 @@ from homeassistant.components.geo_location.geo_json_events import \
     SCAN_INTERVAL, ATTR_EXTERNAL_ID
 from homeassistant.const import CONF_URL, EVENT_HOMEASSISTANT_START, \
     CONF_RADIUS, ATTR_LATITUDE, ATTR_LONGITUDE, ATTR_FRIENDLY_NAME, \
-    ATTR_UNIT_OF_MEASUREMENT
+    ATTR_UNIT_OF_MEASUREMENT, ATTR_SOURCE
 from homeassistant.setup import setup_component
 from tests.common import get_test_home_assistant, assert_setup_component, \
     fire_time_changed
@@ -84,7 +84,8 @@ class TestGeoJsonPlatform(unittest.TestCase):
                 assert state.attributes == {
                     ATTR_EXTERNAL_ID: "1234", ATTR_LATITUDE: -31.0,
                     ATTR_LONGITUDE: 150.0, ATTR_FRIENDLY_NAME: "Title 1",
-                    ATTR_UNIT_OF_MEASUREMENT: "km"}
+                    ATTR_UNIT_OF_MEASUREMENT: "km",
+                    ATTR_SOURCE: 'geo_json_events'}
                 self.assertAlmostEqual(float(state.state), 15.5)
 
                 state = self.hass.states.get("geo_location.title_2")
@@ -93,7 +94,8 @@ class TestGeoJsonPlatform(unittest.TestCase):
                 assert state.attributes == {
                     ATTR_EXTERNAL_ID: "2345", ATTR_LATITUDE: -31.1,
                     ATTR_LONGITUDE: 150.1, ATTR_FRIENDLY_NAME: "Title 2",
-                    ATTR_UNIT_OF_MEASUREMENT: "km"}
+                    ATTR_UNIT_OF_MEASUREMENT: "km",
+                    ATTR_SOURCE: 'geo_json_events'}
                 self.assertAlmostEqual(float(state.state), 20.5)
 
                 state = self.hass.states.get("geo_location.title_3")
@@ -102,7 +104,8 @@ class TestGeoJsonPlatform(unittest.TestCase):
                 assert state.attributes == {
                     ATTR_EXTERNAL_ID: "3456", ATTR_LATITUDE: -31.2,
                     ATTR_LONGITUDE: 150.2, ATTR_FRIENDLY_NAME: "Title 3",
-                    ATTR_UNIT_OF_MEASUREMENT: "km"}
+                    ATTR_UNIT_OF_MEASUREMENT: "km",
+                    ATTR_SOURCE: 'geo_json_events'}
                 self.assertAlmostEqual(float(state.state), 25.5)
 
                 # Simulate an update - one existing, one new entry,

--- a/tests/components/geo_location/test_init.py
+++ b/tests/components/geo_location/test_init.py
@@ -1,4 +1,6 @@
 """The tests for the geo location component."""
+import pytest
+
 from homeassistant.components import geo_location
 from homeassistant.components.geo_location import GeoLocationEvent
 from homeassistant.setup import async_setup_component
@@ -18,4 +20,5 @@ async def test_event(hass):
     assert entity.distance is None
     assert entity.latitude is None
     assert entity.longitude is None
-    assert entity.source is None
+    with pytest.raises(NotImplementedError):
+        assert entity.source is None

--- a/tests/components/geo_location/test_init.py
+++ b/tests/components/geo_location/test_init.py
@@ -18,3 +18,4 @@ async def test_event(hass):
     assert entity.distance is None
     assert entity.latitude is None
     assert entity.longitude is None
+    assert entity.source is None


### PR DESCRIPTION
## Description:
This adds a `source` attribute to the existing `geo_location` platforms. The purpose of this change is to make entities generated by these platforms identifiable for the new [`geo_location` trigger](https://github.com/home-assistant/home-assistant/pull/16967).
Each new platform will need to override the `source` method in its own sub-class of `GeoLocationEvent`, so that the value is automatically added by the `state_attributes` method.

**Related issue (if applicable):** prerequisite for #16967

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable): n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
