### PR TITLE
Fix race in entity_platform.async_add_entities

### DIFF
--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -206,7 +206,6 @@ class EntityPlatform:
             return
 
         hass = self.hass
-        component_entities = set(hass.states.async_entity_ids(self.domain))
 
         device_registry = await \
             hass.helpers.device_registry.async_get_registry()
@@ -214,8 +213,7 @@ class EntityPlatform:
             hass.helpers.entity_registry.async_get_registry()
         tasks = [
             self._async_add_entity(entity, update_before_add,
-                                   component_entities, entity_registry,
-                                   device_registry)
+                                   entity_registry, device_registry)
             for entity in new_entities]
 
         # No entities for processing
@@ -235,8 +233,7 @@ class EntityPlatform:
         )
 
     async def _async_add_entity(self, entity, update_before_add,
-                                component_entities, entity_registry,
-                                device_registry):
+                                entity_registry, device_registry):
         """Add an entity to the platform."""
         if entity is None:
             raise ValueError('Entity cannot be None')
@@ -329,25 +326,24 @@ class EntityPlatform:
             if self.entity_namespace is not None:
                 suggested_object_id = '{} {}'.format(self.entity_namespace,
                                                      suggested_object_id)
-
             entity.entity_id = entity_registry.async_generate_entity_id(
-                self.domain, suggested_object_id)
+                self.domain, suggested_object_id, self.entities.keys())
 
         # Make sure it is valid in case an entity set the value themselves
         if not valid_entity_id(entity.entity_id):
             raise HomeAssistantError(
                 'Invalid entity id: {}'.format(entity.entity_id))
-        elif entity.entity_id in component_entities:
+        elif (entity.entity_id in self.entities or
+              entity.entity_id in self.hass.states.async_entity_ids(
+                  self.domain)):
             msg = 'Entity id already exists: {}'.format(entity.entity_id)
             if entity.unique_id is not None:
                 msg += '. Platform {} does not generate unique IDs'.format(
                     self.platform_name)
-            raise HomeAssistantError(
-                msg)
+            raise HomeAssistantError(msg)
 
         entity_id = entity.entity_id
         self.entities[entity_id] = entity
-        component_entities.add(entity_id)
         entity.async_on_remove(lambda: self.entities.pop(entity_id))
 
         if hasattr(entity, 'async_added_to_hass'):

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -95,7 +95,8 @@ class EntityRegistry:
         return None
 
     @callback
-    def async_generate_entity_id(self, domain, suggested_object_id):
+    def async_generate_entity_id(self, domain, suggested_object_id,
+                                 known_object_ids=None):
         """Generate an entity ID that does not conflict.
 
         Conflicts checked against registered and currently existing entities.
@@ -103,7 +104,8 @@ class EntityRegistry:
         return ensure_unique_string(
             '{}.{}'.format(domain, slugify(suggested_object_id)),
             chain(self.entities.keys(),
-                  self.hass.states.async_entity_ids(domain))
+                  self.hass.states.async_entity_ids(domain),
+                  known_object_ids if known_object_ids else [])
         )
 
     @callback


### PR DESCRIPTION
## Description:
There is a race in `entity_platform.async_add_entities()` which makes the check for duplicated entity_id fail. This in turns may cause several entities to be created with the same entity_id.
The issue can very easily be reproduced by publishing persistent MQTT discovery messages with same name before starting hass.

This has previously been reported in #13316 and #15731, although with a slightly different twist
The root cause is described in some detail in #13316

This PR solves the race when there are multiple concurrent calls to `entity_platform.async_add_entities()` from the same platform.

Possible further improvement:
- Also detect multiple multiple concurrent calls to `entity_platform.async_add_entities()` from different platforms as pointed out by @OttoWinter 
  Maybe this can be fixed by:
  - Add a lock to not allow concurrent calls to `entity_platform.async_add_entities()` - dead simple, but might have a negative performance impact
  - Add a dictionary `reserved_entity_ids` which will hold an `entity_id` until the entity has been added to `hass.states`
  - Format the `entity_id` generated by `entity_registry.async_generate_entity_id` to also include platform name, e.g. `mqtt_name` instead of `name` in the same way as is already done by `homeassistant.helpers.entity.async_generate_entity_id`

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.