### PR TITLE
Fix DTE Energy Bridge V2 scaling issue. (#18124)

### DIFF
--- a/homeassistant/components/sensor/dte_energy_bridge.py
+++ b/homeassistant/components/sensor/dte_energy_bridge.py
@@ -109,4 +109,10 @@ class DteEnergyBridgeSensor(Entity):
         # A workaround for a bug in the DTE energy bridge.
         # The returned value can randomly be in W or kW.  Checking for a
         # a decimal seems to be a reliable way to determine the units.
-        self._state = val if '.' in response_split[0] else val / 1000
+        # Limiting to version 1 because version 2 apparently always returns
+        # values in the format 000000.000 kW, but the scaling is Watts
+        # NOT kWatts
+        if self._version == 1 and '.' in response_split[0]:
+            self._state = val
+        else:
+            self._state = val / 1000


### PR DESCRIPTION
## Description:
This fixes the scaling issue with the DTE Energy Bridge version 2 device. The existing code included a section to fix the scaling that worked around a bug with the version 1 device. The version 2 device does not exhibit the same behaviour. As far as I've been able to test the version 2 device always returns instantaneous energy usage values in the form "nnnnnn.nnn kW". The restful interface from the device is undocumented. The values are actually in Watts, even though the string includes the "kW" characters. In the case of the version 2 device the value returned will always be divided by 1000 to make kiloWatts.

**Related issue (if applicable):** fixes #18124

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** no change required

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
