### PR TITLE
Issue/fix alexa climate device not responding

### DIFF
--- a/homeassistant/components/alexa/smart_home.py
+++ b/homeassistant/components/alexa/smart_home.py
@@ -1607,12 +1607,21 @@ async def async_api_set_thermostat_mode(hass, config, request, context,
     mode = request[API_PAYLOAD]['thermostatMode']
     mode = mode if isinstance(mode, str) else mode['value']
 
+    if mode not in API_THERMOSTAT_MODES:
+        msg = 'The requested thermostat mode {} is not supported'.format(mode)
+        return api_error(
+            request,
+            namespace='Alexa.ThermostatController',
+            error_type='UNSUPPORTED_THERMOSTAT_MODE',
+            error_message=msg
+        )
+
     operation_list = entity.attributes.get(climate.ATTR_OPERATION_LIST)
     op_candidates = API_THERMOSTAT_MODES[mode]
     ha_mode = mode.lower() if mode.lower() in op_candidates else next(
-            (v for v in operation_list if v in op_candidates),
-            None
-        )
+        (v for v in operation_list if v in op_candidates),
+        None
+    )
 
     if ha_mode not in operation_list:
         msg = 'The requested thermostat mode {} is not supported'.format(mode)

--- a/homeassistant/components/alexa/smart_home.py
+++ b/homeassistant/components/alexa/smart_home.py
@@ -1617,3 +1617,8 @@ async def async_api_reportstate(hass, config, request, context, entity):
         name='StateReport',
         entity=entity
     )
+
+
+def turned_off_response(message):
+    """Return a device turned off response."""
+    return api_error(message[API_DIRECTIVE], error_type='BRIDGE_UNREACHABLE')

--- a/homeassistant/components/alexa/smart_home.py
+++ b/homeassistant/components/alexa/smart_home.py
@@ -1500,20 +1500,25 @@ def temperature_from_object(hass, temp_obj, interval=False):
 
 
 def _convert_ha_mode(ha_mode):
-    mode = next(
-        (k for k, v in API_THERMOSTAT_MODES.items() if ha_mode in v),
-        None
-    )
+    for alexa_mode, op_candidates in API_THERMOSTAT_MODES.items():
+        if ha_mode in op_candidates:
+            return alexa_mode
 
-    return mode
+    return None
 
 
 def _thermostat_context_from_entity(hass, entity, mode=None, temp=None):
     unit = hass.config.units.temperature_unit
-    ha_mode = mode if mode\
-        else entity.attributes.get(climate.ATTR_OPERATION_MODE)
-    target_temp = temp if temp\
-        else entity.attributes.get(climate.ATTR_TEMPERATURE)
+    if mode:
+        ha_mode = mode
+    else:
+        ha_mode = entity.attributes.get(climate.ATTR_OPERATION_MODE)
+
+    if temp:
+        target_temp = temp
+    else:
+        target_temp = entity.attributes.get(climate.ATTR_TEMPERATURE)
+
     ctxt = {
         "properties": [{
             "namespace": 'Alexa.ThermostatController',

--- a/homeassistant/components/alexa/smart_home.py
+++ b/homeassistant/components/alexa/smart_home.py
@@ -38,6 +38,9 @@ API_TEMP_UNITS = {
     TEMP_CELSIUS: 'CELSIUS',
 }
 
+# Needs to be ordered dict for `async_api_set_thermostat_mode` which does a
+# reverse mapping of this dict and we want to map the first occurrance of OFF
+# back to HA state.
 API_THERMOSTAT_MODES = OrderedDict(
     [(climate.STATE_HEAT, 'HEAT'),
      (climate.STATE_COOL, 'COOL'),

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -406,7 +406,7 @@ def test_variable_fan(hass):
 @asyncio.coroutine
 def test_lock(hass):
     """Test lock discovery."""
-    device = ('lock.test', 'off', {'friendly_name': "Test lock"})
+    device = ('lock.test', 'unlocked', {'friendly_name': "Test lock"})
     appliance = yield from discovery_test(device, hass)
 
     assert appliance['endpointId'] == 'lock#test'
@@ -423,7 +423,7 @@ def test_lock(hass):
     properties = msg['context']['properties'][0]
     assert properties['name'] == 'lockState'
     assert properties['namespace'] == 'Alexa.LockController'
-    assert properties['value'] == 'LOCKED'
+    assert properties['value'] == 'UNLOCKED'
 
 
 @asyncio.coroutine

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -902,6 +902,14 @@ async def test_thermostat(hass):
     assert msg['event']['payload']['type'] == 'UNSUPPORTED_THERMOSTAT_MODE'
     hass.config.units.temperature_unit = TEMP_CELSIUS
 
+    call, _ = await assert_request_calls_service(
+        'Alexa.ThermostatController', 'SetThermostatMode',
+        'climate#test_thermostat', 'climate.set_operation_mode',
+        hass,
+        payload={'thermostatMode': 'OFF'}
+    )
+    assert call.data['operation_mode'] == 'off'
+
 
 @asyncio.coroutine
 def test_exclude_filters(hass):

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -63,7 +63,7 @@ def test_create_api_message_defaults():
     request = get_new_request('Alexa.PowerController', 'TurnOn', 'switch#xy')
     request = request['directive']
 
-    msg = smart_home.api_message(request, payload={'test': 3})
+    msg = smart_home.api_message(None, None, request, payload={'test': 3})
 
     assert 'event' in msg
     msg = msg['event']
@@ -89,7 +89,8 @@ def test_create_api_message_special():
 
     request['header'].pop('correlationToken')
 
-    msg = smart_home.api_message(request, 'testName', 'testNameSpace')
+    msg = smart_home.api_message(
+        None, None, request, 'testName', 'testNameSpace')
 
     assert 'event' in msg
     msg = msg['event']


### PR DESCRIPTION
## Description:
Continuation of #16333

- Change thermostat modes mapping to an ordered dict so that under Py3.5, we correctly map Alexa `OFF` to our `STATE_OFF` because it's the first item it finds that matches.
- Pass `entity` to api_message to add entity state as context to the response. This is how lock works and what thermostat expects. After inspecting other messages, I noticed it there [too](https://github.com/alexa/alexa-smarthome/blob/master/sample_messages/ColorController/ColorController.SetColor.response.json). Docs are a bit unclear about it but can't hurt to just always include context.
- The lock command was faking a returned property. I removed that. I have code to add it back, but only want to do it if Alexa won't work without. 

I am still having to test this.

**Related issue (if applicable):** fixes #15580, fixes #15183

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
