### PR TITLE
Re-adding the season attribute

### DIFF
--- a/homeassistant/components/sensor/pollen.py
+++ b/homeassistant/components/sensor/pollen.py
@@ -244,6 +244,7 @@ class ForecastSensor(BaseSensor):
         if self._kind == TYPE_ALLERGY_FORECAST:
             outlook = self.pollen.data[TYPE_ALLERGY_OUTLOOK]
             self._attrs[ATTR_OUTLOOK] = outlook['Outlook']
+            self._attrs[ATTR_SEASON] = outlook['Season']
 
         self._state = average
 


### PR DESCRIPTION
## Description:

This PR re-adds the season attribute for Pollen.com that was accidentally removed in a previous PR.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable): N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
