### PR TITLE
Fix mold_indicator errors at startup

### DIFF
--- a/homeassistant/components/sensor/mold_indicator.py
+++ b/homeassistant/components/sensor/mold_indicator.py
@@ -213,6 +213,8 @@ class MoldIndicator(Entity):
         # check all sensors
         if None in (self._indoor_temp, self._indoor_hum, self._outdoor_temp):
             self._available = False
+            self._dewpoint = None
+            self._crit_temp = None
             return
 
         # re-calculate dewpoint and mold indicator
@@ -220,6 +222,8 @@ class MoldIndicator(Entity):
         self._calc_moldindicator()
         if self._state is None:
             self._available = False
+            self._dewpoint = None
+            self._crit_temp = None
         else:
             self._available = True
 
@@ -247,6 +251,7 @@ class MoldIndicator(Entity):
                           self._dewpoint, self._calib_factor)
             self._state = None
             self._available = False
+            self._crit_temp = None
             return
 
         # first calculate the approximate temperature at the calibration point

--- a/homeassistant/components/sensor/mold_indicator.py
+++ b/homeassistant/components/sensor/mold_indicator.py
@@ -54,26 +54,23 @@ async def async_setup_platform(hass, config, async_add_entities,
     calib_factor = config.get(CONF_CALIBRATION_FACTOR)
 
     async_add_entities([MoldIndicator(
-        hass, name, indoor_temp_sensor, outdoor_temp_sensor,
-        indoor_humidity_sensor, calib_factor)], False)
-
-    return True
+        name, hass.config.units.is_metric, indoor_temp_sensor,
+        outdoor_temp_sensor, indoor_humidity_sensor, calib_factor)], False)
 
 
 class MoldIndicator(Entity):
     """Represents a MoldIndication sensor."""
 
-    def __init__(self, hass, name, indoor_temp_sensor,
+    def __init__(self, name, is_metric, indoor_temp_sensor,
                  outdoor_temp_sensor, indoor_humidity_sensor, calib_factor):
         """Initialize the sensor."""
-        self.hass = hass
         self._state = None
         self._name = name
         self._indoor_temp_sensor = indoor_temp_sensor
         self._indoor_humidity_sensor = indoor_humidity_sensor
         self._outdoor_temp_sensor = outdoor_temp_sensor
         self._calib_factor = calib_factor
-        self._is_metric = hass.config.units.is_metric
+        self._is_metric = is_metric
         self._available = False
         self._entities = set([self._indoor_temp_sensor,
                               self._indoor_humidity_sensor,
@@ -110,8 +107,8 @@ class MoldIndicator(Entity):
             outdoor_temp = self.hass.states.get(self._outdoor_temp_sensor)
             indoor_hum = self.hass.states.get(self._indoor_humidity_sensor)
 
-            schedule_update = True if self._update_sensor(
-                self._indoor_temp_sensor, None, indoor_temp) else False
+            schedule_update = self._update_sensor(self._indoor_temp_sensor,
+                                                  None, indoor_temp)
 
             schedule_update = False if not self._update_sensor(
                 self._outdoor_temp_sensor, None, outdoor_temp) else\

--- a/homeassistant/components/sensor/mold_indicator.py
+++ b/homeassistant/components/sensor/mold_indicator.py
@@ -151,16 +151,16 @@ class MoldIndicator(Entity):
 
         # Return an error if the sensor change its state to Unknown.
         if state.state == STATE_UNKNOWN:
-            _LOGGER.error("Unable to parse sensor temperature: %s",
-                          state.state)
+            _LOGGER.error("Unable to parse temperature sensor %s with state:"
+                          " %s", state.entity_id, state.state)
             return None
 
         unit = state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
         temp = util.convert(state.state, float)
 
         if temp is None:
-            _LOGGER.error("Unable to parse sensor temperature: %s",
-                          state.state)
+            _LOGGER.error("Unable to parse temperature sensor %s with state:"
+                          " %s", state.entity_id, state.state)
             return None
 
         # convert to celsius if necessary
@@ -168,8 +168,9 @@ class MoldIndicator(Entity):
             return util.temperature.fahrenheit_to_celsius(temp)
         if unit == TEMP_CELSIUS:
             return temp
-        _LOGGER.error("Temp sensor has unsupported unit: %s (allowed: %s, "
-                      "%s)", unit, TEMP_CELSIUS, TEMP_FAHRENHEIT)
+        _LOGGER.error("Temp sensor %s has unsupported unit: %s (allowed: %s, "
+                      "%s)", state.entity_id, unit, TEMP_CELSIUS,
+                      TEMP_FAHRENHEIT)
 
         return None
 
@@ -180,26 +181,26 @@ class MoldIndicator(Entity):
 
         # Return an error if the sensor change its state to Unknown.
         if state.state == STATE_UNKNOWN:
-            _LOGGER.error('Unable to parse sensor humidity: %s',
-                          state.state)
+            _LOGGER.error('Unable to parse humidity sensor %s, state: %s',
+                          state.entity_id, state.state)
             return None
 
         unit = state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
         hum = util.convert(state.state, float)
 
         if hum is None:
-            _LOGGER.error("Unable to parse sensor humidity: %s",
-                          state.state)
+            _LOGGER.error("Unable to parse humidity sensor %s, state: %s",
+                          state.entity_id, state.state)
             return None
 
         if unit != '%':
-            _LOGGER.error("Humidity sensor has unsupported unit: %s %s",
-                          unit, " (allowed: %)")
+            _LOGGER.error("Humidity sensor %s has unsupported unit: %s %s",
+                          state.entity_id, unit, " (allowed: %)")
             return None
 
         if hum > 100 or hum < 0:
-            _LOGGER.error("Humidity sensor out of range: %s %s", hum,
-                          " (allowed: 0-100%)")
+            _LOGGER.error("Humidity sensor %s is out of range: %s %s",
+                          state.entity_id, hum, "(allowed: 0-100%)")
             return None
 
         return hum

--- a/homeassistant/components/sensor/mold_indicator.py
+++ b/homeassistant/components/sensor/mold_indicator.py
@@ -84,6 +84,7 @@ class MoldIndicator(Entity):
         outdoor_temp = hass.states.get(outdoor_temp_sensor)
         indoor_hum = hass.states.get(indoor_humidity_sensor)
 
+        # Get the current values if the sensors already have this data.
         if indoor_temp and indoor_temp.state != STATE_UNKNOWN:
             _LOGGER.debug("Have indoor temp sensor with state %s",
                           indoor_temp.state)
@@ -104,8 +105,10 @@ class MoldIndicator(Entity):
     def _update_temp_sensor(state):
         """Parse temperature sensor value."""
         _LOGGER.debug("Updating temp sensor with value %s", state.state)
+
+        # Return an error if the sensor change its state to Unknown.
         if state.state == STATE_UNKNOWN:
-            _LOGGER.error("Unable ERIK to parse sensor temperature: %s",
+            _LOGGER.error("Unable to parse sensor temperature: %s",
                           state.state)
             return None
 
@@ -131,8 +134,10 @@ class MoldIndicator(Entity):
     def _update_hum_sensor(state):
         """Parse humidity sensor value."""
         _LOGGER.debug("Updating humidity sensor with value %s", state.state)
+
+        # Return an error if the sensor change its state to Unknown.
         if state.state == STATE_UNKNOWN:
-            _LOGGER.error('Unable to ERIK parse sensor humidity: %s',
+            _LOGGER.error('Unable to parse sensor humidity: %s',
                           state.state)
             return None
 
@@ -168,11 +173,14 @@ class MoldIndicator(Entity):
 
     def _sensor_changed(self, entity_id, old_state, new_state):
         """Handle sensor state changes."""
-        _LOGGER.debug("Sensor state change for %s that had old state %s"
-                       " and new state %s", entity_id, old_state, new_state)
+        _LOGGER.debug("Sensor state change for %s that had old state %s "
+                      "and new state %s", entity_id, old_state, new_state)
+
         if new_state is None:
             return
 
+        # If old_state is not set and new state is unknown then it means that
+        # the sensor just started up and has not yet updated it's data yet.
         if old_state is None and new_state.state == STATE_UNKNOWN:
             return
 
@@ -268,10 +276,10 @@ class MoldIndicator(Entity):
             }
 
         dewpoint = util.temperature.celsius_to_fahrenheit(self._dewpoint) \
-                   if self._dewpoint is not None else None
+            if self._dewpoint is not None else None
 
         crit_temp = util.temperature.celsius_to_fahrenheit(self._crit_temp) \
-                    if self._crit_temp is not None else None
+            if self._crit_temp is not None else None
 
         return {
             ATTR_DEWPOINT:

--- a/tests/components/sensor/test_moldindicator.py
+++ b/tests/components/sensor/test_moldindicator.py
@@ -5,7 +5,8 @@ from homeassistant.setup import setup_component
 import homeassistant.components.sensor as sensor
 from homeassistant.components.sensor.mold_indicator import (ATTR_DEWPOINT,
                                                             ATTR_CRITICAL_TEMP)
-from homeassistant.const import (ATTR_UNIT_OF_MEASUREMENT, TEMP_CELSIUS)
+from homeassistant.const import (
+    ATTR_UNIT_OF_MEASUREMENT, STATE_UNKNOWN, TEMP_CELSIUS)
 
 from tests.common import get_test_home_assistant
 
@@ -160,7 +161,7 @@ class TestSensorMoldIndicator(unittest.TestCase):
         }))
         self.hass.start()
 
-        self.hass.states.set('test.indoortemp', 'UNKNOWN',
+        self.hass.states.set('test.indoortemp', STATE_UNKNOWN,
                              {ATTR_UNIT_OF_MEASUREMENT: TEMP_CELSIUS})
         self.hass.block_till_done()
         moldind = self.hass.states.get('sensor.mold_indicator')
@@ -171,7 +172,7 @@ class TestSensorMoldIndicator(unittest.TestCase):
 
         self.hass.states.set('test.indoortemp', '30',
                              {ATTR_UNIT_OF_MEASUREMENT: TEMP_CELSIUS})
-        self.hass.states.set('test.outdoortemp', 'UNKNOWN',
+        self.hass.states.set('test.outdoortemp', STATE_UNKNOWN,
                              {ATTR_UNIT_OF_MEASUREMENT: TEMP_CELSIUS})
         self.hass.block_till_done()
         moldind = self.hass.states.get('sensor.mold_indicator')
@@ -182,7 +183,7 @@ class TestSensorMoldIndicator(unittest.TestCase):
 
         self.hass.states.set('test.outdoortemp', '25',
                              {ATTR_UNIT_OF_MEASUREMENT: TEMP_CELSIUS})
-        self.hass.states.set('test.indoorhumidity', 'UNKNOWN',
+        self.hass.states.set('test.indoorhumidity', STATE_UNKNOWN,
                              {ATTR_UNIT_OF_MEASUREMENT: '%'})
         self.hass.block_till_done()
         moldind = self.hass.states.get('sensor.mold_indicator')

--- a/tests/components/sensor/test_moldindicator.py
+++ b/tests/components/sensor/test_moldindicator.py
@@ -5,8 +5,7 @@ from homeassistant.setup import setup_component
 import homeassistant.components.sensor as sensor
 from homeassistant.components.sensor.mold_indicator import (ATTR_DEWPOINT,
                                                             ATTR_CRITICAL_TEMP)
-from homeassistant.const import (ATTR_UNIT_OF_MEASUREMENT,
-                                 TEMP_CELSIUS)
+from homeassistant.const import (ATTR_UNIT_OF_MEASUREMENT, TEMP_CELSIUS)
 
 from tests.common import get_test_home_assistant
 
@@ -67,8 +66,8 @@ class TestSensorMoldIndicator(unittest.TestCase):
         moldind = self.hass.states.get('sensor.mold_indicator')
         assert moldind
         assert moldind.state == 'unavailable'
-        assert moldind.attributes.get(ATTR_DEWPOINT) == None
-        assert moldind.attributes.get(ATTR_CRITICAL_TEMP) == None
+        assert moldind.attributes.get(ATTR_DEWPOINT) is None
+        assert moldind.attributes.get(ATTR_CRITICAL_TEMP) is None
 
     def test_invalidhum(self):
         """Test invalid sensor values."""
@@ -94,8 +93,8 @@ class TestSensorMoldIndicator(unittest.TestCase):
         moldind = self.hass.states.get('sensor.mold_indicator')
         assert moldind
         assert moldind.state == 'unavailable'
-        assert moldind.attributes.get(ATTR_DEWPOINT) == None
-        assert moldind.attributes.get(ATTR_CRITICAL_TEMP) == None
+        assert moldind.attributes.get(ATTR_DEWPOINT) is None
+        assert moldind.attributes.get(ATTR_CRITICAL_TEMP) is None
 
         self.hass.states.set('test.indoorhumidity', 'A',
                              {ATTR_UNIT_OF_MEASUREMENT: '%'})
@@ -103,9 +102,8 @@ class TestSensorMoldIndicator(unittest.TestCase):
         moldind = self.hass.states.get('sensor.mold_indicator')
         assert moldind
         assert moldind.state == 'unavailable'
-        assert moldind.attributes.get(ATTR_DEWPOINT) == None
-        assert moldind.attributes.get(ATTR_CRITICAL_TEMP) == None
-
+        assert moldind.attributes.get(ATTR_DEWPOINT) is None
+        assert moldind.attributes.get(ATTR_CRITICAL_TEMP) is None
 
         self.hass.states.set('test.indoorhumidity', '10',
                              {ATTR_UNIT_OF_MEASUREMENT: TEMP_CELSIUS})
@@ -113,8 +111,8 @@ class TestSensorMoldIndicator(unittest.TestCase):
         moldind = self.hass.states.get('sensor.mold_indicator')
         assert moldind
         assert moldind.state == 'unavailable'
-        assert moldind.attributes.get(ATTR_DEWPOINT) == None
-        assert moldind.attributes.get(ATTR_CRITICAL_TEMP) == None
+        assert moldind.attributes.get(ATTR_DEWPOINT) is None
+        assert moldind.attributes.get(ATTR_CRITICAL_TEMP) is None
 
     def test_calculation(self):
         """Test the mold indicator internal calculations."""
@@ -168,8 +166,8 @@ class TestSensorMoldIndicator(unittest.TestCase):
         moldind = self.hass.states.get('sensor.mold_indicator')
         assert moldind
         assert moldind.state == 'unavailable'
-        assert moldind.attributes.get(ATTR_DEWPOINT) == None
-        assert moldind.attributes.get(ATTR_CRITICAL_TEMP) == None
+        assert moldind.attributes.get(ATTR_DEWPOINT) is None
+        assert moldind.attributes.get(ATTR_CRITICAL_TEMP) is None
 
         self.hass.states.set('test.indoortemp', '30',
                              {ATTR_UNIT_OF_MEASUREMENT: TEMP_CELSIUS})
@@ -179,8 +177,8 @@ class TestSensorMoldIndicator(unittest.TestCase):
         moldind = self.hass.states.get('sensor.mold_indicator')
         assert moldind
         assert moldind.state == 'unavailable'
-        assert moldind.attributes.get(ATTR_DEWPOINT) == None
-        assert moldind.attributes.get(ATTR_CRITICAL_TEMP) == None
+        assert moldind.attributes.get(ATTR_DEWPOINT) is None
+        assert moldind.attributes.get(ATTR_CRITICAL_TEMP) is None
 
         self.hass.states.set('test.outdoortemp', '25',
                              {ATTR_UNIT_OF_MEASUREMENT: TEMP_CELSIUS})
@@ -190,8 +188,8 @@ class TestSensorMoldIndicator(unittest.TestCase):
         moldind = self.hass.states.get('sensor.mold_indicator')
         assert moldind
         assert moldind.state == 'unavailable'
-        assert moldind.attributes.get(ATTR_DEWPOINT) == None
-        assert moldind.attributes.get(ATTR_CRITICAL_TEMP) == None
+        assert moldind.attributes.get(ATTR_DEWPOINT) is None
+        assert moldind.attributes.get(ATTR_CRITICAL_TEMP) is None
 
         self.hass.states.set('test.indoorhumidity', '20',
                              {ATTR_UNIT_OF_MEASUREMENT: '%'})


### PR DESCRIPTION
## Description:

See to resolve issue as reported in 16733 on startup. 

Added logic to ensure that if the state is unknown during startup that the error about being unable to parse the value is not logged.
Further,  also ensured that if an attribute is set to None it does not try to convert the None value to Fahrenheit as that will cause an error.

**Related issue (if applicable):** fixes #16733

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
