### PR TITLE
Moved Wink water heater from climate to water heater.

### DIFF
--- a/homeassistant/components/climate/__init__.py
+++ b/homeassistant/components/climate/__init__.py
@@ -48,11 +48,6 @@ STATE_MANUAL = 'manual'
 STATE_DRY = 'dry'
 STATE_FAN_ONLY = 'fan_only'
 STATE_ECO = 'eco'
-STATE_ELECTRIC = 'electric'
-STATE_PERFORMANCE = 'performance'
-STATE_HIGH_DEMAND = 'high_demand'
-STATE_HEAT_PUMP = 'heat_pump'
-STATE_GAS = 'gas'
 
 SUPPORT_TARGET_TEMPERATURE = 1
 SUPPORT_TARGET_TEMPERATURE_HIGH = 2

--- a/homeassistant/components/climate/toon.py
+++ b/homeassistant/components/climate/toon.py
@@ -34,7 +34,7 @@ class ThermostatDevice(ClimateDevice):
         self._temperature = None
         self._setpoint = None
         self._operation_list = [
-            STATE_PERFORMANCE,
+            STATE_AUTO,
             STATE_HEAT,
             STATE_ECO,
             STATE_COOL,

--- a/homeassistant/components/climate/toon.py
+++ b/homeassistant/components/climate/toon.py
@@ -8,7 +8,7 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/climate.toon/
 """
 from homeassistant.components.climate import (
-    ATTR_TEMPERATURE, STATE_COOL, STATE_ECO, STATE_HEAT, STATE_PERFORMANCE,
+    ATTR_TEMPERATURE, STATE_COOL, STATE_ECO, STATE_HEAT, STATE_AUTO,
     SUPPORT_OPERATION_MODE, SUPPORT_TARGET_TEMPERATURE, ClimateDevice)
 import homeassistant.components.toon as toon_main
 from homeassistant.const import TEMP_CELSIUS
@@ -84,7 +84,7 @@ class ThermostatDevice(ClimateDevice):
     def set_operation_mode(self, operation_mode):
         """Set new operation mode."""
         toonlib_values = {
-            STATE_PERFORMANCE: 'Comfort',
+            STATE_AUTO: 'Comfort',
             STATE_HEAT: 'Home',
             STATE_ECO: 'Away',
             STATE_COOL: 'Sleep',

--- a/homeassistant/components/climate/tuya.py
+++ b/homeassistant/components/climate/tuya.py
@@ -7,8 +7,7 @@ https://home-assistant.io/components/climate.tuya/
 
 from homeassistant.components.climate import (
     ATTR_TEMPERATURE, ENTITY_ID_FORMAT, STATE_AUTO, STATE_COOL, STATE_ECO,
-    STATE_ELECTRIC, STATE_FAN_ONLY, STATE_GAS, STATE_HEAT, STATE_HEAT_PUMP,
-    STATE_HIGH_DEMAND, STATE_PERFORMANCE, SUPPORT_FAN_MODE, SUPPORT_ON_OFF,
+    STATE_FAN_ONLY, STATE_HEAT, SUPPORT_FAN_MODE, SUPPORT_ON_OFF,
     SUPPORT_OPERATION_MODE, SUPPORT_TARGET_TEMPERATURE, ClimateDevice)
 from homeassistant.components.fan import SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH
 from homeassistant.components.tuya import DATA_TUYA, TuyaDevice
@@ -23,13 +22,8 @@ HA_STATE_TO_TUYA = {
     STATE_AUTO: 'auto',
     STATE_COOL: 'cold',
     STATE_ECO: 'eco',
-    STATE_ELECTRIC: 'electric',
     STATE_FAN_ONLY: 'wind',
-    STATE_GAS: 'gas',
     STATE_HEAT: 'hot',
-    STATE_HEAT_PUMP: 'heat_pump',
-    STATE_HIGH_DEMAND: 'high_demand',
-    STATE_PERFORMANCE: 'performance',
 }
 
 TUYA_STATE_TO_HA = {value: key for key, value in HA_STATE_TO_TUYA.items()}

--- a/homeassistant/components/climate/wink.py
+++ b/homeassistant/components/climate/wink.py
@@ -1,5 +1,5 @@
 """
-Support for Wink thermostats, Air Conditioners, and Water Heaters.
+Support for Wink thermostats and Air Conditioners.
 
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/climate.wink/
@@ -8,9 +8,9 @@ import logging
 
 from homeassistant.components.climate import (
     ATTR_CURRENT_HUMIDITY, ATTR_TARGET_TEMP_HIGH, ATTR_TARGET_TEMP_LOW,
-    ATTR_TEMPERATURE, STATE_AUTO, STATE_COOL, STATE_ECO, STATE_ELECTRIC,
-    STATE_FAN_ONLY, STATE_GAS, STATE_HEAT, STATE_HEAT_PUMP, STATE_HIGH_DEMAND,
-    STATE_PERFORMANCE, SUPPORT_AUX_HEAT, SUPPORT_AWAY_MODE, SUPPORT_FAN_MODE,
+    ATTR_TEMPERATURE, STATE_AUTO, STATE_COOL, STATE_ECO,
+    STATE_FAN_ONLY, STATE_HEAT, SUPPORT_AUX_HEAT,
+    SUPPORT_AWAY_MODE, SUPPORT_FAN_MODE,
     SUPPORT_OPERATION_MODE, SUPPORT_TARGET_TEMPERATURE,
     SUPPORT_TARGET_TEMPERATURE_HIGH, SUPPORT_TARGET_TEMPERATURE_LOW,
     ClimateDevice)
@@ -24,11 +24,9 @@ _LOGGER = logging.getLogger(__name__)
 ATTR_ECO_TARGET = 'eco_target'
 ATTR_EXTERNAL_TEMPERATURE = 'external_temperature'
 ATTR_OCCUPIED = 'occupied'
-ATTR_RHEEM_TYPE = 'rheem_type'
 ATTR_SCHEDULE_ENABLED = 'schedule_enabled'
 ATTR_SMART_TEMPERATURE = 'smart_temperature'
 ATTR_TOTAL_CONSUMPTION = 'total_consumption'
-ATTR_VACATION_MODE = 'vacation_mode'
 ATTR_HEAT_ON = 'heat_on'
 ATTR_COOL_ON = 'cool_on'
 
@@ -42,14 +40,9 @@ HA_STATE_TO_WINK = {
     STATE_AUTO: 'auto',
     STATE_COOL: 'cool_only',
     STATE_ECO: 'eco',
-    STATE_ELECTRIC: 'electric_only',
     STATE_FAN_ONLY: 'fan_only',
-    STATE_GAS: 'gas',
     STATE_HEAT: 'heat_only',
-    STATE_HEAT_PUMP: 'heat_pump',
-    STATE_HIGH_DEMAND: 'high_demand',
     STATE_OFF: 'off',
-    STATE_PERFORMANCE: 'performance',
 }
 
 WINK_STATE_TO_HA = {value: key for key, value in HA_STATE_TO_WINK.items()}
@@ -61,9 +54,6 @@ SUPPORT_FLAGS_THERMOSTAT = (
 
 SUPPORT_FLAGS_AC = (SUPPORT_TARGET_TEMPERATURE | SUPPORT_OPERATION_MODE |
                     SUPPORT_FAN_MODE)
-
-SUPPORT_FLAGS_HEATER = (SUPPORT_TARGET_TEMPERATURE | SUPPORT_OPERATION_MODE |
-                        SUPPORT_AWAY_MODE)
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
@@ -77,10 +67,6 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         _id = climate.object_id() + climate.name()
         if _id not in hass.data[DOMAIN]['unique_ids']:
             add_entities([WinkAC(climate, hass)])
-    for water_heater in pywink.get_water_heaters():
-        _id = water_heater.object_id() + water_heater.name()
-        if _id not in hass.data[DOMAIN]['unique_ids']:
-            add_entities([WinkWaterHeater(water_heater, hass)])
 
 
 class WinkThermostat(WinkDevice, ClimateDevice):
@@ -504,93 +490,3 @@ class WinkAC(WinkDevice, ClimateDevice):
         elif fan_mode == SPEED_HIGH:
             speed = 1.0
         self.wink.set_ac_fan_speed(speed)
-
-
-class WinkWaterHeater(WinkDevice, ClimateDevice):
-    """Representation of a Wink water heater."""
-
-    @property
-    def supported_features(self):
-        """Return the list of supported features."""
-        return SUPPORT_FLAGS_HEATER
-
-    @property
-    def temperature_unit(self):
-        """Return the unit of measurement."""
-        # The Wink API always returns temp in Celsius
-        return TEMP_CELSIUS
-
-    @property
-    def device_state_attributes(self):
-        """Return the optional device state attributes."""
-        data = {}
-        data[ATTR_VACATION_MODE] = self.wink.vacation_mode_enabled()
-        data[ATTR_RHEEM_TYPE] = self.wink.rheem_type()
-
-        return data
-
-    @property
-    def current_operation(self):
-        """
-        Return current operation one of the following.
-
-        ["eco", "performance", "heat_pump",
-        "high_demand", "electric_only", "gas]
-        """
-        if not self.wink.is_on():
-            current_op = STATE_OFF
-        else:
-            current_op = WINK_STATE_TO_HA.get(self.wink.current_mode())
-            if current_op is None:
-                current_op = STATE_UNKNOWN
-        return current_op
-
-    @property
-    def operation_list(self):
-        """List of available operation modes."""
-        op_list = ['off']
-        modes = self.wink.modes()
-        for mode in modes:
-            if mode == 'aux':
-                continue
-            ha_mode = WINK_STATE_TO_HA.get(mode)
-            if ha_mode is not None:
-                op_list.append(ha_mode)
-            else:
-                error = "Invalid operation mode mapping. " + mode + \
-                    " doesn't map. Please report this."
-                _LOGGER.error(error)
-        return op_list
-
-    def set_temperature(self, **kwargs):
-        """Set new target temperature."""
-        target_temp = kwargs.get(ATTR_TEMPERATURE)
-        self.wink.set_temperature(target_temp)
-
-    def set_operation_mode(self, operation_mode):
-        """Set operation mode."""
-        op_mode_to_set = HA_STATE_TO_WINK.get(operation_mode)
-        self.wink.set_operation_mode(op_mode_to_set)
-
-    @property
-    def target_temperature(self):
-        """Return the temperature we try to reach."""
-        return self.wink.current_set_point()
-
-    def turn_away_mode_on(self):
-        """Turn away on."""
-        self.wink.set_vacation_mode(True)
-
-    def turn_away_mode_off(self):
-        """Turn away off."""
-        self.wink.set_vacation_mode(False)
-
-    @property
-    def min_temp(self):
-        """Return the minimum temperature."""
-        return self.wink.min_set_point()
-
-    @property
-    def max_temp(self):
-        """Return the maximum temperature."""
-        return self.wink.max_set_point()

--- a/homeassistant/components/water_heater/wink.py
+++ b/homeassistant/components/water_heater/wink.py
@@ -1,0 +1,136 @@
+"""
+Support for Wink water heaters.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/water_heater.wink/
+"""
+import logging
+
+from homeassistant.components.water_heater import (
+    ATTR_TEMPERATURE, STATE_ECO, STATE_ELECTRIC,
+    STATE_PERFORMANCE, SUPPORT_AWAY_MODE, STATE_HEAT_PUMP,
+    STATE_GAS, STATE_HIGH_DEMAND,
+    SUPPORT_OPERATION_MODE, SUPPORT_TARGET_TEMPERATURE,
+    WaterHeaterDevice)
+from homeassistant.components.wink import DOMAIN, WinkDevice
+from homeassistant.const import (
+    STATE_OFF, STATE_UNKNOWN, TEMP_CELSIUS)
+
+_LOGGER = logging.getLogger(__name__)
+
+SUPPORT_FLAGS_HEATER = (SUPPORT_TARGET_TEMPERATURE | SUPPORT_OPERATION_MODE |
+                        SUPPORT_AWAY_MODE)
+
+ATTR_RHEEM_TYPE = 'rheem_type'
+ATTR_VACATION_MODE = 'vacation_mode'
+
+HA_STATE_TO_WINK = {
+    STATE_ECO: 'eco',
+    STATE_ELECTRIC: 'electric_only',
+    STATE_GAS: 'gas',
+    STATE_HEAT_PUMP: 'heat_pump',
+    STATE_HIGH_DEMAND: 'high_demand',
+    STATE_OFF: 'off',
+    STATE_PERFORMANCE: 'performance',
+}
+
+WINK_STATE_TO_HA = {value: key for key, value in HA_STATE_TO_WINK.items()}
+
+
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    """Set up the Wink water heater devices."""
+    import pywink
+    for water_heater in pywink.get_water_heaters():
+        _id = water_heater.object_id() + water_heater.name()
+        if _id not in hass.data[DOMAIN]['unique_ids']:
+            add_entities([WinkWaterHeater(water_heater, hass)])
+
+
+class WinkWaterHeater(WinkDevice, WaterHeaterDevice):
+    """Representation of a Wink water heater."""
+
+    @property
+    def supported_features(self):
+        """Return the list of supported features."""
+        return SUPPORT_FLAGS_HEATER
+
+    @property
+    def temperature_unit(self):
+        """Return the unit of measurement."""
+        # The Wink API always returns temp in Celsius
+        return TEMP_CELSIUS
+
+    @property
+    def device_state_attributes(self):
+        """Return the optional device state attributes."""
+        data = {}
+        data[ATTR_VACATION_MODE] = self.wink.vacation_mode_enabled()
+        data[ATTR_RHEEM_TYPE] = self.wink.rheem_type()
+
+        return data
+
+    @property
+    def current_operation(self):
+        """
+        Return current operation one of the following.
+
+        ["eco", "performance", "heat_pump",
+        "high_demand", "electric_only", "gas]
+        """
+        if not self.wink.is_on():
+            current_op = STATE_OFF
+        else:
+            current_op = WINK_STATE_TO_HA.get(self.wink.current_mode())
+            if current_op is None:
+                current_op = STATE_UNKNOWN
+        return current_op
+
+    @property
+    def operation_list(self):
+        """List of available operation modes."""
+        op_list = ['off']
+        modes = self.wink.modes()
+        for mode in modes:
+            if mode == 'aux':
+                continue
+            ha_mode = WINK_STATE_TO_HA.get(mode)
+            if ha_mode is not None:
+                op_list.append(ha_mode)
+            else:
+                error = "Invalid operation mode mapping. " + mode + \
+                    " doesn't map. Please report this."
+                _LOGGER.error(error)
+        return op_list
+
+    def set_temperature(self, **kwargs):
+        """Set new target temperature."""
+        target_temp = kwargs.get(ATTR_TEMPERATURE)
+        self.wink.set_temperature(target_temp)
+
+    def set_operation_mode(self, operation_mode):
+        """Set operation mode."""
+        op_mode_to_set = HA_STATE_TO_WINK.get(operation_mode)
+        self.wink.set_operation_mode(op_mode_to_set)
+
+    @property
+    def target_temperature(self):
+        """Return the temperature we try to reach."""
+        return self.wink.current_set_point()
+
+    def turn_away_mode_on(self):
+        """Turn away on."""
+        self.wink.set_vacation_mode(True)
+
+    def turn_away_mode_off(self):
+        """Turn away off."""
+        self.wink.set_vacation_mode(False)
+
+    @property
+    def min_temp(self):
+        """Return the minimum temperature."""
+        return self.wink.min_set_point()
+
+    @property
+    def max_temp(self):
+        """Return the maximum temperature."""
+        return self.wink.max_set_point()

--- a/homeassistant/components/wink/__init__.py
+++ b/homeassistant/components/wink/__init__.py
@@ -177,7 +177,7 @@ DIAL_STATE_SCHEMA = vol.Schema({
 
 WINK_COMPONENTS = [
     'binary_sensor', 'sensor', 'light', 'switch', 'lock', 'cover', 'climate',
-    'fan', 'alarm_control_panel', 'scene'
+    'fan', 'alarm_control_panel', 'scene', 'water_heater'
 ]
 
 WINK_HUBS = []
@@ -526,6 +526,7 @@ def setup(hass, config):
         discovery.load_platform(hass, wink_component, DOMAIN, {}, config)
 
     component = EntityComponent(_LOGGER, DOMAIN, hass)
+
 
     sirens = []
     has_dome_or_wink_siren = False

--- a/homeassistant/components/wink/__init__.py
+++ b/homeassistant/components/wink/__init__.py
@@ -527,7 +527,6 @@ def setup(hass, config):
 
     component = EntityComponent(_LOGGER, DOMAIN, hass)
 
-
     sirens = []
     has_dome_or_wink_siren = False
     for siren in pywink.get_sirens():


### PR DESCRIPTION
## Description:
This moves the Wink water heater from climate to the new water heater component. 

This is part of https://github.com/home-assistant/home-assistant/issues/13539 and the last change required to remove all the water heater stuff from the climate component. 

**Breaking change:**

- `Wink` water heaters were moved to the new water heater implementation. All `Wink` water heaters will automatically be moved from `climate.wate_heater` to `water_heater.water_heater` Please update your configuration to use `water_heater` now.
- `Toon` "comfort" setting is now available as 'auto' instead of 'performance'

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#6842

## Example entry for `configuration.yaml` (if applicable):
```yaml
wink:
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] New files were added to `.coveragerc`.


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
