### PR TITLE
Ban systemair-savecair

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -22,3 +22,6 @@ enum34==1000000000.0.0
 
 # This is a old unmaintained library and is replaced with pycryptodome
 pycrypto==1000000000.0.0
+
+# Contains code to modify Home Assistant to work around our rules
+python-systemair-savecair==1000000000.0.0

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -142,6 +142,9 @@ enum34==1000000000.0.0
 
 # This is a old unmaintained library and is replaced with pycryptodome
 pycrypto==1000000000.0.0
+
+# Contains code to modify Home Assistant to work around our rules
+python-systemair-savecair==1000000000.0.0
 """
 
 


### PR DESCRIPTION
## Description:
This dependency contains code to mutate Home Assistant to work around how we architect the system and which we enforce in Home Assistant.

https://github.com/perara/python-systemair-savecair/blob/d906a0f49e2ddec7e359d7f43b107f62f63dadac/systemair/savecair/client.py#L58-L74

![image](https://user-images.githubusercontent.com/1444314/48556958-ae0c5a00-e8e5-11e8-95b6-0a79ff60ab7a.png)
