### PR TITLE
Update Avi-On to work with latest API

### DIFF
--- a/homeassistant/components/light/avion.py
+++ b/homeassistant/components/light/avion.py
@@ -26,13 +26,13 @@ SUPPORT_AVION_LED = (SUPPORT_BRIGHTNESS)
 DEVICE_SCHEMA = vol.Schema({
     vol.Optional(CONF_NAME): cv.string,
     vol.Required(CONF_API_KEY): cv.string,
-    vol.Optional(CONF_ID): cv.positive_int,
+    vol.Optional(CONF_ID, default=None): cv.positive_int,
 })
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_DEVICES, default={}): {cv.string: DEVICE_SCHEMA},
-    vol.Optional(CONF_USERNAME): cv.string,
-    vol.Optional(CONF_PASSWORD): cv.string,
+    vol.Optional(CONF_USERNAME, default=None): cv.string,
+    vol.Optional(CONF_PASSWORD, default=None): cv.string,
 })
 
 
@@ -50,10 +50,10 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     for address, device_config in config[CONF_DEVICES].items():
         device = {}
-        device['name'] = device_config.get(CONF_NAME, None)
+        device['name'] = device_config[CONF_NAME]
         device['key'] = device_config[CONF_API_KEY]
         device['address'] = address
-        device['id'] = device_config.get(CONF_ID, None)
+        device['id'] = device_config[CONF_ID]
         lights.append(AvionLight(device))
 
     add_entities(lights)

--- a/homeassistant/components/light/avion.py
+++ b/homeassistant/components/light/avion.py
@@ -52,9 +52,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         device = avion.Avion(
             mac=address,
             passphrase=device_config[CONF_API_KEY],
-            name=(device_config[CONF_NAME] if CONF_NAME in device_config
-                  else None),
-            object_id=device_config[CONF_ID],
+            name=device_config.get(CONF_NAME, None),
+            object_id=device_config.get(CONF_ID, None),
             connect=False)
         lights.append(AvionLight(device))
 

--- a/homeassistant/components/light/avion.py
+++ b/homeassistant/components/light/avion.py
@@ -10,14 +10,14 @@ import time
 import voluptuous as vol
 
 from homeassistant.const import CONF_API_KEY, CONF_DEVICES, CONF_NAME, \
-    CONF_USERNAME, CONF_PASSWORD
+    CONF_USERNAME, CONF_PASSWORD, CONF_ID
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS, SUPPORT_BRIGHTNESS, Light,
     PLATFORM_SCHEMA)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['avion==0.7']
+REQUIREMENTS = ['antsar-avion==0.9']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -26,6 +26,7 @@ SUPPORT_AVION_LED = (SUPPORT_BRIGHTNESS)
 DEVICE_SCHEMA = vol.Schema({
     vol.Optional(CONF_NAME): cv.string,
     vol.Required(CONF_API_KEY): cv.string,
+    vol.Optional(CONF_ID): cv.positive_int,
 })
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -42,24 +43,17 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     lights = []
     if CONF_USERNAME in config and CONF_PASSWORD in config:
-        data = avion.avion_info(config[CONF_USERNAME], config[CONF_PASSWORD])
-        for location in data['locations']:
-            for avion_device in location['location']['devices']:
-                device = {}
-                mac = avion_device['device']['mac_address']
-                device['name'] = avion_device['device']['name']
-                device['key'] = location['location']['passphrase']
-                device['address'] = '%s%s:%s%s:%s%s:%s%s:%s%s:%s%s' % \
-                                    (mac[8], mac[9], mac[10], mac[11], mac[4],
-                                     mac[5], mac[6], mac[7], mac[0], mac[1],
-                                     mac[2], mac[3])
-                lights.append(AvionLight(device))
+        devices = avion.get_devices(
+            config[CONF_USERNAME], config[CONF_PASSWORD])
+        for device in devices:
+            lights.append(AvionLight(device))
 
     for address, device_config in config[CONF_DEVICES].items():
         device = {}
-        device['name'] = device_config[CONF_NAME]
+        device['name'] = device_config.get(CONF_NAME, None)
         device['key'] = device_config[CONF_API_KEY]
         device['address'] = address
+        device['id'] = device_config.get(CONF_ID, None)
         lights.append(AvionLight(device))
 
     add_entities(lights)
@@ -70,15 +64,11 @@ class AvionLight(Light):
 
     def __init__(self, device):
         """Initialize the light."""
-        # pylint: disable=no-member
-        import avion
-
-        self._name = device['name']
-        self._address = device['address']
-        self._key = device['key']
+        self._name = device.name
+        self._address = device.mac
         self._brightness = 255
         self._state = False
-        self._switch = avion.avion(self._address, self._key)
+        self._switch = device
 
     @property
     def unique_id(self):
@@ -129,7 +119,7 @@ class AvionLight(Light):
             try:
                 self._switch.set_brightness(brightness)
                 break
-            except avion.avionException:
+            except avion.AvionException:
                 self._switch.connect()
         return True
 

--- a/homeassistant/components/light/avion.py
+++ b/homeassistant/components/light/avion.py
@@ -17,7 +17,7 @@ from homeassistant.components.light import (
     PLATFORM_SCHEMA)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['antsar-avion==0.9']
+REQUIREMENTS = ['antsar-avion==0.9.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/light/avion.py
+++ b/homeassistant/components/light/avion.py
@@ -9,24 +9,23 @@ import time
 
 import voluptuous as vol
 
-from homeassistant.const import CONF_API_KEY, CONF_DEVICES, CONF_NAME, \
-    CONF_USERNAME, CONF_PASSWORD, CONF_ID
-
 from homeassistant.components.light import (
-    ATTR_BRIGHTNESS, SUPPORT_BRIGHTNESS, Light,
-    PLATFORM_SCHEMA)
+    ATTR_BRIGHTNESS, PLATFORM_SCHEMA, SUPPORT_BRIGHTNESS, Light)
+from homeassistant.const import (
+    CONF_API_KEY, CONF_DEVICES, CONF_ID, CONF_NAME, CONF_PASSWORD,
+    CONF_USERNAME)
 import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['antsar-avion==0.9.1']
 
 _LOGGER = logging.getLogger(__name__)
 
-SUPPORT_AVION_LED = (SUPPORT_BRIGHTNESS)
+SUPPORT_AVION_LED = SUPPORT_BRIGHTNESS
 
 DEVICE_SCHEMA = vol.Schema({
-    vol.Optional(CONF_NAME): cv.string,
     vol.Required(CONF_API_KEY): cv.string,
     vol.Optional(CONF_ID): cv.positive_int,
+    vol.Optional(CONF_NAME): cv.string,
 })
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -52,8 +51,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         device = avion.Avion(
             mac=address,
             passphrase=device_config[CONF_API_KEY],
-            name=device_config.get(CONF_NAME, None),
-            object_id=device_config.get(CONF_ID, None),
+            name=device_config.get(CONF_NAME),
+            object_id=device_config.get(CONF_ID),
             connect=False)
         lights.append(AvionLight(device))
 

--- a/homeassistant/components/light/avion.py
+++ b/homeassistant/components/light/avion.py
@@ -26,13 +26,13 @@ SUPPORT_AVION_LED = (SUPPORT_BRIGHTNESS)
 DEVICE_SCHEMA = vol.Schema({
     vol.Optional(CONF_NAME): cv.string,
     vol.Required(CONF_API_KEY): cv.string,
-    vol.Optional(CONF_ID, default=None): cv.positive_int,
+    vol.Optional(CONF_ID): cv.positive_int,
 })
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_DEVICES, default={}): {cv.string: DEVICE_SCHEMA},
-    vol.Optional(CONF_USERNAME, default=None): cv.string,
-    vol.Optional(CONF_PASSWORD, default=None): cv.string,
+    vol.Optional(CONF_USERNAME): cv.string,
+    vol.Optional(CONF_PASSWORD): cv.string,
 })
 
 
@@ -49,11 +49,13 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             lights.append(AvionLight(device))
 
     for address, device_config in config[CONF_DEVICES].items():
-        device = {}
-        device['name'] = device_config[CONF_NAME]
-        device['key'] = device_config[CONF_API_KEY]
-        device['address'] = address
-        device['id'] = device_config[CONF_ID]
+        device = avion.Avion(
+            mac=address,
+            passphrase=device_config[CONF_API_KEY],
+            name=(device_config[CONF_NAME] if CONF_NAME in device_config
+                  else None),
+            object_id=device_config[CONF_ID],
+            connect=False)
         lights.append(AvionLight(device))
 
     add_entities(lights)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -142,6 +142,9 @@ anel_pwrctrl-homeassistant==0.0.1.dev2
 # homeassistant.components.media_player.anthemav
 anthemav==1.1.8
 
+# homeassistant.components.light.avion
+# antsar-avion==0.9
+
 # homeassistant.components.apcupsd
 apcaccess==0.0.13
 
@@ -157,9 +160,6 @@ asterisk_mbox==0.5.0
 # homeassistant.components.upnp
 # homeassistant.components.media_player.dlna_dmr
 async-upnp-client==0.12.7
-
-# homeassistant.components.light.avion
-# avion==0.7
 
 # homeassistant.components.axis
 axis==14

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -143,7 +143,7 @@ anel_pwrctrl-homeassistant==0.0.1.dev2
 anthemav==1.1.8
 
 # homeassistant.components.light.avion
-# antsar-avion==0.9
+# antsar-avion==0.9.1
 
 # homeassistant.components.apcupsd
 apcaccess==0.0.13


### PR DESCRIPTION
## Description:

The `light.avion` component supports two ways of configuration: username/password (a web API is used to retrieve all device metadata), or manually enumerating devices by MAC address and ID. The Avi-On web API has changed, and the Home Assistant integration can no longer fetch devices. This PR updates Home Assistant to work with the new API.

**Related issue (if applicable):** fixes #17779

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#7073

## Example entry for `configuration.yaml` (if applicable):
This PR does not impact configuration. See current example config [here](https://www.home-assistant.io/components/light.avion).

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - ~Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)~ **N/A**

If the code communicates with devices, web services, or third-party tools:
  - ~New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).~ **N/A**
  - ~New dependencies are only imported inside functions that use them ([example][ex-import]).~ **N/A**
  - ~New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.~ **N/A**
  - ~New files were added to `.coveragerc`.~ **N/A**

If the code does not interact with devices:
  - ~Tests have been added to verify that the new code works.~ **N/A**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54

