### PR TITLE
Add missing hangouts data/image to notify service

### DIFF
--- a/homeassistant/components/notify/hangouts.py
+++ b/homeassistant/components/notify/hangouts.py
@@ -27,7 +27,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 NOTIFY_SERVICE_SCHEMA = NOTIFY_SERVICE_SCHEMA.extend({
     vol.Optional(ATTR_TARGET): [TARGETS_SCHEMA],
-    vol.Optional(ATTR_DATA): MESSAGE_DATA_SCHEMA
+    vol.Optional(ATTR_DATA, default={}): MESSAGE_DATA_SCHEMA
 })
 
 
@@ -61,7 +61,7 @@ class HangoutsNotificationService(BaseNotificationService):
         service_data = {
             ATTR_TARGET: target_conversations,
             ATTR_MESSAGE: messages,
-            ATTR_DATA: kwargs.get(ATTR_DATA, {}) or {}
+            ATTR_DATA: kwargs[ATTR_DATA]
         }
 
         return self.hass.services.call(

--- a/homeassistant/components/notify/hangouts.py
+++ b/homeassistant/components/notify/hangouts.py
@@ -11,10 +11,10 @@ import voluptuous as vol
 from homeassistant.components.notify import (ATTR_TARGET, PLATFORM_SCHEMA,
                                              NOTIFY_SERVICE_SCHEMA,
                                              BaseNotificationService,
-                                             ATTR_MESSAGE)
+                                             ATTR_MESSAGE, ATTR_DATA)
 
 from homeassistant.components.hangouts.const \
-    import (DOMAIN, SERVICE_SEND_MESSAGE,
+    import (DOMAIN, SERVICE_SEND_MESSAGE, MESSAGE_DATA_SCHEMA,
             TARGETS_SCHEMA, CONF_DEFAULT_CONVERSATIONS)
 
 _LOGGER = logging.getLogger(__name__)
@@ -26,7 +26,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 NOTIFY_SERVICE_SCHEMA = NOTIFY_SERVICE_SCHEMA.extend({
-    vol.Optional(ATTR_TARGET): [TARGETS_SCHEMA]
+    vol.Optional(ATTR_TARGET): [TARGETS_SCHEMA],
+    vol.Optional(ATTR_DATA): MESSAGE_DATA_SCHEMA
 })
 
 
@@ -59,7 +60,8 @@ class HangoutsNotificationService(BaseNotificationService):
         messages.append({'text': message, 'parse_str': True})
         service_data = {
             ATTR_TARGET: target_conversations,
-            ATTR_MESSAGE: messages
+            ATTR_MESSAGE: messages,
+            ATTR_DATA: kwargs.get(ATTR_DATA, {}) or {}
         }
 
         return self.hass.services.call(


### PR DESCRIPTION
## Description:
Missed adding support for hangouts data/image to notify service

**Related issue (if applicable):** fixes #17513
## Example entry for `configuration.yaml` (if applicable):
```yaml
notify:
  - name: hangouts_me
    platform: hangouts
    default_conversations:
      - id: "xxxx"
```

## Checklist:
  - [x] The code change is tested and works locally.
