### PR TITLE
WIP: Migrate geofency over to the webhook component

### DIFF
--- a/homeassistant/components/device_tracker/geofency.py
+++ b/homeassistant/components/device_tracker/geofency.py
@@ -4,21 +4,25 @@ Support for the Geofency platform.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/device_tracker.geofency/
 """
-from functools import partial
 import logging
+from functools import partial
 
 import voluptuous as vol
 
-from homeassistant.components.device_tracker import PLATFORM_SCHEMA
-from homeassistant.components.http import HomeAssistantView
-from homeassistant.const import (
-    ATTR_LATITUDE, ATTR_LONGITUDE, HTTP_UNPROCESSABLE_ENTITY, STATE_NOT_HOME)
 import homeassistant.helpers.config_validation as cv
+from homeassistant.components.device_tracker import PLATFORM_SCHEMA, DOMAIN, \
+    see
+from homeassistant.const import (
+    ATTR_LATITUDE, ATTR_LONGITUDE, HTTP_UNPROCESSABLE_ENTITY, STATE_NOT_HOME,
+    CONF_WEBHOOK_ID)
+from homeassistant.helpers import config_entry_flow
 from homeassistant.util import slugify
 
 _LOGGER = logging.getLogger(__name__)
 
-DEPENDENCIES = ['http']
+DEPENDENCIES = ['webhook']
+
+PLATFORM_DOMAIN = '{}.geofency'.format(DOMAIN)
 
 ATTR_CURRENT_LATITUDE = 'currentLatitude'
 ATTR_CURRENT_LONGITUDE = 'currentLongitude'
@@ -29,104 +33,111 @@ CONF_MOBILE_BEACONS = 'mobile_beacons'
 LOCATION_ENTRY = '1'
 LOCATION_EXIT = '0'
 
-URL = '/api/geofency'
-
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Optional(CONF_MOBILE_BEACONS): vol.All(
+    vol.Optional(CONF_MOBILE_BEACONS, default=[]): vol.All(
         cv.ensure_list, [cv.string]),
 })
 
 
 def setup_scanner(hass, config, see, discovery_info=None):
     """Set up an endpoint for the Geofency application."""
-    mobile_beacons = config.get(CONF_MOBILE_BEACONS) or []
-
-    hass.http.register_view(GeofencyView(see, mobile_beacons))
-
+    hass.data[PLATFORM_DOMAIN] = [
+        slugify(beacon) for beacon in (config[CONF_MOBILE_BEACONS])
+    ]
     return True
 
 
-class GeofencyView(HomeAssistantView):
-    """View to handle Geofency requests."""
+async def handle_webhook(hass, webhook_id, request):
+    """Handle incoming webhook with Mailgun inbound messages."""
+    data = _validate_data(await request.post())
 
-    url = URL
-    name = 'api:geofency'
+    if not data:
+        return "Invalid data", HTTP_UNPROCESSABLE_ENTITY
 
-    def __init__(self, see, mobile_beacons):
-        """Initialize Geofency url endpoints."""
-        self.see = see
-        self.mobile_beacons = [slugify(beacon) for beacon in mobile_beacons]
+    if _is_mobile_beacon(data, hass.data[PLATFORM_DOMAIN]):
+        return await _set_location(hass, data, None)
+    if data['entry'] == LOCATION_ENTRY:
+        location_name = data['name']
+    else:
+        location_name = STATE_NOT_HOME
+        if ATTR_CURRENT_LATITUDE in data:
+            data[ATTR_LATITUDE] = data[ATTR_CURRENT_LATITUDE]
+            data[ATTR_LONGITUDE] = data[ATTR_CURRENT_LONGITUDE]
 
-    async def post(self, request):
-        """Handle Geofency requests."""
-        data = await request.post()
-        hass = request.app['hass']
+    return await _set_location(hass, data, location_name)
 
-        data = self._validate_data(data)
-        if not data:
-            return ("Invalid data", HTTP_UNPROCESSABLE_ENTITY)
 
-        if self._is_mobile_beacon(data):
-            return await self._set_location(hass, data, None)
-        if data['entry'] == LOCATION_ENTRY:
-            location_name = data['name']
-        else:
-            location_name = STATE_NOT_HOME
-            if ATTR_CURRENT_LATITUDE in data:
-                data[ATTR_LATITUDE] = data[ATTR_CURRENT_LATITUDE]
-                data[ATTR_LONGITUDE] = data[ATTR_CURRENT_LONGITUDE]
+def _validate_data(data):
+    """Validate POST payload."""
+    data = data.copy()
 
-        return await self._set_location(hass, data, location_name)
+    required_attributes = ['address', 'device', 'entry',
+                           'latitude', 'longitude', 'name']
 
-    @staticmethod
-    def _validate_data(data):
-        """Validate POST payload."""
-        data = data.copy()
+    valid = True
+    for attribute in required_attributes:
+        if attribute not in data:
+            valid = False
+            _LOGGER.error("'%s' not specified in message", attribute)
 
-        required_attributes = ['address', 'device', 'entry',
-                               'latitude', 'longitude', 'name']
+    if not valid:
+        return False
 
-        valid = True
-        for attribute in required_attributes:
-            if attribute not in data:
-                valid = False
-                _LOGGER.error("'%s' not specified in message", attribute)
+    data['address'] = data['address'].replace('\n', ' ')
+    data['device'] = slugify(data['device'])
+    data['name'] = slugify(data['name'])
 
-        if not valid:
-            return False
+    gps_attributes = [ATTR_LATITUDE, ATTR_LONGITUDE,
+                      ATTR_CURRENT_LATITUDE, ATTR_CURRENT_LONGITUDE]
 
-        data['address'] = data['address'].replace('\n', ' ')
-        data['device'] = slugify(data['device'])
-        data['name'] = slugify(data['name'])
+    for attribute in gps_attributes:
+        if attribute in data:
+            data[attribute] = float(data[attribute])
 
-        gps_attributes = [ATTR_LATITUDE, ATTR_LONGITUDE,
-                          ATTR_CURRENT_LATITUDE, ATTR_CURRENT_LONGITUDE]
+    return data
 
-        for attribute in gps_attributes:
-            if attribute in data:
-                data[attribute] = float(data[attribute])
 
-        return data
+def _is_mobile_beacon(data, mobile_beacons):
+    """Check if we have a mobile beacon."""
+    return 'beaconUUID' in data and data['name'] in mobile_beacons
 
-    def _is_mobile_beacon(self, data):
-        """Check if we have a mobile beacon."""
-        return 'beaconUUID' in data and data['name'] in self.mobile_beacons
 
-    @staticmethod
-    def _device_name(data):
-        """Return name of device tracker."""
-        if 'beaconUUID' in data:
-            return "{}_{}".format(BEACON_DEV_PREFIX, data['name'])
-        return data['device']
+def _device_name(data):
+    """Return name of device tracker."""
+    if 'beaconUUID' in data:
+        return "{}_{}".format(BEACON_DEV_PREFIX, data['name'])
+    return data['device']
 
-    async def _set_location(self, hass, data, location_name):
-        """Fire HA event to set location."""
-        device = self._device_name(data)
 
-        await hass.async_add_job(
-            partial(self.see, dev_id=device,
-                    gps=(data[ATTR_LATITUDE], data[ATTR_LONGITUDE]),
-                    location_name=location_name,
-                    attributes=data))
+async def _set_location(hass, data, location_name):
+    """Fire HA event to set location."""
+    device = _device_name(data)
 
-        return "Setting location for {}".format(device)
+    await hass.async_add_job(
+        partial(see, dev_id=device,
+                gps=(data[ATTR_LATITUDE], data[ATTR_LONGITUDE]),
+                location_name=location_name,
+                attributes=data))
+
+    return "Setting location for {}".format(device)
+
+
+async def async_setup_entry(hass, entry):
+    """Configure based on config entry."""
+    hass.components.webhook.async_register(
+        entry.data[CONF_WEBHOOK_ID], handle_webhook)
+    return True
+
+
+async def async_unload_entry(hass, entry):
+    """Unload a config entry."""
+    hass.components.webhook.async_unregister(entry.data[CONF_WEBHOOK_ID])
+    return True
+
+config_entry_flow.register_webhook_flow(
+    DOMAIN,
+    'Geofency Device Tracker Webhook',
+    {
+        'docs_url': 'https://www.home-assistant.io/components/mailgun/'
+    }
+)

--- a/homeassistant/components/device_tracker/strings.geofency.json
+++ b/homeassistant/components/device_tracker/strings.geofency.json
@@ -1,0 +1,18 @@
+{
+  "config": {
+    "title": "Geofency Device Tracker Webhook",
+    "step": {
+      "user": {
+        "title": "Set up the Geofency Webhook",
+        "description": "Are you sure you want to set up the Geofency Device Tracker?"
+      }
+    },
+    "abort": {
+      "one_instance_allowed": "Only a single instance is necessary.",
+      "not_internet_accessible": "Your Home Assistant instance needs to be accessible from the internet to receive messages from Geofency."
+    },
+    "create_entry": {
+      "default": "To send events to Home Assistant, you will need to setup the webhook feature in Geofency.\n\nFill in the following info:\n\n- URL: `{webhook_url}`\n- Method: POST\n\nSee [the documentation]({docs_url}) for further details."
+    }
+  }
+}

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -137,6 +137,7 @@ HANDLERS = Registry()
 FLOWS = [
     'cast',
     'deconz',
+    'device_tracker.geofency',
     'hangouts',
     'homematicip_cloud',
     'hue',


### PR DESCRIPTION
## Description:

Migrating devicetracker.geofency over to the webhook API so that it doesn't need an api password. I don't think we can create a config entry flow for a platform, so I will first break it out into a component and a platform.

**Related issue (if applicable):** Related to #15376

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
