### PR TITLE
Add unique_id to Vera entities

### DIFF
--- a/homeassistant/components/vera.py
+++ b/homeassistant/components/vera.py
@@ -195,3 +195,11 @@ class VeraDevice(Entity):
         attr['Vera Device Id'] = self.vera_device.vera_device_id
 
         return attr
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique ID.
+
+        The Vera assigns a unique and immutable ID number to each device.
+        """
+        return str(self.vera_device.vera_device_id)


### PR DESCRIPTION
I believe this adds registry support. The UI allows me to change
the entity ID now.

For example, a light bulb called "BasementHallLight" in the Vera
has an initial Entity ID like light.basementhalllight_108, where
108 is the unique ID that the Vera assigned the device when I
added it to the z-wave network.

Now I can use the UI to change the Entity ID to
light.basementhalllight and I can still turn it on and off.

## Description:


**Related issue (if applicable):** fixes #17428

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
