### PR TITLE
Switch to using Client from twilio.rest rather than the deleted TwiloRestClient

### DIFF
--- a/homeassistant/components/twilio/__init__.py
+++ b/homeassistant/components/twilio/__init__.py
@@ -32,12 +32,12 @@ CONFIG_SCHEMA = vol.Schema({
 
 async def async_setup(hass, config):
     """Set up the Twilio component."""
-    from twilio.rest import TwilioRestClient
+    from twilio.rest import Client
     if DOMAIN not in config:
         return True
 
     conf = config[DOMAIN]
-    hass.data[DATA_TWILIO] = TwilioRestClient(
+    hass.data[DATA_TWILIO] = Client(
         conf.get(CONF_ACCOUNT_SID), conf.get(CONF_AUTH_TOKEN))
     return True
 


### PR DESCRIPTION
## Description:

Twilio changed the class that needs to be used from `TwilioRestClient` to `Client`. [Source](https://stackoverflow.com/questions/41013556/importerror-cannot-import-name-twiliorestclient).

This broke after the twilio client was upgraded in #17424 and an API change was missed.

**Related issue (if applicable):** fixes #17871

**This one is affecting 0.81 and should be shipped in the next bugfix release.** However, I'm not sure how to do that since the component itself was rewritten in https://github.com/home-assistant/home-assistant/pull/17715 (so the files are not in the same place). This pull request is targeted at dev for release with 0.82.0 and #17885 is targeted at master in case that helps for the hotfix for 0.81.x.



## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
