### PR TITLE
Remove webhook_id from yaml config for mailgun

### DIFF
--- a/homeassistant/components/mailgun/__init__.py
+++ b/homeassistant/components/mailgun/__init__.py
@@ -23,7 +23,6 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Required(CONF_API_KEY): cv.string,
         vol.Required(CONF_DOMAIN): cv.string,
         vol.Optional(CONF_SANDBOX, default=DEFAULT_SANDBOX): cv.boolean,
-        vol.Optional(CONF_WEBHOOK_ID): cv.string,
     }),
 }, extra=vol.ALLOW_EXTRA)
 


### PR DESCRIPTION
## Description:

In #17464, I migrated Mailgun to use the webhook component. While doing that, I accidentally added the `webhook_id` as a yaml configuration option (in addition to it being handled by the configuration entry system. This needs to be removed as the component will never actually use it. This behavior was never documented (and not released yet) so no documentation changes should be needed.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
