### PR TITLE
Set botvac availability

### DIFF
--- a/homeassistant/components/vacuum/neato.py
+++ b/homeassistant/components/vacuum/neato.py
@@ -146,7 +146,7 @@ class NeatoConnectedVacuum(StateVacuumDevice):
 
     @property
     def available(self):
-        """Return if the botvac is available"""
+        """Return if the robot is available."""
         return self._available
 
     @property

--- a/homeassistant/components/vacuum/neato.py
+++ b/homeassistant/components/vacuum/neato.py
@@ -64,6 +64,7 @@ class NeatoConnectedVacuum(StateVacuumDevice):
         self.clean_battery_end = None
         self.clean_suspension_charge_count = None
         self.clean_suspension_time = None
+        self._available = False
 
     def update(self):
         """Update the states of Neato Vacuums."""
@@ -71,12 +72,12 @@ class NeatoConnectedVacuum(StateVacuumDevice):
         self.neato.update_robots()
         try:
             self._state = self.robot.state
+            self._available = True
         except (requests.exceptions.ConnectionError,
                 requests.exceptions.HTTPError) as ex:
             _LOGGER.warning("Neato connection error: %s", ex)
             self._state = None
-            self._clean_state = STATE_ERROR
-            self._status_state = 'Robot Offline'
+            self._available = False
             return
         _LOGGER.debug('self._state=%s', self._state)
         if self._state['state'] == 1:
@@ -140,7 +141,13 @@ class NeatoConnectedVacuum(StateVacuumDevice):
     @property
     def battery_level(self):
         """Return the battery level of the vacuum cleaner."""
-        return self._state['details']['charge']
+        if self._available:
+            return self._state['details']['charge']
+
+    @property
+    def available(self):
+        """Return if the botvac is available"""
+        return self._available
 
     @property
     def state(self):

--- a/homeassistant/components/vacuum/neato.py
+++ b/homeassistant/components/vacuum/neato.py
@@ -65,6 +65,7 @@ class NeatoConnectedVacuum(StateVacuumDevice):
         self.clean_suspension_charge_count = None
         self.clean_suspension_time = None
         self._available = False
+        self._battery_level = None
 
     def update(self):
         """Update the states of Neato Vacuums."""
@@ -128,6 +129,8 @@ class NeatoConnectedVacuum(StateVacuumDevice):
         self.clean_battery_end = (
             self._mapdata[self.robot.serial]['maps'][0]['run_charge_at_end'])
 
+        self._battery_level = self._state['details']['charge']
+
     @property
     def name(self):
         """Return the name of the device."""
@@ -141,8 +144,7 @@ class NeatoConnectedVacuum(StateVacuumDevice):
     @property
     def battery_level(self):
         """Return the battery level of the vacuum cleaner."""
-        if self._available:
-            return self._state['details']['charge']
+        return self._battery_level
 
     @property
     def available(self):


### PR DESCRIPTION
## Description:

Add availability for neato vacuums and don't send battery updates when botvac isn't available

**Related issue (if applicable):** fixes # N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#6710

## Example entry for `configuration.yaml` (if applicable):
```yaml
neato:
  username: username
  password: password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
