### PR TITLE
Google assistant enable fan speed controls

### DIFF
--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -691,10 +691,12 @@ class FanSpeedTrait(_Trait):
     ]
 
     speed_synonyms = {
-        "off": ['stop', 'off'],
-        "low": ['slow', 'low', 'slowest', 'lowest'],
-        "medium": ['medium', 'mid', 'middle'],
-        "high": ['high', 'max', 'fast', 'highest', 'fastest', 'maximum']
+        fan.SPEED_OFF: ['stop', 'off'],
+        fan.SPEED_LOW: ['slow', 'low', 'slowest', 'lowest'],
+        fan.SPEED_MEDIUM: ['medium', 'mid', 'middle'],
+        fan.SPEED_HIGH: [
+            'high', 'max', 'fast', 'highest', 'fastest', 'maximum'
+        ]
     }
 
     @staticmethod
@@ -724,10 +726,8 @@ class FanSpeedTrait(_Trait):
                 'speeds': speeds,
                 'ordered': True
             },
-            "reversible": True if (
-                    self.state.attributes.get(
-                        ATTR_SUPPORTED_FEATURES, 0) & fan.SUPPORT_DIRECTION)
-            else False
+            "reversible": bool(self.state.attributes.get(
+                ATTR_SUPPORTED_FEATURES, 0) & fan.SUPPORT_DIRECTION)
         }
 
     def query_attributes(self):

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -724,8 +724,10 @@ class FanSpeedTrait(_Trait):
                 'speeds': speeds,
                 'ordered': True
             },
-            "reversible": self.state.attributes.get(
-                ATTR_SUPPORTED_FEATURES, 0) & fan.SUPPORT_DIRECTION
+            "reversible": True if (
+                    self.state.attributes.get(
+                        ATTR_SUPPORTED_FEATURES, 0) & fan.SUPPORT_DIRECTION)
+            else False
         }
 
     def query_attributes(self):

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -737,7 +737,7 @@ class FanSpeedTrait(_Trait):
 
         speed = attrs.get(fan.ATTR_SPEED)
         if speed is not None:
-            response['on'] = speed != 'off'
+            response['on'] = speed != fan.SPEED_OFF
             response['online'] = True
             response['currentFanSpeedSetting'] = speed
 

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -725,7 +725,7 @@ class FanSpeedTrait(_Trait):
                 'ordered': True
             },
             "reversible": self.state.attributes.get(
-                ATTR_SUPPORTED_FEATURES) & fan.SUPPORT_DIRECTION
+                ATTR_SUPPORTED_FEATURES, 0) & fan.SUPPORT_DIRECTION
         }
 
     def query_attributes(self):

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -737,7 +737,7 @@ class FanSpeedTrait(_Trait):
 
         speed = attrs.get(fan.ATTR_SPEED)
         if speed is not None:
-            response['on'] = attrs.get(fan.ATTR_SPEED) != 'off'
+            response['on'] = speed != 'off'
             response['online'] = True
             response['currentFanSpeedSetting'] = speed
 

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -684,6 +684,7 @@ class FanSpeedTrait(_Trait):
 
     https://developers.google.com/actions/smarthome/traits/fanspeed
     """
+
     name = TRAIT_FANSPEED
     commands = [
         COMMAND_FANSPEED
@@ -723,7 +724,8 @@ class FanSpeedTrait(_Trait):
                 'speeds': speeds,
                 'ordered': True
             },
-            "reversible": self.state.attributes.get(ATTR_SUPPORTED_FEATURES) & fan.SUPPORT_DIRECTION
+            "reversible": self.state.attributes.get(
+                ATTR_SUPPORTED_FEATURES) & fan.SUPPORT_DIRECTION
         }
 
     def query_attributes(self):
@@ -741,7 +743,8 @@ class FanSpeedTrait(_Trait):
 
     async def execute(self, command, params):
         """Execute an SetFanSpeed command."""
-
-        await self.hass.services.async_call(fan.DOMAIN, fan.SERVICE_SET_SPEED, {
-            ATTR_ENTITY_ID: self.state.entity_id, fan.ATTR_SPEED: params['fanSpeed']
-        }, blocking=True)
+        await self.hass.services.async_call(
+            fan.DOMAIN, fan.SERVICE_SET_SPEED, {
+                ATTR_ENTITY_ID: self.state.entity_id,
+                fan.ATTR_SPEED: params['fanSpeed']
+            }, blocking=True)

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -1,7 +1,6 @@
 """Implement the Smart Home traits."""
 import logging
 
-from homeassistant.core import DOMAIN as HA_DOMAIN
 from homeassistant.components import (
     climate,
     cover,
@@ -26,8 +25,8 @@ from homeassistant.const import (
     TEMP_FAHRENHEIT,
     ATTR_SUPPORTED_FEATURES,
 )
+from homeassistant.core import DOMAIN as HA_DOMAIN
 from homeassistant.util import color as color_util, temperature as temp_util
-
 from .const import ERR_VALUE_OUT_OF_RANGE
 from .helpers import SmartHomeError
 
@@ -43,6 +42,7 @@ TRAIT_COLOR_TEMP = PREFIX_TRAITS + 'ColorTemperature'
 TRAIT_SCENE = PREFIX_TRAITS + 'Scene'
 TRAIT_TEMPERATURE_SETTING = PREFIX_TRAITS + 'TemperatureSetting'
 TRAIT_LOCKUNLOCK = PREFIX_TRAITS + 'LockUnlock'
+TRAIT_FANSPEED = PREFIX_TRAITS + 'FanSpeed'
 
 PREFIX_COMMANDS = 'action.devices.commands.'
 COMMAND_ONOFF = PREFIX_COMMANDS + 'OnOff'
@@ -58,6 +58,7 @@ COMMAND_THERMOSTAT_TEMPERATURE_SET_RANGE = (
     PREFIX_COMMANDS + 'ThermostatTemperatureSetRange')
 COMMAND_THERMOSTAT_SET_MODE = PREFIX_COMMANDS + 'ThermostatSetMode'
 COMMAND_LOCKUNLOCK = PREFIX_COMMANDS + 'LockUnlock'
+COMMAND_FANSPEED = PREFIX_COMMANDS + 'SetFanSpeed'
 
 
 TRAITS = []
@@ -674,4 +675,73 @@ class LockUnlockTrait(_Trait):
 
         await self.hass.services.async_call(lock.DOMAIN, service, {
             ATTR_ENTITY_ID: self.state.entity_id
+        }, blocking=True)
+
+
+@register_trait
+class FanSpeedTrait(_Trait):
+    """Trait to control speed of Fan.
+
+    https://developers.google.com/actions/smarthome/traits/fanspeed
+    """
+    name = TRAIT_FANSPEED
+    commands = [
+        COMMAND_FANSPEED
+    ]
+
+    speed_synonyms = {
+        "off": ['stop', 'off'],
+        "low": ['slow', 'low', 'slowest', 'lowest'],
+        "medium": ['medium', 'mid', 'middle'],
+        "high": ['high', 'max', 'fast', 'highest', 'fastest', 'maximum']
+    }
+
+    @staticmethod
+    def supported(domain, features):
+        """Test if state is supported."""
+        if domain != fan.DOMAIN:
+            return False
+
+        return features & fan.SUPPORT_SET_SPEED
+
+    def sync_attributes(self):
+        """Return speed point and modes attributes for a sync request."""
+        modes = self.state.attributes.get(fan.ATTR_SPEED_LIST, [])
+        speeds = []
+        for mode in modes:
+            speed = {
+                "speed_name": mode,
+                "speed_values": [{
+                    "speed_synonym": self.speed_synonyms.get(mode),
+                    "lang": 'en'
+                }]
+            }
+            speeds.append(speed)
+
+        return {
+            'availableFanSpeeds': {
+                'speeds': speeds,
+                'ordered': True
+            },
+            "reversible": self.state.attributes.get(ATTR_SUPPORTED_FEATURES) & fan.SUPPORT_DIRECTION
+        }
+
+    def query_attributes(self):
+        """Return speed point and modes query attributes."""
+        attrs = self.state.attributes
+        response = {}
+
+        speed = attrs.get(fan.ATTR_SPEED)
+        if speed is not None:
+            response['on'] = attrs.get(fan.ATTR_SPEED) != 'off'
+            response['online'] = True
+            response['currentFanSpeedSetting'] = speed
+
+        return response
+
+    async def execute(self, command, params):
+        """Execute an SetFanSpeed command."""
+
+        await self.hass.services.async_call(fan.DOMAIN, fan.SERVICE_SET_SPEED, {
+            ATTR_ENTITY_ID: self.state.entity_id, fan.ATTR_SPEED: params['fanSpeed']
         }, blocking=True)

--- a/tests/components/google_assistant/__init__.py
+++ b/tests/components/google_assistant/__init__.py
@@ -183,7 +183,9 @@ DEMO_DEVICES = [{
     'name': {
         'name': 'Living Room Fan'
     },
-    'traits': ['action.devices.traits.OnOff', 'action.devices.traits.SetFanSpeed'],
+    'traits': [
+        'action.devices.traits.OnOff',
+        'action.devices.traits.SetFanSpeed'],
     'type': 'action.devices.types.FAN',
     'willReportState': True
 }, {
@@ -191,7 +193,9 @@ DEMO_DEVICES = [{
     'name': {
         'name': 'Ceiling Fan'
     },
-    'traits': ['action.devices.traits.OnOff', 'action.devices.traits.SetFanSpeed'],
+    'traits': [
+        'action.devices.traits.OnOff',
+        'action.devices.traits.SetFanSpeed'],
     'type': 'action.devices.types.FAN',
     'willReportState': False
 }, {

--- a/tests/components/google_assistant/__init__.py
+++ b/tests/components/google_assistant/__init__.py
@@ -184,18 +184,20 @@ DEMO_DEVICES = [{
         'name': 'Living Room Fan'
     },
     'traits': [
-        'action.devices.traits.OnOff',
-        'action.devices.traits.SetFanSpeed'],
+        'action.devices.traits.FanSpeed',
+        'action.devices.traits.OnOff'
+        ],
     'type': 'action.devices.types.FAN',
-    'willReportState': True
+    'willReportState': False
 }, {
     'id': 'fan.ceiling_fan',
     'name': {
         'name': 'Ceiling Fan'
     },
     'traits': [
-        'action.devices.traits.OnOff',
-        'action.devices.traits.SetFanSpeed'],
+        'action.devices.traits.FanSpeed',
+        'action.devices.traits.OnOff'
+        ],
     'type': 'action.devices.types.FAN',
     'willReportState': False
 }, {

--- a/tests/components/google_assistant/__init__.py
+++ b/tests/components/google_assistant/__init__.py
@@ -183,15 +183,15 @@ DEMO_DEVICES = [{
     'name': {
         'name': 'Living Room Fan'
     },
-    'traits': ['action.devices.traits.OnOff'],
+    'traits': ['action.devices.traits.OnOff', 'action.devices.traits.SetFanSpeed'],
     'type': 'action.devices.types.FAN',
-    'willReportState': False
+    'willReportState': True
 }, {
     'id': 'fan.ceiling_fan',
     'name': {
         'name': 'Ceiling Fan'
     },
-    'traits': ['action.devices.traits.OnOff'],
+    'traits': ['action.devices.traits.OnOff', 'action.devices.traits.SetFanSpeed'],
     'type': 'action.devices.types.FAN',
     'willReportState': False
 }, {

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -797,12 +797,15 @@ async def test_lock_unlock_unlock(hass):
 
 
 async def test_fan_speed(hass):
+    """Test FanSpeed trait speed control support for fan domain."""
     assert trait.FanSpeedTrait.supported(fan.DOMAIN, fan.SUPPORT_SET_SPEED)
 
-    trt = trait.FanSpeedTrait(hass, State('fan.living_room_fan', fan.ATTR_SPEED), BASIC_CONFIG)
+    trt = trait.FanSpeedTrait(
+        hass, State('fan.living_room_fan', fan.ATTR_SPEED), BASIC_CONFIG)
 
     assert trt.sync_attributes() is None
 
     assert trt.query_attributes() is None
 
-    trt = trait.FanSpeedTrait(hass, State('fan.living_room_fan', fan.ATTR_SPEED), UNSAFE_CONFIG)
+    trt = trait.FanSpeedTrait(hass, State(
+        'fan.living_room_fan', fan.ATTR_SPEED), UNSAFE_CONFIG)

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -1,10 +1,6 @@
 """Tests for the Google Assistant traits."""
 import pytest
 
-from homeassistant.const import (
-    STATE_ON, STATE_OFF, ATTR_ENTITY_ID, SERVICE_TURN_ON, SERVICE_TURN_OFF,
-    TEMP_CELSIUS, TEMP_FAHRENHEIT, ATTR_SUPPORTED_FEATURES)
-from homeassistant.core import State, DOMAIN as HA_DOMAIN
 from homeassistant.components import (
     climate,
     cover,
@@ -20,8 +16,11 @@ from homeassistant.components import (
     group,
 )
 from homeassistant.components.google_assistant import trait, helpers, const
+from homeassistant.const import (
+    STATE_ON, STATE_OFF, ATTR_ENTITY_ID, SERVICE_TURN_ON, SERVICE_TURN_OFF,
+    TEMP_CELSIUS, TEMP_FAHRENHEIT, ATTR_SUPPORTED_FEATURES)
+from homeassistant.core import State, DOMAIN as HA_DOMAIN
 from homeassistant.util import color
-
 from tests.common import async_mock_service
 
 BASIC_CONFIG = helpers.Config(
@@ -795,3 +794,15 @@ async def test_lock_unlock_unlock(hass):
     assert calls[0].data == {
         ATTR_ENTITY_ID: 'lock.front_door'
     }
+
+
+async def test_fan_speed(hass):
+    assert trait.FanSpeedTrait.supported(fan.DOMAIN, fan.SUPPORT_SET_SPEED)
+
+    trt = trait.FanSpeedTrait(hass, State('fan.living_room_fan', fan.ATTR_SPEED), BASIC_CONFIG)
+
+    assert trt.sync_attributes() is None
+
+    assert trt.query_attributes() is None
+
+    trt = trait.FanSpeedTrait(hass, State('fan.living_room_fan', fan.ATTR_SPEED), UNSAFE_CONFIG)

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -875,6 +875,3 @@ async def test_fan_speed(hass):
         'entity_id': 'fan.living_room_fan',
         'speed': 'medium'
     }
-
-
-


### PR DESCRIPTION
## Description:
Add FanSpeed intent to fans. Currently support English language keywords.
[https://developers.google.com/actions/smarthome/traits/fanspeed](https://developers.google.com/actions/smarthome/traits/fanspeed)

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>
N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):**
home-assistant/home-assistant.io#7462

## Example entry for `configuration.yaml` (if applicable):
N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)
N/A

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
