### PR TITLE
Add additional property to HomeKitSwitch to show whether the Homekit outlet is in use

### DIFF
--- a/homeassistant/components/switch/homekit_controller.py
+++ b/homeassistant/components/switch/homekit_controller.py
@@ -14,10 +14,6 @@ DEPENDENCIES = ['homekit_controller']
 
 OUTLET_IN_USE = "outlet_in_use"
 
-PROP_TO_ATTR = {
-    'outlet_in_use': OUTLET_IN_USE
-}
-
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -72,18 +68,9 @@ class HomeKitSwitch(HomeKitEntity, SwitchDevice):
         self.put_characteristics(characteristics)
 
     @property
-    def state_attributes(self):
+    def device_state_attributes(self):
         """Return the optional state attributes."""
-        data = {}
-
-        for prop, attr in PROP_TO_ATTR.items():
-            value = getattr(self, prop)
-            if value is not None:
-                data[attr] = value
-
-        return data
-
-    @property
-    def outlet_in_use(self):
-        """Return true if device is plugged to outlet."""
-        return self._outlet_in_use
+        if self._outlet_in_use is not None:
+            return {
+                OUTLET_IN_USE: self._outlet_in_use,
+            }


### PR DESCRIPTION
## Description:
This pull request adds a feature where you get additional property to your switch that is representing Homekit outlet indicating whether the actual outlet is in use or not. Tested on Koogeek P1EU and working.
![image](https://user-images.githubusercontent.com/5576134/46920622-55e5ed80-cff1-11e8-9076-dce4798207d7.png)


**Related issue (if applicable):**

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - N/A Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - N/A New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - N/A New dependencies are only imported inside functions that use them ([example][ex-import]).
  - N/A New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - N/A New files were added to `.coveragerc`.

If the code does not interact with devices:
  - N/A Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
