### PR TITLE
Log delay and wait_template steps in scripts

### DIFF
--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -120,6 +120,9 @@ class Script():
                                   self.name, ex)
                     break
 
+                self.last_action = action.get(CONF_ALIAS, 'delay {}'.format(delay))
+                self._log("Executing step %s" % self.last_action)
+
                 unsub = async_track_point_in_utc_time(
                     self.hass, async_script_delay,
                     date_util.utcnow() + delay
@@ -135,6 +138,9 @@ class Script():
                 # Call ourselves in the future to continue work
                 wait_template = action[CONF_WAIT_TEMPLATE]
                 wait_template.hass = self.hass
+
+                self.last_action = action.get(CONF_ALIAS, 'wait template')
+                self._log("Executing step %s" % self.last_action)
 
                 # check if condition already okay
                 if condition.async_template(

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -120,7 +120,8 @@ class Script():
                                   self.name, ex)
                     break
 
-                self.last_action = action.get(CONF_ALIAS, 'delay {}'.format(delay))
+                self.last_action = action.get(
+                    CONF_ALIAS, 'delay {}'.format(delay))
                 self._log("Executing step %s" % self.last_action)
 
                 unsub = async_track_point_in_utc_time(

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -167,6 +167,7 @@ class TestScriptHelper(unittest.TestCase):
         event = 'test_event'
         events = []
         context = Context()
+        delay_alias = 'delay step'
 
         @callback
         def record_event(event):
@@ -177,7 +178,7 @@ class TestScriptHelper(unittest.TestCase):
 
         script_obj = script.Script(self.hass, cv.SCRIPT_SCHEMA([
             {'event': event},
-            {'delay': {'seconds': 5}},
+            {'delay': {'seconds': 5}, 'alias': delay_alias},
             {'event': event}]))
 
         script_obj.run(context=context)
@@ -185,7 +186,7 @@ class TestScriptHelper(unittest.TestCase):
 
         assert script_obj.is_running
         assert script_obj.can_cancel
-        assert script_obj.last_action == event
+        assert script_obj.last_action == delay_alias
         assert len(events) == 1
 
         future = dt_util.utcnow() + timedelta(seconds=5)
@@ -201,6 +202,7 @@ class TestScriptHelper(unittest.TestCase):
         """Test the delay as a template."""
         event = 'test_event'
         events = []
+        delay_alias = 'delay step'
 
         @callback
         def record_event(event):
@@ -211,7 +213,7 @@ class TestScriptHelper(unittest.TestCase):
 
         script_obj = script.Script(self.hass, cv.SCRIPT_SCHEMA([
             {'event': event},
-            {'delay': '00:00:{{ 5 }}'},
+            {'delay': '00:00:{{ 5 }}', 'alias': delay_alias},
             {'event': event}]))
 
         script_obj.run()
@@ -219,7 +221,7 @@ class TestScriptHelper(unittest.TestCase):
 
         assert script_obj.is_running
         assert script_obj.can_cancel
-        assert script_obj.last_action == event
+        assert script_obj.last_action == delay_alias
         assert len(events) == 1
 
         future = dt_util.utcnow() + timedelta(seconds=5)
@@ -259,6 +261,7 @@ class TestScriptHelper(unittest.TestCase):
         """Test the delay with a working complex template."""
         event = 'test_event'
         events = []
+        delay_alias = 'delay step'
 
         @callback
         def record_event(event):
@@ -270,8 +273,8 @@ class TestScriptHelper(unittest.TestCase):
         script_obj = script.Script(self.hass, cv.SCRIPT_SCHEMA([
             {'event': event},
             {'delay': {
-                'seconds': '{{ 5 }}'
-            }},
+                'seconds': '{{ 5 }}'},
+             'alias': delay_alias},
             {'event': event}]))
 
         script_obj.run()
@@ -279,7 +282,7 @@ class TestScriptHelper(unittest.TestCase):
 
         assert script_obj.is_running
         assert script_obj.can_cancel
-        assert script_obj.last_action == event
+        assert script_obj.last_action == delay_alias
         assert len(events) == 1
 
         future = dt_util.utcnow() + timedelta(seconds=5)
@@ -358,6 +361,7 @@ class TestScriptHelper(unittest.TestCase):
         event = 'test_event'
         events = []
         context = Context()
+        wait_alias = 'wait step'
 
         @callback
         def record_event(event):
@@ -370,7 +374,8 @@ class TestScriptHelper(unittest.TestCase):
 
         script_obj = script.Script(self.hass, cv.SCRIPT_SCHEMA([
             {'event': event},
-            {'wait_template': "{{states.switch.test.state == 'off'}}"},
+            {'wait_template': "{{states.switch.test.state == 'off'}}",
+             'alias': wait_alias},
             {'event': event}]))
 
         script_obj.run(context=context)
@@ -378,7 +383,7 @@ class TestScriptHelper(unittest.TestCase):
 
         assert script_obj.is_running
         assert script_obj.can_cancel
-        assert script_obj.last_action == event
+        assert script_obj.last_action == wait_alias
         assert len(events) == 1
 
         self.hass.states.set('switch.test', 'off')
@@ -393,6 +398,7 @@ class TestScriptHelper(unittest.TestCase):
         """Test the wait template cancel action."""
         event = 'test_event'
         events = []
+        wait_alias = 'wait step'
 
         @callback
         def record_event(event):
@@ -405,7 +411,8 @@ class TestScriptHelper(unittest.TestCase):
 
         script_obj = script.Script(self.hass, cv.SCRIPT_SCHEMA([
             {'event': event},
-            {'wait_template': "{{states.switch.test.state == 'off'}}"},
+            {'wait_template': "{{states.switch.test.state == 'off'}}",
+             'alias': wait_alias},
             {'event': event}]))
 
         script_obj.run()
@@ -413,7 +420,7 @@ class TestScriptHelper(unittest.TestCase):
 
         assert script_obj.is_running
         assert script_obj.can_cancel
-        assert script_obj.last_action == event
+        assert script_obj.last_action == wait_alias
         assert len(events) == 1
 
         script_obj.stop()
@@ -457,6 +464,7 @@ class TestScriptHelper(unittest.TestCase):
         """Test the wait template, halt on timeout."""
         event = 'test_event'
         events = []
+        wait_alias = 'wait step'
 
         @callback
         def record_event(event):
@@ -472,7 +480,8 @@ class TestScriptHelper(unittest.TestCase):
             {
                 'wait_template': "{{states.switch.test.state == 'off'}}",
                 'continue_on_timeout': False,
-                'timeout': 5
+                'timeout': 5,
+                'alias': wait_alias
             },
             {'event': event}]))
 
@@ -481,7 +490,7 @@ class TestScriptHelper(unittest.TestCase):
 
         assert script_obj.is_running
         assert script_obj.can_cancel
-        assert script_obj.last_action == event
+        assert script_obj.last_action == wait_alias
         assert len(events) == 1
 
         future = dt_util.utcnow() + timedelta(seconds=5)
@@ -495,6 +504,7 @@ class TestScriptHelper(unittest.TestCase):
         """Test the wait template with continuing the script."""
         event = 'test_event'
         events = []
+        wait_alias = 'wait step'
 
         @callback
         def record_event(event):
@@ -510,7 +520,8 @@ class TestScriptHelper(unittest.TestCase):
             {
                 'wait_template': "{{states.switch.test.state == 'off'}}",
                 'timeout': 5,
-                'continue_on_timeout': True
+                'continue_on_timeout': True,
+                'alias': wait_alias
             },
             {'event': event}]))
 
@@ -519,7 +530,7 @@ class TestScriptHelper(unittest.TestCase):
 
         assert script_obj.is_running
         assert script_obj.can_cancel
-        assert script_obj.last_action == event
+        assert script_obj.last_action == wait_alias
         assert len(events) == 1
 
         future = dt_util.utcnow() + timedelta(seconds=5)
@@ -533,6 +544,7 @@ class TestScriptHelper(unittest.TestCase):
         """Test the wait template with default contiune."""
         event = 'test_event'
         events = []
+        wait_alias = 'wait step'
 
         @callback
         def record_event(event):
@@ -547,7 +559,8 @@ class TestScriptHelper(unittest.TestCase):
             {'event': event},
             {
                 'wait_template': "{{states.switch.test.state == 'off'}}",
-                'timeout': 5
+                'timeout': 5,
+                'alias': wait_alias
             },
             {'event': event}]))
 
@@ -556,7 +569,7 @@ class TestScriptHelper(unittest.TestCase):
 
         assert script_obj.is_running
         assert script_obj.can_cancel
-        assert script_obj.last_action == event
+        assert script_obj.last_action == wait_alias
         assert len(events) == 1
 
         future = dt_util.utcnow() + timedelta(seconds=5)
@@ -570,6 +583,7 @@ class TestScriptHelper(unittest.TestCase):
         """Test the wait template with variables."""
         event = 'test_event'
         events = []
+        wait_alias = 'wait step'
 
         @callback
         def record_event(event):
@@ -582,7 +596,8 @@ class TestScriptHelper(unittest.TestCase):
 
         script_obj = script.Script(self.hass, cv.SCRIPT_SCHEMA([
             {'event': event},
-            {'wait_template': "{{is_state(data, 'off')}}"},
+            {'wait_template': "{{is_state(data, 'off')}}",
+             'alias': wait_alias},
             {'event': event}]))
 
         script_obj.run({
@@ -592,7 +607,7 @@ class TestScriptHelper(unittest.TestCase):
 
         assert script_obj.is_running
         assert script_obj.can_cancel
-        assert script_obj.last_action == event
+        assert script_obj.last_action == wait_alias
         assert len(events) == 1
 
         self.hass.states.set('switch.test', 'off')


### PR DESCRIPTION
## Description:
Help improve script debugging by logging delay and wait_template steps in scripts. Without these steps being logged, users have to guess if/when they have executed. This can be particularly problematic if the script has multiple wait_templates without an interim step that _is_ logged. In this case one cannot easily guess which wait_template the script might be "stuck" in, or when individual wait_templates actually complete.

**Related issue (if applicable):** none

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** none

## Example entry for `configuration.yaml` (if applicable):
```yaml
script:
  my_script:
    sequence:
      - service: A_SERVICE # This step is logged
      - wait_template: SOME_WAIT # This step is NOT logged
      - delay: SOME_DELAY # This step is NOT logged
      - wait_template: SOME_OTHER_WAIT # This step is NOT logged
      - service: ANOTHER_SERVICE # This step is logged
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
