### PR TITLE
Fix netio component

### DIFF
--- a/homeassistant/components/switch/netio.py
+++ b/homeassistant/components/switch/netio.py
@@ -151,15 +151,15 @@ class NetioSwitch(SwitchDevice):
 
     def _set(self, value):
         val = list('uuuu')
-        val[self.outlet - 1] = '1' if value else '0'
+        val[int(self.outlet) - 1] = '1' if value else '0'
         self.netio.get('port list %s' % ''.join(val))
-        self.netio.states[self.outlet - 1] = value
+        self.netio.states[int(self.outlet) - 1] = value
         self.schedule_update_ha_state()
 
     @property
     def is_on(self):
         """Return the switch's status."""
-        return self.netio.states[self.outlet - 1]
+        return self.netio.states[int(self.outlet) - 1]
 
     def update(self):
         """Update the state."""
@@ -176,14 +176,14 @@ class NetioSwitch(SwitchDevice):
     @property
     def current_power_w(self):
         """Return actual power."""
-        return self.netio.consumptions[self.outlet - 1]
+        return self.netio.consumptions[int(self.outlet) - 1]
 
     @property
     def cumulated_consumption_kwh(self):
         """Return the total enerygy consumption since start_date."""
-        return self.netio.cumulated_consumptions[self.outlet - 1]
+        return self.netio.cumulated_consumptions[int(self.outlet) - 1]
 
     @property
     def start_date(self):
         """Point in time when the energy accumulation started."""
-        return self.netio.start_dates[self.outlet - 1]
+        return self.netio.start_dates[int(self.outlet) - 1]

--- a/homeassistant/components/switch/netio.py
+++ b/homeassistant/components/switch/netio.py
@@ -19,7 +19,7 @@ from homeassistant.const import (
 from homeassistant.components.switch import (SwitchDevice, PLATFORM_SCHEMA)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['pynetio==0.1.6']
+REQUIREMENTS = ['pynetio==0.1.9.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1000,7 +1000,7 @@ pynello==1.5.1
 pynetgear==0.4.2
 
 # homeassistant.components.switch.netio
-pynetio==0.1.6
+pynetio==0.1.9.1
 
 # homeassistant.components.lock.nuki
 pynuki==1.3.1


### PR DESCRIPTION
## Description:

This fixes two issues:
* hardcoded login credentials in pynetio by bumping the required version.
* a type error in the netio component of home assistant.

**Related issue:** fixes #14246 #14245

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`.



If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
