### PR TITLE
RFC: Static templates match no entities, not all

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -31,6 +31,7 @@ _RE_GET_ENTITIES = re.compile(
     r"(?:(?:states\.|(?:is_state|is_state_attr|state_attr|states)"
     r"\((?:[\ \'\"]?))([\w]+\.[\w]+)|([\w]+))", re.I | re.M
 )
+_RE_JINJA_DELIMITERS = re.compile(r"\{%|\{\{")
 
 
 @bind_hass
@@ -59,7 +60,10 @@ def render_complex(value, variables=None):
 
 def extract_entities(template, variables=None):
     """Extract all entities for state_changed listener from template string."""
-    if template is None or _RE_NONE_ENTITIES.search(template):
+    if template is None or _RE_JINJA_DELIMITERS.search(template) is None:
+        return []
+
+    if _RE_NONE_ENTITIES.search(template):
         return MATCH_ALL
 
     extraction = _RE_GET_ENTITIES.findall(template)

--- a/tests/components/automation/test_template.py
+++ b/tests/components/automation/test_template.py
@@ -112,7 +112,7 @@ async def test_if_not_fires_on_change_str(hass, calls):
         automation.DOMAIN: {
             'trigger': {
                 'platform': 'template',
-                'value_template': 'False',
+                'value_template': 'true',
             },
             'action': {
                 'service': 'test.automation'

--- a/tests/components/automation/test_template.py
+++ b/tests/components/automation/test_template.py
@@ -55,7 +55,7 @@ async def test_if_fires_on_change_str(hass, calls):
         automation.DOMAIN: {
             'trigger': {
                 'platform': 'template',
-                'value_template': 'true',
+                'value_template': '{{ "true" }}',
             },
             'action': {
                 'service': 'test.automation'
@@ -74,7 +74,7 @@ async def test_if_fires_on_change_str_crazy(hass, calls):
         automation.DOMAIN: {
             'trigger': {
                 'platform': 'template',
-                'value_template': 'TrUE',
+                'value_template': '{{ "TrUE" }}',
             },
             'action': {
                 'service': 'test.automation'
@@ -131,7 +131,7 @@ async def test_if_not_fires_on_change_str_crazy(hass, calls):
         automation.DOMAIN: {
             'trigger': {
                 'platform': 'template',
-                'value_template': 'Anything other than "true" is false.',
+                'value_template': '{{ "Anything other than true is false." }}',
             },
             'action': {
                 'service': 'test.automation'

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -896,7 +896,7 @@ class TestHelpersTemplate(unittest.TestCase):
 
         assert ['device_tracker.phone_2'] == \
             template.extract_entities("""
-is_state_attr('device_tracker.phone_2', 'battery', 40)
+{{ is_state_attr('device_tracker.phone_2', 'battery', 40) }}
             """)
 
         assert sorted([

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -849,7 +849,9 @@ class TestHelpersTemplate(unittest.TestCase):
 
     def test_extract_entities_none_exclude_stuff(self):
         """Test extract entities function with none or exclude stuff."""
-        assert MATCH_ALL == template.extract_entities(None)
+        assert [] == template.extract_entities(None)
+
+        assert [] == template.extract_entities("mdi:water")
 
         assert MATCH_ALL == \
             template.extract_entities(


### PR DESCRIPTION
## Description:

The below template sensor stopped updating with 0.81 because of the `icon_template` where no entity ids can be found. I was surprised to learn that this sensor has been updating with each state change.

I propose to have `extract_entities` return an empty list (i.e. no entity ids) rather than `MATCH_ALL` in this case where a static text is used.

For the template sensor it will be a usability improvement and for other template platforms that still accept `MATCH_ALL` it could be a performance improvement.

This is marked RFC because I realize that in a perfect world nobody would put static texts into the template engine.

CC @balloob @pvizeli 

**Related issue (if applicable):**

https://community.home-assistant.io/t/solved-sensor-template-confusion/75523

https://community.home-assistant.io/t/suppress-template-sensor-warning-in-0-81-1/75658

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: template
    sensors:
      desk_watt:
        value_template: '{{ states.switch.desk.attributes.current_power_w }}'
        icon_template: mdi:power-plug
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.
