### PR TITLE
HomeKit: Ignore Garage state command if target state is current state

### DIFF
--- a/homeassistant/components/homekit/type_covers.py
+++ b/homeassistant/components/homekit/type_covers.py
@@ -41,15 +41,15 @@ class GarageDoorOpener(HomeAccessory):
 
     def set_state(self, value):
         """Change garage state if call came from HomeKit."""
-        
+
         # Check to make sure the target state is different than current state
         current_value = self.char_current_state.get_value()
 
         if (current_value == value):
             # We are already in target state so ignore.
-            _LOGGER.debug('%s: Ingoring set state to %d. Current state is %d', self.entity_id, value, current_value)
+            _LOGGER.debug('%s: Skip set state to %d.', self.entity_id, value)
             return
-        
+
         _LOGGER.debug('%s: Set state to %d', self.entity_id, value)
         self.flag_target_state = True
 

--- a/homeassistant/components/homekit/type_covers.py
+++ b/homeassistant/components/homekit/type_covers.py
@@ -41,6 +41,15 @@ class GarageDoorOpener(HomeAccessory):
 
     def set_state(self, value):
         """Change garage state if call came from HomeKit."""
+        
+        # Check to make sure the target state is different than current state
+        current_value = self.char_current_state.get_value()
+
+        if (current_value == value):
+            # We are already in target state so ignore.
+            _LOGGER.debug('%s: Ingoring set state to %d. Current state is %d', self.entity_id, value, current_value)
+            return
+        
         _LOGGER.debug('%s: Set state to %d', self.entity_id, value)
         self.flag_target_state = True
 


### PR DESCRIPTION
## Description:

I have a HomeKit automation that makes sure my garage is closed at a certain time. If the garage was already closed, it would improperly call the service then set the state as closing. Home Assistant would safely ignore the service call, but HomeKit would show the wrong state (closing). This code adds a check to ensure the the target state is different than the current state before issuing a service call and changing the state.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
