### PR TITLE
Bug fix for clicksend

### DIFF
--- a/homeassistant/components/notify/clicksend.py
+++ b/homeassistant/components/notify/clicksend.py
@@ -22,6 +22,8 @@ _LOGGER = logging.getLogger(__name__)
 
 BASE_API_URL = 'https://rest.clicksend.com/v3'
 
+DEFAULT_SENDER = 'hass'
+
 HEADERS = {CONTENT_TYPE: CONTENT_TYPE_JSON}
 
 
@@ -29,7 +31,7 @@ def validate_sender(config):
     """Set the optional sender name if sender name is not provided."""
     if CONF_SENDER in config:
         return config
-    config[CONF_SENDER] = 'hass'
+    config[CONF_SENDER] = DEFAULT_SENDER
     return config
 
 

--- a/homeassistant/components/notify/clicksend.py
+++ b/homeassistant/components/notify/clicksend.py
@@ -29,7 +29,7 @@ def validate_sender(config):
     """Set the optional sender name if sender name is not provided."""
     if CONF_SENDER in config:
         return config
-    config[CONF_SENDER] = config[CONF_RECIPIENT]
+    config[CONF_SENDER] = 'hass'
     return config
 
 
@@ -61,7 +61,7 @@ class ClicksendNotificationService(BaseNotificationService):
         self.username = config.get(CONF_USERNAME)
         self.api_key = config.get(CONF_API_KEY)
         self.recipients = config.get(CONF_RECIPIENT)
-        self.sender = config.get(CONF_SENDER, CONF_RECIPIENT)
+        self.sender = config.get(CONF_SENDER)
 
     def send_message(self, message="", **kwargs):
         """Send a message to a user."""
@@ -69,7 +69,7 @@ class ClicksendNotificationService(BaseNotificationService):
         for recipient in self.recipients:
             data["messages"].append({
                 'source': 'hass.notify',
-                'from': 'hass',
+                'from': self.sender,
                 'to': recipient,
                 'body': message,
             })

--- a/homeassistant/components/notify/clicksend.py
+++ b/homeassistant/components/notify/clicksend.py
@@ -69,7 +69,7 @@ class ClicksendNotificationService(BaseNotificationService):
         for recipient in self.recipients:
             data["messages"].append({
                 'source': 'hass.notify',
-                'from': self.sender,
+                'from': 'hass',
                 'to': recipient,
                 'body': message,
             })


### PR DESCRIPTION
Current version causes 500 error since it is sending an array of from numbers to ClickSend. Changing the from number to 'hass' identifies all messages as coming from Home Assistant making them more recognisable and removes the bug.

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Checklist:
  - [✓] The code change is tested and works locally.
  - [✓] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [✓] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [✓] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [✓] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [✓] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [✓] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
