### PR TITLE
Fix naming of WeMo discovery option

### DIFF
--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -58,17 +58,17 @@ def coerce_host_port(value):
 
 
 CONF_STATIC = 'static'
-CONF_DISABLE_DISCOVERY = 'disable_discovery'
+CONF_DISCOVERY = 'discovery'
 
-DEFAULT_DISABLE_DISCOVERY = False
+DEFAULT_DISCOVERY = True
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Optional(CONF_STATIC, default=[]): vol.Schema([
             vol.All(cv.string, coerce_host_port)
         ]),
-        vol.Optional(CONF_DISABLE_DISCOVERY,
-                     default=DEFAULT_DISABLE_DISCOVERY): cv.boolean
+        vol.Optional(CONF_DISCOVERY,
+                     default=DEFAULT_DISCOVERY): cv.boolean
     }),
 }, extra=vol.ALLOW_EXTRA)
 
@@ -141,9 +141,7 @@ def setup(hass, config):
 
         devices.append((url, device))
 
-    disable_discovery = config.get(DOMAIN, {}).get(CONF_DISABLE_DISCOVERY)
-
-    if not disable_discovery:
+    if config.get(DOMAIN, {}).get(CONF_DISCOVERY):
         _LOGGER.debug("Scanning for WeMo devices.")
         devices.extend(
             (setup_url_for_device(device), device)


### PR DESCRIPTION
## Description:
This changes the name of the disable_discovery config option for the WeMo component to just discovery. The default value for this option is True.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#7453

## Example entry for `configuration.yaml` (if applicable):
```yaml
# Disables automatic discovery for the WeMo component
wemo:
  discovery: false
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)