### PR TITLE
Improve Lutron RadioRA2 support, adding switches and scenes

### DIFF
--- a/homeassistant/components/lutron.py
+++ b/homeassistant/components/lutron.py
@@ -86,7 +86,7 @@ class LutronDevice(Entity):
 
     async def async_added_to_hass(self):
         """Register callbacks."""
-        self.hass.async_add_job(
+        self.hass.async_add_executor_job(
             self._lutron_device.subscribe,
             self._update_callback,
             None

--- a/homeassistant/components/lutron.py
+++ b/homeassistant/components/lutron.py
@@ -13,7 +13,7 @@ from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.helpers import discovery
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['pylutron==0.1.0']
+REQUIREMENTS = ['pylutron==0.2.0']
 
 DOMAIN = 'lutron'
 
@@ -36,7 +36,10 @@ def setup(hass, base_config):
     from pylutron import Lutron
 
     hass.data[LUTRON_CONTROLLER] = None
-    hass.data[LUTRON_DEVICES] = {'light': [], 'cover': []}
+    hass.data[LUTRON_DEVICES] = {'light': [],
+                                 'cover': [],
+                                 'switch': [],
+                                 'scene': []}
 
     config = base_config.get(DOMAIN)
     hass.data[LUTRON_CONTROLLER] = Lutron(
@@ -51,10 +54,23 @@ def setup(hass, base_config):
         for output in area.outputs:
             if output.type == 'SYSTEM_SHADE':
                 hass.data[LUTRON_DEVICES]['cover'].append((area.name, output))
-            else:
+            elif output.is_dimmable:
                 hass.data[LUTRON_DEVICES]['light'].append((area.name, output))
+            else:
+                hass.data[LUTRON_DEVICES]['switch'].append((area.name, output))
+        for keypad in area.keypads:
+            for button in keypad.buttons:
+                # This is the best way to determine if a button does anything
+                # useful until pylutron is updated to provide information on
+                # which buttons actually control scenes.
+                for led in keypad.leds:
+                    if (led.number == button.number and
+                            button.name != 'Unknown Button' and
+                            button.button_type in ('SingleAction', 'Toggle')):
+                        hass.data[LUTRON_DEVICES]['scene'].append(
+                            (area.name, button, led))
 
-    for component in ('light', 'cover'):
+    for component in ('light', 'cover', 'switch', 'scene'):
         discovery.load_platform(hass, component, DOMAIN, None, base_config)
     return True
 
@@ -71,11 +87,12 @@ class LutronDevice(Entity):
     async def async_added_to_hass(self):
         """Register callbacks."""
         self.hass.async_add_job(
-            self._controller.subscribe, self._lutron_device,
-            self._update_callback
+            self._lutron_device.subscribe,
+            self._update_callback,
+            None
         )
 
-    def _update_callback(self, _device):
+    def _update_callback(self, _device, _context, _event, _params):
         """Run when invoked by pylutron when the device state changes."""
         self.schedule_update_ha_state()
 

--- a/homeassistant/components/scene/lutron.py
+++ b/homeassistant/components/scene/lutron.py
@@ -26,7 +26,6 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         devs.append(dev)
 
     add_entities(devs, True)
-    return True
 
 
 class LutronScene(LutronDevice, Scene):
@@ -39,18 +38,13 @@ class LutronScene(LutronDevice, Scene):
                  lutron_led,
                  controller):
         """Initialize the scene/button."""
-        LutronDevice.__init__(self, area_name, lutron_device, controller)
+        super().__init__(area_name, lutron_device, controller)
         self._keypad_name = keypad_name
         self._led = lutron_led
 
     def activate(self):
         """Activate the scene."""
         self._lutron_device.press()
-
-    @property
-    def state(self):
-        """Return the state of the scene."""
-        return STATE_ON if self._led.state else STATE_OFF
 
     @property
     def name(self):

--- a/homeassistant/components/scene/lutron.py
+++ b/homeassistant/components/scene/lutron.py
@@ -9,7 +9,6 @@ import logging
 from homeassistant.components.lutron import (
     LutronDevice, LUTRON_DEVICES, LUTRON_CONTROLLER)
 from homeassistant.components.scene import Scene
-from homeassistant.const import (STATE_ON, STATE_OFF)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/scene/lutron.py
+++ b/homeassistant/components/scene/lutron.py
@@ -16,7 +16,7 @@ DEPENDENCIES = ['lutron']
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
-    """Set up the Lutron lights."""
+    """Set up the Lutron scenes."""
     devs = []
     for scene_data in hass.data[LUTRON_DEVICES]['scene']:
         (area_name, keypad_name, device, led) = scene_data
@@ -28,7 +28,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
 
 class LutronScene(LutronDevice, Scene):
-    """Representation of a Lutron Switch."""
+    """Representation of a Lutron Scene."""
 
     def __init__(self,
                  area_name,

--- a/homeassistant/components/scene/lutron.py
+++ b/homeassistant/components/scene/lutron.py
@@ -1,0 +1,60 @@
+"""
+Support for Lutron scenes.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/scene.lutron/
+"""
+import logging
+
+from homeassistant.components.lutron import (
+    LutronDevice, LUTRON_DEVICES, LUTRON_CONTROLLER)
+from homeassistant.components.scene import Scene
+from homeassistant.const import (STATE_ON, STATE_OFF)
+
+_LOGGER = logging.getLogger(__name__)
+
+DEPENDENCIES = ['lutron']
+
+
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    """Set up the Lutron lights."""
+    devs = []
+    for scene_data in hass.data[LUTRON_DEVICES]['scene']:
+        (area_name, keypad_name, device, led) = scene_data
+        dev = LutronScene(area_name, keypad_name, device, led,
+                          hass.data[LUTRON_CONTROLLER])
+        devs.append(dev)
+
+    add_entities(devs, True)
+    return True
+
+
+class LutronScene(LutronDevice, Scene):
+    """Representation of a Lutron Switch."""
+
+    def __init__(self,
+                 area_name,
+                 keypad_name,
+                 lutron_device,
+                 lutron_led,
+                 controller):
+        """Initialize the scene/button."""
+        LutronDevice.__init__(self, area_name, lutron_device, controller)
+        self._keypad_name = keypad_name
+        self._led = lutron_led
+
+    def activate(self):
+        """Activate the scene."""
+        self._lutron_device.press()
+
+    @property
+    def state(self):
+        """Return the state of the scene."""
+        return STATE_ON if self._led.state else STATE_OFF
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return "{} {}: {}".format(self._area_name,
+                                  self._keypad_name,
+                                  self._lutron_device.name)

--- a/homeassistant/components/switch/lutron.py
+++ b/homeassistant/components/switch/lutron.py
@@ -23,7 +23,6 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         devs.append(dev)
 
     add_entities(devs, True)
-    return True
 
 
 class LutronSwitch(LutronDevice, SwitchDevice):
@@ -41,7 +40,7 @@ class LutronSwitch(LutronDevice, SwitchDevice):
     def device_state_attributes(self):
         """Return the state attributes."""
         attr = {}
-        attr['Lutron Integration ID'] = self._lutron_device.id
+        attr['lutron_integration_id'] = self._lutron_device.id
         return attr
 
     @property

--- a/homeassistant/components/switch/lutron.py
+++ b/homeassistant/components/switch/lutron.py
@@ -29,10 +29,6 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class LutronSwitch(LutronDevice, SwitchDevice):
     """Representation of a Lutron Switch."""
 
-    def __init__(self, area_name, lutron_device, controller):
-        """Initialize the switch."""
-        LutronDevice.__init__(self, area_name, lutron_device, controller)
-
     def turn_on(self, **kwargs):
         """Turn the switch on."""
         self._lutron_device.level = 100

--- a/homeassistant/components/switch/lutron.py
+++ b/homeassistant/components/switch/lutron.py
@@ -1,0 +1,54 @@
+"""
+Support for Lutron switches.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/switch.lutron/
+"""
+import logging
+
+from homeassistant.components.switch import SwitchDevice
+from homeassistant.components.lutron import (
+    LutronDevice, LUTRON_DEVICES, LUTRON_CONTROLLER)
+
+_LOGGER = logging.getLogger(__name__)
+
+DEPENDENCIES = ['lutron']
+
+
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    """Set up the Lutron switches."""
+    devs = []
+    for (area_name, device) in hass.data[LUTRON_DEVICES]['switch']:
+        dev = LutronSwitch(area_name, device, hass.data[LUTRON_CONTROLLER])
+        devs.append(dev)
+
+    add_entities(devs, True)
+    return True
+
+
+class LutronSwitch(LutronDevice, SwitchDevice):
+    """Representation of a Lutron Switch."""
+
+    def __init__(self, area_name, lutron_device, controller):
+        """Initialize the switch."""
+        LutronDevice.__init__(self, area_name, lutron_device, controller)
+
+    def turn_on(self, **kwargs):
+        """Turn the switch on."""
+        self._lutron_device.level = 100
+
+    def turn_off(self, **kwargs):
+        """Turn the switch off."""
+        self._lutron_device.level = 0
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        attr = {}
+        attr['Lutron Integration ID'] = self._lutron_device.id
+        return attr
+
+    @property
+    def is_on(self):
+        """Return true if device is on."""
+        return self._lutron_device.last_level() > 0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1011,7 +1011,7 @@ pyloopenergy==0.0.18
 pylutron-caseta==0.5.0
 
 # homeassistant.components.lutron
-pylutron==0.1.0
+pylutron==0.2.0
 
 # homeassistant.components.notify.mailgun
 pymailgunner==1.4


### PR DESCRIPTION
## Description:
- Update the version of pylutron to 0.2 which has various bug fixes.
- Switch to pylutron's per-device subscribe
- Add switch support, and configure any non-dimmable output as a switch.
- Add scene support, using any configured keypad button with a corresponding LED as a scene.


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#7444

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
