### PR TITLE
Bumps simplisafe-python to 3.1.12

### DIFF
--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -23,7 +23,7 @@ from homeassistant.helpers import config_validation as cv
 from .config_flow import configured_instances
 from .const import DATA_CLIENT, DEFAULT_SCAN_INTERVAL, DOMAIN, TOPIC_UPDATE
 
-REQUIREMENTS = ['simplisafe-python==3.1.11']
+REQUIREMENTS = ['simplisafe-python==3.1.12']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1346,7 +1346,7 @@ shodan==1.10.4
 simplepush==1.1.4
 
 # homeassistant.components.simplisafe
-simplisafe-python==3.1.11
+simplisafe-python==3.1.12
 
 # homeassistant.components.sisyphus
 sisyphus-control==2.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -216,7 +216,7 @@ ring_doorbell==0.2.1
 rxv==0.5.1
 
 # homeassistant.components.simplisafe
-simplisafe-python==3.1.11
+simplisafe-python==3.1.12
 
 # homeassistant.components.sleepiq
 sleepyq==0.6


### PR DESCRIPTION
## Description:
Bumps `simplisafe-python` to 3.1.12. Changelog [here](https://github.com/bachya/simplisafe-python/releases/tag/3.1.12).

**Related issue (if applicable):** fixes #17597 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml

simplisafe:
  accounts:
    - username: <EMAIL>
      password: <PASSWORD>
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
