### PR TITLE
Merge packages before evaluating config

### DIFF
--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -3,6 +3,7 @@ import asyncio
 from datetime import timedelta
 from itertools import chain
 import logging
+from collections import OrderedDict
 
 from homeassistant import config as conf_util
 from homeassistant.setup import async_prepare_setup_platform
@@ -262,6 +263,16 @@ class EntityComponent:
         except HomeAssistantError as err:
             self.logger.error(err)
             return None
+
+        # Make a copy because we are mutating it.
+        conf = OrderedDict(conf)
+
+        # Merge packages
+        conf_util.merge_packages_config(
+            self.hass,
+            conf,
+            conf.get(conf_util.CONF_CORE, {}).get(conf_util.CONF_PACKAGES, {})
+        )
 
         conf = conf_util.async_process_component_config(
             self.hass, conf, self.domain)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -577,6 +577,7 @@ def test_merge(merge_log_err, hass):
         'pack_list': {'light': {'platform': 'test'}},
         'pack_list2': {'light': [{'platform': 'test'}]},
         'pack_none': {'wake_on_lan': None},
+        'pack_automation': {'automation': [{'alias': 'test'}]}
     }
     config = {
         config_util.CONF_CORE: {config_util.CONF_PACKAGES: packages},
@@ -586,10 +587,11 @@ def test_merge(merge_log_err, hass):
     config_util.merge_packages_config(hass, config, packages)
 
     assert merge_log_err.call_count == 0
-    assert len(config) == 5
+    assert len(config) == 6
     assert len(config['input_boolean']) == 2
     assert len(config['input_select']) == 1
     assert len(config['light']) == 3
+    assert len(config['automation']) == 1
     assert isinstance(config['wake_on_lan'], OrderedDict)
 
 


### PR DESCRIPTION
## Description:
Currently, when calling `automation.reload`, automations located in packages will be removed from the state machine. With this PR, packages are merged into the config dict before the config is evaluated after.

This will also fix behavior of `group.reload` and `script.reload`

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/13254

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
