### PR TITLE
Away mode temperature fix for generic thermostat

### DIFF
--- a/homeassistant/components/climate/generic_thermostat.py
+++ b/homeassistant/components/climate/generic_thermostat.py
@@ -380,17 +380,19 @@ class GenericThermostat(ClimateDevice):
 
     async def async_turn_away_mode_on(self):
         """Turn away mode on by setting it on away hold indefinitely."""
-        if not self._is_away:
-            self._is_away = True
-            self._saved_target_temp = self._target_temp
-            self._target_temp = self._away_temp
-            await self._async_control_heating()
-            await self.async_update_ha_state()
+        if self._is_away:
+            return
+        self._is_away = True
+        self._saved_target_temp = self._target_temp
+        self._target_temp = self._away_temp
+        await self._async_control_heating()
+        await self.async_update_ha_state()
 
     async def async_turn_away_mode_off(self):
         """Turn away off."""
-        if self._is_away:
-            self._is_away = False
-            self._target_temp = self._saved_target_temp
-            await self._async_control_heating()
-            await self.async_update_ha_state()
+        if not self._is_away:
+            return
+        self._is_away = False
+        self._target_temp = self._saved_target_temp
+        await self._async_control_heating()
+        await self.async_update_ha_state()

--- a/homeassistant/components/climate/generic_thermostat.py
+++ b/homeassistant/components/climate/generic_thermostat.py
@@ -380,15 +380,21 @@ class GenericThermostat(ClimateDevice):
 
     async def async_turn_away_mode_on(self):
         """Turn away mode on by setting it on away hold indefinitely."""
-        self._is_away = True
-        self._saved_target_temp = self._target_temp
-        self._target_temp = self._away_temp
-        await self._async_control_heating()
-        await self.async_update_ha_state()
+        if not self._is_away:
+            self._is_away = True
+            self._saved_target_temp = self._target_temp
+            self._target_temp = self._away_temp
+            await self._async_control_heating()
+            await self.async_update_ha_state()
+        else:
+            _LOGGER.debug("Away mode is already turned on for %s", self.entity_id)
 
     async def async_turn_away_mode_off(self):
         """Turn away off."""
-        self._is_away = False
-        self._target_temp = self._saved_target_temp
-        await self._async_control_heating()
-        await self.async_update_ha_state()
+        if self._is_away:
+            self._is_away = False
+            self._target_temp = self._saved_target_temp
+            await self._async_control_heating()
+            await self.async_update_ha_state()
+        else:
+            _LOGGER.debug("Away mode is already turned off for %s", self.entity_id)

--- a/homeassistant/components/climate/generic_thermostat.py
+++ b/homeassistant/components/climate/generic_thermostat.py
@@ -386,8 +386,6 @@ class GenericThermostat(ClimateDevice):
             self._target_temp = self._away_temp
             await self._async_control_heating()
             await self.async_update_ha_state()
-        else:
-            _LOGGER.debug("Away mode is already turned on for %s", self.entity_id)
 
     async def async_turn_away_mode_off(self):
         """Turn away off."""
@@ -396,5 +394,3 @@ class GenericThermostat(ClimateDevice):
             self._target_temp = self._saved_target_temp
             await self._async_control_heating()
             await self.async_update_ha_state()
-        else:
-            _LOGGER.debug("Away mode is already turned off for %s", self.entity_id)

--- a/tests/components/climate/test_generic_thermostat.py
+++ b/tests/components/climate/test_generic_thermostat.py
@@ -220,9 +220,9 @@ class TestClimateGenericThermostat(unittest.TestCase):
         self.hass.block_till_done()
         state = self.hass.states.get(ENTITY)
         self.assertEqual(23, state.attributes.get('temperature'))
-        
+
     def test_set_away_mode_twice_and_restore_prev_temp(self):
-        """Test the setting away mode twice in a row
+        """Test the setting away mode twice in a row.
 
         Verify original temperature is restored.
         """

--- a/tests/components/climate/test_generic_thermostat.py
+++ b/tests/components/climate/test_generic_thermostat.py
@@ -220,6 +220,24 @@ class TestClimateGenericThermostat(unittest.TestCase):
         self.hass.block_till_done()
         state = self.hass.states.get(ENTITY)
         self.assertEqual(23, state.attributes.get('temperature'))
+        
+    def test_set_away_mode_twice_and_restore_prev_temp(self):
+        """Test the setting away mode twice in a row
+
+        Verify original temperature is restored.
+        """
+        common.set_temperature(self.hass, 23)
+        self.hass.block_till_done()
+        common.set_away_mode(self.hass, True)
+        self.hass.block_till_done()
+        common.set_away_mode(self.hass, True)
+        self.hass.block_till_done()
+        state = self.hass.states.get(ENTITY)
+        self.assertEqual(16, state.attributes.get('temperature'))
+        common.set_away_mode(self.hass, False)
+        self.hass.block_till_done()
+        state = self.hass.states.get(ENTITY)
+        self.assertEqual(23, state.attributes.get('temperature'))
 
     def test_sensor_bad_value(self):
         """Test sensor that have None as state."""


### PR DESCRIPTION
## Description:
Away mode temperature issue fix for generic_thermostat

**Related issue (if applicable):** fixes #17433 

## Example entry for `configuration.yaml` (if applicable):
```yaml
climate:
  - platform: generic_thermostat
    name: Child room heater
    heater: switch.40000500dc4f22ccb55e
    target_sensor: sensor.unknown_lumisensor_ht_0222819a_1_temperature
    min_temp: 10
    max_temp: 25
    ac_mode: false
    target_temp: 22
    cold_tolerance: 0.2
    hot_tolerance: 0
    initial_operation_mode: "off"
    away_temp: 10
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
