### PR TITLE
Update pyruter to 1.1.0 to be able to reuse aiohttp session.

### DIFF
--- a/homeassistant/components/sensor/ruter.py
+++ b/homeassistant/components/sensor/ruter.py
@@ -12,8 +12,9 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import CONF_NAME
 from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-REQUIREMENTS = ['pyruter==1.0.2']
+REQUIREMENTS = ['pyruter==1.1.0']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -41,7 +42,8 @@ async def async_setup_platform(
     name = config[CONF_NAME]
     offset = config[CONF_OFFSET]
 
-    ruter = Departures(hass.loop, stop_id, destination)
+    session = async_get_clientsession(hass)
+    ruter = Departures(hass.loop, stop_id, destination, session)
     sensor = [RuterSensor(ruter, name, offset)]
     async_add_entities(sensor, True)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1087,7 +1087,7 @@ pyrainbird==0.1.6
 pyrecswitch==1.0.2
 
 # homeassistant.components.sensor.ruter
-pyruter==1.0.2
+pyruter==1.1.2
 
 # homeassistant.components.sabnzbd
 pysabnzbd==1.1.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1087,7 +1087,7 @@ pyrainbird==0.1.6
 pyrecswitch==1.0.2
 
 # homeassistant.components.sensor.ruter
-pyruter==1.1.2
+pyruter==1.1.0
 
 # homeassistant.components.sabnzbd
 pysabnzbd==1.1.0


### PR DESCRIPTION
## Description:

This updates `pyruter` to be able to reuse the aiohttp session as discussed in the comments here https://github.com/home-assistant/home-assistant/pull/18237#discussion_r231397156
**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  platform: ruter
  stop_id: 2190400
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
