### PR TITLE
Migrate python-openzwave to homeassistant-pyozw

### DIFF
--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -42,7 +42,7 @@ from .discovery_schemas import DISCOVERY_SCHEMAS
 from .util import (check_node_schema, check_value_schema, node_name,
                    check_has_unique_id, is_node_parsed)
 
-REQUIREMENTS = ['pydispatcher==2.0.5', 'python_openzwave==0.4.11']
+REQUIREMENTS = ['pydispatcher==2.0.5', 'homeassistant-pyozw==0.1.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -478,6 +478,9 @@ hole==0.3.0
 # homeassistant.components.binary_sensor.workday
 holidays==0.9.8
 
+# homeassistant.components.zwave
+homeassistant-pyozw==0.1.0
+
 # homeassistant.components.frontend
 home-assistant-frontend==20181103.1
 
@@ -1232,9 +1235,6 @@ python-wink==1.10.1
 
 # homeassistant.components.sensor.swiss_public_transport
 python_opendata_transport==0.1.4
-
-# homeassistant.components.zwave
-python_openzwave==0.4.11
 
 # homeassistant.components.egardia
 pythonegardia==1.0.39

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -478,11 +478,11 @@ hole==0.3.0
 # homeassistant.components.binary_sensor.workday
 holidays==0.9.8
 
-# homeassistant.components.zwave
-homeassistant-pyozw==0.1.0
-
 # homeassistant.components.frontend
 home-assistant-frontend==20181103.1
+
+# homeassistant.components.zwave
+homeassistant-pyozw==0.1.0
 
 # homeassistant.components.homekit_controller
 # homekit==0.10


### PR DESCRIPTION
## Description:

We use our fork for openzwave to fix some issue and feature requests.

- https://github.com/home-assistant/open-zwave/tree/hass
- https://github.com/home-assistant/python-openzwave/tree/hass
