### PR TITLE
Buttons and sensors connected to I²c expanders managed from  Raspberry Pi

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -190,8 +190,15 @@ omit =
     homeassistant/components/rfxtrx.py
     homeassistant/components/*/rfxtrx.py
 
+    homeassistant/components/rpi_i2c_chips/*.py
+
     homeassistant/components/rpi_gpio.py
     homeassistant/components/*/rpi_gpio.py
+    
+    homeassistant/components/rpi_i2c_expanders.py
+    homeassistant/components/*/rpi_i2c_expanders.py
+
+    homeassistant/components/rpi_i2c_ha_expanders.py
 
     homeassistant/components/rpi_pfio.py
     homeassistant/components/*/rpi_pfio.py

--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,11 @@ virtualization/vagrant/config
 # Visual Studio Code
 .vscode
 
+# Eric6 IDE
+.eric6project
+*.e4p
+
+
 # Built docs
 docs/build
 

--- a/homeassistant/components/binary_sensor/rpi_i2c_expanders.py
+++ b/homeassistant/components/binary_sensor/rpi_i2c_expanders.py
@@ -1,0 +1,131 @@
+"""
+Support for binary sensor based on  I²C port expanders
+
+Example configuration:
+
+binary_sensor:
+  - platform: rpi_gpio
+    ports:
+      17: GPIO17
+  - platform: rpi_i2c_expanders
+    chips:
+        0x20: 
+           hw: MCP23018
+           ports:
+               6: P20_IN_6
+           invert_logic_ports: [ 6, ]
+        0x24: 
+            hw: PCF8574
+            ports:
+                7: P24_IN_7
+            invert_logic_ports: [ 7, ]
+
+"""
+
+# TODO:
+# For more details about this component, please refer to the documentation at
+# https://home-assistant.io/components/TODO/
+
+
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components import rpi_i2c_expanders
+import homeassistant.helpers.config_validation as cv
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDevice, PLATFORM_SCHEMA)
+
+_LOGGER = logging.getLogger(__name__)
+
+DEPENDENCIES = ['rpi_i2c_expanders']
+
+
+# TODO: Merge in components.rpi_i2c_expanders ?
+i2c_bus_port = vol.All(vol.Coerce(int), vol.Range(min=0, max=255))
+
+_SWITCHES_SCHEMA = vol.Schema({
+    cv.positive_int: cv.string,
+})
+
+_CHIP_SCHEMA = vol.Schema({
+    vol.Required("hw"): cv.string,
+    vol.Required("ports"): _SWITCHES_SCHEMA,
+    vol.Optional("invert_logic_ports"): [cv.positive_int],
+})
+
+_CHIPS_SCHEMA = vol.Schema({
+    i2c_bus_port: _CHIP_SCHEMA,
+})
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required("chips"): _CHIPS_SCHEMA,
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Setup RPi I²C based I/O expanders."""
+    ## import awesomelights
+
+    import homeassistant.components.rpi_i2c_expanders
+
+    managed_chips = homeassistant.components.rpi_i2c_expanders.g_managed_chips
+
+    sensors = []
+    chips = config.get("chips")
+
+    for address, chip in chips.items():
+        chip_id = chip["hw"]
+        invert_logic_ports = chip.get('invert_logic_ports', ())
+        managed_chip = managed_chips.manage_chip(address, chip_id)
+        _LOGGER.debug("address: 0x%x chip_id: %r -> managed_chip: %r, invert_logic_ports: %r",
+                      address, chip_id,  managed_chip, invert_logic_ports, )
+        for pin, name in chip["ports"].items():
+            invert_logic = pin in invert_logic_ports
+            expander_sensor = ExpanderSensor(name, managed_chip, invert_logic)
+            managed_chip.pin_connect(pin, expander_sensor)
+            sensors.append(expander_sensor)
+            _LOGGER.debug("address: 0x%x managed_chip: %r: pin: %r connected to expander sensor: %r",
+                          address, managed_chip, pin, expander_sensor, )
+        managed_chip.ha_configure()  # HW configuration of chip
+
+    # NOTE: Seems g_pollwatcher is not yet set up
+    add_devices(sensors)
+    _LOGGER.info("rpi_i2c_expanders setup finished")
+
+
+class ExpanderSensor(BinarySensorDevice):
+    """Representation of a sensor based on Expander."""
+
+    def __init__(self, name, ha_expander, invert_logic):
+        """Initialize the sensor."""
+        self._name = name
+        self._ha_expander = ha_expander  # HAExpander
+        self._invert_logic = bool(invert_logic)
+        self._state = None
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def should_poll(self):
+        """No polling needed."""
+        return False
+
+    @property
+    def is_on(self):
+        """Return the state of the entity."""
+        return self._state != self._invert_logic
+
+    def update(self):
+        """Fetch new state data for the sensor.
+        This is the only method that should fetch new data for Home Assistant.
+        """
+        # self._state = 1
+        pass
+
+    def set_state(self, new_state):
+        self._state = new_state

--- a/homeassistant/components/binary_sensor/rpi_i2c_expanders.py
+++ b/homeassistant/components/binary_sensor/rpi_i2c_expanders.py
@@ -9,12 +9,12 @@ binary_sensor:
       17: GPIO17
   - platform: rpi_i2c_expanders
     chips:
-        0x20: 
+        0x20:
            hw: MCP23018
            ports:
                6: P20_IN_6
            invert_logic_ports: [ 6, ]
-        0x24: 
+        0x24:
             hw: PCF8574
             ports:
                 7: P24_IN_7
@@ -66,12 +66,10 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup RPi I²C based I/O expanders."""
-    ## import awesomelights
 
     import homeassistant.components.rpi_i2c_expanders
 
     managed_chips = homeassistant.components.rpi_i2c_expanders.g_managed_chips
-
     sensors = []
     chips = config.get("chips")
 
@@ -80,7 +78,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         invert_logic_ports = chip.get("invert_logic_ports", ())
         managed_chip = managed_chips.manage_chip(address, chip_id)
         _LOGGER.debug(
-            "address: 0x%x chip_id: %r -> managed_chip: %r, invert_logic_ports: %r",
+            "address: 0x%x chip_id: %r -> managed_chip: %r,"
+            " invert_logic_ports: %r",
             address,
             chip_id,
             managed_chip,
@@ -92,7 +91,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             managed_chip.pin_connect(pin, expander_sensor)
             sensors.append(expander_sensor)
             _LOGGER.debug(
-                "address: 0x%x managed_chip: %r: pin: %r connected to expander sensor: %r",
+                "address: 0x%x managed_chip: %r: pin: %r "
+                "connected to expander sensor: %r",
                 address,
                 managed_chip,
                 pin,

--- a/homeassistant/components/binary_sensor/rpi_i2c_expanders.py
+++ b/homeassistant/components/binary_sensor/rpi_i2c_expanders.py
@@ -31,7 +31,6 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.components import rpi_i2c_expanders
 import homeassistant.helpers.config_validation as cv
 
 from homeassistant.components.binary_sensor import (

--- a/homeassistant/components/rpi_i2c_chips/MCP23018.py
+++ b/homeassistant/components/rpi_i2c_chips/MCP23018.py
@@ -12,6 +12,7 @@ class MCP23018(Expander):
     """
     MCP23018 register definitions
     """
+
     # Common to all Exapnders
     PIN_COUNT = 16
     MASK = (1 << PIN_COUNT) - 1  # 0xffff
@@ -27,12 +28,12 @@ class MCP23018(Expander):
     DEFVALB = 0x07
     INTCONA = 0x08
     INTCONB = 0x09
-    IOCON = 0x0a
+    IOCON = 0x0A
     # IOCON    = 0x0b  # duplicate
-    GPPUA = 0x0c
-    GPPUB = 0x0d
-    INTFA = 0x0e
-    INTFB = 0x0f
+    GPPUA = 0x0C
+    GPPUB = 0x0D
+    INTFA = 0x0E
+    INTFB = 0x0F
     INTCAPA = 0x10
     INTCAPB = 0x11
     GPIOA = 0x12
@@ -68,7 +69,8 @@ class MCP23018(Expander):
     def __init__(self, bus, address, log=module_logger):
         if address < 0x20 or address >= 0x20 + 8:
             raise ValueError(
-                "Invalid device address: 0x%x for MCP23018" % (address, ))
+                "Invalid device address: 0x%x for MCP23018" % (address,)
+            )
         super().__init__(bus, address, log)
         ## self.log.debug("%s init done", self)
 
@@ -76,7 +78,7 @@ class MCP23018(Expander):
         """Sets chip like after power on reset.
         """
         # TODO: What if chip is in BANK=1 mode ?
-        self.set_inputs(0xffff)
+        self.set_inputs(0xFFFF)
 
     class IOCON_Register(Register):
         """ IOCON – I/O EXPANDER CONFIGURATION REGISTER
@@ -89,8 +91,10 @@ class MCP23018(Expander):
             INT pin to activate
 
         """
+
         _bitnames = Register.parse_bitnames(
-            "BANK MIRROR SEQOP _ _ ODR INTPOL INTCC")
+            "BANK MIRROR SEQOP _ _ ODR INTPOL INTCC"
+        )
         _bitaliases = Register.parse_bitaliases(_bitnames)
 
     def set_IOCON(self, reg):  # TODO : rename to set_IOCON ?
@@ -109,6 +113,7 @@ class MCP23018(Expander):
         When a bit is set, the corresponding pin becomes an input. 
         When a bit is clear, the corresponding pin becomes an output.
         """
+
         _bitnames = Register.gen_bitnames(8, "IO")  # IO7 .. IO0
         _bitaliases = Register.parse_bitaliases(_bitnames)
 
@@ -131,6 +136,7 @@ class MCP23018(Expander):
         If a bit is set, the corresponding GPIO register bit will
         reflect the inverted value on the pin.
         """
+
         _bitnames = Register.gen_bitnames(8, "IP")  # IP7 .. IP0
         _bitaliases = Register.parse_bitaliases(_bitnames)
 
@@ -154,6 +160,7 @@ class MCP23018(Expander):
         internally pulled up with an internal resistor.
         150 microA for 3.3V in 25°C
         """
+
         _bitnames = Register.gen_bitnames(8, "PU")  # PU7 .. PU0
         _bitaliases = Register.parse_bitaliases(_bitnames)
 
@@ -172,12 +179,12 @@ class MCP23018(Expander):
         return self.GPPU_Register(val)
 
     def set_GPPU(self, mask):
-        self.bus_write_byte_data(self.GPPUA, mask & 0xff)
-        self.bus_write_byte_data(self.GPPUB, (mask >> 8) & 0xff)
+        self.bus_write_byte_data(self.GPPUA, mask & 0xFF)
+        self.bus_write_byte_data(self.GPPUB, (mask >> 8) & 0xFF)
 
     def read_GPPU(self, mask):
         mask = self.bus_read_byte_data(self.GPPUA)
-        mask |= (self.bus_read_byte_data(self.GPPUB) << 8)
+        mask |= self.bus_read_byte_data(self.GPPUB) << 8
         return mask
 
     class GPIO_Register(Register):
@@ -185,6 +192,7 @@ class MCP23018(Expander):
         Reading from this register reads the port. Writing to this
         register modifies the Output Latch (OLAT) register.
         """
+
         # gen_bitnames(num, prefix)
         _bitnames = Register.gen_bitnames(8, "GP")  # GP7 .. GP0
         _bitaliases = Register.parse_bitaliases(_bitnames)
@@ -204,12 +212,12 @@ class MCP23018(Expander):
         return self.GPIO_Register(val)
 
     def set_GPIO(self, mask):
-        self.bus_write_byte_data(self.GPIOA, mask & 0xff)
-        self.bus_write_byte_data(self.GPIOB, (mask >> 8) & 0xff)
+        self.bus_write_byte_data(self.GPIOA, mask & 0xFF)
+        self.bus_write_byte_data(self.GPIOB, (mask >> 8) & 0xFF)
 
     def read_GPIO(self):
         mask = self.bus_read_byte_data(self.GPIOA)
-        mask |= (self.bus_read_byte_data(self.GPIOB) << 8)
+        mask |= self.bus_read_byte_data(self.GPIOB) << 8
         # TODO: Should use 16bit wide GPIO_Register16 having GPA0..GPA7,GPB0..GPB7 ?
         return mask
 
@@ -226,28 +234,35 @@ class MCP23018(Expander):
         Configuraiton tries to preserve previous state of chip as much as possible.
 
         """
-        self.log.debug("CALLED: configure(%s,outputs_mask=%r,inputs_mask=%r,pull_up_mask=%r) ",
-                       self, outputs_mask, inputs_mask, pull_ups_mask)
+        self.log.debug(
+            "CALLED: configure(%s,outputs_mask=%r,inputs_mask=%r,pull_up_mask=%r) ",
+            self,
+            outputs_mask,
+            inputs_mask,
+            pull_ups_mask,
+        )
 
         super().configure(outputs_mask, inputs_mask, pull_ups_mask)
 
         outputs_mask_b, outputs_mask_a = self.mask_split2bytes(
-            self.outputs_mask)
+            self.outputs_mask
+        )
         # When a bit is zero, the corresponding pin becomes an output.
         self.set_IODIRA(self.byte_invert(outputs_mask_a))
         self.set_IODIRB(self.byte_invert(outputs_mask_b))
 
         pull_ups_mask_b, pull_ups_mask_a = self.mask_split2bytes(
-            self.pull_ups_mask)
+            self.pull_ups_mask
+        )
         self.set_GPPUA(pull_ups_mask_a)
         self.set_GPPUB(pull_ups_mask_b)
 
-    def set_outputs(self, mask,):
+    def set_outputs(self, mask):
         mask = self.mask(mask)
-        self.set_outputs_a(mask & 0xff)
-        self.set_outputs_b((mask >> 8) & 0xff)
+        self.set_outputs_a(mask & 0xFF)
+        self.set_outputs_b((mask >> 8) & 0xFF)
         self.outputs_state = mask
-        self.log.debug("%s set_outputs(mask=0x%X).",  self, self.outputs_state)
+        self.log.debug("%s set_outputs(mask=0x%X).", self, self.outputs_state)
 
     def verify_outputs(self):
         """
@@ -256,12 +271,21 @@ class MCP23018(Expander):
         gpio = self.read_GPIO()
         actual_outputs_mask = int(gpio) & self.outputs_mask
         # Inputs state: 65535 (0xFFFF) usually means chip was reset.
-        self.log.debug("Verified inputs state: %s (0x%X) outputs_masked: 0x%X expected: 0x%X", gpio, int(
-            gpio), actual_outputs_mask, self.outputs_state)
+        self.log.debug(
+            "Verified inputs state: %s (0x%X) outputs_masked: 0x%X expected: 0x%X",
+            gpio,
+            int(gpio),
+            actual_outputs_mask,
+            self.outputs_state,
+        )
         if actual_outputs_mask != self.outputs_state:
             # NOTE: Below we work on real ports state, not logical, as values may be inverted.
-            self.log.warn("Outputs state mismatch. Read inputs: 0x%X , outputs_masked: 0x%X but expected: 0x%X", int(
-                gpio), actual_outputs_mask, self.outputs_state)
+            self.log.warn(
+                "Outputs state mismatch. Read inputs: 0x%X , outputs_masked: 0x%X but expected: 0x%X",
+                int(gpio),
+                actual_outputs_mask,
+                self.outputs_state,
+            )
             return False
         return True
 
@@ -281,9 +305,12 @@ class MCP23018(Expander):
 
 if __name__ == "__main__":
     logging.basicConfig(
-        level=logging.DEBUG, format='%(relativeCreated)6d %(threadName)s %(message)s')
+        level=logging.DEBUG,
+        format="%(relativeCreated)6d %(threadName)s %(message)s",
+    )
 
     import smbus
+
     # bus = smbus.SMBus(0)  # Rev 1 Pi uses 0
     bus1 = smbus.SMBus(1)  # Rev 2 Pi uses 1
     mcp23018 = MCP23018(bus1, 0x20)
@@ -295,35 +322,38 @@ if __name__ == "__main__":
         # subprocess.call(['i2cdetect', '-y', '1'])
         # i2cdetect -y 1
 
-        print ("Initial conf_reg: %s" % (conf_reg, ))
+        print("Initial conf_reg: %s" % (conf_reg,))
         conf_reg.MIRROR = 1
         mcp23018.set_configuration(conf_reg)
         conf_reg = mcp23018.read_configuration()
-        print ("After updated conf_reg: %s (MIRROR should be 1)" % (conf_reg, ))
+        print("After updated conf_reg: %s (MIRROR should be 1)" % (conf_reg,))
         conf_reg.MIRROR = 0
         mcp23018.set_configuration(conf_reg)
         conf_reg = mcp23018.read_configuration()
-        print ("After 2nd updated conf_reg: %s (MIRROR should be 0)" %
-               (conf_reg, ))
+        print(
+            "After 2nd updated conf_reg: %s (MIRROR should be 0)" % (conf_reg,)
+        )
 
     if 1:
         ## outputs_mask = 0xffff
         outputs_mask = 0x0001
-        print ("Blinking 1Hz on 0x%04x outputs" % (outputs_mask, ))
+        print("Blinking 1Hz on 0x%04x outputs" % (outputs_mask,))
         # configure(self, output_mask, invert_mask, pull_up_mask):
         # Setting all IO ports as outputs
 
-        mcp23018.configure(outputs_mask, mcp23018.MASK-outputs_mask, 0, 0xffff)
+        mcp23018.configure(
+            outputs_mask, mcp23018.MASK - outputs_mask, 0, 0xFFFF
+        )
 
         for i in range(10):
             mcp23018.set_outputs(0)  # All low, draining
             time.sleep(0.5)
-            mcp23018.set_outputs(0xffff)  # All high, no current
+            mcp23018.set_outputs(0xFFFF)  # All high, no current
             time.sleep(0.5)
-        print ("Blinking done.")
+        print("Blinking done.")
 
     if 0:
-        print ("Reading all inputs in endless loop.. Hit CTRL+C to stop.")
+        print("Reading all inputs in endless loop.. Hit CTRL+C to stop.")
         # Set Pullups on all outputs, so they will stay high, but shorting to GND (via pressing button) will drive them low
         # mcp23018.configure_inputs(0xffff,  set_pull_ups = True,  invert=True)
 
@@ -331,20 +361,21 @@ if __name__ == "__main__":
         input_reg = mcp23018.GPIO_Register()
         input_reg.GP7 = 1
         input_reg.GP6 = 1
-        mcp23018.configure_inputs(input_reg,  set_pull_ups=True,  invert=True)
+        mcp23018.configure_inputs(input_reg, set_pull_ups=True, invert=True)
 
         while 1:
             gpio = mcp23018.read_GPIO()
             gpio_a = mcp23018.read_GPIOA()
-            print ("gpio: %04x -> A: %s" % (int(gpio), str(gpio_a)))
+            print("gpio: %04x -> A: %s" % (int(gpio), str(gpio_a)))
             time.sleep(0.1)
 
     if 0:
-        print (
-            "Detecting pushbutton hits via interrputs in endless loop.. Hit CTRL+C to stop.")
-        mcp23018.set_io_direction_input(0xffff)  # 0 means output
+        print(
+            "Detecting pushbutton hits via interrputs in endless loop.. Hit CTRL+C to stop."
+        )
+        mcp23018.set_io_direction_input(0xFFFF)  # 0 means output
         # Set Pullups on all outputs, so they will stay high, but short to GND will drive them low
-        mcp23018.set_GPPU(0xffff)
+        mcp23018.set_GPPU(0xFFFF)
         # Enable interrputs
         mcp23018.set_interrupt_on_change(0x0000)  # Turn off interrupts
         # Configure interrputs to trigger on value different than in DEFVAL
@@ -352,7 +383,7 @@ if __name__ == "__main__":
         gpio = mcp23018.read_gpio()
         # Set default values for interrupt as read from gpio
         mcp23018.set_DEFVAL(gpio)
-        mcp23018.set_interrupt_on_change(0xffff)  # Turn on interrupts
+        mcp23018.set_interrupt_on_change(0xFFFF)  # Turn on interrupts
 
         last_gpio = None
         last_intf = None
@@ -363,8 +394,9 @@ if __name__ == "__main__":
             intf = mcp23018.read_INTF()
 
             if gpio != last_gpio or intf != last_intf or intcap != last_intcap:
-                print ("gpio: %04x intf: %04x intcap: %04x" %
-                       (gpio, intf, intcap, ))
+                print(
+                    "gpio: %04x intf: %04x intcap: %04x" % (gpio, intf, intcap)
+                )
             last_gpio = gpio
             last_intf = intf
             last_intcap = intcap

--- a/homeassistant/components/rpi_i2c_chips/MCP23018.py
+++ b/homeassistant/components/rpi_i2c_chips/MCP23018.py
@@ -72,7 +72,6 @@ class MCP23018(Expander):
                 "Invalid device address: 0x%x for MCP23018" % (address,)
             )
         super().__init__(bus, address, log)
-        ## self.log.debug("%s init done", self)
 
     def reset(self):
         """Sets chip like after power on reset.
@@ -87,7 +86,7 @@ class MCP23018(Expander):
             OR’ed so that an interrupt on either port will cause
             both pins to activate
         MIRROR = 0, the INT pins are separated.
-            Interrupt conditions on a port will cause its respecive 
+            Interrupt conditions on a port will cause its respecive
             INT pin to activate
 
         """
@@ -110,7 +109,7 @@ class MCP23018(Expander):
 
     class IODIR_Register(Register):
         """  IODIR – I/O DIRECTION REGISTER
-        When a bit is set, the corresponding pin becomes an input. 
+        When a bit is set, the corresponding pin becomes an input.
         When a bit is clear, the corresponding pin becomes an output.
         """
 
@@ -218,7 +217,8 @@ class MCP23018(Expander):
     def read_GPIO(self):
         mask = self.bus_read_byte_data(self.GPIOA)
         mask |= self.bus_read_byte_data(self.GPIOB) << 8
-        # TODO: Should use 16bit wide GPIO_Register16 having GPA0..GPA7,GPB0..GPB7 ?
+        # TODO: Should use 16bit wide GPIO_Register16
+        # having GPA0..GPA7,GPB0..GPB7 ?
         return mask
 
     def configure(self, outputs_mask, inputs_mask, pull_ups_mask):
@@ -226,16 +226,18 @@ class MCP23018(Expander):
         Configures chip:
         outputs_mask - whose pins became outputs, rest is configure inputs
         inputs_mask - whose pins became inputs, must not overlap with inputs
-        pull_ups_mask - whose pins have pull ups set, 
+        pull_ups_mask - whose pins have pull ups set,
 
         Only inputs/outputs_mask is configure, rest is left untouched.
         pull_up_mask can be only set for inputs/outputs
 
-        Configuraiton tries to preserve previous state of chip as much as possible.
+        Configuraiton tries to preserve previous state of
+        chip as much as possible.
 
         """
         self.log.debug(
-            "CALLED: configure(%s,outputs_mask=%r,inputs_mask=%r,pull_up_mask=%r) ",
+            "CALLED: configure(%s,outputs_mask=%r,"
+            "inputs_mask=%r,pull_up_mask=%r) ",
             self,
             outputs_mask,
             inputs_mask,
@@ -272,16 +274,19 @@ class MCP23018(Expander):
         actual_outputs_mask = int(gpio) & self.outputs_mask
         # Inputs state: 65535 (0xFFFF) usually means chip was reset.
         self.log.debug(
-            "Verified inputs state: %s (0x%X) outputs_masked: 0x%X expected: 0x%X",
+            "Verified inputs state: %s (0x%X) "
+            "outputs_masked: 0x%X expected: 0x%X",
             gpio,
             int(gpio),
             actual_outputs_mask,
             self.outputs_state,
         )
         if actual_outputs_mask != self.outputs_state:
-            # NOTE: Below we work on real ports state, not logical, as values may be inverted.
+            # NOTE: Below we work on real ports state, not logical,
+            # as values may be inverted.
             self.log.warn(
-                "Outputs state mismatch. Read inputs: 0x%X , outputs_masked: 0x%X but expected: 0x%X",
+                "Outputs state mismatch. Read inputs: 0x%X, "
+                "outputs_masked: 0x%X but expected: 0x%X",
                 int(gpio),
                 actual_outputs_mask,
                 self.outputs_state,
@@ -296,9 +301,12 @@ class MCP23018(Expander):
         self.bus_write_byte_data(self.OLATB, mask)
 
     def read_inputs(self):
-        # NOTE: We can't get information about outputs by reading inputs in MCP23018
+        # NOTE: We can't get information about outputs
+        # by reading inputs in MCP23018
         input_vals = int(self.read_GPIO())
-        ## self.log.debug("read_inputs(): read GPIO: 0x%X inputs mask: 0x%X  exptected outputs state: 0x%X", input_vals, self.inputs_mask, self.outputs_state, )
+        # self.log.debug("read_inputs(): read GPIO: 0x%X inputs mask: 0x%X "
+        # "expected outputs state: 0x%X",
+        # input_vals, self.inputs_mask, self.outputs_state, )
         input_vals &= self.inputs_mask
         return input_vals
 
@@ -317,7 +325,9 @@ if __name__ == "__main__":
 
     if 1:  # Configuration write test
         conf_reg = mcp23018.read_configuration()
-        # Fails on first run with OSError: [Errno 121] Remote I/O error on return self.bus.read_byte_data(self.address, cmd) ???
+        # Fails on first run with OSError:
+        #   [Errno 121] Remote I/O error on return
+        #   self.bus.read_byte_data(self.address, cmd) ???
         # https://stackoverflow.com/questions/15245235/input-output-error-using-python-module-smbus-a-raspberry-pi-and-an-arduino
         # subprocess.call(['i2cdetect', '-y', '1'])
         # i2cdetect -y 1
@@ -335,7 +345,6 @@ if __name__ == "__main__":
         )
 
     if 1:
-        ## outputs_mask = 0xffff
         outputs_mask = 0x0001
         print("Blinking 1Hz on 0x%04x outputs" % (outputs_mask,))
         # configure(self, output_mask, invert_mask, pull_up_mask):
@@ -354,8 +363,9 @@ if __name__ == "__main__":
 
     if 0:
         print("Reading all inputs in endless loop.. Hit CTRL+C to stop.")
-        # Set Pullups on all outputs, so they will stay high, but shorting to GND (via pressing button) will drive them low
-        # mcp23018.configure_inputs(0xffff,  set_pull_ups = True,  invert=True)
+        # Set Pullups on all outputs, so they will stay high,
+        # but shorting to GND (via pressing button) will drive them low
+        # mcp23018.configure_inputs(0xffff, set_pull_ups = True, invert=True)
 
         # Same as above, but only on GPA7 & GPA6
         input_reg = mcp23018.GPIO_Register()
@@ -371,10 +381,12 @@ if __name__ == "__main__":
 
     if 0:
         print(
-            "Detecting pushbutton hits via interrputs in endless loop.. Hit CTRL+C to stop."
+            "Detecting pushbutton hits via interrputs in endless loop... "
+            "Hit CTRL+C to stop."
         )
         mcp23018.set_io_direction_input(0xFFFF)  # 0 means output
-        # Set Pullups on all outputs, so they will stay high, but short to GND will drive them low
+        # Set Pullups on all outputs, so they will stay high,
+        # but short to GND will drive them low
         mcp23018.set_GPPU(0xFFFF)
         # Enable interrputs
         mcp23018.set_interrupt_on_change(0x0000)  # Turn off interrupts

--- a/homeassistant/components/rpi_i2c_chips/MCP23018.py
+++ b/homeassistant/components/rpi_i2c_chips/MCP23018.py
@@ -1,0 +1,371 @@
+import logging
+import time
+
+from .register import Register
+from .common import Expander
+
+module_logger = logging.getLogger(__name__)
+module_logger.setLevel(logging.DEBUG)
+
+
+class MCP23018(Expander):
+    """
+    MCP23018 register definitions
+    """
+    # Common to all Exapnders
+    PIN_COUNT = 16
+    MASK = (1 << PIN_COUNT) - 1  # 0xffff
+
+    # We use default PoR BANK=0 ports adresses
+    IODIRA = 0x00
+    IODIRB = 0x01
+    IPOLA = 0x02
+    IPOLB = 0x03
+    GPINTENA = 0x04
+    GPINTENB = 0x05
+    DEFVALA = 0x06
+    DEFVALB = 0x07
+    INTCONA = 0x08
+    INTCONB = 0x09
+    IOCON = 0x0a
+    # IOCON    = 0x0b  # duplicate
+    GPPUA = 0x0c
+    GPPUB = 0x0d
+    INTFA = 0x0e
+    INTFB = 0x0f
+    INTCAPA = 0x10
+    INTCAPB = 0x11
+    GPIOA = 0x12
+    GPIOB = 0x13
+    OLATA = 0x14
+    OLATB = 0x15
+
+    # BANK=1 adresses
+    #    IODIRA   = 0x00
+    #    IPOLA    = 0x01
+    #    GPINTENA = 0x02
+    #    DEFVALA  = 0x03
+    #    INTCONA  = 0x04
+    #    IOCON    = 0x05
+    #    GPPUA    = 0x06
+    #    INTFA    = 0x07
+    #    INTCAPA  = 0x08
+    #    GPIOA    = 0x09
+    #    OLATA    = 0x0a
+    #
+    #    IODIRB   = 0x10
+    #    IPOLB    = 0x11
+    #    GPINTENB = 0x12
+    #    DEFVALB  = 0x13
+    #    INTCONB  = 0x14
+    #    # IOCON    = 0x05   # duplicate
+    #    GPPUB    = 0x16
+    #    INTFB    = 0x17
+    #    INTCAPB  = 0x18
+    #    GPIOB    = 0x19
+    #    OLATB    = 0x1a
+
+    def __init__(self, bus, address, log=module_logger):
+        if address < 0x20 or address >= 0x20 + 8:
+            raise ValueError(
+                "Invalid device address: 0x%x for MCP23018" % (address, ))
+        super().__init__(bus, address, log)
+        ## self.log.debug("%s init done", self)
+
+    def reset(self):
+        """Sets chip like after power on reset.
+        """
+        # TODO: What if chip is in BANK=1 mode ?
+        self.set_inputs(0xffff)
+
+    class IOCON_Register(Register):
+        """ IOCON – I/O EXPANDER CONFIGURATION REGISTER
+
+        MIRROR = 1, the INTn pins are functionally
+            OR’ed so that an interrupt on either port will cause
+            both pins to activate
+        MIRROR = 0, the INT pins are separated.
+            Interrupt conditions on a port will cause its respecive 
+            INT pin to activate
+
+        """
+        _bitnames = Register.parse_bitnames(
+            "BANK MIRROR SEQOP _ _ ODR INTPOL INTCC")
+        _bitaliases = Register.parse_bitaliases(_bitnames)
+
+    def set_IOCON(self, reg):  # TODO : rename to set_IOCON ?
+        """
+        """
+        if conf_reg.BANK != 0:
+            raise ValueError("Switching to BANK=1 mode not implemented")
+        self.bus_write_byte_data(self.IOCON, int(reg))
+
+    def read_IOCON(self):
+        val = self.bus_read_byte_data(self.IOCON)
+        return self.IOCON_Register(val)
+
+    class IODIR_Register(Register):
+        """  IODIR – I/O DIRECTION REGISTER
+        When a bit is set, the corresponding pin becomes an input. 
+        When a bit is clear, the corresponding pin becomes an output.
+        """
+        _bitnames = Register.gen_bitnames(8, "IO")  # IO7 .. IO0
+        _bitaliases = Register.parse_bitaliases(_bitnames)
+
+    def set_IODIRA(self, iodir_register):
+        self.bus_write_byte_data(self.IODIRA, int(iodir_register))
+
+    def set_IODIRB(self, iodir_register):
+        self.bus_write_byte_data(self.IODIRB, int(iodir_register))
+
+    def read_IODIRA(self):
+        val = self.bus_read_byte_data(self.IODIRA)
+        return self.IODIR_Register(val)
+
+    def read_IODIRB(self):
+        val = self.bus_read_byte_data(self.IODIRB)
+        return self.IODIR_Register(val)
+
+    class IPOL_Register(Register):
+        """   IPOL – INPUT POLARITY PORT REGISTER
+        If a bit is set, the corresponding GPIO register bit will
+        reflect the inverted value on the pin.
+        """
+        _bitnames = Register.gen_bitnames(8, "IP")  # IP7 .. IP0
+        _bitaliases = Register.parse_bitaliases(_bitnames)
+
+    def set_IPOLA(self, ipol_register):
+        self.bus_write_byte_data(self.IPOLA, int(ipol_register))
+
+    def set_IPOLB(self, ipol_register):
+        self.bus_write_byte_data(self.IPOLB, int(ipol_register))
+
+    def read_IPOLA(self):
+        val = self.bus_read_byte_data(self.IPOLA)
+        return self.IPOL_Register(val)
+
+    def read_IPOLB(self):
+        val = self.bus_read_byte_data(self.IPOLB)
+        return self.IPOL_Register(val)
+
+    class GPPU_Register(Register):
+        """The GPPU register controls the pull-up resistors for the
+        port pins. If a bit is set the corresponding port pin is
+        internally pulled up with an internal resistor.
+        150 microA for 3.3V in 25°C
+        """
+        _bitnames = Register.gen_bitnames(8, "PU")  # PU7 .. PU0
+        _bitaliases = Register.parse_bitaliases(_bitnames)
+
+    def set_GPPUA(self, gppu_register):
+        self.bus_write_byte_data(self.GPPUA, int(gppu_register))
+
+    def set_GPPUB(self, gppu_register):
+        self.bus_write_byte_data(self.GPPUB, int(gppu_register))
+
+    def read_GPPUA(self):
+        val = self.bus_read_byte_data(self.GPPUA)
+        return self.GPPU_Register(val)
+
+    def read_GPPUB(self):
+        val = self.bus_read_byte_data(self.GPPUB)
+        return self.GPPU_Register(val)
+
+    def set_GPPU(self, mask):
+        self.bus_write_byte_data(self.GPPUA, mask & 0xff)
+        self.bus_write_byte_data(self.GPPUB, (mask >> 8) & 0xff)
+
+    def read_GPPU(self, mask):
+        mask = self.bus_read_byte_data(self.GPPUA)
+        mask |= (self.bus_read_byte_data(self.GPPUB) << 8)
+        return mask
+
+    class GPIO_Register(Register):
+        """ The GPIO register reflects the value on the port.
+        Reading from this register reads the port. Writing to this
+        register modifies the Output Latch (OLAT) register.
+        """
+        # gen_bitnames(num, prefix)
+        _bitnames = Register.gen_bitnames(8, "GP")  # GP7 .. GP0
+        _bitaliases = Register.parse_bitaliases(_bitnames)
+
+    def set_GPIOA(self, gpio_register):
+        self.bus_write_byte_data(self.GPIOA, int(gpio_register))
+
+    def set_GPIOB(self, gpio_register):
+        self.bus_write_byte_data(self.GPIOB, int(gpio_register))
+
+    def read_GPIOA(self):
+        val = self.bus_read_byte_data(self.GPIOA)
+        return self.GPIO_Register(val)
+
+    def read_GPIOB(self):
+        val = self.bus_read_byte_data(self.GPIOB)
+        return self.GPIO_Register(val)
+
+    def set_GPIO(self, mask):
+        self.bus_write_byte_data(self.GPIOA, mask & 0xff)
+        self.bus_write_byte_data(self.GPIOB, (mask >> 8) & 0xff)
+
+    def read_GPIO(self):
+        mask = self.bus_read_byte_data(self.GPIOA)
+        mask |= (self.bus_read_byte_data(self.GPIOB) << 8)
+        # TODO: Should use 16bit wide GPIO_Register16 having GPA0..GPA7,GPB0..GPB7 ?
+        return mask
+
+    def configure(self, outputs_mask, inputs_mask, pull_ups_mask):
+        """
+        Configures chip:
+        outputs_mask - whose pins became outputs, rest is configure inputs
+        inputs_mask - whose pins became inputs, must not overlap with inputs
+        pull_ups_mask - whose pins have pull ups set, 
+
+        Only inputs/outputs_mask is configure, rest is left untouched.
+        pull_up_mask can be only set for inputs/outputs
+
+        Configuraiton tries to preserve previous state of chip as much as possible.
+
+        """
+        self.log.debug("CALLED: configure(%s,outputs_mask=%r,inputs_mask=%r,pull_up_mask=%r) ",
+                       self, outputs_mask, inputs_mask, pull_ups_mask)
+
+        super().configure(outputs_mask, inputs_mask, pull_ups_mask)
+
+        outputs_mask_b, outputs_mask_a = self.mask_split2bytes(
+            self.outputs_mask)
+        # When a bit is zero, the corresponding pin becomes an output.
+        self.set_IODIRA(self.byte_invert(outputs_mask_a))
+        self.set_IODIRB(self.byte_invert(outputs_mask_b))
+
+        pull_ups_mask_b, pull_ups_mask_a = self.mask_split2bytes(
+            self.pull_ups_mask)
+        self.set_GPPUA(pull_ups_mask_a)
+        self.set_GPPUB(pull_ups_mask_b)
+
+    def set_outputs(self, mask,):
+        mask = self.mask(mask)
+        self.set_outputs_a(mask & 0xff)
+        self.set_outputs_b((mask >> 8) & 0xff)
+        self.outputs_state = mask
+        self.log.debug("%s set_outputs(mask=0x%X).",  self, self.outputs_state)
+
+    def verify_outputs(self):
+        """
+        Checks if actual outputs state is same as supposed
+        """
+        gpio = self.read_GPIO()
+        actual_outputs_mask = int(gpio) & self.outputs_mask
+        # Inputs state: 65535 (0xFFFF) usually means chip was reset.
+        self.log.debug("Verified inputs state: %s (0x%X) outputs_masked: 0x%X expected: 0x%X", gpio, int(
+            gpio), actual_outputs_mask, self.outputs_state)
+        if actual_outputs_mask != self.outputs_state:
+            # NOTE: Below we work on real ports state, not logical, as values may be inverted.
+            self.log.warn("Outputs state mismatch. Read inputs: 0x%X , outputs_masked: 0x%X but expected: 0x%X", int(
+                gpio), actual_outputs_mask, self.outputs_state)
+            return False
+        return True
+
+    def set_outputs_a(self, mask):
+        self.bus_write_byte_data(self.OLATA, mask)
+
+    def set_outputs_b(self, mask):
+        self.bus_write_byte_data(self.OLATB, mask)
+
+    def read_inputs(self):
+        # NOTE: We can't get information about outputs by reading inputs in MCP23018
+        input_vals = int(self.read_GPIO())
+        ## self.log.debug("read_inputs(): read GPIO: 0x%X inputs mask: 0x%X  exptected outputs state: 0x%X", input_vals, self.inputs_mask, self.outputs_state, )
+        input_vals &= self.inputs_mask
+        return input_vals
+
+
+if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.DEBUG, format='%(relativeCreated)6d %(threadName)s %(message)s')
+
+    import smbus
+    # bus = smbus.SMBus(0)  # Rev 1 Pi uses 0
+    bus1 = smbus.SMBus(1)  # Rev 2 Pi uses 1
+    mcp23018 = MCP23018(bus1, 0x20)
+
+    if 1:  # Configuration write test
+        conf_reg = mcp23018.read_configuration()
+        # Fails on first run with OSError: [Errno 121] Remote I/O error on return self.bus.read_byte_data(self.address, cmd) ???
+        # https://stackoverflow.com/questions/15245235/input-output-error-using-python-module-smbus-a-raspberry-pi-and-an-arduino
+        # subprocess.call(['i2cdetect', '-y', '1'])
+        # i2cdetect -y 1
+
+        print ("Initial conf_reg: %s" % (conf_reg, ))
+        conf_reg.MIRROR = 1
+        mcp23018.set_configuration(conf_reg)
+        conf_reg = mcp23018.read_configuration()
+        print ("After updated conf_reg: %s (MIRROR should be 1)" % (conf_reg, ))
+        conf_reg.MIRROR = 0
+        mcp23018.set_configuration(conf_reg)
+        conf_reg = mcp23018.read_configuration()
+        print ("After 2nd updated conf_reg: %s (MIRROR should be 0)" %
+               (conf_reg, ))
+
+    if 1:
+        ## outputs_mask = 0xffff
+        outputs_mask = 0x0001
+        print ("Blinking 1Hz on 0x%04x outputs" % (outputs_mask, ))
+        # configure(self, output_mask, invert_mask, pull_up_mask):
+        # Setting all IO ports as outputs
+
+        mcp23018.configure(outputs_mask, mcp23018.MASK-outputs_mask, 0, 0xffff)
+
+        for i in range(10):
+            mcp23018.set_outputs(0)  # All low, draining
+            time.sleep(0.5)
+            mcp23018.set_outputs(0xffff)  # All high, no current
+            time.sleep(0.5)
+        print ("Blinking done.")
+
+    if 0:
+        print ("Reading all inputs in endless loop.. Hit CTRL+C to stop.")
+        # Set Pullups on all outputs, so they will stay high, but shorting to GND (via pressing button) will drive them low
+        # mcp23018.configure_inputs(0xffff,  set_pull_ups = True,  invert=True)
+
+        # Same as above, but only on GPA7 & GPA6
+        input_reg = mcp23018.GPIO_Register()
+        input_reg.GP7 = 1
+        input_reg.GP6 = 1
+        mcp23018.configure_inputs(input_reg,  set_pull_ups=True,  invert=True)
+
+        while 1:
+            gpio = mcp23018.read_GPIO()
+            gpio_a = mcp23018.read_GPIOA()
+            print ("gpio: %04x -> A: %s" % (int(gpio), str(gpio_a)))
+            time.sleep(0.1)
+
+    if 0:
+        print (
+            "Detecting pushbutton hits via interrputs in endless loop.. Hit CTRL+C to stop.")
+        mcp23018.set_io_direction_input(0xffff)  # 0 means output
+        # Set Pullups on all outputs, so they will stay high, but short to GND will drive them low
+        mcp23018.set_GPPU(0xffff)
+        # Enable interrputs
+        mcp23018.set_interrupt_on_change(0x0000)  # Turn off interrupts
+        # Configure interrputs to trigger on value different than in DEFVAL
+        mcp23018.set_INTCON(0x1111)
+        gpio = mcp23018.read_gpio()
+        # Set default values for interrupt as read from gpio
+        mcp23018.set_DEFVAL(gpio)
+        mcp23018.set_interrupt_on_change(0xffff)  # Turn on interrupts
+
+        last_gpio = None
+        last_intf = None
+        last_intcap = None
+        while 1:
+            intcap = mcp23018.read_INTCAP()
+            # gpio = mcp23018.read_gpio()  # NOTE: Reading GPIO clears INTCAP
+            intf = mcp23018.read_INTF()
+
+            if gpio != last_gpio or intf != last_intf or intcap != last_intcap:
+                print ("gpio: %04x intf: %04x intcap: %04x" %
+                       (gpio, intf, intcap, ))
+            last_gpio = gpio
+            last_intf = intf
+            last_intcap = intcap
+            time.sleep(0.2)

--- a/homeassistant/components/rpi_i2c_chips/PCF8574.py
+++ b/homeassistant/components/rpi_i2c_chips/PCF8574.py
@@ -27,7 +27,7 @@ class PCF8574(Expander):
         self.log.debug("%s @ 0x%x init done", self, self.address)
 
     class Port_Register(Register):
-        """ 
+        """
         Only PCF8574 register representing both I/O ports
         """
 
@@ -44,16 +44,18 @@ class PCF8574(Expander):
         Configures chip:
         outputs_mask - whose pins became outputs, rest is configure inputs
         inputs_mask - whose pins became inputs, must not overlap with inputs
-        pull_ups_mask - whose pins have pull ups set, 
+        pull_ups_mask - whose pins have pull ups set,
 
         Only inputs/outputs_mask is configure, rest is left untouched.
         pull_ups_mask can be only set for inputs/outputs
 
-        Configuraiton tries to preserve previous state of chip as much as possible.
+        Configuraiton tries to preserve previous state of chip
+        as much as possible.
 
         """
         self.log.debug(
-            "CALLED: configure(%s,outputs_mask=0x%X,inputs_mask=0x%X,pull_ups_mask=0x%X) ",
+            "CALLED: configure(%s,outputs_mask=0x%X,inputs_mask=0x%X,"
+            "pull_ups_mask=0x%X) ",
             self,
             outputs_mask,
             inputs_mask,
@@ -67,7 +69,8 @@ class PCF8574(Expander):
         io_mask = outputs_mask | inputs_mask
         if pull_ups_mask & self.mask_invert(io_mask):
             raise ValueError(
-                "Pull-ups mask (0x%x) set out of inputs (0x%s) and outputs (%x)"
+                "Pull-ups mask (0x%x) set out of inputs (0x%s) "
+                "and outputs (%x)"
                 % (pull_ups_mask,)
             )
         old_state = int(self.read_byte())  # Reading previous state
@@ -101,14 +104,16 @@ class PCF8574(Expander):
         portval = self.read_byte()
         outputs = portval & self.outputs_mask
         self.log.debug(
-            "verify_outputs(): read byte: 0x%X outputs: 0x%X   exptected outputs state: 0x%X",
+            "verify_outputs(): read byte: 0x%X outputs: 0x%X "
+            "exptected outputs state: 0x%X",
             portval,
             outputs,
             self.outputs_state,
         )
         if outputs != self.outputs_state:
             self.log.warn(
-                "verify_outputs(): read byte: 0x%X outputs: 0x%X  exptected outputs state: 0x%X mismatch.",
+                "verify_outputs(): read byte: 0x%X outputs: 0x%X "
+                "exptected outputs state: 0x%X mismatch.",
                 portval,
                 outputs,
                 self.outputs_state,
@@ -121,10 +126,14 @@ class PCF8574(Expander):
         if 1:  # Double check
             if self.outputs_mask != None and self.outputs_state != None:
                 outputs = inputs & self.outputs_mask
-                ## self.log.debug("read_inputs(): read byte: 0x%X outputs: 0x%X  exptected outputs state: 0x%X", inputs, outputs, self.outputs_state, )
+                # self.log.debug("read_inputs():
+                # read byte: 0x%X outputs: 0x%X "
+                # "exptected outputs state: 0x%X",
+                # inputs, outputs, self.outputs_state, )
                 if outputs != self.outputs_state:
                     self.log.warn(
-                        "read_inputs(): read byte: 0x%X outputs: 0x%X mismatch: expected outputs: 0x%X .",
+                        "read_inputs(): read byte: 0x%X outputs: "
+                        "0x%X mismatch: expected outputs: 0x%X .",
                         inputs,
                         outputs,
                         self.outputs_state,

--- a/homeassistant/components/rpi_i2c_chips/PCF8574.py
+++ b/homeassistant/components/rpi_i2c_chips/PCF8574.py
@@ -70,8 +70,7 @@ class PCF8574(Expander):
         if pull_ups_mask & self.mask_invert(io_mask):
             raise ValueError(
                 "Pull-ups mask (0x%x) set out of inputs (0x%s) "
-                "and outputs (%x)"
-                % (pull_ups_mask,)
+                "and outputs (%x)" % (pull_ups_mask,)
             )
         old_state = int(self.read_byte())  # Reading previous state
         new_state = old_state | inputs_mask  # setting inputs to high (pullup)
@@ -124,7 +123,10 @@ class PCF8574(Expander):
     def read_inputs(self):
         inputs = self.read_byte()
         if 1:  # Double check
-            if self.outputs_mask != None and self.outputs_state != None:
+            if (
+                self.outputs_mask is not None
+                and self.outputs_state is not None
+            ):
                 outputs = inputs & self.outputs_mask
                 # self.log.debug("read_inputs():
                 # read byte: 0x%X outputs: 0x%X "

--- a/homeassistant/components/rpi_i2c_chips/PCF8574.py
+++ b/homeassistant/components/rpi_i2c_chips/PCF8574.py
@@ -17,9 +17,12 @@ class PCF8574(Expander):
     MASK = (1 << PIN_COUNT) - 1  # 0xff
 
     def __init__(self, bus, address, log=module_logger):
-        if address < 0x20 or address >= 0x20 + 8:  # TODO: Move to verify_bus_address() ?
+        if (
+            address < 0x20 or address >= 0x20 + 8
+        ):  # TODO: Move to verify_bus_address() ?
             raise ValueError(
-                "Invalid device address: 0x%x for PCF8574" % (address, ))
+                "Invalid device address: 0x%x for PCF8574" % (address,)
+            )
         super().__init__(bus, address, log=log)
         self.log.debug("%s @ 0x%x init done", self, self.address)
 
@@ -27,13 +30,14 @@ class PCF8574(Expander):
         """ 
         Only PCF8574 register representing both I/O ports
         """
+
         _bitnames = Register.gen_bitnames(8, "P")  # P7 .. P0
 
     def reset(self):
         """Sets chip like after power on reset.
         """
         # from official docs:  At power-on the I/Os are HIGH.
-        self.write_byte(0xff)
+        self.write_byte(0xFF)
 
     def configure(self, outputs_mask, inputs_mask, pull_ups_mask=None):
         """
@@ -48,8 +52,13 @@ class PCF8574(Expander):
         Configuraiton tries to preserve previous state of chip as much as possible.
 
         """
-        self.log.debug("CALLED: configure(%s,outputs_mask=0x%X,inputs_mask=0x%X,pull_ups_mask=0x%X) ",
-                       self, outputs_mask, inputs_mask, pull_ups_mask)
+        self.log.debug(
+            "CALLED: configure(%s,outputs_mask=0x%X,inputs_mask=0x%X,pull_ups_mask=0x%X) ",
+            self,
+            outputs_mask,
+            inputs_mask,
+            pull_ups_mask,
+        )
 
         # All inputs must be pulled up to work in PCF8674.
         if pull_ups_mask is None:
@@ -58,15 +67,22 @@ class PCF8574(Expander):
         io_mask = outputs_mask | inputs_mask
         if pull_ups_mask & self.mask_invert(io_mask):
             raise ValueError(
-                "Pull-ups mask (0x%x) set out of inputs (0x%s) and outputs (%x)" % (pull_ups_mask, ))
+                "Pull-ups mask (0x%x) set out of inputs (0x%s) and outputs (%x)"
+                % (pull_ups_mask,)
+            )
         old_state = int(self.read_byte())  # Reading previous state
         new_state = old_state | inputs_mask  # setting inputs to high (pullup)
         if (inputs_mask & pull_ups_mask) != inputs_mask:
             raise ValueError(
-                "In PCF8674 all inputs are pulled up by definition")
+                "In PCF8674 all inputs are pulled up by definition"
+            )
         self.write_byte(new_state)
-        self.log.debug("%s configure()d. state: %s (io pins: 0x%X).",
-                       self, self.state_info(), new_state)
+        self.log.debug(
+            "%s configure()d. state: %s (io pins: 0x%X).",
+            self,
+            self.state_info(),
+            new_state,
+        )
 
     def set_outputs(self, mask):
         """
@@ -76,7 +92,7 @@ class PCF8574(Expander):
         # We have to keep inputs high to be able detect changes.
         mask |= self.inputs_mask
         self.write_byte(int(mask))
-        self.log.debug("%s set_outputs(mask=0x%x).",  self, mask)
+        self.log.debug("%s set_outputs(mask=0x%x).", self, mask)
 
     def verify_outputs(self):
         """
@@ -84,11 +100,19 @@ class PCF8574(Expander):
         """
         portval = self.read_byte()
         outputs = portval & self.outputs_mask
-        self.log.debug("verify_outputs(): read byte: 0x%X outputs: 0x%X   exptected outputs state: 0x%X",
-                       portval, outputs, self.outputs_state, )
+        self.log.debug(
+            "verify_outputs(): read byte: 0x%X outputs: 0x%X   exptected outputs state: 0x%X",
+            portval,
+            outputs,
+            self.outputs_state,
+        )
         if outputs != self.outputs_state:
-            self.log.warn("verify_outputs(): read byte: 0x%X outputs: 0x%X  exptected outputs state: 0x%X mismatch.",
-                          portval,  outputs, self.outputs_state, )
+            self.log.warn(
+                "verify_outputs(): read byte: 0x%X outputs: 0x%X  exptected outputs state: 0x%X mismatch.",
+                portval,
+                outputs,
+                self.outputs_state,
+            )
             return False
         return True
 
@@ -99,8 +123,12 @@ class PCF8574(Expander):
                 outputs = inputs & self.outputs_mask
                 ## self.log.debug("read_inputs(): read byte: 0x%X outputs: 0x%X  exptected outputs state: 0x%X", inputs, outputs, self.outputs_state, )
                 if outputs != self.outputs_state:
-                    self.log.warn("read_inputs(): read byte: 0x%X outputs: 0x%X mismatch: expected outputs: 0x%X .",
-                                  inputs,  outputs, self.outputs_state, )
+                    self.log.warn(
+                        "read_inputs(): read byte: 0x%X outputs: 0x%X mismatch: expected outputs: 0x%X .",
+                        inputs,
+                        outputs,
+                        self.outputs_state,
+                    )
         inputs &= self.inputs_mask
         return inputs
 
@@ -110,16 +138,19 @@ if __name__ == "__main__":
     #   python3 -m rpi_i2c_chips.PCF8574
 
     logging.basicConfig(
-        level=logging.DEBUG, format='%(relativeCreated)6d %(threadName)s %(message)s')
+        level=logging.DEBUG,
+        format="%(relativeCreated)6d %(threadName)s %(message)s",
+    )
 
     import smbus
+
     # bus = smbus.SMBus(0)  # Rev 1 Pi uses 0
     bus1 = smbus.SMBus(1)  # Rev 2 Pi uses 1
     pcf8574 = PCF8574(bus1, 0x24)
-    pcf8574.set_outputs(0xff)
+    pcf8574.set_outputs(0xFF)
     val = pcf8574.read_inputs()
-    print ("Got %s from %s" % (val, pcf8574, ))
+    print("Got %s from %s" % (val, pcf8574))
 
     pcf8574.set_outputs(0x00)
     val = pcf8574.read_inputs()
-    print ("Got %s from %s" % (val, pcf8574, ))
+    print("Got %s from %s" % (val, pcf8574))

--- a/homeassistant/components/rpi_i2c_chips/PCF8574.py
+++ b/homeassistant/components/rpi_i2c_chips/PCF8574.py
@@ -1,0 +1,125 @@
+import logging
+
+from .register import Register
+from .common import Expander
+
+module_logger = logging.getLogger(__name__)
+# module_logger.setLevel(logging.DEBUG)
+
+
+class PCF8574(Expander):
+    """
+    PCF8574 register/operation definitions
+    """
+
+    # Common to all Exapnders
+    PIN_COUNT = 8
+    MASK = (1 << PIN_COUNT) - 1  # 0xff
+
+    def __init__(self, bus, address, log=module_logger):
+        if address < 0x20 or address >= 0x20 + 8:  # TODO: Move to verify_bus_address() ?
+            raise ValueError(
+                "Invalid device address: 0x%x for PCF8574" % (address, ))
+        super().__init__(bus, address, log=log)
+        self.log.debug("%s @ 0x%x init done", self, self.address)
+
+    class Port_Register(Register):
+        """ 
+        Only PCF8574 register representing both I/O ports
+        """
+        _bitnames = Register.gen_bitnames(8, "P")  # P7 .. P0
+
+    def reset(self):
+        """Sets chip like after power on reset.
+        """
+        # from official docs:  At power-on the I/Os are HIGH.
+        self.write_byte(0xff)
+
+    def configure(self, outputs_mask, inputs_mask, pull_ups_mask=None):
+        """
+        Configures chip:
+        outputs_mask - whose pins became outputs, rest is configure inputs
+        inputs_mask - whose pins became inputs, must not overlap with inputs
+        pull_ups_mask - whose pins have pull ups set, 
+
+        Only inputs/outputs_mask is configure, rest is left untouched.
+        pull_ups_mask can be only set for inputs/outputs
+
+        Configuraiton tries to preserve previous state of chip as much as possible.
+
+        """
+        self.log.debug("CALLED: configure(%s,outputs_mask=0x%X,inputs_mask=0x%X,pull_ups_mask=0x%X) ",
+                       self, outputs_mask, inputs_mask, pull_ups_mask)
+
+        # All inputs must be pulled up to work in PCF8674.
+        if pull_ups_mask is None:
+            pull_ups_mask = inputs_mask
+        super().configure(outputs_mask, inputs_mask, pull_ups_mask)
+        io_mask = outputs_mask | inputs_mask
+        if pull_ups_mask & self.mask_invert(io_mask):
+            raise ValueError(
+                "Pull-ups mask (0x%x) set out of inputs (0x%s) and outputs (%x)" % (pull_ups_mask, ))
+        old_state = int(self.read_byte())  # Reading previous state
+        new_state = old_state | inputs_mask  # setting inputs to high (pullup)
+        if (inputs_mask & pull_ups_mask) != inputs_mask:
+            raise ValueError(
+                "In PCF8674 all inputs are pulled up by definition")
+        self.write_byte(new_state)
+        self.log.debug("%s configure()d. state: %s (io pins: 0x%X).",
+                       self, self.state_info(), new_state)
+
+    def set_outputs(self, mask):
+        """
+        Sets expander outputs to given state.
+        """
+        self.outputs_state = mask
+        # We have to keep inputs high to be able detect changes.
+        mask |= self.inputs_mask
+        self.write_byte(int(mask))
+        self.log.debug("%s set_outputs(mask=0x%x).",  self, mask)
+
+    def verify_outputs(self):
+        """
+        Returns false if outputs state can be verified and is not correct.
+        """
+        portval = self.read_byte()
+        outputs = portval & self.outputs_mask
+        self.log.debug("verify_outputs(): read byte: 0x%X outputs: 0x%X   exptected outputs state: 0x%X",
+                       portval, outputs, self.outputs_state, )
+        if outputs != self.outputs_state:
+            self.log.warn("verify_outputs(): read byte: 0x%X outputs: 0x%X  exptected outputs state: 0x%X mismatch.",
+                          portval,  outputs, self.outputs_state, )
+            return False
+        return True
+
+    def read_inputs(self):
+        inputs = self.read_byte()
+        if 1:  # Double check
+            if self.outputs_mask != None and self.outputs_state != None:
+                outputs = inputs & self.outputs_mask
+                ## self.log.debug("read_inputs(): read byte: 0x%X outputs: 0x%X  exptected outputs state: 0x%X", inputs, outputs, self.outputs_state, )
+                if outputs != self.outputs_state:
+                    self.log.warn("read_inputs(): read byte: 0x%X outputs: 0x%X mismatch: expected outputs: 0x%X .",
+                                  inputs,  outputs, self.outputs_state, )
+        inputs &= self.inputs_mask
+        return inputs
+
+
+if __name__ == "__main__":
+    # Run as:
+    #   python3 -m rpi_i2c_chips.PCF8574
+
+    logging.basicConfig(
+        level=logging.DEBUG, format='%(relativeCreated)6d %(threadName)s %(message)s')
+
+    import smbus
+    # bus = smbus.SMBus(0)  # Rev 1 Pi uses 0
+    bus1 = smbus.SMBus(1)  # Rev 2 Pi uses 1
+    pcf8574 = PCF8574(bus1, 0x24)
+    pcf8574.set_outputs(0xff)
+    val = pcf8574.read_inputs()
+    print ("Got %s from %s" % (val, pcf8574, ))
+
+    pcf8574.set_outputs(0x00)
+    val = pcf8574.read_inputs()
+    print ("Got %s from %s" % (val, pcf8574, ))

--- a/homeassistant/components/rpi_i2c_chips/common.py
+++ b/homeassistant/components/rpi_i2c_chips/common.py
@@ -15,7 +15,7 @@ class Expander:
         self.log = log
 
         # Configuration state of chips
-        self.inputs_mask = None   # bits set for input pins.
+        self.inputs_mask = None  # bits set for input pins.
         self.outputs_mask = None  # bits set for output pins.
         # Last time set and expected state of outputs.
         self.outputs_state = None
@@ -23,7 +23,11 @@ class Expander:
         # self.invert_mask =  None  # TBA
 
     def __str__(self):
-        return "<%s %s/@0x%02x >" % (self.__class__.__name__, self.bus, self.address, )
+        return "<%s %s/@0x%02x >" % (
+            self.__class__.__name__,
+            self.bus,
+            self.address,
+        )
 
     def state_info(self):
         """
@@ -56,14 +60,14 @@ class Expander:
 
     def assert_valid_mask(self, mask):
         if mask < 0 or self.MASK < mask:
-            raise ValueError("Invalid mask: %r" % (mask, ))
+            raise ValueError("Invalid mask: %r" % (mask,))
 
     def mask_split2bytes(self, mask):
         """
         Splits mask value to 2 bytes.
         """
-        mask_a = int(mask) & 0xff
-        mask_b = (int(mask) >> 8) & 0xff
+        mask_a = int(mask) & 0xFF
+        mask_b = (int(mask) >> 8) & 0xFF
         return mask_b, mask_a
 
     def mask_invert(self, mask):
@@ -73,7 +77,7 @@ class Expander:
         return self.MASK - (mask & self.MASK)
 
     def byte_invert(self, b):
-        return 0xff - (b & 0xff)
+        return 0xFF - (b & 0xFF)
 
     #
     # Bus operations.
@@ -104,7 +108,8 @@ class Expander:
         Returns chips to state as it was in power up
         """
         raise NotImplementedError(
-            "Must be implemented for specific chip in sub-class")
+            "Must be implemented for specific chip in sub-class"
+        )
 
     def configure(self, outputs_mask, inputs_mask, pull_ups_mask):
         """
@@ -124,8 +129,10 @@ class Expander:
         # self.assert_valid_mask(invert_mask)
         self.assert_valid_mask(pull_ups_mask)
         if outputs_mask & inputs_mask:
-            raise ValueError("Input(0x%x) and output (0x%x) masks overlap." % (
-                inputs_mask, outputs_mask, ))
+            raise ValueError(
+                "Input(0x%x) and output (0x%x) masks overlap."
+                % (inputs_mask, outputs_mask)
+            )
 
         self.outputs_mask = outputs_mask
         self.inputs_mask = inputs_mask
@@ -142,27 +149,33 @@ class Expander:
             pull_ups_mask = inputs_mask
         else:
             if pull_ups_mask & self.mask_invert(inputs_mask):
-                raise ValueError("Pull ups mask (0x%x) outside inputs mask (0x%x)" % (
-                    pull_ups_mask, inputs_mask))
+                raise ValueError(
+                    "Pull ups mask (0x%x) outside inputs mask (0x%x)"
+                    % (pull_ups_mask, inputs_mask)
+                )
 
         if self.outputs_mask and (self.outputs_mask & inputs_mask):
-            raise ValueError("Alredy set outputs: 0x%x overlap with inputs: 0x%x" % (
-                self.outputs_mask,  inputs_mask))
+            raise ValueError(
+                "Alredy set outputs: 0x%x overlap with inputs: 0x%x"
+                % (self.outputs_mask, inputs_mask)
+            )
         if pull_ups_mask:
             # Preserve already set pull_ups outside inputs mask.
             new_pull_ups_mask = self.pull_ups_mask & self.mask_invert(
-                inputs_mask)  # Zeroing coresponding to inputs mask values.
+                inputs_mask
+            )  # Zeroing coresponding to inputs mask values.
             new_pull_ups_mask |= pull_ups_mask
 
-        self.configure(self.outputs_mask, inputs_mask,  new_pull_ups_mask)
+        self.configure(self.outputs_mask, inputs_mask, new_pull_ups_mask)
 
-    def set_outputs(self, mask,):
+    def set_outputs(self, mask):
         """
         Sets outputs to given state
         Always set self.outputs_state 
         """
         raise NotImplementedError(
-            "Must be implemented for specific chip in sub-class")
+            "Must be implemented for specific chip in sub-class"
+        )
 
     def verify_outputs(self):
         """
@@ -177,4 +190,5 @@ class Expander:
         TODO: Are output states ale included ?
         """
         raise NotImplementedError(
-            "Must be implemented for specific chip in sub-class")
+            "Must be implemented for specific chip in sub-class"
+        )

--- a/homeassistant/components/rpi_i2c_chips/common.py
+++ b/homeassistant/components/rpi_i2c_chips/common.py
@@ -1,0 +1,180 @@
+import logging
+
+module_logger = logging.getLogger(__name__)
+module_logger.setLevel(logging.DEBUG)
+
+
+class Expander:
+    PIN_COUNT = None  # Number of outputs and inputs.
+    # MASK = (1 << PIN_COUNT) -1  # 0xffff
+    MASK = None
+
+    def __init__(self, bus, address, log=module_logger):
+        self.bus = bus
+        self.address = address
+        self.log = log
+
+        # Configuration state of chips
+        self.inputs_mask = None   # bits set for input pins.
+        self.outputs_mask = None  # bits set for output pins.
+        # Last time set and expected state of outputs.
+        self.outputs_state = None
+        self.pull_ups_mask = None
+        # self.invert_mask =  None  # TBA
+
+    def __str__(self):
+        return "<%s %s/@0x%02x >" % (self.__class__.__name__, self.bus, self.address, )
+
+    def state_info(self):
+        """
+        One line info about state
+        """
+        txt = []
+        if self.inputs_mask is None:
+            txt.append("inputs: None")
+        else:
+            txt.append("inputs: 0x%x" % (self.inputs_mask))
+        if self.outputs_mask is None:
+            txt.append("outputs: None")
+        else:
+            txt.append("outputs: 0x%x" % (self.outputs_mask))
+        if self.outputs_state is None:
+            txt.append("outputs_state: None")
+        else:
+            txt.append("outputs_state: 0x%x" % (self.outputs_state))
+        return " ".join(txt)
+
+    #
+    # Common classes for all chips
+    #
+
+    def mask(self, val):
+        """
+        Masks given value to chips mask
+        """
+        return self.MASK & int(val)
+
+    def assert_valid_mask(self, mask):
+        if mask < 0 or self.MASK < mask:
+            raise ValueError("Invalid mask: %r" % (mask, ))
+
+    def mask_split2bytes(self, mask):
+        """
+        Splits mask value to 2 bytes.
+        """
+        mask_a = int(mask) & 0xff
+        mask_b = (int(mask) >> 8) & 0xff
+        return mask_b, mask_a
+
+    def mask_invert(self, mask):
+        """
+        Inverts (negates) given mask, keeping result in 0..self.MASK range
+        """
+        return self.MASK - (mask & self.MASK)
+
+    def byte_invert(self, b):
+        return 0xff - (b & 0xff)
+
+    #
+    # Bus operations.
+    # May allow mixing in other bus type, or adding debug.
+    #
+
+    def read_byte(self):
+        val = self.bus.read_byte(self.address)
+        return val
+
+    def write_byte(self, byte_val):
+        val = self.bus.write_byte(self.address, byte_val)
+        return val
+
+    def bus_write_byte_data(self, cmd, val):
+        self.bus.write_byte_data(self.address, cmd, val)
+
+    def bus_read_byte_data(self, cmd):
+        return self.bus.read_byte_data(self.address, cmd)
+
+    #
+    # Common expander interface.
+    # Needs be implemented in sublcass.
+    #
+
+    def reset(self):
+        """
+        Returns chips to state as it was in power up
+        """
+        raise NotImplementedError(
+            "Must be implemented for specific chip in sub-class")
+
+    def configure(self, outputs_mask, inputs_mask, pull_ups_mask):
+        """
+        Configures chip:
+        outputs_mask - whose pins became outputs, rest is configure inputs
+        inputs_mask - currently ignored, negation of outputs_mask is used.
+        pull_ups_mask - whose pins have pull ups set
+
+        TBD:
+        invert_mask - whose pins are inverted (both inputs/outputs) 
+
+        NOTE: Expand this method in sublcases implementing real HW configuration
+        """
+        ## raise NotImplementedError("Must be implemented for specific chip in sub-class")
+        self.assert_valid_mask(outputs_mask)
+        self.assert_valid_mask(inputs_mask)
+        # self.assert_valid_mask(invert_mask)
+        self.assert_valid_mask(pull_ups_mask)
+        if outputs_mask & inputs_mask:
+            raise ValueError("Input(0x%x) and output (0x%x) masks overlap." % (
+                inputs_mask, outputs_mask, ))
+
+        self.outputs_mask = outputs_mask
+        self.inputs_mask = inputs_mask
+        ## self.invert_mask =  invert_mask
+        self.pull_ups_mask = pull_ups_mask
+
+    def configure_inputs(self, inputs_mask, pull_ups_mask=None):
+        """
+        Configure subset of pins as inputs. 
+        Pins must not be already configured as outputs
+        """
+        if pull_ups_mask is None:
+            # By default use pull_up_mask
+            pull_ups_mask = inputs_mask
+        else:
+            if pull_ups_mask & self.mask_invert(inputs_mask):
+                raise ValueError("Pull ups mask (0x%x) outside inputs mask (0x%x)" % (
+                    pull_ups_mask, inputs_mask))
+
+        if self.outputs_mask and (self.outputs_mask & inputs_mask):
+            raise ValueError("Alredy set outputs: 0x%x overlap with inputs: 0x%x" % (
+                self.outputs_mask,  inputs_mask))
+        if pull_ups_mask:
+            # Preserve already set pull_ups outside inputs mask.
+            new_pull_ups_mask = self.pull_ups_mask & self.mask_invert(
+                inputs_mask)  # Zeroing coresponding to inputs mask values.
+            new_pull_ups_mask |= pull_ups_mask
+
+        self.configure(self.outputs_mask, inputs_mask,  new_pull_ups_mask)
+
+    def set_outputs(self, mask,):
+        """
+        Sets outputs to given state
+        Always set self.outputs_state 
+        """
+        raise NotImplementedError(
+            "Must be implemented for specific chip in sub-class")
+
+    def verify_outputs(self):
+        """
+        Returns false if outputs state can be verified and is not correct
+        """
+        return True
+
+    def read_inputs(self):
+        """
+        Reads state of inputs (and outputs ?)
+        Returns Register instance representing inputs state
+        TODO: Are output states ale included ?
+        """
+        raise NotImplementedError(
+            "Must be implemented for specific chip in sub-class")

--- a/homeassistant/components/rpi_i2c_chips/common.py
+++ b/homeassistant/components/rpi_i2c_chips/common.py
@@ -119,11 +119,11 @@ class Expander:
         pull_ups_mask - whose pins have pull ups set
 
         TBD:
-        invert_mask - whose pins are inverted (both inputs/outputs) 
+        invert_mask - whose pins are inverted (both inputs/outputs)
 
-        NOTE: Expand this method in sublcases implementing real HW configuration
+        NOTE: Expand this method in sublcases
+        implementing real HW configuration
         """
-        ## raise NotImplementedError("Must be implemented for specific chip in sub-class")
         self.assert_valid_mask(outputs_mask)
         self.assert_valid_mask(inputs_mask)
         # self.assert_valid_mask(invert_mask)
@@ -136,12 +136,12 @@ class Expander:
 
         self.outputs_mask = outputs_mask
         self.inputs_mask = inputs_mask
-        ## self.invert_mask =  invert_mask
+        # self.invert_mask =  invert_mask
         self.pull_ups_mask = pull_ups_mask
 
     def configure_inputs(self, inputs_mask, pull_ups_mask=None):
         """
-        Configure subset of pins as inputs. 
+        Configure subset of pins as inputs.
         Pins must not be already configured as outputs
         """
         if pull_ups_mask is None:
@@ -171,7 +171,7 @@ class Expander:
     def set_outputs(self, mask):
         """
         Sets outputs to given state
-        Always set self.outputs_state 
+        Always set self.outputs_state
         """
         raise NotImplementedError(
             "Must be implemented for specific chip in sub-class"

--- a/homeassistant/components/rpi_i2c_chips/pollwatcher.py
+++ b/homeassistant/components/rpi_i2c_chips/pollwatcher.py
@@ -1,0 +1,236 @@
+import logging
+import queue
+import time
+import threading
+
+module_logger = logging.getLogger(__name__)
+module_logger.setLevel(logging.DEBUG)
+
+
+class TimedInputs:
+    def __init__(self, inputs, t):
+        self.inputs = inputs
+        self.time = t
+
+    def __str__(self):
+        return "0x%x" % (self.inputs, )
+
+
+class TimedInputsChange:
+    def __init__(self, state, pre_timed_inputs,  post_timed_inputs):
+        self.state = state
+        self.pre_timed_inputs = pre_timed_inputs
+        self.post_timed_inputs = post_timed_inputs
+
+    def __str__(self):
+        return "<TimedInputsChange: %s -> %s>" % (self.pre_timed_inputs, self.post_timed_inputs, )
+
+    def changed_bits(self):
+        """
+        Generates (bit_num, current_val) for each changed value
+        """
+        diffs_mask = self.pre_timed_inputs.inputs ^ self.post_timed_inputs.inputs
+        bit_num = 0
+        inputs_mask = self.post_timed_inputs.inputs
+        while diffs_mask:
+            ## print ("DEBUG: changed_bits(): diffs_mask: %r" % (diffs_mask, ))
+            if diffs_mask & 0x1:
+                yield bit_num,  inputs_mask & 0x1
+            bit_num += 1
+            diffs_mask >>= 1
+            inputs_mask >>= 1
+
+
+class ExpanderState:
+    """
+    Keeps track of previous inputs state of given expander
+    Configures exapnder HW, allows read/writes
+    Allows to calculate changed bits
+    """
+
+    def __init__(self, expander, log=module_logger):
+        self.expander = expander
+        self.log = log
+        self.prev_timed_inputs = None
+        self.cur_timed_inputs = None
+
+    def __str__(self):
+        return "<%s prev: %s cur: %s>" % (self.__class__.__name__, self.prev_timed_inputs,  self.cur_timed_inputs, )
+
+    def configure_inputs(self, inputs_mask, set_pull_ups=True, invert=True):
+        inputs_mask = self.expander.mask(inputs_mask)
+        self.expander.configure_inputs(inputs_mask, pull_ups_mask=inputs_mask)
+        self.cur_timed_inputs = self.read_inputs()
+
+    def read_inputs(self):
+        inputs = int(self.expander.read_inputs())
+        ## inputs = inputs & self.input_mask
+        ## self.log.debug("read_inputs(): masked with input mask(0x%X) : 0x%X", self.input_mask, inputs)
+        return TimedInputs(inputs, time.time())
+
+    def check_state_changed(self):
+        new_timed_inputs = self.read_inputs()
+        ## self.log.debug("check_state_changed(): self.cur_timed_inputs: %s -> new_timed_inputs: %s", self.cur_timed_inputs, new_timed_inputs, )
+        if self.prev_timed_inputs is None:
+            # First change
+            self.prev_timed_inputs = self.cur_timed_inputs
+            self.cur_timed_inputs = new_timed_inputs
+            # Dummy old state - pretending all inputs changed
+            dummy_inputs = self.expander.mask_invert(
+                self.cur_timed_inputs.inputs)
+            dummy_inputs &= self.expander.inputs_mask
+            dummy_timed_inputs = TimedInputs(dummy_inputs, time.time())
+            ti_change = TimedInputsChange(
+                self, dummy_timed_inputs, self.cur_timed_inputs)
+            return ti_change
+        elif new_timed_inputs.inputs != self.cur_timed_inputs.inputs:
+            self.prev_timed_inputs = self.cur_timed_inputs
+            self.cur_timed_inputs = new_timed_inputs
+            ti_change = TimedInputsChange(
+                self, self.prev_timed_inputs, self.cur_timed_inputs)
+            return ti_change
+        return None
+
+
+class CallbackCaller(threading.Thread):
+    """
+    Thread used to call callbacks, when 
+    pending exapnder changed states are in queue
+    """
+
+    def __init__(self, handler,  log=module_logger, name="CallbackCaller"):
+        threading.Thread.__init__(self, name=name)
+        self.handler = handler
+        self.log = log
+        self._stop_flag = None  #
+        self._run_event = threading.Event()
+        self._pending_changed_states_queue = queue.Queue(
+            maxsize=100)  # TODO: Consider some sane value here ?
+
+    def run(self):
+        self.log.info("%s started", self.name)
+        while not self._stop_flag:
+            # time.sleep(0.1)
+            self._run_event.wait(timeout=1.0)
+            self._run_event.clear()
+            while not self._pending_changed_states_queue.empty():
+                changed_states = self._pending_changed_states_queue.get_nowait()
+                try:
+                    self.handler(changed_states)
+                except Exception as e:
+                    self.log.warn("Exception in callback handler: %r/%s", e, e)
+        self.log.info("%s finished", self.name)
+
+    def stop(self):
+        self._stop_flag = time.time()
+        self._run_event.set()
+
+    def add_changes(self, new_changed_states):
+        self._pending_changed_states_queue.put_nowait(new_changed_states)
+        self.log.debug("New pending_changed_states_queue aprox: len: %d",
+                       self._pending_changed_states_queue.qsize(), )
+        self._run_event.set()
+
+
+class PollWatcher(threading.Thread):
+    """
+    Thread polling over single I²C bus.
+    Adds detected changes to callback caller queue.
+    """
+
+    def __init__(self, handler, poll_interval=0.05,  log=module_logger):
+        threading.Thread.__init__(self, name="PollWatcher")
+        self.log = log
+        self._stop_event = threading.Event()
+        self.poll_interval = poll_interval
+        self.expander_states_per_address = {}
+        self.callback_caller = CallbackCaller(handler)
+
+    def run(self):
+        self.log.info("%s started", self.name)
+        try:
+            sleep_time = 0
+            self.callback_caller.start()
+            while not self._stop_event.wait(timeout=sleep_time):
+                loop_start_time = time.time()
+                changed_states = []
+                for state in self.expander_states_per_address.values():
+                    ## self.log.debug("Processing state: %s" % (state, ))
+                    ti_change = None
+                    try:
+                        ti_change = state.check_state_changed()
+                    except OSError as ose:
+                        self.log.warn(
+                            "Unable to check state of %r: %r/%s",  state, ose, ose, )
+                        # TODO: Chip dead, bus locked, reset chip/ bus ?
+                        continue
+                    if ti_change is None:
+                        continue
+                    changed_states.append(ti_change)
+                if changed_states:
+                    self.log.debug("changes detected: %s",
+                                   " ".join(map(str, changed_states)))
+                    self.callback_caller.add_changes(changed_states)
+                sleep_time = self.poll_interval - \
+                    (time.time() - loop_start_time)
+                if sleep_time < 0:  # Means polling took longer than interval
+                    self.log.warn("Poll loop took longer (%.3fs) than poll interval: %.3fs",
+                                  self.poll_interval-sleep_time,  self.poll_interval)
+                    sleep_time = 0
+            # TODO: Join with self.callback_caller() here ?
+        finally:
+            self.stop()
+            self.log.info("%s finished", self.name)
+
+    def stop(self):
+        self.callback_caller.stop()
+        self._stop_event.set()
+
+    def add_to_watch_expander(self, expander, inputs_mask, log=module_logger):
+        state = self.expander_states_per_address.get(expander.address)
+        if state is None:
+            new_state = ExpanderState(expander, log=log)
+            new_state.configure_inputs(inputs_mask)
+            self.expander_states_per_address[expander.address] = new_state
+        else:  # Already have state
+            raise NotImplementedError("TODO: Implement summing up input_masks")
+
+
+def example_watcher():
+    from . import MCP23018
+
+    log = module_logger
+
+    def test_handler(changed_states):
+        print("CALLED test_handler(changed_states=%s" % (changed_states, ))
+        for changed_state in changed_states:
+            print ("  changed_state: %s :%s" %
+                   (changed_state.state,  changed_state, ))
+
+    import smbus
+    # bus = smbus.SMBus(0)  # Rev 1 Pi uses 0
+    bus1 = smbus.SMBus(1)  # Rev 2 Pi uses 1
+    mcp23018 = MCP23018.MCP23018(bus1, 0x20)
+
+    pollwatcher = PollWatcher(test_handler, poll_interval=0.05)
+    pollwatcher.add_to_watch_expander(mcp23018, 0xc0)
+
+    log.info("Staring PollWatcher")
+    pollwatcher.start()
+
+    try:
+        input()
+    except KeyboardInterrupt:
+        log.info("Keyboard interrupt")
+        pass
+    log.info("Stopping PollWatcher ...")
+    pollwatcher.stop()
+    log.info("Waiting to join PollWatcher ...")
+    pollwatcher.join()
+    log.info("Main thread finished")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.DEBUG, format='%(relativeCreated)6d %(threadName)s %(message)s')
+    example_watcher()

--- a/homeassistant/components/rpi_i2c_chips/pollwatcher.py
+++ b/homeassistant/components/rpi_i2c_chips/pollwatcher.py
@@ -38,7 +38,7 @@ class TimedInputsChange:
         bit_num = 0
         inputs_mask = self.post_timed_inputs.inputs
         while diffs_mask:
-            ## print ("DEBUG: changed_bits(): diffs_mask: %r" % (diffs_mask, ))
+            # print ("DEBUG: changed_bits(): diffs_mask: %r" % (diffs_mask, ))
             if diffs_mask & 0x1:
                 yield bit_num, inputs_mask & 0x1
             bit_num += 1
@@ -73,13 +73,16 @@ class ExpanderState:
 
     def read_inputs(self):
         inputs = int(self.expander.read_inputs())
-        ## inputs = inputs & self.input_mask
-        ## self.log.debug("read_inputs(): masked with input mask(0x%X) : 0x%X", self.input_mask, inputs)
+        # inputs = inputs & self.input_mask
+        # self.log.debug("read_inputs(): masked with input mask(0x%X): 0x%X",
+        # self.input_mask, inputs)
         return TimedInputs(inputs, time.time())
 
     def check_state_changed(self):
         new_timed_inputs = self.read_inputs()
-        ## self.log.debug("check_state_changed(): self.cur_timed_inputs: %s -> new_timed_inputs: %s", self.cur_timed_inputs, new_timed_inputs, )
+        # self.log.debug("check_state_changed(): self.cur_timed_inputs: %s "
+        # "-> new_timed_inputs: %s",
+        # self.cur_timed_inputs, new_timed_inputs, )
         if self.prev_timed_inputs is None:
             # First change
             self.prev_timed_inputs = self.cur_timed_inputs
@@ -106,7 +109,7 @@ class ExpanderState:
 
 class CallbackCaller(threading.Thread):
     """
-    Thread used to call callbacks, when 
+    Thread used to call callbacks, when
     pending exapnder changed states are in queue
     """
 
@@ -172,7 +175,7 @@ class PollWatcher(threading.Thread):
                 loop_start_time = time.time()
                 changed_states = []
                 for state in self.expander_states_per_address.values():
-                    ## self.log.debug("Processing state: %s" % (state, ))
+                    # self.log.debug("Processing state: %s" % (state, ))
                     ti_change = None
                     try:
                         ti_change = state.check_state_changed()
@@ -199,7 +202,8 @@ class PollWatcher(threading.Thread):
                 )
                 if sleep_time < 0:  # Means polling took longer than interval
                     self.log.warn(
-                        "Poll loop took longer (%.3fs) than poll interval: %.3fs",
+                        "Poll loop took longer (%.3fs) "
+                        "than poll interval: %.3fs",
                         self.poll_interval - sleep_time,
                         self.poll_interval,
                     )

--- a/homeassistant/components/rpi_i2c_chips/register.py
+++ b/homeassistant/components/rpi_i2c_chips/register.py
@@ -1,0 +1,144 @@
+#
+# class RegisterTypeFactory:
+#
+#
+#
+# class Register:
+#    _bitnames = ()  # From lowest to highest, None means not used
+#    _bitaliases = {}  # Contain extra names, must contain all _bitnames
+#
+#
+#
+# def gen_register(name, bitnames):
+#    Test = type(name, (object,), {'__init__': __init__, 'printX': printX})
+#    @staticlass
+#
+
+
+class Register:
+    """
+    Represents registers.
+    Allows access to bits via names.
+    Keep as close as possible to names used in official docs.
+    """
+    _NOT_USED_BITNAME_ID = "_"
+    _bitnames = ()  # Resulf of  parse_bitnames() / gen_bitnames call.
+    _bitaliases = {}  # Result of  parse_bitaliases(_bitnames) .
+    _mask = None  # base on number of _bitnames .
+    _val = None
+
+    @staticmethod
+    def parse_bitnames(bitnames_string):
+        """Parses bit names given by string seprated by spaces."""
+        bitnames = []
+        for bitname in bitnames_string.split():
+            bitnames.append(bitname.upper())
+        return bitnames
+
+    @staticmethod
+    def gen_bitnames(num, prefix):
+        """Generates num bitnames with given prefix."""
+        bitnames = []
+        for n in range(num-1, -1, -1):
+            bitnames.append("%s%d" % (prefix, n))
+        return tuple(bitnames)
+
+    @staticmethod
+    def parse_bitaliases(bitnames):
+        """
+        Generates names mappings to bitmasks.
+        """
+        bitaliases = {}
+        bitmask = 1 << (len(bitnames)-1)
+
+        for bitname in bitnames:
+            bitaliases[bitname] = bitmask
+            bitmask = bitmask >> 1
+        return bitaliases
+
+    def __init__(self, val=0):
+        self.set(val)
+        self._mask = (2 << len(self._bitnames)-1) - 1
+
+    def __str__(self):
+        bitmask = 1 << (len(self._bitnames)-1)
+        bit_texts = []
+        for bitname in self._bitnames:
+            if bitname == self._NOT_USED_BITNAME_ID:
+                continue
+            bit_texts.append("%s:%d" %
+                             (bitname, 1 if self._val & bitmask else 0))
+            bitmask = bitmask >> 1
+        return " ".join(bit_texts)
+
+    def __repr__(self):
+        return "<%s 0x%x @%x>" % (self.__class__.__name__, self._val, id(self), )
+
+    def __getattr__(self, name):
+        mask = self._bitaliases.get(name)
+        if mask is None:
+            return super().__getattr__(name)
+        return 1 if self._val & mask else 0  # or return self.val & mask
+
+    def __setattr__(self, name,  value):
+        mask = self._bitaliases.get(name)
+        if mask is None:
+            return super().__setattr__(name, value)
+        # Setting bits
+        if value:
+            self._val |= mask
+        else:
+            self._val &= (self._mask - mask)
+
+    def set(self, val):
+        if val < 0:
+            raise ValueError("Negative values not allowed")
+        if val > 2 << len(self._bitnames):
+            raise ValueError(
+                "Value: %r too big to fit into bits: %r",  val,  self._bitnames)
+        self._val = val
+
+    def __int__(self):
+        return self._val
+
+    # Mask operators
+    def __iand__(self, other):
+        self._val &= int(other)
+
+    def __ixor__(self, other):
+        mask = int(other) & self._mask
+        self._val ^= mask
+
+    def __ior__(self, other):
+        mask = int(other) & self._mask
+        self._val |= mask
+
+
+if __name__ == "__main__":
+    import logging
+    # Run as:
+    #   python3 -m rpi_i2c_chips.register
+
+    logging.basicConfig(
+        level=logging.DEBUG, format='%(relativeCreated)6d %(threadName)s %(message)s')
+    # Some simple testing
+
+    if 1:
+        class Test_Register(Register):
+            _bitnames = Register.parse_bitnames(
+                "BANK MIRROR SEQOP _ _ ODR INTPOL INTCC")
+            _bitaliases = Register.parse_bitaliases(_bitnames)
+
+        class TestNum_Register(Register):
+            _bitnames = Register.gen_bitnames(16, prefix="D")
+            _bitaliases = Register.parse_bitaliases(_bitnames)
+
+        reg = Test_Register(0x80 | 0x4)  # BANK ODR set
+        print ("reg: %s" % (reg, ))
+        print ("reg: 0x%02x reg.BANK: %s reg.MIRROR: %s " %
+               (int(reg), reg.BANK, reg.MIRROR))
+
+        reg = TestNum_Register(0xf00f)
+        print ("reg: %s" % (reg, ))
+        print ("reg: 0x%04x reg.D12: %s reg.D11: %s " %
+               (int(reg), reg.D12, reg.D11))

--- a/homeassistant/components/rpi_i2c_chips/register.py
+++ b/homeassistant/components/rpi_i2c_chips/register.py
@@ -21,6 +21,7 @@ class Register:
     Allows access to bits via names.
     Keep as close as possible to names used in official docs.
     """
+
     _NOT_USED_BITNAME_ID = "_"
     _bitnames = ()  # Resulf of  parse_bitnames() / gen_bitnames call.
     _bitaliases = {}  # Result of  parse_bitaliases(_bitnames) .
@@ -39,7 +40,7 @@ class Register:
     def gen_bitnames(num, prefix):
         """Generates num bitnames with given prefix."""
         bitnames = []
-        for n in range(num-1, -1, -1):
+        for n in range(num - 1, -1, -1):
             bitnames.append("%s%d" % (prefix, n))
         return tuple(bitnames)
 
@@ -49,7 +50,7 @@ class Register:
         Generates names mappings to bitmasks.
         """
         bitaliases = {}
-        bitmask = 1 << (len(bitnames)-1)
+        bitmask = 1 << (len(bitnames) - 1)
 
         for bitname in bitnames:
             bitaliases[bitname] = bitmask
@@ -58,21 +59,22 @@ class Register:
 
     def __init__(self, val=0):
         self.set(val)
-        self._mask = (2 << len(self._bitnames)-1) - 1
+        self._mask = (2 << len(self._bitnames) - 1) - 1
 
     def __str__(self):
-        bitmask = 1 << (len(self._bitnames)-1)
+        bitmask = 1 << (len(self._bitnames) - 1)
         bit_texts = []
         for bitname in self._bitnames:
             if bitname == self._NOT_USED_BITNAME_ID:
                 continue
-            bit_texts.append("%s:%d" %
-                             (bitname, 1 if self._val & bitmask else 0))
+            bit_texts.append(
+                "%s:%d" % (bitname, 1 if self._val & bitmask else 0)
+            )
             bitmask = bitmask >> 1
         return " ".join(bit_texts)
 
     def __repr__(self):
-        return "<%s 0x%x @%x>" % (self.__class__.__name__, self._val, id(self), )
+        return "<%s 0x%x @%x>" % (self.__class__.__name__, self._val, id(self))
 
     def __getattr__(self, name):
         mask = self._bitaliases.get(name)
@@ -80,7 +82,7 @@ class Register:
             return super().__getattr__(name)
         return 1 if self._val & mask else 0  # or return self.val & mask
 
-    def __setattr__(self, name,  value):
+    def __setattr__(self, name, value):
         mask = self._bitaliases.get(name)
         if mask is None:
             return super().__setattr__(name, value)
@@ -88,14 +90,15 @@ class Register:
         if value:
             self._val |= mask
         else:
-            self._val &= (self._mask - mask)
+            self._val &= self._mask - mask
 
     def set(self, val):
         if val < 0:
             raise ValueError("Negative values not allowed")
         if val > 2 << len(self._bitnames):
             raise ValueError(
-                "Value: %r too big to fit into bits: %r",  val,  self._bitnames)
+                "Value: %r too big to fit into bits: %r", val, self._bitnames
+            )
         self._val = val
 
     def __int__(self):
@@ -116,17 +119,22 @@ class Register:
 
 if __name__ == "__main__":
     import logging
+
     # Run as:
     #   python3 -m rpi_i2c_chips.register
 
     logging.basicConfig(
-        level=logging.DEBUG, format='%(relativeCreated)6d %(threadName)s %(message)s')
+        level=logging.DEBUG,
+        format="%(relativeCreated)6d %(threadName)s %(message)s",
+    )
     # Some simple testing
 
     if 1:
+
         class Test_Register(Register):
             _bitnames = Register.parse_bitnames(
-                "BANK MIRROR SEQOP _ _ ODR INTPOL INTCC")
+                "BANK MIRROR SEQOP _ _ ODR INTPOL INTCC"
+            )
             _bitaliases = Register.parse_bitaliases(_bitnames)
 
         class TestNum_Register(Register):
@@ -134,11 +142,15 @@ if __name__ == "__main__":
             _bitaliases = Register.parse_bitaliases(_bitnames)
 
         reg = Test_Register(0x80 | 0x4)  # BANK ODR set
-        print ("reg: %s" % (reg, ))
-        print ("reg: 0x%02x reg.BANK: %s reg.MIRROR: %s " %
-               (int(reg), reg.BANK, reg.MIRROR))
+        print("reg: %s" % (reg,))
+        print(
+            "reg: 0x%02x reg.BANK: %s reg.MIRROR: %s "
+            % (int(reg), reg.BANK, reg.MIRROR)
+        )
 
-        reg = TestNum_Register(0xf00f)
-        print ("reg: %s" % (reg, ))
-        print ("reg: 0x%04x reg.D12: %s reg.D11: %s " %
-               (int(reg), reg.D12, reg.D11))
+        reg = TestNum_Register(0xF00F)
+        print("reg: %s" % (reg,))
+        print(
+            "reg: 0x%04x reg.D12: %s reg.D11: %s "
+            % (int(reg), reg.D12, reg.D11)
+        )

--- a/homeassistant/components/rpi_i2c_expanders.py
+++ b/homeassistant/components/rpi_i2c_expanders.py
@@ -1,0 +1,85 @@
+"""
+Support for controlling I²C port expanders connected to Raspberry Pi
+
+"""
+# TODO:  For more details about this component, please refer to the documentation at
+# https://home-assistant.io/components/TODO/
+
+import logging
+
+from homeassistant.const import (
+    EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP)
+
+REQUIREMENTS = ['smbus-cffi']  # 0.5.1
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = 'rpi_i2c_expanders'
+
+g_managed_chips = None
+g_pollwatcher = None
+
+
+def setup(hass, config):
+    """Set up RPi i²C expanders component."""
+    import smbus
+    from . import rpi_i2c_chips
+    from . import rpi_i2c_ha_expanders
+    global g_managed_chips
+    # TODO: Autodetect ?
+    # bus = smbus.SMBus(0)  # Rev 1 Pi uses 0
+    bus = smbus.SMBus(1)  # Rev 2 Pi uses 1
+    g_managed_chips = rpi_i2c_ha_expanders.ManagedChips(bus)
+
+    hass.bus.listen_once(EVENT_HOMEASSISTANT_START, start)
+    hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, cleanup)
+
+    _LOGGER.info("Available expander chips: %r managed by: %r",
+                 g_managed_chips.supported_expanders.chip_ids(), g_managed_chips, )
+    return True
+
+
+def input_state_change_handler(changed_states):
+    from .binary_sensor import BinarySensorDevice
+
+    _LOGGER.debug(
+        "CALLED input_state_change_handler(changed_states=%s", changed_states, )
+    for changed_state in changed_states:
+        _LOGGER.debug("  changed_state: %s :%s",
+                      changed_state.state,  changed_state, )
+        for pin, new_state in changed_state.changed_bits():
+            binary_sensor = changed_state.state.expander.get_pin_dev(pin)
+            _LOGGER.debug("    Updating state of %s (connected via pin: %r) to %s",
+                          binary_sensor,  pin, new_state, )
+            assert isinstance(binary_sensor, BinarySensorDevice)
+            binary_sensor.set_state(new_state)
+            binary_sensor.schedule_update_ha_state()
+
+
+def start(event):
+    """Stuff to do when home assistant starts."""
+    import smbus
+    from .rpi_i2c_chips.pollwatcher import PollWatcher
+    global g_pollwatcher
+
+    g_pollwatcher = PollWatcher(input_state_change_handler)
+    for chip in g_managed_chips.chips():
+        if chip.inputs_mask:
+            g_pollwatcher.add_to_watch_expander(
+                chip, chip.inputs_mask, log=_LOGGER)
+
+    _LOGGER.info("Staring PollWatcher...")
+    g_pollwatcher.start()
+
+
+def cleanup(event):
+    """Stuff to do before stopping."""
+    global g_pollwatcher
+    if not g_pollwatcher:
+        return
+    _LOGGER.info("Stopping PollWatcher %r ...", g_pollwatcher)
+    g_pollwatcher.stop()
+    _LOGGER.info("Waiting to join PollWatcher ...")
+    g_pollwatcher.join()
+    g_pollwatcher = None
+    _LOGGER.info("Pollwatcher thread finished.")

--- a/homeassistant/components/rpi_i2c_expanders.py
+++ b/homeassistant/components/rpi_i2c_expanders.py
@@ -8,13 +8,15 @@ Support for controlling I²C port expanders connected to Raspberry Pi
 import logging
 
 from homeassistant.const import (
-    EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP)
+    EVENT_HOMEASSISTANT_START,
+    EVENT_HOMEASSISTANT_STOP,
+)
 
-REQUIREMENTS = ['smbus-cffi']  # 0.5.1
+REQUIREMENTS = ["smbus-cffi"]  # 0.5.1
 
 _LOGGER = logging.getLogger(__name__)
 
-DOMAIN = 'rpi_i2c_expanders'
+DOMAIN = "rpi_i2c_expanders"
 
 g_managed_chips = None
 g_pollwatcher = None
@@ -25,6 +27,7 @@ def setup(hass, config):
     import smbus
     from . import rpi_i2c_chips
     from . import rpi_i2c_ha_expanders
+
     global g_managed_chips
     # TODO: Autodetect ?
     # bus = smbus.SMBus(0)  # Rev 1 Pi uses 0
@@ -34,8 +37,11 @@ def setup(hass, config):
     hass.bus.listen_once(EVENT_HOMEASSISTANT_START, start)
     hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, cleanup)
 
-    _LOGGER.info("Available expander chips: %r managed by: %r",
-                 g_managed_chips.supported_expanders.chip_ids(), g_managed_chips, )
+    _LOGGER.info(
+        "Available expander chips: %r managed by: %r",
+        g_managed_chips.supported_expanders.chip_ids(),
+        g_managed_chips,
+    )
     return True
 
 
@@ -43,14 +49,20 @@ def input_state_change_handler(changed_states):
     from .binary_sensor import BinarySensorDevice
 
     _LOGGER.debug(
-        "CALLED input_state_change_handler(changed_states=%s", changed_states, )
+        "CALLED input_state_change_handler(changed_states=%s", changed_states
+    )
     for changed_state in changed_states:
-        _LOGGER.debug("  changed_state: %s :%s",
-                      changed_state.state,  changed_state, )
+        _LOGGER.debug(
+            "  changed_state: %s :%s", changed_state.state, changed_state
+        )
         for pin, new_state in changed_state.changed_bits():
             binary_sensor = changed_state.state.expander.get_pin_dev(pin)
-            _LOGGER.debug("    Updating state of %s (connected via pin: %r) to %s",
-                          binary_sensor,  pin, new_state, )
+            _LOGGER.debug(
+                "    Updating state of %s (connected via pin: %r) to %s",
+                binary_sensor,
+                pin,
+                new_state,
+            )
             assert isinstance(binary_sensor, BinarySensorDevice)
             binary_sensor.set_state(new_state)
             binary_sensor.schedule_update_ha_state()
@@ -60,13 +72,15 @@ def start(event):
     """Stuff to do when home assistant starts."""
     import smbus
     from .rpi_i2c_chips.pollwatcher import PollWatcher
+
     global g_pollwatcher
 
     g_pollwatcher = PollWatcher(input_state_change_handler)
     for chip in g_managed_chips.chips():
         if chip.inputs_mask:
             g_pollwatcher.add_to_watch_expander(
-                chip, chip.inputs_mask, log=_LOGGER)
+                chip, chip.inputs_mask, log=_LOGGER
+            )
 
     _LOGGER.info("Staring PollWatcher...")
     g_pollwatcher.start()

--- a/homeassistant/components/rpi_i2c_expanders.py
+++ b/homeassistant/components/rpi_i2c_expanders.py
@@ -12,7 +12,7 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_STOP,
 )
 
-REQUIREMENTS = ["smbus-cffi"]  # 0.5.1
+REQUIREMENTS = ["smbus-cffi==0.5.1"]
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/rpi_i2c_expanders.py
+++ b/homeassistant/components/rpi_i2c_expanders.py
@@ -26,7 +26,6 @@ g_pollwatcher = None
 def setup(hass, config):
     """Set up RPi i²C expanders component."""
     import smbus
-    from . import rpi_i2c_chips
     from . import rpi_i2c_ha_expanders
 
     global g_managed_chips
@@ -71,7 +70,6 @@ def input_state_change_handler(changed_states):
 
 def start(event):
     """Stuff to do when home assistant starts."""
-    import smbus
     from .rpi_i2c_chips.pollwatcher import PollWatcher
 
     global g_pollwatcher

--- a/homeassistant/components/rpi_i2c_expanders.py
+++ b/homeassistant/components/rpi_i2c_expanders.py
@@ -2,7 +2,8 @@
 Support for controlling I²C port expanders connected to Raspberry Pi
 
 """
-# TODO:  For more details about this component, please refer to the documentation at
+# TODO:  For more details about this component,
+# please refer to the documentation at
 # https://home-assistant.io/components/TODO/
 
 import logging

--- a/homeassistant/components/rpi_i2c_ha_expanders.py
+++ b/homeassistant/components/rpi_i2c_ha_expanders.py
@@ -21,7 +21,8 @@ class HAExpanderMixIn:
 
     def __init__(self, perform_outputs_verification=True):
         """
-        perform_outputs_verification - if set, every write to port will be followed by read allowing to verify port state.
+        perform_outputs_verification - if set, every write to port
+        will be followed by read allowing to verify port state.
         """
         self.pin_connections = {}
         self.perform_outputs_verification = perform_outputs_verification
@@ -73,7 +74,8 @@ class HAExpanderMixIn:
                     "Unable assign %r to expander input/outputs" % (dev,)
                 )
         _LOGGER.debug(
-            "Calculated masks: inputs :0x%X  outputs: 0x%X , outputs_on: 0x%X for %r",
+            "Calculated masks: inputs :0x%X  outputs: 0x%X , "
+            "outputs_on: 0x%X for %r",
             inputs_mask,
             outputs_mask,
             outputs_on_mask,
@@ -96,7 +98,8 @@ class HAExpanderMixIn:
         if self.perform_outputs_verification:
             if not self.verify_outputs():
                 _LOGGER.warn(
-                    "Outputs state wrong. Performing HW configuration again (%s).",
+                    "Outputs state wrong. "
+                    "Performing HW configuration again (%s).",
                     self,
                 )
                 self.ha_configure()
@@ -169,7 +172,8 @@ class ManagedChips:
         self.supported_expanders = SupportedExpanders()
         # Chips marked to manage:
         self.chip_per_address = {}
-        # Request for adding chips on buses may come from differnet components (switches/sensors) and different threads.
+        # Request for adding chips on buses may come from differnet components
+        # (switches/sensors) and different threads, so lock needed
         self.lock = threading.Lock()
         # Bus to operate on.
         self.bus = bus
@@ -180,7 +184,8 @@ class ManagedChips:
             if chip:
                 if chip.id != chip_id:
                     raise ValueError(
-                        "Chip (%r) with different id (%r) than expected already managed on address %x"
+                        "Chip (%r) with different id (%r)"
+                        " than expected already managed on address %x"
                         % (chip, chip.id, chip_id, address)
                     )
             else:

--- a/homeassistant/components/rpi_i2c_ha_expanders.py
+++ b/homeassistant/components/rpi_i2c_ha_expanders.py
@@ -1,0 +1,182 @@
+"""
+Extends rpi_i2c_chips exapander extension for HA
+"""
+
+import logging
+import threading
+
+from .rpi_i2c_chips import MCP23018, PCF8574
+
+from homeassistant.helpers.entity import ToggleEntity
+from homeassistant.components.binary_sensor import BinarySensorDevice
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class HAExpanderMixIn:
+    """
+    Exapands rpi_i2c_chips classes with HA specific methods/attributes.
+    Keeps connection between pins of given chip and HA entities.
+    """
+
+    def __init__(self, perform_outputs_verification=True):
+        """
+        perform_outputs_verification - if set, every write to port will be followed by read allowing to verify port state.
+        """
+        self.pin_connections = {}
+        self.perform_outputs_verification = perform_outputs_verification
+
+    def check_pin(self, pin):
+        """
+        Check if given pin is valid
+        """
+        if 0 <= pin < self.PIN_COUNT:
+            return
+        raise ValueError("Pin %r is invalid for %r", pin, self)
+
+    def pin_connect(self, pin, dev):
+        """
+        Assings pin to work with HA switch/sensor
+        """
+        self.check_pin(pin)
+        prev_connection = self.pin_connections.get(pin)
+        if prev_connection:
+            raise ValueError("Unable to connect %r to pin %r. Pin already connected to: %r." % (
+                dev, pin,  prev_connection))
+        self.pin_connections[pin] = dev
+
+    def get_pin_dev(self, pin):
+        return self.pin_connections.get(pin)
+
+    def ha_configure(self):
+        """
+        Performs HW init based on homeassistant connections.
+        """
+        inputs_mask = 0
+        outputs_mask = 0
+        outputs_on_mask = 0
+        pull_up_mask = 0
+
+        for pin, dev in self.pin_connections.items():
+            if isinstance(dev, ToggleEntity):
+                outputs_mask += 2 ** pin
+                pull_up_mask += 2 ** pin
+                if dev.is_pin_high:
+                    outputs_on_mask += 2 ** pin
+            elif isinstance(dev, BinarySensorDevice):
+                inputs_mask += 2 ** pin
+                pull_up_mask += 2 ** pin
+            else:
+                raise RuntimeError(
+                    "Unable assign %r to expander input/outputs" % (dev, ))
+        _LOGGER.debug("Calculated masks: inputs :0x%X  outputs: 0x%X , outputs_on: 0x%X for %r",
+                      inputs_mask, outputs_mask, outputs_on_mask,  self)
+        # TODO: Pass outputs state to configure without HW flipping ?
+        self.configure(outputs_mask, inputs_mask,  pull_up_mask)
+
+    def update_outputs(self):
+        """
+        Sets HW outputs depending on state of HA switches.
+        Performs HW chip reconfiguration if outputs state mismatch detected.
+        """
+        outputs_on_mask = 0
+        for pin, dev in self.pin_connections.items():
+            if isinstance(dev, ToggleEntity):
+                if dev.is_pin_high:
+                    outputs_on_mask += 2 ** pin
+        self.set_outputs(outputs_on_mask)
+        if self.perform_outputs_verification:
+            if not self.verify_outputs():
+                _LOGGER.warn(
+                    "Outputs state wrong. Performing HW configuration again (%s).", self)
+                self.ha_configure()
+                self.set_outputs(outputs_on_mask)
+                if self.verify_outputs():
+                    _LOGGER.warn(
+                        "Outputs state corrected. Reconfigured %s .",  self)
+                else:
+                    _LOGGER.error(
+                        "Outputs state wrong and unable to reconfigure %s .",  self)
+
+
+class HA_MCP23018(MCP23018.MCP23018, HAExpanderMixIn):
+    id = "MCP23018"
+
+    def __init__(self, bus, address):
+        MCP23018.MCP23018.__init__(self, bus, address)
+        HAExpanderMixIn.__init__(self)
+
+
+# NOTE MCP23017 seems be same as MCP23018 in terms of I²C bus operations
+class HA_MCP23017(HA_MCP23018):
+    id = "MCP23017"
+
+
+class HA_PCF8574(PCF8574.PCF8574, HAExpanderMixIn):
+    """
+    """
+    id = "PCF8574"
+
+    def __init__(self, bus, address):
+        PCF8574.PCF8574.__init__(self, bus, address)
+        HAExpanderMixIn.__init__(self)
+
+
+class SupportedExpanders:
+    """
+    Keeps mapping from ids to chip HAExpander classes.
+    """
+    chip_class_per_id = {
+    }
+
+    def __init__(self):
+        self.add_chip_class(HA_MCP23017)
+        self.add_chip_class(HA_MCP23018)
+        self.add_chip_class(HA_PCF8574)
+
+    def add_chip_class(self, haexpander_class):
+        self.chip_class_per_id[haexpander_class.id] = haexpander_class
+
+    def get_chip_class(self, haexpander_class_id):
+        return self.chip_class_per_id.get(haexpander_class_id)
+
+    def chip_ids(self):
+        return sorted(self.chip_class_per_id.keys())
+
+
+class ManagedChips:
+    """
+    Keeps track of managed chips on given bus.
+    Configures managed chips to act as sensors/switches.
+    """
+
+    def __init__(self, bus):
+        # Static list of supported exapnders:
+        self.supported_expanders = SupportedExpanders()
+        # Chips marked to manage:
+        self.chip_per_address = {}
+        # Request for adding chips on buses may come from differnet components (switches/sensors) and different threads.
+        self.lock = threading.Lock()
+        # Bus to operate on.
+        self.bus = bus
+
+    def manage_chip(self, address, chip_id):
+        with self.lock:
+            chip = self.chip_per_address.get(address)
+            if chip:
+                if chip.id != chip_id:
+                    raise ValueError("Chip (%r) with different id (%r) than expected already managed on address %x" % (
+                        chip, chip.id,  chip_id, address, ))
+            else:
+                chip_class = self.supported_expanders.get_chip_class(chip_id)
+                if chip_class is None:
+                    raise ValueError("Unknown chip id: %r" % (chip_id, ))
+                chip = chip_class(self.bus, address)
+                self.chip_per_address[address] = chip
+                _LOGGER.info(
+                    "New chip (%r) managed on bus: %r address: %x in %r", chip, self.bus, address, self, )
+            return chip
+
+    def chips(self):
+        for chip in self.chip_per_address.values():
+            yield chip

--- a/homeassistant/components/rpi_i2c_ha_expanders.py
+++ b/homeassistant/components/rpi_i2c_ha_expanders.py
@@ -41,8 +41,10 @@ class HAExpanderMixIn:
         self.check_pin(pin)
         prev_connection = self.pin_connections.get(pin)
         if prev_connection:
-            raise ValueError("Unable to connect %r to pin %r. Pin already connected to: %r." % (
-                dev, pin,  prev_connection))
+            raise ValueError(
+                "Unable to connect %r to pin %r. Pin already connected to: %r."
+                % (dev, pin, prev_connection)
+            )
         self.pin_connections[pin] = dev
 
     def get_pin_dev(self, pin):
@@ -68,11 +70,17 @@ class HAExpanderMixIn:
                 pull_up_mask += 2 ** pin
             else:
                 raise RuntimeError(
-                    "Unable assign %r to expander input/outputs" % (dev, ))
-        _LOGGER.debug("Calculated masks: inputs :0x%X  outputs: 0x%X , outputs_on: 0x%X for %r",
-                      inputs_mask, outputs_mask, outputs_on_mask,  self)
+                    "Unable assign %r to expander input/outputs" % (dev,)
+                )
+        _LOGGER.debug(
+            "Calculated masks: inputs :0x%X  outputs: 0x%X , outputs_on: 0x%X for %r",
+            inputs_mask,
+            outputs_mask,
+            outputs_on_mask,
+            self,
+        )
         # TODO: Pass outputs state to configure without HW flipping ?
-        self.configure(outputs_mask, inputs_mask,  pull_up_mask)
+        self.configure(outputs_mask, inputs_mask, pull_up_mask)
 
     def update_outputs(self):
         """
@@ -88,15 +96,20 @@ class HAExpanderMixIn:
         if self.perform_outputs_verification:
             if not self.verify_outputs():
                 _LOGGER.warn(
-                    "Outputs state wrong. Performing HW configuration again (%s).", self)
+                    "Outputs state wrong. Performing HW configuration again (%s).",
+                    self,
+                )
                 self.ha_configure()
                 self.set_outputs(outputs_on_mask)
                 if self.verify_outputs():
                     _LOGGER.warn(
-                        "Outputs state corrected. Reconfigured %s .",  self)
+                        "Outputs state corrected. Reconfigured %s .", self
+                    )
                 else:
                     _LOGGER.error(
-                        "Outputs state wrong and unable to reconfigure %s .",  self)
+                        "Outputs state wrong and unable to reconfigure %s .",
+                        self,
+                    )
 
 
 class HA_MCP23018(MCP23018.MCP23018, HAExpanderMixIn):
@@ -115,6 +128,7 @@ class HA_MCP23017(HA_MCP23018):
 class HA_PCF8574(PCF8574.PCF8574, HAExpanderMixIn):
     """
     """
+
     id = "PCF8574"
 
     def __init__(self, bus, address):
@@ -126,8 +140,8 @@ class SupportedExpanders:
     """
     Keeps mapping from ids to chip HAExpander classes.
     """
-    chip_class_per_id = {
-    }
+
+    chip_class_per_id = {}
 
     def __init__(self):
         self.add_chip_class(HA_MCP23017)
@@ -165,16 +179,23 @@ class ManagedChips:
             chip = self.chip_per_address.get(address)
             if chip:
                 if chip.id != chip_id:
-                    raise ValueError("Chip (%r) with different id (%r) than expected already managed on address %x" % (
-                        chip, chip.id,  chip_id, address, ))
+                    raise ValueError(
+                        "Chip (%r) with different id (%r) than expected already managed on address %x"
+                        % (chip, chip.id, chip_id, address)
+                    )
             else:
                 chip_class = self.supported_expanders.get_chip_class(chip_id)
                 if chip_class is None:
-                    raise ValueError("Unknown chip id: %r" % (chip_id, ))
+                    raise ValueError("Unknown chip id: %r" % (chip_id,))
                 chip = chip_class(self.bus, address)
                 self.chip_per_address[address] = chip
                 _LOGGER.info(
-                    "New chip (%r) managed on bus: %r address: %x in %r", chip, self.bus, address, self, )
+                    "New chip (%r) managed on bus: %r address: %x in %r",
+                    chip,
+                    self.bus,
+                    address,
+                    self,
+                )
             return chip
 
     def chips(self):

--- a/homeassistant/components/switch/rpi_i2c_expanders.py
+++ b/homeassistant/components/switch/rpi_i2c_expanders.py
@@ -1,0 +1,109 @@
+"""
+Allows to configure a switch using RPi I²C bus connected expanders.
+"""
+
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components.switch import PLATFORM_SCHEMA
+from homeassistant.helpers.entity import ToggleEntity
+import homeassistant.helpers.config_validation as cv
+
+_LOGGER = logging.getLogger(__name__)
+
+DEPENDENCIES = ['rpi_i2c_expanders']
+
+# TODO: Merge in components.rpi_i2c_expanders ?
+i2c_bus_port = vol.All(vol.Coerce(int), vol.Range(min=0, max=255))
+
+_SWITCHES_SCHEMA = vol.Schema({
+    cv.positive_int: cv.string,
+})
+
+_CHIP_SCHEMA = vol.Schema({
+    vol.Required("hw"): cv.string,
+    vol.Required("ports"): _SWITCHES_SCHEMA,
+    vol.Optional("invert_logic_ports"): [cv.positive_int],
+})
+
+_CHIPS_SCHEMA = vol.Schema({
+    i2c_bus_port: _CHIP_SCHEMA,
+})
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required("chips"): _CHIPS_SCHEMA,
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up """
+    import homeassistant.components.rpi_i2c_expanders
+
+    managed_chips = homeassistant.components.rpi_i2c_expanders.g_managed_chips
+
+    switches = []
+    chips = config.get("chips")
+
+    ## log.info("chips: %r", chips)
+    for address, chip in chips.items():
+        ## _LOGGER.info("address: %r chip: %r", address, chip)
+        chip_id = chip["hw"]
+        invert_logic_ports = chip.get('invert_logic_ports', ())
+        managed_chip = managed_chips.manage_chip(address, chip_id)
+        _LOGGER.debug("address: %r chip_id: %r -> managed_chip: %r, invert_logic_ports: %r",
+                      address, chip_id,  managed_chip, invert_logic_ports, )
+        for pin, name in chip["ports"].items():
+            invert_logic = pin in invert_logic_ports
+            expander_switch = ExpanderSwitch(name, managed_chip, invert_logic)
+            managed_chip.pin_connect(pin, expander_switch)
+            switches.append(expander_switch)
+            _LOGGER.debug("address: %r managed_chip: %r: pin: %r connected to expander_switch: %r",
+                          address, managed_chip, pin, expander_switch, )
+        managed_chip.ha_configure()  # HW configuration of chip.
+        managed_chip.update_outputs()  # Set initial states.
+
+    add_devices(switches)
+
+
+class ExpanderSwitch(ToggleEntity):
+    """Representation of a Raspberry Pi I²C bus expander IO based switch."""
+
+    def __init__(self, name, ha_expander, invert_logic):
+        """Initialize the pin."""
+        self._name = name
+        self._state = False
+        self._ha_expander = ha_expander  # HAExpander
+        self._invert_logic = bool(invert_logic)
+
+    @property
+    def name(self):
+        """Return the name of the switch."""
+        return self._name
+
+    @property
+    def should_poll(self):
+        """No polling needed."""
+        return False
+
+    @property
+    def is_on(self):
+        """Return true if device is on."""
+        return self._state
+
+    @property
+    def is_pin_high(self):
+        """Return true if pin state should be high."""
+        return self._state != self._invert_logic
+
+    def turn_on(self, **kwargs):
+        """Turn the device on."""
+        self._state = True
+        self._ha_expander.update_outputs()
+        self.schedule_update_ha_state()
+
+    def turn_off(self, **kwargs):
+        """Turn the device off."""
+        self._state = False
+        self._ha_expander.update_outputs()
+        self.schedule_update_ha_state()

--- a/homeassistant/components/switch/rpi_i2c_expanders.py
+++ b/homeassistant/components/switch/rpi_i2c_expanders.py
@@ -43,14 +43,13 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     switches = []
     chips = config.get("chips")
 
-    ## log.info("chips: %r", chips)
     for address, chip in chips.items():
-        ## _LOGGER.info("address: %r chip: %r", address, chip)
         chip_id = chip["hw"]
         invert_logic_ports = chip.get("invert_logic_ports", ())
         managed_chip = managed_chips.manage_chip(address, chip_id)
         _LOGGER.debug(
-            "address: %r chip_id: %r -> managed_chip: %r, invert_logic_ports: %r",
+            "address: %r chip_id: %r -> managed_chip: %r,"
+            "invert_logic_ports: %r",
             address,
             chip_id,
             managed_chip,
@@ -62,7 +61,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             managed_chip.pin_connect(pin, expander_switch)
             switches.append(expander_switch)
             _LOGGER.debug(
-                "address: %r managed_chip: %r: pin: %r connected to expander_switch: %r",
+                "address: %r managed_chip: %r:"
+                " pin: %r connected to expander_switch: %r",
                 address,
                 managed_chip,
                 pin,

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1107,6 +1107,7 @@ sleekxmpp==1.3.2
 sleepyq==0.6
 
 # homeassistant.components.raspihats
+# homeassistant.components.rpi_i2c_expanders
 # homeassistant.components.sensor.bh1750
 # homeassistant.components.sensor.bme280
 # homeassistant.components.sensor.bme680


### PR DESCRIPTION
##  Implementation of buttons and sensors connected to I²c expanders managed from  Raspberry Pi
Currently works and developed with MCP23018 and PCF8574

## Example entry for `configuration.yaml`:
```
switch:
  - platform: rpi_i2c_expanders
    chips:
        0x20: 
            hw: MCP23018
            ports:
                0: P20_OUT_0
                1: P20_OUT_1
                7: P20_OUT_7
            invert_logic_ports: [ 0, 1,7,]
        0x24:
            hw: PCF8574
            ports:
                4: P24_OUT_4
            invert_logic_ports: [ 4, ]

binary_sensor:
  - platform: rpi_i2c_expanders
    chips:
        0x20: 
           hw: MCP23018
           ports:
               6: P20_IN_6
           invert_logic_ports: [ 6, ]
        0x24: 
            hw: PCF8574
            ports:
                7: P24_IN_7
            invert_logic_ports: [ 7, ]
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] New files were added to `.coveragerc`.

## Note:
I am not native English speaker nor electronics guy. Vocabulary/terminology/phrasing updates of variables/classes/names will is really welcome.

