### PR TITLE
Add yeelink.light.lamp1model to miio light platform (Mi LED Desk Lamp) 

### DIFF
--- a/homeassistant/components/light/xiaomi_miio.py
+++ b/homeassistant/components/light/xiaomi_miio.py
@@ -818,4 +818,3 @@ class XiaomiMiDeskLamp(XiaomiAbstractLight):
         except DeviceException as ex:
             self._available = False
             _LOGGER.error("Got exception while fetching the state: %s", ex)
-

--- a/homeassistant/components/light/xiaomi_miio.py
+++ b/homeassistant/components/light/xiaomi_miio.py
@@ -781,7 +781,6 @@ class XiaomiMiDeskLamp(XiaomiAbstractLight):
 
             if result:
                 self._color_temp = color_temp
-
         elif ATTR_BRIGHTNESS in kwargs:
             brightness = kwargs[ATTR_BRIGHTNESS]
             percent_brightness = ceil(100 * brightness / 255.0)
@@ -796,7 +795,6 @@ class XiaomiMiDeskLamp(XiaomiAbstractLight):
 
             if result:
                 self._brightness = brightness
-
         else:
             await self._try_command(
                 "Turning the light on failed.", self._light.on)
@@ -814,7 +812,6 @@ class XiaomiMiDeskLamp(XiaomiAbstractLight):
 
             color_temp_mireds = int(1000000.0/float(state.color_temp))
             self._color_temp = color_temp_mireds
-
         except DeviceException as ex:
             self._available = False
             _LOGGER.error("Got exception while fetching the state: %s", ex)


### PR DESCRIPTION
## Description:

After getting a Mi LED Desk Lamp (MJTD01YL), I was very lost on how to get it to work with home assistant. The lamp is controlled with the same app as the Mi Robot Vacuum, and talks to the cloud.

![proxy duckduckgo com](https://user-images.githubusercontent.com/15332/47318782-4435c300-d64d-11e8-8b3b-c9b67bb08e39.jpeg)

After recovering the token with [the miio cli](https://github.com/aholstenson/miio), I went to home assistant Yeelight component, but realized it does not take a token in the configuration. I went then to the miio component, and it failed because it was an unrecognized model (_yeelink.light.lamp1_)

I noticed _python-miio_ has a _yeelight_ device class, so I added a new light that uses this device to control the light. I also refactored the naming a bit to make it less tied to "Philips" in the base classes.

## Example entry for `configuration.yaml` (if applicable):
```yaml
light:
  - platform: xiaomi_miio
    name: Mi LED Desk Lamp
    host: 192.168.178.119
    token: XXXXXXXXXXXXXXXXXXXXXXXXXXX
    model: yeelink.light.lamp1
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io): https://github.com/home-assistant/home-assistant.io/pull/7016

If the code communicates with devices, web services, or third-party tools:
  - [ ] ~~New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir])~~.
  - [ ] ~~New dependencies are only imported inside functions that use them ([example][ex-import])~~.
  - [ ] ~~New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`~~.
  - [ ] ~~New files were added to `.coveragerc`~~.

If the code does not interact with devices:
  - [ ] ~~Tests have been added to verify that the new code works~~.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
