### PR TITLE
Remove FFmpeg 'run_test' config (breaking change)

### DIFF
--- a/homeassistant/components/ffmpeg.py
+++ b/homeassistant/components/ffmpeg.py
@@ -37,14 +37,12 @@ CONF_INPUT = 'input'
 CONF_FFMPEG_BIN = 'ffmpeg_bin'
 CONF_EXTRA_ARGUMENTS = 'extra_arguments'
 CONF_OUTPUT = 'output'
-CONF_RUN_TEST = 'run_test'
 
 DEFAULT_BINARY = 'ffmpeg'
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Optional(CONF_FFMPEG_BIN, default=DEFAULT_BINARY): cv.string,
-        vol.Optional(CONF_RUN_TEST): cv.boolean,
     }),
 }, extra=vol.ALLOW_EXTRA)
 


### PR DESCRIPTION
## Description:
Followup to https://github.com/home-assistant/home-assistant/pull/18131 which disabled functionality, but allowed the config to remain for a point release. This removes the config as a breaking change to complete the removal.

**Related issue (if applicable):** followup to https://github.com/home-assistant/home-assistant/pull/18131

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#7342

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54