### PR TITLE
Report *which* component didn't return a bool

### DIFF
--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -160,8 +160,8 @@ async def _async_setup_component(hass: core.HomeAssistant,
         log_error("Component failed to initialize.")
         return False
     if result is not True:
-        log_error("Component did not return boolean if setup was successful. "
-                  "Disabling component.")
+        log_error("Component {!r} did not return boolean if setup was successful. "
+                  "Disabling component.".format(domain))
         loader.set_component(hass, domain, None)
         return False
 

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -160,8 +160,8 @@ async def _async_setup_component(hass: core.HomeAssistant,
         log_error("Component failed to initialize.")
         return False
     if result is not True:
-        log_error("Component {!r} did not return boolean if setup was successful. "
-                  "Disabling component.".format(domain))
+        log_error("Component {!r} did not return boolean if setup was "
+                  "successful. Disabling component.".format(domain))
         loader.set_component(hass, domain, None)
         return False
 


### PR DESCRIPTION
If/when a breaking component returns a non-bool when setting it up, it'd be cool to know *which* component is the culprit.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`.