### PR TITLE
Add option to manually specify device detection method

### DIFF
--- a/homeassistant/components/device_tracker/mikrotik.py
+++ b/homeassistant/components/device_tracker/mikrotik.py
@@ -16,16 +16,16 @@ from homeassistant.const import (
 
 REQUIREMENTS = ['librouteros==2.1.1']
 
-MTK_DEFAULT_API_PORT = '8728'
-
 _LOGGER = logging.getLogger(__name__)
+
+MTK_DEFAULT_API_PORT = '8728'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
     vol.Required(CONF_USERNAME): cv.string,
     vol.Required(CONF_PASSWORD): cv.string,
+    vol.Optional(CONF_METHOD): cv.string,
     vol.Optional(CONF_PORT, default=MTK_DEFAULT_API_PORT): cv.port,
-    vol.Optional(CONF_METHOD): cv.string
 })
 
 
@@ -55,28 +55,18 @@ class MikrotikScanner(DeviceScanner):
         self.success_init = self.connect_to_device()
 
         if self.success_init:
-            _LOGGER.info(
-                "Start polling Mikrotik (%s) router...",
-                self.host
-            )
+            _LOGGER.info("Start polling Mikrotik (%s) router...", self.host)
             self._update_info()
         else:
-            _LOGGER.error(
-                "Connection to Mikrotik (%s) failed",
-                self.host
-            )
+            _LOGGER.error("Connection to Mikrotik (%s) failed", self.host)
 
     def connect_to_device(self):
         """Connect to Mikrotik method."""
         import librouteros
         try:
             self.client = librouteros.connect(
-                self.host,
-                self.username,
-                self.password,
-                port=int(self.port),
-                encoding='utf-8'
-            )
+                self.host, self.username, self.password, port=int(self.port),
+                encoding='utf-8')
 
             try:
                 routerboard_info = self.client(
@@ -88,16 +78,15 @@ class MikrotikScanner(DeviceScanner):
                 raise
 
             if routerboard_info:
-                _LOGGER.info("Connected to Mikrotik %s with IP %s",
-                             routerboard_info[0].get('model', 'Router'),
-                             self.host)
+                _LOGGER.info(
+                    "Connected to Mikrotik %s with IP %s",
+                    routerboard_info[0].get('model', 'Router'), self.host)
 
                 self.connected = True
 
                 try:
                     self.capsman_exist = self.client(
-                        cmd='/caps-man/interface/getall'
-                    )
+                        cmd='/caps-man/interface/getall')
                 except (librouteros.exceptions.TrapError,
                         librouteros.exceptions.MultiTrapError,
                         librouteros.exceptions.ConnectionError):
@@ -105,15 +94,12 @@ class MikrotikScanner(DeviceScanner):
 
                 if not self.capsman_exist:
                     _LOGGER.info(
-                        'Mikrotik %s: Not a CAPSman controller. Trying '
-                        'local interfaces ',
-                        self.host
-                    )
+                        "Mikrotik %s: Not a CAPSman controller. Trying "
+                        "local interfaces", self.host)
 
                 try:
                     self.wireless_exist = self.client(
-                        cmd='/interface/wireless/getall'
-                    )
+                        cmd='/interface/wireless/getall')
                 except (librouteros.exceptions.TrapError,
                         librouteros.exceptions.MultiTrapError,
                         librouteros.exceptions.ConnectionError):
@@ -121,17 +107,14 @@ class MikrotikScanner(DeviceScanner):
 
                 if not self.wireless_exist or self.method == 'ip':
                     _LOGGER.info(
-                        'Mikrotik %s: Wireless adapters not found. Try to '
-                        'use DHCP lease table as presence tracker source. '
-                        'Please decrease lease time as much as possible.',
-                        self.host
-                    )
+                        "Mikrotik %s: Wireless adapters not found. Try to "
+                        "use DHCP lease table as presence tracker source. "
+                        "Please decrease lease time as much as possible",
+                        self.host)
                 if self.method:
                     _LOGGER.info(
-                        'Mikrotik %s: Manually selected polling method "%s"',
-                        self.host,
-                        self.method
-                    )
+                        "Mikrotik %s: Manually selected polling method %s",
+                        self.host, self.method)
 
         except (librouteros.exceptions.TrapError,
                 librouteros.exceptions.MultiTrapError,
@@ -163,19 +146,15 @@ class MikrotikScanner(DeviceScanner):
 
         _LOGGER.info(
             "Loading %s devices from Mikrotik (%s) ...",
-            devices_tracker,
-            self.host
-        )
+            devices_tracker, self.host)
 
         device_names = self.client(cmd='/ip/dhcp-server/lease/getall')
         if devices_tracker == 'capsman':
             devices = self.client(
-                cmd='/caps-man/registration-table/getall'
-            )
+                cmd='/caps-man/registration-table/getall')
         elif devices_tracker == 'wireless':
             devices = self.client(
-                cmd='/interface/wireless/registration-table/getall'
-            )
+                cmd='/interface/wireless/registration-table/getall')
         else:
             devices = device_names
 
@@ -183,21 +162,17 @@ class MikrotikScanner(DeviceScanner):
             return False
 
         mac_names = {device.get('mac-address'): device.get('host-name')
-                     for device in device_names
-                     if device.get('mac-address')}
+                     for device in device_names if device.get('mac-address')}
 
-        if devices_tracker == 'wireless' or devices_tracker == 'capsman':
+        if devices_tracker in ('wireless', 'capsman'):
             self.last_results = {
                 device.get('mac-address'):
                     mac_names.get(device.get('mac-address'))
-                for device in devices
-            }
+                for device in devices}
         else:
             self.last_results = {
                 device.get('mac-address'):
                     mac_names.get(device.get('mac-address'))
-                for device in device_names
-                if device.get('active-address')
-            }
+                for device in device_names if device.get('active-address')}
 
         return True


### PR DESCRIPTION
## Description:

Mikrotik module automatically detects whether to use wireless, capsman, or dhcp for device detection. If a Mikrotik router has wireless but the use prefers to use dhcp, this new option allows the user to force a specific method.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#7145

## Example entry for `configuration.yaml` (if applicable):
```yaml
device_tracker:
  - platform: mikrotik
    host: IP_ADDRESS
    username: ADMIN_USERNAME
    password: ADMIN_PASSWORD
    method: ip
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io/pull/7145)
