### PR TITLE
Update snapcast to 2.0.9

### DIFF
--- a/homeassistant/components/media_player/snapcast.py
+++ b/homeassistant/components/media_player/snapcast.py
@@ -17,7 +17,7 @@ from homeassistant.const import (
     STATE_PLAYING, STATE_UNKNOWN)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['snapcast==2.0.8']
+REQUIREMENTS = ['snapcast==2.0.9']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1386,7 +1386,7 @@ smappy==0.2.16
 smhi-pkg==1.0.4
 
 # homeassistant.components.media_player.snapcast
-snapcast==2.0.8
+snapcast==2.0.9
 
 # homeassistant.components.sensor.socialblade
 socialbladeclient==0.2


### PR DESCRIPTION
## Description:
Update snapcast to work with async/await.

In https://github.com/home-assistant/home-assistant/pull/17018 we switched to use async/await. This showed that Snapcast was not actually wrapping their async functions correctly. Has been addressed in 2.0.9.

