### PR TITLE
Support devices like VSX-510

### DIFF
--- a/homeassistant/components/media_player/pioneer.py
+++ b/homeassistant/components/media_player/pioneer.py
@@ -155,7 +155,7 @@ class PioneerDevice(MediaPlayerDevice):
     @property
     def state(self):
         """Return the state of the device."""
-        if self._pwstate == "PWR1":
+        if self._pwstate == "PWR1" or self._pwstate == "PWR2":
             return STATE_OFF
         if self._pwstate == "PWR0":
             return STATE_ON


### PR DESCRIPTION
## Description:

Add configuration flags to support other Pioneer devices which is currently not fully supported. I have a VSX-510 that I have tested with.

* Adds step_volume configuration flag to use volume stepping instead of setting
* Adds input_scan to disable source scanning and use a pre-set list of sources
* Interpret standby state as powered off

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#6729

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

