### PR TITLE
Changed checking of cover state closed from 0 to closed_position vari…

### DIFF
--- a/homeassistant/components/cover/mqtt.py
+++ b/homeassistant/components/cover/mqtt.py
@@ -87,7 +87,7 @@ def validate_options(value):
     if (CONF_SET_POSITION_TOPIC in value and
             CONF_GET_POSITION_TOPIC not in value):
         raise vol.Invalid(
-            "Set position topic must be set together with get position topic.")
+            "set_position_topic must be set together with position_topic.")
     return value
 
 
@@ -287,7 +287,7 @@ class MqttCover(MqttAvailability, MqttDiscoveryUpdate, MqttEntityDeviceInfo,
                         float(payload), COVER_PAYLOAD)
                 if 0 <= percentage_payload <= 100:
                     self._position = percentage_payload
-                    self._state = self._position == 0
+                    self._state = self._position == self._position_closed
             else:
                 _LOGGER.warning(
                     "Payload is not integer within range: %s",
@@ -451,7 +451,7 @@ class MqttCover(MqttAvailability, MqttDiscoveryUpdate, MqttEntityDeviceInfo,
             mqtt.async_publish(self.hass, self._set_position_topic,
                                position, self._qos, self._retain)
             if self._optimistic:
-                self._state = percentage_position == 0
+                self._state = percentage_position == self._position_closed
                 self._position = percentage_position
                 self.async_schedule_update_ha_state()
 


### PR DESCRIPTION
Change way of checking state of cover.
Change error message to avoid expression "get_position_topic".

## Description:

Somehow didn't occured to me before that if close/open values are inverted ideally from 100-0 to 0-100 I won't calculate percentage. I deleted 'get_position_topic' text from logs as well as we named it finally just position_topic.

Anyway I think fix is pretty simple, just changed:
```
self._state = self._position == 0
```
to
```
self._state = self._position == self._position_closed
```

Getting position is working properly accorind to related issue.

**Related issue (if applicable): https://github.com/home-assistant/home-assistant/issues/18383


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.