### PR TITLE
Act as a toggle with same payload

### DIFF
--- a/homeassistant/components/binary_sensor/mqtt.py
+++ b/homeassistant/components/binary_sensor/mqtt.py
@@ -143,9 +143,11 @@ class MqttBinarySensor(MqttAvailability, MqttDiscoveryUpdate,
             if self._template is not None:
                 payload = self._template.async_render_with_possible_json_value(
                     payload)
-            if payload == self._payload_on and (self._state == False or self._state == None):
+            if (payload == self._payload_on and 
+                    (self._state is False or self._state == None)):
                 self._state = True
-            elif payload == self._payload_off and (self._state == True or self._state == None):
+            elif (payload == self._payload_off and 
+                    (self._state is True or self._state == None)):
                 self._state = False
             else:  # Payload is not for this entity
                 _LOGGER.warning('No matching payload found'

--- a/homeassistant/components/binary_sensor/mqtt.py
+++ b/homeassistant/components/binary_sensor/mqtt.py
@@ -144,10 +144,10 @@ class MqttBinarySensor(MqttAvailability, MqttDiscoveryUpdate,
                 payload = self._template.async_render_with_possible_json_value(
                     payload)
             if (payload == self._payload_on and
-                    (self._state is False or self._state is None)):
+                  (self._state is False or self._state is None)):
                 self._state = True
             elif (payload == self._payload_off and
-                    (self._state is True or self._state is None)):
+                  (self._state is True or self._state is None)):
                 self._state = False
             else:  # Payload is not for this entity
                 _LOGGER.warning('No matching payload found'

--- a/homeassistant/components/binary_sensor/mqtt.py
+++ b/homeassistant/components/binary_sensor/mqtt.py
@@ -143,9 +143,9 @@ class MqttBinarySensor(MqttAvailability, MqttDiscoveryUpdate,
             if self._template is not None:
                 payload = self._template.async_render_with_possible_json_value(
                     payload)
-            if payload == self._payload_on:
+            if payload == self._payload_on and (self._state == False or self._state == None):
                 self._state = True
-            elif payload == self._payload_off:
+            elif payload == self._payload_off and (self._state == True or self._state == None):
                 self._state = False
             else:  # Payload is not for this entity
                 _LOGGER.warning('No matching payload found'

--- a/homeassistant/components/binary_sensor/mqtt.py
+++ b/homeassistant/components/binary_sensor/mqtt.py
@@ -143,11 +143,11 @@ class MqttBinarySensor(MqttAvailability, MqttDiscoveryUpdate,
             if self._template is not None:
                 payload = self._template.async_render_with_possible_json_value(
                     payload)
-            if (payload == self._payload_on and 
-                    (self._state is False or self._state == None)):
+            if (payload == self._payload_on and
+                    (self._state is False or self._state is None)):
                 self._state = True
-            elif (payload == self._payload_off and 
-                    (self._state is True or self._state == None)):
+            elif (payload == self._payload_off and
+                    (self._state is True or self._state is None)):
                 self._state = False
             else:  # Payload is not for this entity
                 _LOGGER.warning('No matching payload found'

--- a/homeassistant/components/binary_sensor/mqtt.py
+++ b/homeassistant/components/binary_sensor/mqtt.py
@@ -149,7 +149,7 @@ class MqttBinarySensor(MqttAvailability, MqttDiscoveryUpdate,
             elif (payload == self._payload_off and
                   (self._state is True or self._state is None)):
                 self._state = False
-            else:  # Payload is not for this entity
+            elif (payload != self._payload_on and payload != self._payload_off):  # Payload is not for this entity
                 _LOGGER.warning('No matching payload found'
                                 ' for entity: %s with state_topic: %s',
                                 self._name, self._state_topic)

--- a/homeassistant/components/binary_sensor/mqtt.py
+++ b/homeassistant/components/binary_sensor/mqtt.py
@@ -144,12 +144,12 @@ class MqttBinarySensor(MqttAvailability, MqttDiscoveryUpdate,
                 payload = self._template.async_render_with_possible_json_value(
                     payload)
             if (payload == self._payload_on and
-                  (self._state is False or self._state is None)):
+                (self._state is False or self._state is None)):
                 self._state = True
             elif (payload == self._payload_off and
                   (self._state is True or self._state is None)):
                 self._state = False
-            elif (payload != self._payload_on and payload != self._payload_off):  # Payload is not for this entity
+            elif (payload != self._payload_on and payload != self._payload_off):
                 _LOGGER.warning('No matching payload found'
                                 ' for entity: %s with state_topic: %s',
                                 self._name, self._state_topic)


### PR DESCRIPTION
## Description:
If payload_on and payload_off are the same value, then it will act as a toggle.  This comes in handy when using a remote control/fob.  Otherwise, it doesn't change functionality.

Pull request in home-assistant.io with documentation (if applicable): home-assistant/home-assistant.io#7532

## Example entry for `configuration.yaml`:
```yaml
binary_sensor:
  -platform: mqtt
  state_topic: [topic]
  name: [name]
  payload_on: [value]
  payload_off: [value same as on]
```