### PR TITLE
Move FFmpeg 'run_test' configuration from platform to components

### DIFF
--- a/homeassistant/components/binary_sensor/ffmpeg_motion.py
+++ b/homeassistant/components/binary_sensor/ffmpeg_motion.py
@@ -14,7 +14,7 @@ from homeassistant.components.binary_sensor import (
     BinarySensorDevice, PLATFORM_SCHEMA)
 from homeassistant.components.ffmpeg import (
     FFmpegBase, DATA_FFMPEG, CONF_INPUT, CONF_EXTRA_ARGUMENTS,
-    CONF_INITIAL_STATE)
+    CONF_INITIAL_STATE, CONF_RUN_TEST)
 from homeassistant.const import CONF_NAME
 
 DEPENDENCIES = ['ffmpeg']
@@ -25,7 +25,6 @@ CONF_RESET = 'reset'
 CONF_CHANGES = 'changes'
 CONF_REPEAT = 'repeat'
 CONF_REPEAT_TIME = 'repeat_time'
-CONF_RUN_TEST = 'run_test'
 
 DEFAULT_NAME = 'FFmpeg Motion'
 DEFAULT_INIT_STATE = True

--- a/homeassistant/components/binary_sensor/ffmpeg_motion.py
+++ b/homeassistant/components/binary_sensor/ffmpeg_motion.py
@@ -25,9 +25,11 @@ CONF_RESET = 'reset'
 CONF_CHANGES = 'changes'
 CONF_REPEAT = 'repeat'
 CONF_REPEAT_TIME = 'repeat_time'
+CONF_RUN_TEST = 'run_test'
 
 DEFAULT_NAME = 'FFmpeg Motion'
 DEFAULT_INIT_STATE = True
+DEFAULT_RUN_TEST = True
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_INPUT): cv.string,
@@ -42,6 +44,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
         vol.All(vol.Coerce(int), vol.Range(min=1)),
     vol.Inclusive(CONF_REPEAT_TIME, 'repeat'):
         vol.All(vol.Coerce(int), vol.Range(min=1)),
+    vol.Optional(CONF_RUN_TEST, default=DEFAULT_RUN_TEST): cv.boolean,
 })
 
 
@@ -50,8 +53,9 @@ async def async_setup_platform(hass, config, async_add_entities,
     """Set up the FFmpeg binary motion sensor."""
     manager = hass.data[DATA_FFMPEG]
 
-    if not await manager.async_run_test(config.get(CONF_INPUT)):
-        return
+    if config.get(CONF_RUN_TEST):
+        if not await manager.async_run_test(config.get(CONF_INPUT)):
+            return
 
     entity = FFmpegMotion(hass, manager, config)
     async_add_entities([entity])

--- a/homeassistant/components/binary_sensor/ffmpeg_noise.py
+++ b/homeassistant/components/binary_sensor/ffmpeg_noise.py
@@ -14,7 +14,7 @@ from homeassistant.components.binary_sensor.ffmpeg_motion import (
     FFmpegBinarySensor)
 from homeassistant.components.ffmpeg import (
     DATA_FFMPEG, CONF_INPUT, CONF_OUTPUT, CONF_EXTRA_ARGUMENTS,
-    CONF_INITIAL_STATE)
+    CONF_INITIAL_STATE, CONF_RUN_TEST)
 from homeassistant.const import CONF_NAME
 
 DEPENDENCIES = ['ffmpeg']
@@ -24,7 +24,6 @@ _LOGGER = logging.getLogger(__name__)
 CONF_PEAK = 'peak'
 CONF_DURATION = 'duration'
 CONF_RESET = 'reset'
-CONF_RUN_TEST = 'run_test'
 
 DEFAULT_NAME = 'FFmpeg Noise'
 DEFAULT_INIT_STATE = True

--- a/homeassistant/components/binary_sensor/ffmpeg_noise.py
+++ b/homeassistant/components/binary_sensor/ffmpeg_noise.py
@@ -24,9 +24,11 @@ _LOGGER = logging.getLogger(__name__)
 CONF_PEAK = 'peak'
 CONF_DURATION = 'duration'
 CONF_RESET = 'reset'
+CONF_RUN_TEST = 'run_test'
 
 DEFAULT_NAME = 'FFmpeg Noise'
 DEFAULT_INIT_STATE = True
+DEFAULT_RUN_TEST = True
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_INPUT): cv.string,
@@ -39,6 +41,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
         vol.All(vol.Coerce(int), vol.Range(min=1)),
     vol.Optional(CONF_RESET, default=10):
         vol.All(vol.Coerce(int), vol.Range(min=1)),
+    vol.Optional(CONF_RUN_TEST, default=DEFAULT_RUN_TEST): cv.boolean,
 })
 
 
@@ -47,8 +50,9 @@ async def async_setup_platform(hass, config, async_add_entities,
     """Set up the FFmpeg noise binary sensor."""
     manager = hass.data[DATA_FFMPEG]
 
-    if not await manager.async_run_test(config.get(CONF_INPUT)):
-        return
+    if config.get(CONF_RUN_TEST):
+        if not await manager.async_run_test(config.get(CONF_INPUT)):
+            return
 
     entity = FFmpegNoise(hass, manager, config)
     async_add_entities([entity])

--- a/homeassistant/components/camera/ffmpeg.py
+++ b/homeassistant/components/camera/ffmpeg.py
@@ -37,8 +37,10 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 async def async_setup_platform(hass, config, async_add_entities,
                                discovery_info=None):
     """Set up a FFmpeg camera."""
+    manager = hass.data[DATA_FFMPEG]
+
     if config.get(CONF_RUN_TEST):
-        if not await hass.data[DATA_FFMPEG].async_run_test(config.get(CONF_INPUT)):
+        if not await manager.async_run_test(config.get(CONF_INPUT)):
             return
 
     async_add_entities([FFmpegCamera(hass, config)])

--- a/homeassistant/components/camera/ffmpeg.py
+++ b/homeassistant/components/camera/ffmpeg.py
@@ -12,7 +12,7 @@ import voluptuous as vol
 from homeassistant.const import CONF_NAME
 from homeassistant.components.camera import Camera, PLATFORM_SCHEMA
 from homeassistant.components.ffmpeg import (
-    DATA_FFMPEG, CONF_INPUT, CONF_EXTRA_ARGUMENTS)
+    DATA_FFMPEG, CONF_INPUT, CONF_EXTRA_ARGUMENTS, CONF_RUN_TEST)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.aiohttp_client import (
     async_aiohttp_proxy_stream)
@@ -21,9 +21,6 @@ _LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = ['ffmpeg']
 DEFAULT_NAME = 'FFmpeg'
-
-CONF_RUN_TEST = 'run_test'
-
 DEFAULT_RUN_TEST = True
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({

--- a/homeassistant/components/camera/ffmpeg.py
+++ b/homeassistant/components/camera/ffmpeg.py
@@ -22,18 +22,25 @@ _LOGGER = logging.getLogger(__name__)
 DEPENDENCIES = ['ffmpeg']
 DEFAULT_NAME = 'FFmpeg'
 
+CONF_RUN_TEST = 'run_test'
+
+DEFAULT_RUN_TEST = True
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_INPUT): cv.string,
     vol.Optional(CONF_EXTRA_ARGUMENTS): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_RUN_TEST, default=DEFAULT_RUN_TEST): cv.boolean,
 })
 
 
 async def async_setup_platform(hass, config, async_add_entities,
                                discovery_info=None):
     """Set up a FFmpeg camera."""
-    if not await hass.data[DATA_FFMPEG].async_run_test(config.get(CONF_INPUT)):
-        return
+    if config.get(CONF_RUN_TEST):
+        if not await hass.data[DATA_FFMPEG].async_run_test(config.get(CONF_INPUT)):
+            return
+
     async_add_entities([FFmpegCamera(hass, config)])
 
 

--- a/homeassistant/components/ffmpeg.py
+++ b/homeassistant/components/ffmpeg.py
@@ -40,12 +40,10 @@ CONF_OUTPUT = 'output'
 CONF_RUN_TEST = 'run_test'
 
 DEFAULT_BINARY = 'ffmpeg'
-DEFAULT_RUN_TEST = True
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Optional(CONF_FFMPEG_BIN, default=DEFAULT_BINARY): cv.string,
-        vol.Optional(CONF_RUN_TEST, default=DEFAULT_RUN_TEST): cv.boolean,
     }),
 }, extra=vol.ALLOW_EXTRA)
 
@@ -60,8 +58,7 @@ async def async_setup(hass, config):
 
     manager = FFmpegManager(
         hass,
-        conf.get(CONF_FFMPEG_BIN, DEFAULT_BINARY),
-        conf.get(CONF_RUN_TEST, DEFAULT_RUN_TEST)
+        conf.get(CONF_FFMPEG_BIN, DEFAULT_BINARY)
     )
 
     # Register service
@@ -95,12 +92,11 @@ async def async_setup(hass, config):
 class FFmpegManager:
     """Helper for ha-ffmpeg."""
 
-    def __init__(self, hass, ffmpeg_bin, run_test):
+    def __init__(self, hass, ffmpeg_bin):
         """Initialize helper."""
         self.hass = hass
         self._cache = {}
         self._bin = ffmpeg_bin
-        self._run_test = run_test
 
     @property
     def binary(self):
@@ -114,19 +110,19 @@ class FFmpegManager:
         """
         from haffmpeg import Test
 
-        if self._run_test:
-            # if in cache
-            if input_source in self._cache:
-                return self._cache[input_source]
+        # if in cache
+        if input_source in self._cache:
+            return self._cache[input_source]
 
-            # run test
-            ffmpeg_test = Test(self.binary, loop=self.hass.loop)
-            success = await ffmpeg_test.run_test(input_source)
-            if not success:
-                _LOGGER.error("FFmpeg '%s' test fails!", input_source)
-                self._cache[input_source] = False
-                return False
-            self._cache[input_source] = True
+        # run test
+        ffmpeg_test = Test(self.binary, loop=self.hass.loop)
+        success = await ffmpeg_test.run_test(input_source)
+        if not success:
+            _LOGGER.error("FFmpeg '%s' test fails!", input_source)
+            self._cache[input_source] = False
+            return False
+        self._cache[input_source] = True
+
         return True
 
 


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes #17495 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#7064

## Example entry for `configuration.yaml` (if applicable):
```yaml
camera:
  - platform: ffmpeg
    name: My Camera
    input: -rtsp_transport tcp -i rtsp://10.2.3.4:8554/unicast
    run_test: false

binary_sensor:
  - platform: ffmpeg_noise
    name: My Camera Sound
    input: rtsp://10.2.3.4:8554/unicast
    extra_arguments: -filter:a highpass=f=300,lowpass=f=2500,volume=volume=2 -codec:a libmp3lame -ar 16000
    initial_state: false
    duration: 2
    reset: 60
    peak: -32
    run_test: false
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54