### PR TITLE
Filter Coinbase account wallets

### DIFF
--- a/homeassistant/components/coinbase.py
+++ b/homeassistant/components/coinbase.py
@@ -21,6 +21,7 @@ _LOGGER = logging.getLogger(__name__)
 DOMAIN = 'coinbase'
 
 CONF_API_SECRET = 'api_secret'
+CONF_ACCOUNT_CURRENCIES = 'account_balance_currencies'
 CONF_EXCHANGE_CURRENCIES = 'exchange_rate_currencies'
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=1)
@@ -31,6 +32,8 @@ CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Required(CONF_API_KEY): cv.string,
         vol.Required(CONF_API_SECRET): cv.string,
+        vol.Optional(CONF_ACCOUNT_CURRENCIES):
+            vol.All(cv.ensure_list, [cv.string]),
         vol.Optional(CONF_EXCHANGE_CURRENCIES, default=[]):
             vol.All(cv.ensure_list, [cv.string])
     })
@@ -45,6 +48,7 @@ def setup(hass, config):
     """
     api_key = config[DOMAIN].get(CONF_API_KEY)
     api_secret = config[DOMAIN].get(CONF_API_SECRET)
+    account_currencies = config[DOMAIN].get(CONF_ACCOUNT_CURRENCIES)
     exchange_currencies = config[DOMAIN].get(CONF_EXCHANGE_CURRENCIES)
 
     hass.data[DATA_COINBASE] = coinbase_data = CoinbaseData(
@@ -53,7 +57,13 @@ def setup(hass, config):
     if not hasattr(coinbase_data, 'accounts'):
         return False
     for account in coinbase_data.accounts.data:
-        load_platform(hass, 'sensor', DOMAIN, {'account': account}, config)
+        if (account_currencies is None or
+                account.currency in account_currencies):
+            load_platform(hass,
+                          'sensor',
+                          DOMAIN,
+                          {'account': account},
+                          config)
     for currency in exchange_currencies:
         if currency not in coinbase_data.exchange_rates.rates:
             _LOGGER.warning("Currency %s not found", currency)


### PR DESCRIPTION
## Description:
Only add sensor entities for accounts with the specified currencies.
This is a none breaking change. If it's not specified then all account wallets will be loaded.
The default behaviour gives the same results as it does now.

A simple configuration would make all data available for the UI.
Currently there's a discussion (https://github.com/home-assistant/architecture/issues/100)
about removing monitored conditions altogether.

If the user specifies the key without a value (empty list),
then no sensor entities are added for the wallet (e.g. a user only wants exchange rates).

**Related issue (if applicable):** fixes...
Currently you can just customize the entities to hide them.
However, Coinbase regularly adds new account wallets with new currencies.
You would always need to customize these new entities
and there's no way to get them out of the entity registry itself.

However, this is something I would prefer since I don't need all my 'bank accounts' in HA either
(and there's no point in adding them when the wallet is empty anyway).

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** https://github.com/home-assistant/home-assistant.io/pull/7412

## Example entry for `configuration.yaml` (if applicable):
```yaml
coinbase:
  api_key: !secret coinbase_api_key
  api_secret: !secret coinbase_api_secret
  account_balance_currencies:
    - EUR
    - BTC
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
