### PR TITLE
UniFi - Work around User input malformed issue with config flow

### DIFF
--- a/homeassistant/components/unifi/.translations/en.json
+++ b/homeassistant/components/unifi/.translations/en.json
@@ -6,6 +6,7 @@
         },
         "error": {
             "faulty_credentials": "Bad user credentials",
+            "port_invalid": "Port must be an integer",
             "service_unavailable": "No service available"
         },
         "step": {

--- a/homeassistant/components/unifi/__init__.py
+++ b/homeassistant/components/unifi/__init__.py
@@ -18,7 +18,7 @@ from .controller import UniFiController, get_controller
 from .errors import (
     AlreadyConfigured, AuthenticationRequired, CannotConnect, UserLevel)
 
-DEFAULT_PORT = 8443
+DEFAULT_PORT = '8443'
 DEFAULT_SITE_ID = 'default'
 DEFAULT_VERIFY_SSL = False
 
@@ -98,7 +98,7 @@ class UnifiFlowHandler(config_entries.ConfigFlow):
                     CONF_HOST: user_input[CONF_HOST],
                     CONF_USERNAME: user_input[CONF_USERNAME],
                     CONF_PASSWORD: user_input[CONF_PASSWORD],
-                    CONF_PORT: user_input.get(CONF_PORT),
+                    CONF_PORT: int(user_input.get(CONF_PORT)),
                     CONF_VERIFY_SSL: user_input.get(CONF_VERIFY_SSL),
                     CONF_SITE_ID: DEFAULT_SITE_ID,
                 }
@@ -107,6 +107,9 @@ class UnifiFlowHandler(config_entries.ConfigFlow):
                 self.sites = await controller.sites()
 
                 return await self.async_step_site()
+
+            except ValueError:
+                errors['base'] = 'port_invalid'
 
             except AuthenticationRequired:
                 errors['base'] = 'faulty_credentials'
@@ -126,7 +129,7 @@ class UnifiFlowHandler(config_entries.ConfigFlow):
                 vol.Required(CONF_HOST): str,
                 vol.Required(CONF_USERNAME): str,
                 vol.Required(CONF_PASSWORD): str,
-                vol.Optional(CONF_PORT, default=DEFAULT_PORT): int,
+                vol.Optional(CONF_PORT, default=DEFAULT_PORT): str,
                 vol.Optional(
                     CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): bool,
             }),

--- a/homeassistant/components/unifi/strings.json
+++ b/homeassistant/components/unifi/strings.json
@@ -16,6 +16,7 @@
         },
         "error": {
             "faulty_credentials": "Bad user credentials",
+            "port_invalid": "Port must be an integer",
             "service_unavailable": "No service available"
         },
         "abort": {

--- a/tests/components/unifi/test_init.py
+++ b/tests/components/unifi/test_init.py
@@ -288,11 +288,31 @@ async def test_user_credentials_faulty(hass, aioclient_mock):
             unifi.CONF_HOST: '1.2.3.4',
             unifi.CONF_USERNAME: 'username',
             unifi.CONF_PASSWORD: 'password',
+            unifi.CONF_PORT: '8443',
             unifi.CONF_SITE_ID: 'default',
         })
 
     assert result['type'] == 'form'
     assert result['errors'] == {'base': 'faulty_credentials'}
+
+
+async def test_port_invalid(hass, aioclient_mock):
+    """Test config flow."""
+    flow = unifi.UnifiFlowHandler()
+    flow.hass = hass
+
+    with patch.object(unifi, 'get_controller',
+                      side_effect=unifi.errors.AuthenticationRequired):
+        result = await flow.async_step_user({
+            unifi.CONF_HOST: '1.2.3.4',
+            unifi.CONF_USERNAME: 'username',
+            unifi.CONF_PASSWORD: 'password',
+            unifi.CONF_PORT: 's',
+            unifi.CONF_SITE_ID: 'default',
+        })
+
+    assert result['type'] == 'form'
+    assert result['errors'] == {'base': 'port_invalid'}
 
 
 async def test_controller_is_unavailable(hass, aioclient_mock):
@@ -306,6 +326,7 @@ async def test_controller_is_unavailable(hass, aioclient_mock):
             unifi.CONF_HOST: '1.2.3.4',
             unifi.CONF_USERNAME: 'username',
             unifi.CONF_PASSWORD: 'password',
+            unifi.CONF_PORT: '8443',
             unifi.CONF_SITE_ID: 'default',
         })
 


### PR DESCRIPTION
## Description:
For some reason config flow doesn't work properly with integers, instead generating a "User input malformed" message first time trying to validate input.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.
