### PR TITLE
Adds clarifai

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -527,7 +527,6 @@ omit =
     homeassistant/components/foursquare.py
     homeassistant/components/goalfeed.py
     homeassistant/components/ifttt.py
-    homeassistant/components/image_processing/clarifai_general.py
     homeassistant/components/image_processing/dlib_face_detect.py
     homeassistant/components/image_processing/dlib_face_identify.py
     homeassistant/components/image_processing/seven_segments.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -527,6 +527,7 @@ omit =
     homeassistant/components/foursquare.py
     homeassistant/components/goalfeed.py
     homeassistant/components/ifttt.py
+    homeassistant/components/image_processing/clarifai_general.py
     homeassistant/components/image_processing/dlib_face_detect.py
     homeassistant/components/image_processing/dlib_face_identify.py
     homeassistant/components/image_processing/seven_segments.py

--- a/homeassistant/components/image_processing/clarifai_general.py
+++ b/homeassistant/components/image_processing/clarifai_general.py
@@ -1,0 +1,141 @@
+"""
+Component that will perform image classification via Clarifai general model.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/image_processing/clarifai_general
+"""
+import base64
+import json
+import logging
+
+import voluptuous as vol
+
+from homeassistant.core import split_entity_id
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.image_processing import (
+    PLATFORM_SCHEMA, ImageProcessingEntity, CONF_SOURCE, CONF_ENTITY_ID,
+    CONF_NAME)
+from homeassistant.const import STATE_UNKNOWN
+
+
+_LOGGER = logging.getLogger(__name__)
+
+CLASSIFIER = 'Clarifai'
+CONF_API_KEY = 'api_key'
+
+REQUIREMENTS = ['clarifai==2.4.1']
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_API_KEY): cv.string,
+})
+
+
+def encode_image(image):
+    """base64 encode an image stream."""
+    base64_img = base64.b64encode(image)
+    return base64_img
+
+
+def parse_concepts(api_concepts):
+    """Parse the API concepts data."""
+    return {concept['name']: round(100.0*concept['value'], 2)
+            for concept in api_concepts}
+
+
+def validate_api_key(api_key):
+    """Check that an API key is valid, if yes return the app."""
+    try:
+        from clarifai.rest import ClarifaiApp, ApiError
+        app = ClarifaiApp(api_key=api_key)
+        return app
+    except ApiError as exc:
+        error = json.loads(exc.response.content)
+        _LOGGER.error(
+            "%s error: %s", CLASSIFIER, error['status']['description'])
+        return None
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the Clarifai classifier."""
+    api_key = config[CONF_API_KEY]
+    app = validate_api_key(api_key)
+    if app is None:
+        return
+
+    entities = []
+    for camera in config[CONF_SOURCE]:
+        entities.append(ClarifaiClassifier(
+            app,
+            camera[CONF_ENTITY_ID],
+            camera.get(CONF_NAME),
+        ))
+    add_devices(entities)
+
+
+class ClarifaiClassifier(ImageProcessingEntity):
+    """Perform a classification via Clarifai."""
+
+    def __init__(self, app, camera_entity, name=None):
+        """Init with the API key."""
+        model = 'general-v1.3'
+        self.model = app.models.get(model)
+        if name:  # Since name is optional.
+            self._name = name
+        else:
+            entity_name = split_entity_id(camera_entity)[1]
+            self._name = "{} {}".format(CLASSIFIER, entity_name)
+        self._camera_entity = camera_entity
+        self._classifications = {}  # The dict of classifications.
+        self._state = STATE_UNKNOWN  # The most likely classification.
+
+    def model_prediction(self, image):
+        """Make a prediction based on an image."""
+        try:
+            from clarifai.rest import ApiError
+            response = self.model.predict_by_base64(encode_image(image))
+            if response['status']['description'] == 'Ok':
+                return response
+        except ApiError:
+            _LOGGER.error("%s error: check your internet connection",
+                          CLASSIFIER)
+            return None
+
+    def process_image(self, image):
+        """Process an image."""
+        prediction = self.model_prediction(image)
+
+        if prediction:
+            api_concepts = prediction['outputs'][0]['data']['concepts']
+            self._classifications = parse_concepts(api_concepts)
+            self._state = max(self._classifications,
+                              key=self._classifications.get)
+
+        else:
+            self._classifications = {}
+            self._state = STATE_UNKNOWN
+
+    @property
+    def device_class(self):
+        """Return the class of this device, from component DEVICE_CLASSES."""
+        return 'class'
+
+    @property
+    def camera_entity(self):
+        """Return camera entity id from process pictures."""
+        return self._camera_entity
+
+    @property
+    def state(self):
+        """Return the state of the entity."""
+        return self._state
+
+    @property
+    def state_attributes(self):
+        """Return device specific state attributes."""
+        attr = self._classifications
+        return attr
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name

--- a/homeassistant/components/image_processing/clarifai_general.py
+++ b/homeassistant/components/image_processing/clarifai_general.py
@@ -49,8 +49,9 @@ def validate_api_key(api_key):
         return app
     except ApiError as exc:
         if exc.response is None:
-            _LOGGER.error("%s error: setup requires an internet connection",
-                CLASSIFIER)
+            _LOGGER.error(
+                "%s error: setup requires an internet connection", CLASSIFIER
+                )
             return None
         else:
             error = json.loads(exc.response.content)
@@ -100,8 +101,9 @@ class ClarifaiClassifier(ImageProcessingEntity):
                 return response
         except ApiError as exc:
             if exc.response is None:
-                _LOGGER.error("%s error: check your internet connection",
-                    CLASSIFIER)
+                _LOGGER.error(
+                    "%s error: check your internet connection", CLASSIFIER
+                    )
                 return None
             else:
                 error = json.loads(exc.response.content)

--- a/homeassistant/components/image_processing/clarifai_general.py
+++ b/homeassistant/components/image_processing/clarifai_general.py
@@ -49,13 +49,13 @@ def validate_api_key(api_key):
         return app
     except ApiError as exc:
         if exc.response is None:
-            _LOGGER.error("%s error: setup requires an internet connection", 
-            CLASSIFIER)
+            _LOGGER.error("%s error: setup requires an internet connection",
+                CLASSIFIER)
             return None
         else:
             error = json.loads(exc.response.content)
             _LOGGER.error(
-            "%s error: %s", CLASSIFIER, error['status']['description'])
+                "%s error: %s", CLASSIFIER, error['status']['description'])
             return None
 
 
@@ -101,7 +101,7 @@ class ClarifaiClassifier(ImageProcessingEntity):
         except ApiError as exc:
             if exc.response is None:
                 _LOGGER.error("%s error: check your internet connection",
-                CLASSIFIER)
+                    CLASSIFIER)
                 return None
             else:
                 error = json.loads(exc.response.content)

--- a/homeassistant/components/image_processing/clarifai_general.py
+++ b/homeassistant/components/image_processing/clarifai_general.py
@@ -53,11 +53,10 @@ def validate_api_key(api_key):
                 "%s error: setup requires an internet connection", CLASSIFIER
                 )
             return None
-        else:
-            error = json.loads(exc.response.content)
-            _LOGGER.error(
-                "%s error: %s", CLASSIFIER, error['status']['description'])
-            return None
+        error = json.loads(exc.response.content)
+        _LOGGER.error(
+            "%s error: %s", CLASSIFIER, error['status']['description'])
+        return None
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
@@ -105,11 +104,10 @@ class ClarifaiClassifier(ImageProcessingEntity):
                     "%s error: check your internet connection", CLASSIFIER
                     )
                 return None
-            else:
-                error = json.loads(exc.response.content)
-                _LOGGER.error(
-                    "%s error: %s", CLASSIFIER, error['status']['description'])
-                return None
+            error = json.loads(exc.response.content)
+            _LOGGER.error(
+                "%s error: %s", CLASSIFIER, error['status']['description'])
+            return None
 
     def process_image(self, image):
         """Process an image."""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -242,6 +242,9 @@ caldav==0.5.0
 # homeassistant.components.notify.ciscospark
 ciscosparkapi==0.4.2
 
+# homeassistant.components.image_processing.clarifai_general
+clarifai==2.4.1
+
 # homeassistant.components.coinbase
 coinbase==2.1.0
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -49,6 +49,9 @@ apns2==0.3.0
 # homeassistant.components.calendar.caldav
 caldav==0.5.0
 
+# homeassistant.components.image_processing.clarifai_general
+clarifai==2.4.1
+
 # homeassistant.components.sensor.coinmarketcap
 coinmarketcap==5.0.3
 

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -43,6 +43,7 @@ TEST_REQUIREMENTS = (
     'aiounifi',
     'apns2',
     'caldav',
+    'clarifai',
     'coinmarketcap',
     'defusedxml',
     'dsmr_parser',

--- a/tests/components/image_processing/test_clarifai_general.py
+++ b/tests/components/image_processing/test_clarifai_general.py
@@ -1,0 +1,156 @@
+"""The tests for the clarifai_general component."""
+import json
+from unittest.mock import patch
+
+from clarifai.rest import ApiError
+from clarifai.rest.client import Model
+import pytest
+
+from homeassistant.const import (ATTR_ENTITY_ID, CONF_FRIENDLY_NAME,
+                                 STATE_UNKNOWN)
+from homeassistant.setup import async_setup_component
+import homeassistant.components.image_processing as ip
+import homeassistant.components.image_processing.clarifai_general as cg
+
+
+MOCK_NAME = 'mock_name'
+MOCK_API_KEY = '12345'
+MOCK_RESPONSE = {'status': {'description': 'Ok'},
+                 'outputs': [{'data': {'concepts': [{'name': 'dog',
+                                                     'value': 0.85432},
+                                                    {'name': 'cat',
+                                                     'value': 0.14568}]}}]}
+
+PARSED_CONCEPTS = {'cat': 14.57, 'dog': 85.43}
+
+VALID_ENTITY_ID = 'image_processing.clarifai_demo_camera'
+VALID_CONFIG = {
+    ip.DOMAIN: {
+        'platform': 'clarifai_general',
+        cg.CONF_API_KEY: MOCK_API_KEY,
+        ip.CONF_SOURCE: {
+            ip.CONF_ENTITY_ID: 'camera.demo_camera'},
+    },
+    'camera': {
+        'platform': 'demo'
+        }
+    }
+
+
+class MockErrorResponse:
+    """Mock Clarifai response to bad API key."""
+
+    status_code = 404
+    reason = 'Failure'
+    content = json.dumps({'status': {'description': 'API key not found'}})
+
+    @staticmethod
+    def json():
+        """Handle json."""
+        return {}
+
+
+resource = 'https://www.mock.com/url'
+params = {}
+method = 'GET'
+response = MockErrorResponse()
+error = ApiError(resource, params, method, response)
+
+
+@pytest.fixture
+def mock_app():
+    """Return a mock ClarifaiApp object."""
+    with patch('clarifai.rest.ClarifaiApp') as _mock_app:
+        yield _mock_app
+
+
+@pytest.fixture
+def mock_app_with_error():
+    """Throw an ApiError."""
+    with patch('clarifai.rest.ClarifaiApp',
+               side_effect=error) as _mock_mock_app_with_error:
+        yield _mock_mock_app_with_error
+
+
+@pytest.fixture
+def mock_image():
+    """Return a mock camera image."""
+    with patch('homeassistant.components.camera.demo.DemoCamera.camera_image',
+               return_value=b'Test') as image:
+        yield image
+
+
+def test_encode_image():
+    """Test that binary data is encoded correctly."""
+    assert cg.encode_image(b'test') == b'dGVzdA=='
+
+
+def test_parse_data():
+    """Test parsing of raw face data, and generation of matched_faces."""
+    raw_concepts = MOCK_RESPONSE['outputs'][0]['data']['concepts']
+    assert cg.parse_concepts(raw_concepts) == PARSED_CONCEPTS
+
+
+def test_valid_api_key(mock_app):
+    """Test that the api key is validated."""
+    cg.validate_api_key(MOCK_API_KEY)
+    mock_app.assert_called_with(api_key=MOCK_API_KEY)
+
+
+def test_invalid_api_key(mock_app_with_error, caplog):
+    """Test that an invalid api key is caught."""
+    assert cg.validate_api_key(MOCK_API_KEY) is None
+    assert "Clarifai error: API key not found" in caplog.text
+
+
+async def test_setup_platform(hass, mock_app, mock_image):
+    """Set up platform with one entity."""
+    await async_setup_component(hass, ip.DOMAIN, VALID_CONFIG)
+    assert hass.states.get(VALID_ENTITY_ID)
+
+
+@patch.object(Model, 'predict_by_base64', return_value=MOCK_RESPONSE)
+async def test_process_image(hass, mock_app, mock_image):
+    """Test successful processing of an image."""
+    await async_setup_component(hass, ip.DOMAIN, VALID_CONFIG)
+    assert hass.states.get(VALID_ENTITY_ID)
+
+    data = {ATTR_ENTITY_ID: VALID_ENTITY_ID}
+    await hass.services.async_call(ip.DOMAIN,
+                                   ip.SERVICE_SCAN,
+                                   service_data=data)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(VALID_ENTITY_ID)
+    assert state.state == 'dog'
+    assert state.attributes.get('dog') == PARSED_CONCEPTS['dog']
+
+
+@patch.object(Model, 'predict_by_base64', side_effect=error)
+async def test_process_with_error(hass, mock_app, mock_image,
+                                  caplog):
+    """Test processing with error from predict_by_base64."""
+    await async_setup_component(hass, ip.DOMAIN, VALID_CONFIG)
+    assert hass.states.get(VALID_ENTITY_ID)
+    data = {ATTR_ENTITY_ID: VALID_ENTITY_ID}
+    await hass.services.async_call(ip.DOMAIN,
+                                   ip.SERVICE_SCAN,
+                                   service_data=data)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(VALID_ENTITY_ID)
+    assert state.state == STATE_UNKNOWN
+    assert "Clarifai error: check your internet connection" in caplog.text
+
+
+async def test_setup_platform_with_name(hass, mock_app):
+    """Set up platform with one entity and a name."""
+    named_entity_id = 'image_processing.{}'.format(MOCK_NAME)
+
+    valid_config_named = VALID_CONFIG.copy()
+    valid_config_named[ip.DOMAIN][ip.CONF_SOURCE][ip.CONF_NAME] = MOCK_NAME
+
+    await async_setup_component(hass, ip.DOMAIN, valid_config_named)
+    assert hass.states.get(named_entity_id)
+    state = hass.states.get(named_entity_id)
+    assert state.attributes.get(CONF_FRIENDLY_NAME) == MOCK_NAME

--- a/tests/components/image_processing/test_clarifai_general.py
+++ b/tests/components/image_processing/test_clarifai_general.py
@@ -117,7 +117,9 @@ async def test_process_image(hass, mock_app, mock_image):
 
     data = {ATTR_ENTITY_ID: VALID_ENTITY_ID}
 
-    with patch.object(Model, 'predict_by_base64', return_value=MOCK_RESPONSE):
+    with patch.object(
+        'clarifai.rest.client.Model', 'predict_by_base64', 
+        return_value=MOCK_RESPONSE):
         await hass.services.async_call(ip.DOMAIN,
                                        ip.SERVICE_SCAN,
                                        service_data=data)
@@ -134,7 +136,8 @@ async def test_process_with_error(hass, mock_app, mock_image,
     await async_setup_component(hass, ip.DOMAIN, VALID_CONFIG)
     assert hass.states.get(VALID_ENTITY_ID)
     data = {ATTR_ENTITY_ID: VALID_ENTITY_ID}
-    with patch.object(Model, 'predict_by_base64', side_effect=ERROR):
+    with patch.object(
+        'clarifai.rest.client.Model', 'predict_by_base64', side_effect=ERROR):
         await hass.services.async_call(ip.DOMAIN,
                                        ip.SERVICE_SCAN,
                                        service_data=data)


### PR DESCRIPTION
## Description:
Replaces https://github.com/home-assistant/home-assistant/pull/16814

Adds [Clarifai](https://www.clarifai.com/) image processing using the [general model](https://www.clarifai.com/models/general-image-recognition-model-aaa03c23b3724a16a56b629203edc62c). The component creates an entity with a state that is the most likely concept (objects or ideas) within a camera image. The entities attributes contains a dictionary of all identified concepts and their probability (in %). To setup authentication with Clarifai, first generate an API key (YOUR_KEY) as per the [Clarifai docs](https://www.clarifai.com/developer/docs/). The [free plan](https://www.clarifai.com/pricing) allows 5000 requests per month.

Clarifai dev @rok-povsic has kindly offered to help out with this PR

## To do
Update docs as not firing events now

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.io/pull/6284) with documentation (if applicable):** home-assistant/home-assistant.github.io#6284

## Example entry for `configuration.yaml` (if applicable):
```yaml
image_processing:
  - platform: clarifai_general
    api_key: abcd
    source:
      - entity_id: camera.local_file
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.
