### PR TITLE
Add missing await for coroutine

### DIFF
--- a/homeassistant/components/camera/ffmpeg.py
+++ b/homeassistant/components/camera/ffmpeg.py
@@ -32,7 +32,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 async def async_setup_platform(hass, config, async_add_entities,
                                discovery_info=None):
     """Set up a FFmpeg camera."""
-    if not hass.data[DATA_FFMPEG].async_run_test(config.get(CONF_INPUT)):
+    if not await hass.data[DATA_FFMPEG].async_run_test(config.get(CONF_INPUT)):
         return
     async_add_entities([FFmpegCamera(hass, config)])
 


### PR DESCRIPTION
## Description:
Adds missing await for ffmpeg camera setup coroutine.

Fixes warnings on startup:
```
/srv/homeassistant/lib/python3.6/site-packages/homeassistant/components/camera/ffmpeg.py:35: RuntimeWarning: coroutine 'FFmpegManager.async_run_test' was never awaited
  if not hass.data[DATA_FFMPEG].async_run_test(config.get(CONF_INPUT)):
```

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
- platform: ffmpeg
  name: Fancy Camera
  input: -rtsp_transport tcp -i rtsp://10.99.0.110:8554/unicast
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54