### PR TITLE
Doc fix: a circular dependency does not raise an error.

### DIFF
--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -209,8 +209,9 @@ def load_order_component(hass,  # type: HomeAssistant
                          comp_name: str) -> OrderedSet:
     """Return an OrderedSet of components in the correct order of loading.
 
-    Raises HomeAssistantError if a circular dependency is detected.
-    Returns an empty list if component could not be loaded.
+    Returns an empty list if a circular dependency is detected
+    or the component could not be loaded. In both cases, the error is
+    logged.
 
     Async friendly.
     """


### PR DESCRIPTION
This is easier to handle than raising an exception: a circular
dependency causes multiple error entries in the log, which is what we
want.

This is harder to achieve with an exception. Since there is only one
user of this code, I choose to fix the documentation -- instead of
adding a lot of mostly-useless exception handling.

Closes: #13147

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

  - [x] Tests to verify that the code works already exist.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
