### PR TITLE
Fixed sky_hub device tracker schema to reflect documentation

### DIFF
--- a/homeassistant/components/device_tracker/sky_hub.py
+++ b/homeassistant/components/device_tracker/sky_hub.py
@@ -19,7 +19,7 @@ _LOGGER = logging.getLogger(__name__)
 _MAC_REGEX = re.compile(r'(([0-9A-Fa-f]{1,2}\:){5}[0-9A-Fa-f]{1,2})')
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_HOST): cv.string
+    vol.Optional(CONF_HOST): cv.string
 })
 
 


### PR DESCRIPTION
## Description:

Fixed the schema of device_tracker.sky_hub to reflect the documentation: https://www.home-assistant.io/components/device_tracker.sky_hub/

The documentation says that 'host' is optional but it was required.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.