### PR TITLE
Update Magicseaweed sensor

### DIFF
--- a/homeassistant/components/sensor/magicseaweed.py
+++ b/homeassistant/components/sensor/magicseaweed.py
@@ -16,7 +16,7 @@ import homeassistant.util.dt as dt_util
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['magicseaweed==1.0.0']
+REQUIREMENTS = ['magicseaweed==1.0.3']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -606,7 +606,7 @@ lw12==0.9.2
 lyft_rides==0.2
 
 # homeassistant.components.sensor.magicseaweed
-magicseaweed==1.0.0
+magicseaweed==1.0.3
 
 # homeassistant.components.matrix
 matrix-client==0.2.0


### PR DESCRIPTION
## Description:
I've incremented the python-magicseaweed library to include some minor changes. The attributes dictionary will now include the direction of the swell.

**Related issue (if applicable):** 
A home assistant user [requested](https://github.com/jcconnell/python-magicseaweed/issues/2) that swell direction be included in the attributes of this sensor. The python-magicseaweed library has been updated to include this change.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):**  N/A


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [x ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
