### PR TITLE
Update Neato states, actions and alerts based on Neato docs

### DIFF
--- a/homeassistant/components/neato.py
+++ b/homeassistant/components/neato.py
@@ -31,14 +31,6 @@ CONFIG_SCHEMA = vol.Schema({
     })
 }, extra=vol.ALLOW_EXTRA)
 
-STATES = {
-    0: 'Invalid',
-    1: 'Idle',
-    2: 'Busy',
-    3: 'Pause',
-    4: 'Error'
-}
-
 MODE = {
     1: 'Eco',
     2: 'Turbo'

--- a/homeassistant/components/neato.py
+++ b/homeassistant/components/neato.py
@@ -32,6 +32,7 @@ CONFIG_SCHEMA = vol.Schema({
 }, extra=vol.ALLOW_EXTRA)
 
 STATES = {
+    0: 'Invalid',
     1: 'Idle',
     2: 'Busy',
     3: 'Pause',
@@ -44,16 +45,16 @@ MODE = {
 }
 
 ACTION = {
-    0: 'No action',
-    1: 'House cleaning',
-    2: 'Spot cleaning',
-    3: 'Manual cleaning',
+    0: 'Invalid',
+    1: 'House Cleaning',
+    2: 'Spot Cleaning',
+    3: 'Manual Cleaning',
     4: 'Docking',
-    5: 'User menu active',
-    6: 'Cleaning cancelled',
-    7: 'Updating...',
-    8: 'Copying logs...',
-    9: 'Calculating position...',
+    5: 'User Menu Active',
+    6: 'Suspended Cleaning',
+    7: 'Updating',
+    8: 'Copying logs',
+    9: 'Recovering Location',
     10: 'IEC test',
     11: 'Map cleaning',
     12: 'Exploring map (creating a persistent map)',
@@ -98,7 +99,8 @@ ALERTS = {
     'dustbin_full': 'Please empty dust bin',
     'maint_brush_change': 'Change the brush',
     'maint_filter_change': 'Change the filter',
-    'clean_completed_to_start': 'Cleaning completed'
+    'clean_completed_to_start': 'Cleaning completed',
+    'nav_floorplan_not_created': 'No floorplan found'
 }
 
 


### PR DESCRIPTION
## Description:

Neato has updated their actions and alerts, this PR updates the integration to include those changes and also removes unused states: https://developers.neatorobotics.com/api/robot-remote-protocol/request-response-formats

**Breaking Change:**
The vacuum status attribute has new alerts and updated actions.

**Related issue (if applicable):** fixes # N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io# N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
neato:
  username: username
  password: password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
