### PR TITLE
Clean up OpenUV config flow

### DIFF
--- a/homeassistant/components/binary_sensor/openuv.py
+++ b/homeassistant/components/binary_sensor/openuv.py
@@ -50,12 +50,12 @@ class OpenUvBinarySensor(OpenUvEntity, BinarySensorDevice):
         """Initialize the sensor."""
         super().__init__(openuv)
 
+        self._async_unsub_dispatcher_connect = None
         self._entry_id = entry_id
         self._icon = icon
         self._latitude = openuv.client.latitude
         self._longitude = openuv.client.longitude
         self._name = name
-        self._dispatch_remove = None
         self._sensor_type = sensor_type
         self._state = None
 
@@ -80,16 +80,20 @@ class OpenUvBinarySensor(OpenUvEntity, BinarySensorDevice):
         return '{0}_{1}_{2}'.format(
             self._latitude, self._longitude, self._sensor_type)
 
-    @callback
-    def _update_data(self):
-        """Update the state."""
-        self.async_schedule_update_ha_state(True)
-
     async def async_added_to_hass(self):
         """Register callbacks."""
-        self._dispatch_remove = async_dispatcher_connect(
-            self.hass, TOPIC_UPDATE, self._update_data)
-        self.async_on_remove(self._dispatch_remove)
+        @callback
+        def update(self):
+            """Update the state."""
+            self.async_schedule_update_ha_state(True)
+
+        self._async_unsub_dispatcher_connect = async_dispatcher_connect(
+            self.hass, TOPIC_UPDATE, update)
+
+    async def async_will_remove_from_hass(self):
+        """Disconnect dispatcher listener when removed."""
+        if self._async_unsub_dispatcher_connect:
+            self._async_unsub_dispatcher_connect()
 
     async def async_update(self):
         """Update the state."""

--- a/homeassistant/components/binary_sensor/openuv.py
+++ b/homeassistant/components/binary_sensor/openuv.py
@@ -83,7 +83,7 @@ class OpenUvBinarySensor(OpenUvEntity, BinarySensorDevice):
     async def async_added_to_hass(self):
         """Register callbacks."""
         @callback
-        def update(self):
+        def update():
             """Update the state."""
             self.async_schedule_update_ha_state(True)
 

--- a/homeassistant/components/openuv/__init__.py
+++ b/homeassistant/components/openuv/__init__.py
@@ -108,9 +108,8 @@ async def async_setup(hass, config):
         return True
 
     conf = config[DOMAIN]
-    latitude = conf.get(CONF_LATITUDE, hass.config.latitude)
-    longitude = conf.get(CONF_LONGITUDE, hass.config.longitude)
-    elevation = conf.get(CONF_ELEVATION, hass.config.elevation)
+    latitude = conf.get(CONF_LATITUDE)
+    longitude = conf.get(CONF_LONGITUDE)
 
     identifier = '{0}, {1}'.format(latitude, longitude)
     if identifier in configured_instances(hass):
@@ -124,7 +123,7 @@ async def async_setup(hass, config):
                 CONF_API_KEY: conf[CONF_API_KEY],
                 CONF_LATITUDE: latitude,
                 CONF_LONGITUDE: longitude,
-                CONF_ELEVATION: elevation,
+                CONF_ELEVATION: conf.get(CONF_ELEVATION),
                 CONF_BINARY_SENSORS: conf[CONF_BINARY_SENSORS],
                 CONF_SENSORS: conf[CONF_SENSORS],
                 CONF_SCAN_INTERVAL: conf[CONF_SCAN_INTERVAL],

--- a/homeassistant/components/openuv/__init__.py
+++ b/homeassistant/components/openuv/__init__.py
@@ -14,6 +14,7 @@ from homeassistant.const import (
     ATTR_ATTRIBUTION, CONF_API_KEY, CONF_BINARY_SENSORS, CONF_ELEVATION,
     CONF_LATITUDE, CONF_LONGITUDE, CONF_MONITORED_CONDITIONS,
     CONF_SCAN_INTERVAL, CONF_SENSORS)
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import aiohttp_client, config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.entity import Entity
@@ -153,14 +154,7 @@ async def async_setup_entry(hass, config_entry):
         await openuv.async_update()
         hass.data[DOMAIN][DATA_OPENUV_CLIENT][config_entry.entry_id] = openuv
     except OpenUvError as err:
-        _LOGGER.error('An error occurred: %s', str(err))
-        hass.components.persistent_notification.create(
-            'Error: {0}<br />'
-            'You will need to restart hass after fixing.'
-            ''.format(err),
-            title=NOTIFICATION_TITLE,
-            notification_id=NOTIFICATION_ID)
-        return False
+        raise ConfigEntryNotReady(err)
 
     for component in ('binary_sensor', 'sensor'):
         hass.async_create_task(hass.config_entries.async_forward_entry_setup(

--- a/homeassistant/components/openuv/__init__.py
+++ b/homeassistant/components/openuv/__init__.py
@@ -154,7 +154,7 @@ async def async_setup_entry(hass, config_entry):
         await openuv.async_update()
         hass.data[DOMAIN][DATA_OPENUV_CLIENT][config_entry.entry_id] = openuv
     except OpenUvError as err:
-        raise ConfigEntryNotReady(err)
+        raise ConfigEntryNotReady
 
     for component in ('binary_sensor', 'sensor'):
         hass.async_create_task(hass.config_entries.async_forward_entry_setup(

--- a/homeassistant/components/openuv/__init__.py
+++ b/homeassistant/components/openuv/__init__.py
@@ -183,7 +183,7 @@ async def async_unload_entry(hass, config_entry):
     remove_listener = hass.data[DOMAIN][DATA_OPENUV_LISTENER].pop(
         config_entry.entry_id)
     remove_listener()
-    
+
     for component in ('binary_sensor', 'sensor'):
         await hass.config_entries.async_forward_entry_unload(
             config_entry, component)

--- a/homeassistant/components/openuv/config_flow.py
+++ b/homeassistant/components/openuv/config_flow.py
@@ -69,7 +69,7 @@ class OpenUvFlowHandler(config_entries.ConfigFlow):
 
         identifier = '{0}, {1}'.format(latitude, longitude)
         if identifier in configured_instances(self.hass):
-            return await self._show_form({'base': 'identifier_exists'})
+            return await self._show_form({CONF_LATITUDE: 'identifier_exists'})
 
         websession = aiohttp_client.async_get_clientsession(self.hass)
         api_key_validation = await validate_api_key(

--- a/homeassistant/components/openuv/config_flow.py
+++ b/homeassistant/components/openuv/config_flow.py
@@ -61,15 +61,9 @@ class OpenUvFlowHandler(config_entries.ConfigFlow):
         if not user_input:
             return await self._show_form()
 
-        latitude = user_input.get(CONF_LATITUDE)
-        if not latitude:
-            latitude = self.hass.config.latitude
-        longitude = user_input.get(CONF_LONGITUDE)
-        if not longitude:
-            longitude = self.hass.config.longitude
-        elevation = user_input.get(CONF_ELEVATION)
-        if not elevation:
-            elevation = self.hass.config.elevation
+        latitude = user_input[CONF_LATITUDE]
+        longitude = user_input[CONF_LONGITUDE]
+        elevation = user_input[CONF_ELEVATION]
 
         identifier = '{0}, {1}'.format(latitude, longitude)
         if identifier in configured_instances(self.hass):

--- a/homeassistant/components/openuv/config_flow.py
+++ b/homeassistant/components/openuv/config_flow.py
@@ -1,7 +1,5 @@
 """Config flow to configure the OpenUV component."""
 
-from collections import OrderedDict
-
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -32,17 +30,23 @@ class OpenUvFlowHandler(config_entries.ConfigFlow):
 
     def __init__(self):
         """Initialize the config flow."""
-        self.data_schema = OrderedDict()
-        self.data_schema[vol.Required(CONF_API_KEY)] = str
-        self.data_schema[vol.Optional(CONF_LATITUDE)] = cv.latitude
-        self.data_schema[vol.Optional(CONF_LONGITUDE)] = cv.longitude
-        self.data_schema[vol.Optional(CONF_ELEVATION)] = vol.Coerce(float)
+        pass
 
     async def _show_form(self, errors=None):
         """Show the form to the user."""
+        data_schema = vol.Schema({
+            vol.Required(CONF_API_KEY): str,
+            vol.Optional(CONF_LATITUDE, default=self.hass.config.latitude):
+                cv.latitude,
+            vol.Optional(CONF_LONGITUDE, default=self.hass.config.longitude):
+                cv.longitude,
+            vol.Optional(CONF_ELEVATION, default=self.hass.config.elevation):
+                vol.Coerce(float),
+        })
+
         return self.async_show_form(
             step_id='user',
-            data_schema=vol.Schema(self.data_schema),
+            data_schema=data_schema,
             errors=errors if errors else {},
         )
 

--- a/homeassistant/components/openuv/config_flow.py
+++ b/homeassistant/components/openuv/config_flow.py
@@ -76,7 +76,7 @@ class OpenUvFlowHandler(config_entries.ConfigFlow):
             user_input[CONF_API_KEY], websession)
 
         if not api_key_validation:
-            return await self._show_form({'base': 'invalid_api_key'})
+            return await self._show_form({CONF_API_KEY: 'invalid_api_key'})
 
         scan_interval = user_input.get(
             CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)

--- a/homeassistant/components/openuv/config_flow.py
+++ b/homeassistant/components/openuv/config_flow.py
@@ -57,9 +57,15 @@ class OpenUvFlowHandler(config_entries.ConfigFlow):
         if not user_input:
             return await self._show_form()
 
-        latitude = user_input.get(CONF_LATITUDE, self.hass.config.latitude)
-        longitude = user_input.get(CONF_LONGITUDE, self.hass.config.longitude)
-        elevation = user_input.get(CONF_ELEVATION, self.hass.config.elevation)
+        latitude = user_input.get(CONF_LATITUDE)
+        if not latitude:
+            latitude = self.hass.config.latitude
+        longitude = user_input.get(CONF_LONGITUDE)
+        if not longitude:
+            longitude = self.hass.config.longitude
+        elevation = user_input.get(CONF_ELEVATION)
+        if not elevation:
+            elevation = self.hass.config.elevation
 
         identifier = '{0}, {1}'.format(latitude, longitude)
         if identifier in configured_instances(self.hass):

--- a/homeassistant/components/openuv/const.py
+++ b/homeassistant/components/openuv/const.py
@@ -1,3 +1,6 @@
 """Define constants for the OpenUV component."""
+from datetime import timedelta
 
 DOMAIN = 'openuv'
+
+DEFAULT_SCAN_INTERVAL = timedelta(minutes=30)

--- a/homeassistant/components/sensor/openuv.py
+++ b/homeassistant/components/sensor/openuv.py
@@ -103,7 +103,7 @@ class OpenUvSensor(OpenUvEntity):
     async def async_added_to_hass(self):
         """Register callbacks."""
         @callback
-        def update(self):
+        def update():
             """Update the state."""
             self.async_schedule_update_ha_state(True)
 

--- a/homeassistant/components/sensor/openuv.py
+++ b/homeassistant/components/sensor/openuv.py
@@ -64,7 +64,7 @@ class OpenUvSensor(OpenUvEntity):
         """Initialize the sensor."""
         super().__init__(openuv)
 
-        self._dispatch_remove = None
+        self._async_unsub_dispatcher_connect = None
         self._entry_id = entry_id
         self._icon = icon
         self._latitude = openuv.client.latitude
@@ -100,16 +100,20 @@ class OpenUvSensor(OpenUvEntity):
         """Return the unit the value is expressed in."""
         return self._unit
 
-    @callback
-    def _update_data(self):
-        """Update the state."""
-        self.async_schedule_update_ha_state(True)
-
     async def async_added_to_hass(self):
         """Register callbacks."""
-        self._dispatch_remove = async_dispatcher_connect(
-            self.hass, TOPIC_UPDATE, self._update_data)
-        self.async_on_remove(self._dispatch_remove)
+        @callback
+        def update(self):
+            """Update the state."""
+            self.async_schedule_update_ha_state(True)
+
+        self._async_unsub_dispatcher_connect = async_dispatcher_connect(
+            self.hass, TOPIC_UPDATE, update)
+
+    async def async_will_remove_from_hass(self):
+        """Disconnect dispatcher listener when removed."""
+        if self._async_unsub_dispatcher_connect:
+            self._async_unsub_dispatcher_connect()
 
     async def async_update(self):
         """Update the state."""

--- a/tests/components/openuv/test_config_flow.py
+++ b/tests/components/openuv/test_config_flow.py
@@ -61,6 +61,9 @@ async def test_step_import(hass):
     """Test that the import step works."""
     conf = {
         CONF_API_KEY: '12345abcde',
+        CONF_ELEVATION: 59.1234,
+        CONF_LATITUDE: 39.128712,
+        CONF_LONGITUDE: -104.9812612,
     }
 
     flow = config_flow.OpenUvFlowHandler()
@@ -71,13 +74,12 @@ async def test_step_import(hass):
         result = await flow.async_step_import(import_config=conf)
 
         assert result['type'] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-        assert result['title'] == '{0}, {1}'.format(
-            hass.config.latitude, hass.config.longitude)
+        assert result['title'] == '39.128712, -104.9812612'
         assert result['data'] == {
             CONF_API_KEY: '12345abcde',
-            CONF_LATITUDE: hass.config.latitude,
-            CONF_LONGITUDE: hass.config.longitude,
-            CONF_ELEVATION: hass.config.elevation,
+            CONF_ELEVATION: 59.1234,
+            CONF_LATITUDE: 39.128712,
+            CONF_LONGITUDE: -104.9812612,
             CONF_SCAN_INTERVAL: 1800,
         }
 
@@ -100,8 +102,7 @@ async def test_step_user(hass):
         result = await flow.async_step_user(user_input=conf)
 
         assert result['type'] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-        assert result['title'] == '{0}, {1}'.format(
-            conf[CONF_LATITUDE], conf[CONF_LONGITUDE])
+        assert result['title'] == '39.128712, -104.9812612'
         assert result['data'] == {
             CONF_API_KEY: '12345abcde',
             CONF_ELEVATION: 59.1234,

--- a/tests/components/openuv/test_config_flow.py
+++ b/tests/components/openuv/test_config_flow.py
@@ -25,7 +25,7 @@ async def test_duplicate_error(hass):
     flow.hass = hass
 
     result = await flow.async_step_user(user_input=conf)
-    assert result['errors'] == {'base': 'identifier_exists'}
+    assert result['errors'] == {CONF_LATITUDE: 'identifier_exists'}
 
 
 async def test_invalid_api_key(hass):
@@ -43,7 +43,7 @@ async def test_invalid_api_key(hass):
     with patch('pyopenuv.util.validate_api_key',
                return_value=mock_coro(False)):
         result = await flow.async_step_user(user_input=conf)
-        assert result['errors'] == {'base': 'invalid_api_key'}
+        assert result['errors'] == {CONF_API_KEY: 'invalid_api_key'}
 
 
 async def test_show_form(hass):

--- a/tests/components/openuv/test_config_flow.py
+++ b/tests/components/openuv/test_config_flow.py
@@ -1,10 +1,12 @@
 """Define tests for the OpenUV config flow."""
+from datetime import timedelta
 from unittest.mock import patch
 
 from homeassistant import data_entry_flow
 from homeassistant.components.openuv import DOMAIN, config_flow
 from homeassistant.const import (
-    CONF_API_KEY, CONF_ELEVATION, CONF_LATITUDE, CONF_LONGITUDE)
+    CONF_API_KEY, CONF_ELEVATION, CONF_LATITUDE, CONF_LONGITUDE,
+    CONF_SCAN_INTERVAL)
 
 from tests.common import MockConfigEntry, mock_coro
 
@@ -71,7 +73,13 @@ async def test_step_import(hass):
         assert result['type'] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
         assert result['title'] == '{0}, {1}'.format(
             hass.config.latitude, hass.config.longitude)
-        assert result['data'] == conf
+        assert result['data'] == {
+            CONF_API_KEY: '12345abcde',
+            CONF_LATITUDE: hass.config.latitude,
+            CONF_LONGITUDE: hass.config.longitude,
+            CONF_ELEVATION: hass.config.elevation,
+            CONF_SCAN_INTERVAL: 1800,
+        }
 
 
 async def test_step_user(hass):
@@ -81,6 +89,7 @@ async def test_step_user(hass):
         CONF_ELEVATION: 59.1234,
         CONF_LATITUDE: 39.128712,
         CONF_LONGITUDE: -104.9812612,
+        CONF_SCAN_INTERVAL: timedelta(minutes=5)
     }
 
     flow = config_flow.OpenUvFlowHandler()
@@ -93,4 +102,10 @@ async def test_step_user(hass):
         assert result['type'] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
         assert result['title'] == '{0}, {1}'.format(
             conf[CONF_LATITUDE], conf[CONF_LONGITUDE])
-        assert result['data'] == conf
+        assert result['data'] == {
+            CONF_API_KEY: '12345abcde',
+            CONF_ELEVATION: 59.1234,
+            CONF_LATITUDE: 39.128712,
+            CONF_LONGITUDE: -104.9812612,
+            CONF_SCAN_INTERVAL: 300,
+        }


### PR DESCRIPTION
## Description:
The `openuv` config flow was my first; as such, there were lots of inefficiencies. This PR cleans them up and makes things slightly easier to read. Additionally, it fixes a bug wherein an explicitly configured `scan_interval` (in `configuration.yaml`) was not handled properly.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
openuv:
  api_key: OPENUV_API_KEY
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
