### PR TITLE
Make light.yeelight stop doing IO when accessing properties

### DIFF
--- a/homeassistant/components/light/yeelight.py
+++ b/homeassistant/components/light/yeelight.py
@@ -276,7 +276,9 @@ class YeelightLight(Light):
 
     @property
     def _properties(self) -> dict:
-        return self._bulb.last_properties
+        if self._bulb_device is None:
+            return {}
+        return self._bulb_device.last_properties
 
     # F821: https://github.com/PyCQA/pyflakes/issues/373
     @property


### PR DESCRIPTION
## Description:
I noticed that @bieniu posted that light.yeelight was taking a long time to update the state machine. (https://github.com/home-assistant/home-assistant/issues/4210#issuecomment-431704098) Taking a look, it appears that there is some IO happening when the property `_properties` is accessed.

**Related issue (if applicable):** related: #4210

I cannot actually check that this works because I do not have an Yeelight devices.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
