### PR TITLE
Bumped simplisafe-python to 3.1.11

### DIFF
--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -23,7 +23,7 @@ from homeassistant.helpers import config_validation as cv
 from .config_flow import configured_instances
 from .const import DATA_CLIENT, DEFAULT_SCAN_INTERVAL, DOMAIN, TOPIC_UPDATE
 
-REQUIREMENTS = ['simplisafe-python==3.1.7']
+REQUIREMENTS = ['simplisafe-python==3.1.10']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -95,10 +95,6 @@ async def async_setup_entry(hass, config_entry):
         simplisafe = await API.login_via_token(
             config_entry.data[CONF_TOKEN], websession)
     except SimplipyError as err:
-        if 403 in str(err):
-            _LOGGER.error('Invalid credentials provided')
-            return False
-
         _LOGGER.error('Config entry failed: %s', err)
         raise ConfigEntryNotReady
 

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -23,7 +23,7 @@ from homeassistant.helpers import config_validation as cv
 from .config_flow import configured_instances
 from .const import DATA_CLIENT, DEFAULT_SCAN_INTERVAL, DOMAIN, TOPIC_UPDATE
 
-REQUIREMENTS = ['simplisafe-python==3.1.10']
+REQUIREMENTS = ['simplisafe-python==3.1.11']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -87,13 +87,16 @@ async def async_setup(hass, config):
 async def async_setup_entry(hass, config_entry):
     """Set up SimpliSafe as config entry."""
     from simplipy import API
-    from simplipy.errors import SimplipyError
+    from simplipy.errors import InvalidCredentialsError, SimplipyError
 
     websession = aiohttp_client.async_get_clientsession(hass)
 
     try:
         simplisafe = await API.login_via_token(
             config_entry.data[CONF_TOKEN], websession)
+    except InvalidCredentialsError:
+        _LOGGER.error('Invalid credentials provided')
+        return False
     except SimplipyError as err:
         _LOGGER.error('Config entry failed: %s', err)
         raise ConfigEntryNotReady

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1343,7 +1343,7 @@ shodan==1.10.4
 simplepush==1.1.4
 
 # homeassistant.components.simplisafe
-simplisafe-python==3.1.7
+simplisafe-python==3.1.10
 
 # homeassistant.components.sisyphus
 sisyphus-control==2.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1343,7 +1343,7 @@ shodan==1.10.4
 simplepush==1.1.4
 
 # homeassistant.components.simplisafe
-simplisafe-python==3.1.10
+simplisafe-python==3.1.11
 
 # homeassistant.components.sisyphus
 sisyphus-control==2.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -216,7 +216,7 @@ ring_doorbell==0.2.1
 rxv==0.5.1
 
 # homeassistant.components.simplisafe
-simplisafe-python==3.1.10
+simplisafe-python==3.1.11
 
 # homeassistant.components.sleepiq
 sleepyq==0.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -216,7 +216,7 @@ ring_doorbell==0.2.1
 rxv==0.5.1
 
 # homeassistant.components.simplisafe
-simplisafe-python==3.1.7
+simplisafe-python==3.1.10
 
 # homeassistant.components.sleepiq
 sleepyq==0.6


### PR DESCRIPTION
## Description:

This PR bumps simplisafe-python to 3.1.11, which has better support for systems that use the "Standard" monitoring plan (and don't have access to sensors or setting the state).

**Related issue (if applicable):** fixes #17443 

## Example entry for `configuration.yaml` (if applicable):
```yaml
---
simplisafe:
  accounts:
    - username: <USERNAME>
      password: <PASSWORD>
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
