### PR TITLE
WeMo Humidifier - Add wemo_reset_filter_life service

### DIFF
--- a/homeassistant/components/alexa/smart_home.py
+++ b/homeassistant/components/alexa/smart_home.py
@@ -474,6 +474,26 @@ class _AlexaColorController(_AlexaInterface):
     def name(self):
         return 'Alexa.ColorController'
 
+    def properties_supported(self):
+        return [{'name': 'color'}]
+
+    def properties_retrievable(self):
+        return True
+
+    def get_property(self, name):
+        if name != 'color':
+            raise _UnsupportedProperty(name)
+
+        hue, saturation = self.entity.attributes.get(
+            light.ATTR_HS_COLOR, (0, 0))
+
+        return {
+            'hue': hue,
+            'saturation': saturation / 100.0,
+            'brightness': self.entity.attributes.get(
+                light.ATTR_BRIGHTNESS, 0) / 255.0,
+        }
+
 
 class _AlexaColorTemperatureController(_AlexaInterface):
     """Implements Alexa.ColorTemperatureController.

--- a/homeassistant/components/fan/services.yaml
+++ b/homeassistant/components/fan/services.yaml
@@ -214,3 +214,10 @@ wemo_set_humidity:
     target_humidity:
       description: Target humidity. This is a float value between 0 and 100, but will be mapped to the humidity levels that WeMo humidifiers support (45, 50, 55, 60, and 100/Max) by rounding the value down to the nearest supported value.
       example: 56.5
+
+wemo_reset_filter_life:
+  description: Reset the WeMo Humidifier's filter life to 100%.
+  fields:
+    entity_id:
+      description: Names of the WeMo humidifier entities (1 or more entity_ids are required).
+      example: 'fan.wemo_humidifier'

--- a/homeassistant/components/fan/wemo.py
+++ b/homeassistant/components/fan/wemo.py
@@ -122,7 +122,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             target_humidity = service.data.get(ATTR_TARGET_HUMIDITY)
 
             if entity_ids:
-                humidifiers = [device for device in hass.data[DATA_KEY].values() if
+                humidifiers = [device for device in
+                               hass.data[DATA_KEY].values() if
                                device.entity_id in entity_ids]
             else:
                 humidifiers = hass.data[DATA_KEY].values()
@@ -131,7 +132,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                 humidifier.set_humidity(target_humidity)
         elif service.service == SERVICE_RESET_FILTER_LIFE:
             if entity_ids:
-                humidifiers = [device for device in hass.data[DATA_KEY].values() if
+                humidifiers = [device for device in
+                               hass.data[DATA_KEY].values() if
                                device.entity_id in entity_ids]
 
                 for humidifier in humidifiers:

--- a/homeassistant/components/fan/wemo.py
+++ b/homeassistant/components/fan/wemo.py
@@ -83,6 +83,12 @@ SET_HUMIDITY_SCHEMA = vol.Schema({
         vol.All(vol.Coerce(float), vol.Range(min=0, max=100))
 })
 
+SERVICE_RESET_FILTER_LIFE = 'wemo_reset_filter_life'
+
+RESET_FILTER_LIFE_SCHEMA = vol.Schema({
+    vol.Required(ATTR_ENTITY_ID): cv.entity_ids
+})
+
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up discovered WeMo humidifiers."""
@@ -111,21 +117,37 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     def service_handle(service):
         """Handle the WeMo humidifier services."""
         entity_ids = service.data.get(ATTR_ENTITY_ID)
-        target_humidity = service.data.get(ATTR_TARGET_HUMIDITY)
 
-        if entity_ids:
-            humidifiers = [device for device in hass.data[DATA_KEY].values() if
-                           device.entity_id in entity_ids]
-        else:
-            humidifiers = hass.data[DATA_KEY].values()
+        if service.service == SERVICE_SET_HUMIDITY:
+            target_humidity = service.data.get(ATTR_TARGET_HUMIDITY)
 
-        for humidifier in humidifiers:
-            humidifier.set_humidity(target_humidity)
+            if entity_ids:
+                humidifiers = [device for device in hass.data[DATA_KEY].values() if
+                               device.entity_id in entity_ids]
+            else:
+                humidifiers = hass.data[DATA_KEY].values()
+
+            for humidifier in humidifiers:
+                humidifier.set_humidity(target_humidity)
+        elif service.service == SERVICE_RESET_FILTER_LIFE:
+            if entity_ids:
+                humidifiers = [device for device in hass.data[DATA_KEY].values() if
+                               device.entity_id in entity_ids]
+
+                for humidifier in humidifiers:
+                    humidifier.reset_filter_life()
+            else:
+                _LOGGER.error("Unable to reset WeMo Humidifier filter life %s",
+                              "- entity_ids is a required field.")
 
     # Register service(s)
     hass.services.register(
         DOMAIN, SERVICE_SET_HUMIDITY, service_handle,
         schema=SET_HUMIDITY_SCHEMA)
+
+    hass.services.register(
+        DOMAIN, SERVICE_RESET_FILTER_LIFE, service_handle,
+        schema=RESET_FILTER_LIFE_SCHEMA)
 
 
 class WemoHumidifier(FanEntity):
@@ -303,3 +325,7 @@ class WemoHumidifier(FanEntity):
             self.wemo.set_humidity(WEMO_HUMIDITY_60)
         elif humidity >= 100:
             self.wemo.set_humidity(WEMO_HUMIDITY_100)
+
+    def reset_filter_life(self: FanEntity) -> None:
+        """Reset the filter life to 100%."""
+        self.wemo.reset_filter_life()

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -1,7 +1,6 @@
 """Implement the Smart Home traits."""
 import logging
 
-from homeassistant.core import DOMAIN as HA_DOMAIN
 from homeassistant.components import (
     climate,
     cover,
@@ -26,8 +25,8 @@ from homeassistant.const import (
     TEMP_FAHRENHEIT,
     ATTR_SUPPORTED_FEATURES,
 )
+from homeassistant.core import DOMAIN as HA_DOMAIN
 from homeassistant.util import color as color_util, temperature as temp_util
-
 from .const import ERR_VALUE_OUT_OF_RANGE
 from .helpers import SmartHomeError
 
@@ -43,6 +42,7 @@ TRAIT_COLOR_TEMP = PREFIX_TRAITS + 'ColorTemperature'
 TRAIT_SCENE = PREFIX_TRAITS + 'Scene'
 TRAIT_TEMPERATURE_SETTING = PREFIX_TRAITS + 'TemperatureSetting'
 TRAIT_LOCKUNLOCK = PREFIX_TRAITS + 'LockUnlock'
+TRAIT_FANSPEED = PREFIX_TRAITS + 'FanSpeed'
 
 PREFIX_COMMANDS = 'action.devices.commands.'
 COMMAND_ONOFF = PREFIX_COMMANDS + 'OnOff'
@@ -58,6 +58,7 @@ COMMAND_THERMOSTAT_TEMPERATURE_SET_RANGE = (
     PREFIX_COMMANDS + 'ThermostatTemperatureSetRange')
 COMMAND_THERMOSTAT_SET_MODE = PREFIX_COMMANDS + 'ThermostatSetMode'
 COMMAND_LOCKUNLOCK = PREFIX_COMMANDS + 'LockUnlock'
+COMMAND_FANSPEED = PREFIX_COMMANDS + 'SetFanSpeed'
 
 
 TRAITS = []
@@ -675,3 +676,77 @@ class LockUnlockTrait(_Trait):
         await self.hass.services.async_call(lock.DOMAIN, service, {
             ATTR_ENTITY_ID: self.state.entity_id
         }, blocking=True)
+
+
+@register_trait
+class FanSpeedTrait(_Trait):
+    """Trait to control speed of Fan.
+
+    https://developers.google.com/actions/smarthome/traits/fanspeed
+    """
+
+    name = TRAIT_FANSPEED
+    commands = [
+        COMMAND_FANSPEED
+    ]
+
+    speed_synonyms = {
+        fan.SPEED_OFF: ['stop', 'off'],
+        fan.SPEED_LOW: ['slow', 'low', 'slowest', 'lowest'],
+        fan.SPEED_MEDIUM: ['medium', 'mid', 'middle'],
+        fan.SPEED_HIGH: [
+            'high', 'max', 'fast', 'highest', 'fastest', 'maximum'
+        ]
+    }
+
+    @staticmethod
+    def supported(domain, features):
+        """Test if state is supported."""
+        if domain != fan.DOMAIN:
+            return False
+
+        return features & fan.SUPPORT_SET_SPEED
+
+    def sync_attributes(self):
+        """Return speed point and modes attributes for a sync request."""
+        modes = self.state.attributes.get(fan.ATTR_SPEED_LIST, [])
+        speeds = []
+        for mode in modes:
+            speed = {
+                "speed_name": mode,
+                "speed_values": [{
+                    "speed_synonym": self.speed_synonyms.get(mode),
+                    "lang": 'en'
+                }]
+            }
+            speeds.append(speed)
+
+        return {
+            'availableFanSpeeds': {
+                'speeds': speeds,
+                'ordered': True
+            },
+            "reversible": bool(self.state.attributes.get(
+                ATTR_SUPPORTED_FEATURES, 0) & fan.SUPPORT_DIRECTION)
+        }
+
+    def query_attributes(self):
+        """Return speed point and modes query attributes."""
+        attrs = self.state.attributes
+        response = {}
+
+        speed = attrs.get(fan.ATTR_SPEED)
+        if speed is not None:
+            response['on'] = speed != fan.SPEED_OFF
+            response['online'] = True
+            response['currentFanSpeedSetting'] = speed
+
+        return response
+
+    async def execute(self, command, params):
+        """Execute an SetFanSpeed command."""
+        await self.hass.services.async_call(
+            fan.DOMAIN, fan.SERVICE_SET_SPEED, {
+                ATTR_ENTITY_ID: self.state.entity_id,
+                fan.ATTR_SPEED: params['fanSpeed']
+            }, blocking=True)

--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -29,7 +29,7 @@ from .const import (
 from .util import (
     show_setup_message, validate_entity_config, validate_media_player_features)
 
-REQUIREMENTS = ['HAP-python==2.2.2']
+REQUIREMENTS = ['HAP-python==2.4.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/homekit/type_switches.py
+++ b/homeassistant/components/homekit/type_switches.py
@@ -2,7 +2,8 @@
 import logging
 
 from pyhap.const import (
-    CATEGORY_OUTLET, CATEGORY_SWITCH)
+    CATEGORY_FAUCET, CATEGORY_OUTLET, CATEGORY_SHOWER_HEAD,
+    CATEGORY_SPRINKLER, CATEGORY_SWITCH)
 
 from homeassistant.components.script import ATTR_CAN_CANCEL
 from homeassistant.components.switch import DOMAIN
@@ -19,10 +20,6 @@ from .const import (
     TYPE_SPRINKLER, TYPE_VALVE)
 
 _LOGGER = logging.getLogger(__name__)
-
-CATEGORY_SPRINKLER = 28
-CATEGORY_FAUCET = 29
-CATEGORY_SHOWER_HEAD = 30
 
 VALVE_TYPE = {
     TYPE_FAUCET: (CATEGORY_FAUCET, 3),

--- a/homeassistant/components/image_processing/tensorflow.py
+++ b/homeassistant/components/image_processing/tensorflow.py
@@ -246,7 +246,8 @@ class TensorFlowImageProcessor(ImageProcessingEntity):
 
         for category, values in matches.items():
             # Draw custom category regions/areas
-            if self._category_areas[category] != [0, 0, 1, 1]:
+            if (category in self._category_areas
+                    and self._category_areas[category] != [0, 0, 1, 1]):
                 label = "{} Detection Area".format(category.capitalize())
                 draw_box(draw, self._category_areas[category], img_width,
                          img_height, label, (0, 255, 0))

--- a/homeassistant/components/light/avion.py
+++ b/homeassistant/components/light/avion.py
@@ -16,7 +16,7 @@ from homeassistant.const import (
     CONF_USERNAME)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['antsar-avion==0.9.1']
+REQUIREMENTS = ['avion==0.10']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/media_player/dlna_dmr.py
+++ b/homeassistant/components/media_player/dlna_dmr.py
@@ -26,7 +26,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import get_local_ip
 
-REQUIREMENTS = ['async-upnp-client==0.13.1']
+REQUIREMENTS = ['async-upnp-client==0.13.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/mysensors/device.py
+++ b/homeassistant/components/mysensors/device.py
@@ -15,6 +15,7 @@ ATTR_CHILD_ID = 'child_id'
 ATTR_DESCRIPTION = 'description'
 ATTR_DEVICE = 'device'
 ATTR_NODE_ID = 'node_id'
+ATTR_HEARTBEAT = 'heartbeat'
 MYSENSORS_PLATFORM_DEVICES = 'mysensors_devices_{}'
 
 
@@ -51,6 +52,7 @@ class MySensorsDevice:
         child = node.children[self.child_id]
         attr = {
             ATTR_BATTERY_LEVEL: node.battery_level,
+            ATTR_HEARTBEAT: node.heartbeat,
             ATTR_CHILD_ID: self.child_id,
             ATTR_DESCRIPTION: child.description,
             ATTR_DEVICE: self.gateway.device,

--- a/homeassistant/components/mysensors/handler.py
+++ b/homeassistant/components/mysensors/handler.py
@@ -45,6 +45,12 @@ async def handle_battery_level(hass, hass_config, msg):
     _handle_node_update(hass, msg)
 
 
+@HANDLERS.register('I_HEARTBEAT_RESPONSE')
+async def handle_heartbeat(hass, hass_config, msg):
+    """Handle an heartbeat."""
+    _handle_node_update(hass, msg)
+
+
 @HANDLERS.register('I_SKETCH_NAME')
 async def handle_sketch_name(hass, hass_config, msg):
     """Handle an internal sketch name message."""

--- a/homeassistant/components/notify/discord.py
+++ b/homeassistant/components/notify/discord.py
@@ -41,6 +41,8 @@ class DiscordNotificationService(BaseNotificationService):
     async def async_send_message(self, message, **kwargs):
         """Login to Discord, send message to channel(s) and log out."""
         import discord
+
+        discord.VoiceClient.warn_nacl = False
         discord_bot = discord.Client(loop=self.hass.loop)
 
         if ATTR_TARGET not in kwargs:
@@ -53,6 +55,7 @@ class DiscordNotificationService(BaseNotificationService):
             """Send the messages when the bot is ready."""
             try:
                 data = kwargs.get(ATTR_DATA)
+                images = None
                 if data:
                     images = data.get(ATTR_IMAGES)
                 for channelid in kwargs[ATTR_TARGET]:

--- a/homeassistant/components/notify/hangouts.py
+++ b/homeassistant/components/notify/hangouts.py
@@ -9,13 +9,12 @@ import logging
 import voluptuous as vol
 
 from homeassistant.components.notify import (ATTR_TARGET, PLATFORM_SCHEMA,
-                                             NOTIFY_SERVICE_SCHEMA,
                                              BaseNotificationService,
                                              ATTR_MESSAGE, ATTR_DATA)
 
 from homeassistant.components.hangouts.const \
-    import (DOMAIN, SERVICE_SEND_MESSAGE, MESSAGE_DATA_SCHEMA,
-            TARGETS_SCHEMA, CONF_DEFAULT_CONVERSATIONS)
+    import (DOMAIN, SERVICE_SEND_MESSAGE, TARGETS_SCHEMA,
+            CONF_DEFAULT_CONVERSATIONS)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -23,11 +22,6 @@ DEPENDENCIES = [DOMAIN]
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_DEFAULT_CONVERSATIONS): [TARGETS_SCHEMA]
-})
-
-NOTIFY_SERVICE_SCHEMA = NOTIFY_SERVICE_SCHEMA.extend({
-    vol.Optional(ATTR_TARGET): [TARGETS_SCHEMA],
-    vol.Optional(ATTR_DATA, default={}): MESSAGE_DATA_SCHEMA
 })
 
 
@@ -61,8 +55,9 @@ class HangoutsNotificationService(BaseNotificationService):
         service_data = {
             ATTR_TARGET: target_conversations,
             ATTR_MESSAGE: messages,
-            ATTR_DATA: kwargs[ATTR_DATA]
         }
+        if kwargs[ATTR_DATA]:
+            service_data[ATTR_DATA] = kwargs[ATTR_DATA]
 
         return self.hass.services.call(
             DOMAIN, SERVICE_SEND_MESSAGE, service_data=service_data)

--- a/homeassistant/components/sense.py
+++ b/homeassistant/components/sense.py
@@ -27,7 +27,7 @@ CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Required(CONF_EMAIL): cv.string,
         vol.Required(CONF_PASSWORD): cv.string,
-        vol.Optional(CONF_TIMEOUT, DEFAULT_TIMEOUT): cv.positive_int,
+        vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int,
     })
 }, extra=vol.ALLOW_EXTRA)
 

--- a/homeassistant/components/sensor/pollen.py
+++ b/homeassistant/components/sensor/pollen.py
@@ -62,11 +62,11 @@ SENSORS = {
         'IndexSensor', 'Allergy Index: Tomorrow', 'mdi:flower'),
     TYPE_ALLERGY_YESTERDAY: (
         'IndexSensor', 'Allergy Index: Yesterday', 'mdi:flower'),
-    TYPE_ASTHMA_TODAY: ('IndexSensor', 'Ashma Index: Today', 'mdi:flower'),
+    TYPE_ASTHMA_TODAY: ('IndexSensor', 'Asthma Index: Today', 'mdi:flower'),
     TYPE_ASTHMA_TOMORROW: (
-        'IndexSensor', 'Ashma Index: Tomorrow', 'mdi:flower'),
+        'IndexSensor', 'Asthma Index: Tomorrow', 'mdi:flower'),
     TYPE_ASTHMA_YESTERDAY: (
-        'IndexSensor', 'Ashma Index: Yesterday', 'mdi:flower'),
+        'IndexSensor', 'Asthma Index: Yesterday', 'mdi:flower'),
     TYPE_ASTHMA_FORECAST: (
         'ForecastSensor', 'Asthma Index: Forecasted Average', 'mdi:flower'),
     TYPE_ASTHMA_HISTORIC: (

--- a/homeassistant/components/sensor/swiss_hydrological_data.py
+++ b/homeassistant/components/sensor/swiss_hydrological_data.py
@@ -4,145 +4,160 @@ Support for hydrological data from the Federal Office for the Environment FOEN.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.swiss_hydrological_data/
 """
-import logging
 from datetime import timedelta
+import logging
 
 import voluptuous as vol
-import requests
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import (
-    TEMP_CELSIUS, CONF_NAME, STATE_UNKNOWN, ATTR_ATTRIBUTION)
+from homeassistant.const import ATTR_ATTRIBUTION, CONF_MONITORED_CONDITIONS
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['xmltodict==0.11.0']
+REQUIREMENTS = ['swisshydrodata==0.0.3']
 
 _LOGGER = logging.getLogger(__name__)
-_RESOURCE = 'http://www.hydrodata.ch/xml/SMS.xml'
+
+ATTRIBUTION = "Data provided by the Swiss Federal Office for the " \
+              "Environment FOEN"
+
+ATTR_DELTA_24H = 'delta-24h'
+ATTR_MAX_1H = 'max-1h'
+ATTR_MAX_24H = 'max-24h'
+ATTR_MEAN_1H = 'mean-1h'
+ATTR_MEAN_24H = 'mean-24h'
+ATTR_MIN_1H = 'min-1h'
+ATTR_MIN_24H = 'min-24h'
+ATTR_PREVIOUS_24H = 'previous-24h'
+ATTR_STATION = 'station'
+ATTR_STATION_UPDATE = 'station_update'
+ATTR_WATER_BODY = 'water_body'
+ATTR_WATER_BODY_TYPE = 'water_body_type'
 
 CONF_STATION = 'station'
-CONF_ATTRIBUTION = "Data provided by the Swiss Federal Office for the " \
-                   "Environment FOEN"
 
-DEFAULT_NAME = 'Water temperature'
+MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=60)
 
-ICON = 'mdi:cup-water'
+SENSOR_DISCHARGE = 'discharge'
+SENSOR_LEVEL = 'level'
+SENSOR_TEMPERATURE = 'temperature'
 
-ATTR_LOCATION = 'location'
-ATTR_UPDATE = 'update'
-ATTR_DISCHARGE = 'discharge'
-ATTR_WATERLEVEL = 'level'
-ATTR_DISCHARGE_MEAN = 'discharge_mean'
-ATTR_WATERLEVEL_MEAN = 'level_mean'
-ATTR_TEMPERATURE_MEAN = 'temperature_mean'
-ATTR_DISCHARGE_MAX = 'discharge_max'
-ATTR_WATERLEVEL_MAX = 'level_max'
-ATTR_TEMPERATURE_MAX = 'temperature_max'
+CONDITIONS = {
+    SENSOR_DISCHARGE: 'mdi:waves',
+    SENSOR_LEVEL: 'mdi:zodiac-aquarius',
+    SENSOR_TEMPERATURE: 'mdi:oil-temperature',
+}
 
-MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=30)
+CONDITION_DETAILS = [
+    ATTR_DELTA_24H,
+    ATTR_MAX_1H,
+    ATTR_MAX_24H,
+    ATTR_MEAN_1H,
+    ATTR_MEAN_24H,
+    ATTR_MIN_1H,
+    ATTR_MIN_24H,
+    ATTR_PREVIOUS_24H,
+]
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_STATION): vol.Coerce(int),
-    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_MONITORED_CONDITIONS, default=[SENSOR_TEMPERATURE]):
+        vol.All(cv.ensure_list, [vol.In(CONDITIONS)]),
 })
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Swiss hydrological sensor."""
-    import xmltodict
-
-    name = config.get(CONF_NAME)
     station = config.get(CONF_STATION)
+    monitored_conditions = config.get(CONF_MONITORED_CONDITIONS)
 
-    try:
-        response = requests.get(_RESOURCE, timeout=5)
-        if any(str(station) == location.get('@StrNr') for location in
-               xmltodict.parse(response.text)['AKT_Data']['MesPar']) is False:
-            _LOGGER.error("The given station does not exist: %s", station)
-            return False
-    except requests.exceptions.ConnectionError:
-        _LOGGER.error("The URL is not accessible")
-        return False
+    hydro_data = HydrologicalData(station)
+    hydro_data.update()
 
-    data = HydrologicalData(station)
-    add_entities([SwissHydrologicalDataSensor(name, data)], True)
+    if hydro_data.data is None:
+        _LOGGER.error("The station doesn't exists: %s", station)
+        return
+
+    entities = []
+
+    for condition in monitored_conditions:
+        entities.append(
+            SwissHydrologicalDataSensor(hydro_data, station, condition))
+
+    add_entities(entities, True)
 
 
 class SwissHydrologicalDataSensor(Entity):
-    """Implementation of an Swiss hydrological sensor."""
+    """Implementation of a Swiss hydrological sensor."""
 
-    def __init__(self, name, data):
-        """Initialize the sensor."""
-        self.data = data
-        self._name = name
-        self._unit_of_measurement = TEMP_CELSIUS
-        self._state = None
+    def __init__(self, hydro_data, station, condition):
+        """Initialize the Swiss hydrological sensor."""
+        self.hydro_data = hydro_data
+        self._condition = condition
+        self._data = self._state = self._unit_of_measurement = None
+        self._icon = CONDITIONS[condition]
+        self._station = station
 
     @property
     def name(self):
         """Return the name of the sensor."""
-        return self._name
+        return "{0} {1}".format(self._data['water-body-name'], self._condition)
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique, friendly identifier for this entity."""
+        return '{0}_{1}'.format(self._station, self._condition)
 
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement of this entity, if any."""
-        if self._state is not STATE_UNKNOWN:
-            return self._unit_of_measurement
+        if self._state is not None:
+            return self.hydro_data.data['parameters'][self._condition]['unit']
         return None
 
     @property
     def state(self):
         """Return the state of the sensor."""
-        try:
-            return round(float(self._state), 1)
-        except ValueError:
-            return STATE_UNKNOWN
+        if isinstance(self._state, (int, float)):
+            return round(self._state, 2)
+        return None
 
     @property
     def device_state_attributes(self):
-        """Return the state attributes."""
-        attributes = {}
-        if self.data.measurings is not None:
-            if '02' in self.data.measurings:
-                attributes[ATTR_WATERLEVEL] = self.data.measurings['02'][
-                    'current']
-                attributes[ATTR_WATERLEVEL_MEAN] = self.data.measurings['02'][
-                    'mean']
-                attributes[ATTR_WATERLEVEL_MAX] = self.data.measurings['02'][
-                    'max']
-            if '03' in self.data.measurings:
-                attributes[ATTR_TEMPERATURE_MEAN] = self.data.measurings['03'][
-                    'mean']
-                attributes[ATTR_TEMPERATURE_MAX] = self.data.measurings['03'][
-                    'max']
-            if '10' in self.data.measurings:
-                attributes[ATTR_DISCHARGE] = self.data.measurings['10'][
-                    'current']
-                attributes[ATTR_DISCHARGE_MEAN] = self.data.measurings['10'][
-                    'current']
-                attributes[ATTR_DISCHARGE_MAX] = self.data.measurings['10'][
-                    'max']
+        """Return the device state attributes."""
+        attrs = {}
 
-            attributes[ATTR_LOCATION] = self.data.measurings['location']
-            attributes[ATTR_UPDATE] = self.data.measurings['update_time']
-            attributes[ATTR_ATTRIBUTION] = CONF_ATTRIBUTION
-            return attributes
+        if not self._data:
+            attrs[ATTR_ATTRIBUTION] = ATTRIBUTION
+            return attrs
+
+        attrs[ATTR_WATER_BODY_TYPE] = self._data['water-body-type']
+        attrs[ATTR_STATION] = self._data['name']
+        attrs[ATTR_STATION_UPDATE] = \
+            self._data['parameters'][self._condition]['datetime']
+        attrs[ATTR_ATTRIBUTION] = ATTRIBUTION
+
+        for entry in CONDITION_DETAILS:
+            attrs[entry.replace('-', '_')] = \
+                self._data['parameters'][self._condition][entry]
+
+        return attrs
 
     @property
     def icon(self):
-        """Icon to use in the frontend, if any."""
-        return ICON
+        """Icon to use in the frontend."""
+        return self._icon
 
     def update(self):
-        """Get the latest data and update the states."""
-        self.data.update()
-        if self.data.measurings is not None:
-            if '03' not in self.data.measurings:
-                self._state = STATE_UNKNOWN
-            else:
-                self._state = self.data.measurings['03']['current']
+        """Get the latest data and update the state."""
+        self.hydro_data.update()
+        self._data = self.hydro_data.data
+
+        if self._data is None:
+            self._state = None
+        else:
+            self._state = self._data['parameters'][self._condition]['value']
 
 
 class HydrologicalData:
@@ -151,38 +166,12 @@ class HydrologicalData:
     def __init__(self, station):
         """Initialize the data object."""
         self.station = station
-        self.measurings = None
+        self.data = None
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
-        """Get the latest data from hydrodata.ch."""
-        import xmltodict
+        """Get the latest data."""
+        from swisshydrodata import SwissHydroData
 
-        details = {}
-        try:
-            response = requests.get(_RESOURCE, timeout=5)
-        except requests.exceptions.ConnectionError:
-            _LOGGER.error("Unable to retrieve data from %s", _RESOURCE)
-
-        try:
-            stations = xmltodict.parse(response.text)['AKT_Data']['MesPar']
-            # Water level: Typ="02", temperature: Typ="03", discharge: Typ="10"
-            for station in stations:
-                if str(self.station) != station.get('@StrNr'):
-                    continue
-                for data in ['02', '03', '10']:
-                    if data != station.get('@Typ'):
-                        continue
-                    values = station.get('Wert')
-                    if values is not None:
-                        details[data] = {
-                            'current': values[0],
-                            'max': list(values[4].items())[1][1],
-                            'mean': list(values[3].items())[1][1]}
-
-                    details['location'] = station.get('Name')
-                    details['update_time'] = station.get('Zeit')
-
-            self.measurings = details
-        except AttributeError:
-            self.measurings = None
+        shd = SwissHydroData()
+        self.data = shd.get_station(self.station)

--- a/homeassistant/components/sensor/tibber.py
+++ b/homeassistant/components/sensor/tibber.py
@@ -171,8 +171,16 @@ class TibberSensorRT(Entity):
 
     async def _async_callback(self, payload):
         """Handle received data."""
-        data = payload.get('data', {})
-        live_measurement = data.get('liveMeasurement', {})
+        errors = payload.get('errors')
+        if errors:
+            _LOGGER.error(errors[0])
+            return
+        data = payload.get('data')
+        if data is None:
+            return
+        live_measurement = data.get('liveMeasurement')
+        if live_measurement is None:
+            return
         self._state = live_measurement.pop('power', None)
         self._device_state_attributes = live_measurement
         self.async_schedule_update_ha_state()

--- a/homeassistant/components/tibber/__init__.py
+++ b/homeassistant/components/tibber/__init__.py
@@ -16,7 +16,7 @@ from homeassistant.const import (EVENT_HOMEASSISTANT_STOP, CONF_ACCESS_TOKEN,
 from homeassistant.helpers import discovery
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-REQUIREMENTS = ['pyTibber==0.7.4']
+REQUIREMENTS = ['pyTibber==0.7.5']
 
 DOMAIN = 'tibber'
 

--- a/homeassistant/components/upnp/__init__.py
+++ b/homeassistant/components/upnp/__init__.py
@@ -29,7 +29,7 @@ from .config_flow import async_ensure_domain_data
 from .device import Device
 
 
-REQUIREMENTS = ['async-upnp-client==0.13.1']
+REQUIREMENTS = ['async-upnp-client==0.13.2']
 
 NOTIFICATION_ID = 'upnp_notification'
 NOTIFICATION_TITLE = 'UPnP/IGD Setup'

--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -15,7 +15,7 @@ from homeassistant.helpers import config_validation as cv
 
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 
-REQUIREMENTS = ['pywemo==0.4.29']
+REQUIREMENTS = ['pywemo==0.4.32']
 
 DOMAIN = 'wemo'
 

--- a/homeassistant/components/wirelesstag.py
+++ b/homeassistant/components/wirelesstag.py
@@ -271,7 +271,7 @@ class WirelessTagBaseSensor(Entity):
     def device_state_attributes(self):
         """Return the state attributes."""
         return {
-            ATTR_BATTERY_LEVEL: self._tag.battery_remaining,
+            ATTR_BATTERY_LEVEL: int(self._tag.battery_remaining*100),
             ATTR_VOLTAGE: '{:.2f}V'.format(self._tag.battery_volts),
             ATTR_TAG_SIGNAL_STRENGTH: '{}dBm'.format(
                 self._tag.signal_strength),

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
-MINOR_VERSION = 82
+MINOR_VERSION = 83
 PATCH_VERSION = '0.dev0'
 __short_version__ = '{}.{}'.format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = '{}.{}'.format(__short_version__, PATCH_VERSION)

--- a/homeassistant/helpers/deprecation.py
+++ b/homeassistant/helpers/deprecation.py
@@ -1,9 +1,10 @@
 """Deprecation helpers for Home Assistant."""
 import inspect
 import logging
+from typing import Any, Callable, Dict, Optional
 
 
-def deprecated_substitute(substitute_name):
+def deprecated_substitute(substitute_name: str) -> Callable[..., Callable]:
     """Help migrate properties to new names.
 
     When a property is added to replace an older property, this decorator can
@@ -11,9 +12,9 @@ def deprecated_substitute(substitute_name):
     If the old property is defined, its value will be used instead, and a log
     warning will be issued alerting the user of the impending change.
     """
-    def decorator(func):
+    def decorator(func: Callable) -> Callable:
         """Decorate function as deprecated."""
-        def func_wrapper(self):
+        def func_wrapper(self: Callable) -> Any:
             """Wrap for the original function."""
             if hasattr(self, substitute_name):
                 # If this platform is still using the old property, issue
@@ -28,8 +29,7 @@ def deprecated_substitute(substitute_name):
                         substitute_name, substitute_name, func.__name__,
                         inspect.getfile(self.__class__))
                     warnings[module_name] = True
-                    # pylint: disable=protected-access
-                    func._deprecated_substitute_warnings = warnings
+                    setattr(func, '_deprecated_substitute_warnings', warnings)
 
                 # Return the old property
                 return getattr(self, substitute_name)
@@ -38,7 +38,8 @@ def deprecated_substitute(substitute_name):
     return decorator
 
 
-def get_deprecated(config, new_name, old_name, default=None):
+def get_deprecated(config: Dict[str, Any], new_name: str, old_name: str,
+                   default: Optional[Any] = None) -> Optional[Any]:
     """Allow an old config name to be deprecated with a replacement.
 
     If the new config isn't found, but the old one is, the old value is used

--- a/homeassistant/helpers/entityfilter.py
+++ b/homeassistant/helpers/entityfilter.py
@@ -1,4 +1,5 @@
 """Helper class to implement include/exclude of entities and domains."""
+from typing import Callable, Dict, Iterable
 
 import voluptuous as vol
 
@@ -11,14 +12,14 @@ CONF_EXCLUDE_DOMAINS = 'exclude_domains'
 CONF_EXCLUDE_ENTITIES = 'exclude_entities'
 
 
-def _convert_filter(config):
+def _convert_filter(config: Dict[str, Iterable[str]]) -> Callable[[str], bool]:
     filt = generate_filter(
         config[CONF_INCLUDE_DOMAINS],
         config[CONF_INCLUDE_ENTITIES],
         config[CONF_EXCLUDE_DOMAINS],
         config[CONF_EXCLUDE_ENTITIES],
     )
-    filt.config = config
+    setattr(filt, 'config', config)
     return filt
 
 
@@ -33,8 +34,10 @@ FILTER_SCHEMA = vol.All(
     }), _convert_filter)
 
 
-def generate_filter(include_domains, include_entities,
-                    exclude_domains, exclude_entities):
+def generate_filter(include_domains: Iterable[str],
+                    include_entities: Iterable[str],
+                    exclude_domains: Iterable[str],
+                    exclude_entities: Iterable[str]) -> Callable[[str], bool]:
     """Return a function that will filter entities based on the args."""
     include_d = set(include_domains)
     include_e = set(include_entities)
@@ -50,7 +53,7 @@ def generate_filter(include_domains, include_entities,
 
     # Case 2 - includes, no excludes - only include specified entities
     if have_include and not have_exclude:
-        def entity_filter_2(entity_id):
+        def entity_filter_2(entity_id: str) -> bool:
             """Return filter function for case 2."""
             domain = split_entity_id(entity_id)[0]
             return (entity_id in include_e or
@@ -60,7 +63,7 @@ def generate_filter(include_domains, include_entities,
 
     # Case 3 - excludes, no includes - only exclude specified entities
     if not have_include and have_exclude:
-        def entity_filter_3(entity_id):
+        def entity_filter_3(entity_id: str) -> bool:
             """Return filter function for case 3."""
             domain = split_entity_id(entity_id)[0]
             return (entity_id not in exclude_e and
@@ -75,7 +78,7 @@ def generate_filter(include_domains, include_entities,
     # note: if both include and exclude domains specified,
     #   the exclude domains are ignored
     if include_d:
-        def entity_filter_4a(entity_id):
+        def entity_filter_4a(entity_id: str) -> bool:
             """Return filter function for case 4a."""
             domain = split_entity_id(entity_id)[0]
             if domain in include_d:
@@ -88,7 +91,7 @@ def generate_filter(include_domains, include_entities,
     #  - if domain is excluded, pass if entity is included
     #  - if domain is not excluded, pass if entity not excluded
     if exclude_d:
-        def entity_filter_4b(entity_id):
+        def entity_filter_4b(entity_id: str) -> bool:
             """Return filter function for case 4b."""
             domain = split_entity_id(entity_id)[0]
             if domain in exclude_d:
@@ -99,7 +102,7 @@ def generate_filter(include_domains, include_entities,
 
     # Case 4c - neither include or exclude domain specified
     #  - Only pass if entity is included.  Ignore entity excludes.
-    def entity_filter_4c(entity_id):
+    def entity_filter_4c(entity_id: str) -> bool:
         """Return filter function for case 4c."""
         return entity_id in include_e
 

--- a/homeassistant/util/ruamel_yaml.py
+++ b/homeassistant/util/ruamel_yaml.py
@@ -80,7 +80,8 @@ def load_yaml(fname: str, round_trip: bool = False) -> JSON_TYPE:
         yaml = YAML(typ='rt')
         yaml.preserve_quotes = True
     else:
-        ExtSafeConstructor.name = fname
+        if not hasattr(ExtSafeConstructor, 'name'):
+            ExtSafeConstructor.name = fname
         yaml = YAML(typ='safe')
         yaml.Constructor = ExtSafeConstructor
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -32,7 +32,7 @@ Adafruit-SHT31==1.0.2
 # Adafruit_BBIO==1.0.0
 
 # homeassistant.components.homekit
-HAP-python==2.2.2
+HAP-python==2.4.0
 
 # homeassistant.components.notify.mastodon
 Mastodon.py==1.3.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -140,9 +140,6 @@ anel_pwrctrl-homeassistant==0.0.1.dev2
 # homeassistant.components.media_player.anthemav
 anthemav==1.1.8
 
-# homeassistant.components.light.avion
-# antsar-avion==0.9.1
-
 # homeassistant.components.apcupsd
 apcaccess==0.0.13
 
@@ -158,6 +155,9 @@ asterisk_mbox==0.5.0
 # homeassistant.components.upnp
 # homeassistant.components.media_player.dlna_dmr
 async-upnp-client==0.13.1
+
+# homeassistant.components.light.avion
+# avion==0.10
 
 # homeassistant.components.axis
 axis==16

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -812,7 +812,7 @@ pyRFXtrx==0.23
 pySwitchmate==0.4.3
 
 # homeassistant.components.tibber
-pyTibber==0.7.4
+pyTibber==0.7.5
 
 # homeassistant.components.switch.dlink
 pyW215==0.6.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1303,7 +1303,7 @@ pyvlx==0.1.3
 pywebpush==1.6.0
 
 # homeassistant.components.wemo
-pywemo==0.4.29
+pywemo==0.4.32
 
 # homeassistant.components.camera.xeoma
 pyxeoma==1.4.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -154,7 +154,7 @@ asterisk_mbox==0.5.0
 
 # homeassistant.components.upnp
 # homeassistant.components.media_player.dlna_dmr
-async-upnp-client==0.13.1
+async-upnp-client==0.13.2
 
 # homeassistant.components.light.avion
 # avion==0.10

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1474,6 +1474,9 @@ suds-passworddigest-homeassistant==0.1.2a0.dev0
 # homeassistant.components.camera.onvif
 suds-py3==1.3.3.0
 
+# homeassistant.components.sensor.swiss_hydrological_data
+swisshydrodata==0.0.3
+
 # homeassistant.components.tahoma
 tahoma-api==0.0.13
 
@@ -1606,7 +1609,6 @@ xknx==0.9.1
 
 # homeassistant.components.media_player.bluesound
 # homeassistant.components.sensor.startca
-# homeassistant.components.sensor.swiss_hydrological_data
 # homeassistant.components.sensor.ted5000
 # homeassistant.components.sensor.yr
 # homeassistant.components.sensor.zestimate

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -11,7 +11,7 @@ pydocstyle==2.1.1
 pylint==2.1.1
 pytest-aiohttp==0.3.0
 pytest-cov==2.5.1
-pytest-sugar==0.9.1
+pytest-sugar==0.9.2
 pytest-timeout==1.3.2
-pytest==3.9.3
+pytest==3.10.0
 requests_mock==1.5.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -12,9 +12,9 @@ pydocstyle==2.1.1
 pylint==2.1.1
 pytest-aiohttp==0.3.0
 pytest-cov==2.5.1
-pytest-sugar==0.9.1
+pytest-sugar==0.9.2
 pytest-timeout==1.3.2
-pytest==3.9.3
+pytest==3.10.0
 requests_mock==1.5.2
 
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -19,7 +19,7 @@ requests_mock==1.5.2
 
 
 # homeassistant.components.homekit
-HAP-python==2.2.2
+HAP-python==2.4.0
 
 # homeassistant.components.sensor.rmvtransport
 PyRMVtransport==0.1.3

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -1328,6 +1328,32 @@ async def test_report_dimmable_light_state(hass):
     properties.assert_equal('Alexa.BrightnessController', 'brightness', 0)
 
 
+async def test_report_colored_light_state(hass):
+    """Test ColorController reports color correctly."""
+    hass.states.async_set(
+        'light.test_on', 'on', {'friendly_name': "Test light On",
+                                'hs_color': (180, 75),
+                                'brightness': 128,
+                                'supported_features': 17})
+    hass.states.async_set(
+        'light.test_off', 'off', {'friendly_name': "Test light Off",
+                                  'supported_features': 17})
+
+    properties = await reported_properties(hass, 'light.test_on')
+    properties.assert_equal('Alexa.ColorController', 'color', {
+        'hue': 180,
+        'saturation': 0.75,
+        'brightness': 128 / 255.0,
+    })
+
+    properties = await reported_properties(hass, 'light.test_off')
+    properties.assert_equal('Alexa.ColorController', 'color', {
+        'hue': 0,
+        'saturation': 0,
+        'brightness': 0,
+    })
+
+
 async def reported_properties(hass, endpoint):
     """Use ReportState to get properties and return them.
 

--- a/tests/components/google_assistant/__init__.py
+++ b/tests/components/google_assistant/__init__.py
@@ -183,7 +183,10 @@ DEMO_DEVICES = [{
     'name': {
         'name': 'Living Room Fan'
     },
-    'traits': ['action.devices.traits.OnOff'],
+    'traits': [
+        'action.devices.traits.FanSpeed',
+        'action.devices.traits.OnOff'
+        ],
     'type': 'action.devices.types.FAN',
     'willReportState': False
 }, {
@@ -191,7 +194,10 @@ DEMO_DEVICES = [{
     'name': {
         'name': 'Ceiling Fan'
     },
-    'traits': ['action.devices.traits.OnOff'],
+    'traits': [
+        'action.devices.traits.FanSpeed',
+        'action.devices.traits.OnOff'
+        ],
     'type': 'action.devices.types.FAN',
     'willReportState': False
 }, {

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -1,10 +1,6 @@
 """Tests for the Google Assistant traits."""
 import pytest
 
-from homeassistant.const import (
-    STATE_ON, STATE_OFF, ATTR_ENTITY_ID, SERVICE_TURN_ON, SERVICE_TURN_OFF,
-    TEMP_CELSIUS, TEMP_FAHRENHEIT, ATTR_SUPPORTED_FEATURES)
-from homeassistant.core import State, DOMAIN as HA_DOMAIN
 from homeassistant.components import (
     climate,
     cover,
@@ -20,8 +16,11 @@ from homeassistant.components import (
     group,
 )
 from homeassistant.components.google_assistant import trait, helpers, const
+from homeassistant.const import (
+    STATE_ON, STATE_OFF, ATTR_ENTITY_ID, SERVICE_TURN_ON, SERVICE_TURN_OFF,
+    TEMP_CELSIUS, TEMP_FAHRENHEIT, ATTR_SUPPORTED_FEATURES)
+from homeassistant.core import State, DOMAIN as HA_DOMAIN
 from homeassistant.util import color
-
 from tests.common import async_mock_service
 
 BASIC_CONFIG = helpers.Config(
@@ -794,4 +793,85 @@ async def test_lock_unlock_unlock(hass):
     assert len(calls) == 1
     assert calls[0].data == {
         ATTR_ENTITY_ID: 'lock.front_door'
+    }
+
+
+async def test_fan_speed(hass):
+    """Test FanSpeed trait speed control support for fan domain."""
+    assert trait.FanSpeedTrait.supported(fan.DOMAIN, fan.SUPPORT_SET_SPEED)
+
+    trt = trait.FanSpeedTrait(
+        hass, State(
+            'fan.living_room_fan', fan.SPEED_HIGH, attributes={
+                'speed_list': [
+                    fan.SPEED_OFF, fan.SPEED_LOW, fan.SPEED_MEDIUM,
+                    fan.SPEED_HIGH
+                ],
+                'speed': 'low'
+            }), BASIC_CONFIG)
+
+    assert trt.sync_attributes() == {
+        'availableFanSpeeds': {
+            'ordered': True,
+            'speeds': [
+                {
+                    'speed_name': 'off',
+                    'speed_values': [
+                        {
+                            'speed_synonym': ['stop', 'off'],
+                            'lang': 'en'
+                        }
+                    ]
+                },
+                {
+                    'speed_name': 'low',
+                    'speed_values': [
+                        {
+                            'speed_synonym': [
+                                'slow', 'low', 'slowest', 'lowest'],
+                            'lang': 'en'
+                        }
+                    ]
+                },
+                {
+                    'speed_name': 'medium',
+                    'speed_values': [
+                        {
+                            'speed_synonym': ['medium', 'mid', 'middle'],
+                            'lang': 'en'
+                        }
+                    ]
+                },
+                {
+                    'speed_name': 'high',
+                    'speed_values': [
+                        {
+                            'speed_synonym': [
+                                'high', 'max', 'fast', 'highest', 'fastest',
+                                'maximum'],
+                            'lang': 'en'
+                        }
+                    ]
+                }
+            ]
+        },
+        'reversible': False
+    }
+
+    assert trt.query_attributes() == {
+        'currentFanSpeedSetting': 'low',
+        'on': True,
+        'online': True
+    }
+
+    assert trt.can_execute(
+        trait.COMMAND_FANSPEED, params={'fanSpeed': 'medium'})
+
+    calls = async_mock_service(hass, fan.DOMAIN, fan.SERVICE_SET_SPEED)
+    await trt.execute(trait.COMMAND_FANSPEED, params={'fanSpeed': 'medium'})
+
+    assert len(calls) == 1
+    assert calls[0].data == {
+        'entity_id': 'fan.living_room_fan',
+        'speed': 'medium'
     }

--- a/tox.ini
+++ b/tox.ini
@@ -60,4 +60,4 @@ whitelist_externals=/bin/bash
 deps =
      -r{toxinidir}/requirements_test.txt
 commands =
-         /bin/bash -c 'mypy homeassistant/*.py homeassistant/{auth,util}/ homeassistant/helpers/{__init__,dispatcher,entity_values,icon,intent,json,location,signal,state,sun,temperature,translation,typing}.py'
+         /bin/bash -c 'mypy homeassistant/*.py homeassistant/{auth,util}/ homeassistant/helpers/{__init__,deprecation,dispatcher,entity_values,entityfilter,icon,intent,json,location,signal,state,sun,temperature,translation,typing}.py'


### PR DESCRIPTION
## Description:
Adds a service to the WeMo Humidifier to reset filter life back to 100% when replacing the filter.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#7475

## Example entry for `configuration.yaml` (if applicable):
```yaml
wemo:
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)