### PR TITLE
ZHA - add events for remote like devices

### DIFF
--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -13,7 +13,6 @@ import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant import const as ha_const
-from homeassistant.core import EventOrigin, callback
 from homeassistant.helpers import discovery, entity
 from homeassistant.util import slugify
 from homeassistant.helpers.entity_component import EntityComponent

--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -13,6 +13,7 @@ import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant import const as ha_const
+from homeassistant.core import EventOrigin, callback
 from homeassistant.helpers import discovery, entity
 from homeassistant.util import slugify
 from homeassistant.helpers.entity_component import EntityComponent
@@ -24,6 +25,14 @@ REQUIREMENTS = [
 ]
 
 DOMAIN = 'zha'
+SWITCH = 'switch'
+DEVICE = 'device'
+LEVEL = 'level'
+DATA_ZHA_EVENT = 'zha_events'
+OFF_EVENT_KEY = 'zha.off'
+ON_EVENT_KEY = 'zha.on'
+TOGGLE_EVENT_KEY = 'zha.toggle'
+LEVEL_CHANGE_EVENT_KEY = 'zha.level_change'
 
 
 class RadioType(enum.Enum):
@@ -132,6 +141,8 @@ async def async_setup(hass, config):
     hass.services.async_register(DOMAIN, SERVICE_REMOVE, remove,
                                  schema=SERVICE_SCHEMAS[SERVICE_REMOVE])
 
+    hass.data[DATA_ZHA_EVENT] = []
+
     return True
 
 
@@ -236,6 +247,29 @@ class ApplicationListener:
                     {'discovery_key': device_key},
                     self._config,
                 )
+            else:
+                if endpoint.device_type in zha_const.REMOTE_DEVICE_TYPES.get(
+                        endpoint.profile_id, {}):
+                    profile_clusters = profile.CLUSTERS[endpoint.device_type]
+                    in_clusters = [endpoint.in_clusters[c]
+                                   for c in profile_clusters[0]
+                                   if c in endpoint.in_clusters]
+                    out_clusters = [endpoint.out_clusters[c]
+                                    for c in profile_clusters[1]
+                                    if c in endpoint.out_clusters]
+                    discovery_info = {
+                        'application_listener': self,
+                        'endpoint': endpoint,
+                        'in_clusters': {c.cluster_id: c for c in in_clusters},
+                        'out_clusters': {c.cluster_id: c for c in
+                                         out_clusters},
+                        'manufacturer': endpoint.manufacturer,
+                        'model': endpoint.model,
+                        'new_join': join,
+                        'unique_id': device_key,
+                    }
+                    self._hass.data[DISCOVERY_KEY][device_key] = discovery_info
+                    await self._async_setup_remote(discovery_info)
 
             for cluster in endpoint.in_clusters.values():
                 await self._attempt_single_cluster_device(
@@ -320,6 +354,28 @@ class ApplicationListener:
             {'discovery_key': cluster_key},
             self._config,
         )
+
+    async def _async_setup_remote(self, discovery_info):
+        from zigpy.zcl.clusters.general import OnOff, LevelControl
+        out_clusters = discovery_info['out_clusters']
+        if OnOff.cluster_id in out_clusters:
+            cluster = out_clusters[OnOff.cluster_id]
+            event = ZHASwitchEvent(self._hass, cluster, discovery_info)
+            if discovery_info['new_join']:
+                await configure_reporting(event.event_id, cluster, 0, False, 0,
+                                          600, 1)
+            self._hass.data[DATA_ZHA_EVENT].append(
+                event
+            )
+        if LevelControl.cluster_id in out_clusters:
+            cluster = out_clusters[LevelControl.cluster_id]
+            event = ZHALevelEvent(self._hass, cluster, discovery_info)
+            if discovery_info['new_join']:
+                await configure_reporting(event.event_id, cluster, 1, False, 0,
+                                          600, 1)
+            self._hass.data[DATA_ZHA_EVENT].append(
+                event
+            )
 
 
 class Entity(entity.Entity):
@@ -469,6 +525,141 @@ class ZhaDeviceEntity(entity.Entity):
                 self._state = 'offline'
             else:
                 self._state = 'online'
+
+
+class ZHAEvent(object):
+    """When you want signals instead of entities.
+    Stateless sensors such as remotes are expected to generate an event
+    instead of a sensor entity in hass.
+    """
+
+    def __init__(self, hass, cluster, domain, discovery_info):
+        """Register callback that will be used for signals."""
+        self._hass = hass
+        self._cluster = cluster
+        self._cluster.add_listener(self)
+        ieee = discovery_info['endpoint'].device.ieee
+        ieeetail = ''.join(['%02x' % (o, ) for o in ieee[-4:]])
+        if discovery_info['manufacturer'] and discovery_info['model'] is not \
+                None:
+            self.event_id = "{}.{}_{}_{}_{}{}".format(
+                domain,
+                slugify(discovery_info['manufacturer']),
+                slugify(discovery_info['model']),
+                ieeetail,
+                discovery_info['endpoint'].endpoint_id,
+                discovery_info.get('entity_suffix', '')
+            )
+        else:
+            self.event_id = "{}.zha_{}_{}{}".format(
+                domain,
+                ieeetail,
+                discovery_info['endpoint'].endpoint_id,
+                discovery_info.get('entity_suffix', '')
+            )
+
+
+class ZHASwitchEvent(ZHAEvent):
+    """Switch / remote event for zha"""
+
+    def __init__(self, hass, cluster, discovery_info):
+        """Initialize Switch."""
+        super().__init__(hass, cluster, SWITCH, discovery_info)
+
+    @callback
+    def cluster_command(self, tsn, command_id, args):
+        """Handle commands received to this cluster."""
+        if command_id in (0x0000, 0x0040):
+            self._hass.bus.fire(
+                OFF_EVENT_KEY,
+                {DEVICE: self.event_id},
+                EventOrigin.remote
+            )
+            _LOGGER.debug(
+                "%s: fired off event", self.event_id
+            )
+        elif command_id in (0x0001, 0x0041, 0x0042):
+            self._hass.bus.fire(
+                ON_EVENT_KEY,
+                {DEVICE: self.event_id},
+                EventOrigin.remote
+            )
+            _LOGGER.debug(
+                "%s: fired on event", self.event_id
+            )
+        elif command_id == 0x0002:
+            self._hass.bus.fire(
+                TOGGLE_EVENT_KEY,
+                {DEVICE: self.event_id},
+                EventOrigin.remote
+            )
+            _LOGGER.debug(
+                "%s: fired toggle event", self.event_id
+            )
+
+
+class ZHALevelEvent(ZHAEvent):
+    """Switch / remote event for zha"""
+
+    def __init__(self, hass, cluster, discovery_info):
+        """Initialize Switch."""
+        super().__init__(hass, cluster, SWITCH, discovery_info)
+        self._level = 0
+
+    @callback
+    def cluster_command(self, tsn, command_id, args):
+        """Handle commands received to this cluster."""
+        if command_id in (0x0000, 0x0004):  # move_to_level, -with_on_off
+            self.set_level(args[0])
+        elif command_id in (0x0001, 0x0005):  # move, -with_on_off
+            # We should dim slowly -- for now, just step once
+            rate = args[1]
+            if args[0] == 0xff:
+                rate = 10  # Should read default move rate
+            self.move_level(-rate if args[0] else rate)
+        elif command_id == 0x0002:  # step
+            # Step (technically shouldn't change on/off)
+            self.move_level(-args[1] if args[0] else args[1])
+
+    def attribute_update(self, attrid, value):
+        """Handle attribute updates on this cluster."""
+        if attrid == 0:
+            self._level = value
+
+    def move_level(self, change):
+        """Increment the level."""
+        self.set_level(min(255, max(0, self._level + change)))
+
+    def set_level(self, level):
+        """Set the level."""
+        if level == 0 and self._level > 0:
+            self._hass.bus.fire(
+                OFF_EVENT_KEY,
+                {DEVICE: self.event_id},
+                EventOrigin.remote
+            )
+            _LOGGER.debug(
+                "%s: fired off event", self.event_id
+            )
+        elif level > 0 and self._level == 0:
+            self._hass.bus.fire(
+                ON_EVENT_KEY,
+                {DEVICE: self.event_id},
+                EventOrigin.remote
+            )
+            _LOGGER.debug(
+                "%s: fired on event", self.event_id
+            )
+        else:
+            self._hass.bus.fire(
+                LEVEL_CHANGE_EVENT_KEY,
+                {DEVICE: self.event_id, LEVEL: self._level},
+                EventOrigin.remote
+            )
+            _LOGGER.debug(
+                "%s: fired level change event", self.event_id
+            )
+        self._level = level
 
 
 def get_discovery_info(hass, discovery_info):

--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -560,7 +560,7 @@ class ZHAEvent(object):
     def cluster_command(self, tsn, command_id, args):
         """Handle commands received to this cluster."""
         self._hass.bus.async_fire(
-            self._cluster.server_commands.get(command_id)[0],
+            'zha_' + self._cluster.server_commands.get(command_id)[0],
             {'device': self.event_id, 'args': args},
             EventOrigin.remote
         )
@@ -573,7 +573,7 @@ class ZHAEvent(object):
     @callback
     def attribute_updated(self, attrid, value):
         self._hass.bus.async_fire(
-            self._cluster.attributes.get(attrid)[0],
+            'zha_' + self._cluster.attributes.get(attrid)[0],
             {'device': self.event_id, 'value': value},
             EventOrigin.remote
         )

--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -179,7 +179,7 @@ class ApplicationListener:
     async def async_device_initialized(self, device, join):
         """Handle device joined and basic information discovered (async)."""
         import zigpy.profiles
-        import homeassistant.components.zha.event
+        import homeassistant.components.zha.event as zha_event
         import homeassistant.components.zha.const as zha_const
         zha_const.populate_data()
 
@@ -234,7 +234,7 @@ class ApplicationListener:
                     'new_join': join,
                     'unique_id': device_key,
                 }
-                created_events = await event.async_setup_event(
+                created_events = await zha_event.async_setup_event(
                     self._hass,
                     discovery_info
                     )

--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -144,7 +144,6 @@ class ApplicationListener:
         self._config = config
         self._component = EntityComponent(_LOGGER, DOMAIN, hass)
         self._device_registry = collections.defaultdict(list)
-        import homeassistant.components.zha.const as zha_const
         self._events = []
         hass.data[DISCOVERY_KEY] = hass.data.get(DISCOVERY_KEY, {})
 

--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -536,7 +536,6 @@ class ZHAEvent(object):
     def __init__(self, hass, cluster, discovery_info):
         """Register callback that will be used for signals."""
         self._hass = hass
-        self.endpoint = discovery_info['endpoint']
         self._cluster = cluster
         self._cluster.add_listener(self)
         ieee = discovery_info['endpoint'].device.ieee
@@ -551,7 +550,7 @@ class ZHAEvent(object):
                 discovery_info.get('entity_suffix', '')
             )
         else:
-            self.event_id = "{}.zha_{}{}".format(
+            self.event_id = "{}.event_{}{}".format(
                 ieeetail,
                 discovery_info['endpoint'].endpoint_id,
                 discovery_info.get('entity_suffix', '')

--- a/homeassistant/components/zha/const.py
+++ b/homeassistant/components/zha/const.py
@@ -5,6 +5,7 @@ SINGLE_INPUT_CLUSTER_DEVICE_CLASS = {}
 SINGLE_OUTPUT_CLUSTER_DEVICE_CLASS = {}
 CUSTOM_CLUSTER_MAPPINGS = {}
 COMPONENT_CLUSTERS = {}
+REMOTE_DEVICE_TYPES = {}
 
 
 def populate_data():
@@ -18,18 +19,21 @@ def populate_data():
     from homeassistant.components.sensor import zha as sensor_zha
 
     DEVICE_CLASS[zha.PROFILE_ID] = {
-        zha.DeviceType.ON_OFF_SWITCH: 'binary_sensor',
-        zha.DeviceType.LEVEL_CONTROL_SWITCH: 'binary_sensor',
-        zha.DeviceType.REMOTE_CONTROL: 'binary_sensor',
+        zha.DeviceType.ON_OFF_OUTPUT: 'binary_sensor',
         zha.DeviceType.SMART_PLUG: 'switch',
         zha.DeviceType.LEVEL_CONTROLLABLE_OUTPUT: 'light',
         zha.DeviceType.ON_OFF_LIGHT: 'light',
         zha.DeviceType.DIMMABLE_LIGHT: 'light',
         zha.DeviceType.COLOR_DIMMABLE_LIGHT: 'light',
-        zha.DeviceType.ON_OFF_LIGHT_SWITCH: 'binary_sensor',
-        zha.DeviceType.DIMMER_SWITCH: 'binary_sensor',
-        zha.DeviceType.COLOR_DIMMER_SWITCH: 'binary_sensor',
     }
+    REMOTE_DEVICE_TYPES[zha.PROFILE_ID] = [
+        zha.DeviceType.ON_OFF_SWITCH,
+        zha.DeviceType.LEVEL_CONTROL_SWITCH,
+        zha.DeviceType.REMOTE_CONTROL,
+        zha.DeviceType.ON_OFF_LIGHT_SWITCH,
+        zha.DeviceType.DIMMER_SWITCH,
+        zha.DeviceType.COLOR_DIMMER_SWITCH,
+    ]
     DEVICE_CLASS[zll.PROFILE_ID] = {
         zll.DeviceType.ON_OFF_LIGHT: 'light',
         zll.DeviceType.ON_OFF_PLUGIN_UNIT: 'switch',
@@ -44,7 +48,8 @@ def populate_data():
         zll.DeviceType.SCENE_CONTROLLER: 'binary_sensor',
         zll.DeviceType.ON_OFF_SENSOR: 'binary_sensor',
     }
-
+    REMOTE_DEVICE_TYPES[zll.PROFILE_ID] = [
+    ]
     SINGLE_INPUT_CLUSTER_DEVICE_CLASS.update({
         zcl.clusters.general.OnOff: 'switch',
         zcl.clusters.general.LevelControl: 'light',

--- a/homeassistant/components/zha/const.py
+++ b/homeassistant/components/zha/const.py
@@ -1,5 +1,7 @@
 """All constants related to the ZHA component."""
 
+DATA_ZHA_EVENT = 'zha_events'
+
 DEVICE_CLASS = {}
 SINGLE_INPUT_CLUSTER_DEVICE_CLASS = {}
 SINGLE_OUTPUT_CLUSTER_DEVICE_CLASS = {}

--- a/homeassistant/components/zha/const.py
+++ b/homeassistant/components/zha/const.py
@@ -19,21 +19,22 @@ def populate_data():
     from homeassistant.components.sensor import zha as sensor_zha
 
     DEVICE_CLASS[zha.PROFILE_ID] = {
-        zha.DeviceType.ON_OFF_OUTPUT: 'binary_sensor',
+        zha.DeviceType.ON_OFF_SWITCH: 'binary_sensor',
+        zha.DeviceType.LEVEL_CONTROL_SWITCH: 'binary_sensor',
+        zha.DeviceType.REMOTE_CONTROL: 'binary_sensor',
         zha.DeviceType.SMART_PLUG: 'switch',
         zha.DeviceType.LEVEL_CONTROLLABLE_OUTPUT: 'light',
         zha.DeviceType.ON_OFF_LIGHT: 'light',
         zha.DeviceType.DIMMABLE_LIGHT: 'light',
         zha.DeviceType.COLOR_DIMMABLE_LIGHT: 'light',
+        zha.DeviceType.ON_OFF_LIGHT_SWITCH: 'binary_sensor',
+        zha.DeviceType.DIMMER_SWITCH: 'binary_sensor',
+        zha.DeviceType.COLOR_DIMMER_SWITCH: 'binary_sensor',
     }
-    REMOTE_DEVICE_TYPES[zha.PROFILE_ID] = [
-        zha.DeviceType.ON_OFF_SWITCH,
-        zha.DeviceType.LEVEL_CONTROL_SWITCH,
-        zha.DeviceType.REMOTE_CONTROL,
-        zha.DeviceType.ON_OFF_LIGHT_SWITCH,
-        zha.DeviceType.DIMMER_SWITCH,
-        zha.DeviceType.COLOR_DIMMER_SWITCH,
-    ]
+    REMOTE_DEVICE_TYPES[zha.PROFILE_ID] = {
+        'CentraLite': ['3130'],
+        'LUMI': ['lumi.sensor_switch.aq2'],
+    }
     DEVICE_CLASS[zll.PROFILE_ID] = {
         zll.DeviceType.ON_OFF_LIGHT: 'light',
         zll.DeviceType.ON_OFF_PLUGIN_UNIT: 'switch',
@@ -71,6 +72,9 @@ def populate_data():
         (quirks.smartthings.SmartthingsTemperatureHumiditySensor, 64581):
             ('sensor', sensor_zha.RelativeHumiditySensor)
     })
+
+    PROFILES[zha.PROFILE_ID].CLUSTERS[0x5F01] = ([0x0000, 0x0006, 0xFFFF],
+                                                 [0x0000, 0x0004, 0xFFFF])
 
     # A map of hass components to all Zigbee clusters it could use
     for profile_id, classes in DEVICE_CLASS.items():

--- a/homeassistant/components/zha/const.py
+++ b/homeassistant/components/zha/const.py
@@ -34,6 +34,7 @@ def populate_data():
     REMOTE_DEVICE_TYPES[zha.PROFILE_ID] = {
         'CentraLite': ['3130'],
         'LUMI': ['lumi.sensor_switch.aq2'],
+        'OSRAM': ['LIGHTIFY Dimming Switch'],
     }
     DEVICE_CLASS[zll.PROFILE_ID] = {
         zll.DeviceType.ON_OFF_LIGHT: 'light',

--- a/homeassistant/components/zha/const.py
+++ b/homeassistant/components/zha/const.py
@@ -4,6 +4,8 @@ import os
 import logging
 
 REMOTES_CONFIG_FILE = 'zha-remotes.json'
+ZHA = 'Zigbee_home_automation'
+ZLL = 'Zigbee_light_link'
 DEVICE_CLASS = {}
 SINGLE_INPUT_CLUSTER_DEVICE_CLASS = {}
 SINGLE_OUTPUT_CLUSTER_DEVICE_CLASS = {}
@@ -35,16 +37,12 @@ def populate_data(hass):
 
     if not os.path.isfile(remotes_config_path):
         save_json(remotes_config_path,
-                  {str(zha.PROFILE_ID): {}, str(zll.PROFILE_ID): {}}
+                  {ZHA: {}, ZLL: {}}
                   )
 
     remote_devices = load_json(remotes_config_path)
-    REMOTE_DEVICE_TYPES[zha.PROFILE_ID] = remote_devices.get(
-        str(zha.PROFILE_ID)
-        )
-    REMOTE_DEVICE_TYPES[zll.PROFILE_ID] = remote_devices.get(
-        str(zll.PROFILE_ID)
-        )
+    REMOTE_DEVICE_TYPES[zha.PROFILE_ID] = remote_devices.get(ZHA)
+    REMOTE_DEVICE_TYPES[zll.PROFILE_ID] = remote_devices.get(ZLL)
 
     _LOGGER.debug(
         "loaded from remotes config: %s", REMOTE_DEVICE_TYPES

--- a/homeassistant/components/zha/const.py
+++ b/homeassistant/components/zha/const.py
@@ -1,7 +1,5 @@
 """All constants related to the ZHA component."""
 
-DATA_ZHA_EVENT = 'zha_events'
-
 DEVICE_CLASS = {}
 SINGLE_INPUT_CLUSTER_DEVICE_CLASS = {}
 SINGLE_OUTPUT_CLUSTER_DEVICE_CLASS = {}
@@ -76,6 +74,11 @@ def populate_data():
             ('sensor', sensor_zha.RelativeHumiditySensor)
     })
 
+    # This registers a device that Xiaomi didn't follow the spec on.
+    # Translated: For device type: 0x5F01 in the ZHA zigbee profile
+    # the input clusters are: [0x0000, 0x0006, 0xFFFF] and the output
+    # clusters are: [0x0000, 0x0004, 0xFFFF]. The goal is to read this
+    # from a configuration file in the future
     PROFILES[zha.PROFILE_ID].CLUSTERS[0x5F01] = ([0x0000, 0x0006, 0xFFFF],
                                                  [0x0000, 0x0004, 0xFFFF])
 

--- a/homeassistant/components/zha/event.py
+++ b/homeassistant/components/zha/event.py
@@ -74,11 +74,6 @@ class ZHAEvent():
             {'device': self.event_id, 'args': args},
             EventOrigin.remote
         )
-        _LOGGER.debug(
-            "%s: fired [zha_%s] event with arguments: %s", self.event_id,
-            self._cluster.server_commands.get(command_id)[0],
-            args
-        )
 
     @callback
     def attribute_updated(self, attrid, value):
@@ -90,14 +85,6 @@ class ZHAEvent():
              'attribute_id': attrid,
              'value': value},
             EventOrigin.remote
-        )
-        _LOGGER.debug(
-            "%s: fired [zha_attribute_updated] for attribute [%s] \
-             with value: [%s] and id: [%s]",
-            self.event_id,
-            self._cluster.attributes.get(attrid, ['Unknown'])[0],
-            value,
-            attrid
         )
 
     @callback

--- a/homeassistant/components/zha/event.py
+++ b/homeassistant/components/zha/event.py
@@ -1,0 +1,98 @@
+import logging
+from homeassistant.util import slugify
+from homeassistant.core import EventOrigin, callback
+
+
+_LOGGER = logging.getLogger(__name__)
+
+async def _async_setup_event(hass, discovery_info):
+    from homeassistant.components.zha import const as zha_const
+    from homeassistant.components.zha import configure_reporting
+    out_clusters = discovery_info['out_clusters']
+    in_clusters = discovery_info['in_clusters']
+    for in_cluster in in_clusters:
+        event = ZHAEvent(hass, in_cluster, discovery_info)
+        if discovery_info['new_join']:
+            await configure_reporting(event.event_id, in_cluster, 0,
+                                      False, 0, 600, 1)
+        hass.data[zha_const.DATA_ZHA_EVENT].append(
+            event
+        )
+    for out_cluster in out_clusters:
+        event = ZHAEvent(hass, out_cluster, discovery_info)
+        if discovery_info['new_join']:
+            await configure_reporting(event.event_id, out_cluster, 0,
+                                      False, 0, 600, 1)
+        hass.data[zha_const.DATA_ZHA_EVENT].append(
+            event
+        )
+
+
+class ZHAEvent(object):
+    """When you want signals instead of entities.
+    Stateless sensors such as remotes are expected to generate an event
+    instead of a sensor entity in hass.
+    """
+
+    def __init__(self, hass, cluster, discovery_info):
+        """Register callback that will be used for signals."""
+        self._hass = hass
+        self._cluster = cluster
+        self._cluster.add_listener(self)
+        ieee = discovery_info['endpoint'].device.ieee
+        ieeetail = ''.join(['%02x' % (o, ) for o in ieee[-4:]])
+        if discovery_info['manufacturer'] and discovery_info['model'] is not \
+                None:
+            self.event_id = "{}.{}_{}_{}{}".format(
+                slugify(discovery_info['manufacturer']),
+                slugify(discovery_info['model']),
+                ieeetail,
+                discovery_info['endpoint'].endpoint_id,
+                discovery_info.get('entity_suffix', '')
+            )
+        else:
+            self.event_id = "{}.event_{}{}".format(
+                ieeetail,
+                discovery_info['endpoint'].endpoint_id,
+                discovery_info.get('entity_suffix', '')
+            )
+
+    @callback
+    def cluster_command(self, tsn, command_id, args):
+        """Handle commands received to this cluster."""
+        self._hass.bus.async_fire(
+            'zha_' + self._cluster.server_commands.get(command_id)[0],
+            {'device': self.event_id, 'args': args},
+            EventOrigin.remote
+        )
+        _LOGGER.debug(
+            "%s: fired %s event with arguments: %s", self.event_id,
+            self._cluster.server_commands.get(command_id)[0],
+            args
+        )
+
+    @callback
+    def attribute_updated(self, attrid, value):
+        self._hass.bus.async_fire(
+            'zha_attribute_updated',
+            {'device': self.event_id,
+             'attribute': self._cluster.attributes.get(attrid, ['Unknown'])[0],
+             'attribute_id': attrid,
+             'value': value},
+            EventOrigin.remote
+        )
+        _LOGGER.debug(
+            "%s: updated attribute %s with value: %s and id: %s",
+            self.event_id,
+            self._cluster.attributes.get(attrid, ['Unknown'])[0],
+            value,
+            attrid
+        )
+
+    @callback
+    def zdo_command(self, *args, **kwargs):
+        _LOGGER.debug(
+            "%s: issued zdo command %s with args: %s", self.event_id,
+            args,
+            kwargs
+        )

--- a/homeassistant/components/zha/event.py
+++ b/homeassistant/components/zha/event.py
@@ -17,7 +17,6 @@ async def async_setup_event(hass, discovery_info):
 
     Will create events for devices registered in REMOTE_DEVICE_TYPES.
     """
-    from homeassistant.components.zha import const as zha_const
     from homeassistant.components.zha import configure_reporting
     out_clusters = discovery_info['out_clusters']
     in_clusters = discovery_info['in_clusters']

--- a/homeassistant/components/zha/event.py
+++ b/homeassistant/components/zha/event.py
@@ -75,7 +75,7 @@ class ZHAEvent():
             EventOrigin.remote
         )
         _LOGGER.debug(
-            "%s: fired %s event with arguments: %s", self.event_id,
+            "%s: fired [zha_%s] event with arguments: %s", self.event_id,
             self._cluster.server_commands.get(command_id)[0],
             args
         )
@@ -92,7 +92,8 @@ class ZHAEvent():
             EventOrigin.remote
         )
         _LOGGER.debug(
-            "%s: updated attribute %s with value: %s and id: %s",
+            "%s: fired [zha_attribute_updated] for attribute [%s]" + \
+            " with value: [%s] and id: [%s]",
             self.event_id,
             self._cluster.attributes.get(attrid, ['Unknown'])[0],
             value,

--- a/homeassistant/components/zha/event.py
+++ b/homeassistant/components/zha/event.py
@@ -92,8 +92,8 @@ class ZHAEvent():
             EventOrigin.remote
         )
         _LOGGER.debug(
-            "%s: fired [zha_attribute_updated] for attribute [%s]" +
-            " with value: [%s] and id: [%s]",
+            "%s: fired [zha_attribute_updated] for attribute [%s] \
+             with value: [%s] and id: [%s]",
             self.event_id,
             self._cluster.attributes.get(attrid, ['Unknown'])[0],
             value,

--- a/homeassistant/components/zha/event.py
+++ b/homeassistant/components/zha/event.py
@@ -92,7 +92,7 @@ class ZHAEvent():
             EventOrigin.remote
         )
         _LOGGER.debug(
-            "%s: fired [zha_attribute_updated] for attribute [%s]" + \
+            "%s: fired [zha_attribute_updated] for attribute [%s]" +
             " with value: [%s] and id: [%s]",
             self.event_id,
             self._cluster.attributes.get(attrid, ['Unknown'])[0],

--- a/homeassistant/components/zha/event.py
+++ b/homeassistant/components/zha/event.py
@@ -5,6 +5,7 @@ from homeassistant.core import EventOrigin, callback
 
 _LOGGER = logging.getLogger(__name__)
 
+
 async def _async_setup_event(hass, discovery_info):
     from homeassistant.components.zha import const as zha_const
     from homeassistant.components.zha import configure_reporting

--- a/homeassistant/components/zha/event.py
+++ b/homeassistant/components/zha/event.py
@@ -38,6 +38,7 @@ async def async_setup_event(hass, discovery_info):
 
 class ZHAEvent():
     """When you want signals instead of entities.
+
     Stateless sensors such as remotes are expected to generate an event
     instead of a sensor entity in hass.
     """
@@ -100,7 +101,7 @@ class ZHAEvent():
 
     @callback
     def zdo_command(self, *args, **kwargs):
-        """log zdo commands for debugging."""
+        """Log zdo commands for debugging."""
         _LOGGER.debug(
             "%s: issued zdo command %s with args: %s", self.event_id,
             args,


### PR DESCRIPTION
The original motivation for this came from comments in #14795.  I then opened PR #14902 which I closed due to it getting stale and hard to rebase easily. There was good feedback in that PR and I believe I managed to address most of the comments. That being said, I have changed direction a bit. This PR adds support for events for remote like devices. It also avoids breaking changes by leaving the original entities intact and functional. 

This is opt in only. There is a new config file `zha-remotes.json` that has this shape: 

```
{
    "Zigbee_home_automation": {
        "CentraLite": [
            "3130"
        ],
        "LUMI": [
            "lumi.sensor_switch.aq2"
        ],
        "OSRAM": [
            "LIGHTIFY Dimming Switch"
        ]
    },
    "Zigbee_light_link": {}
}
```

This allows users to opt into this functionality without needing HA releases to "remap" devices. 