### PR TITLE
Fix Volumio media player error message

### DIFF
--- a/homeassistant/components/media_player/volumio.py
+++ b/homeassistant/components/media_player/volumio.py
@@ -90,7 +90,6 @@ class Volumio(MediaPlayerDevice):
         self._url = '{}:{}'.format(host, str(port))
         self._name = name
         self._state = {}
-        self.async_update()
         self._lastvol = self._state.get('volume', 0)
         self._playlists = []
         self._currentplaylist = None


### PR DESCRIPTION
## Description:
Remove unnecessary call to get rid of the error message below.

```
2018-10-16 11:29:46 INFO (MainThread) [homeassistant.loader] Loaded media_player.volumio from homeassistant.components.media_player.volumio
2018-10-16 11:29:46 INFO (MainThread) [homeassistant.components.media_player] Setting up media_player.volumio
/home/ubuntu/home-assistant/homeassistant/components/media_player/volumio.py:93: RuntimeWarning: coroutine 'Volumio.async_update' was never awaited
  self.async_update()
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54