### PR TITLE
Fix unloading an entry can leave states around

### DIFF
--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -361,16 +361,16 @@ class Entity:
             self._on_remove = []
         self._on_remove.append(func)
 
-    async def async_remove(self):
-        """Remove entity from Home Assistant."""
+    async def async_will_remove_from_hass(self):
+        """Do things when entity is removed from hass."""
         if self._on_remove is not None:
             while self._on_remove:
                 self._on_remove.pop()()
 
-        if self.platform is not None:
-            await self.platform.async_remove_entity(self.entity_id)
-        else:
-            self.hass.states.async_remove(self.entity_id)
+    async def async_remove(self):
+        """Remove entity from Home Assistant."""
+        await self.async_will_remove_from_hass()
+        self.hass.states.async_remove(self.entity_id)
 
     @callback
     def async_registry_updated(self, old, new):

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -361,15 +361,17 @@ class Entity:
             self._on_remove = []
         self._on_remove.append(func)
 
-    async def async_will_remove_from_hass(self):
-        """Do things when entity is removed from hass."""
+    async def async_remove(self):
+        """Remove entity from Home Assistant."""
+        will_remove = getattr(self, 'async_will_remove_from_hass', None)
+
+        if will_remove:
+            await will_remove()  # pylint: disable=not-callable
+
         if self._on_remove is not None:
             while self._on_remove:
                 self._on_remove.pop()()
 
-    async def async_remove(self):
-        """Remove entity from Home Assistant."""
-        await self.async_will_remove_from_hass()
         self.hass.states.async_remove(self.entity_id)
 
     @callback

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -56,12 +56,14 @@ async def test_remove_entry(hass, manager):
         assert result
         return result
 
+    entity = MockEntity(
+        unique_id='1234',
+        name='Test Entity',
+    )
+
     async def mock_setup_entry_platform(hass, entry, async_add_entities):
         """Mock setting up platform."""
-        async_add_entities([MockEntity(
-            unique_id='1234',
-            name='Test Entity',
-        )])
+        async_add_entities([entity])
 
     loader.set_component(hass, 'test', MockModule(
         'test',

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -11,7 +11,8 @@ from homeassistant.setup import async_setup_component
 from homeassistant.util import dt
 
 from tests.common import (
-    MockModule, mock_coro, MockConfigEntry, async_fire_time_changed)
+    MockModule, mock_coro, MockConfigEntry, async_fire_time_changed,
+    MockPlatform, MockEntity)
 
 
 @pytest.fixture
@@ -40,27 +41,56 @@ def test_call_setup_entry(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-@asyncio.coroutine
-def test_remove_entry(hass, manager):
+async def test_remove_entry(hass, manager):
     """Test that we can remove an entry."""
-    mock_unload_entry = MagicMock(return_value=mock_coro(True))
+    async def mock_setup_entry(hass, entry):
+        """Mock setting up entry."""
+        hass.loop.create_task(hass.config_entries.async_forward_entry_setup(
+            entry, 'light'))
+        return True
 
+    async def mock_unload_entry(hass, entry):
+        """Mock unloading an entry."""
+        result = await hass.config_entries.async_forward_entry_unload(
+            entry, 'light')
+        assert result
+        return result
+
+    async def mock_setup_entry_platform(hass, entry, async_add_entities):
+        """Mock setting up platform."""
+        async_add_entities([MockEntity(
+            unique_id='1234',
+            name='Test Entity',
+        )])
+
+    loader.set_component(hass, 'test', MockModule(
+        'test',
+        async_setup_entry=mock_setup_entry,
+        async_unload_entry=mock_unload_entry
+    ))
     loader.set_component(
-        hass, 'test',
-        MockModule('comp', async_unload_entry=mock_unload_entry))
+        hass, 'light.test',
+        MockPlatform(async_setup_entry=mock_setup_entry_platform))
 
     MockConfigEntry(domain='test', entry_id='test1').add_to_manager(manager)
-    MockConfigEntry(
+    entry = MockConfigEntry(
         domain='test',
         entry_id='test2',
-        state=config_entries.ENTRY_STATE_LOADED
-    ).add_to_manager(manager)
+    )
+    entry.add_to_manager(manager)
     MockConfigEntry(domain='test', entry_id='test3').add_to_manager(manager)
 
     assert [item.entry_id for item in manager.async_entries()] == \
         ['test1', 'test2', 'test3']
 
-    result = yield from manager.async_remove('test2')
+    await entry.async_setup(hass)
+    await hass.async_block_till_done()
+    assert hass.states.get('light.test_entity') is not None
+    # Group all_lights, light.test_entity
+    assert len(hass.states.async_all()) == 2
+
+    result = await manager.async_remove('test2')
+    await hass.async_block_till_done()
 
     assert result == {
         'require_restart': False
@@ -68,7 +98,9 @@ def test_remove_entry(hass, manager):
     assert [item.entry_id for item in manager.async_entries()] == \
         ['test1', 'test3']
 
-    assert len(mock_unload_entry.mock_calls) == 1
+    assert hass.states.get('light.test_entity') is None
+    # Just Group all_lights
+    assert len(hass.states.async_all()) == 1
 
 
 @asyncio.coroutine


### PR DESCRIPTION
## Description:
Fix for #17370. 

The issue is caused by the following (analysis by @amelchio):

 - Load a config entry that forwards to a platform that adds at least 1 entity that has a unique ID and so is entered into the entity registry
 - Remove config entry
 - Component unload will forward unload to platform
 - Entity Platform correctly unloads the entities from the state machine
 - When unload succeeds, config entry is removed
 - Removal of config entry triggers a cleanup on the entity registry to reset the config entry ID of any registered entity with that config entry ID (because the ID will no longer exist). Because this update mutates the entity registry, the attached entity is notified by calling `Entity.async_registry_updated`. 
 - `Entity.async_registry_updated` will cause `async_update_ha_state` to be called, writing the state of a removed entity to the state machine.

**Related issue (if applicable):** fixes #17370

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
