### PR TITLE
Fix mqtt cover inverted

### DIFF
--- a/homeassistant/components/cover/mqtt.py
+++ b/homeassistant/components/cover/mqtt.py
@@ -281,17 +281,11 @@ class MqttCover(MqttAvailability, MqttDiscoveryUpdate, MqttEntityDeviceInfo,
                     payload)
 
             if payload.isnumeric():
-                int_payload = int(payload)
-                if (self._position_open == DEFAULT_POSITION_OPEN
-                        and self._position_closed == DEFAULT_POSITION_CLOSED
-                        and 0 <= int_payload <= 100):
-                    percentage_payload = int_payload
-                else:
-                    percentage_payload = self.find_percentage_in_range(
-                        float(payload), COVER_PAYLOAD)
+                percentage_payload = self.find_percentage_in_range(
+                    float(payload), COVER_PAYLOAD)
                 if 0 <= percentage_payload <= 100:
                     self._position = percentage_payload
-                    self._state = int_payload == self._position_closed
+                    self._state = int(payload) == self._position_closed
             else:
                 _LOGGER.warning(
                     "Payload is not integer within range: %s",
@@ -379,11 +373,8 @@ class MqttCover(MqttAvailability, MqttDiscoveryUpdate, MqttEntityDeviceInfo,
             # Optimistically assume that cover has changed state.
             self._state = False
             if self._get_position_topic:
-                if self._position_open == DEFAULT_POSITION_OPEN:
-                    self._position = self._position_open
-                else:
-                    self._position = self.find_percentage_in_range(
-                        self._position_open, COVER_PAYLOAD)
+                self._position = self.find_percentage_in_range(
+                    self._position_open, COVER_PAYLOAD)
             self.async_schedule_update_ha_state()
 
     async def async_close_cover(self, **kwargs):
@@ -398,11 +389,8 @@ class MqttCover(MqttAvailability, MqttDiscoveryUpdate, MqttEntityDeviceInfo,
             # Optimistically assume that cover has changed state.
             self._state = True
             if self._get_position_topic:
-                if self._position_closed == DEFAULT_POSITION_CLOSED:
-                    self._position = self._position_closed
-                else:
-                    self._position = self.find_percentage_in_range(
-                        self._position_closed, COVER_PAYLOAD)
+                self._position = self.find_percentage_in_range(
+                    self._position_closed, COVER_PAYLOAD)
             self.async_schedule_update_ha_state()
 
     async def async_stop_cover(self, **kwargs):

--- a/homeassistant/components/cover/mqtt.py
+++ b/homeassistant/components/cover/mqtt.py
@@ -283,9 +283,8 @@ class MqttCover(MqttAvailability, MqttDiscoveryUpdate, MqttEntityDeviceInfo,
             if payload.isnumeric():
                 percentage_payload = self.find_percentage_in_range(
                     float(payload), COVER_PAYLOAD)
-                if 0 <= percentage_payload <= 100:
-                    self._position = percentage_payload
-                    self._state = int(payload) == self._position_closed
+                self._position = percentage_payload
+                self._state = percentage_payload == DEFAULT_POSITION_CLOSED
             else:
                 _LOGGER.warning(
                     "Payload is not integer within range: %s",
@@ -470,6 +469,11 @@ class MqttCover(MqttAvailability, MqttDiscoveryUpdate, MqttEntityDeviceInfo,
         offset_position = position - min_range
         position_percentage = round(
             float(offset_position) / current_range * 100.0)
+
+        max_percent = 100
+        min_percent = 0
+        position_percentage = min(max(position_percentage, min_percent),
+                                  max_percent)
         if range_type == TILT_PAYLOAD and self._tilt_invert:
             return 100 - position_percentage
         return position_percentage

--- a/homeassistant/components/cover/mqtt.py
+++ b/homeassistant/components/cover/mqtt.py
@@ -279,21 +279,26 @@ class MqttCover(MqttAvailability, MqttDiscoveryUpdate, MqttEntityDeviceInfo,
             if self._template is not None:
                 payload = self._template.async_render_with_possible_json_value(
                     payload)
+
             if payload.isnumeric():
-                if 0 <= int(payload) <= 100:
-                    percentage_payload = int(payload)
+                int_payload = int(payload)
+                if (self._position_open == DEFAULT_POSITION_OPEN
+                        and self._position_closed == DEFAULT_POSITION_CLOSED
+                        and 0 <= int_payload <= 100):
+                    percentage_payload = int_payload
                 else:
                     percentage_payload = self.find_percentage_in_range(
                         float(payload), COVER_PAYLOAD)
                 if 0 <= percentage_payload <= 100:
                     self._position = percentage_payload
-                    self._state = self._position == self._position_closed
+                    self._state = int_payload == self._position_closed
             else:
                 _LOGGER.warning(
                     "Payload is not integer within range: %s",
                     payload)
                 return
             self.async_schedule_update_ha_state()
+
         if self._get_position_topic:
             await mqtt.async_subscribe(
                 self.hass, self._get_position_topic,
@@ -374,7 +379,11 @@ class MqttCover(MqttAvailability, MqttDiscoveryUpdate, MqttEntityDeviceInfo,
             # Optimistically assume that cover has changed state.
             self._state = False
             if self._get_position_topic:
-                self._position = self._position_open
+                if self._position_open == DEFAULT_POSITION_OPEN:
+                    self._position = self._position_open
+                else:
+                    self._position = self.find_percentage_in_range(
+                        self._position_open, COVER_PAYLOAD)
             self.async_schedule_update_ha_state()
 
     async def async_close_cover(self, **kwargs):
@@ -389,7 +398,11 @@ class MqttCover(MqttAvailability, MqttDiscoveryUpdate, MqttEntityDeviceInfo,
             # Optimistically assume that cover has changed state.
             self._state = True
             if self._get_position_topic:
-                self._position = self._position_closed
+                if self._position_closed == DEFAULT_POSITION_CLOSED:
+                    self._position = self._position_closed
+                else:
+                    self._position = self.find_percentage_in_range(
+                        self._position_closed, COVER_PAYLOAD)
             self.async_schedule_update_ha_state()
 
     async def async_stop_cover(self, **kwargs):

--- a/tests/components/cover/test_mqtt.py
+++ b/tests/components/cover/test_mqtt.py
@@ -320,6 +320,71 @@ class TestCoverMQTT(unittest.TestCase):
             'cover.test').attributes['current_position']
         assert 50 == current_cover_position
 
+    def test_current_cover_position_inverted(self):
+        """Test the current cover position."""
+        assert setup_component(self.hass, cover.DOMAIN, {
+            cover.DOMAIN: {
+                'platform': 'mqtt',
+                'name': 'test',
+                'position_topic': 'get-position-topic',
+                'command_topic': 'command-topic',
+                'position_open': 0,
+                'position_closed': 100,
+                'payload_open': 'OPEN',
+                'payload_close': 'CLOSE',
+                'payload_stop': 'STOP'
+            }
+        })
+
+        state_attributes_dict = self.hass.states.get(
+            'cover.test').attributes
+        assert not ('current_position' in state_attributes_dict)
+        assert not ('current_tilt_position' in state_attributes_dict)
+        assert not (4 & self.hass.states.get(
+            'cover.test').attributes['supported_features'] == 4)
+
+        fire_mqtt_message(self.hass, 'get-position-topic', '100')
+        self.hass.block_till_done()
+        current_percentage_cover_position = self.hass.states.get(
+            'cover.test').attributes['current_position']
+        assert 0 == current_percentage_cover_position
+        print(self.hass.states.get(
+            'cover.test').state)
+        assert STATE_CLOSED == self.hass.states.get(
+            'cover.test').state
+
+        fire_mqtt_message(self.hass, 'get-position-topic', '0')
+        self.hass.block_till_done()
+        current_state = self.hass.states.get(
+            'cover.test')
+        current_cover_position = current_state.attributes['current_position']
+        assert 100 == current_cover_position
+        assert STATE_OPEN == current_state.state
+
+        fire_mqtt_message(self.hass, 'get-position-topic', '50')
+        self.hass.block_till_done()
+        current_percentage_cover_position = self.hass.states.get(
+            'cover.test').attributes['current_position']
+        assert 50 == current_percentage_cover_position
+        assert STATE_OPEN == self.hass.states.get(
+            'cover.test').state
+
+        fire_mqtt_message(self.hass, 'get-position-topic', '101')
+        self.hass.block_till_done()
+        current_percentage_cover_position = self.hass.states.get(
+            'cover.test').attributes['current_position']
+        assert 50 == current_percentage_cover_position
+        assert STATE_OPEN == self.hass.states.get(
+            'cover.test').state
+
+        fire_mqtt_message(self.hass, 'get-position-topic', 'non-numeric')
+        self.hass.block_till_done()
+        current_percentage_cover_position = self.hass.states.get(
+            'cover.test').attributes['current_position']
+        assert 50 == current_percentage_cover_position
+        assert STATE_OPEN == self.hass.states.get(
+            'cover.test').state
+
     def test_set_cover_position(self):
         """Test setting cover position."""
         assert setup_component(self.hass, cover.DOMAIN, {

--- a/tests/components/cover/test_mqtt.py
+++ b/tests/components/cover/test_mqtt.py
@@ -308,17 +308,17 @@ class TestCoverMQTT(unittest.TestCase):
             'cover.test').attributes['current_position']
         assert 50 == current_cover_position
 
-        fire_mqtt_message(self.hass, 'get-position-topic', '101')
-        self.hass.block_till_done()
-        current_cover_position = self.hass.states.get(
-            'cover.test').attributes['current_position']
-        assert 50 == current_cover_position
-
         fire_mqtt_message(self.hass, 'get-position-topic', 'non-numeric')
         self.hass.block_till_done()
         current_cover_position = self.hass.states.get(
             'cover.test').attributes['current_position']
         assert 50 == current_cover_position
+
+        fire_mqtt_message(self.hass, 'get-position-topic', '101')
+        self.hass.block_till_done()
+        current_cover_position = self.hass.states.get(
+            'cover.test').attributes['current_position']
+        assert 100 == current_cover_position
 
     def test_current_cover_position_inverted(self):
         """Test the current cover position."""
@@ -348,28 +348,18 @@ class TestCoverMQTT(unittest.TestCase):
         current_percentage_cover_position = self.hass.states.get(
             'cover.test').attributes['current_position']
         assert 0 == current_percentage_cover_position
-        print(self.hass.states.get(
-            'cover.test').state)
         assert STATE_CLOSED == self.hass.states.get(
             'cover.test').state
 
         fire_mqtt_message(self.hass, 'get-position-topic', '0')
         self.hass.block_till_done()
-        current_state = self.hass.states.get(
-            'cover.test')
-        current_cover_position = current_state.attributes['current_position']
-        assert 100 == current_cover_position
-        assert STATE_OPEN == current_state.state
-
-        fire_mqtt_message(self.hass, 'get-position-topic', '50')
-        self.hass.block_till_done()
         current_percentage_cover_position = self.hass.states.get(
             'cover.test').attributes['current_position']
-        assert 50 == current_percentage_cover_position
+        assert 100 == current_percentage_cover_position
         assert STATE_OPEN == self.hass.states.get(
             'cover.test').state
 
-        fire_mqtt_message(self.hass, 'get-position-topic', '101')
+        fire_mqtt_message(self.hass, 'get-position-topic', '50')
         self.hass.block_till_done()
         current_percentage_cover_position = self.hass.states.get(
             'cover.test').attributes['current_position']
@@ -383,6 +373,14 @@ class TestCoverMQTT(unittest.TestCase):
             'cover.test').attributes['current_position']
         assert 50 == current_percentage_cover_position
         assert STATE_OPEN == self.hass.states.get(
+            'cover.test').state
+
+        fire_mqtt_message(self.hass, 'get-position-topic', '101')
+        self.hass.block_till_done()
+        current_percentage_cover_position = self.hass.states.get(
+            'cover.test').attributes['current_position']
+        assert 0 == current_percentage_cover_position
+        assert STATE_CLOSED == self.hass.states.get(
             'cover.test').state
 
     def test_set_cover_position(self):


### PR DESCRIPTION
## Description:

Position of MQTT cover wasn't calculated if somebody has ideal inverted cover values open-0, close-100. This changes fixes that in:

- getting position
- open/close optimistic mode

Also added test for inverted MQTT cover.

**Related issue (if applicable):**
fixes #18383 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
