### PR TITLE
[WIP]Support for Multi modbus hub

### DIFF
--- a/homeassistant/components/binary_sensor/modbus.py
+++ b/homeassistant/components/binary_sensor/modbus.py
@@ -5,13 +5,15 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/binary_sensor.modbus/
 """
 import logging
+
 import voluptuous as vol
 
 from homeassistant.components import modbus
-from homeassistant.const import CONF_NAME, CONF_SLAVE
 from homeassistant.components.binary_sensor import BinarySensorDevice
-from homeassistant.helpers import config_validation as cv
+from homeassistant.components.modbus import CONF_HUB_NAME
 from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import CONF_NAME, CONF_SLAVE
+from homeassistant.helpers import config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 DEPENDENCIES = ['modbus']
@@ -21,6 +23,7 @@ CONF_COILS = 'coils'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_COILS): [{
+        vol.Required(CONF_HUB_NAME, default="default"): cv.string,
         vol.Required(CONF_COIL): cv.positive_int,
         vol.Required(CONF_NAME): cv.string,
         vol.Optional(CONF_SLAVE): cv.positive_int
@@ -32,18 +35,19 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Modbus binary sensors."""
     sensors = []
     for coil in config.get(CONF_COILS):
-        sensors.append(ModbusCoilSensor(
-            coil.get(CONF_NAME),
-            coil.get(CONF_SLAVE),
-            coil.get(CONF_COIL)))
+        sensors.append(
+            ModbusCoilSensor(
+                coil.get(CONF_HUB_NAME), coil.get(CONF_NAME),
+                coil.get(CONF_SLAVE), coil.get(CONF_COIL)))
     add_entities(sensors)
 
 
 class ModbusCoilSensor(BinarySensorDevice):
     """Modbus coil sensor."""
 
-    def __init__(self, name, slave, coil):
+    def __init__(self, hub_name, name, slave, coil):
         """Initialize the modbus coil sensor."""
+        self._hub_name = hub_name
         self._name = name
         self._slave = int(slave) if slave else None
         self._coil = int(coil)
@@ -59,13 +63,16 @@ class ModbusCoilSensor(BinarySensorDevice):
         """Return the state of the sensor."""
         return self._value
 
+    @property
+    def client(self) -> "BaseModbusClient":
+        """Find and return the client from modbus HUB."""
+        return modbus.HUB[self._hub_name]
+
     def update(self):
         """Update the state of the sensor."""
-        result = modbus.HUB.read_coils(self._slave, self._coil, 1)
+        result = self.client.read_coils(self._slave, self._coil, 1)
         try:
             self._value = result.bits[0]
         except AttributeError:
-            _LOGGER.error(
-                'No response from modbus slave %s coil %s',
-                self._slave,
-                self._coil)
+            _LOGGER.error('No response from modbus slave %s coil %s',
+                          self._slave, self._coil)

--- a/homeassistant/components/binary_sensor/modbus.py
+++ b/homeassistant/components/binary_sensor/modbus.py
@@ -39,7 +39,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             ModbusCoilSensor(
                 coil.get(CONF_HUB_NAME), coil.get(CONF_NAME),
                 coil.get(CONF_SLAVE), coil.get(CONF_COIL)))
-    add_entities(sensors)
+    add_entities(sensors, True)
 
 
 class ModbusCoilSensor(BinarySensorDevice):

--- a/homeassistant/components/binary_sensor/modbus.py
+++ b/homeassistant/components/binary_sensor/modbus.py
@@ -5,15 +5,19 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/binary_sensor.modbus/
 """
 import logging
+from typing import TYPE_CHECKING
 
 import voluptuous as vol
 
-from homeassistant.components import modbus
 from homeassistant.components.binary_sensor import BinarySensorDevice
-from homeassistant.components.modbus import CONF_HUB_NAME
+from homeassistant.components.modbus import CONF_HUB_NAME, DOMAIN
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import CONF_NAME, CONF_SLAVE
 from homeassistant.helpers import config_validation as cv
+
+if TYPE_CHECKING:
+    # pylint: disable=unused-import
+    from pymodbus.client.sync import BaseModbusClient
 
 _LOGGER = logging.getLogger(__name__)
 DEPENDENCIES = ['modbus']
@@ -31,23 +35,24 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
+def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Modbus binary sensors."""
     sensors = []
     for coil in config.get(CONF_COILS):
+        hub_name = coil.get(CONF_HUB_NAME)
+        hub = hass.data[DOMAIN][hub_name]
         sensors.append(
-            ModbusCoilSensor(
-                coil.get(CONF_HUB_NAME), coil.get(CONF_NAME),
-                coil.get(CONF_SLAVE), coil.get(CONF_COIL)))
-    add_entities(sensors, True)
+            ModbusCoilSensor(hub, coil.get(CONF_NAME), coil.get(CONF_SLAVE),
+                             coil.get(CONF_COIL)))
+    add_devices(sensors)
 
 
 class ModbusCoilSensor(BinarySensorDevice):
     """Modbus coil sensor."""
 
-    def __init__(self, hub_name, name, slave, coil):
+    def __init__(self, hub, name, slave, coil):
         """Initialize the modbus coil sensor."""
-        self._hub_name = hub_name
+        self._hub: "BaseModbusClient" = hub
         self._name = name
         self._slave = int(slave) if slave else None
         self._coil = int(coil)
@@ -63,14 +68,9 @@ class ModbusCoilSensor(BinarySensorDevice):
         """Return the state of the sensor."""
         return self._value
 
-    @property
-    def client(self) -> "BaseModbusClient":
-        """Find and return the client from modbus HUB."""
-        return modbus.HUB[self._hub_name]
-
     def update(self):
         """Update the state of the sensor."""
-        result = self.client.read_coils(self._slave, self._coil, 1)
+        result = self._hub.read_coils(self._slave, self._coil, 1)
         try:
             self._value = result.bits[0]
         except AttributeError:

--- a/homeassistant/components/binary_sensor/modbus.py
+++ b/homeassistant/components/binary_sensor/modbus.py
@@ -52,7 +52,7 @@ class ModbusCoilSensor(BinarySensorDevice):
 
     def __init__(self, hub, name, slave, coil):
         """Initialize the modbus coil sensor."""
-        self._hub: "BaseModbusClient" = hub
+        self._hub = hub  # type: BaseModbusClient
         self._name = name
         self._slave = int(slave) if slave else None
         self._coil = int(coil)

--- a/homeassistant/components/binary_sensor/modbus.py
+++ b/homeassistant/components/binary_sensor/modbus.py
@@ -5,19 +5,13 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/binary_sensor.modbus/
 """
 import logging
-from typing import TYPE_CHECKING
-
 import voluptuous as vol
 
-from homeassistant.components.binary_sensor import BinarySensorDevice
 from homeassistant.components.modbus import CONF_HUB_NAME, DOMAIN
-from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import CONF_NAME, CONF_SLAVE
+from homeassistant.components.binary_sensor import BinarySensorDevice
 from homeassistant.helpers import config_validation as cv
-
-if TYPE_CHECKING:
-    # pylint: disable=unused-import
-    from pymodbus.client.sync import BaseModbusClient
+from homeassistant.components.sensor import PLATFORM_SCHEMA
 
 _LOGGER = logging.getLogger(__name__)
 DEPENDENCIES = ['modbus']
@@ -27,7 +21,7 @@ CONF_COILS = 'coils'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_COILS): [{
-        vol.Required(CONF_HUB_NAME, default="default"): cv.string,
+        vol.Required(CONF_HUB_NAME, default='default'): cv.string,
         vol.Required(CONF_COIL): cv.positive_int,
         vol.Required(CONF_NAME): cv.string,
         vol.Optional(CONF_SLAVE): cv.positive_int
@@ -35,16 +29,18 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-def setup_platform(hass, config, add_devices, discovery_info=None):
+def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Modbus binary sensors."""
     sensors = []
     for coil in config.get(CONF_COILS):
         hub_name = coil.get(CONF_HUB_NAME)
         hub = hass.data[DOMAIN][hub_name]
-        sensors.append(
-            ModbusCoilSensor(hub, coil.get(CONF_NAME), coil.get(CONF_SLAVE),
-                             coil.get(CONF_COIL)))
-    add_devices(sensors)
+        sensors.append(ModbusCoilSensor(
+            hub,
+            coil.get(CONF_NAME),
+            coil.get(CONF_SLAVE),
+            coil.get(CONF_COIL)))
+    add_entities(sensors)
 
 
 class ModbusCoilSensor(BinarySensorDevice):
@@ -52,7 +48,7 @@ class ModbusCoilSensor(BinarySensorDevice):
 
     def __init__(self, hub, name, slave, coil):
         """Initialize the modbus coil sensor."""
-        self._hub = hub  # type: BaseModbusClient
+        self._hub = hub
         self._name = name
         self._slave = int(slave) if slave else None
         self._coil = int(coil)

--- a/homeassistant/components/climate/flexit.py
+++ b/homeassistant/components/climate/flexit.py
@@ -20,13 +20,14 @@ from homeassistant.const import (
 from homeassistant.components.climate import (
     ClimateDevice, PLATFORM_SCHEMA, SUPPORT_TARGET_TEMPERATURE,
     SUPPORT_FAN_MODE)
-from homeassistant.components import modbus
+from homeassistant.components.modbus import CONF_HUB_NAME, DOMAIN
 import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['pyflexit==0.3']
 DEPENDENCIES = ['modbus']
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_HUB_NAME, default="default"): cv.string,
     vol.Required(CONF_SLAVE): vol.All(int, vol.Range(min=0, max=32)),
     vol.Optional(CONF_NAME, default=DEVICE_DEFAULT_NAME): cv.string
 })
@@ -40,15 +41,18 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Flexit Platform."""
     modbus_slave = config.get(CONF_SLAVE, None)
     name = config.get(CONF_NAME, None)
-    add_entities([Flexit(modbus_slave, name)], True)
+    hub_name = config.get(CONF_HUB_NAME)
+    hub = hass.data[DOMAIN][hub_name]
+    add_entities([Flexit(hub, modbus_slave, name)], True)
 
 
 class Flexit(ClimateDevice):
     """Representation of a Flexit AC unit."""
 
-    def __init__(self, modbus_slave, name):
+    def __init__(self, hub, modbus_slave, name):
         """Initialize the unit."""
         from pyflexit import pyflexit
+        self._hub = hub
         self._name = name
         self._slave = modbus_slave
         self._target_temperature = None
@@ -64,7 +68,7 @@ class Flexit(ClimateDevice):
         self._heating = None
         self._cooling = None
         self._alarm = False
-        self.unit = pyflexit.pyflexit(modbus.HUB, modbus_slave)
+        self.unit = pyflexit.pyflexit(hub, modbus_slave)
 
     @property
     def supported_features(self):

--- a/homeassistant/components/climate/modbus.py
+++ b/homeassistant/components/climate/modbus.py
@@ -76,7 +76,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices([
         ModbusThermostat(hub, name, modbus_slave, target_temp_register,
                          current_temp_register, data_type, count, precision)
-    ], True)
+    ])
 
 
 class ModbusThermostat(ClimateDevice):

--- a/homeassistant/components/climate/modbus.py
+++ b/homeassistant/components/climate/modbus.py
@@ -85,7 +85,7 @@ class ModbusThermostat(ClimateDevice):
     def __init__(self, hub, name, modbus_slave, target_temp_register,
                  current_temp_register, data_type, count, precision):
         """Initialize the unit."""
-        self._hub: "BaseModbusClient" = hub
+        self._hub = hub  # type: BaseModbusClient
         self._name = name
         self._slave = modbus_slave
         self._target_temperature_register = target_temp_register

--- a/homeassistant/components/modbus.py
+++ b/homeassistant/components/modbus.py
@@ -19,6 +19,8 @@ if TYPE_CHECKING:
     # pylint: disable=unused-import
     from pymodbus.client.sync import BaseModbusClient
 
+_LOGGER = logging.getLogger(__name__)
+
 DOMAIN = "modbus"
 
 REQUIREMENTS = ["pymodbus==1.3.1"]
@@ -154,6 +156,7 @@ def setup(hass: Any, config: dict) -> bool:
         client = setup_client(client_config)
         client_name = client_config[CONF_HUB_NAME]
         hub_collect[client_name] = ModbusHub(client)
+        _LOGGER.debug("Setting up hub_client: %s", client_config)
 
     def stop_modbus(event: Any) -> None:
         """Stop Modbus service."""

--- a/homeassistant/components/modbus.py
+++ b/homeassistant/components/modbus.py
@@ -6,151 +6,199 @@ https://home-assistant.io/components/modbus/
 """
 import logging
 import threading
+from typing import TYPE_CHECKING, Any, Dict, List
 
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.const import (
-    EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP,
-    CONF_HOST, CONF_METHOD, CONF_PORT, CONF_TYPE, CONF_TIMEOUT, ATTR_STATE)
+    ATTR_STATE, CONF_HOST, CONF_METHOD, CONF_PORT, CONF_TIMEOUT, CONF_TYPE,
+    EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP)
 
-DOMAIN = 'modbus'
+if TYPE_CHECKING:
+    from pymodbus.client.sync import BaseModbusClient
 
-REQUIREMENTS = ['pymodbus==1.3.1']
+DOMAIN = "modbus"
+
+REQUIREMENTS = ["pymodbus==1.3.1"]
 
 # Type of network
-CONF_BAUDRATE = 'baudrate'
-CONF_BYTESIZE = 'bytesize'
-CONF_STOPBITS = 'stopbits'
-CONF_PARITY = 'parity'
+CONF_BAUDRATE = "baudrate"
+CONF_BYTESIZE = "bytesize"
+CONF_STOPBITS = "stopbits"
+CONF_PARITY = "parity"
+CONF_HUB_NAME = "hub_name"
 
-SERIAL_SCHEMA = {
+BASE_SCHEMA = vol.Schema({
+    vol.Optional(CONF_HUB_NAME, default="default"): cv.string
+})
+
+SERIAL_SCHEMA = BASE_SCHEMA.extend({
     vol.Required(CONF_BAUDRATE): cv.positive_int,
     vol.Required(CONF_BYTESIZE): vol.Any(5, 6, 7, 8),
-    vol.Required(CONF_METHOD): vol.Any('rtu', 'ascii'),
+    vol.Required(CONF_METHOD): vol.Any("rtu", "ascii"),
     vol.Required(CONF_PORT): cv.string,
-    vol.Required(CONF_PARITY): vol.Any('E', 'O', 'N'),
+    vol.Required(CONF_PARITY): vol.Any("E", "O", "N"),
     vol.Required(CONF_STOPBITS): vol.Any(1, 2),
-    vol.Required(CONF_TYPE): 'serial',
+    vol.Required(CONF_TYPE): "serial",
     vol.Optional(CONF_TIMEOUT, default=3): cv.socket_timeout,
-}
+})
 
-ETHERNET_SCHEMA = {
+ETHERNET_SCHEMA = BASE_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
     vol.Required(CONF_PORT): cv.port,
-    vol.Required(CONF_TYPE): vol.Any('tcp', 'udp', 'rtuovertcp'),
+    vol.Required(CONF_TYPE): vol.Any("tcp", "udp", "rtuovertcp"),
     vol.Optional(CONF_TIMEOUT, default=3): cv.socket_timeout,
-}
+})
 
 
-CONFIG_SCHEMA = vol.Schema({
-    DOMAIN: vol.Any(SERIAL_SCHEMA, ETHERNET_SCHEMA)
-}, extra=vol.ALLOW_EXTRA)
+def check_base_on_type(value: Any) -> Any:
+    """Check modbus component schema base on "type"."""
+    if value[CONF_TYPE] == "serial":
+        return SERIAL_SCHEMA(value)
+    if value[CONF_TYPE] in ("tcp", "udp", "rtuovertcp"):
+        return ETHERNET_SCHEMA(value)
 
+    raise vol.Invalid("%s %s is not supported" % (CONF_TYPE, value[CONF_TYPE]))
+
+CONFIG_SCHEMA = vol.Schema(
+    {
+        DOMAIN:
+            vol.All(cv.ensure_list,
+                    vol.Schema([vol.Any(SERIAL_SCHEMA, ETHERNET_SCHEMA)]))
+    },
+    extra=vol.ALLOW_EXTRA,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
-SERVICE_WRITE_REGISTER = 'write_register'
-SERVICE_WRITE_COIL = 'write_coil'
+SERVICE_WRITE_REGISTER = "write_register"
+SERVICE_WRITE_COIL = "write_coil"
 
-ATTR_ADDRESS = 'address'
-ATTR_UNIT = 'unit'
-ATTR_VALUE = 'value'
+ATTR_ADDRESS = "address"
+ATTR_UNIT = "unit"
+ATTR_VALUE = "value"
 
 SERVICE_WRITE_REGISTER_SCHEMA = vol.Schema({
+    vol.Optional(CONF_HUB_NAME, default="default"): cv.string,
     vol.Required(ATTR_UNIT): cv.positive_int,
     vol.Required(ATTR_ADDRESS): cv.positive_int,
-    vol.Required(ATTR_VALUE): vol.All(cv.ensure_list, [cv.positive_int])
+    vol.Required(ATTR_VALUE): vol.All(cv.ensure_list, [cv.positive_int]),
 })
 
 SERVICE_WRITE_COIL_SCHEMA = vol.Schema({
+    vol.Optional(CONF_HUB_NAME, default="default"): cv.string,
     vol.Required(ATTR_UNIT): cv.positive_int,
     vol.Required(ATTR_ADDRESS): cv.positive_int,
-    vol.Required(ATTR_STATE): cv.boolean
+    vol.Required(ATTR_STATE): cv.boolean,
 })
 
-HUB = None
+HUB = {}  # type: Dict[str, BaseModbusClient]
 
 
-def setup(hass, config):
-    """Set up Modbus component."""
-    # Modbus connection type
-    client_type = config[DOMAIN][CONF_TYPE]
+def setup_client(client_config: dict) -> "BaseModbusClient":
+    """Setup pymodbus client."""
+    from pymodbus.client.sync import (
+        ModbusTcpClient,
+        ModbusUdpClient,
+        ModbusSerialClient,
+    )
+    from pymodbus.transaction import ModbusRtuFramer
+
+    client_type = client_config[CONF_TYPE]
 
     # Connect to Modbus network
     # pylint: disable=import-error
 
-    if client_type == 'serial':
-        from pymodbus.client.sync import ModbusSerialClient as ModbusClient
-        client = ModbusClient(method=config[DOMAIN][CONF_METHOD],
-                              port=config[DOMAIN][CONF_PORT],
-                              baudrate=config[DOMAIN][CONF_BAUDRATE],
-                              stopbits=config[DOMAIN][CONF_STOPBITS],
-                              bytesize=config[DOMAIN][CONF_BYTESIZE],
-                              parity=config[DOMAIN][CONF_PARITY],
-                              timeout=config[DOMAIN][CONF_TIMEOUT])
-    elif client_type == 'rtuovertcp':
-        from pymodbus.client.sync import ModbusTcpClient as ModbusClient
-        from pymodbus.transaction import ModbusRtuFramer as ModbusFramer
-        client = ModbusClient(host=config[DOMAIN][CONF_HOST],
-                              port=config[DOMAIN][CONF_PORT],
-                              framer=ModbusFramer,
-                              timeout=config[DOMAIN][CONF_TIMEOUT])
-    elif client_type == 'tcp':
-        from pymodbus.client.sync import ModbusTcpClient as ModbusClient
-        client = ModbusClient(host=config[DOMAIN][CONF_HOST],
-                              port=config[DOMAIN][CONF_PORT],
-                              timeout=config[DOMAIN][CONF_TIMEOUT])
-    elif client_type == 'udp':
-        from pymodbus.client.sync import ModbusUdpClient as ModbusClient
-        client = ModbusClient(host=config[DOMAIN][CONF_HOST],
-                              port=config[DOMAIN][CONF_PORT],
-                              timeout=config[DOMAIN][CONF_TIMEOUT])
-    else:
-        return False
+    if client_type == "serial":
 
+        return ModbusSerialClient(
+            method=client_config[CONF_METHOD],
+            port=client_config[CONF_PORT],
+            baudrate=client_config[CONF_BAUDRATE],
+            stopbits=client_config[CONF_STOPBITS],
+            bytesize=client_config[CONF_BYTESIZE],
+            parity=client_config[CONF_PARITY],
+            timeout=client_config[CONF_TIMEOUT],
+        )
+    if client_type == "rtuovertcp":
+
+        return ModbusTcpClient(
+            host=client_config[CONF_HOST],
+            port=client_config[CONF_PORT],
+            framer=ModbusRtuFramer,
+            timeout=client_config[CONF_TIMEOUT],
+        )
+    if client_type == "tcp":
+        return ModbusTcpClient(
+            host=client_config[CONF_HOST],
+            port=client_config[CONF_PORT],
+            timeout=client_config[CONF_TIMEOUT],
+        )
+    if client_type == "udp":
+        return ModbusUdpClient(
+            host=client_config[CONF_HOST],
+            port=client_config[CONF_PORT],
+            timeout=client_config[CONF_TIMEOUT],
+        )
+
+    assert False
+
+
+def setup(hass: Any, config: dict) -> bool:
+    """Set up Modbus component."""
+    # Modbus connection type
     global HUB
-    HUB = ModbusHub(client)
 
-    def stop_modbus(event):
+    for client_config in config[DOMAIN]:
+        client = setup_client(client_config)
+        client_name = client_config[CONF_HUB_NAME]
+        HUB[client_name] = ModbusHub(client)
+
+    def stop_modbus(event: Any) -> None:
         """Stop Modbus service."""
-        HUB.close()
+        for client in HUB.values():
+            client.close()
 
-    def start_modbus(event):
+    def start_modbus(event: Any) -> None:
         """Start Modbus service."""
-        HUB.connect()
+        for client in HUB.values():
+            client.connect()
+
         hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, stop_modbus)
 
         # Register services for modbus
         hass.services.register(
-            DOMAIN, SERVICE_WRITE_REGISTER, write_register,
-            schema=SERVICE_WRITE_REGISTER_SCHEMA)
+            DOMAIN,
+            SERVICE_WRITE_REGISTER,
+            write_register,
+            schema=SERVICE_WRITE_REGISTER_SCHEMA,
+        )
         hass.services.register(
-            DOMAIN, SERVICE_WRITE_COIL, write_coil,
+            DOMAIN,
+            SERVICE_WRITE_COIL,
+            write_coil,
             schema=SERVICE_WRITE_COIL_SCHEMA)
 
-    def write_register(service):
+    def write_register(service: Any) -> None:
         """Write modbus registers."""
         unit = int(float(service.data.get(ATTR_UNIT)))
         address = int(float(service.data.get(ATTR_ADDRESS)))
         value = service.data.get(ATTR_VALUE)
+        client_name = service.data.get(CONF_HUB_NAME)
         if isinstance(value, list):
-            HUB.write_registers(
-                unit,
-                address,
-                [int(float(i)) for i in value])
+            HUB[client_name].write_registers(unit, address,
+                                             [int(float(i)) for i in value])
         else:
-            HUB.write_register(
-                unit,
-                address,
-                int(float(value)))
+            HUB[client_name].write_register(unit, address, int(float(value)))
 
-    def write_coil(service):
+    def write_coil(service: Any) -> None:
         """Write modbus coil."""
         unit = service.data.get(ATTR_UNIT)
         address = service.data.get(ATTR_ADDRESS)
         state = service.data.get(ATTR_STATE)
-        HUB.write_coil(unit, address, state)
+        client_name = service.data.get(CONF_HUB_NAME)
+        HUB[client_name].write_coil(unit, address, state)
 
     hass.bus.listen_once(EVENT_HOMEASSISTANT_START, start_modbus)
 
@@ -160,71 +208,56 @@ def setup(hass, config):
 class ModbusHub:
     """Thread safe wrapper class for pymodbus."""
 
-    def __init__(self, modbus_client):
+    def __init__(self, modbus_client: "BaseModbusClient") -> None:
         """Initialize the modbus hub."""
         self._client = modbus_client
         self._lock = threading.Lock()
 
-    def close(self):
+    def close(self) -> None:
         """Disconnect client."""
         with self._lock:
             self._client.close()
 
-    def connect(self):
+    def connect(self) -> None:
         """Connect client."""
         with self._lock:
             self._client.connect()
 
-    def read_coils(self, unit, address, count):
+    def read_coils(self, unit: int, address: int, count: int) -> Any:
         """Read coils."""
         with self._lock:
-            kwargs = {'unit': unit} if unit else {}
-            return self._client.read_coils(
-                address,
-                count,
-                **kwargs)
+            kwargs = {"unit": unit} if unit else {}
+            return self._client.read_coils(address, count, **kwargs)
 
-    def read_input_registers(self, unit, address, count):
+    def read_input_registers(self, unit: int, address: int, count: int) -> Any:
         """Read input registers."""
         with self._lock:
-            kwargs = {'unit': unit} if unit else {}
-            return self._client.read_input_registers(
-                address,
-                count,
-                **kwargs)
+            kwargs = {"unit": unit} if unit else {}
+            return self._client.read_input_registers(address, count, **kwargs)
 
-    def read_holding_registers(self, unit, address, count):
+    def read_holding_registers(self, unit: int, address: int,
+                               count: int) -> Any:
         """Read holding registers."""
         with self._lock:
-            kwargs = {'unit': unit} if unit else {}
-            return self._client.read_holding_registers(
-                address,
-                count,
-                **kwargs)
+            kwargs = {"unit": unit} if unit else {}
+            return self._client.read_holding_registers(address, count,
+                                                       **kwargs)
 
-    def write_coil(self, unit, address, value):
+    def write_coil(self, unit: int, address: int, value: int) -> Any:
         """Write coil."""
         with self._lock:
-            kwargs = {'unit': unit} if unit else {}
-            self._client.write_coil(
-                address,
-                value,
-                **kwargs)
+            kwargs = {"unit": unit} if unit else {}
+            self._client.write_coil(address, value, **kwargs)
 
-    def write_register(self, unit, address, value):
+    def write_register(self, unit: int, address: int, value: int) -> Any:
         """Write register."""
         with self._lock:
-            kwargs = {'unit': unit} if unit else {}
-            self._client.write_register(
-                address,
-                value,
-                **kwargs)
+            kwargs = {"unit": unit} if unit else {}
+            self._client.write_register(address, value, **kwargs)
 
-    def write_registers(self, unit, address, values):
+    def write_registers(self, unit: int, address: int,
+                        values: List[int]) -> Any:
         """Write registers."""
         with self._lock:
-            kwargs = {'unit': unit} if unit else {}
-            self._client.write_registers(
-                address,
-                values,
-                **kwargs)
+            kwargs = {"unit": unit} if unit else {}
+            self._client.write_registers(address, values, **kwargs)

--- a/homeassistant/components/modbus.py
+++ b/homeassistant/components/modbus.py
@@ -54,17 +54,6 @@ ETHERNET_SCHEMA = BASE_SCHEMA.extend({
     vol.Optional(CONF_TIMEOUT, default=3): cv.socket_timeout,
 })
 
-
-def check_base_on_type(value: Any) -> Any:
-    """Check modbus component schema base on "type"."""
-    if value[CONF_TYPE] == "serial":
-        return SERIAL_SCHEMA(value)
-    if value[CONF_TYPE] in ("tcp", "udp", "rtuovertcp"):
-        return ETHERNET_SCHEMA(value)
-
-    raise vol.Invalid("%s %s is not supported" % (CONF_TYPE, value[CONF_TYPE]))
-
-
 CONFIG_SCHEMA = vol.Schema(
     {
         DOMAIN:

--- a/homeassistant/components/sensor/modbus.py
+++ b/homeassistant/components/sensor/modbus.py
@@ -16,6 +16,7 @@ from homeassistant.const import (CONF_NAME, CONF_OFFSET, CONF_SLAVE,
                                  CONF_STRUCTURE, CONF_UNIT_OF_MEASUREMENT)
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.restore_state import async_get_last_state
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import
@@ -163,6 +164,13 @@ class ModbusRegisterSensor(Entity):
         self._precision = precision
         self._structure = structure
         self._value: str = None
+
+    async def async_added_to_hass(self):
+        """Handle entity which will be added."""
+        state = await async_get_last_state(self.hass, self.entity_id)
+        if not state:
+            return
+        self._value = state.state
 
     @property
     def state(self) -> str:

--- a/homeassistant/components/sensor/modbus.py
+++ b/homeassistant/components/sensor/modbus.py
@@ -151,7 +151,7 @@ class ModbusRegisterSensor(Entity):
                  unit_of_measurement, count, reverse_order, scale, offset,
                  structure, precision):
         """Initialize the modbus register sensor."""
-        self._hub: "BaseModbusClient" = hub
+        self._hub = hub  # type: BaseModbusClient
         self._name = name
         self._slave = int(slave) if slave else None
         self._register = int(register)

--- a/homeassistant/components/sensor/modbus.py
+++ b/homeassistant/components/sensor/modbus.py
@@ -142,7 +142,7 @@ def setup_platform(hass: Any,
 
     if not sensors:
         return False
-    add_entities(sensors)
+    add_entities(sensors, True)
     return True
 
 

--- a/homeassistant/components/sensor/modbus.py
+++ b/homeassistant/components/sensor/modbus.py
@@ -6,75 +6,104 @@ https://home-assistant.io/components/sensor.modbus/
 """
 import logging
 import struct
+from typing import TYPE_CHECKING, Any
 
 import voluptuous as vol
 
 from homeassistant.components import modbus
-from homeassistant.const import (
-    CONF_NAME, CONF_OFFSET, CONF_UNIT_OF_MEASUREMENT, CONF_SLAVE,
-    CONF_STRUCTURE)
-from homeassistant.helpers.entity import Entity
-from homeassistant.helpers import config_validation as cv
+from homeassistant.components.modbus import CONF_HUB_NAME
 from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import (
+    CONF_NAME,
+    CONF_OFFSET,
+    CONF_SLAVE,
+    CONF_STRUCTURE,
+    CONF_UNIT_OF_MEASUREMENT,
+)
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.entity import Entity
+
+if TYPE_CHECKING:
+    from pymodbus.client.sync import BaseModbusClient
 
 _LOGGER = logging.getLogger(__name__)
 
-DEPENDENCIES = ['modbus']
+DEPENDENCIES = ["modbus"]
 
-CONF_COUNT = 'count'
-CONF_REVERSE_ORDER = 'reverse_order'
-CONF_PRECISION = 'precision'
-CONF_REGISTER = 'register'
-CONF_REGISTERS = 'registers'
-CONF_SCALE = 'scale'
-CONF_DATA_TYPE = 'data_type'
-CONF_REGISTER_TYPE = 'register_type'
+CONF_COUNT = "count"
+CONF_REVERSE_ORDER = "reverse_order"
+CONF_PRECISION = "precision"
+CONF_REGISTER = "register"
+CONF_REGISTERS = "registers"
+CONF_SCALE = "scale"
+CONF_DATA_TYPE = "data_type"
+CONF_REGISTER_TYPE = "register_type"
 
-REGISTER_TYPE_HOLDING = 'holding'
-REGISTER_TYPE_INPUT = 'input'
+REGISTER_TYPE_HOLDING = "holding"
+REGISTER_TYPE_INPUT = "input"
 
-DATA_TYPE_INT = 'int'
-DATA_TYPE_UINT = 'uint'
-DATA_TYPE_FLOAT = 'float'
-DATA_TYPE_CUSTOM = 'custom'
+DATA_TYPE_INT = "int"
+DATA_TYPE_UINT = "uint"
+DATA_TYPE_FLOAT = "float"
+DATA_TYPE_CUSTOM = "custom"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_REGISTERS): [{
-        vol.Required(CONF_NAME): cv.string,
-        vol.Required(CONF_REGISTER): cv.positive_int,
+        vol.Required(CONF_HUB_NAME, default="default"):
+            cv.string,
+        vol.Required(CONF_NAME):
+            cv.string,
+        vol.Required(CONF_REGISTER):
+            cv.positive_int,
         vol.Optional(CONF_REGISTER_TYPE, default=REGISTER_TYPE_HOLDING):
             vol.In([REGISTER_TYPE_HOLDING, REGISTER_TYPE_INPUT]),
-        vol.Optional(CONF_COUNT, default=1): cv.positive_int,
-        vol.Optional(CONF_REVERSE_ORDER, default=False): cv.boolean,
-        vol.Optional(CONF_OFFSET, default=0): vol.Coerce(float),
-        vol.Optional(CONF_PRECISION, default=0): cv.positive_int,
-        vol.Optional(CONF_SCALE, default=1): vol.Coerce(float),
-        vol.Optional(CONF_SLAVE): cv.positive_int,
+        vol.Optional(CONF_COUNT, default=1):
+            cv.positive_int,
+        vol.Optional(CONF_REVERSE_ORDER, default=False):
+            cv.boolean,
+        vol.Optional(CONF_OFFSET, default=0):
+            vol.Coerce(float),
+        vol.Optional(CONF_PRECISION, default=0):
+            cv.positive_int,
+        vol.Optional(CONF_SCALE, default=1):
+            vol.Coerce(float),
+        vol.Optional(CONF_SLAVE):
+            cv.positive_int,
         vol.Optional(CONF_DATA_TYPE, default=DATA_TYPE_INT):
-            vol.In([DATA_TYPE_INT, DATA_TYPE_UINT, DATA_TYPE_FLOAT,
-                    DATA_TYPE_CUSTOM]),
-        vol.Optional(CONF_STRUCTURE): cv.string,
-        vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string
+            vol.In([
+                DATA_TYPE_INT, DATA_TYPE_UINT, DATA_TYPE_FLOAT,
+                DATA_TYPE_CUSTOM
+            ]),
+        vol.Optional(CONF_STRUCTURE):
+            cv.string,
+        vol.Optional(CONF_UNIT_OF_MEASUREMENT):
+            cv.string,
     }]
 })
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
+def setup_platform(hass: Any,
+                   config: dict,
+                   add_entities: Any,
+                   discovery_info: Any = None) -> bool:
     """Set up the Modbus sensors."""
     sensors = []
-    data_types = {DATA_TYPE_INT: {1: 'h', 2: 'i', 4: 'q'}}
-    data_types[DATA_TYPE_UINT] = {1: 'H', 2: 'I', 4: 'Q'}
-    data_types[DATA_TYPE_FLOAT] = {1: 'e', 2: 'f', 4: 'd'}
+    data_types = {DATA_TYPE_INT: {1: "h", 2: "i", 4: "q"}}
+    data_types[DATA_TYPE_UINT] = {1: "H", 2: "I", 4: "Q"}
+    data_types[DATA_TYPE_FLOAT] = {1: "e", 2: "f", 4: "d"}
 
     for register in config.get(CONF_REGISTERS):
-        structure = '>i'
+        structure = ">i"
         if register.get(CONF_DATA_TYPE) != DATA_TYPE_CUSTOM:
             try:
-                structure = '>{}'.format(data_types[
-                    register.get(CONF_DATA_TYPE)][register.get(CONF_COUNT)])
+                structure = ">{}".format(data_types[register.get(
+                    CONF_DATA_TYPE)][register.get(CONF_COUNT)])
             except KeyError:
-                _LOGGER.error("Unable to detect data type for %s sensor, "
-                              "try a custom type.", register.get(CONF_NAME))
+                _LOGGER.error(
+                    "Unable to detect data type for %s sensor, "
+                    "try a custom type.",
+                    register.get(CONF_NAME),
+                )
                 continue
         else:
             structure = register.get(CONF_STRUCTURE)
@@ -82,42 +111,49 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         try:
             size = struct.calcsize(structure)
         except struct.error as err:
-            _LOGGER.error(
-                "Error in sensor %s structure: %s",
-                register.get(CONF_NAME), err)
+            _LOGGER.error("Error in sensor %s structure: %s",
+                          register.get(CONF_NAME), err)
             continue
 
         if register.get(CONF_COUNT) * 2 != size:
             _LOGGER.error(
                 "Structure size (%d bytes) mismatch registers count "
-                "(%d words)", size, register.get(CONF_COUNT))
+                "(%d words)",
+                size,
+                register.get(CONF_COUNT),
+            )
             continue
 
-        sensors.append(ModbusRegisterSensor(
-            register.get(CONF_NAME),
-            register.get(CONF_SLAVE),
-            register.get(CONF_REGISTER),
-            register.get(CONF_REGISTER_TYPE),
-            register.get(CONF_UNIT_OF_MEASUREMENT),
-            register.get(CONF_COUNT),
-            register.get(CONF_REVERSE_ORDER),
-            register.get(CONF_SCALE),
-            register.get(CONF_OFFSET),
-            structure,
-            register.get(CONF_PRECISION)))
+        sensors.append(
+            ModbusRegisterSensor(
+                register.get(CONF_HUB_NAME),
+                register.get(CONF_NAME),
+                register.get(CONF_SLAVE),
+                register.get(CONF_REGISTER),
+                register.get(CONF_REGISTER_TYPE),
+                register.get(CONF_UNIT_OF_MEASUREMENT),
+                register.get(CONF_COUNT),
+                register.get(CONF_REVERSE_ORDER),
+                register.get(CONF_SCALE),
+                register.get(CONF_OFFSET),
+                structure,
+                register.get(CONF_PRECISION),
+            ))
 
     if not sensors:
         return False
     add_entities(sensors)
+    return True
 
 
 class ModbusRegisterSensor(Entity):
     """Modbus register sensor."""
 
-    def __init__(self, name, slave, register, register_type,
+    def __init__(self, hub_name, name, slave, register, register_type,
                  unit_of_measurement, count, reverse_order, scale, offset,
                  structure, precision):
         """Initialize the modbus register sensor."""
+        self._hub_name = hub_name
         self._name = name
         self._slave = int(slave) if slave else None
         self._register = int(register)
@@ -129,35 +165,36 @@ class ModbusRegisterSensor(Entity):
         self._offset = offset
         self._precision = precision
         self._structure = structure
-        self._value = None
+        self._value: str = None
 
     @property
-    def state(self):
+    def state(self) -> str:
         """Return the state of the sensor."""
         return self._value
 
     @property
-    def name(self):
+    def name(self) -> str:
         """Return the name of the sensor."""
         return self._name
 
     @property
-    def unit_of_measurement(self):
+    def unit_of_measurement(self) -> str:
         """Return the unit of measurement."""
         return self._unit_of_measurement
 
-    def update(self):
+    @property
+    def client(self) -> "BaseModbusClient":
+        """Find and return the client from modbus HUB."""
+        return modbus.HUB[self._hub_name]
+
+    def update(self) -> None:
         """Update the state of the sensor."""
         if self._register_type == REGISTER_TYPE_INPUT:
-            result = modbus.HUB.read_input_registers(
-                self._slave,
-                self._register,
-                self._count)
+            result = self.client.read_input_registers(
+                self._slave, self._register, self._count)
         else:
-            result = modbus.HUB.read_holding_registers(
-                self._slave,
-                self._register,
-                self._count)
+            result = self.client.read_holding_registers(
+                self._slave, self._register, self._count)
         val = 0
 
         try:
@@ -165,12 +202,14 @@ class ModbusRegisterSensor(Entity):
             if self._reverse_order:
                 registers.reverse()
         except AttributeError:
-            _LOGGER.error("No response from modbus slave %s, register %s",
-                          self._slave, self._register)
+            _LOGGER.error(
+                "No response from modbus slave %s, register %s",
+                self._slave,
+                self._register,
+            )
             return
-        byte_string = b''.join(
-            [x.to_bytes(2, byteorder='big') for x in registers]
-        )
+        byte_string = b"".join(
+            [x.to_bytes(2, byteorder="big") for x in registers])
         val = struct.unpack(self._structure, byte_string)[0]
-        self._value = format(
-            self._scale * val + self._offset, '.{}f'.format(self._precision))
+        self._value = format(self._scale * val + self._offset,
+                             ".{}f".format(self._precision))

--- a/homeassistant/components/sensor/modbus.py
+++ b/homeassistant/components/sensor/modbus.py
@@ -6,100 +6,76 @@ https://home-assistant.io/components/sensor.modbus/
 """
 import logging
 import struct
-from typing import TYPE_CHECKING, Any
 
 import voluptuous as vol
 
 from homeassistant.components.modbus import CONF_HUB_NAME, DOMAIN
-from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import (CONF_NAME, CONF_OFFSET, CONF_SLAVE,
-                                 CONF_STRUCTURE, CONF_UNIT_OF_MEASUREMENT)
+from homeassistant.const import (
+    CONF_NAME, CONF_OFFSET, CONF_UNIT_OF_MEASUREMENT, CONF_SLAVE,
+    CONF_STRUCTURE)
+from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.entity import Entity
-from homeassistant.helpers.restore_state import async_get_last_state
-
-if TYPE_CHECKING:
-    # pylint: disable=unused-import
-    from pymodbus.client.sync import BaseModbusClient
+from homeassistant.components.sensor import PLATFORM_SCHEMA
 
 _LOGGER = logging.getLogger(__name__)
 
-DEPENDENCIES = ["modbus"]
+DEPENDENCIES = ['modbus']
 
-CONF_COUNT = "count"
-CONF_REVERSE_ORDER = "reverse_order"
-CONF_PRECISION = "precision"
-CONF_REGISTER = "register"
-CONF_REGISTERS = "registers"
-CONF_SCALE = "scale"
-CONF_DATA_TYPE = "data_type"
-CONF_REGISTER_TYPE = "register_type"
+CONF_COUNT = 'count'
+CONF_REVERSE_ORDER = 'reverse_order'
+CONF_PRECISION = 'precision'
+CONF_REGISTER = 'register'
+CONF_REGISTERS = 'registers'
+CONF_SCALE = 'scale'
+CONF_DATA_TYPE = 'data_type'
+CONF_REGISTER_TYPE = 'register_type'
 
-REGISTER_TYPE_HOLDING = "holding"
-REGISTER_TYPE_INPUT = "input"
+REGISTER_TYPE_HOLDING = 'holding'
+REGISTER_TYPE_INPUT = 'input'
 
-DATA_TYPE_INT = "int"
-DATA_TYPE_UINT = "uint"
-DATA_TYPE_FLOAT = "float"
-DATA_TYPE_CUSTOM = "custom"
+DATA_TYPE_INT = 'int'
+DATA_TYPE_UINT = 'uint'
+DATA_TYPE_FLOAT = 'float'
+DATA_TYPE_CUSTOM = 'custom'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_REGISTERS): [{
-        vol.Required(CONF_HUB_NAME, default="default"):
-            cv.string,
-        vol.Required(CONF_NAME):
-            cv.string,
-        vol.Required(CONF_REGISTER):
-            cv.positive_int,
+        vol.Required(CONF_HUB_NAME, default='default'): cv.string,
+        vol.Required(CONF_NAME): cv.string,
+        vol.Required(CONF_REGISTER): cv.positive_int,
         vol.Optional(CONF_REGISTER_TYPE, default=REGISTER_TYPE_HOLDING):
             vol.In([REGISTER_TYPE_HOLDING, REGISTER_TYPE_INPUT]),
-        vol.Optional(CONF_COUNT, default=1):
-            cv.positive_int,
-        vol.Optional(CONF_REVERSE_ORDER, default=False):
-            cv.boolean,
-        vol.Optional(CONF_OFFSET, default=0):
-            vol.Coerce(float),
-        vol.Optional(CONF_PRECISION, default=0):
-            cv.positive_int,
-        vol.Optional(CONF_SCALE, default=1):
-            vol.Coerce(float),
-        vol.Optional(CONF_SLAVE):
-            cv.positive_int,
+        vol.Optional(CONF_COUNT, default=1): cv.positive_int,
+        vol.Optional(CONF_REVERSE_ORDER, default=False): cv.boolean,
+        vol.Optional(CONF_OFFSET, default=0): vol.Coerce(float),
+        vol.Optional(CONF_PRECISION, default=0): cv.positive_int,
+        vol.Optional(CONF_SCALE, default=1): vol.Coerce(float),
+        vol.Optional(CONF_SLAVE): cv.positive_int,
         vol.Optional(CONF_DATA_TYPE, default=DATA_TYPE_INT):
-            vol.In([
-                DATA_TYPE_INT, DATA_TYPE_UINT, DATA_TYPE_FLOAT,
-                DATA_TYPE_CUSTOM
-            ]),
-        vol.Optional(CONF_STRUCTURE):
-            cv.string,
-        vol.Optional(CONF_UNIT_OF_MEASUREMENT):
-            cv.string,
+            vol.In([DATA_TYPE_INT, DATA_TYPE_UINT, DATA_TYPE_FLOAT,
+                    DATA_TYPE_CUSTOM]),
+        vol.Optional(CONF_STRUCTURE): cv.string,
+        vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string
     }]
 })
 
 
-def setup_platform(hass: Any,
-                   config: dict,
-                   add_devices: Any,
-                   discovery_info: Any = None) -> bool:
+def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Modbus sensors."""
     sensors = []
-    data_types = {DATA_TYPE_INT: {1: "h", 2: "i", 4: "q"}}
-    data_types[DATA_TYPE_UINT] = {1: "H", 2: "I", 4: "Q"}
-    data_types[DATA_TYPE_FLOAT] = {1: "e", 2: "f", 4: "d"}
+    data_types = {DATA_TYPE_INT: {1: 'h', 2: 'i', 4: 'q'}}
+    data_types[DATA_TYPE_UINT] = {1: 'H', 2: 'I', 4: 'Q'}
+    data_types[DATA_TYPE_FLOAT] = {1: 'e', 2: 'f', 4: 'd'}
 
-    for register in config.get(CONF_REGISTERS, []):
-        structure = ">i"
+    for register in config.get(CONF_REGISTERS):
+        structure = '>i'
         if register.get(CONF_DATA_TYPE) != DATA_TYPE_CUSTOM:
             try:
-                structure = ">{}".format(data_types[register.get(
+                structure = '>{}'.format(data_types[register.get(
                     CONF_DATA_TYPE)][register.get(CONF_COUNT)])
             except KeyError:
-                _LOGGER.error(
-                    "Unable to detect data type for %s sensor, "
-                    "try a custom type.",
-                    register.get(CONF_NAME),
-                )
+                _LOGGER.error("Unable to detect data type for %s sensor, "
+                              "try a custom type.", register.get(CONF_NAME))
                 continue
         else:
             structure = register.get(CONF_STRUCTURE)
@@ -107,51 +83,46 @@ def setup_platform(hass: Any,
         try:
             size = struct.calcsize(structure)
         except struct.error as err:
-            _LOGGER.error("Error in sensor %s structure: %s",
-                          register.get(CONF_NAME), err)
+            _LOGGER.error(
+                "Error in sensor %s structure: %s",
+                register.get(CONF_NAME), err)
             continue
 
         if register.get(CONF_COUNT) * 2 != size:
             _LOGGER.error(
                 "Structure size (%d bytes) mismatch registers count "
-                "(%d words)",
-                size,
-                register.get(CONF_COUNT),
-            )
+                "(%d words)", size, register.get(CONF_COUNT))
             continue
 
         hub_name = register.get(CONF_HUB_NAME)
         hub = hass.data[DOMAIN][hub_name]
-        sensors.append(
-            ModbusRegisterSensor(
-                hub,
-                register.get(CONF_NAME),
-                register.get(CONF_SLAVE),
-                register.get(CONF_REGISTER),
-                register.get(CONF_REGISTER_TYPE),
-                register.get(CONF_UNIT_OF_MEASUREMENT),
-                register.get(CONF_COUNT),
-                register.get(CONF_REVERSE_ORDER),
-                register.get(CONF_SCALE),
-                register.get(CONF_OFFSET),
-                structure,
-                register.get(CONF_PRECISION),
-            ))
+        sensors.append(ModbusRegisterSensor(
+            hub,
+            register.get(CONF_NAME),
+            register.get(CONF_SLAVE),
+            register.get(CONF_REGISTER),
+            register.get(CONF_REGISTER_TYPE),
+            register.get(CONF_UNIT_OF_MEASUREMENT),
+            register.get(CONF_COUNT),
+            register.get(CONF_REVERSE_ORDER),
+            register.get(CONF_SCALE),
+            register.get(CONF_OFFSET),
+            structure,
+            register.get(CONF_PRECISION)))
 
     if not sensors:
         return False
-    add_devices(sensors)
-    return True
+    add_entities(sensors)
 
 
-class ModbusRegisterSensor(Entity):
+class ModbusRegisterSensor(RestoreEntity):
     """Modbus register sensor."""
 
     def __init__(self, hub, name, slave, register, register_type,
                  unit_of_measurement, count, reverse_order, scale, offset,
                  structure, precision):
         """Initialize the modbus register sensor."""
-        self._hub = hub  # type: BaseModbusClient
+        self._hub = hub
         self._name = name
         self._slave = int(slave) if slave else None
         self._register = int(register)
@@ -163,38 +134,42 @@ class ModbusRegisterSensor(Entity):
         self._offset = offset
         self._precision = precision
         self._structure = structure
-        self._value: str = None
+        self._value = None
 
     async def async_added_to_hass(self):
         """Handle entity which will be added."""
-        state = await async_get_last_state(self.hass, self.entity_id)
+        state = await self.async_get_last_state()
         if not state:
             return
         self._value = state.state
 
     @property
-    def state(self) -> str:
+    def state(self):
         """Return the state of the sensor."""
         return self._value
 
     @property
-    def name(self) -> str:
+    def name(self):
         """Return the name of the sensor."""
         return self._name
 
     @property
-    def unit_of_measurement(self) -> str:
+    def unit_of_measurement(self):
         """Return the unit of measurement."""
         return self._unit_of_measurement
 
-    def update(self) -> None:
+    def update(self):
         """Update the state of the sensor."""
         if self._register_type == REGISTER_TYPE_INPUT:
             result = self._hub.read_input_registers(
-                self._slave, self._register, self._count)
+                self._slave,
+                self._register,
+                self._count)
         else:
             result = self._hub.read_holding_registers(
-                self._slave, self._register, self._count)
+                self._slave,
+                self._register,
+                self._count)
         val = 0
 
         try:
@@ -202,14 +177,12 @@ class ModbusRegisterSensor(Entity):
             if self._reverse_order:
                 registers.reverse()
         except AttributeError:
-            _LOGGER.error(
-                "No response from modbus slave %s, register %s",
-                self._slave,
-                self._register,
-            )
+            _LOGGER.error("No response from modbus slave %s, register %s",
+                          self._slave, self._register)
             return
-        byte_string = b"".join(
-            [x.to_bytes(2, byteorder="big") for x in registers])
+        byte_string = b''.join(
+            [x.to_bytes(2, byteorder='big') for x in registers]
+        )
         val = struct.unpack(self._structure, byte_string)[0]
-        self._value = format(self._scale * val + self._offset,
-                             ".{}f".format(self._precision))
+        self._value = format(
+            self._scale * val + self._offset, '.{}f'.format(self._precision))

--- a/homeassistant/components/switch/modbus.py
+++ b/homeassistant/components/switch/modbus.py
@@ -93,7 +93,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                     register.get(CONF_VERIFY_REGISTER),
                     register.get(CONF_REGISTER_TYPE),
                     register.get(CONF_STATE_ON), register.get(CONF_STATE_OFF)))
-    add_entities(switches)
+    add_entities(switches, True)
 
 
 class ModbusCoilSwitch(ToggleEntity):

--- a/homeassistant/components/switch/modbus.py
+++ b/homeassistant/components/switch/modbus.py
@@ -12,9 +12,10 @@ import voluptuous as vol
 from homeassistant.components.modbus import CONF_HUB_NAME, DOMAIN
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (CONF_COMMAND_OFF, CONF_COMMAND_ON, CONF_NAME,
-                                 CONF_SLAVE)
+                                 CONF_SLAVE, STATE_ON)
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity import ToggleEntity
+from homeassistant.helpers.restore_state import async_get_last_state
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import
@@ -115,6 +116,13 @@ class ModbusCoilSwitch(ToggleEntity):
         self._slave = int(slave) if slave else None
         self._coil = int(coil)
         self._is_on = None
+
+    async def async_added_to_hass(self):
+        """Handle entity which will be added."""
+        state = await async_get_last_state(self.hass, self.entity_id)
+        if not state:
+            return
+        self._is_on = state.state == STATE_ON
 
     @property
     def is_on(self):

--- a/homeassistant/components/switch/modbus.py
+++ b/homeassistant/components/switch/modbus.py
@@ -111,7 +111,7 @@ class ModbusCoilSwitch(ToggleEntity):
 
     def __init__(self, hub, name, slave, coil):
         """Initialize the coil switch."""
-        self._hub: "BaseModbusClient" = hub
+        self._hub = hub  # type: BaseModbusClient
         self._name = name
         self._slave = int(slave) if slave else None
         self._coil = int(coil)
@@ -160,7 +160,7 @@ class ModbusRegisterSwitch(ModbusCoilSwitch):
                  verify_state, verify_register, register_type, state_on,
                  state_off):
         """Initialize the register switch."""
-        self._hub: "BaseModbusClient" = hub
+        self._hub = hub  # type: BaseModbusClient
         self._name = name
         self._slave = slave
         self._register = register

--- a/homeassistant/components/switch/modbus.py
+++ b/homeassistant/components/switch/modbus.py
@@ -5,21 +5,15 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/switch.modbus/
 """
 import logging
-from typing import TYPE_CHECKING
-
 import voluptuous as vol
 
 from homeassistant.components.modbus import CONF_HUB_NAME, DOMAIN
-from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import (CONF_COMMAND_OFF, CONF_COMMAND_ON, CONF_NAME,
-                                 CONF_SLAVE, STATE_ON)
-from homeassistant.helpers import config_validation as cv
+from homeassistant.const import (
+    CONF_NAME, CONF_SLAVE, CONF_COMMAND_ON, CONF_COMMAND_OFF, STATE_ON)
 from homeassistant.helpers.entity import ToggleEntity
-from homeassistant.helpers.restore_state import async_get_last_state
-
-if TYPE_CHECKING:
-    # pylint: disable=unused-import
-    from pymodbus.client.sync import BaseModbusClient
+from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.helpers import config_validation as cv
+from homeassistant.components.sensor import PLATFORM_SCHEMA
 
 _LOGGER = logging.getLogger(__name__)
 DEPENDENCIES = ['modbus']
@@ -38,32 +32,23 @@ REGISTER_TYPE_HOLDING = 'holding'
 REGISTER_TYPE_INPUT = 'input'
 
 REGISTERS_SCHEMA = vol.Schema({
-    vol.Required(CONF_HUB_NAME, default="default"):
-        cv.string,
-    vol.Required(CONF_NAME):
-        cv.string,
-    vol.Optional(CONF_SLAVE):
-        cv.positive_int,
-    vol.Required(CONF_REGISTER):
-        cv.positive_int,
-    vol.Required(CONF_COMMAND_ON):
-        cv.positive_int,
-    vol.Required(CONF_COMMAND_OFF):
-        cv.positive_int,
-    vol.Optional(CONF_VERIFY_STATE, default=True):
-        cv.boolean,
+    vol.Required(CONF_HUB_NAME, default='default'): cv.string,
+    vol.Required(CONF_NAME): cv.string,
+    vol.Optional(CONF_SLAVE): cv.positive_int,
+    vol.Required(CONF_REGISTER): cv.positive_int,
+    vol.Required(CONF_COMMAND_ON): cv.positive_int,
+    vol.Required(CONF_COMMAND_OFF): cv.positive_int,
+    vol.Optional(CONF_VERIFY_STATE, default=True): cv.boolean,
     vol.Optional(CONF_VERIFY_REGISTER):
         cv.positive_int,
     vol.Optional(CONF_REGISTER_TYPE, default=REGISTER_TYPE_HOLDING):
         vol.In([REGISTER_TYPE_HOLDING, REGISTER_TYPE_INPUT]),
-    vol.Optional(CONF_STATE_ON):
-        cv.positive_int,
-    vol.Optional(CONF_STATE_OFF):
-        cv.positive_int,
+    vol.Optional(CONF_STATE_ON): cv.positive_int,
+    vol.Optional(CONF_STATE_OFF): cv.positive_int,
 })
 
 COILS_SCHEMA = vol.Schema({
-    vol.Required(CONF_HUB_NAME, default="default"): cv.string,
+    vol.Required(CONF_HUB_NAME, default='default'): cv.string,
     vol.Required(CONF_COIL): cv.positive_int,
     vol.Required(CONF_NAME): cv.string,
     vol.Required(CONF_SLAVE): cv.positive_int,
@@ -77,41 +62,44 @@ PLATFORM_SCHEMA = vol.All(
     }))
 
 
-def setup_platform(hass, config, add_devices, discovery_info=None):
+def setup_platform(hass, config, add_entities, discovery_info=None):
     """Read configuration and create Modbus devices."""
     switches = []
     if CONF_COILS in config:
         for coil in config.get(CONF_COILS):
             hub_name = coil.get(CONF_HUB_NAME)
             hub = hass.data[DOMAIN][hub_name]
-            switches.append(
-                ModbusCoilSwitch(hub, coil.get(CONF_NAME),
-                                 coil.get(CONF_SLAVE), coil.get(CONF_COIL)))
+            switches.append(ModbusCoilSwitch(
+                hub,
+                coil.get(CONF_NAME),
+                coil.get(CONF_SLAVE),
+                coil.get(CONF_COIL)))
     if CONF_REGISTERS in config:
         for register in config.get(CONF_REGISTERS):
             hub_name = register.get(CONF_HUB_NAME)
             hub = hass.data[DOMAIN][hub_name]
 
-            switches.append(
-                ModbusRegisterSwitch(hub, register.get(CONF_NAME),
-                                     register.get(CONF_SLAVE),
-                                     register.get(CONF_REGISTER),
-                                     register.get(CONF_COMMAND_ON),
-                                     register.get(CONF_COMMAND_OFF),
-                                     register.get(CONF_VERIFY_STATE),
-                                     register.get(CONF_VERIFY_REGISTER),
-                                     register.get(CONF_REGISTER_TYPE),
-                                     register.get(CONF_STATE_ON),
-                                     register.get(CONF_STATE_OFF)))
-    add_devices(switches)
+            switches.append(ModbusRegisterSwitch(
+                hub,
+                register.get(CONF_NAME),
+                register.get(CONF_SLAVE),
+                register.get(CONF_REGISTER),
+                register.get(CONF_COMMAND_ON),
+                register.get(CONF_COMMAND_OFF),
+                register.get(CONF_VERIFY_STATE),
+                register.get(CONF_VERIFY_REGISTER),
+                register.get(CONF_REGISTER_TYPE),
+                register.get(CONF_STATE_ON),
+                register.get(CONF_STATE_OFF)))
+    add_entities(switches)
 
 
-class ModbusCoilSwitch(ToggleEntity):
+class ModbusCoilSwitch(ToggleEntity, RestoreEntity):
     """Representation of a Modbus coil switch."""
 
     def __init__(self, hub, name, slave, coil):
         """Initialize the coil switch."""
-        self._hub = hub  # type: BaseModbusClient
+        self._hub = hub
         self._name = name
         self._slave = int(slave) if slave else None
         self._coil = int(coil)
@@ -119,7 +107,7 @@ class ModbusCoilSwitch(ToggleEntity):
 
     async def async_added_to_hass(self):
         """Handle entity which will be added."""
-        state = await async_get_last_state(self.hass, self.entity_id)
+        state = await self.async_get_last_state()
         if not state:
             return
         self._is_on = state.state == STATE_ON
@@ -148,27 +136,29 @@ class ModbusCoilSwitch(ToggleEntity):
         try:
             self._is_on = bool(result.bits[0])
         except AttributeError:
-            _LOGGER.error('No response from modbus slave %s coil %s',
-                          self._slave, self._coil)
+            _LOGGER.error(
+                'No response from modbus slave %s coil %s',
+                self._slave,
+                self._coil)
 
 
 class ModbusRegisterSwitch(ModbusCoilSwitch):
     """Representation of a Modbus register switch."""
 
     # pylint: disable=super-init-not-called
-    def __init__(self, hub, name, slave, register, command_on, command_off,
-                 verify_state, verify_register, register_type, state_on,
-                 state_off):
+    def __init__(self, hub, name, slave, register, command_on,
+                 command_off, verify_state, verify_register,
+                 register_type, state_on, state_off):
         """Initialize the register switch."""
-        self._hub = hub  # type: BaseModbusClient
+        self._hub = hub
         self._name = name
         self._slave = slave
         self._register = register
         self._command_on = command_on
         self._command_off = command_off
         self._verify_state = verify_state
-        self._verify_register = (verify_register
-                                 if verify_register else self._register)
+        self._verify_register = (
+            verify_register if verify_register else self._register)
         self._register_type = register_type
 
         if state_on is not None:
@@ -185,14 +175,19 @@ class ModbusRegisterSwitch(ModbusCoilSwitch):
 
     def turn_on(self, **kwargs):
         """Set switch on."""
-        self._hub.write_register(self._slave, self._register, self._command_on)
+        self._hub.write_register(
+            self._slave,
+            self._register,
+            self._command_on)
         if not self._verify_state:
             self._is_on = True
 
     def turn_off(self, **kwargs):
         """Set switch off."""
-        self._hub.write_register(self._slave, self._register,
-                                 self._command_off)
+        self._hub.write_register(
+            self._slave,
+            self._register,
+            self._command_off)
         if not self._verify_state:
             self._is_on = False
 
@@ -203,17 +198,23 @@ class ModbusRegisterSwitch(ModbusCoilSwitch):
 
         value = 0
         if self._register_type == REGISTER_TYPE_INPUT:
-            result = self._hub.read_input_registers(self._slave,
-                                                    self._register, 1)
+            result = self._hub.read_input_registers(
+                self._slave,
+                self._register,
+                1)
         else:
-            result = self._hub.read_holding_registers(self._slave,
-                                                      self._register, 1)
+            result = self._hub.read_holding_registers(
+                self._slave,
+                self._register,
+                1)
 
         try:
             value = int(result.registers[0])
         except AttributeError:
-            _LOGGER.error('No response from modbus slave %s register %s',
-                          self._slave, self._verify_register)
+            _LOGGER.error(
+                'No response from modbus slave %s register %s',
+                self._slave,
+                self._verify_register)
 
         if value == self._state_on:
             self._is_on = True
@@ -222,5 +223,7 @@ class ModbusRegisterSwitch(ModbusCoilSwitch):
         else:
             _LOGGER.error(
                 'Unexpected response from modbus slave %s '
-                'register %s, got 0x%2x', self._slave, self._verify_register,
+                'register %s, got 0x%2x',
+                self._slave,
+                self._verify_register,
                 value)


### PR DESCRIPTION
## Description:
There is a feature request at https://community.home-assistant.io/t/ability-to-add-multiple-modbus-hubs/16365

This PR is try to implement this feature.

Now modbus components can have a config key named "hub_name". If not provided, the default value "default" is used. So this PR does not break the current config.


**Related issue (if applicable):** 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
modbus:
  - type: rtuovertcp
    host: 192.168.15.129
    port: 8887
    hub_name: ventilation
sensor:
- platform: modbus
  scan_interval: 5
  registers:
  - name: ventilation_operation_mode
    slave: 1
    register: 2
    register_type: holding
    count: 1
    hub_name: ventilation 
  - name: ventilation_fan_mode
    slave: 1
    register: 3
    register_type: holding
    count: 1
    hub_name: ventilation
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
