### PR TITLE
Exposes initial attribute on the input_number entity

### DIFF
--- a/homeassistant/components/input_number.py
+++ b/homeassistant/components/input_number.py
@@ -28,6 +28,7 @@ CONF_STEP = 'step'
 MODE_SLIDER = 'slider'
 MODE_BOX = 'box'
 
+ATTR_INITIAL = 'initial'
 ATTR_VALUE = 'value'
 ATTR_MIN = 'min'
 ATTR_MAX = 'max'
@@ -131,6 +132,7 @@ class InputNumber(Entity):
         self.entity_id = ENTITY_ID_FORMAT.format(object_id)
         self._name = name
         self._current_value = initial
+        self._initial = initial
         self._minimum = minimum
         self._maximum = maximum
         self._step = step
@@ -167,6 +169,7 @@ class InputNumber(Entity):
     def state_attributes(self):
         """Return the state attributes."""
         return {
+            ATTR_INITIAL: self._initial,
             ATTR_MIN: self._minimum,
             ATTR_MAX: self._maximum,
             ATTR_STEP: self._step,


### PR DESCRIPTION
## Description:
Exposes one additional attribute for `initial` so we can do templating based on that value like this:
{{ (state_attr('input_number1', 'initial') | float) + 12 }}

<!-- **Related issue (if applicable):** fixes #<home-assistant issue number goes here> 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>
-->
## Example entry for `configuration.yaml` (if applicable):
```yaml
input_number:
  slider1:
    name: Slider
    initial: 30
    min: -20
    max: 35
    step: 1
```
![image](https://user-images.githubusercontent.com/15093472/47920709-00478700-deb3-11e8-9115-8cb19a0e24b4.png)

## Checklist:
  - [X] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
