### PR TITLE
Fix MQTT binary switch 

### DIFF
--- a/homeassistant/components/binary_sensor/mqtt.py
+++ b/homeassistant/components/binary_sensor/mqtt.py
@@ -155,6 +155,7 @@ class MqttBinarySensor(MqttAvailability, MqttDiscoveryUpdate,
 
             if self._delay_listener is not None:
                 self._delay_listener()
+                self._delay_listener = None
 
             if (self._state and self._off_delay is not None):
                 self._delay_listener = evt.async_call_later(


### PR DESCRIPTION
## Description:

I was getting this in my log files:

```2018-11-12 00:21:26 WARNING (MainThread) [homeassistant.core] Unable to remove unknown listener <function async_track_point_in_utc_time.<locals>.point_in_time_listener at 0x102948378>```

After some analysis I reached **binary_sensor/mqtt** line 157 where an async callback was supposed to be called in order to cancel an **evt.async_call_later**.

The proper fix would have been to **await** for self._delay_listener() but we are outside async function.

This patch fixes the warning, but I'm not sure if it is the right approach 😞 

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
binary_sensor:
  - platform: mqtt
    state_topic: "test/1"
    payload_on: 1
    payload_off: 0
    name: test_mqtt_delay_off
    device_class: motion
    off_delay: 5
```

```bash
mosquitto_pub -h 192.168.1.100 -t test/1 -m 1 && mosquitto_pub -h 192.168.1.100 -t test/1 -m 0
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
