### PR TITLE
Rename sensor.launch to sensor.launch_library

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -732,7 +732,7 @@ omit =
     homeassistant/components/sensor/kwb.py
     homeassistant/components/sensor/lacrosse.py
     homeassistant/components/sensor/lastfm.py
-    homeassistant/components/sensor/launch.py
+    homeassistant/components/sensor/launch_library.py
     homeassistant/components/sensor/linky.py
     homeassistant/components/sensor/linux_battery.py
     homeassistant/components/sensor/loopenergy.py

--- a/homeassistant/components/sensor/launch_library.py
+++ b/homeassistant/components/sensor/launch_library.py
@@ -2,7 +2,7 @@
 A sensor platform that give you information about the next space launch.
 
 For more details about this platform, please refer to the documentation at
-https://www.home-assistant.io/components/sensor.launch/
+https://www.home-assistant.io/components/sensor.launch_library/
 """
 from datetime import timedelta
 import logging
@@ -21,7 +21,7 @@ _LOGGER = logging.getLogger(__name__)
 
 ATTRIBUTION = "Data provided by Launch Library."
 
-DEFAULT_NAME = 'Launch'
+DEFAULT_NAME = 'Next launch'
 
 SCAN_INTERVAL = timedelta(hours=1)
 
@@ -39,12 +39,12 @@ async def async_setup_platform(
 
     session = async_get_clientsession(hass)
     launches = Launches(hass.loop, session)
-    sensor = [LaunchSensor(launches, name)]
+    sensor = [LaunchLibrarySensor(launches, name)]
     async_add_entities(sensor, True)
 
 
-class LaunchSensor(Entity):
-    """Representation of a launch Sensor."""
+class LaunchLibrarySensor(Entity):
+    """Representation of a launch_library Sensor."""
 
     def __init__(self, launches, name):
         """Initialize the sensor."""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -991,7 +991,7 @@ pylacrosse==0.3.1
 # homeassistant.components.sensor.lastfm
 pylast==2.4.0
 
-# homeassistant.components.sensor.launch
+# homeassistant.components.sensor.launch_library
 pylaunches==0.1.2
 
 # homeassistant.components.media_player.lg_netcast


### PR DESCRIPTION
## Description:

As discussed in https://github.com/home-assistant/home-assistant/pull/18274 this renames this (unreleased) sensor plaform `sensor.launch` to `sensor.launch_library`

<!-- **Related issue (if applicable):** fixes #<home-assistant issue number goes here> -->

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#7447

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  platform: launch_library
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.
<!--
If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
-->
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
