### PR TITLE
Monitor all sensor types by default to rtorrent

### DIFF
--- a/homeassistant/components/sensor/rtorrent.py
+++ b/homeassistant/components/sensor/rtorrent.py
@@ -17,11 +17,6 @@ _LOGGER = logging.getLogger(__name__)
 SENSOR_TYPE_CURRENT_STATUS = 'current_status'
 SENSOR_TYPE_DOWNLOAD_SPEED = 'download_speed'
 SENSOR_TYPE_UPLOAD_SPEED = 'upload_speed'
-ALL_SENSOR_TYPES = [
-    SENSOR_TYPE_CURRENT_STATUS,
-    SENSOR_TYPE_DOWNLOAD_SPEED,
-    SENSOR_TYPE_UPLOAD_SPEED,
-]
 
 DEFAULT_NAME = 'rtorrent'
 SENSOR_TYPES = {
@@ -33,7 +28,7 @@ SENSOR_TYPES = {
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_URL): cv.url,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional(CONF_MONITORED_VARIABLES, default=ALL_SENSOR_TYPES): vol.All(
+    vol.Optional(CONF_MONITORED_VARIABLES, default=SENSOR_TYPES): vol.All(
         cv.ensure_list, [vol.In(SENSOR_TYPES)]),
 })
 

--- a/homeassistant/components/sensor/rtorrent.py
+++ b/homeassistant/components/sensor/rtorrent.py
@@ -28,7 +28,7 @@ SENSOR_TYPES = {
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_URL): cv.url,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional(CONF_MONITORED_VARIABLES, default=SENSOR_TYPES): vol.All(
+    vol.Optional(CONF_MONITORED_VARIABLES, default=list(SENSOR_TYPES)): vol.All(
         cv.ensure_list, [vol.In(SENSOR_TYPES)]),
 })
 

--- a/homeassistant/components/sensor/rtorrent.py
+++ b/homeassistant/components/sensor/rtorrent.py
@@ -28,8 +28,8 @@ SENSOR_TYPES = {
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_URL): cv.url,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional(CONF_MONITORED_VARIABLES, default=list(SENSOR_TYPES)): vol.All(
-        cv.ensure_list, [vol.In(SENSOR_TYPES)]),
+    vol.Optional(CONF_MONITORED_VARIABLES, default=list(SENSOR_TYPES)):
+        vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
 })
 
 

--- a/homeassistant/components/sensor/rtorrent.py
+++ b/homeassistant/components/sensor/rtorrent.py
@@ -17,6 +17,11 @@ _LOGGER = logging.getLogger(__name__)
 SENSOR_TYPE_CURRENT_STATUS = 'current_status'
 SENSOR_TYPE_DOWNLOAD_SPEED = 'download_speed'
 SENSOR_TYPE_UPLOAD_SPEED = 'upload_speed'
+ALL_SENSOR_TYPES = [
+    SENSOR_TYPE_CURRENT_STATUS,
+    SENSOR_TYPE_DOWNLOAD_SPEED,
+    SENSOR_TYPE_UPLOAD_SPEED,
+]
 
 DEFAULT_NAME = 'rtorrent'
 SENSOR_TYPES = {
@@ -28,7 +33,7 @@ SENSOR_TYPES = {
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_URL): cv.url,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional(CONF_MONITORED_VARIABLES, default=[]): vol.All(
+    vol.Optional(CONF_MONITORED_VARIABLES, default=ALL_SENSOR_TYPES): vol.All(
         cv.ensure_list, [vol.In(SENSOR_TYPES)]),
 })
 


### PR DESCRIPTION
## Description:
After merging #17421, @MartinHjelmare commented:
> I just realised that this shouldn't have an empty list as default if this config option is optional. Either have it be optional and default to all conditions, or make it required and remove default.

This PR adds all three sensor types to `monitored_variables`, if the user omits the field in the configuration.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`.