### PR TITLE
SMHI weather component not showing correct values in current forecast

### DIFF
--- a/homeassistant/components/smhi/__init__.py
+++ b/homeassistant/components/smhi/__init__.py
@@ -12,7 +12,7 @@ from homeassistant.core import Config, HomeAssistant
 from .config_flow import smhi_locations  # noqa: F401
 from .const import DOMAIN  # noqa: F401
 
-REQUIREMENTS = ['smhi-pkg==1.0.4']
+REQUIREMENTS = ['smhi-pkg==1.0.5']
 
 DEFAULT_NAME = 'smhi'
 

--- a/homeassistant/components/smhi/config_flow.py
+++ b/homeassistant/components/smhi/config_flow.py
@@ -20,8 +20,6 @@ from homeassistant.util import slugify
 
 from .const import DOMAIN, HOME_LOCATION_NAME
 
-REQUIREMENTS = ['smhi-pkg==1.0.5']
-
 
 @callback
 def smhi_locations(hass: HomeAssistant):

--- a/homeassistant/components/smhi/config_flow.py
+++ b/homeassistant/components/smhi/config_flow.py
@@ -20,7 +20,7 @@ from homeassistant.util import slugify
 
 from .const import DOMAIN, HOME_LOCATION_NAME
 
-REQUIREMENTS = ['smhi-pkg==1.0.4']
+REQUIREMENTS = ['smhi-pkg==1.0.5']
 
 
 @callback

--- a/homeassistant/components/weather/smhi.py
+++ b/homeassistant/components/weather/smhi.py
@@ -30,7 +30,6 @@ from homeassistant.components.smhi.const import (
     ENTITY_ID_SENSOR_FORMAT, ATTR_SMHI_CLOUDINESS)
 
 DEPENDENCIES = ['smhi']
-REQUIREMENTS = ['smhi-pkg==1.0.5']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/weather/smhi.py
+++ b/homeassistant/components/weather/smhi.py
@@ -30,7 +30,7 @@ from homeassistant.components.smhi.const import (
     ENTITY_ID_SENSOR_FORMAT, ATTR_SMHI_CLOUDINESS)
 
 DEPENDENCIES = ['smhi']
-REQUIREMENTS = ['smhi-pkg==1.0.4']
+REQUIREMENTS = ['smhi-pkg==1.0.5']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1385,7 +1385,7 @@ smappy==0.2.16
 # homeassistant.components.smhi
 # homeassistant.components.smhi.config_flow
 # homeassistant.components.weather.smhi
-smhi-pkg==1.0.4
+smhi-pkg==1.0.5
 
 # homeassistant.components.media_player.snapcast
 snapcast==2.0.9

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1383,8 +1383,6 @@ smappy==0.2.16
 # smbus-cffi==0.5.1
 
 # homeassistant.components.smhi
-# homeassistant.components.smhi.config_flow
-# homeassistant.components.weather.smhi
 smhi-pkg==1.0.5
 
 # homeassistant.components.media_player.snapcast

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -229,7 +229,7 @@ sleepyq==0.6
 # homeassistant.components.smhi
 # homeassistant.components.smhi.config_flow
 # homeassistant.components.weather.smhi
-smhi-pkg==1.0.4
+smhi-pkg==1.0.5
 
 # homeassistant.components.climate.honeywell
 somecomfort==0.5.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -227,8 +227,6 @@ simplisafe-python==3.1.13
 sleepyq==0.6
 
 # homeassistant.components.smhi
-# homeassistant.components.smhi.config_flow
-# homeassistant.components.weather.smhi
 smhi-pkg==1.0.5
 
 # homeassistant.components.climate.honeywell


### PR DESCRIPTION
## Description:
In some cases the Swedish weather forecast lib not returning correct forecast for the current value 

Fix: new lib version 1.0.5

## Checklist:
  - [x ] The code change is tested and works locally.
  - [ x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.


