### PR TITLE
Added new components

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -154,6 +154,9 @@ omit =
     homeassistant/components/homematicip_cloud.py
     homeassistant/components/*/homematicip_cloud.py
 
+    homeassistant/components/homeworks.py
+    homeassistant/components/*/homeworks.py
+
     homeassistant/components/huawei_lte.py
     homeassistant/components/*/huawei_lte.py
 
@@ -344,6 +347,9 @@ omit =
     homeassistant/components/usps.py
     homeassistant/components/*/usps.py
 
+    homeassistant/components/v6m.py
+    homeassistant/components/*/v6m.py
+
     homeassistant/components/velbus.py
     homeassistant/components/*/velbus.py
 
@@ -457,6 +463,7 @@ omit =
     homeassistant/components/cover/knx.py
     homeassistant/components/cover/myq.py
     homeassistant/components/cover/opengarage.py
+    homeassistant/components/cover/r2d7.py
     homeassistant/components/cover/rpi_gpio.py
     homeassistant/components/cover/scsgate.py
     homeassistant/components/device_tracker/actiontec.py
@@ -756,6 +763,7 @@ omit =
     homeassistant/components/sensor/qnap.py
     homeassistant/components/sensor/radarr.py
     homeassistant/components/sensor/rainbird.py
+    homeassistant/components/sensor/rfk101.py
     homeassistant/components/sensor/ripple.py
     homeassistant/components/sensor/rtorrent.py
     homeassistant/components/sensor/scrape.py
@@ -825,6 +833,7 @@ omit =
     homeassistant/components/switch/mystrom.py
     homeassistant/components/switch/netio.py
     homeassistant/components/switch/orvibo.py
+    homeassistant/components/switch/pencom.py
     homeassistant/components/switch/pulseaudio_loopback.py
     homeassistant/components/switch/rainbird.py
     homeassistant/components/switch/rest.py

--- a/homeassistant/components/binary_sensor/homeworks.py
+++ b/homeassistant/components/binary_sensor/homeworks.py
@@ -1,0 +1,86 @@
+"""Component for interfacing to Lutron Homeworks keypads.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/homeworks/
+"""
+import logging
+from homeassistant.components.binary_sensor import (
+    BinarySensorDevice, PLATFORM_SCHEMA)
+from homeassistant.components.homeworks import (
+    HomeworksDevice, HOMEWORKS_CONTROLLER)
+from homeassistant.const import CONF_NAME
+import homeassistant.helpers.config_validation as cv
+import voluptuous as vol
+
+DEPENDENCIES = ['homeworks']
+REQUIREMENTS = ['pyhomeworks==0.0.1']
+
+_LOGGER = logging.getLogger(__name__)
+
+EVENT_BUTTON_PRESSED = 'button_pressed'
+CONF_KEYPADS = 'keypads'
+CONF_ADDR = 'addr'
+CONF_BUTTONS = 'buttons'
+
+BUTTON_SCHEMA = vol.Schema({cv.positive_int: cv.string})
+BUTTONS_SCHEMA = vol.Schema({
+    vol.Required(CONF_ADDR): cv.string,
+    vol.Required(CONF_NAME): cv.string,
+    vol.Required(CONF_BUTTONS): vol.All(cv.ensure_list, [BUTTON_SCHEMA])
+})
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_KEYPADS): vol.All(cv.ensure_list, [BUTTONS_SCHEMA])
+})
+
+
+def setup_platform(hass, config, add_entities, discover_info=None):
+    """Set up the Homeworks keypads."""
+    controller = hass.data[HOMEWORKS_CONTROLLER]
+    devs = []
+    for keypad in config.get(CONF_KEYPADS):
+        name = keypad.get(CONF_NAME)
+        addr = keypad.get(CONF_ADDR)
+        buttons = keypad.get(CONF_BUTTONS)
+        for button in buttons:
+            # FIX: This should be done differently
+            for num, title in button.items():
+                devname = name + '_' + title
+                dev = HomeworksKeypad(controller, addr, num, devname)
+                devs.append(dev)
+    add_entities(devs, True)
+    return True
+
+
+class HomeworksKeypad(HomeworksDevice, BinarySensorDevice):
+    """Homeworks Keypad."""
+
+    def __init__(self, controller, addr, num, name):
+        """Create keypad with addr, num, and name."""
+        HomeworksDevice.__init__(self, controller, addr, name)
+        self._num = num
+        self._state = None
+
+    @property
+    def is_on(self):
+        """Return state of the button."""
+        return self._state
+
+    @property
+    def device_state_attributes(self):
+        """Return supported attributes."""
+        return {"Homeworks Address": self._addr,
+                "Button Number": self._num}
+
+    def callback(self, msg_type, values):
+        """Dispatch messages from the controller."""
+        from pyhomeworks.pyhomeworks import (
+            HW_BUTTON_PRESSED, HW_BUTTON_RELEASED)
+
+        old_state = self._state
+        if msg_type == HW_BUTTON_PRESSED and values[1] == self._num:
+            self.hass.bus.fire(EVENT_BUTTON_PRESSED,
+                               {'entity_id': self.entity_id})
+            self._state = True
+        elif msg_type == HW_BUTTON_RELEASED and values[1] == self._num:
+            self._state = False
+        return old_state == self._state

--- a/homeassistant/components/binary_sensor/v6m.py
+++ b/homeassistant/components/binary_sensor/v6m.py
@@ -1,0 +1,67 @@
+"""Component to read v6m sensors.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/v6m/
+"""
+import logging
+import voluptuous as vol
+from homeassistant.components.binary_sensor import (
+    BinarySensorDevice, PLATFORM_SCHEMA)
+from homeassistant.components.v6m import (
+    V6MDevice, DOMAIN)
+from homeassistant.const import CONF_SENSORS
+import homeassistant.helpers.config_validation as cv
+
+_LOGGER = logging.getLogger(__name__)
+
+DEPENDENCIES = ['v6m']
+REQUIREMENTS = ['pyv6m==0.0.1']
+
+CONF_CONTROLLER = 'controller'
+CONF_ADDR = 'addr'
+
+SENSOR_SCHEMA = vol.Schema({cv.positive_int: cv.string})
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_CONTROLLER, default=DOMAIN): cv.string,
+    vol.Required(CONF_SENSORS): vol.All(cv.ensure_list, [SENSOR_SCHEMA])
+})
+
+
+def setup_platform(hass, config, add_entities, discover_info=None):
+    """Set up the V6M sensors."""
+    controller_name = config.get(CONF_CONTROLLER)
+    controller = hass.data[controller_name]
+    devs = []
+    for sensor in config.get(CONF_SENSORS):
+        # FIX: This should be done differently
+        for num, name in sensor.items():
+            devs.append(V6MSensor(controller, num, name))
+    add_entities(devs, True)
+    return True
+
+
+class V6MSensor(V6MDevice, BinarySensorDevice):
+    """V6M Sensor."""
+
+    def __init__(self, controller, num, name):
+        """Create sensor with addr and name."""
+        V6MDevice.__init__(self, controller, num, name)
+        self._state = None
+        controller.register_sensor(self)
+
+    @property
+    def is_on(self):
+        """Return state of the sensor."""
+        return self._state
+
+    @property
+    def device_state_attributes(self):
+        """Return supported attributes."""
+        return {"Sensor Number": self.num}
+
+    def callback(self, new_state):
+        """Process state changes."""
+        if self._state != new_state:
+            self._state = new_state
+            return True
+        return False

--- a/homeassistant/components/cover/r2d7.py
+++ b/homeassistant/components/cover/r2d7.py
@@ -1,0 +1,128 @@
+"""Support for r2d7 shade controllers.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/r2d7/
+"""
+import logging
+import voluptuous as vol
+from homeassistant.components.cover import (
+    CoverDevice, SUPPORT_OPEN, SUPPORT_CLOSE, SUPPORT_SET_POSITION,
+    SUPPORT_STOP, ATTR_POSITION, PLATFORM_SCHEMA)
+from homeassistant.const import (
+    EVENT_HOMEASSISTANT_STOP,
+    CONF_HOST, CONF_PORT, CONF_NAME, CONF_ADDRESS, CONF_DEVICES)
+import homeassistant.helpers.config_validation as cv
+
+REQUIREMENTS = ['r2d7py==0.0.1']
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_UNIT = 'unit'
+CONF_DURATION = 'duration'
+CV_DURATION = vol.All(vol.Coerce(float), vol.Range(min=1., max=60.))
+
+DEVICE_SCHEMA = vol.Schema({
+    vol.Required(CONF_NAME): cv.string,
+    vol.Optional(CONF_ADDRESS, default=1): cv.positive_int,
+    vol.Required(CONF_UNIT): cv.positive_int,
+    vol.Required(CONF_DURATION): CV_DURATION,
+})
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_HOST): cv.string,
+    vol.Required(CONF_PORT): cv.port,
+    vol.Required(CONF_DEVICES): vol.All(cv.ensure_list, [DEVICE_SCHEMA])
+})
+
+
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    """Set up the r2d7 shade controller and shades."""
+    from r2d7py.r2d7py import R2D7Hub
+
+    host = config.get(CONF_HOST)
+    port = config.get(CONF_PORT)
+    hub = R2D7Hub(host, port)
+
+    devs = []
+    for device in config.get(CONF_DEVICES):
+        name = device.get(CONF_NAME)
+        addr = device.get(CONF_ADDRESS)
+        unit = device.get(CONF_UNIT)
+        duration = device.get(CONF_DURATION)
+        cover = hub.shade(addr, unit, duration)
+        devs.append(R2D7Cover(cover, name))
+
+    add_entities(devs, True)
+
+    def cleanup(event):
+        hub.close()
+
+    hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, cleanup)
+    return True
+
+
+class R2D7Cover(CoverDevice):
+    """Representation of an R2D7 controlled shade."""
+
+    def __init__(self, cover, name):
+        """Initialize the cover."""
+        self._cover = cover
+        self._name = name
+
+    @property
+    def name(self):
+        """Device name."""
+        return self._name
+
+    @property
+    def device_state_attributes(self):
+        """Return supported attributes."""
+        return {"Addr": self._cover.addr,
+                "Unit": self._cover.unit}
+
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+        return (SUPPORT_OPEN | SUPPORT_CLOSE |
+                SUPPORT_SET_POSITION | SUPPORT_STOP)
+
+    @property
+    def is_closed(self):
+        """Return if the cover is closed."""
+        return self._cover.position < 1
+
+    @property
+    def current_cover_position(self):
+        """Return the current position of cover."""
+        return self._cover.position
+
+    def close_cover(self, **kwargs):
+        """Close the cover."""
+        self._cover.close()
+
+    def open_cover(self, **kwargs):
+        """Open the cover."""
+        self._cover.open()
+
+    def stop_cover(self, **kwargs):
+        """Stop the cover."""
+        self._cover.stop()
+
+    def set_cover_position(self, **kwargs):
+        """Move the shade to a specific position."""
+        if ATTR_POSITION in kwargs:
+            self._cover.position = kwargs[ATTR_POSITION]
+
+    @property
+    def is_opening(self):
+        """Is the cover opening."""
+        return self._cover.is_opening
+
+    @property
+    def is_closing(self):
+        """Is the cover closing."""
+        return self._cover.is_closing
+
+    def update(self):
+        """Call when forcing a refresh of the device."""
+        # FIX: Mark the device as non-polling
+        pass

--- a/homeassistant/components/homeworks.py
+++ b/homeassistant/components/homeworks.py
@@ -1,0 +1,95 @@
+"""Component for interfacing to Lutron Homeworks Series 4 and 8 systems.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/homeworks/
+"""
+import logging
+from homeassistant.const import (
+    EVENT_HOMEASSISTANT_STOP, CONF_HOST, CONF_PORT)
+import homeassistant.helpers.config_validation as cv
+import voluptuous as vol
+
+REQUIREMENTS = ['pyhomeworks==0.0.1']
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = 'homeworks'
+
+HOMEWORKS_CONTROLLER = 'homeworks'
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_HOST): cv.string,
+        vol.Required(CONF_PORT): cv.port,
+    }),
+}, extra=vol.ALLOW_EXTRA)
+
+
+def setup(hass, base_config):
+    """Start Homeworks controller."""
+    from pyhomeworks.pyhomeworks import Homeworks
+
+    class HomeworksController(Homeworks):
+        """Interface between HASS and Homeworks controller."""
+
+        def __init__(self, host, port):
+            """Host and port of Lutron Homeworks controller."""
+            Homeworks.__init__(self, host, port, self._callback)
+            self._subscribers = {}
+
+        def register(self, device):
+            """Add a device to subscribe to events."""
+            if device.addr not in self._subscribers:
+                self._subscribers[device.addr] = []
+            self._subscribers[device.addr].append(device)
+
+        def _callback(self, msg_type, values):
+            _LOGGER.debug('_callback: %s, %s', msg_type, values)
+            addr = values[0]
+            for sub in self._subscribers.get(addr, []):
+                _LOGGER.debug("_callback: %s", sub)
+                if sub.callback(msg_type, values):
+                    sub.schedule_update_ha_state()
+
+    config = base_config.get(DOMAIN)
+    host = config[CONF_HOST]
+    port = config[CONF_PORT]
+
+    controller = HomeworksController(host, port)
+    hass.data[HOMEWORKS_CONTROLLER] = controller
+
+    def cleanup(event):
+        controller.close()
+
+    hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, cleanup)
+    return True
+
+
+class HomeworksDevice():
+    """Base class of a Homeworks device."""
+
+    def __init__(self, controller, addr, name):
+        """Controller, address, and name of the device."""
+        self._addr = addr
+        self._name = name
+        self._controller = controller
+        controller.register(self)
+
+    @property
+    def addr(self):
+        """Device address."""
+        return self._addr
+
+    @property
+    def name(self):
+        """Device name."""
+        return self._name
+
+    @property
+    def should_poll(self):
+        """No need to poll."""
+        return False
+
+    def callback(self, msg_type, values):
+        """Must be replaced with device callbacks."""
+        return False

--- a/homeassistant/components/light/homeworks.py
+++ b/homeassistant/components/light/homeworks.py
@@ -1,0 +1,105 @@
+"""Component for interfacing to Lutron Homeworks lights.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/homeworks/
+"""
+import logging
+from homeassistant.components.homeworks import (
+    HomeworksDevice, HOMEWORKS_CONTROLLER)
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS, SUPPORT_BRIGHTNESS, Light, PLATFORM_SCHEMA)
+from homeassistant.const import CONF_NAME
+import homeassistant.helpers.config_validation as cv
+import voluptuous as vol
+
+DEPENDENCIES = ['homeworks']
+REQUIREMENTS = ['pyhomeworks==0.0.1']
+
+_LOGGER = logging.getLogger(__name__)
+
+FADE_RATE = 2.
+
+CONF_DIMMERS = 'dimmers'
+CONF_ADDR = 'addr'
+CONF_RATE = 'rate'
+
+CV_FADE_RATE = vol.All(vol.Coerce(float), vol.Range(min=0, max=20))
+
+DIMMER_SCHEMA = vol.Schema({
+    vol.Required(CONF_ADDR): cv.string,
+    vol.Required(CONF_NAME): cv.string,
+    vol.Optional(CONF_RATE, default=FADE_RATE): CV_FADE_RATE,
+})
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_DIMMERS): vol.All(cv.ensure_list, [DIMMER_SCHEMA])
+})
+
+
+def setup_platform(hass, config, add_entities, discover_info=None):
+    """Set up the Homeworks lights."""
+    controller = hass.data[HOMEWORKS_CONTROLLER]
+    devs = []
+    for dimmer in config.get(CONF_DIMMERS):
+        dev = HomeworksLight(controller, dimmer[CONF_ADDR],
+                             dimmer[CONF_NAME], dimmer[CONF_RATE])
+        devs.append(dev)
+    add_entities(devs, True)
+    return True
+
+
+class HomeworksLight(HomeworksDevice, Light):
+    """Homeworks Light."""
+
+    def __init__(self, controller, addr, name, rate):
+        """Create device with Addr, name, and rate."""
+        HomeworksDevice.__init__(self, controller, addr, name)
+        self._rate = rate
+        self._level = None
+        self._controller.request_dimmer_level(addr)
+
+    @property
+    def supported_features(self):
+        """Supported features."""
+        return SUPPORT_BRIGHTNESS
+
+    def turn_on(self, **kwargs):
+        """Turn on the light."""
+        if ATTR_BRIGHTNESS in kwargs:
+            self.brightness = kwargs[ATTR_BRIGHTNESS]
+        else:
+            self.brightness = 255
+
+    def turn_off(self, **kwargs):
+        """Turn off the light."""
+        self.brightness = 0
+
+    @property
+    def brightness(self):
+        """Control the brightness."""
+        return self._level
+
+    @brightness.setter
+    def brightness(self, level):
+        self._controller.fade_dim(
+            float((level*100.)/255.), self._rate,
+            0, self._addr)
+        self._level = level
+
+    @property
+    def device_state_attributes(self):
+        """Supported attributes."""
+        return {'Homeworks Address': self._addr}
+
+    @property
+    def is_on(self):
+        """Is the light on/off."""
+        return self._level != 0
+
+    def callback(self, msg_type, values):
+        """Process device specific messages."""
+        from pyhomeworks.pyhomeworks import HW_LIGHT_CHANGED
+
+        if msg_type == HW_LIGHT_CHANGED:
+            self._level = int((values[1] * 255.)/100.)
+            return True
+        return False

--- a/homeassistant/components/sensor/rfk101.py
+++ b/homeassistant/components/sensor/rfk101.py
@@ -1,0 +1,92 @@
+"""Component for reading from RFK101 proximity card readers.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/rfk101/
+"""
+import logging
+import voluptuous as vol
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import (
+    CONF_HOST, CONF_PORT, CONF_NAME, EVENT_HOMEASSISTANT_STOP)
+from homeassistant.helpers.entity import Entity
+
+REQUIREMENTS = ['rfk101py==0.0.1']
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_NAME = "RFK101"
+
+EVENT_KEYCARD = 'keycard'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_HOST): cv.string,
+    vol.Required(CONF_PORT): cv.port,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+})
+
+
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    """Set up the RFK101 platform."""
+    host = config.get(CONF_HOST)
+    port = config.get(CONF_PORT)
+    name = config.get(CONF_NAME)
+
+    try:
+        sensor = RFK101Sensor(host, port, name)
+    except OSError as error:
+        _LOGGER.error("Could not connect to rfk101py. %s", error)
+        return False
+
+    def cleanup(event):
+        sensor.stop()
+
+    hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, cleanup)
+    add_entities([sensor], True)
+    return True
+
+
+class RFK101Sensor(Entity):
+    """Representation of an RFK101 sensor."""
+
+    def __init__(self, host, port, name):
+        """Initialize the sensor."""
+        self._host = host
+        self._port = port
+        self._name = name
+        self._state = None
+        self._connection = None
+
+        from rfk101py.rfk101py import rfk101py
+        self._connection = rfk101py(self._host, self._port, self._callback)
+
+    def _callback(self, card):
+        """Send a keycard event message into HASS."""
+        self.hass.bus.fire(
+                EVENT_KEYCARD, {'card': card, 'entity_id': self.entity_id})
+
+    def stop(self):
+        """Close resources."""
+        if self._connection:
+            self._connection.close()
+            self._connection = None
+
+    @property
+    def device_state_attributes(self):
+        """Return supported attributes."""
+        return {"Host": self._host, "Port": self._port}
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def should_poll(self):
+        """No polling needed."""
+        return False
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state

--- a/homeassistant/components/switch/pencom.py
+++ b/homeassistant/components/switch/pencom.py
@@ -1,0 +1,106 @@
+"""Pencom relay control.
+
+For more details about this component, please refer to the documentation at
+http://home-assistant.io/components/pencom
+"""
+import logging
+
+import voluptuous as vol
+
+# Import the device class from the component that you want to support
+from homeassistant.components.switch import SwitchDevice, PLATFORM_SCHEMA
+from homeassistant.const import CONF_HOST, CONF_PORT, CONF_NAME
+import homeassistant.helpers.config_validation as cv
+
+# Home Assistant depends on 3rd party packages for API specific code.
+REQUIREMENTS = ['pencompy==0.0.2']
+
+_LOGGER = logging.getLogger(__name__)
+
+# Number of boards connected to the serial port
+CONF_BOARDS = 'boards'
+CONF_BOARD = 'board'
+CONF_ADDR = 'addr'
+CONF_RELAYS = 'relays'
+CONF_RELAY = 'relay'
+
+RELAY_SCHEMA = vol.Schema({
+    vol.Required(CONF_NAME): cv.string,
+    vol.Required(CONF_ADDR): cv.positive_int,
+    vol.Optional(CONF_BOARD, default=0): cv.positive_int,
+})
+
+# Validation of the user's configuration
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_HOST): cv.string,
+    vol.Required(CONF_PORT): cv.port,
+    vol.Optional(CONF_BOARDS, default=1): cv.positive_int,
+    vol.Required(CONF_RELAYS): vol.All(cv.ensure_list, [RELAY_SCHEMA]),
+})
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Pencom relay platform (pencompy)."""
+    from pencompy.pencompy import Pencompy
+
+    # Assign configuration variables.
+    host = config.get(CONF_HOST)
+    port = config.get(CONF_PORT)
+    boards = config.get(CONF_BOARDS)
+
+    # Setup connection with devices/cloud.
+    try:
+        hub = Pencompy(host, port, boards=boards)
+    except OSError as error:
+        _LOGGER.error("Could not connect to pencompy: %s", error)
+        return False
+
+    # Add devices.
+    devs = []
+    for relay in config.get(CONF_RELAYS):
+        name = relay.get(CONF_NAME)
+        board = relay.get(CONF_BOARD)
+        addr = relay.get(CONF_ADDR)
+        devs.append(PencomRelay(hub, board, addr, name))
+    add_devices(devs, True)
+    return True
+
+
+class PencomRelay(SwitchDevice):
+    """Representation of a pencom relay."""
+
+    def __init__(self, hub, board, addr, name):
+        """Create a relay."""
+        self._hub = hub
+        self._board = board
+        self._addr = addr
+        self._state = None
+        self._name = name
+
+    @property
+    def name(self):
+        """Relay name."""
+        return self._name
+
+    @property
+    def is_on(self):
+        """Return a relay's state."""
+        return self._state
+
+    def turn_on(self, **kwargs):
+        """Turn a relay on."""
+        self._hub.set(self._board, self._addr, True)
+
+    def turn_off(self, **kwargs):
+        """Turn a relay off."""
+        self._hub.set(self._board, self._addr, False)
+
+    def update(self):
+        """Refresh a relay's state."""
+        self._state = self._hub.get(self._board, self._addr)
+
+    @property
+    def device_state_attributes(self):
+        """Return supported attributes."""
+        return {"Board": self._board,
+                "Addr": self._addr}

--- a/homeassistant/components/switch/v6m.py
+++ b/homeassistant/components/switch/v6m.py
@@ -1,0 +1,76 @@
+"""Component to control v6m relays.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/v6m/
+"""
+import logging
+import voluptuous as vol
+from homeassistant.components.switch import (
+    SwitchDevice, PLATFORM_SCHEMA)
+from homeassistant.components.v6m import (
+    V6MDevice, DOMAIN)
+import homeassistant.helpers.config_validation as cv
+
+_LOGGER = logging.getLogger(__name__)
+
+DEPENDENCIES = ['v6m']
+REQUIREMENTS = ['pyv6m==0.0.1']
+
+CONF_CONTROLLER = 'controller'
+CONF_ADDR = 'addr'
+CONF_RELAYS = 'relays'
+
+
+RELAY_SCHEMA = vol.Schema({cv.positive_int: cv.string})
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_CONTROLLER, default=DOMAIN): cv.string,
+    vol.Required(CONF_RELAYS): vol.All(cv.ensure_list, [RELAY_SCHEMA])
+})
+
+
+def setup_platform(hass, config, add_entities, discover_info=None):
+    """Set up the V6M switches."""
+    controller_name = config.get(CONF_CONTROLLER)
+    controller = hass.data[controller_name]
+    devs = []
+    for relay in config.get(CONF_RELAYS):
+        # FIX: This should be done differently
+        for num, name in relay.items():
+            devs.append(V6MRelay(controller, num, name))
+    add_entities(devs, True)
+    return True
+
+
+class V6MRelay(V6MDevice, SwitchDevice):
+    """V6M Sensor."""
+
+    def __init__(self, controller, num, name):
+        """Create switch with num and name."""
+        V6MDevice.__init__(self, controller, num, name)
+        self._state = None
+        controller.register_relay(self)
+
+    @property
+    def is_on(self):
+        """Return state of the relay."""
+        return self._state
+
+    def turn_on(self):
+        """Turn relay on."""
+        self._controller.set_relay(self.num, True)
+
+    def turn_off(self):
+        """Turn relay off."""
+        self._controller.set_relay(self.num, False)
+
+    @property
+    def device_state_attributes(self):
+        """Return supported attributes."""
+        return {"Sensor Number": self.num}
+
+    def callback(self, new_state):
+        """Process state changes."""
+        if self._state != new_state:
+            self._state = new_state
+            return True
+        return False

--- a/homeassistant/components/v6m.py
+++ b/homeassistant/components/v6m.py
@@ -1,0 +1,104 @@
+"""Component to control v6m relays and sensors.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/v6m/
+"""
+import logging
+import voluptuous as vol
+from homeassistant.const import (
+    EVENT_HOMEASSISTANT_STOP, CONF_HOST, CONF_PORT, CONF_NAME)
+import homeassistant.helpers.config_validation as cv
+
+REQUIREMENTS = ['pyv6m==0.0.1']
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = 'v6m'
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_HOST): cv.string,
+        vol.Required(CONF_PORT): cv.port,
+        vol.Optional(CONF_NAME, default=DOMAIN): cv.string,
+    }),
+}, extra=vol.ALLOW_EXTRA)
+
+
+def setup(hass, base_config):
+    """Start V6M controller."""
+    from pyv6m.pyv6m import V6M
+
+    class V6MController(V6M):
+        """Interface between HASS and V6M controller."""
+
+        def __init__(self, host, port):
+            """Host and port of the controller."""
+            V6M.__init__(self, host, port, self.relay_callback,
+                         self.sensor_callback)
+            self._relay_subs = {}
+            self._sensor_subs = {}
+
+        def register_relay(self, device):
+            """Add a device to subscribe to events."""
+            self._register(self._relay_subs, device)
+
+        def relay_callback(self, num, old_state, new_state):
+            """Process relay states."""
+            self._dispatch(self._relay_subs, num, new_state)
+
+        def register_sensor(self, device):
+            """Add a device to subscribe to events."""
+            self._register(self._sensor_subs, device)
+
+        def sensor_callback(self, num, old_state, new_state):
+            """Process sensor states."""
+            self._dispatch(self._sensor_subs, num, new_state)
+
+        def _register(self, subs, device):
+            if device.num not in subs:
+                subs[device.num] = []
+            subs[device.num].append(device)
+
+        def _dispatch(self, subs, num, new_state):
+            if num in subs:
+                for sub in subs[num]:
+                    if sub.callback(new_state):
+                        sub.schedule_update_ha_state()
+
+    config = base_config.get(DOMAIN)
+    host = config[CONF_HOST]
+    port = config[CONF_PORT]
+
+    controller = V6MController(host, port)
+    hass.data[config[CONF_NAME]] = controller
+
+    def cleanup(event):
+        controller.close()
+
+    hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, cleanup)
+    return True
+
+
+class V6MDevice():
+    """Base class of a V6M device."""
+
+    def __init__(self, controller, num, name):
+        """Controller, address, and name of the device."""
+        self._num = num
+        self._name = name
+        self._controller = controller
+
+    @property
+    def num(self):
+        """Device number."""
+        return self._num
+
+    @property
+    def name(self):
+        """Device name."""
+        return self._name
+
+    @property
+    def should_poll(self):
+        """No need to poll."""
+        return False

--- a/man/man1/nosetests.1
+++ b/man/man1/nosetests.1
@@ -1,0 +1,581 @@
+.\" Man page generated from reStructuredText.
+.
+.TH "NOSETESTS" "1" "April 04, 2015" "1.3" "nose"
+.SH NAME
+nosetests \- Nicer testing for Python
+.
+.nr rst2man-indent-level 0
+.
+.de1 rstReportMargin
+\\$1 \\n[an-margin]
+level \\n[rst2man-indent-level]
+level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
+-
+\\n[rst2man-indent0]
+\\n[rst2man-indent1]
+\\n[rst2man-indent2]
+..
+.de1 INDENT
+.\" .rstReportMargin pre:
+. RS \\$1
+. nr rst2man-indent\\n[rst2man-indent-level] \\n[an-margin]
+. nr rst2man-indent-level +1
+.\" .rstReportMargin post:
+..
+.de UNINDENT
+. RE
+.\" indent \\n[an-margin]
+.\" old: \\n[rst2man-indent\\n[rst2man-indent-level]]
+.nr rst2man-indent-level -1
+.\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
+.in \\n[rst2man-indent\\n[rst2man-indent-level]]u
+..
+.SH NICER TESTING FOR PYTHON
+.SS SYNOPSIS
+.INDENT 0.0
+.INDENT 3.5
+nosetests [options] [names]
+.UNINDENT
+.UNINDENT
+.SS DESCRIPTION
+.sp
+nose collects tests automatically from python source files,
+directories and packages found in its working directory (which
+defaults to the current working directory). Any python source file,
+directory or package that matches the testMatch regular expression
+(by default: \fI(?:^|[b_.\-])[Tt]est)\fP will be collected as a test (or
+source for collection of tests). In addition, all other packages
+found in the working directory will be examined for python source files
+or directories that match testMatch. Package discovery descends all
+the way down the tree, so package.tests and package.sub.tests and
+package.sub.sub2.tests will all be collected.
+.sp
+Within a test directory or package, any python source file matching
+testMatch will be examined for test cases. Within a test module,
+functions and classes whose names match testMatch and TestCase
+subclasses with any name will be loaded and executed as tests. Tests
+may use the assert keyword or raise AssertionErrors to indicate test
+failure. TestCase subclasses may do the same or use the various
+TestCase methods available.
+.sp
+\fBIt is important to note that the default behavior of nose is to
+not include tests from files which are executable.\fP  To include
+tests from such files, remove their executable bit or use
+the \-\-exe flag (see \(aqOptions\(aq section below).
+.SS Selecting Tests
+.sp
+To specify which tests to run, pass test names on the command line:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+nosetests only_test_this.py
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Test names specified may be file or module names, and may optionally
+indicate the test case to run by separating the module or file name
+from the test case name with a colon. Filenames may be relative or
+absolute. Examples:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+nosetests test.module
+nosetests another.test:TestCase.test_method
+nosetests a.test:TestCase
+nosetests /path/to/test/file.py:test_function
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+You may also change the working directory where nose looks for tests
+by using the \-w switch:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+nosetests \-w /path/to/tests
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Note, however, that support for multiple \-w arguments is now deprecated
+and will be removed in a future release. As of nose 0.10, you can get
+the same behavior by specifying the target directories \fIwithout\fP
+the \-w switch:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+nosetests /path/to/tests /another/path/to/tests
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Further customization of test selection and loading is possible
+through the use of plugins.
+.sp
+Test result output is identical to that of unittest, except for
+the additional features (error classes, and plugin\-supplied
+features such as output capture and assert introspection) detailed
+in the options below.
+.SS Configuration
+.sp
+In addition to passing command\-line options, you may also put
+configuration options in your project\(aqs \fIsetup.cfg\fP file, or a .noserc
+or nose.cfg file in your home directory. In any of these standard
+ini\-style config files, you put your nosetests configuration in a
+\fB[nosetests]\fP section. Options are the same as on the command line,
+with the \-\- prefix removed. For options that are simple switches, you
+must supply a value:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+[nosetests]
+verbosity=3
+with\-doctest=1
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+All configuration files that are found will be loaded and their
+options combined. You can override the standard config file loading
+with the \fB\-c\fP option.
+.SS Using Plugins
+.sp
+There are numerous nose plugins available via easy_install and
+elsewhere. To use a plugin, just install it. The plugin will add
+command line options to nosetests. To verify that the plugin is installed,
+run:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+nosetests \-\-plugins
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+You can add \-v or \-vv to that command to show more information
+about each plugin.
+.sp
+If you are running nose.main() or nose.run() from a script, you
+can specify a list of plugins to use by passing a list of plugins
+with the plugins keyword argument.
+.SS 0.9 plugins
+.sp
+nose 1.0 can use SOME plugins that were written for nose 0.9. The
+default plugin manager inserts a compatibility wrapper around 0.9
+plugins that adapts the changed plugin api calls. However, plugins
+that access nose internals are likely to fail, especially if they
+attempt to access test case or test suite classes. For example,
+plugins that try to determine if a test passed to startTest is an
+individual test or a suite will fail, partly because suites are no
+longer passed to startTest and partly because it\(aqs likely that the
+plugin is trying to find out if the test is an instance of a class
+that no longer exists.
+.SS 0.10 and 0.11 plugins
+.sp
+All plugins written for nose 0.10 and 0.11 should work with nose 1.0.
+.SS Options
+.INDENT 0.0
+.TP
+.B \-V, \-\-version
+Output nose version and exit
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-p, \-\-plugins
+Output list of available plugins and exit. Combine with higher verbosity for greater detail
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-v=DEFAULT, \-\-verbose=DEFAULT
+Be more verbose. [NOSE_VERBOSE]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-verbosity=VERBOSITY
+Set verbosity; \-\-verbosity=2 is the same as \-v
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-q=DEFAULT, \-\-quiet=DEFAULT
+Be less verbose
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-c=FILES, \-\-config=FILES
+Load configuration from config file(s). May be specified multiple times; in that case, all config files will be loaded and combined
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-w=WHERE, \-\-where=WHERE
+Look for tests in this directory. May be specified multiple times. The first directory passed will be used as the working directory, in place of the current working directory, which is the default. Others will be added to the list of tests to execute. [NOSE_WHERE]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-py3where=PY3WHERE
+Look for tests in this directory under Python 3.x. Functions the same as \(aqwhere\(aq, but only applies if running under Python 3.x or above.  Note that, if present under 3.x, this option completely replaces any directories specified with \(aqwhere\(aq, so the \(aqwhere\(aq option becomes ineffective. [NOSE_PY3WHERE]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-m=REGEX, \-\-match=REGEX, \-\-testmatch=REGEX
+Files, directories, function names, and class names that match this regular expression are considered tests.  Default: (?:^|[b_./\-])[Tt]est [NOSE_TESTMATCH]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-tests=NAMES
+Run these tests (comma\-separated list). This argument is useful mainly from configuration files; on the command line, just pass the tests to run as additional arguments with no switch.
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-l=DEFAULT, \-\-debug=DEFAULT
+Activate debug logging for one or more systems. Available debug loggers: nose, nose.importer, nose.inspector, nose.plugins, nose.result and nose.selector. Separate multiple names with a comma.
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-debug\-log=FILE
+Log debug messages to this file (default: sys.stderr)
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-logging\-config=FILE, \-\-log\-config=FILE
+Load logging config from this file \-\- bypasses all other logging config settings.
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-I=REGEX, \-\-ignore\-files=REGEX
+Completely ignore any file that matches this regular expression. Takes precedence over any other settings or plugins. Specifying this option will replace the default setting. Specify this option multiple times to add more regular expressions [NOSE_IGNORE_FILES]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-e=REGEX, \-\-exclude=REGEX
+Don\(aqt run tests that match regular expression [NOSE_EXCLUDE]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-i=REGEX, \-\-include=REGEX
+This regular expression will be applied to files, directories, function names, and class names for a chance to include additional tests that do not match TESTMATCH.  Specify this option multiple times to add more regular expressions [NOSE_INCLUDE]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-x, \-\-stop
+Stop running tests after the first error or failure
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-P, \-\-no\-path\-adjustment
+Don\(aqt make any changes to sys.path when loading tests [NOSE_NOPATH]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-exe
+Look for tests in python modules that are executable. Normal behavior is to exclude executable modules, since they may not be import\-safe [NOSE_INCLUDE_EXE]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-noexe
+DO NOT look for tests in python modules that are executable. (The default on the windows platform is to do so.)
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-traverse\-namespace
+Traverse through all path entries of a namespace package
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-first\-package\-wins, \-\-first\-pkg\-wins, \-\-1st\-pkg\-wins
+nose\(aqs importer will normally evict a package from sys.modules if it sees a package with the same name in a different location. Set this option to disable that behavior.
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-no\-byte\-compile
+Prevent nose from byte\-compiling the source into .pyc files while nose is scanning for and running tests.
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-a=ATTR, \-\-attr=ATTR
+Run only tests that have attributes specified by ATTR [NOSE_ATTR]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-A=EXPR, \-\-eval\-attr=EXPR
+Run only tests for whose attributes the Python expression EXPR evaluates to True [NOSE_EVAL_ATTR]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-s, \-\-nocapture
+Don\(aqt capture stdout (any stdout output will be printed immediately) [NOSE_NOCAPTURE]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-nologcapture
+Disable logging capture plugin. Logging configuration will be left intact. [NOSE_NOLOGCAPTURE]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-logging\-format=FORMAT
+Specify custom format to print statements. Uses the same format as used by standard logging handlers. [NOSE_LOGFORMAT]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-logging\-datefmt=FORMAT
+Specify custom date/time format to print statements. Uses the same format as used by standard logging handlers. [NOSE_LOGDATEFMT]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-logging\-filter=FILTER
+Specify which statements to filter in/out. By default, everything is captured. If the output is too verbose,
+use this option to filter out needless output.
+Example: filter=foo will capture statements issued ONLY to
+ foo or foo.what.ever.sub but not foobar or other logger.
+Specify multiple loggers with comma: filter=foo,bar,baz.
+If any logger name is prefixed with a minus, eg filter=\-foo,
+it will be excluded rather than included. Default: exclude logging messages from nose itself (\-nose). [NOSE_LOGFILTER]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-logging\-clear\-handlers
+Clear all other logging handlers
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-logging\-level=DEFAULT
+Set the log level to capture
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-with\-coverage
+Enable plugin Coverage: 
+Activate a coverage report using Ned Batchelder\(aqs coverage module.
+ [NOSE_WITH_COVERAGE]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-cover\-package=PACKAGE
+Restrict coverage output to selected packages [NOSE_COVER_PACKAGE]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-cover\-erase
+Erase previously collected coverage statistics before run
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-cover\-tests
+Include test modules in coverage report [NOSE_COVER_TESTS]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-cover\-min\-percentage=DEFAULT
+Minimum percentage of coverage for tests to pass [NOSE_COVER_MIN_PERCENTAGE]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-cover\-inclusive
+Include all python files under working directory in coverage report.  Useful for discovering holes in test coverage if not all files are imported by the test suite. [NOSE_COVER_INCLUSIVE]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-cover\-html
+Produce HTML coverage information
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-cover\-html\-dir=DIR
+Produce HTML coverage information in dir
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-cover\-branches
+Include branch coverage in coverage report [NOSE_COVER_BRANCHES]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-cover\-xml
+Produce XML coverage information
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-cover\-xml\-file=FILE
+Produce XML coverage information in file
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-pdb
+Drop into debugger on failures or errors
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-pdb\-failures
+Drop into debugger on failures
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-pdb\-errors
+Drop into debugger on errors
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-no\-deprecated
+Disable special handling of DeprecatedTest exceptions.
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-with\-doctest
+Enable plugin Doctest: 
+Activate doctest plugin to find and run doctests in non\-test modules.
+ [NOSE_WITH_DOCTEST]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-doctest\-tests
+Also look for doctests in test modules. Note that classes, methods and functions should have either doctests or non\-doctest tests, not both. [NOSE_DOCTEST_TESTS]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-doctest\-extension=EXT
+Also look for doctests in files with this extension [NOSE_DOCTEST_EXTENSION]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-doctest\-result\-variable=VAR
+Change the variable name set to the result of the last interpreter command from the default \(aq_\(aq. Can be used to avoid conflicts with the _() function used for text translation. [NOSE_DOCTEST_RESULT_VAR]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-doctest\-fixtures=SUFFIX
+Find fixtures for a doctest file in module with this name appended to the base name of the doctest file
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-doctest\-options=OPTIONS
+Specify options to pass to doctest. Eg. \(aq+ELLIPSIS,+NORMALIZE_WHITESPACE\(aq
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-with\-isolation
+Enable plugin IsolationPlugin: 
+Activate the isolation plugin to isolate changes to external
+modules to a single test module or package. The isolation plugin
+resets the contents of sys.modules after each test module or
+package runs to its state before the test. PLEASE NOTE that this
+plugin should not be used with the coverage plugin, or in any other case
+where module reloading may produce undesirable side\-effects.
+ [NOSE_WITH_ISOLATION]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-d, \-\-detailed\-errors, \-\-failure\-detail
+Add detail to error output by attempting to evaluate failed asserts [NOSE_DETAILED_ERRORS]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-with\-profile
+Enable plugin Profile: 
+Use this plugin to run tests using the hotshot profiler. 
+ [NOSE_WITH_PROFILE]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-profile\-sort=SORT
+Set sort order for profiler output
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-profile\-stats\-file=FILE
+Profiler stats file; default is a new temp file on each run
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-profile\-restrict=RESTRICT
+Restrict profiler output. See help for pstats.Stats for details
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-no\-skip
+Disable special handling of SkipTest exceptions.
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-with\-id
+Enable plugin TestId: 
+Activate to add a test id (like #1) to each test name output. Activate
+with \-\-failed to rerun failing tests only.
+ [NOSE_WITH_ID]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-id\-file=FILE
+Store test ids found in test runs in this file. Default is the file .noseids in the working directory.
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-failed
+Run the tests that failed in the last test run.
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-processes=NUM
+Spread test run among this many processes. Set a number equal to the number of processors or cores in your machine for best results. Pass a negative number to have the number of processes automatically set to the number of cores. Passing 0 means to disable parallel testing. Default is 0 unless NOSE_PROCESSES is set. [NOSE_PROCESSES]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-process\-timeout=SECONDS
+Set timeout for return of results from each test runner process. Default is 10. [NOSE_PROCESS_TIMEOUT]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-process\-restartworker
+If set, will restart each worker process once their tests are done, this helps control memory leaks from killing the system. [NOSE_PROCESS_RESTARTWORKER]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-with\-xunit
+Enable plugin Xunit: This plugin provides test results in the standard XUnit XML format. [NOSE_WITH_XUNIT]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-xunit\-file=FILE
+Path to xml file to store the xunit report in. Default is nosetests.xml in the working directory [NOSE_XUNIT_FILE]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-xunit\-testsuite\-name=PACKAGE
+Name of the testsuite in the xunit xml, generated by plugin. Default test suite name is nosetests.
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-all\-modules
+Enable plugin AllModules: Collect tests from all python modules.
+ [NOSE_ALL_MODULES]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-collect\-only
+Enable collect\-only: 
+Collect and output test names only, don\(aqt run any tests.
+ [COLLECT_ONLY]
+.UNINDENT
+.SH AUTHOR
+Nose developers
+.SH COPYRIGHT
+2009, Jason Pellerin
+.\" Generated by docutils manpage writer.
+.

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -689,6 +689,9 @@ panasonic_viera==0.3.1
 # homeassistant.components.media_player.dunehd
 pdunehd==1.3
 
+# homeassistant.components.switch.pencom
+pencompy==0.0.1
+
 # homeassistant.components.device_tracker.aruba
 # homeassistant.components.device_tracker.asuswrt
 # homeassistant.components.device_tracker.cisco_ios
@@ -918,6 +921,11 @@ pyhiveapi==0.2.14
 
 # homeassistant.components.homematic
 pyhomematic==0.1.51
+
+# homeassistant.components.homeworks
+# homeassistant.components.binary_sensor.homeworks
+# homeassistant.components.light.homeworks
+pyhomeworks==0.0.1
 
 # homeassistant.components.sensor.hydroquebec
 pyhydroquebec==2.2.2
@@ -1239,6 +1247,11 @@ pyuptimerobot==0.0.5
 # homeassistant.components.keyboard
 # pyuserinput==0.1.11
 
+# homeassistant.components.v6m
+# homeassistant.components.binary_sensor.v6m
+# homeassistant.components.switch.v6m
+pyv6m==0.0.1
+
 # homeassistant.components.vera
 pyvera==0.2.45
 
@@ -1269,6 +1282,9 @@ qnapstats==0.2.7
 # homeassistant.components.device_tracker.quantum_gateway
 quantum-gateway==0.0.3
 
+# homeassistant.components.cover.r2d7
+r2d7py==0.0.1
+
 # homeassistant.components.rachio
 rachiopy==0.1.3
 
@@ -1286,6 +1302,9 @@ regenmaschine==1.0.2
 
 # homeassistant.components.python_script
 restrictedpython==4.0b5
+
+# homeassistant.components.sensor.rfk101
+rfk101py==0.0.1
 
 # homeassistant.components.rflink
 rflink==0.0.37

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -690,7 +690,7 @@ panasonic_viera==0.3.1
 pdunehd==1.3
 
 # homeassistant.components.switch.pencom
-pencompy==0.0.1
+pencompy==0.0.2
 
 # homeassistant.components.device_tracker.aruba
 # homeassistant.components.device_tracker.asuswrt


### PR DESCRIPTION
## Description:
Added support for new components:
* homeworks - Lutron Homeworks Series 4 & 8 systems.  Lights and keypads are supported.
* rfk101 - IDTECK proximity card reader with keypad.
* r27d - Electronic Solutions shade controller.
* v6m - Import ethernet 8 channel relay and 8 channel sensor.
* pencom - Pencom Design relay controller.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>
Full documentation will be added a little later (tonight or tomorrow).

## Example entry for `configuration.yaml` (if applicable):
```yaml
platform: homeworks
    host: 192.168.1.51
    port: 4001

platform: v6m
    host: 192.168.1.52
    port: 4002

sensor:
  - platform: rfk101
    host: 192.168.1.50
    port: 4008
    name: "Lower Entrance Keypad"

light:
  - platform: homeworks
    dimmers:
      - addr: "[02:08:01:20]"
        name: "Entry light"
      - addr: "[02:08:01:21]"
        name: "Foyer lamp"

binary_sensor:
  - platform: homeworks
    keypads:
      - addr: "[02:08:01:01]"
        name: "Main keypad"
        buttons:
          - 1: "Button 1"
          - 2: "Button 2"
  - platform: v6m
    sensors:
        0: Tripwire
        1: Random sensor

cover:
  - platform: r2d7
    host: 192.168.1.52
    port: 4002
    devices:
      - name: Entry shades
        unit: 8
        duration: 14.2

switch:
  - platform: pencom
    host: 192.168.1.53
    port: 4002
    boards: 1
    relays:
      - name: "Irrigation"
        addr: 0
  - platform: v6m
    relays:
        0: "Alarm bell"
        1: "Siren"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
