### PR TITLE
Fixes for upnp-component/#17753 and missing hass-data when only setup from config entry

### DIFF
--- a/homeassistant/components/media_player/dlna_dmr.py
+++ b/homeassistant/components/media_player/dlna_dmr.py
@@ -25,7 +25,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import get_local_ip
 
-REQUIREMENTS = ['async-upnp-client==0.12.7']
+REQUIREMENTS = ['async-upnp-client==0.13.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/upnp/__init__.py
+++ b/homeassistant/components/upnp/__init__.py
@@ -16,7 +16,6 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import dispatcher
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.helpers.typing import HomeAssistantType
-from homeassistant.util import get_local_ip
 
 from .const import (
     CONF_ENABLE_PORT_MAPPING, CONF_ENABLE_SENSORS,
@@ -26,7 +25,7 @@ from .const import (
 )
 from .const import DOMAIN
 from .const import LOGGER as _LOGGER
-from .config_flow import ensure_domain_data
+from .config_flow import async_ensure_domain_data
 from .device import Device
 
 
@@ -87,7 +86,7 @@ def _substitute_hass_ports(ports, hass_port=None):
 # config
 async def async_setup(hass: HomeAssistantType, config: ConfigType):
     """Register a port mapping for Home Assistant via UPnP."""
-    ensure_domain_data(hass)
+    await async_ensure_domain_data(hass)
 
     # ensure sane config
     if DOMAIN not in config:
@@ -97,9 +96,6 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType):
     # overridden local ip
     if CONF_LOCAL_IP in upnp_config:
         hass.data[DOMAIN]['local_ip'] = upnp_config[CONF_LOCAL_IP]
-    else:
-        hass.data[DOMAIN]['local_ip'] = \
-            await hass.async_add_executor_job(get_local_ip)
 
     # determine ports
     ports = {CONF_HASS: CONF_HASS}  # default, port_mapping disabled by default
@@ -121,7 +117,7 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType):
 async def async_setup_entry(hass: HomeAssistantType,
                             config_entry: ConfigEntry):
     """Set up UPnP/IGD-device from a config entry."""
-    ensure_domain_data(hass)
+    await async_ensure_domain_data(hass)
     data = config_entry.data
 
     # build UPnP/IGD device

--- a/homeassistant/components/upnp/__init__.py
+++ b/homeassistant/components/upnp/__init__.py
@@ -30,7 +30,7 @@ from .config_flow import ensure_domain_data
 from .device import Device
 
 
-REQUIREMENTS = ['async-upnp-client==0.12.7']
+REQUIREMENTS = ['async-upnp-client==0.13.0']
 
 NOTIFICATION_ID = 'upnp_notification'
 NOTIFICATION_TITLE = 'UPnP/IGD Setup'

--- a/homeassistant/components/upnp/config_flow.py
+++ b/homeassistant/components/upnp/config_flow.py
@@ -5,6 +5,7 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant import data_entry_flow
+from homeassistant.util import get_local_ip
 
 from .const import (
     CONF_ENABLE_PORT_MAPPING, CONF_ENABLE_SENSORS,
@@ -13,7 +14,7 @@ from .const import (
 from .const import DOMAIN
 
 
-def ensure_domain_data(hass):
+async def async_ensure_domain_data(hass):
     """Ensure hass.data is filled properly."""
     hass.data[DOMAIN] = hass.data.get(DOMAIN, {})
     hass.data[DOMAIN]['devices'] = hass.data[DOMAIN].get('devices', {})
@@ -24,6 +25,9 @@ def ensure_domain_data(hass):
         'enable_port_mapping': False,
         'ports': {'hass': 'hass'},
     })
+    if 'local_ip' not in hass.data[DOMAIN]:
+        hass.data[DOMAIN]['local_ip'] = \
+            await hass.async_add_executor_job(get_local_ip)
 
 
 @config_entries.HANDLERS.register(DOMAIN)
@@ -64,7 +68,7 @@ class UpnpFlowHandler(data_entry_flow.FlowHandler):
         This flow is triggered by the discovery component. It will check if the
         host is already configured and delegate to the import step if not.
         """
-        ensure_domain_data(self.hass)
+        await async_ensure_domain_data(self.hass)
 
         # store discovered device
         discovery_info['friendly_name'] = \
@@ -91,7 +95,7 @@ class UpnpFlowHandler(data_entry_flow.FlowHandler):
 
     async def async_step_user(self, user_input=None):
         """Manual set up."""
-        ensure_domain_data(self.hass)
+        await async_ensure_domain_data(self.hass)
 
         # if user input given, handle it
         user_input = user_input or {}
@@ -132,13 +136,13 @@ class UpnpFlowHandler(data_entry_flow.FlowHandler):
 
     async def async_step_import(self, import_info):
         """Import a new UPnP/IGD as a config entry."""
-        ensure_domain_data(self.hass)
+        await async_ensure_domain_data(self.hass)
 
         return await self._async_save_entry(import_info)
 
     async def _async_save_entry(self, import_info):
         """Store UPNP/IGD as new entry."""
-        ensure_domain_data(self.hass)
+        await async_ensure_domain_data(self.hass)
 
         # ensure we know the host
         name = import_info['name']

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -156,7 +156,7 @@ asterisk_mbox==0.5.0
 
 # homeassistant.components.upnp
 # homeassistant.components.media_player.dlna_dmr
-async-upnp-client==0.12.7
+async-upnp-client==0.13.0
 
 # homeassistant.components.light.avion
 # avion==0.7

--- a/tests/components/upnp/test_init.py
+++ b/tests/components/upnp/test_init.py
@@ -55,7 +55,7 @@ async def test_async_setup_no_auto_config(hass):
         # no upnp
     }
     with MockDependency('netdisco.discovery'), \
-        patch('homeassistant.components.upnp.get_local_ip',
+        patch('homeassistant.components.upnp.config_flow.get_local_ip',
               return_value='192.168.1.10'):
         await async_setup_component(hass, 'upnp', config)
         await hass.async_block_till_done()
@@ -76,7 +76,7 @@ async def test_async_setup_auto_config(hass):
         'upnp': {},
     }
     with MockDependency('netdisco.discovery'), \
-        patch('homeassistant.components.upnp.get_local_ip',
+        patch('homeassistant.components.upnp.config_flow.get_local_ip',
               return_value='192.168.1.10'):
         await async_setup_component(hass, 'upnp', config)
         await hass.async_block_till_done()
@@ -100,7 +100,7 @@ async def test_async_setup_auto_config_port_mapping(hass):
         },
     }
     with MockDependency('netdisco.discovery'), \
-        patch('homeassistant.components.upnp.get_local_ip',
+        patch('homeassistant.components.upnp.config_flow.get_local_ip',
               return_value='192.168.1.10'):
         await async_setup_component(hass, 'upnp', config)
         await hass.async_block_till_done()
@@ -121,7 +121,7 @@ async def test_async_setup_auto_config_no_sensors(hass):
         'upnp': {'sensors': False},
     }
     with MockDependency('netdisco.discovery'), \
-        patch('homeassistant.components.upnp.get_local_ip',
+        patch('homeassistant.components.upnp.config_flow.get_local_ip',
               return_value='192.168.1.10'):
         await async_setup_component(hass, 'upnp', config)
         await hass.async_block_till_done()
@@ -150,7 +150,7 @@ async def test_async_setup_entry_default(hass):
         # no upnp
     }
     with MockDependency('netdisco.discovery'), \
-        patch('homeassistant.components.upnp.get_local_ip',
+        patch('homeassistant.components.upnp.config_flow.get_local_ip',
               return_value='192.168.1.10'):
         await async_setup_component(hass, 'http', config)
         await async_setup_component(hass, 'upnp', config)
@@ -160,7 +160,7 @@ async def test_async_setup_entry_default(hass):
     mock_device = MockDevice(udn)
     with patch.object(Device, 'async_create_device') as create_device:
         create_device.return_value = mock_coro(return_value=mock_device)
-        with patch('homeassistant.components.upnp.get_local_ip',
+        with patch('homeassistant.components.upnp.config_flow.get_local_ip',
                    return_value='192.168.1.10'):
             assert await upnp.async_setup_entry(hass, entry) is True
 
@@ -194,7 +194,7 @@ async def test_async_setup_entry_port_mapping(hass):
         },
     }
     with MockDependency('netdisco.discovery'), \
-        patch('homeassistant.components.upnp.get_local_ip',
+        patch('homeassistant.components.upnp.config_flow.get_local_ip',
               return_value='192.168.1.10'):
         await async_setup_component(hass, 'http', config)
         await async_setup_component(hass, 'upnp', config)


### PR DESCRIPTION
## Description:
Fix traceback in #17753 by upgrading to `async_upnp_client==0.13.0`.
Also fix a traceback when a `upnp`-config entry is set up, but the main `upnp`-platform is not. `local_ip` was missing, but expected.

**Related issue (if applicable):** fixes #17753

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
