### PR TITLE
Add message template support for alert component

### DIFF
--- a/homeassistant/components/alert.py
+++ b/homeassistant/components/alert.py
@@ -81,9 +81,9 @@ async def async_setup(hass, config):
         can_ack = cfg.get(CONF_CAN_ACK)
 
         entities.append(Alert(hass, object_id, name, done_message,
-                        watched_entity_id, alert_state, repeat,
-                        skip_first, message_template, notifiers,
-                        can_ack))
+                              watched_entity_id, alert_state, repeat,
+                              skip_first, message_template, notifiers,
+                              can_ack))
 
     if not entities:
         return False
@@ -93,14 +93,17 @@ async def async_setup(hass, config):
         alert_ids = service.extract_entity_ids(hass, service_call)
 
         for alert_id in alert_ids:
-            alert = all_alerts[alert_id]
-            alert.async_set_context(service_call.context)
-            if service_call.service == SERVICE_TURN_ON:
-                await alert.async_turn_on()
-            elif service_call.service == SERVICE_TOGGLE:
-                await alert.async_toggle()
-            else:
-                await alert.async_turn_off()
+            for alert in entities:
+                if alert.entity_id != alert_id:
+                    continue
+
+                alert.async_set_context(service_call.context)
+                if service_call.service == SERVICE_TURN_ON:
+                    await alert.async_turn_on()
+                elif service_call.service == SERVICE_TOGGLE:
+                    await alert.async_toggle()
+                else:
+                    await alert.async_turn_off()
 
     # Setup service calls
     hass.services.async_register(

--- a/homeassistant/components/alert.py
+++ b/homeassistant/components/alert.py
@@ -231,7 +231,7 @@ class Alert(ToggleEntity):
             if self._message_template is not None:
                 message = self._message_template.async_render()
             else:
-                message = '{0}'.format(self._name)
+                message = self._name
 
             for target in self._notifiers:
                 await self.hass.services.async_call(

--- a/homeassistant/components/alert.py
+++ b/homeassistant/components/alert.py
@@ -17,7 +17,6 @@ from homeassistant.const import (
     SERVICE_TURN_ON, SERVICE_TURN_OFF, SERVICE_TOGGLE, ATTR_ENTITY_ID)
 from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.helpers import service, event
-from homeassistant.components.plant import (ATTR_PROBLEM)
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
@@ -30,11 +29,9 @@ CONF_CAN_ACK = 'can_acknowledge'
 CONF_NOTIFIERS = 'notifiers'
 CONF_REPEAT = 'repeat'
 CONF_SKIP_FIRST = 'skip_first'
-CONF_INCLUDE_PROBLEM = 'include_problem'
 
 DEFAULT_CAN_ACK = True
 DEFAULT_SKIP_FIRST = False
-DEFAULT_INCLUDE_PROBLEM = True
 
 ALERT_SCHEMA = vol.Schema({
     vol.Required(CONF_NAME): cv.string,
@@ -44,8 +41,6 @@ ALERT_SCHEMA = vol.Schema({
     vol.Required(CONF_REPEAT): vol.All(cv.ensure_list, [vol.Coerce(float)]),
     vol.Required(CONF_CAN_ACK, default=DEFAULT_CAN_ACK): cv.boolean,
     vol.Required(CONF_SKIP_FIRST, default=DEFAULT_SKIP_FIRST): cv.boolean,
-    vol.Required(
-        CONF_INCLUDE_PROBLEM, default=DEFAULT_INCLUDE_PROBLEM): cv.boolean,
     vol.Required(CONF_NOTIFIERS): cv.ensure_list})
 
 CONFIG_SCHEMA = vol.Schema({
@@ -90,8 +85,7 @@ async def async_setup(hass, config):
                        alert[CONF_NAME], alert.get(CONF_DONE_MESSAGE),
                        alert[CONF_ENTITY_ID], alert[CONF_STATE],
                        alert[CONF_REPEAT], alert[CONF_SKIP_FIRST],
-                       alert[CONF_INCLUDE_PROBLEM], alert[CONF_NOTIFIERS],
-                       alert[CONF_CAN_ACK])
+                       alert[CONF_NOTIFIERS], alert[CONF_CAN_ACK])
         all_alerts[entity.entity_id] = entity
 
     # Setup service calls
@@ -116,18 +110,15 @@ class Alert(ToggleEntity):
     """Representation of an alert."""
 
     def __init__(self, hass, entity_id, name, done_message, watched_entity_id,
-                 state, repeat, skip_first, include_problem, notifiers,
-                 can_ack):
+                 state, repeat, skip_first, notifiers, can_ack):
         """Initialize the alert."""
         self.hass = hass
         self._name = name
         self._alert_state = state
         self._skip_first = skip_first
-        self._include_problem = include_problem
         self._notifiers = notifiers
         self._can_ack = can_ack
         self._done_message = done_message
-        self._watched_entity_id = watched_entity_id
 
         self._delay = [timedelta(minutes=val) for val in repeat]
         self._next_delay = 0
@@ -213,17 +204,9 @@ class Alert(ToggleEntity):
         if not self._ack:
             _LOGGER.info("Alerting: %s", self._name)
             self._send_done_message = True
-
-            message = '{0}'.format(self._name)
-            if self._include_problem:
-                entity_state = self.hass.states.get(self._watched_entity_id)
-                problem_state = entity_state.attributes.get(ATTR_PROBLEM) or ""
-                if not problem_state == "":
-                    message = '{0} ({1})'.format(message, problem_state)
-
             for target in self._notifiers:
                 await self.hass.services.async_call(
-                    DOMAIN_NOTIFY, target, {ATTR_MESSAGE: message})
+                    DOMAIN_NOTIFY, target, {ATTR_MESSAGE: self._name})
         await self._schedule_notify()
 
     async def _notify_done_message(self, *args):

--- a/homeassistant/components/alert.py
+++ b/homeassistant/components/alert.py
@@ -80,10 +80,10 @@ async def async_setup(hass, config):
         notifiers = cfg.get(CONF_NOTIFIERS)
         can_ack = cfg.get(CONF_CAN_ACK)
 
-        entities.append(Alert(hass, object_id, name, 
+        entities.append(Alert(hass, object_id, name,
                               watched_entity_id, alert_state, repeat,
-                              skip_first, message_template, 
-							  done_message_template, notifiers,
+                              skip_first, message_template,
+                              done_message_template, notifiers,
                               can_ack))
 
     if not entities:
@@ -128,8 +128,8 @@ class Alert(ToggleEntity):
     """Representation of an alert."""
 
     def __init__(self, hass, entity_id, name, watched_entity_id,
-                 state, repeat, skip_first, message_template, 
-				 done_message_template, notifiers, can_ack):
+                 state, repeat, skip_first, message_template,
+                 done_message_template, notifiers, can_ack):
         """Initialize the alert."""
         self.hass = hass
         self._name = name
@@ -143,7 +143,7 @@ class Alert(ToggleEntity):
         self._done_message_template = done_message_template
         if self._done_message_template is not None:
             self._done_message_template.hass = hass
-		
+
         self._notifiers = notifiers
         self._can_ack = can_ack
 
@@ -244,7 +244,7 @@ class Alert(ToggleEntity):
         """Send notification of complete alert."""
         _LOGGER.info("Alerting: %s", self._done_message_template)
         self._send_done_message = False
-		
+
         if self._done_message_template is None:
             return
 

--- a/homeassistant/components/alert.py
+++ b/homeassistant/components/alert.py
@@ -24,25 +24,25 @@ _LOGGER = logging.getLogger(__name__)
 DOMAIN = 'alert'
 ENTITY_ID_FORMAT = DOMAIN + '.{}'
 
-CONF_DONE_MESSAGE = 'done_message'
 CONF_CAN_ACK = 'can_acknowledge'
 CONF_NOTIFIERS = 'notifiers'
 CONF_REPEAT = 'repeat'
 CONF_SKIP_FIRST = 'skip_first'
-CONF_MESSAGE_TEMPLATE = 'message_template'
+CONF_ALERT_MESSAGE = 'message'
+CONF_DONE_MESSAGE = 'done_message'
 
 DEFAULT_CAN_ACK = True
 DEFAULT_SKIP_FIRST = False
 
 ALERT_SCHEMA = vol.Schema({
     vol.Required(CONF_NAME): cv.string,
-    vol.Optional(CONF_DONE_MESSAGE): cv.string,
     vol.Required(CONF_ENTITY_ID): cv.entity_id,
     vol.Required(CONF_STATE, default=STATE_ON): cv.string,
     vol.Required(CONF_REPEAT): vol.All(cv.ensure_list, [vol.Coerce(float)]),
     vol.Required(CONF_CAN_ACK, default=DEFAULT_CAN_ACK): cv.boolean,
     vol.Required(CONF_SKIP_FIRST, default=DEFAULT_SKIP_FIRST): cv.boolean,
-    vol.Optional(CONF_MESSAGE_TEMPLATE): cv.template,
+    vol.Optional(CONF_ALERT_MESSAGE): cv.template,
+    vol.Optional(CONF_DONE_MESSAGE): cv.template,
     vol.Required(CONF_NOTIFIERS): cv.ensure_list})
 
 CONFIG_SCHEMA = vol.Schema({
@@ -71,18 +71,19 @@ async def async_setup(hass, config):
             cfg = {}
 
         name = cfg.get(CONF_NAME)
-        done_message = cfg.get(CONF_DONE_MESSAGE)
         watched_entity_id = cfg.get(CONF_ENTITY_ID)
         alert_state = cfg.get(CONF_STATE)
         repeat = cfg.get(CONF_REPEAT)
         skip_first = cfg.get(CONF_SKIP_FIRST)
-        message_template = cfg.get(CONF_MESSAGE_TEMPLATE)
+        message_template = cfg.get(CONF_ALERT_MESSAGE)
+        done_message_template = cfg.get(CONF_DONE_MESSAGE)
         notifiers = cfg.get(CONF_NOTIFIERS)
         can_ack = cfg.get(CONF_CAN_ACK)
 
-        entities.append(Alert(hass, object_id, name, done_message,
+        entities.append(Alert(hass, object_id, name, 
                               watched_entity_id, alert_state, repeat,
-                              skip_first, message_template, notifiers,
+                              skip_first, message_template, 
+							  done_message_template, notifiers,
                               can_ack))
 
     if not entities:
@@ -126,9 +127,9 @@ async def async_setup(hass, config):
 class Alert(ToggleEntity):
     """Representation of an alert."""
 
-    def __init__(self, hass, entity_id, name, done_message, watched_entity_id,
-                 state, repeat, skip_first, message_template, notifiers,
-                 can_ack):
+    def __init__(self, hass, entity_id, name, watched_entity_id,
+                 state, repeat, skip_first, message_template, 
+				 done_message_template, notifiers, can_ack):
         """Initialize the alert."""
         self.hass = hass
         self._name = name
@@ -139,9 +140,12 @@ class Alert(ToggleEntity):
         if self._message_template is not None:
             self._message_template.hass = hass
 
+        self._done_message_template = done_message_template
+        if self._done_message_template is not None:
+            self._done_message_template.hass = hass
+		
         self._notifiers = notifiers
         self._can_ack = can_ack
-        self._done_message = done_message
 
         self._delay = [timedelta(minutes=val) for val in repeat]
         self._next_delay = 0
@@ -207,7 +211,7 @@ class Alert(ToggleEntity):
         self._cancel()
         self._ack = False
         self._firing = False
-        if self._done_message and self._send_done_message:
+        if self._send_done_message:
             await self._notify_done_message()
         self.async_schedule_update_ha_state()
 
@@ -233,18 +237,25 @@ class Alert(ToggleEntity):
             else:
                 message = self._name
 
-            for target in self._notifiers:
-                await self.hass.services.async_call(
-                    DOMAIN_NOTIFY, target, {ATTR_MESSAGE: message})
+            await self._send_notification_message(message)
         await self._schedule_notify()
 
     async def _notify_done_message(self, *args):
         """Send notification of complete alert."""
-        _LOGGER.info("Alerting: %s", self._done_message)
+        _LOGGER.info("Alerting: %s", self._done_message_template)
         self._send_done_message = False
+		
+        if self._done_message_template is None:
+            return
+
+        message = self._done_message_template.async_render()
+
+        await self._send_notification_message(message)
+
+    async def _send_notification_message(self, message):
         for target in self._notifiers:
             await self.hass.services.async_call(
-                DOMAIN_NOTIFY, target, {ATTR_MESSAGE: self._done_message})
+                DOMAIN_NOTIFY, target, {ATTR_MESSAGE: message})
 
     async def async_turn_on(self, **kwargs):
         """Async Unacknowledge alert."""

--- a/tests/components/test_alert.py
+++ b/tests/components/test_alert.py
@@ -17,6 +17,7 @@ from tests.common import get_test_home_assistant
 NAME = "alert_test"
 DONE_MESSAGE = "alert_gone"
 NOTIFIER = 'test'
+TEMPLATE = "{{ states.sensor.test.entity_id }}"
 TEST_CONFIG = \
     {alert.DOMAIN: {
         NAME: {
@@ -246,7 +247,7 @@ class TestAlert(unittest.TestCase):
         self._setup_notify()
 
         config = deepcopy(TEST_CONFIG)
-        config[alert.DOMAIN][NAME][alert.CONF_MESSAGE_TEMPLATE] = "{{ states.sensor.test.entity_id }}"
+        config[alert.DOMAIN][NAME][alert.CONF_MESSAGE_TEMPLATE] = TEMPLATE
         assert setup_component(self.hass, alert.DOMAIN, TEST_CONFIG)
 
         self.hass.states.set("sensor.test", STATE_ON)

--- a/tests/components/test_alert.py
+++ b/tests/components/test_alert.py
@@ -29,7 +29,7 @@ TEST_CONFIG = \
             alert.CONF_NOTIFIERS: [NOTIFIER]}
         }}
 TEST_NOACK = [NAME, NAME, DONE_MESSAGE, "sensor.test",
-              STATE_ON, [30], False, NOTIFIER, False]
+              STATE_ON, [30], False, None, NOTIFIER, False]
 ENTITY_ID = alert.ENTITY_ID_FORMAT.format(NAME)
 
 

--- a/tests/components/test_alert.py
+++ b/tests/components/test_alert.py
@@ -29,7 +29,7 @@ TEST_CONFIG = \
             alert.CONF_NOTIFIERS: [NOTIFIER]}
         }}
 TEST_NOACK = [NAME, NAME, DONE_MESSAGE, "sensor.test",
-              STATE_ON, [30], False, NOTIFIER, False]
+              STATE_ON, [30], False, True, NOTIFIER, False]
 ENTITY_ID = alert.ENTITY_ID_FORMAT.format(NAME)
 
 

--- a/tests/components/test_alert.py
+++ b/tests/components/test_alert.py
@@ -29,7 +29,7 @@ TEST_CONFIG = \
             alert.CONF_NOTIFIERS: [NOTIFIER]}
         }}
 TEST_NOACK = [NAME, NAME, DONE_MESSAGE, "sensor.test",
-              STATE_ON, [30], False, True, NOTIFIER, False]
+              STATE_ON, [30], False, NOTIFIER, False]
 ENTITY_ID = alert.ENTITY_ID_FORMAT.format(NAME)
 
 

--- a/tests/components/test_alert.py
+++ b/tests/components/test_alert.py
@@ -30,8 +30,8 @@ TEST_CONFIG = \
             alert.CONF_SKIP_FIRST: False,
             alert.CONF_NOTIFIERS: [NOTIFIER]}
         }}
-TEST_NOACK = [NAME, NAME, DONE_MESSAGE, "sensor.test",
-              STATE_ON, [30], False, None, NOTIFIER, False]
+TEST_NOACK = [NAME, NAME, "sensor.test",
+              STATE_ON, [30], False, None, None, NOTIFIER, False]
 ENTITY_ID = alert.ENTITY_ID_FORMAT.format(NAME)
 
 
@@ -260,12 +260,28 @@ class TestAlert(unittest.TestCase):
         events = self._setup_notify()
 
         config = deepcopy(TEST_CONFIG)
-        config[alert.DOMAIN][NAME][alert.CONF_MESSAGE_TEMPLATE] = TEMPLATE
+        config[alert.DOMAIN][NAME][alert.CONF_ALERT_MESSAGE] = TEMPLATE
         assert setup_component(self.hass, alert.DOMAIN, config)
 
         self.hass.states.set(TEST_ENTITY, STATE_ON)
         self.hass.block_till_done()
         self.assertEqual(1, len(events))
+        last_event = events[-1]
+        self.assertEqual(last_event.data[notify.ATTR_MESSAGE], TEST_ENTITY)
+
+    def test_sending_templated_done_notification(self):
+        """Test templated notification."""
+        events = self._setup_notify()
+
+        config = deepcopy(TEST_CONFIG)
+        config[alert.DOMAIN][NAME][alert.CONF_DONE_MESSAGE] = TEMPLATE
+        assert setup_component(self.hass, alert.DOMAIN, config)
+
+        self.hass.states.set(TEST_ENTITY, STATE_ON)
+        self.hass.block_till_done()
+        self.hass.states.set(TEST_ENTITY, STATE_OFF)
+        self.hass.block_till_done()
+        self.assertEqual(2, len(events))
         last_event = events[-1]
         self.assertEqual(last_event.data[notify.ATTR_MESSAGE], TEST_ENTITY)
 

--- a/tests/components/test_alert.py
+++ b/tests/components/test_alert.py
@@ -228,6 +228,32 @@ class TestAlert(unittest.TestCase):
         self.hass.block_till_done()
         assert 2 == len(events)
 
+    def test_sending_non_templated_notification(self):
+        """Test notifications."""
+        self._setup_notify()
+
+        config = deepcopy(TEST_CONFIG)
+        del(config[alert.DOMAIN][NAME][alert.CONF_MESSAGE_TEMPLATE])
+        assert setup_component(self.hass, alert.DOMAIN, TEST_CONFIG)
+
+        self.hass.states.set("sensor.test", STATE_ON)
+        self.hass.block_till_done()
+        last_event = self.events[-1]
+        self.assertEqual(last_event.data[notify.ATTR_MESSAGE], NAME)
+
+    def test_sending_templated_notification(self):
+        """Test templated notification."""
+        self._setup_notify()
+
+        config = deepcopy(TEST_CONFIG)
+        config[alert.DOMAIN][NAME][alert.CONF_MESSAGE_TEMPLATE] = "{{ states.sensor.test.entity_id }}"
+        assert setup_component(self.hass, alert.DOMAIN, TEST_CONFIG)
+
+        self.hass.states.set("sensor.test", STATE_ON)
+        self.hass.block_till_done()
+        last_event = self.events[-1]
+        self.assertEqual(last_event.data[notify.ATTR_MESSAGE], CONF_ENTITY_ID)
+
     def test_skipfirst(self):
         """Test skipping first notification."""
         config = deepcopy(TEST_CONFIG)


### PR DESCRIPTION
## Description:


**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#6859

## Example entry for `configuration.yaml` (if applicable):
```yaml
  plant_office:
    name: Plant in office needs help
    entity_id: plant.plant_office
    state: 'problem'
    repeat:
      - 60
      - 720
    message: "{{ states.plant.plant_office }} ({{ state_attr('plant.plant_office', 'problem') }})"
    notifiers:
      - telegram_receiver
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
