### PR TITLE
Fix in Daikin.py for set swing_mode and speed

### DIFF
--- a/homeassistant/components/climate/daikin.py
+++ b/homeassistant/components/climate/daikin.py
@@ -174,8 +174,10 @@ class DaikinClimate(ClimateDevice):
 
             daikin_attr = HA_ATTR_TO_DAIKIN.get(attr)
             if daikin_attr is not None:
-                if value in self._list[attr]:
+                if attr == ATTR_OPERATION_MODE:
                     values[daikin_attr] = HA_STATE_TO_DAIKIN[value]
+                elif value in self._list[attr]:
+                    values[daikin_attr] = value.lower()
                 else:
                     _LOGGER.error("Invalid value %s for %s", attr, value)
 


### PR DESCRIPTION
## Description:
Minor changes for fixing a bug in setting Swing Mode and Operation Speed of the Unit.

**Related discussion in 
https://community.home-assistant.io/t/daikin-component-no-climate-entities-created-task-exception/39608/139 

    
