### PR TITLE
System groups

### DIFF
--- a/homeassistant/auth/__init__.py
+++ b/homeassistant/auth/__init__.py
@@ -134,7 +134,7 @@ class AuthManager:
             name=name,
             system_generated=True,
             is_active=True,
-            groups=[],
+            group_ids=[],
         )
 
         self.hass.bus.async_fire(EVENT_USER_ADDED, {
@@ -145,11 +145,10 @@ class AuthManager:
 
     async def async_create_user(self, name: str) -> models.User:
         """Create a user."""
-        group = await self._store.async_get_group(GROUP_ID_ADMIN)
         kwargs = {
             'name': name,
             'is_active': True,
-            'groups': [group]
+            'group_ids': [GROUP_ID_ADMIN]
         }  # type: Dict[str, Any]
 
         if await self._user_should_be_owner():

--- a/homeassistant/auth/__init__.py
+++ b/homeassistant/auth/__init__.py
@@ -13,6 +13,7 @@ from homeassistant.core import callback, HomeAssistant
 from homeassistant.util import dt as dt_util
 
 from . import auth_store, models
+from .const import GROUP_ID_ADMIN
 from .mfa_modules import auth_mfa_module_from_config, MultiFactorAuthModule
 from .providers import auth_provider_from_config, AuthProvider, LoginFlow
 
@@ -144,7 +145,7 @@ class AuthManager:
 
     async def async_create_user(self, name: str) -> models.User:
         """Create a user."""
-        group = (await self._store.async_get_groups())[0]
+        group = await self._store.async_get_group(GROUP_ID_ADMIN)
         kwargs = {
             'name': name,
             'is_active': True,

--- a/homeassistant/auth/auth_store.py
+++ b/homeassistant/auth/auth_store.py
@@ -488,7 +488,7 @@ class AuthStore:
         self._groups = groups
 
 
-def _system_admin_group() -> None:
+def _system_admin_group() -> models.Group:
     """Create system admin group."""
     return models.Group(
         name=GROUP_NAME_ADMIN,
@@ -498,7 +498,7 @@ def _system_admin_group() -> None:
     )
 
 
-def _system_read_only_group() -> None:
+def _system_read_only_group() -> models.Group:
     """Create read only group."""
     return models.Group(
         name=GROUP_NAME_READ_ONLY,

--- a/homeassistant/auth/auth_store.py
+++ b/homeassistant/auth/auth_store.py
@@ -310,11 +310,13 @@ class AuthStore:
 
         # This is part of migrating from state 1 and 2
         if not has_admin_group:
-            _add_system_admin_group(groups)
+            admin_group = _system_admin_group()
+            groups[admin_group.id] = admin_group
 
         # This is part of migrating from state 1 and 2
         if not has_read_only_group:
-            _add_system_read_only_group(groups)
+            read_only_group = _system_read_only_group()
+            groups[read_only_group.id] = read_only_group
 
         for user_dict in data['users']:
             # Collect the users group.
@@ -479,14 +481,16 @@ class AuthStore:
         self._users = OrderedDict()  # type: Dict[str, models.User]
 
         groups = OrderedDict()  # type: Dict[str, models.Group]
-        _add_system_admin_group(groups)
-        _add_system_read_only_group(groups)
+        admin_group = _system_admin_group()
+        groups[admin_group.id] = admin_group
+        read_only_group = _system_read_only_group()
+        groups[read_only_group.id] = read_only_group
         self._groups = groups
 
 
-def _add_system_admin_group(groups: Dict[str, models.Group]) -> None:
-    """Add system admin group."""
-    groups[GROUP_ID_ADMIN] = models.Group(
+def _system_admin_group() -> None:
+    """Create system admin group."""
+    return models.Group(
         name=GROUP_NAME_ADMIN,
         id=GROUP_ID_ADMIN,
         policy=system_policies.ADMIN_POLICY,
@@ -494,9 +498,9 @@ def _add_system_admin_group(groups: Dict[str, models.Group]) -> None:
     )
 
 
-def _add_system_read_only_group(groups: Dict[str, models.Group]) -> None:
-    """Add system admin group."""
-    groups[GROUP_ID_READ_ONLY] = models.Group(
+def _system_read_only_group() -> None:
+    """Create read only group."""
+    return models.Group(
         name=GROUP_NAME_READ_ONLY,
         id=GROUP_ID_READ_ONLY,
         policy=system_policies.READ_ONLY_POLICY,

--- a/homeassistant/auth/const.py
+++ b/homeassistant/auth/const.py
@@ -3,3 +3,6 @@ from datetime import timedelta
 
 ACCESS_TOKEN_EXPIRATION = timedelta(minutes=30)
 MFA_SESSION_EXPIRATION = timedelta(minutes=5)
+
+GROUP_ID_ADMIN = 'system-admin'
+GROUP_ID_READ_ONLY = 'system-read-only'

--- a/homeassistant/auth/models.py
+++ b/homeassistant/auth/models.py
@@ -22,6 +22,7 @@ class Group:
     name = attr.ib(type=str)  # type: Optional[str]
     policy = attr.ib(type=perm_mdl.PolicyType)
     id = attr.ib(type=str, factory=lambda: uuid.uuid4().hex)
+    system_generated = attr.ib(type=bool, default=False)
 
 
 @attr.s(slots=True)

--- a/homeassistant/auth/permissions/__init__.py
+++ b/homeassistant/auth/permissions/__init__.py
@@ -7,17 +7,10 @@ import voluptuous as vol
 
 from homeassistant.core import State
 
-from .common import CategoryType, PolicyType
+from .const import CAT_ENTITIES
+from .types import CategoryType, PolicyType
 from .entities import ENTITY_POLICY_SCHEMA, compile_entities
 from .merge import merge_policies  # noqa
-
-
-# Default policy if group has no policy applied.
-DEFAULT_POLICY = {
-    "entities": True
-}  # type: PolicyType
-
-CAT_ENTITIES = 'entities'
 
 POLICY_SCHEMA = vol.Schema({
     vol.Optional(CAT_ENTITIES): ENTITY_POLICY_SCHEMA

--- a/homeassistant/auth/permissions/const.py
+++ b/homeassistant/auth/permissions/const.py
@@ -1,0 +1,7 @@
+"""Permission constants."""
+CAT_ENTITIES = 'entities'
+SUBCAT_ALL = 'all'
+
+POLICY_READ = 'read'
+POLICY_CONTROL = 'control'
+POLICY_EDIT = 'edit'

--- a/homeassistant/auth/permissions/entities.py
+++ b/homeassistant/auth/permissions/entities.py
@@ -5,12 +5,8 @@ from typing import (  # noqa: F401
 
 import voluptuous as vol
 
-from .common import CategoryType, ValueType, SUBCAT_ALL
-
-
-POLICY_READ = 'read'
-POLICY_CONTROL = 'control'
-POLICY_EDIT = 'edit'
+from .const import SUBCAT_ALL, POLICY_READ, POLICY_CONTROL, POLICY_EDIT
+from .types import CategoryType, ValueType
 
 SINGLE_ENTITY_SCHEMA = vol.Any(True, vol.Schema({
     vol.Optional(POLICY_READ): True,

--- a/homeassistant/auth/permissions/merge.py
+++ b/homeassistant/auth/permissions/merge.py
@@ -2,7 +2,7 @@
 from typing import (  # noqa: F401
     cast, Dict, List, Set)
 
-from .common import PolicyType, CategoryType
+from .types import PolicyType, CategoryType
 
 
 def merge_policies(policies: List[PolicyType]) -> PolicyType:

--- a/homeassistant/auth/permissions/system_policies.py
+++ b/homeassistant/auth/permissions/system_policies.py
@@ -1,0 +1,16 @@
+"""System policies."""
+from .const import CAT_ENTITIES, SUBCAT_ALL, POLICY_READ
+
+ADMIN_POLICY = {
+    CAT_ENTITIES: True,
+}
+
+READ_ONLY_POLICY = {
+    CAT_ENTITIES: {
+        SUBCAT_ALL: {
+            POLICY_READ: True
+        }
+    }
+}
+
+ALL = (ADMIN_POLICY, READ_ONLY_POLICY)

--- a/homeassistant/auth/permissions/system_policies.py
+++ b/homeassistant/auth/permissions/system_policies.py
@@ -12,5 +12,3 @@ READ_ONLY_POLICY = {
         }
     }
 }
-
-ALL = (ADMIN_POLICY, READ_ONLY_POLICY)

--- a/homeassistant/auth/permissions/types.py
+++ b/homeassistant/auth/permissions/types.py
@@ -29,5 +29,3 @@ CategoryType = Union[
 
 # Example: { entities: … }
 PolicyType = Mapping[str, CategoryType]
-
-SUBCAT_ALL = 'all'

--- a/tests/auth/permissions/test_init.py
+++ b/tests/auth/permissions/test_init.py
@@ -32,15 +32,3 @@ def test_owner_permissions():
         State('light.balcony', 'on'),
     ]
     assert permissions.OwnerPermissions.filter_states(states) == states
-
-
-def test_default_policy_allow_all():
-    """Test that the default policy is to allow all entity actions."""
-    perm = permissions.PolicyPermissions(permissions.DEFAULT_POLICY)
-    assert perm.check_entity('light.kitchen', 'read')
-    states = [
-        State('light.kitchen', 'on'),
-        State('light.living_room', 'off'),
-        State('light.balcony', 'on'),
-    ]
-    assert perm.filter_states(states) == states

--- a/tests/auth/permissions/test_system_policies.py
+++ b/tests/auth/permissions/test_system_policies.py
@@ -1,0 +1,25 @@
+"""Test system policies."""
+from homeassistant.auth.permissions import (
+    PolicyPermissions, system_policies, POLICY_SCHEMA)
+
+
+def test_admin_policy():
+    """Test admin policy works."""
+    # Make sure it's valid
+    POLICY_SCHEMA(system_policies.ADMIN_POLICY)
+
+    perms = PolicyPermissions(system_policies.ADMIN_POLICY)
+    assert perms.check_entity('light.kitchen', 'read')
+    assert perms.check_entity('light.kitchen', 'control')
+    assert perms.check_entity('light.kitchen', 'edit')
+
+
+def test_read_only_policy():
+    """Test read only policy works."""
+    # Make sure it's valid
+    POLICY_SCHEMA(system_policies.READ_ONLY_POLICY)
+
+    perms = PolicyPermissions(system_policies.READ_ONLY_POLICY)
+    assert perms.check_entity('light.kitchen', 'read')
+    assert not perms.check_entity('light.kitchen', 'control')
+    assert not perms.check_entity('light.kitchen', 'edit')

--- a/tests/auth/test_auth_store.py
+++ b/tests/auth/test_auth_store.py
@@ -2,8 +2,8 @@
 from homeassistant.auth import auth_store
 
 
-async def test_loading_old_data_format(hass, hass_storage):
-    """Test we correctly load an old data format."""
+async def test_loading_no_group_data_format(hass, hass_storage):
+    """Test we correctly load old data without any groups."""
     hass_storage[auth_store.STORAGE_KEY] = {
         'version': 1,
         'data': {
@@ -86,3 +86,126 @@ async def test_loading_old_data_format(hass, hass_storage):
     assert len(system.refresh_tokens) == 1
     system_token = list(system.refresh_tokens.values())[0]
     assert system_token.id == 'system-token-id'
+
+
+async def test_loading_all_access_group_data_format(hass, hass_storage):
+    """Test we correctly load old data with single group."""
+    hass_storage[auth_store.STORAGE_KEY] = {
+        'version': 1,
+        'data': {
+            'credentials': [],
+            'users': [
+                {
+                    "id": "user-id",
+                    "is_active": True,
+                    "is_owner": True,
+                    "name": "Paulus",
+                    "system_generated": False,
+                    'group_ids': ['abcd-all-access']
+                },
+                {
+                    "id": "system-id",
+                    "is_active": True,
+                    "is_owner": True,
+                    "name": "Hass.io",
+                    "system_generated": True,
+                }
+            ],
+            "groups": [
+                {
+                    "id": "abcd-all-access",
+                    "name": "All Access",
+                }
+            ],
+            "refresh_tokens": [
+                {
+                    "access_token_expiration": 1800.0,
+                    "client_id": "http://localhost:8123/",
+                    "created_at": "2018-10-03T13:43:19.774637+00:00",
+                    "id": "user-token-id",
+                    "jwt_key": "some-key",
+                    "last_used_at": "2018-10-03T13:43:19.774712+00:00",
+                    "token": "some-token",
+                    "user_id": "user-id"
+                },
+                {
+                    "access_token_expiration": 1800.0,
+                    "client_id": None,
+                    "created_at": "2018-10-03T13:43:19.774637+00:00",
+                    "id": "system-token-id",
+                    "jwt_key": "some-key",
+                    "last_used_at": "2018-10-03T13:43:19.774712+00:00",
+                    "token": "some-token",
+                    "user_id": "system-id"
+                },
+                {
+                    "access_token_expiration": 1800.0,
+                    "client_id": "http://localhost:8123/",
+                    "created_at": "2018-10-03T13:43:19.774637+00:00",
+                    "id": "hidden-because-no-jwt-id",
+                    "last_used_at": "2018-10-03T13:43:19.774712+00:00",
+                    "token": "some-token",
+                    "user_id": "user-id"
+                },
+            ]
+        }
+    }
+
+    store = auth_store.AuthStore(hass)
+    groups = await store.async_get_groups()
+    assert len(groups) == 2
+    admin_group = groups[0]
+    assert admin_group.name == auth_store.GROUP_NAME_ADMIN
+    assert admin_group.system_generated
+    assert admin_group.id == auth_store.GROUP_ID_ADMIN
+    read_group = groups[1]
+    assert read_group.name == auth_store.GROUP_NAME_READ_ONLY
+    assert read_group.system_generated
+    assert read_group.id == auth_store.GROUP_ID_READ_ONLY
+
+    users = await store.async_get_users()
+    assert len(users) == 2
+
+    owner, system = users
+
+    assert owner.system_generated is False
+    assert owner.groups == [admin_group]
+    assert len(owner.refresh_tokens) == 1
+    owner_token = list(owner.refresh_tokens.values())[0]
+    assert owner_token.id == 'user-token-id'
+
+    assert system.system_generated is True
+    assert system.groups == []
+    assert len(system.refresh_tokens) == 1
+    system_token = list(system.refresh_tokens.values())[0]
+    assert system_token.id == 'system-token-id'
+
+
+async def test_loading_empty_data(hass, hass_storage):
+    """Test we correctly load with no existing data."""
+    store = auth_store.AuthStore(hass)
+    groups = await store.async_get_groups()
+    assert len(groups) == 2
+    admin_group = groups[0]
+    assert admin_group.name == auth_store.GROUP_NAME_ADMIN
+    assert admin_group.system_generated
+    assert admin_group.id == auth_store.GROUP_ID_ADMIN
+    read_group = groups[1]
+    assert read_group.name == auth_store.GROUP_NAME_READ_ONLY
+    assert read_group.system_generated
+    assert read_group.id == auth_store.GROUP_ID_READ_ONLY
+
+    users = await store.async_get_users()
+    assert len(users) == 0
+
+
+async def test_system_groups_only_store_id(hass, hass_storage):
+    """Test that for system groups we only store the ID."""
+    store = auth_store.AuthStore(hass)
+    await store._async_load()
+    data = store._data_to_save()
+    assert len(data['users']) == 0
+    assert data['groups'] == [
+        {'id': auth_store.GROUP_ID_ADMIN},
+        {'id': auth_store.GROUP_ID_READ_ONLY},
+    ]

--- a/tests/auth/test_auth_store.py
+++ b/tests/auth/test_auth_store.py
@@ -60,9 +60,15 @@ async def test_loading_old_data_format(hass, hass_storage):
 
     store = auth_store.AuthStore(hass)
     groups = await store.async_get_groups()
-    assert len(groups) == 1
-    group = groups[0]
-    assert group.name == "All Access"
+    assert len(groups) == 2
+    admin_group = groups[0]
+    assert admin_group.name == auth_store.GROUP_NAME_ADMIN
+    assert admin_group.system_generated
+    assert admin_group.id == auth_store.GROUP_ID_ADMIN
+    read_group = groups[1]
+    assert read_group.name == auth_store.GROUP_NAME_READ_ONLY
+    assert read_group.system_generated
+    assert read_group.id == auth_store.GROUP_ID_READ_ONLY
 
     users = await store.async_get_users()
     assert len(users) == 2
@@ -70,7 +76,7 @@ async def test_loading_old_data_format(hass, hass_storage):
     owner, system = users
 
     assert owner.system_generated is False
-    assert owner.groups == [group]
+    assert owner.groups == [admin_group]
     assert len(owner.refresh_tokens) == 1
     owner_token = list(owner.refresh_tokens.values())[0]
     assert owner_token.id == 'user-token-id'

--- a/tests/common.py
+++ b/tests/common.py
@@ -15,6 +15,7 @@ from contextlib import contextmanager
 from homeassistant import auth, core as ha, config_entries
 from homeassistant.auth import (
     models as auth_models, auth_store, providers as auth_providers)
+from homeassistant.auth.permissions import system_policies
 from homeassistant.setup import setup_component, async_setup_component
 from homeassistant.config import async_process_component_config
 from homeassistant.helpers import (
@@ -349,7 +350,7 @@ class MockGroup(auth_models.Group):
     """Mock a group in Home Assistant."""
 
     def __init__(self, id=None, name='Mock Group',
-                 policy=auth_store.DEFAULT_POLICY):
+                 policy=system_policies.ADMIN_POLICY):
         """Mock a group."""
         kwargs = {
             'name': name,


### PR DESCRIPTION
## Description:
Add system groups Administrators & Read Only. System groups will have hardcoded IDs `system-admin` and `system-read-only`. Policies are not stored on disk, so as HA evolves, so can the policy.

Includes a soft-migration (backwards compatible) that migrates peoples existing single group without a policy to 2 system groups with admin & read only policies attached to it.

Next on my radar will be enforcement and adding users to/from groups.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
