### PR TITLE
deconz: allow setting both entity and field in deconz.configure

### DIFF
--- a/homeassistant/components/deconz/services.yaml
+++ b/homeassistant/components/deconz/services.yaml
@@ -1,12 +1,15 @@
 configure:
   description: Set attribute of device in deCONZ. See https://home-assistant.io/components/deconz/#device-services for details.
   fields:
-    field:
-      description: Field is a string representing a specific device in deCONZ.
-      example: '/lights/1/state'
     entity:
       description: Entity id representing a specific device in deCONZ.
       example: 'light.rgb_light'
+    field:
+      description: >-
+        Field is a string representing a full path to deCONZ endpoint (when
+        entity is not specified) or a subpath of the device path for the
+        entity (when entity is specified).
+      example: '"/lights/1/state" or "/state"'
     data:
       description: Data is a json object with what data you want to alter.
       example: '{"on": true}'


### PR DESCRIPTION
## Description:

*Problem*:

Currently the `deconz.configure` service allows either specifying a `field` or an `entity`, but not both. This makes it impossible to set states in deCONZ when all you have is an entity id (think AppDaemon or other automations), since an `entity` will resolve to a device path such as `/lights/1` (that you can use to change configuration attributes such as the device name) and in order to change states you need to do a `PUT` to `/lights/1/state`.

*Motivation*:

Why setting states via `deconz.configure` instead of (for example) `light.turn_on`? Because right now the feature of increasing/decreasing a light's current brightness (or color temperature) which is exposed by deCONZ (which is actually from the Hue bridge API so it applies to the Hue bridge as well) via the `bri_inc` (and `ct_inc`) attributes is not accessible via the `light` platform.

Two examples of why it's necessary to use this:

1. This is essential to implement a remote control that can smoothly control the lights in HASS, because for example when you hold a "increase brightness" button you want to tell the light to increase its brightness to the max with a transition of (let's say) 5 seconds (`bri_inc: 254, transitiontime: 50`)  and when the button is released you send `bri_inc: 0` (also defined by Hue API) to tell the light to stop the fade (this gets translated to a Zigbee "stop" command). Right now via the `light` platform you can only set explicit brightness targets, and you have to do that in a loop, however this tends to overload the Zigbee network and it's not smooth. The algorithm I describe is how remote controls manage to implement smooth fades with just two Zigbee commands (one to start, one to stop).

2. Some lights such as IKEA trådfri have firmware bugs in which they fail to respond to commands in case they're in the middle of a long transition (https://github.com/dresden-elektronik/deconz-rest-plugin/issues/894). Sending `bri_inc: 0` (which gets translated into a "stop" command in the Zigbee layer) can "ressurect" the lamp. Right now you can't send such a command from HASS, which is useful when you need to work around these kinds of firmware bugs.

However, I'm going to submit a separate WIP PR to introduce that feature (fading brightness/temperature) on the `light` platform. This PR is about offering a way to set state attributes that exist in the Hue/deCONZ API that for whatever reason are not (yet) exposed in "higher-level" platforms, and all you have is the entity id and do not know the device path. I believe that is even the original intent, since the documentation explicitly refers to `/lights/1/state` and the fact you can't do that by specifying an entity was probably an oversight.

*Solution*:

Allow both `entity` and `field` to be set simultaneously. This won't break any existing setups because they're currently mutually exclusive. If you set them both, `entity` is used to resolve the device path and `field` is added as a subpath. In this way you can set state attributes by setting:

```
{ "entity": "light.name", "field": "/state", "data": { ... } }
```

I also considered introducing a new service such as `deconz.put_state` but I deemed it not to be necessary and probably redundant, given the above. Personally I have no strong preference to one way or another, so I can do that if you believe it's a superior alternative.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** https://github.com/home-assistant/home-assistant.io/pull/7078

## Example entry for `configuration.yaml` (if applicable):

N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] ~New dependencies have been added to the `REQUIREMENTS` variable~ N/A
  - [ ] ~New dependencies are only imported inside functions that use them~ N/A
  - [ ] ~New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`~ N/A
  - [ ] ~New files were added to `.coveragerc`~ N/A

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.
