### PR TITLE
Always poll kodi

### DIFF
--- a/homeassistant/components/media_player/kodi.py
+++ b/homeassistant/components/media_player/kodi.py
@@ -231,7 +231,7 @@ async def async_setup_platform(hass, config, async_add_entities,
             await getattr(player, method['method'])(**params)
 
         for player in target_players:
-            if player.should_poll:
+            if not player.is_connected:
                 update_coro = player.async_update_ha_state(True)
                 update_tasks.append(update_coro)
 
@@ -486,7 +486,7 @@ class KodiDevice(MediaPlayerDevice):
     @property
     def server(self):
         """Active server for json-rpc requests."""
-        if self._enable_websocket and self._ws_server.connected:
+        if self.is_connected:
             return self._ws_server
 
         return self._http_server
@@ -497,9 +497,16 @@ class KodiDevice(MediaPlayerDevice):
         return self._name
 
     @property
+    def is_connected(self):
+        """Return True if the entity requires manual updating."""
+        if not self._enable_websocket:
+            return False
+        return self._ws_server.connected
+
+    @property
     def should_poll(self):
         """Return True if entity has to be polled for state."""
-        return not (self._enable_websocket and self._ws_server.connected)
+        return True
 
     @property
     def volume_level(self):


### PR DESCRIPTION
## Description:
Imagine the following:
1. Kodi is **already** running
2. HA is getting started ([should_poll](https://github.com/home-assistant/home-assistant/blob/a71cc67efb05cf343df048885b451581b8cf0bd0/homeassistant/components/media_player/kodi.py#L502) returns `False`)
3. Kodi restarts (system reboot, suspend, application exit..)
4. Kodi starts

In this case, the component will **not** realize kodi is back online as `should_poll` is never polled by HA itself (**I assume!** Please correct me if I'm wrong)

I don't *love* this fix but it's certainly better than what we have now.

**Related issue (if applicable):** fixes #17265

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
