### PR TITLE
Add device_id configuration option to Bluetooth tracker

### DIFF
--- a/homeassistant/components/device_tracker/bluetooth_tracker.py
+++ b/homeassistant/components/device_tracker/bluetooth_tracker.py
@@ -24,9 +24,15 @@ BT_PREFIX = 'BT_'
 
 CONF_REQUEST_RSSI = 'request_rssi'
 
+CONF_DEVICE_ID = "device_id"
+
+DEFAULT_DEVICE_ID = -1
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_TRACK_NEW): cv.boolean,
-    vol.Optional(CONF_REQUEST_RSSI): cv.boolean
+    vol.Optional(CONF_REQUEST_RSSI): cv.boolean,
+    vol.Optional(CONF_DEVICE_ID, default=DEFAULT_DEVICE_ID):
+        vol.All(vol.Coerce(int), vol.Range(min=-1))
 })
 
 
@@ -44,11 +50,13 @@ def setup_scanner(hass, config, see, discovery_info=None):
         see(mac="{}{}".format(BT_PREFIX, mac), host_name=name,
             attributes=attributes, source_type=SOURCE_TYPE_BLUETOOTH)
 
+    device_id = config.get(CONF_DEVICE_ID, DEFAULT_DEVICE_ID)
+
     def discover_devices():
         """Discover Bluetooth devices."""
         result = bluetooth.discover_devices(
             duration=8, lookup_names=True, flush_cache=True,
-            lookup_class=False)
+            lookup_class=False, device_id=device_id)
         _LOGGER.debug("Bluetooth devices discovered = %d", len(result))
         return result
 

--- a/homeassistant/components/device_tracker/bluetooth_tracker.py
+++ b/homeassistant/components/device_tracker/bluetooth_tracker.py
@@ -50,7 +50,7 @@ def setup_scanner(hass, config, see, discovery_info=None):
         see(mac="{}{}".format(BT_PREFIX, mac), host_name=name,
             attributes=attributes, source_type=SOURCE_TYPE_BLUETOOTH)
 
-    device_id = config.get(CONF_DEVICE_ID, DEFAULT_DEVICE_ID)
+    device_id = config.get(CONF_DEVICE_ID)
 
     def discover_devices():
         """Discover Bluetooth devices."""


### PR DESCRIPTION
## Description:

Makes the device id that bluetooth tracker is using configurable instead 
of using the first available device.

**Related issue (if applicable):** feature request https://community.home-assistant.io/t/allow-bluetooth-usb-device-to-be-specified-for-use-with-device-tracking/15696

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#7560 

## Example entry for `configuration.yaml` (if applicable):
```yaml
device_tracker:
  - platform: bluetooth_tracker
    device_id: 1
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass** (_in `tox` tests pass but I am getting `ERROR:   typing: commands failed` error for the same two unrelated files as I get in the dev branch_)
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
