### PR TITLE
Make mikrotik method setting optional as intended

### DIFF
--- a/homeassistant/components/device_tracker/mikrotik.py
+++ b/homeassistant/components/device_tracker/mikrotik.py
@@ -46,7 +46,7 @@ class MikrotikScanner(DeviceScanner):
         self.port = config[CONF_PORT]
         self.username = config[CONF_USERNAME]
         self.password = config[CONF_PASSWORD]
-        self.method = config[CONF_METHOD]
+        self.method = config.get(CONF_METHOD)
 
         self.connected = False
         self.success_init = False


### PR DESCRIPTION
Pull request #17852 accidently made the `method` setting required.

## Description:

Pull request #17852 accidently made the `method` setting required while it was intended to be optional. This tiny change fixes that :)

**Related issue (if applicable):**

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):**

## Example entry for `configuration.yaml` (if applicable):
```yaml
device_tracker:
  - platform: mikrotik
    host: IP_ADDRESS
    username: ADMIN_USERNAME
    password: ADMIN_PASSWORD
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
