### PR TITLE
Add service to set temperature scale for Nest thermostat

### DIFF
--- a/homeassistant/components/climate/nest.py
+++ b/homeassistant/components/climate/nest.py
@@ -313,7 +313,7 @@ class NestThermostat(ClimateDevice):
         return self._max_temperature
 
     def set_temperature_scale(self, temperature_scale):
-        """Return the unit of measurement."""
+        """Set the temperature scale for the device."""
         self.device.temperature_scale = \
             TEMPERATURE_SCALE_MAP[temperature_scale]
 

--- a/homeassistant/components/nest/__init__.py
+++ b/homeassistant/components/nest/__init__.py
@@ -25,7 +25,7 @@ from homeassistant.helpers.entity import Entity
 from .const import DOMAIN
 from . import local_auth
 
-REQUIREMENTS = ['python-nest==4.0.3']
+REQUIREMENTS = ['python-nest==4.0.4']
 
 _CONFIGURING = {}
 _LOGGER = logging.getLogger(__name__)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1170,7 +1170,7 @@ python-mpd2==1.0.0
 python-mystrom==0.4.4
 
 # homeassistant.components.nest
-python-nest==4.0.3
+python-nest==4.0.4
 
 # homeassistant.components.device_tracker.nmap_tracker
 python-nmap==0.6.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -191,7 +191,7 @@ pyspcwebgw==0.4.0
 python-forecastio==1.4.0
 
 # homeassistant.components.nest
-python-nest==4.0.3
+python-nest==4.0.4
 
 # homeassistant.components.sensor.whois
 pythonwhois==2.4.3


### PR DESCRIPTION
## Description:
Add service to set temperature scale for Nest thermostat

Note that this only affects the temperature shown on the thermostat itself and the Nest website. The units shown in HASS are set using `configuration.yaml`.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#7144

## Example entry for `configuration.yaml` (if applicable):
```yaml
N/A
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
