### PR TITLE
Added support for Lutron Homeworks systems.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -154,6 +154,9 @@ omit =
     homeassistant/components/homematicip_cloud.py
     homeassistant/components/*/homematicip_cloud.py
 
+    homeassistant/components/homeworks.py
+    homeassistant/components/*/homeworks.py
+
     homeassistant/components/huawei_lte.py
     homeassistant/components/*/huawei_lte.py
 

--- a/homeassistant/components/binary_sensor/homeworks.py
+++ b/homeassistant/components/binary_sensor/homeworks.py
@@ -1,0 +1,86 @@
+"""Component for interfacing to Lutron Homeworks keypads.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/homeworks/
+"""
+import logging
+from homeassistant.components.binary_sensor import (
+    BinarySensorDevice, PLATFORM_SCHEMA)
+from homeassistant.components.homeworks import (
+    HomeworksDevice, HOMEWORKS_CONTROLLER)
+from homeassistant.const import CONF_NAME
+import homeassistant.helpers.config_validation as cv
+import voluptuous as vol
+
+DEPENDENCIES = ['homeworks']
+REQUIREMENTS = ['pyhomeworks==0.0.1']
+
+_LOGGER = logging.getLogger(__name__)
+
+EVENT_BUTTON_PRESSED = 'button_pressed'
+CONF_KEYPADS = 'keypads'
+CONF_ADDR = 'addr'
+CONF_BUTTONS = 'buttons'
+
+BUTTON_SCHEMA = vol.Schema({cv.positive_int: cv.string})
+BUTTONS_SCHEMA = vol.Schema({
+    vol.Required(CONF_ADDR): cv.string,
+    vol.Required(CONF_NAME): cv.string,
+    vol.Required(CONF_BUTTONS): vol.All(cv.ensure_list, [BUTTON_SCHEMA])
+})
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_KEYPADS): vol.All(cv.ensure_list, [BUTTONS_SCHEMA])
+})
+
+
+def setup_platform(hass, config, add_entities, discover_info=None):
+    """Set up the Homeworks keypads."""
+    controller = hass.data[HOMEWORKS_CONTROLLER]
+    devs = []
+    for keypad in config.get(CONF_KEYPADS):
+        name = keypad.get(CONF_NAME)
+        addr = keypad.get(CONF_ADDR)
+        buttons = keypad.get(CONF_BUTTONS)
+        for button in buttons:
+            # FIX: This should be done differently
+            for num, title in button.items():
+                devname = name + '_' + title
+                dev = HomeworksKeypad(controller, addr, num, devname)
+                devs.append(dev)
+    add_entities(devs, True)
+    return True
+
+
+class HomeworksKeypad(HomeworksDevice, BinarySensorDevice):
+    """Homeworks Keypad."""
+
+    def __init__(self, controller, addr, num, name):
+        """Create keypad with addr, num, and name."""
+        HomeworksDevice.__init__(self, controller, addr, name)
+        self._num = num
+        self._state = None
+
+    @property
+    def is_on(self):
+        """Return state of the button."""
+        return self._state
+
+    @property
+    def device_state_attributes(self):
+        """Return supported attributes."""
+        return {"Homeworks Address": self._addr,
+                "Button Number": self._num}
+
+    def callback(self, msg_type, values):
+        """Dispatch messages from the controller."""
+        from pyhomeworks.pyhomeworks import (
+            HW_BUTTON_PRESSED, HW_BUTTON_RELEASED)
+
+        old_state = self._state
+        if msg_type == HW_BUTTON_PRESSED and values[1] == self._num:
+            self.hass.bus.fire(EVENT_BUTTON_PRESSED,
+                               {'entity_id': self.entity_id})
+            self._state = True
+        elif msg_type == HW_BUTTON_RELEASED and values[1] == self._num:
+            self._state = False
+        return old_state == self._state

--- a/homeassistant/components/homeworks.py
+++ b/homeassistant/components/homeworks.py
@@ -1,0 +1,95 @@
+"""Component for interfacing to Lutron Homeworks Series 4 and 8 systems.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/homeworks/
+"""
+import logging
+from homeassistant.const import (
+    EVENT_HOMEASSISTANT_STOP, CONF_HOST, CONF_PORT)
+import homeassistant.helpers.config_validation as cv
+import voluptuous as vol
+
+REQUIREMENTS = ['pyhomeworks==0.0.1']
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = 'homeworks'
+
+HOMEWORKS_CONTROLLER = 'homeworks'
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_HOST): cv.string,
+        vol.Required(CONF_PORT): cv.port,
+    }),
+}, extra=vol.ALLOW_EXTRA)
+
+
+def setup(hass, base_config):
+    """Start Homeworks controller."""
+    from pyhomeworks.pyhomeworks import Homeworks
+
+    class HomeworksController(Homeworks):
+        """Interface between HASS and Homeworks controller."""
+
+        def __init__(self, host, port):
+            """Host and port of Lutron Homeworks controller."""
+            Homeworks.__init__(self, host, port, self._callback)
+            self._subscribers = {}
+
+        def register(self, device):
+            """Add a device to subscribe to events."""
+            if device.addr not in self._subscribers:
+                self._subscribers[device.addr] = []
+            self._subscribers[device.addr].append(device)
+
+        def _callback(self, msg_type, values):
+            _LOGGER.debug('_callback: %s, %s', msg_type, values)
+            addr = values[0]
+            for sub in self._subscribers.get(addr, []):
+                _LOGGER.debug("_callback: %s", sub)
+                if sub.callback(msg_type, values):
+                    sub.schedule_update_ha_state()
+
+    config = base_config.get(DOMAIN)
+    host = config[CONF_HOST]
+    port = config[CONF_PORT]
+
+    controller = HomeworksController(host, port)
+    hass.data[HOMEWORKS_CONTROLLER] = controller
+
+    def cleanup(event):
+        controller.close()
+
+    hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, cleanup)
+    return True
+
+
+class HomeworksDevice():
+    """Base class of a Homeworks device."""
+
+    def __init__(self, controller, addr, name):
+        """Controller, address, and name of the device."""
+        self._addr = addr
+        self._name = name
+        self._controller = controller
+        controller.register(self)
+
+    @property
+    def addr(self):
+        """Device address."""
+        return self._addr
+
+    @property
+    def name(self):
+        """Device name."""
+        return self._name
+
+    @property
+    def should_poll(self):
+        """No need to poll."""
+        return False
+
+    def callback(self, msg_type, values):
+        """Must be replaced with device callbacks."""
+        return False

--- a/homeassistant/components/light/homeworks.py
+++ b/homeassistant/components/light/homeworks.py
@@ -1,0 +1,105 @@
+"""Component for interfacing to Lutron Homeworks lights.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/homeworks/
+"""
+import logging
+from homeassistant.components.homeworks import (
+    HomeworksDevice, HOMEWORKS_CONTROLLER)
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS, SUPPORT_BRIGHTNESS, Light, PLATFORM_SCHEMA)
+from homeassistant.const import CONF_NAME
+import homeassistant.helpers.config_validation as cv
+import voluptuous as vol
+
+DEPENDENCIES = ['homeworks']
+REQUIREMENTS = ['pyhomeworks==0.0.1']
+
+_LOGGER = logging.getLogger(__name__)
+
+FADE_RATE = 2.
+
+CONF_DIMMERS = 'dimmers'
+CONF_ADDR = 'addr'
+CONF_RATE = 'rate'
+
+CV_FADE_RATE = vol.All(vol.Coerce(float), vol.Range(min=0, max=20))
+
+DIMMER_SCHEMA = vol.Schema({
+    vol.Required(CONF_ADDR): cv.string,
+    vol.Required(CONF_NAME): cv.string,
+    vol.Optional(CONF_RATE, default=FADE_RATE): CV_FADE_RATE,
+})
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_DIMMERS): vol.All(cv.ensure_list, [DIMMER_SCHEMA])
+})
+
+
+def setup_platform(hass, config, add_entities, discover_info=None):
+    """Set up the Homeworks lights."""
+    controller = hass.data[HOMEWORKS_CONTROLLER]
+    devs = []
+    for dimmer in config.get(CONF_DIMMERS):
+        dev = HomeworksLight(controller, dimmer[CONF_ADDR],
+                             dimmer[CONF_NAME], dimmer[CONF_RATE])
+        devs.append(dev)
+    add_entities(devs, True)
+    return True
+
+
+class HomeworksLight(HomeworksDevice, Light):
+    """Homeworks Light."""
+
+    def __init__(self, controller, addr, name, rate):
+        """Create device with Addr, name, and rate."""
+        HomeworksDevice.__init__(self, controller, addr, name)
+        self._rate = rate
+        self._level = None
+        self._controller.request_dimmer_level(addr)
+
+    @property
+    def supported_features(self):
+        """Supported features."""
+        return SUPPORT_BRIGHTNESS
+
+    def turn_on(self, **kwargs):
+        """Turn on the light."""
+        if ATTR_BRIGHTNESS in kwargs:
+            self.brightness = kwargs[ATTR_BRIGHTNESS]
+        else:
+            self.brightness = 255
+
+    def turn_off(self, **kwargs):
+        """Turn off the light."""
+        self.brightness = 0
+
+    @property
+    def brightness(self):
+        """Control the brightness."""
+        return self._level
+
+    @brightness.setter
+    def brightness(self, level):
+        self._controller.fade_dim(
+            float((level*100.)/255.), self._rate,
+            0, self._addr)
+        self._level = level
+
+    @property
+    def device_state_attributes(self):
+        """Supported attributes."""
+        return {'Homeworks Address': self._addr}
+
+    @property
+    def is_on(self):
+        """Is the light on/off."""
+        return self._level != 0
+
+    def callback(self, msg_type, values):
+        """Process device specific messages."""
+        from pyhomeworks.pyhomeworks import HW_LIGHT_CHANGED
+
+        if msg_type == HW_LIGHT_CHANGED:
+            self._level = int((values[1] * 255.)/100.)
+            return True
+        return False

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -919,6 +919,11 @@ pyhiveapi==0.2.14
 # homeassistant.components.homematic
 pyhomematic==0.1.51
 
+# homeassistant.components.homeworks
+# homeassistant.components.binary_sensor.homeworks
+# homeassistant.components.light.homeworks
+pyhomeworks==0.0.1
+
 # homeassistant.components.sensor.hydroquebec
 pyhydroquebec==2.2.2
 


### PR DESCRIPTION
## Description:
Interface between Lutron Homeworks series 4 & 8 systems and Home Assistant.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>7401

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
