### PR TITLE
Fix device reg considered changed

### DIFF
--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -87,8 +87,8 @@ class DeviceRegistry:
             device.id,
             add_config_entry_id=config_entry_id,
             hub_device_id=hub_device_id,
-            merge_connections=connections,
-            merge_identifiers=identifiers,
+            merge_connections=connections or _UNDEF,
+            merge_identifiers=identifiers or _UNDEF,
             manufacturer=manufacturer,
             model=model,
             name=name,
@@ -128,7 +128,8 @@ class DeviceRegistry:
                 ('identifiers', merge_identifiers),
         ):
             old_value = getattr(old, attr_name)
-            if value is not _UNDEF and value != old_value:
+            # If not undefined, check if `value` contains new items.
+            if value is not _UNDEF and not (old_value >= value):
                 changes[attr_name] = old_value | value
 
         for attr_name, value in (

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -129,7 +129,7 @@ class DeviceRegistry:
         ):
             old_value = getattr(old, attr_name)
             # If not undefined, check if `value` contains new items.
-            if value is not _UNDEF and not (old_value >= value):
+            if value is not _UNDEF and not value.issubset(old_value):
                 changes[attr_name] = old_value | value
 
         for attr_name, value in (


### PR DESCRIPTION
## Description:
We would consider the device registry incorrectly changed.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
