### PR TITLE
Bumping aioasuswrt to 1.1.2

### DIFF
--- a/homeassistant/components/device_tracker/asuswrt.py
+++ b/homeassistant/components/device_tracker/asuswrt.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
     CONF_HOST, CONF_PASSWORD, CONF_USERNAME, CONF_PORT, CONF_MODE,
     CONF_PROTOCOL)
 
-REQUIREMENTS = ['aioasuswrt==1.1.1']
+REQUIREMENTS = ['aioasuswrt==1.1.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -88,7 +88,7 @@ abodepy==0.14.0
 afsapi==0.0.4
 
 # homeassistant.components.device_tracker.asuswrt
-aioasuswrt==1.1.1
+aioasuswrt==1.1.2
 
 # homeassistant.components.device_tracker.automatic
 aioautomatic==0.6.5


### PR DESCRIPTION
## Description:
If there is no known_hosts file the component would fail.

**Related issue (if applicable):** fixes #17983

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
