### PR TITLE
Color control for Abode RGB lights

### DIFF
--- a/homeassistant/components/light/abode.py
+++ b/homeassistant/components/light/abode.py
@@ -19,7 +19,7 @@ DEPENDENCIES = ['abode']
 _LOGGER = logging.getLogger(__name__)
 
 
-def setup_platform(hass, config, add_devices, discovery_info=None):
+def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up Abode light devices."""
     import abodepy.helpers.constants as CONST
 
@@ -38,7 +38,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
     data.devices.extend(devices)
 
-    add_devices(devices)
+    add_entities(devices)
 
 
 class AbodeLight(AbodeDevice, Light):

--- a/homeassistant/components/light/abode.py
+++ b/homeassistant/components/light/abode.py
@@ -98,6 +98,6 @@ class AbodeLight(AbodeDevice, Light):
         """Flag supported features."""
         if self._device.is_dimmable and self._device.is_color_capable:
             return SUPPORT_BRIGHTNESS | SUPPORT_COLOR | SUPPORT_COLOR_TEMP
-        elif self._device.is_dimmable:
+        if self._device.is_dimmable:
             return SUPPORT_BRIGHTNESS
         return 0

--- a/homeassistant/components/light/abode.py
+++ b/homeassistant/components/light/abode.py
@@ -48,7 +48,8 @@ class AbodeLight(AbodeDevice, Light):
         """Turn on the light."""
         if ATTR_COLOR_TEMP in kwargs and self._device.is_color_capable:
             self._device.set_color_temp(
-                int(color_temperature_mired_to_kelvin(kwargs[ATTR_COLOR_TEMP])))
+                int(color_temperature_mired_to_kelvin(
+                    kwargs[ATTR_COLOR_TEMP])))
 
         if ATTR_HS_COLOR in kwargs and self._device.is_color_capable:
             self._device.set_color(kwargs[ATTR_HS_COLOR])

--- a/homeassistant/components/light/abode.py
+++ b/homeassistant/components/light/abode.py
@@ -8,9 +8,10 @@ import logging
 from math import ceil
 from homeassistant.components.abode import AbodeDevice, DOMAIN as ABODE_DOMAIN
 from homeassistant.components.light import (
-    ATTR_BRIGHTNESS, ATTR_HS_COLOR,
-    SUPPORT_BRIGHTNESS, SUPPORT_COLOR, Light)
-import homeassistant.util.color as color_util
+    ATTR_BRIGHTNESS, ATTR_HS_COLOR, ATTR_COLOR_TEMP,
+    SUPPORT_BRIGHTNESS, SUPPORT_COLOR, SUPPORT_COLOR_TEMP, Light)
+from homeassistant.util.color import (
+    color_temperature_kelvin_to_mired, color_temperature_mired_to_kelvin)
 
 
 DEPENDENCIES = ['abode']
@@ -18,7 +19,7 @@ DEPENDENCIES = ['abode']
 _LOGGER = logging.getLogger(__name__)
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
+def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up Abode light devices."""
     import abodepy.helpers.constants as CONST
 
@@ -37,7 +38,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     data.devices.extend(devices)
 
-    add_entities(devices)
+    add_devices(devices)
 
 
 class AbodeLight(AbodeDevice, Light):
@@ -45,10 +46,12 @@ class AbodeLight(AbodeDevice, Light):
 
     def turn_on(self, **kwargs):
         """Turn on the light."""
-        if (ATTR_HS_COLOR in kwargs and
-                self._device.is_dimmable and self._device.has_color):
-            self._device.set_color(color_util.color_hs_to_RGB(
-                *kwargs[ATTR_HS_COLOR]))
+        if ATTR_COLOR_TEMP in kwargs and self._device.is_color_capable:
+            self._device.set_color_temp(
+                int(color_temperature_mired_to_kelvin(kwargs[ATTR_COLOR_TEMP])))
+
+        if ATTR_HS_COLOR in kwargs and self._device.is_color_capable:
+            self._device.set_color(kwargs[ATTR_HS_COLOR])
 
         if ATTR_BRIGHTNESS in kwargs and self._device.is_dimmable:
             # Convert HASS brightness (0-255) to Abode brightness (0-99)
@@ -78,17 +81,22 @@ class AbodeLight(AbodeDevice, Light):
             return ceil(brightness * 255 / 99.0)
 
     @property
+    def color_temp(self):
+        """Return the color temp of the light."""
+        if self._device.has_color:
+            return color_temperature_kelvin_to_mired(self._device.color_temp)
+
+    @property
     def hs_color(self):
         """Return the color of the light."""
-        if self._device.is_dimmable and self._device.has_color:
-            return color_util.color_RGB_to_hs(*self._device.color)
+        if self._device.has_color:
+            return self._device.color
 
     @property
     def supported_features(self):
         """Flag supported features."""
-        if self._device.is_dimmable and self._device.has_color:
-            return SUPPORT_BRIGHTNESS | SUPPORT_COLOR
-        if self._device.is_dimmable:
+        if self._device.is_dimmable and self._device.is_color_capable:
+            return SUPPORT_BRIGHTNESS | SUPPORT_COLOR | SUPPORT_COLOR_TEMP
+        elif self._device.is_dimmable:
             return SUPPORT_BRIGHTNESS
-
         return 0


### PR DESCRIPTION
## Description:

This update enables color control for RGB lights connected to Abode with Abodepy 0.14.0. This update is required to be updated with Abodepy 0.14.0 ([#17366](https://github.com/home-assistant/home-assistant/pull/17336)).

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54