### PR TITLE
Prefix all xiaomi_aqara events

### DIFF
--- a/homeassistant/components/binary_sensor/xiaomi_aqara.py
+++ b/homeassistant/components/binary_sensor/xiaomi_aqara.py
@@ -209,7 +209,7 @@ class XiaomiMotionSensor(XiaomiBinarySensor):
             else:
                 self._should_poll = True
                 if self.entity_id is not None:
-                    self._hass.bus.fire('motion', {
+                    self._hass.bus.fire('xiaomi_aqara.motion', {
                         'entity_id': self.entity_id
                     })
 
@@ -414,7 +414,7 @@ class XiaomiButton(XiaomiBinarySensor):
             _LOGGER.warning("Unsupported click_type detected: %s", value)
             return False
 
-        self._hass.bus.fire('click', {
+        self._hass.bus.fire('xiaomi_aqara.click', {
             'entity_id': self.entity_id,
             'click_type': click_type
         })
@@ -450,14 +450,14 @@ class XiaomiCube(XiaomiBinarySensor):
     def parse_data(self, data, raw_data):
         """Parse data sent by gateway."""
         if self._data_key in data:
-            self._hass.bus.fire('cube_action', {
+            self._hass.bus.fire('xiaomi_aqara.cube_action', {
                 'entity_id': self.entity_id,
                 'action_type': data[self._data_key]
             })
             self._last_action = data[self._data_key]
 
         if 'rotate' in data:
-            self._hass.bus.fire('cube_action', {
+            self._hass.bus.fire('xiaomi_aqara.cube_action', {
                 'entity_id': self.entity_id,
                 'action_type': 'rotate',
                 'action_value': float(data['rotate'].replace(",", "."))


### PR DESCRIPTION
## Description:

> It was wrong from the beginning. This integration now behaves badly by firing events not specifically identifiable.

All events are prefixed now by "xiaomi_aqara". Please update your automations:

```
motion -> xiaomi_aqara.motion
click -> xiaomi_aqara.click
cube_action -> xiaomi_aqara.cube_action
```

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#7587