### PR TITLE
Add unique_id for Neato

### DIFF
--- a/homeassistant/components/camera/neato.py
+++ b/homeassistant/components/camera/neato.py
@@ -40,6 +40,8 @@ class NeatoCleaningMap(Camera):
         self.neato = hass.data[NEATO_LOGIN]
         self._image_url = None
         self._image = None
+        self._unique_id = '{}-{}'.format(
+            self._robot_serial, self._robot_name)
 
     def camera_image(self):
         """Return image response."""
@@ -63,3 +65,8 @@ class NeatoCleaningMap(Camera):
     def name(self):
         """Return the name of this camera."""
         return self._robot_name
+
+    @property
+    def unique_id(self):
+        """Return unique ID."""
+        return self._unique_id

--- a/homeassistant/components/camera/neato.py
+++ b/homeassistant/components/camera/neato.py
@@ -40,8 +40,6 @@ class NeatoCleaningMap(Camera):
         self.neato = hass.data[NEATO_LOGIN]
         self._image_url = None
         self._image = None
-        self._unique_id = '{}-{}'.format(
-            self._robot_serial, self._robot_name)
 
     def camera_image(self):
         """Return image response."""
@@ -69,4 +67,4 @@ class NeatoCleaningMap(Camera):
     @property
     def unique_id(self):
         """Return unique ID."""
-        return self._unique_id
+        return self._robot_serial

--- a/homeassistant/components/switch/neato.py
+++ b/homeassistant/components/switch/neato.py
@@ -52,8 +52,7 @@ class NeatoConnectedSwitch(ToggleEntity):
             self._state = None
         self._schedule_state = None
         self._clean_state = None
-        self._unique_id = '{}-{}'.format(
-            self.robot.serial, self._robot_name)
+        self._robot_serial = self.robot.serial
 
     def update(self):
         """Update the states of Neato switches."""
@@ -88,7 +87,7 @@ class NeatoConnectedSwitch(ToggleEntity):
     @property
     def unique_id(self):
         """Return a unique ID."""
-        return self._unique_id
+        return self._robot_serial
 
     @property
     def is_on(self):

--- a/homeassistant/components/switch/neato.py
+++ b/homeassistant/components/switch/neato.py
@@ -52,6 +52,8 @@ class NeatoConnectedSwitch(ToggleEntity):
             self._state = None
         self._schedule_state = None
         self._clean_state = None
+        self._unique_id = '{}-{}'.format(
+            self.robot.serial, self._robot_name)
 
     def update(self):
         """Update the states of Neato switches."""
@@ -82,6 +84,11 @@ class NeatoConnectedSwitch(ToggleEntity):
     def available(self):
         """Return True if entity is available."""
         return self._state
+
+    @property
+    def unique_id(self):
+        """Return a unique ID."""
+        return self._unique_id
 
     @property
     def is_on(self):

--- a/homeassistant/components/vacuum/neato.py
+++ b/homeassistant/components/vacuum/neato.py
@@ -66,6 +66,8 @@ class NeatoConnectedVacuum(StateVacuumDevice):
         self.clean_suspension_time = None
         self._available = False
         self._battery_level = None
+        self._robot_serial = '{}-{}'.format(
+            self.robot.serial, self._name)
 
     def update(self):
         """Update the states of Neato Vacuums."""
@@ -155,6 +157,11 @@ class NeatoConnectedVacuum(StateVacuumDevice):
     def state(self):
         """Return the status of the vacuum cleaner."""
         return self._clean_state
+
+    @property
+    def unique_id(self):
+        """Return a unique ID."""
+        return self._robot_serial
 
     @property
     def device_state_attributes(self):

--- a/homeassistant/components/vacuum/neato.py
+++ b/homeassistant/components/vacuum/neato.py
@@ -66,8 +66,7 @@ class NeatoConnectedVacuum(StateVacuumDevice):
         self.clean_suspension_time = None
         self._available = False
         self._battery_level = None
-        self._robot_serial = '{}-{}'.format(
-            self.robot.serial, self._name)
+        self._robot_serial = self.robot.serial
 
     def update(self):
         """Update the states of Neato Vacuums."""


### PR DESCRIPTION
## Description:

Add unique ID's for Neato components for entity registry support

**Related issue (if applicable):** fixes # N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io# N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
neato:
  username:  username
  password: password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
