### PR TITLE
Updated XKNX dependency to 0.9.1

### DIFF
--- a/homeassistant/components/knx.py
+++ b/homeassistant/components/knx.py
@@ -17,7 +17,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import async_track_state_change
 from homeassistant.helpers.script import Script
 
-REQUIREMENTS = ['xknx==0.8.5']
+REQUIREMENTS = ['xknx==0.9.1']
 
 DOMAIN = "knx"
 DATA_KNX = "data_knx"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1554,7 +1554,7 @@ xbee-helper==0.0.7
 xboxapi==0.1.1
 
 # homeassistant.components.knx
-xknx==0.8.5
+xknx==0.9.1
 
 # homeassistant.components.media_player.bluesound
 # homeassistant.components.sensor.startca


### PR DESCRIPTION
## Description:

Updated version of [xknx](http://xknx.io/). See changelog [here](https://github.com/XKNX/xknx/blob/master/changelog.md).

XKNX 0.9 contains one important change. [The write address is not taken implicitely as read address.](https://github.com/XKNX/xknx/pull/140). The old behaviour often caused trouble in the past, bc some KNX addresses are not readable and this caused warn messages on the console and unnecessary traffic on the bus.


