### PR TITLE
Fixes an issue with OpenUV config import failing

### DIFF
--- a/homeassistant/components/openuv/__init__.py
+++ b/homeassistant/components/openuv/__init__.py
@@ -109,26 +109,30 @@ async def async_setup(hass, config):
         return True
 
     conf = config[DOMAIN]
-    latitude = conf.get(CONF_LATITUDE)
-    longitude = conf.get(CONF_LONGITUDE)
 
-    identifier = '{0}, {1}'.format(latitude, longitude)
+    identifier = '{0}, {1}'.format(
+        conf.get(CONF_LATITUDE, hass.config.latitude),
+        conf.get(CONF_LONGITUDE, hass.config.longitude))
     if identifier in configured_instances(hass):
         return True
 
+    data = {
+        CONF_API_KEY: conf[CONF_API_KEY],
+        CONF_BINARY_SENSORS: conf[CONF_BINARY_SENSORS],
+        CONF_SENSORS: conf[CONF_SENSORS],
+        CONF_SCAN_INTERVAL: conf[CONF_SCAN_INTERVAL],
+    }
+
+    if conf.get(CONF_LATITUDE):
+        data[CONF_LATITUDE] = conf[CONF_LATITUDE]
+    if conf.get(CONF_LONGITUDE):
+        data[CONF_LONGITUDE] = conf[CONF_LONGITUDE]
+    if conf.get(CONF_ELEVATION):
+        data[CONF_ELEVATION] = conf[CONF_ELEVATION]
+
     hass.async_create_task(
         hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={'source': SOURCE_IMPORT},
-            data={
-                CONF_API_KEY: conf[CONF_API_KEY],
-                CONF_LATITUDE: latitude,
-                CONF_LONGITUDE: longitude,
-                CONF_ELEVATION: conf.get(CONF_ELEVATION),
-                CONF_BINARY_SENSORS: conf[CONF_BINARY_SENSORS],
-                CONF_SENSORS: conf[CONF_SENSORS],
-                CONF_SCAN_INTERVAL: conf[CONF_SCAN_INTERVAL],
-            }))
+            DOMAIN, context={'source': SOURCE_IMPORT}, data=data))
 
     return True
 
@@ -143,10 +147,11 @@ async def async_setup_entry(hass, config_entry):
         openuv = OpenUV(
             Client(
                 config_entry.data[CONF_API_KEY],
-                config_entry.data[CONF_LATITUDE],
-                config_entry.data[CONF_LONGITUDE],
+                config_entry.data.get(CONF_LATITUDE, hass.config.latitude),
+                config_entry.data.get(CONF_LONGITUDE, hass.config.longitude),
                 websession,
-                altitude=config_entry.data[CONF_ELEVATION]),
+                altitude=config_entry.data.get(
+                    CONF_ELEVATION, hass.config.elevation)),
             config_entry.data.get(CONF_BINARY_SENSORS, {}).get(
                 CONF_MONITORED_CONDITIONS, list(BINARY_SENSORS)),
             config_entry.data.get(CONF_SENSORS, {}).get(
@@ -158,8 +163,9 @@ async def async_setup_entry(hass, config_entry):
         raise ConfigEntryNotReady
 
     for component in ('binary_sensor', 'sensor'):
-        hass.async_create_task(hass.config_entries.async_forward_entry_setup(
-            config_entry, component))
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_setup(
+                config_entry, component))
 
     async def refresh(event_time):
         """Refresh OpenUV data."""

--- a/homeassistant/components/openuv/__init__.py
+++ b/homeassistant/components/openuv/__init__.py
@@ -123,11 +123,11 @@ async def async_setup(hass, config):
         CONF_SCAN_INTERVAL: conf[CONF_SCAN_INTERVAL],
     }
 
-    if conf.get(CONF_LATITUDE):
+    if CONF_LATITUDE in conf:
         data[CONF_LATITUDE] = conf[CONF_LATITUDE]
-    if conf.get(CONF_LONGITUDE):
+    if CONF_LONGITUDE in conf:
         data[CONF_LONGITUDE] = conf[CONF_LONGITUDE]
-    if conf.get(CONF_ELEVATION):
+    if CONF_ELEVATION in conf:
         data[CONF_ELEVATION] = conf[CONF_ELEVATION]
 
     hass.async_create_task(

--- a/homeassistant/components/openuv/config_flow.py
+++ b/homeassistant/components/openuv/config_flow.py
@@ -72,13 +72,6 @@ class OpenUvFlowHandler(config_entries.ConfigFlow):
         if not api_key_validation:
             return await self._show_form({CONF_API_KEY: 'invalid_api_key'})
 
-        if user_input.get(CONF_LATITUDE):
-            user_input[CONF_LATITUDE] = user_input[CONF_LATITUDE]
-        if user_input.get(CONF_LONGITUDE):
-            user_input[CONF_LONGITUDE] = user_input[CONF_LONGITUDE]
-        if user_input.get(CONF_ELEVATION):
-            user_input[CONF_ELEVATION] = user_input[CONF_ELEVATION]
-
         scan_interval = user_input.get(
             CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
         user_input[CONF_SCAN_INTERVAL] = scan_interval.seconds

--- a/homeassistant/components/openuv/config_flow.py
+++ b/homeassistant/components/openuv/config_flow.py
@@ -36,12 +36,9 @@ class OpenUvFlowHandler(config_entries.ConfigFlow):
         """Show the form to the user."""
         data_schema = vol.Schema({
             vol.Required(CONF_API_KEY): str,
-            vol.Optional(CONF_LATITUDE, default=self.hass.config.latitude):
-                cv.latitude,
-            vol.Optional(CONF_LONGITUDE, default=self.hass.config.longitude):
-                cv.longitude,
-            vol.Optional(CONF_ELEVATION, default=self.hass.config.elevation):
-                vol.Coerce(float),
+            vol.Optional(CONF_LATITUDE): cv.latitude,
+            vol.Optional(CONF_LONGITUDE): cv.longitude,
+            vol.Optional(CONF_ELEVATION): vol.Coerce(float),
         })
 
         return self.async_show_form(
@@ -61,9 +58,15 @@ class OpenUvFlowHandler(config_entries.ConfigFlow):
         if not user_input:
             return await self._show_form()
 
-        latitude = user_input[CONF_LATITUDE]
-        longitude = user_input[CONF_LONGITUDE]
-        elevation = user_input[CONF_ELEVATION]
+        latitude = user_input.get(CONF_LATITUDE)
+        if latitude is None:
+            latitude = self.hass.config.latitude
+        longitude = user_input.get(CONF_LONGITUDE)
+        if longitude is None:
+            longitude = self.hass.config.longitude
+        elevation = user_input.get(CONF_ELEVATION)
+        if elevation is None:
+            elevation = self.hass.config.elevation
 
         identifier = '{0}, {1}'.format(latitude, longitude)
         if identifier in configured_instances(self.hass):


### PR DESCRIPTION
## Description:
Fixes an issue where OpenUV would fail in 0.81 when it was defined in `configuration.yaml` without specific latitude/longitude/elevation (i.e., relying on the default HASS latitude/longitude/elevation):

1. Config data is imported from `configuration.yaml`.
2. Default latitude/longitude/elevation doesn't populate properly.
3. Subsequent API calls fail.

In addition to fixing the bug, this PR makes it so that the latitude/longitude/elevation aren't stored in the config entry unless they are explicitly provided; if the HASS latitude/longitude/elevation ever changes, users shouldn't have to reconfigure this flow.

Until this is pushed out, the issue can be fixed by deleting and re-creating the OpenUV config entry (note that this will have to occur each time HASS restarts). @balloob Given this, would love to have this fix in 0.81.1.

**Breaking Change:** It's possible that users of OpenUV may have to delete and recreate the config entry.

**Related issue (if applicable):** fixes #17830

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
openuv:
  api_key: !secret openuv_api_key
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
