### PR TITLE
Improve handling of unavailable Sonos speakers

### DIFF
--- a/homeassistant/components/sonos/__init__.py
+++ b/homeassistant/components/sonos/__init__.py
@@ -4,7 +4,7 @@ from homeassistant.helpers import config_entry_flow
 
 
 DOMAIN = 'sonos'
-REQUIREMENTS = ['pysonos==0.0.3']
+REQUIREMENTS = ['pysonos==0.0.5']
 
 
 async def async_setup(hass, config):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1128,7 +1128,7 @@ pysma==0.2.2
 pysnmp==4.4.5
 
 # homeassistant.components.sonos
-pysonos==0.0.3
+pysonos==0.0.5
 
 # homeassistant.components.spc
 pyspcwebgw==0.4.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -186,7 +186,7 @@ pyotp==2.2.6
 pyqwikswitch==0.8
 
 # homeassistant.components.sonos
-pysonos==0.0.3
+pysonos==0.0.5
 
 # homeassistant.components.spc
 pyspcwebgw==0.4.0


### PR DESCRIPTION
## Description:

This PR improves the handling of unavailable Sonos speakers:

* Set `PARALLEL_UPDATES = 0` so a single missing speaker will not hang the entire platform update.
* Remember subscriptions and remove them when a speaker goes unavailable.
* Catch an exception that could happen with `self.soco.group` for unavailable speakers.
* Guard for `self.soco.group.coordinator` that can be `None` in situations that I have not fully identified.
* Update to pysonos 0.0.5 that has some fixes for event unsubscription of unavailable speakers.

That should help with cases like [this report in the forum](https://community.home-assistant.io/t/strange-behaviour-with-sonos-speakers/68633).

The updated pysonos also introduces ifaddr enumeration of local network addresses so discovery should work in more situations with multiple network interfaces.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.
  - [X] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
