### PR TITLE
Return color information in Alexa Smart Home response

### DIFF
--- a/homeassistant/components/alexa/smart_home.py
+++ b/homeassistant/components/alexa/smart_home.py
@@ -474,6 +474,26 @@ class _AlexaColorController(_AlexaInterface):
     def name(self):
         return 'Alexa.ColorController'
 
+    def properties_supported(self):
+        return [{'name': 'color'}]
+
+    def properties_retrievable(self):
+        return True
+
+    def get_property(self, name):
+        if name != 'color':
+            raise _UnsupportedProperty(name)
+
+        hue, saturation = self.entity.attributes.get(
+            light.ATTR_HS_COLOR, (0, 0))
+
+        return {
+            'hue': hue,
+            'saturation': saturation / 100.0,
+            'brightness': self.entity.attributes.get(
+                light.ATTR_BRIGHTNESS, 0) / 255.0,
+        }
+
 
 class _AlexaColorTemperatureController(_AlexaInterface):
     """Implements Alexa.ColorTemperatureController.

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -1328,6 +1328,32 @@ async def test_report_dimmable_light_state(hass):
     properties.assert_equal('Alexa.BrightnessController', 'brightness', 0)
 
 
+async def test_report_colored_light_state(hass):
+    """Test ColorController reports color correctly."""
+    hass.states.async_set(
+        'light.test_on', 'on', {'friendly_name': "Test light On",
+                                'hs_color': (180, 75),
+                                'brightness': 128,
+                                'supported_features': 17})
+    hass.states.async_set(
+        'light.test_off', 'off', {'friendly_name': "Test light Off",
+                                  'supported_features': 17})
+
+    properties = await reported_properties(hass, 'light.test_on')
+    properties.assert_equal('Alexa.ColorController', 'color', {
+        'hue': 180,
+        'saturation': 0.75,
+        'brightness': 128 / 255.0,
+    })
+
+    properties = await reported_properties(hass, 'light.test_off')
+    properties.assert_equal('Alexa.ColorController', 'color', {
+        'hue': 0,
+        'saturation': 0,
+        'brightness': 0,
+    })
+
+
 async def reported_properties(hass, endpoint):
     """Use ReportState to get properties and return them.
 


### PR DESCRIPTION
## Description: Return color information in Alexa Smart Home response

This PR adds the `color` attribute for the `Alexa.ColorController` interface in the response, fixing an error that occurs within Alexa when setting the color of a device. 

**Related issue (if applicable):** fixes #18367 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
