### PR TITLE
Blink update - fixes #17316

### DIFF
--- a/homeassistant/components/alarm_control_panel/blink.py
+++ b/homeassistant/components/alarm_control_panel/blink.py
@@ -44,6 +44,11 @@ class BlinkSyncModule(AlarmControlPanel):
         self._state = None
 
     @property
+    def unique_id(self):
+        """Return the unique id for the sync module."""
+        return self.sync.serial
+
+    @property
     def icon(self):
         """Return icon."""
         return ICON
@@ -61,9 +66,10 @@ class BlinkSyncModule(AlarmControlPanel):
     @property
     def device_state_attributes(self):
         """Return the state attributes."""
-        return {
-            ATTR_ATTRIBUTION: DEFAULT_ATTRIBUTION,
-        }
+        attr = self.sync.attributes
+        attr['network_info'] = self.data.networks
+        attr[ATTR_ATTRIBUTION] = DEFAULT_ATTRIBUTION
+        return attr
 
     def update(self):
         """Update the state of the device."""

--- a/homeassistant/components/binary_sensor/blink.py
+++ b/homeassistant/components/binary_sensor/blink.py
@@ -36,6 +36,7 @@ class BlinkBinarySensor(BinarySensorDevice):
         self._icon = icon
         self._camera = data.sync.cameras[camera]
         self._state = None
+        self._unique_id = "{}-{}".format(self._camera.serial, self._type)
 
     @property
     def name(self):

--- a/homeassistant/components/blink/__init__.py
+++ b/homeassistant/components/blink/__init__.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
     CONF_BINARY_SENSORS, CONF_SENSORS, CONF_FILENAME,
     CONF_MONITORED_CONDITIONS, TEMP_FAHRENHEIT)
 
-REQUIREMENTS = ['blinkpy==0.9.0']
+REQUIREMENTS = ['blinkpy==0.10.0']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -36,7 +36,6 @@ TYPE_MOTION_DETECTED = 'motion_detected'
 TYPE_TEMPERATURE = 'temperature'
 TYPE_BATTERY = 'battery'
 TYPE_WIFI_STRENGTH = 'wifi_strength'
-TYPE_STATUS = 'status'
 
 SERVICE_REFRESH = 'blink_update'
 SERVICE_TRIGGER = 'trigger_camera'
@@ -50,8 +49,7 @@ BINARY_SENSORS = {
 SENSORS = {
     TYPE_TEMPERATURE: ['Temperature', TEMP_FAHRENHEIT, 'mdi:thermometer'],
     TYPE_BATTERY: ['Battery', '%', 'mdi:battery-80'],
-    TYPE_WIFI_STRENGTH: ['Wifi Signal', 'dBm', 'mdi:wifi-strength-2'],
-    TYPE_STATUS: ['Status', '', 'mdi:bell']
+    TYPE_WIFI_STRENGTH: ['Wifi Signal', 'bars', 'mdi:wifi-strength-2'],
 }
 
 BINARY_SENSOR_SCHEMA = vol.Schema({

--- a/homeassistant/components/camera/blink.py
+++ b/homeassistant/components/camera/blink.py
@@ -38,6 +38,7 @@ class BlinkCamera(Camera):
         self.data = data
         self._name = "{} {}".format(BLINK_DATA, name)
         self._camera = camera
+        self._unique_id = "{}-camera".format(camera.serial)
         self.response = None
         self.current_image = None
         self.last_image = None
@@ -47,6 +48,11 @@ class BlinkCamera(Camera):
     def name(self):
         """Return the camera name."""
         return self._name
+
+    @property
+    def unique_id(self):
+        """Return the unique camera id."""
+        return self._unique_id
 
     @property
     def device_state_attributes(self):
@@ -64,7 +70,7 @@ class BlinkCamera(Camera):
     @property
     def motion_detection_enabled(self):
         """Return the state of the camera."""
-        return self._camera.armed
+        return self._camera.motion_enabled
 
     @property
     def brand(self):

--- a/homeassistant/components/sensor/blink.py
+++ b/homeassistant/components/sensor/blink.py
@@ -43,11 +43,17 @@ class BlinkSensor(Entity):
         self._state = None
         self._unit_of_measurement = units
         self._icon = icon
+        self._unique_id = "{}-{}".format(self._camera.serial, self._type)
 
     @property
     def name(self):
         """Return the name of the camera."""
         return self._name
+
+    @property
+    def unique_id(self):
+        """Return the unique id for the camera sensor."""
+        return self._unique_id
 
     @property
     def icon(self):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -185,7 +185,7 @@ bellows==0.7.0
 bimmer_connected==0.5.3
 
 # homeassistant.components.blink
-blinkpy==0.9.0
+blinkpy==0.10.0
 
 # homeassistant.components.light.blinksticklight
 blinkstick==1.1.8


### PR DESCRIPTION
## Description:
- Upgrade `blinkpy` to `0.10.0`
- Remove status sensor (API endpoint unreliable for this)
- Wifi strength reports in wifi bars rather than dBm (result of new API
endpoint)
- Added unique ids based on serial number

**Related issue (if applicable):** fixes #17316 fixes #17405 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#6874

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

CC @dgomes 