### PR TITLE
Update pynello to 2.0.2

### DIFF
--- a/homeassistant/components/lock/nello.py
+++ b/homeassistant/components/lock/nello.py
@@ -13,7 +13,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.components.lock import (LockDevice, PLATFORM_SCHEMA)
 from homeassistant.const import (CONF_PASSWORD, CONF_USERNAME)
 
-REQUIREMENTS = ['pynello==1.5.1']
+REQUIREMENTS = ['pynello==2.0.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/lock/nello.py
+++ b/homeassistant/components/lock/nello.py
@@ -29,7 +29,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Nello lock platform."""
-    from pynello import Nello
+    from pynello.private import Nello
     nello = Nello(config.get(CONF_USERNAME), config.get(CONF_PASSWORD))
     add_entities([NelloLock(lock) for lock in nello.locations], True)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1044,7 +1044,7 @@ pymyq==0.0.15
 pymysensors==0.18.0
 
 # homeassistant.components.lock.nello
-pynello==1.5.1
+pynello==2.0.2
 
 # homeassistant.components.device_tracker.netgear
 pynetgear==0.5.1


### PR DESCRIPTION
## Description:
There was an update some time ago for the package, introducing the public api and marking the private as deprecated.

I had a look at the new public api and there are some things to figure out before changing.
The main differences are:
- using of client_id, so you account doesn't get blocked if you are using it in HA
- short_id was removed
- activity was removed
  - worst thing, you are not able to identify a ringing bell easy as before

As long as the private api is still working, we should leave it there. Maybe they will add recent activity in the future.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
