### PR TITLE
Update to async-upnp-client==0.12.5

### DIFF
--- a/homeassistant/components/media_player/dlna_dmr.py
+++ b/homeassistant/components/media_player/dlna_dmr.py
@@ -25,7 +25,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import get_local_ip
 
-REQUIREMENTS = ['async-upnp-client==0.12.4']
+REQUIREMENTS = ['async-upnp-client==0.12.5']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/upnp/__init__.py
+++ b/homeassistant/components/upnp/__init__.py
@@ -30,7 +30,7 @@ from .config_flow import ensure_domain_data
 from .device import Device
 
 
-REQUIREMENTS = ['async-upnp-client==0.12.4']
+REQUIREMENTS = ['async-upnp-client==0.12.5']
 DEPENDENCIES = ['http']
 
 NOTIFICATION_ID = 'upnp_notification'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -150,7 +150,7 @@ asterisk_mbox==0.5.0
 
 # homeassistant.components.upnp
 # homeassistant.components.media_player.dlna_dmr
-async-upnp-client==0.12.4
+async-upnp-client==0.12.5
 
 # homeassistant.components.light.avion
 # avion==0.7


### PR DESCRIPTION
## Description:
Update to async-upnp-client==0.12.5, it has improved robustness.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
