### PR TITLE
Fetch summary for daily Darksky forecasts

### DIFF
--- a/homeassistant/components/sensor/darksky.py
+++ b/homeassistant/components/sensor/darksky.py
@@ -43,7 +43,7 @@ DEPRECATED_SENSOR_TYPES = {
 # Sensor types are defined like so:
 # Name, si unit, us unit, ca unit, uk unit, uk2 unit
 SENSOR_TYPES = {
-    'summary': ['Summary', None, None, None, None, None, None, []],
+    'summary': ['Summary', None, None, None, None, None, None, ['daily']],
     'minutely_summary': ['Minutely Summary',
                          None, None, None, None, None, None, []],
     'hourly_summary': ['Hourly Summary', None, None, None, None, None, None,

--- a/tests/components/sensor/test_darksky.py
+++ b/tests/components/sensor/test_darksky.py
@@ -154,7 +154,7 @@ class TestDarkSkySetup(unittest.TestCase):
 
         assert mock_get_forecast.called
         assert mock_get_forecast.call_count == 1
-        assert len(self.hass.states.entity_ids()) == 7
+        assert len(self.hass.states.entity_ids()) == 9
 
         state = self.hass.states.get('sensor.dark_sky_summary')
         assert state is not None


### PR DESCRIPTION
## Description:

Dark Sky service provides a summary for each forecast day. This (very simple) change will introduce a new entity `sensor.dark_sky_summary_<day>` for each corresponding day listed in `forecast` parameter.

## Example entry for `configuration.yaml`:
```yaml
- platform: darksky
  forecast:
    - 1
  monitored_conditions:
    - summary
```

## Checklist:
  - [X] The code change is tested and works locally.