### PR TITLE
Allow a list ofr update entity

### DIFF
--- a/homeassistant/components/__init__.py
+++ b/homeassistant/components/__init__.py
@@ -31,7 +31,7 @@ SERVICE_RELOAD_CORE_CONFIG = 'reload_core_config'
 SERVICE_CHECK_CONFIG = 'check_config'
 SERVICE_UPDATE_ENTITY = 'update_entity'
 SCHEMA_UPDATE_ENTITY = vol.Schema({
-    ATTR_ENTITY_ID: cv.entity_id
+    ATTR_ENTITY_ID: cv.entity_ids
 })
 
 
@@ -142,8 +142,11 @@ async def async_setup(hass: ha.HomeAssistant, config: dict) -> Awaitable[bool]:
 
     async def async_handle_update_service(call):
         """Service handler for updating an entity."""
-        await hass.helpers.entity_component.async_update_entity(
-            call.data[ATTR_ENTITY_ID])
+        tasks = [hass.helpers.entity_component.async_update_entity(entity)
+                 for entity in call.data[ATTR_ENTITY_ID]]
+
+        if tasks:
+            await asyncio.wait(tasks)
 
     hass.services.async_register(
         ha.DOMAIN, SERVICE_HOMEASSISTANT_STOP, async_handle_core_service)

--- a/homeassistant/components/services.yaml
+++ b/homeassistant/components/services.yaml
@@ -527,6 +527,12 @@ homeassistant:
       entity_id:
         description: The entity_id of the device to turn off.
         example: light.living_room
+  update_entity:
+    description: Force one or more entities to update it's data
+    fields:
+      entity_id:
+        description: One or multiple entity_ids to update. Can be a list.
+        example: light.living_room
 
 xiaomi_aqara:
   play_ringtone:

--- a/homeassistant/components/services.yaml
+++ b/homeassistant/components/services.yaml
@@ -528,7 +528,7 @@ homeassistant:
         description: The entity_id of the device to turn off.
         example: light.living_room
   update_entity:
-    description: Force one or more entities to update it's data
+    description: Force one or more entities to update its data
     fields:
       entity_id:
         description: One or multiple entity_ids to update. Can be a list.

--- a/tests/components/test_init.py
+++ b/tests/components/test_init.py
@@ -364,7 +364,7 @@ async def test_entity_update(hass):
     with patch('homeassistant.helpers.entity_component.async_update_entity',
                return_value=mock_coro()) as mock_update:
         await hass.services.async_call('homeassistant', 'update_entity', {
-            'entity_id': 'light.kitchen'
+            'entity_id': ['light.kitchen']
         }, blocking=True)
 
     assert len(mock_update.mock_calls) == 1


### PR DESCRIPTION
## Description:
Our data validation was a bit too strict on update entity. We would not allow a list with a single entity. This updates the service to take any number of entities.

**Related issue (if applicable):** fixes #17851

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
