### PR TITLE
Fix hangouts notify

### DIFF
--- a/homeassistant/components/notify/hangouts.py
+++ b/homeassistant/components/notify/hangouts.py
@@ -9,13 +9,12 @@ import logging
 import voluptuous as vol
 
 from homeassistant.components.notify import (ATTR_TARGET, PLATFORM_SCHEMA,
-                                             NOTIFY_SERVICE_SCHEMA,
                                              BaseNotificationService,
                                              ATTR_MESSAGE, ATTR_DATA)
 
 from homeassistant.components.hangouts.const \
-    import (DOMAIN, SERVICE_SEND_MESSAGE, MESSAGE_DATA_SCHEMA,
-            TARGETS_SCHEMA, CONF_DEFAULT_CONVERSATIONS)
+    import (DOMAIN, SERVICE_SEND_MESSAGE, TARGETS_SCHEMA,
+            CONF_DEFAULT_CONVERSATIONS)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -23,11 +22,6 @@ DEPENDENCIES = [DOMAIN]
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_DEFAULT_CONVERSATIONS): [TARGETS_SCHEMA]
-})
-
-NOTIFY_SERVICE_SCHEMA = NOTIFY_SERVICE_SCHEMA.extend({
-    vol.Optional(ATTR_TARGET): [TARGETS_SCHEMA],
-    vol.Optional(ATTR_DATA, default={}): MESSAGE_DATA_SCHEMA
 })
 
 

--- a/homeassistant/components/notify/hangouts.py
+++ b/homeassistant/components/notify/hangouts.py
@@ -55,8 +55,9 @@ class HangoutsNotificationService(BaseNotificationService):
         service_data = {
             ATTR_TARGET: target_conversations,
             ATTR_MESSAGE: messages,
-            ATTR_DATA: kwargs[ATTR_DATA]
         }
+        if kwargs[ATTR_DATA]:
+            service_data[ATTR_DATA] = kwargs[ATTR_DATA]
 
         return self.hass.services.call(
             DOMAIN, SERVICE_SEND_MESSAGE, service_data=service_data)


### PR DESCRIPTION
## Description:
* Only pass the data key value to the hangouts send message service if we receive data from the notify service base call.
* Remove the notify service schema from the hangouts notify platform, as it isn't used. Platforms can't overwrite base component schemas.

**Related issue (if applicable):**
fixes #18360 

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.