### PR TITLE
Z-Wave Lock Config Entry Support

### DIFF
--- a/homeassistant/components/lock/__init__.py
+++ b/homeassistant/components/lock/__init__.py
@@ -84,6 +84,13 @@ async def async_setup_entry(hass, entry):
     return await hass.data[DOMAIN].async_setup_entry(entry)
 
 
+<<<<<<< HEAD
+=======
+async def async_unload_entry(hass, entry):
+    """Unload a config entry."""
+    return await hass.data[DOMAIN].async_unload_entry(entry)
+
+>>>>>>> Config Entry setup for zwave lock
 class LockDevice(Entity):
     """Representation of a lock."""
 

--- a/homeassistant/components/lock/__init__.py
+++ b/homeassistant/components/lock/__init__.py
@@ -84,13 +84,6 @@ async def async_setup_entry(hass, entry):
     return await hass.data[DOMAIN].async_setup_entry(entry)
 
 
-<<<<<<< HEAD
-=======
-async def async_unload_entry(hass, entry):
-    """Unload a config entry."""
-    return await hass.data[DOMAIN].async_unload_entry(entry)
-
->>>>>>> Config Entry setup for zwave lock
 class LockDevice(Entity):
     """Representation of a lock."""
 

--- a/homeassistant/components/lock/zwave.py
+++ b/homeassistant/components/lock/zwave.py
@@ -8,8 +8,10 @@ import logging
 
 import voluptuous as vol
 
+from homeassistant.core import callback
 from homeassistant.components.lock import DOMAIN, LockDevice
 from homeassistant.components import zwave
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
@@ -133,9 +135,18 @@ CLEAR_USERCODE_SCHEMA = vol.Schema({
 
 async def async_setup_platform(hass, config, async_add_entities,
                                discovery_info=None):
-    """Set up the Z-Wave Lock platform."""
-    await zwave.async_setup_platform(
-        hass, config, async_add_entities, discovery_info)
+    """Old method of setting up Z-Wave locks."""
+    pass
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up Z-Wave Lock from Config Entry."""
+    @callback
+    def async_add_lock(lock):
+        """Add Z-Wave Lock."""
+        async_add_entities([lock])
+
+    async_dispatcher_connect(hass, 'zwave_new_lock', async_add_lock)
 
     network = hass.data[zwave.const.DATA_NETWORK]
 

--- a/homeassistant/components/lock/zwave.py
+++ b/homeassistant/components/lock/zwave.py
@@ -172,6 +172,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     def get_usercode(service):
         """Get a usercode at index X on the lock."""
+        _LOGGER.debug('running get_usercode')
         node_id = service.data.get(zwave.const.ATTR_NODE_ID)
         lock_node = network.nodes[node_id]
         code_slot = service.data.get(ATTR_CODE_SLOT)

--- a/homeassistant/components/lock/zwave.py
+++ b/homeassistant/components/lock/zwave.py
@@ -172,7 +172,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     def get_usercode(service):
         """Get a usercode at index X on the lock."""
-        _LOGGER.debug('running get_usercode')
         node_id = service.data.get(zwave.const.ATTR_NODE_ID)
         lock_node = network.nodes[node_id]
         code_slot = service.data.get(ATTR_CODE_SLOT)

--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -67,7 +67,7 @@ DEFAULT_CONF_REFRESH_VALUE = False
 DEFAULT_CONF_REFRESH_DELAY = 5
 
 SUPPORTED_PLATFORMS = ['binary_sensor', 'climate', 'cover', 'fan',
-                       'light', 'sensor', 'switch']
+                       'lock', 'light', 'sensor', 'switch']
 
 RENAME_NODE_SCHEMA = vol.Schema({
     vol.Required(const.ATTR_NODE_ID): vol.Coerce(int),

--- a/tests/components/lock/test_zwave.py
+++ b/tests/components/lock/test_zwave.py
@@ -7,7 +7,6 @@ from homeassistant import config_entries
 from homeassistant.components.lock import zwave
 from homeassistant.components.zwave import const
 
-from tests.common import MockConfigEntry
 from tests.mock.zwave import (
     MockNode, MockValue, MockEntityValues, value_changed)
 

--- a/tests/components/lock/test_zwave.py
+++ b/tests/components/lock/test_zwave.py
@@ -3,6 +3,7 @@ import asyncio
 
 from unittest.mock import patch, MagicMock
 
+from homeassistant import config_entries
 from homeassistant.components.lock import zwave
 from homeassistant.components.zwave import const
 
@@ -183,6 +184,16 @@ def test_lock_alarm_level(mock_openzwave):
     assert device.device_state_attributes[zwave.ATTR_LOCK_STATUS] == \
         'Tamper Alarm: Too many keypresses'
 
+@asyncio.coroutine
+def setup_ozw(hass, mock_openzwave):
+    """Load the Z-Wave loc platform with the provided bridge."""
+    hass.config.components.add(zwave.DOMAIN)
+    config_entry = config_entries.ConfigEntry(1, zwave.DOMAIN, 'Mock Title', {
+        'usb_path': 'mock-path',
+        'network_key': 'mock-key'
+    }, 'test', config_entries.CONN_CLASS_LOCAL_PUSH)
+    yield from hass.config_entries.async_forward_entry_setup(config_entry, 'lock')
+    yield from hass.async_block_till_done()
 
 @asyncio.coroutine
 def test_lock_set_usercode_service(hass, mock_openzwave):
@@ -191,8 +202,10 @@ def test_lock_set_usercode_service(hass, mock_openzwave):
     node = MockNode(node_id=12)
     value0 = MockValue(data='          ', node=node, index=0)
     value1 = MockValue(data='          ', node=node, index=1)
-    yield from zwave.async_setup_platform(
-        hass, {}, MagicMock())
+    #yield from zwave.async_setup_platform(
+    #    hass, {}, MagicMock())
+    yield from setup_ozw(hass, mock_openzwave)
+    yield from hass.async_block_till_done()
 
     node.get_values.return_value = {
         value0.value_id: value0,

--- a/tests/components/lock/test_zwave.py
+++ b/tests/components/lock/test_zwave.py
@@ -184,16 +184,19 @@ def test_lock_alarm_level(mock_openzwave):
     assert device.device_state_attributes[zwave.ATTR_LOCK_STATUS] == \
         'Tamper Alarm: Too many keypresses'
 
+
 @asyncio.coroutine
 def setup_ozw(hass, mock_openzwave):
-    """Load the Z-Wave loc platform with the provided bridge."""
+    """Set up the mock ZWave config entry."""
     hass.config.components.add(zwave.DOMAIN)
     config_entry = config_entries.ConfigEntry(1, zwave.DOMAIN, 'Mock Title', {
         'usb_path': 'mock-path',
         'network_key': 'mock-key'
     }, 'test', config_entries.CONN_CLASS_LOCAL_PUSH)
-    yield from hass.config_entries.async_forward_entry_setup(config_entry, 'lock')
+    yield from hass.config_entries.async_forward_entry_setup(config_entry,
+                                                             'lock')
     yield from hass.async_block_till_done()
+
 
 @asyncio.coroutine
 def test_lock_set_usercode_service(hass, mock_openzwave):
@@ -202,8 +205,7 @@ def test_lock_set_usercode_service(hass, mock_openzwave):
     node = MockNode(node_id=12)
     value0 = MockValue(data='          ', node=node, index=0)
     value1 = MockValue(data='          ', node=node, index=1)
-    #yield from zwave.async_setup_platform(
-    #    hass, {}, MagicMock())
+
     yield from setup_ozw(hass, mock_openzwave)
     yield from hass.async_block_till_done()
 

--- a/tests/components/lock/test_zwave.py
+++ b/tests/components/lock/test_zwave.py
@@ -7,6 +7,7 @@ from homeassistant import config_entries
 from homeassistant.components.lock import zwave
 from homeassistant.components.zwave import const
 
+from tests.common import MockConfigEntry
 from tests.mock.zwave import (
     MockNode, MockValue, MockEntityValues, value_changed)
 
@@ -188,8 +189,8 @@ def test_lock_alarm_level(mock_openzwave):
 @asyncio.coroutine
 def setup_ozw(hass, mock_openzwave):
     """Set up the mock ZWave config entry."""
-    hass.config.components.add(zwave.DOMAIN)
-    config_entry = config_entries.ConfigEntry(1, zwave.DOMAIN, 'Mock Title', {
+    hass.config.components.add('zwave')
+    config_entry = config_entries.ConfigEntry(1, 'zwave', 'Mock Title', {
         'usb_path': 'mock-path',
         'network_key': 'mock-key'
     }, 'test', config_entries.CONN_CLASS_LOCAL_PUSH)
@@ -202,12 +203,10 @@ def setup_ozw(hass, mock_openzwave):
 def test_lock_set_usercode_service(hass, mock_openzwave):
     """Test the zwave lock set_usercode service."""
     mock_network = hass.data[zwave.zwave.DATA_NETWORK] = MagicMock()
+
     node = MockNode(node_id=12)
     value0 = MockValue(data='          ', node=node, index=0)
     value1 = MockValue(data='          ', node=node, index=1)
-
-    yield from setup_ozw(hass, mock_openzwave)
-    yield from hass.async_block_till_done()
 
     node.get_values.return_value = {
         value0.value_id: value0,
@@ -217,6 +216,10 @@ def test_lock_set_usercode_service(hass, mock_openzwave):
     mock_network.nodes = {
         node.node_id: node
     }
+
+    yield from setup_ozw(hass, mock_openzwave)
+    yield from hass.async_block_till_done()
+
     yield from hass.services.async_call(
         zwave.DOMAIN, zwave.SERVICE_SET_USERCODE, {
             const.ATTR_NODE_ID: node.node_id,
@@ -249,13 +252,13 @@ def test_lock_get_usercode_service(hass, mock_openzwave):
     value0 = MockValue(data=None, node=node, index=0)
     value1 = MockValue(data='1234', node=node, index=1)
 
-    yield from setup_ozw(hass, mock_openzwave)
-    yield from hass.async_block_till_done()
-
     node.get_values.return_value = {
         value0.value_id: value0,
         value1.value_id: value1,
     }
+
+    yield from setup_ozw(hass, mock_openzwave)
+    yield from hass.async_block_till_done()
 
     with patch.object(zwave, '_LOGGER') as mock_logger:
         mock_network.nodes = {node.node_id: node}
@@ -279,9 +282,6 @@ def test_lock_clear_usercode_service(hass, mock_openzwave):
     value0 = MockValue(data=None, node=node, index=0)
     value1 = MockValue(data='123', node=node, index=1)
 
-    yield from setup_ozw(hass, mock_openzwave)
-    yield from hass.async_block_till_done()
-
     node.get_values.return_value = {
         value0.value_id: value0,
         value1.value_id: value1,
@@ -290,6 +290,10 @@ def test_lock_clear_usercode_service(hass, mock_openzwave):
     mock_network.nodes = {
         node.node_id: node
     }
+
+    yield from setup_ozw(hass, mock_openzwave)
+    yield from hass.async_block_till_done()
+
     yield from hass.services.async_call(
         zwave.DOMAIN, zwave.SERVICE_CLEAR_USERCODE, {
             const.ATTR_NODE_ID: node.node_id,

--- a/tests/components/lock/test_zwave.py
+++ b/tests/components/lock/test_zwave.py
@@ -248,8 +248,9 @@ def test_lock_get_usercode_service(hass, mock_openzwave):
     node = MockNode(node_id=12)
     value0 = MockValue(data=None, node=node, index=0)
     value1 = MockValue(data='1234', node=node, index=1)
-    yield from zwave.async_setup_platform(
-        hass, {}, MagicMock())
+
+    yield from setup_ozw(hass, mock_openzwave)
+    yield from hass.async_block_till_done()
 
     node.get_values.return_value = {
         value0.value_id: value0,
@@ -277,8 +278,9 @@ def test_lock_clear_usercode_service(hass, mock_openzwave):
     node = MockNode(node_id=12)
     value0 = MockValue(data=None, node=node, index=0)
     value1 = MockValue(data='123', node=node, index=1)
-    yield from zwave.async_setup_platform(
-        hass, {}, MagicMock())
+
+    yield from setup_ozw(hass, mock_openzwave)
+    yield from hass.async_block_till_done()
 
     node.get_values.return_value = {
         value0.value_id: value0,


### PR DESCRIPTION
## Description:
Migrates zwave locks to config entry setup.

**Related issue (if applicable):** N/A
**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
zwave:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**