### PR TITLE
Improve version sensor

### DIFF
--- a/homeassistant/components/sensor/version.py
+++ b/homeassistant/components/sensor/version.py
@@ -86,10 +86,9 @@ class VersionSensor(Entity):
         """Return the name of the sensor."""
         if self._name:
             return self._name
-        elif self.haversion.source == DEFAULT_SOURCE:
+        if self.haversion.source == DEFAULT_SOURCE:
             return DEFAULT_NAME_LOCAL
-        else:
-            return DEFAULT_NAME_LATEST
+        return DEFAULT_NAME_LATEST
 
     @property
     def state(self):

--- a/homeassistant/components/sensor/version.py
+++ b/homeassistant/components/sensor/version.py
@@ -20,13 +20,6 @@ REQUIREMENTS = ['pyhaversion==2.0.1']
 
 _LOGGER = logging.getLogger(__name__)
 
-CONF_BETA = 'beta'
-CONF_IMAGE = 'image'
-
-DEFAULT_IMAGE = 'default'
-DEFAULT_NAME = "Current Version"
-DEFAULT_SOURCE = 'local'
-
 ALL_IMAGES = [
     'default', 'intel-nuc', 'qemux86', 'qemux86-64', 'qemuarm',
     'qemuarm-64', 'raspberrypi', 'raspberrypi2', 'raspberrypi3',
@@ -36,6 +29,14 @@ ALL_SOURCES = [
     'local', 'pypi', 'hassio', 'docker'
 ]
 
+CONF_BETA = 'beta'
+CONF_IMAGE = 'image'
+
+DEFAULT_IMAGE = 'default'
+DEFAULT_NAME_LATEST = "Latest Version"
+DEFAULT_NAME_LOCAL = "Current Version"
+DEFAULT_SOURCE = 'local'
+
 ICON = 'mdi:package-up'
 
 TIME_BETWEEN_UPDATES = timedelta(minutes=5)
@@ -43,7 +44,7 @@ TIME_BETWEEN_UPDATES = timedelta(minutes=5)
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_BETA, default=False): cv.boolean,
     vol.Optional(CONF_IMAGE, default=DEFAULT_IMAGE): vol.In(ALL_IMAGES),
-    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_NAME, default=''): cv.string,
     vol.Optional(CONF_SOURCE, default=DEFAULT_SOURCE): vol.In(ALL_SOURCES),
 })
 
@@ -70,7 +71,7 @@ async def async_setup_platform(
 class VersionSensor(Entity):
     """Representation of a Home Assistant version sensor."""
 
-    def __init__(self, haversion, name):
+    def __init__(self, haversion, name=''):
         """Initialize the Version sensor."""
         self.haversion = haversion
         self._name = name
@@ -83,7 +84,12 @@ class VersionSensor(Entity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return self._name
+        if self._name:
+            return self._name
+        elif self.haversion.source == DEFAULT_SOURCE:
+            return DEFAULT_NAME_LOCAL
+        else:
+            return DEFAULT_NAME_LATEST
 
     @property
     def state(self):

--- a/homeassistant/components/sensor/version.py
+++ b/homeassistant/components/sensor/version.py
@@ -27,17 +27,24 @@ DEFAULT_IMAGE = 'default'
 DEFAULT_NAME = "Current Version"
 DEFAULT_SOURCE = 'local'
 
+ALL_IMAGES = [
+    'default', 'intel-nuc', 'qemux86', 'qemux86-64', 'qemuarm',
+    'qemuarm-64', 'raspberrypi', 'raspberrypi2', 'raspberrypi3',
+    'raspberrypi3-64', 'tinker', 'odroid-c2', 'odroid-xu'
+]
+ALL_SOURCES = [
+    'local', 'pypi', 'hassio', 'docker'
+]
+
 ICON = 'mdi:package-up'
 
 TIME_BETWEEN_UPDATES = timedelta(minutes=5)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_BETA, default=False): cv.boolean,
-    vol.Optional(CONF_IMAGE, default=DEFAULT_IMAGE): vol.All(cv.string,
-                                                             vol.Lower),
+    vol.Optional(CONF_IMAGE, default=DEFAULT_IMAGE): vol.In(ALL_IMAGES),
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional(CONF_SOURCE, default=DEFAULT_SOURCE): vol.All(cv.string,
-                                                               vol.Lower),
+    vol.Optional(CONF_SOURCE, default=DEFAULT_SOURCE): vol.In(ALL_SOURCES),
 })
 
 

--- a/homeassistant/components/sensor/version.py
+++ b/homeassistant/components/sensor/version.py
@@ -101,6 +101,11 @@ class VersionSensor(Entity):
         """Return attributes for the sensor."""
         return self.haversion.api.version_data
 
+    @property
+    def icon(self):
+        """Return the icon to use in the frontend, if any."""
+        return ICON
+
 
 class VersionData:
     """Get the latest data and update the states."""


### PR DESCRIPTION
## Description:
This PR builds on the updated version sensor (https://github.com/home-assistant/home-assistant/pull/18067). It improves validation and adds a name that makes sense with the new functionality.

Currently it always shows 'Current Version' as name, which is confusing when using the component to check the latest version available.

I think this is not a breaking change, but maybe someone can verify (@ludeeus reminded me the entity_id is linked to the name):
- If a user specified a custom name before it still uses that one
- If a user is not using the new functionality it still has the same default value

Edit: this now also sets the icon property which was forgotten

**Related issue (if applicable):** fixes #<home-assistant issue number goes here> **NA**

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** https://github.com/home-assistant/home-assistant.io/pull/7409

*should be cherry-picked for the beta 0.82 release*

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
