### PR TITLE
Disable upnp from being discovered

### DIFF
--- a/homeassistant/components/discovery.py
+++ b/homeassistant/components/discovery.py
@@ -51,7 +51,6 @@ CONFIG_ENTRY_HANDLERS = {
     SERVICE_HUE: 'hue',
     SERVICE_IKEA_TRADFRI: 'tradfri',
     'sonos': 'sonos',
-    'igd': 'upnp',
 }
 
 SERVICE_HANDLERS = {


### PR DESCRIPTION
## Description:
This disables upnp component from being discovered.

I realized that by making this discoverable, we are now suggesting every new user to open a port on their router and expose Home Assistant. We shouldn't do this.

