### PR TITLE
AirVisual: Show icon for air pollution level, based on its value

### DIFF
--- a/homeassistant/components/sensor/airvisual.py
+++ b/homeassistant/components/sensor/airvisual.py
@@ -41,33 +41,39 @@ SENSOR_TYPE_LEVEL = 'air_pollution_level'
 SENSOR_TYPE_AQI = 'air_quality_index'
 SENSOR_TYPE_POLLUTANT = 'main_pollutant'
 SENSORS = [
-    (SENSOR_TYPE_LEVEL, 'Air Pollution Level', 'mdi:scale', None),
-    (SENSOR_TYPE_AQI, 'Air Quality Index', 'mdi:format-list-numbers', 'AQI'),
+    (SENSOR_TYPE_LEVEL, 'Air Pollution Level', 'mdi:gauge', None),
+    (SENSOR_TYPE_AQI, 'Air Quality Index', 'mdi:chart-line', 'AQI'),
     (SENSOR_TYPE_POLLUTANT, 'Main Pollutant', 'mdi:chemical-weapon', None),
 ]
 
 POLLUTANT_LEVEL_MAPPING = [{
     'label': 'Good',
+    'icon': 'mdi:emoticon-excited',
     'minimum': 0,
     'maximum': 50
 }, {
     'label': 'Moderate',
+    'icon': 'mdi:emoticon-happy',
     'minimum': 51,
     'maximum': 100
 }, {
-    'label': 'Unhealthy for sensitive group',
+    'label': 'Unhealthy for sensitive groups',
+    'icon': 'mdi:emoticon-neutral',
     'minimum': 101,
     'maximum': 150
 }, {
     'label': 'Unhealthy',
+    'icon': 'mdi:emoticon-sad',
     'minimum': 151,
     'maximum': 200
 }, {
     'label': 'Very Unhealthy',
+    'icon': 'mdi:emoticon-dead',
     'minimum': 201,
     'maximum': 300
 }, {
     'label': 'Hazardous',
+    'icon': 'mdi:biohazard',
     'minimum': 301,
     'maximum': 10000
 }]
@@ -237,6 +243,7 @@ class AirVisualSensor(Entity):
                 if i['minimum'] <= aqi <= i['maximum']
             ]
             self._state = level['label']
+            self._icon = level['icon']
         elif self._type == SENSOR_TYPE_AQI:
             self._state = data['aqi{0}'.format(self._locale)]
         elif self._type == SENSOR_TYPE_POLLUTANT:


### PR DESCRIPTION
## Description:

Show excited, happy, neutral, sad, dead emoticon, or biohazard icon, based on air pollution level.

Also, fix a small typo and change air quality index icon to `mdi:chart-line`. Seems a bit more logical.

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: airvisual
    api_key: YOUR_AIRVISUAL_API_KEY
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.