### PR TITLE
Reconfigure MQTT cover component if discovery info is changed

### DIFF
--- a/homeassistant/components/cover/mqtt.py
+++ b/homeassistant/components/cover/mqtt.py
@@ -5,7 +5,6 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/cover.mqtt/
 """
 import logging
-from typing import Optional
 
 import voluptuous as vol
 
@@ -24,7 +23,7 @@ from homeassistant.components.mqtt import (
     ATTR_DISCOVERY_HASH, CONF_AVAILABILITY_TOPIC, CONF_STATE_TOPIC,
     CONF_COMMAND_TOPIC, CONF_PAYLOAD_AVAILABLE, CONF_PAYLOAD_NOT_AVAILABLE,
     CONF_QOS, CONF_RETAIN, valid_publish_topic, valid_subscribe_topic,
-    MqttAvailability, MqttDiscoveryUpdate, MqttEntityDeviceInfo)
+    MqttAvailability, MqttDiscoveryUpdate, MqttEntityDeviceInfo, subscription)
 from homeassistant.components.mqtt.discovery import MQTT_DISCOVERY_NEW
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -149,103 +148,116 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 async def _async_setup_entity(hass, config, async_add_entities,
                               discovery_hash=None):
     """Set up the MQTT Cover."""
-    value_template = config.get(CONF_VALUE_TEMPLATE)
-    if value_template is not None:
-        value_template.hass = hass
-    set_position_template = config.get(CONF_SET_POSITION_TEMPLATE)
-    if set_position_template is not None:
-        set_position_template.hass = hass
-
-    async_add_entities([MqttCover(
-        config.get(CONF_NAME),
-        config.get(CONF_STATE_TOPIC),
-        config.get(CONF_GET_POSITION_TOPIC),
-        config.get(CONF_COMMAND_TOPIC),
-        config.get(CONF_AVAILABILITY_TOPIC),
-        config.get(CONF_TILT_COMMAND_TOPIC),
-        config.get(CONF_TILT_STATUS_TOPIC),
-        config.get(CONF_QOS),
-        config.get(CONF_RETAIN),
-        config.get(CONF_STATE_OPEN),
-        config.get(CONF_STATE_CLOSED),
-        config.get(CONF_POSITION_OPEN),
-        config.get(CONF_POSITION_CLOSED),
-        config.get(CONF_PAYLOAD_OPEN),
-        config.get(CONF_PAYLOAD_CLOSE),
-        config.get(CONF_PAYLOAD_STOP),
-        config.get(CONF_PAYLOAD_AVAILABLE),
-        config.get(CONF_PAYLOAD_NOT_AVAILABLE),
-        config.get(CONF_OPTIMISTIC),
-        value_template,
-        config.get(CONF_TILT_OPEN_POSITION),
-        config.get(CONF_TILT_CLOSED_POSITION),
-        config.get(CONF_TILT_MIN),
-        config.get(CONF_TILT_MAX),
-        config.get(CONF_TILT_STATE_OPTIMISTIC),
-        config.get(CONF_TILT_INVERT_STATE),
-        config.get(CONF_SET_POSITION_TOPIC),
-        set_position_template,
-        config.get(CONF_UNIQUE_ID),
-        config.get(CONF_DEVICE),
-        discovery_hash
-    )])
+    async_add_entities([MqttCover(hass, config, discovery_hash)])
 
 
 class MqttCover(MqttAvailability, MqttDiscoveryUpdate, MqttEntityDeviceInfo,
                 CoverDevice):
     """Representation of a cover that can be controlled using MQTT."""
 
-    def __init__(self, name, state_topic, get_position_topic,
-                 command_topic, availability_topic,
-                 tilt_command_topic, tilt_status_topic, qos, retain,
-                 state_open, state_closed, position_open, position_closed,
-                 payload_open, payload_close, payload_stop, payload_available,
-                 payload_not_available, optimistic, value_template,
-                 tilt_open_position, tilt_closed_position, tilt_min, tilt_max,
-                 tilt_optimistic, tilt_invert, set_position_topic,
-                 set_position_template, unique_id: Optional[str],
-                 device_config: Optional[ConfigType], discovery_hash):
+    def __init__(self, hass, config, discovery_hash):
         """Initialize the cover."""
-        MqttAvailability.__init__(self, availability_topic, qos,
-                                  payload_available, payload_not_available)
-        MqttDiscoveryUpdate.__init__(self, discovery_hash)
-        MqttEntityDeviceInfo.__init__(self, device_config)
+        self.hass = hass
         self._position = None
         self._state = None
-        self._name = name
-        self._state_topic = state_topic
-        self._get_position_topic = get_position_topic
-        self._command_topic = command_topic
-        self._tilt_command_topic = tilt_command_topic
-        self._tilt_status_topic = tilt_status_topic
-        self._qos = qos
-        self._payload_open = payload_open
-        self._payload_close = payload_close
-        self._payload_stop = payload_stop
-        self._state_open = state_open
-        self._state_closed = state_closed
-        self._position_open = position_open
-        self._position_closed = position_closed
-        self._retain = retain
-        self._tilt_open_position = tilt_open_position
-        self._tilt_closed_position = tilt_closed_position
-        self._optimistic = (optimistic or (state_topic is None and
-                                           get_position_topic is None))
-        self._template = value_template
+        self._sub_state = None
+
+        self._name = None
+        self._state_topic = None
+        self._get_position_topic = None
+        self._command_topic = None
+        self._tilt_command_topic = None
+        self._tilt_status_topic = None
+        self._qos = None
+        self._payload_open = None
+        self._payload_close = None
+        self._payload_stop = None
+        self._state_open = None
+        self._state_closed = None
+        self._position_open = None
+        self._position_closed = None
+        self._retain = None
+        self._tilt_open_position = None
+        self._tilt_closed_position = None
+        self._optimistic = None
+        self._template = None
         self._tilt_value = None
-        self._tilt_min = tilt_min
-        self._tilt_max = tilt_max
-        self._tilt_optimistic = tilt_optimistic
-        self._tilt_invert = tilt_invert
-        self._set_position_topic = set_position_topic
-        self._set_position_template = set_position_template
-        self._unique_id = unique_id
-        self._discovery_hash = discovery_hash
+        self._tilt_min = None
+        self._tilt_max = None
+        self._tilt_optimistic = None
+        self._tilt_invert = None
+        self._set_position_topic = None
+        self._set_position_template = None
+        self._unique_id = None
+
+        # Load config
+        self._setup_from_config(config)
+
+        availability_topic = config.get(CONF_AVAILABILITY_TOPIC)
+        payload_available = config.get(CONF_PAYLOAD_AVAILABLE)
+        payload_not_available = config.get(CONF_PAYLOAD_NOT_AVAILABLE)
+        device_config = config.get(CONF_DEVICE)
+
+        MqttAvailability.__init__(self, availability_topic, self._qos,
+                                  payload_available, payload_not_available)
+        MqttDiscoveryUpdate.__init__(self, discovery_hash,
+                                     self.discovery_update)
+        MqttEntityDeviceInfo.__init__(self, device_config)
 
     async def async_added_to_hass(self):
         """Subscribe MQTT events."""
         await MqttAvailability.async_added_to_hass(self)
         await MqttDiscoveryUpdate.async_added_to_hass(self)
+        await self._subscribe_topics()
+
+    async def discovery_update(self, discovery_payload):
+        """Handle updated discovery message."""
+        config = PLATFORM_SCHEMA(discovery_payload)
+        self._setup_from_config(config)
+        await self.availability_discovery_update(config)
+        await self._subscribe_topics()
+        self.async_schedule_update_ha_state()
+
+    def _setup_from_config(self, config):
+        self._name = config.get(CONF_NAME)
+        self._state_topic = config.get(CONF_STATE_TOPIC)
+        self._get_position_topic = config.get(CONF_GET_POSITION_TOPIC)
+        self._command_topic = config.get(CONF_COMMAND_TOPIC)
+        self._tilt_command_topic = config.get(CONF_TILT_COMMAND_TOPIC)
+        self._tilt_status_topic = config.get(CONF_TILT_STATUS_TOPIC)
+        self._qos = config.get(CONF_QOS)
+        self._retain = config.get(CONF_RETAIN)
+        self._state_open = config.get(CONF_STATE_OPEN)
+        self._state_closed = config.get(CONF_STATE_CLOSED)
+        self._position_open = config.get(CONF_POSITION_OPEN)
+        self._position_closed = config.get(CONF_POSITION_CLOSED)
+        self._payload_open = config.get(CONF_PAYLOAD_OPEN)
+        self._payload_close = config.get(CONF_PAYLOAD_CLOSE)
+        self._payload_stop = config.get(CONF_PAYLOAD_STOP)
+        self._optimistic = (config.get(CONF_OPTIMISTIC) or
+                            (self._state_topic is None and
+                             self._get_position_topic is None))
+        value_template = config.get(CONF_VALUE_TEMPLATE)
+        if value_template is not None:
+            value_template.hass = self.hass
+        self._template = value_template
+        self._tilt_open_position = config.get(CONF_TILT_OPEN_POSITION)
+        self._tilt_closed_position = config.get(CONF_TILT_CLOSED_POSITION)
+        self._tilt_min = config.get(CONF_TILT_MIN)
+        self._tilt_max = config.get(CONF_TILT_MAX)
+        self._tilt_optimistic = config.get(CONF_TILT_STATE_OPTIMISTIC)
+        self._tilt_invert = config.get(CONF_TILT_INVERT_STATE)
+        self._set_position_topic = config.get(CONF_SET_POSITION_TOPIC)
+        set_position_template = config.get(CONF_SET_POSITION_TEMPLATE)
+        if set_position_template is not None:
+            set_position_template.hass = self.hass
+        self._set_position_template = set_position_template
+
+        self._unique_id = config.get(CONF_UNIQUE_ID)
+
+    async def _subscribe_topics(self):
+        """(Re)Subscribe to topics."""
+        topics = {}
 
         @callback
         def tilt_updated(topic, payload, qos):
@@ -295,13 +307,15 @@ class MqttCover(MqttAvailability, MqttDiscoveryUpdate, MqttEntityDeviceInfo,
                 return
             self.async_schedule_update_ha_state()
         if self._get_position_topic:
-            await mqtt.async_subscribe(
-                self.hass, self._get_position_topic,
-                position_message_received, self._qos)
+            topics['get_position_topic'] = {
+                'topic': self._get_position_topic,
+                'msg_callback': position_message_received,
+                'qos': self._qos}
         elif self._state_topic:
-            await mqtt.async_subscribe(
-                self.hass, self._state_topic,
-                state_message_received, self._qos)
+            topics['state_topic'] = {
+                'topic': self._state_topic,
+                'msg_callback': state_message_received,
+                'qos': self._qos}
         else:
             # Force into optimistic mode.
             self._optimistic = True
@@ -311,8 +325,19 @@ class MqttCover(MqttAvailability, MqttDiscoveryUpdate, MqttEntityDeviceInfo,
         else:
             self._tilt_optimistic = False
             self._tilt_value = STATE_UNKNOWN
-            await mqtt.async_subscribe(
-                self.hass, self._tilt_status_topic, tilt_updated, self._qos)
+            topics['tilt_status_topic'] = {
+                'topic': self._tilt_status_topic,
+                'msg_callback': tilt_updated,
+                'qos': self._qos}
+
+        self._sub_state = await subscription.async_subscribe_topics(
+            self.hass, self._sub_state,
+            topics)
+
+    async def async_will_remove_from_hass(self):
+        """Unsubscribe when removed."""
+        await subscription.async_unsubscribe_topics(self.hass, self._sub_state)
+        await MqttAvailability.async_will_remove_from_hass(self)
 
     @property
     def should_poll(self):

--- a/tests/components/cover/test_mqtt.py
+++ b/tests/components/cover/test_mqtt.py
@@ -671,25 +671,30 @@ class TestCoverMQTT(unittest.TestCase):
     def test_find_percentage_in_range_defaults(self):
         """Test find percentage in range with default range."""
         mqtt_cover = MqttCover(
-            name='cover.test',
-            state_topic='state-topic',
-            get_position_topic=None,
-            command_topic='command-topic',
-            availability_topic=None,
-            tilt_command_topic='tilt-command-topic',
-            tilt_status_topic='tilt-status-topic',
-            qos=0,
-            retain=False,
-            state_open='OPEN', state_closed='CLOSE',
-            position_open=100,  position_closed=0,
-            payload_open='OPEN', payload_close='CLOSE', payload_stop='STOP',
-            payload_available=None, payload_not_available=None,
-            optimistic=False, value_template=None,
-            tilt_open_position=100, tilt_closed_position=0,
-            tilt_min=0, tilt_max=100, tilt_optimistic=False,
-            tilt_invert=False,
-            set_position_topic=None, set_position_template=None,
-            unique_id=None, device_config=None, discovery_hash=None)
+            self.hass,
+            {
+                'name': 'cover.test',
+                'state_topic': 'state-topic',
+                'get_position_topic': None,
+                'command_topic': 'command-topic',
+                'availability_topic': None,
+                'tilt_command_topic': 'tilt-command-topic',
+                'tilt_status_topic': 'tilt-status-topic',
+                'qos': 0,
+                'retain': False,
+                'state_open': 'OPEN', 'state_closed': 'CLOSE',
+                'position_open': 100,  'position_closed': 0,
+                'payload_open': 'OPEN', 'payload_close': 'CLOSE',
+                'payload_stop': 'STOP',
+                'payload_available': None, 'payload_not_available': None,
+                'optimistic': False, 'value_template': None,
+                'tilt_open_position': 100, 'tilt_closed_position': 0,
+                'tilt_min': 0, 'tilt_max': 100, 'tilt_optimistic': False,
+                'tilt_invert_state': False,
+                'set_position_topic': None, 'set_position_template': None,
+                'unique_id': None, 'device_config': None,
+            },
+            None)
 
         assert 44 == mqtt_cover.find_percentage_in_range(44)
         assert 44 == mqtt_cover.find_percentage_in_range(44, 'cover')
@@ -697,25 +702,30 @@ class TestCoverMQTT(unittest.TestCase):
     def test_find_percentage_in_range_altered(self):
         """Test find percentage in range with altered range."""
         mqtt_cover = MqttCover(
-            name='cover.test',
-            state_topic='state-topic',
-            get_position_topic=None,
-            command_topic='command-topic',
-            availability_topic=None,
-            tilt_command_topic='tilt-command-topic',
-            tilt_status_topic='tilt-status-topic',
-            qos=0,
-            retain=False,
-            state_open='OPEN', state_closed='CLOSE',
-            position_open=180, position_closed=80,
-            payload_open='OPEN', payload_close='CLOSE', payload_stop='STOP',
-            payload_available=None, payload_not_available=None,
-            optimistic=False, value_template=None,
-            tilt_open_position=180, tilt_closed_position=80,
-            tilt_min=80, tilt_max=180, tilt_optimistic=False,
-            tilt_invert=False,
-            set_position_topic=None, set_position_template=None,
-            unique_id=None, device_config=None, discovery_hash=None)
+            self.hass,
+            {
+                'name': 'cover.test',
+                'state_topic': 'state-topic',
+                'get_position_topic': None,
+                'command_topic': 'command-topic',
+                'availability_topic': None,
+                'tilt_command_topic': 'tilt-command-topic',
+                'tilt_status_topic': 'tilt-status-topic',
+                'qos': 0,
+                'retain': False,
+                'state_open': 'OPEN', 'state_closed': 'CLOSE',
+                'position_open': 180,  'position_closed': 80,
+                'payload_open': 'OPEN', 'payload_close': 'CLOSE',
+                'payload_stop': 'STOP',
+                'payload_available': None, 'payload_not_available': None,
+                'optimistic': False, 'value_template': None,
+                'tilt_open_position': 180, 'tilt_closed_position': 80,
+                'tilt_min': 80, 'tilt_max': 180, 'tilt_optimistic': False,
+                'tilt_invert_state': False,
+                'set_position_topic': None, 'set_position_template': None,
+                'unique_id': None, 'device_config': None,
+            },
+            None)
 
         assert 40 == mqtt_cover.find_percentage_in_range(120)
         assert 40 == mqtt_cover.find_percentage_in_range(120, 'cover')
@@ -723,25 +733,30 @@ class TestCoverMQTT(unittest.TestCase):
     def test_find_percentage_in_range_defaults_inverted(self):
         """Test find percentage in range with default range but inverted."""
         mqtt_cover = MqttCover(
-            name='cover.test',
-            state_topic='state-topic',
-            get_position_topic=None,
-            command_topic='command-topic',
-            availability_topic=None,
-            tilt_command_topic='tilt-command-topic',
-            tilt_status_topic='tilt-status-topic',
-            qos=0,
-            retain=False,
-            state_open='OPEN', state_closed='CLOSE',
-            position_open=0, position_closed=100,
-            payload_open='OPEN', payload_close='CLOSE', payload_stop='STOP',
-            payload_available=None, payload_not_available=None,
-            optimistic=False, value_template=None,
-            tilt_open_position=100, tilt_closed_position=0,
-            tilt_min=0, tilt_max=100, tilt_optimistic=False,
-            tilt_invert=True,
-            set_position_topic=None, set_position_template=None,
-            unique_id=None, device_config=None, discovery_hash=None)
+            self.hass,
+            {
+                'name': 'cover.test',
+                'state_topic': 'state-topic',
+                'get_position_topic': None,
+                'command_topic': 'command-topic',
+                'availability_topic': None,
+                'tilt_command_topic': 'tilt-command-topic',
+                'tilt_status_topic': 'tilt-status-topic',
+                'qos': 0,
+                'retain': False,
+                'state_open': 'OPEN', 'state_closed': 'CLOSE',
+                'position_open': 0,  'position_closed': 100,
+                'payload_open': 'OPEN', 'payload_close': 'CLOSE',
+                'payload_stop': 'STOP',
+                'payload_available': None, 'payload_not_available': None,
+                'optimistic': False, 'value_template': None,
+                'tilt_open_position': 100, 'tilt_closed_position': 0,
+                'tilt_min': 0, 'tilt_max': 100, 'tilt_optimistic': False,
+                'tilt_invert_state': True,
+                'set_position_topic': None, 'set_position_template': None,
+                'unique_id': None, 'device_config': None,
+            },
+            None)
 
         assert 56 == mqtt_cover.find_percentage_in_range(44)
         assert 56 == mqtt_cover.find_percentage_in_range(44, 'cover')
@@ -749,25 +764,30 @@ class TestCoverMQTT(unittest.TestCase):
     def test_find_percentage_in_range_altered_inverted(self):
         """Test find percentage in range with altered range and inverted."""
         mqtt_cover = MqttCover(
-            name='cover.test',
-            state_topic='state-topic',
-            get_position_topic=None,
-            command_topic='command-topic',
-            availability_topic=None,
-            tilt_command_topic='tilt-command-topic',
-            tilt_status_topic='tilt-status-topic',
-            qos=0,
-            retain=False,
-            state_open='OPEN', state_closed='CLOSE',
-            position_open=80, position_closed=180,
-            payload_open='OPEN', payload_close='CLOSE', payload_stop='STOP',
-            payload_available=None, payload_not_available=None,
-            optimistic=False, value_template=None,
-            tilt_open_position=180, tilt_closed_position=80,
-            tilt_min=80, tilt_max=180, tilt_optimistic=False,
-            tilt_invert=True,
-            set_position_topic=None, set_position_template=None,
-            unique_id=None, device_config=None, discovery_hash=None)
+            self.hass,
+            {
+                'name': 'cover.test',
+                'state_topic': 'state-topic',
+                'get_position_topic': None,
+                'command_topic': 'command-topic',
+                'availability_topic': None,
+                'tilt_command_topic': 'tilt-command-topic',
+                'tilt_status_topic': 'tilt-status-topic',
+                'qos': 0,
+                'retain': False,
+                'state_open': 'OPEN', 'state_closed': 'CLOSE',
+                'position_open': 80,  'position_closed': 180,
+                'payload_open': 'OPEN', 'payload_close': 'CLOSE',
+                'payload_stop': 'STOP',
+                'payload_available': None, 'payload_not_available': None,
+                'optimistic': False, 'value_template': None,
+                'tilt_open_position': 180, 'tilt_closed_position': 80,
+                'tilt_min': 80, 'tilt_max': 180, 'tilt_optimistic': False,
+                'tilt_invert_state': True,
+                'set_position_topic': None, 'set_position_template': None,
+                'unique_id': None, 'device_config': None,
+            },
+            None)
 
         assert 60 == mqtt_cover.find_percentage_in_range(120)
         assert 60 == mqtt_cover.find_percentage_in_range(120, 'cover')
@@ -775,25 +795,30 @@ class TestCoverMQTT(unittest.TestCase):
     def test_find_in_range_defaults(self):
         """Test find in range with default range."""
         mqtt_cover = MqttCover(
-            name='cover.test',
-            state_topic='state-topic',
-            get_position_topic=None,
-            command_topic='command-topic',
-            availability_topic=None,
-            tilt_command_topic='tilt-command-topic',
-            tilt_status_topic='tilt-status-topic',
-            qos=0,
-            retain=False,
-            state_open='OPEN', state_closed='CLOSE',
-            position_open=100, position_closed=0,
-            payload_open='OPEN', payload_close='CLOSE', payload_stop='STOP',
-            payload_available=None, payload_not_available=None,
-            optimistic=False, value_template=None,
-            tilt_open_position=100, tilt_closed_position=0,
-            tilt_min=0, tilt_max=100, tilt_optimistic=False,
-            tilt_invert=False,
-            set_position_topic=None, set_position_template=None,
-            unique_id=None, device_config=None, discovery_hash=None)
+            self.hass,
+            {
+                'name': 'cover.test',
+                'state_topic': 'state-topic',
+                'get_position_topic': None,
+                'command_topic': 'command-topic',
+                'availability_topic': None,
+                'tilt_command_topic': 'tilt-command-topic',
+                'tilt_status_topic': 'tilt-status-topic',
+                'qos': 0,
+                'retain': False,
+                'state_open': 'OPEN', 'state_closed': 'CLOSE',
+                'position_open': 100, 'position_closed': 0,
+                'payload_open': 'OPEN', 'payload_close': 'CLOSE',
+                'payload_stop': 'STOP',
+                'payload_available': None, 'payload_not_available': None,
+                'optimistic': False, 'value_template': None,
+                'tilt_open_position': 100, 'tilt_closed_position': 0,
+                'tilt_min': 0, 'tilt_max': 100, 'tilt_optimistic': False,
+                'tilt_invert_state': False,
+                'set_position_topic': None, 'set_position_template': None,
+                'unique_id': None, 'device_config': None,
+            },
+            None)
 
         assert 44 == mqtt_cover.find_in_range_from_percent(44)
         assert 44 == mqtt_cover.find_in_range_from_percent(44, 'cover')
@@ -801,25 +826,30 @@ class TestCoverMQTT(unittest.TestCase):
     def test_find_in_range_altered(self):
         """Test find in range with altered range."""
         mqtt_cover = MqttCover(
-            name='cover.test',
-            state_topic='state-topic',
-            get_position_topic=None,
-            command_topic='command-topic',
-            availability_topic=None,
-            tilt_command_topic='tilt-command-topic',
-            tilt_status_topic='tilt-status-topic',
-            qos=0,
-            retain=False,
-            state_open='OPEN', state_closed='CLOSE',
-            position_open=180, position_closed=80,
-            payload_open='OPEN', payload_close='CLOSE', payload_stop='STOP',
-            payload_available=None, payload_not_available=None,
-            optimistic=False, value_template=None,
-            tilt_open_position=180, tilt_closed_position=80,
-            tilt_min=80, tilt_max=180, tilt_optimistic=False,
-            tilt_invert=False,
-            set_position_topic=None, set_position_template=None,
-            unique_id=None, device_config=None, discovery_hash=None)
+            self.hass,
+            {
+                'name': 'cover.test',
+                'state_topic': 'state-topic',
+                'get_position_topic': None,
+                'command_topic': 'command-topic',
+                'availability_topic': None,
+                'tilt_command_topic': 'tilt-command-topic',
+                'tilt_status_topic': 'tilt-status-topic',
+                'qos': 0,
+                'retain': False,
+                'state_open': 'OPEN', 'state_closed': 'CLOSE',
+                'position_open': 180, 'position_closed': 80,
+                'payload_open': 'OPEN', 'payload_close': 'CLOSE',
+                'payload_stop': 'STOP',
+                'payload_available': None, 'payload_not_available': None,
+                'optimistic': False, 'value_template': None,
+                'tilt_open_position': 180, 'tilt_closed_position': 80,
+                'tilt_min': 80, 'tilt_max': 180, 'tilt_optimistic': False,
+                'tilt_invert_state': False,
+                'set_position_topic': None, 'set_position_template': None,
+                'unique_id': None, 'device_config': None,
+            },
+            None)
 
         assert 120 == mqtt_cover.find_in_range_from_percent(40)
         assert 120 == mqtt_cover.find_in_range_from_percent(40, 'cover')
@@ -827,25 +857,30 @@ class TestCoverMQTT(unittest.TestCase):
     def test_find_in_range_defaults_inverted(self):
         """Test find in range with default range but inverted."""
         mqtt_cover = MqttCover(
-            name='cover.test',
-            state_topic='state-topic',
-            get_position_topic=None,
-            command_topic='command-topic',
-            availability_topic=None,
-            tilt_command_topic='tilt-command-topic',
-            tilt_status_topic='tilt-status-topic',
-            qos=0,
-            retain=False,
-            state_open='OPEN', state_closed='CLOSE',
-            position_open=0, position_closed=100,
-            payload_open='OPEN', payload_close='CLOSE', payload_stop='STOP',
-            payload_available=None, payload_not_available=None,
-            optimistic=False, value_template=None,
-            tilt_open_position=100, tilt_closed_position=0,
-            tilt_min=0, tilt_max=100, tilt_optimistic=False,
-            tilt_invert=True,
-            set_position_topic=None, set_position_template=None,
-            unique_id=None, device_config=None, discovery_hash=None)
+            self.hass,
+            {
+                'name': 'cover.test',
+                'state_topic': 'state-topic',
+                'get_position_topic': None,
+                'command_topic': 'command-topic',
+                'availability_topic': None,
+                'tilt_command_topic': 'tilt-command-topic',
+                'tilt_status_topic': 'tilt-status-topic',
+                'qos': 0,
+                'retain': False,
+                'state_open': 'OPEN', 'state_closed': 'CLOSE',
+                'position_open': 0, 'position_closed': 100,
+                'payload_open': 'OPEN', 'payload_close': 'CLOSE',
+                'payload_stop': 'STOP',
+                'payload_available': None, 'payload_not_available': None,
+                'optimistic': False, 'value_template': None,
+                'tilt_open_position': 100, 'tilt_closed_position': 0,
+                'tilt_min': 0, 'tilt_max': 100, 'tilt_optimistic': False,
+                'tilt_invert_state': True,
+                'set_position_topic': None, 'set_position_template': None,
+                'unique_id': None, 'device_config': None,
+            },
+            None)
 
         assert 44 == mqtt_cover.find_in_range_from_percent(56)
         assert 44 == mqtt_cover.find_in_range_from_percent(56, 'cover')
@@ -853,25 +888,30 @@ class TestCoverMQTT(unittest.TestCase):
     def test_find_in_range_altered_inverted(self):
         """Test find in range with altered range and inverted."""
         mqtt_cover = MqttCover(
-            name='cover.test',
-            state_topic='state-topic',
-            get_position_topic=None,
-            command_topic='command-topic',
-            availability_topic=None,
-            tilt_command_topic='tilt-command-topic',
-            tilt_status_topic='tilt-status-topic',
-            qos=0,
-            retain=False,
-            state_open='OPEN', state_closed='CLOSE',
-            position_open=80, position_closed=180,
-            payload_open='OPEN', payload_close='CLOSE', payload_stop='STOP',
-            payload_available=None, payload_not_available=None,
-            optimistic=False, value_template=None,
-            tilt_open_position=180, tilt_closed_position=80,
-            tilt_min=80, tilt_max=180, tilt_optimistic=False,
-            tilt_invert=True,
-            set_position_topic=None, set_position_template=None,
-            unique_id=None, device_config=None, discovery_hash=None)
+            self.hass,
+            {
+                'name': 'cover.test',
+                'state_topic': 'state-topic',
+                'get_position_topic': None,
+                'command_topic': 'command-topic',
+                'availability_topic': None,
+                'tilt_command_topic': 'tilt-command-topic',
+                'tilt_status_topic': 'tilt-status-topic',
+                'qos': 0,
+                'retain': False,
+                'state_open': 'OPEN', 'state_closed': 'CLOSE',
+                'position_open': 80, 'position_closed': 180,
+                'payload_open': 'OPEN', 'payload_close': 'CLOSE',
+                'payload_stop': 'STOP',
+                'payload_available': None, 'payload_not_available': None,
+                'optimistic': False, 'value_template': None,
+                'tilt_open_position': 180, 'tilt_closed_position': 80,
+                'tilt_min': 80, 'tilt_max': 180, 'tilt_optimistic': False,
+                'tilt_invert_state': True,
+                'set_position_topic': None, 'set_position_template': None,
+                'unique_id': None, 'device_config': None,
+            },
+            None)
 
         assert 120 == mqtt_cover.find_in_range_from_percent(60)
         assert 120 == mqtt_cover.find_in_range_from_percent(60, 'cover')
@@ -966,6 +1006,38 @@ async def test_discovery_removal_cover(hass, mqtt_mock, caplog):
     await hass.async_block_till_done()
     await hass.async_block_till_done()
     state = hass.states.get('cover.beer')
+    assert state is None
+
+
+async def test_discovery_update_cover(hass, mqtt_mock, caplog):
+    """Test removal of discovered cover."""
+    entry = MockConfigEntry(domain=mqtt.DOMAIN)
+    await async_start(hass, 'homeassistant', {}, entry)
+    data1 = (
+        '{ "name": "Beer",'
+        '  "command_topic": "test_topic" }'
+    )
+    data2 = (
+        '{ "name": "Milk",'
+        '  "command_topic": "test_topic" }'
+    )
+    async_fire_mqtt_message(hass, 'homeassistant/cover/bla/config',
+                            data1)
+    await hass.async_block_till_done()
+    state = hass.states.get('cover.beer')
+    assert state is not None
+    assert state.name == 'Beer'
+
+    async_fire_mqtt_message(hass, 'homeassistant/cover/bla/config',
+                            data2)
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+
+    state = hass.states.get('cover.beer')
+    assert state is not None
+    assert state.name == 'Milk'
+
+    state = hass.states.get('cover.milk')
     assert state is None
 
 

--- a/tests/components/cover/test_mqtt.py
+++ b/tests/components/cover/test_mqtt.py
@@ -671,7 +671,6 @@ class TestCoverMQTT(unittest.TestCase):
     def test_find_percentage_in_range_defaults(self):
         """Test find percentage in range with default range."""
         mqtt_cover = MqttCover(
-            self.hass,
             {
                 'name': 'cover.test',
                 'state_topic': 'state-topic',
@@ -702,7 +701,6 @@ class TestCoverMQTT(unittest.TestCase):
     def test_find_percentage_in_range_altered(self):
         """Test find percentage in range with altered range."""
         mqtt_cover = MqttCover(
-            self.hass,
             {
                 'name': 'cover.test',
                 'state_topic': 'state-topic',
@@ -733,7 +731,6 @@ class TestCoverMQTT(unittest.TestCase):
     def test_find_percentage_in_range_defaults_inverted(self):
         """Test find percentage in range with default range but inverted."""
         mqtt_cover = MqttCover(
-            self.hass,
             {
                 'name': 'cover.test',
                 'state_topic': 'state-topic',
@@ -764,7 +761,6 @@ class TestCoverMQTT(unittest.TestCase):
     def test_find_percentage_in_range_altered_inverted(self):
         """Test find percentage in range with altered range and inverted."""
         mqtt_cover = MqttCover(
-            self.hass,
             {
                 'name': 'cover.test',
                 'state_topic': 'state-topic',
@@ -795,7 +791,6 @@ class TestCoverMQTT(unittest.TestCase):
     def test_find_in_range_defaults(self):
         """Test find in range with default range."""
         mqtt_cover = MqttCover(
-            self.hass,
             {
                 'name': 'cover.test',
                 'state_topic': 'state-topic',
@@ -826,7 +821,6 @@ class TestCoverMQTT(unittest.TestCase):
     def test_find_in_range_altered(self):
         """Test find in range with altered range."""
         mqtt_cover = MqttCover(
-            self.hass,
             {
                 'name': 'cover.test',
                 'state_topic': 'state-topic',
@@ -857,7 +851,6 @@ class TestCoverMQTT(unittest.TestCase):
     def test_find_in_range_defaults_inverted(self):
         """Test find in range with default range but inverted."""
         mqtt_cover = MqttCover(
-            self.hass,
             {
                 'name': 'cover.test',
                 'state_topic': 'state-topic',
@@ -888,7 +881,6 @@ class TestCoverMQTT(unittest.TestCase):
     def test_find_in_range_altered_inverted(self):
         """Test find in range with altered range and inverted."""
         mqtt_cover = MqttCover(
-            self.hass,
             {
                 'name': 'cover.test',
                 'state_topic': 'state-topic',


### PR DESCRIPTION
## Description:
Reconfigure MQTT cover component if discovery info is changed.
This PR is an extension of #18169 which introduced support for reconfiguring MQTT binary sensors.

(This is bullet 2 in home-assistant/architecture#70)

PRs for other platforms will be opened separately.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`.
  - [x] Tests have been added to verify that the new code works.