### PR TITLE
Added AU (Australia)

### DIFF
--- a/homeassistant/components/sensor/waze_travel_time.py
+++ b/homeassistant/components/sensor/waze_travel_time.py
@@ -37,7 +37,7 @@ DEFAULT_REALTIME = True
 
 ICON = 'mdi:car'
 
-REGIONS = ['US', 'NA', 'EU', 'IL']
+REGIONS = ['US', 'NA', 'EU', 'IL', 'AU']
 
 SCAN_INTERVAL = timedelta(minutes=5)
 


### PR DESCRIPTION
Added missing Australia region

## Description:
The AU region is missing from the configuration validator

**Related issue (if applicable):** None

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
- platform: waze_travel_time
  name: "Brisbane to Sydney"
  origin: "Brisbane, QLD"
  destination: "Sydney, NSW"
  region: "AU"
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
