### PR TITLE
Add caching to lovelace config

### DIFF
--- a/tests/components/lovelace/test_init.py
+++ b/tests/components/lovelace/test_init.py
@@ -160,19 +160,21 @@ class TestYAML(unittest.TestCase):
 
     def test_add_id(self):
         """Test if id is added."""
-        fname = self._path_for("test6")
+        fname = self._path_for("test")
         with patch('homeassistant.components.lovelace.load_yaml',
                    return_value=self.yaml.load(TEST_YAML_A)), \
-                patch('homeassistant.components.lovelace.save_yaml'):
+                patch('homeassistant.components.lovelace.save_yaml'), \
+                patch('os.path.getmtime', return_value=1):
             data = load_config(fname)
         assert 'id' in data['views'][0]['cards'][0]
         assert 'id' in data['views'][1]
 
     def test_id_not_changed(self):
         """Test if id is not changed if already exists."""
-        fname = self._path_for("test7")
+        fname = self._path_for("test")
         with patch('homeassistant.components.lovelace.load_yaml',
-                   return_value=self.yaml.load(TEST_YAML_B)):
+                   return_value=self.yaml.load(TEST_YAML_B)), \
+                patch('os.path.getmtime', return_value=1):
             data = load_config(fname)
         assert data == self.yaml.load(TEST_YAML_B)
 


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
