### PR TITLE
W800rf32

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -362,6 +362,9 @@ omit =
 
     homeassistant/components/*/webostv.py
 
+    homeassistant/components/w800rf32.py
+    homeassistant/components/*/w800rf32.py
+
     homeassistant/components/wemo.py
     homeassistant/components/*/wemo.py
 

--- a/homeassistant/components/binary_sensor/w800rf32.py
+++ b/homeassistant/components/binary_sensor/w800rf32.py
@@ -26,10 +26,8 @@ import voluptuous as vol
 from homeassistant.components import w800rf32
 from homeassistant.components.binary_sensor import (
     DEVICE_CLASSES_SCHEMA, PLATFORM_SCHEMA, BinarySensorDevice)
-from homeassistant.components.w800rf32 import (
-    ATTR_NAME, CONF_DEVICES, CONF_FIRE_EVENT, CONF_OFF_DELAY)
-from homeassistant.const import (
-    CONF_COMMAND_OFF, CONF_COMMAND_ON, CONF_DEVICE_CLASS, CONF_NAME)
+from homeassistant.components.w800rf32 import (CONF_FIRE_EVENT, CONF_OFF_DELAY)
+from homeassistant.const import (CONF_DEVICE_CLASS, CONF_NAME, ATTR_NAME, CONF_DEVICES)
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import event as evt
 from homeassistant.util import dt as dt_util
@@ -46,9 +44,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
             vol.Optional(CONF_DEVICE_CLASS): DEVICE_CLASSES_SCHEMA,
             vol.Optional(CONF_FIRE_EVENT, default=False): cv.boolean,
             vol.Optional(CONF_OFF_DELAY):
-            vol.Any(cv.time_period, cv.positive_timedelta),
-            vol.Optional(CONF_COMMAND_ON): cv.byte,
-            vol.Optional(CONF_COMMAND_OFF): cv.byte
+            vol.Any(cv.time_period, cv.positive_timedelta)
         })
     },
 }, extra=vol.ALLOW_EXTRA)
@@ -73,7 +69,6 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             event, entity.get(CONF_NAME), entity.get(CONF_DEVICE_CLASS),
             entity[CONF_FIRE_EVENT], entity.get(CONF_OFF_DELAY))
 
-        device.hass = hass
         sensors.append(device)
         w800rf32.W800_DEVICES[device_id] = device
 

--- a/homeassistant/components/binary_sensor/w800rf32.py
+++ b/homeassistant/components/binary_sensor/w800rf32.py
@@ -1,0 +1,172 @@
+"""
+Support for w800rf32 binary sensors.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/binary_sensor.w800rf32/
+
+# Example configuration.yaml entry
+
+binary_sensor:
+  - platform: w800rf32
+    devices:
+      c1:
+        name: motion_hall
+        off_delay: 5
+        device_class: Motion
+      c2:
+        name: motion_kitchen
+        device_class: Motion
+        fire_event: True
+
+"""
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components import w800rf32
+from homeassistant.components.binary_sensor import (
+    DEVICE_CLASSES_SCHEMA, PLATFORM_SCHEMA, BinarySensorDevice)
+from homeassistant.components.w800rf32 import (
+    ATTR_NAME, CONF_DEVICES, CONF_FIRE_EVENT, CONF_OFF_DELAY)
+from homeassistant.const import (
+    CONF_COMMAND_OFF, CONF_COMMAND_ON, CONF_DEVICE_CLASS, CONF_NAME)
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import event as evt
+from homeassistant.util import dt as dt_util
+
+
+_LOGGER = logging.getLogger(__name__)
+
+DEPENDENCIES = ['w800rf32']
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_DEVICES, default={}): {
+        cv.string: vol.Schema({
+            vol.Optional(CONF_NAME): cv.string,
+            vol.Optional(CONF_DEVICE_CLASS): DEVICE_CLASSES_SCHEMA,
+            vol.Optional(CONF_FIRE_EVENT, default=False): cv.boolean,
+            vol.Optional(CONF_OFF_DELAY):
+            vol.Any(cv.time_period, cv.positive_timedelta),
+            vol.Optional(CONF_COMMAND_ON): cv.byte,
+            vol.Optional(CONF_COMMAND_OFF): cv.byte
+        })
+    },
+}, extra=vol.ALLOW_EXTRA)
+
+
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    """Set up the Binary Sensor platform to w800rf32."""
+    import W800rf32 as w800rf32mod
+    sensors = []
+
+    # device_id --> "c1 or a3" X10 device. entity (type dictionary) --> name, device_class etc
+    for device_id, entity in config[CONF_DEVICES].items():
+
+        if device_id in w800rf32.W800_DEVICES:
+            continue
+
+        _LOGGER.debug("Add %s w800rf32.binary_sensor (class %s)",
+                      entity[ATTR_NAME], entity.get(CONF_DEVICE_CLASS))
+
+        event = None  # None until an event happens
+        device = w800rf32BinarySensor(
+            event, entity.get(CONF_NAME), entity.get(CONF_DEVICE_CLASS),
+            entity[CONF_FIRE_EVENT], entity.get(CONF_OFF_DELAY))
+
+        device.hass = hass
+        sensors.append(device)
+        w800rf32.W800_DEVICES[device_id] = device
+
+    add_entities(sensors)
+
+    def binary_sensor_update(event):
+        """Call for control updates from the w800rf32 gateway."""
+        sensor = None
+
+        if not isinstance(event, w800rf32mod.W800rf32Event):
+            return
+
+        # make sure it's lowercase
+        device_id = event.device.lower()
+
+        # get the name, ex: motion_hall
+        if device_id in w800rf32.W800_DEVICES:
+            sensor = w800rf32.W800_DEVICES[device_id]
+
+        if sensor is None:
+            return
+        elif not isinstance(sensor, w800rf32BinarySensor):
+            return
+        else:
+            _LOGGER.debug(
+                "Binary sensor update (Device ID: %s Class: %s)",
+                event.device,
+                event.device.__class__.__name__)
+
+        w800rf32.apply_received_command(event)
+
+        if (sensor.is_on and sensor.off_delay is not None and
+                sensor.delay_listener is None):
+
+            def off_delay_listener(now):
+                """Switch device off after a delay."""
+                sensor.delay_listener = None
+                sensor.update_state(False)
+
+            sensor.delay_listener = evt.track_point_in_time(
+                hass, off_delay_listener, dt_util.utcnow() + sensor.off_delay)
+
+    # Subscribe to main w800rf32 events
+    if binary_sensor_update not in w800rf32.RECEIVED_EVT_SUBSCRIBERS:
+        w800rf32.RECEIVED_EVT_SUBSCRIBERS.append(binary_sensor_update)
+
+
+class w800rf32BinarySensor(BinarySensorDevice):
+    """A representation of a w800rf32 binary sensor."""
+
+    def __init__(self, event, name, device_class=None,
+                 should_fire=False, off_delay=None):
+        """Initialize the w800rf32 sensor."""
+        self.event = event
+        self._name = name
+        self._should_fire_event = should_fire
+        self._device_class = device_class
+        self._off_delay = off_delay
+        self._state = False
+        self.delay_listener = None
+
+
+    @property
+    def name(self):
+        """Return the device name."""
+        return self._name
+
+    @property
+    def should_poll(self):
+        """No polling needed."""
+        return False
+
+    @property
+    def should_fire_event(self):
+        """Return is the device must fire event."""
+        return self._should_fire_event
+
+    @property
+    def device_class(self):
+        """Return the sensor class."""
+        return self._device_class
+
+    @property
+    def off_delay(self):
+        """Return the off_delay attribute value."""
+        return self._off_delay
+
+    @property
+    def is_on(self):
+        """Return true if the sensor state is True."""
+        return self._state
+
+    def update_state(self, state):
+        """Update the state of the device."""
+        self._state = state
+        self.schedule_update_ha_state()

--- a/homeassistant/components/binary_sensor/w800rf32.py
+++ b/homeassistant/components/binary_sensor/w800rf32.py
@@ -4,6 +4,7 @@ Support for w800rf32 binary sensors.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/binary_sensor.w800rf32/
 
+```yaml
 # Example configuration.yaml entry
 
 binary_sensor:
@@ -18,6 +19,7 @@ binary_sensor:
         device_class: Motion
         fire_event: True
 
+```
 """
 import logging
 
@@ -65,7 +67,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                       entity[ATTR_NAME], entity.get(CONF_DEVICE_CLASS))
 
         event = None  # None until an event happens
-        device = w800rf32BinarySensor(
+        device = W800rf32BinarySensor(
             event, entity.get(CONF_NAME), entity.get(CONF_DEVICE_CLASS),
             entity[CONF_FIRE_EVENT], entity.get(CONF_OFF_DELAY))
 
@@ -90,7 +92,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
         if sensor is None:
             return
-        elif not isinstance(sensor, w800rf32BinarySensor):
+
+        if not isinstance(sensor, W800rf32BinarySensor):
             return
         else:
             _LOGGER.debug(
@@ -116,7 +119,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         w800rf32.RECEIVED_EVT_SUBSCRIBERS.append(binary_sensor_update)
 
 
-class w800rf32BinarySensor(BinarySensorDevice):
+class W800rf32BinarySensor(BinarySensorDevice):
     """A representation of a w800rf32 binary sensor."""
 
     def __init__(self, event, name, device_class=None,

--- a/homeassistant/components/switch/w800rf32.py
+++ b/homeassistant/components/switch/w800rf32.py
@@ -1,0 +1,139 @@
+"""
+Support for X10 rf switches and keypads via the W800RF32 receivers.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/switch.w800rf32/
+
+# Example configuration.yaml entry
+
+switch:
+  - platform: w800rf32
+    devices:
+      c1:
+        name: keypad_1_1
+      c2:
+        name: keypad_1_2
+
+"""
+import logging
+
+import voluptuous as vol
+
+
+from homeassistant.components import w800rf32
+from homeassistant.components.switch import (
+    PLATFORM_SCHEMA, SwitchDevice)
+from homeassistant.components.w800rf32 import (CONF_FIRE_EVENT)
+from homeassistant.const import (ATTR_NAME, CONF_DEVICES, CONF_NAME)
+from homeassistant.helpers import config_validation as cv
+
+
+_LOGGER = logging.getLogger(__name__)
+
+DEPENDENCIES = ['w800rf32']
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_DEVICES, default={}): {
+        cv.string: vol.Schema({
+            vol.Optional(CONF_NAME): cv.string,
+            vol.Optional(CONF_FIRE_EVENT, default=False): cv.boolean
+        })
+    },
+}, extra=vol.ALLOW_EXTRA)
+
+
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    """Set up the Switch platform to w800rf32."""
+    import W800rf32 as w800rf32mod
+    switches = []
+
+    # device_id --> "c1 or a3" X10 device. entity (type dictionary) --> name, device_class etc
+    for device_id, entity in config[CONF_DEVICES].items():
+
+        if device_id in w800rf32.W800_DEVICES:
+            continue
+
+        _LOGGER.debug("Add %s w800rf32.switch",
+                      entity[ATTR_NAME])
+
+        event = None  # None until an event happens
+        device = w800rf32Switch(event, entity.get(CONF_NAME),entity[CONF_FIRE_EVENT],)
+
+        switches.append(device)
+        w800rf32.W800_DEVICES[device_id] = device
+
+    add_entities(switches)
+
+    def switch_update(event):
+        """Call for control updates from the w800rf32 gateway."""
+        switch = None
+
+        if not isinstance(event, w800rf32mod.W800rf32Event):
+            return
+
+        # make sure it's lowercase
+        device_id = event.device.lower()
+
+        # get the name, ex: motion_hall
+        if device_id in w800rf32.W800_DEVICES:
+            switch = w800rf32.W800_DEVICES[device_id]
+
+        if switch is None:
+            return
+        elif not isinstance(switch, w800rf32Switch):
+            return
+        else:
+            _LOGGER.debug(
+                "Binary sensor update (Device ID: %s Class: %s)",
+                event.device,
+                event.device.__class__.__name__)
+
+        w800rf32.apply_received_command(event)
+
+    # Subscribe to main w800rf32 events
+    if switch_update not in w800rf32.RECEIVED_EVT_SUBSCRIBERS:
+        w800rf32.RECEIVED_EVT_SUBSCRIBERS.append(switch_update)
+
+
+class w800rf32Switch(SwitchDevice):
+    """A representation of a w800rf32 switch."""
+
+    def __init__(self, event, name, should_fire=False,):
+        """Initialize the w800rf32 switch."""
+        self.event = event
+        self._name = name
+        self._should_fire_event = should_fire
+        self._state = False
+
+    @property
+    def name(self):
+        """Return the device name."""
+        return self._name
+
+    @property
+    def should_poll(self):
+        """No polling needed."""
+        return False
+
+    @property
+    def is_on(self):
+        """Return true if the sensor state is True."""
+        return self._state
+
+    @property
+    def should_fire_event(self):
+        """Return is the device must fire event."""
+        return self._should_fire_event
+
+    def turn_on(self, **kwargs):
+        self._state = True
+        self.schedule_update_ha_state()
+
+    def turn_off(self, **kwargs):
+        self._state = False
+        self.schedule_update_ha_state()
+
+    def update_state(self, state):
+        """Update the state of the device."""
+        self._state = state
+        self.schedule_update_ha_state()

--- a/homeassistant/components/switch/w800rf32.py
+++ b/homeassistant/components/switch/w800rf32.py
@@ -4,6 +4,7 @@ Support for X10 rf switches and keypads via the W800RF32 receivers.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/switch.w800rf32/
 
+```yaml
 # Example configuration.yaml entry
 
 switch:
@@ -14,6 +15,7 @@ switch:
       c2:
         name: keypad_1_2
 
+```
 """
 import logging
 
@@ -57,7 +59,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                       entity[ATTR_NAME])
 
         event = None  # None until an event happens
-        device = w800rf32Switch(event, entity.get(CONF_NAME),entity[CONF_FIRE_EVENT],)
+        device = W800rf32Switch(event, entity.get(CONF_NAME), entity[CONF_FIRE_EVENT],)
 
         switches.append(device)
         w800rf32.W800_DEVICES[device_id] = device
@@ -80,7 +82,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
         if switch is None:
             return
-        elif not isinstance(switch, w800rf32Switch):
+
+        if not isinstance(switch, W800rf32Switch):
             return
         else:
             _LOGGER.debug(
@@ -95,7 +98,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         w800rf32.RECEIVED_EVT_SUBSCRIBERS.append(switch_update)
 
 
-class w800rf32Switch(SwitchDevice):
+class W800rf32Switch(SwitchDevice):
     """A representation of a w800rf32 switch."""
 
     def __init__(self, event, name, should_fire=False,):

--- a/homeassistant/components/w800rf32.py
+++ b/homeassistant/components/w800rf32.py
@@ -4,11 +4,13 @@ Support for w800rf32 components.
 For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/w800rf32/
 
+```yaml
 # Example configuration.yaml entry
 
 w800rf32:
   device: PATH_TO_DEVICE
 
+```
 """
 import logging
 

--- a/homeassistant/components/w800rf32.py
+++ b/homeassistant/components/w800rf32.py
@@ -14,14 +14,12 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.const import (
-     ATTR_ENTITY_ID, ATTR_NAME, ATTR_STATE, CONF_DEVICE, CONF_DEVICES,
-     EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP)
+from homeassistant.const import (ATTR_ENTITY_ID, ATTR_STATE, CONF_DEVICE,
+                                 EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP)
 
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['pyW800rf32']
+REQUIREMENTS = ['pyW800rf32==0.1']
 
 DOMAIN = 'w800rf32'
 
@@ -91,8 +89,7 @@ def apply_received_command(event):
         command
     )
 
-    if command == 'On'\
-            or command == 'Off':
+    if command in ('On', 'Off'):
 
         # Update the w800rf32 device state
         is_on = command == 'On'

--- a/homeassistant/components/w800rf32.py
+++ b/homeassistant/components/w800rf32.py
@@ -1,0 +1,117 @@
+"""
+Support for w800rf32 components.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/w800rf32/
+
+# Example configuration.yaml entry
+
+w800rf32:
+  device: PATH_TO_DEVICE
+
+"""
+import logging
+
+import voluptuous as vol
+
+from homeassistant.const import (
+     ATTR_ENTITY_ID, ATTR_NAME, ATTR_STATE, CONF_DEVICE, CONF_DEVICES,
+     EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP)
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import Entity
+
+REQUIREMENTS = ['pyW800rf32']
+
+DOMAIN = 'w800rf32'
+
+ATTR_FIRE_EVENT = 'fire_event'
+CONF_FIRE_EVENT = 'fire_event'
+CONF_DEBUG = 'debug'
+CONF_OFF_DELAY = 'off_delay'
+EVENT_BUTTON_PRESSED = 'button_pressed'
+
+RECEIVED_EVT_SUBSCRIBERS = []
+W800_DEVICES = {}
+_LOGGER = logging.getLogger(__name__)
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_DEVICE): cv.string,
+        vol.Optional(CONF_DEBUG, default=False): cv.boolean,
+    }),
+}, extra=vol.ALLOW_EXTRA)
+
+
+def setup(hass, config):
+    """Set up the w800rf32 component."""
+    # Declare the Handle event
+    def handle_receive(event):
+        """Handle received messages from w800rf32 gateway."""
+        # Log event
+        if not event.device:
+            return
+        _LOGGER.debug("Receive W800rf32 event in handle_receive")
+
+        # Callback to HA registered components.
+        for subscriber in RECEIVED_EVT_SUBSCRIBERS:
+            subscriber(event)
+
+    # Try to load the W800rf32 module.
+    import W800rf32 as w800
+
+    # device --> /dev/ttyUSB0
+    device = config[DOMAIN][CONF_DEVICE]
+    w800_object = w800.Connect(device, None)
+
+    def _start_w800rf32(event):
+        w800_object.event_callback = handle_receive
+    hass.bus.listen_once(EVENT_HOMEASSISTANT_START, _start_w800rf32)
+
+    def _shutdown_w800rf32(event):
+        """Close connection with w800rf32."""
+        w800_object.close_connection()
+    hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, _shutdown_w800rf32)
+
+    hass.data['w800object'] = w800_object
+    return True
+
+
+def apply_received_command(event):
+    """Apply command from w800rf32."""
+    device_id = event.device.lower()
+    command = event.command
+    # Check if entity exists or previously added automatically
+    if device_id not in W800_DEVICES:
+        return
+
+    _LOGGER.debug(
+        "Device_id: %s, Command: %s",
+        device_id,
+        command
+    )
+
+    if command == 'On'\
+            or command == 'Off':
+
+        # Update the w800rf32 device state
+        is_on = command == 'On'
+        W800_DEVICES[device_id].update_state(is_on)
+
+    # Fire event
+    if W800_DEVICES[device_id].should_fire_event:
+        W800_DEVICES[device_id].hass.bus.fire(
+            EVENT_BUTTON_PRESSED, {
+                ATTR_ENTITY_ID:
+                    W800_DEVICES[device_id].entity_id,
+                ATTR_STATE: command.lower()
+            }
+        )
+        _LOGGER.debug(
+            "w800rf32 fired event: (event_type: %s, %s: %s, %s: %s)",
+            EVENT_BUTTON_PRESSED,
+            ATTR_ENTITY_ID,
+            W800_DEVICES[device_id].entity_id,
+            ATTR_STATE,
+            command.lower()
+        )

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -792,6 +792,9 @@ pyTibber==0.7.2
 # homeassistant.components.switch.dlink
 pyW215==0.6.0
 
+# homeassistant.components.w800rf32
+pyW800rf32==0.1
+
 # homeassistant.components.sensor.noaa_tides
 # py_noaa==0.3.0
 
@@ -1255,9 +1258,6 @@ pyvizio==0.0.3
 
 # homeassistant.components.velux
 pyvlx==0.1.3
-
-# homeassistant.components.w800rf32
-pyW800rf32==0.1
 
 # homeassistant.components.notify.html5
 pywebpush==1.6.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1256,6 +1256,9 @@ pyvizio==0.0.3
 # homeassistant.components.velux
 pyvlx==0.1.3
 
+# homeassistant.components.w800rf32
+pyW800rf32==0.1
+
 # homeassistant.components.notify.html5
 pywebpush==1.6.0
 


### PR DESCRIPTION
## Description:

Adds a w800rf32 component with binary_sensor and switch platforms for use with the W800 family of X10 RF receivers.


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#7187

## Example entry for `configuration.yaml` (if applicable):
```Example yaml entries are in the top of the source files.

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
