### PR TITLE
Add RSRQ, RSRP, and SINR to huawei_lte default sensors

### DIFF
--- a/homeassistant/components/sensor/huawei_lte.py
+++ b/homeassistant/components/sensor/huawei_lte.py
@@ -28,7 +28,10 @@ DEFAULT_NAME_TEMPLATE = 'Huawei {}: {}'
 
 DEFAULT_SENSORS = [
     "device_information.WanIPAddress",
+    "device_signal.rsrq",
+    "device_signal.rsrp",
     "device_signal.rssi",
+    "device_signal.sinr",
 ]
 
 SENSOR_META = {


### PR DESCRIPTION
## Description:

These are important LTE signal monitoring values. (Arguably more so than RSSI which is already there.)

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#6789

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
