### PR TITLE
Extend payment processing time by 2 more days

### DIFF
--- a/homeassistant/components/cloud/__init__.py
+++ b/homeassistant/components/cloud/__init__.py
@@ -5,7 +5,7 @@ For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/cloud/
 """
 import asyncio
-from datetime import datetime
+from datetime import datetime, timedelta
 import json
 import logging
 import os
@@ -162,7 +162,7 @@ class Cloud:
     @property
     def subscription_expired(self):
         """Return a boolean if the subscription has expired."""
-        return dt_util.utcnow() > self.expiration_date
+        return dt_util.utcnow() > self.expiration_date + timedelta(days=3)
 
     @property
     def expiration_date(self):

--- a/tests/components/cloud/test_init.py
+++ b/tests/components/cloud/test_init.py
@@ -142,14 +142,28 @@ def test_write_user_info():
 
 @asyncio.coroutine
 def test_subscription_expired(hass):
-    """Test subscription being expired."""
+    """Test subscription being expired after 3 days of expiration."""
     cl = cloud.Cloud(hass, cloud.MODE_DEV, None, None)
     token_val = {
         'custom:sub-exp': '2017-11-13'
     }
     with patch.object(cl, '_decode_claims', return_value=token_val), \
             patch('homeassistant.util.dt.utcnow',
-                  return_value=utcnow().replace(year=2018)):
+                  return_value=utcnow().replace(year=2017, month=11, day=13)):
+        assert not cl.subscription_expired
+
+    with patch.object(cl, '_decode_claims', return_value=token_val), \
+            patch('homeassistant.util.dt.utcnow',
+                  return_value=utcnow().replace(
+                      year=2017, month=11, day=15, hour=23, minute=59,
+                      second=59)):
+        assert not cl.subscription_expired
+
+    with patch.object(cl, '_decode_claims', return_value=token_val), \
+            patch('homeassistant.util.dt.utcnow',
+                  return_value=utcnow().replace(
+                      year=2017, month=11, day=16, hour=0, minute=0,
+                      second=0)):
         assert cl.subscription_expired
 
 


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
