### PR TITLE
Fix telegram_bot polling warning

### DIFF
--- a/homeassistant/components/telegram_bot/__init__.py
+++ b/homeassistant/components/telegram_bot/__init__.py
@@ -309,10 +309,10 @@ def initialize_bot(p_config):
     proxy_params = p_config.get(CONF_PROXY_PARAMS)
 
     if proxy_url is not None:
-        request = Request(con_pool_size=4, proxy_url=proxy_url,
+        request = Request(con_pool_size=8, proxy_url=proxy_url,
                           urllib3_proxy_kwargs=proxy_params)
     else:
-        request = Request(con_pool_size=4)
+        request = Request(con_pool_size=8)
     return Bot(token=api_key, request=request)
 
 


### PR DESCRIPTION
## Description:
Fix warning from [python-telegram-bot](https://github.com/python-telegram-bot/python-telegram-bot/blob/439790375ed8ed493c43e464aa8e2b60a77939db/telegram/ext/updater.py#L115)
`Connection pool of Request object is smaller than optimal value (8).`

**Related issue (if applicable):** #16740 #15746

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**