### PR TITLE
Update HAP-python to 2.4.0

### DIFF
--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -29,7 +29,7 @@ from .const import (
 from .util import (
     show_setup_message, validate_entity_config, validate_media_player_features)
 
-REQUIREMENTS = ['HAP-python==2.2.2']
+REQUIREMENTS = ['HAP-python==2.4.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/homekit/type_switches.py
+++ b/homeassistant/components/homekit/type_switches.py
@@ -2,7 +2,8 @@
 import logging
 
 from pyhap.const import (
-    CATEGORY_OUTLET, CATEGORY_SWITCH)
+    CATEGORY_FAUCET, CATEGORY_OUTLET, CATEGORY_SHOWER_HEAD,
+    CATEGORY_SPRINKLER, CATEGORY_SWITCH)
 
 from homeassistant.components.script import ATTR_CAN_CANCEL
 from homeassistant.components.switch import DOMAIN
@@ -19,10 +20,6 @@ from .const import (
     TYPE_SPRINKLER, TYPE_VALVE)
 
 _LOGGER = logging.getLogger(__name__)
-
-CATEGORY_SPRINKLER = 28
-CATEGORY_FAUCET = 29
-CATEGORY_SHOWER_HEAD = 30
 
 VALVE_TYPE = {
     TYPE_FAUCET: (CATEGORY_FAUCET, 3),

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -32,7 +32,7 @@ Adafruit-SHT31==1.0.2
 # Adafruit_BBIO==1.0.0
 
 # homeassistant.components.homekit
-HAP-python==2.2.2
+HAP-python==2.4.0
 
 # homeassistant.components.notify.mastodon
 Mastodon.py==1.3.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -19,7 +19,7 @@ requests_mock==1.5.2
 
 
 # homeassistant.components.homekit
-HAP-python==2.2.2
+HAP-python==2.4.0
 
 # homeassistant.components.sensor.rmvtransport
 PyRMVtransport==0.1.3


### PR DESCRIPTION
## Description:
Changes
- Fixed issue that caused revert of #17778
- `AccessoryDriver.safe_mode` option to enable pairing through `zeroconf` errors (PR adding this function will follow soon)
- Fixed `CLOSE_WAIT` issue and open sockets
- Fixed slow shutdown with python3.7

Full changelog: https://github.com/ikalchev/HAP-python/blob/dev/CHANGELOG.md

**Related issues:**
#15675
#16692
#17365
https://community.home-assistant.io/t/homekit-devices-not-responding/74656

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

---

@dmonagle, @ehendrix23 can you both do some testing with this PR. Especially for your respective issues (`CLOSE_WAIT` and long time to stop HAP)? I don't want to revert it again if it worsens the connection with HomeKit.