### PR TITLE
Keep cmake in finished Docker build

### DIFF
--- a/virtualization/Docker/setup_docker_prereqs
+++ b/virtualization/Docker/setup_docker_prereqs
@@ -29,11 +29,12 @@ PACKAGES=(
   ffmpeg
   # homeassistant.components.sensor.iperf3
   iperf3
+  # homeassistant.components.image_processing.dlib_face_detect
+  cmake
 )
 
 # Required debian packages for building dependencies
 PACKAGES_DEV=(
-  cmake
   git
   swig
 )


### PR DESCRIPTION
## Description:

Add `cmake` to the `PACKAGES` section instead of `PACKAGES_DEV`. This is because `image_processing.dlib_face_detect` and `image_processing.dlib_face_identify` build `dlib` when installed, which requires `cmake`. Currently, it is impossible to do so in Docker because `cmake` is removed. Another option would be to install the Pip package `face_recognition==1.0.0` when building the Docker image.

**Related issue (if applicable):** possibly #11605

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
