### PR TITLE
Add functionality to the version sensor

### DIFF
--- a/homeassistant/components/sensor/version.py
+++ b/homeassistant/components/sensor/version.py
@@ -40,6 +40,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
                                                                cv.string),
 })
 
+
 async def async_setup_platform(
         hass, config, async_add_entities, discovery_info=None):
     """Set up the Version sensor platform."""

--- a/homeassistant/components/sensor/version.py
+++ b/homeassistant/components/sensor/version.py
@@ -1,42 +1,75 @@
 """
-Support for displaying the current version of Home Assistant.
+Sensor that can displaying the current Home Assistant versions.
 
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.version/
 """
 import logging
+from datetime import timedelta
 
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import __version__, CONF_NAME
+from homeassistant.const import CONF_NAME, CONF_SOURCE
 from homeassistant.helpers.entity import Entity
+from homeassistant.util import Throttle
+
+REQUIREMENTS = ['pyhaversion==2.0.1']
 
 _LOGGER = logging.getLogger(__name__)
 
-DEFAULT_NAME = "Current Version"
+CONF_BETA = 'beta'
+CONF_IMAGE = 'image'
+
+DEFAULT_IMAGE = 'default'
+DEFAULT_NAME = "Home Assistant Version"
+DEFAULT_SOURCE = 'local'
+
+ICON = 'mdi:package-up'
+
+TIME_BETWEEN_UPDATES = timedelta(minutes=5)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_BETA, default=False): cv.boolean,
+    vol.Optional(CONF_IMAGE, default=DEFAULT_IMAGE): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_SOURCE, default=DEFAULT_SOURCE): cv.string,
 })
 
 
 async def async_setup_platform(
         hass, config, async_add_entities, discovery_info=None):
     """Set up the Version sensor platform."""
+    from pyhaversion import Version
+    beta = config.get(CONF_BETA)
+    image = config.get(CONF_IMAGE).lower()
     name = config.get(CONF_NAME)
+    source = config.get(CONF_SOURCE).lower()
 
-    async_add_entities([VersionSensor(name)])
+    session = async_get_clientsession(hass)
+    if beta:
+        branch = 'beta'
+    else:
+        branch = 'stable'
+    haversion = VersionData(Version(hass.loop, session, branch, image), source)
+
+    async_add_entities([VersionSensor(haversion, name)], True)
 
 
 class VersionSensor(Entity):
     """Representation of a Home Assistant version sensor."""
 
-    def __init__(self, name):
+    def __init__(self, haversion, name):
         """Initialize the Version sensor."""
+        self.haversion = haversion
         self._name = name
-        self._state = __version__
+        self._state = None
+
+    async def async_update(self):
+        """Get the latest version information."""
+        await self.haversion.async_update()
 
     @property
     def name(self):
@@ -44,11 +77,32 @@ class VersionSensor(Entity):
         return self._name
 
     @property
-    def should_poll(self):
-        """No polling needed."""
-        return False
-
-    @property
     def state(self):
         """Return the state of the sensor."""
-        return self._state
+        return self.haversion.api.version
+
+    @property
+    def device_state_attributes(self):
+        """Return attributes for the sensor."""
+        return self.haversion.api.version_data
+
+
+class VersionData:
+    """Get the latest data and update the states."""
+
+    def __init__(self, api, source):
+        """Initialize the data object."""
+        self.api = api
+        self.source = source
+
+    @Throttle(TIME_BETWEEN_UPDATES)
+    async def async_update(self):
+        """Get the latest version information."""
+        if self.source == 'pypi':
+            await self.api.get_pypi_version()
+        elif self.source == 'hassio':
+            await self.api.get_hassio_version()
+        elif self.source == 'docker':
+            await self.api.get_docker_version()
+        else:
+            await self.api.get_local_version()

--- a/homeassistant/components/sensor/version.py
+++ b/homeassistant/components/sensor/version.py
@@ -33,11 +33,11 @@ TIME_BETWEEN_UPDATES = timedelta(minutes=5)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_BETA, default=False): cv.boolean,
-    vol.Optional(CONF_IMAGE, default=DEFAULT_IMAGE): vol.All(vol.Lower,
-                                                             cv.string),
+    vol.Optional(CONF_IMAGE, default=DEFAULT_IMAGE): vol.All(cv.string,
+                                                             vol.Lower),
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional(CONF_SOURCE, default=DEFAULT_SOURCE): vol.All(vol.Lower,
-                                                               cv.string),
+    vol.Optional(CONF_SOURCE, default=DEFAULT_SOURCE): vol.All(cv.string,
+                                                               vol.Lower),
 })
 
 

--- a/homeassistant/components/sensor/version.py
+++ b/homeassistant/components/sensor/version.py
@@ -24,7 +24,7 @@ CONF_BETA = 'beta'
 CONF_IMAGE = 'image'
 
 DEFAULT_IMAGE = 'default'
-DEFAULT_NAME = "Home Assistant Version"
+DEFAULT_NAME = "Current Version"
 DEFAULT_SOURCE = 'local'
 
 ICON = 'mdi:package-up'

--- a/homeassistant/components/sensor/version.py
+++ b/homeassistant/components/sensor/version.py
@@ -1,5 +1,5 @@
 """
-Sensor that can displaying the current Home Assistant versions.
+Sensor that can display the current Home Assistant versions.
 
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.version/

--- a/homeassistant/components/sensor/version.py
+++ b/homeassistant/components/sensor/version.py
@@ -33,20 +33,21 @@ TIME_BETWEEN_UPDATES = timedelta(minutes=5)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_BETA, default=False): cv.boolean,
-    vol.Optional(CONF_IMAGE, default=DEFAULT_IMAGE): cv.string,
+    vol.Optional(CONF_IMAGE, default=DEFAULT_IMAGE): vol.All(vol.Lower,
+                                                             cv.string),
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional(CONF_SOURCE, default=DEFAULT_SOURCE): cv.string,
+    vol.Optional(CONF_SOURCE, default=DEFAULT_SOURCE): vol.All(vol.Lower,
+                                                               cv.string),
 })
-
 
 async def async_setup_platform(
         hass, config, async_add_entities, discovery_info=None):
     """Set up the Version sensor platform."""
     from pyhaversion import Version
     beta = config.get(CONF_BETA)
-    image = config.get(CONF_IMAGE).lower()
+    image = config.get(CONF_IMAGE)
     name = config.get(CONF_NAME)
-    source = config.get(CONF_SOURCE).lower()
+    source = config.get(CONF_SOURCE)
 
     session = async_get_clientsession(hass)
     if beta:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -915,6 +915,9 @@ pygtfs-homeassistant==0.1.3.dev0
 # homeassistant.components.remote.harmony
 pyharmony==1.0.20
 
+# homeassistant.components.sensor.version
+pyhaversion==2.0.1
+
 # homeassistant.components.binary_sensor.hikvision
 pyhik==0.1.8
 


### PR DESCRIPTION
## Description:
This PR adds more functionality to the existing `version` sensor platform.
It can track the published version from multiple sources:

- Current locally installed version (Like it does now)
- PyPi for manual installations
- Dockerhub for docker installs
- The files hosted on AWS for hassio installations.

This change utilizes [pyhaversion](https://github.com/ludeeus/pyhaversion) to fetch new information.
For hassio installations there is also some extra version attributes:

- hassos
- supervisor
- hassos-cli

It defaults to track `local` so that current users of this sensor will not have any issues.

<!-- **Related issue (if applicable):** fixes #<home-assistant issue number goes here> -->

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#7305

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  platform: version
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
