### PR TITLE
Add input_boolean reporting to Prometheus

### DIFF
--- a/homeassistant/components/prometheus.py
+++ b/homeassistant/components/prometheus.py
@@ -138,6 +138,15 @@ class PrometheusMetrics:
         value = state_helper.state_as_number(state)
         metric.labels(**self._labels(state)).set(value)
 
+    def _handle_input_boolean(self, state):
+        metric = self._metric(
+            'input_boolean_state',
+            self.prometheus_client.Gauge,
+            'State of the input boolean (0/1)',
+        )
+        value = state_helper.state_as_number(state)
+        metric.labels(**self._labels(state)).set(value)
+
     def _handle_device_tracker(self, state):
         metric = self._metric(
             'device_tracker_state',


### PR DESCRIPTION
## Description:

Very simple change to expose input_booleans to Prometheus


**Related issue (if applicable):** N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable): N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
N/A
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [N/A] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [N/A] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [N/A] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [N/A] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [N/A] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [N/A] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
