### PR TITLE
Add season icons

### DIFF
--- a/homeassistant/components/sensor/season.py
+++ b/homeassistant/components/sensor/season.py
@@ -19,10 +19,10 @@ REQUIREMENTS = ['ephem==3.7.6.0']
 _LOGGER = logging.getLogger(__name__)
 
 SEASON_ICONS = {
-    'spring': 'mdi:flower',
-    'summer': 'mdi:sunglasses',
-    'autumn': 'mdi:leaf',
-    'winter': 'mdi:snowflake'
+    STATE_SPRING: 'mdi:flower',
+    STATE_SUMMER: 'mdi:sunglasses',
+    STATE_AUTUMN: 'mdi:leaf',
+    STATE_WINTER: 'mdi:snowflake'
 }
 DEFAULT_CLOUD_ICON = 'mdi:cloud'
 

--- a/homeassistant/components/sensor/season.py
+++ b/homeassistant/components/sensor/season.py
@@ -18,14 +18,6 @@ REQUIREMENTS = ['ephem==3.7.6.0']
 
 _LOGGER = logging.getLogger(__name__)
 
-SEASON_ICONS = {
-    STATE_SPRING: 'mdi:flower',
-    STATE_SUMMER: 'mdi:sunglasses',
-    STATE_AUTUMN: 'mdi:leaf',
-    STATE_WINTER: 'mdi:snowflake'
-}
-DEFAULT_CLOUD_ICON = 'mdi:cloud'
-
 NORTHERN = 'northern'
 SOUTHERN = 'southern'
 EQUATOR = 'equator'
@@ -41,6 +33,14 @@ HEMISPHERE_SEASON_SWAP = {STATE_WINTER: STATE_SUMMER,
                           STATE_SPRING: STATE_AUTUMN,
                           STATE_AUTUMN: STATE_SPRING,
                           STATE_SUMMER: STATE_WINTER}
+
+SEASON_ICONS = {
+    STATE_SPRING: 'mdi:flower',
+    STATE_SUMMER: 'mdi:sunglasses',
+    STATE_AUTUMN: 'mdi:leaf',
+    STATE_WINTER: 'mdi:snowflake'
+}
+DEFAULT_CLOUD_ICON = 'mdi:cloud'
 
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({

--- a/homeassistant/components/sensor/season.py
+++ b/homeassistant/components/sensor/season.py
@@ -40,7 +40,6 @@ SEASON_ICONS = {
     STATE_AUTUMN: 'mdi:leaf',
     STATE_WINTER: 'mdi:snowflake'
 }
-DEFAULT_CLOUD_ICON = 'mdi:cloud'
 
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -127,7 +126,7 @@ class Season(Entity):
     @property
     def icon(self):
         """Icon to use in the frontend, if any."""
-        return SEASON_ICONS.get(self.season, DEFAULT_CLOUD_ICON)
+        return SEASON_ICONS.get(self.season, 'mdi:cloud')
 
     def update(self):
         """Update season."""

--- a/homeassistant/components/sensor/season.py
+++ b/homeassistant/components/sensor/season.py
@@ -18,6 +18,14 @@ REQUIREMENTS = ['ephem==3.7.6.0']
 
 _LOGGER = logging.getLogger(__name__)
 
+SEASON_ICONS = {
+    'spring': 'mdi:flower',
+    'summer': 'mdi:sunglasses',
+    'autumn': 'mdi:leaf',
+    'winter': 'mdi:snowflake'
+}
+DEFAULT_CLOUD_ICON = 'mdi:cloud'
+
 NORTHERN = 'northern'
 SOUTHERN = 'southern'
 EQUATOR = 'equator'
@@ -115,6 +123,11 @@ class Season(Entity):
     def state(self):
         """Return the current season."""
         return self.season
+
+    @property
+    def icon(self):
+        """Icon to use in the frontend, if any."""
+        return SEASON_ICONS.get(self.season, DEFAULT_CLOUD_ICON)
 
     def update(self):
         """Update season."""


### PR DESCRIPTION
## Description:
This PR adds icons to display the current season.
Currently the season icon has the default eye icon.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here> **NA**

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here> **NA**

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
