### PR TITLE
BUGFIX: Allow jinja namespace command to work.

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -9,6 +9,7 @@ import re
 import jinja2
 from jinja2 import contextfilter
 from jinja2.sandbox import ImmutableSandboxedEnvironment
+from jinja2.utils import Namespace
 
 from homeassistant.const import (
     ATTR_LATITUDE, ATTR_LONGITUDE, ATTR_UNIT_OF_MEASUREMENT, MATCH_ALL,
@@ -617,6 +618,11 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
     def is_safe_callable(self, obj):
         """Test if callback is safe."""
         return isinstance(obj, AllStates) or super().is_safe_callable(obj)
+
+    def is_safe_attribute(self, obj, attr, value):
+        """Test if attribute is safe."""
+        return isinstance(obj, Namespace) or \
+            super().is_safe_attribute(obj, attr, value)
 
 
 ENV = TemplateEnvironment()

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -963,6 +963,23 @@ class TestHelpersTemplate(unittest.TestCase):
                 "{{ is_state('media_player.' ~ where , 'playing') }}",
                 {'where': 'livingroom'})
 
+    def test_jinja_namespace(self):
+        """Test Jinja's namespace command can be used."""
+        test_template = template.Template(
+            (
+                "{% set ns = namespace(a_key='') %}"
+                "{% set ns.a_key = states.sensor.dummy.state %}"
+                "{{ ns.a_key }}"
+            ),
+            self.hass
+        )
+
+        self.hass.states.set('sensor.dummy', 'a value')
+        assert 'a value' == test_template.render()
+
+        self.hass.states.set('sensor.dummy', 'another value')
+        assert 'another value' == test_template.render()
+
 
 @asyncio.coroutine
 def test_state_with_unit(hass):


### PR DESCRIPTION
## Description:

Allows the Jinja 2 [namesapce](http://jinja.pocoo.org/docs/2.10/templates/#namespace) class that was added in 2.10 to work in Home Assistant.

`namespace` does not currently work as Home Assistant is using the `ImmutableSandboxedEnvironment` and when `namespace` was added no code was written on the Jinja side to handle this situation. In the case of dicts or lists attempting to be mutated a jinja error is correctly raised and shown to the user, whereas when a namespace is used  in conjunction with this environment type a recursive loop is entered with no output given to the user and a stacktrace thrown into the logs.

Given that the `namespace` class was added in order to stop the need for the hacks that the `ImmutableSandboxedEnvironment` is protecting against, and we're already specialcasing `AllStates` as a mutable object it seems reasonable to do the same with `namespace`.

The added test fails before the change in `helpers/template.py` is applied.

**Related issue (if applicable):** fixes #16480

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable): n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
