### PR TITLE
Fix small issue related to topic prefix

### DIFF
--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -202,10 +202,11 @@ async def async_start(hass: HomeAssistantType, discovery_topic, hass_config,
         if TOPIC_BASE in payload:
             base = payload[TOPIC_BASE]
             for key, value in payload.items():
-                if value[0] == TOPIC_BASE and key.endswith('_topic'):
-                    payload[key] = "{}{}".format(base, value[1:])
-                if value[-1] == TOPIC_BASE and key.endswith('_topic'):
-                    payload[key] = "{}{}".format(value[:-1], base)
+                if isinstance(value, str):
+                    if value[0] == TOPIC_BASE and key.endswith('_topic'):
+                        payload[key] = "{}{}".format(base, value[1:])
+                    if value[-1] == TOPIC_BASE and key.endswith('_topic'):
+                        payload[key] = "{}{}".format(value[:-1], base)
 
         # If present, the node_id will be included in the discovered object id
         discovery_id = '_'.join((node_id, object_id)) if node_id else object_id


### PR DESCRIPTION
## Description:
Fix expansion of topic prefix when discovery message contains non string-type items.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.