### PR TITLE
Revert changes that broke UI

### DIFF
--- a/homeassistant/components/media_player/samsungtv.py
+++ b/homeassistant/components/media_player/samsungtv.py
@@ -18,7 +18,7 @@ from homeassistant.components.media_player import (
     MediaPlayerDevice)
 from homeassistant.const import (
     CONF_HOST, CONF_MAC, CONF_NAME, CONF_PORT, CONF_TIMEOUT, STATE_OFF,
-    STATE_ON, STATE_UNKNOWN)
+    STATE_ON)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import dt as dt_util
 

--- a/homeassistant/components/media_player/samsungtv.py
+++ b/homeassistant/components/media_player/samsungtv.py
@@ -105,7 +105,7 @@ class SamsungTVDevice(MediaPlayerDevice):
         self._muted = False
         # Assume that the TV is in Play mode
         self._playing = True
-        self._state = STATE_UNKNOWN
+        self._state = None
         self._remote = None
         # Mark the end of a shutdown command (need to wait 15 seconds before
         # sending the next command to avoid turning the TV back ON).

--- a/homeassistant/components/media_player/samsungtv.py
+++ b/homeassistant/components/media_player/samsungtv.py
@@ -17,7 +17,8 @@ from homeassistant.components.media_player import (
     SUPPORT_TURN_ON, SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_STEP,
     MediaPlayerDevice)
 from homeassistant.const import (
-    CONF_HOST, CONF_MAC, CONF_NAME, CONF_PORT, CONF_TIMEOUT, STATE_OFF)
+    CONF_HOST, CONF_MAC, CONF_NAME, CONF_PORT, CONF_TIMEOUT, STATE_OFF,
+    STATE_ON, STATE_UNKNOWN)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import dt as dt_util
 
@@ -104,7 +105,7 @@ class SamsungTVDevice(MediaPlayerDevice):
         self._muted = False
         # Assume that the TV is in Play mode
         self._playing = True
-        self._state = None
+        self._state = STATE_UNKNOWN
         self._remote = None
         # Mark the end of a shutdown command (need to wait 15 seconds before
         # sending the next command to avoid turning the TV back ON).
@@ -153,11 +154,11 @@ class SamsungTVDevice(MediaPlayerDevice):
                         BrokenPipeError):
                     # BrokenPipe can occur when the commands is sent to fast
                     self._remote = None
-            self._state = None
+            self._state = STATE_ON
         except (self._exceptions_class.UnhandledResponse,
                 self._exceptions_class.AccessDenied):
             # We got a response so it's on.
-            self._state = None
+            self._state = STATE_ON
             self._remote = None
             _LOGGER.debug("Failed sending command %s", key, exc_info=True)
             return

--- a/tests/components/media_player/test_samsungtv.py
+++ b/tests/components/media_player/test_samsungtv.py
@@ -12,8 +12,8 @@ from homeassistant.components.media_player import SUPPORT_TURN_ON, \
     MEDIA_TYPE_CHANNEL, MEDIA_TYPE_URL
 from homeassistant.components.media_player.samsungtv import setup_platform, \
     CONF_TIMEOUT, SamsungTVDevice, SUPPORT_SAMSUNGTV
-from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT, CONF_MAC, \
-    STATE_OFF
+from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT, STATE_ON, \
+    CONF_MAC, STATE_OFF
 from tests.common import MockDependency
 from homeassistant.util import dt as dt_util
 from datetime import timedelta
@@ -103,7 +103,7 @@ class TestSamsungTv(unittest.TestCase):
     def test_update_on(self):
         """Testing update tv on."""
         self.device.update()
-        assert self.device._state is None
+        self.assertEqual(STATE_ON, self.device._state)
 
     def test_update_off(self):
         """Testing update tv off."""
@@ -117,7 +117,7 @@ class TestSamsungTv(unittest.TestCase):
     def test_send_key(self):
         """Test for send key."""
         self.device.send_key('KEY_POWER')
-        assert self.device._state is None
+        self.assertEqual(STATE_ON, self.device._state)
 
     def test_send_key_broken_pipe(self):
         """Testing broken pipe Exception."""
@@ -126,8 +126,8 @@ class TestSamsungTv(unittest.TestCase):
             side_effect=BrokenPipeError('Boom'))
         self.device.get_remote = mock.Mock(return_value=_remote)
         self.device.send_key('HELLO')
-        assert self.device._remote is None
-        assert self.device._state is None
+        self.assertIsNone(self.device._remote)
+        self.assertEqual(STATE_ON, self.device._state)
 
     def test_send_key_connection_closed_retry_succeed(self):
         """Test retry on connection closed."""
@@ -138,7 +138,7 @@ class TestSamsungTv(unittest.TestCase):
         self.device.get_remote = mock.Mock(return_value=_remote)
         command = 'HELLO'
         self.device.send_key(command)
-        assert self.device._state is None
+        self.assertEqual(STATE_ON, self.device._state)
         # verify that _remote.control() get called twice because of retry logic
         expected = [mock.call(command),
                     mock.call(command)]
@@ -152,8 +152,8 @@ class TestSamsungTv(unittest.TestCase):
         )
         self.device.get_remote = mock.Mock(return_value=_remote)
         self.device.send_key('HELLO')
-        assert self.device._remote is None
-        assert self.device._state is None
+        self.assertIsNone(self.device._remote)
+        self.assertEqual(STATE_ON, self.device._state)
 
     def test_send_key_os_error(self):
         """Testing broken pipe Exception."""
@@ -178,8 +178,8 @@ class TestSamsungTv(unittest.TestCase):
 
     def test_state(self):
         """Test for state property."""
-        self.device._state = None
-        assert self.device.state is None
+        self.device._state = STATE_ON
+        self.assertEqual(STATE_ON, self.device.state)
         self.device._state = STATE_OFF
         assert STATE_OFF == self.device.state
 


### PR DESCRIPTION
## Description:
Commit 1cbb5b8e51e849dfa37185fc133c599170196ec0, "State is set to UNKNOWN rather than ON in order to make UI have an pl...", made a change that caused the UI to show the device as "Unknown" when it was turned on in order. There was never a scenario where the TV would be in STATE_ON. I reverted the changes made. 

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
