### PR TITLE
Add new rtorrent sensor

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -756,6 +756,7 @@ omit =
     homeassistant/components/sensor/radarr.py
     homeassistant/components/sensor/rainbird.py
     homeassistant/components/sensor/ripple.py
+    homeassistant/components/sensor/rtorrent.py
     homeassistant/components/sensor/scrape.py
     homeassistant/components/sensor/sense.py
     homeassistant/components/sensor/sensehat.py

--- a/homeassistant/components/sensor/rtorrent.py
+++ b/homeassistant/components/sensor/rtorrent.py
@@ -36,9 +36,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the rtorrent sensors."""
-
-    # For arch-rtorrentvpn:
-    # url = 'http://admin:rutorrent@localhost:9080/RPC2/'
     url = config.get(CONF_URL)
     name = config.get(CONF_NAME)
 
@@ -52,6 +49,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         dev.append(RTorrentSensor(variable, rtorrent, name))
 
     add_entities(dev)
+
 
 class RTorrentSensor(Entity):
     """Representation of an rtorrent sensor."""
@@ -100,7 +98,7 @@ class RTorrentSensor(Entity):
             _LOGGER.error("Connection to rtorrent lost")
             self._available = False
             return
-    
+
         upload = self.data[0]
         download = self.data[1]
 

--- a/homeassistant/components/sensor/rtorrent.py
+++ b/homeassistant/components/sensor/rtorrent.py
@@ -39,7 +39,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     try:
         rtorrent = xmlrpc.client.ServerProxy(url)
-    except ConnectionRefusedError:
+    except (xmlrpc.client.ProtocolError, ConnectionRefusedError):
         _LOGGER.error("Connection to rtorrent daemon failed")
         raise PlatformNotReady
     dev = []
@@ -92,7 +92,7 @@ class RTorrentSensor(Entity):
         try:
             self.data = multicall()
             self._available = True
-        except:
+        except (xmlrpc.client.ProtocolError, ConnectionRefusedError):
             _LOGGER.error("Connection to rtorrent lost")
             self._available = False
             return

--- a/homeassistant/components/sensor/rtorrent.py
+++ b/homeassistant/components/sensor/rtorrent.py
@@ -1,6 +1,4 @@
-"""
-Support for monitoring the rtorrent BitTorrent client API.
-"""
+"""Support for monitoring the rtorrent BitTorrent client API."""
 import logging
 import xmlrpc.client
 

--- a/homeassistant/components/sensor/rtorrent.py
+++ b/homeassistant/components/sensor/rtorrent.py
@@ -1,0 +1,128 @@
+"""
+Support for monitoring the rtorrent BitTorrent client API.
+"""
+import logging
+import xmlrpc.client
+
+import voluptuous as vol
+
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import (
+    CONF_URL, CONF_NAME,
+    CONF_MONITORED_VARIABLES, STATE_IDLE)
+from homeassistant.helpers.entity import Entity
+import homeassistant.helpers.config_validation as cv
+from homeassistant.exceptions import PlatformNotReady
+
+_LOGGER = logging.getLogger(__name__)
+_THROTTLED_REFRESH = None
+
+DEFAULT_NAME = 'rtorrent'
+DHT_UPLOAD = 1000
+DHT_DOWNLOAD = 1000
+SENSOR_TYPES = {
+    'current_status': ['Status', None],
+    'download_speed': ['Down Speed', 'kB/s'],
+    'upload_speed': ['Up Speed', 'kB/s'],
+}
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_URL): cv.url,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_MONITORED_VARIABLES, default=[]): vol.All(
+        cv.ensure_list, [vol.In(SENSOR_TYPES)]),
+})
+
+
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    """Set up the rtorrent sensors."""
+
+    # For arch-rtorrentvpn:
+    # url = 'http://admin:rutorrent@localhost:9080/RPC2/'
+    url = config.get(CONF_URL)
+    name = config.get(CONF_NAME)
+
+    try:
+        rtorrent = xmlrpc.client.ServerProxy(url)
+    except ConnectionRefusedError:
+        _LOGGER.error("Connection to rtorrent daemon failed")
+        raise PlatformNotReady
+    dev = []
+    for variable in config[CONF_MONITORED_VARIABLES]:
+        dev.append(RTorrentSensor(variable, rtorrent, name))
+
+    add_entities(dev)
+
+class RTorrentSensor(Entity):
+    """Representation of an rtorrent sensor."""
+
+    def __init__(self, sensor_type, rtorrent_client, client_name):
+        """Initialize the sensor."""
+        self._name = SENSOR_TYPES[sensor_type][0]
+        self.client = rtorrent_client
+        self.type = sensor_type
+        self.client_name = client_name
+        self._state = None
+        self._unit_of_measurement = SENSOR_TYPES[sensor_type][1]
+        self.data = None
+        self._available = False
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return '{} {}'.format(self.client_name, self._name)
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def available(self):
+        """Return true if device is available."""
+        return self._available
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement of this entity, if any."""
+        return self._unit_of_measurement
+
+    def update(self):
+        """Get the latest data from rtorrent and updates the state."""
+        multicall = xmlrpc.client.MultiCall(self.client)
+        multicall.throttle.global_up.rate()
+        multicall.throttle.global_down.rate()
+
+        try:
+            self.data = multicall()
+            self._available = True
+        except Exception as e:
+            _LOGGER.error("Connection to rtorrent lost")
+            self._available = False
+            return
+    
+        upload = self.data[0]
+        download = self.data[1]
+
+        if self.type == 'current_status':
+            if self.data:
+                if upload > 0 and download > 0:
+                    self._state = 'Up/Down'
+                elif upload > 0 and download == 0:
+                    self._state = 'Seeding'
+                elif upload == 0 and download > 0:
+                    self._state = 'Downloading'
+                else:
+                    self._state = STATE_IDLE
+            else:
+                self._state = None
+
+        if self.data:
+            if self.type == 'download_speed':
+                kb_spd = float(download)
+                kb_spd = kb_spd / 1024
+                self._state = round(kb_spd, 2 if kb_spd < 0.1 else 1)
+            elif self.type == 'upload_speed':
+                kb_spd = float(upload)
+                kb_spd = kb_spd / 1024
+                self._state = round(kb_spd, 2 if kb_spd < 0.1 else 1)

--- a/homeassistant/components/sensor/rtorrent.py
+++ b/homeassistant/components/sensor/rtorrent.py
@@ -49,6 +49,11 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     add_entities(dev)
 
+def format_speed(speed):
+    """Return a bytes/s measurement as a human readable string."""
+    kb_spd = float(speed) / 1024
+    return round(kb_spd, 2 if kb_spd < 0.1 else 1)
+
 
 class RTorrentSensor(Entity):
     """Representation of an rtorrent sensor."""
@@ -84,11 +89,6 @@ class RTorrentSensor(Entity):
         """Return the unit of measurement of this entity, if any."""
         return self._unit_of_measurement
 
-    def format_speed(self, speed):
-        """Returns a bytes/s measurement as a human readable string."""
-        kb_spd = float(speed) / 1024
-        return round(kb_spd, 2 if kb_spd < 0.1 else 1)
-
     def update(self):
         """Get the latest data from rtorrent and updates the state."""
         multicall = xmlrpc.client.MultiCall(self.client)
@@ -121,6 +121,6 @@ class RTorrentSensor(Entity):
 
         if self.data:
             if self.type == SENSOR_TYPE_DOWNLOAD_SPEED:
-                self._state = self.format_speed(download)
+                self._state = format_speed(download)
             elif self.type == SENSOR_TYPE_UPLOAD_SPEED:
-                self._state = self.format_speed(upload)
+                self._state = format_speed(upload)

--- a/homeassistant/components/sensor/rtorrent.py
+++ b/homeassistant/components/sensor/rtorrent.py
@@ -49,6 +49,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     add_entities(dev)
 
+
 def format_speed(speed):
     """Return a bytes/s measurement as a human readable string."""
     kb_spd = float(speed) / 1024

--- a/homeassistant/components/sensor/rtorrent.py
+++ b/homeassistant/components/sensor/rtorrent.py
@@ -92,7 +92,7 @@ class RTorrentSensor(Entity):
         try:
             self.data = multicall()
             self._available = True
-        except Exception as e:
+        except:
             _LOGGER.error("Connection to rtorrent lost")
             self._available = False
             return


### PR DESCRIPTION
## Description:
Simple sensor for [rtorrent](https://github.com/rakshasa/rtorrent/wiki) based on the Deluge sensor [code](https://github.com/home-assistant/home-assistant/blob/master/homeassistant/components/sensor/deluge.py).
Only a few lines of code differ from the Deluge sensor and the same functionality is implemented:
 * Status: _Error, Idle, Downloading, Down/Up_
 * Total Download Rate
 * Total Upload Rate

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation:** 
home-assistant/home-assistant.io/pull/6780

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: rtorrent
    url: 'http://<user>:<password>@<host>:<port>/RPC2'
    monitored_variables:
      - 'current_status'
      - 'download_speed'
      - 'upload_speed'
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] Sensor has no `REQUIREMENTS` variable (only uses `xmlrpc.client`). 
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.