### PR TITLE
0.80.1

### DIFF
--- a/homeassistant/components/alarm_control_panel/spc.py
+++ b/homeassistant/components/alarm_control_panel/spc.py
@@ -85,19 +85,23 @@ class SpcAlarm(alarm.AlarmControlPanel):
     async def async_alarm_disarm(self, code=None):
         """Send disarm command."""
         from pyspcwebgw.const import AreaMode
-        self._api.change_mode(area=self._area, new_mode=AreaMode.UNSET)
+        await self._api.change_mode(area=self._area,
+                                    new_mode=AreaMode.UNSET)
 
     async def async_alarm_arm_home(self, code=None):
         """Send arm home command."""
         from pyspcwebgw.const import AreaMode
-        self._api.change_mode(area=self._area, new_mode=AreaMode.PART_SET_A)
+        await self._api.change_mode(area=self._area,
+                                    new_mode=AreaMode.PART_SET_A)
 
     async def async_alarm_arm_night(self, code=None):
         """Send arm home command."""
         from pyspcwebgw.const import AreaMode
-        self._api.change_mode(area=self._area, new_mode=AreaMode.PART_SET_B)
+        await self._api.change_mode(area=self._area,
+                                    new_mode=AreaMode.PART_SET_B)
 
     async def async_alarm_arm_away(self, code=None):
         """Send arm away command."""
         from pyspcwebgw.const import AreaMode
-        self._api.change_mode(area=self._area, new_mode=AreaMode.FULL_SET)
+        await self._api.change_mode(area=self._area,
+                                    new_mode=AreaMode.FULL_SET)

--- a/homeassistant/components/api.py
+++ b/homeassistant/components/api.py
@@ -141,6 +141,8 @@ class APIEventStream(HomeAssistantView):
             _LOGGER.debug("STREAM %s RESPONSE CLOSED", id(stop_obj))
             unsub_stream()
 
+        return response
+
 
 class APIConfigView(HomeAssistantView):
     """View to handle Configuration requests."""

--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -24,7 +24,7 @@ from homeassistant.core import callback
 from homeassistant.helpers.translation import async_get_translations
 from homeassistant.loader import bind_hass
 
-REQUIREMENTS = ['home-assistant-frontend==20181012.0']
+REQUIREMENTS = ['home-assistant-frontend==20181014.0']
 
 DOMAIN = 'frontend'
 DEPENDENCIES = ['api', 'websocket_api', 'http', 'system_log',

--- a/homeassistant/components/hangouts/hangouts_bot.py
+++ b/homeassistant/components/hangouts/hangouts_bot.py
@@ -304,7 +304,7 @@ class HangoutsBot:
         """Handle the send_message service."""
         await self._async_send_message(service.data[ATTR_MESSAGE],
                                        service.data[ATTR_TARGET],
-                                       service.data[ATTR_DATA])
+                                       service.data.get(ATTR_DATA, {}))
 
     async def async_handle_update_users_and_conversations(self, _=None):
         """Handle the update_users_and_conversations service."""

--- a/homeassistant/components/websocket_api/http.py
+++ b/homeassistant/components/websocket_api/http.py
@@ -187,3 +187,5 @@ class WebSocketHandler:
                 self._logger.debug("Disconnected")
             else:
                 self._logger.warning("Disconnected: %s", disconnect_warn)
+
+        return wsock

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -2,7 +2,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 80
-PATCH_VERSION = '0'
+PATCH_VERSION = '1'
 __short_version__ = '{}.{}'.format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = '{}.{}'.format(__short_version__, PATCH_VERSION)
 REQUIRED_PYTHON_VER = (3, 5, 3)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -458,7 +458,7 @@ hole==0.3.0
 holidays==0.9.7
 
 # homeassistant.components.frontend
-home-assistant-frontend==20181012.0
+home-assistant-frontend==20181014.0
 
 # homeassistant.components.homekit_controller
 # homekit==0.10

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -90,7 +90,7 @@ hdate==0.6.3
 holidays==0.9.7
 
 # homeassistant.components.frontend
-home-assistant-frontend==20181012.0
+home-assistant-frontend==20181014.0
 
 # homeassistant.components.homematicip_cloud
 homematicip==0.9.8


### PR DESCRIPTION
- Fix automation editor (@armills)
- Fix arm/disarm calls. ([@mbrrg] - [#17381]) ([alarm_control_panel.spc docs])
- Fix hangout.send_message requiring data key ([@quazzie] - [#17393]) ([hangouts docs])
- Bugfix eventstream with EOF on end ([@pvizeli] - [#17465]) ([api docs])
- Fix websocket API ([@balloob] - [#17471]) ([websocket_api docs])

[#17381]: https://github.com/home-assistant/home-assistant/pull/17381
[#17393]: https://github.com/home-assistant/home-assistant/pull/17393
[#17465]: https://github.com/home-assistant/home-assistant/pull/17465
[#17471]: https://github.com/home-assistant/home-assistant/pull/17471
[@balloob]: https://github.com/balloob
[@mbrrg]: https://github.com/mbrrg
[@pvizeli]: https://github.com/pvizeli
[@quazzie]: https://github.com/quazzie
[alarm_control_panel.spc docs]: https://www.home-assistant.io/components/alarm_control_panel.spc/
[api docs]: https://www.home-assistant.io/components/api/
[hangouts docs]: https://www.home-assistant.io/components/hangouts/
[websocket_api docs]: https://www.home-assistant.io/components/websocket_api/