### PR TITLE
Fix logi_circle sensor update method naming

### DIFF
--- a/homeassistant/components/sensor/logi_circle.py
+++ b/homeassistant/components/sensor/logi_circle.py
@@ -137,7 +137,7 @@ class LogiSensor(Entity):
         """Return the units of measurement."""
         return SENSOR_TYPES.get(self._sensor_type)[1]
 
-    async def update(self):
+    async def async_update(self):
         """Get the latest data and updates the state."""
         _LOGGER.debug("Pulling data from %s sensor", self._name)
         await self._camera.update()


### PR DESCRIPTION
## Description:
The `logi_circle` sensor component's update method has the incorrect name. It should be `async_update`, instead of `update`.

Because 0.81 now calls the update method with `async_add_executor_job`, the sensor update method now fails (coroutines cannot be used with run_in_executor()).

Sorry for missing this in my original PR!

**Related issue (if applicable):** fixes #17908

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
