### PR TITLE
Use a fixture for dialogflow calls in unit tests

### DIFF
--- a/tests/components/dialogflow/test_init.py
+++ b/tests/components/dialogflow/test_init.py
@@ -16,18 +16,25 @@ REQUEST_ID = "19ef7e78-fe15-4e94-99dd-0c0b1e8753c3"
 REQUEST_TIMESTAMP = "2017-01-21T17:54:18.952Z"
 CONTEXT_NAME = "78a5db95-b7d6-4d50-9c9b-2fc73a5e34c3_id_dialog_context"
 
-calls = []
-
 
 @pytest.fixture
-async def fixture(hass, aiohttp_client):
-    """Initialize a Home Assistant server for testing this module."""
+async def calls(hass, fixture):
+    """Return a list of Dialogflow calls triggered."""
+    calls = []
+
     @callback
     def mock_service(call):
         """Mock action call."""
         calls.append(call)
 
     hass.services.async_register('test', 'dialogflow', mock_service)
+
+    return calls
+
+
+@pytest.fixture
+async def fixture(hass, aiohttp_client):
+    """Initialize a Home Assistant server for testing this module."""
 
     await async_setup_component(hass, dialogflow.DOMAIN, {
         "dialogflow": {},
@@ -371,7 +378,7 @@ async def test_intent_request_without_slots(hass, fixture):
     assert "You are both home, you silly" == text
 
 
-async def test_intent_request_calling_service(fixture):
+async def test_intent_request_calling_service(fixture, calls):
     """Test a request for calling a service.
 
     If this request is done async the test could finish before the action

--- a/tests/components/dialogflow/test_init.py
+++ b/tests/components/dialogflow/test_init.py
@@ -35,7 +35,6 @@ async def calls(hass, fixture):
 @pytest.fixture
 async def fixture(hass, aiohttp_client):
     """Initialize a Home Assistant server for testing this module."""
-
     await async_setup_component(hass, dialogflow.DOMAIN, {
         "dialogflow": {},
     })


### PR DESCRIPTION
## Description:
Cleaned up the dialogflow unit tests to use a fixture instead of a global.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
