### PR TITLE
Convert MQTT Light tests to async

### DIFF
--- a/tests/components/light/test_mqtt.py
+++ b/tests/components/light/test_mqtt.py
@@ -153,11 +153,10 @@ light:
   payload_off: "off"
 
 """
-import unittest
 from unittest import mock
 from unittest.mock import patch
 
-from homeassistant.setup import setup_component
+from homeassistant.setup import async_setup_component
 from homeassistant.const import (
     STATE_ON, STATE_OFF, STATE_UNAVAILABLE, ATTR_ASSUMED_STATE)
 from homeassistant.components import light, mqtt
@@ -165,860 +164,877 @@ from homeassistant.components.mqtt.discovery import async_start
 import homeassistant.core as ha
 
 from tests.common import (
-    assert_setup_component, get_test_home_assistant, mock_mqtt_component,
-    async_fire_mqtt_message, fire_mqtt_message, mock_coro, MockConfigEntry)
+    assert_setup_component, async_fire_mqtt_message,
+    mock_coro, MockConfigEntry)
 from tests.components.light import common
 
 
-class TestLightMQTT(unittest.TestCase):
-    """Test the MQTT light."""
+async def test_fail_setup_if_no_command_topic(hass, mqtt_mock):
+    """Test if command fails with command topic."""
+    assert await async_setup_component(hass, light.DOMAIN, {
+        light.DOMAIN: {
+            'platform': 'mqtt',
+            'name': 'test',
+        }
+    })
+    assert hass.states.get('light.test') is None
 
-    # pylint: disable=invalid-name
 
-    def setUp(self):
-        """Set up things to be run when tests are started."""
-        self.hass = get_test_home_assistant()
-        self.mock_publish = mock_mqtt_component(self.hass)
-
-    def tearDown(self):  # pylint: disable=invalid-name
-        """Stop everything that was started."""
-        self.hass.stop()
-
-    def test_fail_setup_if_no_command_topic(self):
-        """Test if command fails with command topic."""
-        with assert_setup_component(0, light.DOMAIN):
-            assert setup_component(self.hass, light.DOMAIN, {
-                light.DOMAIN: {
-                    'platform': 'mqtt',
-                    'name': 'test',
-                }
-            })
-        assert self.hass.states.get('light.test') is None
-
-    def test_no_color_brightness_color_temp_hs_white_xy_if_no_topics(self):
-        """Test if there is no color and brightness if no topic."""
-        with assert_setup_component(1, light.DOMAIN):
-            assert setup_component(self.hass, light.DOMAIN, {
-                light.DOMAIN: {
-                    'platform': 'mqtt',
-                    'name': 'test',
-                    'state_topic': 'test_light_rgb/status',
-                    'command_topic': 'test_light_rgb/set',
-                }
-            })
-
-        state = self.hass.states.get('light.test')
-        assert STATE_OFF == state.state
-        assert state.attributes.get('rgb_color') is None
-        assert state.attributes.get('brightness') is None
-        assert state.attributes.get('color_temp') is None
-        assert state.attributes.get('hs_color') is None
-        assert state.attributes.get('white_value') is None
-        assert state.attributes.get('xy_color') is None
-
-        fire_mqtt_message(self.hass, 'test_light_rgb/status', 'ON')
-        self.hass.block_till_done()
-
-        state = self.hass.states.get('light.test')
-        assert STATE_ON == state.state
-        assert state.attributes.get('rgb_color') is None
-        assert state.attributes.get('brightness') is None
-        assert state.attributes.get('color_temp') is None
-        assert state.attributes.get('hs_color') is None
-        assert state.attributes.get('white_value') is None
-        assert state.attributes.get('xy_color') is None
-
-    def test_controlling_state_via_topic(self):
-        """Test the controlling of the state via topic."""
-        config = {light.DOMAIN: {
+async def test_no_color_brightness_color_temp_hs_white_xy_if_no_topics(
+        hass, mqtt_mock):
+    """Test if there is no color and brightness if no topic."""
+    assert await async_setup_component(hass, light.DOMAIN, {
+        light.DOMAIN: {
             'platform': 'mqtt',
             'name': 'test',
             'state_topic': 'test_light_rgb/status',
             'command_topic': 'test_light_rgb/set',
-            'brightness_state_topic': 'test_light_rgb/brightness/status',
-            'brightness_command_topic': 'test_light_rgb/brightness/set',
-            'rgb_state_topic': 'test_light_rgb/rgb/status',
-            'rgb_command_topic': 'test_light_rgb/rgb/set',
-            'color_temp_state_topic': 'test_light_rgb/color_temp/status',
-            'color_temp_command_topic': 'test_light_rgb/color_temp/set',
-            'effect_state_topic': 'test_light_rgb/effect/status',
-            'effect_command_topic': 'test_light_rgb/effect/set',
-            'hs_state_topic': 'test_light_rgb/hs/status',
-            'hs_command_topic': 'test_light_rgb/hs/set',
-            'white_value_state_topic': 'test_light_rgb/white_value/status',
-            'white_value_command_topic': 'test_light_rgb/white_value/set',
-            'xy_state_topic': 'test_light_rgb/xy/status',
-            'xy_command_topic': 'test_light_rgb/xy/set',
-            'qos': '0',
-            'payload_on': 1,
-            'payload_off': 0
-        }}
+        }
+    })
 
+    state = hass.states.get('light.test')
+    assert STATE_OFF == state.state
+    assert state.attributes.get('rgb_color') is None
+    assert state.attributes.get('brightness') is None
+    assert state.attributes.get('color_temp') is None
+    assert state.attributes.get('hs_color') is None
+    assert state.attributes.get('white_value') is None
+    assert state.attributes.get('xy_color') is None
+
+    async_fire_mqtt_message(hass, 'test_light_rgb/status', 'ON')
+    await hass.async_block_till_done()
+
+    state = hass.states.get('light.test')
+    assert STATE_ON == state.state
+    assert state.attributes.get('rgb_color') is None
+    assert state.attributes.get('brightness') is None
+    assert state.attributes.get('color_temp') is None
+    assert state.attributes.get('hs_color') is None
+    assert state.attributes.get('white_value') is None
+    assert state.attributes.get('xy_color') is None
+
+
+async def test_controlling_state_via_topic(hass, mqtt_mock):
+    """Test the controlling of the state via topic."""
+    config = {light.DOMAIN: {
+        'platform': 'mqtt',
+        'name': 'test',
+        'state_topic': 'test_light_rgb/status',
+        'command_topic': 'test_light_rgb/set',
+        'brightness_state_topic': 'test_light_rgb/brightness/status',
+        'brightness_command_topic': 'test_light_rgb/brightness/set',
+        'rgb_state_topic': 'test_light_rgb/rgb/status',
+        'rgb_command_topic': 'test_light_rgb/rgb/set',
+        'color_temp_state_topic': 'test_light_rgb/color_temp/status',
+        'color_temp_command_topic': 'test_light_rgb/color_temp/set',
+        'effect_state_topic': 'test_light_rgb/effect/status',
+        'effect_command_topic': 'test_light_rgb/effect/set',
+        'hs_state_topic': 'test_light_rgb/hs/status',
+        'hs_command_topic': 'test_light_rgb/hs/set',
+        'white_value_state_topic': 'test_light_rgb/white_value/status',
+        'white_value_command_topic': 'test_light_rgb/white_value/set',
+        'xy_state_topic': 'test_light_rgb/xy/status',
+        'xy_command_topic': 'test_light_rgb/xy/set',
+        'qos': '0',
+        'payload_on': 1,
+        'payload_off': 0
+    }}
+
+    assert await async_setup_component(hass, light.DOMAIN, config)
+
+    state = hass.states.get('light.test')
+    assert STATE_OFF == state.state
+    assert state.attributes.get('rgb_color') is None
+    assert state.attributes.get('brightness') is None
+    assert state.attributes.get('color_temp') is None
+    assert state.attributes.get('effect') is None
+    assert state.attributes.get('hs_color') is None
+    assert state.attributes.get('white_value') is None
+    assert state.attributes.get('xy_color') is None
+    assert not state.attributes.get(ATTR_ASSUMED_STATE)
+
+    async_fire_mqtt_message(hass, 'test_light_rgb/status', '1')
+    await hass.async_block_till_done()
+
+    state = hass.states.get('light.test')
+    assert STATE_ON == state.state
+    assert (255, 255, 255) == state.attributes.get('rgb_color')
+    assert 255 == state.attributes.get('brightness')
+    assert 150 == state.attributes.get('color_temp')
+    assert 'none' == state.attributes.get('effect')
+    assert (0, 0) == state.attributes.get('hs_color')
+    assert 255 == state.attributes.get('white_value')
+    assert (0.323, 0.329) == state.attributes.get('xy_color')
+
+    async_fire_mqtt_message(hass, 'test_light_rgb/status', '0')
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+
+    state = hass.states.get('light.test')
+    assert STATE_OFF == state.state
+
+    async_fire_mqtt_message(hass, 'test_light_rgb/status', '1')
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+
+    async_fire_mqtt_message(hass, 'test_light_rgb/brightness/status', '100')
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+
+    light_state = hass.states.get('light.test')
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+    assert 100 == \
+        light_state.attributes['brightness']
+
+    async_fire_mqtt_message(hass, 'test_light_rgb/color_temp/status', '300')
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+    light_state = hass.states.get('light.test')
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+    assert 300 == light_state.attributes['color_temp']
+
+    async_fire_mqtt_message(hass, 'test_light_rgb/effect/status', 'rainbow')
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+    light_state = hass.states.get('light.test')
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+    assert 'rainbow' == light_state.attributes['effect']
+
+    async_fire_mqtt_message(hass, 'test_light_rgb/white_value/status',
+                            '100')
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+
+    light_state = hass.states.get('light.test')
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+    assert 100 == \
+        light_state.attributes['white_value']
+
+    async_fire_mqtt_message(hass, 'test_light_rgb/status', '1')
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+
+    async_fire_mqtt_message(hass, 'test_light_rgb/rgb/status',
+                            '125,125,125')
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+
+    light_state = hass.states.get('light.test')
+    assert (255, 255, 255) == \
+        light_state.attributes.get('rgb_color')
+
+    async_fire_mqtt_message(hass, 'test_light_rgb/hs/status',
+                            '200,50')
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+
+    light_state = hass.states.get('light.test')
+    assert (200, 50) == \
+        light_state.attributes.get('hs_color')
+
+    async_fire_mqtt_message(hass, 'test_light_rgb/xy/status',
+                            '0.675,0.322')
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+
+    light_state = hass.states.get('light.test')
+    assert (0.672, 0.324) == \
+        light_state.attributes.get('xy_color')
+
+
+async def test_brightness_controlling_scale(hass, mqtt_mock):
+    """Test the brightness controlling scale."""
+    with assert_setup_component(1, light.DOMAIN):
+        assert await async_setup_component(hass, light.DOMAIN, {
+            light.DOMAIN: {
+                'platform': 'mqtt',
+                'name': 'test',
+                'state_topic': 'test_scale/status',
+                'command_topic': 'test_scale/set',
+                'brightness_state_topic': 'test_scale/brightness/status',
+                'brightness_command_topic': 'test_scale/brightness/set',
+                'brightness_scale': '99',
+                'qos': 0,
+                'payload_on': 'on',
+                'payload_off': 'off'
+            }
+        })
+
+    state = hass.states.get('light.test')
+    assert STATE_OFF == state.state
+    assert state.attributes.get('brightness') is None
+    assert not state.attributes.get(ATTR_ASSUMED_STATE)
+
+    async_fire_mqtt_message(hass, 'test_scale/status', 'on')
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+
+    state = hass.states.get('light.test')
+    assert STATE_ON == state.state
+    assert 255 == state.attributes.get('brightness')
+
+    async_fire_mqtt_message(hass, 'test_scale/status', 'off')
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+
+    state = hass.states.get('light.test')
+    assert STATE_OFF == state.state
+
+    async_fire_mqtt_message(hass, 'test_scale/status', 'on')
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+
+    async_fire_mqtt_message(hass, 'test_scale/brightness/status', '99')
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+
+    light_state = hass.states.get('light.test')
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+    assert 255 == \
+        light_state.attributes['brightness']
+
+
+async def test_brightness_from_rgb_controlling_scale(hass, mqtt_mock):
+    """Test the brightness controlling scale."""
+    with assert_setup_component(1, light.DOMAIN):
+        assert await async_setup_component(hass, light.DOMAIN, {
+            light.DOMAIN: {
+                'platform': 'mqtt',
+                'name': 'test',
+                'state_topic': 'test_scale_rgb/status',
+                'command_topic': 'test_scale_rgb/set',
+                'rgb_state_topic': 'test_scale_rgb/rgb/status',
+                'rgb_command_topic': 'test_scale_rgb/rgb/set',
+                'qos': 0,
+                'payload_on': 'on',
+                'payload_off': 'off'
+            }
+        })
+
+    state = hass.states.get('light.test')
+    assert STATE_OFF == state.state
+    assert state.attributes.get('brightness') is None
+    assert not state.attributes.get(ATTR_ASSUMED_STATE)
+
+    async_fire_mqtt_message(hass, 'test_scale_rgb/status', 'on')
+    async_fire_mqtt_message(hass, 'test_scale_rgb/rgb/status', '255,0,0')
+    await hass.async_block_till_done()
+
+    state = hass.states.get('light.test')
+    assert 255 == state.attributes.get('brightness')
+
+    async_fire_mqtt_message(hass, 'test_scale_rgb/rgb/status', '127,0,0')
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+
+    state = hass.states.get('light.test')
+    assert 127 == state.attributes.get('brightness')
+
+
+async def test_white_value_controlling_scale(hass, mqtt_mock):
+    """Test the white_value controlling scale."""
+    with assert_setup_component(1, light.DOMAIN):
+        assert await async_setup_component(hass, light.DOMAIN, {
+            light.DOMAIN: {
+                'platform': 'mqtt',
+                'name': 'test',
+                'state_topic': 'test_scale/status',
+                'command_topic': 'test_scale/set',
+                'white_value_state_topic': 'test_scale/white_value/status',
+                'white_value_command_topic': 'test_scale/white_value/set',
+                'white_value_scale': '99',
+                'qos': 0,
+                'payload_on': 'on',
+                'payload_off': 'off'
+            }
+        })
+
+    state = hass.states.get('light.test')
+    assert STATE_OFF == state.state
+    assert state.attributes.get('white_value') is None
+    assert not state.attributes.get(ATTR_ASSUMED_STATE)
+
+    async_fire_mqtt_message(hass, 'test_scale/status', 'on')
+    await hass.async_block_till_done()
+
+    state = hass.states.get('light.test')
+    assert STATE_ON == state.state
+    assert 255 == state.attributes.get('white_value')
+
+    async_fire_mqtt_message(hass, 'test_scale/status', 'off')
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+
+    state = hass.states.get('light.test')
+    assert STATE_OFF == state.state
+
+    async_fire_mqtt_message(hass, 'test_scale/status', 'on')
+    await hass.async_block_till_done()
+
+    async_fire_mqtt_message(hass, 'test_scale/white_value/status', '99')
+    await hass.async_block_till_done()
+
+    light_state = hass.states.get('light.test')
+    await hass.async_block_till_done()
+    assert 255 == \
+        light_state.attributes['white_value']
+
+
+async def test_controlling_state_via_topic_with_templates(hass, mqtt_mock):
+    """Test the setting of the state with a template."""
+    config = {light.DOMAIN: {
+        'platform': 'mqtt',
+        'name': 'test',
+        'state_topic': 'test_light_rgb/status',
+        'command_topic': 'test_light_rgb/set',
+        'brightness_command_topic': 'test_light_rgb/brightness/set',
+        'rgb_command_topic': 'test_light_rgb/rgb/set',
+        'color_temp_command_topic': 'test_light_rgb/color_temp/set',
+        'effect_command_topic': 'test_light_rgb/effect/set',
+        'hs_command_topic': 'test_light_rgb/hs/set',
+        'white_value_command_topic': 'test_light_rgb/white_value/set',
+        'xy_command_topic': 'test_light_rgb/xy/set',
+        'brightness_state_topic': 'test_light_rgb/brightness/status',
+        'color_temp_state_topic': 'test_light_rgb/color_temp/status',
+        'effect_state_topic': 'test_light_rgb/effect/status',
+        'hs_state_topic': 'test_light_rgb/hs/status',
+        'rgb_state_topic': 'test_light_rgb/rgb/status',
+        'white_value_state_topic': 'test_light_rgb/white_value/status',
+        'xy_state_topic': 'test_light_rgb/xy/status',
+        'state_value_template': '{{ value_json.hello }}',
+        'brightness_value_template': '{{ value_json.hello }}',
+        'color_temp_value_template': '{{ value_json.hello }}',
+        'effect_value_template': '{{ value_json.hello }}',
+        'hs_value_template': '{{ value_json.hello | join(",") }}',
+        'rgb_value_template': '{{ value_json.hello | join(",") }}',
+        'white_value_template': '{{ value_json.hello }}',
+        'xy_value_template': '{{ value_json.hello | join(",") }}',
+    }}
+
+    assert await async_setup_component(hass, light.DOMAIN, config)
+
+    state = hass.states.get('light.test')
+    assert STATE_OFF == state.state
+    assert state.attributes.get('brightness') is None
+    assert state.attributes.get('rgb_color') is None
+
+    async_fire_mqtt_message(hass, 'test_light_rgb/rgb/status',
+                            '{"hello": [1, 2, 3]}')
+    async_fire_mqtt_message(hass, 'test_light_rgb/status',
+                            '{"hello": "ON"}')
+    async_fire_mqtt_message(hass, 'test_light_rgb/brightness/status',
+                            '{"hello": "50"}')
+    async_fire_mqtt_message(hass, 'test_light_rgb/color_temp/status',
+                            '{"hello": "300"}')
+    async_fire_mqtt_message(hass, 'test_light_rgb/effect/status',
+                            '{"hello": "rainbow"}')
+    async_fire_mqtt_message(hass, 'test_light_rgb/white_value/status',
+                            '{"hello": "75"}')
+    await hass.async_block_till_done()
+
+    state = hass.states.get('light.test')
+    assert STATE_ON == state.state
+    assert 50 == state.attributes.get('brightness')
+    assert (84, 169, 255) == state.attributes.get('rgb_color')
+    assert 300 == state.attributes.get('color_temp')
+    assert 'rainbow' == state.attributes.get('effect')
+    assert 75 == state.attributes.get('white_value')
+
+    async_fire_mqtt_message(hass, 'test_light_rgb/hs/status',
+                            '{"hello": [100,50]}')
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+
+    state = hass.states.get('light.test')
+    assert (100, 50) == state.attributes.get('hs_color')
+
+    async_fire_mqtt_message(hass, 'test_light_rgb/xy/status',
+                            '{"hello": [0.123,0.123]}')
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+
+    state = hass.states.get('light.test')
+    assert (0.14, 0.131) == state.attributes.get('xy_color')
+
+
+async def test_sending_mqtt_commands_and_optimistic(hass, mqtt_mock):
+    """Test the sending of command in optimistic mode."""
+    config = {light.DOMAIN: {
+        'platform': 'mqtt',
+        'name': 'test',
+        'command_topic': 'test_light_rgb/set',
+        'brightness_command_topic': 'test_light_rgb/brightness/set',
+        'rgb_command_topic': 'test_light_rgb/rgb/set',
+        'color_temp_command_topic': 'test_light_rgb/color_temp/set',
+        'effect_command_topic': 'test_light_rgb/effect/set',
+        'hs_command_topic': 'test_light_rgb/hs/set',
+        'white_value_command_topic': 'test_light_rgb/white_value/set',
+        'xy_command_topic': 'test_light_rgb/xy/set',
+        'effect_list': ['colorloop', 'random'],
+        'qos': 2,
+        'payload_on': 'on',
+        'payload_off': 'off'
+    }}
+    fake_state = ha.State('light.test', 'on', {'brightness': 95,
+                                               'hs_color': [100, 100],
+                                               'effect': 'random',
+                                               'color_temp': 100,
+                                               'white_value': 50})
+    with patch('homeassistant.components.light.mqtt.async_get_last_state',
+               return_value=mock_coro(fake_state)):
         with assert_setup_component(1, light.DOMAIN):
-            assert setup_component(self.hass, light.DOMAIN, config)
-
-        state = self.hass.states.get('light.test')
-        assert STATE_OFF == state.state
-        assert state.attributes.get('rgb_color') is None
-        assert state.attributes.get('brightness') is None
-        assert state.attributes.get('color_temp') is None
-        assert state.attributes.get('effect') is None
-        assert state.attributes.get('hs_color') is None
-        assert state.attributes.get('white_value') is None
-        assert state.attributes.get('xy_color') is None
-        assert not state.attributes.get(ATTR_ASSUMED_STATE)
-
-        fire_mqtt_message(self.hass, 'test_light_rgb/status', '1')
-        self.hass.block_till_done()
-
-        state = self.hass.states.get('light.test')
-        assert STATE_ON == state.state
-        assert (255, 255, 255) == state.attributes.get('rgb_color')
-        assert 255 == state.attributes.get('brightness')
-        assert 150 == state.attributes.get('color_temp')
-        assert 'none' == state.attributes.get('effect')
-        assert (0, 0) == state.attributes.get('hs_color')
-        assert 255 == state.attributes.get('white_value')
-        assert (0.323, 0.329) == state.attributes.get('xy_color')
-
-        fire_mqtt_message(self.hass, 'test_light_rgb/status', '0')
-        self.hass.block_till_done()
-
-        state = self.hass.states.get('light.test')
-        assert STATE_OFF == state.state
-
-        fire_mqtt_message(self.hass, 'test_light_rgb/status', '1')
-        self.hass.block_till_done()
-
-        fire_mqtt_message(self.hass, 'test_light_rgb/brightness/status', '100')
-        self.hass.block_till_done()
-
-        light_state = self.hass.states.get('light.test')
-        self.hass.block_till_done()
-        assert 100 == \
-            light_state.attributes['brightness']
-
-        fire_mqtt_message(self.hass, 'test_light_rgb/color_temp/status', '300')
-        self.hass.block_till_done()
-        light_state = self.hass.states.get('light.test')
-        self.hass.block_till_done()
-        assert 300 == light_state.attributes['color_temp']
-
-        fire_mqtt_message(self.hass, 'test_light_rgb/effect/status', 'rainbow')
-        self.hass.block_till_done()
-        light_state = self.hass.states.get('light.test')
-        self.hass.block_till_done()
-        assert 'rainbow' == light_state.attributes['effect']
-
-        fire_mqtt_message(self.hass, 'test_light_rgb/white_value/status',
-                          '100')
-        self.hass.block_till_done()
-
-        light_state = self.hass.states.get('light.test')
-        self.hass.block_till_done()
-        assert 100 == \
-            light_state.attributes['white_value']
-
-        fire_mqtt_message(self.hass, 'test_light_rgb/status', '1')
-        self.hass.block_till_done()
-
-        fire_mqtt_message(self.hass, 'test_light_rgb/rgb/status',
-                          '125,125,125')
-        self.hass.block_till_done()
-
-        light_state = self.hass.states.get('light.test')
-        assert (255, 255, 255) == \
-            light_state.attributes.get('rgb_color')
-
-        fire_mqtt_message(self.hass, 'test_light_rgb/hs/status',
-                          '200,50')
-        self.hass.block_till_done()
-
-        light_state = self.hass.states.get('light.test')
-        assert (200, 50) == \
-            light_state.attributes.get('hs_color')
-
-        fire_mqtt_message(self.hass, 'test_light_rgb/xy/status',
-                          '0.675,0.322')
-        self.hass.block_till_done()
-
-        light_state = self.hass.states.get('light.test')
-        assert (0.672, 0.324) == \
-            light_state.attributes.get('xy_color')
-
-    def test_brightness_controlling_scale(self):
-        """Test the brightness controlling scale."""
-        with assert_setup_component(1, light.DOMAIN):
-            assert setup_component(self.hass, light.DOMAIN, {
-                light.DOMAIN: {
-                    'platform': 'mqtt',
-                    'name': 'test',
-                    'state_topic': 'test_scale/status',
-                    'command_topic': 'test_scale/set',
-                    'brightness_state_topic': 'test_scale/brightness/status',
-                    'brightness_command_topic': 'test_scale/brightness/set',
-                    'brightness_scale': '99',
-                    'qos': 0,
-                    'payload_on': 'on',
-                    'payload_off': 'off'
-                }
-            })
-
-        state = self.hass.states.get('light.test')
-        assert STATE_OFF == state.state
-        assert state.attributes.get('brightness') is None
-        assert not state.attributes.get(ATTR_ASSUMED_STATE)
-
-        fire_mqtt_message(self.hass, 'test_scale/status', 'on')
-        self.hass.block_till_done()
-
-        state = self.hass.states.get('light.test')
-        assert STATE_ON == state.state
-        assert 255 == state.attributes.get('brightness')
-
-        fire_mqtt_message(self.hass, 'test_scale/status', 'off')
-        self.hass.block_till_done()
-
-        state = self.hass.states.get('light.test')
-        assert STATE_OFF == state.state
-
-        fire_mqtt_message(self.hass, 'test_scale/status', 'on')
-        self.hass.block_till_done()
-
-        fire_mqtt_message(self.hass, 'test_scale/brightness/status', '99')
-        self.hass.block_till_done()
-
-        light_state = self.hass.states.get('light.test')
-        self.hass.block_till_done()
-        assert 255 == \
-            light_state.attributes['brightness']
-
-    def test_brightness_from_rgb_controlling_scale(self):
-        """Test the brightness controlling scale."""
-        with assert_setup_component(1, light.DOMAIN):
-            assert setup_component(self.hass, light.DOMAIN, {
-                light.DOMAIN: {
-                    'platform': 'mqtt',
-                    'name': 'test',
-                    'state_topic': 'test_scale_rgb/status',
-                    'command_topic': 'test_scale_rgb/set',
-                    'rgb_state_topic': 'test_scale_rgb/rgb/status',
-                    'rgb_command_topic': 'test_scale_rgb/rgb/set',
-                    'qos': 0,
-                    'payload_on': 'on',
-                    'payload_off': 'off'
-                }
-            })
-
-        state = self.hass.states.get('light.test')
-        assert STATE_OFF == state.state
-        assert state.attributes.get('brightness') is None
-        assert not state.attributes.get(ATTR_ASSUMED_STATE)
-
-        fire_mqtt_message(self.hass, 'test_scale_rgb/status', 'on')
-        fire_mqtt_message(self.hass, 'test_scale_rgb/rgb/status', '255,0,0')
-        self.hass.block_till_done()
-
-        state = self.hass.states.get('light.test')
-        assert 255 == state.attributes.get('brightness')
-
-        fire_mqtt_message(self.hass, 'test_scale_rgb/rgb/status', '127,0,0')
-        self.hass.block_till_done()
-
-        state = self.hass.states.get('light.test')
-        assert 127 == state.attributes.get('brightness')
-
-    def test_white_value_controlling_scale(self):
-        """Test the white_value controlling scale."""
-        with assert_setup_component(1, light.DOMAIN):
-            assert setup_component(self.hass, light.DOMAIN, {
-                light.DOMAIN: {
-                    'platform': 'mqtt',
-                    'name': 'test',
-                    'state_topic': 'test_scale/status',
-                    'command_topic': 'test_scale/set',
-                    'white_value_state_topic': 'test_scale/white_value/status',
-                    'white_value_command_topic': 'test_scale/white_value/set',
-                    'white_value_scale': '99',
-                    'qos': 0,
-                    'payload_on': 'on',
-                    'payload_off': 'off'
-                }
-            })
-
-        state = self.hass.states.get('light.test')
-        assert STATE_OFF == state.state
-        assert state.attributes.get('white_value') is None
-        assert not state.attributes.get(ATTR_ASSUMED_STATE)
-
-        fire_mqtt_message(self.hass, 'test_scale/status', 'on')
-        self.hass.block_till_done()
-
-        state = self.hass.states.get('light.test')
-        assert STATE_ON == state.state
-        assert 255 == state.attributes.get('white_value')
-
-        fire_mqtt_message(self.hass, 'test_scale/status', 'off')
-        self.hass.block_till_done()
-
-        state = self.hass.states.get('light.test')
-        assert STATE_OFF == state.state
-
-        fire_mqtt_message(self.hass, 'test_scale/status', 'on')
-        self.hass.block_till_done()
-
-        fire_mqtt_message(self.hass, 'test_scale/white_value/status', '99')
-        self.hass.block_till_done()
-
-        light_state = self.hass.states.get('light.test')
-        self.hass.block_till_done()
-        assert 255 == \
-            light_state.attributes['white_value']
-
-    def test_controlling_state_via_topic_with_templates(self):
-        """Test the setting of the state with a template."""
-        config = {light.DOMAIN: {
-            'platform': 'mqtt',
-            'name': 'test',
-            'state_topic': 'test_light_rgb/status',
-            'command_topic': 'test_light_rgb/set',
-            'brightness_command_topic': 'test_light_rgb/brightness/set',
-            'rgb_command_topic': 'test_light_rgb/rgb/set',
-            'color_temp_command_topic': 'test_light_rgb/color_temp/set',
-            'effect_command_topic': 'test_light_rgb/effect/set',
-            'hs_command_topic': 'test_light_rgb/hs/set',
-            'white_value_command_topic': 'test_light_rgb/white_value/set',
-            'xy_command_topic': 'test_light_rgb/xy/set',
-            'brightness_state_topic': 'test_light_rgb/brightness/status',
-            'color_temp_state_topic': 'test_light_rgb/color_temp/status',
-            'effect_state_topic': 'test_light_rgb/effect/status',
-            'hs_state_topic': 'test_light_rgb/hs/status',
-            'rgb_state_topic': 'test_light_rgb/rgb/status',
-            'white_value_state_topic': 'test_light_rgb/white_value/status',
-            'xy_state_topic': 'test_light_rgb/xy/status',
-            'state_value_template': '{{ value_json.hello }}',
-            'brightness_value_template': '{{ value_json.hello }}',
-            'color_temp_value_template': '{{ value_json.hello }}',
-            'effect_value_template': '{{ value_json.hello }}',
-            'hs_value_template': '{{ value_json.hello | join(",") }}',
-            'rgb_value_template': '{{ value_json.hello | join(",") }}',
-            'white_value_template': '{{ value_json.hello }}',
-            'xy_value_template': '{{ value_json.hello | join(",") }}',
-        }}
-
-        with assert_setup_component(1, light.DOMAIN):
-            assert setup_component(self.hass, light.DOMAIN, config)
-
-        state = self.hass.states.get('light.test')
-        assert STATE_OFF == state.state
-        assert state.attributes.get('brightness') is None
-        assert state.attributes.get('rgb_color') is None
-
-        fire_mqtt_message(self.hass, 'test_light_rgb/rgb/status',
-                          '{"hello": [1, 2, 3]}')
-        fire_mqtt_message(self.hass, 'test_light_rgb/status',
-                          '{"hello": "ON"}')
-        fire_mqtt_message(self.hass, 'test_light_rgb/brightness/status',
-                          '{"hello": "50"}')
-        fire_mqtt_message(self.hass, 'test_light_rgb/color_temp/status',
-                          '{"hello": "300"}')
-        fire_mqtt_message(self.hass, 'test_light_rgb/effect/status',
-                          '{"hello": "rainbow"}')
-        fire_mqtt_message(self.hass, 'test_light_rgb/white_value/status',
-                          '{"hello": "75"}')
-        self.hass.block_till_done()
-
-        state = self.hass.states.get('light.test')
-        assert STATE_ON == state.state
-        assert 50 == state.attributes.get('brightness')
-        assert (84, 169, 255) == state.attributes.get('rgb_color')
-        assert 300 == state.attributes.get('color_temp')
-        assert 'rainbow' == state.attributes.get('effect')
-        assert 75 == state.attributes.get('white_value')
-
-        fire_mqtt_message(self.hass, 'test_light_rgb/hs/status',
-                          '{"hello": [100,50]}')
-        self.hass.block_till_done()
-
-        state = self.hass.states.get('light.test')
-        assert (100, 50) == state.attributes.get('hs_color')
-
-        fire_mqtt_message(self.hass, 'test_light_rgb/xy/status',
-                          '{"hello": [0.123,0.123]}')
-        self.hass.block_till_done()
-
-        state = self.hass.states.get('light.test')
-        assert (0.14, 0.131) == state.attributes.get('xy_color')
-
-    def test_sending_mqtt_commands_and_optimistic(self):
-        """Test the sending of command in optimistic mode."""
-        config = {light.DOMAIN: {
-            'platform': 'mqtt',
-            'name': 'test',
-            'command_topic': 'test_light_rgb/set',
-            'brightness_command_topic': 'test_light_rgb/brightness/set',
-            'rgb_command_topic': 'test_light_rgb/rgb/set',
-            'color_temp_command_topic': 'test_light_rgb/color_temp/set',
-            'effect_command_topic': 'test_light_rgb/effect/set',
-            'hs_command_topic': 'test_light_rgb/hs/set',
-            'white_value_command_topic': 'test_light_rgb/white_value/set',
-            'xy_command_topic': 'test_light_rgb/xy/set',
-            'effect_list': ['colorloop', 'random'],
-            'qos': 2,
-            'payload_on': 'on',
-            'payload_off': 'off'
-        }}
-        fake_state = ha.State('light.test', 'on', {'brightness': 95,
-                                                   'hs_color': [100, 100],
-                                                   'effect': 'random',
-                                                   'color_temp': 100,
-                                                   'white_value': 50})
-        with patch('homeassistant.components.light.mqtt.async_get_last_state',
-                   return_value=mock_coro(fake_state)):
-            with assert_setup_component(1, light.DOMAIN):
-                assert setup_component(self.hass, light.DOMAIN, config)
-
-        state = self.hass.states.get('light.test')
-        assert STATE_ON == state.state
-        assert 95 == state.attributes.get('brightness')
-        assert (100, 100) == state.attributes.get('hs_color')
-        assert 'random' == state.attributes.get('effect')
-        assert 100 == state.attributes.get('color_temp')
-        assert 50 == state.attributes.get('white_value')
-        assert state.attributes.get(ATTR_ASSUMED_STATE)
-
-        common.turn_on(self.hass, 'light.test')
-        self.hass.block_till_done()
-
-        self.mock_publish.async_publish.assert_called_once_with(
-            'test_light_rgb/set', 'on', 2, False)
-        self.mock_publish.async_publish.reset_mock()
-        state = self.hass.states.get('light.test')
-        assert STATE_ON == state.state
-
-        common.turn_off(self.hass, 'light.test')
-        self.hass.block_till_done()
-
-        self.mock_publish.async_publish.assert_called_once_with(
-            'test_light_rgb/set', 'off', 2, False)
-        self.mock_publish.async_publish.reset_mock()
-        state = self.hass.states.get('light.test')
-        assert STATE_OFF == state.state
-
-        self.mock_publish.reset_mock()
-        common.turn_on(self.hass, 'light.test',
-                       brightness=50, xy_color=[0.123, 0.123])
-        common.turn_on(self.hass, 'light.test',
-                       brightness=50, hs_color=[359, 78])
-        common.turn_on(self.hass, 'light.test', rgb_color=[255, 128, 0],
-                       white_value=80)
-        self.hass.block_till_done()
-
-        self.mock_publish.async_publish.assert_has_calls([
-            mock.call('test_light_rgb/set', 'on', 2, False),
-            mock.call('test_light_rgb/rgb/set', '255,128,0', 2, False),
-            mock.call('test_light_rgb/brightness/set', 50, 2, False),
-            mock.call('test_light_rgb/hs/set', '359.0,78.0', 2, False),
-            mock.call('test_light_rgb/white_value/set', 80, 2, False),
-            mock.call('test_light_rgb/xy/set', '0.14,0.131', 2, False),
-        ], any_order=True)
-
-        state = self.hass.states.get('light.test')
-        assert STATE_ON == state.state
-        assert (255, 128, 0) == state.attributes['rgb_color']
-        assert 50 == state.attributes['brightness']
-        assert (30.118, 100) == state.attributes['hs_color']
-        assert 80 == state.attributes['white_value']
-        assert (0.611, 0.375) == state.attributes['xy_color']
-
-    def test_sending_mqtt_rgb_command_with_template(self):
-        """Test the sending of RGB command with template."""
-        config = {light.DOMAIN: {
-            'platform': 'mqtt',
-            'name': 'test',
-            'command_topic': 'test_light_rgb/set',
-            'rgb_command_topic': 'test_light_rgb/rgb/set',
-            'rgb_command_template': '{{ "#%02x%02x%02x" | '
-                                    'format(red, green, blue)}}',
-            'payload_on': 'on',
-            'payload_off': 'off',
-            'qos': 0
-        }}
-
-        with assert_setup_component(1, light.DOMAIN):
-            assert setup_component(self.hass, light.DOMAIN, config)
-
-        state = self.hass.states.get('light.test')
-        assert STATE_OFF == state.state
-
-        common.turn_on(self.hass, 'light.test', rgb_color=[255, 128, 64])
-        self.hass.block_till_done()
-
-        self.mock_publish.async_publish.assert_has_calls([
-            mock.call('test_light_rgb/set', 'on', 0, False),
-            mock.call('test_light_rgb/rgb/set', '#ff803f', 0, False),
-        ], any_order=True)
-
-        state = self.hass.states.get('light.test')
-        assert STATE_ON == state.state
-        assert (255, 128, 63) == state.attributes['rgb_color']
-
-    def test_show_brightness_if_only_command_topic(self):
-        """Test the brightness if only a command topic is present."""
-        config = {light.DOMAIN: {
-            'platform': 'mqtt',
-            'name': 'test',
-            'brightness_command_topic': 'test_light_rgb/brightness/set',
-            'command_topic': 'test_light_rgb/set',
-            'state_topic': 'test_light_rgb/status',
-        }}
-
-        with assert_setup_component(1, light.DOMAIN):
-            assert setup_component(self.hass, light.DOMAIN, config)
-
-        state = self.hass.states.get('light.test')
-        assert STATE_OFF == state.state
-        assert state.attributes.get('brightness') is None
-
-        fire_mqtt_message(self.hass, 'test_light_rgb/status', 'ON')
-        self.hass.block_till_done()
-
-        state = self.hass.states.get('light.test')
-        assert STATE_ON == state.state
-        assert 255 == state.attributes.get('brightness')
-
-    def test_show_color_temp_only_if_command_topic(self):
-        """Test the color temp only if a command topic is present."""
-        config = {light.DOMAIN: {
-            'platform': 'mqtt',
-            'name': 'test',
-            'color_temp_command_topic': 'test_light_rgb/brightness/set',
-            'command_topic': 'test_light_rgb/set',
-            'state_topic': 'test_light_rgb/status'
-        }}
-
-        with assert_setup_component(1, light.DOMAIN):
-            assert setup_component(self.hass, light.DOMAIN, config)
-
-        state = self.hass.states.get('light.test')
-        assert STATE_OFF == state.state
-        assert state.attributes.get('color_temp') is None
-
-        fire_mqtt_message(self.hass, 'test_light_rgb/status', 'ON')
-        self.hass.block_till_done()
-
-        state = self.hass.states.get('light.test')
-        assert STATE_ON == state.state
-        assert 150 == state.attributes.get('color_temp')
-
-    def test_show_effect_only_if_command_topic(self):
-        """Test the color temp only if a command topic is present."""
-        config = {light.DOMAIN: {
-            'platform': 'mqtt',
-            'name': 'test',
-            'effect_command_topic': 'test_light_rgb/effect/set',
-            'command_topic': 'test_light_rgb/set',
-            'state_topic': 'test_light_rgb/status'
-        }}
-
-        with assert_setup_component(1, light.DOMAIN):
-            assert setup_component(self.hass, light.DOMAIN, config)
-
-        state = self.hass.states.get('light.test')
-        assert STATE_OFF == state.state
-        assert state.attributes.get('effect') is None
-
-        fire_mqtt_message(self.hass, 'test_light_rgb/status', 'ON')
-        self.hass.block_till_done()
-
-        state = self.hass.states.get('light.test')
-        assert STATE_ON == state.state
-        assert 'none' == state.attributes.get('effect')
-
-    def test_show_hs_if_only_command_topic(self):
-        """Test the hs if only a command topic is present."""
-        config = {light.DOMAIN: {
-            'platform': 'mqtt',
-            'name': 'test',
-            'hs_command_topic': 'test_light_rgb/hs/set',
-            'command_topic': 'test_light_rgb/set',
-            'state_topic': 'test_light_rgb/status',
-        }}
-
-        with assert_setup_component(1, light.DOMAIN):
-            assert setup_component(self.hass, light.DOMAIN, config)
-
-        state = self.hass.states.get('light.test')
-        assert STATE_OFF == state.state
-        assert state.attributes.get('hs_color') is None
-
-        fire_mqtt_message(self.hass, 'test_light_rgb/status', 'ON')
-        self.hass.block_till_done()
-
-        state = self.hass.states.get('light.test')
-        assert STATE_ON == state.state
-        assert (0, 0) == state.attributes.get('hs_color')
-
-    def test_show_white_value_if_only_command_topic(self):
-        """Test the white_value if only a command topic is present."""
-        config = {light.DOMAIN: {
-            'platform': 'mqtt',
-            'name': 'test',
-            'white_value_command_topic': 'test_light_rgb/white_value/set',
-            'command_topic': 'test_light_rgb/set',
-            'state_topic': 'test_light_rgb/status',
-        }}
-
-        with assert_setup_component(1, light.DOMAIN):
-            assert setup_component(self.hass, light.DOMAIN, config)
-
-        state = self.hass.states.get('light.test')
-        assert STATE_OFF == state.state
-        assert state.attributes.get('white_value') is None
-
-        fire_mqtt_message(self.hass, 'test_light_rgb/status', 'ON')
-        self.hass.block_till_done()
-
-        state = self.hass.states.get('light.test')
-        assert STATE_ON == state.state
-        assert 255 == state.attributes.get('white_value')
-
-    def test_show_xy_if_only_command_topic(self):
-        """Test the xy if only a command topic is present."""
-        config = {light.DOMAIN: {
-            'platform': 'mqtt',
-            'name': 'test',
-            'xy_command_topic': 'test_light_rgb/xy/set',
-            'command_topic': 'test_light_rgb/set',
-            'state_topic': 'test_light_rgb/status',
-        }}
-
-        with assert_setup_component(1, light.DOMAIN):
-            assert setup_component(self.hass, light.DOMAIN, config)
-
-        state = self.hass.states.get('light.test')
-        assert STATE_OFF == state.state
-        assert state.attributes.get('xy_color') is None
-
-        fire_mqtt_message(self.hass, 'test_light_rgb/status', 'ON')
-        self.hass.block_till_done()
-
-        state = self.hass.states.get('light.test')
-        assert STATE_ON == state.state
-        assert (0.323, 0.329) == state.attributes.get('xy_color')
-
-    def test_on_command_first(self):
-        """Test on command being sent before brightness."""
-        config = {light.DOMAIN: {
-            'platform': 'mqtt',
-            'name': 'test',
-            'command_topic': 'test_light/set',
-            'brightness_command_topic': 'test_light/bright',
-            'on_command_type': 'first',
-        }}
-
-        with assert_setup_component(1, light.DOMAIN):
-            assert setup_component(self.hass, light.DOMAIN, config)
-
-        state = self.hass.states.get('light.test')
-        assert STATE_OFF == state.state
-
-        common.turn_on(self.hass, 'light.test', brightness=50)
-        self.hass.block_till_done()
-
-        # Should get the following MQTT messages.
-        #    test_light/set: 'ON'
-        #    test_light/bright: 50
-        self.mock_publish.async_publish.assert_has_calls([
-            mock.call('test_light/set', 'ON', 0, False),
-            mock.call('test_light/bright', 50, 0, False),
-        ], any_order=True)
-        self.mock_publish.async_publish.reset_mock()
-
-        common.turn_off(self.hass, 'light.test')
-        self.hass.block_till_done()
-
-        self.mock_publish.async_publish.assert_called_once_with(
-            'test_light/set', 'OFF', 0, False)
-
-    def test_on_command_last(self):
-        """Test on command being sent after brightness."""
-        config = {light.DOMAIN: {
-            'platform': 'mqtt',
-            'name': 'test',
-            'command_topic': 'test_light/set',
-            'brightness_command_topic': 'test_light/bright',
-        }}
-
-        with assert_setup_component(1, light.DOMAIN):
-            assert setup_component(self.hass, light.DOMAIN, config)
-
-        state = self.hass.states.get('light.test')
-        assert STATE_OFF == state.state
-
-        common.turn_on(self.hass, 'light.test', brightness=50)
-        self.hass.block_till_done()
-
-        # Should get the following MQTT messages.
-        #    test_light/bright: 50
-        #    test_light/set: 'ON'
-        self.mock_publish.async_publish.assert_has_calls([
-            mock.call('test_light/bright', 50, 0, False),
-            mock.call('test_light/set', 'ON', 0, False),
-        ], any_order=True)
-        self.mock_publish.async_publish.reset_mock()
-
-        common.turn_off(self.hass, 'light.test')
-        self.hass.block_till_done()
-
-        self.mock_publish.async_publish.assert_called_once_with(
-            'test_light/set', 'OFF', 0, False)
-
-    def test_on_command_brightness(self):
-        """Test on command being sent as only brightness."""
-        config = {light.DOMAIN: {
+            assert await async_setup_component(hass, light.DOMAIN, config)
+
+    state = hass.states.get('light.test')
+    assert STATE_ON == state.state
+    assert 95 == state.attributes.get('brightness')
+    assert (100, 100) == state.attributes.get('hs_color')
+    assert 'random' == state.attributes.get('effect')
+    assert 100 == state.attributes.get('color_temp')
+    assert 50 == state.attributes.get('white_value')
+    assert state.attributes.get(ATTR_ASSUMED_STATE)
+
+    common.async_turn_on(hass, 'light.test')
+    await hass.async_block_till_done()
+
+    mqtt_mock.async_publish.assert_called_once_with(
+        'test_light_rgb/set', 'on', 2, False)
+    mqtt_mock.async_publish.reset_mock()
+    state = hass.states.get('light.test')
+    assert STATE_ON == state.state
+
+    common.async_turn_off(hass, 'light.test')
+    await hass.async_block_till_done()
+
+    mqtt_mock.async_publish.assert_called_once_with(
+        'test_light_rgb/set', 'off', 2, False)
+    mqtt_mock.async_publish.reset_mock()
+    state = hass.states.get('light.test')
+    assert STATE_OFF == state.state
+
+    mqtt_mock.reset_mock()
+    common.async_turn_on(hass, 'light.test',
+                         brightness=50, xy_color=[0.123, 0.123])
+    common.async_turn_on(hass, 'light.test',
+                         brightness=50, hs_color=[359, 78])
+    common.async_turn_on(hass, 'light.test', rgb_color=[255, 128, 0],
+                         white_value=80)
+    await hass.async_block_till_done()
+
+    mqtt_mock.async_publish.assert_has_calls([
+        mock.call('test_light_rgb/set', 'on', 2, False),
+        mock.call('test_light_rgb/rgb/set', '255,128,0', 2, False),
+        mock.call('test_light_rgb/brightness/set', 50, 2, False),
+        mock.call('test_light_rgb/hs/set', '359.0,78.0', 2, False),
+        mock.call('test_light_rgb/white_value/set', 80, 2, False),
+        mock.call('test_light_rgb/xy/set', '0.14,0.131', 2, False),
+    ], any_order=True)
+
+    state = hass.states.get('light.test')
+    assert STATE_ON == state.state
+    assert (255, 128, 0) == state.attributes['rgb_color']
+    assert 50 == state.attributes['brightness']
+    assert (30.118, 100) == state.attributes['hs_color']
+    assert 80 == state.attributes['white_value']
+    assert (0.611, 0.375) == state.attributes['xy_color']
+
+
+async def test_sending_mqtt_rgb_command_with_template(hass, mqtt_mock):
+    """Test the sending of RGB command with template."""
+    config = {light.DOMAIN: {
+        'platform': 'mqtt',
+        'name': 'test',
+        'command_topic': 'test_light_rgb/set',
+        'rgb_command_topic': 'test_light_rgb/rgb/set',
+        'rgb_command_template': '{{ "#%02x%02x%02x" | '
+                                'format(red, green, blue)}}',
+        'payload_on': 'on',
+        'payload_off': 'off',
+        'qos': 0
+    }}
+
+    assert await async_setup_component(hass, light.DOMAIN, config)
+
+    state = hass.states.get('light.test')
+    assert STATE_OFF == state.state
+
+    common.async_turn_on(hass, 'light.test', rgb_color=[255, 128, 64])
+    await hass.async_block_till_done()
+
+    mqtt_mock.async_publish.assert_has_calls([
+        mock.call('test_light_rgb/set', 'on', 0, False),
+        mock.call('test_light_rgb/rgb/set', '#ff803f', 0, False),
+    ], any_order=True)
+
+    state = hass.states.get('light.test')
+    assert STATE_ON == state.state
+    assert (255, 128, 63) == state.attributes['rgb_color']
+
+
+async def test_show_brightness_if_only_command_topic(hass, mqtt_mock):
+    """Test the brightness if only a command topic is present."""
+    config = {light.DOMAIN: {
+        'platform': 'mqtt',
+        'name': 'test',
+        'brightness_command_topic': 'test_light_rgb/brightness/set',
+        'command_topic': 'test_light_rgb/set',
+        'state_topic': 'test_light_rgb/status',
+    }}
+
+    assert await async_setup_component(hass, light.DOMAIN, config)
+
+    state = hass.states.get('light.test')
+    assert STATE_OFF == state.state
+    assert state.attributes.get('brightness') is None
+
+    async_fire_mqtt_message(hass, 'test_light_rgb/status', 'ON')
+    await hass.async_block_till_done()
+
+    state = hass.states.get('light.test')
+    assert STATE_ON == state.state
+    assert 255 == state.attributes.get('brightness')
+
+
+async def test_show_color_temp_only_if_command_topic(hass, mqtt_mock):
+    """Test the color temp only if a command topic is present."""
+    config = {light.DOMAIN: {
+        'platform': 'mqtt',
+        'name': 'test',
+        'color_temp_command_topic': 'test_light_rgb/brightness/set',
+        'command_topic': 'test_light_rgb/set',
+        'state_topic': 'test_light_rgb/status'
+    }}
+
+    assert await async_setup_component(hass, light.DOMAIN, config)
+
+    state = hass.states.get('light.test')
+    assert STATE_OFF == state.state
+    assert state.attributes.get('color_temp') is None
+
+    async_fire_mqtt_message(hass, 'test_light_rgb/status', 'ON')
+    await hass.async_block_till_done()
+
+    state = hass.states.get('light.test')
+    assert STATE_ON == state.state
+    assert 150 == state.attributes.get('color_temp')
+
+
+async def test_show_effect_only_if_command_topic(hass, mqtt_mock):
+    """Test the color temp only if a command topic is present."""
+    config = {light.DOMAIN: {
+        'platform': 'mqtt',
+        'name': 'test',
+        'effect_command_topic': 'test_light_rgb/effect/set',
+        'command_topic': 'test_light_rgb/set',
+        'state_topic': 'test_light_rgb/status'
+    }}
+
+    assert await async_setup_component(hass, light.DOMAIN, config)
+
+    state = hass.states.get('light.test')
+    assert STATE_OFF == state.state
+    assert state.attributes.get('effect') is None
+
+    async_fire_mqtt_message(hass, 'test_light_rgb/status', 'ON')
+    await hass.async_block_till_done()
+
+    state = hass.states.get('light.test')
+    assert STATE_ON == state.state
+    assert 'none' == state.attributes.get('effect')
+
+
+async def test_show_hs_if_only_command_topic(hass, mqtt_mock):
+    """Test the hs if only a command topic is present."""
+    config = {light.DOMAIN: {
+        'platform': 'mqtt',
+        'name': 'test',
+        'hs_command_topic': 'test_light_rgb/hs/set',
+        'command_topic': 'test_light_rgb/set',
+        'state_topic': 'test_light_rgb/status',
+    }}
+
+    assert await async_setup_component(hass, light.DOMAIN, config)
+
+    state = hass.states.get('light.test')
+    assert STATE_OFF == state.state
+    assert state.attributes.get('hs_color') is None
+
+    async_fire_mqtt_message(hass, 'test_light_rgb/status', 'ON')
+    await hass.async_block_till_done()
+
+    state = hass.states.get('light.test')
+    assert STATE_ON == state.state
+    assert (0, 0) == state.attributes.get('hs_color')
+
+
+async def test_show_white_value_if_only_command_topic(hass, mqtt_mock):
+    """Test the white_value if only a command topic is present."""
+    config = {light.DOMAIN: {
+        'platform': 'mqtt',
+        'name': 'test',
+        'white_value_command_topic': 'test_light_rgb/white_value/set',
+        'command_topic': 'test_light_rgb/set',
+        'state_topic': 'test_light_rgb/status',
+    }}
+
+    assert await async_setup_component(hass, light.DOMAIN, config)
+
+    state = hass.states.get('light.test')
+    assert STATE_OFF == state.state
+    assert state.attributes.get('white_value') is None
+
+    async_fire_mqtt_message(hass, 'test_light_rgb/status', 'ON')
+    await hass.async_block_till_done()
+
+    state = hass.states.get('light.test')
+    assert STATE_ON == state.state
+    assert 255 == state.attributes.get('white_value')
+
+
+async def test_show_xy_if_only_command_topic(hass, mqtt_mock):
+    """Test the xy if only a command topic is present."""
+    config = {light.DOMAIN: {
+        'platform': 'mqtt',
+        'name': 'test',
+        'xy_command_topic': 'test_light_rgb/xy/set',
+        'command_topic': 'test_light_rgb/set',
+        'state_topic': 'test_light_rgb/status',
+    }}
+
+    assert await async_setup_component(hass, light.DOMAIN, config)
+
+    state = hass.states.get('light.test')
+    assert STATE_OFF == state.state
+    assert state.attributes.get('xy_color') is None
+
+    async_fire_mqtt_message(hass, 'test_light_rgb/status', 'ON')
+    await hass.async_block_till_done()
+
+    state = hass.states.get('light.test')
+    assert STATE_ON == state.state
+    assert (0.323, 0.329) == state.attributes.get('xy_color')
+
+
+async def test_on_command_first(hass, mqtt_mock):
+    """Test on command being sent before brightness."""
+    config = {light.DOMAIN: {
+        'platform': 'mqtt',
+        'name': 'test',
+        'command_topic': 'test_light/set',
+        'brightness_command_topic': 'test_light/bright',
+        'on_command_type': 'first',
+    }}
+
+    assert await async_setup_component(hass, light.DOMAIN, config)
+
+    state = hass.states.get('light.test')
+    assert STATE_OFF == state.state
+
+    common.async_turn_on(hass, 'light.test', brightness=50)
+    await hass.async_block_till_done()
+
+    # Should get the following MQTT messages.
+    #    test_light/set: 'ON'
+    #    test_light/bright: 50
+    mqtt_mock.async_publish.assert_has_calls([
+        mock.call('test_light/set', 'ON', 0, False),
+        mock.call('test_light/bright', 50, 0, False),
+    ], any_order=True)
+    mqtt_mock.async_publish.reset_mock()
+
+    common.async_turn_off(hass, 'light.test')
+    await hass.async_block_till_done()
+
+    mqtt_mock.async_publish.assert_called_once_with(
+        'test_light/set', 'OFF', 0, False)
+
+
+async def test_on_command_last(hass, mqtt_mock):
+    """Test on command being sent after brightness."""
+    config = {light.DOMAIN: {
+        'platform': 'mqtt',
+        'name': 'test',
+        'command_topic': 'test_light/set',
+        'brightness_command_topic': 'test_light/bright',
+    }}
+
+    assert await async_setup_component(hass, light.DOMAIN, config)
+
+    state = hass.states.get('light.test')
+    assert STATE_OFF == state.state
+
+    common.async_turn_on(hass, 'light.test', brightness=50)
+    await hass.async_block_till_done()
+
+    # Should get the following MQTT messages.
+    #    test_light/bright: 50
+    #    test_light/set: 'ON'
+    mqtt_mock.async_publish.assert_has_calls([
+        mock.call('test_light/bright', 50, 0, False),
+        mock.call('test_light/set', 'ON', 0, False),
+    ], any_order=True)
+    mqtt_mock.async_publish.reset_mock()
+
+    common.async_turn_off(hass, 'light.test')
+    await hass.async_block_till_done()
+
+    mqtt_mock.async_publish.assert_called_once_with(
+        'test_light/set', 'OFF', 0, False)
+
+
+async def test_on_command_brightness(hass, mqtt_mock):
+    """Test on command being sent as only brightness."""
+    config = {light.DOMAIN: {
+        'platform': 'mqtt',
+        'name': 'test',
+        'command_topic': 'test_light/set',
+        'brightness_command_topic': 'test_light/bright',
+        'rgb_command_topic': "test_light/rgb",
+        'on_command_type': 'brightness',
+    }}
+
+    assert await async_setup_component(hass, light.DOMAIN, config)
+
+    state = hass.states.get('light.test')
+    assert STATE_OFF == state.state
+
+    # Turn on w/ no brightness - should set to max
+    common.async_turn_on(hass, 'light.test')
+    await hass.async_block_till_done()
+
+    # Should get the following MQTT messages.
+    #    test_light/bright: 255
+    mqtt_mock.async_publish.assert_called_once_with(
+        'test_light/bright', 255, 0, False)
+    mqtt_mock.async_publish.reset_mock()
+
+    common.async_turn_off(hass, 'light.test')
+    await hass.async_block_till_done()
+
+    mqtt_mock.async_publish.assert_called_once_with(
+        'test_light/set', 'OFF', 0, False)
+    mqtt_mock.async_publish.reset_mock()
+
+    # Turn on w/ brightness
+    common.async_turn_on(hass, 'light.test', brightness=50)
+    await hass.async_block_till_done()
+
+    mqtt_mock.async_publish.assert_called_once_with(
+        'test_light/bright', 50, 0, False)
+    mqtt_mock.async_publish.reset_mock()
+
+    common.async_turn_off(hass, 'light.test')
+    await hass.async_block_till_done()
+
+    # Turn on w/ just a color to insure brightness gets
+    # added and sent.
+    common.async_turn_on(hass, 'light.test', rgb_color=[255, 128, 0])
+    await hass.async_block_till_done()
+
+    mqtt_mock.async_publish.assert_has_calls([
+        mock.call('test_light/rgb', '255,128,0', 0, False),
+        mock.call('test_light/bright', 50, 0, False)
+    ], any_order=True)
+
+
+async def test_on_command_rgb(hass, mqtt_mock):
+    """Test on command in RGB brightness mode."""
+    config = {light.DOMAIN: {
+        'platform': 'mqtt',
+        'name': 'test',
+        'command_topic': 'test_light/set',
+        'rgb_command_topic': "test_light/rgb",
+    }}
+
+    assert await async_setup_component(hass, light.DOMAIN, config)
+
+    state = hass.states.get('light.test')
+    assert STATE_OFF == state.state
+
+    common.async_turn_on(hass, 'light.test', brightness=127)
+    await hass.async_block_till_done()
+
+    # Should get the following MQTT messages.
+    #    test_light/rgb: '127,127,127'
+    #    test_light/set: 'ON'
+    mqtt_mock.async_publish.assert_has_calls([
+        mock.call('test_light/rgb', '127,127,127', 0, False),
+        mock.call('test_light/set', 'ON', 0, False),
+    ], any_order=True)
+    mqtt_mock.async_publish.reset_mock()
+
+    common.async_turn_off(hass, 'light.test')
+    await hass.async_block_till_done()
+
+    mqtt_mock.async_publish.assert_called_once_with(
+        'test_light/set', 'OFF', 0, False)
+
+
+async def test_default_availability_payload(hass, mqtt_mock):
+    """Test availability by default payload with defined topic."""
+    assert await async_setup_component(hass, light.DOMAIN, {
+        light.DOMAIN: {
             'platform': 'mqtt',
             'name': 'test',
             'command_topic': 'test_light/set',
             'brightness_command_topic': 'test_light/bright',
             'rgb_command_topic': "test_light/rgb",
-            'on_command_type': 'brightness',
-        }}
+            'availability_topic': 'availability-topic'
+        }
+    })
 
-        with assert_setup_component(1, light.DOMAIN):
-            assert setup_component(self.hass, light.DOMAIN, config)
+    state = hass.states.get('light.test')
+    assert STATE_UNAVAILABLE == state.state
 
-        state = self.hass.states.get('light.test')
-        assert STATE_OFF == state.state
+    async_fire_mqtt_message(hass, 'availability-topic', 'online')
+    await hass.async_block_till_done()
 
-        # Turn on w/ no brightness - should set to max
-        common.turn_on(self.hass, 'light.test')
-        self.hass.block_till_done()
+    state = hass.states.get('light.test')
+    assert STATE_UNAVAILABLE != state.state
 
-        # Should get the following MQTT messages.
-        #    test_light/bright: 255
-        self.mock_publish.async_publish.assert_called_once_with(
-            'test_light/bright', 255, 0, False)
-        self.mock_publish.async_publish.reset_mock()
+    async_fire_mqtt_message(hass, 'availability-topic', 'offline')
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
 
-        common.turn_off(self.hass, 'light.test')
-        self.hass.block_till_done()
+    state = hass.states.get('light.test')
+    assert STATE_UNAVAILABLE == state.state
 
-        self.mock_publish.async_publish.assert_called_once_with(
-            'test_light/set', 'OFF', 0, False)
-        self.mock_publish.async_publish.reset_mock()
 
-        # Turn on w/ brightness
-        common.turn_on(self.hass, 'light.test', brightness=50)
-        self.hass.block_till_done()
-
-        self.mock_publish.async_publish.assert_called_once_with(
-            'test_light/bright', 50, 0, False)
-        self.mock_publish.async_publish.reset_mock()
-
-        common.turn_off(self.hass, 'light.test')
-        self.hass.block_till_done()
-
-        # Turn on w/ just a color to insure brightness gets
-        # added and sent.
-        common.turn_on(self.hass, 'light.test', rgb_color=[255, 128, 0])
-        self.hass.block_till_done()
-
-        self.mock_publish.async_publish.assert_has_calls([
-            mock.call('test_light/rgb', '255,128,0', 0, False),
-            mock.call('test_light/bright', 50, 0, False)
-        ], any_order=True)
-
-    def test_on_command_rgb(self):
-        """Test on command in RGB brightness mode."""
-        config = {light.DOMAIN: {
+async def test_custom_availability_payload(hass, mqtt_mock):
+    """Test availability by custom payload with defined topic."""
+    assert await async_setup_component(hass, light.DOMAIN, {
+        light.DOMAIN: {
             'platform': 'mqtt',
             'name': 'test',
             'command_topic': 'test_light/set',
+            'brightness_command_topic': 'test_light/bright',
             'rgb_command_topic': "test_light/rgb",
-        }}
+            'availability_topic': 'availability-topic',
+            'payload_available': 'good',
+            'payload_not_available': 'nogood'
+        }
+    })
 
-        with assert_setup_component(1, light.DOMAIN):
-            assert setup_component(self.hass, light.DOMAIN, config)
+    state = hass.states.get('light.test')
+    assert STATE_UNAVAILABLE == state.state
 
-        state = self.hass.states.get('light.test')
-        assert STATE_OFF == state.state
+    async_fire_mqtt_message(hass, 'availability-topic', 'good')
+    await hass.async_block_till_done()
 
-        common.turn_on(self.hass, 'light.test', brightness=127)
-        self.hass.block_till_done()
+    state = hass.states.get('light.test')
+    assert STATE_UNAVAILABLE != state.state
 
-        # Should get the following MQTT messages.
-        #    test_light/rgb: '127,127,127'
-        #    test_light/set: 'ON'
-        self.mock_publish.async_publish.assert_has_calls([
-            mock.call('test_light/rgb', '127,127,127', 0, False),
-            mock.call('test_light/set', 'ON', 0, False),
-        ], any_order=True)
-        self.mock_publish.async_publish.reset_mock()
+    async_fire_mqtt_message(hass, 'availability-topic', 'nogood')
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
 
-        common.turn_off(self.hass, 'light.test')
-        self.hass.block_till_done()
-
-        self.mock_publish.async_publish.assert_called_once_with(
-            'test_light/set', 'OFF', 0, False)
-
-    def test_default_availability_payload(self):
-        """Test availability by default payload with defined topic."""
-        assert setup_component(self.hass, light.DOMAIN, {
-            light.DOMAIN: {
-                'platform': 'mqtt',
-                'name': 'test',
-                'command_topic': 'test_light/set',
-                'brightness_command_topic': 'test_light/bright',
-                'rgb_command_topic': "test_light/rgb",
-                'availability_topic': 'availability-topic'
-            }
-        })
-
-        state = self.hass.states.get('light.test')
-        assert STATE_UNAVAILABLE == state.state
-
-        fire_mqtt_message(self.hass, 'availability-topic', 'online')
-        self.hass.block_till_done()
-
-        state = self.hass.states.get('light.test')
-        assert STATE_UNAVAILABLE != state.state
-
-        fire_mqtt_message(self.hass, 'availability-topic', 'offline')
-        self.hass.block_till_done()
-
-        state = self.hass.states.get('light.test')
-        assert STATE_UNAVAILABLE == state.state
-
-    def test_custom_availability_payload(self):
-        """Test availability by custom payload with defined topic."""
-        assert setup_component(self.hass, light.DOMAIN, {
-            light.DOMAIN: {
-                'platform': 'mqtt',
-                'name': 'test',
-                'command_topic': 'test_light/set',
-                'brightness_command_topic': 'test_light/bright',
-                'rgb_command_topic': "test_light/rgb",
-                'availability_topic': 'availability-topic',
-                'payload_available': 'good',
-                'payload_not_available': 'nogood'
-            }
-        })
-
-        state = self.hass.states.get('light.test')
-        assert STATE_UNAVAILABLE == state.state
-
-        fire_mqtt_message(self.hass, 'availability-topic', 'good')
-        self.hass.block_till_done()
-
-        state = self.hass.states.get('light.test')
-        assert STATE_UNAVAILABLE != state.state
-
-        fire_mqtt_message(self.hass, 'availability-topic', 'nogood')
-        self.hass.block_till_done()
-
-        state = self.hass.states.get('light.test')
-        assert STATE_UNAVAILABLE == state.state
+    state = hass.states.get('light.test')
+    assert STATE_UNAVAILABLE == state.state
 
 
 async def test_discovery_removal_light(hass, mqtt_mock, caplog):


### PR DESCRIPTION
## Description:
To migrate restore_state (PR #17270) to use the storage helper instead of history, we need to migrate all tests for components/platforms that use restore state to async or else the pytest fixtures won't work.

As a test to see how difficult it was, I converted the MQTT light tests. It took ~15-20 min because I had to figure out what things to change, but future ones we should be able to do faster. Things to do per test migration:

- `self.mock_publish` should be replaced with fixture `mock_mqtt`
- All functions need `mock_publish` fixture, also if they don't use it. This is because the fixture mocks out the whole MQTT component and we do use that.
- `self.hass` should be replaced with fixture `hass`
- Calls to `common.*` should be replaced with `common.async_`
- all functions need to be moved outside of the class, have parameter `self` removed and be marked as async.
- `hass.block_till_done` -> `await hass.async_block_till_done()`. Because `async_block_till_done` blocks 1 less cycle than block_till_done, you might sometimes have to call it twice 🤷‍♂️ 
- calls to setup_component need to be replaced with `await async_setup_component`
- `fire_mqtt_message` -> `async_fire_mqtt_message`

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
