### PR TITLE
Meteofrance platform for the weather component

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -866,6 +866,7 @@ omit =
     homeassistant/components/weather/buienradar.py
     homeassistant/components/weather/darksky.py
     homeassistant/components/weather/met.py
+    homeassistant/components/weather/meteo_france.py
     homeassistant/components/weather/metoffice.py
     homeassistant/components/weather/openweathermap.py
     homeassistant/components/weather/zamg.py

--- a/homeassistant/components/sensor/meteo_france.py
+++ b/homeassistant/components/sensor/meteo_france.py
@@ -17,7 +17,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['meteofrance==0.2.7']
+REQUIREMENTS = ['meteofrance==0.2.8']
 _LOGGER = logging.getLogger(__name__)
 
 CONF_ATTRIBUTION = "Data provided by Meteo-France"

--- a/homeassistant/components/weather/__init__.py
+++ b/homeassistant/components/weather/__init__.py
@@ -36,6 +36,8 @@ ATTR_WEATHER_TEMPERATURE = 'temperature'
 ATTR_WEATHER_VISIBILITY = 'visibility'
 ATTR_WEATHER_WIND_BEARING = 'wind_bearing'
 ATTR_WEATHER_WIND_SPEED = 'wind_speed'
+ATTR_WEATHER_RAIN_FORECAST = 'rain_forecast'
+ATTR_WEATHER_CONDITION_ICON = 'condition_icon'
 
 
 async def async_setup(hass, config):
@@ -104,6 +106,16 @@ class WeatherEntity(Entity):
         return None
 
     @property
+    def rain_forecast(self):
+        """Return the rain forecast."""
+        return None
+
+    @property
+    def condition_icon(self):
+        """Return the condition icon."""
+        return self.condition
+
+    @property
     def forecast(self):
         """Return the forecast."""
         return None
@@ -146,6 +158,14 @@ class WeatherEntity(Entity):
         visibility = self.visibility
         if visibility is not None:
             data[ATTR_WEATHER_VISIBILITY] = visibility
+
+        rain_forecast = self.rain_forecast
+        if rain_forecast is not None:
+            data[ATTR_WEATHER_RAIN_FORECAST] = rain_forecast
+
+        condition_icon = self.condition_icon
+        if condition_icon is not None:
+            data[ATTR_WEATHER_CONDITION_ICON] = condition_icon
 
         attribution = self.attribution
         if attribution is not None:

--- a/homeassistant/components/weather/meteo_france.py
+++ b/homeassistant/components/weather/meteo_france.py
@@ -140,7 +140,8 @@ class MeteoFranceWeather(WeatherEntity):
                 ATTR_FORECAST_TIME: reftime.isoformat(),
                 ATTR_FORECAST_TEMP: int(value['max_temp']),
                 ATTR_FORECAST_TEMP_LOW: int(value['min_temp']),
-                ATTR_FORECAST_CONDITION: self.format_condition(value["weather"])
+                ATTR_FORECAST_CONDITION:
+                    self.format_condition(value["weather"])
             }
             reftime = reftime + timedelta(hours=24)
             forecast_data.append(data_dict)

--- a/homeassistant/components/weather/meteo_france.py
+++ b/homeassistant/components/weather/meteo_france.py
@@ -1,0 +1,155 @@
+"""
+Support for Meteo france weather service.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/weather.meteo_france/
+"""
+import logging
+from datetime import datetime, timedelta
+
+import voluptuous as vol
+
+from homeassistant.components.weather import (
+    WeatherEntity, PLATFORM_SCHEMA, ATTR_FORECAST_CONDITION,
+    ATTR_FORECAST_TEMP, ATTR_FORECAST_TEMP_LOW, ATTR_FORECAST_TIME)
+from homeassistant.const import TEMP_CELSIUS
+from homeassistant.helpers import config_validation as cv
+# Reuse data and API logic from the sensor implementation
+from homeassistant.components.sensor.meteo_france import \
+    MeteoFranceUpdater, CONF_POSTAL_CODE, CONF_ATTRIBUTION
+
+_LOGGER = logging.getLogger(__name__)
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_POSTAL_CODE): cv.string,
+})
+
+CONDITION_CLASSES = {
+    'clear-night': ['Nuit Claire'],
+    'cloudy': ['Très nuageux'],
+    'fog': ['Brume ou bancs de brouillard',
+            'Brouillard', 'Brouillard givrant'],
+    'hail': ['Risque de grêle'],
+    'lightning': ["Risque d'orages", 'Orages'],
+    'lightning-rainy': ['Pluie orageuses', 'Pluies orageuses'],
+    'partlycloudy': ['Ciel voilé', 'Ciel voilé nuit', 'Éclaircies'],
+    'pouring': ['Pluie forte'],
+    'rainy': ['Bruine / Pluie faible', 'Bruine', 'Pluie faible',
+              'Pluies éparses / Rares averses', 'Pluies éparses',
+              'Rares averses', 'Pluie / Averses', 'Averses', 'Pluie'],
+    'snowy': ['Neige / Averses de neige', 'Neige', 'Averses de neige',
+              'Neige forte', 'Quelques flocons'],
+    'snowy-rainy': ['Pluie et neige', 'Pluie verglaçante'],
+    'sunny': ['Ensoleillé'],
+    'windy': [],
+    'windy-variant': [],
+    'exceptional': [],
+}
+
+
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    """Set up the Meteo-France weather platform."""
+    postal_code = config[CONF_POSTAL_CODE]
+
+    from meteofrance.client import meteofranceClient, meteofranceError
+
+    try:
+        meteofrance_client = meteofranceClient(postal_code)
+    except meteofranceError as exp:
+        _LOGGER.error(exp)
+        return
+
+    client = MeteoFranceUpdater(meteofrance_client)
+
+    add_entities([MeteoFranceWeather(client)], True)
+
+
+class MeteoFranceWeather(WeatherEntity):
+    """Representation of a weather condition."""
+
+    def __init__(self, client):
+        """Initialise the platform with a data instance and station name."""
+        self._client = client
+        self._data = {}
+
+    def update(self):
+        """Update current conditions."""
+        self._client.update()
+        self._data = self._client.get_data()
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._data["name"]
+
+    @property
+    def condition(self):
+        """Return the current condition."""
+        return self._data["weather"]
+
+    @property
+    def condition_icon(self):
+        """Return the current condition."""
+        return self.format_condition(self._data["weather"])
+
+    # Now implement the WeatherEntity interface
+    @property
+    def temperature(self):
+        """Return the platform temperature."""
+        return self._data["temperature"]
+
+    @property
+    def humidity(self):
+        """Return the platform temperature."""
+        return None
+
+    @property
+    def temperature_unit(self):
+        """Return the unit of measurement."""
+        return TEMP_CELSIUS
+
+    @property
+    def rain_forecast(self):
+        """Return the 1 hour rain forecast."""
+        return self._data["rain_forecast_text"]
+
+    @property
+    def wind_speed(self):
+        """Return the wind speed."""
+        return self._data["wind_speed"]
+
+    @property
+    def wind_bearing(self):
+        """Return the wind bearing."""
+        return self._data["wind_bearing"]
+
+    @property
+    def attribution(self):
+        """Return the attribution."""
+        return CONF_ATTRIBUTION
+
+    @property
+    def forecast(self):
+        """Return the forecast."""
+        reftime = datetime.now().replace(hour=12, minute=00)
+        reftime += timedelta(hours=24)
+        forecast_data = []
+        for key in self._data["forecast"]:
+            value = self._data["forecast"][key]
+            data_dict = {
+                ATTR_FORECAST_TIME: reftime.isoformat(),
+                ATTR_FORECAST_TEMP: int(value['max_temp']),
+                ATTR_FORECAST_TEMP_LOW: int(value['min_temp']),
+                ATTR_FORECAST_CONDITION: self.format_condition(value["weather"])
+            }
+            reftime = reftime + timedelta(hours=24)
+            forecast_data.append(data_dict)
+        return forecast_data
+
+    @staticmethod
+    def format_condition(condition):
+        """Return condition from dict CONDITION_CLASSES."""
+        for key, value in CONDITION_CLASSES.items():
+            if condition in value:
+                return key
+        return condition

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -618,7 +618,7 @@ maxcube-api==0.1.0
 messagebird==1.2.0
 
 # homeassistant.components.sensor.meteo_france
-meteofrance==0.2.7
+meteofrance==0.2.8
 
 # homeassistant.components.sensor.mfi
 # homeassistant.components.switch.mfi


### PR DESCRIPTION
## Description:
After the recently merged Météo-France sensor providing weather datas from Météo-France, here is the `weather` component
As this weather provider returns different type of datas the other weather platforms, I updated the weather card on the front-end to display the 1 hour rain forecast.

I also added the possibility to separate the textual condition and the icon condition
Currently if the condition is "Light rain", "Rain" or "drizzle", I had to change it to "rainy" to display the correct icon, losing a part of the information for the text condition.
Weather component have a new attribute called `condition_icon` which returns the `condition` attribute by default but can return something more specific if the plaform uses it
PR on the frontend : https://github.com/home-assistant/home-assistant-polymer/pull/2027

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>
Documentation in progress

## Example entry for `configuration.yaml` (if applicable):
```yaml
weather:
  - platform: meteo_france
    postal_code: 76000
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
