### PR TITLE
Fix google assistant request sync service call

### DIFF
--- a/homeassistant/components/google_assistant/__init__.py
+++ b/homeassistant/components/google_assistant/__init__.py
@@ -67,10 +67,11 @@ async def async_setup(hass: HomeAssistant, yaml_config: Dict[str, Any]):
         websession = async_get_clientsession(hass)
         try:
             with async_timeout.timeout(5, loop=hass.loop):
+                agent_user_id = call.context.user_id or DEFAULT_AGENT_USER_ID
                 res = await websession.post(
                     REQUEST_SYNC_BASE_URL,
                     params={'key': api_key},
-                    json={'agent_user_id': call.context.user_id})
+                    json={'agent_user_id': agent_user_id})
                 _LOGGER.info("Submitted request_sync request to Google")
                 res.raise_for_status()
         except aiohttp.ClientResponseError:

--- a/homeassistant/components/google_assistant/__init__.py
+++ b/homeassistant/components/google_assistant/__init__.py
@@ -32,8 +32,6 @@ _LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = ['http']
 
-DEFAULT_AGENT_USER_ID = 'home-assistant'
-
 ENTITY_SCHEMA = vol.Schema({
     vol.Optional(CONF_NAME): cv.string,
     vol.Optional(CONF_EXPOSE): cv.boolean,
@@ -67,7 +65,8 @@ async def async_setup(hass: HomeAssistant, yaml_config: Dict[str, Any]):
         websession = async_get_clientsession(hass)
         try:
             with async_timeout.timeout(5, loop=hass.loop):
-                agent_user_id = call.context.user_id or DEFAULT_AGENT_USER_ID
+                agent_user_id = call.data.get('agent_user_id') or \
+                                call.context.user_id
                 res = await websession.post(
                     REQUEST_SYNC_BASE_URL,
                     params={'key': api_key},

--- a/homeassistant/components/google_assistant/services.yaml
+++ b/homeassistant/components/google_assistant/services.yaml
@@ -2,4 +2,4 @@ request_sync:
   description: Send a request_sync command to Google.
   fields:
     agent_user_id:
-      description: [Optional] specific Home Assistant user id to sync with Google Assistant. Do no need when you call this services through Home Assistant front end or API. Used in automation script or other place where context.user_id is missing.
+      description: Optional. Only needed for automations. Specific Home Assistant user id to sync with Google Assistant. Do not need when you call this service through Home Assistant front end or API. Used in automation script or other place where context.user_id is missing.

--- a/homeassistant/components/google_assistant/services.yaml
+++ b/homeassistant/components/google_assistant/services.yaml
@@ -1,2 +1,5 @@
 request_sync:
   description: Send a request_sync command to Google.
+  fields:
+    agent_user_id:
+      description: [Optional] specific Home Assistant user id to sync with Google Assistant. Do no need when you call this services through Home Assistant front end or API. Used in automation script or other place where context.user_id is missing.


### PR DESCRIPTION
## Description:
`context.user_id` will be None if `request_sync` service call was triggered by platform event in Automation.

The fix add an optional `agent_user_id` field to `request_sync` service, so that automation script can provide the user id

**Related issue (if applicable):** fixes #17380

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
# automations.yaml
- id: refresh_google_assistant
  alias: "Refresh Google Assistant devices"
  hide_entity: true
  trigger:
    platform: homeassistant
    event: start
  action:
    - service: google_assistant.request_sync
      data:
        # you can find the owner user id from configuration -> users
        agent_user_id: OWNER_USER_ID
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

