### PR TITLE
Add websocket calls to shopping-list

### DIFF
--- a/homeassistant/components/shopping_list.py
+++ b/homeassistant/components/shopping_list.py
@@ -310,6 +310,7 @@ async def websocket_handle_items(hass, connection, msg):
     connection.send_message(websocket_api.result_message(
         msg['id'], hass.data[DOMAIN].items))
 
+
 @websocket_api.async_response
 async def websocket_handle_add(hass, connection, msg):
     """Handle add item to shopping_list"""
@@ -317,6 +318,7 @@ async def websocket_handle_add(hass, connection, msg):
     hass.bus.async_fire(EVENT)
     connection.send_message(websocket_api.result_message(
         msg['id'], item))
+
 
 @websocket_api.async_response
 async def websocket_handle_update(hass, connection, msg):

--- a/homeassistant/components/shopping_list.py
+++ b/homeassistant/components/shopping_list.py
@@ -13,6 +13,7 @@ from homeassistant.components.http.data_validator import (
 from homeassistant.helpers import intent
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util.json import load_json, save_json
+from homeassistant.components import websocket_api
 
 ATTR_NAME = 'name'
 
@@ -36,6 +37,34 @@ SERVICE_ITEM_SCHEMA = vol.Schema({
     vol.Required(ATTR_NAME): vol.Any(None, cv.string)
 })
 
+WS_TYPE_SHOPPING_LIST_GET_ITEMS = 'shopping_list/items/get'
+WS_TYPE_SHOPPING_LIST_ADD_ITEM = 'shopping_list/items/add'
+WS_TYPE_SHOPPING_LIST_UPDATE_ITEM = 'shopping_list/items/update'
+WS_TYPE_SHOPPING_LIST_CLEAR_ITEMS = 'shopping_list/items/clear'
+
+SCHEMA_WEBSOCKET_GET_ITEMS = \
+    websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend({
+        vol.Required('type'): WS_TYPE_SHOPPING_LIST_GET_ITEMS
+    })
+
+SCHEMA_WEBSOCKET_ADD_ITEM = \
+    websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend({
+        vol.Required('type'): WS_TYPE_SHOPPING_LIST_ADD_ITEM,
+        vol.Required('name'): str
+    })
+
+SCHEMA_WEBSOCKET_UPDATE_ITEM = \
+    websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend({
+        vol.Required('type'): WS_TYPE_SHOPPING_LIST_UPDATE_ITEM,
+        vol.Required('item_id'): str,
+        vol.Optional('name'): str,
+        vol.Optional('complete'): bool
+    })
+
+SCHEMA_WEBSOCKET_CLEAR_ITEMS = \
+    websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend({
+        vol.Required('type'): WS_TYPE_SHOPPING_LIST_CLEAR_ITEMS
+    })
 
 @asyncio.coroutine
 def async_setup(hass, config):
@@ -90,6 +119,15 @@ def async_setup(hass, config):
 
     yield from hass.components.frontend.async_register_built_in_panel(
         'shopping-list', 'shopping_list', 'mdi:cart')
+
+    hass.components.websocket_api.async_register_command(
+        WS_TYPE_SHOPPING_LIST_GET_ITEMS, websocket_handle_items, SCHEMA_WEBSOCKET_GET_ITEMS)
+    hass.components.websocket_api.async_register_command(
+        WS_TYPE_SHOPPING_LIST_ADD_ITEM, websocket_handle_add, SCHEMA_WEBSOCKET_ADD_ITEM)
+    hass.components.websocket_api.async_register_command(
+        WS_TYPE_SHOPPING_LIST_UPDATE_ITEM, websocket_handle_update, SCHEMA_WEBSOCKET_UPDATE_ITEM)
+    hass.components.websocket_api.async_register_command(
+        WS_TYPE_SHOPPING_LIST_CLEAR_ITEMS, websocket_handle_clear, SCHEMA_WEBSOCKET_CLEAR_ITEMS)
 
     return True
 
@@ -256,3 +294,44 @@ class ClearCompletedItemsView(http.HomeAssistantView):
         hass.data[DOMAIN].async_clear_completed()
         hass.bus.async_fire(EVENT)
         return self.json_message('Cleared completed items.')
+
+
+@websocket_api.async_response
+async def websocket_handle_items(hass, connection, msg):
+    """Handle get shopping_list items"""
+    connection.send_message(websocket_api.result_message(
+        msg['id'], hass.data[DOMAIN].items))
+
+@websocket_api.async_response
+async def websocket_handle_add(hass, connection, msg):
+    """Handle add item to shopping_list"""
+    item = hass.data[DOMAIN].async_add(msg['name'])
+    hass.bus.async_fire(EVENT)
+    connection.send_message(websocket_api.result_message(
+        msg['id'], item))
+
+@websocket_api.async_response
+async def websocket_handle_update(hass, connection, msg):
+    """Handle update shopping_list item"""
+    try:
+        data = {}
+        if 'name' in msg:
+            data = {'name': msg['name']}
+        else:
+            data = {'complete': msg['complete']}
+        item = hass.data[DOMAIN].async_update(msg['item_id'], data)
+        hass.bus.async_fire(EVENT)
+        connection.send_message(websocket_api.result_message(
+            msg['id'], item))
+    except KeyError:
+        connection.send_message(websocket_api.error_message(
+            msg['id'], 'shopping_list_update_failed', 'Item not found'))
+
+
+@websocket_api.async_response
+async def websocket_handle_clear(hass, connection, msg):
+    """Handle clearing shopping_list items"""
+    hass.data[DOMAIN].async_clear_completed()
+    hass.bus.async_fire(EVENT)
+    connection.send_message(websocket_api.result_message(
+        msg['id'], 'Cleared completed items.'))

--- a/homeassistant/components/shopping_list.py
+++ b/homeassistant/components/shopping_list.py
@@ -121,13 +121,21 @@ def async_setup(hass, config):
         'shopping-list', 'shopping_list', 'mdi:cart')
 
     hass.components.websocket_api.async_register_command(
-        WS_TYPE_SHOPPING_LIST_GET_ITEMS, websocket_handle_items, SCHEMA_WEBSOCKET_GET_ITEMS)
+        WS_TYPE_SHOPPING_LIST_GET_ITEMS,
+        websocket_handle_items,
+        SCHEMA_WEBSOCKET_GET_ITEMS)
     hass.components.websocket_api.async_register_command(
-        WS_TYPE_SHOPPING_LIST_ADD_ITEM, websocket_handle_add, SCHEMA_WEBSOCKET_ADD_ITEM)
+        WS_TYPE_SHOPPING_LIST_ADD_ITEM,
+        websocket_handle_add,
+        SCHEMA_WEBSOCKET_ADD_ITEM)
     hass.components.websocket_api.async_register_command(
-        WS_TYPE_SHOPPING_LIST_UPDATE_ITEM, websocket_handle_update, SCHEMA_WEBSOCKET_UPDATE_ITEM)
+        WS_TYPE_SHOPPING_LIST_UPDATE_ITEM,
+        websocket_handle_update,
+        SCHEMA_WEBSOCKET_UPDATE_ITEM)
     hass.components.websocket_api.async_register_command(
-        WS_TYPE_SHOPPING_LIST_CLEAR_ITEMS, websocket_handle_clear, SCHEMA_WEBSOCKET_CLEAR_ITEMS)
+        WS_TYPE_SHOPPING_LIST_CLEAR_ITEMS,
+        websocket_handle_clear,
+        SCHEMA_WEBSOCKET_CLEAR_ITEMS)
 
     return True
 

--- a/homeassistant/components/shopping_list.py
+++ b/homeassistant/components/shopping_list.py
@@ -66,6 +66,7 @@ SCHEMA_WEBSOCKET_CLEAR_ITEMS = \
         vol.Required('type'): WS_TYPE_SHOPPING_LIST_CLEAR_ITEMS
     })
 
+
 @asyncio.coroutine
 def async_setup(hass, config):
     """Initialize the shopping list."""
@@ -306,14 +307,14 @@ class ClearCompletedItemsView(http.HomeAssistantView):
 
 @websocket_api.async_response
 async def websocket_handle_items(hass, connection, msg):
-    """Handle get shopping_list items"""
+    """Handle get shopping_list items."""
     connection.send_message(websocket_api.result_message(
         msg['id'], hass.data[DOMAIN].items))
 
 
 @websocket_api.async_response
 async def websocket_handle_add(hass, connection, msg):
-    """Handle add item to shopping_list"""
+    """Handle add item to shopping_list."""
     item = hass.data[DOMAIN].async_add(msg['name'])
     hass.bus.async_fire(EVENT)
     connection.send_message(websocket_api.result_message(
@@ -322,7 +323,7 @@ async def websocket_handle_add(hass, connection, msg):
 
 @websocket_api.async_response
 async def websocket_handle_update(hass, connection, msg):
-    """Handle update shopping_list item"""
+    """Handle update shopping_list item."""
     try:
         data = {}
         if 'name' in msg:
@@ -340,7 +341,7 @@ async def websocket_handle_update(hass, connection, msg):
 
 @websocket_api.async_response
 async def websocket_handle_clear(hass, connection, msg):
-    """Handle clearing shopping_list items"""
+    """Handle clearing shopping_list items."""
     hass.data[DOMAIN].async_clear_completed()
     hass.bus.async_fire(EVENT)
     connection.send_message(websocket_api.result_message(

--- a/tests/components/test_shopping_list.py
+++ b/tests/components/test_shopping_list.py
@@ -93,7 +93,7 @@ async def test_ws_get_items(hass, hass_ws_client):
 
     await client.send_json({
         'id': 5,
-        'type': 'shopping_list/items/get',
+        'type': 'shopping_list/items',
     })
     msg = await client.receive_json()
     assert msg['success'] is True
@@ -110,7 +110,7 @@ async def test_ws_get_items(hass, hass_ws_client):
 
 
 @asyncio.coroutine
-def test_deprecated_api_update(hass, aiohttp_client):
+def test_api_update(hass, aiohttp_client):
     """Test the API."""
     yield from async_setup_component(hass, 'shopping_list', {})
 
@@ -164,68 +164,8 @@ def test_deprecated_api_update(hass, aiohttp_client):
     }
 
 
-async def test_ws_update_item(hass, hass_ws_client):
-    """Test update shopping_list item websocket command."""
-    await async_setup_component(hass, 'shopping_list', {})
-
-    await intent.async_handle(
-        hass, 'test', 'HassShoppingListAddItem', {'item': {'value': 'beer'}}
-    )
-    await intent.async_handle(
-        hass, 'test', 'HassShoppingListAddItem', {'item': {'value': 'wine'}}
-    )
-
-    beer_id = hass.data['shopping_list'].items[0]['id']
-    wine_id = hass.data['shopping_list'].items[1]['id']
-    client = await hass_ws_client(hass)
-
-    await client.send_json({
-        'id': 5,
-        'type': 'shopping_list/items/update',
-        'item_id': beer_id,
-        'name': 'soda'
-    })
-    msg = await client.receive_json()
-    assert msg['success'] is True
-
-    data = msg['result']
-    assert data == {
-        'id': beer_id,
-        'name': 'soda',
-        'complete': False
-    }
-
-    await client.send_json({
-        'id': 6,
-        'type': 'shopping_list/items/update',
-        'item_id': wine_id,
-        'complete': True
-    })
-    msg = await client.receive_json()
-    assert msg['success'] is True
-
-    data = msg['result']
-    assert data == {
-        'id': wine_id,
-        'name': 'wine',
-        'complete': True
-    }
-
-    beer, wine = hass.data['shopping_list'].items
-    assert beer == {
-        'id': beer_id,
-        'name': 'soda',
-        'complete': False
-    }
-    assert wine == {
-        'id': wine_id,
-        'name': 'wine',
-        'complete': True
-    }
-
-
 @asyncio.coroutine
-def test_deprecated_api_update_fails(hass, aiohttp_client):
+def test_api_update_fails(hass, aiohttp_client):
     """Test the API."""
     yield from async_setup_component(hass, 'shopping_list', {})
 
@@ -250,42 +190,8 @@ def test_deprecated_api_update_fails(hass, aiohttp_client):
     assert resp.status == 400
 
 
-async def test_ws_update_item_fail(hass, hass_ws_client):
-    """Test failure of update shopping_list item websocket command."""
-    await async_setup_component(hass, 'shopping_list', {})
-
-    await intent.async_handle(
-        hass, 'test', 'HassShoppingListAddItem', {'item': {'value': 'beer'}}
-    )
-
-    client = await hass_ws_client(hass)
-
-    await client.send_json({
-        'id': 5,
-        'type': 'shopping_list/items/update',
-        'item_id': 'non_existing',
-        'name': 'soda'
-    })
-    msg = await client.receive_json()
-    assert msg['success'] is False
-
-    data = msg['error']
-    assert data == {
-        'code': 'shopping_list_update_failed',
-        'message': 'Item not found'
-    }
-
-    await client.send_json({
-        'id': 6,
-        'type': 'shopping_list/items/update',
-        'name': 123,
-    })
-    msg = await client.receive_json()
-    assert msg['success'] is False
-
-
 @asyncio.coroutine
-def test_deprecated_api_clear_completed(hass, aiohttp_client):
+def test_api_clear_completed(hass, aiohttp_client):
     """Test the API."""
     yield from async_setup_component(hass, 'shopping_list', {})
 
@@ -321,47 +227,6 @@ def test_deprecated_api_clear_completed(hass, aiohttp_client):
     }
 
 
-async def test_ws_clear_items(hass, hass_ws_client):
-    """Test clearing shopping_list items websocket command."""
-    await async_setup_component(hass, 'shopping_list', {})
-
-    await intent.async_handle(
-        hass, 'test', 'HassShoppingListAddItem', {'item': {'value': 'beer'}}
-    )
-    await intent.async_handle(
-        hass, 'test', 'HassShoppingListAddItem', {'item': {'value': 'wine'}}
-    )
-
-    beer_id = hass.data['shopping_list'].items[0]['id']
-    wine_id = hass.data['shopping_list'].items[1]['id']
-    client = await hass_ws_client(hass)
-
-    await client.send_json({
-        'id': 5,
-        'type': 'shopping_list/items/update',
-        'item_id': beer_id,
-        'complete': True
-    })
-    msg = await client.receive_json()
-    assert msg['success'] is True
-
-    await client.send_json({
-        'id': 6,
-        'type': 'shopping_list/items/clear'
-    })
-    msg = await client.receive_json()
-    assert msg['success'] is True
-
-    items = hass.data['shopping_list'].items
-    assert len(items) == 1
-
-    assert items[0] == {
-        'id': wine_id,
-        'name': 'wine',
-        'complete': False
-    }
-
-
 @asyncio.coroutine
 def test_deprecated_api_create(hass, aiohttp_client):
     """Test the API."""
@@ -383,31 +248,8 @@ def test_deprecated_api_create(hass, aiohttp_client):
     assert items[0]['complete'] is False
 
 
-async def test_ws_add_item(hass, hass_ws_client):
-    """Test adding shopping_list item websocket command."""
-    await async_setup_component(hass, 'shopping_list', {})
-
-    client = await hass_ws_client(hass)
-
-    await client.send_json({
-        'id': 5,
-        'type': 'shopping_list/items/add',
-        'name': 'soda',
-    })
-    msg = await client.receive_json()
-    assert msg['success'] is True
-    data = msg['result']
-    assert data['name'] == 'soda'
-    assert data['complete'] is False
-
-    items = hass.data['shopping_list'].items
-    assert len(items) == 1
-    assert items[0]['name'] == 'soda'
-    assert items[0]['complete'] is False
-
-
 @asyncio.coroutine
-def test_deprecated_api_create_fail(hass, aiohttp_client):
+def test_api_create_fail(hass, aiohttp_client):
     """Test the API."""
     yield from async_setup_component(hass, 'shopping_list', {})
 
@@ -417,20 +259,4 @@ def test_deprecated_api_create_fail(hass, aiohttp_client):
     })
 
     assert resp.status == 400
-    assert len(hass.data['shopping_list'].items) == 0
-
-
-async def test_ws_add_item_fail(hass, hass_ws_client):
-    """Test adding shopping_list item failure websocket command."""
-    await async_setup_component(hass, 'shopping_list', {})
-
-    client = await hass_ws_client(hass)
-
-    await client.send_json({
-        'id': 5,
-        'type': 'shopping_list/items/add',
-        'name': 123,
-    })
-    msg = await client.receive_json()
-    assert msg['success'] is False
     assert len(hass.data['shopping_list'].items) == 0

--- a/tests/components/test_shopping_list.py
+++ b/tests/components/test_shopping_list.py
@@ -228,7 +228,7 @@ def test_api_clear_completed(hass, aiohttp_client):
 
 
 @asyncio.coroutine
-def test_deprecated_api_create(hass, aiohttp_client):
+def test_api_create(hass, aiohttp_client):
     """Test the API."""
     yield from async_setup_component(hass, 'shopping_list', {})
 

--- a/tests/components/test_shopping_list.py
+++ b/tests/components/test_shopping_list.py
@@ -301,7 +301,6 @@ def test_deprecated_api_clear_completed(hass, aiohttp_client):
 
     client = yield from aiohttp_client(hass.http.app)
 
-
     # Mark beer as completed
     resp = yield from client.post(
         '/api/shopping_list/item/{}'.format(beer_id), json={

--- a/tests/components/test_shopping_list.py
+++ b/tests/components/test_shopping_list.py
@@ -96,7 +96,7 @@ async def test_ws_get_items(hass, hass_ws_client):
         'type': 'shopping_list/items/get',
     })
     msg = await client.receive_json()
-    assert msg['success'] == True
+    assert msg['success'] is True
 
     assert msg['id'] == 5
     assert msg['type'] == TYPE_RESULT
@@ -186,7 +186,7 @@ async def test_ws_update_item(hass, hass_ws_client):
         'name': 'soda'
     })
     msg = await client.receive_json()
-    assert msg['success'] == True
+    assert msg['success'] is True
 
     data = msg['result']
     assert data == {
@@ -202,7 +202,7 @@ async def test_ws_update_item(hass, hass_ws_client):
         'complete': True
     })
     msg = await client.receive_json()
-    assert msg['success'] == True
+    assert msg['success'] is True
 
     data = msg['result']
     assert data == {
@@ -267,7 +267,7 @@ async def test_ws_update_item_fail(hass, hass_ws_client):
         'name': 'soda'
     })
     msg = await client.receive_json()
-    assert msg['success'] == False
+    assert msg['success'] is False
 
     data = msg['error']
     assert data == {
@@ -281,7 +281,7 @@ async def test_ws_update_item_fail(hass, hass_ws_client):
         'name': 123,
     })
     msg = await client.receive_json()
-    assert msg['success'] == False
+    assert msg['success'] is False
 
 
 @asyncio.coroutine
@@ -300,6 +300,7 @@ def test_deprecated_api_clear_completed(hass, aiohttp_client):
     wine_id = hass.data['shopping_list'].items[1]['id']
 
     client = yield from aiohttp_client(hass.http.app)
+
 
     # Mark beer as completed
     resp = yield from client.post(
@@ -343,14 +344,14 @@ async def test_ws_clear_items(hass, hass_ws_client):
         'complete': True
     })
     msg = await client.receive_json()
-    assert msg['success'] == True
+    assert msg['success'] is True
 
     await client.send_json({
         'id': 6,
         'type': 'shopping_list/items/clear'
     })
     msg = await client.receive_json()
-    assert msg['success'] == True
+    assert msg['success'] is True
 
     items = hass.data['shopping_list'].items
     assert len(items) == 1
@@ -395,7 +396,7 @@ async def test_ws_add_item(hass, hass_ws_client):
         'name': 'soda',
     })
     msg = await client.receive_json()
-    assert msg['success'] == True
+    assert msg['success'] is True
     data = msg['result']
     assert data['name'] == 'soda'
     assert data['complete'] is False
@@ -432,5 +433,5 @@ async def test_ws_add_item_fail(hass, hass_ws_client):
         'name': 123,
     })
     msg = await client.receive_json()
-    assert msg['success'] == False
+    assert msg['success'] is False
     assert len(hass.data['shopping_list'].items) == 0

--- a/tests/components/test_shopping_list.py
+++ b/tests/components/test_shopping_list.py
@@ -6,6 +6,7 @@ import pytest
 
 from homeassistant.bootstrap import async_setup_component
 from homeassistant.helpers import intent
+from homeassistant.components.websocket_api.const import TYPE_RESULT
 
 
 @pytest.fixture(autouse=True)
@@ -54,7 +55,7 @@ def test_recent_items_intent(hass):
 
 
 @asyncio.coroutine
-def test_api_get_all(hass, aiohttp_client):
+def test_deprecated_api_get_all(hass, aiohttp_client):
     """Test the API."""
     yield from async_setup_component(hass, 'shopping_list', {})
 
@@ -77,8 +78,39 @@ def test_api_get_all(hass, aiohttp_client):
     assert not data[1]['complete']
 
 
+async def test_ws_get_items(hass, hass_ws_client):
+    """Test get shopping_list items websocket command."""
+    await async_setup_component(hass, 'shopping_list', {})
+
+    await intent.async_handle(
+        hass, 'test', 'HassShoppingListAddItem', {'item': {'value': 'beer'}}
+    )
+    await intent.async_handle(
+        hass, 'test', 'HassShoppingListAddItem', {'item': {'value': 'wine'}}
+    )
+
+    client = await hass_ws_client(hass)
+
+    await client.send_json({
+        'id': 5,
+        'type': 'shopping_list/items/get',
+    })
+    msg = await client.receive_json()
+    assert msg['success'] == True
+
+    assert msg['id'] == 5
+    assert msg['type'] == TYPE_RESULT
+    assert msg['success']
+    data = msg['result']
+    assert len(data) == 2
+    assert data[0]['name'] == 'beer'
+    assert not data[0]['complete']
+    assert data[1]['name'] == 'wine'
+    assert not data[1]['complete']
+
+
 @asyncio.coroutine
-def test_api_update(hass, aiohttp_client):
+def test_deprecated_api_update(hass, aiohttp_client):
     """Test the API."""
     yield from async_setup_component(hass, 'shopping_list', {})
 
@@ -132,8 +164,68 @@ def test_api_update(hass, aiohttp_client):
     }
 
 
+async def test_ws_update_item(hass, hass_ws_client):
+    """Test update shopping_list item websocket command."""
+    await async_setup_component(hass, 'shopping_list', {})
+
+    await intent.async_handle(
+        hass, 'test', 'HassShoppingListAddItem', {'item': {'value': 'beer'}}
+    )
+    await intent.async_handle(
+        hass, 'test', 'HassShoppingListAddItem', {'item': {'value': 'wine'}}
+    )
+
+    beer_id = hass.data['shopping_list'].items[0]['id']
+    wine_id = hass.data['shopping_list'].items[1]['id']
+    client = await hass_ws_client(hass)
+
+    await client.send_json({
+        'id': 5,
+        'type': 'shopping_list/items/update',
+        'item_id': beer_id,
+        'name': 'soda'
+    })
+    msg = await client.receive_json()
+    assert msg['success'] == True
+
+    data = msg['result']
+    assert data == {
+        'id': beer_id,
+        'name': 'soda',
+        'complete': False
+    }
+
+    await client.send_json({
+        'id': 6,
+        'type': 'shopping_list/items/update',
+        'item_id': wine_id,
+        'complete': True
+    })
+    msg = await client.receive_json()
+    assert msg['success'] == True
+
+    data = msg['result']
+    assert data == {
+        'id': wine_id,
+        'name': 'wine',
+        'complete': True
+    }
+
+    beer, wine = hass.data['shopping_list'].items
+    assert beer == {
+        'id': beer_id,
+        'name': 'soda',
+        'complete': False
+    }
+    assert wine == {
+        'id': wine_id,
+        'name': 'wine',
+        'complete': True
+    }
+
+
 @asyncio.coroutine
-def test_api_update_fails(hass, aiohttp_client):
+def test_deprecated_api_update_fails(hass, aiohttp_client):
     """Test the API."""
     yield from async_setup_component(hass, 'shopping_list', {})
 
@@ -158,8 +250,42 @@ def test_api_update_fails(hass, aiohttp_client):
     assert resp.status == 400
 
 
+async def test_ws_update_item_fail(hass, hass_ws_client):
+    """Test failure of update shopping_list item websocket command."""
+    await async_setup_component(hass, 'shopping_list', {})
+
+    await intent.async_handle(
+        hass, 'test', 'HassShoppingListAddItem', {'item': {'value': 'beer'}}
+    )
+
+    client = await hass_ws_client(hass)
+
+    await client.send_json({
+        'id': 5,
+        'type': 'shopping_list/items/update',
+        'item_id': 'non_existing',
+        'name': 'soda'
+    })
+    msg = await client.receive_json()
+    assert msg['success'] == False
+
+    data = msg['error']
+    assert data == {
+        'code': 'shopping_list_update_failed',
+        'message': 'Item not found'
+    }
+
+    await client.send_json({
+        'id': 6,
+        'type': 'shopping_list/items/update',
+        'name': 123,
+    })
+    msg = await client.receive_json()
+    assert msg['success'] == False
+
+
 @asyncio.coroutine
-def test_api_clear_completed(hass, aiohttp_client):
+def test_deprecated_api_clear_completed(hass, aiohttp_client):
     """Test the API."""
     yield from async_setup_component(hass, 'shopping_list', {})
 
@@ -195,8 +321,49 @@ def test_api_clear_completed(hass, aiohttp_client):
     }
 
 
+async def test_ws_clear_items(hass, hass_ws_client):
+    """Test clearing shopping_list items websocket command."""
+    await async_setup_component(hass, 'shopping_list', {})
+
+    await intent.async_handle(
+        hass, 'test', 'HassShoppingListAddItem', {'item': {'value': 'beer'}}
+    )
+    await intent.async_handle(
+        hass, 'test', 'HassShoppingListAddItem', {'item': {'value': 'wine'}}
+    )
+
+    beer_id = hass.data['shopping_list'].items[0]['id']
+    wine_id = hass.data['shopping_list'].items[1]['id']
+    client = await hass_ws_client(hass)
+
+    await client.send_json({
+        'id': 5,
+        'type': 'shopping_list/items/update',
+        'item_id': beer_id,
+        'complete': True
+    })
+    msg = await client.receive_json()
+    assert msg['success'] == True
+
+    await client.send_json({
+        'id': 6,
+        'type': 'shopping_list/items/clear'
+    })
+    msg = await client.receive_json()
+    assert msg['success'] == True
+
+    items = hass.data['shopping_list'].items
+    assert len(items) == 1
+
+    assert items[0] == {
+        'id': wine_id,
+        'name': 'wine',
+        'complete': False
+    }
+
+
 @asyncio.coroutine
-def test_api_create(hass, aiohttp_client):
+def test_deprecated_api_create(hass, aiohttp_client):
     """Test the API."""
     yield from async_setup_component(hass, 'shopping_list', {})
 
@@ -216,8 +383,31 @@ def test_api_create(hass, aiohttp_client):
     assert items[0]['complete'] is False
 
 
+async def test_ws_add_item(hass, hass_ws_client):
+    """Test adding shopping_list item websocket command."""
+    await async_setup_component(hass, 'shopping_list', {})
+
+    client = await hass_ws_client(hass)
+
+    await client.send_json({
+        'id': 5,
+        'type': 'shopping_list/items/add',
+        'name': 'soda',
+    })
+    msg = await client.receive_json()
+    assert msg['success'] == True
+    data = msg['result']
+    assert data['name'] == 'soda'
+    assert data['complete'] is False
+
+    items = hass.data['shopping_list'].items
+    assert len(items) == 1
+    assert items[0]['name'] == 'soda'
+    assert items[0]['complete'] is False
+
+
 @asyncio.coroutine
-def test_api_create_fail(hass, aiohttp_client):
+def test_deprecated_api_create_fail(hass, aiohttp_client):
     """Test the API."""
     yield from async_setup_component(hass, 'shopping_list', {})
 
@@ -227,4 +417,20 @@ def test_api_create_fail(hass, aiohttp_client):
     })
 
     assert resp.status == 400
+    assert len(hass.data['shopping_list'].items) == 0
+
+
+async def test_ws_add_item_fail(hass, hass_ws_client):
+    """Test adding shopping_list item failure websocket command."""
+    await async_setup_component(hass, 'shopping_list', {})
+
+    client = await hass_ws_client(hass)
+
+    await client.send_json({
+        'id': 5,
+        'type': 'shopping_list/items/add',
+        'name': 123,
+    })
+    msg = await client.receive_json()
+    assert msg['success'] == False
     assert len(hass.data['shopping_list'].items) == 0


### PR DESCRIPTION
Plan to deprecate API calls once shopping-list panel is removed from UI and replaced fully by Lovelace card

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.
