### PR TITLE
Reconfigure MQTT sensor component if discovery info is changed

### DIFF
--- a/homeassistant/components/sensor/mqtt.py
+++ b/homeassistant/components/sensor/mqtt.py
@@ -144,12 +144,12 @@ class MqttSensor(MqttAvailability, MqttDiscoveryUpdate, MqttEntityDeviceInfo,
         self._template = config.get(CONF_VALUE_TEMPLATE)
         self._json_attributes = set(config.get(CONF_JSON_ATTRS))
         self._unique_id = config.get(CONF_UNIQUE_ID)
-        self._unique_id = config.get(CONF_UNIQUE_ID)
 
     async def _subscribe_topics(self):
         """(Re)Subscribe to topics."""
         if self._template is not None:
             self._template.hass = self.hass
+
         @callback
         def message_received(topic, payload, qos):
             """Handle new MQTT messages."""

--- a/tests/components/sensor/test_mqtt.py
+++ b/tests/components/sensor/test_mqtt.py
@@ -412,6 +412,39 @@ async def test_discovery_removal_sensor(hass, mqtt_mock, caplog):
     assert state is None
 
 
+async def test_discovery_update_sensor(hass, mqtt_mock, caplog):
+    """Test removal of discovered sensor."""
+    entry = MockConfigEntry(domain=mqtt.DOMAIN)
+    await async_start(hass, 'homeassistant', {}, entry)
+    data1 = (
+        '{ "name": "Beer",'
+        '  "status_topic": "test_topic" }'
+    )
+    data2 = (
+        '{ "name": "Milk",'
+        '  "status_topic": "test_topic" }'
+    )
+    async_fire_mqtt_message(hass, 'homeassistant/sensor/bla/config',
+                            data1)
+    await hass.async_block_till_done()
+
+    state = hass.states.get('sensor.beer')
+    assert state is not None
+    assert state.name == 'Beer'
+
+    async_fire_mqtt_message(hass, 'homeassistant/sensor/bla/config',
+                            data2)
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+
+    state = hass.states.get('sensor.beer')
+    assert state is not None
+    assert state.name == 'Milk'
+
+    state = hass.states.get('sensor.milk')
+    assert state is None
+
+
 async def test_entity_device_info_with_identifier(hass, mqtt_mock):
     """Test MQTT sensor device registry integration."""
     entry = MockConfigEntry(domain=mqtt.DOMAIN)


### PR DESCRIPTION
## Description:
Reconfigure MQTT sensor component if discovery info is changed.
This PR is an extension of #18169 which introduced support for reconfiguring MQTT binary sensors.

(This is bullet 2 in home-assistant/architecture#70)

PRs for other platforms will be opened separately.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`.
  - [x] Tests have been added to verify that the new code works.