### PR TITLE
Remove turn_on and turn_off feature for clients

### DIFF
--- a/homeassistant/components/media_player/directv.py
+++ b/homeassistant/components/media_player/directv.py
@@ -23,17 +23,10 @@ REQUIREMENTS = ['directpy==0.5']
 
 _LOGGER = logging.getLogger(__name__)
 
-<<<<<<< HEAD
 ATTR_MEDIA_CURRENTLY_RECORDING = 'media_currently_recording'
 ATTR_MEDIA_RATING = 'media_rating'
 ATTR_MEDIA_RECORDED = 'media_recorded'
 ATTR_MEDIA_START_TIME = 'media_start_time'
-=======
-ATTR_MEDIA_CURRENTLYRECORDING = 'media_currently_recording'
-ATTR_MEDIA_RATING = 'media_rating'
-ATTR_MEDIA_RECORDED = 'media_recorded'
-ATTR_MEDIA_STARTTIME = 'media_starttime'
->>>>>>> Enhancements for DirecTV media player
 
 DEFAULT_DEVICE = '0'
 DEFAULT_NAME = "DirecTV Receiver"

--- a/homeassistant/components/media_player/directv.py
+++ b/homeassistant/components/media_player/directv.py
@@ -241,7 +241,7 @@ class DirecTvDevice(MediaPlayerDevice):
         if self._is_standby:
             return None
 
-       return self._last_position
+        return self._last_position
 
     @property
     def media_position_updated_at(self):
@@ -269,23 +269,6 @@ class DirecTvDevice(MediaPlayerDevice):
             return None
 
         return self._current.get('episodeTitle')
-
-    @property
-    def media_channel(self):
-        """Return the channel current playing media."""
-        if self._is_standby:
-            return None
-
-        return "{} ({})".format(
-            self._current['callsign'], self._current['major'])
-
-    @property
-    def source(self):
-        """Name of the current input source."""
-        if self._is_standby:
-            return None
-
-        return self._current['major']
 
     @property
     def media_channel(self):

--- a/homeassistant/components/media_player/directv.py
+++ b/homeassistant/components/media_player/directv.py
@@ -23,10 +23,17 @@ REQUIREMENTS = ['directpy==0.5']
 
 _LOGGER = logging.getLogger(__name__)
 
+<<<<<<< HEAD
 ATTR_MEDIA_CURRENTLY_RECORDING = 'media_currently_recording'
 ATTR_MEDIA_RATING = 'media_rating'
 ATTR_MEDIA_RECORDED = 'media_recorded'
 ATTR_MEDIA_START_TIME = 'media_start_time'
+=======
+ATTR_MEDIA_CURRENTLYRECORDING = 'media_currently_recording'
+ATTR_MEDIA_RATING = 'media_rating'
+ATTR_MEDIA_RECORDED = 'media_recorded'
+ATTR_MEDIA_STARTTIME = 'media_starttime'
+>>>>>>> Enhancements for DirecTV media player
 
 DEFAULT_DEVICE = '0'
 DEFAULT_NAME = "DirecTV Receiver"
@@ -241,7 +248,7 @@ class DirecTvDevice(MediaPlayerDevice):
         if self._is_standby:
             return None
 
-        return self._last_position
+       return self._last_position
 
     @property
     def media_position_updated_at(self):
@@ -269,6 +276,23 @@ class DirecTvDevice(MediaPlayerDevice):
             return None
 
         return self._current.get('episodeTitle')
+
+    @property
+    def media_channel(self):
+        """Return the channel current playing media."""
+        if self._is_standby:
+            return None
+
+        return "{} ({})".format(
+            self._current['callsign'], self._current['major'])
+
+    @property
+    def source(self):
+        """Name of the current input source."""
+        if self._is_standby:
+            return None
+
+        return self._current['major']
 
     @property
     def media_channel(self):

--- a/homeassistant/components/media_player/directv.py
+++ b/homeassistant/components/media_player/directv.py
@@ -130,7 +130,7 @@ class DirecTvDevice(MediaPlayerDevice):
         self._paused = None
         self._last_position = None
         self._is_recorded = None
-        self._is_client = False if device == '0' else True
+        self._is_client = device != '0'
         self._assumed_state = None
         self._available = False
 
@@ -336,15 +336,19 @@ class DirecTvDevice(MediaPlayerDevice):
 
     def turn_on(self):
         """Turn on the receiver."""
-        if not self._is_client:
-            _LOGGER.debug("Turn on %s", self._name)
-            self.dtv.key_press('poweron')
+        if self._is_client:
+            raise NotImplementedError()
+
+        _LOGGER.debug("Turn on %s", self._name)
+        self.dtv.key_press('poweron')
 
     def turn_off(self):
         """Turn off the receiver."""
-        if not self._is_client:
-            _LOGGER.debug("Turn off %s", self._name)
-            self.dtv.key_press('poweroff')
+        if self._is_client:
+            raise NotImplementedError()
+
+        _LOGGER.debug("Turn off %s", self._name)
+        self.dtv.key_press('poweroff')
 
     def media_play(self):
         """Send play command."""

--- a/homeassistant/components/media_player/directv.py
+++ b/homeassistant/components/media_player/directv.py
@@ -36,6 +36,10 @@ SUPPORT_DTV = SUPPORT_PAUSE | SUPPORT_TURN_ON | SUPPORT_TURN_OFF | \
     SUPPORT_PLAY_MEDIA | SUPPORT_SELECT_SOURCE | SUPPORT_STOP | \
     SUPPORT_NEXT_TRACK | SUPPORT_PREVIOUS_TRACK | SUPPORT_PLAY
 
+SUPPORT_DTV_CLIENT = SUPPORT_PAUSE | \
+    SUPPORT_PLAY_MEDIA | SUPPORT_SELECT_SOURCE | SUPPORT_STOP | \
+    SUPPORT_NEXT_TRACK | SUPPORT_PREVIOUS_TRACK | SUPPORT_PLAY
+
 DATA_DIRECTV = 'data_directv'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -126,10 +130,15 @@ class DirecTvDevice(MediaPlayerDevice):
         self._paused = None
         self._last_position = None
         self._is_recorded = None
+        self._is_client = False if device == '0' else True
         self._assumed_state = None
         self._available = False
 
-        _LOGGER.debug("Created DirecTV device for %s", self._name)
+        if self._is_client:
+            _LOGGER.debug("Created DirecTV client %s for device %s",
+                          self._name, device)
+        else:
+            _LOGGER.debug("Created DirecTV device for %s", self._name)
 
     def update(self):
         """Retrieve latest state."""
@@ -290,7 +299,7 @@ class DirecTvDevice(MediaPlayerDevice):
     @property
     def supported_features(self):
         """Flag media player features that are supported."""
-        return SUPPORT_DTV
+        return SUPPORT_DTV_CLIENT if self._is_client else SUPPORT_DTV
 
     @property
     def media_currently_recording(self):
@@ -327,13 +336,15 @@ class DirecTvDevice(MediaPlayerDevice):
 
     def turn_on(self):
         """Turn on the receiver."""
-        _LOGGER.debug("Turn on %s", self._name)
-        self.dtv.key_press('poweron')
+        if not self._is_client:
+            _LOGGER.debug("Turn on %s", self._name)
+            self.dtv.key_press('poweron')
 
     def turn_off(self):
         """Turn off the receiver."""
-        _LOGGER.debug("Turn off %s", self._name)
-        self.dtv.key_press('poweroff')
+        if not self._is_client:
+            _LOGGER.debug("Turn off %s", self._name)
+            self.dtv.key_press('poweroff')
 
     def media_play(self):
         """Send play command."""


### PR DESCRIPTION
## Description:

Remove listing turn_on and turn_off as a supported feature for DVR clients as power_on and power_off do not work and are not supported in the DirecTV API for clients. It is only supported for the main DVR.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
