### PR TITLE
Report correct thermostat mode to Alexa

### DIFF
--- a/homeassistant/components/alexa/smart_home.py
+++ b/homeassistant/components/alexa/smart_home.py
@@ -1839,11 +1839,17 @@ async def async_api_set_thermostat_mode(hass, config, directive, context):
         climate.ATTR_OPERATION_MODE: ha_mode,
     }
 
+    response = directive.response()
     await hass.services.async_call(
         entity.domain, climate.SERVICE_SET_OPERATION_MODE, data,
         blocking=False, context=context)
+    response.add_context_property({
+        'name': 'thermostatMode',
+        'namespace': 'Alexa.ThermostatController',
+        'value': mode,
+    })
 
-    return directive.response()
+    return response
 
 
 @HANDLERS.register(('Alexa', 'ReportState'))

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -873,22 +873,41 @@ async def test_thermostat(hass):
     )
     assert msg['event']['payload']['type'] == 'TEMPERATURE_VALUE_OUT_OF_RANGE'
 
-    call, _ = await assert_request_calls_service(
+    # Setting mode, the payload can be an object with a value attribute...
+    call, msg = await assert_request_calls_service(
         'Alexa.ThermostatController', 'SetThermostatMode',
         'climate#test_thermostat', 'climate.set_operation_mode',
         hass,
         payload={'thermostatMode': {'value': 'HEAT'}}
     )
     assert call.data['operation_mode'] == 'heat'
+    properties = _ReportedProperties(msg['context']['properties'])
+    properties.assert_equal(
+        'Alexa.ThermostatController', 'thermostatMode', 'HEAT')
 
-    call, _ = await assert_request_calls_service(
+    call, msg = await assert_request_calls_service(
+        'Alexa.ThermostatController', 'SetThermostatMode',
+        'climate#test_thermostat', 'climate.set_operation_mode',
+        hass,
+        payload={'thermostatMode': {'value': 'COOL'}}
+    )
+    assert call.data['operation_mode'] == 'cool'
+    properties = _ReportedProperties(msg['context']['properties'])
+    properties.assert_equal(
+        'Alexa.ThermostatController', 'thermostatMode', 'COOL')
+
+    # ...it can also be just the mode.
+    call, msg = await assert_request_calls_service(
         'Alexa.ThermostatController', 'SetThermostatMode',
         'climate#test_thermostat', 'climate.set_operation_mode',
         hass,
         payload={'thermostatMode': 'HEAT'}
     )
-
     assert call.data['operation_mode'] == 'heat'
+    properties = _ReportedProperties(msg['context']['properties'])
+    properties.assert_equal(
+        'Alexa.ThermostatController', 'thermostatMode', 'HEAT')
+
     msg = await assert_request_fails(
         'Alexa.ThermostatController', 'SetThermostatMode',
         'climate#test_thermostat', 'climate.set_operation_mode',


### PR DESCRIPTION
## Description:

We were erroneously reporting the _previous_ mode. So if the thermostat was off
and the user asks, "Alexa, set the thermostat to heat", the thermostat would be
set to heat but Alexa would respond, "The thermostat is off."

Bug caught by @Thunderbird2086 at
https://github.com/home-assistant/home-assistant/pull/17969#issuecomment-434654345

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
