### PR TITLE
Bump hdate version to 0.6.5

### DIFF
--- a/homeassistant/components/sensor/jewish_calendar.py
+++ b/homeassistant/components/sensor/jewish_calendar.py
@@ -15,7 +15,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 import homeassistant.util.dt as dt_util
 
-REQUIREMENTS = ['hdate==0.6.4']
+REQUIREMENTS = ['hdate==0.6.5']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sensor/jewish_calendar.py
+++ b/homeassistant/components/sensor/jewish_calendar.py
@@ -15,7 +15,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 import homeassistant.util.dt as dt_util
 
-REQUIREMENTS = ['hdate==0.6.3']
+REQUIREMENTS = ['hdate==0.6.4']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -445,7 +445,7 @@ hangups==0.4.5
 hbmqtt==0.9.4
 
 # homeassistant.components.sensor.jewish_calendar
-hdate==0.6.3
+hdate==0.6.4
 
 # homeassistant.components.climate.heatmiser
 heatmiserV3==0.9.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -445,7 +445,7 @@ hangups==0.4.5
 hbmqtt==0.9.4
 
 # homeassistant.components.sensor.jewish_calendar
-hdate==0.6.4
+hdate==0.6.5
 
 # homeassistant.components.climate.heatmiser
 heatmiserV3==0.9.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -88,7 +88,7 @@ hangups==0.4.5
 hbmqtt==0.9.4
 
 # homeassistant.components.sensor.jewish_calendar
-hdate==0.6.4
+hdate==0.6.5
 
 # homeassistant.components.binary_sensor.workday
 holidays==0.9.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -88,7 +88,7 @@ hangups==0.4.5
 hbmqtt==0.9.4
 
 # homeassistant.components.sensor.jewish_calendar
-hdate==0.6.3
+hdate==0.6.4
 
 # homeassistant.components.binary_sensor.workday
 holidays==0.9.7

--- a/tests/components/sensor/test_jewish_calendar.py
+++ b/tests/components/sensor/test_jewish_calendar.py
@@ -5,6 +5,7 @@ from datetime import datetime as dt
 from unittest.mock import patch
 
 from homeassistant.util.async_ import run_coroutine_threadsafe
+from homeassistant.util.dt import get_time_zone
 from homeassistant.setup import setup_component
 from homeassistant.components.sensor.jewish_calendar import JewishCalSensor
 from tests.common import get_test_home_assistant
@@ -138,7 +139,7 @@ class TestJewishCalenderSensor(unittest.TestCase):
         sensor = JewishCalSensor(
             name='test', language='hebrew', sensor_type='first_stars',
             latitude=40.7128, longitude=-74.0060,
-            timezone="America/New_York", diaspora=False)
+            timezone=get_time_zone("America/New_York"), diaspora=False)
         with patch('homeassistant.util.dt.now', return_value=test_time):
             run_coroutine_threadsafe(
                 sensor.async_update(), self.hass.loop).result()


### PR DESCRIPTION
## Description:
This version of hdate adds support for providing to hdate timezone as a datetime.tzinfo object.

**Related issue (if applicable):** fixes #17487 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable): N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  N/A

If the code communicates with devices, web services, or third-party tools:
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
