### PR TITLE
Fix for epson state not updating

### DIFF
--- a/homeassistant/components/media_player/epson.py
+++ b/homeassistant/components/media_player/epson.py
@@ -75,7 +75,7 @@ async def async_setup_platform(
             if service.service == SERVICE_SELECT_CMODE:
                 cmode = service.data.get(ATTR_CMODE)
                 await device.select_cmode(cmode)
-            await device.async_update()
+            device.async_schedule_update_ha_state(True)
 
     epson_schema = MEDIA_PLAYER_SCHEMA.extend({
         vol.Required(ATTR_CMODE): vol.All(cv.string, vol.Any(*CMODE_LIST_SET))

--- a/homeassistant/components/media_player/epson.py
+++ b/homeassistant/components/media_player/epson.py
@@ -75,7 +75,7 @@ async def async_setup_platform(
             if service.service == SERVICE_SELECT_CMODE:
                 cmode = service.data.get(ATTR_CMODE)
                 await device.select_cmode(cmode)
-            await device.update()
+            await device.async_update()
 
     epson_schema = MEDIA_PLAYER_SCHEMA.extend({
         vol.Required(ATTR_CMODE): vol.All(cv.string, vol.Any(*CMODE_LIST_SET))
@@ -102,7 +102,7 @@ class EpsonProjector(MediaPlayerDevice):
         self._volume = None
         self._state = None
 
-    async def update(self):
+    async def async_update(self):
         """Update state of device."""
         from epson_projector.const import (
             EPSON_CODES, POWER, CMODE, CMODE_LIST, SOURCE, VOLUME, BUSY,


### PR DESCRIPTION
## Description:
Corrects update method name to override the async version of update. Overriding the wrong version of update worked in 0.80.x, but doesn't anymore. 

**Related issue (if applicable):** fixes #18253

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
