### PR TITLE
Fixed an incorrect reference in the entity registry

### DIFF
--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -185,7 +185,7 @@ class EntityRegistry:
         for listener_ref in new.update_listeners:
             listener = listener_ref()
             if listener is None:
-                to_remove.append(listener)
+                to_remove.append(listener_ref)
             else:
                 try:
                     listener.async_registry_updated(old, new)


### PR DESCRIPTION
## Description:

Fixes an unhandled exception in the entity registry. Pulled from a conversation with @balloob and @amelchio: https://discordapp.com/channels/330944238910963714/330990195199442944/504754594396635167

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable): N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
