### PR TITLE
Correct expose_by_default interaction with expose_domains

### DIFF
--- a/homeassistant/components/google_assistant/http.py
+++ b/homeassistant/components/google_assistant/http.py
@@ -42,7 +42,7 @@ def async_register_http(hass, cfg):
             entity_config.get(entity.entity_id, {}).get(CONF_EXPOSE)
 
         domain_exposed_by_default = \
-            expose_by_default and entity.domain in exposed_domains
+            expose_by_default or entity.domain in exposed_domains
 
         # Expose an entity if the entity's domain is exposed by default and
         # the configuration doesn't explicitly exclude it from being


### PR DESCRIPTION
<!-- READ THIS FIRST:
- If you need additional help with this template please refer to https://www.home-assistant.io/help/reporting_issues/
- Make sure you are running the latest version of Home Assistant before reporting an issue: https://github.com/home-assistant/home-assistant/releases
- Do not report issues for components if you are using custom components: files in <config-dir>/custom_components
- This is for bugs only. Feature and enhancement requests should go in our community forum: https://community.home-assistant.io/c/feature-requests
- Provide as many details as possible. Paste logs, configuration sample and code into the backticks. Do not delete any text from this template!
-->

**Home Assistant release with the issue:**
<!--
- Frontend -> Developer tools -> Info
- Or use this command: hass --version
-->
0.80.3

**Last working Home Assistant release (if known):**


**Operating environment (Hass.io/Docker/Windows/etc.):**
<!--
Please provide details about your environment.
-->

**Component/platform:**
<!--
Please add the link to the documentation at https://www.home-assistant.io/components/ of the component/platform in question.
-->
https://www.home-assistant.io/components/google_assistant/#expose_by_default

**Description of problem:**
Based on the documentation here: https://www.home-assistant.io/components/google_assistant/#expose_by_default it seems that expose_by_default means all devices should be exposed unless explicitly set to false, and that regardless if this is set domains in exposed_domains should be exposed.


**Problem-relevant `configuration.yaml` entries and (fill out even if it seems unimportant):**
```yaml
google_assistant:
  project_id: xxx
  api_key: xxx
  expose_by_default: false
  exposed_domains:
    - switch
    - light
```

**Traceback (if applicable):**
```

```

**Additional information:**

