### PR TITLE
MyQ updates, scan_interval, status retries

### DIFF
--- a/homeassistant/components/cover/myq.py
+++ b/homeassistant/components/cover/myq.py
@@ -80,7 +80,7 @@ class MyQDevice(CoverDevice):
         self.device_id = device['deviceid']
         self._name = device['name']
 
-        if (self.myq.get_status(self.device_id)):
+        if self.myq.get_status(self.device_id):
             self._status = self.myq.get_status(self.device_id)
         else:
             self._status = None
@@ -131,7 +131,7 @@ class MyQDevice(CoverDevice):
             iterations += 1
             sleep(10)
 
-        if (iterations <= 5):
+        if iterations <= 5:
             closed_confired_interations = 0
             while True:
                 self._status = self.myq.get_status(self.device_id)
@@ -146,10 +146,7 @@ class MyQDevice(CoverDevice):
                 closed_confired_interations += 1
                 sleep(10)
 
-        if (iterations <= 5 and closed_confired_interations <= 5):
-            return True
-        else:
-            return False
+        return iterations <= 5 and closed_confired_interations <= 5
 
     def open_cover(self, **kwargs):
         """Issue open command to cover."""
@@ -165,7 +162,7 @@ class MyQDevice(CoverDevice):
             iterations += 1
             sleep(10)
 
-        if (iterations <= 5):
+        if iterations <= 5:
             open_confirmed_interations = 0
             while True:
                 self._status = self.myq.get_status(self.device_id)
@@ -180,10 +177,7 @@ class MyQDevice(CoverDevice):
                 open_confirmed_interations += 1
                 sleep(10)
 
-        if (iterations <= 5 and open_confirmed_interations <= 5):
-            return True
-        else:
-            return False
+        return iterations <= 5 and open_confirmed_interations <= 5
 
     @property
     def supported_features(self):

--- a/homeassistant/components/cover/myq.py
+++ b/homeassistant/components/cover/myq.py
@@ -40,6 +40,7 @@ COVER_SCHEMA = vol.Schema({
 
 SCAN_INTERVAL = timedelta(seconds=120)
 
+
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the MyQ component."""
     from pymyq import MyQAPI as pymyq

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -999,7 +999,7 @@ pymonoprice==0.3
 pymusiccast==0.1.6
 
 # homeassistant.components.cover.myq
-pymyq==0.0.15
+pymyq==0.0.16
 
 # homeassistant.components.mysensors
 pymysensors==0.17.0


### PR DESCRIPTION
## Description:
- default SCAN_INTERVAL defined as 120 seconds not the standard 15 seconds
- SCAN_INTERVAL (the default of 120 seconds) can be overridden in configuration.yaml with scan_interval on the component
- Switch to 0.0.16 of the pymyq library which includes an endpoint change for get_status, its a more direct endpoint and the return is much smaller. Also retries 3 times for status update if server returns an error.
- change init to check door status immediately and if fails fall back to None, better than waiting for the update to get the status after HA start/restart
- Updates to close_cover and open_cover based on @ehendrix23 code with additional status check. Does two things, retries sending the open/close command if it initially fails the API call. Once API is successful it queries status until it gets an open or close status or fails. Provides a quicker update of confirmed open/close than waiting for update to occur.
- Change to update to check for False from pymyq and return either current status or None.

**Related issue (if applicable):** fixes #17301 #16244 #16078 #9193(maybe)

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#6873

## Example entry for `configuration.yaml` (if applicable):
```
cover:
  - platform: myq
    username: !secret myq_username
    password: !secret myq_password
    type: chamberlain
    scan_interval: 300
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
