### PR TITLE
add service to reconnect the bot

### DIFF
--- a/homeassistant/components/hangouts/__init__.py
+++ b/homeassistant/components/hangouts/__init__.py
@@ -22,7 +22,7 @@ from .const import (
     SERVICE_UPDATE, CONF_SENTENCES, CONF_MATCHERS,
     CONF_ERROR_SUPPRESSED_CONVERSATIONS, INTENT_SCHEMA, TARGETS_SCHEMA,
     CONF_DEFAULT_CONVERSATIONS, EVENT_HANGOUTS_CONVERSATIONS_RESOLVED,
-    INTENT_HELP)
+    INTENT_HELP, SERVICE_RECONNECT)
 
 # We need an import from .config_flow, without it .config_flow is never loaded.
 from .config_flow import HangoutsFlowHandler  # noqa: F401
@@ -128,6 +128,12 @@ async def async_setup_entry(hass, config):
                                  SERVICE_UPDATE,
                                  bot.
                                  async_handle_update_users_and_conversations,
+                                 schema=vol.Schema({}))
+
+    hass.services.async_register(DOMAIN,
+                                 SERVICE_RECONNECT,
+                                 bot.
+                                 async_handle_reconnect,
                                  schema=vol.Schema({}))
 
     intent.async_register(hass, HelpIntent(hass))

--- a/homeassistant/components/hangouts/const.py
+++ b/homeassistant/components/hangouts/const.py
@@ -39,6 +39,7 @@ CONF_CONVERSATION_NAME = 'name'
 
 SERVICE_SEND_MESSAGE = 'send_message'
 SERVICE_UPDATE = 'update'
+SERVICE_RECONNECT = 'reconnect'
 
 
 TARGETS_SCHEMA = vol.All(

--- a/homeassistant/components/hangouts/hangouts_bot.py
+++ b/homeassistant/components/hangouts/hangouts_bot.py
@@ -313,6 +313,11 @@ class HangoutsBot:
         """Handle the update_users_and_conversations service."""
         await self._async_list_conversations()
 
+    async def async_handle_reconnect(self, _=None):
+        """Handle the reconnect service."""
+        await self.async_disconnect()
+        await self.async_connect()
+
     def get_intents(self, conv_id):
         """Return the intents for a specific conversation."""
         return self._conversation_intents.get(conv_id)

--- a/homeassistant/components/hangouts/services.yaml
+++ b/homeassistant/components/hangouts/services.yaml
@@ -1,5 +1,5 @@
 update:
-  description: Updates the list of users and conversations.
+  description: Updates the list of conversations.
 
 send_message:
   description: Send a notification to a specific target.
@@ -13,3 +13,6 @@ send_message:
     data:
       description: Other options ['image_file' / 'image_url']
       example: '{ "image_file": "file" }  or  { "image_url": "url" }'
+
+reconnect:
+  description: Reconnect the bot.


### PR DESCRIPTION
## Description:
Adds a service for reconnecting the hangups bot.

**Related issue (if applicable):** workaround for #17622

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#7347

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
