### PR TITLE
Upgrade sphinx-autodoc-typehints to 1.5.0

### DIFF
--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,3 +1,3 @@
 Sphinx==1.8.1
-sphinx-autodoc-typehints==1.3.0
+sphinx-autodoc-typehints==1.5.0
 sphinx-autodoc-annotation==1.0.post1


### PR DESCRIPTION
## Description:
Upgrade sphinx-autodoc-typehints to 1.5.0

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

