### PR TITLE
Lovelace: Move migrate to separate WS command

### DIFF
--- a/homeassistant/components/lovelace/__init__.py
+++ b/homeassistant/components/lovelace/__init__.py
@@ -24,6 +24,7 @@ FORMAT_JSON = 'json'
 OLD_WS_TYPE_GET_LOVELACE_UI = 'frontend/lovelace_config'
 WS_TYPE_GET_LOVELACE_UI = 'lovelace/config'
 
+WS_TYPE_MIGRATE_CONFIG = 'lovelace/config/migrate'
 WS_TYPE_GET_CARD = 'lovelace/config/card/get'
 WS_TYPE_UPDATE_CARD = 'lovelace/config/card/update'
 WS_TYPE_ADD_CARD = 'lovelace/config/card/add'
@@ -33,6 +34,10 @@ WS_TYPE_DELETE_CARD = 'lovelace/config/card/delete'
 SCHEMA_GET_LOVELACE_UI = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend({
     vol.Required('type'): vol.Any(WS_TYPE_GET_LOVELACE_UI,
                                   OLD_WS_TYPE_GET_LOVELACE_UI),
+})
+
+SCHEMA_MIGRATE_CONFIG = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend({
+    vol.Required('type'): WS_TYPE_MIGRATE_CONFIG,
 })
 
 SCHEMA_GET_CARD = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend({
@@ -150,6 +155,11 @@ def load_yaml(fname: str) -> JSON_TYPE:
 
 
 def load_config(fname: str) -> JSON_TYPE:
+    """Load a YAML file."""
+    return load_yaml(fname)
+
+
+def migrate_config(fname: str) -> JSON_TYPE:
     """Load a YAML file and adds id to views and cards if not present."""
     config = load_yaml(fname)
     # Check if all views and cards have a unique id or else add one
@@ -342,6 +352,10 @@ async def async_setup(hass, config):
         SCHEMA_GET_LOVELACE_UI)
 
     hass.components.websocket_api.async_register_command(
+        WS_TYPE_MIGRATE_CONFIG, websocket_lovelace_migrate_config,
+        SCHEMA_MIGRATE_CONFIG)
+
+    hass.components.websocket_api.async_register_command(
         WS_TYPE_GET_LOVELACE_UI, websocket_lovelace_config,
         SCHEMA_GET_LOVELACE_UI)
 
@@ -375,6 +389,30 @@ async def websocket_lovelace_config(hass, connection, msg):
     try:
         config = await hass.async_add_executor_job(
             load_config, hass.config.path(LOVELACE_CONFIG_FILE))
+        message = websocket_api.result_message(
+            msg['id'], config
+        )
+    except FileNotFoundError:
+        error = ('file_not_found',
+                 'Could not find ui-lovelace.yaml in your config dir.')
+    except UnsupportedYamlError as err:
+        error = 'unsupported_error', str(err)
+    except HomeAssistantError as err:
+        error = 'load_error', str(err)
+
+    if error is not None:
+        message = websocket_api.error_message(msg['id'], *error)
+
+    connection.send_message(message)
+
+
+@websocket_api.async_response
+async def websocket_lovelace_migrate_config(hass, connection, msg):
+    """Migrate lovelace UI config."""
+    error = None
+    try:
+        config = await hass.async_add_executor_job(
+            migrate_config, hass.config.path(LOVELACE_CONFIG_FILE))
         message = websocket_api.result_message(
             msg['id'], config
         )

--- a/tests/components/lovelace/test_init.py
+++ b/tests/components/lovelace/test_init.py
@@ -9,8 +9,8 @@ from ruamel.yaml import YAML
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.setup import async_setup_component
 from homeassistant.components.websocket_api.const import TYPE_RESULT
-from homeassistant.components.lovelace import (load_yaml,
-                                               save_yaml, load_config,
+from homeassistant.components.lovelace import (load_yaml, migrate_config,
+                                               save_yaml,
                                                UnsupportedYamlError)
 
 TEST_YAML_A = """\
@@ -164,7 +164,7 @@ class TestYAML(unittest.TestCase):
         with patch('homeassistant.components.lovelace.load_yaml',
                    return_value=self.yaml.load(TEST_YAML_A)), \
                 patch('homeassistant.components.lovelace.save_yaml'):
-            data = load_config(fname)
+            data = migrate_config(fname)
         assert 'id' in data['views'][0]['cards'][0]
         assert 'id' in data['views'][1]
 
@@ -173,7 +173,7 @@ class TestYAML(unittest.TestCase):
         fname = self._path_for("test7")
         with patch('homeassistant.components.lovelace.load_yaml',
                    return_value=self.yaml.load(TEST_YAML_B)):
-            data = load_config(fname)
+            data = migrate_config(fname)
         assert data == self.yaml.load(TEST_YAML_B)
 
 


### PR DESCRIPTION
## Description:
Move Lovelace migration to a separate WS command, to be called by UI after confirming with the user.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
