### PR TITLE
WIP: "owfs" platform: Access 1wire devices via owserver

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -183,6 +183,8 @@ homeassistant/components/*/huawei_lte.py @scop
 # K
 homeassistant/components/knx.py @Julius2342
 homeassistant/components/*/knx.py @Julius2342
+homeassistant/components/owfs.py @Smurfix
+homeassistant/components/*/owfs.py @Smurfix
 homeassistant/components/konnected.py @heythisisnate
 homeassistant/components/*/konnected.py @heythisisnate
 

--- a/homeassistant/components/owfs.py
+++ b/homeassistant/components/owfs.py
@@ -16,23 +16,18 @@ except ImportError:
 
 import voluptuous as vol
 
-from homeassistant.const import (
-    CONF_NAME, CONF_ENTITY_ID, CONF_HOST, CONF_PORT, EVENT_HOMEASSISTANT_STOP)
-from homeassistant.core import callback, HomeAssistant
+from homeassistant.const import (CONF_NAME, CONF_HOST, CONF_PORT,
+                                 EVENT_HOMEASSISTANT_STOP)
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import discovery
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.event import async_track_state_change
-from homeassistant.helpers.script import Script
 
 from trio_owfs import OWFS
-import trio_owfs.service
 from trio_owfs.device import Device as OW_Device
-from trio_owfs.event import ServerRegistered, ServerConnected, ServerDisconnected, \
-    ServerDeregistered, DeviceAdded, DeviceLocated, DeviceNotFound, BusAdded_Path, \
-    BusAdded, BusDeleted, DeviceEvent, DeviceAlarm, DeviceValue
-
-from typing import Optional
+from trio_owfs.event import ServerRegistered, \
+    ServerDeregistered, \
+    DeviceEvent, DeviceAlarm, DeviceValue
 
 positive_float = vol.All(vol.Coerce(float), vol.Range(min=0))
 
@@ -72,73 +67,86 @@ SERVER_SCHEMA = vol.Schema({
     vol.Optional(CONF_SCAN_DELAY): positive_float,
 })
 
-CONFIG_SCHEMA = vol.Schema({
-  DOMAIN: vol.Schema({
-    vol.Required(CONF_OWFS_SERVER):
-        vol.All(
-            cv.ensure_list,
-            [SERVER_SCHEMA]),
+CONFIG_SCHEMA = vol.Schema(
+    {
+        DOMAIN:
+        vol.Schema({
+            vol.Required(CONF_OWFS_SERVER):
+            vol.All(cv.ensure_list, [SERVER_SCHEMA]),
         }),
-}, extra=vol.ALLOW_EXTRA)
+    },
+    extra=vol.ALLOW_EXTRA)
 
 SERVICE_OWFS_SEND_SCHEMA = vol.Schema({
-    vol.Required(SERVICE_OWFS_ADDRESS): cv.string,
-    vol.Required(SERVICE_OWFS_ATTRIBUTE): cv.string,
-    vol.Required(SERVICE_OWFS_VALUE): cv.string,
+    vol.Required(SERVICE_OWFS_ADDRESS):
+    cv.string,
+    vol.Required(SERVICE_OWFS_ATTRIBUTE):
+    cv.string,
+    vol.Required(SERVICE_OWFS_VALUE):
+    cv.string,
 })
 
 SERVICE_OWFS_READ_SCHEMA = vol.Schema({
-    vol.Required(SERVICE_OWFS_ADDRESS): cv.string,
-    vol.Required(SERVICE_OWFS_ATTRIBUTE): cv.string,
+    vol.Required(SERVICE_OWFS_ADDRESS):
+    cv.string,
+    vol.Required(SERVICE_OWFS_ATTRIBUTE):
+    cv.string,
 })
+
 
 def owfs_address(value):
     """Validate an OWFS address."""
     regex = re.compile(r'[0-9A-Fa-f]{2}\.[0-9A-Fa-f]{12}\.[0-9A-Fa-f]{2}$')
     if not regex.match(value):
-        raise vol.Invalid('correct is XX.YYYYYYYYYYYY.ZZ; use "owdir -f f.i.c"')
+        raise vol.Invalid(
+            'correct is XX.YYYYYYYYYYYY.ZZ; use "owdir -f f.i.c"')
     return str(value).upper()
+
 
 KNOWN_POLL_ITEMS = {'alarm', 'temperature', 'voltage', 'attr'}
 
 DEVICE_SCHEMA = vol.Schema({
-    vol.Required(CONF_ADDRESS): owfs_address,
-    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional(CONF_ATTRIBUTE): cv.string,
-    vol.Optional(CONF_POLL): vol.Schema(
-        dict((vol.Optional(k), cv.positive_int) for k in KNOWN_POLL_ITEMS)
-    ),
+    vol.Required(CONF_ADDRESS):
+    owfs_address,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME):
+    cv.string,
+    vol.Optional(CONF_ATTRIBUTE):
+    cv.string,
+    vol.Optional(CONF_POLL):
+    vol.Schema(
+        dict((vol.Optional(k), cv.positive_int) for k in KNOWN_POLL_ITEMS)),
 })
 
 # CLASSES in ha.<PLATFORM>.owfs points to the actual classes to be
 # used. These use the default attribute and thus must not set '_attr'.
-CODEMAP = {
+CODEMAP = {  # family -> default platform
     0x10: 'sensor',
-    0x1F: None, # Buses are handled transparently
-    0x81: None, # ID chips are skipped
+    0x1F: None,  # Buses are handled transparently
+    0x81: None,  # ID chips are skipped
 }
+
 
 async def async_setup(hass, config):
     """Set up the OWFS component."""
     try:
         hass.data[DATA_OWFS] = mod = OWFSModule(hass, config)
-        #hass.data[DATA_OWFS].async_create_exposures()
         await hass.data[DATA_OWFS].start()
 
     except Exception as ex:
         _LOGGER.exception("Can't connect to OWFS interface: %s", repr(ex))
         hass.components.persistent_notification.async_create(
-            "Can't connect to OWFS interface: {0!r}".format(ex),
-            title="OWFS")
+            "Can't connect to OWFS interface: {0!r}".format(ex), title="OWFS")
         return False
 
     hass.services.async_register(
-        DOMAIN, SERVICE_OWFS_SEND,
+        DOMAIN,
+        SERVICE_OWFS_SEND,
         hass.data[DATA_OWFS].service_set_owfs_value,
         schema=SERVICE_OWFS_SEND_SCHEMA)
 
     hass.services.async_register(
-        DOMAIN, SERVICE_OWFS_READ,
+        DOMAIN,
+        SERVICE_OWFS_READ,
         hass.data[DATA_OWFS].service_get_owfs_value,
         schema=SERVICE_OWFS_READ_SCHEMA)
 
@@ -146,9 +154,10 @@ async def async_setup(hass, config):
 
     return True
 
-async def init_devices(hass, domain, config, discovery_info, async_add_entities, classes):
+
+async def init_devices(hass, domain, config, discovery_info,
+                       async_add_entities, classes):
     mod = hass.data[DATA_OWFS]
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
 
     if config:
         assert not discovery_info, discovery_info
@@ -167,13 +176,13 @@ async def init_devices(hass, domain, config, discovery_info, async_add_entities,
         await obj._init(False)
 
         poll = config.get(CONF_POLL, {})
-        for k,v in poll.items():
+        for k, v in poll.items():
             if k == 'attr':
                 obj._do_poll = v
             else:
-                await dev.set_polling_interval(k,v)
+                await dev.set_polling_interval(k, v)
 
-        async_add_entities((obj,))
+        async_add_entities((obj, ))
 
     else:
         objs = []
@@ -202,12 +211,14 @@ class OWFSDevice(Entity):
     _val = None
     _do_poll = 0
     _next_poll = 0
+    _events = None  # list: remembered events
 
-    def __init__(self, hass: HomeAssistant, dev: OW_Device, config: dict={}):
+    def __init__(self, hass: HomeAssistant, dev: OW_Device, config: dict = {}):
         self.hass = hass
         self.dev = dev
+        self._events = None
 
-        name=config.get(CONF_NAME)
+        name = config.get(CONF_NAME)
         if name is None:
             name = "{} {}".format(self.__class__.__name__, dev.id)
         self._name = name
@@ -218,7 +229,7 @@ class OWFSDevice(Entity):
             reg = dev.__objects
         except AttributeError:
             dev.__objects = reg = WeakValueDictionary()
-        attr=config.get(CONF_ATTRIBUTE)
+        attr = config.get(CONF_ATTRIBUTE)
         if attr is None:
             attr = "_default"
         else:
@@ -226,8 +237,12 @@ class OWFSDevice(Entity):
         reg[attr] = self
 
     async def _init(self, without_config: bool):
-        """Async part of device initialization."""
-        pass
+        """Async part of device initialization.
+        This code processes queued events and ensures that no more events
+        may be queued."""
+        events, self._events = self._events, None
+        for e in events:
+            await self.process_event(e)
 
     @property
     def name(self):
@@ -253,7 +268,7 @@ class OWFSDevice(Entity):
         """
         res = self.dev.id
         if self._attr is not None:
-            res += "_" + self._attr.replace('/','_')
+            res += "_" + self._attr.replace('/', '_')
         return res
 
     @property
@@ -266,7 +281,7 @@ class OWFSDevice(Entity):
     def __repr__(self):
         rd = repr(self.dev)[1:]
         if self.name and not self.name.endswith(self.dev.id):
-            rd = self.name+' '+rd
+            rd = self.name + ' ' + rd
         return "<%s:%s>" % (self.__class__.__name__, rd)
 
     async def process_event(self, evt: DeviceEvent):
@@ -275,15 +290,15 @@ class OWFSDevice(Entity):
         If the event is an alarm, trigger a message.
         """
         if isinstance(evt, DeviceAlarm):
-            self.hass.bus.async_fire(EVENT_OWFS_ALARM, {
+            self.hass.bus.async_fire(
+                EVENT_OWFS_ALARM, {
                     SERVICE_OWFS_ADDRESS: evt.device.id,
                     SERVICE_OWFS_RESULTS: evt.device.results,
-                    })
+                })
         elif isinstance(evt, DeviceValue):
             if self._attr is not None and evt.attribute == self._attr:
                 await self.async_update_ha_state()
                 self._val = evt.value
-
 
     async def async_update(self):
         if self.dev.bus is None:
@@ -335,7 +350,8 @@ class OWFSModule:
                     elif isinstance(evt, ServerDeregistered):
                         n_servers -= 1
                         if not n_servers:
-                            _LOGGER.debug("E: all registered servers gone. Exiting.")
+                            _LOGGER.debug(
+                                "E: all registered servers gone. Exiting.")
                             return
 
                     elif isinstance(evt, DeviceEvent):
@@ -343,20 +359,19 @@ class OWFSModule:
                         try:
                             objs = dev._OWFSDevice__objects.values()
                         except AttributeError:
-                            obj = await self.auto_device(evt.device)
-                            if obj is not None:
-                                objs = [obj]
-                            else:
-                                objs = ()
-                        for obj in objs:
-                            await obj.process_event(evt)
+                            await self.auto_device(evt.device)
+                            evt.device.queue_event(evt)
+                        else:
+                            for obj in objs:
+                                await obj.process_event(evt)
 
-                        if isinstance(evt, DeviceValue):
-                            self.hass.bus.async_fire(EVENT_OWFS_VALUE, {
-                                SERVICE_OWFS_ADDRESS: evt.device.id,
-                                SERVICE_OWFS_ATTRIBUTE: evt.attribute,
-                                SERVICE_OWFS_VALUE: evt.value,
-                                })
+                            if isinstance(evt, DeviceValue):
+                                self.hass.bus.async_fire(
+                                    EVENT_OWFS_VALUE, {
+                                        SERVICE_OWFS_ADDRESS: evt.device.id,
+                                        SERVICE_OWFS_ATTRIBUTE: evt.attribute,
+                                        SERVICE_OWFS_VALUE: evt.value,
+                                    })
 
                 except Exception as exc:
                     _LOGGER.exception("While processing %s", repr(evt))
@@ -368,24 +383,17 @@ class OWFSModule:
             return
         elif t is False:
             _LOGGER.warning("Device not handled: %s", repr(dev))
-            obj = UnknownDevice(hass, dev)
-            await obj._init(True)
-            await async_add_entities([obj])
-        else:
-            await discovery.async_load_platform(
-                    self.hass, t, DOMAIN,
-                    { ATTR_DEVICES: [dev] },
-                    None,
-                )
-            return None
-
-        _LOGGER.info("%s device: {}".format(obj))
-        return obj
+        await discovery.async_load_platform(
+            self.hass,
+            t,
+            DOMAIN,
+            {ATTR_DEVICES: [dev]},
+            None,
+        )
 
     async def start(self):
         """Start OWFS service. Connect to servers."""
         hass = self.hass
-        service = hass.data[DATA_OWFS]
 
         evt_start = asyncio.Event()
         self.evt_stop = asyncio.Event()
@@ -397,6 +405,7 @@ class OWFSModule:
 
         def stop_listen(*args, **kwargs):
             self.evt_stop.set()
+
         hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, stop_listen)
 
     async def start_done(self):
@@ -425,31 +434,34 @@ class OWFSModule:
         dev = self.service.get_device(call.data[SERVICE_OWFS_ADDRESS])
         if dev.bus is None:
             _LOGGER.warning("{} is not available".format(dev))
-            return 
+            return
 
         try:
-            await dev.attr_set(*call.data[SERVICE_OWFS_ATTRIBUTE].split('/'),
+            await dev.attr_set(
+                *call.data[SERVICE_OWFS_ATTRIBUTE].split('/'),
                 value=call.data[SERVICE_OWFS_VALUE])
         except Exception as exc:
-            logger.exception("Writing OWFS: %s %s %s", dev,id, call.data[SERVICE_OWFS_ATTRIBUTE], call.data[SERVICE_OWFS_VALUE])
+            _LOGGER.exception("Writing OWFS: %s %s %s", dev, id,
+                              call.data[SERVICE_OWFS_ATTRIBUTE],
+                              call.data[SERVICE_OWFS_VALUE])
 
     async def service_get_owfs_value(self, call):
         """Service for reading an arbitrary OWFS device's attribute"""
         dev = self.service.get_device(call.data[SERVICE_OWFS_ADDRESS])
         if dev.bus is None:
             _LOGGER.warning("{} is not available".format(dev))
-            return 
+            return
 
         try:
-            res = await dev.attr_get(*call.data[SERVICE_OWFS_ATTRIBUTE].split('/'))
+            res = await dev.attr_get(
+                *call.data[SERVICE_OWFS_ATTRIBUTE].split('/'))
         except Exception as exc:
-            logger.exception("Reading OWFS: %s %s", dev,id, call.data[SERVICE_OWFS_ATTRIBUTE])
+            _LOGGER.exception("Reading OWFS: %s %s", dev, id,
+                              call.data[SERVICE_OWFS_ATTRIBUTE])
         else:
-            self.hass.bus.async_fire(EVENT_OWFS_VALUE, {
-                    SERVICE_OWFS_ADDRESS: evt.device.id,
-                    SERVICE_OWFS_ATTRIBUTE: evt.attribute,
-                    SERVICE_OWFS_VALUE: evt.value,
+            self.hass.bus.async_fire(
+                EVENT_OWFS_VALUE, {
+                    SERVICE_OWFS_ADDRESS: dev.id,
+                    SERVICE_OWFS_ATTRIBUTE: call.data[SERVICE_OWFS_ATTRIBUTE],
+                    SERVICE_OWFS_VALUE: res,
                 })
-
-
-

--- a/homeassistant/components/owfs.py
+++ b/homeassistant/components/owfs.py
@@ -1,0 +1,428 @@
+"""
+Connects to the OWFS platform.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/owfs/
+"""
+
+import logging
+import asyncio
+import anyio
+import re
+
+import voluptuous as vol
+
+from homeassistant.const import (
+    CONF_NAME, CONF_ENTITY_ID, CONF_HOST, CONF_PORT, EVENT_HOMEASSISTANT_STOP)
+from homeassistant.core import callback, HomeAssistant
+from homeassistant.helpers import discovery
+from homeassistant.helpers.entity import Entity
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.event import async_track_state_change
+from homeassistant.helpers.script import Script
+
+from trio_owfs import OWFS
+import trio_owfs.service
+from trio_owfs.device import Device as OW_Device
+from trio_owfs.event import ServerRegistered, ServerConnected, ServerDisconnected, \
+    ServerDeregistered, DeviceAdded, DeviceLocated, DeviceNotFound, BusAdded_Path, \
+    BusAdded, BusDeleted, DeviceEvent, DeviceAlarm, DeviceValue
+
+from typing import Optional
+
+positive_float = vol.All(vol.Coerce(float), vol.Range(min=0))
+
+REQUIREMENTS = ['trio_owfs>=0.6.7']
+
+DOMAIN = "owfs"
+DATA_OWFS = "data_owfs"
+
+EVENT_OWFS_ALARM = "owfs.alarm"
+EVENT_OWFS_VALUE = "owfs.value"
+
+CONF_OWFS_SERVER = "server"
+CONF_POLL = "poll"
+CONF_ADDRESS = 'address'
+CONF_TYPE = 'type'
+CONF_SCAN = 'scan'
+CONF_SCAN_DELAY = 'scan_delay'
+
+DEFAULT_NAME = 'OWFS Sensor'
+
+SERVICE_OWFS_SEND = "write"
+SERVICE_OWFS_READ = "read"
+SERVICE_OWFS_ADDRESS = "device"
+SERVICE_OWFS_ATTRIBUTE = "attr"
+SERVICE_OWFS_VALUE = "value"
+SERVICE_OWFS_RESULTS = "results"
+
+ATTR_DEVICES = 'devices'
+
+_LOGGER = logging.getLogger(__name__)
+
+SERVER_SCHEMA = vol.Schema({
+    vol.Required(CONF_HOST): cv.string,
+    vol.Optional(CONF_PORT): cv.port,
+    vol.Optional(CONF_POLL): cv.boolean,
+    vol.Optional(CONF_SCAN): positive_float,
+    vol.Optional(CONF_SCAN_DELAY): positive_float,
+})
+
+CONFIG_SCHEMA = vol.Schema({
+  DOMAIN: vol.Schema({
+    vol.Required(CONF_OWFS_SERVER):
+        vol.All(
+            cv.ensure_list,
+            [SERVER_SCHEMA]),
+        }),
+}, extra=vol.ALLOW_EXTRA)
+
+SERVICE_OWFS_SEND_SCHEMA = vol.Schema({
+    vol.Required(SERVICE_OWFS_ADDRESS): cv.string,
+    vol.Required(SERVICE_OWFS_ATTRIBUTE): cv.string,
+    vol.Required(SERVICE_OWFS_VALUE): cv.string,
+})
+
+SERVICE_OWFS_READ_SCHEMA = vol.Schema({
+    vol.Required(SERVICE_OWFS_ADDRESS): cv.string,
+    vol.Required(SERVICE_OWFS_ATTRIBUTE): cv.string,
+})
+
+def owfs_address(value):
+    """Validate an OWFS address."""
+    regex = re.compile(r'[0-9A-Fa-f]{2}\.[0-9A-Fa-f]{12}\.[0-9A-Fa-f]{2}$')
+    if not regex.match(value):
+        raise vol.Invalid('correct is XX.YYYYYYYYYYYY.ZZ; use "owdir -f f.i.c"')
+    return str(value).upper()
+
+KNOWN_POLL_ITEMS = {'alarm', 'temperature', 'value'}
+
+DEVICE_SCHEMA = vol.Schema({
+    vol.Required(CONF_ADDRESS): owfs_address,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_TYPE): cv.string,
+    vol.Optional(CONF_SCAN): positive_float,
+    vol.Optional(CONF_POLL): vol.Schema(
+        dict((vol.Optional(k), cv.positive_int) for k in KNOWN_POLL_ITEMS)
+    ),
+})
+
+async def async_setup(hass, config):
+    """Set up the OWFS component."""
+    evt = anyio.create_event()
+
+    try:
+        hass.data[DATA_OWFS] = mod = OWFSModule(hass, config)
+        #hass.data[DATA_OWFS].async_create_exposures()
+        await hass.data[DATA_OWFS].start(evt)
+
+    except Exception as ex:
+        _LOGGER.exception("Can't connect to OWFS interface: %s", repr(ex))
+        hass.components.persistent_notification.async_create(
+            "Can't connect to OWFS interface: {0!r}".format(ex),
+            title="OWFS")
+        return False
+
+    codemap = {
+            0x10: 'sensor',
+            0x1F: None, # Buses are handled transparently
+            0x81: None, # ID chips are skipped
+            }
+
+    disc = {} # component: [(device, class)]
+    objs = []
+    for dev in mod.service.devices:
+        t = codemap.get(dev.family, False)
+        if t is None:
+            _LOGGER.info("Ignored device: %s", repr(dev))
+            continue
+        elif t is False:
+            _LOGGER.warning("Device not handled: %s", repr(dev))
+            objs.append(UnknownDevice(hass, dev))
+        else:
+            d = disc.setdefault(t, [])
+            d.append(dev)
+
+    for component, data in disc.items():
+        mod.start_run(discovery.async_load_platform,
+            hass, component, DOMAIN, {
+                ATTR_DEVICES: data,
+            }, config)
+
+    hass.services.async_register(
+        DOMAIN, SERVICE_OWFS_SEND,
+        hass.data[DATA_OWFS].service_set_owfs_value,
+        schema=SERVICE_OWFS_SEND_SCHEMA)
+
+    hass.services.async_register(
+        DOMAIN, SERVICE_OWFS_READ,
+        hass.data[DATA_OWFS].service_get_owfs_value,
+        schema=SERVICE_OWFS_READ_SCHEMA)
+
+    if objs:
+        for obj in objs:
+            self._devices[obj.dev.id] = obj
+        mod.start_run(async_add_entities, objs)
+
+    hass.async_create_task(mod.start_done())
+
+    return True
+
+async def init_devices(hass, domain, config, discovery_info, async_add_entities, classes):
+    mod = hass.data[DATA_OWFS]
+    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+
+    if config:
+        assert not discovery_info, discovery_info
+        dev = mod.service.get_device(config[CONF_ADDRESS])
+        try:
+            cls = classes[dev.family]
+        except KeyError:
+            cls = UnknownDevice
+
+        obj = cls(hass, dev, config=config)
+        mod._add_device(obj)
+        async_add_entities((obj,))
+        poll = config.get('poll', {})
+        for k,v in poll.items():
+            await dev.set_polling_interval(k,v)
+
+    else:
+        objs = []
+        for dev in discovery_info.get('devices', ()):
+            reg = entity_registry.async_get_entity_id(domain, DOMAIN, dev.id)
+            if reg is not None:
+                continue # already known
+            try:
+                cls = classes[dev.family]
+            except KeyError:
+                cls = UnknownDevice
+            else:
+                objs.append(cls(hass, dev))
+        if objs:
+            for obj in objs:
+                mod._add_device(obj)
+            async_add_entities(objs)
+
+
+class OWFSDevice(Entity):
+    """Representation of HomeAssistant's OWFS device"""
+    def __init__(self, hass: HomeAssistant, dev: OW_Device, config: dict={}):
+        self.hass = hass
+        self.dev = dev
+        name=config.get('name')
+        if name is None:
+            name = "{} {}".format(self.__class__.__name__, dev.id)
+        self._name = name
+        self._config = config
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def should_poll(self):
+        """overrides this Entity property.
+        OWFS doesn't require polling by HASS.
+        """
+        return False
+
+    @property
+    def unique_id(self):
+        """overrides this Entity property.
+        Return the OWFS device ID (considered unique).
+        """
+        return self.dev.id
+
+    @property
+    def entity_id(self):
+        """overrides this Entity property.
+        Return the OWFS device ID (considered unique).
+        """
+        try:
+            return self.dev.__entity_id
+        except AttributeError:
+            return None
+    
+    @entity_id.setter
+    def entity_id(self, value):
+        self.dev.__entity_id = value
+
+    @property
+    def available(self):
+        """overrides this Entity property.
+        Returns True if the device's bus address is known.
+        """
+        return self.dev.bus is not None
+
+    def __repr__(self):
+        rd = repr(self.dev)[1:]
+        if self.name and not self.name.endswith(self.dev.id):
+            rd = self.name+' '+rd
+        return "<%s:%s>" % (self.__class__.__name__, rd)
+
+    async def process_event(self, evt: DeviceEvent):
+        """handle an event from OWFS.
+
+        If the event is an alarm, trigger a message.
+        """
+        if isinstance(evt, DeviceAlarm):
+            self.hass.bus.async_fire(EVENT_OWFS_ALARM, {
+                    SERVICE_OWFS_ADDRESS: evt.device.id,
+                    SERVICE_OWFS_RESULTS: evt.device.results,
+                    })
+        elif isinstance(evt, DeviceValue):
+            await self.async_update_ha_state()
+            self.hass.bus.async_fire(EVENT_OWFS_VALUE, {
+                    SERVICE_OWFS_ADDRESS: evt.device.id,
+                    SERVICE_OWFS_ATTRIBUTE: evt.attribute,
+                    SERVICE_OWFS_VALUE: evt.value,
+                    })
+
+
+class UnknownDevice(OWFSDevice, Entity):
+    """This class represents a device without a specialized handler.
+    It is only used for devices that are configured explicitly.
+    """
+    pass
+
+class OWFSModule:
+    """Representation of OWFS connection."""
+
+    def __init__(self, hass, config):
+        """Initialize of OWFS module."""
+        self.hass = hass
+        self.config = config
+        self._devices = {}
+        self._start_count = 0
+        self._start_wait = asyncio.Event()
+
+    async def _start_run(self, proc, args, kwargs):
+        try:
+            await proc(*args, **kwargs)
+        finally:
+            self._start_count -= 1
+            if not self.start_count:
+                self._start_wait.set()
+
+    def start_run(self, proc, *args, **kwargs):
+        """Start a setup task"""
+        self._start_count += 1
+        self.hass.async_create_task(self._start_run, proc, args, kwargs)
+
+    def _add_device(self, obj: OWFSDevice):
+        self._devices[obj.dev.id] = obj
+
+    async def _owfs_service(self, evt_start: asyncio.Event):
+        """Hold the OWFS service"""
+        try:
+            async with OWFS() as service:
+                self.service = service
+                evt_start.set()
+                await self.evt_stop.wait()
+        except Exception as exc:
+            self.service = exc
+            evt_start.set()
+
+    async def _owfs_loop(self):
+        """Listen for OWFS events"""
+        n_servers = 0
+        with self.service.events as eq:
+            async for evt in eq:
+                _LOGGER.debug("E: {}".format(evt))
+
+                if isinstance(evt, ServerRegistered):
+                    n_servers += 1
+
+                elif isinstance(evt, ServerDeregistered):
+                    n_servers -= 1
+                    if not n_servers:
+                        _LOGGER.debug("E: all registered servers gone. Exiting.")
+                        return
+
+                elif isinstance(evt, DeviceEvent):
+                    dev = self._devices.get(evt.device.id)
+                    if dev is None:
+                        dev = await self.auto_device(evt.device)
+                    if dev is not None:
+                        await dev.process_event(evt)
+
+    async def auto_device(self, device: OW_Device):
+        _LOGGER.info("Unknown device: {}".format(device))
+
+    async def start(self, ready: Optional[anyio.abc.Event] = None):
+        """Start OWFS service. Connect to servers."""
+        hass = self.hass
+        service = hass.data[DATA_OWFS]
+
+        evt_start = asyncio.Event()
+        self.evt_stop = asyncio.Event()
+        hass.loop.create_task(self._owfs_service(evt_start))
+        await evt_start.wait()
+        if isinstance(self.service, Exception):
+            raise self.service
+        hass.loop.create_task(self._owfs_loop())
+
+        def stop_listen(*args, **kwargs):
+            self.evt_stop.set()
+        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, stop_listen)
+
+    async def start_done(self):
+        """Actually start the server connections, and poll"""
+        if self._start_count > 0:
+            await self._start_wait.wait()
+
+        for s in self.config[DOMAIN][CONF_OWFS_SERVER]:
+            sd = {'host': s[CONF_HOST]}
+            if 'CONF_PORT' in s:
+                sd['port'] = s[CONF_PORT]
+            if 'CONF_SCAN' in s:
+                sd['scan'] = s[CONF_SCAN]
+            if 'CONF_SCAN_DELAY' in s:
+                sd['initial_scan'] = s[CONF_SCAN_DELAY]
+            if 'CONF_POLL' in s:
+                sd['polling'] = s[CONF_POLL]
+            if 'CONF_SCAN' in s:
+                scan = s[CONF_SCAN]
+                if scan == -1:
+                    scan = None
+                sd['scan'] = scan
+            await self.service.add_server(**sd)
+
+    async def stop(self, event):
+        """Stop OWFFS service. Disconnect from servers."""
+        self.evt_stop.set()
+
+    async def service_set_owfs_value(self, call):
+        """Service for setting an arbitrary OWFS device's attribute."""
+        dev = self.service.get_device(call.data[SERVICE_OWFS_ADDRESS])
+        if dev.bus is None:
+            _LOGGER.warning("{} is not available".format(dev))
+            return 
+
+        try:
+            await dev.attr_set(*call.data[SERVICE_OWFS_ATTRIBUTE].split('/'),
+                value=call.data[SERVICE_OWFS_VALUE])
+        except Exception as exc:
+            logger.exception("Writing OWFS: %s %s %s", dev,id, call.data[SERVICE_OWFS_ATTRIBUTE], call.data[SERVICE_OWFS_VALUE])
+
+    async def service_get_owfs_value(self, call):
+        """Service for reading an arbitrary OWFS device's attribute"""
+        dev = self.service.get_device(call.data[SERVICE_OWFS_ADDRESS])
+        if dev.bus is None:
+            _LOGGER.warning("{} is not available".format(dev))
+            return 
+
+        try:
+            res = await dev.attr_get(*call.data[SERVICE_OWFS_ATTRIBUTE].split('/'))
+        except Exception as exc:
+            logger.exception("Reading OWFS: %s %s", dev,id, call.data[SERVICE_OWFS_ATTRIBUTE])
+        else:
+            self.hass.bus.async_fire(EVENT_OWFS_VALUE, {
+                    SERVICE_OWFS_ADDRESS: evt.device.id,
+                    SERVICE_OWFS_ATTRIBUTE: evt.attribute,
+                    SERVICE_OWFS_VALUE: evt.value,
+                })
+
+
+

--- a/homeassistant/components/owfs.py
+++ b/homeassistant/components/owfs.py
@@ -25,7 +25,7 @@ import homeassistant.helpers.config_validation as cv
 
 positive_float = vol.All(vol.Coerce(float), vol.Range(min=0))
 
-REQUIREMENTS = ['trio_owfs>=0.6.7']
+REQUIREMENTS = ['trio_owfs==0.6.7']
 
 DOMAIN = "owfs"
 DATA_OWFS = "data_owfs"

--- a/homeassistant/components/sensor/owfs.py
+++ b/homeassistant/components/sensor/owfs.py
@@ -5,32 +5,30 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.owfs/
 """
 
-import voluptuous as vol
 from datetime import timedelta
 
-from homeassistant.core import HomeAssistant
-from homeassistant.components.owfs import ATTR_DEVICES, DATA_OWFS, \
-     OWFSDevice, init_devices, DEVICE_SCHEMA
+from homeassistant.components.owfs import (OWFSDevice, init_devices,
+                                           DEVICE_SCHEMA)
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import CONF_NAME
-from homeassistant.core import callback
-import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.entity import Entity
 
-from trio_owfs.device import Device as OW_Device
 from trio_owfs.event import DeviceValue
 
 DEPENDENCIES = ['owfs']
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(DEVICE_SCHEMA.schema)
 
-SCAN_INTERVAL = timedelta(minutes=5) # default; don't do it too often, may be expensive
+SCAN_INTERVAL = timedelta(
+    minutes=5)  # default; don't do it too often, may be expensive
 
-async def async_setup_platform(hass, config, async_add_entities,
+
+async def async_setup_platform(hass,
+                               config,
+                               async_add_entities,
                                discovery_info=None):
     """Set up sensor(s) for OWFS platform."""
 
-    await init_devices(hass, 'sensor', config, discovery_info, async_add_entities, CLASSES)
+    await init_devices(hass, 'sensor', config, discovery_info,
+                       async_add_entities, CLASSES)
 
 
 class TemperatureSensor(OWFSDevice):
@@ -43,7 +41,7 @@ class TemperatureSensor(OWFSDevice):
         """Async part of device initialization."""
         await super()._init(without_config)
         if without_config:
-            await self.dev.set_polling_interval("temperature",30)
+            await self.dev.set_polling_interval("temperature", 30)
 
     async def process_event(self, event):
         if isinstance(event, DeviceValue) and \
@@ -67,7 +65,7 @@ class TemperatureSensor(OWFSDevice):
         """Return the state attributes."""
         return None  # XXX
 
+
 CLASSES = {
     0x10: TemperatureSensor,
 }
-

--- a/homeassistant/components/sensor/owfs.py
+++ b/homeassistant/components/sensor/owfs.py
@@ -1,0 +1,61 @@
+"""
+Support for OWFS sensors.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.owfs/
+"""
+
+import voluptuous as vol
+
+from homeassistant.components.owfs import ATTR_DEVICES, DATA_OWFS, \
+     OWFSDevice, init_devices, DEVICE_SCHEMA
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import CONF_NAME
+from homeassistant.core import callback
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import Entity
+
+from trio_owfs.event import DeviceValue
+
+DEPENDENCIES = ['owfs']
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(DEVICE_SCHEMA.schema)
+
+async def async_setup_platform(hass, config, async_add_entities,
+                               discovery_info=None):
+    """Set up sensor(s) for OWFS platform."""
+
+    await init_devices(hass, 'sensor', config, discovery_info, async_add_entities, CLASSES)
+
+
+class TemperatureSensor(OWFSDevice):
+    """Representation of an OWFS temperature sensor."""
+
+    temperature = None
+
+    async def process_event(self, event):
+        if isinstance(event, DeviceValue) and \
+                event.attribute in {'temperature', 'latesttemp'}:
+            self.temperature = event.value
+
+        await super().process_event(event)
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self.temperature
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit this state is expressed in."""
+        return "°C"
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        return None  # XXX
+
+CLASSES = {
+    0x10: TemperatureSensor,
+}
+

--- a/homeassistant/components/sensor/owfs.py
+++ b/homeassistant/components/sensor/owfs.py
@@ -11,8 +11,6 @@ from homeassistant.components.owfs import (OWFSDevice, init_devices,
                                            DEVICE_SCHEMA)
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 
-from trio_owfs.event import DeviceValue
-
 DEPENDENCIES = ['owfs']
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(DEVICE_SCHEMA.schema)
@@ -44,6 +42,8 @@ class TemperatureSensor(OWFSDevice):
             await self.dev.set_polling_interval("temperature", 30)
 
     async def process_event(self, event):
+        from trio_owfs.event import DeviceValue
+
         if isinstance(event, DeviceValue) and \
                 event.attribute in {'temperature', 'latesttemp'}:
             self.temperature = event.value

--- a/homeassistant/components/services.yaml
+++ b/homeassistant/components/services.yaml
@@ -590,3 +590,27 @@ nest:
       trip_id:
         description: Optional identity of a trip. Using the same trip_ID will update the estimation.
         example: trip_back_home
+
+owfs:
+  read:
+    description: Read a value. The data will be returned in an "owfs.value" event.
+    fields:
+      address:
+        description: The OWFS device address to read from.
+        example: '10.123456789ABC.DE'
+      attr:
+        description: The device attribute to read.
+        example: 'latesttemp'
+  write:
+    description: Write a value to an OWFS device.
+    fields:
+      address:
+        description: The OWFS device address to write to.
+        example: '10.123456789ABC.DE'
+      attr:
+        description: The device attribute to write.
+        example: temphigh
+      value:
+        description: The data to write.
+        example: 95
+

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -694,10 +694,6 @@ openhomedevice==0.4.2
 # homeassistant.components.switch.orvibo
 orvibo==1.1.1
 
-# homeassistant.components.owfs
-# homeassistant.components.*.owfs
-trio_owfs==0.6.7
-
 # homeassistant.components.mqtt
 # homeassistant.components.shiftr
 paho-mqtt==1.4.0
@@ -1508,6 +1504,9 @@ tplink==0.2.1
 # homeassistant.components.sensor.transmission
 # homeassistant.components.switch.transmission
 transmissionrpc==0.11
+
+# homeassistant.components.owfs
+trio_owfs==0.6.7
 
 # homeassistant.components.tuya
 tuyapy==0.1.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -694,6 +694,10 @@ openhomedevice==0.4.2
 # homeassistant.components.switch.orvibo
 orvibo==1.1.1
 
+# homeassistant.components.owfs
+# homeassistant.components.*.owfs
+trio_owfs==0.6.7
+
 # homeassistant.components.mqtt
 # homeassistant.components.shiftr
 paho-mqtt==1.4.0


### PR DESCRIPTION
## Description:

This PR contains a replacement for the "onewire" platform. It talks to one or more owserver processes, instead of doing the bus access itself.

Advantages:
* works with all device attributes, auto-discovered by reading the owserver `/structure` data
* works with arbitrarily many owserver instances
* reconnects on connection loss
* auto-creates entities for all discovered devices
* transparently accesses 1wire slaves "hidden" behind DS2409 bus multiplexers
* can support binary sensors and switches and whatnot (planned)
* supports non-bus-blocking temperature conversion on 18B20 temperature sensors
* easily add new components (IMHO)
* `trio-owfs` has "real" tests, based on a mock 1wire server; I will add appropriate tests to HASS

This PR is a work in progress; it's not yet ready for merging, mainly because the `trio-owfs` library used to access the owserver depends on the `anyio` module, which does not yet have a usable stable release – but also because this is my first major HASS contribution and I'd like feedback.

Open question: shall the existing `onewire` platform be removed, and this one be renamed to "onewire"? "owfs" is a bit cryptic, two platform that do the same thing are not a good idea, and I'd like to note that, besides the missing features, `onewire` uses file system level access (either sysfs or a FUSE mountpoint) which is not thread safe and might block the reading indefinitely. If you agree, I would of course add a "how to convert" section to the documentation.

**Related issue (if applicable): pr#14616 (adds switches for existing onewire platform, which this PR would eventually supersede)

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable): (documentation mostly written but not yet pushed)

## Example entry for `configuration.yaml` (if applicable):
```yaml
owfs:
  server:
  - host: ow.my.example
    scan: 30
    scan_delay: 2

sensor room_temp:
    platform: owfs
    name: room_temp
    address: 10.717AE1010800.9F
    poll:
        temperature: 10
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.
