### PR TITLE
Logbook speedup

### DIFF
--- a/homeassistant/components/logbook.py
+++ b/homeassistant/components/logbook.py
@@ -142,7 +142,7 @@ class DomainsAndEntitiesFilter:
         if self.excluded_domains and domain in self.excluded_domains \
                 and not self.included_domains:
             if (self.included_entities and
-                entity_id not in self.included_entities) \
+                    entity_id not in self.included_entities) \
                     or not self.included_entities:
                 return False
 
@@ -150,7 +150,7 @@ class DomainsAndEntitiesFilter:
         elif not self.excluded_domains and self.included_domains \
                 and domain not in self.included_domains:
             if (self.included_entities and
-                entity_id not in self.included_entities) \
+                    entity_id not in self.included_entities) \
                     or not self.included_entities:
                 return False
 
@@ -159,7 +159,7 @@ class DomainsAndEntitiesFilter:
                 and (domain not in self.included_domains
                      or domain in self.excluded_domains):
             if (self.included_entities
-                and entity_id not in self.included_entities) \
+                    and entity_id not in self.included_entities) \
                     or not self.included_entities \
                     or domain in self.excluded_domains:
                 return False
@@ -420,13 +420,13 @@ def _get_events(hass, config, start_day, end_day, entity_id=None):
     from homeassistant.components.recorder.util import (
         execute, session_scope)
 
-    filter = DomainsAndEntitiesFilter(config)
+    entities_filter = DomainsAndEntitiesFilter(config)
 
     with session_scope(hass=hass) as session:
         if entity_id is not None:
             entity_ids = [entity_id.lower()]
         else:
-            entity_ids = _get_related_entity_ids(session, filter)
+            entity_ids = _get_related_entity_ids(session, entities_filter)
 
         query = session.query(Events).order_by(Events.time_fired) \
             .outerjoin(States, (Events.event_id == States.event_id)) \
@@ -439,10 +439,10 @@ def _get_events(hass, config, start_day, end_day, entity_id=None):
 
         events = execute(query)
 
-    return humanify(hass, _exclude_events(events, filter))
+    return humanify(hass, _exclude_events(events, entities_filter))
 
 
-def _exclude_events(events, filter):
+def _exclude_events(events, entities_filter):
     filtered_events = []
     for event in events:
         domain, entity_id = None, None
@@ -487,7 +487,7 @@ def _exclude_events(events, filter):
             domain = event.data.get(ATTR_DOMAIN)
             entity_id = event.data.get(ATTR_ENTITY_ID)
 
-        if filter.is_included(domain, entity_id):
+        if entities_filter.is_included(domain, entity_id):
             filtered_events.append(event)
 
     return filtered_events

--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -218,6 +218,8 @@ def _apply_update(engine, new_version, old_version):
         ])
         _create_index(engine, "states", "ix_states_context_id")
         _create_index(engine, "states", "ix_states_context_user_id")
+    elif new_version == 7:
+        _create_index(engine, "states", "ix_states_domain_entity_id")
     else:
         raise ValueError("No schema migration defined for version {}"
                          .format(new_version))

--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -219,7 +219,7 @@ def _apply_update(engine, new_version, old_version):
         _create_index(engine, "states", "ix_states_context_id")
         _create_index(engine, "states", "ix_states_context_user_id")
     elif new_version == 7:
-        _create_index(engine, "states", "ix_states_domain_entity_id")
+        _create_index(engine, "states", "ix_states_entity_id")
     else:
         raise ValueError("No schema migration defined for version {}"
                          .format(new_version))

--- a/homeassistant/components/recorder/models.py
+++ b/homeassistant/components/recorder/models.py
@@ -17,7 +17,7 @@ from homeassistant.helpers.json import JSONEncoder
 # pylint: disable=invalid-name
 Base = declarative_base()
 
-SCHEMA_VERSION = 6
+SCHEMA_VERSION = 7
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -86,7 +86,12 @@ class States(Base):   # type: ignore
         # Used for fetching the state of entities at a specific time
         # (get_states in history.py)
         Index(
-            'ix_states_entity_id_last_updated', 'entity_id', 'last_updated'),)
+            'ix_states_entity_id_last_updated', 'entity_id', 'last_updated'),
+        # Used for filtering logbook entries
+        # (_get_related_entity_ids in logbook.py)
+        Index(
+            'ix_states_domain_entity_id', 'domain', 'entity_id'),
+    )
 
     @staticmethod
     def from_event(event):

--- a/homeassistant/components/recorder/models.py
+++ b/homeassistant/components/recorder/models.py
@@ -71,7 +71,7 @@ class States(Base):   # type: ignore
     __tablename__ = 'states'
     state_id = Column(Integer, primary_key=True)
     domain = Column(String(64))
-    entity_id = Column(String(255))
+    entity_id = Column(String(255), index=True)
     state = Column(String(255))
     attributes = Column(Text)
     event_id = Column(Integer, ForeignKey('events.event_id'), index=True)
@@ -87,10 +87,6 @@ class States(Base):   # type: ignore
         # (get_states in history.py)
         Index(
             'ix_states_entity_id_last_updated', 'entity_id', 'last_updated'),
-        # Used for filtering logbook entries
-        # (_get_related_entity_ids in logbook.py)
-        Index(
-            'ix_states_domain_entity_id', 'domain', 'entity_id'),
     )
 
     @staticmethod

--- a/tests/components/test_logbook.py
+++ b/tests/components/test_logbook.py
@@ -136,9 +136,10 @@ class TestComponentLogbook(unittest.TestCase):
         eventB = self.create_state_changed_event(pointB, entity_id2, 20)
         eventA.data['old_state'] = None
 
-        events = logbook._exclude_events((ha.Event(EVENT_HOMEASSISTANT_STOP),
-                                          eventA, eventB),
-                                         logbook.DomainsAndEntitiesFilter({}))
+        events = logbook._exclude_events(
+            (ha.Event(EVENT_HOMEASSISTANT_STOP),
+             eventA, eventB),
+            logbook._generate_filter_from_config({}))
         entries = list(logbook.humanify(self.hass, events))
 
         assert 2 == len(entries)
@@ -159,9 +160,10 @@ class TestComponentLogbook(unittest.TestCase):
         eventB = self.create_state_changed_event(pointB, entity_id2, 20)
         eventA.data['new_state'] = None
 
-        events = logbook._exclude_events((ha.Event(EVENT_HOMEASSISTANT_STOP),
-                                          eventA, eventB),
-                                         logbook.DomainsAndEntitiesFilter({}))
+        events = logbook._exclude_events(
+            (ha.Event(EVENT_HOMEASSISTANT_STOP),
+             eventA, eventB),
+            logbook._generate_filter_from_config({}))
         entries = list(logbook.humanify(self.hass, events))
 
         assert 2 == len(entries)
@@ -182,9 +184,10 @@ class TestComponentLogbook(unittest.TestCase):
                                                  {ATTR_HIDDEN: 'true'})
         eventB = self.create_state_changed_event(pointB, entity_id2, 20)
 
-        events = logbook._exclude_events((ha.Event(EVENT_HOMEASSISTANT_STOP),
-                                          eventA, eventB),
-                                         logbook.DomainsAndEntitiesFilter({}))
+        events = logbook._exclude_events(
+            (ha.Event(EVENT_HOMEASSISTANT_STOP),
+             eventA, eventB),
+            logbook._generate_filter_from_config({}))
         entries = list(logbook.humanify(self.hass, events))
 
         assert 2 == len(entries)
@@ -210,7 +213,7 @@ class TestComponentLogbook(unittest.TestCase):
                 logbook.CONF_ENTITIES: [entity_id, ]}}})
         events = logbook._exclude_events(
             (ha.Event(EVENT_HOMEASSISTANT_STOP), eventA, eventB),
-            logbook.DomainsAndEntitiesFilter(config[logbook.DOMAIN]))
+            logbook._generate_filter_from_config(config[logbook.DOMAIN]))
         entries = list(logbook.humanify(self.hass, events))
 
         assert 2 == len(entries)
@@ -236,7 +239,7 @@ class TestComponentLogbook(unittest.TestCase):
                 logbook.CONF_DOMAINS: ['switch', ]}}})
         events = logbook._exclude_events(
             (ha.Event(EVENT_HOMEASSISTANT_START), eventA, eventB),
-            logbook.DomainsAndEntitiesFilter(config[logbook.DOMAIN]))
+            logbook._generate_filter_from_config(config[logbook.DOMAIN]))
         entries = list(logbook.humanify(self.hass, events))
 
         assert 2 == len(entries)
@@ -273,7 +276,7 @@ class TestComponentLogbook(unittest.TestCase):
                 logbook.CONF_ENTITIES: [entity_id, ]}}})
         events = logbook._exclude_events(
             (ha.Event(EVENT_HOMEASSISTANT_STOP), eventA, eventB),
-            logbook.DomainsAndEntitiesFilter(config[logbook.DOMAIN]))
+            logbook._generate_filter_from_config(config[logbook.DOMAIN]))
         entries = list(logbook.humanify(self.hass, events))
 
         assert 2 == len(entries)
@@ -299,7 +302,7 @@ class TestComponentLogbook(unittest.TestCase):
                 logbook.CONF_ENTITIES: [entity_id2, ]}}})
         events = logbook._exclude_events(
             (ha.Event(EVENT_HOMEASSISTANT_STOP), eventA, eventB),
-            logbook.DomainsAndEntitiesFilter(config[logbook.DOMAIN]))
+            logbook._generate_filter_from_config(config[logbook.DOMAIN]))
         entries = list(logbook.humanify(self.hass, events))
 
         assert 2 == len(entries)
@@ -325,7 +328,7 @@ class TestComponentLogbook(unittest.TestCase):
                 logbook.CONF_DOMAINS: ['sensor', ]}}})
         events = logbook._exclude_events(
             (ha.Event(EVENT_HOMEASSISTANT_START), eventA, eventB),
-            logbook.DomainsAndEntitiesFilter(config[logbook.DOMAIN]))
+            logbook._generate_filter_from_config(config[logbook.DOMAIN]))
         entries = list(logbook.humanify(self.hass, events))
 
         assert 2 == len(entries)
@@ -360,15 +363,19 @@ class TestComponentLogbook(unittest.TestCase):
         events = logbook._exclude_events(
             (ha.Event(EVENT_HOMEASSISTANT_START), eventA1, eventA2, eventA3,
              eventB1, eventB2),
-            logbook.DomainsAndEntitiesFilter(config[logbook.DOMAIN]))
+            logbook._generate_filter_from_config(config[logbook.DOMAIN]))
         entries = list(logbook.humanify(self.hass, events))
 
-        assert 3 == len(entries)
+        assert 5 == len(entries)
         self.assert_entry(entries[0], name='Home Assistant', message='started',
                           domain=ha.DOMAIN)
-        self.assert_entry(entries[1], pointA, 'blu', domain='sensor',
+        self.assert_entry(entries[1], pointA, 'bla', domain='switch',
+                          entity_id=entity_id)
+        self.assert_entry(entries[2], pointA, 'blu', domain='sensor',
                           entity_id=entity_id2)
-        self.assert_entry(entries[2], pointB, 'blu', domain='sensor',
+        self.assert_entry(entries[3], pointB, 'bla', domain='switch',
+                          entity_id=entity_id)
+        self.assert_entry(entries[4], pointB, 'blu', domain='sensor',
                           entity_id=entity_id2)
 
     def test_exclude_auto_groups(self):
@@ -381,8 +388,9 @@ class TestComponentLogbook(unittest.TestCase):
         eventB = self.create_state_changed_event(pointA, entity_id2, 20,
                                                  {'auto': True})
 
-        events = logbook._exclude_events((eventA, eventB),
-                                         logbook.DomainsAndEntitiesFilter({}))
+        events = logbook._exclude_events(
+            (eventA, eventB),
+            logbook._generate_filter_from_config({}))
         entries = list(logbook.humanify(self.hass, events))
 
         assert 1 == len(entries)
@@ -400,8 +408,9 @@ class TestComponentLogbook(unittest.TestCase):
         eventB = self.create_state_changed_event(
             pointA, entity_id2, 20, last_changed=pointA, last_updated=pointB)
 
-        events = logbook._exclude_events((eventA, eventB),
-                                         logbook.DomainsAndEntitiesFilter({}))
+        events = logbook._exclude_events(
+            (eventA, eventB),
+            logbook._generate_filter_from_config({}))
         entries = list(logbook.humanify(self.hass, events))
 
         assert 1 == len(entries)

--- a/tests/components/test_logbook.py
+++ b/tests/components/test_logbook.py
@@ -137,7 +137,8 @@ class TestComponentLogbook(unittest.TestCase):
         eventA.data['old_state'] = None
 
         events = logbook._exclude_events((ha.Event(EVENT_HOMEASSISTANT_STOP),
-                                          eventA, eventB), {})
+                                          eventA, eventB),
+                                         logbook.DomainsAndEntitiesFilter({}))
         entries = list(logbook.humanify(self.hass, events))
 
         assert 2 == len(entries)
@@ -159,7 +160,8 @@ class TestComponentLogbook(unittest.TestCase):
         eventA.data['new_state'] = None
 
         events = logbook._exclude_events((ha.Event(EVENT_HOMEASSISTANT_STOP),
-                                          eventA, eventB), {})
+                                          eventA, eventB),
+                                         logbook.DomainsAndEntitiesFilter({}))
         entries = list(logbook.humanify(self.hass, events))
 
         assert 2 == len(entries)
@@ -181,7 +183,8 @@ class TestComponentLogbook(unittest.TestCase):
         eventB = self.create_state_changed_event(pointB, entity_id2, 20)
 
         events = logbook._exclude_events((ha.Event(EVENT_HOMEASSISTANT_STOP),
-                                          eventA, eventB), {})
+                                          eventA, eventB),
+                                         logbook.DomainsAndEntitiesFilter({}))
         entries = list(logbook.humanify(self.hass, events))
 
         assert 2 == len(entries)
@@ -207,7 +210,7 @@ class TestComponentLogbook(unittest.TestCase):
                 logbook.CONF_ENTITIES: [entity_id, ]}}})
         events = logbook._exclude_events(
             (ha.Event(EVENT_HOMEASSISTANT_STOP), eventA, eventB),
-            config[logbook.DOMAIN])
+            logbook.DomainsAndEntitiesFilter(config[logbook.DOMAIN]))
         entries = list(logbook.humanify(self.hass, events))
 
         assert 2 == len(entries)
@@ -233,7 +236,7 @@ class TestComponentLogbook(unittest.TestCase):
                 logbook.CONF_DOMAINS: ['switch', ]}}})
         events = logbook._exclude_events(
             (ha.Event(EVENT_HOMEASSISTANT_START), eventA, eventB),
-            config[logbook.DOMAIN])
+            logbook.DomainsAndEntitiesFilter(config[logbook.DOMAIN]))
         entries = list(logbook.humanify(self.hass, events))
 
         assert 2 == len(entries)
@@ -270,7 +273,7 @@ class TestComponentLogbook(unittest.TestCase):
                 logbook.CONF_ENTITIES: [entity_id, ]}}})
         events = logbook._exclude_events(
             (ha.Event(EVENT_HOMEASSISTANT_STOP), eventA, eventB),
-            config[logbook.DOMAIN])
+            logbook.DomainsAndEntitiesFilter(config[logbook.DOMAIN]))
         entries = list(logbook.humanify(self.hass, events))
 
         assert 2 == len(entries)
@@ -296,7 +299,7 @@ class TestComponentLogbook(unittest.TestCase):
                 logbook.CONF_ENTITIES: [entity_id2, ]}}})
         events = logbook._exclude_events(
             (ha.Event(EVENT_HOMEASSISTANT_STOP), eventA, eventB),
-            config[logbook.DOMAIN])
+            logbook.DomainsAndEntitiesFilter(config[logbook.DOMAIN]))
         entries = list(logbook.humanify(self.hass, events))
 
         assert 2 == len(entries)
@@ -322,7 +325,7 @@ class TestComponentLogbook(unittest.TestCase):
                 logbook.CONF_DOMAINS: ['sensor', ]}}})
         events = logbook._exclude_events(
             (ha.Event(EVENT_HOMEASSISTANT_START), eventA, eventB),
-            config[logbook.DOMAIN])
+            logbook.DomainsAndEntitiesFilter(config[logbook.DOMAIN]))
         entries = list(logbook.humanify(self.hass, events))
 
         assert 2 == len(entries)
@@ -356,7 +359,8 @@ class TestComponentLogbook(unittest.TestCase):
                     logbook.CONF_ENTITIES: ['sensor.bli', ]}}})
         events = logbook._exclude_events(
             (ha.Event(EVENT_HOMEASSISTANT_START), eventA1, eventA2, eventA3,
-             eventB1, eventB2), config[logbook.DOMAIN])
+             eventB1, eventB2),
+            logbook.DomainsAndEntitiesFilter(config[logbook.DOMAIN]))
         entries = list(logbook.humanify(self.hass, events))
 
         assert 3 == len(entries)
@@ -377,7 +381,8 @@ class TestComponentLogbook(unittest.TestCase):
         eventB = self.create_state_changed_event(pointA, entity_id2, 20,
                                                  {'auto': True})
 
-        events = logbook._exclude_events((eventA, eventB), {})
+        events = logbook._exclude_events((eventA, eventB),
+                                         logbook.DomainsAndEntitiesFilter({}))
         entries = list(logbook.humanify(self.hass, events))
 
         assert 1 == len(entries)
@@ -395,7 +400,8 @@ class TestComponentLogbook(unittest.TestCase):
         eventB = self.create_state_changed_event(
             pointA, entity_id2, 20, last_changed=pointA, last_updated=pointB)
 
-        events = logbook._exclude_events((eventA, eventB), {})
+        events = logbook._exclude_events((eventA, eventB),
+                                         logbook.DomainsAndEntitiesFilter({}))
         entries = list(logbook.humanify(self.hass, events))
 
         assert 1 == len(entries)


### PR DESCRIPTION
## Description:

Logbook is unusable on my setup (underline request for data times out nginx proxy with 504 which results in "No logbook entries found" message to the user).

My setup for reference: less than 40k events per day with 7 days retention, running on AWS free tier mariaDB.
Logbook config only includes couple entities that produce just a couple of events per day.

This PR makes it usable again by fetching all possible domain/entity_id's pairs and running them through include/exclude filters (from config). That way we get a list of entity_id's that can be passed to DB for filtering main query.

Logbook requests timing (on my setup):
- master: minutes
- PR: 20-100 ms

## Breaking change
In configurations where both `exclude` and `include` domains are specified, excluded domains are ignored now (were not ignored previously). To get it inline with other similar components.

**Related issue (if applicable):** fixes #17565 (for some setups)

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
