### PR TITLE
Add Rainmachine config entry

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -268,7 +268,7 @@ omit =
     homeassistant/components/raincloud.py
     homeassistant/components/*/raincloud.py
 
-    homeassistant/components/rainmachine/*
+    homeassistant/components/rainmachine/__init__.py
     homeassistant/components/*/rainmachine.py
 
     homeassistant/components/raspihats.py

--- a/homeassistant/components/binary_sensor/rainmachine.py
+++ b/homeassistant/components/binary_sensor/rainmachine.py
@@ -8,14 +8,14 @@ import logging
 
 from homeassistant.components.binary_sensor import BinarySensorDevice
 from homeassistant.components.rainmachine import (
-    BINARY_SENSORS, DATA_CLIENT, DOMAIN, SENSOR_UPDATE_TOPIC, TYPE_FREEZE,
-    TYPE_FREEZE_PROTECTION, TYPE_HOT_DAYS, TYPE_HOURLY, TYPE_MONTH,
-    TYPE_RAINDELAY, TYPE_RAINSENSOR, TYPE_WEEKDAY, RainMachineEntity)
+    BINARY_SENSORS, DATA_CLIENT, DOMAIN as RAINMACHINE_DOMAIN,
+    SENSOR_UPDATE_TOPIC, TYPE_FREEZE, TYPE_FREEZE_PROTECTION, TYPE_HOT_DAYS,
+    TYPE_HOURLY, TYPE_MONTH, TYPE_RAINDELAY, TYPE_RAINSENSOR, TYPE_WEEKDAY,
+    RainMachineEntity)
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 DEPENDENCIES = ['rainmachine']
-
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -27,7 +27,7 @@ async def async_setup_platform(
 
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up RainMachine binary sensors based on a config entry."""
-    rainmachine = hass.data[DOMAIN][DATA_CLIENT][entry.entry_id]
+    rainmachine = hass.data[RAINMACHINE_DOMAIN][DATA_CLIENT][entry.entry_id]
 
     binary_sensors = []
     for sensor_type in rainmachine.binary_sensor_conditions:
@@ -49,6 +49,19 @@ class RainMachineBinarySensor(RainMachineEntity, BinarySensorDevice):
         self._name = name
         self._sensor_type = sensor_type
         self._state = None
+
+    @property
+    def device_info(self):
+        return {
+            'identifiers': {
+                (RAINMACHINE_DOMAIN, self.rainmachine.client.mac)
+            },
+            'name': self.rainmachine.client.name,
+            'manufacturer': 'RainMachine',
+            'model': 'Hardware Version {0}'.format(
+                self.rainmachine.client.hardware_version),
+            'sw_version': self.rainmachine.client.software_version,
+        }
 
     @property
     def icon(self) -> str:

--- a/homeassistant/components/binary_sensor/rainmachine.py
+++ b/homeassistant/components/binary_sensor/rainmachine.py
@@ -51,20 +51,6 @@ class RainMachineBinarySensor(RainMachineEntity, BinarySensorDevice):
         self._state = None
 
     @property
-    def device_info(self):
-        """Return device registry information for this binary sensor."""
-        return {
-            'identifiers': {
-                (RAINMACHINE_DOMAIN, self.rainmachine.client.mac)
-            },
-            'name': self.rainmachine.client.name,
-            'manufacturer': 'RainMachine',
-            'model': 'Hardware Version {0}'.format(
-                self.rainmachine.client.hardware_version),
-            'sw_version': self.rainmachine.client.software_version,
-        }
-
-    @property
     def icon(self) -> str:
         """Return the icon."""
         return self._icon

--- a/homeassistant/components/binary_sensor/rainmachine.py
+++ b/homeassistant/components/binary_sensor/rainmachine.py
@@ -52,6 +52,7 @@ class RainMachineBinarySensor(RainMachineEntity, BinarySensorDevice):
 
     @property
     def device_info(self):
+        """Return device registry information for this binary sensor."""
         return {
             'identifiers': {
                 (RAINMACHINE_DOMAIN, self.rainmachine.client.mac)

--- a/homeassistant/components/binary_sensor/rainmachine.py
+++ b/homeassistant/components/binary_sensor/rainmachine.py
@@ -71,15 +71,20 @@ class RainMachineBinarySensor(RainMachineEntity, BinarySensorDevice):
         return '{0}_{1}'.format(
             self.rainmachine.device_mac.replace(':', ''), self._sensor_type)
 
-    @callback
-    def _update_data(self):
-        """Update the state."""
-        self.async_schedule_update_ha_state(True)
-
     async def async_added_to_hass(self):
         """Register callbacks."""
-        async_dispatcher_connect(
-            self.hass, SENSOR_UPDATE_TOPIC, self._update_data)
+        @callback
+        def update(self):
+            """Update the state."""
+            self.async_schedule_update_ha_state(True)
+
+        self._async_unsub_dispatcher_connect = async_dispatcher_connect(
+            self.hass, SENSOR_UPDATE_TOPIC, update)
+
+    async def async_will_remove_from_hass(self):
+        """Disconnect dispatcher listener when removed."""
+        if self._async_unsub_dispatcher_connect:
+            self._async_unsub_dispatcher_connect()
 
     async def async_update(self):
         """Update the state."""

--- a/homeassistant/components/binary_sensor/rainmachine.py
+++ b/homeassistant/components/binary_sensor/rainmachine.py
@@ -8,10 +8,9 @@ import logging
 
 from homeassistant.components.binary_sensor import BinarySensorDevice
 from homeassistant.components.rainmachine import (
-    BINARY_SENSORS, DATA_RAINMACHINE, SENSOR_UPDATE_TOPIC, TYPE_FREEZE,
+    BINARY_SENSORS, DATA_CLIENT, DOMAIN, SENSOR_UPDATE_TOPIC, TYPE_FREEZE,
     TYPE_FREEZE_PROTECTION, TYPE_HOT_DAYS, TYPE_HOURLY, TYPE_MONTH,
     TYPE_RAINDELAY, TYPE_RAINSENSOR, TYPE_WEEKDAY, RainMachineEntity)
-from homeassistant.const import CONF_MONITORED_CONDITIONS
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
@@ -22,14 +21,16 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_platform(
         hass, config, async_add_entities, discovery_info=None):
-    """Set up the RainMachine Switch platform."""
-    if discovery_info is None:
-        return
+    """Set up  RainMachine binary sensors based on the old way."""
+    pass
 
-    rainmachine = hass.data[DATA_RAINMACHINE]
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up RainMachine binary sensors based on a config entry."""
+    rainmachine = hass.data[DOMAIN][DATA_CLIENT][entry.entry_id]
 
     binary_sensors = []
-    for sensor_type in discovery_info[CONF_MONITORED_CONDITIONS]:
+    for sensor_type in rainmachine.binary_sensor_conditions:
         name, icon = BINARY_SENSORS[sensor_type]
         binary_sensors.append(
             RainMachineBinarySensor(rainmachine, sensor_type, name, icon))

--- a/homeassistant/components/rainmachine/.translations/en.json
+++ b/homeassistant/components/rainmachine/.translations/en.json
@@ -9,8 +9,7 @@
                 "data": {
                     "ip_address": "Hostname or IP Address",
                     "password": "Password",
-                    "port": "Port",
-                    "ssl": "Use SSL"
+                    "port": "Port"
                 },
                 "title": "Fill in your information"
             }

--- a/homeassistant/components/rainmachine/.translations/en.json
+++ b/homeassistant/components/rainmachine/.translations/en.json
@@ -1,0 +1,20 @@
+{
+    "config": {
+        "error": {
+            "identifier_exists": "Account already registered",
+            "invalid_credentials": "Invalid credentials"
+        },
+        "step": {
+            "user": {
+                "data": {
+                    "ip_address": "Hostname or IP Address",
+                    "password": "Password",
+                    "port": "Port",
+                    "ssl": "Use SSL"
+                },
+                "title": "Fill in your information"
+            }
+        },
+        "title": "RainMachine"
+    }
+}

--- a/homeassistant/components/rainmachine/__init__.py
+++ b/homeassistant/components/rainmachine/__init__.py
@@ -21,8 +21,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import async_track_time_interval
 
 from .config_flow import configured_instances
-from .const import (
-    DATA_CLIENT, DEFAULT_PORT, DEFAULT_SCAN_INTERVAL, DEFAULT_SSL, DOMAIN)
+from .const import DATA_CLIENT, DEFAULT_PORT, DEFAULT_SCAN_INTERVAL, DOMAIN
 
 REQUIREMENTS = ['regenmaschine==1.0.7']
 

--- a/homeassistant/components/rainmachine/__init__.py
+++ b/homeassistant/components/rainmachine/__init__.py
@@ -24,7 +24,7 @@ from .config_flow import configured_instances
 from .const import (
     DATA_CLIENT, DEFAULT_PORT, DEFAULT_SCAN_INTERVAL, DEFAULT_SSL, DOMAIN)
 
-REQUIREMENTS = ['regenmaschine==1.0.6']
+REQUIREMENTS = ['regenmaschine==1.0.7']
 _LOGGER = logging.getLogger(__name__)
 
 DATA_LISTENER = 'listener'

--- a/homeassistant/components/rainmachine/__init__.py
+++ b/homeassistant/components/rainmachine/__init__.py
@@ -25,6 +25,7 @@ from .const import (
     DATA_CLIENT, DEFAULT_PORT, DEFAULT_SCAN_INTERVAL, DEFAULT_SSL, DOMAIN)
 
 REQUIREMENTS = ['regenmaschine==1.0.7']
+
 _LOGGER = logging.getLogger(__name__)
 
 DATA_LISTENER = 'listener'
@@ -96,23 +97,23 @@ SERVICE_STOP_ZONE_SCHEMA = vol.Schema({
 
 SWITCH_SCHEMA = vol.Schema({vol.Optional(CONF_ZONE_RUN_TIME): cv.positive_int})
 
-CONFIG_SCHEMA = vol.Schema({
-    DOMAIN:
+CONFIG_SCHEMA = vol.Schema(
+    {
+        DOMAIN:
         vol.Schema({
             vol.Required(CONF_IP_ADDRESS): cv.string,
             vol.Required(CONF_PASSWORD): cv.string,
             vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
             vol.Optional(CONF_SSL, default=DEFAULT_SSL): cv.boolean,
-            vol.Optional(CONF_BINARY_SENSORS, default={}):
-                BINARY_SENSOR_SCHEMA,
-            vol.Optional(CONF_SENSORS, default={}):
-                SENSOR_SCHEMA,
-            vol.Optional(CONF_SWITCHES, default={}):
-                SWITCH_SCHEMA,
             vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL):
                 cv.time_period,
+            vol.Optional(CONF_BINARY_SENSORS, default={}):
+                BINARY_SENSOR_SCHEMA,
+            vol.Optional(CONF_SENSORS, default={}): SENSOR_SCHEMA,
+            vol.Optional(CONF_SWITCHES, default={}): SWITCH_SCHEMA,
         })
-}, extra=vol.ALLOW_EXTRA)
+    },
+    extra=vol.ALLOW_EXTRA)
 
 
 async def async_setup(hass, config):
@@ -133,16 +134,7 @@ async def async_setup(hass, config):
         hass.config_entries.flow.async_init(
             DOMAIN,
             context={'source': SOURCE_IMPORT},
-            data={
-                CONF_IP_ADDRESS: conf[CONF_IP_ADDRESS],
-                CONF_PASSWORD: conf[CONF_PASSWORD],
-                CONF_PORT: conf[CONF_PORT],
-                CONF_SSL: conf[CONF_SSL],
-                CONF_BINARY_SENSORS: conf[CONF_BINARY_SENSORS],
-                CONF_SENSORS: conf[CONF_SENSORS],
-                CONF_SWITCHES: conf[CONF_SWITCHES],
-                CONF_SCAN_INTERVAL: conf[CONF_SCAN_INTERVAL],
-            }))
+            data=conf))
 
     return True
 

--- a/homeassistant/components/rainmachine/config_flow.py
+++ b/homeassistant/components/rainmachine/config_flow.py
@@ -1,0 +1,88 @@
+"""Config flow to configure the RainMachine component."""
+
+from collections import OrderedDict
+
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.core import callback
+from homeassistant.const import (
+    CONF_IP_ADDRESS, CONF_PASSWORD, CONF_PORT, CONF_SCAN_INTERVAL, CONF_SSL,
+    CONF_TOKEN)
+from homeassistant.helpers import aiohttp_client
+
+from .const import DEFAULT_PORT, DEFAULT_SCAN_INTERVAL, DEFAULT_SSL, DOMAIN
+
+
+@callback
+def configured_instances(hass):
+    """Return a set of configured RainMachine instances."""
+    return set(
+        entry.data[CONF_IP_ADDRESS]
+        for entry in hass.config_entries.async_entries(DOMAIN))
+
+
+@config_entries.HANDLERS.register(DOMAIN)
+class RainMachineFlowHandler(config_entries.ConfigFlow):
+    """Handle a RainMachine config flow."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
+
+    def __init__(self):
+        """Initialize the config flow."""
+        self.data_schema = OrderedDict()
+        self.data_schema[vol.Required(CONF_IP_ADDRESS)] = str
+        self.data_schema[vol.Required(CONF_PASSWORD)] = str
+        self.data_schema[vol.Optional(CONF_PORT)] = int
+        self.data_schema[vol.Optional(CONF_SSL)] = bool
+
+    async def _show_form(self, errors=None):
+        """Show the form to the user."""
+        return self.async_show_form(
+            step_id='user',
+            data_schema=vol.Schema(self.data_schema),
+            errors=errors if errors else {},
+        )
+
+    async def async_step_import(self, import_config):
+        """Import a config entry from configuration.yaml."""
+        return await self.async_step_user(import_config)
+
+    async def async_step_user(self, user_input=None):
+        """Handle the start of the config flow."""
+        from regenmaschine import Client
+        from regenmaschine.errors import RainMachineError
+
+        if not user_input:
+            return await self._show_form()
+
+        if user_input[CONF_IP_ADDRESS] in configured_instances(self.hass):
+            return await self._show_form({
+                CONF_IP_ADDRESS: 'identifier_exists'
+            })
+
+        websession = aiohttp_client.async_get_clientsession(self.hass)
+
+        try:
+            client = Client(
+                user_input[CONF_IP_ADDRESS],
+                websession,
+                port=user_input.get(CONF_PORT, DEFAULT_PORT),
+                ssl=user_input.get(CONF_SSL, DEFAULT_SSL))
+            await client.authenticate(user_input[CONF_PASSWORD])
+        except RainMachineError:
+            return await self._show_form({
+                CONF_PASSWORD: 'invalid_credentials'
+            })
+
+        scan_interval = user_input.get(
+            CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+
+        return self.async_create_entry(
+            title=user_input[CONF_IP_ADDRESS],
+            data={
+                CONF_TOKEN: simplisafe.refresh_token,
+                CONF_SCAN_INTERVAL: scan_interval.seconds,
+            },
+        )

--- a/homeassistant/components/rainmachine/config_flow.py
+++ b/homeassistant/components/rainmachine/config_flow.py
@@ -34,7 +34,6 @@ class RainMachineFlowHandler(config_entries.ConfigFlow):
         self.data_schema[vol.Required(CONF_IP_ADDRESS)] = str
         self.data_schema[vol.Required(CONF_PASSWORD)] = str
         self.data_schema[vol.Optional(CONF_PORT, default=DEFAULT_PORT)] = int
-        self.data_schema[vol.Optional(CONF_SSL, default=True)] = bool
 
     async def _show_form(self, errors=None):
         """Show the form to the user."""
@@ -69,7 +68,7 @@ class RainMachineFlowHandler(config_entries.ConfigFlow):
                 user_input[CONF_PASSWORD],
                 websession,
                 port=user_input.get(CONF_PORT, DEFAULT_PORT),
-                ssl=user_input.get(CONF_SSL, DEFAULT_SSL))
+                ssl=True)
         except RainMachineError:
             return await self._show_form({
                 CONF_PASSWORD: 'invalid_credentials'
@@ -83,6 +82,4 @@ class RainMachineFlowHandler(config_entries.ConfigFlow):
         # access token without using the IP address and password, so we have to
         # store it:
         return self.async_create_entry(
-            title=user_input[CONF_IP_ADDRESS],
-            data=user_input
-        )
+            title=user_input[CONF_IP_ADDRESS], data=user_input)

--- a/homeassistant/components/rainmachine/config_flow.py
+++ b/homeassistant/components/rainmachine/config_flow.py
@@ -7,10 +7,10 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.core import callback
 from homeassistant.const import (
-    CONF_IP_ADDRESS, CONF_PASSWORD, CONF_PORT, CONF_SCAN_INTERVAL, CONF_SSL)
+    CONF_IP_ADDRESS, CONF_PASSWORD, CONF_PORT, CONF_SCAN_INTERVAL)
 from homeassistant.helpers import aiohttp_client
 
-from .const import DEFAULT_PORT, DEFAULT_SCAN_INTERVAL, DEFAULT_SSL, DOMAIN
+from .const import DEFAULT_PORT, DEFAULT_SCAN_INTERVAL, DOMAIN
 
 
 @callback

--- a/homeassistant/components/rainmachine/config_flow.py
+++ b/homeassistant/components/rainmachine/config_flow.py
@@ -10,8 +10,7 @@ from homeassistant.const import (
     CONF_IP_ADDRESS, CONF_PASSWORD, CONF_PORT, CONF_SCAN_INTERVAL, CONF_SSL)
 from homeassistant.helpers import aiohttp_client
 
-from .const import (
-    DEFAULT_PORT, DEFAULT_SCAN_INTERVAL, DEFAULT_SSL, DOMAIN, LOGGER)
+from .const import DEFAULT_PORT, DEFAULT_SCAN_INTERVAL, DEFAULT_SSL, DOMAIN
 
 
 @callback
@@ -34,8 +33,8 @@ class RainMachineFlowHandler(config_entries.ConfigFlow):
         self.data_schema = OrderedDict()
         self.data_schema[vol.Required(CONF_IP_ADDRESS)] = str
         self.data_schema[vol.Required(CONF_PASSWORD)] = str
-        self.data_schema[vol.Optional(CONF_PORT)] = int
-        self.data_schema[vol.Optional(CONF_SSL)] = bool
+        self.data_schema[vol.Optional(CONF_PORT, default=DEFAULT_PORT)] = int
+        self.data_schema[vol.Optional(CONF_SSL, default=True)] = bool
 
     async def _show_form(self, errors=None):
         """Show the form to the user."""
@@ -81,7 +80,7 @@ class RainMachineFlowHandler(config_entries.ConfigFlow):
         user_input[CONF_SCAN_INTERVAL] = scan_interval.seconds
 
         # Unfortunately, RainMachine doesn't provide a way to refresh the
-        # access token without using the IP address and pasword, so we have to
+        # access token without using the IP address and password, so we have to
         # store it:
         return self.async_create_entry(
             title=user_input[CONF_IP_ADDRESS],

--- a/homeassistant/components/rainmachine/const.py
+++ b/homeassistant/components/rainmachine/const.py
@@ -10,6 +10,5 @@ DATA_CLIENT = 'client'
 
 DEFAULT_PORT = 8080
 DEFAULT_SCAN_INTERVAL = timedelta(seconds=60)
-DEFAULT_SSL = True
 
 TOPIC_UPDATE = 'update_{0}'

--- a/homeassistant/components/rainmachine/const.py
+++ b/homeassistant/components/rainmachine/const.py
@@ -1,0 +1,12 @@
+"""Define constants for the SimpliSafe component."""
+from datetime import timedelta
+
+DOMAIN = 'rainmachine'
+
+DATA_CLIENT = 'client'
+
+DEFAULT_PORT = 8080
+DEFAULT_SCAN_INTERVAL = timedelta(seconds=60)
+DEFAULT_SSL = True
+
+TOPIC_UPDATE = 'update_{0}'

--- a/homeassistant/components/rainmachine/const.py
+++ b/homeassistant/components/rainmachine/const.py
@@ -1,5 +1,8 @@
 """Define constants for the SimpliSafe component."""
+import logging
 from datetime import timedelta
+
+LOGGER = logging.getLogger('homeassistant.components.rainmachine')
 
 DOMAIN = 'rainmachine'
 

--- a/homeassistant/components/rainmachine/strings.json
+++ b/homeassistant/components/rainmachine/strings.json
@@ -7,7 +7,7 @@
         "data": {
           "ip_address": "Hostname or IP Address",
           "password": "Password",
-          "port": "Port",
+          "port": "Port"
         }
       }
     },

--- a/homeassistant/components/rainmachine/strings.json
+++ b/homeassistant/components/rainmachine/strings.json
@@ -1,0 +1,20 @@
+{
+  "config": {
+    "title": "RainMacjine",
+    "step": {
+      "user": {
+        "title": "Fill in your information",
+        "data": {
+          "ip_address": "Hostname or IP Address",
+          "password": "Password",
+          "port": "Port",
+          "ssl": "Use SSL"
+        }
+      }
+    },
+    "error": {
+      "identifier_exists": "Account already registered",
+      "invalid_credentials": "Invalid credentials"
+    }
+  }
+}

--- a/homeassistant/components/rainmachine/strings.json
+++ b/homeassistant/components/rainmachine/strings.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "title": "RainMacjine",
+    "title": "RainMachine",
     "step": {
       "user": {
         "title": "Fill in your information",

--- a/homeassistant/components/rainmachine/strings.json
+++ b/homeassistant/components/rainmachine/strings.json
@@ -8,7 +8,6 @@
           "ip_address": "Hostname or IP Address",
           "password": "Password",
           "port": "Port",
-          "ssl": "Use SSL"
         }
       }
     },

--- a/homeassistant/components/sensor/rainmachine.py
+++ b/homeassistant/components/sensor/rainmachine.py
@@ -7,8 +7,7 @@ https://home-assistant.io/components/sensor.rainmachine/
 import logging
 
 from homeassistant.components.rainmachine import (
-    DATA_RAINMACHINE, SENSOR_UPDATE_TOPIC, SENSORS, RainMachineEntity)
-from homeassistant.const import CONF_MONITORED_CONDITIONS
+    DATA_CLIENT, DOMAIN, SENSOR_UPDATE_TOPIC, SENSORS, RainMachineEntity)
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
@@ -19,14 +18,16 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_platform(
         hass, config, async_add_entities, discovery_info=None):
-    """Set up the RainMachine Switch platform."""
-    if discovery_info is None:
-        return
+    """Set up RainMachine sensors based on the old way."""
+    pass
 
-    rainmachine = hass.data[DATA_RAINMACHINE]
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up RainMachine sensors based on a config entry."""
+    rainmachine = hass.data[DOMAIN][DATA_CLIENT][entry.entry_id]
 
     sensors = []
-    for sensor_type in discovery_info[CONF_MONITORED_CONDITIONS]:
+    for sensor_type in rainmachine.sensor_conditions:
         name, icon, unit = SENSORS[sensor_type]
         sensors.append(
             RainMachineSensor(rainmachine, sensor_type, name, icon, unit))

--- a/homeassistant/components/sensor/rainmachine.py
+++ b/homeassistant/components/sensor/rainmachine.py
@@ -7,12 +7,12 @@ https://home-assistant.io/components/sensor.rainmachine/
 import logging
 
 from homeassistant.components.rainmachine import (
-    DATA_CLIENT, DOMAIN, SENSOR_UPDATE_TOPIC, SENSORS, RainMachineEntity)
+    DATA_CLIENT, DOMAIN as RAINMACHINE_DOMAIN, SENSOR_UPDATE_TOPIC, SENSORS,
+    RainMachineEntity)
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 DEPENDENCIES = ['rainmachine']
-
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -24,7 +24,7 @@ async def async_setup_platform(
 
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up RainMachine sensors based on a config entry."""
-    rainmachine = hass.data[DOMAIN][DATA_CLIENT][entry.entry_id]
+    rainmachine = hass.data[RAINMACHINE_DOMAIN][DATA_CLIENT][entry.entry_id]
 
     sensors = []
     for sensor_type in rainmachine.sensor_conditions:
@@ -47,6 +47,19 @@ class RainMachineSensor(RainMachineEntity):
         self._sensor_type = sensor_type
         self._state = None
         self._unit = unit
+
+    @property
+    def device_info(self):
+        return {
+            'identifiers': {
+                (RAINMACHINE_DOMAIN, self.rainmachine.client.mac)
+            },
+            'name': self.rainmachine.client.name,
+            'manufacturer': 'RainMachine',
+            'model': 'Hardware Version {0}'.format(
+                self.rainmachine.client.hardware_version),
+            'sw_version': self.rainmachine.client.software_version,
+        }
 
     @property
     def icon(self) -> str:

--- a/homeassistant/components/sensor/rainmachine.py
+++ b/homeassistant/components/sensor/rainmachine.py
@@ -50,6 +50,7 @@ class RainMachineSensor(RainMachineEntity):
 
     @property
     def device_info(self):
+        """Return device registry information for this binary sensor."""
         return {
             'identifiers': {
                 (RAINMACHINE_DOMAIN, self.rainmachine.client.mac)

--- a/homeassistant/components/sensor/rainmachine.py
+++ b/homeassistant/components/sensor/rainmachine.py
@@ -49,20 +49,6 @@ class RainMachineSensor(RainMachineEntity):
         self._unit = unit
 
     @property
-    def device_info(self):
-        """Return device registry information for this binary sensor."""
-        return {
-            'identifiers': {
-                (RAINMACHINE_DOMAIN, self.rainmachine.client.mac)
-            },
-            'name': self.rainmachine.client.name,
-            'manufacturer': 'RainMachine',
-            'model': 'Hardware Version {0}'.format(
-                self.rainmachine.client.hardware_version),
-            'sw_version': self.rainmachine.client.software_version,
-        }
-
-    @property
     def icon(self) -> str:
         """Return the icon."""
         return self._icon

--- a/homeassistant/components/sensor/rainmachine.py
+++ b/homeassistant/components/sensor/rainmachine.py
@@ -74,15 +74,20 @@ class RainMachineSensor(RainMachineEntity):
         """Return the unit the value is expressed in."""
         return self._unit
 
-    @callback
-    def _update_data(self):
-        """Update the state."""
-        self.async_schedule_update_ha_state(True)
-
     async def async_added_to_hass(self):
         """Register callbacks."""
-        async_dispatcher_connect(
-            self.hass, SENSOR_UPDATE_TOPIC, self._update_data)
+        @callback
+        def update(self):
+            """Update the state."""
+            self.async_schedule_update_ha_state(True)
+
+        self._async_unsub_dispatcher_connect = async_dispatcher_connect(
+            self.hass, SENSOR_UPDATE_TOPIC, update)
+
+    async def async_will_remove_from_hass(self):
+        """Disconnect dispatcher listener when removed."""
+        if self._async_unsub_dispatcher_connect:
+            self._async_unsub_dispatcher_connect()
 
     async def async_update(self):
         """Update the sensor's state."""

--- a/homeassistant/components/switch/rainmachine.py
+++ b/homeassistant/components/switch/rainmachine.py
@@ -146,6 +146,7 @@ class RainMachineSwitch(RainMachineEntity, SwitchDevice):
 
     @property
     def device_info(self):
+        """Return device registry information for this binary sensor."""
         return {
             'identifiers': {
                 (RAINMACHINE_DOMAIN, self.rainmachine.client.mac)

--- a/homeassistant/components/switch/rainmachine.py
+++ b/homeassistant/components/switch/rainmachine.py
@@ -7,7 +7,7 @@ https://home-assistant.io/components/switch.rainmachine/
 import logging
 
 from homeassistant.components.rainmachine import (
-    CONF_ZONE_RUN_TIME, DATA_RAINMACHINE, DEFAULT_ZONE_RUN,
+    CONF_ZONE_RUN_TIME, DATA_CLIENT, DEFAULT_ZONE_RUN, DOMAIN,
     PROGRAM_UPDATE_TOPIC, ZONE_UPDATE_TOPIC, RainMachineEntity)
 from homeassistant.const import ATTR_ID
 from homeassistant.components.switch import SwitchDevice
@@ -101,15 +101,13 @@ VEGETATION_MAP = {
 
 async def async_setup_platform(
         hass, config, async_add_entities, discovery_info=None):
-    """Set up the RainMachine Switch platform."""
-    if discovery_info is None:
-        return
+    """Set up RainMachine switches sensor based on the old way."""
+    pass
 
-    _LOGGER.debug('Config received: %s', discovery_info)
 
-    zone_run_time = discovery_info.get(CONF_ZONE_RUN_TIME, DEFAULT_ZONE_RUN)
-
-    rainmachine = hass.data[DATA_RAINMACHINE]
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up RainMachine switches based on a config entry."""
+    rainmachine = hass.data[DOMAIN][DATA_CLIENT][entry.entry_id]
 
     entities = []
 
@@ -127,7 +125,9 @@ async def async_setup_platform(
             continue
 
         _LOGGER.debug('Adding zone: %s', zone)
-        entities.append(RainMachineZone(rainmachine, zone, zone_run_time))
+        entities.append(
+            RainMachineZone(
+                rainmachine, zone, rainmachine.default_zone_runtime))
 
     async_add_entities(entities, True)
 

--- a/homeassistant/components/switch/rainmachine.py
+++ b/homeassistant/components/switch/rainmachine.py
@@ -186,8 +186,13 @@ class RainMachineProgram(RainMachineSwitch):
 
     async def async_added_to_hass(self):
         """Register callbacks."""
-        async_dispatcher_connect(
+        self._async_unsub_dispatcher_connect = async_dispatcher_connect(
             self.hass, PROGRAM_UPDATE_TOPIC, self._program_updated)
+
+    async def async_will_remove_from_hass(self):
+        """Disconnect dispatcher listener when removed."""
+        if self._async_unsub_dispatcher_connect:
+            self._async_unsub_dispatcher_connect()
 
     async def async_turn_off(self, **kwargs) -> None:
         """Turn the program off."""

--- a/homeassistant/components/switch/rainmachine.py
+++ b/homeassistant/components/switch/rainmachine.py
@@ -7,8 +7,8 @@ https://home-assistant.io/components/switch.rainmachine/
 import logging
 
 from homeassistant.components.rainmachine import (
-    CONF_ZONE_RUN_TIME, DATA_CLIENT, DEFAULT_ZONE_RUN, DOMAIN,
-    PROGRAM_UPDATE_TOPIC, ZONE_UPDATE_TOPIC, RainMachineEntity)
+    DATA_CLIENT, DOMAIN as RAINMACHINE_DOMAIN, PROGRAM_UPDATE_TOPIC,
+    ZONE_UPDATE_TOPIC, RainMachineEntity)
 from homeassistant.const import ATTR_ID
 from homeassistant.components.switch import SwitchDevice
 from homeassistant.core import callback
@@ -107,7 +107,7 @@ async def async_setup_platform(
 
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up RainMachine switches based on a config entry."""
-    rainmachine = hass.data[DOMAIN][DATA_CLIENT][entry.entry_id]
+    rainmachine = hass.data[RAINMACHINE_DOMAIN][DATA_CLIENT][entry.entry_id]
 
     entities = []
 
@@ -144,6 +144,19 @@ class RainMachineSwitch(RainMachineEntity, SwitchDevice):
         self._rainmachine_entity_id = obj['uid']
         self._switch_type = switch_type
 
+    @property
+    def device_info(self):
+        return {
+            'identifiers': {
+                (RAINMACHINE_DOMAIN, self.rainmachine.client.mac)
+            },
+            'name': self.rainmachine.client.name,
+            'manufacturer': 'RainMachine',
+            'model': 'Version {0} (API: {1})'.format(
+                self.rainmachine.client.hardware_version,
+                self.rainmachine.client.api_version),
+            'sw_version': self.rainmachine.client.software_version,
+        }
     @property
     def icon(self) -> str:
         """Return the icon."""

--- a/homeassistant/components/switch/rainmachine.py
+++ b/homeassistant/components/switch/rainmachine.py
@@ -157,6 +157,7 @@ class RainMachineSwitch(RainMachineEntity, SwitchDevice):
                 self.rainmachine.client.api_version),
             'sw_version': self.rainmachine.client.software_version,
         }
+
     @property
     def icon(self) -> str:
         """Return the icon."""

--- a/homeassistant/components/switch/rainmachine.py
+++ b/homeassistant/components/switch/rainmachine.py
@@ -145,21 +145,6 @@ class RainMachineSwitch(RainMachineEntity, SwitchDevice):
         self._switch_type = switch_type
 
     @property
-    def device_info(self):
-        """Return device registry information for this binary sensor."""
-        return {
-            'identifiers': {
-                (RAINMACHINE_DOMAIN, self.rainmachine.client.mac)
-            },
-            'name': self.rainmachine.client.name,
-            'manufacturer': 'RainMachine',
-            'model': 'Version {0} (API: {1})'.format(
-                self.rainmachine.client.hardware_version,
-                self.rainmachine.client.api_version),
-            'sw_version': self.rainmachine.client.software_version,
-        }
-
-    @property
     def icon(self) -> str:
         """Return the icon."""
         return 'mdi:water'

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -149,6 +149,7 @@ FLOWS = [
     'mqtt',
     'nest',
     'openuv',
+    'rainmachine',
     'simplisafe',
     'smhi',
     'sonos',

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1333,7 +1333,7 @@ raincloudy==0.0.5
 # raspihats==2.2.3
 
 # homeassistant.components.rainmachine
-regenmaschine==1.0.2
+regenmaschine==1.0.6
 
 # homeassistant.components.python_script
 restrictedpython==4.0b6

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1333,7 +1333,7 @@ raincloudy==0.0.5
 # raspihats==2.2.3
 
 # homeassistant.components.rainmachine
-regenmaschine==1.0.6
+regenmaschine==1.0.7
 
 # homeassistant.components.python_script
 restrictedpython==4.0b6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -210,6 +210,9 @@ pyunifi==2.13
 # homeassistant.components.notify.html5
 pywebpush==1.6.0
 
+# homeassistant.components.rainmachine
+regenmaschine==1.0.6
+
 # homeassistant.components.python_script
 restrictedpython==4.0b6
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -211,7 +211,7 @@ pyunifi==2.13
 pywebpush==1.6.0
 
 # homeassistant.components.rainmachine
-regenmaschine==1.0.6
+regenmaschine==1.0.7
 
 # homeassistant.components.python_script
 restrictedpython==4.0b6

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -95,6 +95,7 @@ TEST_REQUIREMENTS = (
     'pyunifi',
     'pyupnp-async',
     'pywebpush',
+    'regenmaschine',
     'restrictedpython',
     'rflink',
     'ring_doorbell',

--- a/tests/components/rainmachine/__init__.py
+++ b/tests/components/rainmachine/__init__.py
@@ -1,0 +1,1 @@
+"""Define tests for the RainMachine component."""

--- a/tests/components/rainmachine/test_config_flow.py
+++ b/tests/components/rainmachine/test_config_flow.py
@@ -91,7 +91,6 @@ async def test_step_user(hass):
         CONF_PASSWORD: 'password',
         CONF_PORT: 8080,
         CONF_SSL: True,
-        CONF_SCAN_INTERVAL: timedelta(minutes=5)
     }
 
     flow = config_flow.RainMachineFlowHandler()
@@ -107,5 +106,5 @@ async def test_step_user(hass):
             CONF_PASSWORD: 'password',
             CONF_PORT: 8080,
             CONF_SSL: True,
-            CONF_SCAN_INTERVAL: 300,
+            CONF_SCAN_INTERVAL: 60,
         }

--- a/tests/components/rainmachine/test_config_flow.py
+++ b/tests/components/rainmachine/test_config_flow.py
@@ -1,5 +1,4 @@
 """Define tests for the OpenUV config flow."""
-from datetime import timedelta
 from unittest.mock import patch
 
 from homeassistant import data_entry_flow

--- a/tests/components/rainmachine/test_config_flow.py
+++ b/tests/components/rainmachine/test_config_flow.py
@@ -1,0 +1,113 @@
+"""Define tests for the OpenUV config flow."""
+from datetime import timedelta
+from unittest.mock import patch
+
+from homeassistant import data_entry_flow
+from homeassistant.components.rainmachine import DOMAIN, config_flow
+from homeassistant.const import (
+    CONF_IP_ADDRESS, CONF_PASSWORD, CONF_PORT, CONF_SSL, CONF_SCAN_INTERVAL)
+
+from tests.common import MockConfigEntry, mock_coro
+
+
+async def test_duplicate_error(hass):
+    """Test that errors are shown when duplicates are added."""
+    conf = {
+        CONF_IP_ADDRESS: '192.168.1.100',
+        CONF_PASSWORD: 'password',
+        CONF_PORT: 8080,
+        CONF_SSL: True,
+    }
+
+    MockConfigEntry(domain=DOMAIN, data=conf).add_to_hass(hass)
+    flow = config_flow.RainMachineFlowHandler()
+    flow.hass = hass
+
+    result = await flow.async_step_user(user_input=conf)
+    assert result['errors'] == {CONF_IP_ADDRESS: 'identifier_exists'}
+
+
+async def test_invalid_password(hass):
+    """Test that an invalid password throws an error."""
+    from regenmaschine.errors import RainMachineError
+
+    conf = {
+        CONF_IP_ADDRESS: '192.168.1.100',
+        CONF_PASSWORD: 'bad_password',
+        CONF_PORT: 8080,
+        CONF_SSL: True,
+    }
+
+    flow = config_flow.RainMachineFlowHandler()
+    flow.hass = hass
+
+    with patch('regenmaschine.login',
+               return_value=mock_coro(exception=RainMachineError)):
+        result = await flow.async_step_user(user_input=conf)
+        assert result['errors'] == {CONF_PASSWORD: 'invalid_credentials'}
+
+
+# async def test_show_form(hass):
+#     """Test that the form is served with no input."""
+#     flow = config_flow.RainMachineFlowHandler()
+#     flow.hass = hass
+
+#     result = await flow.async_step_user(user_input=None)
+
+#     assert result['type'] == data_entry_flow.RESULT_TYPE_FORM
+#     assert result['step_id'] == 'user'
+
+
+# async def test_step_import(hass):
+#     """Test that the import step works."""
+#     conf = {
+#         CONF_API_KEY: '12345abcde',
+#         CONF_ELEVATION: 59.1234,
+#         CONF_LATITUDE: 39.128712,
+#         CONF_LONGITUDE: -104.9812612,
+#     }
+
+#     flow = config_flow.RainMachineFlowHandler()
+#     flow.hass = hass
+
+#     with patch('pyopenuv.util.validate_api_key',
+#                return_value=mock_coro(True)):
+#         result = await flow.async_step_import(import_config=conf)
+
+#         assert result['type'] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+#         assert result['title'] == '39.128712, -104.9812612'
+#         assert result['data'] == {
+#             CONF_API_KEY: '12345abcde',
+#             CONF_ELEVATION: 59.1234,
+#             CONF_LATITUDE: 39.128712,
+#             CONF_LONGITUDE: -104.9812612,
+#             CONF_SCAN_INTERVAL: 1800,
+#         }
+
+
+# async def test_step_user(hass):
+#     """Test that the user step works."""
+#     conf = {
+#         CONF_API_KEY: '12345abcde',
+#         CONF_ELEVATION: 59.1234,
+#         CONF_LATITUDE: 39.128712,
+#         CONF_LONGITUDE: -104.9812612,
+#         CONF_SCAN_INTERVAL: timedelta(minutes=5)
+#     }
+
+#     flow = config_flow.RainMachineFlowHandler()
+#     flow.hass = hass
+
+#     with patch('pyopenuv.util.validate_api_key',
+#                return_value=mock_coro(True)):
+#         result = await flow.async_step_user(user_input=conf)
+
+#         assert result['type'] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+#         assert result['title'] == '39.128712, -104.9812612'
+#         assert result['data'] == {
+#             CONF_API_KEY: '12345abcde',
+#             CONF_ELEVATION: 59.1234,
+#             CONF_LATITUDE: 39.128712,
+#             CONF_LONGITUDE: -104.9812612,
+#             CONF_SCAN_INTERVAL: 300,
+#         }

--- a/tests/components/rainmachine/test_config_flow.py
+++ b/tests/components/rainmachine/test_config_flow.py
@@ -47,67 +47,65 @@ async def test_invalid_password(hass):
         assert result['errors'] == {CONF_PASSWORD: 'invalid_credentials'}
 
 
-# async def test_show_form(hass):
-#     """Test that the form is served with no input."""
-#     flow = config_flow.RainMachineFlowHandler()
-#     flow.hass = hass
+async def test_show_form(hass):
+    """Test that the form is served with no input."""
+    flow = config_flow.RainMachineFlowHandler()
+    flow.hass = hass
 
-#     result = await flow.async_step_user(user_input=None)
+    result = await flow.async_step_user(user_input=None)
 
-#     assert result['type'] == data_entry_flow.RESULT_TYPE_FORM
-#     assert result['step_id'] == 'user'
-
-
-# async def test_step_import(hass):
-#     """Test that the import step works."""
-#     conf = {
-#         CONF_API_KEY: '12345abcde',
-#         CONF_ELEVATION: 59.1234,
-#         CONF_LATITUDE: 39.128712,
-#         CONF_LONGITUDE: -104.9812612,
-#     }
-
-#     flow = config_flow.RainMachineFlowHandler()
-#     flow.hass = hass
-
-#     with patch('pyopenuv.util.validate_api_key',
-#                return_value=mock_coro(True)):
-#         result = await flow.async_step_import(import_config=conf)
-
-#         assert result['type'] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-#         assert result['title'] == '39.128712, -104.9812612'
-#         assert result['data'] == {
-#             CONF_API_KEY: '12345abcde',
-#             CONF_ELEVATION: 59.1234,
-#             CONF_LATITUDE: 39.128712,
-#             CONF_LONGITUDE: -104.9812612,
-#             CONF_SCAN_INTERVAL: 1800,
-#         }
+    assert result['type'] == data_entry_flow.RESULT_TYPE_FORM
+    assert result['step_id'] == 'user'
 
 
-# async def test_step_user(hass):
-#     """Test that the user step works."""
-#     conf = {
-#         CONF_API_KEY: '12345abcde',
-#         CONF_ELEVATION: 59.1234,
-#         CONF_LATITUDE: 39.128712,
-#         CONF_LONGITUDE: -104.9812612,
-#         CONF_SCAN_INTERVAL: timedelta(minutes=5)
-#     }
+async def test_step_import(hass):
+    """Test that the import step works."""
+    conf = {
+        CONF_IP_ADDRESS: '192.168.1.100',
+        CONF_PASSWORD: 'password',
+        CONF_PORT: 8080,
+        CONF_SSL: True,
+    }
 
-#     flow = config_flow.RainMachineFlowHandler()
-#     flow.hass = hass
+    flow = config_flow.RainMachineFlowHandler()
+    flow.hass = hass
 
-#     with patch('pyopenuv.util.validate_api_key',
-#                return_value=mock_coro(True)):
-#         result = await flow.async_step_user(user_input=conf)
+    with patch('regenmaschine.login', return_value=mock_coro(True)):
+        result = await flow.async_step_import(import_config=conf)
 
-#         assert result['type'] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-#         assert result['title'] == '39.128712, -104.9812612'
-#         assert result['data'] == {
-#             CONF_API_KEY: '12345abcde',
-#             CONF_ELEVATION: 59.1234,
-#             CONF_LATITUDE: 39.128712,
-#             CONF_LONGITUDE: -104.9812612,
-#             CONF_SCAN_INTERVAL: 300,
-#         }
+        assert result['type'] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result['title'] == '192.168.1.100'
+        assert result['data'] == {
+            CONF_IP_ADDRESS: '192.168.1.100',
+            CONF_PASSWORD: 'password',
+            CONF_PORT: 8080,
+            CONF_SSL: True,
+            CONF_SCAN_INTERVAL: 60,
+        }
+
+
+async def test_step_user(hass):
+    """Test that the user step works."""
+    conf = {
+        CONF_IP_ADDRESS: '192.168.1.100',
+        CONF_PASSWORD: 'password',
+        CONF_PORT: 8080,
+        CONF_SSL: True,
+        CONF_SCAN_INTERVAL: timedelta(minutes=5)
+    }
+
+    flow = config_flow.RainMachineFlowHandler()
+    flow.hass = hass
+
+    with patch('regenmaschine.login', return_value=mock_coro(True)):
+        result = await flow.async_step_user(user_input=conf)
+
+        assert result['type'] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert result['title'] == '192.168.1.100'
+        assert result['data'] == {
+            CONF_IP_ADDRESS: '192.168.1.100',
+            CONF_PASSWORD: 'password',
+            CONF_PORT: 8080,
+            CONF_SSL: True,
+            CONF_SCAN_INTERVAL: 300,
+        }


### PR DESCRIPTION
## Description:

This PR adds a UI config entry for RainMachine.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
rainmachine:
  ip_address: !secret rainmachine_host
  password: !secret rainmachine_password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
