### PR TITLE
Allow non-string variables

### DIFF
--- a/homeassistant/components/binary_sensor/pilight.py
+++ b/homeassistant/components/binary_sensor/pilight.py
@@ -113,6 +113,10 @@ class PilightBinarySensor(BinarySensorDevice):
             if self._variable not in call.data:
                 return
             value = call.data[self._variable]
+            # The following forces string comparison for all types. 
+            # More proper solution ideas can be found in the PR:
+            # https://github.com/home-assistant/home-assistant/pull/17870
+            # The same applies to the PilightTriggerSensor
             self._state = (str(value) == self._on_value)
             self.schedule_update_ha_state()
 
@@ -178,6 +182,8 @@ class PilightTriggerSensor(BinarySensorDevice):
             if self._variable not in call.data:
                 return
             value = call.data[self._variable]
+            # The following forces string comparison for all types. 
+            # See also the note in PilightBinarySensor
             self._state = (str(value) == self._on_value)
             if self._delay_after is None:
                 self._delay_after = dt_util.utcnow() + datetime.timedelta(

--- a/homeassistant/components/binary_sensor/pilight.py
+++ b/homeassistant/components/binary_sensor/pilight.py
@@ -113,7 +113,7 @@ class PilightBinarySensor(BinarySensorDevice):
             if self._variable not in call.data:
                 return
             value = call.data[self._variable]
-            self._state = (value == self._on_value)
+            self._state = (str(value) == self._on_value)
             self.schedule_update_ha_state()
 
 
@@ -178,7 +178,7 @@ class PilightTriggerSensor(BinarySensorDevice):
             if self._variable not in call.data:
                 return
             value = call.data[self._variable]
-            self._state = (value == self._on_value)
+            self._state = (str(value) == self._on_value)
             if self._delay_after is None:
                 self._delay_after = dt_util.utcnow() + datetime.timedelta(
                     seconds=self._reset_delay_sec)


### PR DESCRIPTION
This change makes non-string variables available to a pilight binary_sensor.

Background: The payload_on parameter is a string. If a pilight sensor sends a numeric variable, this variable not usable for the binary sensor, because a numeric veriable never is equal to a string as per the == operator.

Change: The pilight variable is converted to a string before comparison. This preserves backward compatibility of configurations.

## Description:

**Related issue (if applicable):** https://github.com/home-assistant/home-assistant/issues/17882

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** none

## Example entry for `configuration.yaml` (if applicable):
```yaml
binary_sensor:
  - platform: pilight
    variable: 'battery'
    payload_on:  '1.0'
```
or
```yaml
binary_sensor:
  - platform: pilight
    variable: 'battery'
    payload_on:  1.0
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
