### PR TITLE
Remove day (fixes #17741)

### DIFF
--- a/homeassistant/components/sensor/fastdotcom.py
+++ b/homeassistant/components/sensor/fastdotcom.py
@@ -22,7 +22,6 @@ _LOGGER = logging.getLogger(__name__)
 CONF_SECOND = 'second'
 CONF_MINUTE = 'minute'
 CONF_HOUR = 'hour'
-CONF_DAY = 'day'
 CONF_MANUAL = 'manual'
 
 ICON = 'mdi:speedometer'
@@ -34,8 +33,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
         vol.All(cv.ensure_list, [vol.All(vol.Coerce(int), vol.Range(0, 59))]),
     vol.Optional(CONF_HOUR):
         vol.All(cv.ensure_list, [vol.All(vol.Coerce(int), vol.Range(0, 23))]),
-    vol.Optional(CONF_DAY):
-        vol.All(cv.ensure_list, [vol.All(vol.Coerce(int), vol.Range(1, 31))]),
     vol.Optional(CONF_MANUAL, default=False): cv.boolean,
 })
 
@@ -109,8 +106,7 @@ class SpeedtestData:
         if not config.get(CONF_MANUAL):
             track_time_change(
                 hass, self.update, second=config.get(CONF_SECOND),
-                minute=config.get(CONF_MINUTE), hour=config.get(CONF_HOUR),
-                day=config.get(CONF_DAY))
+                minute=config.get(CONF_MINUTE), hour=config.get(CONF_HOUR))
 
     def update(self, now):
         """Get the latest data from fast.com."""


### PR DESCRIPTION
## Description:
This removes the day configuration. As `day` was removed with #17199.

**Breaking change**: The configuration option `day` has been removed from the `fastdotcom` sensor.

**Related issue (if applicable):** fixes #17741

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#7040

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: fastdotcom
    minute:
      - 0
      - 30
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)
