### PR TITLE
0.81.3

### DIFF
--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -24,7 +24,7 @@ from homeassistant.core import callback
 from homeassistant.helpers.translation import async_get_translations
 from homeassistant.loader import bind_hass
 
-REQUIREMENTS = ['home-assistant-frontend==20181026.1']
+REQUIREMENTS = ['home-assistant-frontend==20181026.2']
 
 DOMAIN = 'frontend'
 DEPENDENCIES = ['api', 'websocket_api', 'http', 'system_log',

--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -29,7 +29,7 @@ from .const import (
 from .util import (
     show_setup_message, validate_entity_config, validate_media_player_features)
 
-REQUIREMENTS = ['HAP-python==2.3.0']
+REQUIREMENTS = ['HAP-python==2.2.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/homekit/type_switches.py
+++ b/homeassistant/components/homekit/type_switches.py
@@ -2,8 +2,7 @@
 import logging
 
 from pyhap.const import (
-    CATEGORY_FAUCET, CATEGORY_OUTLET, CATEGORY_SHOWER_HEAD,
-    CATEGORY_SPRINKLER, CATEGORY_SWITCH)
+    CATEGORY_OUTLET, CATEGORY_SWITCH)
 
 from homeassistant.components.switch import DOMAIN
 from homeassistant.const import (
@@ -18,6 +17,10 @@ from .const import (
     TYPE_SPRINKLER, TYPE_VALVE)
 
 _LOGGER = logging.getLogger(__name__)
+
+CATEGORY_SPRINKLER = 28
+CATEGORY_FAUCET = 29
+CATEGORY_SHOWER_HEAD = 30
 
 VALVE_TYPE = {
     TYPE_FAUCET: (CATEGORY_FAUCET, 3),

--- a/homeassistant/components/konnected.py
+++ b/homeassistant/components/konnected.py
@@ -156,7 +156,7 @@ async def async_setup(hass, config):
 
     # Initialize devices specified in the configuration on boot
     for device in cfg.get(CONF_DEVICES):
-        ConfiguredDevice(hass, device).save_data()
+        ConfiguredDevice(hass, device, config).save_data()
 
     discovery.async_listen(
         hass,
@@ -172,10 +172,11 @@ async def async_setup(hass, config):
 class ConfiguredDevice:
     """A representation of a configured Konnected device."""
 
-    def __init__(self, hass, config):
+    def __init__(self, hass, config, hass_config):
         """Initialize the Konnected device."""
         self.hass = hass
         self.config = config
+        self.hass_config = hass_config
 
     @property
     def device_id(self):
@@ -237,11 +238,11 @@ class ConfiguredDevice:
         self.hass.data[DOMAIN][CONF_DEVICES][self.device_id] = device_data
 
         discovery.load_platform(
-            self.hass, 'binary_sensor',
-            DOMAIN, {'device_id': self.device_id})
+            self.hass, 'binary_sensor', DOMAIN,
+            {'device_id': self.device_id}, self.hass_config)
         discovery.load_platform(
             self.hass, 'switch', DOMAIN,
-            {'device_id': self.device_id})
+            {'device_id': self.device_id}, self.hass_config)
 
 
 class DiscoveredDevice:

--- a/homeassistant/components/nest/__init__.py
+++ b/homeassistant/components/nest/__init__.py
@@ -55,7 +55,7 @@ SENSOR_SCHEMA = vol.Schema({
 
 AWAY_SCHEMA = vol.Schema({
     vol.Required(ATTR_HOME_MODE): vol.In([HOME_MODE_AWAY, HOME_MODE_HOME]),
-    vol.Optional(ATTR_STRUCTURE): vol.All(cv.ensure_list, cv.string),
+    vol.Optional(ATTR_STRUCTURE): vol.All(cv.ensure_list, [cv.string]),
     vol.Optional(ATTR_TRIP_ID): cv.string,
     vol.Optional(ATTR_ETA): cv.time_period,
     vol.Optional(ATTR_ETA_WINDOW): cv.time_period
@@ -65,7 +65,7 @@ CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Required(CONF_CLIENT_ID): cv.string,
         vol.Required(CONF_CLIENT_SECRET): cv.string,
-        vol.Optional(CONF_STRUCTURE): vol.All(cv.ensure_list, cv.string),
+        vol.Optional(CONF_STRUCTURE): vol.All(cv.ensure_list, [cv.string]),
         vol.Optional(CONF_SENSORS): SENSOR_SCHEMA,
         vol.Optional(CONF_BINARY_SENSORS): SENSOR_SCHEMA
     })

--- a/homeassistant/components/switch/flux.py
+++ b/homeassistant/components/switch/flux.py
@@ -25,7 +25,7 @@ from homeassistant.util import slugify
 from homeassistant.util.color import (
     color_temperature_to_rgb, color_RGB_to_xy_brightness,
     color_temperature_kelvin_to_mired)
-from homeassistant.util.dt import now as dt_now
+from homeassistant.util.dt import utcnow as dt_utcnow, as_local
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -195,10 +195,12 @@ class FluxSwitch(SwitchDevice):
 
         self.schedule_update_ha_state()
 
-    def flux_update(self, now=None):
+    def flux_update(self, utcnow=None):
         """Update all the lights using flux."""
-        if now is None:
-            now = dt_now()
+        if utcnow is None:
+            utcnow = dt_utcnow()
+
+        now = as_local(utcnow)
 
         sunset = get_astral_event_date(self.hass, 'sunset', now.date())
         start_time = self.find_start_time(now)

--- a/homeassistant/components/weather/ipma.py
+++ b/homeassistant/components/weather/ipma.py
@@ -20,7 +20,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers import config_validation as cv
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['pyipma==1.1.3']
+REQUIREMENTS = ['pyipma==1.1.4']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -71,8 +71,8 @@ async def async_setup_platform(hass, config, async_add_entities,
         station = await Station.get(websession, float(latitude),
                                     float(longitude))
 
-    _LOGGER.debug("Initializing ipma weather: coordinates %s, %s",
-                  latitude, longitude)
+    _LOGGER.debug("Initializing for coordinates %s, %s -> station %s",
+                  latitude, longitude, station.local)
 
     async_add_entities([IPMAWeather(station, config)], True)
 
@@ -93,6 +93,8 @@ class IPMAWeather(WeatherEntity):
         """Update Condition and Forecast."""
         with async_timeout.timeout(10, loop=self.hass.loop):
             self._condition = await self._station.observation()
+            _LOGGER.debug("Updating station %s, condition %s",
+                          self._station.local, self._condition)
             self._forecast = await self._station.forecast()
             self._description = self._forecast[0].description
 

--- a/homeassistant/components/weather/smhi.py
+++ b/homeassistant/components/weather/smhi.py
@@ -19,7 +19,7 @@ from homeassistant.const import (
     CONF_NAME, TEMP_CELSIUS)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import aiohttp_client
-from homeassistant.util import dt, Throttle
+from homeassistant.util import dt, slugify, Throttle
 
 from homeassistant.components.weather import (
     WeatherEntity, ATTR_FORECAST_CONDITION, ATTR_FORECAST_TEMP,
@@ -73,11 +73,11 @@ async def async_setup_entry(hass: HomeAssistant,
                             config_entries) -> bool:
     """Add a weather entity from map location."""
     location = config_entry.data
-    name = location[CONF_NAME]
+    name = slugify(location[CONF_NAME])
 
     session = aiohttp_client.async_get_clientsession(hass)
 
-    entity = SmhiWeather(name, location[CONF_LATITUDE],
+    entity = SmhiWeather(location[CONF_NAME], location[CONF_LATITUDE],
                          location[CONF_LONGITUDE],
                          session=session)
     entity.entity_id = ENTITY_ID_SENSOR_FORMAT.format(name)

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -2,7 +2,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 81
-PATCH_VERSION = '2'
+PATCH_VERSION = '3'
 __short_version__ = '{}.{}'.format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = '{}.{}'.format(__short_version__, PATCH_VERSION)
 REQUIRED_PYTHON_VER = (3, 5, 3)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -466,7 +466,7 @@ hole==0.3.0
 holidays==0.9.8
 
 # homeassistant.components.frontend
-home-assistant-frontend==20181026.1
+home-assistant-frontend==20181026.2
 
 # homeassistant.components.homekit_controller
 # homekit==0.10

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -34,7 +34,7 @@ Adafruit-SHT31==1.0.2
 DoorBirdPy==0.1.3
 
 # homeassistant.components.homekit
-HAP-python==2.3.0
+HAP-python==2.2.2
 
 # homeassistant.components.notify.mastodon
 Mastodon.py==1.3.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -929,7 +929,7 @@ pyialarm==0.2
 pyicloud==0.9.1
 
 # homeassistant.components.weather.ipma
-pyipma==1.1.3
+pyipma==1.1.4
 
 # homeassistant.components.sensor.irish_rail_transport
 pyirishrail==0.0.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -97,7 +97,7 @@ hdate==0.6.5
 holidays==0.9.8
 
 # homeassistant.components.frontend
-home-assistant-frontend==20181026.1
+home-assistant-frontend==20181026.2
 
 # homeassistant.components.homematicip_cloud
 homematicip==0.9.8

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -19,7 +19,7 @@ requests_mock==1.5.2
 
 
 # homeassistant.components.homekit
-HAP-python==2.3.0
+HAP-python==2.2.2
 
 # homeassistant.components.sensor.rmvtransport
 PyRMVtransport==0.1.3

--- a/tests/components/homekit/test_type_locks.py
+++ b/tests/components/homekit/test_type_locks.py
@@ -82,7 +82,6 @@ async def test_no_code(hass, hk_driver, config, events):
     # Set from HomeKit
     call_lock = async_mock_service(hass, DOMAIN, 'lock')
 
-    acc.char_target_state.value = 0
     await hass.async_add_job(acc.char_target_state.client_update_value, 1)
     await hass.async_block_till_done()
     assert call_lock

--- a/tests/components/homekit/test_type_media_players.py
+++ b/tests/components/homekit/test_type_media_players.py
@@ -64,7 +64,6 @@ async def test_media_player_set_state(hass, hk_driver, events):
     call_media_stop = async_mock_service(hass, DOMAIN, 'media_stop')
     call_toggle_mute = async_mock_service(hass, DOMAIN, 'volume_mute')
 
-    acc.chars[FEATURE_ON_OFF].value = False
     await hass.async_add_job(acc.chars[FEATURE_ON_OFF]
                              .client_update_value, True)
     await hass.async_block_till_done()

--- a/tests/components/switch/test_flux.py
+++ b/tests/components/switch/test_flux.py
@@ -87,7 +87,7 @@ class TestSwitchFlux(unittest.TestCase):
         self.assertIsNone(state.attributes.get('xy_color'))
         self.assertIsNone(state.attributes.get('brightness'))
 
-        test_time = dt_util.now().replace(hour=10, minute=30, second=0)
+        test_time = dt_util.utcnow().replace(hour=10, minute=30, second=0)
         sunset_time = test_time.replace(hour=17, minute=0, second=0)
         sunrise_time = test_time.replace(hour=5, minute=0, second=0)
 
@@ -96,7 +96,7 @@ class TestSwitchFlux(unittest.TestCase):
                 return sunrise_time
             return sunset_time
 
-        with patch('homeassistant.util.dt.now', return_value=test_time):
+        with patch('homeassistant.util.dt.utcnow', return_value=test_time):
             with patch('homeassistant.helpers.sun.get_astral_event_date',
                        side_effect=event_date):
                 assert setup_component(self.hass, switch.DOMAIN, {
@@ -128,7 +128,7 @@ class TestSwitchFlux(unittest.TestCase):
         self.assertIsNone(state.attributes.get('xy_color'))
         self.assertIsNone(state.attributes.get('brightness'))
 
-        test_time = dt_util.now().replace(hour=2, minute=30, second=0)
+        test_time = dt_util.utcnow().replace(hour=2, minute=30, second=0)
         sunset_time = test_time.replace(hour=17, minute=0, second=0)
         sunrise_time = test_time.replace(hour=5, minute=0, second=0)
 
@@ -137,7 +137,7 @@ class TestSwitchFlux(unittest.TestCase):
                 return sunrise_time
             return sunset_time
 
-        with patch('homeassistant.util.dt.now', return_value=test_time):
+        with patch('homeassistant.util.dt.utcnow', return_value=test_time):
             with patch('homeassistant.helpers.sun.get_astral_event_date',
                        side_effect=event_date):
                 assert setup_component(self.hass, switch.DOMAIN, {
@@ -174,7 +174,7 @@ class TestSwitchFlux(unittest.TestCase):
         self.assertIsNone(state.attributes.get('xy_color'))
         self.assertIsNone(state.attributes.get('brightness'))
 
-        test_time = dt_util.now().replace(hour=8, minute=30, second=0)
+        test_time = dt_util.utcnow().replace(hour=8, minute=30, second=0)
         sunset_time = test_time.replace(hour=17, minute=0, second=0)
         sunrise_time = test_time.replace(hour=5, minute=0, second=0)
 
@@ -183,7 +183,7 @@ class TestSwitchFlux(unittest.TestCase):
                 return sunrise_time
             return sunset_time
 
-        with patch('homeassistant.components.switch.flux.dt_now',
+        with patch('homeassistant.components.switch.flux.dt_utcnow',
                    return_value=test_time), \
             patch('homeassistant.helpers.sun.get_astral_event_date',
                   side_effect=event_date):
@@ -221,7 +221,7 @@ class TestSwitchFlux(unittest.TestCase):
         self.assertIsNone(state.attributes.get('xy_color'))
         self.assertIsNone(state.attributes.get('brightness'))
 
-        test_time = dt_util.now().replace(hour=17, minute=30, second=0)
+        test_time = dt_util.utcnow().replace(hour=17, minute=30, second=0)
         sunset_time = test_time.replace(hour=17, minute=0, second=0)
         sunrise_time = test_time.replace(hour=5, minute=0, second=0)
 
@@ -230,7 +230,7 @@ class TestSwitchFlux(unittest.TestCase):
                 return sunrise_time
             return sunset_time
 
-        with patch('homeassistant.components.switch.flux.dt_now',
+        with patch('homeassistant.components.switch.flux.dt_utcnow',
                    return_value=test_time), \
             patch('homeassistant.helpers.sun.get_astral_event_date',
                   side_effect=event_date):
@@ -269,7 +269,7 @@ class TestSwitchFlux(unittest.TestCase):
         self.assertIsNone(state.attributes.get('xy_color'))
         self.assertIsNone(state.attributes.get('brightness'))
 
-        test_time = dt_util.now().replace(hour=23, minute=30, second=0)
+        test_time = dt_util.utcnow().replace(hour=23, minute=30, second=0)
         sunset_time = test_time.replace(hour=17, minute=0, second=0)
         sunrise_time = test_time.replace(hour=5, minute=0, second=0)
 
@@ -278,7 +278,7 @@ class TestSwitchFlux(unittest.TestCase):
                 return sunrise_time
             return sunset_time
 
-        with patch('homeassistant.util.dt.now', return_value=test_time):
+        with patch('homeassistant.util.dt.utcnow', return_value=test_time):
             with patch('homeassistant.helpers.sun.get_astral_event_date',
                        side_effect=event_date):
                 assert setup_component(self.hass, switch.DOMAIN, {
@@ -315,7 +315,7 @@ class TestSwitchFlux(unittest.TestCase):
         self.assertIsNone(state.attributes.get('xy_color'))
         self.assertIsNone(state.attributes.get('brightness'))
 
-        test_time = dt_util.now().replace(hour=17, minute=30, second=0)
+        test_time = dt_util.utcnow().replace(hour=17, minute=30, second=0)
         sunset_time = test_time.replace(hour=17, minute=0, second=0)
         sunrise_time = test_time.replace(hour=5, minute=0, second=0)
 
@@ -324,7 +324,7 @@ class TestSwitchFlux(unittest.TestCase):
                 return sunrise_time
             return sunset_time
 
-        with patch('homeassistant.components.switch.flux.dt_now',
+        with patch('homeassistant.components.switch.flux.dt_utcnow',
                    return_value=test_time), \
             patch('homeassistant.helpers.sun.get_astral_event_date',
                   side_effect=event_date):
@@ -366,7 +366,7 @@ class TestSwitchFlux(unittest.TestCase):
         self.assertIsNone(state.attributes.get('xy_color'))
         self.assertIsNone(state.attributes.get('brightness'))
 
-        test_time = dt_util.now().replace(hour=2, minute=30, second=0)
+        test_time = dt_util.utcnow().replace(hour=2, minute=30, second=0)
         sunset_time = test_time.replace(hour=17, minute=0, second=0)
         sunrise_time = test_time.replace(hour=5, minute=0, second=0)
 
@@ -375,7 +375,7 @@ class TestSwitchFlux(unittest.TestCase):
                 return sunrise_time
             return sunset_time
 
-        with patch('homeassistant.components.switch.flux.dt_now',
+        with patch('homeassistant.components.switch.flux.dt_utcnow',
                    return_value=test_time), \
             patch('homeassistant.helpers.sun.get_astral_event_date',
                   side_effect=event_date):
@@ -418,7 +418,7 @@ class TestSwitchFlux(unittest.TestCase):
         self.assertIsNone(state.attributes.get('xy_color'))
         self.assertIsNone(state.attributes.get('brightness'))
 
-        test_time = dt_util.now().replace(hour=8, minute=30, second=0)
+        test_time = dt_util.utcnow().replace(hour=8, minute=30, second=0)
         sunset_time = test_time.replace(hour=17, minute=0, second=0)
         sunrise_time = test_time.replace(hour=5, minute=0, second=0)
 
@@ -427,7 +427,7 @@ class TestSwitchFlux(unittest.TestCase):
                 return sunrise_time
             return sunset_time
 
-        with patch('homeassistant.components.switch.flux.dt_now',
+        with patch('homeassistant.components.switch.flux.dt_utcnow',
                    return_value=test_time), \
             patch('homeassistant.helpers.sun.get_astral_event_date',
                   side_effect=event_date):
@@ -469,7 +469,7 @@ class TestSwitchFlux(unittest.TestCase):
         self.assertIsNone(state.attributes.get('xy_color'))
         self.assertIsNone(state.attributes.get('brightness'))
 
-        test_time = dt_util.now().replace(hour=23, minute=30, second=0)
+        test_time = dt_util.utcnow().replace(hour=23, minute=30, second=0)
         sunset_time = test_time.replace(hour=17, minute=0, second=0)
         sunrise_time = test_time.replace(hour=5, minute=0, second=0)
 
@@ -478,7 +478,7 @@ class TestSwitchFlux(unittest.TestCase):
                 return sunrise_time
             return sunset_time
 
-        with patch('homeassistant.util.dt.now', return_value=test_time):
+        with patch('homeassistant.util.dt.utcnow', return_value=test_time):
             with patch('homeassistant.helpers.sun.get_astral_event_date',
                        side_effect=event_date):
                 assert setup_component(self.hass, switch.DOMAIN, {
@@ -519,7 +519,7 @@ class TestSwitchFlux(unittest.TestCase):
         self.assertIsNone(state.attributes.get('xy_color'))
         self.assertIsNone(state.attributes.get('brightness'))
 
-        test_time = dt_util.now().replace(hour=00, minute=30, second=0)
+        test_time = dt_util.utcnow().replace(hour=00, minute=30, second=0)
         sunset_time = test_time.replace(hour=17, minute=0, second=0)
         sunrise_time = test_time.replace(hour=5, minute=0, second=0)
 
@@ -528,7 +528,7 @@ class TestSwitchFlux(unittest.TestCase):
                 return sunrise_time
             return sunset_time
 
-        with patch('homeassistant.components.switch.flux.dt_now',
+        with patch('homeassistant.components.switch.flux.dt_utcnow',
                    return_value=test_time), \
             patch('homeassistant.helpers.sun.get_astral_event_date',
                   side_effect=event_date):
@@ -570,7 +570,7 @@ class TestSwitchFlux(unittest.TestCase):
         self.assertIsNone(state.attributes.get('xy_color'))
         self.assertIsNone(state.attributes.get('brightness'))
 
-        test_time = dt_util.now().replace(hour=2, minute=30, second=0)
+        test_time = dt_util.utcnow().replace(hour=2, minute=30, second=0)
         sunset_time = test_time.replace(hour=17, minute=0, second=0)
         sunrise_time = test_time.replace(hour=5, minute=0, second=0)
 
@@ -579,7 +579,7 @@ class TestSwitchFlux(unittest.TestCase):
                 return sunrise_time
             return sunset_time
 
-        with patch('homeassistant.components.switch.flux.dt_now',
+        with patch('homeassistant.components.switch.flux.dt_utcnow',
                    return_value=test_time), \
             patch('homeassistant.helpers.sun.get_astral_event_date',
                   side_effect=event_date):
@@ -618,7 +618,7 @@ class TestSwitchFlux(unittest.TestCase):
         self.assertIsNone(state.attributes.get('xy_color'))
         self.assertIsNone(state.attributes.get('brightness'))
 
-        test_time = dt_util.now().replace(hour=17, minute=30, second=0)
+        test_time = dt_util.utcnow().replace(hour=17, minute=30, second=0)
         sunset_time = test_time.replace(hour=17, minute=0, second=0)
         sunrise_time = test_time.replace(hour=5, minute=0, second=0)
 
@@ -627,7 +627,7 @@ class TestSwitchFlux(unittest.TestCase):
                 return sunrise_time
             return sunset_time
 
-        with patch('homeassistant.components.switch.flux.dt_now',
+        with patch('homeassistant.components.switch.flux.dt_utcnow',
                    return_value=test_time), \
             patch('homeassistant.helpers.sun.get_astral_event_date',
                   side_effect=event_date):
@@ -668,7 +668,7 @@ class TestSwitchFlux(unittest.TestCase):
         self.assertIsNone(state.attributes.get('xy_color'))
         self.assertIsNone(state.attributes.get('brightness'))
 
-        test_time = dt_util.now().replace(hour=17, minute=30, second=0)
+        test_time = dt_util.utcnow().replace(hour=17, minute=30, second=0)
         sunset_time = test_time.replace(hour=17, minute=0, second=0)
         sunrise_time = test_time.replace(hour=5, minute=0, second=0)
 
@@ -677,7 +677,7 @@ class TestSwitchFlux(unittest.TestCase):
                 return sunrise_time
             return sunset_time
 
-        with patch('homeassistant.components.switch.flux.dt_now',
+        with patch('homeassistant.components.switch.flux.dt_utcnow',
                    return_value=test_time), \
             patch('homeassistant.helpers.sun.get_astral_event_date',
                   side_effect=event_date):
@@ -729,7 +729,7 @@ class TestSwitchFlux(unittest.TestCase):
         self.assertIsNone(state.attributes.get('xy_color'))
         self.assertIsNone(state.attributes.get('brightness'))
 
-        test_time = dt_util.now().replace(hour=12, minute=0, second=0)
+        test_time = dt_util.utcnow().replace(hour=12, minute=0, second=0)
         sunset_time = test_time.replace(hour=17, minute=0, second=0)
         sunrise_time = test_time.replace(hour=5, minute=0, second=0)
 
@@ -740,7 +740,7 @@ class TestSwitchFlux(unittest.TestCase):
             print('sunset {}'.format(sunset_time))
             return sunset_time
 
-        with patch('homeassistant.components.switch.flux.dt_now',
+        with patch('homeassistant.components.switch.flux.dt_utcnow',
                    return_value=test_time), \
             patch('homeassistant.helpers.sun.get_astral_event_date',
                   side_effect=event_date):
@@ -784,7 +784,7 @@ class TestSwitchFlux(unittest.TestCase):
         self.assertEqual(STATE_ON, state.state)
         self.assertIsNone(state.attributes.get('color_temp'))
 
-        test_time = dt_util.now().replace(hour=8, minute=30, second=0)
+        test_time = dt_util.utcnow().replace(hour=8, minute=30, second=0)
         sunset_time = test_time.replace(hour=17, minute=0, second=0)
         sunrise_time = test_time.replace(hour=5, minute=0, second=0)
 
@@ -793,7 +793,7 @@ class TestSwitchFlux(unittest.TestCase):
                 return sunrise_time
             return sunset_time
 
-        with patch('homeassistant.components.switch.flux.dt_now',
+        with patch('homeassistant.components.switch.flux.dt_utcnow',
                    return_value=test_time), \
             patch('homeassistant.helpers.sun.get_astral_event_date',
                   side_effect=event_date):
@@ -829,7 +829,7 @@ class TestSwitchFlux(unittest.TestCase):
         self.assertEqual(STATE_ON, state.state)
         self.assertIsNone(state.attributes.get('color_temp'))
 
-        test_time = dt_util.now().replace(hour=8, minute=30, second=0)
+        test_time = dt_util.utcnow().replace(hour=8, minute=30, second=0)
         sunset_time = test_time.replace(hour=17, minute=0, second=0)
         sunrise_time = test_time.replace(hour=5, minute=0, second=0)
 
@@ -838,7 +838,7 @@ class TestSwitchFlux(unittest.TestCase):
                 return sunrise_time
             return sunset_time
 
-        with patch('homeassistant.components.switch.flux.dt_now',
+        with patch('homeassistant.components.switch.flux.dt_utcnow',
                    return_value=test_time), \
             patch('homeassistant.helpers.sun.get_astral_event_date',
                   side_effect=event_date):


### PR DESCRIPTION
- fix naming bug ([@helto4real] - [#17976]) ([weather.smhi docs])
- Konnected: Pass hass_config to load_platform ([@heythisisnate] - [#18027]) ([konnected docs])
- Change cv.string to [cv.string] ([@awarecan] - [#18050]) ([nest docs])
- Revert HomeKit update to 2.2.2 ([@cdce8p] - [#18069]) ([homekit docs])
- Fix time zone for flux switch ([@amelchio] - [#18102]) ([switch.flux docs])
- Bunch of frontend fixes ([link](https://github.com/home-assistant/home-assistant-polymer/releases/tag/20181026.2))
- Upgrade pyipma 

[#17976]: https://github.com/home-assistant/home-assistant/pull/17976
[#18027]: https://github.com/home-assistant/home-assistant/pull/18027
[#18050]: https://github.com/home-assistant/home-assistant/pull/18050
[#18069]: https://github.com/home-assistant/home-assistant/pull/18069
[#18102]: https://github.com/home-assistant/home-assistant/pull/18102
[@amelchio]: https://github.com/amelchio
[@awarecan]: https://github.com/awarecan
[@cdce8p]: https://github.com/cdce8p
[@helto4real]: https://github.com/helto4real
[@heythisisnate]: https://github.com/heythisisnate
[homekit docs]: https://www.home-assistant.io/components/homekit/
[konnected docs]: https://www.home-assistant.io/components/konnected/
[nest docs]: https://www.home-assistant.io/components/nest/
[switch.flux docs]: https://www.home-assistant.io/components/switch.flux/
[weather.smhi docs]: https://www.home-assistant.io/components/weather.smhi/