### PR TITLE
Revert HAP-python update

### DIFF
--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -29,7 +29,7 @@ from .const import (
 from .util import (
     show_setup_message, validate_entity_config, validate_media_player_features)
 
-REQUIREMENTS = ['HAP-python==2.3.0']
+REQUIREMENTS = ['HAP-python==2.2.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/homekit/type_switches.py
+++ b/homeassistant/components/homekit/type_switches.py
@@ -2,8 +2,7 @@
 import logging
 
 from pyhap.const import (
-    CATEGORY_FAUCET, CATEGORY_OUTLET, CATEGORY_SHOWER_HEAD,
-    CATEGORY_SPRINKLER, CATEGORY_SWITCH)
+    CATEGORY_OUTLET, CATEGORY_SWITCH)
 
 from homeassistant.components.switch import DOMAIN
 from homeassistant.const import (
@@ -18,6 +17,10 @@ from .const import (
     TYPE_SPRINKLER, TYPE_VALVE)
 
 _LOGGER = logging.getLogger(__name__)
+
+CATEGORY_SPRINKLER = 28
+CATEGORY_FAUCET = 29
+CATEGORY_SHOWER_HEAD = 30
 
 VALVE_TYPE = {
     TYPE_FAUCET: (CATEGORY_FAUCET, 3),

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -35,7 +35,7 @@ Adafruit-SHT31==1.0.2
 DoorBirdPy==0.1.3
 
 # homeassistant.components.homekit
-HAP-python==2.3.0
+HAP-python==2.2.2
 
 # homeassistant.components.notify.mastodon
 Mastodon.py==1.3.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -19,7 +19,7 @@ requests_mock==1.5.2
 
 
 # homeassistant.components.homekit
-HAP-python==2.3.0
+HAP-python==2.2.2
 
 # homeassistant.components.sensor.rmvtransport
 PyRMVtransport==0.1.3

--- a/tests/components/homekit/test_type_locks.py
+++ b/tests/components/homekit/test_type_locks.py
@@ -82,7 +82,6 @@ async def test_no_code(hass, hk_driver, config, events):
     # Set from HomeKit
     call_lock = async_mock_service(hass, DOMAIN, 'lock')
 
-    acc.char_target_state.value = 0
     await hass.async_add_job(acc.char_target_state.client_update_value, 1)
     await hass.async_block_till_done()
     assert call_lock

--- a/tests/components/homekit/test_type_media_players.py
+++ b/tests/components/homekit/test_type_media_players.py
@@ -64,7 +64,6 @@ async def test_media_player_set_state(hass, hk_driver, events):
     call_media_stop = async_mock_service(hass, DOMAIN, 'media_stop')
     call_toggle_mute = async_mock_service(hass, DOMAIN, 'volume_mute')
 
-    acc.chars[FEATURE_ON_OFF].value = False
     await hass.async_add_job(acc.chars[FEATURE_ON_OFF]
                              .client_update_value, True)
     await hass.async_block_till_done()


### PR DESCRIPTION
## Description:
This PR reverts the `HAP-python` update made with #17778
Although early testing looked promising, it turned out to cause more errors than it solved.

https://github.com/home-assistant/home-assistant/issues/17944
https://github.com/home-assistant/home-assistant/issues/15675#issuecomment-433676912

Unfortunately this will reopen #17557. However I'll work on a Home Assistant side fix for it soon.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

---

CC: @wasp100, @timothybrown, @dmonagle, @ehendrix23 