### PR TITLE
Add unique_id for Bloomsky

### DIFF
--- a/homeassistant/components/binary_sensor/bloomsky.py
+++ b/homeassistant/components/binary_sensor/bloomsky.py
@@ -50,6 +50,12 @@ class BloomSkySensor(BinarySensorDevice):
         self._sensor_name = sensor_name
         self._name = '{} {}'.format(device['DeviceName'], sensor_name)
         self._state = None
+        self._unique_id = '{}-{}'.format(self._device_id, self._sensor_name)
+
+    @property
+    def unique_id(self):
+        """Return a unique ID."""
+        return self._unique_id
 
     @property
     def name(self):

--- a/homeassistant/components/camera/bloomsky.py
+++ b/homeassistant/components/camera/bloomsky.py
@@ -54,6 +54,11 @@ class BloomSkyCamera(Camera):
         return self._last_image
 
     @property
+    def unique_id(self):
+        """Return a unique ID."""
+        return self._id
+
+    @property
     def name(self):
         """Return the name of this BloomSky device."""
         return self._name

--- a/homeassistant/components/sensor/bloomsky.py
+++ b/homeassistant/components/sensor/bloomsky.py
@@ -63,6 +63,12 @@ class BloomSkySensor(Entity):
         self._sensor_name = sensor_name
         self._name = '{} {}'.format(device['DeviceName'], sensor_name)
         self._state = None
+        self._unique_id = '{}-{}'.format(self._device_id, self._sensor_name)
+
+    @property
+    def unique_id(self):
+        """Return a unique ID."""
+        return self._unique_id
 
     @property
     def name(self):


### PR DESCRIPTION
## Description:

Add unique ID's for Bloomsky components for entity registry support.

**Related issue (if applicable):** fixes # N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io# N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
bloomsky:
  api_key: api_key
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
