### PR TITLE
Don’t round sensor value of thethingsnetwork platform

### DIFF
--- a/homeassistant/components/sensor/thethingsnetwork.py
+++ b/homeassistant/components/sensor/thethingsnetwork.py
@@ -84,7 +84,7 @@ class TtnDataSensor(Entity):
         """Return the state of the entity."""
         if self._ttn_data_storage.data is not None:
             try:
-                return round(self._state[self._value], 1)
+                return self._state[self._value]
             except KeyError:
                 pass
 


### PR DESCRIPTION
## Description:

I found my sensor values rounded to one decimal place instead of two that are available. I checked the code of the thethingsnetwork sensor and found the hard coded rounding there.

In my opinion the rounding should happen on the side of The Things Network, e.g. in the decoder function. As an alternative you can use a template sensor to round the thethingsnetwork sensor values like you need it.

Looking forward to read about your opinions.


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
