### PR TITLE
Raise PlatformNotReady for RMVtransport if API not available

### DIFF
--- a/homeassistant/components/sensor/rmvtransport.py
+++ b/homeassistant/components/sensor/rmvtransport.py
@@ -9,11 +9,12 @@ from datetime import timedelta
 
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.entity import Entity
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (CONF_NAME, ATTR_ATTRIBUTION)
+from homeassistant.exceptions import PlatformNotReady
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 
 REQUIREMENTS = ['PyRMVtransport==0.1.3']
@@ -24,7 +25,7 @@ CONF_NEXT_DEPARTURE = 'next_departure'
 
 CONF_STATION = 'station'
 CONF_DESTINATIONS = 'destinations'
-CONF_DIRECTION = 'direction'
+CONF_DIRECTIONS = 'directions'
 CONF_LINES = 'lines'
 CONF_PRODUCTS = 'products'
 CONF_TIME_OFFSET = 'time_offset'
@@ -57,7 +58,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
         vol.Required(CONF_STATION): cv.string,
         vol.Optional(CONF_DESTINATIONS, default=[]):
             vol.All(cv.ensure_list, [cv.string]),
-        vol.Optional(CONF_DIRECTION): cv.string,
+        vol.Optional(CONF_DIRECTIONS, default=[]):
+            vol.All(cv.ensure_list, [cv.string]),
         vol.Optional(CONF_LINES, default=[]):
             vol.All(cv.ensure_list, [cv.positive_int, cv.string]),
         vol.Optional(CONF_PRODUCTS, default=VALID_PRODUCTS):
@@ -83,27 +85,34 @@ async def async_setup_platform(hass, config, async_add_entities,
                 session,
                 next_departure[CONF_STATION],
                 next_departure.get(CONF_DESTINATIONS),
-                next_departure.get(CONF_DIRECTION),
+                next_departure.get(CONF_DIRECTIONS),
                 next_departure.get(CONF_LINES),
                 next_departure.get(CONF_PRODUCTS),
                 next_departure.get(CONF_TIME_OFFSET),
                 next_departure.get(CONF_MAX_JOURNEYS),
                 next_departure.get(CONF_NAME),
                 timeout))
+
+    for sensor in sensors:
+        await sensor.async_update()
+
+        if not sensor.data.departures:
+            raise PlatformNotReady
+
     async_add_entities(sensors, True)
 
 
 class RMVDepartureSensor(Entity):
     """Implementation of an RMV departure sensor."""
 
-    def __init__(self, session, station, destinations, direction, lines,
+    def __init__(self, session, station, destinations, directions, lines,
                  products, time_offset, max_journeys, name, timeout):
         """Initialize the sensor."""
         self._station = station
         self._name = name
         self._state = None
         self.data = RMVDepartureData(session, station, destinations,
-                                     direction, lines, products, time_offset,
+                                     directions, lines, products, time_offset,
                                      max_journeys, timeout)
         self._icon = ICONS[None]
 
@@ -166,7 +175,7 @@ class RMVDepartureSensor(Entity):
 class RMVDepartureData:
     """Pull data from the opendata.rmv.de web page."""
 
-    def __init__(self, session, station_id, destinations, direction, lines,
+    def __init__(self, session, station_id, destinations, directions, lines,
                  products, time_offset, max_journeys, timeout):
         """Initialize the sensor."""
         from RMVtransport import RMVtransport
@@ -174,7 +183,7 @@ class RMVDepartureData:
         self.station = None
         self._station_id = station_id
         self._destinations = destinations
-        self._direction = direction
+        self._directions = directions
         self._lines = lines
         self._products = products
         self._time_offset = time_offset
@@ -185,12 +194,13 @@ class RMVDepartureData:
     @Throttle(SCAN_INTERVAL)
     async def async_update(self):
         """Update the connection data."""
+        from RMVtransport.rmvtransport import RMVtransportApiConnectionError
+        
         try:
             _data = await self.rmv.get_departures(self._station_id,
                                                   products=self._products,
-                                                  directionId=self._direction,
                                                   maxJourneys=50)
-        except ValueError:
+        except RMVtransportApiConnectionError:
             self.departures = []
             _LOGGER.warning("Returned data not understood")
             return

--- a/homeassistant/components/sensor/rmvtransport.py
+++ b/homeassistant/components/sensor/rmvtransport.py
@@ -198,10 +198,11 @@ class RMVDepartureData:
         try:
             _data = await self.rmv.get_departures(self._station_id,
                                                   products=self._products,
+                                                  directionId=self._direction,
                                                   maxJourneys=50)
         except RMVtransportApiConnectionError:
             self.departures = []
-            _LOGGER.warning("Returned data not understood")
+            _LOGGER.warning("Could not retrive data from rmv.de")
             return
         self.station = _data.get('station')
         _deps = []

--- a/homeassistant/components/sensor/rmvtransport.py
+++ b/homeassistant/components/sensor/rmvtransport.py
@@ -25,7 +25,7 @@ CONF_NEXT_DEPARTURE = 'next_departure'
 
 CONF_STATION = 'station'
 CONF_DESTINATIONS = 'destinations'
-CONF_DIRECTIONS = 'directions'
+CONF_DIRECTION = 'direction'
 CONF_LINES = 'lines'
 CONF_PRODUCTS = 'products'
 CONF_TIME_OFFSET = 'time_offset'
@@ -58,8 +58,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
         vol.Required(CONF_STATION): cv.string,
         vol.Optional(CONF_DESTINATIONS, default=[]):
             vol.All(cv.ensure_list, [cv.string]),
-        vol.Optional(CONF_DIRECTIONS, default=[]):
-            vol.All(cv.ensure_list, [cv.string]),
+        vol.Optional(CONF_DIRECTION): cv.string,
         vol.Optional(CONF_LINES, default=[]):
             vol.All(cv.ensure_list, [cv.positive_int, cv.string]),
         vol.Optional(CONF_PRODUCTS, default=VALID_PRODUCTS):
@@ -85,7 +84,7 @@ async def async_setup_platform(hass, config, async_add_entities,
                 session,
                 next_departure[CONF_STATION],
                 next_departure.get(CONF_DESTINATIONS),
-                next_departure.get(CONF_DIRECTIONS),
+                next_departure.get(CONF_DIRECTION),
                 next_departure.get(CONF_LINES),
                 next_departure.get(CONF_PRODUCTS),
                 next_departure.get(CONF_TIME_OFFSET),
@@ -105,14 +104,14 @@ async def async_setup_platform(hass, config, async_add_entities,
 class RMVDepartureSensor(Entity):
     """Implementation of an RMV departure sensor."""
 
-    def __init__(self, session, station, destinations, directions, lines,
+    def __init__(self, session, station, destinations, direction, lines,
                  products, time_offset, max_journeys, name, timeout):
         """Initialize the sensor."""
         self._station = station
         self._name = name
         self._state = None
         self.data = RMVDepartureData(session, station, destinations,
-                                     directions, lines, products, time_offset,
+                                     direction, lines, products, time_offset,
                                      max_journeys, timeout)
         self._icon = ICONS[None]
 
@@ -175,7 +174,7 @@ class RMVDepartureSensor(Entity):
 class RMVDepartureData:
     """Pull data from the opendata.rmv.de web page."""
 
-    def __init__(self, session, station_id, destinations, directions, lines,
+    def __init__(self, session, station_id, destinations, direction, lines,
                  products, time_offset, max_journeys, timeout):
         """Initialize the sensor."""
         from RMVtransport import RMVtransport
@@ -183,7 +182,7 @@ class RMVDepartureData:
         self.station = None
         self._station_id = station_id
         self._destinations = destinations
-        self._directions = directions
+        self._direction = direction
         self._lines = lines
         self._products = products
         self._time_offset = time_offset

--- a/homeassistant/components/sensor/rmvtransport.py
+++ b/homeassistant/components/sensor/rmvtransport.py
@@ -98,7 +98,7 @@ async def async_setup_platform(hass, config, async_add_entities,
         if not sensor.data.departures:
             raise PlatformNotReady
 
-    async_add_entities(sensors, True)
+    async_add_entities(sensors)
 
 
 class RMVDepartureSensor(Entity):

--- a/homeassistant/components/sensor/rmvtransport.py
+++ b/homeassistant/components/sensor/rmvtransport.py
@@ -195,7 +195,7 @@ class RMVDepartureData:
     async def async_update(self):
         """Update the connection data."""
         from RMVtransport.rmvtransport import RMVtransportApiConnectionError
-        
+
         try:
             _data = await self.rmv.get_departures(self._station_id,
                                                   products=self._products,


### PR DESCRIPTION
## Description:
Raise PlatformNotReady for RMVtransport sensor if the API not available.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54