### PR TITLE
Add services to set/update and cancel Nest ETA

### DIFF
--- a/homeassistant/components/nest/__init__.py
+++ b/homeassistant/components/nest/__init__.py
@@ -12,10 +12,12 @@ import threading
 import voluptuous as vol
 
 from homeassistant import config_entries
+from homeassistant.components.climate import (
+    ATTR_AWAY_MODE, SERVICE_SET_AWAY_MODE)
 from homeassistant.const import (
-    CONF_STRUCTURE, CONF_FILENAME, CONF_BINARY_SENSORS, CONF_SENSORS,
-    CONF_MONITORED_CONDITIONS,
-    EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP)
+    CONF_BINARY_SENSORS, CONF_FILENAME, CONF_MONITORED_CONDITIONS,
+    CONF_SENSORS, CONF_STRUCTURE, EVENT_HOMEASSISTANT_START,
+    EVENT_HOMEASSISTANT_STOP)
 from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.dispatcher import dispatcher_send, \
@@ -30,6 +32,8 @@ REQUIREMENTS = ['python-nest==4.0.4']
 _CONFIGURING = {}
 _LOGGER = logging.getLogger(__name__)
 
+SERVICE_CANCEL_ETA = 'cancel_eta'
+SERVICE_SET_ETA = 'set_eta'
 
 DATA_NEST = 'nest'
 DATA_NEST_CONFIG = 'nest_config'
@@ -40,21 +44,30 @@ NEST_CONFIG_FILE = 'nest.conf'
 CONF_CLIENT_ID = 'client_id'
 CONF_CLIENT_SECRET = 'client_secret'
 
-ATTR_HOME_MODE = 'home_mode'
-ATTR_STRUCTURE = 'structure'
-ATTR_TRIP_ID = 'trip_id'
 ATTR_ETA = 'eta'
 ATTR_ETA_WINDOW = 'eta_window'
+ATTR_STRUCTURE = 'structure'
+ATTR_TRIP_ID = 'trip_id'
 
-HOME_MODE_AWAY = 'away'
-HOME_MODE_HOME = 'home'
+AWAY_MODE_AWAY = 'away'
+AWAY_MODE_HOME = 'home'
 
 SENSOR_SCHEMA = vol.Schema({
     vol.Optional(CONF_MONITORED_CONDITIONS): vol.All(cv.ensure_list)
 })
 
-CANCEL_ETA_SCHEMA = vol.Schema({
-    vol.Required(ATTR_TRIP_ID): cv.string,
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_CLIENT_ID): cv.string,
+        vol.Required(CONF_CLIENT_SECRET): cv.string,
+        vol.Optional(CONF_STRUCTURE): vol.All(cv.ensure_list, cv.string),
+        vol.Optional(CONF_SENSORS): SENSOR_SCHEMA,
+        vol.Optional(CONF_BINARY_SENSORS): SENSOR_SCHEMA
+    })
+}, extra=vol.ALLOW_EXTRA)
+
+SET_AWAY_MODE_SCHEMA = vol.Schema({
+    vol.Required(ATTR_AWAY_MODE): vol.In([AWAY_MODE_AWAY, AWAY_MODE_HOME]),
     vol.Optional(ATTR_STRUCTURE): vol.All(cv.ensure_list, cv.string)
 })
 
@@ -64,20 +77,11 @@ SET_ETA_SCHEMA = vol.Schema({
     vol.Optional(ATTR_ETA_WINDOW): cv.time_period,
     vol.Optional(ATTR_STRUCTURE): vol.All(cv.ensure_list, cv.string)
 })
-SET_MODE_SCHEMA = vol.Schema({
-    vol.Required(ATTR_HOME_MODE): vol.In([HOME_MODE_AWAY, HOME_MODE_HOME]),
+
+CANCEL_ETA_SCHEMA = vol.Schema({
+    vol.Required(ATTR_TRIP_ID): cv.string,
     vol.Optional(ATTR_STRUCTURE): vol.All(cv.ensure_list, cv.string)
 })
-
-CONFIG_SCHEMA = vol.Schema({
-    DOMAIN: vol.Schema({
-        vol.Required(CONF_CLIENT_ID): cv.string,
-        vol.Required(CONF_CLIENT_SECRET): cv.string,
-        vol.Optional(CONF_STRUCTURE): vol.All(cv.ensure_list, [cv.string]),
-        vol.Optional(CONF_SENSORS): SENSOR_SCHEMA,
-        vol.Optional(CONF_BINARY_SENSORS): SENSOR_SCHEMA
-    })
-}, extra=vol.ALLOW_EXTRA)
 
 
 def nest_update_event_broker(hass, nest):
@@ -142,24 +146,21 @@ async def async_setup_entry(hass, entry):
         hass.async_create_task(hass.config_entries.async_forward_entry_setup(
             entry, component))
 
-    def cancel_eta(service):
-        """Cancel ETA for a Nest structure."""
+    def set_away_mode(service):
+        """Set the away mode for a Nest structure."""
         if ATTR_STRUCTURE in service.data:
             target_structures = service.data[ATTR_STRUCTURE]
         else:
             target_structures = hass.data[DATA_NEST].local_structure
 
         for structure in nest.structures:
-            if structure.name in target_structures and structure.thermostats:
-                trip_id = service.data[ATTR_TRIP_ID]
-                _LOGGER.info("Cancelling ETA for trip: %s", trip_id)
-                structure.cancel_eta(trip_id)
-            else:
-                _LOGGER.error("Invalid structure: %s",
-                              service.data[ATTR_STRUCTURE])
+            if structure.name in target_structures:
+                _LOGGER.info("Setting away mode for: %s to: %s",
+                             structure.name, service.data[AWAY_MODE_HOME])
+                structure.away = service.data[AWAY_MODE_HOME]
 
     def set_eta(service):
-        """Set mode to away and include ETA for a Nest structure."""
+        """Set away mode to away and include ETA for a Nest structure."""
         if ATTR_STRUCTURE in service.data:
             target_structures = service.data[ATTR_STRUCTURE]
         else:
@@ -168,8 +169,8 @@ async def async_setup_entry(hass, entry):
         for structure in nest.structures:
             if structure.name in target_structures and structure.thermostats:
                 _LOGGER.info("Setting mode for: %s to: %s",
-                             structure.name, HOME_MODE_AWAY)
-                structure.away = HOME_MODE_AWAY
+                             structure.name, AWAY_MODE_AWAY)
+                structure.away = AWAY_MODE_AWAY
 
                 now = datetime.utcnow()
                 trip_id = service.data.get(
@@ -183,33 +184,34 @@ async def async_setup_entry(hass, entry):
                              trip_id, eta_begin, eta_end)
                 structure.set_eta(trip_id, eta_begin, eta_end)
             else:
-                _LOGGER.error("Invalid structure: %s",
-                              service.data[ATTR_STRUCTURE])
+                _LOGGER.info("No thermostats found in structure: %s, unable "
+                             "to set ETA", service.data[ATTR_STRUCTURE])
 
-    def set_mode(service):
-        """Set the home/away mode for a Nest structure."""
+    def cancel_eta(service):
+        """Cancel ETA for a Nest structure."""
         if ATTR_STRUCTURE in service.data:
             target_structures = service.data[ATTR_STRUCTURE]
         else:
             target_structures = hass.data[DATA_NEST].local_structure
 
         for structure in nest.structures:
-            if structure.name in target_structures:
-                _LOGGER.info("Setting mode for: %s to: %s",
-                             structure.name, service.data[ATTR_HOME_MODE])
-                structure.away = service.data[ATTR_HOME_MODE]
+            if structure.name in target_structures and structure.thermostats:
+                trip_id = service.data[ATTR_TRIP_ID]
+                _LOGGER.info("Cancelling ETA for trip: %s", trip_id)
+                structure.cancel_eta(trip_id)
             else:
-                _LOGGER.error("Invalid structure: %s",
-                              service.data[ATTR_STRUCTURE])
+                _LOGGER.info("No thermostats found in structure: %s, unable "
+                             "to set ETA", service.data[ATTR_STRUCTURE])
 
     hass.services.async_register(
-        DOMAIN, 'cancel_eta', cancel_eta, schema=CANCEL_ETA_SCHEMA)
+        DOMAIN, SERVICE_SET_AWAY_MODE, set_away_mode,
+        schema=SET_AWAY_MODE_SCHEMA)
 
     hass.services.async_register(
-        DOMAIN, 'set_eta', set_eta, schema=SET_ETA_SCHEMA)
+        DOMAIN, SERVICE_SET_ETA, set_eta, schema=SET_ETA_SCHEMA)
 
     hass.services.async_register(
-        DOMAIN, 'set_mode', set_mode, schema=SET_MODE_SCHEMA)
+        DOMAIN, SERVICE_CANCEL_ETA, cancel_eta, schema=CANCEL_ETA_SCHEMA)
 
     @callback
     def start_up(event):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1186,7 +1186,7 @@ python-mpd2==1.0.0
 python-mystrom==0.4.4
 
 # homeassistant.components.nest
-python-nest==4.0.3
+python-nest==4.0.4
 
 # homeassistant.components.device_tracker.nmap_tracker
 python-nmap==0.6.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -193,7 +193,7 @@ pyspcwebgw==0.4.0
 python-forecastio==1.4.0
 
 # homeassistant.components.nest
-python-nest==4.0.3
+python-nest==4.0.4
 
 # homeassistant.components.sensor.whois
 pythonwhois==2.4.3


### PR DESCRIPTION
## Description:
- Add service `cancel_eta` to cancel ETA
- Add service `set_eta` to set/update ETA (break out from existing `set_mode` service)
- Rename service `set_mode` to `set_away_mode` [breaking change]

I chose to break out the ETA setting/updating function as it's own service because I think it's more logical to have discrete services for setting mode, setting/updating ETA and cancelling ETA. Feedback is welcome though.

**Related issue (if applicable):** fixes #15371, #15818

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#7163

## Example entry for `configuration.yaml` (if applicable):
```yaml
N/A
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
