### PR TITLE
Fix temperature interval Thermostat HomeKit

### DIFF
--- a/homeassistant/components/homekit/const.py
+++ b/homeassistant/components/homekit/const.py
@@ -127,6 +127,7 @@ CHAR_VALVE_TYPE = 'ValveType'
 # #### Properties ####
 PROP_MAX_VALUE = 'maxValue'
 PROP_MIN_VALUE = 'minValue'
+PROP_MIN_STEP = 'minStep'
 PROP_CELSIUS = {'minValue': -273, 'maxValue': 999}
 
 # #### Device Classes ####

--- a/homeassistant/components/homekit/util.py
+++ b/homeassistant/components/homekit/util.py
@@ -135,12 +135,12 @@ def convert_to_float(state):
 
 def temperature_to_homekit(temperature, unit):
     """Convert temperature to Celsius for HomeKit."""
-    return round(temp_util.convert(temperature, unit, TEMP_CELSIUS), 1)
+    return round(temp_util.convert(temperature, unit, TEMP_CELSIUS) * 2) / 2
 
 
 def temperature_to_states(temperature, unit):
     """Convert temperature back from Celsius to Home Assistant unit."""
-    return round(temp_util.convert(temperature, TEMP_CELSIUS, unit), 1)
+    return round(temp_util.convert(temperature, TEMP_CELSIUS, unit) * 2) / 2
 
 
 def density_to_air_quality(density):

--- a/tests/components/homekit/test_util.py
+++ b/tests/components/homekit/test_util.py
@@ -99,13 +99,13 @@ def test_convert_to_float():
 def test_temperature_to_homekit():
     """Test temperature conversion from HA to HomeKit."""
     assert temperature_to_homekit(20.46, TEMP_CELSIUS) == 20.5
-    assert temperature_to_homekit(92.1, TEMP_FAHRENHEIT) == 33.4
+    assert temperature_to_homekit(92.1, TEMP_FAHRENHEIT) == 33.5
 
 
 def test_temperature_to_states():
     """Test temperature conversion from HomeKit to HA."""
     assert temperature_to_states(20, TEMP_CELSIUS) == 20.0
-    assert temperature_to_states(20.2, TEMP_FAHRENHEIT) == 68.4
+    assert temperature_to_states(20.2, TEMP_FAHRENHEIT) == 68.5
 
 
 def test_density_to_air_quality():


### PR DESCRIPTION
## Description:
Although HomeKit and Home Assistant both round to the nearest `.0` or `.5` value for climate temperatures, under some circumstances it could happen to be other values `.1`, ...
This PR will make sure that the temperature values are updated correctly.

**Related issue (if applicable):** fixes #18187

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.

---

Reported by: @kamkilt