### PR TITLE
Add myself to CODEOWNERS for Yeelight Sunflower light platform

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -68,6 +68,7 @@ homeassistant/components/influx.py @fabaff
 homeassistant/components/light/lifx_legacy.py @amelchio
 homeassistant/components/light/tplink.py @rytilahti
 homeassistant/components/light/yeelight.py @rytilahti
+homeassistant/components/light/yeelightsunflower.py @lindsaymarkward
 homeassistant/components/lock/nello.py @pschmitt
 homeassistant/components/lock/nuki.py @pschmitt
 homeassistant/components/media_player/emby.py @mezz64


### PR DESCRIPTION
## Description:
Add myself to CODEOWNERS for the Yeelight Sunflower light platform that I authored.