### PR TITLE
Make flux switch async

### DIFF
--- a/homeassistant/components/switch/flux.py
+++ b/homeassistant/components/switch/flux.py
@@ -19,7 +19,7 @@ from homeassistant.components.switch import DOMAIN, SwitchDevice
 from homeassistant.const import (
     ATTR_ENTITY_ID, CONF_NAME, CONF_PLATFORM, CONF_LIGHTS, CONF_MODE,
     SERVICE_TURN_ON, SUN_EVENT_SUNRISE, SUN_EVENT_SUNSET)
-from homeassistant.helpers.event import track_time_interval
+from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.sun import get_astral_event_date
 from homeassistant.util import slugify
 from homeassistant.util.color import (
@@ -67,7 +67,7 @@ PLATFORM_SCHEMA = vol.Schema({
 })
 
 
-def set_lights_xy(hass, lights, x_val, y_val, brightness, transition):
+async def async_set_lights_xy(hass, lights, x_val, y_val, brightness, transition):
     """Set color of array of lights."""
     for light in lights:
         if is_on(hass, light):
@@ -79,11 +79,11 @@ def set_lights_xy(hass, lights, x_val, y_val, brightness, transition):
                 service_data[ATTR_WHITE_VALUE] = brightness
             if transition is not None:
                 service_data[ATTR_TRANSITION] = transition
-            hass.services.call(
+            await hass.services.async_call(
                 LIGHT_DOMAIN, SERVICE_TURN_ON, service_data)
 
 
-def set_lights_temp(hass, lights, mired, brightness, transition):
+async def async_set_lights_temp(hass, lights, mired, brightness, transition):
     """Set color of array of lights."""
     for light in lights:
         if is_on(hass, light):
@@ -94,11 +94,11 @@ def set_lights_temp(hass, lights, mired, brightness, transition):
                 service_data[ATTR_BRIGHTNESS] = brightness
             if transition is not None:
                 service_data[ATTR_TRANSITION] = transition
-            hass.services.call(
+            await hass.services.async_call(
                 LIGHT_DOMAIN, SERVICE_TURN_ON, service_data)
 
 
-def set_lights_rgb(hass, lights, rgb, transition):
+async def async_set_lights_rgb(hass, lights, rgb, transition):
     """Set color of array of lights."""
     for light in lights:
         if is_on(hass, light):
@@ -107,11 +107,11 @@ def set_lights_rgb(hass, lights, rgb, transition):
                 service_data[ATTR_RGB_COLOR] = rgb
             if transition is not None:
                 service_data[ATTR_TRANSITION] = transition
-            hass.services.call(
+            await hass.services.async_call(
                 LIGHT_DOMAIN, SERVICE_TURN_ON, service_data)
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the Flux switches."""
     name = config.get(CONF_NAME)
     lights = config.get(CONF_LIGHTS)
@@ -129,14 +129,14 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                       start_colortemp, sunset_colortemp, stop_colortemp,
                       brightness, disable_brightness_adjust, mode, interval,
                       transition)
-    add_entities([flux])
+    async_add_entities([flux])
 
-    def update(call=None):
+    async def async_update(call=None):
         """Update lights."""
-        flux.flux_update()
+        await flux.async_flux_update()
 
     service_name = slugify("{} {}".format(name, 'update'))
-    hass.services.register(DOMAIN, service_name, update)
+    hass.services.async_register(DOMAIN, service_name, async_update)
 
 
 class FluxSwitch(SwitchDevice):
@@ -172,30 +172,30 @@ class FluxSwitch(SwitchDevice):
         """Return true if switch is on."""
         return self.unsub_tracker is not None
 
-    def turn_on(self, **kwargs):
+    async def async_turn_on(self, **kwargs):
         """Turn on flux."""
         if self.is_on:
             return
 
         # Make initial update
-        self.flux_update()
+        await self.async_flux_update()
 
-        self.unsub_tracker = track_time_interval(
+        self.unsub_tracker = async_track_time_interval(
             self.hass,
-            self.flux_update,
+            self.async_flux_update,
             datetime.timedelta(seconds=self._interval))
 
-        self.schedule_update_ha_state()
+        self.async_schedule_update_ha_state()
 
-    def turn_off(self, **kwargs):
+    async def async_turn_off(self, **kwargs):
         """Turn off flux."""
-        if self.unsub_tracker is not None:
+        if self.is_on:
             self.unsub_tracker()
             self.unsub_tracker = None
 
-        self.schedule_update_ha_state()
+        self.async_schedule_update_ha_state()
 
-    def flux_update(self, utcnow=None):
+    async def async_flux_update(self, utcnow=None):
         """Update all the lights using flux."""
         if utcnow is None:
             utcnow = dt_utcnow()
@@ -258,21 +258,21 @@ class FluxSwitch(SwitchDevice):
         if self._disable_brightness_adjust:
             brightness = None
         if self._mode == MODE_XY:
-            set_lights_xy(self.hass, self._lights, x_val,
+            await async_set_lights_xy(self.hass, self._lights, x_val,
                           y_val, brightness, self._transition)
             _LOGGER.info("Lights updated to x:%s y:%s brightness:%s, %s%% "
                          "of %s cycle complete at %s", x_val, y_val,
                          brightness, round(
                              percentage_complete * 100), time_state, now)
         elif self._mode == MODE_RGB:
-            set_lights_rgb(self.hass, self._lights, rgb, self._transition)
+            await async_set_lights_rgb(self.hass, self._lights, rgb, self._transition)
             _LOGGER.info("Lights updated to rgb:%s, %s%% "
                          "of %s cycle complete at %s", rgb,
                          round(percentage_complete * 100), time_state, now)
         else:
             # Convert to mired and clamp to allowed values
             mired = color_temperature_kelvin_to_mired(temp)
-            set_lights_temp(self.hass, self._lights, mired, brightness,
+            await async_set_lights_temp(self.hass, self._lights, mired, brightness,
                             self._transition)
             _LOGGER.info("Lights updated to mired:%s brightness:%s, %s%% "
                          "of %s cycle complete at %s", mired, brightness,

--- a/homeassistant/components/switch/flux.py
+++ b/homeassistant/components/switch/flux.py
@@ -67,7 +67,8 @@ PLATFORM_SCHEMA = vol.Schema({
 })
 
 
-async def async_set_lights_xy(hass, lights, x_val, y_val, brightness, transition):
+async def async_set_lights_xy(hass, lights, x_val, y_val, brightness,
+                              transition):
     """Set color of array of lights."""
     for light in lights:
         if is_on(hass, light):
@@ -111,7 +112,8 @@ async def async_set_lights_rgb(hass, lights, rgb, transition):
                 LIGHT_DOMAIN, SERVICE_TURN_ON, service_data)
 
 
-async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_entities,
+                               discovery_info=None):
     """Set up the Flux switches."""
     name = config.get(CONF_NAME)
     lights = config.get(CONF_LIGHTS)
@@ -265,15 +267,16 @@ class FluxSwitch(SwitchDevice):
                          brightness, round(
                              percentage_complete * 100), time_state, now)
         elif self._mode == MODE_RGB:
-            await async_set_lights_rgb(self.hass, self._lights, rgb, self._transition)
+            await async_set_lights_rgb(self.hass, self._lights, rgb,
+                            self._transition)
             _LOGGER.info("Lights updated to rgb:%s, %s%% "
                          "of %s cycle complete at %s", rgb,
                          round(percentage_complete * 100), time_state, now)
         else:
             # Convert to mired and clamp to allowed values
             mired = color_temperature_kelvin_to_mired(temp)
-            await async_set_lights_temp(self.hass, self._lights, mired, brightness,
-                            self._transition)
+            await async_set_lights_temp(self.hass, self._lights, mired,
+                            brightness, self._transition)
             _LOGGER.info("Lights updated to mired:%s brightness:%s, %s%% "
                          "of %s cycle complete at %s", mired, brightness,
                          round(percentage_complete * 100), time_state, now)

--- a/homeassistant/components/switch/flux.py
+++ b/homeassistant/components/switch/flux.py
@@ -261,7 +261,7 @@ class FluxSwitch(SwitchDevice):
             brightness = None
         if self._mode == MODE_XY:
             await async_set_lights_xy(self.hass, self._lights, x_val,
-                          y_val, brightness, self._transition)
+                                      y_val, brightness, self._transition)
             _LOGGER.info("Lights updated to x:%s y:%s brightness:%s, %s%% "
                          "of %s cycle complete at %s", x_val, y_val,
                          brightness, round(

--- a/homeassistant/components/switch/flux.py
+++ b/homeassistant/components/switch/flux.py
@@ -268,7 +268,7 @@ class FluxSwitch(SwitchDevice):
                              percentage_complete * 100), time_state, now)
         elif self._mode == MODE_RGB:
             await async_set_lights_rgb(self.hass, self._lights, rgb,
-                            self._transition)
+                                       self._transition)
             _LOGGER.info("Lights updated to rgb:%s, %s%% "
                          "of %s cycle complete at %s", rgb,
                          round(percentage_complete * 100), time_state, now)
@@ -276,7 +276,7 @@ class FluxSwitch(SwitchDevice):
             # Convert to mired and clamp to allowed values
             mired = color_temperature_kelvin_to_mired(temp)
             await async_set_lights_temp(self.hass, self._lights, mired,
-                            brightness, self._transition)
+                                        brightness, self._transition)
             _LOGGER.info("Lights updated to mired:%s brightness:%s, %s%% "
                          "of %s cycle complete at %s", mired, brightness,
                          round(percentage_complete * 100), time_state, now)

--- a/homeassistant/components/switch/flux.py
+++ b/homeassistant/components/switch/flux.py
@@ -179,13 +179,13 @@ class FluxSwitch(SwitchDevice):
         if self.is_on:
             return
 
-        # Make initial update
-        await self.async_flux_update()
-
         self.unsub_tracker = async_track_time_interval(
             self.hass,
             self.async_flux_update,
             datetime.timedelta(seconds=self._interval))
+
+        # Make initial update
+        await self.async_flux_update()
 
         self.async_schedule_update_ha_state()
 


### PR DESCRIPTION
## Description:
Updates the `switch.flux` component to be async.

I had an automation that was triggered by both home assistant start and when the automation itself was turned on as I wanted it to re-run when reloading automations (see below).

Upon startup, this automation would be triggered so quickly in succession that there was a race condition setting `self.unsub_tracker` in `FluxSwitch.turn_on`. This would result in two trackers running, one that could never be turned off. This caused lights to still be modified by the fluxer even after the component was supposed to be off.

Making the component async fixes this race condition.

## Example entry for `configuration.yaml` (if applicable):
```yaml
switch:
  - platform: flux
    name: Bedroom Fluxer
    lights:
      - light.bedroom
    mode: mired
    start_time: '6:00'
    stop_time: '22:00'
    start_colortemp: 4000
    sunset_colortemp: 3000
    stop_colortemp: 1700
  - platform: flux
    name: Closet Fluxer
    lights:
      - light.closet
    mode: mired
    start_time: '6:00'
    stop_time: '22:00'
    start_colortemp: 4000
    sunset_colortemp: 3000
    stop_colortemp: 1900
  - platform: flux
    name: Bathroom Fluxer
    lights:
      - light.bathroom
    mode: mired
    start_time: '6:00'
    stop_time: '22:00'
    start_colortemp: 3500
    sunset_colortemp: 3000
    stop_colortemp: 1900
automation old:
  - alias: Home Assistant Start
    trigger:
      - platform: homeassistant
        event: start
      - platform: state
        entity_id: automation.home_assistant_start
        to: 'on'
    action:
      - service: automation.turn_off
        entity_id: automation.home_assistant_start
      - service: switch.turn_on
        entity_id:
          - switch.bedroom_fluxer
          - switch.closet_fluxer
          - switch.bathroom_fluxer
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
