### PR TITLE
0.80.3

### DIFF
--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -24,7 +24,7 @@ from homeassistant.core import callback
 from homeassistant.helpers.translation import async_get_translations
 from homeassistant.loader import bind_hass
 
-REQUIREMENTS = ['home-assistant-frontend==20181017.0']
+REQUIREMENTS = ['home-assistant-frontend==20181018.0']
 
 DOMAIN = 'frontend'
 DEPENDENCIES = ['api', 'websocket_api', 'http', 'system_log',

--- a/homeassistant/components/hangouts/__init__.py
+++ b/homeassistant/components/hangouts/__init__.py
@@ -27,7 +27,7 @@ from .const import (
 # We need an import from .config_flow, without it .config_flow is never loaded.
 from .config_flow import HangoutsFlowHandler  # noqa: F401
 
-REQUIREMENTS = ['hangups==0.4.5']
+REQUIREMENTS = ['hangups==0.4.6']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/hangouts/hangouts_bot.py
+++ b/homeassistant/components/hangouts/hangouts_bot.py
@@ -191,16 +191,19 @@ class HangoutsBot:
         self._connected = True
         dispatcher.async_dispatcher_send(self.hass, EVENT_HANGOUTS_CONNECTED)
 
-    def _on_disconnect(self):
+    async def _on_disconnect(self):
         """Handle disconnecting."""
-        _LOGGER.debug('Connection lost!')
-        self._connected = False
-        dispatcher.async_dispatcher_send(self.hass,
-                                         EVENT_HANGOUTS_DISCONNECTED)
+        if self._connected:
+            _LOGGER.debug('Connection lost! Reconnect...')
+            await self.async_connect()
+        else:
+            dispatcher.async_dispatcher_send(self.hass,
+                                             EVENT_HANGOUTS_DISCONNECTED)
 
     async def async_disconnect(self):
         """Disconnect the client if it is connected."""
         if self._connected:
+            self._connected = False
             await self._client.disconnect()
 
     async def async_handle_hass_stop(self, _):

--- a/homeassistant/components/media_player/dlna_dmr.py
+++ b/homeassistant/components/media_player/dlna_dmr.py
@@ -25,7 +25,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import get_local_ip
 
-REQUIREMENTS = ['async-upnp-client==0.12.4']
+REQUIREMENTS = ['async-upnp-client==0.12.5']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/media_player/dlna_dmr.py
+++ b/homeassistant/components/media_player/dlna_dmr.py
@@ -25,7 +25,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import get_local_ip
 
-REQUIREMENTS = ['async-upnp-client==0.12.5']
+REQUIREMENTS = ['async-upnp-client==0.12.6']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/media_player/snapcast.py
+++ b/homeassistant/components/media_player/snapcast.py
@@ -17,7 +17,7 @@ from homeassistant.const import (
     STATE_PLAYING, STATE_UNKNOWN)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['snapcast==2.0.8']
+REQUIREMENTS = ['snapcast==2.0.9']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/upnp/__init__.py
+++ b/homeassistant/components/upnp/__init__.py
@@ -30,7 +30,7 @@ from .config_flow import ensure_domain_data
 from .device import Device
 
 
-REQUIREMENTS = ['async-upnp-client==0.12.4']
+REQUIREMENTS = ['async-upnp-client==0.12.5']
 DEPENDENCIES = ['http']
 
 NOTIFICATION_ID = 'upnp_notification'

--- a/homeassistant/components/upnp/__init__.py
+++ b/homeassistant/components/upnp/__init__.py
@@ -30,7 +30,7 @@ from .config_flow import ensure_domain_data
 from .device import Device
 
 
-REQUIREMENTS = ['async-upnp-client==0.12.5']
+REQUIREMENTS = ['async-upnp-client==0.12.6']
 DEPENDENCIES = ['http']
 
 NOTIFICATION_ID = 'upnp_notification'

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -2,7 +2,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 80
-PATCH_VERSION = '2'
+PATCH_VERSION = '3'
 __short_version__ = '{}.{}'.format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = '{}.{}'.format(__short_version__, PATCH_VERSION)
 REQUIRED_PYTHON_VER = (3, 5, 3)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -434,7 +434,7 @@ ha-philipsjs==0.0.5
 habitipy==0.2.0
 
 # homeassistant.components.hangouts
-hangups==0.4.5
+hangups==0.4.6
 
 # homeassistant.components.mqtt.server
 hbmqtt==0.9.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -458,7 +458,7 @@ hole==0.3.0
 holidays==0.9.7
 
 # homeassistant.components.frontend
-home-assistant-frontend==20181017.0
+home-assistant-frontend==20181018.0
 
 # homeassistant.components.homekit_controller
 # homekit==0.10

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -147,7 +147,7 @@ asterisk_mbox==0.5.0
 
 # homeassistant.components.upnp
 # homeassistant.components.media_player.dlna_dmr
-async-upnp-client==0.12.4
+async-upnp-client==0.12.5
 
 # homeassistant.components.light.avion
 # avion==0.7

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1364,7 +1364,7 @@ smappy==0.2.16
 # smbus-cffi==0.5.1
 
 # homeassistant.components.media_player.snapcast
-snapcast==2.0.8
+snapcast==2.0.9
 
 # homeassistant.components.sensor.socialblade
 socialbladeclient==0.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -147,7 +147,7 @@ asterisk_mbox==0.5.0
 
 # homeassistant.components.upnp
 # homeassistant.components.media_player.dlna_dmr
-async-upnp-client==0.12.5
+async-upnp-client==0.12.6
 
 # homeassistant.components.light.avion
 # avion==0.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -90,7 +90,7 @@ hdate==0.6.3
 holidays==0.9.7
 
 # homeassistant.components.frontend
-home-assistant-frontend==20181017.0
+home-assistant-frontend==20181018.0
 
 # homeassistant.components.homematicip_cloud
 homematicip==0.9.8

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -78,7 +78,7 @@ georss_client==0.3
 ha-ffmpeg==1.9
 
 # homeassistant.components.hangouts
-hangups==0.4.5
+hangups==0.4.6
 
 # homeassistant.components.mqtt.server
 hbmqtt==0.9.4


### PR DESCRIPTION
- update hangups to 0.4.6 and fix Issue #16593 hangouts reconnects. ([@hobbypunk90] - [#17518]) ([hangouts docs])
- Update to async-upnp-client==0.12.5 ([@StevenLooman] - [#17401]) ([upnp docs]) ([media_player.dlna_dmr docs])
- Upgrade async_upnp_client to 0.12.6 ([@StevenLooman] - [#17560]) ([upnp docs]) ([media_player.dlna_dmr docs])
- Update snapcast to 2.0.9 ([@balloob] - [#17573]) ([media_player.snapcast docs])

[#17401]: https://github.com/home-assistant/home-assistant/pull/17401
[#17518]: https://github.com/home-assistant/home-assistant/pull/17518
[#17560]: https://github.com/home-assistant/home-assistant/pull/17560
[#17573]: https://github.com/home-assistant/home-assistant/pull/17573
[@StevenLooman]: https://github.com/StevenLooman
[@balloob]: https://github.com/balloob
[@hobbypunk90]: https://github.com/hobbypunk90
[hangouts docs]: https://www.home-assistant.io/components/hangouts/
[media_player.dlna_dmr docs]: https://www.home-assistant.io/components/media_player.dlna_dmr/
[media_player.snapcast docs]: https://www.home-assistant.io/components/media_player.snapcast/
[upnp docs]: https://www.home-assistant.io/components/upnp/