### PR TITLE
Supports the new Netatmo Home Coach

### DIFF
--- a/homeassistant/components/netatmo.py
+++ b/homeassistant/components/netatmo.py
@@ -16,7 +16,7 @@ from homeassistant.helpers import discovery
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['pyatmo==1.2']
+REQUIREMENTS = ['pyatmo==1.3']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -52,7 +52,7 @@ def setup(hass, config):
             config[DOMAIN][CONF_USERNAME], config[DOMAIN][CONF_PASSWORD],
             'read_station read_camera access_camera '
             'read_thermostat write_thermostat '
-            'read_presence access_presence')
+            'read_presence access_presence read_homecoach')
     except HTTPError:
         _LOGGER.error("Unable to connect to Netatmo API")
         return False

--- a/homeassistant/components/sensor/netatmo.py
+++ b/homeassistant/components/sensor/netatmo.py
@@ -305,6 +305,8 @@ class NetAtmoData:
         return self.data.keys()
 
     def _detect_platform_type(self):
+        """Returns a WeatherStationData or HomeCoachData (pyatmo objects)
+        for the specified platform."""
         import pyatmo
         for data_class in [pyatmo.WeatherStationData, pyatmo.HomeCoachData]:
             try:

--- a/homeassistant/components/sensor/netatmo.py
+++ b/homeassistant/components/sensor/netatmo.py
@@ -304,6 +304,16 @@ class NetAtmoData:
         self.update()
         return self.data.keys()
 
+    def _detect_platform_type(self):
+        import pyatmo
+        for data_class in [pyatmo.WeatherStationData, pyatmo.HomeCoachData]:
+            try:
+                station_data = data_class(self.auth)
+                _LOGGER.debug("%s detected!" % str(data_class.__name__))
+                return station_data
+            except TypeError:
+                continue
+
     def update(self):
         """Call the Netatmo API to update the data.
 
@@ -317,11 +327,10 @@ class NetAtmoData:
 
         try:
             import pyatmo
-            try:
-                self.station_data = pyatmo.WeatherStationData(self.auth)
-            except TypeError:
-                _LOGGER.error("Failed to connect to NetAtmo")
-                return  # finally statement will be executed
+
+            self.station_data = self._detect_platform_type()
+            if not self.station_data:
+                raise Exception("No Weather nor HomeCoach devices found")
 
             if self.station is not None:
                 self.data = self.station_data.lastData(

--- a/homeassistant/components/sensor/netatmo.py
+++ b/homeassistant/components/sensor/netatmo.py
@@ -305,9 +305,7 @@ class NetAtmoData:
         return self.data.keys()
 
     def _detect_platform_type(self):
-        """Return a WeatherStationData or HomeCoachData (pyatmo objects) or the
-        specified platform.
-        """
+        """Return a WeatherStationData or HomeCoachData (pyatmo objs) or the specified platform."""
         import pyatmo
         for data_class in [pyatmo.WeatherStationData, pyatmo.HomeCoachData]:
             try:

--- a/homeassistant/components/sensor/netatmo.py
+++ b/homeassistant/components/sensor/netatmo.py
@@ -305,7 +305,10 @@ class NetAtmoData:
         return self.data.keys()
 
     def _detect_platform_type(self):
-        """Return a WeatherStationData or HomeCoachData (pyatmo objs) or the specified platform."""
+        """Return the XXXData object corresponding to the specified platform.
+
+        The return can be a WeatherStationData or a HomeCoachData.
+        """
         import pyatmo
         for data_class in [pyatmo.WeatherStationData, pyatmo.HomeCoachData]:
             try:

--- a/homeassistant/components/sensor/netatmo.py
+++ b/homeassistant/components/sensor/netatmo.py
@@ -326,8 +326,6 @@ class NetAtmoData:
             return
 
         try:
-            import pyatmo
-
             self.station_data = self._detect_platform_type()
             if not self.station_data:
                 raise Exception("No Weather nor HomeCoach devices found")

--- a/homeassistant/components/sensor/netatmo.py
+++ b/homeassistant/components/sensor/netatmo.py
@@ -305,13 +305,14 @@ class NetAtmoData:
         return self.data.keys()
 
     def _detect_platform_type(self):
-        """Returns a WeatherStationData or HomeCoachData (pyatmo objects)
-        for the specified platform."""
+        """Return a WeatherStationData or HomeCoachData (pyatmo objects) or the
+        specified platform.
+        """
         import pyatmo
         for data_class in [pyatmo.WeatherStationData, pyatmo.HomeCoachData]:
             try:
                 station_data = data_class(self.auth)
-                _LOGGER.debug("%s detected!" % str(data_class.__name__))
+                _LOGGER.debug("%s detected!", str(data_class.__name__))
                 return station_data
             except TypeError:
                 continue

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -830,7 +830,7 @@ pyalarmdotcom==0.3.2
 pyarlo==0.2.2
 
 # homeassistant.components.netatmo
-pyatmo==1.2
+pyatmo==1.3
 
 # homeassistant.components.apple_tv
 pyatv==0.3.10


### PR DESCRIPTION
## Description:

Netatmo has released a new device, very similar to the currently supported `WeatherStation` but it uses a different API endpoint in the netatmo online service. 
A PR has been merged to `pyatmo` and the author released `1.3` version: https://github.com/jabesq/netatmo-api-python/pull/18
This PR allows this new device to work with exactly the same configuration than the `WeatherStation` using the `netatmo sensor` in the same way: https://www.home-assistant.io/components/sensor.netatmo/

- [ ] Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable): https://github.com/home-assistant/home-assistant.io/pull/7420

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) PENDING

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
 
Bumped `pyatmo` to `1.3` that adds the support for the Home Coach (https://github.com/jabesq/netatmo-api-python/pull/18) 

  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

