### PR TITLE
Add support for keypad keypress

### DIFF
--- a/homeassistant/components/elkm1/__init__.py
+++ b/homeassistant/components/elkm1/__init__.py
@@ -20,7 +20,7 @@ from homeassistant.helpers.typing import ConfigType  # noqa
 
 DOMAIN = "elkm1"
 
-REQUIREMENTS = ['elkm1-lib==0.7.10']
+REQUIREMENTS = ['elkm1-lib==0.7.11']
 
 CONF_AREA = 'area'
 CONF_COUNTER = 'counter'

--- a/homeassistant/components/sensor/elkm1.py
+++ b/homeassistant/components/sensor/elkm1.py
@@ -91,6 +91,7 @@ class ElkKeypad(ElkSensor):
         attrs['last_user'] = self._element.last_user + 1
         attrs['code'] = self._element.code
         attrs['last_user_name'] = username(self._elk, self._element.last_user)
+        attrs['last_keypress'] = self._element.last_keypress
         return attrs
 
     def _element_changed(self, element, changeset):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -333,7 +333,7 @@ einder==0.3.1
 eliqonline==1.0.14
 
 # homeassistant.components.elkm1
-elkm1-lib==0.7.10
+elkm1-lib==0.7.11
 
 # homeassistant.components.enocean
 enocean==0.40


### PR DESCRIPTION
## Description:
Adds support for reporting keypad keypresses on the keypad sensor. A new single `device_state_attribute` is added. No doc changes or config changes required.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
