### PR TITLE
Update HAP-python to 2.3.0

### DIFF
--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -29,7 +29,7 @@ from .const import (
 from .util import (
     show_setup_message, validate_entity_config, validate_media_player_features)
 
-REQUIREMENTS = ['HAP-python==2.2.2']
+REQUIREMENTS = ['HAP-python==2.3.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/homekit/type_switches.py
+++ b/homeassistant/components/homekit/type_switches.py
@@ -1,7 +1,9 @@
 """Class to hold all switch accessories."""
 import logging
 
-from pyhap.const import CATEGORY_OUTLET, CATEGORY_SWITCH
+from pyhap.const import (
+    CATEGORY_FAUCET, CATEGORY_OUTLET, CATEGORY_SHOWER_HEAD,
+    CATEGORY_SPRINKLER, CATEGORY_SWITCH)
 
 from homeassistant.components.switch import DOMAIN
 from homeassistant.const import (
@@ -16,10 +18,6 @@ from .const import (
     TYPE_SPRINKLER, TYPE_VALVE)
 
 _LOGGER = logging.getLogger(__name__)
-
-CATEGORY_SPRINKLER = 28
-CATEGORY_FAUCET = 29
-CATEGORY_SHOWER_HEAD = 30
 
 VALVE_TYPE = {
     TYPE_FAUCET: (CATEGORY_FAUCET, 3),

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -34,7 +34,7 @@ Adafruit-SHT31==1.0.2
 DoorBirdPy==0.1.3
 
 # homeassistant.components.homekit
-HAP-python==2.2.2
+HAP-python==2.3.0
 
 # homeassistant.components.notify.mastodon
 Mastodon.py==1.3.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -19,7 +19,7 @@ requests_mock==1.5.2
 
 
 # homeassistant.components.homekit
-HAP-python==2.2.2
+HAP-python==2.3.0
 
 # homeassistant.components.sensor.rmvtransport
 PyRMVtransport==0.1.3

--- a/tests/components/homekit/test_type_locks.py
+++ b/tests/components/homekit/test_type_locks.py
@@ -82,6 +82,7 @@ async def test_no_code(hass, hk_driver, config, events):
     # Set from HomeKit
     call_lock = async_mock_service(hass, DOMAIN, 'lock')
 
+    acc.char_target_state.value = 0
     await hass.async_add_job(acc.char_target_state.client_update_value, 1)
     await hass.async_block_till_done()
     assert call_lock

--- a/tests/components/homekit/test_type_media_players.py
+++ b/tests/components/homekit/test_type_media_players.py
@@ -64,6 +64,7 @@ async def test_media_player_set_state(hass, hk_driver, events):
     call_media_stop = async_mock_service(hass, DOMAIN, 'media_stop')
     call_toggle_mute = async_mock_service(hass, DOMAIN, 'volume_mute')
 
+    acc.chars[FEATURE_ON_OFF].value = False
     await hass.async_add_job(acc.chars[FEATURE_ON_OFF]
                              .client_update_value, True)
     await hass.async_block_till_done()


### PR DESCRIPTION
## Description:
Full changelog: https://github.com/ikalchev/HAP-python/blob/dev/CHANGELOG.md#230---2018-10-25
This update fixes some an issue that Accessories were marked as not responding.
General stability improvements.

Additionally the update lays the foundation for support of the camera accessory. However this is not used by Home Assistant at the moment.

Fixes:
#16692
#17365 (possible)
#17557
https://community.home-assistant.io/t/homekit-devices-not-responding/74656

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

---
CC: @dmonagle, @ehendrix23