### PR TITLE
Add support for Google Home device tracking

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -474,6 +474,7 @@ omit =
     homeassistant/components/device_tracker/freebox.py
     homeassistant/components/device_tracker/fritz.py
     homeassistant/components/device_tracker/google_maps.py
+    homeassistant/components/device_tracker/googlehome.py
     homeassistant/components/device_tracker/gpslogger.py
     homeassistant/components/device_tracker/hitron_coda.py
     homeassistant/components/device_tracker/huawei_router.py

--- a/homeassistant/components/device_tracker/googlehome.py
+++ b/homeassistant/components/device_tracker/googlehome.py
@@ -46,7 +46,7 @@ class GoogleHomeDeviceScanner(DeviceScanner):
 
         self.success_init = False
         self._host = config[CONF_HOST]
-        self.rssi_threshold = config.get(CONF_RSSI_THRESHOLD)
+        self.rssi_threshold = config[CONF_RSSI_THRESHOLD]
 
         session = async_get_clientsession(hass)
         self.deviceinfo = DeviceInfo(hass.loop, session, self._host)

--- a/homeassistant/components/device_tracker/googlehome.py
+++ b/homeassistant/components/device_tracker/googlehome.py
@@ -1,0 +1,96 @@
+"""
+Support for Google Home bluetooth tacker.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/device_tracker.googlehome/
+"""
+import logging
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.components.device_tracker import (
+    DOMAIN, PLATFORM_SCHEMA, DeviceScanner)
+from homeassistant.const import CONF_HOST
+
+REQUIREMENTS = ['ghlocalapi==0.0.1']
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_RSSI_THRESHOLD = 'rssi_threshold'
+
+PLATFORM_SCHEMA = vol.All(
+    PLATFORM_SCHEMA.extend({
+        vol.Required(CONF_HOST): cv.string,
+        vol.Optional(CONF_RSSI_THRESHOLD, default=-70): vol.Coerce(int),
+    }))
+
+
+async def async_get_scanner(hass, config):
+    """Validate the configuration and return an Google Home scanner."""
+    scanner = GoogleHomeDeviceScanner(hass, config[DOMAIN])
+    await scanner.async_connect()
+    return scanner if scanner.success_init else None
+
+
+class GoogleHomeDeviceScanner(DeviceScanner):
+    """This class queries a Google Home unit."""
+
+    def __init__(self, hass, config):
+        """Initialize the scanner."""
+        from ghlocalapi.device_info import DeviceInfo
+        from ghlocalapi.bluetooth import BluetoothScan
+
+        self.last_results = {}
+
+        self.success_init = False
+        self._host = config[CONF_HOST]
+        self.rssi_threshold = config.get(CONF_RSSI_THRESHOLD)
+
+        session = async_get_clientsession(hass)
+        self.deviceinfo = DeviceInfo(hass.loop, session, self._host)
+        self.scanner = BluetoothScan(hass.loop, session, self._host)
+
+    async def async_connect(self):
+        """Initialize connection to Google Home."""
+        await self.deviceinfo.get_device_info()
+        data = self.deviceinfo.device_info
+        self.success_init = data is not None
+
+    async def async_scan_devices(self):
+        """Scan for new devices and return a list with found device IDs."""
+        await self.async_update_info()
+        return list(self.last_results.keys())
+
+    async def async_get_device_name(self, device):
+        """Return the name of the given device or None if we don't know."""
+        if device not in self.last_results:
+            return None
+        return self._host + '_' + self.last_results[device]['mac_address']
+
+    async def get_extra_attributes(self, device):
+        """Return the extra attributes of the device."""
+        attributes = {}
+        for attribute in self.last_results[device]:
+            attributes[attribute] = self.last_results[device][attribute]
+
+        _LOGGER.debug("Device %s attributes %s", device, attributes)
+        return attributes
+
+    async def async_update_info(self):
+        """Ensure the information from Google Home is up to date."""
+        _LOGGER.debug('Checking Devices...')
+        await self.scanner.scan_for_devices()
+        await self.scanner.get_scan_result()
+        ghname = self.deviceinfo.device_info['name']
+        devices = {}
+        for device in self.scanner.devices:
+            if device['rssi'] > self.rssi_threshold:
+                uuid = self._host + '_' + device['mac_address']
+                devices[uuid] = {}
+                devices[uuid]['rssi'] = device['rssi']
+                devices[uuid]['mac_address'] = device['mac_address']
+                devices[uuid]['ghname'] = ghname
+                devices[uuid]['source_type'] = 'bluetooth'
+        self.last_results = devices

--- a/homeassistant/components/device_tracker/googlehome.py
+++ b/homeassistant/components/device_tracker/googlehome.py
@@ -67,16 +67,12 @@ class GoogleHomeDeviceScanner(DeviceScanner):
         """Return the name of the given device or None if we don't know."""
         if device not in self.last_results:
             return None
-        return self._host + '_' + self.last_results[device]['mac_address']
+        return '{}_{}'.format(self._host,
+                              self.last_results[device]['btle_mac_address'])
 
     async def get_extra_attributes(self, device):
         """Return the extra attributes of the device."""
-        attributes = {}
-        for attribute in self.last_results[device]:
-            attributes[attribute] = self.last_results[device][attribute]
-
-        _LOGGER.debug("Device %s attributes %s", device, attributes)
-        return attributes
+        return self.last_results[device]
 
     async def async_update_info(self):
         """Ensure the information from Google Home is up to date."""
@@ -87,10 +83,10 @@ class GoogleHomeDeviceScanner(DeviceScanner):
         devices = {}
         for device in self.scanner.devices:
             if device['rssi'] > self.rssi_threshold:
-                uuid = self._host + '_' + device['mac_address']
+                uuid = '{}_{}'.format(self._host, device['mac_address'])
                 devices[uuid] = {}
                 devices[uuid]['rssi'] = device['rssi']
-                devices[uuid]['mac_address'] = device['mac_address']
+                devices[uuid]['btle_mac_address'] = device['mac_address']
                 devices[uuid]['ghname'] = ghname
                 devices[uuid]['source_type'] = 'bluetooth'
         self.last_results = devices

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -415,6 +415,9 @@ geojson_client==0.3
 # homeassistant.components.sensor.geo_rss_events
 georss_client==0.4
 
+# homeassistant.components.device_tracker.googlehome
+ghlocalapi==0.0.1
+
 # homeassistant.components.sensor.gitter
 gitterpy==0.1.7
 


### PR DESCRIPTION
## Description:

This adds the option to use the bluetooth capabilities of Google Home devices as a device tracker.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#7357

## Example entry for `configuration.yaml` (if applicable):
```yaml
device_tracker:
  platform: googlehome
  host: 192.168.1.113
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
