### PR TITLE
Add target temperature low high to MQTT climate

### DIFF
--- a/homeassistant/components/climate/mqtt.py
+++ b/homeassistant/components/climate/mqtt.py
@@ -91,9 +91,9 @@ PLATFORM_SCHEMA = SCHEMA_BASE.extend({
     vol.Optional(CONF_MODE_COMMAND_TOPIC): mqtt.valid_publish_topic,
     vol.Optional(CONF_TEMPERATURE_COMMAND_TOPIC): mqtt.valid_publish_topic,
     vol.Optional(CONF_TEMPERATURE_LOW_COMMAND_TOPIC):
-                 mqtt.valid_publish_topic,
+        mqtt.valid_publish_topic,
     vol.Optional(CONF_TEMPERATURE_HIGH_COMMAND_TOPIC):
-                 mqtt.valid_publish_topic,
+        mqtt.valid_publish_topic,
     vol.Optional(CONF_FAN_MODE_COMMAND_TOPIC): mqtt.valid_publish_topic,
     vol.Optional(CONF_SWING_MODE_COMMAND_TOPIC): mqtt.valid_publish_topic,
     vol.Optional(CONF_AWAY_MODE_COMMAND_TOPIC): mqtt.valid_publish_topic,
@@ -104,9 +104,9 @@ PLATFORM_SCHEMA = SCHEMA_BASE.extend({
     vol.Optional(CONF_MODE_STATE_TOPIC): mqtt.valid_subscribe_topic,
     vol.Optional(CONF_TEMPERATURE_STATE_TOPIC): mqtt.valid_subscribe_topic,
     vol.Optional(CONF_TEMPERATURE_LOW_STATE_TOPIC):
-                 mqtt.valid_subscribe_topic,
+        mqtt.valid_subscribe_topic,
     vol.Optional(CONF_TEMPERATURE_HIGH_STATE_TOPIC):
-                 mqtt.valid_subscribe_topic,
+        mqtt.valid_subscribe_topic,
     vol.Optional(CONF_FAN_MODE_STATE_TOPIC): mqtt.valid_subscribe_topic,
     vol.Optional(CONF_SWING_MODE_STATE_TOPIC): mqtt.valid_subscribe_topic,
     vol.Optional(CONF_AWAY_MODE_STATE_TOPIC): mqtt.valid_subscribe_topic,

--- a/homeassistant/components/climate/mqtt.py
+++ b/homeassistant/components/climate/mqtt.py
@@ -90,8 +90,10 @@ PLATFORM_SCHEMA = SCHEMA_BASE.extend({
     vol.Optional(CONF_POWER_COMMAND_TOPIC): mqtt.valid_publish_topic,
     vol.Optional(CONF_MODE_COMMAND_TOPIC): mqtt.valid_publish_topic,
     vol.Optional(CONF_TEMPERATURE_COMMAND_TOPIC): mqtt.valid_publish_topic,
-    vol.Optional(CONF_TEMPERATURE_LOW_COMMAND_TOPIC): mqtt.valid_publish_topic,
-    vol.Optional(CONF_TEMPERATURE_HIGH_COMMAND_TOPIC): mqtt.valid_publish_topic,
+    vol.Optional(CONF_TEMPERATURE_LOW_COMMAND_TOPIC):
+                 mqtt.valid_publish_topic,
+    vol.Optional(CONF_TEMPERATURE_HIGH_COMMAND_TOPIC):
+                 mqtt.valid_publish_topic,
     vol.Optional(CONF_FAN_MODE_COMMAND_TOPIC): mqtt.valid_publish_topic,
     vol.Optional(CONF_SWING_MODE_COMMAND_TOPIC): mqtt.valid_publish_topic,
     vol.Optional(CONF_AWAY_MODE_COMMAND_TOPIC): mqtt.valid_publish_topic,

--- a/homeassistant/components/climate/mqtt.py
+++ b/homeassistant/components/climate/mqtt.py
@@ -101,8 +101,10 @@ PLATFORM_SCHEMA = SCHEMA_BASE.extend({
     vol.Optional(CONF_POWER_STATE_TOPIC): mqtt.valid_subscribe_topic,
     vol.Optional(CONF_MODE_STATE_TOPIC): mqtt.valid_subscribe_topic,
     vol.Optional(CONF_TEMPERATURE_STATE_TOPIC): mqtt.valid_subscribe_topic,
-    vol.Optional(CONF_TEMPERATURE_LOW_STATE_TOPIC): mqtt.valid_subscribe_topic,
-    vol.Optional(CONF_TEMPERATURE_HIGH_STATE_TOPIC): mqtt.valid_subscribe_topic,
+    vol.Optional(CONF_TEMPERATURE_LOW_STATE_TOPIC):
+                 mqtt.valid_subscribe_topic,
+    vol.Optional(CONF_TEMPERATURE_HIGH_STATE_TOPIC):
+                 mqtt.valid_subscribe_topic,
     vol.Optional(CONF_FAN_MODE_STATE_TOPIC): mqtt.valid_subscribe_topic,
     vol.Optional(CONF_SWING_MODE_STATE_TOPIC): mqtt.valid_subscribe_topic,
     vol.Optional(CONF_AWAY_MODE_STATE_TOPIC): mqtt.valid_subscribe_topic,
@@ -247,8 +249,8 @@ class MqttClimate(MqttAvailability, MqttDiscoveryUpdate, ClimateDevice):
 
     def __init__(self, hass, name, topic, value_templates, qos, retain,
                  mode_list, fan_mode_list, swing_mode_list,
-                 target_temperature, target_temperature_low, target_temperature_high,
-                 away, hold, current_fan_mode,
+                 target_temperature, target_temperature_low,
+                 target_temperature_high, away, hold, current_fan_mode,
                  current_swing_mode, current_operation, aux, send_if_off,
                  payload_on, payload_off, availability_topic,
                  payload_available, payload_not_available,
@@ -593,19 +595,25 @@ class MqttClimate(MqttAvailability, MqttDiscoveryUpdate, ClimateDevice):
            kwargs.get(ATTR_TARGET_TEMP_LOW) is not None:
             if self._topic[CONF_TEMPERATURE_LOW_STATE_TOPIC] is None:
                 # optimistic mode
-                self._target_low_temperature = kwargs.get(ATTR_TARGET_TEMP_LOW)
+                self._target_low_temperature = \
+                    kwargs.get(ATTR_TARGET_TEMP_LOW)
 
             if self._topic[CONF_TEMPERATURE_HIGH_STATE_TOPIC] is None:
                 # optimistic mode
-                self._target_high_temperature = kwargs.get(ATTR_TARGET_TEMP_HIGH)
+                self._target_high_temperature = \
+                    kwargs.get(ATTR_TARGET_TEMP_HIGH)
 
             if self._send_if_off or self._current_operation != STATE_OFF:
                 mqtt.async_publish(
-                    self.hass, self._topic[CONF_TEMPERATURE_LOW_COMMAND_TOPIC],
-                    kwargs.get(ATTR_TARGET_TEMP_LOW), self._qos, self._retain)
+                    self.hass,
+                    self._topic[CONF_TEMPERATURE_LOW_COMMAND_TOPIC],
+                    kwargs.get(ATTR_TARGET_TEMP_LOW),
+                    self._qos, self._retain)
                 mqtt.async_publish(
-                    self.hass, self._topic[CONF_TEMPERATURE_HIGH_COMMAND_TOPIC],
-                    kwargs.get(ATTR_TARGET_TEMP_HIGH), self._qos, self._retain)
+                    self.hass,
+                    self._topic[CONF_TEMPERATURE_HIGH_COMMAND_TOPIC],
+                    kwargs.get(ATTR_TARGET_TEMP_HIGH),
+                    self._qos, self._retain)
 
         self.async_schedule_update_ha_state()
 

--- a/homeassistant/components/climate/mqtt.py
+++ b/homeassistant/components/climate/mqtt.py
@@ -597,12 +597,12 @@ class MqttClimate(MqttAvailability, MqttDiscoveryUpdate, ClimateDevice):
            kwargs.get(ATTR_TARGET_TEMP_LOW) is not None:
             if self._topic[CONF_TEMPERATURE_LOW_STATE_TOPIC] is None:
                 # optimistic mode
-                self._target_low_temperature = \
+                self._target_temperature_low = \
                     kwargs.get(ATTR_TARGET_TEMP_LOW)
 
             if self._topic[CONF_TEMPERATURE_HIGH_STATE_TOPIC] is None:
                 # optimistic mode
-                self._target_high_temperature = \
+                self._target_temperature_high = \
                     kwargs.get(ATTR_TARGET_TEMP_HIGH)
 
             if self._send_if_off or self._current_operation != STATE_OFF:


### PR DESCRIPTION
## Description:

Add support for target low and high temperature setpoints in MQTT climate.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#6739

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
