### PR TITLE
[WIP] Qwikswitch Cloud with config entries

### DIFF
--- a/homeassistant/components/qwikswitch/.translations/en.json
+++ b/homeassistant/components/qwikswitch/.translations/en.json
@@ -13,7 +13,6 @@
         },
         "error": {
             "no_key": "Couldn't get an API key",
-            "timeout": "Timeout",
             "name_exists": "Name already exists"
         }
     }

--- a/homeassistant/components/qwikswitch/__init__.py
+++ b/homeassistant/components/qwikswitch/__init__.py
@@ -1,0 +1,12 @@
+"""
+Support for Qwikswitch devices.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/qwikswitch/
+"""
+# pylint: disable=unused-import
+from .qs import DOMAIN, QSEntity, QSToggleEntity  # noqa
+from .qsusb import async_setup, CONFIG_SCHEMA  # noqa
+# from .qscloud import async_setup_entry, async_unload_entry  # noqa
+
+REQUIREMENTS = ['pyqwikswitch==0.8']

--- a/homeassistant/components/qwikswitch/__init__.py
+++ b/homeassistant/components/qwikswitch/__init__.py
@@ -7,6 +7,6 @@ https://home-assistant.io/components/qwikswitch/
 # pylint: disable=unused-import
 from .qs import DOMAIN, QSEntity, QSToggleEntity  # noqa
 from .qsusb import async_setup, CONFIG_SCHEMA  # noqa
-# from .qscloud import async_setup_entry, async_unload_entry  # noqa
+from .qscloud import async_setup_entry, async_unload_entry  # noqa
 
 REQUIREMENTS = ['pyqwikswitch==0.8']

--- a/homeassistant/components/qwikswitch/qs.py
+++ b/homeassistant/components/qwikswitch/qs.py
@@ -1,0 +1,73 @@
+"""Generic Qwikswitch Entities and constants."""
+from homeassistant.components.light import ATTR_BRIGHTNESS
+from homeassistant.core import callback
+from homeassistant.helpers.entity import Entity
+
+
+DOMAIN = 'qwikswitch'
+
+
+class QSEntity(Entity):
+    """Qwikswitch Entity base."""
+
+    def __init__(self, qsid, name):
+        """Initialize the QSEntity."""
+        self._name = name
+        self.qsid = qsid
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def poll(self):
+        """QS sensors gets packets in update_packet."""
+        return False
+
+    @property
+    def unique_id(self):
+        """Return a unique identifier for this sensor."""
+        return "qs{}".format(self.qsid)
+
+    @callback
+    def update_packet(self, packet):
+        """Receive update packet from QSUSB. Match dispather_send signature."""
+        self.async_schedule_update_ha_state()
+
+    async def async_added_to_hass(self):
+        """Listen for updates from QSUSb via dispatcher."""
+        self.hass.helpers.dispatcher.async_dispatcher_connect(
+            self.qsid, self.update_packet)
+
+
+class QSToggleEntity(QSEntity):
+    """Representation of a Qwikswitch Toggle Entity.
+
+    Implemented:
+     - QSLight extends QSToggleEntity and Light[2] (ToggleEntity[1])
+     - QSSwitch extends QSToggleEntity and SwitchDevice[3] (ToggleEntity[1])
+
+    [1] /helpers/entity.py
+    [2] /components/light/__init__.py
+    [3] /components/switch/__init__.py
+    """
+
+    def __init__(self, qsid, qsusb):
+        """Initialize the ToggleEntity."""
+        self.device = qsusb.devices[qsid]
+        super().__init__(qsid, self.device.name)
+
+    @property
+    def is_on(self):
+        """Check if device is on (non-zero)."""
+        return self.device.value > 0
+
+    async def async_turn_on(self, **kwargs):
+        """Turn the device on."""
+        new = kwargs.get(ATTR_BRIGHTNESS, 255)
+        self.hass.data[DOMAIN].devices.set_value(self.qsid, new)
+
+    async def async_turn_off(self, **_):
+        """Turn the device off."""
+        self.hass.data[DOMAIN].devices.set_value(self.qsid, 0)

--- a/homeassistant/components/qwikswitch/qscloud.py
+++ b/homeassistant/components/qwikswitch/qscloud.py
@@ -1,11 +1,14 @@
 """Implementation of a QS Cloud Interface and related config entries."""
 import logging
 
+import asyncio
 import voluptuous as vol
+import async_timeout
 
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.const import (
-    CONF_API_KEY, CONF_EMAIL, CONF_NAME)
+    CONF_EMAIL, CONF_NAME)
 from homeassistant.core import callback
 from homeassistant.helpers.entity import async_generate_entity_id
 from homeassistant.util import slugify
@@ -13,24 +16,24 @@ from homeassistant.util import slugify
 from .qs import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
+_LOGGER.setLevel(logging.DEBUG)
 
 QSDOMAIN = '{}.cloud-hub'.format(DOMAIN)
 ENTITY_ID_FORMAT = DOMAIN + '.{}'
-QS_TOKEN_WEBHOOK = "https://qwikswitch.com/api/v1/keys"
-CONF_MASTERKEY = "masterKey"
+QS_TOKEN_WEBHOOK = 'https://qwikswitch.com/api/v1/keys'
+CONF_MASTERKEY = 'masterKey'
+CONF_TOKEN = 'token'
 
 
 class QSCloud():
     """QSCloud class."""
 
-    key = None
-    name = None
-    entity_id = None
-
-    def __init__(self, hass, config_entry):
+    def __init__(self, hass, name, token=None):
         """Init QScloud class."""
-        self.key = config_entry[CONF_API_KEY]
-        self.name = config_entry.get(CONF_NAME, 'QS Cloud')
+        self.token = token
+        self.name = name
+        self.hass = hass
+        self._aio_session = async_get_clientsession(hass)
         self.entity_id = async_generate_entity_id(
             ENTITY_ID_FORMAT, self.name, None, hass)
 
@@ -38,8 +41,22 @@ class QSCloud():
         """Remove this QS cloud instance."""
         pass
 
+    async def get_token(self, email, masterkey):
+        """Retrieve an access token."""
+        _LOGGER.debug('Request token %s, %s***', email, masterkey[:2])
+        with async_timeout.timeout(3):
+            res = await self._aio_session.post(
+                QS_TOKEN_WEBHOOK, data={
+                    'email': email,
+                    'masterKey': masterkey
+                })
+            data = (await res.json()) or {}
+        self.token = data.get['rw']
+        _LOGGER.debug('  got token %s', self.token)
+        # {'ok': 1, 'r': 'f10b-56b7-dba4-0475', 'rw': 'ddb3-9f0b-81d2-0475'}
 
-async def async_setup_entry(hass, config_entry):
+
+async def async_setup_entry(hass, config_entry, async_add_devices):
     """Set up config entry."""
     qsc = QSCloud(hass, config_entry.data)
     if QSDOMAIN not in hass.data:
@@ -60,7 +77,7 @@ async def async_unload_entry(hass, config_entry):
 @callback
 def configured_qscloud(hass):
     """Return a set of the configured entries."""
-    return set((slugify(entry.data[CONF_NAME])) for
+    return set((slugify(entry.data[CONF_EMAIL])) for
                entry in hass.config_entries.async_entries(DOMAIN))
 
 
@@ -69,11 +86,8 @@ class QSCloudFlowHandler(data_entry_flow.FlowHandler):
     """Qwikswitch config flow."""
 
     VERSION = 1
-    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_PUSH
-
-    def __init__(self):
-        """Initialize zone configuration flow."""
-        pass
+    CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
+    qscloud = None  # type=QSCloud
 
     async def async_step_user(self, user_input=None):
         """Handle a flow initialized by the user."""
@@ -84,22 +98,36 @@ class QSCloudFlowHandler(data_entry_flow.FlowHandler):
         errors = {}
 
         if user_input is not None:
+            email = user_input[CONF_EMAIL].lower()
             name = user_input[CONF_NAME]
-            # Try get a token
 
-            if name not in configured_qscloud(self.hass):
-                return self.async_create_entry(
-                    title=user_input[CONF_NAME],
-                    data=user_input,
-                )
-            errors['base'] = 'name_exists'
+            if email in configured_qscloud(self.hass):
+                errors['base'] = 'name_exists'
+                return
+
+            self.qscloud = QSCloud(self.hass, name)
+            try:
+                token = self.qscloud.get_token(
+                    email, user_input[CONF_MASTERKEY])
+            except asyncio.TimeoutError:
+                errors['base'] = 'timeout'
+                return
+
+            if token is None:
+                errors['base'] = 'no_key'
+                return
+
+            return self.async_create_entry(
+                title=name,
+                data={CONF_EMAIL: email, CONF_TOKEN: token},
+            )
 
         return self.async_show_form(
             step_id='init',
             data_schema=vol.Schema({
-                vol.Optional(CONF_NAME, default='QS Cloud'): str,
-                vol.Required(CONF_EMAIL): vol.Email,
+                vol.Required(CONF_EMAIL): str,
                 vol.Required(CONF_MASTERKEY): str,
+                vol.Optional(CONF_NAME, default='QS Cloud'): str,
             }),
             errors=errors,
         )

--- a/homeassistant/components/qwikswitch/qscloud.py
+++ b/homeassistant/components/qwikswitch/qscloud.py
@@ -1,0 +1,77 @@
+"""Implementation of a QS Cloud Interface and related config entries."""
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant import config_entries, data_entry_flow
+from homeassistant.const import (
+    CONF_NAME, CONF_LATITUDE, CONF_LONGITUDE, CONF_ICON, CONF_RADIUS)
+from homeassistant.core import callback
+from homeassistant.util import slugify
+
+from .qs import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+async def async_setup_entry(hass, config_entry):
+    """Set up config entry."""
+    entry = config_entry.data
+    name = entry[CONF_NAME]
+    zone = Zone(hass, name, entry[CONF_LATITUDE], entry[CONF_LONGITUDE],
+                entry.get(CONF_RADIUS, DEFAULT_RADIUS), entry.get(CONF_ICON),
+                entry.get(CONF_PASSIVE, DEFAULT_PASSIVE))
+    zone.entity_id = async_generate_entity_id(
+        ENTITY_ID_FORMAT, name, None, hass)
+    hass.async_add_job(zone.async_update_ha_state())
+    hass.data[DOMAIN][slugify(name)] = zone
+    return True
+
+
+async def async_unload_entry(hass, config_entry):
+    """Unload a config entry."""
+    zones = hass.data[DOMAIN]
+    name = slugify(config_entry.data[CONF_NAME])
+    zone = zones.pop(name)
+    await zone.async_remove()
+    return True
+
+
+
+@config_entries.HANDLERS.register(DOMAIN)
+class QSCloudFlowHandler(data_entry_flow.FlowHandler):
+    """Qwikswitch config flow."""
+
+    VERSION = 1
+
+    def __init__(self):
+        """Initialize zone configuration flow."""
+        pass
+
+    async def async_step_user(self, user_input=None):
+        """Handle a flow initialized by the user."""
+        return await self.async_step_init(user_input)
+
+    async def async_step_init(self, user_input=None):
+        """Handle a flow start."""
+        errors = {}
+
+        if user_input is not None:
+            name = slugify(user_input[CONF_NAME])
+            if name not in configured_zones(self.hass) and name != HOME_ZONE:
+                return self.async_create_entry(
+                    title=user_input[CONF_NAME],
+                    data=user_input,
+                )
+            errors['base'] = 'name_exists'
+
+        return self.async_show_form(
+            step_id='init',
+            data_schema=vol.Schema({
+                vol.Required(CONF_NAME): str,
+                vol.Required(CONF_LATITUDE): cv.latitude,
+                vol.Required(CONF_LONGITUDE): cv.longitude,
+                vol.Optional(CONF_RADIUS): vol.Coerce(float),
+                vol.Optional(CONF_ICON): str,
+                vol.Optional(CONF_PASSIVE): bool,
+            }),
+            errors=errors,
+        )

--- a/homeassistant/components/qwikswitch/qsusb.py
+++ b/homeassistant/components/qwikswitch/qsusb.py
@@ -1,15 +1,9 @@
-"""
-Support for Qwikswitch devices.
-
-For more details about this component, please refer to the documentation at
-https://home-assistant.io/components/qwikswitch/
-"""
+"""Implementation of the QS USB Hub."""
 import logging
 
 import voluptuous as vol
 
 from homeassistant.components.binary_sensor import DEVICE_CLASSES_SCHEMA
-from homeassistant.components.light import ATTR_BRIGHTNESS
 from homeassistant.const import (
     CONF_SENSORS, CONF_SWITCHES, CONF_URL, EVENT_HOMEASSISTANT_START,
     EVENT_HOMEASSISTANT_STOP)
@@ -17,18 +11,15 @@ from homeassistant.core import callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.discovery import load_platform
-from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['pyqwikswitch==0.8']
+from .qs import DOMAIN
 
-_LOGGER = logging.getLogger(__name__)
-
-DOMAIN = 'qwikswitch'
 
 CONF_DIMMER_ADJUST = 'dimmer_adjust'
 CONF_BUTTON_EVENTS = 'button_events'
 CV_DIM_VALUE = vol.All(vol.Coerce(float), vol.Range(min=1, max=3))
 
+_LOGGER = logging.getLogger(__name__)
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
@@ -48,72 +39,6 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(CONF_SWITCHES, default=[]): vol.All(
             cv.ensure_list, [str])
     })}, extra=vol.ALLOW_EXTRA)
-
-
-class QSEntity(Entity):
-    """Qwikswitch Entity base."""
-
-    def __init__(self, qsid, name):
-        """Initialize the QSEntity."""
-        self._name = name
-        self.qsid = qsid
-
-    @property
-    def name(self):
-        """Return the name of the sensor."""
-        return self._name
-
-    @property
-    def poll(self):
-        """QS sensors gets packets in update_packet."""
-        return False
-
-    @property
-    def unique_id(self):
-        """Return a unique identifier for this sensor."""
-        return "qs{}".format(self.qsid)
-
-    @callback
-    def update_packet(self, packet):
-        """Receive update packet from QSUSB. Match dispather_send signature."""
-        self.async_schedule_update_ha_state()
-
-    async def async_added_to_hass(self):
-        """Listen for updates from QSUSb via dispatcher."""
-        self.hass.helpers.dispatcher.async_dispatcher_connect(
-            self.qsid, self.update_packet)
-
-
-class QSToggleEntity(QSEntity):
-    """Representation of a Qwikswitch Toggle Entity.
-
-    Implemented:
-     - QSLight extends QSToggleEntity and Light[2] (ToggleEntity[1])
-     - QSSwitch extends QSToggleEntity and SwitchDevice[3] (ToggleEntity[1])
-
-    [1] /helpers/entity.py
-    [2] /components/light/__init__.py
-    [3] /components/switch/__init__.py
-    """
-
-    def __init__(self, qsid, qsusb):
-        """Initialize the ToggleEntity."""
-        self.device = qsusb.devices[qsid]
-        super().__init__(qsid, self.device.name)
-
-    @property
-    def is_on(self):
-        """Check if device is on (non-zero)."""
-        return self.device.value > 0
-
-    async def async_turn_on(self, **kwargs):
-        """Turn the device on."""
-        new = kwargs.get(ATTR_BRIGHTNESS, 255)
-        self.hass.data[DOMAIN].devices.set_value(self.qsid, new)
-
-    async def async_turn_off(self, **_):
-        """Turn the device off."""
-        self.hass.data[DOMAIN].devices.set_value(self.qsid, 0)
 
 
 async def async_setup(hass, config):

--- a/homeassistant/components/qwikswitch/strings.json
+++ b/homeassistant/components/qwikswitch/strings.json
@@ -1,0 +1,21 @@
+{
+    "config": {
+        "title": "Zone",
+        "step": {
+            "init": {
+                "title": "Define zone parameters",
+                "data": {
+                    "name": "Name",
+                    "latitude": "Latitude",
+                    "longitude": "Longitude",
+                    "radius": "Radius",
+                    "passive": "Passive",
+                    "icon": "Icon"
+                }
+            }
+        },
+        "error": {
+            "name_exists": "Name already exists"
+        }
+    }
+}

--- a/homeassistant/components/qwikswitch/strings.json
+++ b/homeassistant/components/qwikswitch/strings.json
@@ -1,20 +1,18 @@
 {
     "config": {
-        "title": "Zone",
+        "title": "QwikSwitch Cloud Hub",
         "step": {
             "init": {
-                "title": "Define zone parameters",
+                "title": "Connect to QS cloud",
                 "data": {
-                    "name": "Name",
-                    "latitude": "Latitude",
-                    "longitude": "Longitude",
-                    "radius": "Radius",
-                    "passive": "Passive",
-                    "icon": "Icon"
+                    "name": "Name (default: QS cloud)",
+                    "email": "Email",
+                    "password": "Password"
                 }
             }
         },
         "error": {
+            "no_key": "Couldn't get an API key",
             "name_exists": "Name already exists"
         }
     }

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -149,6 +149,7 @@ FLOWS = [
     'mqtt',
     'nest',
     'openuv',
+    'qwikswitch',
     'simplisafe',
     'smhi',
     'sonos',


### PR DESCRIPTION
## Description:
Adding QS Cloud Hub with config entries

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
