### PR TITLE
Bump python-avion dependency

### DIFF
--- a/homeassistant/components/light/avion.py
+++ b/homeassistant/components/light/avion.py
@@ -16,7 +16,7 @@ from homeassistant.const import (
     CONF_USERNAME)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['antsar-avion==0.9.1']
+REQUIREMENTS = ['avion==0.10']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -140,9 +140,6 @@ anel_pwrctrl-homeassistant==0.0.1.dev2
 # homeassistant.components.media_player.anthemav
 anthemav==1.1.8
 
-# homeassistant.components.light.avion
-# antsar-avion==0.9.1
-
 # homeassistant.components.apcupsd
 apcaccess==0.0.13
 
@@ -158,6 +155,9 @@ asterisk_mbox==0.5.0
 # homeassistant.components.upnp
 # homeassistant.components.media_player.dlna_dmr
 async-upnp-client==0.13.1
+
+# homeassistant.components.light.avion
+# avion==0.10
 
 # homeassistant.components.axis
 axis==16


### PR DESCRIPTION
## Description:
The current version of python-avion doesn't work correctly with Python 3.5.
Update it to one that does.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.