### PR TITLE
Reflect Alexa Smart Home API v3 name change for additionalApplianceDetails

### DIFF
--- a/homeassistant/components/alexa/smart_home.py
+++ b/homeassistant/components/alexa/smart_home.py
@@ -1233,7 +1233,7 @@ async def async_api_discovery(hass, config, directive, context):
 
         endpoint = {
             'displayCategories': alexa_entity.display_categories(),
-            'additionalApplianceDetails': {},
+            'cookie': {},
             'endpointId': alexa_entity.entity_id(),
             'friendlyName': alexa_entity.friendly_name(),
             'description': alexa_entity.description(),


### PR DESCRIPTION
## Description:

The v3 payload for the Alexa Smart Home API changes the name of the `additionalApplianceDetails` property to `cookie`.

As `additionalApplianceDetails` (or `cookie`) is not being used at this time, there aren't any (breaking) changes to be expected. This is more of a future-proofing of the payload for future developments.

Validation/Reference for this API change: https://developer.amazon.com/blogs/alexa/post/87c5cf67-1f27-42d3-a07a-e4f559674392/how-to-migrate-your-alexa-skill-to-the-updated-smart-home-skill-api

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.