### PR TITLE
Fix NoEntitySpecifiedError during knx startup

### DIFF
--- a/homeassistant/components/binary_sensor/knx.py
+++ b/homeassistant/components/binary_sensor/knx.py
@@ -106,7 +106,6 @@ class KNXBinarySensor(BinarySensorDevice):
     def __init__(self, hass, device):
         """Initialize of KNX binary sensor."""
         self.device = device
-        self.hass = hass
         self.automations = []
 
     @callback

--- a/homeassistant/components/binary_sensor/knx.py
+++ b/homeassistant/components/binary_sensor/knx.py
@@ -69,7 +69,7 @@ def async_add_entities_discovery(hass, discovery_info, async_add_entities):
     entities = []
     for device_name in discovery_info[ATTR_DISCOVER_DEVICES]:
         device = hass.data[DATA_KNX].xknx.devices[device_name]
-        entities.append(KNXBinarySensor(hass, device))
+        entities.append(KNXBinarySensor(device))
     async_add_entities(entities)
 
 
@@ -87,7 +87,7 @@ def async_add_entities_config(hass, config, async_add_entities):
         reset_after=config.get(CONF_RESET_AFTER))
     hass.data[DATA_KNX].xknx.devices.add(binary_sensor)
 
-    entity = KNXBinarySensor(hass, binary_sensor)
+    entity = KNXBinarySensor(binary_sensor)
     automations = config.get(CONF_AUTOMATION)
     if automations is not None:
         for automation in automations:
@@ -103,7 +103,7 @@ def async_add_entities_config(hass, config, async_add_entities):
 class KNXBinarySensor(BinarySensorDevice):
     """Representation of a KNX binary sensor."""
 
-    def __init__(self, hass, device):
+    def __init__(self, device):
         """Initialize of KNX binary sensor."""
         self.device = device
         self.automations = []

--- a/homeassistant/components/binary_sensor/knx.py
+++ b/homeassistant/components/binary_sensor/knx.py
@@ -107,7 +107,6 @@ class KNXBinarySensor(BinarySensorDevice):
         """Initialize of KNX binary sensor."""
         self.device = device
         self.hass = hass
-        self.async_register_callbacks()
         self.automations = []
 
     @callback
@@ -117,6 +116,10 @@ class KNXBinarySensor(BinarySensorDevice):
             """Call after device was updated."""
             await self.async_update_ha_state()
         self.device.register_device_updated_cb(after_update_callback)
+
+    async def async_added_to_hass(self):
+        """Store register state change callback."""
+        self.async_register_callbacks()
 
     @property
     def name(self):

--- a/homeassistant/components/climate/knx.py
+++ b/homeassistant/components/climate/knx.py
@@ -119,7 +119,6 @@ class KNXClimate(ClimateDevice):
     def __init__(self, hass, device):
         """Initialize of a KNX climate device."""
         self.device = device
-        self.hass = hass
 
     @property
     def supported_features(self):

--- a/homeassistant/components/climate/knx.py
+++ b/homeassistant/components/climate/knx.py
@@ -75,7 +75,7 @@ def async_add_entities_discovery(hass, discovery_info, async_add_entities):
     entities = []
     for device_name in discovery_info[ATTR_DISCOVER_DEVICES]:
         device = hass.data[DATA_KNX].xknx.devices[device_name]
-        entities.append(KNXClimate(hass, device))
+        entities.append(KNXClimate(device))
     async_add_entities(entities)
 
 
@@ -110,13 +110,13 @@ def async_add_entities_config(hass, config, async_add_entities):
         group_address_operation_mode_comfort=config.get(
             CONF_OPERATION_MODE_COMFORT_ADDRESS))
     hass.data[DATA_KNX].xknx.devices.add(climate)
-    async_add_entities([KNXClimate(hass, climate)])
+    async_add_entities([KNXClimate(climate)])
 
 
 class KNXClimate(ClimateDevice):
     """Representation of a KNX climate device."""
 
-    def __init__(self, hass, device):
+    def __init__(self, device):
         """Initialize of a KNX climate device."""
         self.device = device
 

--- a/homeassistant/components/climate/knx.py
+++ b/homeassistant/components/climate/knx.py
@@ -120,7 +120,6 @@ class KNXClimate(ClimateDevice):
         """Initialize of a KNX climate device."""
         self.device = device
         self.hass = hass
-        self.async_register_callbacks()
 
     @property
     def supported_features(self):
@@ -136,6 +135,10 @@ class KNXClimate(ClimateDevice):
             """Call after device was updated."""
             await self.async_update_ha_state()
         self.device.register_device_updated_cb(after_update_callback)
+
+    async def async_added_to_hass(self):
+        """Store register state change callback."""
+        self.async_register_callbacks()
 
     @property
     def name(self):

--- a/homeassistant/components/cover/knx.py
+++ b/homeassistant/components/cover/knx.py
@@ -97,8 +97,6 @@ class KNXCover(CoverDevice):
     def __init__(self, hass, device):
         """Initialize the cover."""
         self.device = device
-        self.hass = hass
-
         self._unsubscribe_auto_updater = None
 
     @callback

--- a/homeassistant/components/cover/knx.py
+++ b/homeassistant/components/cover/knx.py
@@ -64,7 +64,7 @@ def async_add_entities_discovery(hass, discovery_info, async_add_entities):
     entities = []
     for device_name in discovery_info[ATTR_DISCOVER_DEVICES]:
         device = hass.data[DATA_KNX].xknx.devices[device_name]
-        entities.append(KNXCover(hass, device))
+        entities.append(KNXCover(device))
     async_add_entities(entities)
 
 
@@ -88,13 +88,13 @@ def async_add_entities_config(hass, config, async_add_entities):
         invert_angle=config.get(CONF_INVERT_ANGLE))
 
     hass.data[DATA_KNX].xknx.devices.add(cover)
-    async_add_entities([KNXCover(hass, cover)])
+    async_add_entities([KNXCover(cover)])
 
 
 class KNXCover(CoverDevice):
     """Representation of a KNX cover."""
 
-    def __init__(self, hass, device):
+    def __init__(self, device):
         """Initialize the cover."""
         self.device = device
         self._unsubscribe_auto_updater = None

--- a/homeassistant/components/cover/knx.py
+++ b/homeassistant/components/cover/knx.py
@@ -98,7 +98,6 @@ class KNXCover(CoverDevice):
         """Initialize the cover."""
         self.device = device
         self.hass = hass
-        self.async_register_callbacks()
 
         self._unsubscribe_auto_updater = None
 
@@ -109,6 +108,10 @@ class KNXCover(CoverDevice):
             """Call after device was updated."""
             await self.async_update_ha_state()
         self.device.register_device_updated_cb(after_update_callback)
+
+    async def async_added_to_hass(self):
+        """Store register state change callback."""
+        self.async_register_callbacks()
 
     @property
     def name(self):

--- a/homeassistant/components/light/knx.py
+++ b/homeassistant/components/light/knx.py
@@ -52,7 +52,7 @@ def async_add_entities_discovery(hass, discovery_info, async_add_entities):
     entities = []
     for device_name in discovery_info[ATTR_DISCOVER_DEVICES]:
         device = hass.data[DATA_KNX].xknx.devices[device_name]
-        entities.append(KNXLight(hass, device))
+        entities.append(KNXLight(device))
     async_add_entities(entities)
 
 
@@ -71,13 +71,13 @@ def async_add_entities_config(hass, config, async_add_entities):
         group_address_color=config.get(CONF_COLOR_ADDRESS),
         group_address_color_state=config.get(CONF_COLOR_STATE_ADDRESS))
     hass.data[DATA_KNX].xknx.devices.add(light)
-    async_add_entities([KNXLight(hass, light)])
+    async_add_entities([KNXLight(light)])
 
 
 class KNXLight(Light):
     """Representation of a KNX light."""
 
-    def __init__(self, hass, device):
+    def __init__(self, device):
         """Initialize of KNX light."""
         self.device = device
 

--- a/homeassistant/components/light/knx.py
+++ b/homeassistant/components/light/knx.py
@@ -80,7 +80,6 @@ class KNXLight(Light):
     def __init__(self, hass, device):
         """Initialize of KNX light."""
         self.device = device
-        self.hass = hass
 
     @callback
     def async_register_callbacks(self):

--- a/homeassistant/components/light/knx.py
+++ b/homeassistant/components/light/knx.py
@@ -81,7 +81,6 @@ class KNXLight(Light):
         """Initialize of KNX light."""
         self.device = device
         self.hass = hass
-        self.async_register_callbacks()
 
     @callback
     def async_register_callbacks(self):
@@ -90,6 +89,10 @@ class KNXLight(Light):
             """Call after device was updated."""
             await self.async_update_ha_state()
         self.device.register_device_updated_cb(after_update_callback)
+
+    async def async_added_to_hass(self):
+        """Store register state change callback."""
+        self.async_register_callbacks()
 
     @property
     def name(self):

--- a/homeassistant/components/sensor/knx.py
+++ b/homeassistant/components/sensor/knx.py
@@ -65,7 +65,6 @@ class KNXSensor(Entity):
     def __init__(self, hass, device):
         """Initialize of a KNX sensor."""
         self.device = device
-        self.hass = hass
 
     @callback
     def async_register_callbacks(self):

--- a/homeassistant/components/sensor/knx.py
+++ b/homeassistant/components/sensor/knx.py
@@ -42,7 +42,7 @@ def async_add_entities_discovery(hass, discovery_info, async_add_entities):
     entities = []
     for device_name in discovery_info[ATTR_DISCOVER_DEVICES]:
         device = hass.data[DATA_KNX].xknx.devices[device_name]
-        entities.append(KNXSensor(hass, device))
+        entities.append(KNXSensor(device))
     async_add_entities(entities)
 
 
@@ -56,13 +56,13 @@ def async_add_entities_config(hass, config, async_add_entities):
         group_address=config.get(CONF_ADDRESS),
         value_type=config.get(CONF_TYPE))
     hass.data[DATA_KNX].xknx.devices.add(sensor)
-    async_add_entities([KNXSensor(hass, sensor)])
+    async_add_entities([KNXSensor(sensor)])
 
 
 class KNXSensor(Entity):
     """Representation of a KNX sensor."""
 
-    def __init__(self, hass, device):
+    def __init__(self, device):
         """Initialize of a KNX sensor."""
         self.device = device
 

--- a/homeassistant/components/sensor/knx.py
+++ b/homeassistant/components/sensor/knx.py
@@ -66,7 +66,6 @@ class KNXSensor(Entity):
         """Initialize of a KNX sensor."""
         self.device = device
         self.hass = hass
-        self.async_register_callbacks()
 
     @callback
     def async_register_callbacks(self):
@@ -75,6 +74,10 @@ class KNXSensor(Entity):
             """Call after device was updated."""
             await self.async_update_ha_state()
         self.device.register_device_updated_cb(after_update_callback)
+
+    async def async_added_to_hass(self):
+        """Store register state change callback."""
+        self.async_register_callbacks()
 
     @property
     def name(self):

--- a/homeassistant/components/switch/knx.py
+++ b/homeassistant/components/switch/knx.py
@@ -41,7 +41,7 @@ def async_add_entities_discovery(hass, discovery_info, async_add_entities):
     entities = []
     for device_name in discovery_info[ATTR_DISCOVER_DEVICES]:
         device = hass.data[DATA_KNX].xknx.devices[device_name]
-        entities.append(KNXSwitch(hass, device))
+        entities.append(KNXSwitch(device))
     async_add_entities(entities)
 
 
@@ -55,13 +55,13 @@ def async_add_entities_config(hass, config, async_add_entities):
         group_address=config.get(CONF_ADDRESS),
         group_address_state=config.get(CONF_STATE_ADDRESS))
     hass.data[DATA_KNX].xknx.devices.add(switch)
-    async_add_entities([KNXSwitch(hass, switch)])
+    async_add_entities([KNXSwitch(switch)])
 
 
 class KNXSwitch(SwitchDevice):
     """Representation of a KNX switch."""
 
-    def __init__(self, hass, device):
+    def __init__(self, device):
         """Initialize of KNX switch."""
         self.device = device
 

--- a/homeassistant/components/switch/knx.py
+++ b/homeassistant/components/switch/knx.py
@@ -64,7 +64,6 @@ class KNXSwitch(SwitchDevice):
     def __init__(self, hass, device):
         """Initialize of KNX switch."""
         self.device = device
-        self.hass = hass
 
     @callback
     def async_register_callbacks(self):

--- a/homeassistant/components/switch/knx.py
+++ b/homeassistant/components/switch/knx.py
@@ -65,7 +65,6 @@ class KNXSwitch(SwitchDevice):
         """Initialize of KNX switch."""
         self.device = device
         self.hass = hass
-        self.async_register_callbacks()
 
     @callback
     def async_register_callbacks(self):
@@ -74,6 +73,10 @@ class KNXSwitch(SwitchDevice):
             """Call after device was updated."""
             await self.async_update_ha_state()
         self.device.register_device_updated_cb(after_update_callback)
+
+    async def async_added_to_hass(self):
+        """Store register state change callback."""
+        self.async_register_callbacks()
 
     @property
     def name(self):


### PR DESCRIPTION
## Description:

The callbacks should be registered at the very last moment.

fixes #13699

Fixed according to suggestion by @MartinHjelmare : https://github.com/home-assistant/home-assistant/issues/13699#issuecomment-379199112

My fix was tested by @rsterrenburg https://github.com/home-assistant/home-assistant/issues/13699#issuecomment-429371084
