### PR TITLE
Add legrandinone hub, cover & light

### DIFF
--- a/homeassistant/components/cover/legrandinone.py
+++ b/homeassistant/components/cover/legrandinone.py
@@ -1,0 +1,108 @@
+"""
+Support for legrandinone Cover devices.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/cover.legrandinone/
+"""
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components.legrandinone import (
+    DATA_ENTITY_LOOKUP, CONF_MEDIA, CONF_COMM_MODE,
+    DEVICE_DEFAULTS_SCHEMA, EVENT_KEY_COMMAND, LegrandInOneCommand)
+from homeassistant.components.cover import (
+    CoverDevice, PLATFORM_SCHEMA)
+import homeassistant.helpers.config_validation as cv
+from homeassistant.const import CONF_NAME
+
+
+DEPENDENCIES = ['legrandinone']
+
+_LOGGER = logging.getLogger(__name__)
+
+
+CONF_DEVICE_DEFAULTS = 'device_defaults'
+CONF_DEVICES = 'devices'
+CONF_AUTOMATIC_ADD = 'automatic_add'
+CONF_FIRE_EVENT = 'fire_event'
+CONF_RECONNECT_INTERVAL = 'reconnect_interval'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_DEVICE_DEFAULTS, default=DEVICE_DEFAULTS_SCHEMA({})):
+    DEVICE_DEFAULTS_SCHEMA,
+    vol.Optional(CONF_DEVICES, default={}): vol.Schema({
+        cv.string: {
+            vol.Optional(CONF_NAME): cv.string,
+            vol.Optional(CONF_FIRE_EVENT, default=False): cv.boolean,
+            vol.Optional(CONF_MEDIA, default='plc'): cv.string,
+            vol.Optional(CONF_COMM_MODE, default='unicast'): cv.string,
+        },
+    }),
+})
+
+
+def devices_from_config(domain_config, hass=None):
+    """Parse configuration and add IOBL cover devices."""
+    devices = []
+    for device_id, config in domain_config[CONF_DEVICES].items():
+        device_config = dict(domain_config[CONF_DEVICE_DEFAULTS], **config)
+        device = LegrandInOneCover(device_id, hass, **device_config)
+        devices.append(device)
+
+        # Register entity (and aliases) to listen to incoming IOBL events
+        # Device id and normal aliases respond to normal and group command
+        hass.data[DATA_ENTITY_LOOKUP][
+            EVENT_KEY_COMMAND][device_id].append(device)
+
+    return devices
+
+
+async def async_setup_platform(hass, config, async_add_entities,
+                               discovery_info=None):
+    """Set up the IOBL cover platform."""
+    async_add_entities(devices_from_config(config, hass))
+
+
+class LegrandInOneCover(LegrandInOneCommand, CoverDevice):
+    """IOBL entity which can switch on/stop/off (eg: cover)."""
+
+    def __init__(self, *args, **kwargs):
+        self.iobl_type = 'automation'
+        self.iobl_unit = '2'
+        super().__init__(*args, **kwargs)
+
+    def _handle_event(self, event):
+
+        command = event['what']
+        if command in ['move_up']:
+            self._state = True
+        elif command in ['move_down']:
+            self._state = False
+
+    @property
+    def should_poll(self):
+        """No polling available in iobl cover."""
+        return False
+
+    @property
+    def is_closed(self):
+        """Return if the cover is closed."""
+        return not self._state
+
+    @property
+    def assumed_state(self):
+        """Return True because covers can be stopped midway."""
+        return True
+
+    def async_close_cover(self, **kwargs):
+        """Turn the device close."""
+        return self._async_handle_command("close_cover")
+
+    def async_open_cover(self, **kwargs):
+        """Turn the device open."""
+        return self._async_handle_command("open_cover")
+
+    def async_stop_cover(self, **kwargs):
+        """Turn the device stop."""
+        return self._async_handle_command("stop_cover")

--- a/homeassistant/components/cover/legrandinone.py
+++ b/homeassistant/components/cover/legrandinone.py
@@ -66,13 +66,15 @@ async def async_setup_platform(hass, config, async_add_entities,
         device_id = event[EVENT_KEY_ID]
 
         device_config = config[CONF_DEVICE_DEFAULTS]
-        device = LegrandInOneCover(device_id, initial_event=event, **device_config)
+        device = LegrandInOneCover(device_id, initial_event=event,
+                                   **device_config)
         async_add_entities([device])
         hass.data[DATA_ENTITY_LOOKUP][
             EVENT_KEY_COMMAND][device_id].append(device)
 
     if config[CONF_AUTOMATIC_ADD]:
-        hass.data[DATA_DEVICE_REGISTER][EVENT_KEY_COMMAND][DEVICE_TYPE_AUTOMATION] = add_new_device
+        hass.data[DATA_DEVICE_REGISTER][EVENT_KEY_COMMAND][
+            DEVICE_TYPE_AUTOMATION] = add_new_device
 
 
 class LegrandInOneCover(LegrandInOneCommand, CoverDevice):
@@ -82,7 +84,6 @@ class LegrandInOneCover(LegrandInOneCommand, CoverDevice):
         """Initialize device type and unit number."""
         self.iobl_type = 'automation'
         self.iobl_unit = '2'
-        # TODO: Fetch initial state from initial event if present
         super().__init__(*args, **kwargs)
 
     def _handle_event(self, event):

--- a/homeassistant/components/cover/legrandinone.py
+++ b/homeassistant/components/cover/legrandinone.py
@@ -68,6 +68,7 @@ class LegrandInOneCover(LegrandInOneCommand, CoverDevice):
     """IOBL entity which can switch on/stop/off (eg: cover)."""
 
     def __init__(self, *args, **kwargs):
+        """Initialize device type and unit number."""
         self.iobl_type = 'automation'
         self.iobl_unit = '2'
         super().__init__(*args, **kwargs)

--- a/homeassistant/components/legrandinone.py
+++ b/homeassistant/components/legrandinone.py
@@ -193,7 +193,9 @@ async def async_setup(hass, config):
                             device_type](event))
 
                 else:
-                    _LOGGER.debug('device_id not known and automatic %s add disabled', device_type)
+                    _LOGGER.debug(
+                        'device_id not known and automatic %s add disabled',
+                        device_type)
             else:
                 _LOGGER.debug('device_id not known and automatic add disabled')
 
@@ -280,7 +282,6 @@ class LegrandInOneDevice(Entity):
     iobl_media = None
     iobl_type = None
     iobl_unit = None
-
 
     def __init__(self, device_id, initial_event=None, name=None,
                  fire_event=False, iobl_media='plc', iobl_comm_mode='unicast'):

--- a/homeassistant/components/legrandinone.py
+++ b/homeassistant/components/legrandinone.py
@@ -1,0 +1,443 @@
+"""
+Support for legrandinone components.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/legrandinone/
+"""
+import asyncio
+from collections import defaultdict
+from typing import Any, Dict, cast
+import functools as ft
+import logging
+import async_timeout
+
+import voluptuous as vol
+
+from homeassistant.const import (
+    ATTR_ENTITY_ID, CONF_COMMAND, CONF_HOST, CONF_PORT,
+    EVENT_HOMEASSISTANT_STOP, STATE_UNKNOWN)
+from homeassistant.core import CoreState, callback
+from homeassistant.exceptions import HomeAssistantError
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.deprecation import get_deprecated
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.dispatcher import (
+    async_dispatcher_send, async_dispatcher_connect)
+
+
+REQUIREMENTS = ['iobl']
+
+_LOGGER = logging.getLogger(__name__)
+
+ATTR_EVENT = 'event'
+ATTR_STATE = 'state'
+
+CONF_DEVICE_DEFAULTS = 'device_defaults'
+CONF_DEVICE_ID = 'legrand_id'
+CONF_DEVICE_TYPE = 'device_type'
+CONF_DEVICE_UNIT = 'device_unit'
+CONF_COMM_MEDIA = 'media'
+CONF_COMM_MODE = 'comm_mode'
+CONF_DEVICES = 'devices'
+CONF_AUTOMATIC_ADD = 'automatic_add'
+CONF_FIRE_EVENT = 'fire_event'
+CONF_MEDIA = 'iobl_media'
+CONF_COMM_MODE = 'iobl_comm_mode'
+CONF_IGNORE_DEVICES = 'ignore_devices'
+CONF_RECONNECT_INTERVAL = 'reconnect_interval'
+
+DATA_DEVICE_REGISTER = 'iobl_device_register'
+DATA_ENTITY_LOOKUP = 'iobl_entity_lookup'
+DEFAULT_RECONNECT_INTERVAL = 10
+DEFAULT_SIGNAL_REPETITIONS = 1
+CONNECTION_TIMEOUT = 10
+
+EVENT_BUTTON_PRESSED = 'button_pressed'
+EVENT_KEY_COMMAND = 'command'
+EVENT_TYPE_COMMAND = 'what'
+
+DOMAIN = 'legrandinone'
+
+SERVICE_SEND_COMMAND = 'send_packet'
+
+SIGNAL_AVAILABILITY = 'iobl_device_available'
+
+DEVICE_DEFAULTS_SCHEMA = vol.Schema({
+    vol.Optional(CONF_FIRE_EVENT, default=False): cv.boolean,
+    vol.Optional(CONF_MEDIA, default='cpl'): cv.string,
+    vol.Optional(CONF_COMM_MODE, default='unicast'): cv.string,
+})
+
+DEVICE_DEFAULTS_SCHEMA = vol.Schema({
+    vol.Optional(CONF_FIRE_EVENT, default=False): cv.boolean,
+})
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_PORT): vol.Any(cv.port, cv.string),
+        vol.Optional(CONF_HOST): cv.string,
+        vol.Optional(CONF_RECONNECT_INTERVAL,
+                     default=DEFAULT_RECONNECT_INTERVAL): int,
+    }),
+}, extra=vol.ALLOW_EXTRA)
+
+SEND_COMMAND_SCHEMA = vol.Schema({
+    vol.Required(CONF_DEVICE_ID): cv.string,
+    vol.Required(CONF_DEVICE_TYPE): cv.string,
+    vol.Required(CONF_DEVICE_UNIT): cv.string,
+    vol.Required(CONF_COMM_MEDIA): cv.string,
+    vol.Required(CONF_COMM_MODE): cv.string,
+    vol.Required(CONF_COMMAND): cv.string,
+})
+
+
+def identify_event_type(event):
+    """Look at event to determine type of device.
+
+    Async friendly.
+    """
+    if EVENT_KEY_COMMAND in event:
+        return EVENT_KEY_COMMAND
+
+    return 'unknown'
+
+
+@asyncio.coroutine
+def async_setup(hass, config):
+    """Set up the IOBL component."""
+    from iobl.protocol import create_iobl_connection
+    import serial
+
+    # Allow entities to register themselves by device_id to be looked up when
+    # new IOBL events arrive to be handled
+    hass.data[DATA_ENTITY_LOOKUP] = {
+        EVENT_KEY_COMMAND: defaultdict(list),
+    }
+
+    # Allow platform to specify function to register new unknown devices
+    hass.data[DATA_DEVICE_REGISTER] = {}
+
+    @asyncio.coroutine
+    def async_send_command(call):
+        """Send legrandinone command."""
+        _LOGGER.debug('LegrandInOne command for %s', str(call.data))
+
+        data = cast(Dict[str, Any], {
+            'type': 'command',
+            'legrand_id' : call.data.get(CONF_DEVICE_ID),
+            'who' : call.data.get(CONF_DEVICE_TYPE),
+            'mode': call.data.get(CONF_COMM_MODE),
+            'media': call.data.get(CONF_COMM_MEDIA),
+            'unit': call.data.get(CONF_DEVICE_UNIT),
+            'what': call.data.get(CONF_COMMAND)
+        })
+
+        if not (yield from LegrandInOneCommand.send_command(data)):
+            _LOGGER.error('Failed LegrandInOne command for %s', str(call.data))
+
+    hass.services.async_register(
+        DOMAIN, SERVICE_SEND_COMMAND, async_send_command,
+        schema=SEND_COMMAND_SCHEMA)
+
+    @callback
+    def event_callback(event):
+        """Handle incoming legrandinone events.
+
+        IOBL events arrive as dictionaries of varying content
+        depending on their type. Identify the events and distribute
+        accordingly.
+        """
+        event_type = event.get('type')
+        _LOGGER.debug('event of type %s: %s', event_type, event)
+
+        # Don't propagate non entity events (eg: version string, ack response)
+        if event_type not in hass.data[DATA_ENTITY_LOOKUP]:
+            _LOGGER.debug('unhandled event of type: %s', event_type)
+            return
+
+        # Lookup entities who registered this device id as device id or alias
+        event_id = event.get('legrand_id', None)
+
+        entities = hass.data[DATA_ENTITY_LOOKUP][event_type][event_id]
+
+        if entities:
+            # Propagate event to every entity matching the device id
+            for entity in entities:
+                _LOGGER.debug('passing event to %s', entities)
+                entity.handle_event(event)
+        else:
+            _LOGGER.debug('device_id not known, adding new device')
+
+            # If device is not yet known, register with platform (if loaded)
+            if event_type in hass.data[DATA_DEVICE_REGISTER]:
+                hass.async_run_job(
+                    hass.data[DATA_DEVICE_REGISTER][event_type], event)
+
+    # When connecting to tcp host instead of serial port (optional)
+    host = config[DOMAIN].get(CONF_HOST)
+    # TCP port when host configured, otherwise serial port
+    port = config[DOMAIN][CONF_PORT]
+
+    @callback
+    def reconnect(exc=None):
+        """Schedule reconnect after connection has been unexpectedly lost."""
+        # Reset protocol binding before starting reconnect
+        LegrandInOneCommand.set_iobl_protocol(None)
+
+        async_dispatcher_send(hass, SIGNAL_AVAILABILITY, False)
+
+        # If HA is not stopping, initiate new connection
+        if hass.state != CoreState.stopping:
+            _LOGGER.warning('disconnected from Iobl, reconnecting')
+            hass.async_add_job(connect)
+
+    @asyncio.coroutine
+    def connect():
+        """Set up connection and hook it into HA for reconnect/shutdown."""
+        _LOGGER.info('Initiating Iobl connection')
+
+        # IOBL create_iobl_connection decides based on the value of host
+        # (string or None) if serial or tcp mode should be used
+
+        # Initiate serial/tcp connection to IOBL gateway
+        connection = create_iobl_connection(
+            port=port,
+            host=host,
+            event_callback=event_callback,
+            disconnect_callback=reconnect,
+            loop=hass.loop,
+            ignore=None
+        )
+
+        try:
+            with async_timeout.timeout(CONNECTION_TIMEOUT,
+                                       loop=hass.loop):
+                transport, protocol = yield from connection
+
+        except (serial.serialutil.SerialException, ConnectionRefusedError,
+                TimeoutError, OSError, asyncio.TimeoutError) as exc:
+            reconnect_interval = config[DOMAIN][CONF_RECONNECT_INTERVAL]
+            _LOGGER.exception(
+                "Error connecting to iobl, reconnecting in %s",
+                reconnect_interval)
+            # Connection to IOBL device is lost, make entities unavailable
+            async_dispatcher_send(hass, SIGNAL_AVAILABILITY, False)
+
+            hass.loop.call_later(reconnect_interval, reconnect, exc)
+            return
+
+        # There is a valid connection to a IOBL device now so
+        # mark entities as available
+        async_dispatcher_send(hass, SIGNAL_AVAILABILITY, True)
+
+        # Bind protocol to command class to allow entities to send commands
+        LegrandInOneCommand.set_iobl_protocol(
+            protocol)
+
+        # handle shutdown of IOBL asyncio transport
+        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP,
+                                   lambda x: transport.close())
+
+        _LOGGER.info('Connected to Iobl')
+
+    hass.async_add_job(connect)
+    return True
+
+
+class IoblDevice(Entity):
+    """Representation of an iobl device.
+
+    Contains the common logic for Iobl entities.
+    """
+
+    platform = None
+    _state = STATE_UNKNOWN
+    _available = True
+
+    def __init__(self, device_id, hass, name=None, fire_event=False, iobl_media = 'cpl', iobl_comm_mode = 'unicast'):
+        """Initialize the device."""
+        self.hass = hass
+
+        self.legrand_id = device_id
+        self.iobl_mode = iobl_comm_mode
+        self.iobl_media = iobl_media
+        
+        if name:
+            self._name = name
+        else:
+            self._name = device_id
+
+        self._should_fire_event = fire_event
+
+    def handle_event(self, event):
+        """Handle incoming event for device type."""
+        # Call platform specific event handler
+        self._handle_event(event)
+
+        # Propagate changes through ha
+        self.async_schedule_update_ha_state()
+
+        # Put command onto bus for user to subscribe to
+        if self._should_fire_event and identify_event_type(
+                event) == EVENT_KEY_COMMAND:
+            self.hass.bus.fire(EVENT_BUTTON_PRESSED, {
+                ATTR_ENTITY_ID: self.entity_id,
+                ATTR_STATE: event[EVENT_TYPE_COMMAND],
+            })
+            _LOGGER.debug("Fired bus event for %s: %s",
+                          self.entity_id, event[EVENT_KEY_COMMAND])
+
+    def _handle_event(self, event):
+        """Platform specific event handler."""
+        raise NotImplementedError()
+
+    @property
+    def should_poll(self):
+        """No polling needed."""
+        return False
+
+    @property
+    def name(self):
+        """Return a name for the device."""
+        return self._name
+
+    @property
+    def is_on(self):
+        """Return true if device is on."""
+        if self.assumed_state:
+            return False
+        return self._state
+
+    @property
+    def assumed_state(self):
+        """Assume device state until first device event sets state."""
+        return self._state is STATE_UNKNOWN
+
+    @property
+    def available(self):
+        """Return True if entity is available."""
+        return self._available
+
+    @callback
+    def set_availability(self, availability):
+        """Update availability state."""
+        self._available = availability
+        self.async_schedule_update_ha_state()
+
+    @asyncio.coroutine
+    def async_added_to_hass(self):
+        """Register update callback."""
+        async_dispatcher_connect(self.hass, SIGNAL_AVAILABILITY,
+                                 self.set_availability)
+
+
+class LegrandInOneCommand(IoblDevice):
+    """Singleton class to make IOBL command interface available to entities.
+
+    This class is to be inherited by every Entity class that is actionable
+    (switches/lights). It exposes the IOBL command interface for these
+    entities.
+
+    The IOBL interface is managed as a class level and set during setup (and
+    reset on reconnect).
+    """
+
+    _protocol = None
+
+    @classmethod
+    def set_iobl_protocol(cls, protocol):
+        """Set the IOBL asyncio protocol as a class variable."""
+        cls._protocol = protocol
+
+    @classmethod
+    def is_connected(cls):
+        """Return connection status."""
+        return bool(cls._protocol)
+
+    @classmethod
+    @asyncio.coroutine
+    def send_command(cls, device_id, action):
+        """Send device command to IOBL."""
+        return (yield from cls._protocol.send_packet(device_id, action))
+
+    @asyncio.coroutine
+    def _async_handle_command(self, command, *args):
+
+        if command == 'turn_on':
+            cmd = 'on'
+            self._state = True
+
+        elif command == 'turn_off':
+            cmd = 'off'
+            self._state = False
+
+        elif command == 'toggle':
+            cmd = 'on'
+            # if the state is unknown or false, it gets set as true
+            # if the state is true, it gets set as false
+            self._state = self._state in [STATE_UNKNOWN, False]
+
+        # Cover options for IOBL
+        elif command == 'close_cover':
+            cmd = 'move_down'
+            self._state = False
+
+        elif command == 'open_cover':
+            cmd = 'move_up'
+            self._state = True
+
+        elif command == 'stop_cover':
+            cmd = 'move_stop'
+            self._state = True
+
+        # Send initial command and queue repetitions.
+        # This allows the entity state to be updated quickly and not having to
+        # wait for all repetitions to be sent
+        yield from self._async_send_command(cmd)
+
+        # Update state of entity
+        yield from self.async_update_ha_state()
+
+    @asyncio.coroutine
+    def _async_send_command(self, cmd):
+        """Send a command for device to iobl gateway."""
+        _LOGGER.debug(
+            "Sending command: %s to iobl device: %s", cmd, self.legrand_id)
+
+        if not self.is_connected():
+            raise HomeAssistantError('Cannot send command, not connected!')
+
+        # Puts command on outgoing buffer and returns straight away.
+        # IOBL protocol/transport handles asynchronous writing of buffer
+        # to serial/tcp device. Does not wait for command send
+        # confirmation.
+        data = cast(Dict[str, Any], {
+            'type': 'command',
+            'legrand_id' : self.legrand_id,
+            'who' : self.iobl_type,
+            'mode': self.iobl_mode,
+            'media': self.iobl_media,
+            'unit': self.iobl_unit,
+            'what': cmd
+        })
+
+        self.hass.async_add_job(ft.partial(
+            self._protocol.send_packet, data))
+
+class SwitchableIoblDevice(LegrandInOneCommand):
+    """IOBL entity which can switch on/off (eg: light, switch)."""
+
+    def _handle_event(self, event):
+
+        command = event['command']
+        if command in ['on']:
+            self._state = True
+        elif command in ['off']:
+            self._state = False
+
+    def async_turn_on(self, **kwargs):
+        """Turn the device on."""
+        return self._async_handle_command("on")
+
+    def async_turn_off(self, **kwargs):
+        """Turn the device off."""
+        return self._async_handle_command("off")

--- a/homeassistant/components/light/legrandinone.py
+++ b/homeassistant/components/light/legrandinone.py
@@ -12,8 +12,8 @@ from homeassistant.components.legrandinone import (
     CONF_AUTOMATIC_ADD, CONF_DEVICE_DEFAULTS,
     CONF_DEVICES, CONF_FIRE_EVENT, DATA_DEVICE_REGISTER,
     DEVICE_DEFAULTS_SCHEMA, CONF_MEDIA, CONF_COMM_MODE,
-    EVENT_KEY_COMMAND, EVENT_KEY_ID, DATA_ENTITY_LOOKUP,
-    DEVICE_TYPE_LIGHT, SwitchableLegrandInOneDevice, cv,
+    EVENT_KEY_COMMAND, EVENT_KEY_ID, DEVICE_TYPE_LIGHT,
+    SwitchableLegrandInOneDevice, cv,
     vol)
 from homeassistant.const import (CONF_NAME, CONF_TYPE)
 
@@ -47,10 +47,10 @@ def entity_class_for_type(entity_type):
     Async friendly.
     """
     entity_device_mapping = {
-        # sends 'dim', 'off' and 'on' command to support both dimmers and on/off
-        # switches.
+        # sends 'dim', 'off' and 'on' command to support both
+        # dimmers and on/off switches.
         TYPE_DIMMABLE: DimmableLegrandInOneLight,
-        # sends only 'on/off' commands not advices with dimmers 
+        # sends only 'on/off' commands not advices with dimmers
         TYPE_SWITCHABLE: LegrandInOneLight,
     }
 
@@ -67,7 +67,7 @@ def devices_from_config(domain_config):
             # instantiation
             entity_type = config.pop(CONF_TYPE)
         else:
-        # When no type is specified, defaults to switchable.
+            # When no type is specified, defaults to switchable.
             entity_type = TYPE_SWITCHABLE
 
         entity_class = entity_class_for_type(entity_type)
@@ -99,13 +99,15 @@ async def async_setup_platform(hass, config, async_add_entities,
         async_add_entities([device])
 
     if config[CONF_AUTOMATIC_ADD]:
-        hass.data[DATA_DEVICE_REGISTER][EVENT_KEY_COMMAND][DEVICE_TYPE_LIGHT] = add_new_device
+        hass.data[DATA_DEVICE_REGISTER][EVENT_KEY_COMMAND][
+            DEVICE_TYPE_LIGHT] = add_new_device
 
 
 class LegrandInOneLight(SwitchableLegrandInOneDevice, Light):
     """Representation of an IOBL light."""
 
     pass
+
 
 class DimmableLegrandInOneLight(SwitchableLegrandInOneDevice, Light):
     """IOBL light device that support dimming."""
@@ -121,7 +123,6 @@ class DimmableLegrandInOneLight(SwitchableLegrandInOneDevice, Light):
         else:
             await self._async_handle_command('turn_on')
 
-
     @property
     def brightness(self):
         """Return the brightness of this light between 0..255."""
@@ -131,5 +132,3 @@ class DimmableLegrandInOneLight(SwitchableLegrandInOneDevice, Light):
     def supported_features(self):
         """Flag supported features."""
         return SUPPORT_BRIGHTNESS
-
-

--- a/homeassistant/components/light/legrandinone.py
+++ b/homeassistant/components/light/legrandinone.py
@@ -90,7 +90,6 @@ async def async_setup_platform(hass, config, async_add_entities,
         device_id = event[EVENT_KEY_ID]
 
     # Added devices from detection defaults to SWITCHABLE.
-    # TODO: Request device description from bus to know the actual class
         entity_type = TYPE_SWITCHABLE
         entity_class = entity_class_for_type(entity_type)
 

--- a/homeassistant/components/light/legrandinone.py
+++ b/homeassistant/components/light/legrandinone.py
@@ -1,0 +1,177 @@
+"""
+Support for IOBL lights.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/light.iobl/
+"""
+import logging
+
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS, PLATFORM_SCHEMA, SUPPORT_BRIGHTNESS, Light)
+from homeassistant.components.legrandinone import (
+    CONF_AUTOMATIC_ADD, CONF_DEVICE_DEFAULTS,
+    CONF_DEVICES, CONF_FIRE_EVENT, DATA_DEVICE_REGISTER,
+    DEVICE_DEFAULTS_SCHEMA, CONF_MEDIA, CONF_COMM_MODE,
+    EVENT_KEY_COMMAND, EVENT_KEY_ID, SwitchableIoblDevice, cv,
+    vol)
+from homeassistant.const import (CONF_NAME, CONF_TYPE)
+
+DEPENDENCIES = ['legrandinone']
+
+_LOGGER = logging.getLogger(__name__)
+
+TYPE_DIMMABLE = 'dimmable'
+TYPE_SWITCHABLE = 'switchable'
+TYPE_TOGGLE = 'toggle'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_DEVICE_DEFAULTS, default=DEVICE_DEFAULTS_SCHEMA({})):
+        DEVICE_DEFAULTS_SCHEMA,
+    vol.Optional(CONF_AUTOMATIC_ADD, default=True): cv.boolean,
+    vol.Optional(CONF_DEVICES, default={}): {
+        cv.string: vol.Schema({
+            vol.Optional(CONF_NAME): cv.string,
+            vol.Optional(CONF_TYPE):
+                vol.Any(TYPE_DIMMABLE, TYPE_SWITCHABLE,
+                        TYPE_TOGGLE),
+            vol.Optional(CONF_FIRE_EVENT): cv.boolean,
+            vol.Optional(CONF_MEDIA, default='plc'): cv.string,
+            vol.Optional(CONF_COMM_MODE, default='unicast'): cv.string,
+        })
+    },
+}, extra=vol.ALLOW_EXTRA)
+
+
+def entity_class_for_type(entity_type):
+    """Translate entity type to entity class.
+
+    Async friendly.
+    """
+    entity_device_mapping = {
+        # sends 'dim', 'off' and 'on' command to support both dimmers and on/off
+        # switches.
+        TYPE_DIMMABLE: DimmableIoblLight,
+        # sends only 'on/off' commands not advices with dimmers 
+        TYPE_SWITCHABLE: IoblLight,
+        # sends only 'on' commands for switches which turn on and off
+        # using the same 'on' command for both.
+        TYPE_TOGGLE: ToggleIoblLight,
+    }
+
+    return entity_device_mapping.get(entity_type, IoblLight)
+
+
+def devices_from_config(domain_config, hass=None):
+    """Parse configuration and add IOBL light devices."""
+    devices = []
+    for device_id, config in domain_config[CONF_DEVICES].items():
+        # Determine which kind of entity to create
+        if CONF_TYPE in config:
+            # Remove type from config to not pass it as and argument to entity
+            # instantiation
+            entity_type = config.pop(CONF_TYPE)
+        else:
+            entity_type = TYPE_SWITCHABLE
+
+        entity_class = entity_class_for_type(entity_type)
+
+        device_config = dict(domain_config[CONF_DEVICE_DEFAULTS], **config)
+
+        device = entity_class(device_id, hass, **device_config)
+        devices.append(device)
+
+    return devices
+
+
+async def async_setup_platform(hass, config, async_add_entities,
+                               discovery_info=None):
+    """Set up the IOBL light platform."""
+    async_add_entities(devices_from_config(config))
+
+    async def add_new_device(event):
+        """Check if device is known, otherwise add to list of known devices."""
+        device_id = event[EVENT_KEY_ID]
+
+        entity_type = entity_type_for_device_id(event[EVENT_KEY_ID])
+        entity_class = entity_class_for_type(entity_type)
+
+        device_config = config[CONF_DEVICE_DEFAULTS]
+        device = entity_class(device_id, initial_event=event, **device_config)
+        async_add_entities([device])
+
+    if config[CONF_AUTOMATIC_ADD]:
+        hass.data[DATA_DEVICE_REGISTER][EVENT_KEY_COMMAND] = add_new_device
+
+
+class IoblLight(SwitchableIoblDevice, Light):
+
+    async def async_turn_on(self, **kwargs):
+        """Turn the device on."""
+        await self._async_handle_command('turn_on')
+
+    async def async_turn_off(self, **kwargs):
+        """Turn the device off."""
+        await self._async_handle_command('turn_off')
+
+
+class DimmableIoblLight(SwitchableIoblDevice, Light):
+    """IOBL light device that support dimming."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize device type and unit number."""
+        self.iobl_type = 'light'
+        self.iobl_unit = '0'
+        super().__init__(*args, **kwargs)
+
+    _brightness = 255
+
+    async def async_turn_on(self, **kwargs):
+        """Turn the device on."""
+        if ATTR_BRIGHTNESS in kwargs:
+            self._brightness = int(kwargs[ATTR_BRIGHTNESS])
+            # Turn on light at the requested dim level
+            await self._async_handle_command('dim', self._brightness)
+        else:
+            await self._async_handle_command('turn_on')
+
+
+    @property
+    def brightness(self):
+        """Return the brightness of this light between 0..255."""
+        return self._brightness
+
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+        return SUPPORT_BRIGHTNESS
+
+
+class ToggleIoblLight(SwitchableIoblDevice, Light):
+    """Iobl light device which sends out only 'on' commands."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize device type and unit number."""
+        self.iobl_type = 'light'
+        self.iobl_unit = '0'
+        super().__init__(*args, **kwargs)
+
+    @property
+    def entity_id(self):
+        """Return entity id."""
+        return "light.{}".format(self.name)
+
+    def _handle_event(self, event):
+        """Adjust state if IOBL picks up a remote command for this device."""
+        command = event['command']
+        if command == 'on':
+            # if the state is unknown or false, it gets set as true
+            # if the state is true, it gets set as false
+            self._state = self._state in [None, False]
+
+    async def async_turn_on(self, **kwargs):
+        """Turn the device on."""
+        await self._async_handle_command('toggle')
+
+    async def async_turn_off(self, **kwargs):
+        """Turn the device off."""
+        await self._async_handle_command('toggle')

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -505,6 +505,9 @@ influxdb==5.0.0
 # homeassistant.components.insteon
 insteonplm==0.15.0
 
+# homeassistant.components.legrandinone
+iobl==0.0.4
+
 # homeassistant.components.sensor.iperf3
 iperf3==0.1.10
 
@@ -1137,9 +1140,6 @@ python-gitlab==1.6.0
 
 # homeassistant.components.sensor.hp_ilo
 python-hpilo==3.9
-
-# homeassistant.components.legrandinone
-iobl==0.0.3
 
 # homeassistant.components.joaoapps_join
 # homeassistant.components.notify.joaoapps_join

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1138,6 +1138,9 @@ python-gitlab==1.6.0
 # homeassistant.components.sensor.hp_ilo
 python-hpilo==3.9
 
+# homeassistant.components.legrandinone
+iobl==0.0.3
+
 # homeassistant.components.joaoapps_join
 # homeassistant.components.notify.joaoapps_join
 python-join-api==0.0.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -106,6 +106,9 @@ homematicip==0.9.8
 # homeassistant.components.sensor.influxdb
 influxdb==5.0.0
 
+# homeassistant.components.rflink
+iobl==0.0.3
+
 # homeassistant.components.dyson
 libpurecoollink==0.4.2
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -106,8 +106,8 @@ homematicip==0.9.8
 # homeassistant.components.sensor.influxdb
 influxdb==5.0.0
 
-# homeassistant.components.rflink
-iobl==0.0.3
+# homeassistant.components.legrandinone
+iobl==0.0.4
 
 # homeassistant.components.dyson
 libpurecoollink==0.4.2

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -63,6 +63,7 @@ TEST_REQUIREMENTS = (
     'home-assistant-frontend',
     'homematicip',
     'influxdb',
+    'iobl',
     'libpurecoollink',
     'libsoundtouch',
     'mficlient',

--- a/tests/components/light/test_legrandinone.py
+++ b/tests/components/light/test_legrandinone.py
@@ -1,0 +1,250 @@
+"""Test for IOBL light components.
+
+Test setup of IOBL lights component/platform. State tracking and
+control of IOBL switch devices.
+
+"""
+
+import asyncio
+
+from homeassistant.components.light import ATTR_BRIGHTNESS
+from homeassistant.components.legrandinone import EVENT_BUTTON_PRESSED
+from homeassistant.const import (
+    ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON)
+from homeassistant.core import callback
+
+from ..test_legrandinone import mock_legrandinone
+
+DOMAIN = 'light'
+
+CONFIG = {
+    'legrandinone': {
+        'port': '/dev/ttyABC0',
+    },
+    DOMAIN: {
+        'platform': 'legrandinone',
+        'devices': {
+            123456: {
+                'name': 'test',
+            },
+            234567: {
+                'name': 'dim_test',
+                'type': 'dimmable',
+            },
+            345678: {
+                'name': 'switch_test',
+                'type': 'switchable',
+            }
+        },
+    },
+}
+
+
+@asyncio.coroutine
+def test_default_setup(hass, monkeypatch):
+    """Test all basic functionality of the IOBL switch component."""
+    # setup mocking rflink module
+    event_callback, create, protocol, _ = yield from mock_legrandinone(
+        hass, CONFIG, DOMAIN, monkeypatch)
+
+    # test default state of light loaded from config
+    light_initial = hass.states.get(DOMAIN + '.test')
+    assert light_initial.state == 'off'
+    assert light_initial.attributes['assumed_state']
+
+    # light should follow state of the hardware device by interpreting
+    # incoming events for its name and aliases
+
+    # mock incoming command event for this device
+    event_callback({
+        'type': 'bus_command',
+        'legrand_id': '123456',
+        'what': 'on',
+    })
+    yield from hass.async_block_till_done()
+
+    light_after_first_command = hass.states.get(DOMAIN + '.test')
+    assert light_after_first_command.state == 'on'
+    # also after receiving first command state not longer has to be assumed
+    assert not light_after_first_command.attributes.get('assumed_state')
+
+    # mock incoming command event for this device
+    event_callback({
+        'type': 'bus_command',
+        'legrand_id': '123456',
+        'what': 'off',
+    })
+    yield from hass.async_block_till_done()
+
+    assert hass.states.get(DOMAIN + '.test').state == 'off'
+
+    # test event for new unconfigured sensor
+    event_callback({
+        'type': 'bus_command',
+        'legrand_id': '666666',
+        'what': 'on',
+    })
+    yield from hass.async_block_till_done()
+
+    assert hass.states.get(DOMAIN + '.666666').state == 'on'
+
+    # test changing state from HA propagates to IOBL
+    hass.async_add_job(
+        hass.services.async_call(DOMAIN, SERVICE_TURN_OFF,
+                                 {ATTR_ENTITY_ID: DOMAIN + '.test'}))
+    yield from hass.async_block_till_done()
+    assert hass.states.get(DOMAIN + '.test').state == 'off'
+    assert protocol.send_packet.call_args_list[0][0][0] == (Dict[str, Any], {
+    'type': 'bus_command',
+    'legrand_id' : '666666',
+    'who' : 'light',
+    'mode': 'unicast',
+    'media': 'plc',
+    'unit': '1',
+    'what': 'off'
+    })
+
+    hass.async_add_job(
+        hass.services.async_call(DOMAIN, SERVICE_TURN_ON,
+                                 {ATTR_ENTITY_ID: DOMAIN + '.test'}))
+    yield from hass.async_block_till_done()
+    assert hass.states.get(DOMAIN + '.test').state == 'on'
+    assert protocol.send_packet.call_args_list[1][0][0] == (Dict[str, Any], {
+    'type': 'bus_command',
+    'legrand_id' : '666666',
+    'who' : 'light',
+    'mode': 'unicast',
+    'media': 'plc',
+    'unit': '1',
+    'what': 'on'
+    })
+
+    # protocols supporting dimming and on/off should create hybrid light entity
+    event_callback({
+        'type': 'bus_command',
+        'legrand_id': '234567',
+        'what': 'off',
+    })
+    yield from hass.async_block_till_done()
+    hass.async_add_job(
+        hass.services.async_call(DOMAIN, SERVICE_TURN_ON,
+                                 {
+                                     ATTR_ENTITY_ID: DOMAIN + '.234567',
+                                     ATTR_BRIGHTNESS: 128,
+                                 }))
+    yield from hass.async_block_till_done()
+
+    assert protocol.send_command_ack.call_args_list[2][0][0] == (Dict[str, Any], {
+    'type': 'set_dimension',
+    'legrand_id' : '234567',
+    'who' : 'light',
+    'mode': 'unicast',
+    'media': 'plc',
+    'unit': '1',
+    'dimension': 'go_to_level_time',
+    'values': ['50']
+    })
+
+
+@asyncio.coroutine
+def test_firing_bus_event(hass, monkeypatch):
+    """Incoming iobl command events should be put on the HA event bus."""
+    config = {
+        'legrandinone': {
+            'port': '/dev/ttyABC0',
+        },
+        DOMAIN: {
+            'platform': 'legrandinone',
+            'devices': {
+                '123456': {
+                    'name': 'test',
+                    'fire_event': True,
+                },
+            },
+        },
+    }
+
+    # setup mocking rflink module
+    event_callback, _, _, _ = yield from mock_legrandinone(
+        hass, config, DOMAIN, monkeypatch)
+
+    calls = []
+
+    @callback
+    def listener(event):
+        calls.append(event)
+    hass.bus.async_listen_once(EVENT_BUTTON_PRESSED, listener)
+
+    # test event for new unconfigured sensor
+    event_callback({
+        'type': 'bus_command',
+        'legrand_id': '123456',
+        'what': 'off',
+    })
+    yield from hass.async_block_till_done()
+
+    assert calls[0].data == {'state': 'off', 'entity_id': DOMAIN + '.test'}
+
+
+@asyncio.coroutine
+def test_type_toggle(hass, monkeypatch):
+    """Test toggle type lights (on/on)."""
+    config = {
+        'legrandinone': {
+            'port': '/dev/ttyABC0',
+        },
+        DOMAIN: {
+            'platform': 'legrandinone',
+            'devices': {
+                '123456': {
+                    'name': 'toggle_test',
+                    'type': 'toggle',
+                },
+            },
+        },
+    }
+
+    # setup mocking rflink module
+    event_callback, _, _, _ = yield from mock_legrandinone(
+        hass, config, DOMAIN, monkeypatch)
+
+    assert hass.states.get(DOMAIN + '.toggle_test').state == 'off'
+
+    # test sending on command to toggle alias
+    event_callback({
+        'type': 'bus_command',
+        'legrand_id': '123456',
+        'what': 'on',
+    })
+    yield from hass.async_block_till_done()
+
+    assert hass.states.get(DOMAIN + '.toggle_test').state == 'on'
+
+
+@asyncio.coroutine
+def test_disable_automatic_add(hass, monkeypatch):
+    """If disabled new devices should not be automatically added."""
+    config = {
+        'legrandinone': {
+            'port': '/dev/ttyABC0',
+        },
+        DOMAIN: {
+            'platform': 'legrandinone',
+            'automatic_add': False,
+        },
+    }
+
+    # setup mocking rflink module
+    event_callback, _, _, _ = yield from mock_legrandinone(
+        hass, config, DOMAIN, monkeypatch)
+
+    # test event for new unconfigured sensor
+    event_callback({
+        'type': 'bus_command',
+        'legrand_id': '123456',
+        'what': 'off',
+    })
+    yield from hass.async_block_till_done()
+
+    # make sure new device is not added
+    assert not hass.states.get(DOMAIN + '.123456')

--- a/tests/components/light/test_legrandinone.py
+++ b/tests/components/light/test_legrandinone.py
@@ -6,7 +6,6 @@ control of IOBL switch devices.
 """
 
 import asyncio
-from typing import Any, Dict, cast
 
 from homeassistant.components.light import ATTR_BRIGHTNESS
 from homeassistant.components.legrandinone import EVENT_BUTTON_PRESSED
@@ -97,14 +96,14 @@ def test_default_setup(hass, monkeypatch):
     yield from hass.async_block_till_done()
     assert hass.states.get(DOMAIN + '.test').state == 'off'
     assert protocol.send_packet.call_args_list[0][0][0] == {
-    'type': 'bus_command',
-    'legrand_id' : '123456',
-    'who' : 'light',
-    'mode': 'unicast',
-    'media': 'plc',
-    'unit': '0',
-    'what': 'off'
-    }
+        'type': 'bus_command',
+        'legrand_id': '123456',
+        'who': 'light',
+        'mode': 'unicast',
+        'media': 'plc',
+        'unit': '0',
+        'what': 'off'
+        }
 
     hass.async_add_job(
         hass.services.async_call(DOMAIN, SERVICE_TURN_ON,
@@ -112,14 +111,14 @@ def test_default_setup(hass, monkeypatch):
     yield from hass.async_block_till_done()
     assert hass.states.get(DOMAIN + '.test').state == 'on'
     assert protocol.send_packet.call_args_list[1][0][0] == {
-    'type': 'bus_command',
-    'legrand_id' : '123456',
-    'who' : 'light',
-    'mode': 'unicast',
-    'media': 'plc',
-    'unit': '0',
-    'what': 'on'
-    }
+        'type': 'bus_command',
+        'legrand_id': '123456',
+        'who': 'light',
+        'mode': 'unicast',
+        'media': 'plc',
+        'unit': '0',
+        'what': 'on'
+        }
 
     # protocols supporting dimming and on/off should create hybrid light entity
     event_callback({
@@ -137,15 +136,15 @@ def test_default_setup(hass, monkeypatch):
     yield from hass.async_block_till_done()
 
     assert protocol.send_packet.call_args_list[2][0][0] == {
-    'type': 'set_dimension',
-    'legrand_id' : '234567',
-    'who' : 'light',
-    'mode': 'unicast',
-    'media': 'plc',
-    'unit': '0',
-    'dimension': 'go_to_level_time',
-    'values': ['50']
-    }
+        'type': 'set_dimension',
+        'legrand_id': '234567',
+        'who': 'light',
+        'mode': 'unicast',
+        'media': 'plc',
+        'unit': '0',
+        'dimension': 'go_to_level_time',
+        'values': ['50']
+        }
 
 
 @asyncio.coroutine

--- a/tests/components/test_legrandinone.py
+++ b/tests/components/test_legrandinone.py
@@ -1,5 +1,4 @@
-"""Common functions for legrandinone component tests and generic platform
-tests."""
+"""Common functions for legrandinone component and generic platform tests."""
 
 import asyncio
 from unittest.mock import Mock

--- a/tests/components/test_legrandinone.py
+++ b/tests/components/test_legrandinone.py
@@ -1,0 +1,232 @@
+"""Common functions for legrandinone component tests and generic platform tests."""
+
+import asyncio
+from collections import defaultdict
+from typing import Any, Dict, cast
+from unittest.mock import Mock
+
+from homeassistant.bootstrap import async_setup_component
+from homeassistant.components.legrandinone import (
+    CONF_RECONNECT_INTERVAL, SERVICE_SEND_COMMAND)
+from homeassistant.const import (
+    ATTR_ENTITY_ID, SERVICE_OPEN_COVER, SERVICE_STOP_COVER)
+
+
+@asyncio.coroutine
+def mock_legrandinone(hass, config, domain, monkeypatch, failures=None):
+    """Create mock legrandinone asyncio protocol, test component setup."""
+    transport, protocol = (Mock(), Mock())
+
+    @asyncio.coroutine
+    def send_command(*command):
+        return True
+    protocol.send_command = Mock(wraps=send_command)
+
+    @asyncio.coroutine
+    def create_iobl_connection(*args, **kwargs):
+        """Return mocked transport and protocol."""
+        # failures can be a list of booleans indicating in which sequence
+        # creating a connection should success or fail
+        if failures:
+            fail = failures.pop()
+        else:
+            fail = False
+
+        if fail:
+            raise ConnectionRefusedError
+        else:
+            return transport, protocol
+
+    mock_create = Mock(wraps=create_iobl_connection)
+    monkeypatch.setattr(
+        'iobl.protocol.create_iobl_connection',
+        mock_create)
+
+    yield from async_setup_component(hass, domain, config)
+
+    # hook into mock config for injecting events
+    event_callback = mock_create.call_args_list[0][1]['event_callback']
+    assert event_callback
+
+    disconnect_callback = mock_create.call_args_list[0][1]['disconnect_callback']
+
+    return event_callback, mock_create, protocol, disconnect_callback
+
+
+@asyncio.coroutine
+def test_send_command(hass, monkeypatch):
+    """Test command sending."""
+    domain = 'cover'
+    config = {
+        'legrandinone': {
+            'port': '/dev/ttyABC0',
+        },
+        domain: {
+            'platform': 'legrandinone',
+            'devices': {
+                '123456': {
+                        'name': 'test',
+                },
+            },
+        },
+    }
+
+    # setup mocking iobl module
+    _, _, protocol, _ = yield from mock_legrandinone(
+        hass, config, domain, monkeypatch)
+
+    hass.async_add_job(
+        hass.services.async_call(domain, SERVICE_OPEN_COVER,
+                                 {ATTR_ENTITY_ID: 'cover.test'}))
+    yield from hass.async_block_till_done()
+
+    data = cast(Dict[str, Any], {
+    'type': 'bus_command',
+    'legrand_id' : '123456',
+    'who' : 'automation',
+    'mode': 'unicast',
+    'media': 'plc',
+    'unit': '2',
+    'what': 'move_up'
+    })
+
+    assert protocol.send_packet.call_args_list[0][0][0] == data
+
+@asyncio.coroutine
+def test_send_command_invalid_arguments(hass, monkeypatch):
+    """Test send_command service."""
+    domain = 'legrandinone'
+    config = {
+        'legrandinone': {
+            'port': '/dev/ttyABC0',
+        },
+    }
+
+    # setup mocking iobl module
+    _, _, protocol, _ = yield from mock_legrandinone(
+        hass, config, domain, monkeypatch)
+
+    # one argument missing
+    data = cast(Dict[str, Any], {
+    'type': 'bus_command',
+    'who' : 'automation',
+    'mode': 'unicast',
+    'media': 'plc',
+    'unit': '2',
+    'what': 'move_up'
+    })
+
+    hass.async_add_job(
+        hass.services.async_call(domain, SERVICE_SEND_COMMAND,
+                                 data))
+    # no arguments
+    hass.async_add_job(
+        hass.services.async_call(domain, SERVICE_SEND_COMMAND, {}))
+    yield from hass.async_block_till_done()
+    assert protocol.send_packet.call_args_list == []
+
+
+@asyncio.coroutine
+def test_reconnecting_after_disconnect(hass, monkeypatch):
+    """An unexpected disconnect should cause a reconnect."""
+    domain = 'cover'
+    config = {
+        'legrandinone': {
+            'port': '/dev/ttyABC0',
+             CONF_RECONNECT_INTERVAL: 0,
+       },
+        domain: {
+            'platform': 'legrandinone',
+            'devices': {
+                '123456': {
+                        'name': 'test',
+                },
+            },
+        },
+    }
+
+    # setup mocking iobl module
+    _, mock_create, _, disconnect_callback = yield from mock_legrandinone(
+        hass, config, domain, monkeypatch)
+
+    assert disconnect_callback, 'disconnect callback not passed to iobl'
+
+    # iobl initiated disconnect
+    disconnect_callback(None)
+
+    yield from hass.async_block_till_done()
+
+    # we expect 2 call, the initial and reconnect
+    assert mock_create.call_count == 2
+
+
+@asyncio.coroutine
+def test_reconnecting_after_failure(hass, monkeypatch):
+    """A failure to reconnect should be retried."""
+    domain = 'cover'
+    config = {
+        'legrandinone': {
+            'port': '/dev/ttyABC0',
+            CONF_RECONNECT_INTERVAL: 0,
+        },
+        domain: {
+            'platform': 'legrandinone',
+            'devices': {
+                '123456': {
+                        'name': 'test',
+                },
+            },
+        },
+    }
+
+    # success first time but fail second
+    failures = [False, True, False]
+
+    # setup mocking iobl module
+    _, mock_create, _, disconnect_callback = yield from mock_legrandinone(
+        hass, config, domain, monkeypatch, failures=failures)
+
+    # iobl initiated disconnect
+    disconnect_callback(None)
+
+    # wait for reconnects to have happened
+    yield from hass.async_block_till_done()
+    yield from hass.async_block_till_done()
+
+    # we expect 3 calls, the initial and 2 reconnects
+    assert mock_create.call_count == 3
+
+
+@asyncio.coroutine
+def test_error_when_not_connected(hass, monkeypatch):
+    """Sending command should error when not connected."""
+    domain = 'cover'
+    config = {
+        'legrandinone': {
+            'port': '/dev/ttyABC0',
+        },
+        domain: {
+            'platform': 'legrandinone',
+            'devices': {
+                '123456': {
+                        'name': 'test',
+                },
+            },
+        },
+    }
+
+    # success first time but fail second
+    failures = [False, True, False]
+
+    # setup mocking iobl module
+    _, mock_create, _, disconnect_callback = yield from mock_legrandinone(
+        hass, config, domain, monkeypatch, failures=failures)
+
+    # rflink initiated disconnect
+    disconnect_callback(None)
+
+    yield from asyncio.sleep(0, loop=hass.loop)
+
+    success = yield from hass.services.async_call(
+        domain, SERVICE_OPEN_COVER, {ATTR_ENTITY_ID: 'cover.test'})
+    assert not success, 'changing state should not succeed when disconnected'

--- a/tests/components/test_legrandinone.py
+++ b/tests/components/test_legrandinone.py
@@ -1,4 +1,5 @@
-"""Common functions for legrandinone component tests and generic platform tests."""
+"""Common functions for legrandinone component tests and generic platform
+tests."""
 
 import asyncio
 from unittest.mock import Mock


### PR DESCRIPTION
## Description:

Add LegrandInOne/Openwebnet interface to Home Assistant.
Work based on RFLink components.
Openwebnet is a standard communication protocol used in Legrand/BTCino devices.
This patchset has been tested with PLC devices.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#7232

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
