### PR TITLE
Add support for Lupusec alarm control panel

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -200,6 +200,9 @@ omit =
     homeassistant/components/logi_circle.py
     homeassistant/components/*/logi_circle.py
 
+    homeassistant/components/lupusec.py
+    homeassistant/components/*/lupusec.py
+
     homeassistant/components/lutron.py
     homeassistant/components/*/lutron.py
 

--- a/homeassistant/components/alarm_control_panel/lupusec.py
+++ b/homeassistant/components/alarm_control_panel/lupusec.py
@@ -10,7 +10,6 @@ from datetime import timedelta
 from homeassistant.components.alarm_control_panel import AlarmControlPanel
 from homeassistant.components.lupusec import DOMAIN as LUPUSEC_DOMAIN
 from homeassistant.components.lupusec import LupusecDevice
-
 from homeassistant.const import (STATE_ALARM_ARMED_AWAY,
                                  STATE_ALARM_ARMED_HOME,
                                  STATE_ALARM_DISARMED)
@@ -24,9 +23,12 @@ SCAN_INTERVAL = timedelta(seconds=2)
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up an alarm control panel for a Lupusec device."""
+    if discovery_info is None:
+        return
+
     data = hass.data[LUPUSEC_DOMAIN]
 
-    alarm_devices = [LupusecAlarm(data, data.lupusec.get_alarm(), data.name)]
+    alarm_devices = [LupusecDevice(data, data.lupusec.get_alarm())]
 
     add_entities(alarm_devices)
 
@@ -34,9 +36,9 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class LupusecAlarm(LupusecDevice, AlarmControlPanel):
     """An alarm_control_panel implementation for Lupusec."""
 
-    def __init__(self, data, device):
-        """Initialize the alarm control panel."""
-        super().__init__(data, device)
+    # def __init__(self, data, device):
+    #     """Initialize the alarm control panel."""
+    #     super().__init__(data, device)
 
     @property
     def icon(self):

--- a/homeassistant/components/alarm_control_panel/lupusec.py
+++ b/homeassistant/components/alarm_control_panel/lupusec.py
@@ -5,6 +5,8 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/alarm_control_panel.lupusec/
 """
 
+from datetime import timedelta
+
 from homeassistant.components.alarm_control_panel import AlarmControlPanel
 from homeassistant.components.lupusec import DOMAIN as LUPUSEC_DOMAIN
 from homeassistant.components.lupusec import LupusecDevice
@@ -17,6 +19,7 @@ DEPENDENCIES = ['lupusec']
 
 ICON = 'mdi:security'
 
+SCAN_INTERVAL = timedelta(seconds=2)
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up an alarm control panel for a Lupusec device."""

--- a/homeassistant/components/alarm_control_panel/lupusec.py
+++ b/homeassistant/components/alarm_control_panel/lupusec.py
@@ -5,14 +5,9 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/alarm_control_panel.lupusec/
 """
 
-from datetime import timedelta
-
 from homeassistant.components.alarm_control_panel import AlarmControlPanel
 from homeassistant.components.lupusec import DOMAIN as LUPUSEC_DOMAIN
-from homeassistant.components.lupusec import SCAN_INTERVAL as SCAN_INTERVAL
 from homeassistant.components.lupusec import LupusecDevice
-
-import homeassistant.util.dt as dt_util
 
 from homeassistant.const import (STATE_ALARM_ARMED_AWAY,
                                  STATE_ALARM_ARMED_HOME,
@@ -29,8 +24,6 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     alarm_devices = [LupusecAlarm(data, data.lupusec.get_alarm(), data.name)]
 
-    # data.devices.extend(alarm_devices)
-
     add_entities(alarm_devices)
 
 
@@ -40,9 +33,6 @@ class LupusecAlarm(LupusecDevice, AlarmControlPanel):
     def __init__(self, data, device, name):
         """Initialize the alarm control panel."""
         super().__init__(data, device)
-        # self._state = STATE_ALARM_DISARMED
-        # self._previous_state = ''
-        # self._state_ts = ''
 
     @property
     def icon(self):

--- a/homeassistant/components/alarm_control_panel/lupusec.py
+++ b/homeassistant/components/alarm_control_panel/lupusec.py
@@ -28,17 +28,13 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     data = hass.data[LUPUSEC_DOMAIN]
 
-    alarm_devices = [LupusecDevice(data, data.lupusec.get_alarm())]
+    alarm_devices = [LupusecAlarm(data, data.lupusec.get_alarm())]
 
     add_entities(alarm_devices)
 
 
 class LupusecAlarm(LupusecDevice, AlarmControlPanel):
     """An alarm_control_panel implementation for Lupusec."""
-
-    # def __init__(self, data, device):
-    #     """Initialize the alarm control panel."""
-    #     super().__init__(data, device)
 
     @property
     def icon(self):

--- a/homeassistant/components/alarm_control_panel/lupusec.py
+++ b/homeassistant/components/alarm_control_panel/lupusec.py
@@ -34,7 +34,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class LupusecAlarm(LupusecDevice, AlarmControlPanel):
     """An alarm_control_panel implementation for Lupusec."""
 
-    def __init__(self, data, device, name):
+    def __init__(self, data, device):
         """Initialize the alarm control panel."""
         super().__init__(data, device)
 

--- a/homeassistant/components/alarm_control_panel/lupusec.py
+++ b/homeassistant/components/alarm_control_panel/lupusec.py
@@ -1,0 +1,90 @@
+"""
+This component provides HA alarm_control_panel support for Lupusec System.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/alarm_control_panel.lupusec/
+"""
+
+from datetime import timedelta
+
+from homeassistant.components.alarm_control_panel import AlarmControlPanel
+from homeassistant.components.lupusec import LupusecDevice
+
+import homeassistant.util.dt as dt_util
+
+from homeassistant.const import (STATE_ALARM_ARMED_AWAY,
+                                 STATE_ALARM_ARMED_HOME,
+                                 STATE_ALARM_DISARMED)
+
+DEPENDENCIES = ['lupusec']
+DOMAIN = 'lupusec'
+ICON = 'mdi:security'
+
+SCAN_INTERVAL = timedelta(seconds=2)
+
+
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    """Set up an alarm control panel for a Lupusec device."""
+    data = hass.data[DOMAIN]
+
+    alarm_devices = [LupusecAlarm(data, data.lupusec.get_alarm(), data.name)]
+
+    data.devices.extend(alarm_devices)
+
+    add_entities(alarm_devices)
+
+
+class LupusecAlarm(LupusecDevice, AlarmControlPanel):
+    """An alarm_control_panel implementation for Lupusec."""
+
+    def __init__(self, data, device, name):
+        """Initialize the alarm control panel."""
+        super().__init__(data, device)
+        self._name = name
+        self._state = STATE_ALARM_DISARMED
+        self._previous_state = ''
+        self._state_ts = ''
+
+    @property
+    def icon(self):
+        """Return the icon."""
+        return ICON
+
+    @property
+    def state(self):
+        """Return the state of the device."""
+        if self._device.is_standby:
+            state = STATE_ALARM_DISARMED
+        elif self._device.is_away:
+            state = STATE_ALARM_ARMED_AWAY
+        elif self._device.is_home:
+            state = STATE_ALARM_ARMED_HOME
+        else:
+            state = None
+        return state
+
+    def alarm_arm_away(self, code=None):
+        """Send arm away command."""
+        self._device.set_away()
+        self._update_state(STATE_ALARM_ARMED_AWAY)
+
+    def alarm_disarm(self, code=None):
+        """Send disarm command."""
+        self._device.set_standby()
+        self._update_state(STATE_ALARM_DISARMED)
+
+    def alarm_arm_home(self, code=None):
+        """Send arm home command."""
+        self._device.set_home()
+        self._update_state(STATE_ALARM_ARMED_HOME)
+
+    def _update_state(self, state):
+        """Update the state."""
+        if self._state == state:
+            return
+        self._previous_state = self._state
+        self._state = state
+        self._state_ts = dt_util.utcnow()
+        self.schedule_update_ha_state()
+
+        # self.async_update_ha_state

--- a/homeassistant/components/alarm_control_panel/lupusec.py
+++ b/homeassistant/components/alarm_control_panel/lupusec.py
@@ -29,7 +29,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     alarm_devices = [LupusecAlarm(data, data.lupusec.get_alarm(), data.name)]
 
-    data.devices.extend(alarm_devices)
+    # data.devices.extend(alarm_devices)
 
     add_entities(alarm_devices)
 
@@ -40,9 +40,9 @@ class LupusecAlarm(LupusecDevice, AlarmControlPanel):
     def __init__(self, data, device, name):
         """Initialize the alarm control panel."""
         super().__init__(data, device)
-        self._state = STATE_ALARM_DISARMED
-        self._previous_state = ''
-        self._state_ts = ''
+        # self._state = STATE_ALARM_DISARMED
+        # self._previous_state = ''
+        # self._state_ts = ''
 
     @property
     def icon(self):

--- a/homeassistant/components/alarm_control_panel/lupusec.py
+++ b/homeassistant/components/alarm_control_panel/lupusec.py
@@ -21,6 +21,7 @@ ICON = 'mdi:security'
 
 SCAN_INTERVAL = timedelta(seconds=2)
 
+
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up an alarm control panel for a Lupusec device."""
     data = hass.data[LUPUSEC_DOMAIN]

--- a/homeassistant/components/alarm_control_panel/lupusec.py
+++ b/homeassistant/components/alarm_control_panel/lupusec.py
@@ -8,6 +8,8 @@ https://home-assistant.io/components/alarm_control_panel.lupusec/
 from datetime import timedelta
 
 from homeassistant.components.alarm_control_panel import AlarmControlPanel
+from homeassistant.components.lupusec import DOMAIN as LUPUSEC_DOMAIN
+from homeassistant.components.lupusec import SCAN_INTERVAL as SCAN_INTERVAL
 from homeassistant.components.lupusec import LupusecDevice
 
 import homeassistant.util.dt as dt_util
@@ -17,15 +19,13 @@ from homeassistant.const import (STATE_ALARM_ARMED_AWAY,
                                  STATE_ALARM_DISARMED)
 
 DEPENDENCIES = ['lupusec']
-DOMAIN = 'lupusec'
-ICON = 'mdi:security'
 
-SCAN_INTERVAL = timedelta(seconds=2)
+ICON = 'mdi:security'
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up an alarm control panel for a Lupusec device."""
-    data = hass.data[DOMAIN]
+    data = hass.data[LUPUSEC_DOMAIN]
 
     alarm_devices = [LupusecAlarm(data, data.lupusec.get_alarm(), data.name)]
 
@@ -40,7 +40,6 @@ class LupusecAlarm(LupusecDevice, AlarmControlPanel):
     def __init__(self, data, device, name):
         """Initialize the alarm control panel."""
         super().__init__(data, device)
-        self._name = name
         self._state = STATE_ALARM_DISARMED
         self._previous_state = ''
         self._state_ts = ''
@@ -66,25 +65,11 @@ class LupusecAlarm(LupusecDevice, AlarmControlPanel):
     def alarm_arm_away(self, code=None):
         """Send arm away command."""
         self._device.set_away()
-        self._update_state(STATE_ALARM_ARMED_AWAY)
 
     def alarm_disarm(self, code=None):
         """Send disarm command."""
         self._device.set_standby()
-        self._update_state(STATE_ALARM_DISARMED)
 
     def alarm_arm_home(self, code=None):
         """Send arm home command."""
         self._device.set_home()
-        self._update_state(STATE_ALARM_ARMED_HOME)
-
-    def _update_state(self, state):
-        """Update the state."""
-        if self._state == state:
-            return
-        self._previous_state = self._state
-        self._state = state
-        self._state_ts = dt_util.utcnow()
-        self.schedule_update_ha_state()
-
-        # self.async_update_ha_state

--- a/homeassistant/components/binary_sensor/lupusec.py
+++ b/homeassistant/components/binary_sensor/lupusec.py
@@ -6,11 +6,15 @@ https://home-assistant.io/components/binary_sensor.lupusec/
 """
 import logging
 
+from datetime import timedelta
+
 from homeassistant.components.lupusec import (LupusecDevice,
                                               DOMAIN as LUPUSEC_DOMAIN)
-from homeassistant.components.binary_sensor import BinarySensorDevice
+from homeassistant.components.binary_sensor import BinarySensorDevice, DEVICE_CLASSES
 
 DEPENDENCIES = ['lupusec']
+
+SCAN_INTERVAL = timedelta(seconds=2)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -27,7 +31,6 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     for device in data.lupusec.get_devices(generic_type=device_types):
         devices.append(LupusecBinarySensor(data, device))
 
-    data.devices.extend(devices)
     add_entities(devices)
 
 
@@ -42,4 +45,8 @@ class LupusecBinarySensor(LupusecDevice, BinarySensorDevice):
     @property
     def device_class(self):
         """Return the class of the binary sensor."""
-        return self._device.generic_type
+        if self._device.generic_type in DEVICE_CLASSES:
+            return self._device.generic_type
+        else:
+            _LOGGER.error('Binary sensor device class not known')
+            return False

--- a/homeassistant/components/binary_sensor/lupusec.py
+++ b/homeassistant/components/binary_sensor/lupusec.py
@@ -1,0 +1,47 @@
+"""
+This component provides HA binary_sensor support for Lupusec Security System.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/binary_sensor.lupusec/
+"""
+import logging
+from datetime import timedelta
+
+from homeassistant.components.lupusec import (LupusecDevice,
+                                              DOMAIN as LUPUSEC_DOMAIN)
+from homeassistant.components.binary_sensor import BinarySensorDevice
+
+DEPENDENCIES = ['lupusec']
+SCAN_INTERVAL = timedelta(seconds=2)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    """Set up a sensor for an Lupusec device."""
+    import lupupy.constants as CONST
+
+    data = hass.data[LUPUSEC_DOMAIN]
+
+    device_types = [CONST.TYPE_OPENING]
+
+    devices = []
+    for device in data.lupusec.get_devices(generic_type=device_types):
+        devices.append(LupusecBinarySensor(data, device))
+
+    data.devices.extend(devices)
+    add_entities(devices)
+
+
+class LupusecBinarySensor(LupusecDevice, BinarySensorDevice):
+    """A binary sensor implementation for Lupusec device."""
+
+    @property
+    def is_on(self):
+        """Return True if the binary sensor is on."""
+        return self._device.is_on
+
+    @property
+    def device_class(self):
+        """Return the class of the binary sensor."""
+        return self._device.type

--- a/homeassistant/components/binary_sensor/lupusec.py
+++ b/homeassistant/components/binary_sensor/lupusec.py
@@ -8,7 +8,6 @@ import logging
 
 from homeassistant.components.lupusec import (LupusecDevice,
                                               DOMAIN as LUPUSEC_DOMAIN)
-from homeassistant.components.lupusec import SCAN_INTERVAL as SCAN_INTERVAL
 from homeassistant.components.binary_sensor import BinarySensorDevice
 
 DEPENDENCIES = ['lupusec']

--- a/homeassistant/components/binary_sensor/lupusec.py
+++ b/homeassistant/components/binary_sensor/lupusec.py
@@ -10,7 +10,8 @@ from datetime import timedelta
 
 from homeassistant.components.lupusec import (LupusecDevice,
                                               DOMAIN as LUPUSEC_DOMAIN)
-from homeassistant.components.binary_sensor import BinarySensorDevice, DEVICE_CLASSES
+from homeassistant.components.binary_sensor import (BinarySensorDevice,
+                                                    DEVICE_CLASSES)
 
 DEPENDENCIES = ['lupusec']
 

--- a/homeassistant/components/binary_sensor/lupusec.py
+++ b/homeassistant/components/binary_sensor/lupusec.py
@@ -5,7 +5,6 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/binary_sensor.lupusec/
 """
 import logging
-
 from datetime import timedelta
 
 from homeassistant.components.lupusec import (LupusecDevice,
@@ -22,6 +21,9 @@ _LOGGER = logging.getLogger(__name__)
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up a sensor for an Lupusec device."""
+    if discovery_info is None:
+        return
+
     import lupupy.constants as CONST
 
     data = hass.data[LUPUSEC_DOMAIN]

--- a/homeassistant/components/binary_sensor/lupusec.py
+++ b/homeassistant/components/binary_sensor/lupusec.py
@@ -47,5 +47,5 @@ class LupusecBinarySensor(LupusecDevice, BinarySensorDevice):
     def device_class(self):
         """Return the class of the binary sensor."""
         if self._device.generic_type not in DEVICE_CLASSES:
-            return False
+            return None
         return self._device.generic_type

--- a/homeassistant/components/binary_sensor/lupusec.py
+++ b/homeassistant/components/binary_sensor/lupusec.py
@@ -47,6 +47,5 @@ class LupusecBinarySensor(LupusecDevice, BinarySensorDevice):
     def device_class(self):
         """Return the class of the binary sensor."""
         if self._device.generic_type not in DEVICE_CLASSES:
-            _LOGGER.error('Binary sensor device class not known')
-        else:
-            return self._device.generic_type
+            return False
+        return self._device.generic_type

--- a/homeassistant/components/binary_sensor/lupusec.py
+++ b/homeassistant/components/binary_sensor/lupusec.py
@@ -43,4 +43,4 @@ class LupusecBinarySensor(LupusecDevice, BinarySensorDevice):
     @property
     def device_class(self):
         """Return the class of the binary sensor."""
-        return self._device.type
+        return self._device.generic_type

--- a/homeassistant/components/binary_sensor/lupusec.py
+++ b/homeassistant/components/binary_sensor/lupusec.py
@@ -46,8 +46,7 @@ class LupusecBinarySensor(LupusecDevice, BinarySensorDevice):
     @property
     def device_class(self):
         """Return the class of the binary sensor."""
-        if self._device.generic_type in DEVICE_CLASSES:
-            return self._device.generic_type
-        else:
+        if self._device.generic_type not in DEVICE_CLASSES:
             _LOGGER.error('Binary sensor device class not known')
-            return False
+        else:
+            return self._device.generic_type

--- a/homeassistant/components/binary_sensor/lupusec.py
+++ b/homeassistant/components/binary_sensor/lupusec.py
@@ -5,14 +5,13 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/binary_sensor.lupusec/
 """
 import logging
-from datetime import timedelta
 
 from homeassistant.components.lupusec import (LupusecDevice,
                                               DOMAIN as LUPUSEC_DOMAIN)
+from homeassistant.components.lupusec import SCAN_INTERVAL as SCAN_INTERVAL
 from homeassistant.components.binary_sensor import BinarySensorDevice
 
 DEPENDENCIES = ['lupusec']
-SCAN_INTERVAL = timedelta(seconds=2)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/lupusec.py
+++ b/homeassistant/components/lupusec.py
@@ -5,7 +5,6 @@ For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/lupusec
 """
 
-from datetime import timedelta
 import logging
 
 import voluptuous as vol

--- a/homeassistant/components/lupusec.py
+++ b/homeassistant/components/lupusec.py
@@ -12,15 +12,13 @@ import voluptuous as vol
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import discovery
 from homeassistant.const import (CONF_USERNAME, CONF_PASSWORD,
-                                 CONF_NAME, CONF_IP_ADDRESS,
-                                 CONF_SCAN_INTERVAL)
+                                 CONF_NAME, CONF_IP_ADDRESS)
 from homeassistant.helpers.entity import Entity
 _LOGGER = logging.getLogger(__name__)
 
 REQUIREMENTS = ['lupupy==0.0.10']
 
 DOMAIN = 'lupusec'
-DEFAULT_SCAN_INTERVAL = timedelta(seconds=2)
 
 NOTIFICATION_ID = 'lupusec_notification'
 NOTIFICATION_TITLE = 'Lupusec Security Setup'
@@ -30,9 +28,7 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Required(CONF_USERNAME): cv.string,
         vol.Required(CONF_PASSWORD): cv.string,
         vol.Required(CONF_IP_ADDRESS): cv.string,
-        vol.Optional(CONF_NAME): cv.string,
-        vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL):
-            cv.time_period,
+        vol.Optional(CONF_NAME): cv.string
     }),
 }, extra=vol.ALLOW_EXTRA)
 
@@ -52,13 +48,12 @@ def setup(hass, config):
     password = conf[CONF_PASSWORD]
     ip_address = conf[CONF_IP_ADDRESS]
     name = conf.get(CONF_NAME)
-    SCAN_INTERVAL = conf.get(CONF_SCAN_INTERVAL)
 
     try:
         hass.data[DOMAIN] = LupusecSystem(username, password, ip_address, name)
     except LupusecException as ex:
         _LOGGER.warning(ex)
-        
+
         hass.components.persistent_notification.create(
             'Error: {}<br />'
             'You will need to restart hass after fixing.'
@@ -72,6 +67,7 @@ def setup(hass, config):
 
     return True
 
+
 class LupusecSystem:
     """Lupusec System class."""
 
@@ -81,6 +77,7 @@ class LupusecSystem:
         self.lupusec = lupupy.Lupusec(username, password, ip_address)
         self.name = name
         self.devices = []
+
 
 class LupusecDevice(Entity):
     """Representation of a Lupusec device."""

--- a/homeassistant/components/lupusec.py
+++ b/homeassistant/components/lupusec.py
@@ -1,0 +1,88 @@
+"""
+This component provides basic support for Lupusec Home Security system.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/lupusec
+"""
+
+from datetime import timedelta
+import logging
+import voluptuous as vol
+
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import discovery
+from homeassistant.const import (CONF_USERNAME, CONF_PASSWORD,
+                                 CONF_NAME, CONF_IP_ADDRESS,
+                                 CONF_SCAN_INTERVAL)
+from homeassistant.helpers.entity import Entity
+_LOGGER = logging.getLogger(__name__)
+
+REQUIREMENTS = ['lupupy==0.0.4']
+
+DOMAIN = 'lupusec'
+DEFAULT_SCAN_INTERVAL = timedelta(seconds=5)
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_USERNAME): cv.string,
+        vol.Required(CONF_PASSWORD): cv.string,
+        vol.Required(CONF_IP_ADDRESS): cv.string,
+        vol.Optional(CONF_NAME): cv.string,
+        vol.Optional(CONF_SCAN_INTERVAL): cv.string
+    }),
+}, extra=vol.ALLOW_EXTRA)
+
+LUPUS_PLATFORMS = [
+    'alarm_control_panel', 'binary_sensor', 'switch'
+]
+
+
+class LupusecSystem:
+    """Lupusec System class."""
+
+    def __init__(self, username, password, ip_address, name, get_devices=True):
+        """Initialize the system."""
+        import lupupy
+        self.lupusec = lupupy.Lupusec(username, password, ip_address)
+        self.name = name
+        self.devices = []
+
+
+def setup(hass, config):
+    """Set up Lupusec component."""
+    conf = config[DOMAIN]
+    username = conf.get(CONF_USERNAME)
+    password = conf.get(CONF_PASSWORD)
+    ip_address = conf.get(CONF_IP_ADDRESS)
+    name = conf.get(CONF_NAME)
+    try:
+        hass.data[DOMAIN] = LupusecSystem(username, password, ip_address, name)
+    except BaseException:
+        _LOGGER.error("Unable to setup Lupusec Panel.")
+
+    for platform in LUPUS_PLATFORMS:
+        discovery.load_platform(hass, platform, DOMAIN, {}, config)
+
+    return True
+
+
+class LupusecDevice(Entity):
+    """Representation of a Lupusec device."""
+
+    def __init__(self, data, device):
+        """Initialize a sensor for Lupusec device."""
+        self._data = data
+        self._device = device
+
+    def update(self):
+        """Update automation state."""
+        self._device.refresh()
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._device.name
+
+    def _update_callback(self, device):
+        """Update the device state."""
+        self.schedule_update_ha_state()

--- a/homeassistant/components/lupusec.py
+++ b/homeassistant/components/lupusec.py
@@ -17,10 +17,13 @@ from homeassistant.const import (CONF_USERNAME, CONF_PASSWORD,
 from homeassistant.helpers.entity import Entity
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['lupupy==0.0.5']
+REQUIREMENTS = ['lupupy==0.0.10']
 
 DOMAIN = 'lupusec'
 DEFAULT_SCAN_INTERVAL = timedelta(seconds=2)
+
+NOTIFICATION_ID = 'lupusec_notification'
+NOTIFICATION_TITLE = 'Lupusec Security Setup'
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
@@ -40,8 +43,6 @@ LUPUSEC_PLATFORMS = [
 ]
 
 
-
-
 def setup(hass, config):
     """Set up Lupusec component."""
     from lupupy.exceptions import LupusecException
@@ -57,6 +58,14 @@ def setup(hass, config):
         hass.data[DOMAIN] = LupusecSystem(username, password, ip_address, name)
     except LupusecException as ex:
         _LOGGER.warning(ex)
+        
+        hass.components.persistent_notification.create(
+            'Error: {}<br />'
+            'You will need to restart hass after fixing.'
+            ''.format(ex),
+            title=NOTIFICATION_TITLE,
+            notification_id=NOTIFICATION_ID)
+        return False
 
     for platform in LUPUSEC_PLATFORMS:
         discovery.load_platform(hass, platform, DOMAIN, {}, config)

--- a/homeassistant/components/lupusec.py
+++ b/homeassistant/components/lupusec.py
@@ -7,6 +7,7 @@ https://home-assistant.io/components/lupusec
 
 from datetime import timedelta
 import logging
+
 import voluptuous as vol
 
 from homeassistant.helpers import config_validation as cv
@@ -32,8 +33,6 @@ CONFIG_SCHEMA = vol.Schema({
     }),
 }, extra=vol.ALLOW_EXTRA)
 
-SCAN_INTERVAL = timedelta(seconds=2)
-
 LUPUSEC_PLATFORMS = [
     'alarm_control_panel', 'binary_sensor', 'switch'
 ]
@@ -52,7 +51,7 @@ def setup(hass, config):
     try:
         hass.data[DOMAIN] = LupusecSystem(username, password, ip_address, name)
     except LupusecException as ex:
-        _LOGGER.warning(ex)
+        _LOGGER.error(ex)
 
         hass.components.persistent_notification.create(
             'Error: {}<br />'
@@ -76,7 +75,6 @@ class LupusecSystem:
         import lupupy
         self.lupusec = lupupy.Lupusec(username, password, ip_address)
         self.name = name
-        self.devices = []
 
 
 class LupusecDevice(Entity):

--- a/homeassistant/components/lupusec.py
+++ b/homeassistant/components/lupusec.py
@@ -17,10 +17,10 @@ from homeassistant.const import (CONF_USERNAME, CONF_PASSWORD,
 from homeassistant.helpers.entity import Entity
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['lupupy==0.0.4']
+REQUIREMENTS = ['lupupy==0.0.5']
 
 DOMAIN = 'lupusec'
-DEFAULT_SCAN_INTERVAL = timedelta(seconds=5)
+DEFAULT_SCAN_INTERVAL = timedelta(seconds=2)
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
@@ -28,43 +28,50 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Required(CONF_PASSWORD): cv.string,
         vol.Required(CONF_IP_ADDRESS): cv.string,
         vol.Optional(CONF_NAME): cv.string,
-        vol.Optional(CONF_SCAN_INTERVAL): cv.string
+        vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL):
+            cv.time_period,
     }),
 }, extra=vol.ALLOW_EXTRA)
 
-LUPUS_PLATFORMS = [
+SCAN_INTERVAL = timedelta(seconds=2)
+
+LUPUSEC_PLATFORMS = [
     'alarm_control_panel', 'binary_sensor', 'switch'
 ]
 
 
+
+
+def setup(hass, config):
+    """Set up Lupusec component."""
+    from lupupy.exceptions import LupusecException
+
+    conf = config[DOMAIN]
+    username = conf[CONF_USERNAME]
+    password = conf[CONF_PASSWORD]
+    ip_address = conf[CONF_IP_ADDRESS]
+    name = conf.get(CONF_NAME)
+    SCAN_INTERVAL = conf.get(CONF_SCAN_INTERVAL)
+
+    try:
+        hass.data[DOMAIN] = LupusecSystem(username, password, ip_address, name)
+    except LupusecException as ex:
+        _LOGGER.warning(ex)
+
+    for platform in LUPUSEC_PLATFORMS:
+        discovery.load_platform(hass, platform, DOMAIN, {}, config)
+
+    return True
+
 class LupusecSystem:
     """Lupusec System class."""
 
-    def __init__(self, username, password, ip_address, name, get_devices=True):
+    def __init__(self, username, password, ip_address, name):
         """Initialize the system."""
         import lupupy
         self.lupusec = lupupy.Lupusec(username, password, ip_address)
         self.name = name
         self.devices = []
-
-
-def setup(hass, config):
-    """Set up Lupusec component."""
-    conf = config[DOMAIN]
-    username = conf.get(CONF_USERNAME)
-    password = conf.get(CONF_PASSWORD)
-    ip_address = conf.get(CONF_IP_ADDRESS)
-    name = conf.get(CONF_NAME)
-    try:
-        hass.data[DOMAIN] = LupusecSystem(username, password, ip_address, name)
-    except BaseException:
-        _LOGGER.error("Unable to setup Lupusec Panel.")
-
-    for platform in LUPUS_PLATFORMS:
-        discovery.load_platform(hass, platform, DOMAIN, {}, config)
-
-    return True
-
 
 class LupusecDevice(Entity):
     """Representation of a Lupusec device."""
@@ -82,7 +89,3 @@ class LupusecDevice(Entity):
     def name(self):
         """Return the name of the sensor."""
         return self._device.name
-
-    def _update_callback(self, device):
-        """Update the device state."""
-        self.schedule_update_ha_state()

--- a/homeassistant/components/switch/lupusec.py
+++ b/homeassistant/components/switch/lupusec.py
@@ -8,7 +8,6 @@ import logging
 
 from homeassistant.components.lupusec import (LupusecDevice,
                                               DOMAIN as LUPUSEC_DOMAIN)
-from homeassistant.components.lupusec import SCAN_INTERVAL as SCAN_INTERVAL
 from homeassistant.components.switch import SwitchDevice
 
 DEPENDENCIES = ['lupusec']

--- a/homeassistant/components/switch/lupusec.py
+++ b/homeassistant/components/switch/lupusec.py
@@ -1,0 +1,48 @@
+"""
+This component provides HA switch support for Lupusec Security System.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/switch.lupusec/
+"""
+import logging
+
+from homeassistant.components.lupusec import (LupusecDevice,
+                                              DOMAIN as LUPUSEC_DOMAIN)
+from homeassistant.components.switch import SwitchDevice
+
+DEPENDENCIES = ['lupusec']
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    """Set up Lupusec switch devices."""
+    import lupupy.constants as CONST
+
+    data = hass.data[LUPUSEC_DOMAIN]
+
+    devices = []
+
+    for device in data.lupusec.get_devices(generic_type=CONST.TYPE_SWITCH):
+
+        devices.append(LupusecSwitch(data, device))
+
+    data.devices.extend(devices)
+    add_entities(devices)
+
+
+class LupusecSwitch(LupusecDevice, SwitchDevice):
+    """Representation of an Lupusec switch."""
+
+    def turn_on(self, **kwargs):
+        """Turn on the device."""
+        self._device.switch_on()
+
+    def turn_off(self, **kwargs):
+        """Turn off the device."""
+        self._device.switch_off()
+
+    @property
+    def is_on(self):
+        """Return true if device is on."""
+        return self._device.is_on

--- a/homeassistant/components/switch/lupusec.py
+++ b/homeassistant/components/switch/lupusec.py
@@ -8,6 +8,7 @@ import logging
 
 from homeassistant.components.lupusec import (LupusecDevice,
                                               DOMAIN as LUPUSEC_DOMAIN)
+from homeassistant.components.lupusec import SCAN_INTERVAL as SCAN_INTERVAL
 from homeassistant.components.switch import SwitchDevice
 
 DEPENDENCIES = ['lupusec']
@@ -32,7 +33,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
 
 class LupusecSwitch(LupusecDevice, SwitchDevice):
-    """Representation of an Lupusec switch."""
+    """Representation of a Lupusec switch."""
 
     def turn_on(self, **kwargs):
         """Turn on the device."""

--- a/homeassistant/components/switch/lupusec.py
+++ b/homeassistant/components/switch/lupusec.py
@@ -5,7 +5,6 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/switch.lupusec/
 """
 import logging
-
 from datetime import timedelta
 
 from homeassistant.components.lupusec import (LupusecDevice,
@@ -21,6 +20,9 @@ _LOGGER = logging.getLogger(__name__)
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up Lupusec switch devices."""
+    if discovery_info is None:
+        return
+
     import lupupy.constants as CONST
 
     data = hass.data[LUPUSEC_DOMAIN]

--- a/homeassistant/components/switch/lupusec.py
+++ b/homeassistant/components/switch/lupusec.py
@@ -6,11 +6,15 @@ https://home-assistant.io/components/switch.lupusec/
 """
 import logging
 
+from datetime import timedelta
+
 from homeassistant.components.lupusec import (LupusecDevice,
                                               DOMAIN as LUPUSEC_DOMAIN)
 from homeassistant.components.switch import SwitchDevice
 
 DEPENDENCIES = ['lupusec']
+
+SCAN_INTERVAL = timedelta(seconds=2)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -27,7 +31,6 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
         devices.append(LupusecSwitch(data, device))
 
-    data.devices.extend(devices)
     add_entities(devices)
 
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -568,6 +568,9 @@ logi_circle==0.1.7
 # homeassistant.components.sensor.luftdaten
 luftdaten==0.2.0
 
+# homeassistant.components.lupusec
+lupupy==0.0.4
+
 # homeassistant.components.light.lw12wifi
 lw12==0.9.2
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -569,7 +569,7 @@ logi_circle==0.1.7
 luftdaten==0.2.0
 
 # homeassistant.components.lupusec
-lupupy==0.0.4
+lupupy==0.0.10
 
 # homeassistant.components.light.lw12wifi
 lw12==0.9.2


### PR DESCRIPTION
## Description:
Adds support for the alarm control panel of the german company Lupus electronics (second try, I reseted everything so here is my new PR).

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** https://github.com/home-assistant/home-assistant.io/pull/6601

## Example entry for `configuration.yaml` (if applicable):
```yaml
lupusec:
  username: user 
  password: 'greatpassword'
  ip_address: 192.168.178.35
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
