### PR TITLE
Start type annotating/testing helpers

### DIFF
--- a/homeassistant/helpers/location.py
+++ b/homeassistant/helpers/location.py
@@ -1,6 +1,6 @@
 """Location helpers for Home Assistant."""
 
-from typing import Sequence
+from typing import Optional, Sequence
 
 from homeassistant.const import ATTR_LATITUDE, ATTR_LONGITUDE
 from homeassistant.core import State
@@ -18,7 +18,7 @@ def has_location(state: State) -> bool:
 
 
 def closest(latitude: float, longitude: float,
-            states: Sequence[State]) -> State:
+            states: Sequence[State]) -> Optional[State]:
     """Return closest state to point.
 
     Async friendly.
@@ -31,6 +31,7 @@ def closest(latitude: float, longitude: float,
     return min(
         with_location,
         key=lambda state: loc_util.distance(
-            latitude, longitude, state.attributes.get(ATTR_LATITUDE),
-            state.attributes.get(ATTR_LONGITUDE))
+            state.attributes.get(ATTR_LATITUDE),
+            state.attributes.get(ATTR_LONGITUDE),
+            latitude, longitude)
     )

--- a/homeassistant/helpers/state.py
+++ b/homeassistant/helpers/state.py
@@ -1,8 +1,12 @@
 """Helpers that help with state related things."""
 import asyncio
+import datetime as dt
 import json
 import logging
 from collections import defaultdict
+from types import TracebackType
+from typing import (  # noqa: F401 pylint: disable=unused-import
+    Awaitable, Dict, Iterable, List, Optional, Tuple, Type, Union)
 
 from homeassistant.loader import bind_hass
 import homeassistant.util.dt as dt_util
@@ -42,6 +46,7 @@ from homeassistant.const import (
     STATE_UNLOCKED, SERVICE_SELECT_OPTION)
 from homeassistant.core import State
 from homeassistant.util.async_ import run_coroutine_threadsafe
+from .typing import HomeAssistantType
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -102,43 +107,50 @@ class AsyncTrackStates:
     Must be run within the event loop.
     """
 
-    def __init__(self, hass):
+    def __init__(self, hass: HomeAssistantType) -> None:
         """Initialize a TrackStates block."""
         self.hass = hass
-        self.states = []
+        self.states = []  # type: List[State]
 
     # pylint: disable=attribute-defined-outside-init
-    def __enter__(self):
+    def __enter__(self) -> List[State]:
         """Record time from which to track changes."""
         self.now = dt_util.utcnow()
         return self.states
 
-    def __exit__(self, exc_type, exc_value, traceback):
+    def __exit__(self, exc_type: Optional[Type[BaseException]],
+                 exc_value: Optional[BaseException],
+                 traceback: Optional[TracebackType]) -> None:
         """Add changes states to changes list."""
         self.states.extend(get_changed_since(self.hass.states.async_all(),
                                              self.now))
 
 
-def get_changed_since(states, utc_point_in_time):
+def get_changed_since(states: Iterable[State],
+                      utc_point_in_time: dt.datetime) -> List[State]:
     """Return list of states that have been changed since utc_point_in_time."""
     return [state for state in states
             if state.last_updated >= utc_point_in_time]
 
 
 @bind_hass
-def reproduce_state(hass, states, blocking=False):
+def reproduce_state(hass: HomeAssistantType,
+                    states: Union[State, Iterable[State]],
+                    blocking: bool = False) -> None:
     """Reproduce given state."""
-    return run_coroutine_threadsafe(
+    return run_coroutine_threadsafe(  # type: ignore
         async_reproduce_state(hass, states, blocking), hass.loop).result()
 
 
 @bind_hass
-async def async_reproduce_state(hass, states, blocking=False):
+async def async_reproduce_state(hass: HomeAssistantType,
+                                states: Union[State, Iterable[State]],
+                                blocking: bool = False) -> None:
     """Reproduce given state."""
     if isinstance(states, State):
         states = [states]
 
-    to_call = defaultdict(list)
+    to_call = defaultdict(list)  # type: Dict[Tuple[str, str, str], List[str]]
 
     for state in states:
 
@@ -182,7 +194,7 @@ async def async_reproduce_state(hass, states, blocking=False):
                json.dumps(dict(state.attributes), sort_keys=True))
         to_call[key].append(state.entity_id)
 
-    domain_tasks = {}
+    domain_tasks = {}  # type: Dict[str, List[Awaitable[Optional[bool]]]]
     for (service_domain, service, service_data), entity_ids in to_call.items():
         data = json.loads(service_data)
         data[ATTR_ENTITY_ID] = entity_ids
@@ -194,7 +206,8 @@ async def async_reproduce_state(hass, states, blocking=False):
             hass.services.async_call(service_domain, service, data, blocking)
         )
 
-    async def async_handle_service_calls(coro_list):
+    async def async_handle_service_calls(
+            coro_list: Iterable[Awaitable]) -> None:
         """Handle service calls by domain sequence."""
         for coro in coro_list:
             await coro
@@ -205,7 +218,7 @@ async def async_reproduce_state(hass, states, blocking=False):
         await asyncio.wait(execute_tasks, loop=hass.loop)
 
 
-def state_as_number(state):
+def state_as_number(state: State) -> float:
     """
     Try to coerce our state to a number.
 

--- a/homeassistant/helpers/translation.py
+++ b/homeassistant/helpers/translation.py
@@ -1,17 +1,19 @@
 """Translation string lookup helpers."""
 import logging
 from os import path
+from typing import Any, Dict, Iterable
 
 from homeassistant import config_entries
 from homeassistant.loader import get_component, bind_hass
 from homeassistant.util.json import load_json
+from .typing import HomeAssistantType
 
 _LOGGER = logging.getLogger(__name__)
 
 TRANSLATION_STRING_CACHE = 'translation_string_cache'
 
 
-def recursive_flatten(prefix, data):
+def recursive_flatten(prefix: Any, data: Dict) -> Dict[str, Any]:
     """Return a flattened representation of dict data."""
     output = {}
     for key, value in data.items():
@@ -23,12 +25,13 @@ def recursive_flatten(prefix, data):
     return output
 
 
-def flatten(data):
+def flatten(data: Dict) -> Dict[str, Any]:
     """Return a flattened representation of dict data."""
     return recursive_flatten('', data)
 
 
-def component_translation_file(hass, component, language):
+def component_translation_file(hass: HomeAssistantType, component: str,
+                               language: str) -> str:
     """Return the translation json file location for a component."""
     if '.' in component:
         name = component.split('.', 1)[1]
@@ -36,6 +39,7 @@ def component_translation_file(hass, component, language):
         name = component
 
     module = get_component(hass, component)
+    assert module is not None
     component_path = path.dirname(module.__file__)
 
     # If loading translations for the package root, (__init__.py), the
@@ -48,19 +52,23 @@ def component_translation_file(hass, component, language):
     return path.join(component_path, '.translations', filename)
 
 
-def load_translations_files(translation_files):
+def load_translations_files(translation_files: Dict[str, str]) \
+        -> Dict[str, Dict[str, Any]]:
     """Load and parse translation.json files."""
     loaded = {}
     for component, translation_file in translation_files.items():
-        loaded[component] = load_json(translation_file)
+        loaded_json = load_json(translation_file)
+        assert isinstance(loaded_json, dict)
+        loaded[component] = loaded_json
 
     return loaded
 
 
-def build_resources(translation_cache, components):
+def build_resources(translation_cache: Dict[str, Dict[str, Any]],
+                    components: Iterable[str]) -> Dict[str, Dict[str, Any]]:
     """Build the resources response for the given components."""
     # Build response
-    resources = {}
+    resources = {}  # type: Dict[str, Dict[str, Any]]
     for component in components:
         if '.' not in component:
             domain = component
@@ -79,7 +87,8 @@ def build_resources(translation_cache, components):
 
 
 @bind_hass
-async def async_get_component_resources(hass, language):
+async def async_get_component_resources(hass: HomeAssistantType,
+                                        language: str) -> Dict[str, Any]:
     """Return translation resources for all components."""
     if TRANSLATION_STRING_CACHE not in hass.data:
         hass.data[TRANSLATION_STRING_CACHE] = {}
@@ -99,12 +108,13 @@ async def async_get_component_resources(hass, language):
 
     # Load missing files
     if missing_files:
-        loaded_translations = await hass.async_add_job(
+        load_translations_job = hass.async_add_job(
             load_translations_files, missing_files)
+        assert load_translations_job is not None
+        loaded_translations = await load_translations_job
 
         # Update cache
-        for component, translation_data in loaded_translations.items():
-            translation_cache[component] = translation_data
+        translation_cache.update(loaded_translations)
 
     resources = build_resources(translation_cache, components)
 
@@ -114,7 +124,8 @@ async def async_get_component_resources(hass, language):
 
 
 @bind_hass
-async def async_get_translations(hass, language):
+async def async_get_translations(hass: HomeAssistantType,
+                                 language: str) -> Dict[str, Any]:
     """Return all backend translations."""
     resources = await async_get_component_resources(hass, language)
     if language != 'en':

--- a/tox.ini
+++ b/tox.ini
@@ -60,4 +60,4 @@ whitelist_externals=/bin/bash
 deps =
      -r{toxinidir}/requirements_test.txt
 commands =
-         /bin/bash -c 'mypy homeassistant/*.py homeassistant/{auth,util}/ homeassistant/helpers/{intent,location}.py'
+         /bin/bash -c 'mypy homeassistant/*.py homeassistant/{auth,util}/ homeassistant/helpers/{icon,intent,json,location,typing}.py'

--- a/tox.ini
+++ b/tox.ini
@@ -60,4 +60,4 @@ whitelist_externals=/bin/bash
 deps =
      -r{toxinidir}/requirements_test.txt
 commands =
-         /bin/bash -c 'mypy homeassistant/*.py homeassistant/auth/ homeassistant/util/'
+         /bin/bash -c 'mypy homeassistant/*.py homeassistant/{auth,util}/ homeassistant/helpers/{intent,location}.py'

--- a/tox.ini
+++ b/tox.ini
@@ -60,4 +60,4 @@ whitelist_externals=/bin/bash
 deps =
      -r{toxinidir}/requirements_test.txt
 commands =
-         /bin/bash -c 'mypy homeassistant/*.py homeassistant/{auth,util}/ homeassistant/helpers/{icon,intent,json,location,state,typing}.py'
+         /bin/bash -c 'mypy homeassistant/*.py homeassistant/{auth,util}/ homeassistant/helpers/{icon,intent,json,location,state,translation,typing}.py'

--- a/tox.ini
+++ b/tox.ini
@@ -60,4 +60,4 @@ whitelist_externals=/bin/bash
 deps =
      -r{toxinidir}/requirements_test.txt
 commands =
-         /bin/bash -c 'mypy homeassistant/*.py homeassistant/{auth,util}/ homeassistant/helpers/{icon,intent,json,location,typing}.py'
+         /bin/bash -c 'mypy homeassistant/*.py homeassistant/{auth,util}/ homeassistant/helpers/{icon,intent,json,location,state,typing}.py'


### PR DESCRIPTION
## Description:

Here's a start for adding type annotations to and typing-testing helpers.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
