### PR TITLE
deCONZ - reflect hub status on entities

### DIFF
--- a/homeassistant/components/deconz/const.py
+++ b/homeassistant/components/deconz/const.py
@@ -5,9 +5,6 @@ _LOGGER = logging.getLogger('homeassistant.components.deconz')
 
 DOMAIN = 'deconz'
 CONFIG_FILE = 'deconz.conf'
-DATA_DECONZ_EVENT = 'deconz_events'
-DATA_DECONZ_ID = 'deconz_entities'
-DATA_DECONZ_UNSUB = 'deconz_dispatchers'
 DECONZ_DOMAIN = 'deconz'
 
 CONF_ALLOW_CLIP_SENSOR = 'allow_clip_sensor'
@@ -15,6 +12,8 @@ CONF_ALLOW_DECONZ_GROUPS = 'allow_deconz_groups'
 
 SUPPORTED_PLATFORMS = ['binary_sensor', 'cover',
                        'light', 'scene', 'sensor', 'switch']
+
+DECONZ_REACHABLE = 'deconz_reachable'
 
 ATTR_DARK = 'dark'
 ATTR_ON = 'on'

--- a/homeassistant/components/deconz/gateway.py
+++ b/homeassistant/components/deconz/gateway.py
@@ -8,7 +8,7 @@ from homeassistant.helpers.dispatcher import (
 from homeassistant.util import slugify
 
 from .const import (
-    _LOGGER, CONF_ALLOW_CLIP_SENSOR, SUPPORTED_PLATFORMS)
+    _LOGGER, DECONZ_REACHABLE, CONF_ALLOW_CLIP_SENSOR, SUPPORTED_PLATFORMS)
 
 
 class DeconzGateway:
@@ -18,6 +18,7 @@ class DeconzGateway:
         """Initialize the system."""
         self.hass = hass
         self.config_entry = config_entry
+        self.available = True
         self.api = None
         self._cancel_retry_setup = None
 
@@ -30,7 +31,8 @@ class DeconzGateway:
         hass = self.hass
 
         self.api = await get_gateway(
-            hass, self.config_entry.data, self.async_add_device_callback
+            hass, self.config_entry.data, self.async_add_device_callback,
+            self.async_connection_status_callback
         )
 
         if self.api is False:
@@ -64,6 +66,13 @@ class DeconzGateway:
         self.api.start()
 
         return True
+
+    @callback
+    def async_connection_status_callback(self, available):
+        """Callback for signals of connection status."""
+        self.available = available
+        async_dispatcher_send(
+            self.hass, DECONZ_REACHABLE, {'state': True, 'attr': 'reachable'})
 
     @callback
     def async_add_device_callback(self, device_type, device):
@@ -122,13 +131,15 @@ class DeconzGateway:
         return True
 
 
-async def get_gateway(hass, config, async_add_device_callback):
+async def get_gateway(hass, config, async_add_device_callback,
+                      async_connection_status_callback):
     """Create a gateway object and verify configuration."""
     from pydeconz import DeconzSession
 
     session = aiohttp_client.async_get_clientsession(hass)
     deconz = DeconzSession(hass.loop, session, **config,
-                           async_add_device=async_add_device_callback)
+                           async_add_device=async_add_device_callback,
+                           connection_status=async_connection_status_callback)
     result = await deconz.async_load_parameters()
 
     if result:

--- a/homeassistant/components/deconz/gateway.py
+++ b/homeassistant/components/deconz/gateway.py
@@ -69,7 +69,7 @@ class DeconzGateway:
 
     @callback
     def async_connection_status_callback(self, available):
-        """Callback for signals of connection status."""
+        """Handle signals of gateway connection status."""
         self.available = available
         async_dispatcher_send(
             self.hass, DECONZ_REACHABLE, {'state': True, 'attr': 'reachable'})

--- a/homeassistant/components/sensor/deconz.py
+++ b/homeassistant/components/sensor/deconz.py
@@ -5,8 +5,8 @@ For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/sensor.deconz/
 """
 from homeassistant.components.deconz.const import (
-    ATTR_DARK, ATTR_ON, CONF_ALLOW_CLIP_SENSOR, DOMAIN as DATA_DECONZ,
-    DECONZ_DOMAIN)
+    ATTR_DARK, ATTR_ON, CONF_ALLOW_CLIP_SENSOR, DECONZ_REACHABLE,
+    DOMAIN as DECONZ_DOMAIN)
 from homeassistant.const import (
     ATTR_BATTERY_LEVEL, ATTR_VOLTAGE, DEVICE_CLASS_BATTERY)
 from homeassistant.core import callback
@@ -30,6 +30,8 @@ async def async_setup_platform(hass, config, async_add_entities,
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the deCONZ sensors."""
+    gateway = hass.data[DECONZ_DOMAIN]
+
     @callback
     def async_add_sensor(sensors):
         """Add sensors from deCONZ."""
@@ -41,32 +43,37 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                not (not allow_clip_sensor and sensor.type.startswith('CLIP')):
                 if sensor.type in DECONZ_REMOTE:
                     if sensor.battery:
-                        entities.append(DeconzBattery(sensor))
+                        entities.append(DeconzBattery(sensor, gateway))
                 else:
-                    entities.append(DeconzSensor(sensor))
+                    entities.append(DeconzSensor(sensor, gateway))
         async_add_entities(entities, True)
 
-    hass.data[DATA_DECONZ].listeners.append(
+    gateway.listeners.append(
         async_dispatcher_connect(hass, 'deconz_new_sensor', async_add_sensor))
 
-    async_add_sensor(hass.data[DATA_DECONZ].api.sensors.values())
+    async_add_sensor(gateway.api.sensors.values())
 
 
 class DeconzSensor(Entity):
     """Representation of a sensor."""
 
-    def __init__(self, sensor):
+    def __init__(self, sensor, gateway):
         """Set up sensor and add update callback to get data from websocket."""
         self._sensor = sensor
+        self.gateway = gateway
+        self.unsub_dispatcher = None
 
     async def async_added_to_hass(self):
         """Subscribe to sensors events."""
         self._sensor.register_async_callback(self.async_update_callback)
-        self.hass.data[DATA_DECONZ].deconz_ids[self.entity_id] = \
-            self._sensor.deconz_id
+        self.gateway.deconz_ids[self.entity_id] = self._sensor.deconz_id
+        self.unsub_dispatcher = async_dispatcher_connect(
+            self.hass, DECONZ_REACHABLE, self.async_update_callback)
 
     async def async_will_remove_from_hass(self) -> None:
         """Disconnect sensor object when removed."""
+        if self.unsub_dispatcher is not None:
+            self.unsub_dispatcher()
         self._sensor.remove_callback(self.async_update_callback)
         self._sensor = None
 
@@ -116,7 +123,7 @@ class DeconzSensor(Entity):
     @property
     def available(self):
         """Return true if sensor is available."""
-        return self._sensor.reachable
+        return self.gateway.available and self._sensor.reachable
 
     @property
     def should_poll(self):
@@ -148,7 +155,7 @@ class DeconzSensor(Entity):
                 self._sensor.uniqueid.count(':') != 7):
             return None
         serial = self._sensor.uniqueid.split('-', 1)[0]
-        bridgeid = self.hass.data[DATA_DECONZ].api.config.bridgeid
+        bridgeid = self.gateway.api.config.bridgeid
         return {
             'connections': {(CONNECTION_ZIGBEE, serial)},
             'identifiers': {(DECONZ_DOMAIN, serial)},
@@ -163,20 +170,26 @@ class DeconzSensor(Entity):
 class DeconzBattery(Entity):
     """Battery class for when a device is only represented as an event."""
 
-    def __init__(self, sensor):
+    def __init__(self, sensor, gateway):
         """Register dispatcher callback for update of battery state."""
         self._sensor = sensor
+        self.gateway = gateway
+        self.unsub_dispatcher = None
+
         self._name = '{} {}'.format(self._sensor.name, 'Battery Level')
         self._unit_of_measurement = "%"
 
     async def async_added_to_hass(self):
         """Subscribe to sensors events."""
         self._sensor.register_async_callback(self.async_update_callback)
-        self.hass.data[DATA_DECONZ].deconz_ids[self.entity_id] = \
-            self._sensor.deconz_id
+        self.gateway.deconz_ids[self.entity_id] = self._sensor.deconz_id
+        self.unsub_dispatcher = async_dispatcher_connect(
+            self.hass, DECONZ_REACHABLE, self.async_update_callback)
 
     async def async_will_remove_from_hass(self) -> None:
         """Disconnect sensor object when removed."""
+        if self.unsub_dispatcher is not None:
+            self.unsub_dispatcher()
         self._sensor.remove_callback(self.async_update_callback)
         self._sensor = None
 
@@ -212,6 +225,11 @@ class DeconzBattery(Entity):
         return self._unit_of_measurement
 
     @property
+    def available(self):
+        """Return true if sensor is available."""
+        return self.gateway.available and self._sensor.reachable
+
+    @property
     def should_poll(self):
         """No polling needed."""
         return False
@@ -231,7 +249,7 @@ class DeconzBattery(Entity):
                 self._sensor.uniqueid.count(':') != 7):
             return None
         serial = self._sensor.uniqueid.split('-', 1)[0]
-        bridgeid = self.hass.data[DATA_DECONZ].api.config.bridgeid
+        bridgeid = self.gateway.api.config.bridgeid
         return {
             'connections': {(CONNECTION_ZIGBEE, serial)},
             'identifiers': {(DECONZ_DOMAIN, serial)},

--- a/homeassistant/components/switch/deconz.py
+++ b/homeassistant/components/switch/deconz.py
@@ -5,7 +5,7 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/switch.deconz/
 """
 from homeassistant.components.deconz.const import (
-    DOMAIN as DATA_DECONZ, DECONZ_DOMAIN, POWER_PLUGS, SIRENS)
+    DECONZ_REACHABLE, DOMAIN as DECONZ_DOMAIN, POWER_PLUGS, SIRENS)
 from homeassistant.components.switch import SwitchDevice
 from homeassistant.core import callback
 from homeassistant.helpers.device_registry import CONNECTION_ZIGBEE
@@ -25,38 +25,45 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     Switches are based same device class as lights in deCONZ.
     """
+    gateway = hass.data[DECONZ_DOMAIN]
+
     @callback
     def async_add_switch(lights):
         """Add switch from deCONZ."""
         entities = []
         for light in lights:
             if light.type in POWER_PLUGS:
-                entities.append(DeconzPowerPlug(light))
+                entities.append(DeconzPowerPlug(light, gateway))
             elif light.type in SIRENS:
-                entities.append(DeconzSiren(light))
+                entities.append(DeconzSiren(light, gateway))
         async_add_entities(entities, True)
 
-    hass.data[DATA_DECONZ].listeners.append(
+    gateway.listeners.append(
         async_dispatcher_connect(hass, 'deconz_new_light', async_add_switch))
 
-    async_add_switch(hass.data[DATA_DECONZ].api.lights.values())
+    async_add_switch(gateway.api.lights.values())
 
 
 class DeconzSwitch(SwitchDevice):
     """Representation of a deCONZ switch."""
 
-    def __init__(self, switch):
+    def __init__(self, switch, gateway):
         """Set up switch and add update callback to get data from websocket."""
         self._switch = switch
+        self.gateway = gateway
+        self.unsub_dispatcher = None
 
     async def async_added_to_hass(self):
         """Subscribe to switches events."""
         self._switch.register_async_callback(self.async_update_callback)
-        self.hass.data[DATA_DECONZ].deconz_ids[self.entity_id] = \
-            self._switch.deconz_id
+        self.gateway.deconz_ids[self.entity_id] = self._switch.deconz_id
+        self.unsub_dispatcher = async_dispatcher_connect(
+            self.hass, DECONZ_REACHABLE, self.async_update_callback)
 
     async def async_will_remove_from_hass(self) -> None:
         """Disconnect switch object when removed."""
+        if self.unsub_dispatcher is not None:
+            self.unsub_dispatcher()
         self._switch.remove_callback(self.async_update_callback)
         self._switch = None
 
@@ -78,7 +85,7 @@ class DeconzSwitch(SwitchDevice):
     @property
     def available(self):
         """Return True if light is available."""
-        return self._switch.reachable
+        return self.gateway.available and self._switch.reachable
 
     @property
     def should_poll(self):
@@ -92,7 +99,7 @@ class DeconzSwitch(SwitchDevice):
                 self._switch.uniqueid.count(':') != 7):
             return None
         serial = self._switch.uniqueid.split('-', 1)[0]
-        bridgeid = self.hass.data[DATA_DECONZ].api.config.bridgeid
+        bridgeid = self.gateway.api.config.bridgeid
         return {
             'connections': {(CONNECTION_ZIGBEE, serial)},
             'identifiers': {(DECONZ_DOMAIN, serial)},


### PR DESCRIPTION
Add support for setting entities availability based on the connection status to the gateway

## Description:
**Documentation:** home-assistant/home-assistant.io#7328

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
