### PR TITLE
Add problem text to alert message if available

### DIFF
--- a/tests/components/test_alert.py
+++ b/tests/components/test_alert.py
@@ -29,7 +29,7 @@ TEST_CONFIG = \
             alert.CONF_NOTIFIERS: [NOTIFIER]}
         }}
 TEST_NOACK = [NAME, NAME, DONE_MESSAGE, "sensor.test",
-              STATE_ON, [30], False, NOTIFIER, False]
+              STATE_ON, [30], False, True, NOTIFIER, False]
 ENTITY_ID = alert.ENTITY_ID_FORMAT.format(NAME)
 
 


### PR DESCRIPTION
## Description:

Add problem text of configured entity to alert message if available (e.g. for plants).

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`.

If user exposed functionality or configuration variables are added/changed:

  - [x] Documentation added/updated in home-assistant.io

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54