### PR TITLE
Initial hlk-sw16 relay switch support

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -145,6 +145,9 @@ omit =
     homeassistant/components/hive.py
     homeassistant/components/*/hive.py
 
+    homeassistant/components/hlk_sw16.py
+    homeassistant/components/*/hlk_sw16.py
+
     homeassistant/components/homekit_controller/__init__.py
     homeassistant/components/*/homekit_controller.py
 

--- a/homeassistant/components/hlk_sw16.py
+++ b/homeassistant/components/hlk_sw16.py
@@ -22,9 +22,6 @@ REQUIREMENTS = ['hlk-sw16==0.0.6']
 
 _LOGGER = logging.getLogger(__name__)
 
-ATTR_EVENT = 'event'
-ATTR_STATE = 'state'
-
 DATA_DEVICE_REGISTER = 'hlk_sw16_device_register'
 DEFAULT_RECONNECT_INTERVAL = 10
 CONNECTION_TIMEOUT = 10

--- a/homeassistant/components/hlk_sw16.py
+++ b/homeassistant/components/hlk_sw16.py
@@ -148,10 +148,6 @@ class SW16Device(Entity):
         self._protocol = protocol
         self._name = relay_name
 
-    def is_connected(self):
-        """Return connection status."""
-        return bool(self._protocol)
-
     @callback
     def handle_event_callback(self, event):
         """Propagate changes through ha."""
@@ -178,7 +174,7 @@ class SW16Device(Entity):
     @property
     def available(self):
         """Return True if entity is available."""
-        return self.is_connected()
+        return bool(self._protocol)
 
     @callback
     def _availability_callback(self, availability):
@@ -199,21 +195,21 @@ class SwitchableSW16Device(SW16Device):
 
     async def async_update(self):
         """Get current switch status from the device."""
-        if not self.is_connected():
+        if not self.available:
             _LOGGER.error('Cannot send command, not connected!')
             return
         await self._protocol.status(self._device_port)
 
     async def async_turn_on(self, **kwargs):
         """Turn the device on."""
-        if not self.is_connected():
+        if not self.available:
             _LOGGER.error('Cannot send command, not connected!')
             return
         await self._protocol.turn_on(self._device_port)
 
     async def async_turn_off(self, **kwargs):
         """Turn the device off."""
-        if not self.is_connected():
+        if not self.available:
             _LOGGER.error('Cannot send command, not connected!')
             return
         await self._protocol.turn_off(self._device_port)

--- a/homeassistant/components/hlk_sw16.py
+++ b/homeassistant/components/hlk_sw16.py
@@ -18,7 +18,7 @@ from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_send, async_dispatcher_connect)
 
-REQUIREMENTS = ['hlk-sw16==0.0.4']
+REQUIREMENTS = ['hlk-sw16==0.0.5']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/hlk_sw16.py
+++ b/homeassistant/components/hlk_sw16.py
@@ -94,11 +94,10 @@ async def async_setup(hass, config):
             hass.data[DATA_DEVICE_REGISTER][device] = client
 
             # Load platforms
-            for comp_name, comp_conf in switches.items():
-                hass.async_create_task(
-                    async_load_platform(hass, 'switch', DOMAIN,
-                                        (comp_name, comp_conf, device),
-                                        config))
+            hass.async_create_task(
+                async_load_platform(hass, 'switch', DOMAIN,
+                                    (switches, device),
+                                    config))
 
             # handle shutdown of HLK-SW16 asyncio transport
             hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP,

--- a/homeassistant/components/hlk_sw16.py
+++ b/homeassistant/components/hlk_sw16.py
@@ -109,15 +109,11 @@ async def async_setup(hass, config):
             hass.loop.call_later(reconnect_interval, reconnect, exc)
             return
 
-        comps = {'switch': []}
-        for switch in switches.items():
-            comps['switch'].append(switch)
-
         # Load platforms
-        for comp_name, comp_conf in comps.items():
+        for comp_name, comp_conf in switches.items():
             hass.async_create_task(
-                async_load_platform(hass, comp_name, DOMAIN,
-                                    {DOMAIN: comp_conf}, config))
+                async_load_platform(hass, 'switch', DOMAIN,
+                                    (comp_name, comp_conf), config))
 
         # Bind protocol to command class to allow entities to send commands
         SW16Command.set_hlk_sw16_protocol(protocol)

--- a/homeassistant/components/hlk_sw16.py
+++ b/homeassistant/components/hlk_sw16.py
@@ -1,0 +1,298 @@
+"""
+Support for HLK-SW16 relay switch.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/hlk-sw16/
+"""
+import asyncio
+import logging
+import codecs
+import async_timeout
+
+import voluptuous as vol
+
+from homeassistant.const import (
+    CONF_HOST, CONF_PORT,
+    EVENT_HOMEASSISTANT_STOP, CONF_SWITCHES, CONF_NAME)
+from homeassistant.core import CoreState, callback
+from homeassistant.exceptions import HomeAssistantError
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.discovery import load_platform
+from homeassistant.helpers.dispatcher import (
+    async_dispatcher_send, async_dispatcher_connect)
+
+REQUIREMENTS = ['hlk-sw16==0.0.1']
+
+_LOGGER = logging.getLogger(__name__)
+
+ATTR_EVENT = 'event'
+ATTR_STATE = 'state'
+
+CONF_RECONNECT_INTERVAL = 'reconnect_interval'
+
+DATA_DEVICE_REGISTER = 'hlk_sw16_device_register'
+DATA_ENTITY_LOOKUP = 'hlk_sw16_entity_lookup'
+DEFAULT_RECONNECT_INTERVAL = 10
+CONNECTION_TIMEOUT = 10
+
+DOMAIN = 'hlk_sw16'
+
+SIGNAL_AVAILABILITY = 'hlk_sw16_device_available'
+SIGNAL_HANDLE_EVENT = 'hlk_sw16_handle_event_{}'
+
+TMP_ENTITY = 'tmp.{}'
+
+SWITCH_SCHEMA = vol.Schema({
+    vol.Optional(CONF_NAME): cv.string,
+})
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_PORT): vol.Any(cv.port, cv.string),
+        vol.Optional(CONF_HOST): cv.string,
+        vol.Optional(CONF_RECONNECT_INTERVAL,
+                     default=DEFAULT_RECONNECT_INTERVAL): int,
+        vol.Required(CONF_SWITCHES): vol.Schema({cv.slug: SWITCH_SCHEMA}),
+    }),
+}, extra=vol.ALLOW_EXTRA)
+
+
+async def async_setup(hass, config):
+    """Set up the HLK-SW16 switch."""
+    # Allow platform to specify function to register new unknown devices
+    from hlk_sw16 import create_hlk_sw16_connection
+    hass.data[DATA_DEVICE_REGISTER] = {}
+    switches = config[DOMAIN][CONF_SWITCHES]
+
+    @callback
+    def event_callback(event):
+        """Handle incoming HLK-SW16 events.
+
+        HLK-SW16 events arrive as dictionaries of varying content
+        depending on their type. Identify the events and distribute
+        accordingly.
+        """
+        _LOGGER.debug('event: %s', event)
+
+    host = config[DOMAIN][CONF_HOST]
+    port = config[DOMAIN][CONF_PORT]
+
+    @callback
+    def reconnect(exc=None):
+        """Schedule reconnect after connection has been unexpectedly lost."""
+        # Reset protocol binding before starting reconnect
+        SW16Command.set_hlk_sw16_protocol(None)
+
+        async_dispatcher_send(hass, SIGNAL_AVAILABILITY, False)
+
+        # If HA is not stopping, initiate new connection
+        if hass.state != CoreState.stopping:
+            _LOGGER.warning('disconnected from HLK-SW16, reconnecting')
+            hass.async_create_task(connect())
+
+    async def connect():
+        """Set up connection and hook it into HA for reconnect/shutdown."""
+        _LOGGER.info('Initiating HLK-SW16 connection')
+
+        # HLK-SW16 create_hlk_sw16_connection
+
+        try:
+            with async_timeout.timeout(CONNECTION_TIMEOUT,
+                                       loop=hass.loop):
+                transport, protocol = await create_hlk_sw16_connection(
+                    host=host,
+                    port=port,
+                    event_callback=event_callback,
+                    disconnect_callback=reconnect,
+                    loop=hass.loop,
+                    logger=_LOGGER)
+                _LOGGER.info(transport)
+
+        except (ConnectionRefusedError, TimeoutError, OSError,
+                asyncio.TimeoutError) as exc:
+            reconnect_interval = config[DOMAIN][CONF_RECONNECT_INTERVAL]
+            _LOGGER.exception(
+                "Error connecting to HLK-SW16, reconnecting in %s",
+                reconnect_interval)
+            # Connection to HLK-SW16 device is lost, make entities unavailable
+            async_dispatcher_send(hass, SIGNAL_AVAILABILITY, False)
+
+            hass.loop.call_later(reconnect_interval, reconnect, exc)
+            return
+
+        comps = {'switch': []}
+        for switch in switches.items():
+            comps['switch'].append(switch)
+
+        # Load platforms
+        for comp_name, comp_conf in comps.items():
+            if comp_conf:
+                load_platform(hass, comp_name, DOMAIN, {DOMAIN: comp_conf},
+                              config)
+
+        # Bind protocol to command class to allow entities to send commands
+        SW16Command.set_hlk_sw16_protocol(protocol)
+
+        # There is a valid connection to a HLK-SW16 device now so
+        # mark entities as available
+        async_dispatcher_send(hass, SIGNAL_AVAILABILITY, True)
+
+        # handle shutdown of HLK-SW16 asyncio transport
+        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP,
+                                   lambda x: transport.close())
+
+        _LOGGER.info('Connected to HLK-SW16')
+
+    hass.async_create_task(connect())
+    return True
+
+
+class SW16Device(Entity):
+    """Representation of a HLK-SW16 device.
+
+    Contains the common logic for HLK-SW16 entities.
+    """
+
+    platform = None
+    _available = True
+
+    def __init__(self, device_id, device_port, initial_event=None,
+                 name=None):
+        """Initialize the device."""
+        # HLK-SW16 specific attributes for every component type
+        self._initial_event = initial_event
+        self._device_id = device_id
+        self._device_port = device_port
+        self._is_on = None
+        if name:
+            self._name = name
+        else:
+            self._name = device_id
+
+    @callback
+    def handle_event_callback(self, event):
+        """Propagate changes through ha."""
+        self.async_schedule_update_ha_state()
+
+    def _handle_event(self, event):
+        """Platform specific event handler."""
+        raise NotImplementedError()
+
+    @property
+    def should_poll(self):
+        """No polling needed."""
+        return False
+
+    @property
+    def name(self):
+        """Return a name for the device."""
+        return self._name
+
+    @property
+    def is_on(self):
+        """Return true if device is on."""
+        return self._is_on
+
+    @property
+    def available(self):
+        """Return True if entity is available."""
+        return self._available
+
+    @callback
+    def _availability_callback(self, availability):
+        """Update availability state."""
+        self._available = availability
+        self.async_schedule_update_ha_state()
+
+    async def async_added_to_hass(self):
+        """Register update callback."""
+        # Remove temporary bogus entity_id if added
+        async_dispatcher_connect(self.hass, SIGNAL_AVAILABILITY,
+                                 self._availability_callback)
+        async_dispatcher_connect(self.hass,
+                                 SIGNAL_HANDLE_EVENT.format(self.entity_id),
+                                 self.handle_event_callback)
+
+        # Process the initial event now that the entity is created
+        if self._initial_event:
+            self.handle_event_callback(self._initial_event)
+
+
+class SW16Command(SW16Device):
+    """Singleton class to make HLK-SW16 command interface available to entities.
+
+    This class is to be inherited by every Entity class that is actionable
+    (switches/lights). It exposes the HLK-S16 command interface for these
+    entities.
+
+    The HLK-SW16 interface is managed as a class level and set during setup
+    (and reset on reconnect).
+    """
+
+    _protocol = None
+
+    @classmethod
+    def set_hlk_sw16_protocol(cls, protocol):
+        """Set the HLK-S16 asyncio protocol as a class variable."""
+        cls._protocol = protocol
+
+    @classmethod
+    def is_connected(cls):
+        """Return connection status."""
+        return bool(cls._protocol)
+
+    async def _async_handle_command(self, command, *args):
+        """Do bookkeeping for command, send it to HLK-SW16 and update state."""
+        if not self.is_connected():
+            raise HomeAssistantError('Cannot send command, not connected!')
+
+        if command == 'turn_on':
+            state = await self._protocol.turn_on(codecs.decode(
+                self._device_port.rjust(2, '0'), 'hex'))
+            _LOGGER.debug("new state:")
+            _LOGGER.debug(state)
+            self._is_on = True
+            # Update state of entity
+            await self.async_update_ha_state()
+
+        elif command == 'turn_off':
+            state = await self._protocol.turn_off(codecs.decode(
+                self._device_port.rjust(2, '0'), 'hex'))
+            _LOGGER.debug("new state:")
+            _LOGGER.debug(state)
+            self._is_on = False
+            # Update state of entity
+            await self.async_update_ha_state()
+
+        elif command == 'status':
+            state = await self._protocol.status()
+            _LOGGER.debug("new state:")
+            _LOGGER.debug(state)
+            # if the state is unknown or false, it gets set as true
+            # if the state is true, it gets set as false
+            self._is_on = state[self._device_port]
+
+
+class SwitchableSW16Device(SW16Command):
+    """HLK-SW16 entity which can switch on/off (eg: light, switch)."""
+
+    def _handle_event(self, event):
+        """Adjust state if HLK-SW16 picks up a remote command."""
+        command = event['command']
+        if command in ['on', 'allon']:
+            self._is_on = True
+        elif command in ['off', 'alloff']:
+            self._is_on = False
+
+    async def async_update(self):
+        """Get current switch status from the device."""
+        return await self._async_handle_command("status")
+
+    async def async_turn_on(self, **kwargs):
+        """Turn the device on."""
+        return await self._async_handle_command("turn_on")
+
+    async def async_turn_off(self, **kwargs):
+        """Turn the device off."""
+        return await self._async_handle_command("turn_off")

--- a/homeassistant/components/hlk_sw16.py
+++ b/homeassistant/components/hlk_sw16.py
@@ -18,7 +18,7 @@ from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_send, async_dispatcher_connect)
 
-REQUIREMENTS = ['hlk-sw16==0.0.5']
+REQUIREMENTS = ['hlk-sw16==0.0.6']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/hlk_sw16.py
+++ b/homeassistant/components/hlk_sw16.py
@@ -75,7 +75,6 @@ async def async_setup(hass, config):
         @callback
         def reconnect():
             """Schedule reconnect after connection has been lost."""
-
             async_dispatcher_send(hass, SIGNAL_AVAILABILITY, False)
 
             # If HA is not stopping, initiate new connection

--- a/homeassistant/components/hlk_sw16.py
+++ b/homeassistant/components/hlk_sw16.py
@@ -46,7 +46,9 @@ SWITCH_SCHEMA = vol.Schema({
     vol.Optional(CONF_NAME): cv.string,
 })
 
-RELAY_ID = vol.Any(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 'a', 'b', 'c', 'd', 'e', 'f')
+RELAY_ID = vol.All(
+    vol.Any(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 'a', 'b', 'c', 'd', 'e', 'f'),
+    vol.Coerce(str))
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
@@ -141,7 +143,7 @@ class SW16Device(Entity):
         """Initialize the device."""
         # HLK-SW16 specific attributes for every component type
         self._device_id = device_id
-        self._device_port = str(device_port)
+        self._device_port = device_port
         self._is_on = None
         if name:
             self._name = name

--- a/homeassistant/components/hlk_sw16.py
+++ b/homeassistant/components/hlk_sw16.py
@@ -31,16 +31,14 @@ ATTR_STATE = 'state'
 CONF_RECONNECT_INTERVAL = 'reconnect_interval'
 
 DATA_DEVICE_REGISTER = 'hlk_sw16_device_register'
-DATA_ENTITY_LOOKUP = 'hlk_sw16_entity_lookup'
 DEFAULT_RECONNECT_INTERVAL = 10
 CONNECTION_TIMEOUT = 10
+DEFAULT_PORT = 8080
 
 DOMAIN = 'hlk_sw16'
 
 SIGNAL_AVAILABILITY = 'hlk_sw16_device_available'
 SIGNAL_HANDLE_EVENT = 'hlk_sw16_handle_event_{}'
-
-TMP_ENTITY = 'tmp.{}'
 
 SWITCH_SCHEMA = vol.Schema({
     vol.Optional(CONF_NAME): cv.string,
@@ -52,8 +50,8 @@ RELAY_ID = vol.All(
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
-        vol.Required(CONF_PORT): vol.Any(cv.port, cv.string),
-        vol.Optional(CONF_HOST): cv.string,
+        vol.Required(CONF_HOST): cv.string,
+        vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
         vol.Optional(CONF_RECONNECT_INTERVAL,
                      default=DEFAULT_RECONNECT_INTERVAL): int,
         vol.Required(CONF_SWITCHES): vol.Schema({RELAY_ID: SWITCH_SCHEMA}),

--- a/homeassistant/components/switch/hlk_sw16.py
+++ b/homeassistant/components/switch/hlk_sw16.py
@@ -29,8 +29,7 @@ def devices_from_config(domain_config):
 async def async_setup_platform(hass, config, async_add_entities,
                                discovery_info=None):
     """Set up the HLK-SW16 platform."""
-    async_add_entities(devices_from_config(discovery_info),
-                       update_before_add=True)
+    async_add_entities(devices_from_config(discovery_info))
 
 
 class SW16Switch(SwitchableSW16Device, ToggleEntity):

--- a/homeassistant/components/switch/hlk_sw16.py
+++ b/homeassistant/components/switch/hlk_sw16.py
@@ -19,12 +19,11 @@ _LOGGER = logging.getLogger(__name__)
 
 def devices_from_config(domain_config):
     """Parse configuration and add HLK-SW16 switch devices."""
-    devices = []
-    for device_port, device_name in domain_config[HLK_SW16]:
-        device = SW16Switch(device_name.get(CONF_NAME, device_port),
-                            device_port)
-        devices.append(device)
-    return devices
+    device_port = domain_config[0]
+    device_config = domain_config[1]
+    device_name = device_config.get(CONF_NAME, device_port)
+    device = SW16Switch(device_name, device_port)
+    return [device]
 
 
 async def async_setup_platform(hass, config, async_add_entities,

--- a/homeassistant/components/switch/hlk_sw16.py
+++ b/homeassistant/components/switch/hlk_sw16.py
@@ -7,7 +7,8 @@ https://home-assistant.io/components/switch.hlk_sw16/
 import logging
 
 from homeassistant.components.hlk_sw16 import (
-    SwitchableSW16Device, DOMAIN as HLK_SW16)
+    SwitchableSW16Device, DOMAIN as HLK_SW16,
+    DATA_DEVICE_REGISTER)
 from homeassistant.components.switch import (
     ToggleEntity)
 from homeassistant.const import CONF_NAME
@@ -17,20 +18,21 @@ DEPENDENCIES = [HLK_SW16]
 _LOGGER = logging.getLogger(__name__)
 
 
-def devices_from_config(domain_config):
+def devices_from_config(hass, domain_config):
     """Parse configuration and add HLK-SW16 switch devices."""
     device_port = domain_config[0]
     device_config = domain_config[1]
     device_id = domain_config[2]
+    device_protocol = hass.data[DATA_DEVICE_REGISTER][device_id]
     device_name = device_config.get(CONF_NAME, device_port)
-    device = SW16Switch(device_name, device_port, device_id)
+    device = SW16Switch(device_name, device_port, device_id, device_protocol)
     return [device]
 
 
 async def async_setup_platform(hass, config, async_add_entities,
                                discovery_info=None):
     """Set up the HLK-SW16 platform."""
-    async_add_entities(devices_from_config(discovery_info))
+    async_add_entities(devices_from_config(hass, discovery_info))
 
 
 class SW16Switch(SwitchableSW16Device, ToggleEntity):

--- a/homeassistant/components/switch/hlk_sw16.py
+++ b/homeassistant/components/switch/hlk_sw16.py
@@ -22,9 +22,9 @@ def devices_from_config(hass, domain_config):
     """Parse configuration and add HLK-SW16 switch devices."""
     switches = domain_config[0]
     device_id = domain_config[1]
+    device_client = hass.data[DATA_DEVICE_REGISTER][device_id]
     devices = []
     for device_port, device_config in switches.items():
-        device_client = hass.data[DATA_DEVICE_REGISTER][device_id]
         device_name = device_config.get(CONF_NAME, device_port)
         device = SW16Switch(device_name, device_port, device_id, device_client)
         devices.append(device)

--- a/homeassistant/components/switch/hlk_sw16.py
+++ b/homeassistant/components/switch/hlk_sw16.py
@@ -35,8 +35,3 @@ async def async_setup_platform(hass, config, async_add_entities,
 
 class SW16Switch(SwitchableSW16Device, ToggleEntity):
     """Representation of a HLK-SW16 switch."""
-
-    @property
-    def force_update(self) -> bool:
-        """Will trigger anytime the state property is updated."""
-        return True

--- a/homeassistant/components/switch/hlk_sw16.py
+++ b/homeassistant/components/switch/hlk_sw16.py
@@ -2,7 +2,7 @@
 Support for HLK-SW16 switches.
 
 For more details about this platform, please refer to the documentation at
-https://home-assistant.io/components/switch.hlk-sw16/
+https://home-assistant.io/components/switch.hlk_sw16/
 """
 import logging
 

--- a/homeassistant/components/switch/hlk_sw16.py
+++ b/homeassistant/components/switch/hlk_sw16.py
@@ -1,0 +1,43 @@
+"""
+Support for HLK-SW16 switches.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/switch.hlk-sw16/
+"""
+import logging
+
+from homeassistant.components.hlk_sw16 import (
+    SwitchableSW16Device, DOMAIN as HLK_SW16)
+from homeassistant.components.switch import (
+    ToggleEntity)
+from homeassistant.const import CONF_NAME
+
+DEPENDENCIES = [HLK_SW16]
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def devices_from_config(domain_config):
+    """Parse configuration and add HLK-SW16 switch devices."""
+    devices = []
+    for device_port, device_name in domain_config[HLK_SW16]:
+        device = SW16Switch(device_name.get(CONF_NAME, device_port),
+                            device_port)
+        devices.append(device)
+    return devices
+
+
+async def async_setup_platform(hass, config, async_add_entities,
+                               discovery_info=None):
+    """Set up the HLK-SW16 platform."""
+    async_add_entities(devices_from_config(discovery_info),
+                       update_before_add=True)
+
+
+class SW16Switch(SwitchableSW16Device, ToggleEntity):
+    """Representation of a HLK-SW16 switch."""
+
+    @property
+    def force_update(self) -> bool:
+        """Will trigger anytime the state property is updated."""
+        return True

--- a/homeassistant/components/switch/hlk_sw16.py
+++ b/homeassistant/components/switch/hlk_sw16.py
@@ -21,8 +21,9 @@ def devices_from_config(domain_config):
     """Parse configuration and add HLK-SW16 switch devices."""
     device_port = domain_config[0]
     device_config = domain_config[1]
+    device_id = domain_config[2]
     device_name = device_config.get(CONF_NAME, device_port)
-    device = SW16Switch(device_name, device_port)
+    device = SW16Switch(device_name, device_port, device_id)
     return [device]
 
 

--- a/homeassistant/components/switch/hlk_sw16.py
+++ b/homeassistant/components/switch/hlk_sw16.py
@@ -23,9 +23,9 @@ def devices_from_config(hass, domain_config):
     device_port = domain_config[0]
     device_config = domain_config[1]
     device_id = domain_config[2]
-    device_protocol = hass.data[DATA_DEVICE_REGISTER][device_id]
+    device_client = hass.data[DATA_DEVICE_REGISTER][device_id]
     device_name = device_config.get(CONF_NAME, device_port)
-    device = SW16Switch(device_name, device_port, device_id, device_protocol)
+    device = SW16Switch(device_name, device_port, device_id, device_client)
     return [device]
 
 

--- a/homeassistant/components/switch/hlk_sw16.py
+++ b/homeassistant/components/switch/hlk_sw16.py
@@ -26,7 +26,7 @@ def devices_from_config(hass, domain_config):
     for device_port, device_config in switches.items():
         device_client = hass.data[DATA_DEVICE_REGISTER][device_id]
         device_name = device_config.get(CONF_NAME, device_port)
-        device = SW16Switch(device_name, device_port, device_client)
+        device = SW16Switch(device_name, device_port, device_id, device_client)
         devices.append(device)
     return devices
 

--- a/homeassistant/components/switch/hlk_sw16.py
+++ b/homeassistant/components/switch/hlk_sw16.py
@@ -20,13 +20,15 @@ _LOGGER = logging.getLogger(__name__)
 
 def devices_from_config(hass, domain_config):
     """Parse configuration and add HLK-SW16 switch devices."""
-    device_port = domain_config[0]
-    device_config = domain_config[1]
-    device_id = domain_config[2]
-    device_client = hass.data[DATA_DEVICE_REGISTER][device_id]
-    device_name = device_config.get(CONF_NAME, device_port)
-    device = SW16Switch(device_name, device_port, device_client)
-    return [device]
+    switches = domain_config[0]
+    device_id = domain_config[1]
+    devices = []
+    for device_port, device_config in switches.items():
+        device_client = hass.data[DATA_DEVICE_REGISTER][device_id]
+        device_name = device_config.get(CONF_NAME, device_port)
+        device = SW16Switch(device_name, device_port, device_client)
+        devices.append(device)
+    return devices
 
 
 async def async_setup_platform(hass, config, async_add_entities,

--- a/homeassistant/components/switch/hlk_sw16.py
+++ b/homeassistant/components/switch/hlk_sw16.py
@@ -7,7 +7,7 @@ https://home-assistant.io/components/switch.hlk_sw16/
 import logging
 
 from homeassistant.components.hlk_sw16 import (
-    SwitchableSW16Device, DOMAIN as HLK_SW16,
+    SW16Device, DOMAIN as HLK_SW16,
     DATA_DEVICE_REGISTER)
 from homeassistant.components.switch import (
     ToggleEntity)
@@ -25,7 +25,7 @@ def devices_from_config(hass, domain_config):
     device_id = domain_config[2]
     device_client = hass.data[DATA_DEVICE_REGISTER][device_id]
     device_name = device_config.get(CONF_NAME, device_port)
-    device = SW16Switch(device_name, device_port, device_id, device_client)
+    device = SW16Switch(device_name, device_port, device_client)
     return [device]
 
 
@@ -35,5 +35,18 @@ async def async_setup_platform(hass, config, async_add_entities,
     async_add_entities(devices_from_config(hass, discovery_info))
 
 
-class SW16Switch(SwitchableSW16Device, ToggleEntity):
+class SW16Switch(SW16Device, ToggleEntity):
     """Representation of a HLK-SW16 switch."""
+
+    @property
+    def is_on(self):
+        """Return true if device is on."""
+        return self._is_on
+
+    async def async_turn_on(self, **kwargs):
+        """Turn the device on."""
+        await self._client.turn_on(self._device_port)
+
+    async def async_turn_off(self, **kwargs):
+        """Turn the device off."""
+        await self._client.turn_off(self._device_port)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -466,7 +466,7 @@ hikvision==0.4
 hipnotify==1.0.8
 
 # homeassistant.components.hlk_sw16
-hlk-sw16==0.0.3
+hlk-sw16==0.0.4
 
 # homeassistant.components.sensor.pi_hole
 hole==0.3.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -465,6 +465,9 @@ hikvision==0.4
 # homeassistant.components.notify.hipchat
 hipnotify==1.0.8
 
+# homeassistant.components.hlk_sw16
+hlk-sw16==0.0.1
+
 # homeassistant.components.sensor.pi_hole
 hole==0.3.0
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -466,7 +466,7 @@ hikvision==0.4
 hipnotify==1.0.8
 
 # homeassistant.components.hlk_sw16
-hlk-sw16==0.0.2
+hlk-sw16==0.0.3
 
 # homeassistant.components.sensor.pi_hole
 hole==0.3.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -466,7 +466,7 @@ hikvision==0.4
 hipnotify==1.0.8
 
 # homeassistant.components.hlk_sw16
-hlk-sw16==0.0.1
+hlk-sw16==0.0.2
 
 # homeassistant.components.sensor.pi_hole
 hole==0.3.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -466,7 +466,7 @@ hikvision==0.4
 hipnotify==1.0.8
 
 # homeassistant.components.hlk_sw16
-hlk-sw16==0.0.4
+hlk-sw16==0.0.5
 
 # homeassistant.components.sensor.pi_hole
 hole==0.3.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -466,7 +466,7 @@ hikvision==0.4
 hipnotify==1.0.8
 
 # homeassistant.components.hlk_sw16
-hlk-sw16==0.0.5
+hlk-sw16==0.0.6
 
 # homeassistant.components.sensor.pi_hole
 hole==0.3.0


### PR DESCRIPTION
## Description:

This PR adds initial support for controlling the [HLK-SW16](http://www.hlktech.net/product_detail.php?ProId=48). I plan to use this for controlling a multi-zone hot water heating system in addition to possible other low voltage devices such as sprinklers.

The MCU reference code for the device is available [here](https://github.com/jameshilliard/stm8_stdperiph_lib-sw16_20150706/blob/master/STM8S_StdPeriph_Lib_V2.1.0/Project/STM8S_StdPeriph_Template/main.c). The device does have an internal timer feature as well but I'm not sure if there's a reason to add support for that in home-assistant.

Currently I have implemented/tested toggling all 16 relays individually in addition to reading their current state on startup, I'm looking to see if my general approach looks correct and how I might best expose the individual switch controls and how I would best configure this for controlling hot water zone valves. I'm still working on cleaning things up.

Documentation PR: home-assistant/home-assistant.io#7250

## Example entry for `configuration.yaml` (if applicable):
```yaml
hlk_sw16:
  relay1:
    host: 10.225.225.53
    switches:
      0:
        name: relay1-0
      1:
        name: relay1-1
      2:
        name: relay1-2
      3:
        name: relay1-3
      4:
        name: relay1-4
      5:
        name: relay1-5
      6:
        name: relay1-6
      7:
        name: relay1-7
      8:
        name: relay1-8
      9:
        name: relay1-9
      a:
        name: relay1-a
      b:
        name: relay1-b
      c:
        name: relay1-c
      d:
        name: relay1-d
      e:
        name: relay1-e
      f:
        name: relay1-f

  relay2:
    host: 10.225.225.55
    switches:
      0:
        name: relay2-0
      1:
        name: relay2-1
      2:
        name: relay2-2
      3:
        name: relay2-3
      4:
        name: relay2-4
      5:
        name: relay2-5
      6:
        name: relay2-6
      7:
        name: relay2-7
      8:
        name: relay2-8
      9:
        name: relay2-9
      a:
        name: relay2-a
      b:
        name: relay2-b
      c:
        name: relay2-c
      d:
        name: relay2-d
      e:
        name: relay2-e
      f:
        name: relay2-f
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
