### PR TITLE
Fix unhandled exception which creates many useless logs

### DIFF
--- a/homeassistant/components/media_player/horizon.py
+++ b/homeassistant/components/media_player/horizon.py
@@ -93,9 +93,10 @@ class HorizonDevice(MediaPlayerDevice):
     def update(self):
         """Update State using the media server running on the Horizon."""
         try:
-            self._state = (STATE_PLAYING
-                           if self._client.is_powered_on()
-                           else STATE_OFF)
+            if self._client.is_powered_on():
+                self._state = STATE_PLAYING
+            else:
+                self._state = STATE_OFF
         except OSError:
             self._state = STATE_OFF
 

--- a/homeassistant/components/media_player/horizon.py
+++ b/homeassistant/components/media_player/horizon.py
@@ -92,9 +92,10 @@ class HorizonDevice(MediaPlayerDevice):
     @util.Throttle(MIN_TIME_BETWEEN_SCANS, MIN_TIME_BETWEEN_FORCED_SCANS)
     def update(self):
         """Update State using the media server running on the Horizon."""
-        if self._client.is_powered_on():
-            self._state = STATE_PLAYING
-        else:
+        try:
+            if self._client.is_powered_on():
+                self._state = STATE_PLAYING
+        except OSError:
             self._state = STATE_OFF
 
     def turn_on(self):

--- a/homeassistant/components/media_player/horizon.py
+++ b/homeassistant/components/media_player/horizon.py
@@ -93,8 +93,9 @@ class HorizonDevice(MediaPlayerDevice):
     def update(self):
         """Update State using the media server running on the Horizon."""
         try:
-            if self._client.is_powered_on():
-                self._state = STATE_PLAYING
+            self._state = (STATE_PLAYING
+                           if self._client.is_powered_on()
+                           else STATE_OFF)
         except OSError:
             self._state = STATE_OFF
 


### PR DESCRIPTION
## Description:
Fixes unhandled exception in horizon component.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
