### PR TITLE
Add new launch sensor to keep track of space launches.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -715,6 +715,7 @@ omit =
     homeassistant/components/sensor/kwb.py
     homeassistant/components/sensor/lacrosse.py
     homeassistant/components/sensor/lastfm.py
+    homeassistant/components/sensor/launch.py
     homeassistant/components/sensor/linky.py
     homeassistant/components/sensor/linux_battery.py
     homeassistant/components/sensor/loopenergy.py

--- a/homeassistant/components/sensor/launch.py
+++ b/homeassistant/components/sensor/launch.py
@@ -92,6 +92,7 @@ class LaunchSensor(Entity):
         """Return attributes for the sensor."""
         return self._attributes
 
+
 class LaunchData():
     """Get the latest data and update the states."""
 

--- a/homeassistant/components/sensor/launch.py
+++ b/homeassistant/components/sensor/launch.py
@@ -38,7 +38,7 @@ async def async_setup_platform(
     name = config[CONF_NAME]
 
     session = async_get_clientsession(hass)
-    launches = LaunchData(Launches(hass.loop, session))
+    launches = Launches(hass.loop, session)
     sensor = [LaunchSensor(launches, name)]
     async_add_entities(sensor, True)
 
@@ -55,12 +55,12 @@ class LaunchSensor(Entity):
 
     async def async_update(self):
         """Get the latest data."""
-        await self.launches.async_update()
-        if self.launches.api.launches is None:
+        await self.launches.get_launches()
+        if self.launches.launches is None:
             _LOGGER.error("No data recieved.")
             return
         try:
-            data = self.launches.api.launches[0]
+            data = self.launches.launches[0]
             self._state = data['name']
             self._attributes['launch_time'] = data['start']
             self._attributes['agency'] = data['agency']
@@ -90,15 +90,3 @@ class LaunchSensor(Entity):
     def device_state_attributes(self):
         """Return attributes for the sensor."""
         return self._attributes
-
-
-class LaunchData():
-    """Get the latest data and update the states."""
-
-    def __init__(self, api):
-        """Initialize the data object."""
-        self.api = api
-
-    async def async_update(self):
-        """Get the latest launch data."""
-        await self.api.get_launches()

--- a/homeassistant/components/sensor/launch.py
+++ b/homeassistant/components/sensor/launch.py
@@ -15,11 +15,11 @@ from homeassistant.const import ATTR_ATTRIBUTION, CONF_NAME
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-REQUIREMENTS = ['pylaunches==0.1.1']
+REQUIREMENTS = ['pylaunches==0.1.2']
 
 _LOGGER = logging.getLogger(__name__)
 
-CONF_ATTRIBUTION = "Data provided by Launch Library."
+ATTRIBUTION = "Data provided by Launch Library."
 
 DEFAULT_NAME = 'Launch'
 
@@ -57,17 +57,17 @@ class LaunchSensor(Entity):
         """Get the latest data."""
         await self.launches.get_launches()
         if self.launches.launches is None:
-            _LOGGER.error("No data recieved.")
+            _LOGGER.error("No data recieved")
             return
         try:
             data = self.launches.launches[0]
             self._state = data['name']
             self._attributes['launch_time'] = data['start']
             self._attributes['agency'] = data['agency']
-            self._attributes['agency_country_code'] = (data
-                                                       ['agency_country_code'])
+            agency_country_code = data['agency_country_code']
+            self._attributes['agency_country_code'] = agency_country_code
             self._attributes['stream'] = data['stream']
-            self._attributes[ATTR_ATTRIBUTION] = CONF_ATTRIBUTION
+            self._attributes[ATTR_ATTRIBUTION] = ATTRIBUTION
         except (KeyError, IndexError) as error:
             _LOGGER.debug("Error getting data, %s", error)
 

--- a/homeassistant/components/sensor/launch.py
+++ b/homeassistant/components/sensor/launch.py
@@ -1,0 +1,84 @@
+"""
+A sensor platform that give you information about the next space launch.
+
+For more details about this platform, please refer to the documentation at
+https://www.home-assistant.io/components/sensor.launch/
+"""
+import logging
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import CONF_NAME
+from homeassistant.helpers.entity import Entity
+
+REQUIREMENTS = ['pylaunches==0.0.2']
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_NAME = 'Launch'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    })
+
+
+async def async_setup_platform(
+        hass, config, async_add_entities, discovery_info=None):
+    """Create the launch sensor."""
+    from pylaunches.api import Launches
+
+    name = config[CONF_NAME]
+
+    launches = Launches(hass.loop)
+    sensor = [LaunchSensor(launches, name)]
+    async_add_entities(sensor, True)
+
+
+class LaunchSensor(Entity):
+    """Representation of a launch Sensor."""
+
+    def __init__(self, launches, name):
+        """Initialize the sensor."""
+        self.launches = launches
+        self._attributes = {}
+        self._name = name
+        self._state = None
+
+    async def async_update(self):
+        """Get the latest data."""
+        await self.launches.get_launches()
+        if self.launches.launches is None:
+            _LOGGER.error("No data recieved.")
+            return
+        try:
+            data = self.launches.launches[0]
+            self._state = data['name']
+            self._attributes['launch_time'] = data['start']
+            self._attributes['agency'] = data['agency']
+            self._attributes['agency_country_code'] = (data
+                                                       ['agency_country_code'])
+            self._attributes['stream'] = data['stream']
+        except (KeyError, IndexError) as error:
+            _LOGGER.debug("Error getting data, %s", error)
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def icon(self):
+        """Return the icon of the sensor."""
+        return 'mdi:rocket'
+
+    @property
+    def device_state_attributes(self):
+        """Return attributes for the sensor."""
+        return self._attributes

--- a/homeassistant/components/sensor/launch.py
+++ b/homeassistant/components/sensor/launch.py
@@ -14,7 +14,6 @@ from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import ATTR_ATTRIBUTION, CONF_NAME
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.util import Throttle
 
 REQUIREMENTS = ['pylaunches==0.1.1']
 
@@ -24,7 +23,7 @@ CONF_ATTRIBUTION = "Data provided by Launch Library."
 
 DEFAULT_NAME = 'Launch'
 
-TIME_BETWEEN_UPDATES = timedelta(hours=1)
+SCAN_INTERVAL = timedelta(hours=1)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
@@ -100,7 +99,6 @@ class LaunchData():
         """Initialize the data object."""
         self.api = api
 
-    @Throttle(TIME_BETWEEN_UPDATES)
     async def async_update(self):
         """Get the latest launch data."""
         await self.api.get_launches()

--- a/homeassistant/components/sensor/launch.py
+++ b/homeassistant/components/sensor/launch.py
@@ -10,12 +10,14 @@ import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import CONF_NAME
+from homeassistant.const import ATTR_ATTRIBUTION, CONF_NAME
 from homeassistant.helpers.entity import Entity
 
 REQUIREMENTS = ['pylaunches==0.0.2']
 
 _LOGGER = logging.getLogger(__name__)
+
+CONF_ATTRIBUTION = "Data provided by Launch Library."
 
 DEFAULT_NAME = 'Launch'
 
@@ -60,6 +62,7 @@ class LaunchSensor(Entity):
             self._attributes['agency_country_code'] = (data
                                                        ['agency_country_code'])
             self._attributes['stream'] = data['stream']
+            self._attributes[ATTR_ATTRIBUTION] = CONF_ATTRIBUTION
         except (KeyError, IndexError) as error:
             _LOGGER.debug("Error getting data, %s", error)
 

--- a/homeassistant/components/sensor/launch.py
+++ b/homeassistant/components/sensor/launch.py
@@ -4,6 +4,7 @@ A sensor platform that give you information about the next space launch.
 For more details about this platform, please refer to the documentation at
 https://www.home-assistant.io/components/sensor.launch/
 """
+from datetime import timedelta
 import logging
 
 import voluptuous as vol
@@ -12,14 +13,18 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import ATTR_ATTRIBUTION, CONF_NAME
 from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.util import Throttle
 
-REQUIREMENTS = ['pylaunches==0.0.2']
+REQUIREMENTS = ['pylaunches==0.1.1']
 
 _LOGGER = logging.getLogger(__name__)
 
 CONF_ATTRIBUTION = "Data provided by Launch Library."
 
 DEFAULT_NAME = 'Launch'
+
+TIME_BETWEEN_UPDATES = timedelta(hours=1)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
@@ -33,7 +38,8 @@ async def async_setup_platform(
 
     name = config[CONF_NAME]
 
-    launches = Launches(hass.loop)
+    session = async_get_clientsession(hass)
+    launches = LaunchData(Launches(hass.loop, session))
     sensor = [LaunchSensor(launches, name)]
     async_add_entities(sensor, True)
 
@@ -50,12 +56,12 @@ class LaunchSensor(Entity):
 
     async def async_update(self):
         """Get the latest data."""
-        await self.launches.get_launches()
-        if self.launches.launches is None:
+        await self.launches.async_update()
+        if self.launches.api.launches is None:
             _LOGGER.error("No data recieved.")
             return
         try:
-            data = self.launches.launches[0]
+            data = self.launches.api.launches[0]
             self._state = data['name']
             self._attributes['launch_time'] = data['start']
             self._attributes['agency'] = data['agency']
@@ -85,3 +91,15 @@ class LaunchSensor(Entity):
     def device_state_attributes(self):
         """Return attributes for the sensor."""
         return self._attributes
+
+class LaunchData():
+    """Get the latest data and update the states."""
+
+    def __init__(self, api):
+        """Initialize the data object."""
+        self.api = api
+
+    @Throttle(TIME_BETWEEN_UPDATES)
+    async def async_update(self):
+        """Get the latest launch data."""
+        await self.api.get_launches()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -958,7 +958,7 @@ pylacrosse==0.3.1
 pylast==2.4.0
 
 # homeassistant.components.sensor.launch
-pylaunches==0.0.2
+pylaunches==0.1.1
 
 # homeassistant.components.media_player.lg_netcast
 pylgnetcast-homeassistant==0.2.0.dev0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -957,6 +957,9 @@ pylacrosse==0.3.1
 # homeassistant.components.sensor.lastfm
 pylast==2.4.0
 
+# homeassistant.components.sensor.launch
+pylaunches==0.0.2
+
 # homeassistant.components.media_player.lg_netcast
 pylgnetcast-homeassistant==0.2.0.dev0
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -958,7 +958,7 @@ pylacrosse==0.3.1
 pylast==2.4.0
 
 # homeassistant.components.sensor.launch
-pylaunches==0.1.1
+pylaunches==0.1.2
 
 # homeassistant.components.media_player.lg_netcast
 pylgnetcast-homeassistant==0.2.0.dev0


### PR DESCRIPTION
## Description:

Adda a new sensor to show the next upcoming space launch 🚀 

![image](https://user-images.githubusercontent.com/15093472/48085131-bf74a880-e1f9-11e8-99f7-f9d2aef89aba.png)

<!-- **Related issue (if applicable):** fixes #<home-assistant issue number goes here> -->

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#7397

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  platform: launch
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

<!--If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works. -->

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
