### PR TITLE
0.81 beta Z-Wave Cover Fix

### DIFF
--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -66,7 +66,7 @@ DEFAULT_CONF_INVERT_OPENCLOSE_BUTTONS = False
 DEFAULT_CONF_REFRESH_VALUE = False
 DEFAULT_CONF_REFRESH_DELAY = 5
 
-SUPPORTED_PLATFORMS = ['binary_sensor', 'climate', 'fan',
+SUPPORTED_PLATFORMS = ['binary_sensor', 'climate', 'cover', 'fan',
                        'light', 'sensor', 'switch']
 
 RENAME_NODE_SCHEMA = vol.Schema({


### PR DESCRIPTION
## Description:
The `cover` domain was left out of the supported platforms list when I migrated Z-Wave over to config entries, so no cover entities were generated. This should fix that.

**Related issue (if applicable):** fixes #17710

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
zwave:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
