### PR TITLE
Allow disabling WeMo Discovery

### DIFF
--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -83,7 +83,7 @@ def setup(hass, config):
 
     def stop_wemo(event):
         """Shutdown Wemo subscriptions and subscription thread on exit."""
-        _LOGGER.info("Shutting down subscriptions.")
+        _LOGGER.debug("Shutting down subscriptions.")
         SUBSCRIPTION_REGISTRY.stop()
 
     hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, stop_wemo)
@@ -150,7 +150,7 @@ def setup(hass, config):
             for device in pywemo.discover_devices())
 
     for url, device in devices:
-        _LOGGER.info('Adding wemo at %s:%i', device.host, device.port)
+        _LOGGER.debug('Adding wemo at %s:%i', device.host, device.port)
 
         discovery_info = {
             'model_name': device.model_name,

--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -58,12 +58,17 @@ def coerce_host_port(value):
 
 
 CONF_STATIC = 'static'
+CONF_DISABLE_DISCOVERY = 'disable_discovery'
+
+DEFAULT_DISABLE_DISCOVERY = False
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Optional(CONF_STATIC, default=[]): vol.Schema([
             vol.All(cv.string, coerce_host_port)
-        ])
+        ]),
+        vol.Optional(CONF_DISABLE_DISCOVERY,
+                     default=DEFAULT_DISABLE_DISCOVERY): cv.boolean
     }),
 }, extra=vol.ALLOW_EXTRA)
 
@@ -136,10 +141,13 @@ def setup(hass, config):
 
         devices.append((url, device))
 
-    _LOGGER.info("Scanning for WeMo devices.")
-    devices.extend(
-        (setup_url_for_device(device), device)
-        for device in pywemo.discover_devices())
+    disable_discovery = config.get(DOMAIN, {}).get(CONF_DISABLE_DISCOVERY)
+
+    if not disable_discovery:
+        _LOGGER.info("Scanning for WeMo devices.")
+        devices.extend(
+            (setup_url_for_device(device), device)
+            for device in pywemo.discover_devices())
 
     for url, device in devices:
         _LOGGER.info('Adding wemo at %s:%i', device.host, device.port)

--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -144,7 +144,7 @@ def setup(hass, config):
     disable_discovery = config.get(DOMAIN, {}).get(CONF_DISABLE_DISCOVERY)
 
     if not disable_discovery:
-        _LOGGER.info("Scanning for WeMo devices.")
+        _LOGGER.debug("Scanning for WeMo devices.")
         devices.extend(
             (setup_url_for_device(device), device)
             for device in pywemo.discover_devices())


### PR DESCRIPTION
## Description:
Added a new optional configuration.yaml item for the WeMo platform called "disable_discovery", which allows a user to turn off the automatic discovery of WeMo devices.

**Related issue (if applicable):** fixes #16475

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#7314

## Example entry for `configuration.yaml` (if applicable):
```yaml
wemo:
  disable_disovery: true
  static:
    - 192.168.1.23
    - 192.168.52.172
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)