### PR TITLE
Fire an event when timer gets out of sync

### DIFF
--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -167,6 +167,7 @@ EVENT_SERVICE_REGISTERED = 'service_registered'
 EVENT_SERVICE_REMOVED = 'service_removed'
 EVENT_LOGBOOK_ENTRY = 'logbook_entry'
 EVENT_THEMES_UPDATED = 'themes_updated'
+EVENT_TIMER_OUT_OF_SYNC = 'timer_out_of_sync'
 
 # #### DEVICE CLASSES ####
 DEVICE_CLASS_BATTERY = 'battery'
@@ -215,6 +216,7 @@ ATTR_CREDENTIALS = 'credentials'
 ATTR_NOW = 'now'
 ATTR_DATE = 'date'
 ATTR_TIME = 'time'
+ATTR_SECONDS = 'seconds'
 
 # Contains domain, service for a SERVICE_CALL event
 ATTR_DOMAIN = 'domain'


### PR DESCRIPTION
## Description:

Since #17199, missed timer events are non-fatal because interval timers will execute on the following event, even if that following event does not match the interval definition. We can thus remove the hard-to-understand error message about the timer being out of sync.

Missed timer events are still useful for diagnostics, though. They are a symptom of both an overloaded system and of blocking code on the event loop. So rather than outright removing the log message, we replace it with an event that can be analyzed by diagnostic tools (that do not yet exist).

I am marking this as fixing #7133 because it resolves the situation where users are just confused about the message but do not notice the slowdown. This PR obviously does not solve any underlying issue but those are hard to find in #7133 anyway because everything is lumped together due to this common error message.

**Related issue (if applicable):** fixes #7133

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.
