### PR TITLE
Add iAlarm "triggered" support

### DIFF
--- a/homeassistant/components/alarm_control_panel/ialarm.py
+++ b/homeassistant/components/alarm_control_panel/ialarm.py
@@ -12,10 +12,10 @@ import homeassistant.components.alarm_control_panel as alarm
 from homeassistant.components.alarm_control_panel import PLATFORM_SCHEMA
 from homeassistant.const import (
     CONF_HOST, CONF_NAME, CONF_PASSWORD, CONF_USERNAME, STATE_ALARM_ARMED_AWAY,
-    STATE_ALARM_ARMED_HOME, STATE_ALARM_DISARMED)
+    STATE_ALARM_ARMED_HOME, STATE_ALARM_DISARMED, STATE_ALARM_TRIGGERED)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['pyialarm==0.2']
+REQUIREMENTS = ['pyialarm==0.3']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -89,6 +89,8 @@ class IAlarmPanel(alarm.AlarmControlPanel):
             state = STATE_ALARM_ARMED_AWAY
         elif status == self._client.ARMED_STAY:
             state = STATE_ALARM_ARMED_HOME
+        elif status == self._client.TRIGGERED:
+            state = STATE_ALARM_TRIGGERED
         else:
             state = None
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -947,7 +947,7 @@ pyhomematic==0.1.51
 pyhydroquebec==2.2.2
 
 # homeassistant.components.alarm_control_panel.ialarm
-pyialarm==0.2
+pyialarm==0.3
 
 # homeassistant.components.device_tracker.icloud
 pyicloud==0.9.1


### PR DESCRIPTION
## Description:

Add the "triggered" state handling for Antifurto365 iAlarm alarm systems.


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
