### PR TITLE
Fix sun conditions

### DIFF
--- a/homeassistant/helpers/condition.py
+++ b/homeassistant/helpers/condition.py
@@ -243,6 +243,12 @@ def sun(hass, before=None, after=None, before_offset=None, after_offset=None):
     before_offset = before_offset or timedelta(0)
     after_offset = after_offset or timedelta(0)
 
+    def is_between(tm, time_range):
+        """Test if tm is within a timerange."""
+        if time_range[1] < time_range[0]:
+            return tm >= time_range[0] or tm <= time_range[1]
+        return time_range[0] <= tm <= time_range[1]
+
     sunrise = get_astral_event_date(hass, 'sunrise', today)
     sunset = get_astral_event_date(hass, 'sunset', today)
 
@@ -254,16 +260,20 @@ def sun(hass, before=None, after=None, before_offset=None, after_offset=None):
         # There is no sunset today
         return False
 
-    if before == SUN_EVENT_SUNRISE and utcnow > sunrise + before_offset:
+    if before == SUN_EVENT_SUNRISE and not is_between(
+            utcnow.time(), [sunset.time(), (sunrise + before_offset).time()]):
         return False
 
-    if before == SUN_EVENT_SUNSET and utcnow > sunset + before_offset:
+    if before == SUN_EVENT_SUNSET and not is_between(
+            utcnow.time(), [sunrise.time(), (sunset + before_offset).time()]):
         return False
 
-    if after == SUN_EVENT_SUNRISE and utcnow < sunrise + after_offset:
+    if after == SUN_EVENT_SUNRISE and not is_between(
+            utcnow.time(), [(sunrise + after_offset).time(), sunset.time()]):
         return False
 
-    if after == SUN_EVENT_SUNSET and utcnow < sunset + after_offset:
+    if after == SUN_EVENT_SUNSET and not is_between(
+            utcnow.time(), [(sunset + after_offset).time(), sunrise.time()]):
         return False
 
     return True


### PR DESCRIPTION
## Description:
The sun conditions (after: sunset, after: sunrise, before: sunset, before: sunrise) do not work as documented.
This PR fixes the conditions to work as per the documentation:
![image](https://user-images.githubusercontent.com/14281572/47602881-d68aed80-d9e4-11e8-810b-dc390f55baf6.png)

Note: The implementation does NOT take into account change of daylength between days, the sunset and sunrise of "today" are used for calculation, where in reality it's the time of yesterday / tomorrow that should be used. Let me know if this level of exactness is needed.

**Related issue (if applicable):** fixes #12765

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**