### PR TITLE
 Add hadockermon switch platform

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -840,6 +840,7 @@ omit =
     homeassistant/components/switch/dlink.py
     homeassistant/components/switch/edimax.py
     homeassistant/components/switch/fritzdect.py
+    homeassistant/components/switch/hadockermon.py
     homeassistant/components/switch/hikvisioncam.py
     homeassistant/components/switch/hook.py
     homeassistant/components/switch/kankun.py

--- a/homeassistant/components/switch/hadockermon.py
+++ b/homeassistant/components/switch/hadockermon.py
@@ -10,9 +10,10 @@ import logging
 import voluptuous as vol
 
 from homeassistant.components.switch import (DOMAIN, PLATFORM_SCHEMA,
-        SwitchDevice)
+                                             SwitchDevice)
 from homeassistant.const import (CONF_HOST, CONF_PORT, CONF_NAME,
-        CONF_USERNAME, CONF_PASSWORD, CONF_SSL, CONF_VERIFY_SSL)
+                                 CONF_USERNAME, CONF_PASSWORD,
+                                 CONF_SSL, CONF_VERIFY_SSL)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
@@ -68,7 +69,8 @@ async def async_setup_platform(hass, config, async_add_entities,
         _LOGGER.info("Restarting %s", container)
         await api.container_restart(container)
 
-    hass.services.async_register(DOMAIN, 'hadockermon_restart', restart_container)
+    hass.services.async_register(DOMAIN, 'hadockermon_restart',
+                                 restart_container)
 
     async_add_entities(devices, True)
 

--- a/homeassistant/components/switch/hadockermon.py
+++ b/homeassistant/components/switch/hadockermon.py
@@ -89,11 +89,11 @@ class HADockermonSwitch(SwitchDevice):
         self._status = None
         self._image = None
 
-    async def async_turn_on(self):
+    async def async_turn_on(self, **kwargs):
         """Turn on the switch."""
         await self.api.container_start(self.container)
 
-    async def async_turn_off(self):
+    async def async_turn_off(self, **kwargs):
         """Turn off the switch."""
         await self.api.container_stop(self.container)
 

--- a/homeassistant/components/switch/hadockermon.py
+++ b/homeassistant/components/switch/hadockermon.py
@@ -16,13 +16,12 @@ from homeassistant.const import (CONF_HOST, CONF_PORT, CONF_NAME,
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-
 _LOGGER = logging.getLogger(__name__)
 
 REQUIREMENTS = ['pydockermon==1.0.0']
 DEFAULT_NAME = 'HA Dockermon {0}'
 
-CONFCONTAINERS = 'containers'
+CONF_CONTAINERS = 'containers'
 
 ATTR_CONTAINER = 'container'
 ATTR_STATUS = 'status'
@@ -36,7 +35,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_PASSWORD): cv.string,
     vol.Optional(CONF_SSL, default=False): cv.boolean,
     vol.Optional(CONF_VERIFY_SSL, default=False): cv.boolean,
-    vol.Optional(CONFCONTAINERS, default=None):
+    vol.Optional(CONF_CONTAINERS, default=None):
         vol.All(cv.ensure_list, [cv.string]),
 })
 
@@ -53,7 +52,7 @@ async def async_setup_platform(hass, config, async_add_entities,
     ssl = config[CONF_SSL]
     verify_ssl = config[CONF_VERIFY_SSL]
     device_name = config.get(CONF_NAME)
-    containers = config[CONFCONTAINERS]
+    containers = config[CONF_CONTAINERS]
     session = async_get_clientsession(hass, verify_ssl)
     api = API(hass.loop, session, host, port, username, password, ssl)
     devices = []

--- a/homeassistant/components/switch/hadockermon.py
+++ b/homeassistant/components/switch/hadockermon.py
@@ -74,10 +74,10 @@ async def async_setup_platform(hass, config, async_add_entities,
 
 
 class HADockermonSwitch(SwitchDevice):
-    """Representation of a recswitch device."""
+    """Representation of a HA Dockermon switch."""
 
     def __init__(self, api, device_name, container):
-        """Initialize a recswitch device."""
+        """Initialize a HA Dockermon switch."""
         self.api = api
         self.device_name = device_name
         self.container = container

--- a/homeassistant/components/switch/hadockermon.py
+++ b/homeassistant/components/switch/hadockermon.py
@@ -1,0 +1,137 @@
+"""
+Support for controlling HA Dockermon.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/switch.hadockermon/
+"""
+
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components.switch import (DOMAIN, PLATFORM_SCHEMA,
+        SwitchDevice)
+from homeassistant.const import (CONF_HOST, CONF_PORT, CONF_NAME,
+        CONF_USERNAME, CONF_PASSWORD, CONF_SSL, CONF_VERIFY_SSL)
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+
+_LOGGER = logging.getLogger(__name__)
+
+REQUIREMENTS = ['pydockermon==1.0.0']
+DEFAULT_NAME = 'HA Dockermon {0}'
+
+CONFCONTAINERS = 'containers'
+
+ATTR_CONTAINER = 'container'
+ATTR_STATUS = 'status'
+ATTR_IMAGE = 'image'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_HOST): cv.string,
+    vol.Required(CONF_PORT, default=8126): cv.port,
+    vol.Optional(CONF_NAME): cv.string,
+    vol.Optional(CONF_USERNAME): cv.string,
+    vol.Optional(CONF_PASSWORD): cv.string,
+    vol.Optional(CONF_SSL, default=False): cv.boolean,
+    vol.Optional(CONF_VERIFY_SSL, default=False): cv.boolean,
+    vol.Optional(CONFCONTAINERS, default=None):
+        vol.All(cv.ensure_list, [cv.string]),
+})
+
+
+async def async_setup_platform(hass, config, async_add_entities,
+                               discovery_info=None):
+    """Set up the device."""
+    from pydockermon.api import API
+
+    host = config[CONF_HOST]
+    port = config[CONF_PORT]
+    username = config.get(CONF_PASSWORD)
+    password = config.get(CONF_PASSWORD)
+    ssl = config[CONF_SSL]
+    verify_ssl = config[CONF_VERIFY_SSL]
+    device_name = config.get(CONF_NAME)
+    containers = config[CONFCONTAINERS]
+    session = async_get_clientsession(hass, verify_ssl)
+    api = API(hass.loop, session, host, port, username, password, ssl)
+    devices = []
+    await api.list_containers()
+    for container in api.all_containers['data']:
+        if not containers or container in containers:
+            if not container.startswith("addon_"):
+                devices.append(HADockermonSwitch(api, device_name, container))
+
+    async def restart_container(call):
+        """Restart a container."""
+        container = call.data.get(ATTR_CONTAINER)
+        _LOGGER.info("Restarting %s", container)
+        await api.container_restart(container)
+
+    hass.services.async_register(DOMAIN, 'hadockermon_restart', restart_container)
+
+    async_add_entities(devices, True)
+
+
+class HADockermonSwitch(SwitchDevice):
+    """Representation of a recswitch device."""
+
+    def __init__(self, api, device_name, container):
+        """Initialize a recswitch device."""
+        self.api = api
+        self.device_name = device_name
+        self.container = container
+        if not self.device_name:
+            self.device_name = DEFAULT_NAME.format(self.container)
+        self._state = None
+        self._status = None
+        self._image = None
+
+    async def async_turn_on(self):
+        """Turn on the switch."""
+        await self.api.container_start(self.container)
+
+    async def async_turn_off(self):
+        """Turn off the switch."""
+        await self.api.container_stop(self.container)
+
+    async def async_update(self):
+        """Update the current switch status."""
+        state = await self.api.container_state(self.container)
+        try:
+            self._state = state['data']['state']
+        except (TypeError, KeyError):
+            _LOGGER.debug("Could not fetch state for %s", self.container)
+        try:
+            self._status = state['data']['status']
+        except (TypeError, KeyError):
+            _LOGGER.debug("Could not fetch status for %s", self.container)
+        try:
+            self._image = state['data']['image']
+        except (TypeError, KeyError):
+            _LOGGER.debug("Could not fetch image for %s", self.container)
+
+    @property
+    def name(self):
+        """Return the switch name."""
+        return self.device_name
+
+    @property
+    def is_on(self):
+        """Return true if switch is on."""
+        state = True if self._state == 'running' else False
+        return state
+
+    @property
+    def icon(self):
+        """Set the device icon."""
+        return 'mdi:docker'
+
+    @property
+    def device_state_attributes(self):
+        """Set device attributes."""
+        return {
+            ATTR_STATUS: self._status,
+            ATTR_IMAGE: self._image,
+        }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -885,6 +885,9 @@ pydeconz==47
 # homeassistant.components.zwave
 pydispatcher==2.0.5
 
+# homeassistant.components.switch.hadockermon
+pydockermon==1.0.0
+
 # homeassistant.components.android_ip_webcam
 pydroid-ipcam==0.8
 


### PR DESCRIPTION
## Description:

This platform will expose containers that are controllable with HA Dockermon as switches.

![image](https://user-images.githubusercontent.com/15093472/48317389-c0d71400-e5f1-11e8-8428-733b523ead7a.png)


<!-- **Related issue (if applicable):** fixes #<home-assistant issue number goes here> -->

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#7470

## Example entry for `configuration.yaml` (if applicable):
```yaml
switch:
  platform: hadockermon
  host: 192.168.1.155
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.
<!--
If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works. -->

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
