### PR TITLE
Update Pollen.com to use numpy for trend analysis

### DIFF
--- a/homeassistant/components/sensor/pollen.py
+++ b/homeassistant/components/sensor/pollen.py
@@ -143,13 +143,13 @@ def calculate_trend(indices):
     """Calculate the "moving average" of a set of indices."""
     import numpy as np
 
-    def moving_average(a, n=3):
+    def moving_average(data, samples):
         """Determine the "moving average" (http://tinyurl.com/yaereb3c)."""
-        ret = np.cumsum(a, dtype=float)
-        ret[n:] = ret[n:] - ret[:-n]
-        return ret[n - 1:] / n
+        ret = np.cumsum(data, dtype=float)
+        ret[samples:] = ret[samples:] - ret[:-samples]
+        return ret[samples - 1:] / samples
 
-    increasing = np.all(np.diff(moving_average(np.array(indices), n=4)) > 0)
+    increasing = np.all(np.diff(moving_average(np.array(indices), 4)) > 0)
 
     if increasing:
         return TREND_INCREASING

--- a/homeassistant/components/sensor/pollen.py
+++ b/homeassistant/components/sensor/pollen.py
@@ -138,6 +138,7 @@ def calculate_average_rating(indices):
         if r['minimum'] <= n <= r['maximum'])
     return max(set(ratings), key=ratings.count)
 
+
 def calculate_trend(indices):
     """Calculate the "moving average" of a set of indices."""
     import numpy as np
@@ -217,8 +218,6 @@ class ForecastSensor(BaseSensor):
 
     async def async_update(self):
         """Update the sensor."""
-        import numpy as np
-
         await self.pollen.async_update()
         if not self.pollen.data:
             return

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -669,6 +669,7 @@ nuheat==0.3.0
 
 # homeassistant.components.binary_sensor.trend
 # homeassistant.components.image_processing.opencv
+# homeassistant.components.sensor.pollen
 numpy==1.15.3
 
 # homeassistant.components.google

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -118,6 +118,7 @@ mficlient==0.3.0
 
 # homeassistant.components.binary_sensor.trend
 # homeassistant.components.image_processing.opencv
+# homeassistant.components.sensor.pollen
 numpy==1.15.3
 
 # homeassistant.components.mqtt


### PR DESCRIPTION
## Description:
Previously, Pollen.com calculated historical and forecasted trends by merely looking at two data points and determining the slope – not very accurate. This PR shifts to a `numpy`-driven method (a moving average) that adds more data points and greatly increases the accuracy.

**Breaking Change:** Because of the longer statistical view, trend attributes will no longer return a value of "Flat". All automations relying on that value will need to be updated.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: pollen
    zip_code: "80238"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
