### PR TITLE
Use cached robot serial for Neato update

### DIFF
--- a/homeassistant/components/vacuum/neato.py
+++ b/homeassistant/components/vacuum/neato.py
@@ -108,27 +108,27 @@ class NeatoConnectedVacuum(StateVacuumDevice):
             self._clean_state = STATE_ERROR
             self._status_state = ERRORS.get(self._state['error'])
 
-        if not self._mapdata.get(self.robot.serial, {}).get('maps', []):
+        if not self._mapdata.get(self._robot_serial, {}).get('maps', []):
             return
         self.clean_time_start = (
-            (self._mapdata[self.robot.serial]['maps'][0]['start_at']
+            (self._mapdata[self._robot_serial]['maps'][0]['start_at']
              .strip('Z'))
             .replace('T', ' '))
         self.clean_time_stop = (
-            (self._mapdata[self.robot.serial]['maps'][0]['end_at'].strip('Z'))
+            (self._mapdata[self._robot_serial]['maps'][0]['end_at'].strip('Z'))
             .replace('T', ' '))
         self.clean_area = (
-            self._mapdata[self.robot.serial]['maps'][0]['cleaned_area'])
+            self._mapdata[self._robot_serial]['maps'][0]['cleaned_area'])
         self.clean_suspension_charge_count = (
-            self._mapdata[self.robot.serial]['maps'][0]
+            self._mapdata[self._robot_serial]['maps'][0]
             ['suspended_cleaning_charging_count'])
         self.clean_suspension_time = (
-            self._mapdata[self.robot.serial]['maps'][0]
+            self._mapdata[self._robot_serial]['maps'][0]
             ['time_in_suspended_cleaning'])
         self.clean_battery_start = (
-            self._mapdata[self.robot.serial]['maps'][0]['run_charge_at_start'])
+            self._mapdata[self._robot_serial]['maps'][0]['run_charge_at_start'])
         self.clean_battery_end = (
-            self._mapdata[self.robot.serial]['maps'][0]['run_charge_at_end'])
+            self._mapdata[self._robot_serial]['maps'][0]['run_charge_at_end'])
 
         self._battery_level = self._state['details']['charge']
 

--- a/homeassistant/components/vacuum/neato.py
+++ b/homeassistant/components/vacuum/neato.py
@@ -126,7 +126,8 @@ class NeatoConnectedVacuum(StateVacuumDevice):
             self._mapdata[self._robot_serial]['maps'][0]
             ['time_in_suspended_cleaning'])
         self.clean_battery_start = (
-            self._mapdata[self._robot_serial]['maps'][0]['run_charge_at_start'])
+            self._mapdata[self._robot_serial]['maps'][0]['run_charge_at_start']
+            )
         self.clean_battery_end = (
             self._mapdata[self._robot_serial]['maps'][0]['run_charge_at_end'])
 


### PR DESCRIPTION
## Description:

Make the Neato vacuum update more efficient by using the cached robot serial when necessary.

**Related issue (if applicable):** fixes # N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io# N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
neato:
  username: username
  password: password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
