### PR TITLE
Fixed bug

### DIFF
--- a/homeassistant/components/notify/clicksend.py
+++ b/homeassistant/components/notify/clicksend.py
@@ -69,7 +69,7 @@ class ClicksendNotificationService(BaseNotificationService):
         for recipient in self.recipients:
             data["messages"].append({
                 'source': 'hass.notify',
-                'from': self.sender,
+                'from': 'hass',
                 'to': recipient,
                 'body': message,
             })


### PR DESCRIPTION
From was sending the from number in an array which cannot be handled by the ClickSend system and causes a 500 error. Changed from to "hass" as from number/name can only be up to 11 characters with no special characters or spaces.
Bug was introduced 6 months ago when support for multiple recipients was added.

## Description:

Single line change removing a bug so that the From number in the sms sent is set to "hass" to correct sender array 500 error issue.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
notify:
  - platform: clicksend
    name: ClickSend
    username: xxxx
    api_key: xxxxx
    recipient: +61451111111
```

## Checklist:
  - [✓] The code change is tested and works locally.
  - [✓] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [✓] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [✓] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [✓] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [✓] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [✓] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [✓] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
