### PR TITLE
Bump total connect client to 0.22

### DIFF
--- a/homeassistant/components/alarm_control_panel/totalconnect.py
+++ b/homeassistant/components/alarm_control_panel/totalconnect.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
     STATE_ALARM_ARMED_CUSTOM_BYPASS)
 
 
-REQUIREMENTS = ['total_connect_client==0.20']
+REQUIREMENTS = ['total_connect_client==0.22']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1517,7 +1517,7 @@ todoist-python==7.0.17
 toonlib==1.1.3
 
 # homeassistant.components.alarm_control_panel.totalconnect
-total_connect_client==0.20
+total_connect_client==0.22
 
 # homeassistant.components.tplink_lte
 tp-connected==0.0.4


### PR DESCRIPTION
## Description:
Bumping total-connect-client to 0.22

**Related issue (if applicable):** fixes #18181 

## Example entry for `configuration.yaml` (if applicable):
```yaml
alarm_control_panel:
  - platform: totalconnect
    username: YOUR_USERNAME
    password: YOUR_PASSWORD
```
If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.