### PR TITLE
Upgrade hdate to 0.7.5

### DIFF
--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -461,7 +461,7 @@ hangups==0.4.6
 hbmqtt==0.9.4
 
 # homeassistant.components.sensor.jewish_calendar
-hdate==0.6.5
+hdate==0.7.5
 
 # homeassistant.components.climate.heatmiser
 heatmiserV3==0.9.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -91,7 +91,7 @@ hangups==0.4.6
 hbmqtt==0.9.4
 
 # homeassistant.components.sensor.jewish_calendar
-hdate==0.6.5
+hdate==0.7.5
 
 # homeassistant.components.binary_sensor.workday
 holidays==0.9.8

--- a/tests/components/sensor/test_jewish_calendar.py
+++ b/tests/components/sensor/test_jewish_calendar.py
@@ -64,7 +64,7 @@ class TestJewishCalenderSensor():
         (dt(2018, 9, 3), 'UTC', 31.778, 35.235, "english", "date",
          False, "23 Elul 5778"),
         (dt(2018, 9, 3), 'UTC', 31.778, 35.235, "hebrew", "date",
-         False, "כ\"ג באלול ה\' תשע\"ח"),
+         False, "כ\"ג אלול ה\' תשע\"ח"),
         (dt(2018, 9, 10), 'UTC', 31.778, 35.235, "hebrew", "holiday_name",
          False, "א\' ראש השנה"),
         (dt(2018, 9, 10), 'UTC', 31.778, 35.235, "english", "holiday_name",
@@ -72,17 +72,17 @@ class TestJewishCalenderSensor():
         (dt(2018, 9, 10), 'UTC', 31.778, 35.235, "english", "holyness",
          False, 1),
         (dt(2018, 9, 8), 'UTC', 31.778, 35.235, "hebrew", "weekly_portion",
-         False, "פרשת נצבים"),
+         False, "נצבים"),
         (dt(2018, 9, 8), 'America/New_York', 40.7128, -74.0060, "hebrew",
          "first_stars", True, time(19, 48)),
         (dt(2018, 9, 8), "Asia/Jerusalem", 31.778, 35.235, "hebrew",
          "first_stars", False, time(19, 21)),
         (dt(2018, 10, 14), "Asia/Jerusalem", 31.778, 35.235, "hebrew",
-         "weekly_portion", False, "פרשת לך לך"),
+         "weekly_portion", False, "לך לך"),
         (dt(2018, 10, 14, 17, 0, 0), "Asia/Jerusalem", 31.778, 35.235,
-         "hebrew", "date", False, "ה\' בחשון ה\' תשע\"ט"),
+         "hebrew", "date", False, "ה\' מרחשוון ה\' תשע\"ט"),
         (dt(2018, 10, 14, 19, 0, 0), "Asia/Jerusalem", 31.778, 35.235,
-         "hebrew", "date", False, "ו\' בחשון ה\' תשע\"ט")
+         "hebrew", "date", False, "ו\' מרחשוון ה\' תשע\"ט")
     ]
 
     test_ids = [


### PR DESCRIPTION
## Description:

In 0.7.x the API to HDate was cleaned up so as to move logic from homeassistant to
the HDate external library.

This commit removes all the superfluous code, updates the required tests and changes the
requirement from version 0.6.5 to 0.7.5

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable): N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  N/A

If the code communicates with devices, web services, or third-party tools:
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

If the code does not interact with devices:
 N/A

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
