### PR TITLE
Prometheus input boolean

### DIFF
--- a/homeassistant/components/prometheus.py
+++ b/homeassistant/components/prometheus.py
@@ -138,6 +138,15 @@ class PrometheusMetrics:
         value = state_helper.state_as_number(state)
         metric.labels(**self._labels(state)).set(value)
 
+    def _handle_input_boolean(self, state):
+        metric = self._metric(
+            'input_boolean_state',
+            self.prometheus_client.Gauge,
+            'State of the input boolean (0/1)',
+        )
+        value = state_helper.state_as_number(state)
+        metric.labels(**self._labels(state)).set(value)
+
     def _handle_device_tracker(self, state):
         metric = self._metric(
             'device_tracker_state',

--- a/homeassistant/components/sensor/min_max.py
+++ b/homeassistant/components/sensor/min_max.py
@@ -20,6 +20,7 @@ _LOGGER = logging.getLogger(__name__)
 
 ATTR_MIN_VALUE = 'min_value'
 ATTR_MAX_VALUE = 'max_value'
+ATTR_DELTA_VALUE = 'delta_value'
 ATTR_COUNT_SENSORS = 'count_sensors'
 ATTR_MEAN = 'mean'
 ATTR_LAST = 'last'
@@ -30,6 +31,7 @@ ATTR_TO_PROPERTY = [
     ATTR_MEAN,
     ATTR_MIN_VALUE,
     ATTR_LAST,
+    ATTR_DELTA_VALUE,
 ]
 
 CONF_ENTITY_IDS = 'entity_ids'
@@ -40,6 +42,7 @@ ICON = 'mdi:calculator'
 SENSOR_TYPES = {
     ATTR_MIN_VALUE: 'min',
     ATTR_MAX_VALUE: 'max',
+    ATTR_DELTA_VALUE: 'delta',
     ATTR_MEAN: 'mean',
     ATTR_LAST: 'last',
 }
@@ -118,7 +121,7 @@ class MinMaxSensor(Entity):
                      if self._sensor_type == v)).capitalize()
         self._unit_of_measurement = None
         self._unit_of_measurement_mismatch = False
-        self.min_value = self.max_value = self.mean = self.last = STATE_UNKNOWN
+        self.min_value = self.max_value = self.delta_value = self.mean = self.last = STATE_UNKNOWN
         self.count_sensors = len(self._entity_ids)
         self.states = {}
 
@@ -198,4 +201,5 @@ class MinMaxSensor(Entity):
                          if k in self.states]
         self.min_value = calc_min(sensor_values)
         self.max_value = calc_max(sensor_values)
+        self.delta_value = self.max_value - self.min_value
         self.mean = calc_mean(sensor_values, self._round_digits)


### PR DESCRIPTION
## Description:

Very simple change to expose input_booleans to Prometheus

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable): N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
N/A
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [N/A] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [N/A] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [N/A] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [N/A] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [N/A] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [N/A] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
