### PR TITLE
Fix: Xiaomi Plug state is set twice

### DIFF
--- a/homeassistant/components/switch/xiaomi_aqara.py
+++ b/homeassistant/components/switch/xiaomi_aqara.py
@@ -137,7 +137,7 @@ class XiaomiGenericSwitch(XiaomiDevice, SwitchDevice):
             self._load_power = round(float(data[LOAD_POWER]), 2)
 
         value = data.get(self._data_key)
-        if value is None or value == 'unknown':
+        if value not in ['on', 'off']:
             return False
 
         state = value == 'on'

--- a/homeassistant/components/switch/xiaomi_aqara.py
+++ b/homeassistant/components/switch/xiaomi_aqara.py
@@ -137,7 +137,7 @@ class XiaomiGenericSwitch(XiaomiDevice, SwitchDevice):
             self._load_power = round(float(data[LOAD_POWER]), 2)
 
         value = data.get(self._data_key)
-        if value is None:
+        if value is None or value == 'unknown':
             return False
 
         state = value == 'on'


### PR DESCRIPTION
## Description:
Xiaomi Wireless Socket "vibrate" in UI since HA 0.80.0

**Related issue (if applicable):** fixes #17422

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

