### PR TITLE
Modbus write_register accept integer and list

### DIFF
--- a/homeassistant/components/modbus.py
+++ b/homeassistant/components/modbus.py
@@ -61,7 +61,7 @@ SERVICE_WRITE_REGISTER_SCHEMA = vol.Schema({
     vol.Required(ATTR_UNIT): cv.positive_int,
     vol.Required(ATTR_ADDRESS): cv.positive_int,
     vol.Required(ATTR_VALUE): vol.Any(
-        cv.positive_int, 
+        cv.positive_int,
         vol.All(cv.ensure_list, [cv.positive_int]))
 })
 

--- a/homeassistant/components/modbus.py
+++ b/homeassistant/components/modbus.py
@@ -60,7 +60,7 @@ ATTR_VALUE = 'value'
 SERVICE_WRITE_REGISTER_SCHEMA = vol.Schema({
     vol.Required(ATTR_UNIT): cv.positive_int,
     vol.Required(ATTR_ADDRESS): cv.positive_int,
-    vol.Required(ATTR_VALUE): vol.All(cv.ensure_list, [cv.positive_int])
+    vol.Required(ATTR_VALUE): vol.Any(cv.positive_int, vol.All(cv.ensure_list, [cv.positive_int]))
 })
 
 SERVICE_WRITE_COIL_SCHEMA = vol.Schema({

--- a/homeassistant/components/modbus.py
+++ b/homeassistant/components/modbus.py
@@ -60,7 +60,9 @@ ATTR_VALUE = 'value'
 SERVICE_WRITE_REGISTER_SCHEMA = vol.Schema({
     vol.Required(ATTR_UNIT): cv.positive_int,
     vol.Required(ATTR_ADDRESS): cv.positive_int,
-    vol.Required(ATTR_VALUE): vol.Any(cv.positive_int, vol.All(cv.ensure_list, [cv.positive_int]))
+    vol.Required(ATTR_VALUE): vol.Any(
+        cv.positive_int, 
+        vol.All(cv.ensure_list, [cv.positive_int]))
 })
 
 SERVICE_WRITE_COIL_SCHEMA = vol.Schema({


### PR DESCRIPTION
Updated voluptuous schema to accept integer and list. That way the correct function code modbus function code is called (0x06 for integer (single register), 0x10 for list (multiple registers)).

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
