### PR TITLE
Reconnect if sub info comes in that is valid again

### DIFF
--- a/homeassistant/components/cloud/__init__.py
+++ b/homeassistant/components/cloud/__init__.py
@@ -162,7 +162,7 @@ class Cloud:
     @property
     def subscription_expired(self):
         """Return a boolean if the subscription has expired."""
-        return dt_util.utcnow() > self.expiration_date + timedelta(days=3)
+        return dt_util.utcnow() > self.expiration_date + timedelta(days=7)
 
     @property
     def expiration_date(self):

--- a/homeassistant/components/cloud/auth_api.py
+++ b/homeassistant/components/cloud/auth_api.py
@@ -113,6 +113,24 @@ def check_token(cloud):
         raise _map_aws_exception(err)
 
 
+def renew_access_token(cloud):
+    """Renew access token."""
+    from botocore.exceptions import ClientError
+
+    cognito = _cognito(
+        cloud,
+        access_token=cloud.access_token,
+        refresh_token=cloud.refresh_token)
+
+    try:
+        cognito.renew_access_token()
+        cloud.id_token = cognito.id_token
+        cloud.access_token = cognito.access_token
+        cloud.write_user_info()
+    except ClientError as err:
+        raise _map_aws_exception(err)
+
+
 def _authenticate(cloud, email, password):
     """Log in and return an authenticated Cognito instance."""
     from botocore.exceptions import ClientError

--- a/tests/components/cloud/test_init.py
+++ b/tests/components/cloud/test_init.py
@@ -155,14 +155,14 @@ def test_subscription_expired(hass):
     with patch.object(cl, '_decode_claims', return_value=token_val), \
             patch('homeassistant.util.dt.utcnow',
                   return_value=utcnow().replace(
-                      year=2017, month=11, day=15, hour=23, minute=59,
+                      year=2017, month=11, day=19, hour=23, minute=59,
                       second=59)):
         assert not cl.subscription_expired
 
     with patch.object(cl, '_decode_claims', return_value=token_val), \
             patch('homeassistant.util.dt.utcnow',
                   return_value=utcnow().replace(
-                      year=2017, month=11, day=16, hour=0, minute=0,
+                      year=2017, month=11, day=20, hour=0, minute=0,
                       second=0)):
         assert cl.subscription_expired
 


### PR DESCRIPTION
## Description:
Have the cloud connection automatically reconnect if it's disconnected and it fetches sub info that indicates that the sub is valid.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
