### PR TITLE
Show torah reading during weekdays

### DIFF
--- a/homeassistant/components/sensor/jewish_calendar.py
+++ b/homeassistant/components/sensor/jewish_calendar.py
@@ -4,6 +4,7 @@ Platform to retrieve Jewish calendar information for Home Assistant.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.jewish_calendar/
 """
+from datetime import timedelta
 import logging
 
 import voluptuous as vol
@@ -107,16 +108,20 @@ class JewishCalSensor(Entity):
         import hdate
 
         today = dt_util.now().date()
+        upcoming_saturday = today + timedelta((12 - today.weekday()) % 7)
 
         date = hdate.HDate(
             today, diaspora=self.diaspora, hebrew=self._hebrew)
+        upcoming_shabbat = hdate.HDate(
+            upcoming_saturday, diaspora=self.diaspora, hebrew=self._hebrew)
 
         if self.type == 'date':
             self._state = hdate.date.get_hebrew_date(
                 date.h_day, date.h_month, date.h_year, hebrew=self._hebrew)
         elif self.type == 'weekly_portion':
             self._state = hdate.date.get_parashe(
-                date.get_reading(self.diaspora), hebrew=self._hebrew)
+                upcoming_shabbat.get_reading(self.diaspora),
+                hebrew=self._hebrew)
         elif self.type == 'holiday_name':
             try:
                 description = next(

--- a/tests/components/sensor/test_jewish_calendar.py
+++ b/tests/components/sensor/test_jewish_calendar.py
@@ -155,3 +155,15 @@ class TestJewishCalenderSensor(unittest.TestCase):
             run_coroutine_threadsafe(
                 sensor.async_update(), self.hass.loop).result()
             self.assertEqual(sensor.state, time(19, 21))
+
+    def test_jewish_calendar_sensor_torah_reading_weekday(self):
+        """Test the sensor showing torah reading also on weekdays."""
+        test_time = dt(2018, 10, 14)
+        sensor = JewishCalSensor(
+            name='test', language='hebrew', sensor_type='weekly_portion',
+            latitude=self.TEST_LATITUDE, longitude=self.TEST_LONGITUDE,
+            timezone="Asia/Jerusalem", diaspora=False)
+        with patch('homeassistant.util.dt.now', return_value=test_time):
+            run_coroutine_threadsafe(
+                sensor.async_update(), self.hass.loop).result()
+            self.assertEqual(sensor.state, "פרשת לך לך")

--- a/tests/components/sensor/test_jewish_calendar.py
+++ b/tests/components/sensor/test_jewish_calendar.py
@@ -85,7 +85,7 @@ class TestJewishCalenderSensor(unittest.TestCase):
             self.assertEqual(sensor.state, "כ\"ג באלול ה\' תשע\"ח")
 
     def test_jewish_calendar_sensor_holiday_name(self):
-        """Test Jewish calendar sensor date output in hebrew."""
+        """Test Jewish calendar sensor holiday name output in hebrew."""
         test_time = dt(2018, 9, 10)
         sensor = JewishCalSensor(
             name='test', language='hebrew', sensor_type='holiday_name',
@@ -97,7 +97,7 @@ class TestJewishCalenderSensor(unittest.TestCase):
             self.assertEqual(sensor.state, "א\' ראש השנה")
 
     def test_jewish_calendar_sensor_holiday_name_english(self):
-        """Test Jewish calendar sensor date output in hebrew."""
+        """Test Jewish calendar sensor holiday name output in english."""
         test_time = dt(2018, 9, 10)
         sensor = JewishCalSensor(
             name='test', language='english', sensor_type='holiday_name',
@@ -109,7 +109,7 @@ class TestJewishCalenderSensor(unittest.TestCase):
             self.assertEqual(sensor.state, "Rosh Hashana I")
 
     def test_jewish_calendar_sensor_holyness(self):
-        """Test Jewish calendar sensor date output in hebrew."""
+        """Test Jewish calendar sensor holyness value."""
         test_time = dt(2018, 9, 10)
         sensor = JewishCalSensor(
             name='test', language='hebrew', sensor_type='holyness',
@@ -121,7 +121,7 @@ class TestJewishCalenderSensor(unittest.TestCase):
             self.assertEqual(sensor.state, 1)
 
     def test_jewish_calendar_sensor_torah_reading(self):
-        """Test Jewish calendar sensor date output in hebrew."""
+        """Test Jewish calendar sensor torah reading in hebrew."""
         test_time = dt(2018, 9, 8)
         sensor = JewishCalSensor(
             name='test', language='hebrew', sensor_type='weekly_portion',
@@ -133,7 +133,7 @@ class TestJewishCalenderSensor(unittest.TestCase):
             self.assertEqual(sensor.state, "פרשת נצבים")
 
     def test_jewish_calendar_sensor_first_stars_ny(self):
-        """Test Jewish calendar sensor date output in hebrew."""
+        """Test Jewish calendar sensor first stars time in NY, US."""
         test_time = dt(2018, 9, 8)
         sensor = JewishCalSensor(
             name='test', language='hebrew', sensor_type='first_stars',
@@ -145,7 +145,7 @@ class TestJewishCalenderSensor(unittest.TestCase):
             self.assertEqual(sensor.state, time(19, 48))
 
     def test_jewish_calendar_sensor_first_stars_jerusalem(self):
-        """Test Jewish calendar sensor date output in hebrew."""
+        """Test Jewish calendar sensor first stars time in Jerusalem, IL."""
         test_time = dt(2018, 9, 8)
         sensor = JewishCalSensor(
             name='test', language='hebrew', sensor_type='first_stars',


### PR DESCRIPTION
## Description:
This fixes the issue that during weekdays, the torah reading is not shown

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable): N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - N/A

If the code communicates with devices, web services, or third-party tools:
N/A

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
