### PR TITLE
async_add_job: always return a Future

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -264,7 +264,8 @@ class HomeAssistant:
         elif is_callback(target):
             task = asyncio.Future()
 
-            def _run(fut: asyncio.Future, target: Callable[..., Any], *args: Any) -> Any:
+            def _run(fut: asyncio.Future, target: Callable[..., Any],
+                     *args: Any) -> Any:
                 try:
                     fut.set_result(target(*args))
                 except Exception as exc:

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -262,7 +262,7 @@ class HomeAssistant:
             task = self.loop.create_task(target)  # type: ignore
 
         elif is_callback(target):
-            task = asyncio.Future()
+            task = asyncio.Future(loop=self.loop)
 
             def _run(fut: asyncio.Future, target: Callable[..., Any],
                      *args: Any) -> Any:

--- a/tests/components/test_system_log.py
+++ b/tests/components/test_system_log.py
@@ -145,10 +145,11 @@ async def test_clear_logs(hass, aiohttp_client):
     await async_setup_component(hass, system_log.DOMAIN, BASIC_CONFIG)
     _LOGGER.error('error message')
 
-    hass.async_add_job(
+    fut = hass.async_add_job(
         hass.services.async_call(
-            system_log.DOMAIN, system_log.SERVICE_CLEAR, {}))
-    await hass.async_block_till_done()
+            system_log.DOMAIN, system_log.SERVICE_CLEAR, {},
+            blocking=True))
+    await fut
 
     # Assert done by get_error_log
     await get_error_log(hass, aiohttp_client, 0)


### PR DESCRIPTION
Previously, async_add_job returned a future – or not – depending on the
type of the to-be-called function. That's not a good idea.

This change allows @callback-decorated functions to always return a
value (or raise an exception) which the caller can await.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.
