### PR TITLE
Add attributes of ARP table

### DIFF
--- a/homeassistant/components/device_tracker/luci.py
+++ b/homeassistant/components/device_tracker/luci.py
@@ -96,10 +96,10 @@ class LuciDeviceScanner(DeviceScanner):
         """Return the IP of the given device."""
         filter_att = next((
             {
-              'ip':     result.ip,
-              'flags':  result.flags,
-              'device': result.device,
-              'host':   result.host
+                'ip':     result.ip,
+                'flags':  result.flags,
+                'device': result.device,
+                'host':   result.host
             } for result in self.last_results
             if result.mac == device), None)
         return filter_att

--- a/homeassistant/components/device_tracker/luci.py
+++ b/homeassistant/components/device_tracker/luci.py
@@ -7,6 +7,7 @@ https://home-assistant.io/components/device_tracker.luci/
 import json
 import logging
 import re
+from collections import namedtuple
 
 import requests
 import voluptuous as vol
@@ -43,14 +44,17 @@ def get_scanner(hass, config):
     return scanner if scanner.success_init else None
 
 
+Device = namedtuple('Device', ['mac', 'ip', 'flags', 'device', 'host'])
+
+
 class LuciDeviceScanner(DeviceScanner):
     """This class queries a wireless router running OpenWrt firmware."""
 
     def __init__(self, config):
         """Initialize the scanner."""
-        host = config[CONF_HOST]
+        self.host = config[CONF_HOST]
         protocol = 'http' if not config[CONF_SSL] else 'https'
-        self.origin = '{}://{}'.format(protocol, host)
+        self.origin = '{}://{}'.format(protocol, self.host)
         self.username = config[CONF_USERNAME]
         self.password = config[CONF_PASSWORD]
 
@@ -68,7 +72,7 @@ class LuciDeviceScanner(DeviceScanner):
     def scan_devices(self):
         """Scan for new devices and return a list with found device IDs."""
         self._update_info()
-        return self.last_results
+        return [device.mac for device in self.last_results]
 
     def get_device_name(self, device):
         """Return the name of the given device or None if we don't know."""
@@ -87,6 +91,18 @@ class LuciDeviceScanner(DeviceScanner):
                 # Error, handled in the _req_json_rpc
                 return
         return self.mac2name.get(device.upper(), None)
+
+    def get_extra_attributes(self, device):
+        """Return the IP of the given device."""
+        filter_att = next((
+            {
+              'ip':     result.ip,
+              'flags':  result.flags,
+              'device': result.device,
+              'host':   result.host
+            } for result in self.last_results
+            if result.mac == device), None)
+        return filter_att
 
     def _update_info(self):
         """Ensure the information from the Luci router is up to date.
@@ -114,7 +130,11 @@ class LuciDeviceScanner(DeviceScanner):
                 # Check if the Flags for each device contain
                 # NUD_REACHABLE and if so, add it to last_results
                 if int(device_entry['Flags'], 16) & 0x2:
-                    self.last_results.append(device_entry['HW address'])
+                    self.last_results.append(Device(device_entry['HW address'],
+                                                    device_entry['IP address'],
+                                                    device_entry['Flags'],
+                                                    device_entry['Device'],
+                                                    self.host))
 
             return True
 


### PR DESCRIPTION
This adds the device attributes available in the ARP table and a few more. Implementation is inspired by the nmap scanner.

## Description:


**Related issue (if applicable):** none
**Related feature request:** https://community.home-assistant.io/t/luci-device-scanner-with-ip-address/71447

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#7251

## Example entry for `configuration.yaml` (if applicable):
```yaml
device_tracker:
  - platform: luci
    host: !secret luci_shak_ip
    username: !secret luci_shak_username
    password: !secret luci_shak_password
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
