### PR TITLE
Add upload and download sensors and component for asuswrt

### DIFF
--- a/homeassistant/components/asuswrt.py
+++ b/homeassistant/components/asuswrt.py
@@ -55,13 +55,9 @@ async def async_setup(hass, config):
                   conf.get('ssh_key', conf.get('pub_key', '')),
                   conf[CONF_MODE], conf[CONF_REQUIRE_IP])
 
-    try:
-        await api.connection.async_connect()
-        if not api.is_connected:
-            _LOGGER.error("Unable to setup asuswrt component")
-            return False
-    except Exception as e:
-        _LOGGER.exception("Unable to setup asuswrt component", e)
+    await api.connection.async_connect()
+    if not api.is_connected:
+        _LOGGER.error("Unable to setup asuswrt component")
         return False
 
     hass.data[DATA_ASUSWRT] = api

--- a/homeassistant/components/asuswrt.py
+++ b/homeassistant/components/asuswrt.py
@@ -11,11 +11,10 @@ import voluptuous as vol
 from homeassistant.const import (
     CONF_HOST, CONF_PASSWORD, CONF_USERNAME, CONF_PORT, CONF_MODE,
     CONF_PROTOCOL)
-
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.discovery import async_load_platform
 
-REQUIREMENTS = ['aioasuswrt==1.1.2']
+REQUIREMENTS = ['aioasuswrt==1.1.3']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -48,6 +47,9 @@ async def async_setup(hass, config):
     from aioasuswrt.asuswrt import AsusWrt
 
     conf = config[DOMAIN]
+    if conf[CONF_HOST] is None or conf[CONF_USERNAME] is None:
+        _LOGGER.error("Cant setup asuswrt platform.")
+        return False
 
     api = AsusWrt(conf[CONF_HOST], conf[CONF_PORT],
                   conf[CONF_PROTOCOL] == 'telnet',
@@ -55,6 +57,7 @@ async def async_setup(hass, config):
                   conf.get(CONF_PASSWORD, ''),
                   conf.get('ssh_key', conf.get('pub_key', '')),
                   conf[CONF_MODE], conf[CONF_REQUIRE_IP])
+
     hass.data[DATA_ASUSWRT] = api
 
     hass.async_create_task(async_load_platform(

--- a/homeassistant/components/asuswrt.py
+++ b/homeassistant/components/asuswrt.py
@@ -45,7 +45,6 @@ CONFIG_SCHEMA = vol.Schema({
 async def async_setup(hass, config):
     """Set up the asuswrt component."""
     from aioasuswrt.asuswrt import AsusWrt
-
     conf = config[DOMAIN]
 
     api = AsusWrt(conf[CONF_HOST], conf.get(CONF_PORT),

--- a/homeassistant/components/asuswrt.py
+++ b/homeassistant/components/asuswrt.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.discovery import async_load_platform
 
-REQUIREMENTS = ['aioasuswrt==1.1.0']
+REQUIREMENTS = ['aioasuswrt==1.1.2']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -57,7 +57,8 @@ async def async_setup(hass, config):
                   conf[CONF_MODE], conf[CONF_REQUIRE_IP])
     hass.data[DATA_ASUSWRT] = api
 
-    hass.async_create_task(async_load_platform(hass, 'sensor', DOMAIN, {}))
     hass.async_create_task(async_load_platform(
-        hass, 'device_tracker', DOMAIN, {}))
+        hass, 'sensor', DOMAIN, {}, config))
+    hass.async_create_task(async_load_platform(
+        hass, 'device_tracker', DOMAIN, {}, config))
     return True

--- a/homeassistant/components/asuswrt.py
+++ b/homeassistant/components/asuswrt.py
@@ -48,12 +48,12 @@ async def async_setup(hass, config):
 
     conf = config[DOMAIN]
 
-    api = AsusWrt(conf[CONF_HOST], conf[CONF_PORT],
-                  conf[CONF_PROTOCOL] == 'telnet',
+    api = AsusWrt(conf[CONF_HOST], conf.get(CONF_PORT),
+                  conf.get(CONF_PROTOCOL) == 'telnet',
                   conf[CONF_USERNAME],
                   conf.get(CONF_PASSWORD, ''),
                   conf.get('ssh_key', conf.get('pub_key', '')),
-                  conf[CONF_MODE], conf[CONF_REQUIRE_IP])
+                  conf.get(CONF_MODE), conf.get(CONF_REQUIRE_IP))
 
     await api.connection.async_connect()
     if not api.is_connected:

--- a/homeassistant/components/asuswrt.py
+++ b/homeassistant/components/asuswrt.py
@@ -1,0 +1,63 @@
+"""
+Support for ASUSWRT devices.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/asuswrt/
+"""
+import logging
+
+import voluptuous as vol
+
+from homeassistant.const import (
+    CONF_HOST, CONF_PASSWORD, CONF_USERNAME, CONF_PORT, CONF_MODE,
+    CONF_PROTOCOL)
+
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.discovery import async_load_platform
+
+REQUIREMENTS = ['aioasuswrt==1.1.0']
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = "asuswrt"
+DATA_ASUSWRT = DOMAIN
+
+CONF_PUB_KEY = 'pub_key'
+CONF_SSH_KEY = 'ssh_key'
+CONF_REQUIRE_IP = 'require_ip'
+DEFAULT_SSH_PORT = 22
+SECRET_GROUP = 'Password or SSH Key'
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_HOST): cv.string,
+        vol.Required(CONF_USERNAME): cv.string,
+        vol.Optional(CONF_PROTOCOL, default='ssh'): vol.In(['ssh', 'telnet']),
+        vol.Optional(CONF_MODE, default='router'): vol.In(['router', 'ap']),
+        vol.Optional(CONF_PORT, default=DEFAULT_SSH_PORT): cv.port,
+        vol.Optional(CONF_REQUIRE_IP, default=True): cv.boolean,
+        vol.Exclusive(CONF_PASSWORD, SECRET_GROUP): cv.string,
+        vol.Exclusive(CONF_SSH_KEY, SECRET_GROUP): cv.isfile,
+        vol.Exclusive(CONF_PUB_KEY, SECRET_GROUP): cv.isfile
+    }),
+}, extra=vol.ALLOW_EXTRA)
+
+
+async def async_setup(hass, config):
+    """Set up the asuswrt component."""
+    from aioasuswrt.asuswrt import AsusWrt
+
+    conf = config[DOMAIN]
+
+    api = AsusWrt(conf[CONF_HOST], conf[CONF_PORT],
+                  conf[CONF_PROTOCOL] == 'telnet',
+                  conf[CONF_USERNAME],
+                  conf.get(CONF_PASSWORD, ''),
+                  conf.get('ssh_key', conf.get('pub_key', '')),
+                  conf[CONF_MODE], conf[CONF_REQUIRE_IP])
+    hass.data[DATA_ASUSWRT] = api
+
+    hass.async_create_task(async_load_platform(hass, 'sensor', DOMAIN, {}))
+    hass.async_create_task(async_load_platform(
+        hass, 'device_tracker', DOMAIN, {}))
+    return True

--- a/homeassistant/components/sensor/asuswrt.py
+++ b/homeassistant/components/sensor/asuswrt.py
@@ -1,0 +1,126 @@
+"""
+Asuswrt status sensors.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.asuswrt/
+"""
+import logging
+
+from homeassistant.helpers.entity import Entity
+from homeassistant.components.asuswrt import DATA_ASUSWRT
+
+DEPENDENCIES = ['asuswrt']
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_platform(
+        hass, config, add_entities, discovery_info=None):
+    """Set up the asuswrt sensors."""
+    api = hass.data[DATA_ASUSWRT]
+    add_entities([
+        AsuswrtRXSensor(api),
+        AsuswrtTXSensor(api),
+        AsuswrtTotalRXSensor(api),
+        AsuswrtTotalTXSensor(api)
+    ])
+
+
+class AsuswrtSensor(Entity):
+    """Representation of a asuswrt sensor."""
+
+    _name = 'generic'
+
+    def __init__(self, api):
+        """Initialize the sensor."""
+        self._api = api
+        self._state = None
+        self._rates = None
+        self._speed = None
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    async def async_update(self, warning=True):
+        """Fetch status from asuswrt."""
+        self._rates = await self._api.async_get_packets_total()
+        self._speed = await self._api.async_get_current_transfer_rates()
+
+
+class AsuswrtRXSensor(AsuswrtSensor):
+    """Representation of a asuswrt download speed sensor."""
+
+    _name = 'Asuswrt Download Speed'
+    _unit = 'Mbit/s'
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement."""
+        return self._unit
+
+    async def async_update(self, warning=True):
+        """Fetch new state data for the sensor."""
+        await super().async_device_update(warning)
+        if self._speed is not None:
+            self._state = round(self._speed[0] / 125000, 2)
+
+
+class AsuswrtTXSensor(AsuswrtSensor):
+    """Representation of a asuswrt upload speed sensor."""
+
+    _name = 'Asuswrt Upload Speed'
+    _unit = 'Mbit/s'
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement."""
+        return self._unit
+
+    async def async_update(self, warning=True):
+        """Fetch new state data for the sensor."""
+        await super().async_device_update(warning)
+        if self._speed is not None:
+            self._state = round(self._speed[1] / 125000, 2)
+
+
+class AsuswrtTotalRXSensor(AsuswrtSensor):
+    """Representation of a asuswrt total download sensor."""
+
+    _name = 'Asuswrt Total Download'
+    _unit = 'Gigabyte'
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement."""
+        return self._unit
+
+    async def async_update(self, warning=True):
+        """Fetch new state data for the sensor."""
+        await super().async_device_update(warning)
+        if self._rates is not None:
+            self._state = round(self._rates[0] / 1000000000, 1)
+
+
+class AsuswrtTotalTXSensor(AsuswrtSensor):
+    """Representation of a asuswrt total upload sensor."""
+
+    _name = 'Asuswrt Total Upload'
+    _unit = 'Gigabyte'
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement."""
+        return self._unit
+
+    async def async_update(self, warning=True):
+        """Fetch new state data for the sensor."""
+        await super().async_device_update(warning)
+        if self._rates is not None:
+            self._state = round(self._rates[1] / 1000000000, 1)

--- a/homeassistant/components/sensor/asuswrt.py
+++ b/homeassistant/components/sensor/asuswrt.py
@@ -67,7 +67,7 @@ class AsuswrtRXSensor(AsuswrtSensor):
 
     async def async_update(self):
         """Fetch new state data for the sensor."""
-        await super().async_device_update()
+        await super().async_update()
         if self._speed is not None:
             self._state = round(self._speed[0] / 125000, 2)
 
@@ -85,7 +85,7 @@ class AsuswrtTXSensor(AsuswrtSensor):
 
     async def async_update(self):
         """Fetch new state data for the sensor."""
-        await super().async_device_update()
+        await super().async_update()
         if self._speed is not None:
             self._state = round(self._speed[1] / 125000, 2)
 
@@ -103,7 +103,7 @@ class AsuswrtTotalRXSensor(AsuswrtSensor):
 
     async def async_update(self):
         """Fetch new state data for the sensor."""
-        await super().async_device_update()
+        await super().async_update()
         if self._rates is not None:
             self._state = round(self._rates[0] / 1000000000, 1)
 
@@ -121,6 +121,6 @@ class AsuswrtTotalTXSensor(AsuswrtSensor):
 
     async def async_update(self):
         """Fetch new state data for the sensor."""
-        await super().async_device_update()
+        await super().async_update()
         if self._rates is not None:
             self._state = round(self._rates[1] / 1000000000, 1)

--- a/homeassistant/components/sensor/asuswrt.py
+++ b/homeassistant/components/sensor/asuswrt.py
@@ -48,7 +48,7 @@ class AsuswrtSensor(Entity):
         """Return the state of the sensor."""
         return self._state
 
-    async def async_update(self, warning=True):
+    async def async_update(self):
         """Fetch status from asuswrt."""
         self._rates = await self._api.async_get_packets_total()
         self._speed = await self._api.async_get_current_transfer_rates()
@@ -65,9 +65,9 @@ class AsuswrtRXSensor(AsuswrtSensor):
         """Return the unit of measurement."""
         return self._unit
 
-    async def async_update(self, warning=True):
+    async def async_update(self):
         """Fetch new state data for the sensor."""
-        await super().async_device_update(warning)
+        await super().async_device_update()
         if self._speed is not None:
             self._state = round(self._speed[0] / 125000, 2)
 
@@ -83,9 +83,9 @@ class AsuswrtTXSensor(AsuswrtSensor):
         """Return the unit of measurement."""
         return self._unit
 
-    async def async_update(self, warning=True):
+    async def async_update(self):
         """Fetch new state data for the sensor."""
-        await super().async_device_update(warning)
+        await super().async_device_update()
         if self._speed is not None:
             self._state = round(self._speed[1] / 125000, 2)
 
@@ -101,9 +101,9 @@ class AsuswrtTotalRXSensor(AsuswrtSensor):
         """Return the unit of measurement."""
         return self._unit
 
-    async def async_update(self, warning=True):
+    async def async_update(self):
         """Fetch new state data for the sensor."""
-        await super().async_device_update(warning)
+        await super().async_device_update()
         if self._rates is not None:
             self._state = round(self._rates[0] / 1000000000, 1)
 
@@ -119,8 +119,8 @@ class AsuswrtTotalTXSensor(AsuswrtSensor):
         """Return the unit of measurement."""
         return self._unit
 
-    async def async_update(self, warning=True):
+    async def async_update(self):
         """Fetch new state data for the sensor."""
-        await super().async_device_update(warning)
+        await super().async_device_update()
         if self._rates is not None:
             self._state = round(self._rates[1] / 1000000000, 1)

--- a/homeassistant/components/sensor/asuswrt.py
+++ b/homeassistant/components/sensor/asuswrt.py
@@ -93,7 +93,7 @@ class AsuswrtTXSensor(AsuswrtSensor):
 class AsuswrtTotalRXSensor(AsuswrtSensor):
     """Representation of a asuswrt total download sensor."""
 
-    _name = 'Asuswrt Total Download'
+    _name = 'Asuswrt Download'
     _unit = 'Gigabyte'
 
     @property
@@ -111,7 +111,7 @@ class AsuswrtTotalRXSensor(AsuswrtSensor):
 class AsuswrtTotalTXSensor(AsuswrtSensor):
     """Representation of a asuswrt total upload sensor."""
 
-    _name = 'Asuswrt Total Upload'
+    _name = 'Asuswrt Upload'
     _unit = 'Gigabyte'
 
     @property

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -86,7 +86,7 @@ abodepy==0.14.0
 afsapi==0.0.4
 
 # homeassistant.components.device_tracker.asuswrt
-aioasuswrt==1.1.2
+aioasuswrt==1.1.4
 
 # homeassistant.components.device_tracker.automatic
 aioautomatic==0.6.5

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -85,7 +85,7 @@ abodepy==0.14.0
 # homeassistant.components.media_player.frontier_silicon
 afsapi==0.0.4
 
-# homeassistant.components.device_tracker.asuswrt
+# homeassistant.components.asuswrt
 aioasuswrt==1.1.4
 
 # homeassistant.components.device_tracker.automatic

--- a/tests/components/device_tracker/test_asuswrt.py
+++ b/tests/components/device_tracker/test_asuswrt.py
@@ -1,6 +1,10 @@
 """The tests for the ASUSWRT device tracker platform."""
+import asyncio
+
+from homeassistant.setup import async_setup_component
+
 from homeassistant.components.asuswrt import (
-    CONF_PROTOCOL, CONF_MODE, DOMAIN, CONF_PORT, DATA_ASUSWRT, async_setup)
+    CONF_PROTOCOL, CONF_MODE, DOMAIN, CONF_PORT, DATA_ASUSWRT)
 from homeassistant.const import (CONF_PLATFORM, CONF_PASSWORD, CONF_USERNAME,
                                  CONF_HOST)
 
@@ -18,34 +22,33 @@ VALID_CONFIG_ROUTER_SSH = {DOMAIN: {
 }}
 
 
-async def test_password_or_pub_key_required(hass):
+@asyncio.coroutine
+def test_password_or_pub_key_required(hass):
     """Test creating an AsusWRT scanner without a pass or pubkey."""
     with MockDependency('aioasuswrt.asuswrt')as mocked_asus:
         mocked_asus.AsusWrt().connection.async_connect = mock_coro_func()
         mocked_asus.AsusWrt().is_connected = False
-        assert not await async_setup(
-            hass, {DOMAIN: {
-                CONF_PLATFORM: 'asuswrt',
+        result = yield from async_setup_component(
+            hass, DOMAIN, {DOMAIN: {
                 CONF_HOST: 'fake_host',
                 CONF_USERNAME: 'fake_user'
             }})
-        await hass.async_block_till_done()
-        assert hass.data.get(DATA_ASUSWRT) is None
+        assert not result
 
 
-async def test_get_scanner_with_password_no_pubkey(hass):
+@asyncio.coroutine
+def test_get_scanner_with_password_no_pubkey(hass):
     """Test creating an AsusWRT scanner with a password and no pubkey."""
     with MockDependency('aioasuswrt.asuswrt')as mocked_asus:
         mocked_asus.AsusWrt().connection.async_connect = mock_coro_func()
         mocked_asus.AsusWrt(
         ).connection.async_get_connected_devices = mock_coro_func(
             return_value={})
-        assert await async_setup(
-            hass, {DOMAIN: {
-                CONF_PLATFORM: 'asuswrt',
+        result = yield from async_setup_component(
+            hass, DOMAIN, {DOMAIN: {
                 CONF_HOST: 'fake_host',
                 CONF_USERNAME: 'fake_user',
                 CONF_PASSWORD: '4321'
             }})
-        await hass.async_block_till_done()
+        assert result
         assert hass.data[DATA_ASUSWRT] is not None

--- a/tests/components/device_tracker/test_asuswrt.py
+++ b/tests/components/device_tracker/test_asuswrt.py
@@ -1,6 +1,4 @@
 """The tests for the ASUSWRT device tracker platform."""
-import asyncio
-
 from homeassistant.setup import async_setup_component
 
 from homeassistant.components.asuswrt import (
@@ -22,13 +20,12 @@ VALID_CONFIG_ROUTER_SSH = {DOMAIN: {
 }}
 
 
-@asyncio.coroutine
-def test_password_or_pub_key_required(hass):
+async def test_password_or_pub_key_required(hass):
     """Test creating an AsusWRT scanner without a pass or pubkey."""
     with MockDependency('aioasuswrt.asuswrt')as mocked_asus:
         mocked_asus.AsusWrt().connection.async_connect = mock_coro_func()
         mocked_asus.AsusWrt().is_connected = False
-        result = yield from async_setup_component(
+        result = await async_setup_component(
             hass, DOMAIN, {DOMAIN: {
                 CONF_HOST: 'fake_host',
                 CONF_USERNAME: 'fake_user'
@@ -36,15 +33,14 @@ def test_password_or_pub_key_required(hass):
         assert not result
 
 
-@asyncio.coroutine
-def test_get_scanner_with_password_no_pubkey(hass):
+async def test_get_scanner_with_password_no_pubkey(hass):
     """Test creating an AsusWRT scanner with a password and no pubkey."""
     with MockDependency('aioasuswrt.asuswrt')as mocked_asus:
         mocked_asus.AsusWrt().connection.async_connect = mock_coro_func()
         mocked_asus.AsusWrt(
         ).connection.async_get_connected_devices = mock_coro_func(
             return_value={})
-        result = yield from async_setup_component(
+        result = await async_setup_component(
             hass, DOMAIN, {DOMAIN: {
                 CONF_HOST: 'fake_host',
                 CONF_USERNAME: 'fake_user',

--- a/tests/components/device_tracker/test_asuswrt.py
+++ b/tests/components/device_tracker/test_asuswrt.py
@@ -1,0 +1,107 @@
+"""The tests for the ASUSWRT device tracker platform."""
+import os
+from datetime import timedelta
+import unittest
+from unittest import mock
+
+from homeassistant.setup import setup_component
+from homeassistant.components import device_tracker
+from homeassistant.components.device_tracker import (
+    CONF_CONSIDER_HOME, CONF_TRACK_NEW, CONF_NEW_DEVICE_DEFAULTS,
+    CONF_AWAY_HIDE)
+from homeassistant.components.device_tracker.asuswrt import (
+    CONF_PROTOCOL, CONF_MODE, DOMAIN, CONF_PORT)
+from homeassistant.const import (CONF_PLATFORM, CONF_PASSWORD, CONF_USERNAME,
+                                 CONF_HOST)
+
+import pytest
+from tests.common import (
+    get_test_home_assistant, get_test_config_dir, assert_setup_component,
+    mock_component)
+
+FAKEFILE = None
+
+VALID_CONFIG_ROUTER_SSH = {DOMAIN: {
+    CONF_PLATFORM: 'asuswrt',
+    CONF_HOST: 'fake_host',
+    CONF_USERNAME: 'fake_user',
+    CONF_PROTOCOL: 'ssh',
+    CONF_MODE: 'router',
+    CONF_PORT: '22'
+}}
+
+
+def setup_module():
+    """Set up the test module."""
+    global FAKEFILE
+    FAKEFILE = get_test_config_dir('fake_file')
+    with open(FAKEFILE, 'w') as out:
+        out.write(' ')
+
+
+def teardown_module():
+    """Tear down the module."""
+    os.remove(FAKEFILE)
+
+
+@pytest.mark.skip(
+    reason="These tests are performing actual failing network calls. They "
+    "need to be cleaned up before they are re-enabled. They're frequently "
+    "failing in Travis.")
+class TestComponentsDeviceTrackerASUSWRT(unittest.TestCase):
+    """Tests for the ASUSWRT device tracker platform."""
+
+    hass = None
+
+    def setup_method(self, _):
+        """Set up things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+        mock_component(self.hass, 'zone')
+
+    def teardown_method(self, _):
+        """Stop everything that was started."""
+        self.hass.stop()
+        try:
+            os.remove(self.hass.config.path(device_tracker.YAML_DEVICES))
+        except FileNotFoundError:
+            pass
+
+    def test_password_or_pub_key_required(self):
+        """Test creating an AsusWRT scanner without a pass or pubkey."""
+        with assert_setup_component(0, DOMAIN):
+            assert setup_component(
+                self.hass, DOMAIN, {DOMAIN: {
+                    CONF_PLATFORM: 'asuswrt',
+                    CONF_HOST: 'fake_host',
+                    CONF_USERNAME: 'fake_user',
+                    CONF_PROTOCOL: 'ssh'
+                }})
+
+    @mock.patch(
+        'homeassistant.components.device_tracker.asuswrt.AsusWrtDeviceScanner',
+        return_value=mock.MagicMock())
+    def test_get_scanner_with_password_no_pubkey(self, asuswrt_mock):
+        """Test creating an AsusWRT scanner with a password and no pubkey."""
+        conf_dict = {
+            DOMAIN: {
+                CONF_PLATFORM: 'asuswrt',
+                CONF_HOST: 'fake_host',
+                CONF_USERNAME: 'fake_user',
+                CONF_PASSWORD: 'fake_pass',
+                CONF_TRACK_NEW: True,
+                CONF_CONSIDER_HOME: timedelta(seconds=180),
+                CONF_NEW_DEVICE_DEFAULTS: {
+                    CONF_TRACK_NEW: True,
+                    CONF_AWAY_HIDE: False
+                }
+            }
+        }
+
+        with assert_setup_component(1, DOMAIN):
+            assert setup_component(self.hass, DOMAIN, conf_dict)
+
+        conf_dict[DOMAIN][CONF_MODE] = 'router'
+        conf_dict[DOMAIN][CONF_PROTOCOL] = 'ssh'
+        conf_dict[DOMAIN][CONF_PORT] = 22
+        assert asuswrt_mock.call_count == 1
+        assert asuswrt_mock.call_args == mock.call(conf_dict[DOMAIN])

--- a/tests/components/device_tracker/test_asuswrt.py
+++ b/tests/components/device_tracker/test_asuswrt.py
@@ -1,23 +1,12 @@
 """The tests for the ASUSWRT device tracker platform."""
-import os
-from datetime import timedelta
-import unittest
-from unittest import mock
+from homeassistant.components.device_tracker.asuswrt import async_get_scanner
 
-from homeassistant.setup import setup_component
-from homeassistant.components import device_tracker
-from homeassistant.components.device_tracker import (
-    CONF_CONSIDER_HOME, CONF_TRACK_NEW, CONF_NEW_DEVICE_DEFAULTS,
-    CONF_AWAY_HIDE)
-from homeassistant.components.device_tracker.asuswrt import (
-    CONF_PROTOCOL, CONF_MODE, DOMAIN, CONF_PORT)
+from homeassistant.components.asuswrt import (
+    CONF_PROTOCOL, CONF_MODE, DOMAIN, CONF_PORT, DATA_ASUSWRT)
 from homeassistant.const import (CONF_PLATFORM, CONF_PASSWORD, CONF_USERNAME,
                                  CONF_HOST)
 
-import pytest
-from tests.common import (
-    get_test_home_assistant, get_test_config_dir, assert_setup_component,
-    mock_component)
+from tests.common import MockDependency, mock_coro_func
 
 FAKEFILE = None
 
@@ -31,77 +20,33 @@ VALID_CONFIG_ROUTER_SSH = {DOMAIN: {
 }}
 
 
-def setup_module():
-    """Set up the test module."""
-    global FAKEFILE
-    FAKEFILE = get_test_config_dir('fake_file')
-    with open(FAKEFILE, 'w') as out:
-        out.write(' ')
+async def test_password_or_pub_key_required(hass):
+    """Test creating an AsusWRT scanner without a pass or pubkey."""
+    with MockDependency('aioasuswrt') as mocked_asus:
+        mocked_asus.async_get_connected_devices = mock_coro_func()
+        hass.data[DATA_ASUSWRT] = mocked_asus
+        scanner = await async_get_scanner(
+            hass, {
+                CONF_PLATFORM: 'asuswrt',
+                CONF_HOST: 'fake_host',
+                CONF_USERNAME: 'fake_user'
+            })
+        await hass.async_block_till_done()
+        assert scanner is None
 
 
-def teardown_module():
-    """Tear down the module."""
-    os.remove(FAKEFILE)
-
-
-@pytest.mark.skip(
-    reason="These tests are performing actual failing network calls. They "
-    "need to be cleaned up before they are re-enabled. They're frequently "
-    "failing in Travis.")
-class TestComponentsDeviceTrackerASUSWRT(unittest.TestCase):
-    """Tests for the ASUSWRT device tracker platform."""
-
-    hass = None
-
-    def setup_method(self, _):
-        """Set up things to be run when tests are started."""
-        self.hass = get_test_home_assistant()
-        mock_component(self.hass, 'zone')
-
-    def teardown_method(self, _):
-        """Stop everything that was started."""
-        self.hass.stop()
-        try:
-            os.remove(self.hass.config.path(device_tracker.YAML_DEVICES))
-        except FileNotFoundError:
-            pass
-
-    def test_password_or_pub_key_required(self):
-        """Test creating an AsusWRT scanner without a pass or pubkey."""
-        with assert_setup_component(0, DOMAIN):
-            assert setup_component(
-                self.hass, DOMAIN, {DOMAIN: {
-                    CONF_PLATFORM: 'asuswrt',
-                    CONF_HOST: 'fake_host',
-                    CONF_USERNAME: 'fake_user',
-                    CONF_PROTOCOL: 'ssh'
-                }})
-
-    @mock.patch(
-        'homeassistant.components.device_tracker.asuswrt.AsusWrtDeviceScanner',
-        return_value=mock.MagicMock())
-    def test_get_scanner_with_password_no_pubkey(self, asuswrt_mock):
-        """Test creating an AsusWRT scanner with a password and no pubkey."""
-        conf_dict = {
-            DOMAIN: {
+async def test_get_scanner_with_password_no_pubkey(hass):
+    """Test creating an AsusWRT scanner with a password and no pubkey."""
+    with MockDependency('aioasuswrt') as mocked_asus:
+        mocked_asus.async_get_connected_devices = mock_coro_func(
+            return_value={})
+        hass.data[DATA_ASUSWRT] = mocked_asus
+        scanner = await async_get_scanner(
+            hass, {
                 CONF_PLATFORM: 'asuswrt',
                 CONF_HOST: 'fake_host',
                 CONF_USERNAME: 'fake_user',
-                CONF_PASSWORD: 'fake_pass',
-                CONF_TRACK_NEW: True,
-                CONF_CONSIDER_HOME: timedelta(seconds=180),
-                CONF_NEW_DEVICE_DEFAULTS: {
-                    CONF_TRACK_NEW: True,
-                    CONF_AWAY_HIDE: False
-                }
-            }
-        }
-
-        with assert_setup_component(1, DOMAIN):
-            assert setup_component(self.hass, DOMAIN, conf_dict)
-
-        conf_dict[DOMAIN][CONF_MODE] = 'router'
-        conf_dict[DOMAIN][CONF_PROTOCOL] = 'ssh'
-        conf_dict[DOMAIN][CONF_PORT] = 22
-        assert asuswrt_mock.call_count == 1
-        assert asuswrt_mock.call_args == mock.call(conf_dict[DOMAIN])
+                CONF_PASSWORD: '4321'
+            })
+        await hass.async_block_till_done()
+        assert scanner is not None


### PR DESCRIPTION
## Description:
This will add sensors for upload and download, it will also make asuswrt a component rather than device_tracker.

It's a breaking change for the device_tracker.

**Breaking Change**
The asuswrt device_tracker platform is now set up as a component.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#7324

## Example entry for `configuration.yaml` (if applicable):
```yaml
asuswrt:
    host: 192.168.1.1
    username: !secret asuswrt_username
    password: !secret asuswrt_password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
