### PR TITLE
Add icon to Darksky summary sensors

### DIFF
--- a/homeassistant/components/sensor/darksky.py
+++ b/homeassistant/components/sensor/darksky.py
@@ -135,16 +135,26 @@ SENSOR_TYPES = {
 }
 
 CONDITION_PICTURES = {
-    'clear-day': '/static/images/darksky/weather-sunny.svg',
-    'clear-night': '/static/images/darksky/weather-night.svg',
-    'rain': '/static/images/darksky/weather-pouring.svg',
-    'snow': '/static/images/darksky/weather-snowy.svg',
-    'sleet': '/static/images/darksky/weather-hail.svg',
-    'wind': '/static/images/darksky/weather-windy.svg',
-    'fog': '/static/images/darksky/weather-fog.svg',
-    'cloudy': '/static/images/darksky/weather-cloudy.svg',
-    'partly-cloudy-day': '/static/images/darksky/weather-partlycloudy.svg',
-    'partly-cloudy-night': '/static/images/darksky/weather-cloudy.svg',
+    'clear-day': ['/static/images/darksky/weather-sunny.svg',
+                  'mdi:weather-sunny'],
+    'clear-night': ['/static/images/darksky/weather-night.svg',
+                    'mdi:weather-sunny'],
+    'rain': ['/static/images/darksky/weather-pouring.svg',
+             'mdi:weather-pouring'],
+    'snow': ['/static/images/darksky/weather-snowy.svg',
+             'mdi:weather-snowy'],
+    'sleet': ['/static/images/darksky/weather-hail.svg',
+              'mdi:weather-snowy-rainy'],
+    'wind': ['/static/images/darksky/weather-windy.svg',
+             'mdi:weather-windy'],
+    'fog': ['/static/images/darksky/weather-fog.svg',
+            'mdi:weather-fog'],
+    'cloudy': ['/static/images/darksky/weather-cloudy.svg',
+               'mdi:weather-cloudy'],
+    'partly-cloudy-day': ['/static/images/darksky/weather-partlycloudy.svg',
+                          'mdi:weather-partlycloudy'],
+    'partly-cloudy-night': ['/static/images/darksky/weather-cloudy.svg',
+                            'mdi:weather-partlycloudy'],
 }
 
 # Language Supported Codes
@@ -259,7 +269,7 @@ class DarkSkySensor(Entity):
             return None
 
         if self._icon in CONDITION_PICTURES:
-            return CONDITION_PICTURES[self._icon]
+            return CONDITION_PICTURES[self._icon][0]
 
         return None
 
@@ -277,6 +287,9 @@ class DarkSkySensor(Entity):
     @property
     def icon(self):
         """Icon to use in the frontend, if any."""
+        if 'summary' in self.type and self._icon in CONDITION_PICTURES:
+            return CONDITION_PICTURES[self._icon][1]
+
         return SENSOR_TYPES[self.type][6]
 
     @property


### PR DESCRIPTION
## Description:
Some cards in HA show entity's icon instead of entity picture (e.g. `type: sensor` in Lovelace UI). This change sets icon for summary sensors using the same logic as used for their entity picture.

![image](https://user-images.githubusercontent.com/857627/48087777-7b38d680-e200-11e8-86c3-3dbff72304d7.png)

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] There is no commented out code in this PR.