### PR TITLE
Change source, add attributes, and improve state of DirecTV

### DIFF
--- a/homeassistant/components/media_player/directv.py
+++ b/homeassistant/components/media_player/directv.py
@@ -4,26 +4,37 @@ Support for the DirecTV receivers.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/media_player.directv/
 """
+import logging
 import requests
 import voluptuous as vol
 
 from homeassistant.components.media_player import (
     MEDIA_TYPE_MOVIE, MEDIA_TYPE_TVSHOW, PLATFORM_SCHEMA, SUPPORT_NEXT_TRACK,
     SUPPORT_PAUSE, SUPPORT_PLAY, SUPPORT_PLAY_MEDIA, SUPPORT_PREVIOUS_TRACK,
-    SUPPORT_STOP, SUPPORT_TURN_OFF, SUPPORT_TURN_ON, MediaPlayerDevice)
+    SUPPORT_SELECT_SOURCE, SUPPORT_STOP, SUPPORT_TURN_OFF, SUPPORT_TURN_ON,
+    MediaPlayerDevice)
 from homeassistant.const import (
-    CONF_DEVICE, CONF_HOST, CONF_NAME, CONF_PORT, STATE_OFF, STATE_PLAYING)
+    CONF_DEVICE, CONF_HOST, CONF_NAME, CONF_PORT, STATE_OFF, STATE_PAUSED,
+    STATE_PLAYING)
 import homeassistant.helpers.config_validation as cv
+import homeassistant.util.dt as dt_util
 
 REQUIREMENTS = ['directpy==0.5']
+
+_LOGGER = logging.getLogger(__name__)
+
+ATTR_MEDIA_CURRENTLYRECORDING = 'media_currently_recording'
+ATTR_MEDIA_RATING = 'media_rating'
+ATTR_MEDIA_RECORDED = 'media_recorded'
+ATTR_MEDIA_STARTTIME = 'media_starttime'
 
 DEFAULT_DEVICE = '0'
 DEFAULT_NAME = "DirecTV Receiver"
 DEFAULT_PORT = 8080
 
 SUPPORT_DTV = SUPPORT_PAUSE | SUPPORT_TURN_ON | SUPPORT_TURN_OFF | \
-    SUPPORT_PLAY_MEDIA | SUPPORT_STOP | SUPPORT_NEXT_TRACK | \
-    SUPPORT_PREVIOUS_TRACK | SUPPORT_PLAY
+    SUPPORT_PLAY_MEDIA | SUPPORT_SELECT_SOURCE | SUPPORT_STOP | \
+    SUPPORT_NEXT_TRACK | SUPPORT_PREVIOUS_TRACK | SUPPORT_PLAY
 
 DATA_DIRECTV = 'data_directv'
 
@@ -88,14 +99,43 @@ class DirecTvDevice(MediaPlayerDevice):
         self._name = name
         self._is_standby = True
         self._current = None
+        self._lastupdate = None
+        self._paused = None
+        self._lastposition = None
+        self._isrecorded = None
+
+        _LOGGER.debug("Created DirecTV device for %s", self._name)
 
     def update(self):
         """Retrieve latest state."""
+        _LOGGER.debug("Updating state for %s", self._name)
         self._is_standby = self.dtv.get_standby()
         if self._is_standby:
             self._current = None
+            self._isrecorded = None
+            self._lastposition = None
+            self._lastupdate = None
         else:
             self._current = self.dtv.get_tuned()
+            self._isrecorded = False if self._current['uniqueId'] is None\
+                else True
+            self._paused = True if\
+                self._lastposition == self._current['offset'] else False
+            self._lastposition = self._current['offset']
+            self._lastupdate = dt_util.now()
+
+    @property
+    def device_state_attributes(self):
+        """Return device specific state attributes."""
+        attributes = {}
+        if not self._is_standby:
+            attributes[ATTR_MEDIA_CURRENTLYRECORDING] =\
+                self.media_currentlyrecording
+            attributes[ATTR_MEDIA_RATING] = self.media_rating
+            attributes[ATTR_MEDIA_RECORDED] = self.media_recorded
+            attributes[ATTR_MEDIA_STARTTIME] = self.media_starttime
+
+        return attributes
 
     @property
     def name(self):
@@ -108,7 +148,13 @@ class DirecTvDevice(MediaPlayerDevice):
         """Return the state of the device."""
         if self._is_standby:
             return STATE_OFF
-        # Haven't determined a way to see if the content is paused
+
+        # For recorded media we can determine if it is paused or not.
+        # For live media we're unable to determine and will always return
+        # playing instead.
+        if self._paused:
+            return STATE_PAUSED
+
         return STATE_PLAYING
 
     @property
@@ -119,11 +165,37 @@ class DirecTvDevice(MediaPlayerDevice):
         return self._current['programId']
 
     @property
+    def media_content_type(self):
+        """Return the content type of current playing media."""
+        if 'episodeTitle' in self._current:
+            return MEDIA_TYPE_TVSHOW
+        return MEDIA_TYPE_MOVIE
+
+    @property
     def media_duration(self):
         """Return the duration of current playing media in seconds."""
         if self._is_standby:
             return None
         return self._current['duration']
+
+    @property
+    def media_position(self):
+        """Position of current playing media in seconds."""
+        if self._is_standby:
+            return None
+
+        return self._lastposition
+
+    @property
+    def media_position_updated_at(self):
+        """When was the position of the current playing media valid.
+
+        Returns value from homeassistant.util.dt.utcnow().
+        """
+        if self._is_standby:
+            return None
+
+        return self._lastupdate
 
     @property
     def media_title(self):
@@ -142,18 +214,6 @@ class DirecTvDevice(MediaPlayerDevice):
         return None
 
     @property
-    def supported_features(self):
-        """Flag media player features that are supported."""
-        return SUPPORT_DTV
-
-    @property
-    def media_content_type(self):
-        """Return the content type of current playing media."""
-        if 'episodeTitle' in self._current:
-            return MEDIA_TYPE_TVSHOW
-        return MEDIA_TYPE_MOVIE
-
-    @property
     def media_channel(self):
         """Return the channel current playing media."""
         if self._is_standby:
@@ -162,30 +222,88 @@ class DirecTvDevice(MediaPlayerDevice):
         return "{} ({})".format(
             self._current['callsign'], self._current['major'])
 
+    @property
+    def source(self):
+        """Name of the current input source."""
+        if self._is_standby:
+            return None
+
+        return self._current['major']
+
+    @property
+    def supported_features(self):
+        """Flag media player features that are supported."""
+        return SUPPORT_DTV
+
+    @property
+    def media_currentlyrecording(self):
+        """If the media is currently being recorded or not."""
+        if self._is_standby:
+            return None
+
+        return self._current['isRecording']
+
+    @property
+    def media_rating(self):
+        """TV Rating of the current playing media."""
+        if self._is_standby:
+            return None
+
+        return self._current['rating']
+
+    @property
+    def media_recorded(self):
+        """If the media was recorded or live."""
+        if self._is_standby:
+            return None
+
+        return self._isrecorded
+
+    @property
+    def media_starttime(self):
+        """Start time the program aired."""
+        if self._is_standby:
+            return None
+
+        return dt_util.as_local(
+            dt_util.utc_from_timestamp(self._current['startTime']))
+
     def turn_on(self):
         """Turn on the receiver."""
+        _LOGGER.debug("Turn on %s", self._name)
         self.dtv.key_press('poweron')
 
     def turn_off(self):
         """Turn off the receiver."""
+        _LOGGER.debug("Turn off %s", self._name)
         self.dtv.key_press('poweroff')
 
     def media_play(self):
         """Send play command."""
+        _LOGGER.debug("Play on %s", self._name)
         self.dtv.key_press('play')
 
     def media_pause(self):
         """Send pause command."""
+        _LOGGER.debug("Pause on %s", self._name)
         self.dtv.key_press('pause')
 
     def media_stop(self):
         """Send stop command."""
+        _LOGGER.debug("Stop on %s", self._name)
         self.dtv.key_press('stop')
 
     def media_previous_track(self):
         """Send rewind command."""
+        _LOGGER.debug("Rewind on %s", self._name)
         self.dtv.key_press('rew')
 
     def media_next_track(self):
         """Send fast forward command."""
+        _LOGGER.debug("Fast forward on %s", self._name)
         self.dtv.key_press('ffwd')
+
+    def select_source(self, source):
+        """Select input source."""
+        _LOGGER.debug("Changing channel on %s to %s", self._name, source)
+        self.dtv.tune_channel(source)

--- a/homeassistant/components/media_player/directv.py
+++ b/homeassistant/components/media_player/directv.py
@@ -99,7 +99,7 @@ class DirecTvDevice(MediaPlayerDevice):
         self._name = name
         self._is_standby = True
         self._current = None
-        self._lastupdate = None
+        self._last_update = None
         self._paused = None
         self._last_position = None
         self._is_recorded = None
@@ -117,15 +117,15 @@ class DirecTvDevice(MediaPlayerDevice):
             self._paused = None
             self._assumed_state = False
             self._last_position = None
-            self._lastupdate = None
+            self._last_update = None
         else:
             self._current = self.dtv.get_tuned()
             self._is_recorded = self._current.get('uniqueId') is not None
             self._paused = self._last_position == self._current['offset']
             self._assumed_state = self._is_recorded
             self._last_position = self._current['offset']
-            self._lastupdate = dt_util.now() if not self._paused or\
-                self._lastupdate is None else self._lastupdate
+            self._last_update = dt_util.now() if not self._paused or\
+                self._last_update is None else self._last_update
 
     @property
     def device_state_attributes(self):
@@ -209,7 +209,7 @@ class DirecTvDevice(MediaPlayerDevice):
         if self._is_standby:
             return None
 
-        return self._lastupdate
+        return self._last_update
 
     @property
     def media_title(self):

--- a/homeassistant/components/media_player/directv.py
+++ b/homeassistant/components/media_player/directv.py
@@ -117,10 +117,8 @@ class DirecTvDevice(MediaPlayerDevice):
             self._lastupdate = None
         else:
             self._current = self.dtv.get_tuned()
-            self._isrecorded = False if self._current['uniqueId'] is None\
-                else True
-            self._paused = True if\
-                self._lastposition == self._current['offset'] else False
+            self._isrecorded = self._current.get('uniqueId') is not None
+            self._paused = self._lastposition == self._current['offset']
             self._lastposition = self._current['offset']
             self._lastupdate = dt_util.now()
 
@@ -209,9 +207,8 @@ class DirecTvDevice(MediaPlayerDevice):
         """Return the title of current episode of TV show."""
         if self._is_standby:
             return None
-        if 'episodeTitle' in self._current:
-            return self._current['episodeTitle']
-        return None
+
+        return self._current.get('episodeTitle')
 
     @property
     def media_channel(self):

--- a/homeassistant/components/media_player/directv.py
+++ b/homeassistant/components/media_player/directv.py
@@ -23,10 +23,10 @@ REQUIREMENTS = ['directpy==0.5']
 
 _LOGGER = logging.getLogger(__name__)
 
-ATTR_MEDIA_CURRENTLYRECORDING = 'media_currently_recording'
+ATTR_MEDIA_CURRENTLY_RECORDING = 'media_currently_recording'
 ATTR_MEDIA_RATING = 'media_rating'
 ATTR_MEDIA_RECORDED = 'media_recorded'
-ATTR_MEDIA_STARTTIME = 'media_starttime'
+ATTR_MEDIA_START_TIME = 'media_start_time'
 
 DEFAULT_DEVICE = '0'
 DEFAULT_NAME = "DirecTV Receiver"
@@ -101,8 +101,8 @@ class DirecTvDevice(MediaPlayerDevice):
         self._current = None
         self._lastupdate = None
         self._paused = None
-        self._lastposition = None
-        self._isrecorded = None
+        self._last_position = None
+        self._is_recorded = None
         self._assumed_state = None
 
         _LOGGER.debug("Created DirecTV device for %s", self._name)
@@ -113,17 +113,17 @@ class DirecTvDevice(MediaPlayerDevice):
         self._is_standby = self.dtv.get_standby()
         if self._is_standby:
             self._current = None
-            self._isrecorded = None
+            self._is_recorded = None
             self._paused = None
             self._assumed_state = False
-            self._lastposition = None
+            self._last_position = None
             self._lastupdate = None
         else:
             self._current = self.dtv.get_tuned()
-            self._isrecorded = self._current.get('uniqueId') is not None
-            self._paused = self._lastposition == self._current['offset']
-            self._assumed_state = self._isrecorded
-            self._lastposition = self._current['offset']
+            self._is_recorded = self._current.get('uniqueId') is not None
+            self._paused = self._last_position == self._current['offset']
+            self._assumed_state = self._is_recorded
+            self._last_position = self._current['offset']
             self._lastupdate = dt_util.now() if not self._paused or\
                 self._lastupdate is None else self._lastupdate
 
@@ -132,11 +132,11 @@ class DirecTvDevice(MediaPlayerDevice):
         """Return device specific state attributes."""
         attributes = {}
         if not self._is_standby:
-            attributes[ATTR_MEDIA_CURRENTLYRECORDING] =\
-                self.media_currentlyrecording
+            attributes[ATTR_MEDIA_CURRENTLY_RECORDING] =\
+                self.media_currently_recording
             attributes[ATTR_MEDIA_RATING] = self.media_rating
             attributes[ATTR_MEDIA_RECORDED] = self.media_recorded
-            attributes[ATTR_MEDIA_STARTTIME] = self.media_starttime
+            attributes[ATTR_MEDIA_START_TIME] = self.media_start_time
 
         return attributes
 
@@ -198,7 +198,7 @@ class DirecTvDevice(MediaPlayerDevice):
         if self._is_standby:
             return None
 
-        return self._lastposition
+        return self._last_position
 
     @property
     def media_position_updated_at(self):
@@ -250,7 +250,7 @@ class DirecTvDevice(MediaPlayerDevice):
         return SUPPORT_DTV
 
     @property
-    def media_currentlyrecording(self):
+    def media_currently_recording(self):
         """If the media is currently being recorded or not."""
         if self._is_standby:
             return None
@@ -271,10 +271,10 @@ class DirecTvDevice(MediaPlayerDevice):
         if self._is_standby:
             return None
 
-        return self._isrecorded
+        return self._is_recorded
 
     @property
-    def media_starttime(self):
+    def media_start_time(self):
         """Start time the program aired."""
         if self._is_standby:
             return None

--- a/homeassistant/components/media_player/directv.py
+++ b/homeassistant/components/media_player/directv.py
@@ -170,6 +170,7 @@ class DirecTvDevice(MediaPlayerDevice):
         """Return the content ID of current playing media."""
         if self._is_standby:
             return None
+
         return self._current['programId']
 
     @property
@@ -180,6 +181,7 @@ class DirecTvDevice(MediaPlayerDevice):
 
         if 'episodeTitle' in self._current:
             return MEDIA_TYPE_TVSHOW
+
         return MEDIA_TYPE_MOVIE
 
     @property
@@ -187,6 +189,7 @@ class DirecTvDevice(MediaPlayerDevice):
         """Return the duration of current playing media in seconds."""
         if self._is_standby:
             return None
+
         return self._current['duration']
 
     @property
@@ -213,6 +216,7 @@ class DirecTvDevice(MediaPlayerDevice):
         """Return the title of current playing media."""
         if self._is_standby:
             return None
+
         return self._current['title']
 
     @property


### PR DESCRIPTION
## Description:

Following enhancements have been made:

1. Added debug logging
2. Added ability to change channel using select_source service of the remote platform.
3. State will now show paused if a recorded program is paused, for live TV playing will always be returned.
4. Added the following attributes:
    a. media_position: current position of the media (in seconds)
    b. media_position_updated_at: timestamp when media_position was updated.
    c. source: current source (channel).
    d. media_isbeingrecorded: if current media is being recorded or not.
    e. media_rating: TV/Movie rating of the media
    f. media_recorded: if current media is recorded or live TV
    g. media_starttime: Timestamp media was aired
5. Reordered properties to follow same order as how they are in __init__.py of remote platform.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**