### PR TITLE
Add unique_id for Ring

### DIFF
--- a/homeassistant/components/binary_sensor/ring.py
+++ b/homeassistant/components/binary_sensor/ring.py
@@ -73,6 +73,7 @@ class RingBinarySensor(BinarySensorDevice):
                                       SENSOR_TYPES.get(self._sensor_type)[0])
         self._device_class = SENSOR_TYPES.get(self._sensor_type)[2]
         self._state = None
+        self._unique_id = '{}-{}'.format(self._data.id, self._sensor_type)
 
     @property
     def name(self):
@@ -88,6 +89,11 @@ class RingBinarySensor(BinarySensorDevice):
     def device_class(self):
         """Return the class of the binary sensor."""
         return self._device_class
+
+    @property
+    def unique_id(self):
+        """Return a unique ID."""
+        return self._unique_id
 
     @property
     def device_state_attributes(self):

--- a/homeassistant/components/camera/ring.py
+++ b/homeassistant/components/camera/ring.py
@@ -98,6 +98,11 @@ class RingCam(Camera):
         return self._name
 
     @property
+    def unique_id(self):
+        """Return a unique ID."""
+        return self._camera.id
+
+    @property
     def device_state_attributes(self):
         """Return the state attributes."""
         return {

--- a/homeassistant/components/sensor/ring.py
+++ b/homeassistant/components/sensor/ring.py
@@ -100,6 +100,7 @@ class RingSensor(Entity):
             self._data.name, SENSOR_TYPES.get(self._sensor_type)[0])
         self._state = STATE_UNKNOWN
         self._tz = str(hass.config.time_zone)
+        self._unique_id = '{}-{}'.format(self._data.id, self._sensor_type)
 
     @property
     def name(self):
@@ -110,6 +111,11 @@ class RingSensor(Entity):
     def state(self):
         """Return the state of the sensor."""
         return self._state
+
+    @property
+    def unique_id(self):
+        """Return a unique ID."""
+        return self._unique_id
 
     @property
     def device_state_attributes(self):


### PR DESCRIPTION
## Description:

Add Unique ID's for Ring components for entity registry support.

**Related issue (if applicable):** fixes # N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io# N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
ring:
  username: username
  password: password

binary_sensor:
  - platform: ring

sensor:
  - platform: ring

camera:
  - platform: ring
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
