### PR TITLE
Lovelace ws: add move command

### DIFF
--- a/homeassistant/components/lovelace/__init__.py
+++ b/homeassistant/components/lovelace/__init__.py
@@ -85,7 +85,7 @@ class UnsupportedYamlError(HomeAssistantError):
 
 
 class DuplicateIdError(HomeAssistantError):
-    """Duplicate ID's"""
+    """Duplicate ID's."""
 
 
 def save_yaml(fname: str, data: JSON_TYPE):
@@ -312,7 +312,6 @@ def move_card_view(fname: str, card_id: str, view_id: str,
         destination.insert(position, card_to_move)
 
     save_yaml(fname, config)
-    return
 
 
 async def async_setup(hass, config):
@@ -456,7 +455,7 @@ async def websocket_lovelace_move_card(hass, connection, msg):
     """Move card to different position over websocket and save."""
     error = None
     try:
-        if ('view_id' in msg):
+        if 'view_id' in msg:
             await hass.async_add_executor_job(
                 move_card_view, hass.config.path(LOVELACE_CONFIG_FILE),
                 msg['card_id'], msg['view_id'], msg.get('position'))

--- a/homeassistant/components/lovelace/__init__.py
+++ b/homeassistant/components/lovelace/__init__.py
@@ -61,10 +61,8 @@ SCHEMA_ADD_CARD = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend({
 SCHEMA_MOVE_CARD = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend({
     vol.Required('type'): WS_TYPE_MOVE_CARD,
     vol.Required('card_id'): str,
-    vol.Optional('position'): int,
-    vol.Optional('view_id'): str,
-    vol.Optional('format', default=FORMAT_YAML): vol.Any(FORMAT_JSON,
-                                                         FORMAT_YAML),
+    vol.Optional('new_position'): int,
+    vol.Optional('new_view_id'): str,
 })
 
 
@@ -404,7 +402,7 @@ async def websocket_lovelace_update_card(hass, connection, msg):
             update_card, hass.config.path(LOVELACE_CONFIG_FILE),
             msg['card_id'], msg['card_config'], msg.get('format', FORMAT_YAML))
         message = websocket_api.result_message(
-            msg['id'], True
+            msg['id']
         )
     except FileNotFoundError:
         error = ('file_not_found',
@@ -432,7 +430,7 @@ async def websocket_lovelace_add_card(hass, connection, msg):
             msg['view_id'], msg['card_config'], msg.get('position'),
             msg.get('format', FORMAT_YAML))
         message = websocket_api.result_message(
-            msg['id'], True
+            msg['id']
         )
     except FileNotFoundError:
         error = ('file_not_found',
@@ -455,17 +453,17 @@ async def websocket_lovelace_move_card(hass, connection, msg):
     """Move card to different position over websocket and save."""
     error = None
     try:
-        if 'view_id' in msg:
+        if 'new_view_id' in msg:
             await hass.async_add_executor_job(
                 move_card_view, hass.config.path(LOVELACE_CONFIG_FILE),
-                msg['card_id'], msg['view_id'], msg.get('position'))
+                msg['card_id'], msg['new_view_id'], msg.get('new_position'))
         else:
             await hass.async_add_executor_job(
                 move_card, hass.config.path(LOVELACE_CONFIG_FILE),
-                msg['card_id'], msg.get('position'))
+                msg['card_id'], msg.get('new_position'))
 
         message = websocket_api.result_message(
-            msg['id'], True
+            msg['id']
         )
     except FileNotFoundError:
         error = ('file_not_found',

--- a/tests/components/lovelace/test_init.py
+++ b/tests/components/lovelace/test_init.py
@@ -59,6 +59,7 @@ views:
     cards:
       - id: test
         type: entities
+        title: Test card
         # Entities card will take a list of entities and show their state.
       - type: entities
         # Title of the entities card
@@ -327,7 +328,7 @@ async def test_lovelace_get_card(hass, hass_ws_client):
     assert msg['id'] == 5
     assert msg['type'] == TYPE_RESULT
     assert msg['success']
-    assert msg['result'] == 'id: test\ntype: entities\n'
+    assert msg['result'] == 'id: test\ntype: entities\ntitle: Test card\n'
 
 
 async def test_lovelace_get_card_not_found(hass, hass_ws_client):
@@ -491,6 +492,85 @@ async def test_lovelace_add_card_position(hass, hass_ws_client):
     result = save_yaml_mock.call_args_list[0][0][1]
     assert result.mlget(['views', 0, 'cards', 0, 'type'],
                         list_ok=True) == 'added'
+    assert msg['id'] == 5
+    assert msg['type'] == TYPE_RESULT
+    assert msg['success']
+
+
+async def test_lovelace_move_card_position(hass, hass_ws_client):
+    """Test add_card command."""
+    await async_setup_component(hass, 'lovelace')
+    client = await hass_ws_client(hass)
+    yaml = YAML(typ='rt')
+
+    with patch('homeassistant.components.lovelace.load_yaml',
+               return_value=yaml.load(TEST_YAML_A)), \
+        patch('homeassistant.components.lovelace.save_yaml') \
+            as save_yaml_mock:
+        await client.send_json({
+            'id': 5,
+            'type': 'lovelace/config/card/move',
+            'card_id': 'test',
+            'position': 2,
+        })
+        msg = await client.receive_json()
+
+    result = save_yaml_mock.call_args_list[0][0][1]
+    assert result.mlget(['views', 1, 'cards', 2, 'title'],
+                        list_ok=True) == 'Test card'
+    assert msg['id'] == 5
+    assert msg['type'] == TYPE_RESULT
+    assert msg['success']
+
+
+async def test_lovelace_move_card_view(hass, hass_ws_client):
+    """Test add_card command."""
+    await async_setup_component(hass, 'lovelace')
+    client = await hass_ws_client(hass)
+    yaml = YAML(typ='rt')
+
+    with patch('homeassistant.components.lovelace.load_yaml',
+               return_value=yaml.load(TEST_YAML_A)), \
+        patch('homeassistant.components.lovelace.save_yaml') \
+            as save_yaml_mock:
+        await client.send_json({
+            'id': 5,
+            'type': 'lovelace/config/card/move',
+            'card_id': 'test',
+            'view_id': 'example',
+        })
+        msg = await client.receive_json()
+
+    result = save_yaml_mock.call_args_list[0][0][1]
+    assert result.mlget(['views', 0, 'cards', 2, 'title'],
+                        list_ok=True) == 'Test card'
+    assert msg['id'] == 5
+    assert msg['type'] == TYPE_RESULT
+    assert msg['success']
+
+
+async def test_lovelace_move_card_view_position(hass, hass_ws_client):
+    """Test add_card command."""
+    await async_setup_component(hass, 'lovelace')
+    client = await hass_ws_client(hass)
+    yaml = YAML(typ='rt')
+
+    with patch('homeassistant.components.lovelace.load_yaml',
+               return_value=yaml.load(TEST_YAML_A)), \
+        patch('homeassistant.components.lovelace.save_yaml') \
+            as save_yaml_mock:
+        await client.send_json({
+            'id': 5,
+            'type': 'lovelace/config/card/move',
+            'card_id': 'test',
+            'view_id': 'example',
+            'position': 1,
+        })
+        msg = await client.receive_json()
+
+    result = save_yaml_mock.call_args_list[0][0][1]
+    assert result.mlget(['views', 0, 'cards', 1, 'title'],
+                        list_ok=True) == 'Test card'
     assert msg['id'] == 5
     assert msg['type'] == TYPE_RESULT
     assert msg['success']

--- a/tests/components/lovelace/test_init.py
+++ b/tests/components/lovelace/test_init.py
@@ -511,7 +511,7 @@ async def test_lovelace_move_card_position(hass, hass_ws_client):
             'id': 5,
             'type': 'lovelace/config/card/move',
             'card_id': 'test',
-            'position': 2,
+            'new_position': 2,
         })
         msg = await client.receive_json()
 
@@ -537,7 +537,7 @@ async def test_lovelace_move_card_view(hass, hass_ws_client):
             'id': 5,
             'type': 'lovelace/config/card/move',
             'card_id': 'test',
-            'view_id': 'example',
+            'new_view_id': 'example',
         })
         msg = await client.receive_json()
 
@@ -563,8 +563,8 @@ async def test_lovelace_move_card_view_position(hass, hass_ws_client):
             'id': 5,
             'type': 'lovelace/config/card/move',
             'card_id': 'test',
-            'view_id': 'example',
-            'position': 1,
+            'new_view_id': 'example',
+            'new_position': 1,
         })
         msg = await client.receive_json()
 

--- a/tests/components/lovelace/test_init.py
+++ b/tests/components/lovelace/test_init.py
@@ -3,6 +3,7 @@ import os
 import unittest
 from unittest.mock import patch
 from tempfile import mkdtemp
+import pytest
 from ruamel.yaml import YAML
 
 from homeassistant.exceptions import HomeAssistantError
@@ -11,7 +12,6 @@ from homeassistant.components.websocket_api.const import TYPE_RESULT
 from homeassistant.components.lovelace import (load_yaml,
                                                save_yaml, load_config,
                                                UnsupportedYamlError)
-import pytest
 
 TEST_YAML_A = """\
 title: My Awesome Home


### PR DESCRIPTION
## Description:
Adds a command to move cards in lovelace to a different view of a different position on a view.
Adds a check for duplicate ids in cards and views

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
