### PR TITLE
Round all Darksky temperatures to 1 decimal place

### DIFF
--- a/homeassistant/components/sensor/darksky.py
+++ b/homeassistant/components/sensor/darksky.py
@@ -354,10 +354,12 @@ class DarkSkySensor(Entity):
         if self.type in ['precip_probability', 'cloud_cover', 'humidity']:
             return round(state * 100, 1)
         if self.type in ['dew_point', 'temperature', 'apparent_temperature',
-                         'temperature_min', 'temperature_max',
-                         'apparent_temperature_min',
-                         'apparent_temperature_max', 'precip_accumulation',
-                         'pressure', 'ozone', 'uvIndex']:
+                         'temperature_low', 'apparent_temperature_low',
+                         'temperature_min', 'apparent_temperature_min',
+                         'temperature_high', 'apparent_temperature_high',
+                         'temperature_max', 'apparent_temperature_max'
+                         'precip_accumulation', 'pressure', 'ozone',
+                         'uvIndex']:
             return round(state, 1)
         return state
 


### PR DESCRIPTION
Some temperatures were not rounded to 1 decimal place:
`temperature_low`, `apparent_temperature_low`, `temperature_high`,
`apparent_temperature_high`.

  - [x] The code change is tested and works locally.