### PR TITLE
Add 'monitor all' extra attributes option

### DIFF
--- a/tests/components/device_tracker/test_unifi.py
+++ b/tests/components/device_tracker/test_unifi.py
@@ -55,7 +55,7 @@ def test_config_valid_verify_ssl(hass, mock_scanner, mock_ctrl):
     assert mock_scanner.call_count == 1
     assert mock_scanner.call_args == mock.call(mock_ctrl.return_value,
                                                DEFAULT_DETECTION_TIME,
-                                               None, None)
+                                               None, False, None)
 
 
 def test_config_minimal(hass, mock_scanner, mock_ctrl):
@@ -162,7 +162,7 @@ def test_scanner_update():
          'last_seen': dt_util.as_timestamp(dt_util.utcnow())},
     ]
     ctrl.get_clients.return_value = fake_clients
-    unifi.UnifiScanner(ctrl, DEFAULT_DETECTION_TIME, None, None)
+    unifi.UnifiScanner(ctrl, DEFAULT_DETECTION_TIME, None, False, None)
     assert ctrl.get_clients.call_count == 1
     assert ctrl.get_clients.call_args == mock.call()
 
@@ -172,7 +172,7 @@ def test_scanner_update_error():
     ctrl = mock.MagicMock()
     ctrl.get_clients.side_effect = APIError(
         '/', 500, 'foo', {}, None)
-    unifi.UnifiScanner(ctrl, DEFAULT_DETECTION_TIME, None, None)
+    unifi.UnifiScanner(ctrl, DEFAULT_DETECTION_TIME, None, False, None)
 
 
 def test_scan_devices():
@@ -185,7 +185,7 @@ def test_scan_devices():
          'last_seen': dt_util.as_timestamp(dt_util.utcnow())},
     ]
     ctrl.get_clients.return_value = fake_clients
-    scanner = unifi.UnifiScanner(ctrl, DEFAULT_DETECTION_TIME, None, 
+    scanner = unifi.UnifiScanner(ctrl, DEFAULT_DETECTION_TIME, None,
                                  False, None)
     assert set(scanner.scan_devices()) == set(['123', '234'])
 
@@ -228,7 +228,7 @@ def test_get_device_name():
          'last_seen': '1504786810'},
     ]
     ctrl.get_clients.return_value = fake_clients
-    scanner = unifi.UnifiScanner(ctrl, DEFAULT_DETECTION_TIME, None, 
+    scanner = unifi.UnifiScanner(ctrl, DEFAULT_DETECTION_TIME, None,
                                  False, None)
     assert scanner.get_device_name('123') == 'foobar'
     assert scanner.get_device_name('234') == 'Nice Name'

--- a/tests/components/device_tracker/test_unifi.py
+++ b/tests/components/device_tracker/test_unifi.py
@@ -77,7 +77,7 @@ def test_config_minimal(hass, mock_scanner, mock_ctrl):
     assert mock_scanner.call_count == 1
     assert mock_scanner.call_args == mock.call(mock_ctrl.return_value,
                                                DEFAULT_DETECTION_TIME,
-                                               None, None)
+                                               None, False, None)
 
 
 def test_config_full(hass, mock_scanner, mock_ctrl):
@@ -89,6 +89,7 @@ def test_config_full(hass, mock_scanner, mock_ctrl):
             CONF_PASSWORD: 'password',
             CONF_HOST: 'myhost',
             CONF_VERIFY_SSL: False,
+            'monitor_all': False,
             CONF_MONITORED_CONDITIONS: ['essid', 'signal'],
             'port': 123,
             'site_id': 'abcdef01',
@@ -106,7 +107,7 @@ def test_config_full(hass, mock_scanner, mock_ctrl):
     assert mock_scanner.call_args == mock.call(
         mock_ctrl.return_value,
         DEFAULT_DETECTION_TIME,
-        None,
+        None, False,
         config[DOMAIN][CONF_MONITORED_CONDITIONS])
 
 
@@ -184,7 +185,7 @@ def test_scan_devices():
          'last_seen': dt_util.as_timestamp(dt_util.utcnow())},
     ]
     ctrl.get_clients.return_value = fake_clients
-    scanner = unifi.UnifiScanner(ctrl, DEFAULT_DETECTION_TIME, None, None)
+    scanner = unifi.UnifiScanner(ctrl, DEFAULT_DETECTION_TIME, None, False, None)
     assert set(scanner.scan_devices()) == set(['123', '234'])
 
 
@@ -205,7 +206,7 @@ def test_scan_devices_filtered():
     ssid_filter = ['foonet', 'barnet']
     ctrl.get_clients.return_value = fake_clients
     scanner = unifi.UnifiScanner(ctrl, DEFAULT_DETECTION_TIME, ssid_filter,
-                                 None)
+                                 False, None)
     assert set(scanner.scan_devices()) == set(['123', '234', '890'])
 
 
@@ -226,7 +227,7 @@ def test_get_device_name():
          'last_seen': '1504786810'},
     ]
     ctrl.get_clients.return_value = fake_clients
-    scanner = unifi.UnifiScanner(ctrl, DEFAULT_DETECTION_TIME, None, None)
+    scanner = unifi.UnifiScanner(ctrl, DEFAULT_DETECTION_TIME, None, False, None)
     assert scanner.get_device_name('123') == 'foobar'
     assert scanner.get_device_name('234') == 'Nice Name'
     assert scanner.get_device_name('456') is None
@@ -253,7 +254,7 @@ def test_monitored_conditions():
          'last_seen': dt_util.as_timestamp(dt_util.utcnow())},
     ]
     ctrl.get_clients.return_value = fake_clients
-    scanner = unifi.UnifiScanner(ctrl, DEFAULT_DETECTION_TIME, None,
+    scanner = unifi.UnifiScanner(ctrl, DEFAULT_DETECTION_TIME, None, False,
                                  ['essid', 'signal'])
     assert scanner.get_extra_attributes('123') == {'essid': 'barnet',
                                                    'signal': -60}

--- a/tests/components/device_tracker/test_unifi.py
+++ b/tests/components/device_tracker/test_unifi.py
@@ -185,7 +185,8 @@ def test_scan_devices():
          'last_seen': dt_util.as_timestamp(dt_util.utcnow())},
     ]
     ctrl.get_clients.return_value = fake_clients
-    scanner = unifi.UnifiScanner(ctrl, DEFAULT_DETECTION_TIME, None, False, None)
+    scanner = unifi.UnifiScanner(ctrl, DEFAULT_DETECTION_TIME, None, 
+                                 False, None)
     assert set(scanner.scan_devices()) == set(['123', '234'])
 
 
@@ -227,7 +228,8 @@ def test_get_device_name():
          'last_seen': '1504786810'},
     ]
     ctrl.get_clients.return_value = fake_clients
-    scanner = unifi.UnifiScanner(ctrl, DEFAULT_DETECTION_TIME, None, False, None)
+    scanner = unifi.UnifiScanner(ctrl, DEFAULT_DETECTION_TIME, None, 
+                                 False, None)
     assert scanner.get_device_name('123') == 'foobar'
     assert scanner.get_device_name('234') == 'Nice Name'
     assert scanner.get_device_name('456') is None


### PR DESCRIPTION
The extra attributes available for each device are extensive and possibly change based on the device type and controller version software. Added a monitor_all option that will add all available attributes as opposed to only those explicitly specified.

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#6858

## Example entry for `configuration.yaml` (if applicable):
```yaml
device_tracker:
  - platform: unifi
    host: 10.10.10.2
    site_id: 'default'
    verify_ssl: false
    username: !secret unifi_user
    password: !secret unifi_pw
    monitor_all: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
