### PR TITLE
Changed pifacecommon 4.1.2 to 4.2.2 to make piface digital i/o boards work on rpi 3

### DIFF
--- a/homeassistant/components/rpi_pfio.py
+++ b/homeassistant/components/rpi_pfio.py
@@ -9,7 +9,7 @@ import logging
 from homeassistant.const import (
     EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP)
 
-REQUIREMENTS = ['pifacecommon==4.1.2', 'pifacedigitalio==3.0.5']
+REQUIREMENTS = ['pifacecommon==4.2.2', 'pifacedigitalio==3.0.5']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -709,7 +709,7 @@ pdunehd==1.3
 pexpect==4.6.0
 
 # homeassistant.components.rpi_pfio
-pifacecommon==4.1.2
+pifacecommon==4.2.2
 
 # homeassistant.components.rpi_pfio
 pifacedigitalio==3.0.5


### PR DESCRIPTION
## Description:
I changed from pifacecommon 4.1.2 to 4.2.2 as it contain a couple of years of bug fixes. Most notably it makes the piface boards work with rpi 3 that have a higher default clock frequency on the SPI bus.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**


If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: homeassistant/components/rpi_pfio.py #L12
[ex-import]: homeassistant/components/rpi_pfio.py #L12

Note: My fist pull request :) 