### PR TITLE
add config to load_platform in konnected component

### DIFF
--- a/homeassistant/components/konnected.py
+++ b/homeassistant/components/konnected.py
@@ -238,10 +238,10 @@ class ConfiguredDevice:
 
         discovery.load_platform(
             self.hass, 'binary_sensor',
-            DOMAIN, {'device_id': self.device_id})
+            DOMAIN, {'device_id': self.device_id}, self.config)
         discovery.load_platform(
             self.hass, 'switch', DOMAIN,
-            {'device_id': self.device_id})
+            {'device_id': self.device_id}, self.config)
 
 
 class DiscoveredDevice:


### PR DESCRIPTION
## Description:
Adds config to load_platform in konnected.  Related to #17952

**Related issue (if applicable):** fixes #18003

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
