### PR TITLE
Support additional property for Homematic sabotage detection

### DIFF
--- a/homeassistant/components/homematic/__init__.py
+++ b/homeassistant/components/homematic/__init__.py
@@ -106,6 +106,7 @@ HM_ATTRIBUTE_SUPPORT = {
     'LOWBAT': ['battery', {0: 'High', 1: 'Low'}],
     'LOW_BAT': ['battery', {0: 'High', 1: 'Low'}],
     'ERROR': ['sabotage', {0: 'No', 1: 'Yes'}],
+    'ERROR_SABOTAGE': ['sabotage', {0: 'No', 1: 'Yes'}],
     'SABOTAGE': ['sabotage', {0: 'No', 1: 'Yes'}],
     'RSSI_PEER': ['rssi', {}],
     'RSSI_DEVICE': ['rssi', {}],


### PR DESCRIPTION
At least HM-Sec-Sir-WM uses `ERROR_SABOTAGE`, see `pyhomematic.devicetypes.actors.RFSiren`.

## Description:

The Homematic siren uses a different attribute for sabotage reporting (`ERROR_SABOTAGE`). `pyhomematic` already handles this correctly, so let's also handle it in Home Assistant.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

