### PR TITLE
Add support for Daikin BRP069B41

### DIFF
--- a/homeassistant/components/climate/daikin.py
+++ b/homeassistant/components/climate/daikin.py
@@ -101,12 +101,10 @@ class DaikinClimate(ClimateDevice):
         self._supported_features = SUPPORT_TARGET_TEMPERATURE \
             | SUPPORT_OPERATION_MODE
 
-        daikin_attr = HA_ATTR_TO_DAIKIN[ATTR_FAN_MODE]
-        if self._api.device.values.get(daikin_attr) is not None:
+        if self._api.device.support_fan_mode:
             self._supported_features |= SUPPORT_FAN_MODE
 
-        daikin_attr = HA_ATTR_TO_DAIKIN[ATTR_SWING_MODE]
-        if self._api.device.values.get(daikin_attr) is not None:
+        if self._api.device.support_swing_mode:
             self._supported_features |= SUPPORT_SWING_MODE
 
     def get(self, key):

--- a/homeassistant/components/climate/daikin.py
+++ b/homeassistant/components/climate/daikin.py
@@ -22,7 +22,7 @@ from homeassistant.const import (
     ATTR_TEMPERATURE, CONF_HOST, CONF_NAME, TEMP_CELSIUS)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['pydaikin==0.7']
+REQUIREMENTS = ['pydaikin==0.8']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/daikin.py
+++ b/homeassistant/components/daikin.py
@@ -19,7 +19,7 @@ from homeassistant.helpers import discovery
 from homeassistant.helpers.discovery import load_platform
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['pydaikin==0.7']
+REQUIREMENTS = ['pydaikin==0.8']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -883,7 +883,7 @@ pycsspeechtts==1.0.2
 
 # homeassistant.components.daikin
 # homeassistant.components.climate.daikin
-pydaikin==0.7
+pydaikin==0.8
 
 # homeassistant.components.deconz
 pydeconz==47


### PR DESCRIPTION
## Description:

Version bump on `pydaikin` that adds support for BRP069B4x devices.

**Related issue (if applicable):** fixes #18563


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.


If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
