### PR TITLE
Fix time zone for flux switch

### DIFF
--- a/homeassistant/components/switch/flux.py
+++ b/homeassistant/components/switch/flux.py
@@ -25,7 +25,7 @@ from homeassistant.util import slugify
 from homeassistant.util.color import (
     color_temperature_to_rgb, color_RGB_to_xy_brightness,
     color_temperature_kelvin_to_mired)
-from homeassistant.util.dt import now as dt_now
+from homeassistant.util.dt import utcnow as dt_utcnow, as_local
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -195,10 +195,12 @@ class FluxSwitch(SwitchDevice):
 
         self.schedule_update_ha_state()
 
-    def flux_update(self, now=None):
+    def flux_update(self, utcnow=None):
         """Update all the lights using flux."""
-        if now is None:
-            now = dt_now()
+        if utcnow is None:
+            utcnow = dt_utcnow()
+
+        now = as_local(utcnow)
 
         sunset = get_astral_event_date(self.hass, 'sunset', now.date())
         start_time = self.find_start_time(now)

--- a/tests/components/switch/test_flux.py
+++ b/tests/components/switch/test_flux.py
@@ -86,7 +86,7 @@ class TestSwitchFlux(unittest.TestCase):
         assert state.attributes.get('xy_color') is None
         assert state.attributes.get('brightness') is None
 
-        test_time = dt_util.now().replace(hour=10, minute=30, second=0)
+        test_time = dt_util.utcnow().replace(hour=10, minute=30, second=0)
         sunset_time = test_time.replace(hour=17, minute=0, second=0)
         sunrise_time = test_time.replace(hour=5, minute=0, second=0)
 
@@ -95,7 +95,7 @@ class TestSwitchFlux(unittest.TestCase):
                 return sunrise_time
             return sunset_time
 
-        with patch('homeassistant.util.dt.now', return_value=test_time):
+        with patch('homeassistant.util.dt.utcnow', return_value=test_time):
             with patch('homeassistant.helpers.sun.get_astral_event_date',
                        side_effect=event_date):
                 assert setup_component(self.hass, switch.DOMAIN, {
@@ -126,7 +126,7 @@ class TestSwitchFlux(unittest.TestCase):
         assert state.attributes.get('xy_color') is None
         assert state.attributes.get('brightness') is None
 
-        test_time = dt_util.now().replace(hour=2, minute=30, second=0)
+        test_time = dt_util.utcnow().replace(hour=2, minute=30, second=0)
         sunset_time = test_time.replace(hour=17, minute=0, second=0)
         sunrise_time = test_time.replace(hour=5, minute=0, second=0)
 
@@ -135,7 +135,7 @@ class TestSwitchFlux(unittest.TestCase):
                 return sunrise_time
             return sunset_time
 
-        with patch('homeassistant.util.dt.now', return_value=test_time):
+        with patch('homeassistant.util.dt.utcnow', return_value=test_time):
             with patch('homeassistant.helpers.sun.get_astral_event_date',
                        side_effect=event_date):
                 assert setup_component(self.hass, switch.DOMAIN, {
@@ -171,7 +171,7 @@ class TestSwitchFlux(unittest.TestCase):
         assert state.attributes.get('xy_color') is None
         assert state.attributes.get('brightness') is None
 
-        test_time = dt_util.now().replace(hour=8, minute=30, second=0)
+        test_time = dt_util.utcnow().replace(hour=8, minute=30, second=0)
         sunset_time = test_time.replace(hour=17, minute=0, second=0)
         sunrise_time = test_time.replace(hour=5, minute=0, second=0)
 
@@ -180,7 +180,7 @@ class TestSwitchFlux(unittest.TestCase):
                 return sunrise_time
             return sunset_time
 
-        with patch('homeassistant.components.switch.flux.dt_now',
+        with patch('homeassistant.components.switch.flux.dt_utcnow',
                    return_value=test_time), \
             patch('homeassistant.helpers.sun.get_astral_event_date',
                   side_effect=event_date):
@@ -217,7 +217,7 @@ class TestSwitchFlux(unittest.TestCase):
         assert state.attributes.get('xy_color') is None
         assert state.attributes.get('brightness') is None
 
-        test_time = dt_util.now().replace(hour=17, minute=30, second=0)
+        test_time = dt_util.utcnow().replace(hour=17, minute=30, second=0)
         sunset_time = test_time.replace(hour=17, minute=0, second=0)
         sunrise_time = test_time.replace(hour=5, minute=0, second=0)
 
@@ -226,7 +226,7 @@ class TestSwitchFlux(unittest.TestCase):
                 return sunrise_time
             return sunset_time
 
-        with patch('homeassistant.components.switch.flux.dt_now',
+        with patch('homeassistant.components.switch.flux.dt_utcnow',
                    return_value=test_time), \
             patch('homeassistant.helpers.sun.get_astral_event_date',
                   side_effect=event_date):
@@ -264,7 +264,7 @@ class TestSwitchFlux(unittest.TestCase):
         assert state.attributes.get('xy_color') is None
         assert state.attributes.get('brightness') is None
 
-        test_time = dt_util.now().replace(hour=23, minute=30, second=0)
+        test_time = dt_util.utcnow().replace(hour=23, minute=30, second=0)
         sunset_time = test_time.replace(hour=17, minute=0, second=0)
         sunrise_time = test_time.replace(hour=5, minute=0, second=0)
 
@@ -273,7 +273,7 @@ class TestSwitchFlux(unittest.TestCase):
                 return sunrise_time
             return sunset_time
 
-        with patch('homeassistant.util.dt.now', return_value=test_time):
+        with patch('homeassistant.util.dt.utcnow', return_value=test_time):
             with patch('homeassistant.helpers.sun.get_astral_event_date',
                        side_effect=event_date):
                 assert setup_component(self.hass, switch.DOMAIN, {
@@ -309,7 +309,7 @@ class TestSwitchFlux(unittest.TestCase):
         assert state.attributes.get('xy_color') is None
         assert state.attributes.get('brightness') is None
 
-        test_time = dt_util.now().replace(hour=17, minute=30, second=0)
+        test_time = dt_util.utcnow().replace(hour=17, minute=30, second=0)
         sunset_time = test_time.replace(hour=17, minute=0, second=0)
         sunrise_time = test_time.replace(hour=5, minute=0, second=0)
 
@@ -318,7 +318,7 @@ class TestSwitchFlux(unittest.TestCase):
                 return sunrise_time
             return sunset_time
 
-        with patch('homeassistant.components.switch.flux.dt_now',
+        with patch('homeassistant.components.switch.flux.dt_utcnow',
                    return_value=test_time), \
             patch('homeassistant.helpers.sun.get_astral_event_date',
                   side_effect=event_date):
@@ -359,7 +359,7 @@ class TestSwitchFlux(unittest.TestCase):
         assert state.attributes.get('xy_color') is None
         assert state.attributes.get('brightness') is None
 
-        test_time = dt_util.now().replace(hour=2, minute=30, second=0)
+        test_time = dt_util.utcnow().replace(hour=2, minute=30, second=0)
         sunset_time = test_time.replace(hour=17, minute=0, second=0)
         sunrise_time = test_time.replace(hour=5, minute=0, second=0)
 
@@ -368,7 +368,7 @@ class TestSwitchFlux(unittest.TestCase):
                 return sunrise_time
             return sunset_time
 
-        with patch('homeassistant.components.switch.flux.dt_now',
+        with patch('homeassistant.components.switch.flux.dt_utcnow',
                    return_value=test_time), \
             patch('homeassistant.helpers.sun.get_astral_event_date',
                   side_effect=event_date):
@@ -410,7 +410,7 @@ class TestSwitchFlux(unittest.TestCase):
         assert state.attributes.get('xy_color') is None
         assert state.attributes.get('brightness') is None
 
-        test_time = dt_util.now().replace(hour=8, minute=30, second=0)
+        test_time = dt_util.utcnow().replace(hour=8, minute=30, second=0)
         sunset_time = test_time.replace(hour=17, minute=0, second=0)
         sunrise_time = test_time.replace(hour=5, minute=0, second=0)
 
@@ -419,7 +419,7 @@ class TestSwitchFlux(unittest.TestCase):
                 return sunrise_time
             return sunset_time
 
-        with patch('homeassistant.components.switch.flux.dt_now',
+        with patch('homeassistant.components.switch.flux.dt_utcnow',
                    return_value=test_time), \
             patch('homeassistant.helpers.sun.get_astral_event_date',
                   side_effect=event_date):
@@ -460,7 +460,7 @@ class TestSwitchFlux(unittest.TestCase):
         assert state.attributes.get('xy_color') is None
         assert state.attributes.get('brightness') is None
 
-        test_time = dt_util.now().replace(hour=23, minute=30, second=0)
+        test_time = dt_util.utcnow().replace(hour=23, minute=30, second=0)
         sunset_time = test_time.replace(hour=17, minute=0, second=0)
         sunrise_time = test_time.replace(hour=5, minute=0, second=0)
 
@@ -469,7 +469,7 @@ class TestSwitchFlux(unittest.TestCase):
                 return sunrise_time
             return sunset_time
 
-        with patch('homeassistant.util.dt.now', return_value=test_time):
+        with patch('homeassistant.util.dt.utcnow', return_value=test_time):
             with patch('homeassistant.helpers.sun.get_astral_event_date',
                        side_effect=event_date):
                 assert setup_component(self.hass, switch.DOMAIN, {
@@ -509,7 +509,7 @@ class TestSwitchFlux(unittest.TestCase):
         assert state.attributes.get('xy_color') is None
         assert state.attributes.get('brightness') is None
 
-        test_time = dt_util.now().replace(hour=00, minute=30, second=0)
+        test_time = dt_util.utcnow().replace(hour=00, minute=30, second=0)
         sunset_time = test_time.replace(hour=17, minute=0, second=0)
         sunrise_time = test_time.replace(hour=5, minute=0, second=0)
 
@@ -518,7 +518,7 @@ class TestSwitchFlux(unittest.TestCase):
                 return sunrise_time
             return sunset_time
 
-        with patch('homeassistant.components.switch.flux.dt_now',
+        with patch('homeassistant.components.switch.flux.dt_utcnow',
                    return_value=test_time), \
             patch('homeassistant.helpers.sun.get_astral_event_date',
                   side_effect=event_date):
@@ -559,7 +559,7 @@ class TestSwitchFlux(unittest.TestCase):
         assert state.attributes.get('xy_color') is None
         assert state.attributes.get('brightness') is None
 
-        test_time = dt_util.now().replace(hour=2, minute=30, second=0)
+        test_time = dt_util.utcnow().replace(hour=2, minute=30, second=0)
         sunset_time = test_time.replace(hour=17, minute=0, second=0)
         sunrise_time = test_time.replace(hour=5, minute=0, second=0)
 
@@ -568,7 +568,7 @@ class TestSwitchFlux(unittest.TestCase):
                 return sunrise_time
             return sunset_time
 
-        with patch('homeassistant.components.switch.flux.dt_now',
+        with patch('homeassistant.components.switch.flux.dt_utcnow',
                    return_value=test_time), \
             patch('homeassistant.helpers.sun.get_astral_event_date',
                   side_effect=event_date):
@@ -606,7 +606,7 @@ class TestSwitchFlux(unittest.TestCase):
         assert state.attributes.get('xy_color') is None
         assert state.attributes.get('brightness') is None
 
-        test_time = dt_util.now().replace(hour=17, minute=30, second=0)
+        test_time = dt_util.utcnow().replace(hour=17, minute=30, second=0)
         sunset_time = test_time.replace(hour=17, minute=0, second=0)
         sunrise_time = test_time.replace(hour=5, minute=0, second=0)
 
@@ -615,7 +615,7 @@ class TestSwitchFlux(unittest.TestCase):
                 return sunrise_time
             return sunset_time
 
-        with patch('homeassistant.components.switch.flux.dt_now',
+        with patch('homeassistant.components.switch.flux.dt_utcnow',
                    return_value=test_time), \
             patch('homeassistant.helpers.sun.get_astral_event_date',
                   side_effect=event_date):
@@ -655,7 +655,7 @@ class TestSwitchFlux(unittest.TestCase):
         assert state.attributes.get('xy_color') is None
         assert state.attributes.get('brightness') is None
 
-        test_time = dt_util.now().replace(hour=17, minute=30, second=0)
+        test_time = dt_util.utcnow().replace(hour=17, minute=30, second=0)
         sunset_time = test_time.replace(hour=17, minute=0, second=0)
         sunrise_time = test_time.replace(hour=5, minute=0, second=0)
 
@@ -664,7 +664,7 @@ class TestSwitchFlux(unittest.TestCase):
                 return sunrise_time
             return sunset_time
 
-        with patch('homeassistant.components.switch.flux.dt_now',
+        with patch('homeassistant.components.switch.flux.dt_utcnow',
                    return_value=test_time), \
             patch('homeassistant.helpers.sun.get_astral_event_date',
                   side_effect=event_date):
@@ -715,7 +715,7 @@ class TestSwitchFlux(unittest.TestCase):
         assert state.attributes.get('xy_color') is None
         assert state.attributes.get('brightness') is None
 
-        test_time = dt_util.now().replace(hour=12, minute=0, second=0)
+        test_time = dt_util.utcnow().replace(hour=12, minute=0, second=0)
         sunset_time = test_time.replace(hour=17, minute=0, second=0)
         sunrise_time = test_time.replace(hour=5, minute=0, second=0)
 
@@ -726,7 +726,7 @@ class TestSwitchFlux(unittest.TestCase):
             print('sunset {}'.format(sunset_time))
             return sunset_time
 
-        with patch('homeassistant.components.switch.flux.dt_now',
+        with patch('homeassistant.components.switch.flux.dt_utcnow',
                    return_value=test_time), \
             patch('homeassistant.helpers.sun.get_astral_event_date',
                   side_effect=event_date):
@@ -769,7 +769,7 @@ class TestSwitchFlux(unittest.TestCase):
         assert STATE_ON == state.state
         assert state.attributes.get('color_temp') is None
 
-        test_time = dt_util.now().replace(hour=8, minute=30, second=0)
+        test_time = dt_util.utcnow().replace(hour=8, minute=30, second=0)
         sunset_time = test_time.replace(hour=17, minute=0, second=0)
         sunrise_time = test_time.replace(hour=5, minute=0, second=0)
 
@@ -778,7 +778,7 @@ class TestSwitchFlux(unittest.TestCase):
                 return sunrise_time
             return sunset_time
 
-        with patch('homeassistant.components.switch.flux.dt_now',
+        with patch('homeassistant.components.switch.flux.dt_utcnow',
                    return_value=test_time), \
             patch('homeassistant.helpers.sun.get_astral_event_date',
                   side_effect=event_date):
@@ -813,7 +813,7 @@ class TestSwitchFlux(unittest.TestCase):
         assert STATE_ON == state.state
         assert state.attributes.get('color_temp') is None
 
-        test_time = dt_util.now().replace(hour=8, minute=30, second=0)
+        test_time = dt_util.utcnow().replace(hour=8, minute=30, second=0)
         sunset_time = test_time.replace(hour=17, minute=0, second=0)
         sunrise_time = test_time.replace(hour=5, minute=0, second=0)
 
@@ -822,7 +822,7 @@ class TestSwitchFlux(unittest.TestCase):
                 return sunrise_time
             return sunset_time
 
-        with patch('homeassistant.components.switch.flux.dt_now',
+        with patch('homeassistant.components.switch.flux.dt_utcnow',
                    return_value=test_time), \
             patch('homeassistant.helpers.sun.get_astral_event_date',
                   side_effect=event_date):


### PR DESCRIPTION
## Description:

In #17458 I changed `track_time_change` to `track_time_interval` but did not notice that the update action is then called with UTC rather than local time. The tests did not catch this either as they were still passing in the local time.

**Related issue (if applicable):** fixes #18075, fixes #17900

## Checklist:
  - [ ] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.
