### PR TITLE
huawei_router: fix last device being ignored

### DIFF
--- a/homeassistant/components/device_tracker/huawei_router.py
+++ b/homeassistant/components/device_tracker/huawei_router.py
@@ -39,7 +39,7 @@ Device = namedtuple('Device', ['name', 'ip', 'mac', 'state'])
 class HuaweiDeviceScanner(DeviceScanner):
     """This class queries a router running HUAWEI firmware."""
 
-    ARRAY_REGEX = re.compile(r'var UserDevinfo = new Array\((.*),null\);')
+    ARRAY_REGEX = re.compile(r'var UserDevinfo = new Array\((.*)null\);')
     DEVICE_REGEX = re.compile(r'new USERDevice\((.*?)\),')
     DEVICE_ATTR_REGEX = re.compile(
         '"(?P<Domain>.*?)","(?P<IpAddr>.*?)",'


### PR DESCRIPTION
## Description:
The regex was not matching the last device on the list, so it was never added to HA.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

