### PR TITLE
Update pyhomematic to 0.1.52 and add features for lights

### DIFF
--- a/homeassistant/components/homematic/__init__.py
+++ b/homeassistant/components/homematic/__init__.py
@@ -18,7 +18,7 @@ from homeassistant.helpers import discovery
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['pyhomematic==0.1.51']
+REQUIREMENTS = ['pyhomematic==0.1.52']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -64,8 +64,9 @@ HM_DEVICE_TYPES = {
     DISCOVER_SWITCHES: [
         'Switch', 'SwitchPowermeter', 'IOSwitch', 'IPSwitch', 'RFSiren',
         'IPSwitchPowermeter', 'HMWIOSwitch', 'Rain', 'EcoLogic',
-        'IPKeySwitchPowermeter'],
-    DISCOVER_LIGHTS: ['Dimmer', 'KeyDimmer', 'IPKeyDimmer'],
+        'IPKeySwitchPowermeter', 'IPGarage'],
+    DISCOVER_LIGHTS: ['Dimmer', 'KeyDimmer', 'IPKeyDimmer', 'IPDimmer',
+        'ColorEffectLight'],
     DISCOVER_SENSORS: [
         'SwitchPowermeter', 'Motion', 'MotionV2', 'RemoteMotion', 'MotionIP',
         'ThermostatWall', 'AreaThermostat', 'RotaryHandleSensor',
@@ -76,7 +77,7 @@ HM_DEVICE_TYPES = {
         'IPSmoke', 'RFSiren', 'PresenceIP', 'IPAreaThermostat',
         'IPWeatherSensor', 'RotaryHandleSensorIP', 'IPPassageSensor',
         'IPKeySwitchPowermeter', 'IPThermostatWall230V', 'IPWeatherSensorPlus',
-        'IPWeatherSensorBasic', 'IPBrightnessSensor'],
+        'IPWeatherSensorBasic', 'IPBrightnessSensor', 'IPGarage'],
     DISCOVER_CLIMATE: [
         'Thermostat', 'ThermostatWall', 'MAXThermostat', 'ThermostatWall2',
         'MAXWallThermostat', 'IPThermostat', 'IPThermostatWall',

--- a/homeassistant/components/homematic/__init__.py
+++ b/homeassistant/components/homematic/__init__.py
@@ -66,7 +66,7 @@ HM_DEVICE_TYPES = {
         'IPSwitchPowermeter', 'HMWIOSwitch', 'Rain', 'EcoLogic',
         'IPKeySwitchPowermeter', 'IPGarage'],
     DISCOVER_LIGHTS: ['Dimmer', 'KeyDimmer', 'IPKeyDimmer', 'IPDimmer',
-        'ColorEffectLight'],
+                      'ColorEffectLight'],
     DISCOVER_SENSORS: [
         'SwitchPowermeter', 'Motion', 'MotionV2', 'RemoteMotion', 'MotionIP',
         'ThermostatWall', 'AreaThermostat', 'RotaryHandleSensor',

--- a/homeassistant/components/light/homematic.py
+++ b/homeassistant/components/light/homematic.py
@@ -11,7 +11,6 @@ from homeassistant.components.light import (
     ATTR_BRIGHTNESS, SUPPORT_BRIGHTNESS,
     ATTR_HS_COLOR, SUPPORT_COLOR,
     ATTR_EFFECT, SUPPORT_EFFECT, Light)
-from homeassistant.const import STATE_UNKNOWN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -40,7 +39,7 @@ class HMLight(HMDevice, Light):
     def brightness(self):
         """Return the brightness of this light between 0..255."""
         # Is dimmer?
-        if self._state == "LEVEL":
+        if self._state == 'LEVEL':
             return int(self._hm_get_state() * 255)
         return None
 
@@ -55,7 +54,7 @@ class HMLight(HMDevice, Light):
     @property
     def supported_features(self):
         """Flag supported features."""
-        if hasattr(self._hmdevice, "get_effect"):
+        if 'COLOR' in self._hmdevice.WRITENODE:
             return SUPPORT_BRIGHTNESS | SUPPORT_COLOR | SUPPORT_EFFECT
         return SUPPORT_BRIGHTNESS
 
@@ -86,9 +85,8 @@ class HMLight(HMDevice, Light):
         if ATTR_BRIGHTNESS in kwargs and self._state == "LEVEL":
             percent_bright = float(kwargs[ATTR_BRIGHTNESS]) / 255
             self._hmdevice.set_level(percent_bright, self._channel)
-        else:
-            if ATTR_HS_COLOR not in kwargs and ATTR_EFFECT not in kwargs:
-                self._hmdevice.on(self._channel)
+        elif ATTR_HS_COLOR not in kwargs and ATTR_EFFECT not in kwargs:
+            self._hmdevice.on(self._channel)
 
         if ATTR_HS_COLOR in kwargs:
             self._hmdevice.set_hs_color(
@@ -105,8 +103,7 @@ class HMLight(HMDevice, Light):
         """Generate a data dict (self._data) from the Homematic metadata."""
         # Use LEVEL
         self._state = "LEVEL"
-        self._data.update({self._state: STATE_UNKNOWN})
+        self._data[self._state] = None
 
         if self.supported_features & SUPPORT_COLOR:
-            self._data.update(
-                {"COLOR": STATE_UNKNOWN, "PROGRAM": STATE_UNKNOWN})
+            self._data.update({"COLOR": None, "PROGRAM": None})

--- a/homeassistant/components/light/homematic.py
+++ b/homeassistant/components/light/homematic.py
@@ -8,8 +8,7 @@ import logging
 
 from homeassistant.components.homematic import ATTR_DISCOVER_DEVICES, HMDevice
 from homeassistant.components.light import (
-    ATTR_BRIGHTNESS, SUPPORT_BRIGHTNESS,
-    ATTR_HS_COLOR, SUPPORT_COLOR,
+    ATTR_BRIGHTNESS, SUPPORT_BRIGHTNESS, ATTR_HS_COLOR, SUPPORT_COLOR,
     ATTR_EFFECT, SUPPORT_EFFECT, Light)
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/light/homematic.py
+++ b/homeassistant/components/light/homematic.py
@@ -69,12 +69,14 @@ class HMLight(HMDevice, Light):
 
     @property
     def effect_list(self):
+        """Return the list of supported effects."""
         if not self.supported_features & SUPPORT_EFFECT:
             return None
         return self._hmdevice.get_effect_list()
 
     @property
     def effect(self):
+        """Return the current color change program of the light."""
         if not self.supported_features & SUPPORT_EFFECT:
             return None
         return self._hmdevice.get_effect()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -962,7 +962,7 @@ pyhik==0.1.8
 pyhiveapi==0.2.14
 
 # homeassistant.components.homematic
-pyhomematic==0.1.51
+pyhomematic==0.1.52
 
 # homeassistant.components.sensor.hydroquebec
 pyhydroquebec==2.2.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -162,7 +162,7 @@ pydeconz==47
 pydispatcher==2.0.5
 
 # homeassistant.components.homematic
-pyhomematic==0.1.51
+pyhomematic==0.1.52
 
 # homeassistant.components.litejet
 pylitejet==0.1


### PR DESCRIPTION
## Description:
- Fix for HM-CC-TC
- Adds support for HomeMatic device: HmIP-PCBS, HmIP-MOD-TM, HmIP-PDT, HM-LC-RGBW-WM

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
