### PR TITLE
Tuya light icon fix

### DIFF
--- a/homeassistant/components/light/tuya.py
+++ b/homeassistant/components/light/tuya.py
@@ -40,7 +40,7 @@ class TuyaLight(TuyaDevice, Light):
     @property
     def brightness(self):
         """Return the brightness of the light."""
-        return self.tuya.brightness()
+        return int(self.tuya.brightness())
 
     @property
     def hs_color(self):

--- a/homeassistant/components/light/tuya.py
+++ b/homeassistant/components/light/tuya.py
@@ -45,12 +45,12 @@ class TuyaLight(TuyaDevice, Light):
     @property
     def hs_color(self):
         """Return the hs_color of the light."""
-        return self.tuya.hs_color()
+        return tuple(map(int, self.tuya.hs_color()))
 
     @property
     def color_temp(self):
         """Return the color_temp of the light."""
-        color_temp = self.tuya.color_temp()
+        color_temp = int(self.tuya.color_temp())
         if color_temp is None:
             return None
         return colorutil.color_temperature_kelvin_to_mired(color_temp)


### PR DESCRIPTION
## Description:
The problem described in #15686 is is caused by [tuyapy](https://pypi.org/project/tuyapy/) returning some values that are supposed to be integers as strings.
This caused icon brightness to go through the roof in the UI when calculated as `(brightness + 245)/5` since in javascript `"100" + 245 = 100245`...

I also added type coercion to some more values that might be badly formatted (that way the number of characters in the change can compete with the number of lines in their description...).

I have not tested this as I should, since I don't have any tuya light.
One user have tested the first commit, though, and reported that it works.

**Related issue (if applicable):** fixes #15686 




**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
