### PR TITLE
Elk-M1 fixes

### DIFF
--- a/homeassistant/components/elkm1/__init__.py
+++ b/homeassistant/components/elkm1/__init__.py
@@ -11,7 +11,7 @@ import re
 import voluptuous as vol
 from homeassistant.const import (
     CONF_EXCLUDE, CONF_HOST, CONF_INCLUDE, CONF_PASSWORD,
-    CONF_TEMPERATURE_UNIT, CONF_USERNAME, TEMP_FAHRENHEIT)
+    CONF_TEMPERATURE_UNIT, CONF_USERNAME)
 from homeassistant.core import HomeAssistant, callback  # noqa
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import discovery

--- a/homeassistant/components/elkm1/__init__.py
+++ b/homeassistant/components/elkm1/__init__.py
@@ -85,15 +85,24 @@ CONFIG_SCHEMA = vol.Schema({
             vol.Optional(CONF_PASSWORD, default=''): cv.string,
             vol.Optional(CONF_TEMPERATURE_UNIT, default='F'):
                 cv.temperature_unit,
-            vol.Optional(CONF_AREA): CONFIG_SCHEMA_SUBDOMAIN,
-            vol.Optional(CONF_COUNTER): CONFIG_SCHEMA_SUBDOMAIN,
-            vol.Optional(CONF_KEYPAD): CONFIG_SCHEMA_SUBDOMAIN,
-            vol.Optional(CONF_OUTPUT): CONFIG_SCHEMA_SUBDOMAIN,
-            vol.Optional(CONF_PLC): CONFIG_SCHEMA_SUBDOMAIN,
-            vol.Optional(CONF_SETTING): CONFIG_SCHEMA_SUBDOMAIN,
-            vol.Optional(CONF_TASK): CONFIG_SCHEMA_SUBDOMAIN,
-            vol.Optional(CONF_THERMOSTAT): CONFIG_SCHEMA_SUBDOMAIN,
-            vol.Optional(CONF_ZONE): CONFIG_SCHEMA_SUBDOMAIN,
+            vol.Optional(CONF_AREA, default={CONF_ENABLED: True}):
+                CONFIG_SCHEMA_SUBDOMAIN,
+            vol.Optional(CONF_COUNTER, default={CONF_ENABLED: True}):
+                CONFIG_SCHEMA_SUBDOMAIN,
+            vol.Optional(CONF_KEYPAD, default={CONF_ENABLED: True}):
+                CONFIG_SCHEMA_SUBDOMAIN,
+            vol.Optional(CONF_OUTPUT, default={CONF_ENABLED: True}):
+                CONFIG_SCHEMA_SUBDOMAIN,
+            vol.Optional(CONF_PLC, default={CONF_ENABLED: True}):
+                CONFIG_SCHEMA_SUBDOMAIN,
+            vol.Optional(CONF_SETTING, default={CONF_ENABLED: True}):
+                CONFIG_SCHEMA_SUBDOMAIN,
+            vol.Optional(CONF_TASK, default={CONF_ENABLED: True}):
+                CONFIG_SCHEMA_SUBDOMAIN,
+            vol.Optional(CONF_THERMOSTAT, default={CONF_ENABLED: True}):
+                CONFIG_SCHEMA_SUBDOMAIN,
+            vol.Optional(CONF_ZONE, default={CONF_ENABLED: True}):
+                CONFIG_SCHEMA_SUBDOMAIN,
         },
         _host_validator,
     )

--- a/homeassistant/components/elkm1/__init__.py
+++ b/homeassistant/components/elkm1/__init__.py
@@ -83,7 +83,7 @@ CONFIG_SCHEMA = vol.Schema({
             vol.Required(CONF_HOST): cv.string,
             vol.Optional(CONF_USERNAME, default=''): cv.string,
             vol.Optional(CONF_PASSWORD, default=''): cv.string,
-            vol.Optional(CONF_TEMPERATURE_UNIT, default=TEMP_FAHRENHEIT):
+            vol.Optional(CONF_TEMPERATURE_UNIT, default='F'):
                 cv.temperature_unit,
             vol.Optional(CONF_AREA): CONFIG_SCHEMA_SUBDOMAIN,
             vol.Optional(CONF_COUNTER): CONFIG_SCHEMA_SUBDOMAIN,

--- a/homeassistant/components/elkm1/__init__.py
+++ b/homeassistant/components/elkm1/__init__.py
@@ -85,24 +85,15 @@ CONFIG_SCHEMA = vol.Schema({
             vol.Optional(CONF_PASSWORD, default=''): cv.string,
             vol.Optional(CONF_TEMPERATURE_UNIT, default='F'):
                 cv.temperature_unit,
-            vol.Optional(CONF_AREA, default={CONF_ENABLED: True}):
-                CONFIG_SCHEMA_SUBDOMAIN,
-            vol.Optional(CONF_COUNTER, default={CONF_ENABLED: True}):
-                CONFIG_SCHEMA_SUBDOMAIN,
-            vol.Optional(CONF_KEYPAD, default={CONF_ENABLED: True}):
-                CONFIG_SCHEMA_SUBDOMAIN,
-            vol.Optional(CONF_OUTPUT, default={CONF_ENABLED: True}):
-                CONFIG_SCHEMA_SUBDOMAIN,
-            vol.Optional(CONF_PLC, default={CONF_ENABLED: True}):
-                CONFIG_SCHEMA_SUBDOMAIN,
-            vol.Optional(CONF_SETTING, default={CONF_ENABLED: True}):
-                CONFIG_SCHEMA_SUBDOMAIN,
-            vol.Optional(CONF_TASK, default={CONF_ENABLED: True}):
-                CONFIG_SCHEMA_SUBDOMAIN,
-            vol.Optional(CONF_THERMOSTAT, default={CONF_ENABLED: True}):
-                CONFIG_SCHEMA_SUBDOMAIN,
-            vol.Optional(CONF_ZONE, default={CONF_ENABLED: True}):
-                CONFIG_SCHEMA_SUBDOMAIN,
+            vol.Optional(CONF_AREA, default={}): CONFIG_SCHEMA_SUBDOMAIN,
+            vol.Optional(CONF_COUNTER, default={}): CONFIG_SCHEMA_SUBDOMAIN,
+            vol.Optional(CONF_KEYPAD, default={}): CONFIG_SCHEMA_SUBDOMAIN,
+            vol.Optional(CONF_OUTPUT, default={}): CONFIG_SCHEMA_SUBDOMAIN,
+            vol.Optional(CONF_PLC, default={}): CONFIG_SCHEMA_SUBDOMAIN,
+            vol.Optional(CONF_SETTING, default={}): CONFIG_SCHEMA_SUBDOMAIN,
+            vol.Optional(CONF_TASK, default={}): CONFIG_SCHEMA_SUBDOMAIN,
+            vol.Optional(CONF_THERMOSTAT, default={}): CONFIG_SCHEMA_SUBDOMAIN,
+            vol.Optional(CONF_ZONE, default={}): CONFIG_SCHEMA_SUBDOMAIN,
         },
         _host_validator,
     )


### PR DESCRIPTION
## Description:
This fixes two problems that were found on the newly released Elk-M1 code in 0.81. Both are setting defaults in voluptuous. Both are minor fixes. No documentation changes required.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
