### PR TITLE
Update librouteros and re-connect to api if connection is lost

### DIFF
--- a/homeassistant/components/device_tracker/mikrotik.py
+++ b/homeassistant/components/device_tracker/mikrotik.py
@@ -136,8 +136,8 @@ class MikrotikScanner(DeviceScanner):
         import librouteros
         try:
             self._update_info()
-        except (librouteros.exceptions.TrapError, 
-                librouteros.exceptions.MultiTrapError, 
+        except (librouteros.exceptions.TrapError,
+                librouteros.exceptions.MultiTrapError,
                 librouteros.exceptions.ConnectionError) as api_error:
             _LOGGER.error("Connection error: %s", api_error)
             self.connect_to_device()

--- a/homeassistant/components/device_tracker/mikrotik.py
+++ b/homeassistant/components/device_tracker/mikrotik.py
@@ -128,7 +128,7 @@ class MikrotikScanner(DeviceScanner):
         except (librouteros.exceptions.TrapError,
                 librouteros.exceptions.MultiTrapError,
                 librouteros.exceptions.ConnectionError) as api_error:
-            _LOGGER.error("Connection error: %s",api_error)
+            _LOGGER.error("Connection error: %s", api_error)
         return self.connected
 
     def scan_devices(self):

--- a/homeassistant/components/device_tracker/mikrotik.py
+++ b/homeassistant/components/device_tracker/mikrotik.py
@@ -127,7 +127,8 @@ class MikrotikScanner(DeviceScanner):
 
         except (librouteros.exceptions.TrapError,
                 librouteros.exceptions.MultiTrapError,
-                librouteros.exceptions.ConnectionError):
+                librouteros.exceptions.ConnectionError) as api_error:
+            _LOGGER.error("Connection error: %s", api_error)
         return self.connected
 
     def scan_devices(self):

--- a/homeassistant/components/device_tracker/mikrotik.py
+++ b/homeassistant/components/device_tracker/mikrotik.py
@@ -134,7 +134,7 @@ class MikrotikScanner(DeviceScanner):
 
     def scan_devices(self):
         """Scan for new devices and return a list with found device MACs."""
-		try:
+        try:
             self._update_info()
         except:
             self.connect_to_device()

--- a/homeassistant/components/device_tracker/mikrotik.py
+++ b/homeassistant/components/device_tracker/mikrotik.py
@@ -136,9 +136,8 @@ class MikrotikScanner(DeviceScanner):
         """Scan for new devices and return a list with found device MACs."""
         try:
             self._update_info()
-        except (librouteros.exceptions.TrapError,
-                    librouteros.exceptions.MultiTrapError,
-                    librouteros.exceptions.ConnectionError):
+        except (librouteros.exceptions.TrapError, librouteros.exceptions.MultiTrapError, librouteros.exceptions.ConnectionError) as api_error:
+            _LOGGER.error("Connection error: %s", api_error)
             self.connect_to_device()
         return [device for device in self.last_results]
 

--- a/homeassistant/components/device_tracker/mikrotik.py
+++ b/homeassistant/components/device_tracker/mikrotik.py
@@ -134,6 +134,7 @@ class MikrotikScanner(DeviceScanner):
 
     def scan_devices(self):
         """Scan for new devices and return a list with found device MACs."""
+        import librouteros
         try:
             self._update_info()
         except (librouteros.exceptions.TrapError, 

--- a/homeassistant/components/device_tracker/mikrotik.py
+++ b/homeassistant/components/device_tracker/mikrotik.py
@@ -136,7 +136,9 @@ class MikrotikScanner(DeviceScanner):
         """Scan for new devices and return a list with found device MACs."""
         try:
             self._update_info()
-        except:
+        except (librouteros.exceptions.TrapError,
+                    librouteros.exceptions.MultiTrapError,
+                    librouteros.exceptions.ConnectionError):
             self.connect_to_device()
         return [device for device in self.last_results]
 

--- a/homeassistant/components/device_tracker/mikrotik.py
+++ b/homeassistant/components/device_tracker/mikrotik.py
@@ -136,7 +136,9 @@ class MikrotikScanner(DeviceScanner):
         """Scan for new devices and return a list with found device MACs."""
         try:
             self._update_info()
-        except (librouteros.exceptions.TrapError, librouteros.exceptions.MultiTrapError, librouteros.exceptions.ConnectionError) as api_error:
+        except (librouteros.exceptions.TrapError, 
+                librouteros.exceptions.MultiTrapError, 
+                librouteros.exceptions.ConnectionError) as api_error:
             _LOGGER.error("Connection error: %s", api_error)
             self.connect_to_device()
         return [device for device in self.last_results]

--- a/homeassistant/components/device_tracker/mikrotik.py
+++ b/homeassistant/components/device_tracker/mikrotik.py
@@ -127,8 +127,7 @@ class MikrotikScanner(DeviceScanner):
 
         except (librouteros.exceptions.TrapError,
                 librouteros.exceptions.MultiTrapError,
-                librouteros.exceptions.ConnectionError) as api_error:
-            _LOGGER.error("Connection error: %s", api_error)
+                librouteros.exceptions.ConnectionError):
         return self.connected
 
     def scan_devices(self):

--- a/homeassistant/components/device_tracker/mikrotik.py
+++ b/homeassistant/components/device_tracker/mikrotik.py
@@ -14,7 +14,7 @@ from homeassistant.components.device_tracker import (
 from homeassistant.const import (
     CONF_HOST, CONF_PASSWORD, CONF_USERNAME, CONF_PORT)
 
-REQUIREMENTS = ['librouteros==2.1.1']
+REQUIREMENTS = ['librouteros==2.2.0']
 
 MTK_DEFAULT_API_PORT = '8728'
 
@@ -134,7 +134,10 @@ class MikrotikScanner(DeviceScanner):
 
     def scan_devices(self):
         """Scan for new devices and return a list with found device MACs."""
-        self._update_info()
+		try:
+            self._update_info()
+        except:
+            self.connect_to_device()
         return [device for device in self.last_results]
 
     def get_device_name(self, device):

--- a/homeassistant/components/device_tracker/mikrotik.py
+++ b/homeassistant/components/device_tracker/mikrotik.py
@@ -128,8 +128,7 @@ class MikrotikScanner(DeviceScanner):
         except (librouteros.exceptions.TrapError,
                 librouteros.exceptions.MultiTrapError,
                 librouteros.exceptions.ConnectionError) as api_error:
-            _LOGGER.error("Connection error: %s", api_error)
-
+            _LOGGER.error("Connection error: %s",api_error)
         return self.connected
 
     def scan_devices(self):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -536,7 +536,7 @@ libpurecoollink==0.4.2
 libpyfoscam==1.0
 
 # homeassistant.components.device_tracker.mikrotik
-librouteros==2.1.1
+librouteros==2.2.0
 
 # homeassistant.components.media_player.soundtouch
 libsoundtouch==0.7.2


### PR DESCRIPTION
## Description:
Bump librouteros version to 2.2.0 and add exception to re-connect if API connection has been lost to the Mikrotik device


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

