### PR TITLE
UniFi - No Switch for Cloud key

### DIFF
--- a/homeassistant/components/switch/unifi.py
+++ b/homeassistant/components/switch/unifi.py
@@ -129,7 +129,8 @@ async def async_update_items(controller, async_add_entities,
         # Network device with active POE
         if not client.is_wired or client.sw_mac not in devices or \
            not devices[client.sw_mac].ports[client.sw_port].port_poe or \
-           not devices[client.sw_mac].ports[client.sw_port].poe_enable:
+           not devices[client.sw_mac].ports[client.sw_port].poe_enable or \
+           controller.mac == client.mac:
             continue
 
         # Multiple POE-devices on same port means non UniFi POE driven switch

--- a/tests/components/switch/test_unifi.py
+++ b/tests/components/switch/test_unifi.py
@@ -64,6 +64,18 @@ CLIENT_4 = {
     'wired-rx_bytes': 1234000000,
     'wired-tx_bytes': 5678000000
 }
+CLOUDKEY = {
+    'hostname': 'client_1',
+    'ip': 'mock-host',
+    'is_wired': True,
+    'mac': '10:00:00:00:00:01',
+    'name': 'Cloud key',
+    'oui': 'Producer',
+    'sw_mac': '00:00:00:00:01:01',
+    'sw_port': 1,
+    'wired-rx_bytes': 1234000000,
+    'wired-tx_bytes': 5678000000
+}
 POE_SWITCH_CLIENTS = [
     {
         'hostname': 'client_1',
@@ -179,6 +191,7 @@ def mock_controller(hass):
         api=Mock(),
         spec=unifi.UniFiController
     )
+    controller.mac = '10:00:00:00:00:01'
     controller.mock_requests = []
 
     controller.mock_client_responses = deque()
@@ -228,6 +241,17 @@ async def test_no_clients(hass, mock_controller):
     await setup_controller(hass, mock_controller)
     assert len(mock_controller.mock_requests) == 2
     assert not hass.states.async_all()
+
+
+async def test_controller_not_client(hass, mock_controller):
+    """Test that the controller doesn't become a switch."""
+    mock_controller.mock_client_responses.append([CLOUDKEY])
+    mock_controller.mock_device_responses.append([DEVICE_1])
+    await setup_controller(hass, mock_controller)
+    assert len(mock_controller.mock_requests) == 2
+    assert not hass.states.async_all()
+    cloudkey = hass.states.get('switch.cloud_key')
+    assert cloudkey is None
 
 
 async def test_switches(hass, mock_controller):


### PR DESCRIPTION
## Description
Don't create a POE Control switch for cloud key

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.