### PR TITLE
Fix operation mode for Alexa thermostat

### DIFF
--- a/homeassistant/components/alexa/smart_home.py
+++ b/homeassistant/components/alexa/smart_home.py
@@ -1,4 +1,5 @@
 """Support for alexa Smart Home Skill API."""
+from collections import OrderedDict
 import logging
 import math
 from datetime import datetime
@@ -37,16 +38,19 @@ API_TEMP_UNITS = {
     TEMP_CELSIUS: 'CELSIUS',
 }
 
-API_THERMOSTAT_MODES = {
-    climate.STATE_HEAT: 'HEAT',
-    climate.STATE_COOL: 'COOL',
-    climate.STATE_AUTO: 'AUTO',
-    climate.STATE_ECO: 'ECO',
-    climate.STATE_OFF: 'OFF',
-    climate.STATE_IDLE: 'OFF',
-    climate.STATE_FAN_ONLY: 'OFF',
-    climate.STATE_DRY: 'OFF',
-}
+# Needs to be ordered dict for `async_api_set_thermostat_mode` which does a
+# reverse mapping of this dict and we want to map the first occurrance of OFF
+# back to HA state.
+API_THERMOSTAT_MODES = OrderedDict([
+    (climate.STATE_HEAT, 'HEAT'),
+    (climate.STATE_COOL, 'COOL'),
+    (climate.STATE_AUTO, 'AUTO'),
+    (climate.STATE_ECO, 'ECO'),
+    (climate.STATE_OFF, 'OFF'),
+    (climate.STATE_IDLE, 'OFF'),
+    (climate.STATE_FAN_ONLY, 'OFF'),
+    (climate.STATE_DRY, 'OFF')
+])
 
 SMART_HOME_HTTP_ENDPOINT = '/api/alexa/smart_home'
 

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -902,6 +902,14 @@ async def test_thermostat(hass):
     assert msg['event']['payload']['type'] == 'UNSUPPORTED_THERMOSTAT_MODE'
     hass.config.units.temperature_unit = TEMP_CELSIUS
 
+    call, _ = await assert_request_calls_service(
+        'Alexa.ThermostatController', 'SetThermostatMode',
+        'climate#test_thermostat', 'climate.set_operation_mode',
+        hass,
+        payload={'thermostatMode': 'OFF'}
+    )
+    assert call.data['operation_mode'] == 'off'
+
 
 @asyncio.coroutine
 def test_exclude_filters(hass):


### PR DESCRIPTION
## Description:
On Py3.5, dictionaries are not ordered. Making it explicitely an ordered dict because we do a reverse lookup when mapping Alexa -> HA and we want to have the first match for OFF.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
