### PR TITLE
Handle TensorFlow like OpenCV

### DIFF
--- a/homeassistant/components/image_processing/tensorflow.py
+++ b/homeassistant/components/image_processing/tensorflow.py
@@ -20,8 +20,7 @@ from homeassistant.core import split_entity_id
 from homeassistant.helpers import template
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['numpy==1.15.3', 'pillow==5.2.0',
-                'protobuf==3.6.1', 'tensorflow==1.11.0']
+REQUIREMENTS = ['numpy==1.15.3', 'pillow==5.2.0', 'protobuf==3.6.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1472,9 +1472,6 @@ temescal==0.1
 # homeassistant.components.sensor.temper
 temperusb==1.5.3
 
-# homeassistant.components.image_processing.tensorflow
-tensorflow==1.11.0
-
 # homeassistant.components.tesla
 teslajsonpy==0.0.23
 


### PR DESCRIPTION
## Description:

That is the same problem as we have with OpenCV. The python wheels are not available for all platforms (amd64/i386/arm/aarch64) and OS.

With this change, the user needs self-install TensorFlow like OpenCV. Need also an update on Documentation.