### PR TITLE
Fix HomeMatic availability detection

### DIFF
--- a/homeassistant/components/homematic/__init__.py
+++ b/homeassistant/components/homematic/__init__.py
@@ -797,7 +797,9 @@ class HMDevice(Entity):
                 has_changed = True
 
         # Availability has changed
+        # pylint: disable=protected-access
         if self.available != (not self._hmdevice._unreach):
+            # pylint: disable=protected-access
             self._available = not self._hmdevice._unreach
             has_changed = True
 

--- a/homeassistant/components/homematic/__init__.py
+++ b/homeassistant/components/homematic/__init__.py
@@ -797,10 +797,8 @@ class HMDevice(Entity):
                 has_changed = True
 
         # Availability has changed
-        # pylint: disable=protected-access
-        if self.available != (not self._hmdevice._unreach):
-            # pylint: disable=protected-access
-            self._available = not self._hmdevice._unreach
+        if self.available != (not self._hmdevice.UNREACH):
+            self._available = not self._hmdevice.UNREACH
             has_changed = True
 
         # If it has changed data point, update HASS

--- a/homeassistant/components/homematic/__init__.py
+++ b/homeassistant/components/homematic/__init__.py
@@ -808,7 +808,6 @@ class HMDevice(Entity):
     def _subscribe_homematic_events(self):
         """Subscribe all required events to handle job."""
         channels_to_sub = set()
-        channels_to_sub.add(0)  # Add channel 0 for UNREACH
 
         # Push data to channels_to_sub from hmdevice metadata
         for metadata in (self._hmdevice.SENSORNODE, self._hmdevice.BINARYNODE,

--- a/homeassistant/components/homematic/__init__.py
+++ b/homeassistant/components/homematic/__init__.py
@@ -797,11 +797,8 @@ class HMDevice(Entity):
                 has_changed = True
 
         # Availability has changed
-        if attribute == 'UNREACH':
-            self._available = not bool(value)
-            has_changed = True
-        elif not self.available:
-            self._available = False
+        if self.available != (not self._hmdevice._unreach):
+            self._available = not self._hmdevice._unreach
             has_changed = True
 
         # If it has changed data point, update HASS


### PR DESCRIPTION
## Description:
Currently the transition from unavailable to available for devices that are offline during startup doesn't work reliably. pyhomematic handles the availability state internally though, and this change makes use of that. This should have been fixed with https://github.com/home-assistant/home-assistant/pull/16202, but for some reason it still didn't work.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
