### PR TITLE
Suppress PyNaCl warnings of Discord notify

### DIFF
--- a/homeassistant/components/notify/discord.py
+++ b/homeassistant/components/notify/discord.py
@@ -41,7 +41,7 @@ class DiscordNotificationService(BaseNotificationService):
     async def async_send_message(self, message, **kwargs):
         """Login to Discord, send message to channel(s) and log out."""
         import discord
-        
+
         discord.VoiceClient.warn_nacl = False
         discord_bot = discord.Client(loop=self.hass.loop)
 

--- a/homeassistant/components/notify/discord.py
+++ b/homeassistant/components/notify/discord.py
@@ -41,6 +41,8 @@ class DiscordNotificationService(BaseNotificationService):
     async def async_send_message(self, message, **kwargs):
         """Login to Discord, send message to channel(s) and log out."""
         import discord
+        
+        discord.VoiceClient.warn_nacl = False
         discord_bot = discord.Client(loop=self.hass.loop)
 
         if ATTR_TARGET not in kwargs:
@@ -53,6 +55,7 @@ class DiscordNotificationService(BaseNotificationService):
             """Send the messages when the bot is ready."""
             try:
                 data = kwargs.get(ATTR_DATA)
+                images = None
                 if data:
                     images = data.get(ATTR_IMAGES)
                 for channelid in kwargs[ATTR_TARGET]:


### PR DESCRIPTION
## Description:
Suppress PyNaCl warnings, since we're not using the voice features of the discord.py package. Correct variable used before it is assigned error for the images variable.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.