### PR TITLE
Fix Alexa unsupported operation_mode off

### DIFF
--- a/homeassistant/components/alexa/smart_home.py
+++ b/homeassistant/components/alexa/smart_home.py
@@ -41,6 +41,7 @@ API_THERMOSTAT_MODES = {
     climate.STATE_COOL: 'COOL',
     climate.STATE_AUTO: 'AUTO',
     climate.STATE_ECO: 'ECO',
+    climate.STATE_OFF: 'OFF',
     climate.STATE_IDLE: 'OFF',
     climate.STATE_FAN_ONLY: 'OFF',
     climate.STATE_DRY: 'OFF',


### PR DESCRIPTION
## Description:
Fix Alexa integration unsupported_mode error when thermostat mode is off.

[homeassistant.components.alexa.smart_home] climate.shop (<class 'homeassistant.core.State'>) has unsupported operation_mode value 'off'

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
