### PR TITLE
Fix Bloomsky api call

### DIFF
--- a/homeassistant/components/bloomsky.py
+++ b/homeassistant/components/bloomsky.py
@@ -54,7 +54,7 @@ class BloomSky:
     """Handle all communication with the BloomSky API."""
 
     # API documentation at http://weatherlution.com/bloomsky-api/
-    API_URL = 'https://api.bloomsky.com/api/skydata'
+    API_URL = 'http://api.bloomsky.com/api/skydata'
 
     def __init__(self, api_key):
         """Initialize the BookSky."""


### PR DESCRIPTION
## Description:

After 0.81.2 the requests module was updated to v2.20.0 which removes the authorization header from HTTPS to HTTP redirects for the same base URL.  The Bloomksy API was previously using HTTPS however it was being redirected to HTTP.  This updates the API URL to use one that is accepted.  

https://github.com/requests/requests/pull/4835 3rd bullet point

**Related issue (if applicable):** fixes #18014 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io# N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
bloomsky:
  api_key: apikey
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
