### PR TITLE
Flux-led: use None instead of 0 for white

### DIFF
--- a/homeassistant/components/light/flux_led.py
+++ b/homeassistant/components/light/flux_led.py
@@ -266,6 +266,8 @@ class FluxLight(Light):
 
         # handle RGBW mode
         elif self._mode == MODE_RGBW:
+            if white == 0:
+                white = None
             self._bulb.setRgbw(*tuple(rgb), w=white, brightness=brightness)
 
         # handle RGB mode


### PR DESCRIPTION
## Description:
I have several cheap Flux LED bulbs. They do not work properly with the wrapper in this code; I can only set white values and trying to set colors turns the device off. The problem is due to the fact that some of these RGBW bulbs do not support both RGB and W at the same time; i.e. a single packet to the device can either set it to RGB values or W values, but never both. This behavior is controlled by a 1-byte mask in the wire protocol; 'f0' for colors, '0f' for white, and '00' for both. The devices in question do not support '00' and will default to white only if the mask is '00'.

The underlying `flux_led` library accounts for this behavior somewhat; however, Haas passes `0` when white is turned off, but the library expects `None`:
https://github.com/beville/flux_led/blob/c14d4d6c852598853d62f247644a524642f6a125/flux_led/__main__.py#L971

This fix simply passes `None` instead of `0` if the provided white value is 0. This is not a perfect fix, since colors cannot be set on the frontend without first turning white off, but it fixes the issue for any requests where white is set to 0.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable): N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
