### PR TITLE
Upgrade to asuswrt 1.1.1 to better handle mac addresses with letters in them

### DIFF
--- a/homeassistant/components/device_tracker/asuswrt.py
+++ b/homeassistant/components/device_tracker/asuswrt.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
     CONF_HOST, CONF_PASSWORD, CONF_USERNAME, CONF_PORT, CONF_MODE,
     CONF_PROTOCOL)
 
-REQUIREMENTS = ['aioasuswrt==1.1.0']
+REQUIREMENTS = ['aioasuswrt==1.1.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -88,7 +88,7 @@ abodepy==0.14.0
 afsapi==0.0.4
 
 # homeassistant.components.device_tracker.asuswrt
-aioasuswrt==1.1.0
+aioasuswrt==1.1.1
 
 # homeassistant.components.device_tracker.automatic
 aioautomatic==0.6.5


### PR DESCRIPTION
## Description:

No new change needed to home assistant, the backend library had an issue processing mac addresses from one command.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.
