### PR TITLE
Added identifier and name to connect/disconnect events

### DIFF
--- a/homeassistant/components/keyboard_remote.py
+++ b/homeassistant/components/keyboard_remote.py
@@ -135,11 +135,12 @@ class KeyboardRemoteThread(threading.Thread):
                 self.dev = self._get_keyboard_device()
                 if self.dev is not None:
                     self.dev.grab()
-                    self.hass.bus.fire(KEYBOARD_REMOTE_CONNECTED,
-                      {
-                        DEVICE_DESCRIPTOR: self.device_descriptor,
-                        DEVICE_NAME: self.device_name
-                      }
+                    self.hass.bus.fire(
+                        KEYBOARD_REMOTE_CONNECTED,
+                        {
+                            DEVICE_DESCRIPTOR: self.device_descriptor,
+                            DEVICE_NAME: self.device_name
+                        }
                     )
                     _LOGGER.debug("Keyboard re-connected, %s", self.device_id)
                 else:
@@ -149,12 +150,13 @@ class KeyboardRemoteThread(threading.Thread):
                 event = self.dev.read_one()
             except IOError:  # Keyboard Disconnected
                 self.dev = None
-                self.hass.bus.fire(KEYBOARD_REMOTE_DISCONNECTED,
-                      {
+                self.hass.bus.fire(
+                    KEYBOARD_REMOTE_DISCONNECTED,
+                    {
                         DEVICE_DESCRIPTOR: self.device_descriptor,
                         DEVICE_NAME: self.device_name
-                      }
-                    )
+                    }
+                )
                 _LOGGER.debug("Keyboard disconnected, %s", self.device_id)
                 continue
 

--- a/homeassistant/components/keyboard_remote.py
+++ b/homeassistant/components/keyboard_remote.py
@@ -4,6 +4,7 @@ Receive signals from a keyboard and use it as a remote control.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/keyboard_remote/
 """
+# pylint: disable=import-error
 import threading
 import logging
 import os
@@ -89,7 +90,6 @@ class KeyboardRemoteThread(threading.Thread):
             id_folder = '/dev/input/by-id/'
 
             if os.path.isdir(id_folder):
-                # pylint: disable=import-error
                 from evdev import InputDevice, list_devices
                 device_names = [InputDevice(file_name).name
                                 for file_name in list_devices()]
@@ -104,7 +104,6 @@ class KeyboardRemoteThread(threading.Thread):
 
     def _get_keyboard_device(self):
         """Get the keyboard device."""
-        # pylint: disable=import-error
         from evdev import InputDevice, list_devices
         if self.device_name:
             devices = [InputDevice(file_name) for file_name in list_devices()]
@@ -122,7 +121,6 @@ class KeyboardRemoteThread(threading.Thread):
 
     def run(self):
         """Run the loop of the KeyboardRemote."""
-        # pylint: disable=import-error
         from evdev import categorize, ecodes
 
         if self.dev is not None:
@@ -137,7 +135,12 @@ class KeyboardRemoteThread(threading.Thread):
                 self.dev = self._get_keyboard_device()
                 if self.dev is not None:
                     self.dev.grab()
-                    self.hass.bus.fire(KEYBOARD_REMOTE_CONNECTED)
+                    self.hass.bus.fire(KEYBOARD_REMOTE_CONNECTED,
+                      {
+                        DEVICE_DESCRIPTOR: self.device_descriptor,
+                        DEVICE_NAME: self.device_name
+                      }
+                    )
                     _LOGGER.debug("Keyboard re-connected, %s", self.device_id)
                 else:
                     continue
@@ -146,7 +149,12 @@ class KeyboardRemoteThread(threading.Thread):
                 event = self.dev.read_one()
             except IOError:  # Keyboard Disconnected
                 self.dev = None
-                self.hass.bus.fire(KEYBOARD_REMOTE_DISCONNECTED)
+                self.hass.bus.fire(KEYBOARD_REMOTE_DISCONNECTED,
+                      {
+                        DEVICE_DESCRIPTOR: self.device_descriptor,
+                        DEVICE_NAME: self.device_name
+                      }
+                    )
                 _LOGGER.debug("Keyboard disconnected, %s", self.device_id)
                 continue
 


### PR DESCRIPTION
## Description:

Add device identifier and description to keyboard_remote component connect and disconnect events.  Previously events were published with no identification details.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#7313

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
