### PR TITLE
Option to provide an additional UNIX socket for local connection

### DIFF
--- a/homeassistant/components/http/real_ip.py
+++ b/homeassistant/components/http/real_ip.py
@@ -1,6 +1,7 @@
 """Middleware to fetch real IP."""
 
 from ipaddress import ip_address
+from socket import AF_UNIX
 
 from aiohttp.web import middleware
 from aiohttp.hdrs import X_FORWARDED_FOR
@@ -16,8 +17,11 @@ def setup_real_ip(app, use_x_forwarded_for, trusted_proxies):
     @middleware
     async def real_ip_middleware(request, handler):
         """Real IP middleware."""
-        connected_ip = ip_address(
-            request.transport.get_extra_info('peername')[0])
+        if request.transport.get_extra_info('socket').family is AF_UNIX:
+            connected_ip = ip_address("127.0.0.1")
+        else:
+            connected_ip = ip_address(
+                request.transport.get_extra_info('peername')[0])
         request[KEY_REAL_IP] = connected_ip
 
         # Only use the XFF header if enabled, present, and from a trusted proxy


### PR DESCRIPTION
## Description:
This adds the ability to create a local UNIX socket. Connecting via a UNIX socket creates less overhead than TCP and also gives a little speed boost (maybe barely noticeable in many setups). Originally the idea was to circumvent the docker networking layers by using a UNIX socket which can be mounted into containers as a docker volume. I am using this code since 3-4 days to run my appdaemon apps and everything ran smoothly in this time. I also created the needed PR for appdaemon, see (will be updated in a second).

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant): home-assistant/home-assistant#17489
**Pull request in [appdaemon](https://github.com/home-assistant/appdaemon): home-assistant/appdaemon#386

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#6824

## Example entry for `configuration.yaml` (if applicable):
```yaml
http:
  ...
  unix_socket: /run/homeassistant/homeassistant.socket
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
