### PR TITLE
Add Mythic Beasts DNSAPI Component

### DIFF
--- a/homeassistant/components/mythicbeastsdns.py
+++ b/homeassistant/components/mythicbeastsdns.py
@@ -36,7 +36,6 @@ CONFIG_SCHEMA = vol.Schema({
 
 async def async_setup(hass, config):
     """Initialize the Mythic Beasts component."""
-
     import mbddns
 
     domain = config[DOMAIN][CONF_DOMAIN]

--- a/homeassistant/components/mythicbeastsdns.py
+++ b/homeassistant/components/mythicbeastsdns.py
@@ -1,0 +1,84 @@
+"""
+Integrate with Mythic Beasts Dynamic DNS service.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/mythicbeastsdns/
+"""
+from datetime import timedelta
+import logging
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.const import CONF_HOST, CONF_DOMAIN, CONF_PASSWORD
+from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = 'mythicbeastsdns'
+
+DEFAULT_INTERVAL = timedelta(minutes=10)
+
+UPDATE_URL = 'https://dnsapi4.mythic-beasts.com/'
+
+CONF_UPDATE_INTERVAL = 'update_interval'
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_HOST): cv.string,
+        vol.Required(CONF_DOMAIN): cv.string,
+        vol.Required(CONF_PASSWORD): cv.string,
+        vol.Optional(CONF_UPDATE_INTERVAL, default=DEFAULT_INTERVAL): vol.All(
+            cv.time_period, cv.positive_timedelta),
+    })
+}, extra=vol.ALLOW_EXTRA)
+
+
+async def async_setup(hass, config):
+    """Initialize the Mythic Beasts component."""
+    domain = config[DOMAIN][CONF_DOMAIN]
+    password = config[DOMAIN][CONF_PASSWORD]
+    host = config[DOMAIN][CONF_HOST]
+    update_interval = config[DOMAIN][CONF_UPDATE_INTERVAL]
+
+    session = async_get_clientsession(hass)
+
+    result = await _update_mythicbeastsdns(session, domain, password, host)
+
+    if not result:
+        return False
+
+    async def update_domain_interval(now):
+        """Update the DNS entry."""
+        await _update_mythicbeastsdns(session, domain, password, host)
+
+    async_track_time_interval(hass, update_domain_interval, update_interval)
+
+    return result
+
+
+async def _update_mythicbeastsdns(session, domain, password, host):
+    """Update Mythic Beasts."""
+    data = {
+        'domain': domain,
+        'password': password,
+        'command': "REPLACE {} 5 A DYNAMIC_IP".format(host)
+    }
+
+    resp = await session.post(UPDATE_URL, data=data)
+    body = await resp.text()
+
+    if body.startswith("REPLACE"):
+        _LOGGER.debug("Updating Mythic Beasts successful: %s", body)
+        return True
+
+    if body.startswith("ERR"):
+        _LOGGER.error("Updating Mythic Beasts failed: %s",
+                      body.partition(' ')[2])
+
+    if body.startswith("NREPLACE"):
+        _LOGGER.warning("Updating Mythic Beasts failed: %s",
+                        body.partition(';')[2])
+
+    return False

--- a/homeassistant/components/mythicbeastsdns.py
+++ b/homeassistant/components/mythicbeastsdns.py
@@ -7,7 +7,6 @@ https://home-assistant.io/components/mythicbeastsdns/
 from datetime import timedelta
 import logging
 import voluptuous as vol
-import mbddns
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.const import CONF_HOST, CONF_DOMAIN, CONF_PASSWORD
@@ -37,6 +36,9 @@ CONFIG_SCHEMA = vol.Schema({
 
 async def async_setup(hass, config):
     """Initialize the Mythic Beasts component."""
+
+    import mbddns
+
     domain = config[DOMAIN][CONF_DOMAIN]
     password = config[DOMAIN][CONF_PASSWORD]
     host = config[DOMAIN][CONF_HOST]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -620,6 +620,9 @@ matrix-client==0.2.0
 # homeassistant.components.maxcube
 maxcube-api==0.1.0
 
+# homeassistant.components.mythicbeastsdns
+mbddns==0.1.2
+
 # homeassistant.components.notify.message_bird
 messagebird==1.2.0
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -115,6 +115,9 @@ libsoundtouch==0.7.2
 # homeassistant.components.luftdaten
 luftdaten==0.3.4
 
+# homeassistant.components.mythicbeastsdns
+mbddns==0.1.2
+
 # homeassistant.components.sensor.mfi
 # homeassistant.components.switch.mfi
 mficlient==0.3.0

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -66,6 +66,7 @@ TEST_REQUIREMENTS = (
     'libpurecoollink',
     'libsoundtouch',
     'luftdaten',
+    'mbddns',
     'mficlient',
     'numpy',
     'paho-mqtt',

--- a/tests/components/test_mythicbeastsdns.py
+++ b/tests/components/test_mythicbeastsdns.py
@@ -1,0 +1,99 @@
+"""Test the Mythic Beasts DNS component."""
+import asyncio
+import pytest
+
+from homeassistant.setup import async_setup_component
+from homeassistant.components import mythicbeastsdns
+from homeassistant.util.dt import utcnow
+
+from tests.common import async_fire_time_changed
+
+DOMAIN = 'example.org'
+PASSWORD = 'test_password'
+HOST = 'test'
+UPDATE_INTERVAL = mythicbeastsdns.DEFAULT_INTERVAL
+UPDATE_URL = mythicbeastsdns.UPDATE_URL
+
+
+@pytest.fixture
+def setup_mythicbeastsdns(hass, aioclient_mock):
+    """Fixture that sets up Mythic Beasts."""
+    aioclient_mock.post(UPDATE_URL, data={
+        'domain': DOMAIN,
+        'password': PASSWORD,
+        'command': "REPLACE {} 5 A DYNAMIC_IP".format(HOST)
+    }, text='REPLACE {} 5 A DYNAMIC_IP'.format(HOST))
+
+    hass.loop.run_until_complete(
+        async_setup_component(hass, mythicbeastsdns.DOMAIN, {
+            mythicbeastsdns.DOMAIN: {
+                'domain': DOMAIN,
+                'password': PASSWORD,
+                'host': HOST,
+            }
+        }))
+
+
+@asyncio.coroutine
+def test_setup(hass, aioclient_mock):
+    """Test setup works if update passes."""
+    aioclient_mock.post(UPDATE_URL, data={
+        'domain': DOMAIN,
+        'password': PASSWORD,
+        'command': "REPLACE {} 5 A DYNAMIC_IP".format(HOST)
+    }, text='REPLACE {} 5 A DYNAMIC_IP'.format(HOST))
+
+    result = yield from async_setup_component(hass, mythicbeastsdns.DOMAIN, {
+        mythicbeastsdns.DOMAIN: {
+            'domain': DOMAIN,
+            'password': PASSWORD,
+            'host': HOST
+        }
+    })
+    assert result
+    assert aioclient_mock.call_count == 1
+
+    async_fire_time_changed(hass, utcnow() + UPDATE_INTERVAL)
+    yield from hass.async_block_till_done()
+    assert aioclient_mock.call_count == 2
+
+
+@asyncio.coroutine
+def test_setup_fails_if_wrong_token(hass, aioclient_mock):
+    """Test setup fails if first update fails through wrong token."""
+    aioclient_mock.post(UPDATE_URL, data={
+        'domain': DOMAIN,
+        'password': PASSWORD,
+        'command': "REPLACE {} 5 A DYNAMIC_IP".format(HOST)
+    }, text='ERR Not authenticated')
+
+    result = yield from async_setup_component(hass, mythicbeastsdns.DOMAIN, {
+        mythicbeastsdns.DOMAIN: {
+            'domain': DOMAIN,
+            'password': PASSWORD,
+            'host': HOST,
+        }
+    })
+    assert not result
+    assert aioclient_mock.call_count == 1
+
+
+@asyncio.coroutine
+def test_setup_fails_if_invalid_host(hass, aioclient_mock):
+    """Test setup fails if first update fails through wrong token."""
+    aioclient_mock.post(UPDATE_URL, data={
+        'domain': DOMAIN,
+        'password': PASSWORD,
+        'command': "REPLACE {} 5 A DYNAMIC_IP".format(HOST)
+    }, text='NREPLACE test 5 A DYNAMIC_IP;Invalid host (must be "@", "*" or\
+     only contain a-z, 0-9, - and .)')
+
+    result = yield from async_setup_component(hass, mythicbeastsdns.DOMAIN, {
+        mythicbeastsdns.DOMAIN: {
+            'domain': DOMAIN,
+            'password': PASSWORD,
+            'host': HOST,
+        }
+    })
+    assert not result
+    assert aioclient_mock.call_count == 1

--- a/tests/components/test_mythicbeastsdns.py
+++ b/tests/components/test_mythicbeastsdns.py
@@ -12,7 +12,7 @@ DOMAIN = 'example.org'
 PASSWORD = 'test_password'
 HOST = 'test'
 UPDATE_INTERVAL = mythicbeastsdns.DEFAULT_INTERVAL
-UPDATE_URL = mythicbeastsdns.UPDATE_URL
+UPDATE_URL = 'https://dnsapi4.mythic-beasts.com/'
 
 
 @pytest.fixture
@@ -40,8 +40,8 @@ def test_setup(hass, aioclient_mock):
     aioclient_mock.post(UPDATE_URL, data={
         'domain': DOMAIN,
         'password': PASSWORD,
-        'command': "REPLACE {} 5 A DYNAMIC_IP".format(HOST)
-    }, text='REPLACE {} 5 A DYNAMIC_IP'.format(HOST))
+        'command': "REPLACE {} 60 A DYNAMIC_IP".format(HOST)
+    }, text='REPLACE {} 60 A DYNAMIC_IP'.format(HOST))
 
     result = yield from async_setup_component(hass, mythicbeastsdns.DOMAIN, {
         mythicbeastsdns.DOMAIN: {
@@ -64,7 +64,7 @@ def test_setup_fails_if_wrong_token(hass, aioclient_mock):
     aioclient_mock.post(UPDATE_URL, data={
         'domain': DOMAIN,
         'password': PASSWORD,
-        'command': "REPLACE {} 5 A DYNAMIC_IP".format(HOST)
+        'command': "REPLACE {} 60 A DYNAMIC_IP".format(HOST)
     }, text='ERR Not authenticated')
 
     result = yield from async_setup_component(hass, mythicbeastsdns.DOMAIN, {
@@ -80,12 +80,12 @@ def test_setup_fails_if_wrong_token(hass, aioclient_mock):
 
 @asyncio.coroutine
 def test_setup_fails_if_invalid_host(hass, aioclient_mock):
-    """Test setup fails if first update fails through wrong token."""
+    """Test setup fails if first update fails through invalid host."""
     aioclient_mock.post(UPDATE_URL, data={
         'domain': DOMAIN,
         'password': PASSWORD,
-        'command': "REPLACE {} 5 A DYNAMIC_IP".format(HOST)
-    }, text='NREPLACE test 5 A DYNAMIC_IP;Invalid host (must be "@", "*" or\
+        'command': "REPLACE {} 60 A DYNAMIC_IP".format(HOST)
+    }, text='NREPLACE test 60 A DYNAMIC_IP;Invalid host (must be "@", "*" or\
      only contain a-z, 0-9, - and .)')
 
     result = yield from async_setup_component(hass, mythicbeastsdns.DOMAIN, {


### PR DESCRIPTION
## Description:

This adds a dns component to automatically update your domain at [mythic beasts](https://www.mythic-beasts.com/) on IP changes. 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#7446

## Example entry for `configuration.yaml` (if applicable):
```yaml
mythicbeastsdns:
  host: hostname
  domain: your.domain
  password: APIKEYFORMYTHICBEASTS
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.