### PR TITLE
Support eco mode option on Ziggo Mediabox XL

### DIFF
--- a/homeassistant/components/media_player/ziggo_mediabox_xl.py
+++ b/homeassistant/components/media_player/ziggo_mediabox_xl.py
@@ -14,8 +14,7 @@ from homeassistant.components.media_player import (
     SUPPORT_PREVIOUS_TRACK, SUPPORT_SELECT_SOURCE, SUPPORT_TURN_OFF,
     SUPPORT_TURN_ON, MediaPlayerDevice)
 from homeassistant.const import (
-    CONF_HOST, CONF_NAME, STATE_OFF, STATE_UNAVAILABLE, STATE_PAUSED,
-    STATE_PLAYING)
+    CONF_HOST, CONF_NAME, STATE_OFF, STATE_PAUSED, STATE_PLAYING)
 import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['ziggo-mediabox-xl==1.1.0']
@@ -56,17 +55,26 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     # Only add a device once, so discovered devices do not override manual
     # config.
     hosts = []
+    connection_successful = False
     ip_addr = socket.gethostbyname(host)
     if ip_addr not in known_devices:
         try:
-            mediabox = ZiggoMediaboxXL(ip_addr, 5)
-            # Add the device manually or check if a connection can be
-            # established to the discovered device.
-            if manual_config or mediabox.test_connection():
-                hosts.append(ZiggoMediaboxXLDevice(mediabox, host, name))
-                known_devices.add(ip_addr)
+            # Mediabox instance with a timeout of 3 seconds.
+            mediabox = ZiggoMediaboxXL(ip_addr, 3)
+            # Check if a connection can be established to the device.
+            if mediabox.test_connection():
+                connection_successful = True
             else:
-                _LOGGER.error("Can't connect to %s", host)
+                if manual_config:
+                    _LOGGER.info("Can't connect to %s", host)
+                else:
+                    _LOGGER.error("Can't connect to %s", host)
+            # When the device is in eco mode it's not connected to the network
+            # so it needs to be added anyway if it's configured manually.
+            if manual_config or connection_successful:
+                hosts.append(ZiggoMediaboxXLDevice(mediabox, host, name,
+                                                   connection_successful))
+                known_devices.add(ip_addr)
         except socket.error as error:
             _LOGGER.error("Can't connect to %s: %s", host, error)
     else:
@@ -77,23 +85,29 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class ZiggoMediaboxXLDevice(MediaPlayerDevice):
     """Representation of a Ziggo Mediabox XL Device."""
 
-    def __init__(self, mediabox, host, name):
+    def __init__(self, mediabox, host, name, available):
         """Initialize the device."""
         self._mediabox = mediabox
         self._host = host
         self._name = name
+        self._available = available
         self._state = None
 
     def update(self):
         """Retrieve the state of the device."""
         try:
-            if self._mediabox.turned_on():
-                if self._state != STATE_PAUSED:
-                    self._state = STATE_PLAYING
+            if self._mediabox.test_connection():
+                if self._mediabox.turned_on():
+                    if self._state != STATE_PAUSED:
+                        self._state = STATE_PLAYING
+                else:
+                    self._state = STATE_OFF
+                self._available = True
             else:
-                self._state = STATE_OFF
+                self._available = False
         except socket.error:
-            self._state = STATE_UNAVAILABLE
+            _LOGGER.error("Couldn't fetch state from %s", self._host)
+            self._available = False
 
     def send_keys(self, keys):
         """Send keys to the device and handle exceptions."""
@@ -111,6 +125,11 @@ class ZiggoMediaboxXLDevice(MediaPlayerDevice):
     def state(self):
         """Return the state of the device."""
         return self._state
+
+    @property
+    def available(self):
+        """Return True if the device is available."""
+        return self._available
 
     @property
     def source_list(self):

--- a/homeassistant/components/media_player/ziggo_mediabox_xl.py
+++ b/homeassistant/components/media_player/ziggo_mediabox_xl.py
@@ -14,11 +14,11 @@ from homeassistant.components.media_player import (
     SUPPORT_PREVIOUS_TRACK, SUPPORT_SELECT_SOURCE, SUPPORT_TURN_OFF,
     SUPPORT_TURN_ON, MediaPlayerDevice)
 from homeassistant.const import (
-    CONF_HOST, CONF_NAME, STATE_OFF, STATE_ON, STATE_UNAVAILABLE,
-    STATE_PAUSED, STATE_PLAYING)
+    CONF_HOST, CONF_NAME, STATE_OFF, STATE_UNAVAILABLE, STATE_PAUSED,
+    STATE_PLAYING)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['ziggo-mediabox-xl==1.0.0']
+REQUIREMENTS = ['ziggo-mediabox-xl==1.1.0']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -59,7 +59,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     ip_addr = socket.gethostbyname(host)
     if ip_addr not in known_devices:
         try:
-            mediabox = ZiggoMediaboxXL(ip_addr)
+            mediabox = ZiggoMediaboxXL(ip_addr, 5)
             # Add the device manually or check if a connection can be
             # established to the discovered device.
             if manual_config or mediabox.test_connection():
@@ -126,12 +126,10 @@ class ZiggoMediaboxXLDevice(MediaPlayerDevice):
     def turn_on(self):
         """Turn the media player on."""
         self.send_keys(['POWER'])
-        self._state = STATE_ON
 
     def turn_off(self):
         """Turn off media player."""
         self.send_keys(['POWER'])
-        self._state = STATE_OFF
 
     def media_play(self):
         """Send play command."""

--- a/homeassistant/components/media_player/ziggo_mediabox_xl.py
+++ b/homeassistant/components/media_player/ziggo_mediabox_xl.py
@@ -23,6 +23,10 @@ _LOGGER = logging.getLogger(__name__)
 
 DATA_KNOWN_DEVICES = 'ziggo_mediabox_xl_known_devices'
 
+DEFAULT_ECO_MODE_ON = False
+
+CONF_ECO_MODE_ON = 'eco_mode_on'
+
 SUPPORT_ZIGGO = SUPPORT_TURN_ON | SUPPORT_TURN_OFF | \
     SUPPORT_NEXT_TRACK | SUPPORT_PAUSE | SUPPORT_PREVIOUS_TRACK | \
     SUPPORT_SELECT_SOURCE | SUPPORT_PLAY
@@ -30,6 +34,7 @@ SUPPORT_ZIGGO = SUPPORT_TURN_ON | SUPPORT_TURN_OFF | \
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
     vol.Optional(CONF_NAME): cv.string,
+    vol.Optional(CONF_ECO_MODE_ON, default=DEFAULT_ECO_MODE_ON): cv.boolean,
 })
 
 
@@ -43,9 +48,11 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     if config.get(CONF_HOST) is not None:
         host = config.get(CONF_HOST)
         name = config.get(CONF_NAME)
+        eco_mode_on = config.get(CONF_ECO_MODE_ON)
     elif discovery_info is not None:
         host = discovery_info.get('host')
         name = discovery_info.get('name')
+        eco_mode_on = False
     else:
         _LOGGER.error("Cannot determine device")
         return
@@ -57,8 +64,9 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     if ip_addr not in known_devices:
         try:
             mediabox = ZiggoMediaboxXL(ip_addr)
-            if mediabox.test_connection():
-                hosts.append(ZiggoMediaboxXLDevice(mediabox, host, name))
+            if eco_mode_on or mediabox.test_connection():
+                hosts.append(ZiggoMediaboxXLDevice(mediabox, eco_mode_on,
+                                                   host, name))
                 known_devices.add(ip_addr)
             else:
                 _LOGGER.error("Can't connect to %s", host)
@@ -72,10 +80,10 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class ZiggoMediaboxXLDevice(MediaPlayerDevice):
     """Representation of a Ziggo Mediabox XL Device."""
 
-    def __init__(self, mediabox, host, name):
+    def __init__(self, mediabox, eco_mode_on, host, name):
         """Initialize the device."""
-        # Generate a configuration for the Samsung library
         self._mediabox = mediabox
+        self._eco_mode_on = eco_mode_on
         self._host = host
         self._name = name
         self._state = None
@@ -89,7 +97,10 @@ class ZiggoMediaboxXLDevice(MediaPlayerDevice):
             else:
                 self._state = STATE_OFF
         except socket.error:
-            _LOGGER.error("Couldn't fetch state from %s", self._host)
+            if self._eco_mode_on:
+                self._state = STATE_OFF
+            else:
+                _LOGGER.error("Couldn't fetch state from %s", self._host)
 
     def send_keys(self, keys):
         """Send keys to the device and handle exceptions."""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1614,7 +1614,7 @@ zeroconf==0.21.3
 zhong_hong_hvac==1.0.9
 
 # homeassistant.components.media_player.ziggo_mediabox_xl
-ziggo-mediabox-xl==1.0.0
+ziggo-mediabox-xl==1.1.0
 
 # homeassistant.components.zha
 zigpy-xbee==0.1.1


### PR DESCRIPTION
## Description:
The Ziggo Mediabox XL has an eco function which turn off the device when it's not in use. This PR adds an option to override the online check, so it's still added when the device is in eco modus.

~~**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#7255~~

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  - platform: ziggo_mediabox_xl
    host: 192.168.0.123
    name: Ziggo Mediabox
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

~~If user exposed functionality or configuration variables are added/changed:~~
  - [x] ~~Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)~~

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
