### PR TITLE
Fixed misspellings in some of the Pollen sensor names

### DIFF
--- a/homeassistant/components/sensor/pollen.py
+++ b/homeassistant/components/sensor/pollen.py
@@ -62,11 +62,11 @@ SENSORS = {
         'IndexSensor', 'Allergy Index: Tomorrow', 'mdi:flower'),
     TYPE_ALLERGY_YESTERDAY: (
         'IndexSensor', 'Allergy Index: Yesterday', 'mdi:flower'),
-    TYPE_ASTHMA_TODAY: ('IndexSensor', 'Ashma Index: Today', 'mdi:flower'),
+    TYPE_ASTHMA_TODAY: ('IndexSensor', 'Asthma Index: Today', 'mdi:flower'),
     TYPE_ASTHMA_TOMORROW: (
-        'IndexSensor', 'Ashma Index: Tomorrow', 'mdi:flower'),
+        'IndexSensor', 'Asthma Index: Tomorrow', 'mdi:flower'),
     TYPE_ASTHMA_YESTERDAY: (
-        'IndexSensor', 'Ashma Index: Yesterday', 'mdi:flower'),
+        'IndexSensor', 'Asthma Index: Yesterday', 'mdi:flower'),
     TYPE_ASTHMA_FORECAST: (
         'ForecastSensor', 'Asthma Index: Forecasted Average', 'mdi:flower'),
     TYPE_ASTHMA_HISTORIC: (


### PR DESCRIPTION
## Description:
This PR fixes misspellings in the friendly names of some Pollen.com sensors.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: pollen
    zip_code: "12345"
    monitored_conditions:
      - allergy_average_forecasted
      - allergy_average_historical
      - allergy_index_today
      - allergy_index_tomorrow
      - allergy_index_yesterday
      - disease_average_forecasted
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
