### PR TITLE
Bugfix eventstream with EOF on end

### DIFF
--- a/homeassistant/components/api.py
+++ b/homeassistant/components/api.py
@@ -141,6 +141,8 @@ class APIEventStream(HomeAssistantView):
             _LOGGER.debug("STREAM %s RESPONSE CLOSED", id(stop_obj))
             unsub_stream()
 
+        return response
+
 
 class APIConfigView(HomeAssistantView):
     """View to handle Configuration requests."""


### PR DESCRIPTION
## Description:

With aiohttp > 3.2.0 we need return the StreamResponse back to aiohttp core that they write a EOF to stream. Some clients (also aiohttp) never close the reading if they not see a EOF on end of the stream.