### PR TITLE
Make dicttoxml logging less verbose

### DIFF
--- a/homeassistant/components/huawei_lte.py
+++ b/homeassistant/components/huawei_lte.py
@@ -21,6 +21,9 @@ from homeassistant.util import Throttle
 
 _LOGGER = logging.getLogger(__name__)
 
+# dicttoxml (used by huawei-lte-api) has uselessly verbose INFO level.
+logging.getLogger('dicttoxml').setLevel(logging.WARNING)
+
 REQUIREMENTS = ['huawei-lte-api==1.0.16']
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=10)


### PR DESCRIPTION
## Description:

The huawei_lte component uses huawei-lte-api which uses dicttoxml, which outputs uselessly verbose stuff like this in INFO level:

```
2018-10-14 10:28:58 INFO (SyncWorker_6) [dicttoxml] Looping inside convert_dict(): key="Username", val="...", type(val)="str"
2018-10-14 10:28:58 INFO (SyncWorker_6) [dicttoxml] Inside make_valid_xml_name(). Testing key "Username" with attr "{}"
2018-10-14 10:28:58 INFO (SyncWorker_6) [dicttoxml] Inside key_is_valid_xml(). Testing "Username"
2018-10-14 10:28:58 INFO (SyncWorker_6) [dicttoxml] Inside convert_kv(): key="Username", val="...", type(val) is: "str"
2018-10-14 10:28:58 INFO (SyncWorker_6) [dicttoxml] Inside make_valid_xml_name(). Testing key "Username" with attr "{}"
2018-10-14 10:28:58 INFO (SyncWorker_6) [dicttoxml] Inside key_is_valid_xml(). Testing "Username"
2018-10-14 10:28:58 INFO (SyncWorker_6) [dicttoxml] Looping inside convert_dict(): key="Password", val="...", type(val)="str"
2018-10-14 10:28:58 INFO (SyncWorker_6) [dicttoxml] Inside make_valid_xml_name(). Testing key "Password" with attr "{}"
2018-10-14 10:28:58 INFO (SyncWorker_6) [dicttoxml] Inside key_is_valid_xml(). Testing "Password"
2018-10-14 10:28:58 INFO (SyncWorker_6) [dicttoxml] Inside convert_kv(): key="Password", val="...", type(val) is: "str"
2018-10-14 10:28:58 INFO (SyncWorker_6) [dicttoxml] Inside make_valid_xml_name(). Testing key "Password" with attr "{}"
2018-10-14 10:28:58 INFO (SyncWorker_6) [dicttoxml] Inside key_is_valid_xml(). Testing "Password"
2018-10-14 10:28:58 INFO (SyncWorker_6) [dicttoxml] Looping inside convert_dict(): key="password_type", val="4", type(val)="int"
2018-10-14 10:28:58 INFO (SyncWorker_6) [dicttoxml] Inside make_valid_xml_name(). Testing key "password_type" with attr "{}"
2018-10-14 10:28:58 INFO (SyncWorker_6) [dicttoxml] Inside key_is_valid_xml(). Testing "password_type"
2018-10-14 10:28:58 INFO (SyncWorker_6) [dicttoxml] Inside convert_kv(): key="password_type", val="4", type(val) is: "int"
2018-10-14 10:28:58 INFO (SyncWorker_6) [dicttoxml] Inside make_valid_xml_name(). Testing key "password_type" with attr "{}"
2018-10-14 10:28:58 INFO (SyncWorker_6) [dicttoxml] Inside key_is_valid_xml(). Testing "password_type"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
