### PR TITLE
Clean up left-behind dispatcher handlers when removing RainMachine

### DIFF
--- a/homeassistant/components/binary_sensor/rainmachine.py
+++ b/homeassistant/components/binary_sensor/rainmachine.py
@@ -78,13 +78,8 @@ class RainMachineBinarySensor(RainMachineEntity, BinarySensorDevice):
             """Update the state."""
             self.async_schedule_update_ha_state(True)
 
-        self._async_unsub_dispatcher_connect = async_dispatcher_connect(
-            self.hass, SENSOR_UPDATE_TOPIC, update)
-
-    async def async_will_remove_from_hass(self):
-        """Disconnect dispatcher listener when removed."""
-        if self._async_unsub_dispatcher_connect:
-            self._async_unsub_dispatcher_connect()
+        self._dispatcher_handlers.append(async_dispatcher_connect(
+            self.hass, SENSOR_UPDATE_TOPIC, update))
 
     async def async_update(self):
         """Update the state."""

--- a/homeassistant/components/rainmachine/__init__.py
+++ b/homeassistant/components/rainmachine/__init__.py
@@ -283,6 +283,5 @@ class RainMachineEntity(Entity):
 
     async def async_will_remove_from_hass(self):
         """Disconnect dispatcher listener when removed."""
-        if self._dispatcher_handlers:
-            for handler in self._dispatcher_handlers:
-                handler()
+        for handler in self._dispatcher_handlers:
+            handler()

--- a/homeassistant/components/rainmachine/__init__.py
+++ b/homeassistant/components/rainmachine/__init__.py
@@ -267,7 +267,7 @@ class RainMachineEntity(Entity):
     def __init__(self, rainmachine):
         """Initialize."""
         self._attrs = {ATTR_ATTRIBUTION: DEFAULT_ATTRIBUTION}
-        self._async_unsub_dispatcher_connect = None
+        self._dispatcher_handlers = []
         self._name = None
         self.rainmachine = rainmachine
 
@@ -280,3 +280,9 @@ class RainMachineEntity(Entity):
     def name(self) -> str:
         """Return the name of the entity."""
         return self._name
+
+    async def async_will_remove_from_hass(self):
+        """Disconnect dispatcher listener when removed."""
+        if self._dispatcher_handlers:
+            for handler in self._dispatcher_handlers:
+                handler()

--- a/homeassistant/components/sensor/rainmachine.py
+++ b/homeassistant/components/sensor/rainmachine.py
@@ -81,13 +81,8 @@ class RainMachineSensor(RainMachineEntity):
             """Update the state."""
             self.async_schedule_update_ha_state(True)
 
-        self._async_unsub_dispatcher_connect = async_dispatcher_connect(
-            self.hass, SENSOR_UPDATE_TOPIC, update)
-
-    async def async_will_remove_from_hass(self):
-        """Disconnect dispatcher listener when removed."""
-        if self._async_unsub_dispatcher_connect:
-            self._async_unsub_dispatcher_connect()
+        self._dispatcher_handlers.append(async_dispatcher_connect(
+            self.hass, SENSOR_UPDATE_TOPIC, update))
 
     async def async_update(self):
         """Update the sensor's state."""

--- a/homeassistant/components/switch/rainmachine.py
+++ b/homeassistant/components/switch/rainmachine.py
@@ -186,13 +186,8 @@ class RainMachineProgram(RainMachineSwitch):
 
     async def async_added_to_hass(self):
         """Register callbacks."""
-        self._async_unsub_dispatcher_connect = async_dispatcher_connect(
-            self.hass, PROGRAM_UPDATE_TOPIC, self._program_updated)
-
-    async def async_will_remove_from_hass(self):
-        """Disconnect dispatcher listener when removed."""
-        if self._async_unsub_dispatcher_connect:
-            self._async_unsub_dispatcher_connect()
+        self._dispatcher_handlers.append(async_dispatcher_connect(
+            self.hass, PROGRAM_UPDATE_TOPIC, self._program_updated))
 
     async def async_turn_off(self, **kwargs) -> None:
         """Turn the program off."""
@@ -256,10 +251,10 @@ class RainMachineZone(RainMachineSwitch):
 
     async def async_added_to_hass(self):
         """Register callbacks."""
-        async_dispatcher_connect(
-            self.hass, PROGRAM_UPDATE_TOPIC, self._program_updated)
-        async_dispatcher_connect(
-            self.hass, ZONE_UPDATE_TOPIC, self._program_updated)
+        self._dispatcher_handlers.append(async_dispatcher_connect(
+            self.hass, PROGRAM_UPDATE_TOPIC, self._program_updated))
+        self._dispatcher_handlers.append(async_dispatcher_connect(
+            self.hass, ZONE_UPDATE_TOPIC, self._program_updated))
 
     async def async_turn_off(self, **kwargs) -> None:
         """Turn the zone off."""


### PR DESCRIPTION
## Description:

The current implementation of RainMachine leaves behind some active dispatcher handlers when removing the component via the UI. This PR cleans that up (and centralizes that logic in the component, rather than across the platforms).

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
rainmachine:
  ip_address: !secret rainmachine_host
  password: !secret rainmachine_password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
