### PR TITLE
Don't try to re-add existing Z-Wave entities

### DIFF
--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -935,7 +935,6 @@ class ZWaveDeviceEntityValues():
 
         async def discover_device(component, device):
             """Put device in a dictionary and call discovery on it."""
-
             if self._hass.data[DATA_DEVICES].get(device.unique_id):
                 return
 
@@ -946,7 +945,8 @@ class ZWaveDeviceEntityValues():
             else:
                 await discovery.async_load_platform(
                     self._hass, component, DOMAIN,
-                    {const.DISCOVERY_DEVICE: device.unique_id}, self._zwave_config)
+                    {const.DISCOVERY_DEVICE: device.unique_id},
+                    self._zwave_config)
 
         if device.unique_id:
             self._hass.add_job(discover_device, component, device)

--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -223,10 +223,11 @@ async def async_setup_platform(hass, config, async_add_entities,
     if discovery_info is None or DATA_NETWORK not in hass.data:
         return False
 
-    device = hass.data[DATA_DEVICES].pop(
+    device = hass.data[DATA_DEVICES].get(
         discovery_info[const.DISCOVERY_DEVICE], None)
     if device is None:
         return False
+
     async_add_entities([device])
     return True
 
@@ -340,6 +341,9 @@ async def async_setup_entry(hass, config_entry):
         entity = ZWaveNodeEntity(node, network)
 
         def _add_node_to_component():
+            if hass.data[DATA_DEVICES].get(entity.unique_id):
+                return
+
             name = node_name(node)
             generated_id = generate_entity_id(DOMAIN + '.{}', name, [])
             node_config = device_config.get(generated_id)
@@ -348,6 +352,8 @@ async def async_setup_entry(hass, config_entry):
                     "Ignoring node entity %s due to device settings",
                     generated_id)
                 return
+
+            hass.data[DATA_DEVICES][entity.unique_id] = entity
             component.add_entities([entity])
 
         if entity.unique_id:
@@ -912,15 +918,12 @@ class ZWaveDeviceEntityValues():
 
         self._entity = device
 
-        dict_id = id(self)
-
         @callback
         def _on_ready(sec):
             _LOGGER.info(
                 "Z-Wave entity %s (node_id: %d) ready after %d seconds",
                 device.name, self._node.node_id, sec)
-            self._hass.async_add_job(discover_device, component, device,
-                                     dict_id)
+            self._hass.async_add_job(discover_device, component, device)
 
         @callback
         def _on_timeout(sec):
@@ -928,22 +931,25 @@ class ZWaveDeviceEntityValues():
                 "Z-Wave entity %s (node_id: %d) not ready after %d seconds, "
                 "continuing anyway",
                 device.name, self._node.node_id, sec)
-            self._hass.async_add_job(discover_device, component, device,
-                                     dict_id)
+            self._hass.async_add_job(discover_device, component, device)
 
-        async def discover_device(component, device, dict_id):
+        async def discover_device(component, device):
             """Put device in a dictionary and call discovery on it."""
-            self._hass.data[DATA_DEVICES][dict_id] = device
+
+            if self._hass.data[DATA_DEVICES].get(device.unique_id):
+                return
+
+            self._hass.data[DATA_DEVICES][device.unique_id] = device
             if component in SUPPORTED_PLATFORMS:
                 async_dispatcher_send(
                     self._hass, 'zwave_new_{}'.format(component), device)
             else:
                 await discovery.async_load_platform(
                     self._hass, component, DOMAIN,
-                    {const.DISCOVERY_DEVICE: dict_id}, self._zwave_config)
+                    {const.DISCOVERY_DEVICE: device.unique_id}, self._zwave_config)
 
         if device.unique_id:
-            self._hass.add_job(discover_device, component, device, dict_id)
+            self._hass.add_job(discover_device, component, device)
         else:
             self._hass.add_job(check_has_unique_id, device, _on_ready,
                                _on_timeout, self._hass.loop)

--- a/tests/components/zwave/test_init.py
+++ b/tests/components/zwave/test_init.py
@@ -584,7 +584,7 @@ class TestZWaveDeviceEntityValues(unittest.TestCase):
         assert args[0] == self.hass
         assert args[1] == 'mock_component'
         assert args[2] == 'zwave'
-        assert args[3] == {const.DISCOVERY_DEVICE: id(values)}
+        assert args[3] == {const.DISCOVERY_DEVICE: mock_device.unique_id}
         assert args[4] == self.zwave_config
 
         discovery.async_load_platform.reset_mock()
@@ -646,7 +646,7 @@ class TestZWaveDeviceEntityValues(unittest.TestCase):
         assert args[0] == self.hass
         assert args[1] == 'mock_component'
         assert args[2] == 'zwave'
-        assert args[3] == {const.DISCOVERY_DEVICE: id(values)}
+        assert args[3] == {const.DISCOVERY_DEVICE: mock_device.unique_id}
         assert args[4] == self.zwave_config
         assert not self.primary.enable_poll.called
 


### PR DESCRIPTION
## Description:
This keeps track of the Z-Wave entities that were already created/added and does not try to re-create them if the Z-Wave network is stopped and restarted.

**Related issue (if applicable):** fixes #17957

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
zwave:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
