### PR TITLE
The ping command will not detect samsung tv in standby as off

### DIFF
--- a/homeassistant/components/media_player/samsungtv.py
+++ b/homeassistant/components/media_player/samsungtv.py
@@ -8,8 +8,6 @@ import asyncio
 from datetime import timedelta
 import logging
 import socket
-import subprocess
-import sys
 
 import voluptuous as vol
 
@@ -124,24 +122,7 @@ class SamsungTVDevice(MediaPlayerDevice):
 
     def update(self):
         """Update state of device."""
-        if sys.platform == 'win32':
-            timeout_arg = '-w {}000'.format(self._config['timeout'])
-            _ping_cmd = [
-                'ping', '-n 3', timeout_arg, self._config['host']]
-        else:
-            timeout_arg = '-W{}'.format(self._config['timeout'])
-            _ping_cmd = [
-                'ping', '-n', '-q',
-                '-c3', timeout_arg, self._config['host']]
-
-        ping = subprocess.Popen(
-            _ping_cmd,
-            stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
-        try:
-            ping.communicate()
-            self._state = STATE_ON if ping.returncode == 0 else STATE_OFF
-        except subprocess.CalledProcessError:
-            self._state = STATE_OFF
+        self.send_key("KEY")
 
     def get_remote(self):
         """Create or return a remote control instance."""


### PR DESCRIPTION
## Description:
This will revert the ping code!
In my live tests I've checked against 3 different samsung tvs and they all show on/off as intended now. 

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>
#11564

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**