### PR TITLE
Upgrade georss_client to 0.4

### DIFF
--- a/homeassistant/components/geo_location/geo_json_events.py
+++ b/homeassistant/components/geo_location/geo_json_events.py
@@ -20,7 +20,7 @@ from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect, dispatcher_send)
 from homeassistant.helpers.event import track_time_interval
 
-REQUIREMENTS = ['geojson_client==0.1']
+REQUIREMENTS = ['geojson_client==0.3']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/geo_location/nsw_rural_fire_service_feed.py
+++ b/homeassistant/components/geo_location/nsw_rural_fire_service_feed.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect, dispatcher_send)
 from homeassistant.helpers.event import track_time_interval
 
-REQUIREMENTS = ['geojson_client==0.1']
+REQUIREMENTS = ['geojson_client==0.3']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sensor/geo_rss_events.py
+++ b/homeassistant/components/sensor/geo_rss_events.py
@@ -20,7 +20,7 @@ from homeassistant.const import (
     CONF_LATITUDE, CONF_LONGITUDE, CONF_RADIUS, CONF_URL)
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['georss_client==0.3']
+REQUIREMENTS = ['georss_client==0.4']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -413,7 +413,7 @@ geizhals==0.0.7
 geojson_client==0.3
 
 # homeassistant.components.sensor.geo_rss_events
-georss_client==0.3
+georss_client==0.4
 
 # homeassistant.components.sensor.gitter
 gitterpy==0.1.7

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -410,7 +410,7 @@ geizhals==0.0.7
 
 # homeassistant.components.geo_location.geo_json_events
 # homeassistant.components.geo_location.nsw_rural_fire_service_feed
-geojson_client==0.1
+geojson_client==0.3
 
 # homeassistant.components.sensor.geo_rss_events
 georss_client==0.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -76,7 +76,7 @@ gTTS-token==1.1.2
 
 # homeassistant.components.geo_location.geo_json_events
 # homeassistant.components.geo_location.nsw_rural_fire_service_feed
-geojson_client==0.1
+geojson_client==0.3
 
 # homeassistant.components.sensor.geo_rss_events
 georss_client==0.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -79,7 +79,7 @@ gTTS-token==1.1.2
 geojson_client==0.3
 
 # homeassistant.components.sensor.geo_rss_events
-georss_client==0.3
+georss_client==0.4
 
 # homeassistant.components.ffmpeg
 ha-ffmpeg==1.9


### PR DESCRIPTION
## Description:
Update geojson_client to version 0.3 and georss_client to version 0.4 which both loosen their own third-party dependencies, trying not to interfere with Home Assistant's own dependencies.

**Related issue (if applicable):** n/a

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable): n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
