### PR TITLE
Init statistics sensor upon HASS start

### DIFF
--- a/homeassistant/components/sensor/statistics.py
+++ b/homeassistant/components/sensor/statistics.py
@@ -247,7 +247,10 @@ class StatisticsSensor(Entity):
         The query will get the list of states in DESCENDING order so that we
         can limit the result to self._sample_size. Afterwards reverse the
         list so that we get it in the right order again.
+<<<<<<< HEAD
 
+=======
+>>>>>>> Update query to include maxAge
         If MaxAge is provided then query will restrict to entries younger then
         current datetime - MaxAge.
         """

--- a/homeassistant/components/sensor/statistics.py
+++ b/homeassistant/components/sensor/statistics.py
@@ -247,10 +247,7 @@ class StatisticsSensor(Entity):
         The query will get the list of states in DESCENDING order so that we
         can limit the result to self._sample_size. Afterwards reverse the
         list so that we get it in the right order again.
-<<<<<<< HEAD
 
-=======
->>>>>>> Update query to include maxAge
         If MaxAge is provided then query will restrict to entries younger then
         current datetime - MaxAge.
         """

--- a/tests/components/sensor/test_statistics.py
+++ b/tests/components/sensor/test_statistics.py
@@ -49,6 +49,9 @@ class TestStatisticsSensor(unittest.TestCase):
             }
         })
 
+        self.hass.start()
+        self.hass.block_till_done()
+
         for value in values:
             self.hass.states.set('binary_sensor.test_monitored', value)
             self.hass.block_till_done()
@@ -66,6 +69,9 @@ class TestStatisticsSensor(unittest.TestCase):
                 'entity_id': 'sensor.test_monitored',
             }
         })
+
+        self.hass.start()
+        self.hass.block_till_done()
 
         for value in self.values:
             self.hass.states.set('sensor.test_monitored', value,
@@ -100,6 +106,9 @@ class TestStatisticsSensor(unittest.TestCase):
             }
         })
 
+        self.hass.start()
+        self.hass.block_till_done()
+
         for value in self.values:
             self.hass.states.set('sensor.test_monitored', value,
                                  {ATTR_UNIT_OF_MEASUREMENT: TEMP_CELSIUS})
@@ -120,6 +129,9 @@ class TestStatisticsSensor(unittest.TestCase):
                 'sampling_size': 1,
             }
         })
+
+        self.hass.start()
+        self.hass.block_till_done()
 
         for value in self.values[-3:]:  # just the last 3 will do
             self.hass.states.set('sensor.test_monitored', value,
@@ -162,6 +174,9 @@ class TestStatisticsSensor(unittest.TestCase):
                 }
             })
 
+            self.hass.start()
+            self.hass.block_till_done()
+
             for value in self.values:
                 self.hass.states.set('sensor.test_monitored', value,
                                      {ATTR_UNIT_OF_MEASUREMENT: TEMP_CELSIUS})
@@ -193,6 +208,9 @@ class TestStatisticsSensor(unittest.TestCase):
                     'entity_id': 'sensor.test_monitored'
                 }
             })
+
+            self.hass.start()
+            self.hass.block_till_done()
 
             for value in self.values:
                 self.hass.states.set('sensor.test_monitored', value,
@@ -231,6 +249,10 @@ class TestStatisticsSensor(unittest.TestCase):
                 'sampling_size': 100,
             }
         })
+
+        self.hass.start()
+        self.hass.block_till_done()
+
         # check if the result is as in test_sensor_source()
         state = self.hass.states.get('sensor.test_mean')
         assert str(self.mean) == state.state

--- a/tests/components/sensor/test_statistics.py
+++ b/tests/components/sensor/test_statistics.py
@@ -306,6 +306,9 @@ class TestStatisticsSensor(unittest.TestCase):
                 }
             })
 
+            self.hass.start()
+            self.hass.block_till_done()
+
             # check if the result is as in test_sensor_source()
             state = self.hass.states.get('sensor.test_mean')
 


### PR DESCRIPTION
## Description:

Register the state listener and read from the recorder only once HASS has been started.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
