### PR TITLE
Add SUPPORT_SEEK for DLNA DMR devices + now (better) providing media_image_url for DLNA DMR devices

### DIFF
--- a/homeassistant/components/media_player/dlna_dmr.py
+++ b/homeassistant/components/media_player/dlna_dmr.py
@@ -25,7 +25,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import get_local_ip
 
-REQUIREMENTS = ['async-upnp-client==0.13.0']
+REQUIREMENTS = ['async-upnp-client==0.13.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/media_player/dlna_dmr.py
+++ b/homeassistant/components/media_player/dlna_dmr.py
@@ -6,6 +6,7 @@ https://home-assistant.io/components/media_player.dlna_dmr/
 """
 import asyncio
 from datetime import datetime
+from datetime import timedelta
 import functools
 import logging
 
@@ -14,7 +15,7 @@ import voluptuous as vol
 
 from homeassistant.components.media_player import (
     PLATFORM_SCHEMA, SUPPORT_NEXT_TRACK, SUPPORT_PAUSE, SUPPORT_PLAY,
-    SUPPORT_PLAY_MEDIA, SUPPORT_PREVIOUS_TRACK, SUPPORT_STOP,
+    SUPPORT_PLAY_MEDIA, SUPPORT_PREVIOUS_TRACK, SUPPORT_SEEK, SUPPORT_STOP,
     SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_SET, MediaPlayerDevice)
 from homeassistant.const import (
     CONF_NAME, CONF_URL, EVENT_HOMEASSISTANT_STOP, STATE_IDLE, STATE_OFF,
@@ -233,6 +234,8 @@ class DlnaDmrDevice(MediaPlayerDevice):
             supported_features |= SUPPORT_NEXT_TRACK
         if self._device.has_play_media:
             supported_features |= SUPPORT_PLAY_MEDIA
+        if self._device.has_seek_rel_time:
+            supported_features |= SUPPORT_SEEK
 
         return supported_features
 
@@ -285,6 +288,16 @@ class DlnaDmrDevice(MediaPlayerDevice):
         await self._device.async_stop()
 
     @catch_request_errors()
+    async def async_media_seek(self, position):
+        """Send seek command."""
+        if not self._device.can_seek_rel_time:
+            _LOGGER.debug('Cannot do Seek/rel_time')
+            return
+
+        time = timedelta(seconds=position)
+        await self._device.async_seek_rel_time(time)
+
+    @catch_request_errors()
     async def async_play_media(self, media_type, media_id, **kwargs):
         """Play a piece of media."""
         title = "Home Assistant"
@@ -295,7 +308,7 @@ class DlnaDmrDevice(MediaPlayerDevice):
         if self._device.can_stop:
             await self.async_media_stop()
 
-        # +ueue media
+        # Queue media
         await self._device.async_set_transport_uri(
             media_id, title, mime_type, upnp_class)
         await self._device.async_wait_for_can_play()

--- a/homeassistant/components/upnp/__init__.py
+++ b/homeassistant/components/upnp/__init__.py
@@ -29,7 +29,7 @@ from .config_flow import async_ensure_domain_data
 from .device import Device
 
 
-REQUIREMENTS = ['async-upnp-client==0.13.0']
+REQUIREMENTS = ['async-upnp-client==0.13.1']
 
 NOTIFICATION_ID = 'upnp_notification'
 NOTIFICATION_TITLE = 'UPnP/IGD Setup'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -157,7 +157,7 @@ asterisk_mbox==0.5.0
 
 # homeassistant.components.upnp
 # homeassistant.components.media_player.dlna_dmr
-async-upnp-client==0.13.0
+async-upnp-client==0.13.1
 
 # homeassistant.components.axis
 axis==16


### PR DESCRIPTION
## Description:

Add SEEK mode for to DLNA DMR devices and upgrade to `async_upnp_client==0.13.2` to better support media_image_url

**Related issue (if applicable):** fixes #18040

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** not applicable

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
