### PR TITLE
Added service select_video_output and video_out attribute

### DIFF
--- a/homeassistant/components/media_player/onkyo.py
+++ b/homeassistant/components/media_player/onkyo.py
@@ -15,7 +15,8 @@ from homeassistant.components.media_player import (
     PLATFORM_SCHEMA, SUPPORT_PLAY, SUPPORT_PLAY_MEDIA, SUPPORT_SELECT_SOURCE,
     SUPPORT_TURN_OFF, SUPPORT_TURN_ON, SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_SET,
     SUPPORT_VOLUME_STEP, MediaPlayerDevice)
-from homeassistant.const import CONF_HOST, CONF_NAME, STATE_OFF, STATE_ON, ATTR_ENTITY_ID
+from homeassistant.const import (
+    CONF_HOST, CONF_NAME, STATE_OFF, STATE_ON, ATTR_ENTITY_ID)
 import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['onkyo-eiscp==1.2.4']
@@ -56,9 +57,13 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 TIMEOUT_MESSAGE = 'Timeout waiting for response.'
 
 ATTR_VIDEO_OUTPUT = 'video_output'
-ONKYO_SELECT_OUTPUT_SCHEMA = vol.Schema({vol.Required(ATTR_ENTITY_ID): cv.entity_ids, vol.Required(ATTR_VIDEO_OUTPUT): vol.In(['no', 'analog', 'yes', 'out', 'out-sub', 'sub', 'hdbaset', 'both', 'up'])})
+ACCEPTED_VALUES = ['no', 'analog', 'yes', 'out',
+                   'out-sub', 'sub', 'hdbaset', 'both', 'up']
+ONKYO_SELECT_OUTPUT_SCHEMA = vol.Schema({vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
+                                         vol.Required(ATTR_VIDEO_OUTPUT): vol.In(ACCEPTED_VALUES)})
 DOMAIN = 'media_player'
 SERVICE_SELECT_VIDEO_OUTPUT = 'select_video_output'
+
 
 def determine_zones(receiver):
     """Determine what zones are available for the receiver."""
@@ -98,11 +103,11 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         """Handle for services."""
         entity_ids = service.data.get(ATTR_ENTITY_ID)
         devices = [d for d in hosts if d.entity_id in entity_ids]
-      
+
         for device in devices:
             if service.service == SERVICE_SELECT_VIDEO_OUTPUT:
                 device.select_output(service.data.get(ATTR_VIDEO_OUTPUT))
-    
+
     hass.services.register(
         DOMAIN, SERVICE_SELECT_VIDEO_OUTPUT, service_handle,
         schema=ONKYO_SELECT_OUTPUT_SCHEMA)
@@ -300,10 +305,10 @@ class OnkyoDevice(MediaPlayerDevice):
                 source in DEFAULT_PLAYABLE_SOURCES):
             self.command('preset {}'.format(media_id))
 
-
     def select_output(self, output):
         """Set hdmi-out"""
         self.command('hdmi-output-selector={}'.format(output))
+
 
 class OnkyoDeviceZone(OnkyoDevice):
     """Representation of an Onkyo device's extra zone."""
@@ -375,7 +380,7 @@ class OnkyoDeviceZone(OnkyoDevice):
 
     def set_volume_level(self, volume):
         """Set volume level, input is range 0..1. Onkyo ranges from 1-80."""
-        self.command('zone{}.volume={}'.format(self._zone, int(volume*80)))
+        self.command('zone{}.volume={}'.format(self._zone, int(volume * 80)))
 
     def volume_up(self):
         """Increase volume by 1 step."""

--- a/homeassistant/components/media_player/onkyo.py
+++ b/homeassistant/components/media_player/onkyo.py
@@ -56,7 +56,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 TIMEOUT_MESSAGE = 'Timeout waiting for response.'
 
-ATTR_HDMI_OUTPUT = 'video_output'
+ATTR_HDMI_OUTPUT = 'hdmi_output'
 ACCEPTED_VALUES = ['no', 'analog', 'yes', 'out',
                    'out-sub', 'sub', 'hdbaset', 'both', 'up']
 ONKYO_SELECT_OUTPUT_SCHEMA = vol.Schema({

--- a/homeassistant/components/media_player/onkyo.py
+++ b/homeassistant/components/media_player/onkyo.py
@@ -56,15 +56,15 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 TIMEOUT_MESSAGE = 'Timeout waiting for response.'
 
-ATTR_VIDEO_OUTPUT = 'video_output'
+ATTR_HDMI_OUTPUT = 'video_output'
 ACCEPTED_VALUES = ['no', 'analog', 'yes', 'out',
                    'out-sub', 'sub', 'hdbaset', 'both', 'up']
 ONKYO_SELECT_OUTPUT_SCHEMA = vol.Schema({
     vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
-    vol.Required(ATTR_VIDEO_OUTPUT): vol.In(ACCEPTED_VALUES)
+    vol.Required(ATTR_HDMI_OUTPUT): vol.In(ACCEPTED_VALUES)
 })
 
-SERVICE_SELECT_VIDEO_OUTPUT = 'onkyo_select_video_output'
+SERVICE_SELECT_HDMI_OUTPUT = 'onkyo_select_hdmi_output'
 
 
 def determine_zones(receiver):
@@ -107,11 +107,11 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         devices = [d for d in hosts if d.entity_id in entity_ids]
 
         for device in devices:
-            if service.service == SERVICE_SELECT_VIDEO_OUTPUT:
-                device.select_output(service.data.get(ATTR_VIDEO_OUTPUT))
+            if service.service == SERVICE_SELECT_HDMI_OUTPUT:
+                device.select_output(service.data.get(ATTR_HDMI_OUTPUT))
 
     hass.services.register(
-        DOMAIN, SERVICE_SELECT_VIDEO_OUTPUT, service_handle,
+        DOMAIN, SERVICE_SELECT_HDMI_OUTPUT, service_handle,
         schema=ONKYO_SELECT_OUTPUT_SCHEMA)
 
     if CONF_HOST in config and host not in KNOWN_HOSTS:

--- a/homeassistant/components/media_player/onkyo.py
+++ b/homeassistant/components/media_player/onkyo.py
@@ -14,7 +14,7 @@ import voluptuous as vol
 from homeassistant.components.media_player import (
     PLATFORM_SCHEMA, SUPPORT_PLAY, SUPPORT_PLAY_MEDIA, SUPPORT_SELECT_SOURCE,
     SUPPORT_TURN_OFF, SUPPORT_TURN_ON, SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_SET,
-    SUPPORT_VOLUME_STEP, MediaPlayerDevice)
+    SUPPORT_VOLUME_STEP, MediaPlayerDevice, DOMAIN)
 from homeassistant.const import (
     CONF_HOST, CONF_NAME, STATE_OFF, STATE_ON, ATTR_ENTITY_ID)
 import homeassistant.helpers.config_validation as cv
@@ -63,7 +63,7 @@ ONKYO_SELECT_OUTPUT_SCHEMA = vol.Schema({
     vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
     vol.Required(ATTR_VIDEO_OUTPUT): vol.In(ACCEPTED_VALUES)
 })
-DOMAIN = 'media_player'
+
 SERVICE_SELECT_VIDEO_OUTPUT = 'select_video_output'
 
 

--- a/homeassistant/components/media_player/onkyo.py
+++ b/homeassistant/components/media_player/onkyo.py
@@ -59,8 +59,10 @@ TIMEOUT_MESSAGE = 'Timeout waiting for response.'
 ATTR_VIDEO_OUTPUT = 'video_output'
 ACCEPTED_VALUES = ['no', 'analog', 'yes', 'out',
                    'out-sub', 'sub', 'hdbaset', 'both', 'up']
-ONKYO_SELECT_OUTPUT_SCHEMA = vol.Schema({vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
-                                         vol.Required(ATTR_VIDEO_OUTPUT): vol.In(ACCEPTED_VALUES)})
+ONKYO_SELECT_OUTPUT_SCHEMA = vol.Schema({
+    vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
+    vol.Required(ATTR_VIDEO_OUTPUT): vol.In(ACCEPTED_VALUES)
+})
 DOMAIN = 'media_player'
 SERVICE_SELECT_VIDEO_OUTPUT = 'select_video_output'
 

--- a/homeassistant/components/media_player/onkyo.py
+++ b/homeassistant/components/media_player/onkyo.py
@@ -15,7 +15,7 @@ from homeassistant.components.media_player import (
     PLATFORM_SCHEMA, SUPPORT_PLAY, SUPPORT_PLAY_MEDIA, SUPPORT_SELECT_SOURCE,
     SUPPORT_TURN_OFF, SUPPORT_TURN_ON, SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_SET,
     SUPPORT_VOLUME_STEP, MediaPlayerDevice)
-from homeassistant.const import CONF_HOST, CONF_NAME, STATE_OFF, STATE_ON
+from homeassistant.const import CONF_HOST, CONF_NAME, STATE_OFF, STATE_ON, ATTR_ENTITY_ID
 import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['onkyo-eiscp==1.2.4']
@@ -55,6 +55,10 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 TIMEOUT_MESSAGE = 'Timeout waiting for response.'
 
+ATTR_VIDEO_OUTPUT = 'video_output'
+ONKYO_SELECT_OUTPUT_SCHEMA = vol.Schema({vol.Required(ATTR_ENTITY_ID): cv.entity_ids, vol.Required(ATTR_VIDEO_OUTPUT): vol.In(['no', 'analog', 'yes', 'out', 'out-sub', 'sub', 'hdbaset', 'both', 'up'])})
+DOMAIN = 'media_player'
+SERVICE_SELECT_VIDEO_OUTPUT = 'select_video_output'
 
 def determine_zones(receiver):
     """Determine what zones are available for the receiver."""
@@ -89,6 +93,19 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     host = config.get(CONF_HOST)
     hosts = []
+
+    def service_handle(service):
+        """Handle for services."""
+        entity_ids = service.data.get(ATTR_ENTITY_ID)
+        devices = [d for d in hosts if d.entity_id in entity_ids]
+      
+        for device in devices:
+            if service.service == SERVICE_SELECT_VIDEO_OUTPUT:
+                device.select_output(service.data.get(ATTR_VIDEO_OUTPUT))
+    
+    hass.services.register(
+        DOMAIN, SERVICE_SELECT_VIDEO_OUTPUT, service_handle,
+        schema=ONKYO_SELECT_OUTPUT_SCHEMA)
 
     if CONF_HOST in config and host not in KNOWN_HOSTS:
         try:
@@ -144,6 +161,7 @@ class OnkyoDevice(MediaPlayerDevice):
         self._source_list = list(sources.values())
         self._source_mapping = sources
         self._reverse_mapping = {value: key for key, value in sources.items()}
+        self._attributes = {}
 
     def command(self, command):
         """Run an eiscp command and catch connection errors."""
@@ -174,6 +192,7 @@ class OnkyoDevice(MediaPlayerDevice):
         volume_raw = self.command('volume query')
         mute_raw = self.command('audio-muting query')
         current_source_raw = self.command('input-selector query')
+        hdmi_out_raw = self.command('hdmi-output-selector query')
 
         if not (volume_raw and mute_raw and current_source_raw):
             return
@@ -194,6 +213,7 @@ class OnkyoDevice(MediaPlayerDevice):
                     [i for i in current_source_tuples[1]])
         self._muted = bool(mute_raw[1] == 'on')
         self._volume = volume_raw[1] / self._max_volume
+        self._attributes["video_out"] = ','.join(hdmi_out_raw[1])
 
     @property
     def name(self):
@@ -229,6 +249,11 @@ class OnkyoDevice(MediaPlayerDevice):
     def source_list(self):
         """List of available input sources."""
         return self._source_list
+
+    @property
+    def device_state_attributes(self):
+        """Return device specific state attributes."""
+        return self._attributes
 
     def turn_off(self):
         """Turn the media player off."""
@@ -275,6 +300,10 @@ class OnkyoDevice(MediaPlayerDevice):
                 source in DEFAULT_PLAYABLE_SOURCES):
             self.command('preset {}'.format(media_id))
 
+
+    def select_output(self, output):
+        """Set hdmi-out"""
+        self.command('hdmi-output-selector={}'.format(output))
 
 class OnkyoDeviceZone(OnkyoDevice):
     """Representation of an Onkyo device's extra zone."""

--- a/homeassistant/components/media_player/onkyo.py
+++ b/homeassistant/components/media_player/onkyo.py
@@ -64,7 +64,7 @@ ONKYO_SELECT_OUTPUT_SCHEMA = vol.Schema({
     vol.Required(ATTR_VIDEO_OUTPUT): vol.In(ACCEPTED_VALUES)
 })
 
-SERVICE_SELECT_VIDEO_OUTPUT = 'select_video_output'
+SERVICE_SELECT_VIDEO_OUTPUT = 'onkyo_select_video_output'
 
 
 def determine_zones(receiver):

--- a/homeassistant/components/media_player/onkyo.py
+++ b/homeassistant/components/media_player/onkyo.py
@@ -308,7 +308,7 @@ class OnkyoDevice(MediaPlayerDevice):
             self.command('preset {}'.format(media_id))
 
     def select_output(self, output):
-        """Set hdmi-out"""
+        """Set hdmi-out."""
         self.command('hdmi-output-selector={}'.format(output))
 
 


### PR DESCRIPTION
## Description:
  Added service to change video hdmi output
  service data "video_output" takes a value of:
    'no', 'analog', 'yes', 'out', 'out-sub', 'sub', 'hdbaset', 'both', 'up'

  Also adds attribute of "video_out" to display current output

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
