### PR TITLE
WIP: Add last clean times to xiaomi vacuum

### DIFF
--- a/homeassistant/components/vacuum/xiaomi_miio.py
+++ b/homeassistant/components/vacuum/xiaomi_miio.py
@@ -45,6 +45,8 @@ FAN_SPEEDS = {
     'Turbo': 77,
     'Max': 90}
 
+ATTR_CLEAN_START = 'clean_start'
+ATTR_CLEAN_STOP = 'clean_stop'
 ATTR_CLEANING_TIME = 'cleaning_time'
 ATTR_DO_NOT_DISTURB = 'do_not_disturb'
 ATTR_DO_NOT_DISTURB_START = 'do_not_disturb_start'
@@ -248,6 +250,10 @@ class MiroboVacuum(StateVacuumDevice):
                 ATTR_STATUS: str(self.vacuum_state.state)
                 })
 
+            if self.last_clean:
+                attrs[ATTR_CLEAN_START] = self.last_clean.start
+                attrs[ATTR_CLEAN_STOP] = self.last_clean.end
+
             if self.vacuum_state.got_error:
                 attrs[ATTR_ERROR] = self.vacuum_state.error
         return attrs
@@ -368,6 +374,7 @@ class MiroboVacuum(StateVacuumDevice):
 
             self.consumable_state = self._vacuum.consumable_status()
             self.clean_history = self._vacuum.clean_history()
+            self.last_clean = self._vacuum.last_clean_details()
             self.dnd_state = self._vacuum.dnd_status()
 
             self._available = True

--- a/homeassistant/components/vacuum/xiaomi_miio.py
+++ b/homeassistant/components/vacuum/xiaomi_miio.py
@@ -171,6 +171,7 @@ class MiroboVacuum(StateVacuumDevice):
         self.consumable_state = None
         self.clean_history = None
         self.dnd_state = None
+        self.last_clean = None
 
     @property
     def name(self):


### PR DESCRIPTION
The keys are the same as used by neato platform.

## Description:
Depends on https://github.com/rytilahti/python-miio/pull/413 and a release bump.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
