### PR TITLE
Fix wait_for_ack: False option for RFLink

### DIFF
--- a/homeassistant/components/rflink.py
+++ b/homeassistant/components/rflink.py
@@ -492,8 +492,7 @@ class RflinkCommand(RflinkDevice):
             # Rflink protocol/transport handles asynchronous writing of buffer
             # to serial/tcp device. Does not wait for command send
             # confirmation.
-            self.hass.async_create_task(self._protocol.send_command(
-                self._device_id, cmd))
+            self._protocol.send_command(self._device_id, cmd)
 
         if repetitions > 1:
             self._repetition_task = self.hass.async_create_task(


### PR DESCRIPTION
## Description:
Fix wait_for_ack: False option for RFLink

**Related issue):** fixes #17875

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**