### PR TITLE
Added a default timeout to Tradfri observations

### DIFF
--- a/homeassistant/components/light/tradfri.py
+++ b/homeassistant/components/light/tradfri.py
@@ -14,7 +14,7 @@ from homeassistant.components.light import (
 from homeassistant.components.light import \
     PLATFORM_SCHEMA as LIGHT_PLATFORM_SCHEMA
 from homeassistant.components.tradfri import (
-    KEY_GATEWAY, KEY_API, DOMAIN as TRADFRI_DOMAIN)
+    KEY_GATEWAY, KEY_API, DEFAULT_OBSERVE_TIMEOUT, DOMAIN as TRADFRI_DOMAIN)
 from homeassistant.components.tradfri.const import (
     CONF_IMPORT_GROUPS, CONF_GATEWAY_ID)
 import homeassistant.util.color as color_util
@@ -126,7 +126,7 @@ class TradfriGroup(Light):
         try:
             cmd = self._group.observe(callback=self._observe_update,
                                       err_callback=self._async_start_observe,
-                                      duration=0)
+                                      duration=DEFAULT_OBSERVE_TIMEOUT)
             self.hass.async_create_task(self._api(cmd))
         except PytradfriError as err:
             _LOGGER.warning("Observation failed, trying again", exc_info=err)
@@ -345,7 +345,7 @@ class TradfriLight(Light):
         try:
             cmd = self._light.observe(callback=self._observe_update,
                                       err_callback=self._async_start_observe,
-                                      duration=0)
+                                      duration=DEFAULT_OBSERVE_TIMEOUT)
             self.hass.async_create_task(self._api(cmd))
         except PytradfriError as err:
             _LOGGER.warning("Observation failed, trying again", exc_info=err)

--- a/homeassistant/components/light/tradfri.py
+++ b/homeassistant/components/light/tradfri.py
@@ -128,6 +128,8 @@ class TradfriGroup(Light):
                                       err_callback=self._async_start_observe,
                                       duration=DEFAULT_OBSERVE_TIMEOUT)
             self.hass.async_create_task(self._api(cmd))
+            self.hass.loop.call_later(DEFAULT_OBSERVE_TIMEOUT - 1, 
+                                      self._async_start_observe)
         except PytradfriError as err:
             _LOGGER.warning("Observation failed, trying again", exc_info=err)
             self._async_start_observe()
@@ -347,6 +349,8 @@ class TradfriLight(Light):
                                       err_callback=self._async_start_observe,
                                       duration=DEFAULT_OBSERVE_TIMEOUT)
             self.hass.async_create_task(self._api(cmd))
+            self.hass.loop.call_later(DEFAULT_OBSERVE_TIMEOUT - 1, 
+                                      self._async_start_observe)
         except PytradfriError as err:
             _LOGGER.warning("Observation failed, trying again", exc_info=err)
             self._async_start_observe()

--- a/homeassistant/components/switch/tradfri.py
+++ b/homeassistant/components/switch/tradfri.py
@@ -116,6 +116,8 @@ class TradfriSwitch(SwitchDevice):
                                        err_callback=self._async_start_observe,
                                        duration=DEFAULT_OBSERVE_TIMEOUT)
             self.hass.async_create_task(self._api(cmd))
+            self.hass.loop.call_later(DEFAULT_OBSERVE_TIMEOUT - 1, 
+                                      self._async_start_observe)
         except PytradfriError as err:
             _LOGGER.warning("Observation failed, trying again", exc_info=err)
             self._async_start_observe()

--- a/homeassistant/components/switch/tradfri.py
+++ b/homeassistant/components/switch/tradfri.py
@@ -9,7 +9,7 @@ import logging
 from homeassistant.core import callback
 from homeassistant.components.switch import SwitchDevice
 from homeassistant.components.tradfri import (
-    KEY_GATEWAY, KEY_API, DOMAIN as TRADFRI_DOMAIN)
+    KEY_GATEWAY, KEY_API, DEFAULT_OBSERVE_TIMEOUT, DOMAIN as TRADFRI_DOMAIN)
 from homeassistant.components.tradfri.const import (
     CONF_GATEWAY_ID)
 
@@ -114,7 +114,7 @@ class TradfriSwitch(SwitchDevice):
         try:
             cmd = self._switch.observe(callback=self._observe_update,
                                        err_callback=self._async_start_observe,
-                                       duration=0)
+                                       duration=DEFAULT_OBSERVE_TIMEOUT)
             self.hass.async_create_task(self._api(cmd))
         except PytradfriError as err:
             _LOGGER.warning("Observation failed, trying again", exc_info=err)

--- a/homeassistant/components/tradfri/__init__.py
+++ b/homeassistant/components/tradfri/__init__.py
@@ -26,6 +26,7 @@ KEY_GATEWAY = 'tradfri_gateway'
 KEY_API = 'tradfri_api'
 CONF_ALLOW_TRADFRI_GROUPS = 'allow_tradfri_groups'
 DEFAULT_ALLOW_TRADFRI_GROUPS = False
+DEFAULT_OBSERVE_TIMEOUT = 3600  # Set default timeout to 1 hour in seconds
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({


### PR DESCRIPTION
## Description:

The IKEA Tradfri devices were configured by default that the observation of the
individual devices never timed out. These observations are used to check the
current state of the device.

However, I have experienced that having an infinite observation, there is a
fair possibility that devices aren't responsive any more from the UI. This
seem to be caused by a race condition somewhere in the async code of Home
Assistant or pytradfri. Or possibly even the underlying apicoap library.

Since setting states through automation still seems to work and after
debugging for a couple of hours, I figured a workaround to this issue was the
least I could contribute. As I was unable to find the root cause. This at least
(partially) solves #9822 and #14386 and is almost equal to the proposal of
@max-te, but with a less frequent observation timeout.

**Related issue (if applicable):** partially fixes #9822 and #14386

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

> Other checks were not applicable.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
