### PR TITLE
Just use debug instead of error if the binary_sensor in openuv does not get data

### DIFF
--- a/homeassistant/components/openuv/__init__.py
+++ b/homeassistant/components/openuv/__init__.py
@@ -210,7 +210,7 @@ class OpenUV:
             if data.get('from_time') and data.get('to_time'):
                 self.data[DATA_PROTECTION_WINDOW] = data
             else:
-                _LOGGER.error(
+                _LOGGER.debug(
                     'No valid protection window data for this location')
                 self.data[DATA_PROTECTION_WINDOW] = {}
 


### PR DESCRIPTION
## Description:
This will make the unnecessary error spamming go away in log.

**Related issue (if applicable):** fixes #17716

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**