### PR TITLE
Add motionEye camera platfrom

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -439,6 +439,7 @@ omit =
     homeassistant/components/camera/ffmpeg.py
     homeassistant/components/camera/foscam.py
     homeassistant/components/camera/mjpeg.py
+    homeassistant/components/camera/motioneye.py
     homeassistant/components/camera/onvif.py
     homeassistant/components/camera/proxy.py
     homeassistant/components/camera/ring.py

--- a/homeassistant/components/camera/motioneye.py
+++ b/homeassistant/components/camera/motioneye.py
@@ -1,0 +1,80 @@
+"""
+Support for motionEye Cameras.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/camera.motioneye/
+"""
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components.camera import (PLATFORM_SCHEMA, Camera)
+from homeassistant.const import (CONF_HOST, CONF_SSL, CONF_USERNAME,
+                                 CONF_PASSWORD, CONF_VERIFY_SSL)
+from homeassistant.exceptions import PlatformNotReady
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+REQUIREMENTS = ['pymotion==0.1.6']
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_API_PORT = 'api_port'
+CONF_WEB_PORT = 'web_port'
+
+DEFAULT_WEB_PORT = 8765
+DEFAULT_API_PORT = 7999
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_HOST): cv.string,
+    vol.Optional(CONF_API_PORT, default=DEFAULT_API_PORT): cv.port,
+    vol.Optional(CONF_WEB_PORT, default=DEFAULT_WEB_PORT): cv.port,
+    vol.Optional(CONF_USERNAME): cv.string,
+    vol.Optional(CONF_PASSWORD): cv.string,
+    vol.Optional(CONF_SSL, default=False): cv.boolean,
+    vol.Optional(CONF_VERIFY_SSL, default=True): cv.boolean,
+})
+
+
+async def async_setup_platform(hass, config, async_add_entities,
+                               discovery_info=None):
+    """Set up a generic IP Camera."""
+    from pymotion.api import API
+    session = async_get_clientsession(hass, config[CONF_VERIFY_SSL])
+    motion = API(session, hass.loop, config.get(CONF_USERNAME),
+                 config.get(CONF_PASSWORD), config[CONF_HOST],
+                 config[CONF_API_PORT], config[CONF_WEB_PORT],
+                 config[CONF_SSL])
+    all_cameraes = await motion.list_cameraes()
+    if all_cameraes is None:
+        raise PlatformNotReady
+    cameraes = []
+    for camera_id in all_cameraes:
+        name = all_cameraes[camera_id]['name']
+        cameraes.append(MotionEyeCamera(name, motion, camera_id))
+
+    async_add_entities(cameraes)
+
+
+class MotionEyeCamera(Camera):
+    """A generic implementation of an IP camera."""
+
+    def __init__(self, name, motion, camera_id):
+        """Initialize a generic camera."""
+        super().__init__()
+        self.motion = motion
+        self._name = name
+        self._camera_id = camera_id
+        self._last_image = None
+
+    async def async_camera_image(self):
+        """Return image response."""
+        image = await self.motion.camera_image(self._camera_id)
+        if image is not None:
+            self._last_image = image
+        return self._last_image
+
+    @property
+    def name(self):
+        """Return the name of this device."""
+        return self._name

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1040,6 +1040,9 @@ pymodbus==1.3.1
 # homeassistant.components.media_player.monoprice
 pymonoprice==0.3
 
+# homeassistant.components.camera.motioneye
+pymotion==0.1.6
+
 # homeassistant.components.media_player.yamaha_musiccast
 pymusiccast==0.1.6
 


### PR DESCRIPTION
## Description:

This will add the motionEye camera platform.

<!-- **Related issue (if applicable):** fixes #<home-assistant issue number goes here> -->

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#7522
## Example entry for `configuration.yaml` (if applicable):
```yaml
camera:
  platform: motioneye
  host: 192.168.1.55
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.
<!--
If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
-->
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
