### PR TITLE
Scan all network interfaces for LIFX bulbs

### DIFF
--- a/homeassistant/components/lifx/__init__.py
+++ b/homeassistant/components/lifx/__init__.py
@@ -1,8 +1,4 @@
 """Component to embed LIFX."""
-import asyncio
-import socket
-
-import async_timeout
 import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
 
@@ -12,17 +8,20 @@ from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
 
 
 DOMAIN = 'lifx'
-REQUIREMENTS = ['aiolifx==0.6.3']
+REQUIREMENTS = ['aiolifx==0.6.5']
 
 CONF_SERVER = 'server'
 CONF_BROADCAST = 'broadcast'
 
+INTERFACE_SCHEMA = vol.Schema({
+    vol.Optional(CONF_SERVER): cv.string,
+    vol.Optional(CONF_BROADCAST): cv.string,
+})
+
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: {
-        LIGHT_DOMAIN: {
-            vol.Optional(CONF_SERVER): cv.string,
-            vol.Optional(CONF_BROADCAST): cv.string,
-        }
+        LIGHT_DOMAIN:
+            vol.Schema(vol.All(cv.ensure_list, [INTERFACE_SCHEMA])),
     }
 }, extra=vol.ALLOW_EXTRA)
 
@@ -51,47 +50,9 @@ async def _async_has_devices(hass):
     """Return if there are devices that can be discovered."""
     import aiolifx
 
-    manager = DiscoveryManager()
-    lifx_discovery = aiolifx.LifxDiscovery(hass.loop, manager)
-    coro = hass.loop.create_datagram_endpoint(
-        lambda: lifx_discovery,
-        family=socket.AF_INET)
-    hass.async_create_task(coro)
-
-    has_devices = await manager.found_devices()
-    lifx_discovery.cleanup()
-
-    return has_devices
+    lifx_ip_addresses = await aiolifx.LifxScan(hass.loop).scan()
+    return len(lifx_ip_addresses) > 0
 
 
 config_entry_flow.register_discovery_flow(
     DOMAIN, 'LIFX', _async_has_devices, config_entries.CONN_CLASS_LOCAL_POLL)
-
-
-class DiscoveryManager:
-    """Temporary LIFX manager for discovering any bulb."""
-
-    def __init__(self):
-        """Initialize the manager."""
-        self._event = asyncio.Event()
-
-    async def found_devices(self):
-        """Return whether any device could be discovered."""
-        try:
-            async with async_timeout.timeout(2):
-                await self._event.wait()
-
-                # Let bulbs recover from the discovery
-                await asyncio.sleep(1)
-
-                return True
-        except asyncio.TimeoutError:
-            return False
-
-    def register(self, bulb):
-        """Handle aiolifx detected bulb."""
-        self._event.set()
-
-    def unregister(self, bulb):
-        """Handle aiolifx disappearing bulbs."""
-        pass

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -110,7 +110,7 @@ aiohue==1.5.0
 aioimaplib==0.7.13
 
 # homeassistant.components.lifx
-aiolifx==0.6.3
+aiolifx==0.6.5
 
 # homeassistant.components.light.lifx
 aiolifx_effects==0.2.1


### PR DESCRIPTION
## Description:

This uses the new `aiolifx.LifxScan.scan()` method to discover LIFX bulbs.

While unlikely, bulbs may be seen on multiple network interfaces so I reworked the code to connect on each of them.

For feature parity I also updated the manual configuration schema to allow multiple addresses.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
lifx:
```
```yaml
lifx:
  light:
    - server: 10.0.9.149
      broadcast: 10.0.9.255
    - server: 10.0.16.5
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
