### PR TITLE
Install face_recognition on Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ LABEL maintainer="Paulus Schoutsen <Paulus@PaulusSchoutsen.nl>"
 #ENV INSTALL_FFMPEG no
 #ENV INSTALL_LIBCEC no
 #ENV INSTALL_SSOCR no
+#ENV INSTALL_DLIB no
 #ENV INSTALL_IPERF3 no
 
 VOLUME /config

--- a/virtualization/Docker/Dockerfile.dev
+++ b/virtualization/Docker/Dockerfile.dev
@@ -12,6 +12,7 @@ LABEL maintainer="Paulus Schoutsen <Paulus@PaulusSchoutsen.nl>"
 #ENV INSTALL_LIBCEC no
 #ENV INSTALL_COAP no
 #ENV INSTALL_SSOCR no
+#ENV INSTALL_DLIB no
 #ENV INSTALL_IPERF3 no
 
 VOLUME /config

--- a/virtualization/Docker/setup_docker_prereqs
+++ b/virtualization/Docker/setup_docker_prereqs
@@ -8,6 +8,7 @@ INSTALL_TELLSTICK="${INSTALL_TELLSTICK:-yes}"
 INSTALL_OPENALPR="${INSTALL_OPENALPR:-yes}"
 INSTALL_LIBCEC="${INSTALL_LIBCEC:-yes}"
 INSTALL_SSOCR="${INSTALL_SSOCR:-yes}"
+INSTALL_DLIB="${INSTALL_DLIB:-yes}"
 
 # Required debian packages for running hass or components
 PACKAGES=(
@@ -60,6 +61,10 @@ fi
 
 if [ "$INSTALL_SSOCR" == "yes" ]; then
   virtualization/Docker/scripts/ssocr
+fi
+
+if [ "$INSTALL_DLIB" == "yes" ]; then
+  pip3 install --no-cache-dir face_recognition==1.0.0
 fi
 
 # Remove packages

--- a/virtualization/Docker/setup_docker_prereqs
+++ b/virtualization/Docker/setup_docker_prereqs
@@ -64,7 +64,7 @@ if [ "$INSTALL_SSOCR" == "yes" ]; then
 fi
 
 if [ "$INSTALL_DLIB" == "yes" ]; then
-  pip3 install --no-cache-dir face_recognition==1.0.0
+  pip3 install --no-cache-dir "dlib>=19.5"
 fi
 
 # Remove packages


### PR DESCRIPTION
## Description:
Install `face_recognition` in the Docker build. This is because `image_processing.dlib_face_detect` and `image_processing.dlib_face_identify` build `dlib` when installed, which requires `cmake`. This PR builds `dlib` before `cmake` is removed.


**Related issue (if applicable):** #17451, possibly #11605

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.