### PR TITLE
Add scenes as switches HomeKit

### DIFF
--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -170,7 +170,8 @@ def get_accessory(hass, driver, state, aid, config):
         switch_type = config.get(CONF_TYPE, TYPE_SWITCH)
         a_type = SWITCH_TYPES[switch_type]
 
-    elif state.domain in ('automation', 'input_boolean', 'remote', 'script'):
+    elif state.domain in ('automation', 'input_boolean', 'remote', 'scene',
+                          'script'):
         a_type = 'Switch'
 
     elif state.domain == 'water_heater':

--- a/homeassistant/components/homekit/type_switches.py
+++ b/homeassistant/components/homekit/type_switches.py
@@ -86,8 +86,9 @@ class Switch(HomeAccessory):
     def is_activate(self, state):
         """Check if entity is activate only."""
         can_cancel = state.attributes.get(ATTR_CAN_CANCEL)
-        if (self._domain == 'scene' or
-                self._domain == 'script' and not can_cancel):
+        if self._domain == 'scene':
+            return True
+        if self._domain == 'script' and not can_cancel:
             return True
         return False
 

--- a/homeassistant/components/homekit/type_switches.py
+++ b/homeassistant/components/homekit/type_switches.py
@@ -86,7 +86,8 @@ class Switch(HomeAccessory):
     def is_activate(self, state):
         """Check if entity is activate only."""
         can_cancel = state.attributes.get(ATTR_CAN_CANCEL)
-        if self._domain == 'script' and not can_cancel:
+        if (self._domain == 'scene' or
+                self._domain == 'script' and not can_cancel):
             return True
         return False
 

--- a/tests/components/homekit/test_get_accessories.py
+++ b/tests/components/homekit/test_get_accessories.py
@@ -139,6 +139,7 @@ def test_type_sensors(type_name, entity_id, state, attrs):
     ('Switch', 'automation.test', 'on', {}, {}),
     ('Switch', 'input_boolean.test', 'on', {}, {}),
     ('Switch', 'remote.test', 'on', {}, {}),
+    ('Switch', 'scene.test', 'on', {}, {}),
     ('Switch', 'script.test', 'on', {}, {}),
     ('Switch', 'switch.test', 'on', {}, {}),
     ('Switch', 'switch.test', 'on', {}, {CONF_TYPE: TYPE_SWITCH}),

--- a/tests/components/homekit/test_type_switches.py
+++ b/tests/components/homekit/test_type_switches.py
@@ -62,6 +62,7 @@ async def test_outlet_set_state(hass, hk_driver, events):
     ('automation.test', {}),
     ('input_boolean.test', {}),
     ('remote.test', {}),
+    ('scene.test', {}),
     ('script.test', {ATTR_CAN_CANCEL: True}),
     ('switch.test', {}),
 ])
@@ -180,6 +181,7 @@ async def test_valve_set_state(hass, hk_driver, events):
 
 
 @pytest.mark.parametrize('entity_id, attrs', [
+    ('scene.test', {}),
     ('script.test', {}),
     ('script.test', {ATTR_CAN_CANCEL: False}),
 ])

--- a/tests/components/homekit/test_type_switches.py
+++ b/tests/components/homekit/test_type_switches.py
@@ -62,7 +62,6 @@ async def test_outlet_set_state(hass, hk_driver, events):
     ('automation.test', {}),
     ('input_boolean.test', {}),
     ('remote.test', {}),
-    ('scene.test', {}),
     ('script.test', {ATTR_CAN_CANCEL: True}),
     ('switch.test', {}),
 ])


### PR DESCRIPTION
## Description:
Adds scenes as switches to HomeKit

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#7371

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)
  - [x] Tests have been added to verify that the new code works.