### PR TITLE
Adds SomfyContactIOSystemSensor to TaHoma

### DIFF
--- a/homeassistant/components/tahoma.py
+++ b/homeassistant/components/tahoma.py
@@ -48,7 +48,7 @@ TAHOMA_TYPES = {
     'io:VerticalExteriorAwningIOComponent': 'cover',
     'io:WindowOpenerVeluxIOComponent': 'cover',
     'rtds:RTDSContactSensor': 'sensor',
-    'rtds:RTDSMotionSensor': 'sensor'
+    'rtds:RTDSMotionSensor': 'sensor',
     'rtds:RTDSSmokeSensor': 'smoke',
     'rts:BlindRTSComponent': 'cover',
     'rts:CurtainRTSComponent': 'cover',
@@ -56,7 +56,7 @@ TAHOMA_TYPES = {
     'rts:ExteriorVenetianBlindRTSComponent': 'cover',
     'rts:GarageDoor4TRTSComponent': 'switch',
     'rts:RollerShutterRTSComponent': 'cover',
-    'rts:VenetianBlindRTSComponent': 'cover',
+    'rts:VenetianBlindRTSComponent': 'cover'
 }
 
 

--- a/homeassistant/components/tahoma.py
+++ b/homeassistant/components/tahoma.py
@@ -36,26 +36,27 @@ TAHOMA_COMPONENTS = [
 ]
 
 TAHOMA_TYPES = {
-    'rts:RollerShutterRTSComponent': 'cover',
-    'rts:CurtainRTSComponent': 'cover',
-    'rts:BlindRTSComponent': 'cover',
-    'rts:VenetianBlindRTSComponent': 'cover',
-    'rts:DualCurtainRTSComponent': 'cover',
-    'rts:ExteriorVenetianBlindRTSComponent': 'cover',
     'io:ExteriorVenetianBlindIOComponent': 'cover',
-    'io:RollerShutterUnoIOComponent': 'cover',
-    'io:RollerShutterWithLowSpeedManagementIOComponent': 'cover',
-    'io:RollerShutterVeluxIOComponent': 'cover',
-    'io:RollerShutterGenericIOComponent': 'cover',
-    'io:WindowOpenerVeluxIOComponent': 'cover',
-    'io:LightIOSystemSensor': 'sensor',
-    'rts:GarageDoor4TRTSComponent': 'switch',
-    'io:VerticalExteriorAwningIOComponent': 'cover',
     'io:HorizontalAwningIOComponent': 'cover',
+    'io:LightIOSystemSensor': 'sensor',
     'io:OnOffLightIOComponent': 'switch',
-    'rtds:RTDSSmokeSensor': 'smoke',
+    'io:RollerShutterGenericIOComponent': 'cover',
+    'io:RollerShutterUnoIOComponent': 'cover',
+    'io:RollerShutterVeluxIOComponent': 'cover',
+    'io:RollerShutterWithLowSpeedManagementIOComponent': 'cover',
+    'io:SomfyContactIOSystemSensor': 'sensor',
+    'io:VerticalExteriorAwningIOComponent': 'cover',
+    'io:WindowOpenerVeluxIOComponent': 'cover',
     'rtds:RTDSContactSensor': 'sensor',
     'rtds:RTDSMotionSensor': 'sensor'
+    'rtds:RTDSSmokeSensor': 'smoke',
+    'rts:BlindRTSComponent': 'cover',
+    'rts:CurtainRTSComponent': 'cover',
+    'rts:DualCurtainRTSComponent': 'cover',
+    'rts:ExteriorVenetianBlindRTSComponent': 'cover',
+    'rts:GarageDoor4TRTSComponent': 'switch',
+    'rts:RollerShutterRTSComponent': 'cover',
+    'rts:VenetianBlindRTSComponent': 'cover',
 }
 
 


### PR DESCRIPTION
## Description:

Sorts all TAHOME_TYPES and adds SomfyContactIOSystemSensor as it wasn't added with https://github.com/home-assistant/home-assistant/commit/558b659f7caad4027e5d696dfa4d581cf5240a41

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.