### PR TITLE
Ffmpeg async lock

### DIFF
--- a/homeassistant/components/camera/onvif.py
+++ b/homeassistant/components/camera/onvif.py
@@ -74,7 +74,7 @@ SERVICE_PTZ_SCHEMA = vol.Schema({
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up a ONVIF camera."""
-    if not hass.data[DATA_FFMPEG].async_run_test(config.get(CONF_HOST)):
+    if not await hass.data[DATA_FFMPEG].async_run_test(config.get(CONF_HOST)):
         return
 
     def handle_ptz(service):

--- a/homeassistant/components/camera/onvif.py
+++ b/homeassistant/components/camera/onvif.py
@@ -72,7 +72,8 @@ SERVICE_PTZ_SCHEMA = vol.Schema({
 })
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_entities,
+                               discovery_info=None):
     """Set up a ONVIF camera."""
     if not await hass.data[DATA_FFMPEG].async_run_test(config.get(CONF_HOST)):
         return
@@ -95,7 +96,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     hass.services.async_register(DOMAIN, SERVICE_PTZ, handle_ptz,
                                  schema=SERVICE_PTZ_SCHEMA)
-    add_entities([ONVIFHassCamera(hass, config)])
+    async_add_entities([ONVIFHassCamera(hass, config)])
 
 
 class ONVIFHassCamera(Camera):


### PR DESCRIPTION
## Description:
Add lock around ffmpeg test.

Tested by @edif30 

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
