### PR TITLE
Revert #17609 (remove await for coroutine)

### DIFF
--- a/homeassistant/components/camera/ffmpeg.py
+++ b/homeassistant/components/camera/ffmpeg.py
@@ -32,8 +32,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 async def async_setup_platform(hass, config, async_add_entities,
                                discovery_info=None):
     """Set up a FFmpeg camera."""
-    if not hass.data[DATA_FFMPEG].async_run_test(config.get(CONF_INPUT)):
-        return
     async_add_entities([FFmpegCamera(hass, config)])
 
 

--- a/homeassistant/components/camera/ffmpeg.py
+++ b/homeassistant/components/camera/ffmpeg.py
@@ -32,7 +32,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 async def async_setup_platform(hass, config, async_add_entities,
                                discovery_info=None):
     """Set up a FFmpeg camera."""
-    if not await hass.data[DATA_FFMPEG].async_run_test(config.get(CONF_INPUT)):
+    if not hass.data[DATA_FFMPEG].async_run_test(config.get(CONF_INPUT)):
         return
     async_add_entities([FFmpegCamera(hass, config)])
 


### PR DESCRIPTION
Revert - https://github.com/home-assistant/home-assistant/pull/17609

Was causing issues in - https://github.com/home-assistant/home-assistant/issues/17934 and https://github.com/home-assistant/home-assistant/issues/17684

## Description:
PR #17609 inadvertently caused errors and segmentation faults.  This was validated and tested by reverting this change locally and the issues did not reappear.  Reverting this PR would revert ffmpeg.py back to its original state under 0.80.0

**Related issue (if applicable):** fixes #17934 and #17684 

## Checklist:
  - [x ] The code change is tested and works locally.

