### PR TITLE
 Added support for .yml extension in includes

### DIFF
--- a/tests/util/test_yaml.py
+++ b/tests/util/test_yaml.py
@@ -108,6 +108,22 @@ class TestYaml(unittest.TestCase):
                 assert sorted(doc["key"]) == sorted(["one", "two"])
 
     @patch('homeassistant.util.yaml.os.walk')
+    def test_include_dir_list_yml(self, mock_walk):
+        """Test include dir list yml."""
+        mock_walk.return_value = [
+            ['/tmp', [], ['one.yml', 'two.yml']],
+        ]
+
+        with patch_yaml_files({
+            '/tmp/one.yml': 'one',
+            '/tmp/two.yml': 'two',
+        }):
+            conf = "key: !include_dir_list /tmp"
+            with io.StringIO(conf) as file:
+                doc = yaml.yaml.safe_load(file)
+                assert sorted(doc["key"]) == sorted(["one", "two"])
+
+    @patch('homeassistant.util.yaml.os.walk')
     def test_include_dir_list_recursive(self, mock_walk):
         """Test include dir recursive list yaml."""
         mock_walk.return_value = [


### PR DESCRIPTION
## Description:
Added support for .yml extension in includes

I've not updated the documentation on purpose. I ran into the same problem in my beginnings, so a "just works" solution is nice. But i still think .yaml should be the default.
It would require some more work to autodetect it for hardcoded files like configuration/secrets...

**Related issue (if applicable):** fixes #16808

## Example entry for `configuration.yaml` (if applicable):
```yaml
camera: !include_dir_merge_list camera/
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
