### PR TITLE
Guard against older pysma, #18099 checked only for no pysma

### DIFF
--- a/homeassistant/components/sensor/sma.py
+++ b/homeassistant/components/sensor/sma.py
@@ -37,11 +37,11 @@ def _check_sensor_schema(conf):
     """Check sensors and attributes are valid."""
     try:
         import pysma
-    except ImportError:
+        valid = [s.name for s in pysma.SENSORS]
+    except (ImportError, AttributeError):
         return conf
 
-    valid = list(conf[CONF_CUSTOM].keys())
-    valid.extend([s.name for s in pysma.SENSORS])
+    valid.extend(conf[CONF_CUSTOM].keys())
     for sname, attrs in conf[CONF_SENSORS].items():
         if sname not in valid:
             raise vol.Invalid("{} does not exist".format(sname))


### PR DESCRIPTION
## Description:
Guard against older pysma, #18099 checked only for no pysma

`pysma.SENSORS` introduced in the latest library, allows to only specify sensors in one place and not duplicate in hass component.

Reported on discord, even after 0.82.b2:
```bash
File "/srv/homeassistant/lib/python3.6/site-packages/homeassistant/components/sensor/sma.py", line 44, in _check_sensor_schema
    valid.extend([s.name for s in pysma.SENSORS])
AttributeError: module 'pysma' has no attribute 'SENSORS'
  File "/srv/homeassistant/lib/python3.6/site-packages/homeassistant/components/sensor/sma.py", line 44, in _check_sensor_schema
    valid.extend([s.name for s in pysma.SENSORS])
```

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platorm: sma
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
