### PR TITLE
0.81.1

### DIFF
--- a/homeassistant/components/__init__.py
+++ b/homeassistant/components/__init__.py
@@ -31,7 +31,7 @@ SERVICE_RELOAD_CORE_CONFIG = 'reload_core_config'
 SERVICE_CHECK_CONFIG = 'check_config'
 SERVICE_UPDATE_ENTITY = 'update_entity'
 SCHEMA_UPDATE_ENTITY = vol.Schema({
-    ATTR_ENTITY_ID: cv.entity_id
+    ATTR_ENTITY_ID: cv.entity_ids
 })
 
 
@@ -142,8 +142,11 @@ async def async_setup(hass: ha.HomeAssistant, config: dict) -> Awaitable[bool]:
 
     async def async_handle_update_service(call):
         """Service handler for updating an entity."""
-        await hass.helpers.entity_component.async_update_entity(
-            call.data[ATTR_ENTITY_ID])
+        tasks = [hass.helpers.entity_component.async_update_entity(entity)
+                 for entity in call.data[ATTR_ENTITY_ID]]
+
+        if tasks:
+            await asyncio.wait(tasks)
 
     hass.services.async_register(
         ha.DOMAIN, SERVICE_HOMEASSISTANT_STOP, async_handle_core_service)

--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -24,7 +24,7 @@ from homeassistant.core import callback
 from homeassistant.helpers.translation import async_get_translations
 from homeassistant.loader import bind_hass
 
-REQUIREMENTS = ['home-assistant-frontend==20181026.0']
+REQUIREMENTS = ['home-assistant-frontend==20181026.1']
 
 DOMAIN = 'frontend'
 DEPENDENCIES = ['api', 'websocket_api', 'http', 'system_log',

--- a/homeassistant/components/openuv/config_flow.py
+++ b/homeassistant/components/openuv/config_flow.py
@@ -17,7 +17,8 @@ def configured_instances(hass):
     """Return a set of configured OpenUV instances."""
     return set(
         '{0}, {1}'.format(
-            entry.data[CONF_LATITUDE], entry.data[CONF_LONGITUDE])
+            entry.data.get(CONF_LATITUDE, hass.config.latitude),
+            entry.data.get(CONF_LONGITUDE, hass.config.longitude))
         for entry in hass.config_entries.async_entries(DOMAIN))
 
 
@@ -36,12 +37,9 @@ class OpenUvFlowHandler(config_entries.ConfigFlow):
         """Show the form to the user."""
         data_schema = vol.Schema({
             vol.Required(CONF_API_KEY): str,
-            vol.Optional(CONF_LATITUDE, default=self.hass.config.latitude):
-                cv.latitude,
-            vol.Optional(CONF_LONGITUDE, default=self.hass.config.longitude):
-                cv.longitude,
-            vol.Optional(CONF_ELEVATION, default=self.hass.config.elevation):
-                vol.Coerce(float),
+            vol.Optional(CONF_LATITUDE): cv.latitude,
+            vol.Optional(CONF_LONGITUDE): cv.longitude,
+            vol.Optional(CONF_ELEVATION): vol.Coerce(float),
         })
 
         return self.async_show_form(
@@ -61,11 +59,9 @@ class OpenUvFlowHandler(config_entries.ConfigFlow):
         if not user_input:
             return await self._show_form()
 
-        latitude = user_input[CONF_LATITUDE]
-        longitude = user_input[CONF_LONGITUDE]
-        elevation = user_input[CONF_ELEVATION]
-
-        identifier = '{0}, {1}'.format(latitude, longitude)
+        identifier = '{0}, {1}'.format(
+            user_input.get(CONF_LATITUDE, self.hass.config.latitude),
+            user_input.get(CONF_LONGITUDE, self.hass.config.longitude))
         if identifier in configured_instances(self.hass):
             return await self._show_form({CONF_LATITUDE: 'identifier_exists'})
 
@@ -78,11 +74,6 @@ class OpenUvFlowHandler(config_entries.ConfigFlow):
 
         scan_interval = user_input.get(
             CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
-        user_input.update({
-            CONF_LATITUDE: latitude,
-            CONF_LONGITUDE: longitude,
-            CONF_ELEVATION: elevation,
-            CONF_SCAN_INTERVAL: scan_interval.seconds,
-        })
+        user_input[CONF_SCAN_INTERVAL] = scan_interval.seconds
 
         return self.async_create_entry(title=identifier, data=user_input)

--- a/homeassistant/components/services.yaml
+++ b/homeassistant/components/services.yaml
@@ -527,6 +527,12 @@ homeassistant:
       entity_id:
         description: The entity_id of the device to turn off.
         example: light.living_room
+  update_entity:
+    description: Force one or more entities to update its data
+    fields:
+      entity_id:
+        description: One or multiple entity_ids to update. Can be a list.
+        example: light.living_room
 
 xiaomi_aqara:
   play_ringtone:

--- a/homeassistant/components/twilio.py
+++ b/homeassistant/components/twilio.py
@@ -34,9 +34,9 @@ CONFIG_SCHEMA = vol.Schema({
 
 def setup(hass, config):
     """Set up the Twilio component."""
-    from twilio.rest import TwilioRestClient
+    from twilio.rest import Client
     conf = config[DOMAIN]
-    hass.data[DATA_TWILIO] = TwilioRestClient(
+    hass.data[DATA_TWILIO] = Client(
         conf.get(CONF_ACCOUNT_SID), conf.get(CONF_AUTH_TOKEN))
     hass.http.register_view(TwilioReceiveDataView())
     return True

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -2,7 +2,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 81
-PATCH_VERSION = '0'
+PATCH_VERSION = '1'
 __short_version__ = '{}.{}'.format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = '{}.{}'.format(__short_version__, PATCH_VERSION)
 REQUIRED_PYTHON_VER = (3, 5, 3)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -466,7 +466,7 @@ hole==0.3.0
 holidays==0.9.8
 
 # homeassistant.components.frontend
-home-assistant-frontend==20181026.0
+home-assistant-frontend==20181026.1
 
 # homeassistant.components.homekit_controller
 # homekit==0.10

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -97,7 +97,7 @@ hdate==0.6.5
 holidays==0.9.8
 
 # homeassistant.components.frontend
-home-assistant-frontend==20181026.0
+home-assistant-frontend==20181026.1
 
 # homeassistant.components.homematicip_cloud
 homematicip==0.9.8

--- a/tests/components/lovelace/test_init.py
+++ b/tests/components/lovelace/test_init.py
@@ -8,8 +8,8 @@ from ruamel.yaml import YAML
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.setup import async_setup_component
 from homeassistant.components.websocket_api.const import TYPE_RESULT
-from homeassistant.components.lovelace import (load_yaml,
-                                               save_yaml, load_config,
+from homeassistant.components.lovelace import (load_yaml, migrate_config,
+                                               save_yaml,
                                                UnsupportedYamlError)
 
 TEST_YAML_A = """\
@@ -162,7 +162,7 @@ class TestYAML(unittest.TestCase):
         with patch('homeassistant.components.lovelace.load_yaml',
                    return_value=self.yaml.load(TEST_YAML_A)), \
                 patch('homeassistant.components.lovelace.save_yaml'):
-            data = load_config(fname)
+            data = migrate_config(fname)
         assert 'id' in data['views'][0]['cards'][0]
         assert 'id' in data['views'][1]
 
@@ -171,8 +171,8 @@ class TestYAML(unittest.TestCase):
         fname = self._path_for("test7")
         with patch('homeassistant.components.lovelace.load_yaml',
                    return_value=self.yaml.load(TEST_YAML_B)):
-            data = load_config(fname)
-        self.assertEqual(data, self.yaml.load(TEST_YAML_B))
+            data = migrate_config(fname)
+        assert data == self.yaml.load(TEST_YAML_B)
 
 
 async def test_deprecated_lovelace_ui(hass, hass_ws_client):

--- a/tests/components/test_init.py
+++ b/tests/components/test_init.py
@@ -364,7 +364,7 @@ async def test_entity_update(hass):
     with patch('homeassistant.helpers.entity_component.async_update_entity',
                return_value=mock_coro()) as mock_update:
         await hass.services.async_call('homeassistant', 'update_entity', {
-            'entity_id': 'light.kitchen'
+            'entity_id': ['light.kitchen']
         }, blocking=True)
 
     assert len(mock_update.mock_calls) == 1


### PR DESCRIPTION
- Switch to using Client from twilio.rest rather than the deleted TwilioRestClient ([@rohankapoorcom] - [#17885]) ([twilio docs])
- Fixes an issue with OpenUV config import failing ([@bachya] - [#17831]) ([openuv docs]) (breaking change)
- Allow a list ofr update entity ([@balloob] - [#17860])
- Move migrate to separate WS command ([@balloob] - [#17890]) ([lovelace docs])

[#17831]: https://github.com/home-assistant/home-assistant/pull/17831
[#17860]: https://github.com/home-assistant/home-assistant/pull/17860
[#17885]: https://github.com/home-assistant/home-assistant/pull/17885
[#17890]: https://github.com/home-assistant/home-assistant/pull/17890
[@bachya]: https://github.com/bachya
[@balloob]: https://github.com/balloob
[@rohankapoorcom]: https://github.com/rohankapoorcom
[lovelace docs]: https://www.home-assistant.io/components/lovelace/
[openuv docs]: https://www.home-assistant.io/components/openuv/
[twilio docs]: https://www.home-assistant.io/components/twilio/