### PR TITLE
Add support for switches in homekit controller

### DIFF
--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -24,6 +24,7 @@ HOMEKIT_DIR = '.homekit'
 HOMEKIT_ACCESSORY_DISPATCH = {
     'lightbulb': 'light',
     'outlet': 'switch',
+    'switch': 'switch',
     'thermostat': 'climate',
 }
 


### PR DESCRIPTION
## Description:

This PR adds support for on/off switches on homekit_controller platform as per issue https://github.com/home-assistant/home-assistant/issues/17544

**Related issue (if applicable):** fixes #17544 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>
N/A

## Example entry for `configuration.yaml` (if applicable):
N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - N/A Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - N/A New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - N/A New dependencies are only imported inside functions that use them ([example][ex-import]).
  - N/A New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - N/A New files were added to `.coveragerc`.

If the code does not interact with devices:
  - N/A Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
