### PR TITLE
Enable Google Assistant OnOffTrait for climate devices that support them

### DIFF
--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -199,16 +199,15 @@ class OnOffTrait(_Trait):
         """Test if state is supported."""
         if domain == climate.DOMAIN:
             return features & climate.SUPPORT_ON_OFF != 0
-        else:
-            return domain in (
-                group.DOMAIN,
-                input_boolean.DOMAIN,
-                switch.DOMAIN,
-                fan.DOMAIN,
-                light.DOMAIN,
-                cover.DOMAIN,
-                media_player.DOMAIN,
-            )
+        return domain in (
+            group.DOMAIN,
+            input_boolean.DOMAIN,
+            switch.DOMAIN,
+            fan.DOMAIN,
+            light.DOMAIN,
+            cover.DOMAIN,
+            media_player.DOMAIN,
+        )
 
     def sync_attributes(self):
         """Return OnOff attributes for a sync request."""

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -197,15 +197,18 @@ class OnOffTrait(_Trait):
     @staticmethod
     def supported(domain, features):
         """Test if state is supported."""
-        return domain in (
-            group.DOMAIN,
-            input_boolean.DOMAIN,
-            switch.DOMAIN,
-            fan.DOMAIN,
-            light.DOMAIN,
-            cover.DOMAIN,
-            media_player.DOMAIN,
-        )
+        if domain == climate.DOMAIN:
+            return features & climate.SUPPORT_ON_OFF != 0
+        else:
+            return domain in (
+                group.DOMAIN,
+                input_boolean.DOMAIN,
+                switch.DOMAIN,
+                fan.DOMAIN,
+                light.DOMAIN,
+                cover.DOMAIN,
+                media_player.DOMAIN,
+            )
 
     def sync_attributes(self):
         """Return OnOff attributes for a sync request."""

--- a/tests/components/google_assistant/__init__.py
+++ b/tests/components/google_assistant/__init__.py
@@ -225,7 +225,10 @@ DEMO_DEVICES = [{
     'name': {
         'name': 'HeatPump'
     },
-    'traits': ['action.devices.traits.TemperatureSetting'],
+    'traits': [
+        'action.devices.traits.OnOff',
+        'action.devices.traits.TemperatureSetting'
+    ],
     'type': 'action.devices.types.THERMOSTAT',
     'willReportState': False
 }, {

--- a/tests/components/google_assistant/test_google_assistant.py
+++ b/tests/components/google_assistant/test_google_assistant.py
@@ -204,6 +204,7 @@ def test_query_climate_request(hass_fixture, assistant_client, auth_header):
     devices = body['payload']['devices']
     assert len(devices) == 3
     assert devices['climate.heatpump'] == {
+        'on': True,
         'online': True,
         'thermostatTemperatureSetpoint': 20.0,
         'thermostatTemperatureAmbient': 25.0,
@@ -260,6 +261,7 @@ def test_query_climate_request_f(hass_fixture, assistant_client, auth_header):
     devices = body['payload']['devices']
     assert len(devices) == 3
     assert devices['climate.heatpump'] == {
+        'on': True,
         'online': True,
         'thermostatTemperatureSetpoint': -6.7,
         'thermostatTemperatureAmbient': -3.9,

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -388,6 +388,47 @@ async def test_onoff_media_player(hass):
     }
 
 
+async def test_onoff_climate(hass):
+    """Test OnOff trait support for climate domain."""
+    assert trait.OnOffTrait.supported(climate.DOMAIN, climate.SUPPORT_ON_OFF)
+
+    trt_on = trait.OnOffTrait(hass, State('climate.bla', STATE_ON),
+                              BASIC_CONFIG)
+
+    assert trt_on.sync_attributes() == {}
+
+    assert trt_on.query_attributes() == {
+        'on': True
+    }
+
+    trt_off = trait.OnOffTrait(hass, State('climate.bla', STATE_OFF),
+                               BASIC_CONFIG)
+
+    assert trt_off.query_attributes() == {
+        'on': False
+    }
+
+    on_calls = async_mock_service(hass, climate.DOMAIN, SERVICE_TURN_ON)
+    await trt_on.execute(trait.COMMAND_ONOFF, {
+        'on': True
+    })
+    assert len(on_calls) == 1
+    assert on_calls[0].data == {
+        ATTR_ENTITY_ID: 'climate.bla',
+    }
+
+    off_calls = async_mock_service(hass, climate.DOMAIN,
+                                   SERVICE_TURN_OFF)
+
+    await trt_on.execute(trait.COMMAND_ONOFF, {
+        'on': False
+    })
+    assert len(off_calls) == 1
+    assert off_calls[0].data == {
+        ATTR_ENTITY_ID: 'climate.bla',
+    }
+
+
 async def test_dock_vacuum(hass):
     """Test dock trait support for vacuum domain."""
     assert trait.DockTrait.supported(vacuum.DOMAIN, 0)


### PR DESCRIPTION
This commit enables the OnOffTrait for climate devices that have the SUPPORT_ON_OFF feature. I have tested this locally with a Sensibo device which supports ON_OFF and a nest device that does not.

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
