### PR TITLE
Adjusted KNX component to Home Assistant's changes to light colors

### DIFF
--- a/homeassistant/components/light/knx.py
+++ b/homeassistant/components/light/knx.py
@@ -88,7 +88,6 @@ class KNXLight(Light):
         """Register callbacks to update hass after device was changed."""
         async def after_update_callback(device):
             """Call after device was updated."""
-            # pylint: disable=unused-argument
             await self.async_update_ha_state()
         self.device.register_device_updated_cb(after_update_callback)
 

--- a/homeassistant/components/light/knx.py
+++ b/homeassistant/components/light/knx.py
@@ -114,9 +114,9 @@ class KNXLight(Light):
     def brightness(self):
         """Return the brightness of this light between 0..255."""
         if self.device.supports_color:
-            return max(self.device.current_color) \
-                if self.device.current_color is not None else \
-                DEFAULT_BRIGHTNESS
+            if self.device.current_color is None:
+                return DEFAULT_BRIGHTNESS
+            return max(self.device.current_color)
         if self.device.supports_brightness:
             return self.device.current_brightness
         return None
@@ -126,8 +126,9 @@ class KNXLight(Light):
         """Return the HS color value."""
         if self.device.supports_color:
             rgb = self.device.current_color
-            return color_util.color_RGB_to_hs(*rgb) \
-                if rgb is not None else DEFAULT_COLOR
+            if rgb is None:
+                return DEFAULT_COLOR
+            return color_util.color_RGB_to_hs(*rgb)
         return None
 
     @property

--- a/homeassistant/components/light/knx.py
+++ b/homeassistant/components/light/knx.py
@@ -115,18 +115,20 @@ class KNXLight(Light):
     def brightness(self):
         """Return the brightness of this light between 0..255."""
         if self.device.supports_color:
-            return max(self.device.current_color) if self.device.current_color is not None else DEFAULT_BRIGHTNESS
+            return max(self.device.current_color) \
+                if self.device.current_color is not None else \
+                DEFAULT_BRIGHTNESS
         elif self.device.supports_brightness:
             return self.device.current_brightness
-        else:
-            return None
+        return None
 
     @property
     def hs_color(self):
         """Return the HS color value."""
         if self.device.supports_color:
             rgb = self.device.current_color
-            return color_util.color_RGB_to_hs(*rgb) if rgb is not None else DEFAULT_COLOR
+            return color_util.color_RGB_to_hs(*rgb) \
+                if rgb is not None else DEFAULT_COLOR
         return None
 
     @property
@@ -166,19 +168,28 @@ class KNXLight(Light):
 
     async def async_turn_on(self, **kwargs):
         """Turn the light on."""
-        brightness = int(kwargs[ATTR_BRIGHTNESS]) if ATTR_BRIGHTNESS in kwargs else self.brightness
-        hs_color = kwargs[ATTR_HS_COLOR] if ATTR_HS_COLOR in kwargs else self.hs_color
+        brightness = int(kwargs[ATTR_BRIGHTNESS]) \
+            if ATTR_BRIGHTNESS in kwargs else \
+            self.brightness
+        hs_color = kwargs[ATTR_HS_COLOR] \
+            if ATTR_HS_COLOR in kwargs else \
+            self.hs_color
 
         update_color = ATTR_HS_COLOR in kwargs
         update_brightness = ATTR_BRIGHTNESS in kwargs
 
-        # always only go one path for turning on (avoid conflicting changes and weird effects)
-        if self.device.supports_brightness and (update_brightness and not update_color):
-            # if we don't need to update the color, try updating brightness directly if supported
+        # always only go one path for turning on (avoid conflicting changes
+        # and weird effects)
+        if self.device.supports_brightness and \
+                (update_brightness and not update_color):
+            # if we don't need to update the color, try updating brightness
+            # directly if supported
             await self.device.set_brightness(brightness)
-        elif self.device.supports_color and (update_brightness or update_color):
+        elif self.device.supports_color and \
+                (update_brightness or update_color):
             # change RGB color (includes brightness)
-            await self.device.set_color(color_util.color_hsv_to_RGB(*hs_color, brightness * 100 / 255))
+            await self.device.set_color(
+                color_util.color_hsv_to_RGB(*hs_color, brightness * 100 / 255))
         else:
             # no color/brightness change, so just turn it on
             await self.device.set_on()

--- a/homeassistant/components/light/knx.py
+++ b/homeassistant/components/light/knx.py
@@ -183,7 +183,8 @@ class KNXLight(Light):
         if self.device.supports_brightness and \
                 (update_brightness and not update_color):
             # if we don't need to update the color, try updating brightness
-            # directly if supported
+            # directly if supported; don't do it if color also has to be changed,
+            # as RGB color implicitly sets the brightness as well
             await self.device.set_brightness(brightness)
         elif self.device.supports_color and \
                 (update_brightness or update_color):
@@ -191,7 +192,7 @@ class KNXLight(Light):
             await self.device.set_color(
                 color_util.color_hsv_to_RGB(*hs_color, brightness * 100 / 255))
         else:
-            # no color/brightness change, so just turn it on
+            # no color/brightness change requested, so just turn it on
             await self.device.set_on()
 
     async def async_turn_off(self, **kwargs):

--- a/homeassistant/components/light/knx.py
+++ b/homeassistant/components/light/knx.py
@@ -168,7 +168,6 @@ class KNXLight(Light):
 
     async def async_turn_on(self, **kwargs):
         """Turn the light on."""
-
         # initialize with current values
         brightness = self.brightness
         hs_color = self.hs_color

--- a/homeassistant/components/light/knx.py
+++ b/homeassistant/components/light/knx.py
@@ -193,8 +193,8 @@ class KNXLight(Light):
         if self.device.supports_brightness and \
                 (update_brightness and not update_color):
             # if we don't need to update the color, try updating brightness
-            # directly if supported; don't do it if color also has to be changed,
-            # as RGB color implicitly sets the brightness as well
+            # directly if supported; don't do it if color also has to be
+            # changed, as RGB color implicitly sets the brightness as well
             await self.device.set_brightness(brightness)
         elif self.device.supports_color and \
                 (update_brightness or update_color):

--- a/homeassistant/components/light/knx.py
+++ b/homeassistant/components/light/knx.py
@@ -118,7 +118,7 @@ class KNXLight(Light):
             return max(self.device.current_color) \
                 if self.device.current_color is not None else \
                 DEFAULT_BRIGHTNESS
-        elif self.device.supports_brightness:
+        if self.device.supports_brightness:
             return self.device.current_brightness
         return None
 


### PR DESCRIPTION
This is a follow-up on the (closed) PR #16056 - I believe the mentioned concerns have been addressed.

- Use HS color instead of RGB.
- As HS doesn't include brightness, offer setting brightness for colored lights directly.
- Added support for brightness & color being set simultaneously (even though that should be a rare case).
- If both brightness_address and color_address are configured then changing the brightness will use the dedicated brightness_address, except if the color is to be changed at the exact same time.
- When the light is turned off, KNX devices typically report back #000000 for the RGB color, so the last set color is lost. If there is no dedicated brightness_address configured, then turning the light on via setting a new brightness will cause the color to be reset to white (dimming up from #000000 = black). Future changes can include HSV support, which does not suffer from this problem.

