### PR TITLE
Bump NDMS2 client to 0.0.5 to fix unicode characters support

### DIFF
--- a/homeassistant/components/device_tracker/keenetic_ndms2.py
+++ b/homeassistant/components/device_tracker/keenetic_ndms2.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
     CONF_HOST, CONF_PORT, CONF_PASSWORD, CONF_USERNAME
 )
 
-REQUIREMENTS = ['ndms2_client==0.0.4']
+REQUIREMENTS = ['ndms2_client==0.0.5']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -640,7 +640,7 @@ nad_receiver==0.0.9
 nanoleaf==0.4.1
 
 # homeassistant.components.device_tracker.keenetic_ndms2
-ndms2_client==0.0.4
+ndms2_client==0.0.5
 
 # homeassistant.components.sensor.netdata
 netdata==0.1.2


### PR DESCRIPTION
## Description:
NDMS2 client version 0.0.4 fails if user names device with unicode names, e.g. Cyrillic chars.
Fixed in 0.0.5: foxel/python_ndms2_client#1

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

