### PR TITLE
Remove ryobi from .coveragerc

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -458,7 +458,6 @@ omit =
     homeassistant/components/cover/myq.py
     homeassistant/components/cover/opengarage.py
     homeassistant/components/cover/rpi_gpio.py
-    homeassistant/components/cover/ryobi_gdo.py
     homeassistant/components/cover/scsgate.py
     homeassistant/components/device_tracker/actiontec.py
     homeassistant/components/device_tracker/aruba.py


### PR DESCRIPTION
## Description:
Remove ryobi from .coveragerc

See pr #17637
