### PR TITLE
Fix for verify_ssl in the pi_hole sensor.

### DIFF
--- a/homeassistant/components/sensor/pi_hole.py
+++ b/homeassistant/components/sensor/pi_hole.py
@@ -81,10 +81,9 @@ async def async_setup_platform(
     location = config.get(CONF_LOCATION)
     verify_tls = config.get(CONF_VERIFY_SSL)
 
-    session = async_get_clientsession(hass)
+    session = async_get_clientsession(hass, verify_tls)
     pi_hole = PiHoleData(Hole(
-        host, hass.loop, session, location=location, tls=use_tls,
-        verify_tls=verify_tls))
+        host, hass.loop, session, location=location, tls=use_tls))
 
     await pi_hole.async_update()
 


### PR DESCRIPTION
## Description:

Fixes issue where the pi_hole sensor did not respect the `verify_ssl` option.

**Related issue (if applicable):** fixes #16810

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
    - Some tests failed <https://hastebin.com/felugimobi.bash> unrelated to this change.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
