### PR TITLE
Ignore duplicate state changes GarageDoor HomeKit

### DIFF
--- a/homeassistant/components/homekit/type_covers.py
+++ b/homeassistant/components/homekit/type_covers.py
@@ -42,17 +42,16 @@ class GarageDoorOpener(HomeAccessory):
     def set_state(self, value):
         """Change garage state if call came from HomeKit."""
         _LOGGER.debug('%s: Set state to %d', self.entity_id, value)
-        if self.char_current_state.value == value:
-            _LOGGER.debug('%s: Ignoring state change', self.entity_id)
-            return
         self._flag_state = True
 
         params = {ATTR_ENTITY_ID: self.entity_id}
         if value == 0:
-            self.char_current_state.set_value(3)
+            if self.char_current_state.value != value:
+                self.char_current_state.set_value(3)
             self.call_service(DOMAIN, SERVICE_OPEN_COVER, params)
         elif value == 1:
-            self.char_current_state.set_value(2)
+            if self.char_current_state.value != value:
+                self.char_current_state.set_value(2)
             self.call_service(DOMAIN, SERVICE_CLOSE_COVER, params)
 
     def update_state(self, new_state):

--- a/homeassistant/components/homekit/type_covers.py
+++ b/homeassistant/components/homekit/type_covers.py
@@ -42,6 +42,9 @@ class GarageDoorOpener(HomeAccessory):
     def set_state(self, value):
         """Change garage state if call came from HomeKit."""
         _LOGGER.debug('%s: Set state to %d', self.entity_id, value)
+        if self.char_current_state.value == value:
+            _LOGGER.debug('%s: Ignoring state change', self.entity_id)
+            return
         self._flag_state = True
 
         params = {ATTR_ENTITY_ID: self.entity_id}

--- a/tests/components/homekit/test_type_covers.py
+++ b/tests/components/homekit/test_type_covers.py
@@ -80,6 +80,10 @@ async def test_garage_door_open_close(hass, hk_driver, cls, events):
     hass.states.async_set(entity_id, STATE_CLOSED)
     await hass.async_block_till_done()
 
+    await hass.async_add_job(acc.char_target_state.client_update_value, 1)
+    await hass.async_block_till_done()
+    assert len(events) == 1
+
     await hass.async_add_job(acc.char_target_state.client_update_value, 0)
     await hass.async_block_till_done()
     assert call_open_cover
@@ -88,6 +92,13 @@ async def test_garage_door_open_close(hass, hk_driver, cls, events):
     assert acc.char_target_state.value == 0
     assert len(events) == 2
     assert events[-1].data[ATTR_VALUE] is None
+
+    hass.states.async_set(entity_id, STATE_OPEN)
+    await hass.async_block_till_done()
+
+    await hass.async_add_job(acc.char_target_state.client_update_value, 0)
+    await hass.async_block_till_done()
+    assert len(events) == 2
 
 
 async def test_window_set_cover_position(hass, hk_driver, cls, events):

--- a/tests/components/homekit/test_type_covers.py
+++ b/tests/components/homekit/test_type_covers.py
@@ -82,7 +82,10 @@ async def test_garage_door_open_close(hass, hk_driver, cls, events):
 
     await hass.async_add_job(acc.char_target_state.client_update_value, 1)
     await hass.async_block_till_done()
-    assert len(events) == 1
+    assert acc.char_current_state.value == 1
+    assert acc.char_target_state.value == 1
+    assert len(events) == 2
+    assert events[-1].data[ATTR_VALUE] is None
 
     await hass.async_add_job(acc.char_target_state.client_update_value, 0)
     await hass.async_block_till_done()
@@ -90,7 +93,7 @@ async def test_garage_door_open_close(hass, hk_driver, cls, events):
     assert call_open_cover[0].data[ATTR_ENTITY_ID] == entity_id
     assert acc.char_current_state.value == 3
     assert acc.char_target_state.value == 0
-    assert len(events) == 2
+    assert len(events) == 3
     assert events[-1].data[ATTR_VALUE] is None
 
     hass.states.async_set(entity_id, STATE_OPEN)
@@ -98,7 +101,10 @@ async def test_garage_door_open_close(hass, hk_driver, cls, events):
 
     await hass.async_add_job(acc.char_target_state.client_update_value, 0)
     await hass.async_block_till_done()
-    assert len(events) == 2
+    assert acc.char_current_state.value == 0
+    assert acc.char_target_state.value == 0
+    assert len(events) == 4
+    assert events[-1].data[ATTR_VALUE] is None
 
 
 async def test_window_set_cover_position(hass, hk_driver, cls, events):


### PR DESCRIPTION
## Description:
Ignore duplicate state chage calls from HomeKit for GarageDoor accessories. Those could happen with the use of HomeKit automations. This PR is necessary after I had to revert the HAP-python update #18069. It's also largely based on the work @adrum did with #17453. Just added the tests for it.

**Related issue (if applicable):** fixes #17557


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

---

CC: @wasp100