### PR TITLE
Always add listener for _update_entity_states

### DIFF
--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -225,9 +225,7 @@ class EntityPlatform:
         await asyncio.wait(tasks, loop=self.hass.loop)
         self.async_entities_added_callback()
 
-        if self._async_unsub_polling is not None or \
-           not any(entity.should_poll for entity
-                   in self.entities.values()):
+        if self._async_unsub_polling is not None:
             return
 
         self._async_unsub_polling = async_track_time_interval(
@@ -379,9 +377,7 @@ class EntityPlatform:
         await self._async_remove_entity(entity_id)
 
         # Clean up polling job if no longer needed
-        if (self._async_unsub_polling is not None and
-                not any(entity.should_poll for entity
-                        in self.entities.values())):
+        if self._async_unsub_polling is not None:
             self._async_unsub_polling()
             self._async_unsub_polling = None
 


### PR DESCRIPTION
If `should_poll` for ALL `EntityComponent` is `False` at startup but
dynamically change to `True` at runtime, entities can get stuck at an
undesirable states.

## Description:
Currently, kodi shows such behavior.  
To better illustrate the issue here's how to easily reproduce it.
1. Have **one** media_player configured (kodi)
2. Start kodi
3. Start HA. [should_poll](https://github.com/home-assistant/home-assistant/blob/a71cc67efb05cf343df048885b451581b8cf0bd0/homeassistant/components/media_player/kodi.py#L502) for kodi returns `False`
4. Exit kodi
5. Start kodi
=> HA does show kodi as being offline.

**Related issue (if applicable):** fixes #17265

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
