### PR TITLE
Sense will not list removed devices

### DIFF
--- a/homeassistant/components/binary_sensor/sense.py
+++ b/homeassistant/components/binary_sensor/sense.py
@@ -61,7 +61,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     sense_devices = data.get_discovered_device_data()
     devices = [SenseDevice(data, device) for device in sense_devices
-               if device['tags']['DeviceListAllowed'] == "true"]
+               if device['tags']['DeviceListAllowed'] == 'true']
     add_entities(devices)
 
 

--- a/homeassistant/components/binary_sensor/sense.py
+++ b/homeassistant/components/binary_sensor/sense.py
@@ -60,7 +60,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     data = hass.data[SENSE_DATA]
 
     sense_devices = data.get_discovered_device_data()
-    devices = [SenseDevice(data, device) for device in sense_devices]
+    devices = [SenseDevice(data, device) for device in sense_devices
+               if device['tags']['DeviceListAllowed'] == "true"]
     add_entities(devices)
 
 


### PR DESCRIPTION
## Description:
Sense was previously adding all devices as binary sensors, including those that the user had removed.  This fix changes it to only include those that are listable in the app
