### PR TITLE
Allow webhooks that support GET

### DIFF
--- a/homeassistant/components/webhook.py
+++ b/homeassistant/components/webhook.py
@@ -63,7 +63,7 @@ class WebhookView(HomeAssistantView):
     name = "api:webhook"
     requires_auth = False
 
-    async def post(self, request, webhook_id):
+    async def handle(self, request, webhook_id):
         """Handle webhook call."""
         hass = request.app['hass']
         handlers = hass.data.setdefault(DOMAIN, {})
@@ -83,3 +83,11 @@ class WebhookView(HomeAssistantView):
         except Exception:  # pylint: disable=broad-except
             _LOGGER.exception("Error processing webhook %s", webhook_id)
             return Response(status=200)
+
+    async def post(self, request, webhook_id):
+        """Handle webhook POST call."""
+        await self.handle(request, webhook_id)
+
+    async def get(self, request, webhook_id):
+        """Handle webhook GET call."""
+        await self.handle(request, webhook_id)

--- a/tests/components/test_webhook.py
+++ b/tests/components/test_webhook.py
@@ -94,3 +94,27 @@ async def test_posting_webhook_no_data(hass, mock_client):
     assert hooks[0][0] is hass
     assert hooks[0][1] == webhook_id
     assert await hooks[0][2].text() == ''
+
+
+async def test_getting_webhook_nonexisting(hass, mock_client):
+    """Test posting to a nonexisting webhook."""
+    resp = await mock_client.get('/api/webhook/non-existing')
+    assert resp.status == 200
+
+
+async def test_getting_webhook(hass, mock_client):
+    """Test posting a webhook with no data."""
+    hooks = []
+    webhook_id = hass.components.webhook.async_generate_id()
+
+    async def handle(*args):
+        """Handle webhook."""
+        hooks.append(args)
+
+    hass.components.webhook.async_register(webhook_id, handle)
+
+    resp = await mock_client.get('/api/webhook/{}'.format(webhook_id))
+    assert resp.status == 200
+    assert len(hooks) == 1
+    assert hooks[0][0] is hass
+    assert hooks[0][1] == webhook_id


### PR DESCRIPTION
## Description:

Copying the description from my comment https://github.com/home-assistant/home-assistant/issues/15376#issuecomment-432903999:

> I'm just starting migrating over the Prometheus component to an auto-generated webhook url and noticed that it (and several others) are using GET requests to scrape data from Home Assistant instead of POSTing data to Home Assistant. I'm going to extend the webhook component to support GET requests as well first.

**Related issue (if applicable):** relates to #15376

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
