### PR TITLE
Allow unloading of LIFX config entry

### DIFF
--- a/homeassistant/components/lifx/__init__.py
+++ b/homeassistant/components/lifx/__init__.py
@@ -8,7 +8,7 @@ from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
 
 
 DOMAIN = 'lifx'
-REQUIREMENTS = ['aiolifx==0.6.5']
+REQUIREMENTS = ['aiolifx==0.6.6']
 
 CONF_SERVER = 'server'
 CONF_BROADCAST = 'broadcast'
@@ -24,6 +24,8 @@ CONFIG_SCHEMA = vol.Schema({
             vol.Schema(vol.All(cv.ensure_list, [INTERFACE_SCHEMA])),
     }
 }, extra=vol.ALLOW_EXTRA)
+
+DATA_LIFX_MANAGER = 'lifx_manager'
 
 
 async def async_setup(hass, config):
@@ -43,6 +45,16 @@ async def async_setup_entry(hass, entry):
     """Set up LIFX from a config entry."""
     hass.async_create_task(hass.config_entries.async_forward_entry_setup(
         entry, LIGHT_DOMAIN))
+
+    return True
+
+
+async def async_unload_entry(hass, entry):
+    """Unload a config entry."""
+    hass.data.pop(DATA_LIFX_MANAGER).cleanup()
+
+    await hass.config_entries.async_forward_entry_unload(entry, LIGHT_DOMAIN)
+
     return True
 
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -111,7 +111,7 @@ aiohue==1.5.0
 aioimaplib==0.7.13
 
 # homeassistant.components.lifx
-aiolifx==0.6.5
+aiolifx==0.6.6
 
 # homeassistant.components.light.lifx
 aiolifx_effects==0.2.1


### PR DESCRIPTION
## Description:

Allow unloading of LIFX by stopping the aiolifx `LifxDiscovery` and removing our service calls.

We used to set and forget the discovery. This is moved to our `LIFXManager` so we are able to locate the discovery object when we want to clean it up.

This also fixes a bug with multiple network interfaces where only a single discovery object was cleaned up on `EVENT_HOMEASSISTANT_STOP`.

The aiolifx 0.6.6 release fixes a race during `cleanup()`.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
