### PR TITLE
Updated ring_doorbell dependency to 0.2.2

### DIFF
--- a/homeassistant/components/ring.py
+++ b/homeassistant/components/ring.py
@@ -12,7 +12,7 @@ import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
 from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
 
-REQUIREMENTS = ['ring_doorbell==0.2.1']
+REQUIREMENTS = ['ring_doorbell==0.2.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1296,7 +1296,7 @@ restrictedpython==4.0b5
 rflink==0.0.37
 
 # homeassistant.components.ring
-ring_doorbell==0.2.1
+ring_doorbell==0.2.2
 
 # homeassistant.components.device_tracker.ritassist
 ritassist==0.9.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -212,7 +212,7 @@ restrictedpython==4.0b5
 rflink==0.0.37
 
 # homeassistant.components.ring
-ring_doorbell==0.2.1
+ring_doorbell==0.2.2
 
 # homeassistant.components.lovelace
 ruamel.yaml==0.15.72


### PR DESCRIPTION
## Description:
Updated `ring_doorbell` to 0.2.2 to resolve an issue with the `sensor` platform and Ring Spotlight Cam battery devices. See related issue for more information.


**Related issue (if applicable):** fixes #17932

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
