### PR TITLE
Fixed bug for receivers without support for new command

### DIFF
--- a/homeassistant/components/media_player/onkyo.py
+++ b/homeassistant/components/media_player/onkyo.py
@@ -220,6 +220,9 @@ class OnkyoDevice(MediaPlayerDevice):
                     [i for i in current_source_tuples[1]])
         self._muted = bool(mute_raw[1] == 'on')
         self._volume = volume_raw[1] / self._max_volume
+
+        if not (hdmi_out_raw):
+            return
         self._attributes["video_out"] = ','.join(hdmi_out_raw[1])
 
     @property

--- a/homeassistant/components/media_player/onkyo.py
+++ b/homeassistant/components/media_player/onkyo.py
@@ -221,7 +221,7 @@ class OnkyoDevice(MediaPlayerDevice):
         self._muted = bool(mute_raw[1] == 'on')
         self._volume = volume_raw[1] / self._max_volume
 
-        if not (hdmi_out_raw):
+        if not hdmi_out_raw:
             return
         self._attributes["video_out"] = ','.join(hdmi_out_raw[1])
 


### PR DESCRIPTION
## Description:
Fixing error on receivers that don't support the new command

**Related issue (if applicable):** fixes #18353

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
