### PR TITLE
Upgrade async_upnp_client to 0.12.6 - fixes #17469

### DIFF
--- a/homeassistant/components/media_player/dlna_dmr.py
+++ b/homeassistant/components/media_player/dlna_dmr.py
@@ -25,7 +25,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import get_local_ip
 
-REQUIREMENTS = ['async-upnp-client==0.12.5']
+REQUIREMENTS = ['async-upnp-client==0.12.6']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/upnp/__init__.py
+++ b/homeassistant/components/upnp/__init__.py
@@ -30,7 +30,7 @@ from .config_flow import ensure_domain_data
 from .device import Device
 
 
-REQUIREMENTS = ['async-upnp-client==0.12.5']
+REQUIREMENTS = ['async-upnp-client==0.12.6']
 DEPENDENCIES = ['http']
 
 NOTIFICATION_ID = 'upnp_notification'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -153,7 +153,7 @@ asterisk_mbox==0.5.0
 
 # homeassistant.components.upnp
 # homeassistant.components.media_player.dlna_dmr
-async-upnp-client==0.12.5
+async-upnp-client==0.12.6
 
 # homeassistant.components.light.avion
 # avion==0.7


### PR DESCRIPTION
## Description:

Upgrade async_upnp_client to 0.12.6 which fixes a bug where incomplete XML results in an error.

**Related issue (if applicable):** fixes #17469

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`.

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
