### PR TITLE
show battery_level as a percent vs a decimal

### DIFF
--- a/homeassistant/components/wirelesstag.py
+++ b/homeassistant/components/wirelesstag.py
@@ -271,7 +271,7 @@ class WirelessTagBaseSensor(Entity):
     def device_state_attributes(self):
         """Return the state attributes."""
         return {
-            ATTR_BATTERY_LEVEL: self._tag.battery_remaining,
+            ATTR_BATTERY_LEVEL: '{:.0%}'.format(self._tag.battery_remaining),
             ATTR_VOLTAGE: '{:.2f}V'.format(self._tag.battery_volts),
             ATTR_TAG_SIGNAL_STRENGTH: '{}dBm'.format(
                 self._tag.signal_strength),

--- a/homeassistant/components/wirelesstag.py
+++ b/homeassistant/components/wirelesstag.py
@@ -271,7 +271,7 @@ class WirelessTagBaseSensor(Entity):
     def device_state_attributes(self):
         """Return the state attributes."""
         return {
-            ATTR_BATTERY_LEVEL: self._tag.battery_remaining*100,
+            ATTR_BATTERY_LEVEL: int(self._tag.battery_remaining*100),
             ATTR_VOLTAGE: '{:.2f}V'.format(self._tag.battery_volts),
             ATTR_TAG_SIGNAL_STRENGTH: '{}dBm'.format(
                 self._tag.signal_strength),

--- a/homeassistant/components/wirelesstag.py
+++ b/homeassistant/components/wirelesstag.py
@@ -271,7 +271,7 @@ class WirelessTagBaseSensor(Entity):
     def device_state_attributes(self):
         """Return the state attributes."""
         return {
-            ATTR_BATTERY_LEVEL: '{:.0}'.format(self._tag.battery_remaining),
+            ATTR_BATTERY_LEVEL: self._tag.battery_remaining*100,
             ATTR_VOLTAGE: '{:.2f}V'.format(self._tag.battery_volts),
             ATTR_TAG_SIGNAL_STRENGTH: '{}dBm'.format(
                 self._tag.signal_strength),

--- a/homeassistant/components/wirelesstag.py
+++ b/homeassistant/components/wirelesstag.py
@@ -271,7 +271,7 @@ class WirelessTagBaseSensor(Entity):
     def device_state_attributes(self):
         """Return the state attributes."""
         return {
-            ATTR_BATTERY_LEVEL: '{:.0%}'.format(self._tag.battery_remaining),
+            ATTR_BATTERY_LEVEL: '{:.0}'.format(self._tag.battery_remaining),
             ATTR_VOLTAGE: '{:.2f}V'.format(self._tag.battery_volts),
             ATTR_TAG_SIGNAL_STRENGTH: '{}dBm'.format(
                 self._tag.signal_strength),


### PR DESCRIPTION
## Description:

Currently the battery level for the WirelessTag component is returned as a decimal (e.g. 0.79 for 79%).  This causes issues when these sensors are exposed via HomeKit (as HomeKit interoperates 0.79 as 0.79%), this fixes that issue properly return the battery_level as a percent.

Note: This is my first time working with Python, so please be gentile ;)

**Related issue (if applicable):** N/A

## Breaking change note

The WirelessTag `battery_level` attribute is now reported as percent (i.e. 79, not 0.79).

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed: N/A

If the code communicates with devices, web services, or third-party tools: N/A

If the code does not interact with devices: N/A
