### PR TITLE
Bumps pytile to 2.0.5

### DIFF
--- a/homeassistant/components/device_tracker/tile.py
+++ b/homeassistant/components/device_tracker/tile.py
@@ -18,7 +18,7 @@ from homeassistant.util import slugify
 from homeassistant.util.json import load_json, save_json
 
 _LOGGER = logging.getLogger(__name__)
-REQUIREMENTS = ['pytile==2.0.2']
+REQUIREMENTS = ['pytile==2.0.5']
 
 CLIENT_UUID_CONFIG_FILE = '.tile.conf'
 DEVICE_TYPES = ['PHONE', 'TILE']

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1261,7 +1261,7 @@ pythonegardia==1.0.39
 pythonwhois==2.4.3
 
 # homeassistant.components.device_tracker.tile
-pytile==2.0.2
+pytile==2.0.5
 
 # homeassistant.components.climate.touchline
 pytouchline==0.7


### PR DESCRIPTION
## Description:

This PR bumps `pytile` to 2.0.5. Changelog: https://github.com/bachya/pytile/releases/tag/2.0.5

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
device_tracker:
  - platform: tile
    username: !secret tile_username
    password: !secret tile_password
    monitored_variables:
      - TILE
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
