### PR TITLE
Fix Issue #16364 dev-doc: Documentation empty

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,8 @@
+# .readthedocs.yml
+
+build:
+  image: latest
+
+python:
+  version: 3.6
+  setup_py_install: true


### PR DESCRIPTION
## Description:
Add readthedoc.yml file to specify the version of python to run during documentation building.

Read the docs was building documentation in Python 3.5.2 which was causing:
WARNING: autodoc: failed to import module 'homeassistant.bootstrap'; the following exception was raised:
cannot import name 'Coroutine'

Read the docs allows you to specify the required version of python by using a yaml file. https://docs.readthedocs.io/en/latest/yaml-config.html

**Related issue (if applicable):** fixes #16364

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:

If the code communicates with devices, web services, or third-party tools:

If the code does not interact with devices:.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
