### PR TITLE
Fix retry functionality failing of Unifi

### DIFF
--- a/homeassistant/components/unifi/__init__.py
+++ b/homeassistant/components/unifi/__init__.py
@@ -32,19 +32,20 @@ async def async_setup(hass, config):
 
 async def async_setup_entry(hass, config_entry):
     """Set up the UniFi component."""
-    controller = UniFiController(hass, config_entry)
-
     if DOMAIN not in hass.data:
         hass.data[DOMAIN] = {}
+
+    controller = UniFiController(hass, config_entry)
+
     controller_id = CONTROLLER_ID.format(
         host=config_entry.data[CONF_CONTROLLER][CONF_HOST],
         site=config_entry.data[CONF_CONTROLLER][CONF_SITE_ID]
     )
 
+    hass.data[DOMAIN][controller_id] = controller
+
     if not await controller.async_setup():
         return False
-
-    hass.data[DOMAIN][controller_id] = controller
 
     if controller.mac is None:
         return True

--- a/tests/components/unifi/test_init.py
+++ b/tests/components/unifi/test_init.py
@@ -54,7 +54,7 @@ async def test_successful_config_entry(hass):
 
 
 async def test_controller_fail_setup(hass):
-    """Test that configured options for a host are loaded via config entry."""
+    """Test that a failed setup still stores controller."""
     entry = MockConfigEntry(domain=unifi.DOMAIN, data={
         'controller': {
             'host': '0.0.0.0',
@@ -75,7 +75,7 @@ async def test_controller_fail_setup(hass):
     controller_id = unifi.CONTROLLER_ID.format(
         host='0.0.0.0', site='default'
     )
-    assert controller_id not in hass.data[unifi.DOMAIN]
+    assert controller_id in hass.data[unifi.DOMAIN]
 
 
 async def test_controller_no_mac(hass):


### PR DESCRIPTION
## Description:

Fix controller not being stored when setup fails and sequentially fails the retry functionality

Same fix as https://github.com/home-assistant/home-assistant/pull/17877, but fixes tests as well.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

