### PR TITLE
Add Tautulli sensor platform

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -784,6 +784,7 @@ omit =
     homeassistant/components/sensor/systemmonitor.py
     homeassistant/components/sensor/sytadin.py
     homeassistant/components/sensor/tank_utility.py
+    homeassistant/components/sensor/tautulli.py
     homeassistant/components/sensor/ted5000.py
     homeassistant/components/sensor/temper.py
     homeassistant/components/sensor/thermoworks_smoke.py

--- a/homeassistant/components/sensor/tautulli.py
+++ b/homeassistant/components/sensor/tautulli.py
@@ -131,4 +131,3 @@ class Tautulli(Entity):
     def device_state_attributes(self):
         """Return attributes for the sensor."""
         return self._data
-

--- a/homeassistant/components/sensor/tautulli.py
+++ b/homeassistant/components/sensor/tautulli.py
@@ -1,126 +1,129 @@
 """
 A platform which allows you to get information from Tautulli.
 
-For more details about this component, please refer to the documentation at
-https://www.home-assistant.io/components/sensor.tautulli
+For more details about this platform, please refer to the documentation at
+https://www.home-assistant.io/components/sensor.tautulli/
 """
-
 import logging
+from datetime import timedelta
+
 import voluptuous as vol
-from homeassistant.helpers.entity import Entity
-from homeassistant.const import (CONF_API_KEY,
-                                 CONF_HOST,
-                                 CONF_MONITORED_VARIABLES,
-                                 CONF_PORT,
-                                 CONF_SSL,
-                                 STATE_UNAVAILABLE)
 import homeassistant.helpers.config_validation as cv
-from homeassistant.components.sensor import (PLATFORM_SCHEMA)
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import (CONF_API_KEY, CONF_HOST,
+                                 CONF_MONITORED_CONDITIONS, CONF_NAME,
+                                 CONF_PORT, CONF_SSL, CONF_VERIFY_SSL)
+from homeassistant.exceptions import PlatformNotReady
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.entity import Entity
+from homeassistant.util import Throttle
 
-__version__ = '1.1.0'
-
-REQUIREMENTS = ['pytautulli==0.1.4']
+REQUIREMENTS = ['pytautulli==0.4.0']
 
 _LOGGER = logging.getLogger(__name__)
 
 CONF_MONITORED_USERS = 'monitored_users'
+CONF_UPDATE_INTERVAL = 'update_interval'
+
+DEFAULT_NAME = 'Tautulli'
+DEFAULT_PORT = '8181'
+DEFAULT_MONITORED_CONDITIONS = 'None'
+DEFAULT_MONITORED_USERS = 'None'
+DEFAULT_SSL = False
+DEFAULT_VERIFY_SSL = True
+
+TIME_BETWEEN_UPDATES = timedelta(seconds=10)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Required(CONF_API_KEY): cv.string,
     vol.Required(CONF_HOST): cv.string,
-    vol.Optional(CONF_PORT, default='8181'): cv.string,
-    vol.Optional(CONF_SSL, default=False): cv.boolean,
-    vol.Optional(CONF_MONITORED_VARIABLES, default=None):
+    vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.string,
+    vol.Optional(CONF_SSL, default=DEFAULT_SSL): cv.boolean,
+    vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): cv.boolean,
+    vol.Optional(CONF_MONITORED_CONDITIONS,
+                 default=DEFAULT_MONITORED_CONDITIONS):
         vol.All(cv.ensure_list, [cv.string]),
-    vol.Optional(CONF_MONITORED_USERS, default=None):
+    vol.Optional(CONF_MONITORED_USERS, default=DEFAULT_MONITORED_USERS):
         vol.All(cv.ensure_list, [cv.string]),
     })
 
 
-def setup_platform(hass, config, add_devices, discovery_info=None):
+async def async_setup_platform(
+        hass, config, async_add_entities, discovery_info=None):
     """Create the sensor."""
-    api_key = config.get(CONF_API_KEY)
+    from pytautulli import Tautulli
+
+    name = config.get(CONF_NAME)
     host = config.get(CONF_HOST)
     port = config.get(CONF_PORT)
-    monitored_variables = config.get(CONF_MONITORED_VARIABLES)
-    monitored_users = config.get(CONF_MONITORED_USERS)
-    ssl = config.get(CONF_SSL)
-    if ssl:
-        schema = 'https'
-    else:
-        schema = 'http'
-    add_devices([Tautulli(api_key, monitored_variables,
-                          host, port, monitored_users, schema)])
+    api_key = config.get(CONF_API_KEY)
+    monitored_conditions = config.get(CONF_MONITORED_CONDITIONS)
+    user = config.get(CONF_MONITORED_USERS)
+    use_ssl = config.get(CONF_SSL)
+    verify_ssl = config.get(CONF_VERIFY_SSL)
+
+    session = async_get_clientsession(hass, verify_ssl)
+    tautulli = TautulliData(Tautulli(
+        host, port, api_key, hass.loop, session, use_ssl))
+
+    await tautulli.test_connection()
+
+    if not tautulli.test_connection:
+        raise PlatformNotReady
+
+    sensor = [TautulliSensor(tautulli, name, monitored_conditions, user)]
+
+    async_add_entities(sensor, True)
 
 
-class Tautulli(Entity):
+class TautulliSensor(Entity):
     """Representation of a Sensor."""
 
-    def __init__(self, api_key, monitored_variables,
-                 host, port, users, schema):
+    def __init__(self, tautulli, name, monitored_conditions, users):
         """Initialize the sensor."""
-        import pytautulli
-        self.tautulli = pytautulli
-        self._state = STATE_UNAVAILABLE
-        self._api_key = api_key
-        self._monitored_variables = monitored_variables
-        self._host = host
-        self._port = port
-        self._user = users
-        self._schema = schema
-        self._data = {}
-        self.update()
+        self.tautulli = tautulli
+        self.monitored_conditions = monitored_conditions
+        self.usernames = users
+        self.users = []
+        self.sessions = {}
+        self.home = {}
+        self._attributes = {}
+        self._name = name
+        self._state = None
 
-    def update(self):
-        """Update sensor value."""
-        most_stats = self.tautulli.get_most_stats(self._host,
-                                                  self._port,
-                                                  self._api_key,
-                                                  self._schema)
-        for key in most_stats:
-            self._data[str(key)] = str(most_stats[key])
-
-        sever_stats = self.tautulli.get_server_stats(self._host,
-                                                     self._port,
-                                                     self._api_key,
-                                                     self._schema)
-        for key in sever_stats:
-            self._data[str(key)] = str(sever_stats[key])
-
-        users = self.tautulli.get_users(self._host,
-                                        self._port,
-                                        self._api_key,
-                                        self._schema)
-        for user in users:
-            if user != 'Local' and (user in self._user or self._user is None):
-                userstate = self.tautulli.get_user_state(self._host,
-                                                         self._port,
-                                                         self._api_key,
-                                                         user,
-                                                         self._schema)
-                self._data[str(user)] = {}
-                self._data[str(user)]['activity'] = str(userstate)
-                attrlist = self.tautulli.get_user_activity(self._host,
-                                                           self._port,
-                                                           self._api_key,
-                                                           user,
-                                                           self._schema)
-                for key in self._monitored_variables:
-                    try:
-                        self._data[str(user)][str(key)] = str(attrlist[key])
-                    except KeyError:
-                        self._data[str(user)][str(key)] = ""
-        self._state = sever_stats['count']
+    async def async_update(self):
+        """Get the latest data from the Pi-hole API."""
+        await self.tautulli.async_update()
+        self.home = self.tautulli.api.home_data
+        self.sessions = self.tautulli.api.session_data
+        self._attributes['Top Movie'] = self.home[0]['rows'][0]['title']
+        self._attributes['Top TV Show'] = self.home[3]['rows'][0]['title']
+        self._attributes['Top User'] = self.home[7]['rows'][0]['user']
+        for key in self.sessions:
+            if 'sessions' not in key:
+                self._attributes[key] = self.sessions[key]
+        for user in self.tautulli.api.users:
+            if user in self.users or not self.users:
+                userdata = self.tautulli.api.user_data
+                self._attributes[user] = {}
+                self._attributes[user]['Activity'] = userdata[user]['Activity']
+                for key in self.monitored_conditions:
+                    if key != 'None':
+                        try:
+                            self._attributes[user][key] = userdata[user][key]
+                        except (KeyError, TypeError):
+                            self._attributes[user][key] = ''
 
     @property
     def name(self):
         """Return the name of the sensor."""
-        return 'Tautulli'
+        return self._name
 
     @property
     def state(self):
         """Return the state of the sensor."""
-        return self._state
+        return self.sessions['stream_count']
 
     @property
     def icon(self):
@@ -130,4 +133,22 @@ class Tautulli(Entity):
     @property
     def device_state_attributes(self):
         """Return attributes for the sensor."""
-        return self._data
+        return self._attributes
+
+class TautulliData:
+    """Get the latest data and update the states."""
+
+    def __init__(self, api):
+        """Initialize the data object."""
+        self.api = api
+
+    @Throttle(TIME_BETWEEN_UPDATES)
+    async def async_update(self):
+        """Get the latest data from Tautulli."""
+        await self.api.get_data()
+
+    async def test_connection(self):
+        """Test connection to Tautulli."""
+        connection_status = await self.api.test_connection()
+        return connection_status
+

--- a/homeassistant/components/sensor/tautulli.py
+++ b/homeassistant/components/sensor/tautulli.py
@@ -52,9 +52,9 @@ async def async_setup_platform(
     from pytautulli import Tautulli
 
     name = config.get(CONF_NAME)
-    host = config.get(CONF_HOST)
+    host = config[CONF_HOST]
     port = config.get(CONF_PORT)
-    api_key = config.get(CONF_API_KEY)
+    api_key = config[CONF_API_KEY]
     monitored_conditions = config.get(CONF_MONITORED_CONDITIONS)
     user = config.get(CONF_MONITORED_USERS)
     use_ssl = config.get(CONF_SSL)

--- a/homeassistant/components/sensor/tautulli.py
+++ b/homeassistant/components/sensor/tautulli.py
@@ -27,8 +27,8 @@ CONF_UPDATE_INTERVAL = 'update_interval'
 
 DEFAULT_NAME = 'Tautulli'
 DEFAULT_PORT = '8181'
-DEFAULT_MONITORED_CONDITIONS = 'None'
-DEFAULT_MONITORED_USERS = 'None'
+DEFAULT_CONDITIONS = 'None'
+DEFAULT_USERS = 'None'
 DEFAULT_SSL = False
 DEFAULT_VERIFY_SSL = True
 
@@ -41,10 +41,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.string,
     vol.Optional(CONF_SSL, default=DEFAULT_SSL): cv.boolean,
     vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): cv.boolean,
-    vol.Optional(CONF_MONITORED_CONDITIONS,
-                 default=DEFAULT_MONITORED_CONDITIONS):
+    vol.Optional(CONF_MONITORED_CONDITIONS, default=DEFAULT_CONDITIONS):
         vol.All(cv.ensure_list, [cv.string]),
-    vol.Optional(CONF_MONITORED_USERS, default=DEFAULT_MONITORED_USERS):
+    vol.Optional(CONF_MONITORED_USERS, default=DEFAULT_USERS):
         vol.All(cv.ensure_list, [cv.string]),
     })
 
@@ -134,6 +133,7 @@ class TautulliSensor(Entity):
     def device_state_attributes(self):
         """Return attributes for the sensor."""
         return self._attributes
+
 
 class TautulliData:
     """Get the latest data and update the states."""

--- a/homeassistant/components/sensor/tautulli.py
+++ b/homeassistant/components/sensor/tautulli.py
@@ -1,0 +1,134 @@
+"""
+A platform which allows you to get information from Tautulli.
+
+For more details about this component, please refer to the documentation at
+https://www.home-assistant.io/components/sensor.tautulli
+"""
+
+import logging
+import voluptuous as vol
+from homeassistant.helpers.entity import Entity
+from homeassistant.const import (CONF_API_KEY,
+                                 CONF_HOST,
+                                 CONF_MONITORED_VARIABLES,
+                                 CONF_PORT,
+                                 CONF_SSL,
+                                 STATE_UNAVAILABLE)
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.sensor import (PLATFORM_SCHEMA)
+
+__version__ = '1.1.0'
+
+REQUIREMENTS = ['pytautulli==0.1.4']
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_MONITORED_USERS = 'monitored_users'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_API_KEY): cv.string,
+    vol.Required(CONF_HOST): cv.string,
+    vol.Optional(CONF_PORT, default='8181'): cv.string,
+    vol.Optional(CONF_SSL, default=False): cv.boolean,
+    vol.Optional(CONF_MONITORED_VARIABLES, default=None):
+        vol.All(cv.ensure_list, [cv.string]),
+    vol.Optional(CONF_MONITORED_USERS, default=None):
+        vol.All(cv.ensure_list, [cv.string]),
+    })
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Create the sensor."""
+    api_key = config.get(CONF_API_KEY)
+    host = config.get(CONF_HOST)
+    port = config.get(CONF_PORT)
+    monitored_variables = config.get(CONF_MONITORED_VARIABLES)
+    monitored_users = config.get(CONF_MONITORED_USERS)
+    ssl = config.get(CONF_SSL)
+    if ssl:
+        schema = 'https'
+    else:
+        schema = 'http'
+    add_devices([Tautulli(api_key, monitored_variables,
+                          host, port, monitored_users, schema)])
+
+
+class Tautulli(Entity):
+    """Representation of a Sensor."""
+
+    def __init__(self, api_key, monitored_variables,
+                 host, port, users, schema):
+        """Initialize the sensor."""
+        import pytautulli
+        self.tautulli = pytautulli
+        self._state = STATE_UNAVAILABLE
+        self._api_key = api_key
+        self._monitored_variables = monitored_variables
+        self._host = host
+        self._port = port
+        self._user = users
+        self._schema = schema
+        self._data = {}
+        self.update()
+
+    def update(self):
+        """Update sensor value."""
+        most_stats = self.tautulli.get_most_stats(self._host,
+                                                  self._port,
+                                                  self._api_key,
+                                                  self._schema)
+        for key in most_stats:
+            self._data[str(key)] = str(most_stats[key])
+
+        sever_stats = self.tautulli.get_server_stats(self._host,
+                                                     self._port,
+                                                     self._api_key,
+                                                     self._schema)
+        for key in sever_stats:
+            self._data[str(key)] = str(sever_stats[key])
+
+        users = self.tautulli.get_users(self._host,
+                                        self._port,
+                                        self._api_key,
+                                        self._schema)
+        for user in users:
+            if user != 'Local' and (user in self._user or self._user is None):
+                userstate = self.tautulli.get_user_state(self._host,
+                                                         self._port,
+                                                         self._api_key,
+                                                         user,
+                                                         self._schema)
+                self._data[str(user)] = {}
+                self._data[str(user)]['activity'] = str(userstate)
+                attrlist = self.tautulli.get_user_activity(self._host,
+                                                           self._port,
+                                                           self._api_key,
+                                                           user,
+                                                           self._schema)
+                for key in self._monitored_variables:
+                    try:
+                        self._data[str(user)][str(key)] = str(attrlist[key])
+                    except KeyError:
+                        self._data[str(user)][str(key)] = ""
+        self._state = sever_stats['count']
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return 'Tautulli'
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def icon(self):
+        """Return the icon of the sensor."""
+        return 'mdi:plex'
+
+    @property
+    def device_state_attributes(self):
+        """Return attributes for the sensor."""
+        return self._data
+

--- a/homeassistant/components/sensor/tautulli.py
+++ b/homeassistant/components/sensor/tautulli.py
@@ -4,18 +4,18 @@ A platform which allows you to get information from Tautulli.
 For more details about this platform, please refer to the documentation at
 https://www.home-assistant.io/components/sensor.tautulli/
 """
-import logging
 from datetime import timedelta
+import logging
 
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import (CONF_API_KEY, CONF_HOST,
-                                 CONF_MONITORED_CONDITIONS, CONF_NAME,
-                                 CONF_PORT, CONF_SSL, CONF_VERIFY_SSL)
+from homeassistant.const import (
+    CONF_API_KEY, CONF_HOST, CONF_MONITORED_CONDITIONS, CONF_NAME, CONF_PORT,
+    CONF_SSL, CONF_VERIFY_SSL)
 from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 
@@ -33,22 +33,21 @@ DEFAULT_VERIFY_SSL = True
 TIME_BETWEEN_UPDATES = timedelta(seconds=10)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Required(CONF_API_KEY): cv.string,
     vol.Required(CONF_HOST): cv.string,
+    vol.Optional(CONF_MONITORED_CONDITIONS):
+        vol.All(cv.ensure_list, [cv.string]),
+    vol.Optional(CONF_MONITORED_USERS): vol.All(cv.ensure_list, [cv.string]),
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.string,
     vol.Optional(CONF_SSL, default=DEFAULT_SSL): cv.boolean,
     vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): cv.boolean,
-    vol.Optional(CONF_MONITORED_CONDITIONS):
-        vol.All(cv.ensure_list, [cv.string]),
-    vol.Optional(CONF_MONITORED_USERS):
-        vol.All(cv.ensure_list, [cv.string]),
-    })
+})
 
 
 async def async_setup_platform(
         hass, config, async_add_entities, discovery_info=None):
-    """Create the sensor."""
+    """Create the Tautulli sensor."""
     from pytautulli import Tautulli
 
     name = config.get(CONF_NAME)
@@ -73,10 +72,10 @@ async def async_setup_platform(
 
 
 class TautulliSensor(Entity):
-    """Representation of a Sensor."""
+    """Representation of a Tautulli sensor."""
 
     def __init__(self, tautulli, name, monitored_conditions, users):
-        """Initialize the sensor."""
+        """Initialize the Tautulli sensor."""
         self.tautulli = tautulli
         self.monitored_conditions = monitored_conditions
         self.usernames = users

--- a/homeassistant/components/sensor/tautulli.py
+++ b/homeassistant/components/sensor/tautulli.py
@@ -151,4 +151,3 @@ class TautulliData:
         """Test connection to Tautulli."""
         connection_status = await self.api.test_connection()
         return connection_status
-

--- a/homeassistant/components/sensor/tautulli.py
+++ b/homeassistant/components/sensor/tautulli.py
@@ -92,7 +92,7 @@ class TautulliSensor(Entity):
         self._state = None
 
     async def async_update(self):
-        """Get the latest data from the Pi-hole API."""
+        """Get the latest data from the Tautulli API."""
         await self.tautulli.async_update()
         self.home = self.tautulli.api.home_data
         self.sessions = self.tautulli.api.session_data

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1099,6 +1099,9 @@ pystride==0.1.7
 # homeassistant.components.sensor.syncthru
 pysyncthru==0.3.1
 
+# homeassistant.components.sensor.tautulli
+pytautulli==0.1.4
+
 # homeassistant.components.media_player.liveboxplaytv
 pyteleloisirs==3.4
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1100,7 +1100,7 @@ pystride==0.1.7
 pysyncthru==0.3.1
 
 # homeassistant.components.sensor.tautulli
-pytautulli==0.1.4
+pytautulli==0.4.0
 
 # homeassistant.components.media_player.liveboxplaytv
 pyteleloisirs==3.4


### PR DESCRIPTION
## Description:

This PR adds a Tautulli sensor platform to display statistics from a Tautulli server.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#7151

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: tautulli
    api_key: 24b6eac0a858748664878d146bf63623b4
    host: 192.168.1.14
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
    - Some tests failed <https://hastebin.com/huyoqejuja.http> unrelated to this change.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
