### PR TITLE
Remove day as a config option in speedtest sensor

### DIFF
--- a/homeassistant/components/sensor/speedtest.py
+++ b/homeassistant/components/sensor/speedtest.py
@@ -32,7 +32,6 @@ CONF_ATTRIBUTION = "Data retrieved from Speedtest by Ookla"
 CONF_SECOND = 'second'
 CONF_MINUTE = 'minute'
 CONF_HOUR = 'hour'
-CONF_DAY = 'day'
 CONF_SERVER_ID = 'server_id'
 CONF_MANUAL = 'manual'
 
@@ -47,8 +46,6 @@ SENSOR_TYPES = {
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_MONITORED_CONDITIONS):
         vol.All(cv.ensure_list, [vol.In(list(SENSOR_TYPES))]),
-    vol.Optional(CONF_DAY):
-        vol.All(cv.ensure_list, [vol.All(vol.Coerce(int), vol.Range(1, 31))]),
     vol.Optional(CONF_HOUR):
         vol.All(cv.ensure_list, [vol.All(vol.Coerce(int), vol.Range(0, 23))]),
     vol.Optional(CONF_MANUAL, default=False): cv.boolean,
@@ -156,8 +153,7 @@ class SpeedtestData:
         if not config.get(CONF_MANUAL):
             track_time_change(
                 hass, self.update, second=config.get(CONF_SECOND),
-                minute=config.get(CONF_MINUTE), hour=config.get(CONF_HOUR),
-                day=config.get(CONF_DAY))
+                minute=config.get(CONF_MINUTE), hour=config.get(CONF_HOUR))
 
     def update(self, now):
         """Get the latest data from speedtest.net."""


### PR DESCRIPTION
## Description:
This removes the day configuration.

**Breaking change**: The configuration option `day` has been removed from the `speedtest` sensor.

**Related issue (if applicable):** fixes #17352

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#6807

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)
