### PR TITLE
Fix flux switch update interval

### DIFF
--- a/homeassistant/components/switch/flux.py
+++ b/homeassistant/components/switch/flux.py
@@ -45,7 +45,16 @@ DEFAULT_MODE = MODE_XY
 DEPENDENCIES = ['light']
 
 
-PLATFORM_SCHEMA = vol.Schema({
+def is_valid_transition(config):
+    """Validate transition compared to interval."""
+    transition = config[ATTR_TRANSITION]
+    interval = config[CONF_INTERVAL]
+    if transition > interval:
+        config[ATTR_TRANSITION] = interval
+    return config
+
+
+PLATFORM_SCHEMA = vol.Schema(vol.All({
     vol.Required(CONF_PLATFORM): 'flux',
     vol.Required(CONF_LIGHTS): cv.entity_ids,
     vol.Optional(CONF_NAME, default="Flux"): cv.string,
@@ -64,7 +73,7 @@ PLATFORM_SCHEMA = vol.Schema({
         vol.Any(MODE_XY, MODE_MIRED, MODE_RGB),
     vol.Optional(CONF_INTERVAL, default=30): cv.positive_int,
     vol.Optional(ATTR_TRANSITION, default=30): VALID_TRANSITION
-})
+}, is_valid_transition))
 
 
 def set_lights_xy(hass, lights, x_val, y_val, brightness, transition):

--- a/homeassistant/components/switch/flux.py
+++ b/homeassistant/components/switch/flux.py
@@ -45,16 +45,7 @@ DEFAULT_MODE = MODE_XY
 DEPENDENCIES = ['light']
 
 
-def is_valid_transition(config):
-    """Validate transition compared to interval."""
-    transition = config[ATTR_TRANSITION]
-    interval = config[CONF_INTERVAL]
-    if transition > interval:
-        config[ATTR_TRANSITION] = interval
-    return config
-
-
-PLATFORM_SCHEMA = vol.Schema(vol.All({
+PLATFORM_SCHEMA = vol.Schema({
     vol.Required(CONF_PLATFORM): 'flux',
     vol.Required(CONF_LIGHTS): cv.entity_ids,
     vol.Optional(CONF_NAME, default="Flux"): cv.string,
@@ -73,7 +64,7 @@ PLATFORM_SCHEMA = vol.Schema(vol.All({
         vol.Any(MODE_XY, MODE_MIRED, MODE_RGB),
     vol.Optional(CONF_INTERVAL, default=30): cv.positive_int,
     vol.Optional(ATTR_TRANSITION, default=30): VALID_TRANSITION
-}, is_valid_transition))
+})
 
 
 def set_lights_xy(hass, lights, x_val, y_val, brightness, transition):

--- a/homeassistant/components/switch/flux.py
+++ b/homeassistant/components/switch/flux.py
@@ -125,8 +125,6 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     mode = config.get(CONF_MODE)
     interval = config.get(CONF_INTERVAL)
     transition = config.get(ATTR_TRANSITION)
-    if transition > interval:
-        transition = interval
     flux = FluxSwitch(name, hass, lights, start_time, stop_time,
                       start_colortemp, sunset_colortemp, stop_colortemp,
                       brightness, disable_brightness_adjust, mode, interval,

--- a/homeassistant/components/switch/flux.py
+++ b/homeassistant/components/switch/flux.py
@@ -19,7 +19,7 @@ from homeassistant.components.switch import DOMAIN, SwitchDevice
 from homeassistant.const import (
     ATTR_ENTITY_ID, CONF_NAME, CONF_PLATFORM, CONF_LIGHTS, CONF_MODE,
     SERVICE_TURN_ON)
-from homeassistant.helpers.event import track_time_change
+from homeassistant.helpers.event import track_time_interval
 from homeassistant.helpers.sun import get_astral_event_date
 from homeassistant.util import slugify
 from homeassistant.util.color import (
@@ -125,6 +125,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     mode = config.get(CONF_MODE)
     interval = config.get(CONF_INTERVAL)
     transition = config.get(ATTR_TRANSITION)
+    if transition > interval:
+        transition = interval
     flux = FluxSwitch(name, hass, lights, start_time, stop_time,
                       start_colortemp, sunset_colortemp, stop_colortemp,
                       brightness, disable_brightness_adjust, mode, interval,
@@ -180,8 +182,10 @@ class FluxSwitch(SwitchDevice):
         # Make initial update
         self.flux_update()
 
-        self.unsub_tracker = track_time_change(
-            self.hass, self.flux_update, second=[0, self._interval])
+        self.unsub_tracker = track_time_interval(
+            self.hass,
+            self.flux_update,
+            datetime.timedelta(seconds=self._interval))
 
         self.schedule_update_ha_state()
 

--- a/tests/components/switch/test_flux.py
+++ b/tests/components/switch/test_flux.py
@@ -71,25 +71,6 @@ class TestSwitchFlux(unittest.TestCase):
                 }
             })
 
-    # pylint: disable=invalid-name
-    def test_flux_config_with_big_transition(self):
-        """Test the flux with transition larger than interval."""
-        with patch('homeassistant.components.switch.flux.FluxSwitch') as flux:
-            assert setup_component(self.hass, switch.DOMAIN, {
-                switch.DOMAIN: {
-                    'platform': 'flux',
-                    'name': 'flux',
-                    'lights': ['light.office'],
-                    'mode': 'rgb',
-                    'interval': 10,
-                    'transition': 60,
-                }
-            })
-            self.hass.block_till_done()
-            flux.assert_called_once_with(
-                'flux', self.hass, ['light.office'], None, None,
-                4000, 3000, 1900, None, None, 'rgb', 10, 10)
-
     def test_flux_when_switch_is_off(self):
         """Test the flux switch when it is off."""
         platform = loader.get_component(self.hass, 'light.test')

--- a/tests/components/switch/test_flux.py
+++ b/tests/components/switch/test_flux.py
@@ -184,7 +184,7 @@ class TestSwitchFlux(unittest.TestCase):
             return sunset_time
 
         with patch('homeassistant.components.switch.flux.dt_now',
-                  return_value=test_time), \
+                   return_value=test_time), \
             patch('homeassistant.helpers.sun.get_astral_event_date',
                   side_effect=event_date):
             assert setup_component(self.hass, switch.DOMAIN, {
@@ -231,7 +231,7 @@ class TestSwitchFlux(unittest.TestCase):
             return sunset_time
 
         with patch('homeassistant.components.switch.flux.dt_now',
-                  return_value=test_time), \
+                   return_value=test_time), \
             patch('homeassistant.helpers.sun.get_astral_event_date',
                   side_effect=event_date):
             assert setup_component(self.hass, switch.DOMAIN, {
@@ -325,7 +325,7 @@ class TestSwitchFlux(unittest.TestCase):
             return sunset_time
 
         with patch('homeassistant.components.switch.flux.dt_now',
-                  return_value=test_time), \
+                   return_value=test_time), \
             patch('homeassistant.helpers.sun.get_astral_event_date',
                   side_effect=event_date):
             assert setup_component(self.hass, switch.DOMAIN, {
@@ -376,7 +376,7 @@ class TestSwitchFlux(unittest.TestCase):
             return sunset_time
 
         with patch('homeassistant.components.switch.flux.dt_now',
-                  return_value=test_time), \
+                   return_value=test_time), \
             patch('homeassistant.helpers.sun.get_astral_event_date',
                   side_effect=event_date):
             assert setup_component(self.hass, switch.DOMAIN, {
@@ -428,7 +428,7 @@ class TestSwitchFlux(unittest.TestCase):
             return sunset_time
 
         with patch('homeassistant.components.switch.flux.dt_now',
-                  return_value=test_time), \
+                   return_value=test_time), \
             patch('homeassistant.helpers.sun.get_astral_event_date',
                   side_effect=event_date):
             assert setup_component(self.hass, switch.DOMAIN, {
@@ -529,7 +529,7 @@ class TestSwitchFlux(unittest.TestCase):
             return sunset_time
 
         with patch('homeassistant.components.switch.flux.dt_now',
-                  return_value=test_time), \
+                   return_value=test_time), \
             patch('homeassistant.helpers.sun.get_astral_event_date',
                   side_effect=event_date):
             assert setup_component(self.hass, switch.DOMAIN, {
@@ -580,7 +580,7 @@ class TestSwitchFlux(unittest.TestCase):
             return sunset_time
 
         with patch('homeassistant.components.switch.flux.dt_now',
-                  return_value=test_time), \
+                   return_value=test_time), \
             patch('homeassistant.helpers.sun.get_astral_event_date',
                   side_effect=event_date):
             assert setup_component(self.hass, switch.DOMAIN, {
@@ -628,7 +628,7 @@ class TestSwitchFlux(unittest.TestCase):
             return sunset_time
 
         with patch('homeassistant.components.switch.flux.dt_now',
-                  return_value=test_time), \
+                   return_value=test_time), \
             patch('homeassistant.helpers.sun.get_astral_event_date',
                   side_effect=event_date):
             assert setup_component(self.hass, switch.DOMAIN, {
@@ -678,7 +678,7 @@ class TestSwitchFlux(unittest.TestCase):
             return sunset_time
 
         with patch('homeassistant.components.switch.flux.dt_now',
-                  return_value=test_time), \
+                   return_value=test_time), \
             patch('homeassistant.helpers.sun.get_astral_event_date',
                   side_effect=event_date):
             assert setup_component(self.hass, switch.DOMAIN, {
@@ -741,7 +741,7 @@ class TestSwitchFlux(unittest.TestCase):
             return sunset_time
 
         with patch('homeassistant.components.switch.flux.dt_now',
-                  return_value=test_time), \
+                   return_value=test_time), \
             patch('homeassistant.helpers.sun.get_astral_event_date',
                   side_effect=event_date):
             assert setup_component(self.hass, switch.DOMAIN, {
@@ -794,7 +794,7 @@ class TestSwitchFlux(unittest.TestCase):
             return sunset_time
 
         with patch('homeassistant.components.switch.flux.dt_now',
-                  return_value=test_time), \
+                   return_value=test_time), \
             patch('homeassistant.helpers.sun.get_astral_event_date',
                   side_effect=event_date):
             assert setup_component(self.hass, switch.DOMAIN, {
@@ -839,7 +839,7 @@ class TestSwitchFlux(unittest.TestCase):
             return sunset_time
 
         with patch('homeassistant.components.switch.flux.dt_now',
-                  return_value=test_time), \
+                   return_value=test_time), \
             patch('homeassistant.helpers.sun.get_astral_event_date',
                   side_effect=event_date):
             assert setup_component(self.hass, switch.DOMAIN, {

--- a/tests/components/switch/test_flux.py
+++ b/tests/components/switch/test_flux.py
@@ -183,22 +183,24 @@ class TestSwitchFlux(unittest.TestCase):
                 return sunrise_time
             return sunset_time
 
-        with patch('homeassistant.util.dt.now', return_value=test_time):
-            with patch('homeassistant.helpers.sun.get_astral_event_date',
-                       side_effect=event_date):
-                assert setup_component(self.hass, switch.DOMAIN, {
-                    switch.DOMAIN: {
-                        'platform': 'flux',
-                        'name': 'flux',
-                        'lights': [dev1.entity_id]
-                    }
-                })
-                turn_on_calls = mock_service(
-                    self.hass, light.DOMAIN, SERVICE_TURN_ON)
-                common.turn_on(self.hass, 'switch.flux')
-                self.hass.block_till_done()
-                fire_time_changed(self.hass, test_time)
-                self.hass.block_till_done()
+        with patch('homeassistant.util.dt.now', return_value=test_time), \
+            patch('homeassistant.components.switch.flux.dt_now',
+                  return_value=test_time), \
+            patch('homeassistant.helpers.sun.get_astral_event_date',
+                  side_effect=event_date):
+            assert setup_component(self.hass, switch.DOMAIN, {
+                switch.DOMAIN: {
+                    'platform': 'flux',
+                    'name': 'flux',
+                    'lights': [dev1.entity_id]
+                }
+            })
+            turn_on_calls = mock_service(
+                self.hass, light.DOMAIN, SERVICE_TURN_ON)
+            common.turn_on(self.hass, 'switch.flux')
+            self.hass.block_till_done()
+            fire_time_changed(self.hass, test_time)
+            self.hass.block_till_done()
         call = turn_on_calls[-1]
         self.assertEqual(call.data[light.ATTR_BRIGHTNESS], 173)
         self.assertEqual(call.data[light.ATTR_XY_COLOR], [0.439, 0.37])
@@ -229,23 +231,25 @@ class TestSwitchFlux(unittest.TestCase):
                 return sunrise_time
             return sunset_time
 
-        with patch('homeassistant.util.dt.now', return_value=test_time):
-            with patch('homeassistant.helpers.sun.get_astral_event_date',
-                       side_effect=event_date):
-                assert setup_component(self.hass, switch.DOMAIN, {
-                    switch.DOMAIN: {
-                        'platform': 'flux',
-                        'name': 'flux',
-                        'lights': [dev1.entity_id],
-                        'stop_time': '22:00'
-                    }
-                })
-                turn_on_calls = mock_service(
-                    self.hass, light.DOMAIN, SERVICE_TURN_ON)
-                common.turn_on(self.hass, 'switch.flux')
-                self.hass.block_till_done()
-                fire_time_changed(self.hass, test_time)
-                self.hass.block_till_done()
+        with patch('homeassistant.util.dt.now', return_value=test_time), \
+            patch('homeassistant.components.switch.flux.dt_now',
+                  return_value=test_time), \
+            patch('homeassistant.helpers.sun.get_astral_event_date',
+                  side_effect=event_date):
+            assert setup_component(self.hass, switch.DOMAIN, {
+                switch.DOMAIN: {
+                    'platform': 'flux',
+                    'name': 'flux',
+                    'lights': [dev1.entity_id],
+                    'stop_time': '22:00'
+                }
+            })
+            turn_on_calls = mock_service(
+                self.hass, light.DOMAIN, SERVICE_TURN_ON)
+            common.turn_on(self.hass, 'switch.flux')
+            self.hass.block_till_done()
+            fire_time_changed(self.hass, test_time)
+            self.hass.block_till_done()
         call = turn_on_calls[-1]
         self.assertEqual(call.data[light.ATTR_BRIGHTNESS], 146)
         self.assertEqual(call.data[light.ATTR_XY_COLOR], [0.506, 0.385])
@@ -322,24 +326,26 @@ class TestSwitchFlux(unittest.TestCase):
                 return sunrise_time
             return sunset_time
 
-        with patch('homeassistant.util.dt.now', return_value=test_time):
-            with patch('homeassistant.helpers.sun.get_astral_event_date',
-                       side_effect=event_date):
-                assert setup_component(self.hass, switch.DOMAIN, {
-                    switch.DOMAIN: {
-                        'platform': 'flux',
-                        'name': 'flux',
-                        'lights': [dev1.entity_id],
-                        'start_time': '6:00',
-                        'stop_time': '23:30'
-                    }
-                })
-                turn_on_calls = mock_service(
-                    self.hass, light.DOMAIN, SERVICE_TURN_ON)
-                common.turn_on(self.hass, 'switch.flux')
-                self.hass.block_till_done()
-                fire_time_changed(self.hass, test_time)
-                self.hass.block_till_done()
+        with patch('homeassistant.util.dt.now', return_value=test_time), \
+            patch('homeassistant.components.switch.flux.dt_now',
+                  return_value=test_time), \
+            patch('homeassistant.helpers.sun.get_astral_event_date',
+                  side_effect=event_date):
+            assert setup_component(self.hass, switch.DOMAIN, {
+                switch.DOMAIN: {
+                    'platform': 'flux',
+                    'name': 'flux',
+                    'lights': [dev1.entity_id],
+                    'start_time': '6:00',
+                    'stop_time': '23:30'
+                }
+            })
+            turn_on_calls = mock_service(
+                self.hass, light.DOMAIN, SERVICE_TURN_ON)
+            common.turn_on(self.hass, 'switch.flux')
+            self.hass.block_till_done()
+            fire_time_changed(self.hass, test_time)
+            self.hass.block_till_done()
         call = turn_on_calls[-1]
         self.assertEqual(call.data[light.ATTR_BRIGHTNESS], 147)
         self.assertEqual(call.data[light.ATTR_XY_COLOR], [0.504, 0.385])
@@ -372,23 +378,25 @@ class TestSwitchFlux(unittest.TestCase):
                 return sunrise_time
             return sunset_time
 
-        with patch('homeassistant.util.dt.now', return_value=test_time):
-            with patch('homeassistant.helpers.sun.get_astral_event_date',
-                       side_effect=event_date):
-                assert setup_component(self.hass, switch.DOMAIN, {
-                    switch.DOMAIN: {
-                        'platform': 'flux',
-                        'name': 'flux',
-                        'lights': [dev1.entity_id],
-                        'stop_time': '01:00'
-                    }
-                })
-                turn_on_calls = mock_service(
-                    self.hass, light.DOMAIN, SERVICE_TURN_ON)
-                common.turn_on(self.hass, 'switch.flux')
-                self.hass.block_till_done()
-                fire_time_changed(self.hass, test_time)
-                self.hass.block_till_done()
+        with patch('homeassistant.util.dt.now', return_value=test_time), \
+            patch('homeassistant.components.switch.flux.dt_now',
+                  return_value=test_time), \
+            patch('homeassistant.helpers.sun.get_astral_event_date',
+                  side_effect=event_date):
+            assert setup_component(self.hass, switch.DOMAIN, {
+                switch.DOMAIN: {
+                    'platform': 'flux',
+                    'name': 'flux',
+                    'lights': [dev1.entity_id],
+                    'stop_time': '01:00'
+                }
+            })
+            turn_on_calls = mock_service(
+                self.hass, light.DOMAIN, SERVICE_TURN_ON)
+            common.turn_on(self.hass, 'switch.flux')
+            self.hass.block_till_done()
+            fire_time_changed(self.hass, test_time)
+            self.hass.block_till_done()
         call = turn_on_calls[-1]
         self.assertEqual(call.data[light.ATTR_BRIGHTNESS], 112)
         self.assertEqual(call.data[light.ATTR_XY_COLOR], [0.606, 0.379])
@@ -423,23 +431,25 @@ class TestSwitchFlux(unittest.TestCase):
                 return sunrise_time
             return sunset_time
 
-        with patch('homeassistant.util.dt.now', return_value=test_time):
-            with patch('homeassistant.helpers.sun.get_astral_event_date',
-                       side_effect=event_date):
-                assert setup_component(self.hass, switch.DOMAIN, {
-                    switch.DOMAIN: {
-                        'platform': 'flux',
-                        'name': 'flux',
-                        'lights': [dev1.entity_id],
-                        'stop_time': '01:00'
-                    }
-                })
-                turn_on_calls = mock_service(
-                    self.hass, light.DOMAIN, SERVICE_TURN_ON)
-                common.turn_on(self.hass, 'switch.flux')
-                self.hass.block_till_done()
-                fire_time_changed(self.hass, test_time)
-                self.hass.block_till_done()
+        with patch('homeassistant.util.dt.now', return_value=test_time), \
+            patch('homeassistant.components.switch.flux.dt_now',
+                  return_value=test_time), \
+            patch('homeassistant.helpers.sun.get_astral_event_date',
+                  side_effect=event_date):
+            assert setup_component(self.hass, switch.DOMAIN, {
+                switch.DOMAIN: {
+                    'platform': 'flux',
+                    'name': 'flux',
+                    'lights': [dev1.entity_id],
+                    'stop_time': '01:00'
+                }
+            })
+            turn_on_calls = mock_service(
+                self.hass, light.DOMAIN, SERVICE_TURN_ON)
+            common.turn_on(self.hass, 'switch.flux')
+            self.hass.block_till_done()
+            fire_time_changed(self.hass, test_time)
+            self.hass.block_till_done()
         call = turn_on_calls[-1]
         self.assertEqual(call.data[light.ATTR_BRIGHTNESS], 173)
         self.assertEqual(call.data[light.ATTR_XY_COLOR], [0.439, 0.37])
@@ -523,23 +533,25 @@ class TestSwitchFlux(unittest.TestCase):
                 return sunrise_time
             return sunset_time
 
-        with patch('homeassistant.util.dt.now', return_value=test_time):
-            with patch('homeassistant.helpers.sun.get_astral_event_date',
-                       side_effect=event_date):
-                assert setup_component(self.hass, switch.DOMAIN, {
-                    switch.DOMAIN: {
-                        'platform': 'flux',
-                        'name': 'flux',
-                        'lights': [dev1.entity_id],
-                        'stop_time': '01:00'
-                    }
-                })
-                turn_on_calls = mock_service(
-                    self.hass, light.DOMAIN, SERVICE_TURN_ON)
-                common.turn_on(self.hass, 'switch.flux')
-                self.hass.block_till_done()
-                fire_time_changed(self.hass, test_time)
-                self.hass.block_till_done()
+        with patch('homeassistant.util.dt.now', return_value=test_time), \
+            patch('homeassistant.components.switch.flux.dt_now',
+                  return_value=test_time), \
+            patch('homeassistant.helpers.sun.get_astral_event_date',
+                  side_effect=event_date):
+            assert setup_component(self.hass, switch.DOMAIN, {
+                switch.DOMAIN: {
+                    'platform': 'flux',
+                    'name': 'flux',
+                    'lights': [dev1.entity_id],
+                    'stop_time': '01:00'
+                }
+            })
+            turn_on_calls = mock_service(
+                self.hass, light.DOMAIN, SERVICE_TURN_ON)
+            common.turn_on(self.hass, 'switch.flux')
+            self.hass.block_till_done()
+            fire_time_changed(self.hass, test_time)
+            self.hass.block_till_done()
         call = turn_on_calls[-1]
         self.assertEqual(call.data[light.ATTR_BRIGHTNESS], 114)
         self.assertEqual(call.data[light.ATTR_XY_COLOR], [0.601, 0.382])
@@ -573,23 +585,25 @@ class TestSwitchFlux(unittest.TestCase):
                 return sunrise_time
             return sunset_time
 
-        with patch('homeassistant.util.dt.now', return_value=test_time):
-            with patch('homeassistant.helpers.sun.get_astral_event_date',
-                       side_effect=event_date):
-                assert setup_component(self.hass, switch.DOMAIN, {
-                    switch.DOMAIN: {
-                        'platform': 'flux',
-                        'name': 'flux',
-                        'lights': [dev1.entity_id],
-                        'stop_time': '01:00'
-                    }
-                })
-                turn_on_calls = mock_service(
-                    self.hass, light.DOMAIN, SERVICE_TURN_ON)
-                common.turn_on(self.hass, 'switch.flux')
-                self.hass.block_till_done()
-                fire_time_changed(self.hass, test_time)
-                self.hass.block_till_done()
+        with patch('homeassistant.util.dt.now', return_value=test_time), \
+            patch('homeassistant.components.switch.flux.dt_now',
+                  return_value=test_time), \
+            patch('homeassistant.helpers.sun.get_astral_event_date',
+                  side_effect=event_date):
+            assert setup_component(self.hass, switch.DOMAIN, {
+                switch.DOMAIN: {
+                    'platform': 'flux',
+                    'name': 'flux',
+                    'lights': [dev1.entity_id],
+                    'stop_time': '01:00'
+                }
+            })
+            turn_on_calls = mock_service(
+                self.hass, light.DOMAIN, SERVICE_TURN_ON)
+            common.turn_on(self.hass, 'switch.flux')
+            self.hass.block_till_done()
+            fire_time_changed(self.hass, test_time)
+            self.hass.block_till_done()
         call = turn_on_calls[-1]
         self.assertEqual(call.data[light.ATTR_BRIGHTNESS], 112)
         self.assertEqual(call.data[light.ATTR_XY_COLOR], [0.606, 0.379])
@@ -620,25 +634,27 @@ class TestSwitchFlux(unittest.TestCase):
                 return sunrise_time
             return sunset_time
 
-        with patch('homeassistant.util.dt.now', return_value=test_time):
-            with patch('homeassistant.helpers.sun.get_astral_event_date',
-                       side_effect=event_date):
-                assert setup_component(self.hass, switch.DOMAIN, {
-                    switch.DOMAIN: {
-                        'platform': 'flux',
-                        'name': 'flux',
-                        'lights': [dev1.entity_id],
-                        'start_colortemp': '1000',
-                        'stop_colortemp': '6000',
-                        'stop_time': '22:00'
-                    }
-                })
-                turn_on_calls = mock_service(
-                    self.hass, light.DOMAIN, SERVICE_TURN_ON)
-                common.turn_on(self.hass, 'switch.flux')
-                self.hass.block_till_done()
-                fire_time_changed(self.hass, test_time)
-                self.hass.block_till_done()
+        with patch('homeassistant.util.dt.now', return_value=test_time), \
+            patch('homeassistant.components.switch.flux.dt_now',
+                  return_value=test_time), \
+            patch('homeassistant.helpers.sun.get_astral_event_date',
+                  side_effect=event_date):
+            assert setup_component(self.hass, switch.DOMAIN, {
+                switch.DOMAIN: {
+                    'platform': 'flux',
+                    'name': 'flux',
+                    'lights': [dev1.entity_id],
+                    'start_colortemp': '1000',
+                    'stop_colortemp': '6000',
+                    'stop_time': '22:00'
+                }
+            })
+            turn_on_calls = mock_service(
+                self.hass, light.DOMAIN, SERVICE_TURN_ON)
+            common.turn_on(self.hass, 'switch.flux')
+            self.hass.block_till_done()
+            fire_time_changed(self.hass, test_time)
+            self.hass.block_till_done()
         call = turn_on_calls[-1]
         self.assertEqual(call.data[light.ATTR_BRIGHTNESS], 159)
         self.assertEqual(call.data[light.ATTR_XY_COLOR], [0.469, 0.378])
@@ -669,24 +685,26 @@ class TestSwitchFlux(unittest.TestCase):
                 return sunrise_time
             return sunset_time
 
-        with patch('homeassistant.util.dt.now', return_value=test_time):
-            with patch('homeassistant.helpers.sun.get_astral_event_date',
-                       side_effect=event_date):
-                assert setup_component(self.hass, switch.DOMAIN, {
-                    switch.DOMAIN: {
-                        'platform': 'flux',
-                        'name': 'flux',
-                        'lights': [dev1.entity_id],
-                        'brightness': 255,
-                        'stop_time': '22:00'
-                    }
-                })
-                turn_on_calls = mock_service(
-                    self.hass, light.DOMAIN, SERVICE_TURN_ON)
-                common.turn_on(self.hass, 'switch.flux')
-                self.hass.block_till_done()
-                fire_time_changed(self.hass, test_time)
-                self.hass.block_till_done()
+        with patch('homeassistant.util.dt.now', return_value=test_time), \
+            patch('homeassistant.components.switch.flux.dt_now',
+                  return_value=test_time), \
+            patch('homeassistant.helpers.sun.get_astral_event_date',
+                  side_effect=event_date):
+            assert setup_component(self.hass, switch.DOMAIN, {
+                switch.DOMAIN: {
+                    'platform': 'flux',
+                    'name': 'flux',
+                    'lights': [dev1.entity_id],
+                    'brightness': 255,
+                    'stop_time': '22:00'
+                }
+            })
+            turn_on_calls = mock_service(
+                self.hass, light.DOMAIN, SERVICE_TURN_ON)
+            common.turn_on(self.hass, 'switch.flux')
+            self.hass.block_till_done()
+            fire_time_changed(self.hass, test_time)
+            self.hass.block_till_done()
         call = turn_on_calls[-1]
         self.assertEqual(call.data[light.ATTR_BRIGHTNESS], 255)
         self.assertEqual(call.data[light.ATTR_XY_COLOR], [0.506, 0.385])
@@ -731,24 +749,26 @@ class TestSwitchFlux(unittest.TestCase):
             print('sunset {}'.format(sunset_time))
             return sunset_time
 
-        with patch('homeassistant.util.dt.now', return_value=test_time):
-            with patch('homeassistant.helpers.sun.get_astral_event_date',
-                       side_effect=event_date):
-                assert setup_component(self.hass, switch.DOMAIN, {
-                    switch.DOMAIN: {
-                        'platform': 'flux',
-                        'name': 'flux',
-                        'lights': [dev1.entity_id,
-                                   dev2.entity_id,
-                                   dev3.entity_id]
-                    }
-                })
-                turn_on_calls = mock_service(
-                    self.hass, light.DOMAIN, SERVICE_TURN_ON)
-                common.turn_on(self.hass, 'switch.flux')
-                self.hass.block_till_done()
-                fire_time_changed(self.hass, test_time)
-                self.hass.block_till_done()
+        with patch('homeassistant.util.dt.now', return_value=test_time), \
+            patch('homeassistant.components.switch.flux.dt_now',
+                  return_value=test_time), \
+            patch('homeassistant.helpers.sun.get_astral_event_date',
+                  side_effect=event_date):
+            assert setup_component(self.hass, switch.DOMAIN, {
+                switch.DOMAIN: {
+                    'platform': 'flux',
+                    'name': 'flux',
+                    'lights': [dev1.entity_id,
+                               dev2.entity_id,
+                               dev3.entity_id]
+                }
+            })
+            turn_on_calls = mock_service(
+                self.hass, light.DOMAIN, SERVICE_TURN_ON)
+            common.turn_on(self.hass, 'switch.flux')
+            self.hass.block_till_done()
+            fire_time_changed(self.hass, test_time)
+            self.hass.block_till_done()
         call = turn_on_calls[-1]
         self.assertEqual(call.data[light.ATTR_BRIGHTNESS], 163)
         self.assertEqual(call.data[light.ATTR_XY_COLOR], [0.46, 0.376])
@@ -783,23 +803,25 @@ class TestSwitchFlux(unittest.TestCase):
                 return sunrise_time
             return sunset_time
 
-        with patch('homeassistant.util.dt.now', return_value=test_time):
-            with patch('homeassistant.helpers.sun.get_astral_event_date',
-                       side_effect=event_date):
-                assert setup_component(self.hass, switch.DOMAIN, {
-                    switch.DOMAIN: {
-                        'platform': 'flux',
-                        'name': 'flux',
-                        'lights': [dev1.entity_id],
-                        'mode': 'mired'
-                    }
-                })
-                turn_on_calls = mock_service(
-                    self.hass, light.DOMAIN, SERVICE_TURN_ON)
-                common.turn_on(self.hass, 'switch.flux')
-                self.hass.block_till_done()
-                fire_time_changed(self.hass, test_time)
-                self.hass.block_till_done()
+        with patch('homeassistant.util.dt.now', return_value=test_time), \
+            patch('homeassistant.components.switch.flux.dt_now',
+                  return_value=test_time), \
+            patch('homeassistant.helpers.sun.get_astral_event_date',
+                  side_effect=event_date):
+            assert setup_component(self.hass, switch.DOMAIN, {
+                switch.DOMAIN: {
+                    'platform': 'flux',
+                    'name': 'flux',
+                    'lights': [dev1.entity_id],
+                    'mode': 'mired'
+                }
+            })
+            turn_on_calls = mock_service(
+                self.hass, light.DOMAIN, SERVICE_TURN_ON)
+            common.turn_on(self.hass, 'switch.flux')
+            self.hass.block_till_done()
+            fire_time_changed(self.hass, test_time)
+            self.hass.block_till_done()
         call = turn_on_calls[-1]
         self.assertEqual(call.data[light.ATTR_COLOR_TEMP], 269)
 
@@ -827,23 +849,25 @@ class TestSwitchFlux(unittest.TestCase):
                 return sunrise_time
             return sunset_time
 
-        with patch('homeassistant.util.dt.now', return_value=test_time):
-            with patch('homeassistant.helpers.sun.get_astral_event_date',
-                       side_effect=event_date):
-                assert setup_component(self.hass, switch.DOMAIN, {
-                    switch.DOMAIN: {
-                        'platform': 'flux',
-                        'name': 'flux',
-                        'lights': [dev1.entity_id],
-                        'mode': 'rgb'
-                    }
-                })
-                turn_on_calls = mock_service(
-                    self.hass, light.DOMAIN, SERVICE_TURN_ON)
-                common.turn_on(self.hass, 'switch.flux')
-                self.hass.block_till_done()
-                fire_time_changed(self.hass, test_time)
-                self.hass.block_till_done()
+        with patch('homeassistant.util.dt.now', return_value=test_time), \
+            patch('homeassistant.components.switch.flux.dt_now',
+                  return_value=test_time), \
+            patch('homeassistant.helpers.sun.get_astral_event_date',
+                  side_effect=event_date):
+            assert setup_component(self.hass, switch.DOMAIN, {
+                switch.DOMAIN: {
+                    'platform': 'flux',
+                    'name': 'flux',
+                    'lights': [dev1.entity_id],
+                    'mode': 'rgb'
+                }
+            })
+            turn_on_calls = mock_service(
+                self.hass, light.DOMAIN, SERVICE_TURN_ON)
+            common.turn_on(self.hass, 'switch.flux')
+            self.hass.block_till_done()
+            fire_time_changed(self.hass, test_time)
+            self.hass.block_till_done()
         call = turn_on_calls[-1]
         rgb = (255, 198, 152)
         rounded_call = tuple(map(round, call.data[light.ATTR_RGB_COLOR]))

--- a/tests/components/switch/test_flux.py
+++ b/tests/components/switch/test_flux.py
@@ -183,8 +183,7 @@ class TestSwitchFlux(unittest.TestCase):
                 return sunrise_time
             return sunset_time
 
-        with patch('homeassistant.util.dt.now', return_value=test_time), \
-            patch('homeassistant.components.switch.flux.dt_now',
+        with patch('homeassistant.components.switch.flux.dt_now',
                   return_value=test_time), \
             patch('homeassistant.helpers.sun.get_astral_event_date',
                   side_effect=event_date):
@@ -231,8 +230,7 @@ class TestSwitchFlux(unittest.TestCase):
                 return sunrise_time
             return sunset_time
 
-        with patch('homeassistant.util.dt.now', return_value=test_time), \
-            patch('homeassistant.components.switch.flux.dt_now',
+        with patch('homeassistant.components.switch.flux.dt_now',
                   return_value=test_time), \
             patch('homeassistant.helpers.sun.get_astral_event_date',
                   side_effect=event_date):
@@ -326,8 +324,7 @@ class TestSwitchFlux(unittest.TestCase):
                 return sunrise_time
             return sunset_time
 
-        with patch('homeassistant.util.dt.now', return_value=test_time), \
-            patch('homeassistant.components.switch.flux.dt_now',
+        with patch('homeassistant.components.switch.flux.dt_now',
                   return_value=test_time), \
             patch('homeassistant.helpers.sun.get_astral_event_date',
                   side_effect=event_date):
@@ -378,8 +375,7 @@ class TestSwitchFlux(unittest.TestCase):
                 return sunrise_time
             return sunset_time
 
-        with patch('homeassistant.util.dt.now', return_value=test_time), \
-            patch('homeassistant.components.switch.flux.dt_now',
+        with patch('homeassistant.components.switch.flux.dt_now',
                   return_value=test_time), \
             patch('homeassistant.helpers.sun.get_astral_event_date',
                   side_effect=event_date):
@@ -431,8 +427,7 @@ class TestSwitchFlux(unittest.TestCase):
                 return sunrise_time
             return sunset_time
 
-        with patch('homeassistant.util.dt.now', return_value=test_time), \
-            patch('homeassistant.components.switch.flux.dt_now',
+        with patch('homeassistant.components.switch.flux.dt_now',
                   return_value=test_time), \
             patch('homeassistant.helpers.sun.get_astral_event_date',
                   side_effect=event_date):
@@ -533,8 +528,7 @@ class TestSwitchFlux(unittest.TestCase):
                 return sunrise_time
             return sunset_time
 
-        with patch('homeassistant.util.dt.now', return_value=test_time), \
-            patch('homeassistant.components.switch.flux.dt_now',
+        with patch('homeassistant.components.switch.flux.dt_now',
                   return_value=test_time), \
             patch('homeassistant.helpers.sun.get_astral_event_date',
                   side_effect=event_date):
@@ -585,8 +579,7 @@ class TestSwitchFlux(unittest.TestCase):
                 return sunrise_time
             return sunset_time
 
-        with patch('homeassistant.util.dt.now', return_value=test_time), \
-            patch('homeassistant.components.switch.flux.dt_now',
+        with patch('homeassistant.components.switch.flux.dt_now',
                   return_value=test_time), \
             patch('homeassistant.helpers.sun.get_astral_event_date',
                   side_effect=event_date):
@@ -634,8 +627,7 @@ class TestSwitchFlux(unittest.TestCase):
                 return sunrise_time
             return sunset_time
 
-        with patch('homeassistant.util.dt.now', return_value=test_time), \
-            patch('homeassistant.components.switch.flux.dt_now',
+        with patch('homeassistant.components.switch.flux.dt_now',
                   return_value=test_time), \
             patch('homeassistant.helpers.sun.get_astral_event_date',
                   side_effect=event_date):
@@ -685,8 +677,7 @@ class TestSwitchFlux(unittest.TestCase):
                 return sunrise_time
             return sunset_time
 
-        with patch('homeassistant.util.dt.now', return_value=test_time), \
-            patch('homeassistant.components.switch.flux.dt_now',
+        with patch('homeassistant.components.switch.flux.dt_now',
                   return_value=test_time), \
             patch('homeassistant.helpers.sun.get_astral_event_date',
                   side_effect=event_date):
@@ -749,8 +740,7 @@ class TestSwitchFlux(unittest.TestCase):
             print('sunset {}'.format(sunset_time))
             return sunset_time
 
-        with patch('homeassistant.util.dt.now', return_value=test_time), \
-            patch('homeassistant.components.switch.flux.dt_now',
+        with patch('homeassistant.components.switch.flux.dt_now',
                   return_value=test_time), \
             patch('homeassistant.helpers.sun.get_astral_event_date',
                   side_effect=event_date):
@@ -803,8 +793,7 @@ class TestSwitchFlux(unittest.TestCase):
                 return sunrise_time
             return sunset_time
 
-        with patch('homeassistant.util.dt.now', return_value=test_time), \
-            patch('homeassistant.components.switch.flux.dt_now',
+        with patch('homeassistant.components.switch.flux.dt_now',
                   return_value=test_time), \
             patch('homeassistant.helpers.sun.get_astral_event_date',
                   side_effect=event_date):
@@ -849,8 +838,7 @@ class TestSwitchFlux(unittest.TestCase):
                 return sunrise_time
             return sunset_time
 
-        with patch('homeassistant.util.dt.now', return_value=test_time), \
-            patch('homeassistant.components.switch.flux.dt_now',
+        with patch('homeassistant.components.switch.flux.dt_now',
                   return_value=test_time), \
             patch('homeassistant.helpers.sun.get_astral_event_date',
                   side_effect=event_date):

--- a/tests/components/switch/test_flux.py
+++ b/tests/components/switch/test_flux.py
@@ -71,6 +71,25 @@ class TestSwitchFlux(unittest.TestCase):
                 }
             })
 
+    # pylint: disable=invalid-name
+    def test_flux_config_with_big_transition(self):
+        """Test the flux with transition larger than interval."""
+        with patch('homeassistant.components.switch.flux.FluxSwitch') as flux:
+            assert setup_component(self.hass, switch.DOMAIN, {
+                switch.DOMAIN: {
+                    'platform': 'flux',
+                    'name': 'flux',
+                    'lights': ['light.office'],
+                    'mode': 'rgb',
+                    'interval': 10,
+                    'transition': 60,
+                }
+            })
+            self.hass.block_till_done()
+            flux.assert_called_once_with(
+                'flux', self.hass, ['light.office'], None, None,
+                4000, 3000, 1900, None, None, 'rgb', 10, 10)
+
     def test_flux_when_switch_is_off(self):
         """Test the flux switch when it is off."""
         platform = loader.get_component(self.hass, 'light.test')


### PR DESCRIPTION
## Description:

The previous implementation only worked as advertised for the `interval` default value of 30.

This change revealed an issue in the tests where time moved backwards. Since that does not work with `track_time_interval()`, the tests were updated with an extra `patch` for current time as seen by the switch.

**Related issue (if applicable):** fixes #17368

## Example entry for `configuration.yaml` (if applicable):
```yaml
  - platform: flux
    lights: light.chandelier, light.living_wall_lamps
    name: Fluxer Living Room
    mode: mired
    start_colortemp: 5000
    sunset_colortemp: 4000
    stop_colortemp: 3000
    disable_brightness_adjust: True
    interval: 3000
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
