### PR TITLE
Add sensors

### DIFF
--- a/homeassistant/components/sensor/waterfurnace.py
+++ b/homeassistant/components/sensor/waterfurnace.py
@@ -46,7 +46,8 @@ SENSORS = [
     WFSensorConfig("Fan Power", "fanpower", "mdi:flash", "W"),
     WFSensorConfig("Aux Power", "auxpower", "mdi:flash", "W"),
     WFSensorConfig("Loop Pump Power", "looppumppower", "mdi:flash", "W"),
-    WFSensorConfig("Compressor Speed", "actualcompressorspeed", "mdi:speedometer"),
+    WFSensorConfig("Compressor Speed", "actualcompressorspeed",
+                   "mdi:speedometer"),
     WFSensorConfig("Fan Speed", "airflowcurrentspeed", "mdi:fan"),
 
 ]

--- a/homeassistant/components/sensor/waterfurnace.py
+++ b/homeassistant/components/sensor/waterfurnace.py
@@ -42,6 +42,13 @@ SENSORS = [
                    "mdi:water-percent", "%"),
     WFSensorConfig("Humidity", "tstatrelativehumidity",
                    "mdi:water-percent", "%"),
+    WFSensorConfig("Compressor Power", "compressorpower", "mdi:flash", "W"),
+    WFSensorConfig("Fan Power", "fanpower", "mdi:flash", "W"),
+    WFSensorConfig("Aux Power", "aupower", "mdi:flash", "W"),
+    WFSensorConfig("Loop Pump Power", "looppumppower", "mdi:flash", "W"),
+    WFSensorConfig("Compressor Speed", "actualcompressorspeed", "mdi:speedometer"),
+    WFSensorConfig("Fan Speed", "airflowcurrentspeed", "mdi:fan"),
+
 ]
 
 

--- a/homeassistant/components/sensor/waterfurnace.py
+++ b/homeassistant/components/sensor/waterfurnace.py
@@ -44,7 +44,7 @@ SENSORS = [
                    "mdi:water-percent", "%"),
     WFSensorConfig("Compressor Power", "compressorpower", "mdi:flash", "W"),
     WFSensorConfig("Fan Power", "fanpower", "mdi:flash", "W"),
-    WFSensorConfig("Aux Power", "aupower", "mdi:flash", "W"),
+    WFSensorConfig("Aux Power", "auxpower", "mdi:flash", "W"),
     WFSensorConfig("Loop Pump Power", "looppumppower", "mdi:flash", "W"),
     WFSensorConfig("Compressor Speed", "actualcompressorspeed", "mdi:speedometer"),
     WFSensorConfig("Fan Speed", "airflowcurrentspeed", "mdi:fan"),


### PR DESCRIPTION
## Description:
Add the following sensors that provide interesting data when using a variable speed geothermal system:

- Compressor Power
- Fan Power
- Aux Power
- Loop Pump Power
- Compressor Speed
- Fan Speed

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#7497


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)
