### PR TITLE
Lovelace: Duplicate ID check on load config + caching

### DIFF
--- a/homeassistant/components/lovelace/__init__.py
+++ b/homeassistant/components/lovelace/__init__.py
@@ -332,36 +332,38 @@ def get_view(fname: str, view_id: str, data_format: str = FORMAT_YAML) -> None:
     """Get view without it's cards."""
     round_trip = data_format == FORMAT_YAML
     config = yaml.load_yaml(fname, round_trip)
-    view = None
+    found = None
     for view in config.get('views', []):
         if str(view.get('id', '')) == view_id:
+            found = view
             break
-    if view is None:
+    if found is None:
         raise ViewNotFoundError(
             "View with ID: {} was not found in {}.".format(view_id, fname))
 
-    del view['cards']
+    del found['cards']
     if data_format == FORMAT_YAML:
-        return yaml.object_to_yaml(view)
-    return view
+        return yaml.object_to_yaml(found)
+    return found
 
 
 def update_view(fname: str, view_id: str, view_config, data_format:
                 str = FORMAT_YAML) -> None:
     """Update view."""
     config = yaml.load_yaml(fname, True)
-    view = None
+    found = None
     for view in config.get('views', []):
         if str(view.get('id', '')) == view_id:
+            found = view
             break
-    if view is None:
+    if found is None:
         raise ViewNotFoundError(
             "View with ID: {} was not found in {}.".format(view_id, fname))
     if data_format == FORMAT_YAML:
         view_config = yaml.yaml_to_object(view_config)
     view_config['cards'] = view.get('cards', [])
-    view.clear()
-    view.update(view_config)
+    found.clear()
+    found.update(view_config)
     yaml.save_yaml(fname, config)
 
 
@@ -383,15 +385,16 @@ def move_view(fname: str, view_id: str, position: int) -> None:
     """Move a view to a different position."""
     config = yaml.load_yaml(fname, True)
     views = config.get('views', [])
-    view = None
+    found = None
     for view in views:
         if str(view.get('id', '')) == view_id:
+            found = view
             break
-    if view is None:
+    if found is None:
         raise ViewNotFoundError(
             "View with ID: {} was not found in {}.".format(view_id, fname))
 
-    views.insert(position, views.pop(views.index(view)))
+    views.insert(position, views.pop(views.index(found)))
     yaml.save_yaml(fname, config)
 
 
@@ -399,15 +402,16 @@ def delete_view(fname: str, view_id: str) -> None:
     """Delete a view."""
     config = yaml.load_yaml(fname, True)
     views = config.get('views', [])
-    view = None
+    found = None
     for view in views:
         if str(view.get('id', '')) == view_id:
+            found = view
             break
-    if view is None:
+    if found is None:
         raise ViewNotFoundError(
             "View with ID: {} was not found in {}.".format(view_id, fname))
 
-    views.pop(views.index(view))
+    views.pop(views.index(found))
     yaml.save_yaml(fname, config)
 
 

--- a/homeassistant/components/lovelace/__init__.py
+++ b/homeassistant/components/lovelace/__init__.py
@@ -4,13 +4,11 @@ Support for the Lovelace UI.
 For more details about this component, please refer to the documentation
 at https://www.home-assistant.io/lovelace/
 """
-import logging
-import os
-import uuid
-import time
 from functools import wraps
 import logging
+import os
 from typing import Dict, List, Union
+import time
 import uuid
 
 import voluptuous as vol

--- a/homeassistant/components/lovelace/__init__.py
+++ b/homeassistant/components/lovelace/__init__.py
@@ -361,7 +361,7 @@ def update_view(fname: str, view_id: str, view_config, data_format:
             "View with ID: {} was not found in {}.".format(view_id, fname))
     if data_format == FORMAT_YAML:
         view_config = yaml.yaml_to_object(view_config)
-    view_config['cards'] = view.get('cards', [])
+    view_config['cards'] = found.get('cards', [])
     found.clear()
     found.update(view_config)
     yaml.save_yaml(fname, config)

--- a/homeassistant/components/lovelace/__init__.py
+++ b/homeassistant/components/lovelace/__init__.py
@@ -362,7 +362,6 @@ def update_view(fname: str, view_id: str, view_config, data_format:
     view.clear()
     view.update(view_config)
     yaml.save_yaml(fname, config)
-    return
 
 
 def add_view(fname: str, view_config: str,
@@ -392,7 +391,6 @@ def move_view(fname: str, view_id: str, position: int) -> None:
 
     views.insert(position, views.pop(views.index(view)))
     yaml.save_yaml(fname, config)
-    return
 
 
 def delete_view(fname: str, view_id: str) -> None:
@@ -408,7 +406,6 @@ def delete_view(fname: str, view_id: str) -> None:
 
     views.pop(views.index(view))
     yaml.save_yaml(fname, config)
-    return
 
 
 async def async_setup(hass, config):

--- a/homeassistant/components/lovelace/__init__.py
+++ b/homeassistant/components/lovelace/__init__.py
@@ -332,10 +332,11 @@ def get_view(fname: str, view_id: str, data_format: str = FORMAT_YAML) -> None:
     """Get view without it's cards."""
     round_trip = data_format == FORMAT_YAML
     config = yaml.load_yaml(fname, round_trip)
+    view = None
     for view in config.get('views', []):
         if str(view.get('id', '')) == view_id:
             break
-    else:
+    if view is None:
         raise ViewNotFoundError(
             "View with ID: {} was not found in {}.".format(view_id, fname))
 
@@ -349,13 +350,13 @@ def update_view(fname: str, view_id: str, view_config, data_format:
                 str = FORMAT_YAML) -> None:
     """Update view."""
     config = yaml.load_yaml(fname, True)
+    view = None
     for view in config.get('views', []):
         if str(view.get('id', '')) == view_id:
             break
-    else:
+    if view is None:
         raise ViewNotFoundError(
             "View with ID: {} was not found in {}.".format(view_id, fname))
-
     if data_format == FORMAT_YAML:
         view_config = yaml.yaml_to_object(view_config)
     view_config['cards'] = view.get('cards', [])
@@ -382,10 +383,11 @@ def move_view(fname: str, view_id: str, position: int) -> None:
     """Move a view to a different position."""
     config = yaml.load_yaml(fname, True)
     views = config.get('views', [])
+    view = None
     for view in views:
         if str(view.get('id', '')) == view_id:
             break
-    else:
+    if view is None:
         raise ViewNotFoundError(
             "View with ID: {} was not found in {}.".format(view_id, fname))
 
@@ -397,10 +399,11 @@ def delete_view(fname: str, view_id: str) -> None:
     """Delete a view."""
     config = yaml.load_yaml(fname, True)
     views = config.get('views', [])
+    view = None
     for view in views:
         if str(view.get('id', '')) == view_id:
             break
-    else:
+    if view is None:
         raise ViewNotFoundError(
             "View with ID: {} was not found in {}.".format(view_id, fname))
 


### PR DESCRIPTION
## Description:
Will now check for duplicate IDs on `load_config`, to not do this every time you open hass, added caching for `load_config`.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
