### PR TITLE
Pass though file_url from extended data attrs

### DIFF
--- a/homeassistant/components/notify/synology_chat.py
+++ b/homeassistant/components/notify/synology_chat.py
@@ -11,10 +11,11 @@ import requests
 import voluptuous as vol
 
 from homeassistant.components.notify import (
-    BaseNotificationService, PLATFORM_SCHEMA)
+    BaseNotificationService, PLATFORM_SCHEMA, ATTR_DATA)
 from homeassistant.const import CONF_RESOURCE
 import homeassistant.helpers.config_validation as cv
 
+ATTR_FILE_URL =  'file_url'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_RESOURCE): cv.url,
@@ -42,6 +43,12 @@ class SynologyChatNotificationService(BaseNotificationService):
         data = {
             'text': message
         }
+
+        extended_data = kwargs.get(ATTR_DATA)
+        file_url = extended_data.get(ATTR_FILE_URL, None) if extended_data else None
+
+        if file_url:
+            data['file_url'] = file_url
 
         to_send = 'payload={}'.format(json.dumps(data))
 

--- a/homeassistant/components/notify/synology_chat.py
+++ b/homeassistant/components/notify/synology_chat.py
@@ -15,7 +15,7 @@ from homeassistant.components.notify import (
 from homeassistant.const import CONF_RESOURCE
 import homeassistant.helpers.config_validation as cv
 
-ATTR_FILE_URL =  'file_url'
+ATTR_FILE_URL = 'file_url'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_RESOURCE): cv.url,
@@ -45,7 +45,7 @@ class SynologyChatNotificationService(BaseNotificationService):
         }
 
         extended_data = kwargs.get(ATTR_DATA)
-        file_url = extended_data.get(ATTR_FILE_URL, None) if extended_data else None
+        file_url = extended_data.get(ATTR_FILE_URL) if extended_data else None
 
         if file_url:
             data['file_url'] = file_url


### PR DESCRIPTION
## Description:
Pass through file_url to the Synology chat API so that it can send attachments in Synology Chat.

**Related issue (if applicable):** fixes #17748

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#7100

## Example entry for `configuration.yaml` (if applicable):
```yaml
notify:
  - platform: synology_chat
    name: hass_synchat_name
    resource: https://synology.example.com/webapi/entry.cgi?api=SYNO.Chat.External&method=incoming&version=1&token=foobar
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)
