### PR TITLE
ryobi python module was deleted

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -458,7 +458,6 @@ omit =
     homeassistant/components/cover/myq.py
     homeassistant/components/cover/opengarage.py
     homeassistant/components/cover/rpi_gpio.py
-    homeassistant/components/cover/ryobi_gdo.py
     homeassistant/components/cover/scsgate.py
     homeassistant/components/device_tracker/actiontec.py
     homeassistant/components/device_tracker/aruba.py


### PR DESCRIPTION
The builds are failing due to missing requirement.
See https://github.com/home-assistant/home-assistant/pull/17637