### PR TITLE
Revert "De-syncing binary_sensor.ping (#17056)"

### DIFF
--- a/homeassistant/components/binary_sensor/ping.py
+++ b/homeassistant/components/binary_sensor/ping.py
@@ -4,19 +4,18 @@ Tracks the latency of a host by sending ICMP echo requests (ping).
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/binary_sensor.ping/
 """
-import asyncio
-from datetime import timedelta
 import logging
-import re
 import subprocess
+import re
 import sys
+from datetime import timedelta
 
 import voluptuous as vol
 
-from homeassistant.components.binary_sensor import (
-    PLATFORM_SCHEMA, BinarySensorDevice)
-from homeassistant.const import CONF_HOST, CONF_NAME
 import homeassistant.helpers.config_validation as cv
+from homeassistant.components.binary_sensor import (
+    BinarySensorDevice, PLATFORM_SCHEMA)
+from homeassistant.const import CONF_NAME, CONF_HOST
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -49,14 +48,13 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-async def async_setup_platform(
-        hass, config, async_add_entities, discovery_info=None):
+def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Ping Binary sensor."""
     name = config.get(CONF_NAME)
     host = config.get(CONF_HOST)
     count = config.get(CONF_PING_COUNT)
 
-    async_add_entities([PingBinarySensor(name, PingData(host, count))], True)
+    add_entities([PingBinarySensor(name, PingData(host, count))], True)
 
 
 class PingBinarySensor(BinarySensorDevice):
@@ -93,9 +91,9 @@ class PingBinarySensor(BinarySensorDevice):
                 ATTR_ROUND_TRIP_TIME_MIN: self.ping.data['min'],
             }
 
-    async def async_update(self):
+    def update(self):
         """Get the latest data."""
-        await self.ping.update()
+        self.ping.update()
 
 
 class PingData:
@@ -116,13 +114,12 @@ class PingData:
                 'ping', '-n', '-q', '-c', str(self._count), '-W1',
                 self._ip_address]
 
-    async def ping(self):
+    def ping(self):
         """Send ICMP echo request and return details if success."""
-        pinger = await asyncio.create_subprocess_shell(
-            ' '.join(self._ping_cmd), stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE)
+        pinger = subprocess.Popen(
+            self._ping_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         try:
-            out = await pinger.communicate()
+            out = pinger.communicate()
             _LOGGER.debug("Output is %s", str(out))
             if sys.platform == 'win32':
                 match = WIN32_PING_MATCHER.search(str(out).split('\n')[-1])
@@ -131,8 +128,7 @@ class PingData:
                     'min': rtt_min,
                     'avg': rtt_avg,
                     'max': rtt_max,
-                    'mdev': '',
-                }
+                    'mdev': ''}
             if 'max/' not in str(out):
                 match = PING_MATCHER_BUSYBOX.search(str(out).split('\n')[-1])
                 rtt_min, rtt_avg, rtt_max = match.groups()
@@ -140,20 +136,18 @@ class PingData:
                     'min': rtt_min,
                     'avg': rtt_avg,
                     'max': rtt_max,
-                    'mdev': '',
-                }
+                    'mdev': ''}
             match = PING_MATCHER.search(str(out).split('\n')[-1])
             rtt_min, rtt_avg, rtt_max, rtt_mdev = match.groups()
             return {
                 'min': rtt_min,
                 'avg': rtt_avg,
                 'max': rtt_max,
-                'mdev': rtt_mdev,
-            }
+                'mdev': rtt_mdev}
         except (subprocess.CalledProcessError, AttributeError):
             return False
 
-    async def update(self):
+    def update(self):
         """Retrieve the latest details from the host."""
-        self.data = await self.ping()
+        self.data = self.ping()
         self.available = bool(self.data)


### PR DESCRIPTION
## Description:
This reverts commit 11d5671ee0a4dbf98c5e9f58a2dec85bdb35f4d0.
Original PR:  #17056 

My attempts at desyncing ping sensors cause crashes to some people.

See:
- comments to: #17056 
- #16986 
- #17534 
- #17562 
- #17511


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
