### PR TITLE
Enable alarmdecoder to see open/close state of bypassed RF zones when armed

### DIFF
--- a/homeassistant/components/alarmdecoder.py
+++ b/homeassistant/components/alarmdecoder.py
@@ -32,6 +32,7 @@ CONF_DEVICE_TYPE = 'type'
 CONF_PANEL_DISPLAY = 'panel_display'
 CONF_ZONE_NAME = 'name'
 CONF_ZONE_TYPE = 'type'
+CONF_ZONE_LOOP = 'loop'
 CONF_ZONE_RFID = 'rfid'
 CONF_ZONES = 'zones'
 CONF_RELAY_ADDR = 'relayaddr'
@@ -75,6 +76,8 @@ ZONE_SCHEMA = vol.Schema({
     vol.Optional(CONF_ZONE_TYPE,
                  default=DEFAULT_ZONE_TYPE): vol.Any(DEVICE_CLASSES_SCHEMA),
     vol.Optional(CONF_ZONE_RFID): cv.string,
+    vol.Optional(CONF_ZONE_LOOP):
+        vol.All(vol.Coerce(int), vol.Range(min=1, max=4)),
     vol.Inclusive(CONF_RELAY_ADDR, 'relaylocation',
                   'Relay address and channel must exist together'): cv.byte,
     vol.Inclusive(CONF_RELAY_CHAN, 'relaylocation',

--- a/homeassistant/components/binary_sensor/alarmdecoder.py
+++ b/homeassistant/components/binary_sensor/alarmdecoder.py
@@ -7,7 +7,7 @@ https://home-assistant.io/components/binary_sensor.alarmdecoder/
 import logging
 
 from homeassistant.components.binary_sensor import BinarySensorDevice
-from ..alarmdecoder import (
+from homeassistant.components.alarmdecoder import (
     ZONE_SCHEMA, CONF_ZONES, CONF_ZONE_NAME, CONF_ZONE_TYPE,
     CONF_ZONE_RFID, CONF_ZONE_LOOP, SIGNAL_ZONE_FAULT, SIGNAL_ZONE_RESTORE,
     SIGNAL_RFX_MESSAGE, SIGNAL_REL_MESSAGE, CONF_RELAY_ADDR,


### PR DESCRIPTION
## Description:
The alarmdecoder component already reported RF state bits as attributes. If the user knows which loop is set up for the zone in the alarm panel, they can use that information to tell whether the zone is open or closed even when the system is armed by monitoring the appropriate attribute. That’s awkward, so this commit enables the user to simply configure which loop is used and the component will update the state itself.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#7513

## Example entry for `configuration.yaml` (if applicable):
```yaml
alarmdecoder:
  # ... other alarmdecoder stuff here ...
  zones:
    01:
      name: 'Smoke Detector'
      type: 'smoke'
      rfid: '0123456'
      loop: 1
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
