### PR TITLE
Add Xiaomi Air Purifier 2s support

### DIFF
--- a/homeassistant/components/fan/xiaomi_miio.py
+++ b/homeassistant/components/fan/xiaomi_miio.py
@@ -48,6 +48,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
          'zhimi.airpurifier.v3',
          'zhimi.airpurifier.v5',
          'zhimi.airpurifier.v6',
+         'zhimi.airpurifier.mc1',
          'zhimi.humidifier.v1',
          'zhimi.humidifier.ca1',
          'zhimi.airfresh.va2']),


### PR DESCRIPTION
A new model/hardware (Xiaomi Air Purifier 2s: zhimi.airpurifier.mc1) revision has shown up: https://github.com/rytilahti/python-miio/issues/403