### PR TITLE
Update pynetgear to 0.5.1 to fix #17800

### DIFF
--- a/homeassistant/components/device_tracker/netgear.py
+++ b/homeassistant/components/device_tracker/netgear.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
     CONF_HOST, CONF_PASSWORD, CONF_USERNAME, CONF_PORT, CONF_SSL,
     CONF_DEVICES, CONF_EXCLUDE)
 
-REQUIREMENTS = ['pynetgear==0.5.0']
+REQUIREMENTS = ['pynetgear==0.5.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1026,7 +1026,7 @@ pymysensors==0.18.0
 pynello==1.5.1
 
 # homeassistant.components.device_tracker.netgear
-pynetgear==0.5.0
+pynetgear==0.5.1
 
 # homeassistant.components.switch.netio
 pynetio==0.1.9.1


### PR DESCRIPTION
I wanted to make this pull request to get my first hass.io install working with netgear router. It seems that MatMaul has fixed the bug in pynetgear and hopefully it works. I had no idea how to get the fixed version on my home assistant instance on Raspberry Pi Zero, nor how to properly test this from my laptop.

But I was able to run the tests and do these simple changes based on a previous pull request.

Hopefully someone with the know can verify that this actually works and I can get a working version of it on my hass.

https://github.com/MatMaul/pynetgear/releases/tag/0.5.1

## Description:
Updates pynetgear to 0.5.1, fixes login infinite loop as seen here: https://github.com/MatMaul/pynetgear/commit/d5bcca584c2bac343449e5bf9f93a13b0b66c7fc

**Related issue (if applicable):** fixes #17800

## Checklist:
  - [ ] The code change is tested and works locally.
(Sorry, I'm new here, do not know how to properly do this yet.)
  - [X ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
I was able to run the tests tho, seemed to work.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)
*Not applicable that I know of.*

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.
Not applicable in any of the above afaik.