### PR TITLE
Upgrade psutil to 5.4.8

### DIFF
--- a/homeassistant/components/sensor/systemmonitor.py
+++ b/homeassistant/components/sensor/systemmonitor.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.dt as dt_util
 
-REQUIREMENTS = ['psutil==5.4.7']
+REQUIREMENTS = ['psutil==5.4.8']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -747,7 +747,7 @@ proliphix==0.4.1
 prometheus_client==0.2.0
 
 # homeassistant.components.sensor.systemmonitor
-psutil==5.4.7
+psutil==5.4.8
 
 # homeassistant.components.wink
 pubnubsub-handler==1.0.2


### PR DESCRIPTION
## Description:
Changelog: https://github.com/giampaolo/psutil/blob/master/HISTORY.rst#548

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: systemmonitor
    resources:
      - type: disk_use_percent
        arg: /home
      - type: memory_free
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
