### PR TITLE
Upgrade async_timeout to 3.0.1

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -1,6 +1,6 @@
 aiohttp==3.4.4
 astral==1.6.1
-async_timeout==3.0.0
+async_timeout==3.0.1
 attrs==18.2.0
 bcrypt==3.1.4
 certifi>=2018.04.16

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1,7 +1,7 @@
 # Home Assistant core
 aiohttp==3.4.4
 astral==1.6.1
-async_timeout==3.0.0
+async_timeout==3.0.1
 attrs==18.2.0
 bcrypt==3.1.4
 certifi>=2018.04.16

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ PACKAGES = find_packages(exclude=['tests', 'tests.*'])
 REQUIRES = [
     'aiohttp==3.4.4',
     'astral==1.6.1',
-    'async_timeout==3.0.0',
+    'async_timeout==3.0.1',
     'attrs==18.2.0',
     'bcrypt==3.1.4',
     'certifi>=2018.04.16',


### PR DESCRIPTION
## Description:
Changelog: https://github.com/aio-libs/async-timeout/blob/master/CHANGES.rst#301-2018-10-09

## Example entry for `configuration.yaml` (if applicable):
```yaml
http:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

