### PR TITLE
HomematicIP_Cloud fix test

### DIFF
--- a/homeassistant/components/homematicip_cloud/hap.py
+++ b/homeassistant/components/homematicip_cloud/hap.py
@@ -61,7 +61,6 @@ class HomematicipAuth:
         from homematicip.base.base_connection import HmipConnectionError
 
         auth = AsyncAuth(hass.loop, async_get_clientsession(hass))
-        print(auth)
         try:
             await auth.init(hapid)
             if pin:

--- a/tests/components/homematicip_cloud/test_config_flow.py
+++ b/tests/components/homematicip_cloud/test_config_flow.py
@@ -19,9 +19,9 @@ async def test_flow_works(hass):
 
     hap = hmipc.HomematicipAuth(hass, config)
     with patch.object(hap, 'get_auth', return_value=mock_coro()), \
-            patch.object(hmipc.HomematicipAuth, 'async_checkbutton', \
+            patch.object(hmipc.HomematicipAuth, 'async_checkbutton',
                          return_value=mock_coro(True)), \
-            patch.object(hmipc.HomematicipAuth, 'async_setup', \
+            patch.object(hmipc.HomematicipAuth, 'async_setup',
                          return_value=mock_coro(True)), \
             patch.object(hmipc.HomematicipAuth, 'async_register',
                          return_value=mock_coro(True)):

--- a/tests/components/homematicip_cloud/test_config_flow.py
+++ b/tests/components/homematicip_cloud/test_config_flow.py
@@ -19,7 +19,9 @@ async def test_flow_works(hass):
 
     hap = hmipc.HomematicipAuth(hass, config)
     with patch.object(hap, 'get_auth', return_value=mock_coro()), \
-            patch.object(hmipc.HomematicipAuth, 'async_checkbutton',
+            patch.object(hmipc.HomematicipAuth, 'async_checkbutton', \
+                         return_value=mock_coro(True)), \
+            patch.object(hmipc.HomematicipAuth, 'async_setup', \
                          return_value=mock_coro(True)), \
             patch.object(hmipc.HomematicipAuth, 'async_register',
                          return_value=mock_coro(True)):


### PR DESCRIPTION
## Description:
Fix of a missed patch object in test_flow_works and a missed print.

Found issue of: 
DEBUG    Connection timed out or another error occurred https://lookup.homematic.com:48335/getHost

**Related issue (if applicable):** fixes #10966 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54