### PR TITLE
[WIP] Add generic thermostat boost mode

### DIFF
--- a/homeassistant/components/climate/generic_thermostat.py
+++ b/homeassistant/components/climate/generic_thermostat.py
@@ -400,7 +400,7 @@ class GenericThermostat(ClimateDevice):
         self._target_temp = self._saved_target_temp
         await self._async_control_heating()
         await self.async_update_ha_state()
-        
+
     @property
     def is_boost_mode_on(self):
         """Return true if boost mode is on."""

--- a/homeassistant/components/climate/generic_thermostat.py
+++ b/homeassistant/components/climate/generic_thermostat.py
@@ -98,7 +98,7 @@ class GenericThermostat(ClimateDevice):
     def __init__(self, hass, name, heater_entity_id, sensor_entity_id,
                  min_temp, max_temp, target_temp, ac_mode, min_cycle_duration,
                  cold_tolerance, hot_tolerance, keep_alive,
-                 initial_operation_mode, away_temp):
+                 initial_operation_mode, away_temp, boost_temp):
         """Initialize the thermostat."""
         self.hass = hass
         self._name = name
@@ -400,8 +400,7 @@ class GenericThermostat(ClimateDevice):
         self._target_temp = self._saved_target_temp
         await self._async_control_heating()
         await self.async_update_ha_state()
-
-
+        
     @property
     def is_boost_mode_on(self):
         """Return true if boost mode is on."""

--- a/homeassistant/components/climate/services.yaml
+++ b/homeassistant/components/climate/services.yaml
@@ -148,3 +148,14 @@ sensibo_assume_state:
     state:
       description: State to set.
       example: 'idle'
+
+
+set_boost_mode:
+  description: Turn boost mode on/off for climate device.
+  fields:
+    entity_id:
+      description: Name(s) of entities to change.
+      example: 'climate.kitchen'
+    boost_mode:
+      description: New value of away mode.
+      example: true


### PR DESCRIPTION
I did run this locally for a while but recreated it for this PR - let me know if it's no ok, will update with documentation etc 

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
