### PR TITLE
Reconfigure MQTT binary_sensor component if discovery info is changed

### DIFF
--- a/homeassistant/components/binary_sensor/mqtt.py
+++ b/homeassistant/components/binary_sensor/mqtt.py
@@ -151,9 +151,6 @@ class MqttBinarySensor(MqttAvailability, MqttDiscoveryUpdate,
 
         self._unique_id = config.get(CONF_UNIQUE_ID)
 
-        # TODO: Handle changed device?
-        # config.get(CONF_DEVICE),
-
     async def _subscribe_topics(self):
         """(Re)Subscribe to topics."""
         @callback

--- a/homeassistant/components/binary_sensor/mqtt.py
+++ b/homeassistant/components/binary_sensor/mqtt.py
@@ -145,7 +145,7 @@ class MqttBinarySensor(MqttAvailability, MqttDiscoveryUpdate,
         self._payload_on = config.get(CONF_PAYLOAD_ON)
         self._payload_off = config.get(CONF_PAYLOAD_OFF)
         value_template = config.get(CONF_VALUE_TEMPLATE)
-        if value_template is not None:
+        if value_template is not None and value_template.hass is None:
             value_template.hass = self.hass
         self._template = value_template
 

--- a/homeassistant/components/binary_sensor/mqtt.py
+++ b/homeassistant/components/binary_sensor/mqtt.py
@@ -186,8 +186,10 @@ class MqttBinarySensor(MqttAvailability, MqttDiscoveryUpdate,
             self.async_schedule_update_ha_state()
 
         self._sub_state = await subscription.async_subscribe_topics(
-            self.hass, self._sub_state, {'state_topic': self._state_topic},
-            state_message_received, self._qos)
+            self.hass, self._sub_state,
+            {'state_topic': {'topic': self._state_topic,
+                             'msg_callback': state_message_received,
+                             'qos': self._qos}})
 
     async def async_will_remove_from_hass(self):
         """Unsubscribe when removed."""

--- a/homeassistant/components/binary_sensor/mqtt.py
+++ b/homeassistant/components/binary_sensor/mqtt.py
@@ -99,8 +99,8 @@ class MqttBinarySensor(MqttAvailability, MqttDiscoveryUpdate,
         """Initialize the MQTT binary sensor."""
         MqttAvailability.__init__(self, availability_topic, qos,
                                   payload_available, payload_not_available)
-        MqttDiscoveryUpdate.__init__(self, None, self.discovery_callback,
-                                     discovery_payload)
+        MqttDiscoveryUpdate.__init__(self, None, discovery_payload,
+                                     self.discovery_callback)
         MqttEntityDeviceInfo.__init__(self, device_config)
         self._config = config
         self._state = None
@@ -108,7 +108,7 @@ class MqttBinarySensor(MqttAvailability, MqttDiscoveryUpdate,
         self._delay_listener = None
 
         # Config
-        self._name = None
+        self._name = config.get(CONF_NAME)
         self._state_topic = None
         self._device_class = None
         self._payload_on = None
@@ -117,7 +117,7 @@ class MqttBinarySensor(MqttAvailability, MqttDiscoveryUpdate,
         self._force_update = None
         self._off_delay = None
         self._template = None
-        self._unique_id = None
+        self._unique_id = config.get(CONF_UNIQUE_ID)
 
     async def async_added_to_hass(self):
         """Subscribe mqtt events."""

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -832,12 +832,30 @@ class MqttAvailability(Entity):
         self._available = availability_topic is None  # type: bool
         self._payload_available = payload_available
         self._payload_not_available = payload_not_available
+        self._availability_sub_state = None
 
     async def async_added_to_hass(self) -> None:
         """Subscribe MQTT events.
 
         This method must be run in the event loop and returns a coroutine.
         """
+        await self._availability_subscribe_topics()
+
+    async def availability_discovery_update(self, config: dict):
+        """Handle updated discovery message."""
+        self._availability_setup_from_config(config)
+        await self._availability_subscribe_topics()
+
+    def _availability_setup_from_config(self, config):
+        """(Re)Setup."""
+        self._availability_topic = config.get(CONF_AVAILABILITY_TOPIC)
+        self._payload_available = config.get(CONF_PAYLOAD_AVAILABLE)
+        self._payload_not_available = config.get(CONF_PAYLOAD_NOT_AVAILABLE)
+
+    async def _availability_subscribe_topics(self):
+        """(Re)Subscribe to topics."""
+        from .subscription import async_subscribe_topics
+
         @callback
         def availability_message_received(topic: str,
                                           payload: SubscribePayloadType,
@@ -850,10 +868,15 @@ class MqttAvailability(Entity):
 
             self.async_schedule_update_ha_state()
 
-        if self._availability_topic is not None:
-            await async_subscribe(
-                self.hass, self._availability_topic,
-                availability_message_received, self._availability_qos)
+        self._availability_sub_state = await async_subscribe_topics(
+            self.hass, self._availability_sub_state,
+            {'availability_topic': self._availability_topic},
+            availability_message_received, self._availability_qos)
+
+    async def async_will_remove_from_hass(self):
+        """Unsubscribe when removed."""
+        from .subscription import async_unsubscribe_topics
+        await async_unsubscribe_topics(self.hass, self._availability_sub_state)
 
     @property
     def available(self) -> bool:

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -870,8 +870,10 @@ class MqttAvailability(Entity):
 
         self._availability_sub_state = await async_subscribe_topics(
             self.hass, self._availability_sub_state,
-            {'availability_topic': self._availability_topic},
-            availability_message_received, self._availability_qos)
+            {'availability_topic': {
+                'topic': self._availability_topic,
+                'msg_callback': availability_message_received,
+                'qos': self._availability_qos}})
 
     async def async_will_remove_from_hass(self):
         """Unsubscribe when removed."""

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -885,16 +885,16 @@ class MqttDiscoveryUpdate(Entity):
             """Handle discovery update."""
             _LOGGER.info("Got update for entity with hash: %s '%s'",
                          self._discovery_hash, payload)
-            if ((self._async_discover and self._discovery_payload != payload)
-                    or not payload):
+            if not payload:
                 # Empty payload: Remove component
                 _LOGGER.info("Removing component: %s", self.entity_id)
                 self.hass.async_create_task(self.async_remove())
                 del self.hass.data[ALREADY_DISCOVERED][self._discovery_hash]
                 self._remove_signal()
-                if payload and self._async_discover:
-                    _LOGGER.info("Adding component: %s", self.entity_id)
-                    self.hass.async_create_task(self._async_discover(payload))
+            elif self._async_discover and self._discovery_payload != payload:
+                # Non-empty payload: Notify component
+                _LOGGER.info("Updating component: %s", self.entity_id)
+                self.hass.async_create_task(self._async_discover(payload))
 
         if self._discovery_hash:
             self._remove_signal = async_dispatcher_connect(

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -864,14 +864,10 @@ class MqttAvailability(Entity):
 class MqttDiscoveryUpdate(Entity):
     """Mixin used to handle updated discovery message."""
 
-    def __init__(self, discovery_hash, discovery_payload=None,
-                 async_discover=None) -> None:
+    def __init__(self, discovery_hash, discovery_update=None) -> None:
         """Initialize the discovery update mixin."""
-        if discovery_payload:
-            discovery_hash = discovery_payload[ATTR_DISCOVERY_HASH]
         self._discovery_hash = discovery_hash
-        self._discovery_payload = discovery_payload
-        self._async_discover = async_discover
+        self._discovery_update = discovery_update
         self._remove_signal = None
 
     async def async_added_to_hass(self) -> None:
@@ -891,10 +887,10 @@ class MqttDiscoveryUpdate(Entity):
                 self.hass.async_create_task(self.async_remove())
                 del self.hass.data[ALREADY_DISCOVERED][self._discovery_hash]
                 self._remove_signal()
-            elif self._async_discover and self._discovery_payload != payload:
+            elif self._discovery_update:
                 # Non-empty payload: Notify component
                 _LOGGER.info("Updating component: %s", self.entity_id)
-                self.hass.async_create_task(self._async_discover(payload))
+                self.hass.async_create_task(self._discovery_update(payload))
 
         if self._discovery_hash:
             self._remove_signal = async_dispatcher_connect(

--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -206,12 +206,11 @@ async def async_start(hass: HomeAssistantType, discovery_topic, hass_config,
                 if value[-1] == TOPIC_BASE and key.endswith('_topic'):
                     payload[key] = "{}{}".format(value[:-1], base)
 
-        # If present, the node_id will be included in the discovered object id
-        discovery_id = '_'.join((node_id, object_id)) if node_id else object_id
-
-        if ALREADY_DISCOVERED not in hass.data:
-            hass.data[ALREADY_DISCOVERED] = {}
-
+        # If present, unique_id is used as the discovered object id. Otherwise,
+        # if present, the node_id will be included in the discovered object id
+        discovery_id = payload.get(
+            'unique_id', '_'.join(
+                (node_id, object_id)) if node_id else object_id)
         discovery_hash = (component, discovery_id)
 
         if payload:
@@ -229,6 +228,8 @@ async def async_start(hass: HomeAssistantType, discovery_topic, hass_config,
 
             payload[ATTR_DISCOVERY_HASH] = discovery_hash
 
+        if ALREADY_DISCOVERED not in hass.data:
+            hass.data[ALREADY_DISCOVERED] = {}
         if discovery_hash in hass.data[ALREADY_DISCOVERED]:
             # Dispatch update
             _LOGGER.info(

--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -214,7 +214,23 @@ async def async_start(hass: HomeAssistantType, discovery_topic, hass_config,
 
         discovery_hash = (component, discovery_id)
 
+        if payload:
+            platform = payload.get(CONF_PLATFORM, 'mqtt')
+            if platform not in ALLOWED_PLATFORMS.get(component, []):
+                _LOGGER.warning("Platform %s (component %s) is not allowed",
+                                platform, component)
+                return
+            payload[CONF_PLATFORM] = platform
+
+            if CONF_STATE_TOPIC not in payload:
+                payload[CONF_STATE_TOPIC] = '{}/{}/{}{}/state'.format(
+                    discovery_topic, component,
+                    '%s/' % node_id if node_id else '', object_id)
+
+            payload[ATTR_DISCOVERY_HASH] = discovery_hash
+
         if discovery_hash in hass.data[ALREADY_DISCOVERED]:
+            # Dispatch update
             _LOGGER.info(
                 "Component has already been discovered: %s %s, sending update",
                 component, discovery_id)
@@ -222,22 +238,8 @@ async def async_start(hass: HomeAssistantType, discovery_topic, hass_config,
                 hass, MQTT_DISCOVERY_UPDATED.format(discovery_hash), payload)
         elif payload:
             # Add component
-            platform = payload.get(CONF_PLATFORM, 'mqtt')
-            if platform not in ALLOWED_PLATFORMS.get(component, []):
-                _LOGGER.warning("Platform %s (component %s) is not allowed",
-                                platform, component)
-                return
-
-            payload[CONF_PLATFORM] = platform
-            if CONF_STATE_TOPIC not in payload:
-                payload[CONF_STATE_TOPIC] = '{}/{}/{}{}/state'.format(
-                    discovery_topic, component,
-                    '%s/' % node_id if node_id else '', object_id)
-
-            hass.data[ALREADY_DISCOVERED][discovery_hash] = None
-            payload[ATTR_DISCOVERY_HASH] = discovery_hash
-
             _LOGGER.info("Found new component: %s %s", component, discovery_id)
+            hass.data[ALREADY_DISCOVERED][discovery_hash] = None
 
             if platform not in CONFIG_ENTRY_PLATFORMS.get(component, []):
                 await async_load_platform(

--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -209,7 +209,7 @@ async def async_start(hass: HomeAssistantType, discovery_topic, hass_config,
         # If present, unique_id is used as the discovered object id. Otherwise,
         # if present, the node_id will be included in the discovered object id
         discovery_id = payload.get(
-            'unique_id', '_'.join(
+            'unique_id', ' '.join(
                 (node_id, object_id)) if node_id else object_id)
         discovery_hash = (component, discovery_id)
 

--- a/homeassistant/components/mqtt/subscription.py
+++ b/homeassistant/components/mqtt/subscription.py
@@ -1,0 +1,51 @@
+"""
+Helper to handle a set of topics to subscribe to.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/mqtt/
+"""
+import logging
+
+from homeassistant.components import mqtt
+from homeassistant.components.mqtt import DEFAULT_QOS, MessageCallbackType
+from homeassistant.loader import bind_hass
+from homeassistant.helpers.typing import (
+    HomeAssistantType)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@bind_hass
+async def async_subscribe_topics(hass: HomeAssistantType, sub_state: dict,
+                                 new_topics: dict,
+                                 msg_callback: MessageCallbackType,
+                                 qos: int = DEFAULT_QOS,
+                                 encoding: str = 'utf-8'):
+    """(Re)Subscribe to a set of MQTT topics.
+
+    State is kept in sub_state.
+    """
+    if sub_state is None:
+        sub_state = {'topics': {}}
+    old_topics = sub_state['topics']
+    for key, sub in list(old_topics.items()):
+        topic = sub[0]
+        unsub = sub[1]
+        if key not in new_topics or topic != new_topics[key]:
+            if unsub is not None:
+                unsub()
+            del old_topics[key]
+    for key, topic in new_topics.items():
+        if key not in old_topics and topic is not None:
+            unsub = await mqtt.async_subscribe(hass, topic, msg_callback, qos)
+            old_topics[key] = (topic, unsub)
+
+    return sub_state
+
+
+@bind_hass
+async def async_unsubscribe_topics(hass: HomeAssistantType, sub_state: dict):
+    """Unsubscribe from all MQTT topics managed by async_subscribe_topics."""
+    await async_subscribe_topics(hass, sub_state, {}, None)
+
+    return sub_state

--- a/tests/common.py
+++ b/tests/common.py
@@ -294,6 +294,7 @@ def async_mock_mqtt_component(hass, config=None):
     with patch('paho.mqtt.client.Client') as mock_client:
         mock_client().connect.return_value = 0
         mock_client().subscribe.return_value = (0, 0)
+        mock_client().unsubscribe.return_value = (0, 0)
         mock_client().publish.return_value = (0, 0)
 
         result = yield from async_setup_component(hass, mqtt.DOMAIN, {

--- a/tests/components/binary_sensor/test_mqtt.py
+++ b/tests/components/binary_sensor/test_mqtt.py
@@ -300,6 +300,36 @@ async def test_discovery_removal_binary_sensor(hass, mqtt_mock, caplog):
     assert state is None
 
 
+async def test_discovery_update_binary_sensor(hass, mqtt_mock, caplog):
+    """Test removal of discovered binary_sensor."""
+    entry = MockConfigEntry(domain=mqtt.DOMAIN)
+    await async_start(hass, 'homeassistant', {}, entry)
+    data1 = (
+        '{ "name": "Beer",'
+        '  "status_topic": "test_topic" }'
+    )
+    data2 = (
+        '{ "name": "Milk",'
+        '  "status_topic": "test_topic" }'
+    )
+    async_fire_mqtt_message(hass, 'homeassistant/binary_sensor/bla/config',
+                            data1)
+    await hass.async_block_till_done()
+    state = hass.states.get('binary_sensor.beer')
+    assert state is not None
+    assert state.name == 'Beer'
+    async_fire_mqtt_message(hass, 'homeassistant/binary_sensor/bla/config',
+                            data2)
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+    state = hass.states.get('binary_sensor.beer')
+    assert state is None
+
+    state = hass.states.get('binary_sensor.milk')
+    assert state is not None
+    assert state.name == 'Milk'
+
+
 async def test_entity_device_info_with_identifier(hass, mqtt_mock):
     """Test MQTT binary sensor device registry integration."""
     entry = MockConfigEntry(domain=mqtt.DOMAIN)

--- a/tests/components/binary_sensor/test_mqtt.py
+++ b/tests/components/binary_sensor/test_mqtt.py
@@ -284,7 +284,8 @@ async def test_discovery_removal_binary_sensor(hass, mqtt_mock, caplog):
     await async_start(hass, 'homeassistant', {}, entry)
     data = (
         '{ "name": "Beer",'
-        '  "status_topic": "test_topic" }'
+        '  "state_topic": "test_topic",'
+        '  "availability_topic": "availability_topic" }'
     )
     async_fire_mqtt_message(hass, 'homeassistant/binary_sensor/bla/config',
                             data)
@@ -306,11 +307,13 @@ async def test_discovery_update_binary_sensor(hass, mqtt_mock, caplog):
     await async_start(hass, 'homeassistant', {}, entry)
     data1 = (
         '{ "name": "Beer",'
-        '  "status_topic": "test_topic" }'
+        '  "state_topic": "test_topic",'
+        '  "availability_topic": "availability_topic1" }'
     )
     data2 = (
         '{ "name": "Milk",'
-        '  "status_topic": "test_topic" }'
+        '  "state_topic": "test_topic2",'
+        '  "availability_topic": "availability_topic2" }'
     )
     async_fire_mqtt_message(hass, 'homeassistant/binary_sensor/bla/config',
                             data1)
@@ -328,6 +331,39 @@ async def test_discovery_update_binary_sensor(hass, mqtt_mock, caplog):
 
     state = hass.states.get('binary_sensor.milk')
     assert state is None
+
+
+async def test_discovery_unique_id(hass, mqtt_mock, caplog):
+    """Test unique id option only creates one sensor per unique_id."""
+    entry = MockConfigEntry(domain=mqtt.DOMAIN)
+    await async_start(hass, 'homeassistant', {}, entry)
+    data1 = (
+        '{ "name": "Beer",'
+        '  "state_topic": "test_topic",'
+        '  "unique_id": "TOTALLY_UNIQUE" }'
+    )
+    data2 = (
+        '{ "name": "Milk",'
+        '  "state_topic": "test_topic",'
+        '  "unique_id": "TOTALLY_DIFFERENT" }'
+    )
+    async_fire_mqtt_message(hass, 'homeassistant/binary_sensor/bla/config',
+                            data1)
+    await hass.async_block_till_done()
+    state = hass.states.get('binary_sensor.beer')
+    assert state is not None
+    assert state.name == 'Beer'
+    async_fire_mqtt_message(hass, 'homeassistant/binary_sensor/bla/config',
+                            data2)
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+    state = hass.states.get('binary_sensor.beer')
+    assert state is not None
+    assert state.name == 'Beer'
+
+    state = hass.states.get('binary_sensor.milk')
+    assert state is not None
+    assert state.name == 'Milk'
 
 
 async def test_entity_device_info_with_identifier(hass, mqtt_mock):

--- a/tests/components/binary_sensor/test_mqtt.py
+++ b/tests/components/binary_sensor/test_mqtt.py
@@ -323,11 +323,11 @@ async def test_discovery_update_binary_sensor(hass, mqtt_mock, caplog):
     await hass.async_block_till_done()
     await hass.async_block_till_done()
     state = hass.states.get('binary_sensor.beer')
-    assert state is None
-
-    state = hass.states.get('binary_sensor.milk')
     assert state is not None
     assert state.name == 'Milk'
+
+    state = hass.states.get('binary_sensor.milk')
+    assert state is None
 
 
 async def test_entity_device_info_with_identifier(hass, mqtt_mock):

--- a/tests/components/mqtt/test_discovery.py
+++ b/tests/components/mqtt/test_discovery.py
@@ -185,7 +185,7 @@ def test_discovery_incl_nodeid(hass, mqtt_mock, caplog):
 
     assert state is not None
     assert state.name == 'Beer'
-    assert ('binary_sensor', 'my_node_id_bla') in hass.data[ALREADY_DISCOVERED]
+    assert ('binary_sensor', 'my_node_id bla') in hass.data[ALREADY_DISCOVERED]
 
 
 @asyncio.coroutine

--- a/tests/components/mqtt/test_subscription.py
+++ b/tests/components/mqtt/test_subscription.py
@@ -1,0 +1,180 @@
+"""The tests for the MQTT subscription component."""
+from homeassistant.core import callback
+from homeassistant.components.mqtt.subscription import (
+    async_subscribe_topics, async_unsubscribe_topics)
+
+from tests.common import async_fire_mqtt_message, async_mock_mqtt_component
+
+
+async def test_subscribe_topics(hass, mqtt_mock, caplog):
+    """Test subscription to topics."""
+    calls1 = []
+
+    @callback
+    def record_calls1(*args):
+        """Record calls."""
+        calls1.append(args)
+
+    calls2 = []
+
+    @callback
+    def record_calls2(*args):
+        """Record calls."""
+        calls2.append(args)
+
+    sub_state = None
+    sub_state = await async_subscribe_topics(
+        hass, sub_state,
+        {'test_topic1': {'topic': 'test-topic1',
+                         'msg_callback': record_calls1},
+         'test_topic2': {'topic': 'test-topic2',
+                         'msg_callback': record_calls2}})
+
+    async_fire_mqtt_message(hass, 'test-topic1', 'test-payload1')
+    await hass.async_block_till_done()
+    assert 1 == len(calls1)
+    assert 'test-topic1' == calls1[0][0]
+    assert 'test-payload1' == calls1[0][1]
+    assert 0 == len(calls2)
+
+    async_fire_mqtt_message(hass, 'test-topic2', 'test-payload2')
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+    assert 1 == len(calls1)
+    assert 1 == len(calls2)
+    assert 'test-topic2' == calls2[0][0]
+    assert 'test-payload2' == calls2[0][1]
+
+    await async_unsubscribe_topics(hass, sub_state)
+
+    async_fire_mqtt_message(hass, 'test-topic1', 'test-payload')
+    async_fire_mqtt_message(hass, 'test-topic2', 'test-payload')
+
+    await hass.async_block_till_done()
+    assert 1 == len(calls1)
+    assert 1 == len(calls2)
+
+
+async def test_modify_topics(hass, mqtt_mock, caplog):
+    """Test modification of topics."""
+    calls1 = []
+
+    @callback
+    def record_calls1(*args):
+        """Record calls."""
+        calls1.append(args)
+
+    calls2 = []
+
+    @callback
+    def record_calls2(*args):
+        """Record calls."""
+        calls2.append(args)
+
+    sub_state = None
+    sub_state = await async_subscribe_topics(
+        hass, sub_state,
+        {'test_topic1': {'topic': 'test-topic1',
+                         'msg_callback': record_calls1},
+         'test_topic2': {'topic': 'test-topic2',
+                         'msg_callback': record_calls2}})
+
+    async_fire_mqtt_message(hass, 'test-topic1', 'test-payload')
+    await hass.async_block_till_done()
+    assert 1 == len(calls1)
+    assert 0 == len(calls2)
+
+    async_fire_mqtt_message(hass, 'test-topic2', 'test-payload')
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+    assert 1 == len(calls1)
+    assert 1 == len(calls2)
+
+    sub_state = await async_subscribe_topics(
+        hass, sub_state,
+        {'test_topic1': {'topic': 'test-topic1_1',
+                         'msg_callback': record_calls1}})
+
+    async_fire_mqtt_message(hass, 'test-topic1', 'test-payload')
+    async_fire_mqtt_message(hass, 'test-topic2', 'test-payload')
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+    assert 1 == len(calls1)
+    assert 1 == len(calls2)
+
+    async_fire_mqtt_message(hass, 'test-topic1_1', 'test-payload')
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+    assert 2 == len(calls1)
+    assert 'test-topic1_1' == calls1[1][0]
+    assert 'test-payload' == calls1[1][1]
+    assert 1 == len(calls2)
+
+    await async_unsubscribe_topics(hass, sub_state)
+
+    async_fire_mqtt_message(hass, 'test-topic1_1', 'test-payload')
+    async_fire_mqtt_message(hass, 'test-topic2', 'test-payload')
+
+    await hass.async_block_till_done()
+    assert 2 == len(calls1)
+    assert 1 == len(calls2)
+
+
+async def test_qos_encoding_default(hass, mqtt_mock, caplog):
+    """Test default qos and encoding."""
+    mock_mqtt = await async_mock_mqtt_component(hass)
+
+    @callback
+    def msg_callback(*args):
+        """Do nothing."""
+        pass
+
+    sub_state = None
+    sub_state = await async_subscribe_topics(
+        hass, sub_state,
+        {'test_topic1': {'topic': 'test-topic1',
+                         'msg_callback': msg_callback}})
+    mock_mqtt.async_subscribe.assert_called_once_with(
+        'test-topic1', msg_callback, 0, 'utf-8')
+
+
+async def test_qos_encoding_custom(hass, mqtt_mock, caplog):
+    """Test custom qos and encoding."""
+    mock_mqtt = await async_mock_mqtt_component(hass)
+
+    @callback
+    def msg_callback(*args):
+        """Do nothing."""
+        pass
+
+    sub_state = None
+    sub_state = await async_subscribe_topics(
+        hass, sub_state,
+        {'test_topic1': {'topic': 'test-topic1',
+                         'msg_callback': msg_callback,
+                         'qos': 1,
+                         'encoding': 'utf-16'}})
+    mock_mqtt.async_subscribe.assert_called_once_with(
+        'test-topic1', msg_callback, 1, 'utf-16')
+
+
+async def test_no_change(hass, mqtt_mock, caplog):
+    """Test subscription to topics without change."""
+    mock_mqtt = await async_mock_mqtt_component(hass)
+
+    @callback
+    def msg_callback(*args):
+        """Do nothing."""
+        pass
+
+    sub_state = None
+    sub_state = await async_subscribe_topics(
+        hass, sub_state,
+        {'test_topic1': {'topic': 'test-topic1',
+                         'msg_callback': msg_callback}})
+    call_count = mock_mqtt.async_subscribe.call_count
+    sub_state = await async_subscribe_topics(
+        hass, sub_state,
+        {'test_topic1': {'topic': 'test-topic1',
+                         'msg_callback': msg_callback}})
+    assert call_count == mock_mqtt.async_subscribe.call_count


### PR DESCRIPTION
## Description:
Reconfigure component if discovery info is changed.
This is bullet 2 in home-assistant/architecture#70

PRs for other platforms will be opened separately.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`.
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
