### PR TITLE
Add a mac_address config validation helper

### DIFF
--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -477,7 +477,6 @@ def deprecated(key):
 def is_mac_address(value=None, separators=None, allow_lowercase=True,
                    allow_uppercase=True, chunk=2):
     """Validate that a value is a MAC address."""
-
     if not allow_lowercase and not allow_uppercase:
         raise vol.Invalid("Must not disallow upper and lowercase")
 
@@ -512,7 +511,6 @@ def is_mac_address(value=None, separators=None, allow_lowercase=True,
 
     def validator(value: Any) -> str:
         """Validate that the value is a MAC address."""
-
         if not isinstance(value, str):
             raise vol.Invalid('not a string value: {}'.format(value))
 

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -584,3 +584,74 @@ def test_is_regex():
 
     valid_re = ".*"
     schema(valid_re)
+
+
+def test_is_mac_address():
+    """Test the mac_address validator."""
+    with pytest.raises(vol.Invalid):
+        schema = vol.Schema(cv.is_mac_address(separators=True))
+
+    with pytest.raises(vol.Invalid):
+        schema = vol.Schema(cv.is_mac_address(chunk=11))
+
+    with pytest.raises(vol.Invalid):
+        schema = vol.Schema(cv.is_mac_address(allow_lowercase=False,
+                                              allow_uppercase=False))
+
+    with pytest.raises(vol.Invalid):
+        schema = vol.Schema(cv.is_mac_address(allow_uppercase=False))
+        schema('0123456789AB')
+
+    with pytest.raises(vol.Invalid):
+        schema = vol.Schema(cv.is_mac_address(allow_lowercase=False))
+        schema('0123456789ab')
+
+    with pytest.raises(vol.Invalid):
+        schema = vol.Schema(cv.is_mac_address(separators=[':']))
+        schema('01-23-45-67-89-ab')
+
+    with pytest.raises(vol.Invalid):
+        schema = vol.Schema(cv.is_mac_address(separators=[':']))
+        schema('not a mac!')
+
+    test_2_chunk = [
+        '01:23:45:67:89:AB',
+        '01:23:45:67:89:ab',
+        '01.23.45.67.89.AB',
+        '01.23.45.67.89.ab',
+        '01-23-45-67-89-AB',
+        '01-23-45-67-89-ab',
+        '0123456789AB',
+        '0123456789ab',
+    ]
+    schema = vol.Schema(cv.is_mac_address)
+    for mac in test_2_chunk:
+        schema(mac)
+
+    test_4_chunk = [
+        '0123:4567:89AB',
+        '0123:4567:89ab',
+        '0123.4567.89AB',
+        '0123.4567.89ab',
+        '0123-4567-89AB',
+        '0123-4567-89ab',
+        '0123456789AB',
+        '0123456789ab',
+    ]
+    schema = vol.Schema(cv.is_mac_address(chunk=4))
+    for mac in test_4_chunk:
+        schema(mac)
+
+    test_6_chunk = [
+        '012345:6789AB',
+        '012345:6789ab',
+        '012345.6789AB',
+        '012345.6789ab',
+        '012345-6789AB',
+        '012345-6789ab',
+        '0123456789AB',
+        '0123456789ab',
+    ]
+    schema = vol.Schema(cv.is_mac_address(chunk=6))
+    for mac in test_6_chunk:
+        schema(mac)


### PR DESCRIPTION
## Description:

This adds a helper to verify that a given string is indeed a MAC
address. While this is possible with the regex config validation
helper, this purpose-specific helper has the following benefits:

- You don't have to write a regex yourself!
- Allows you to easily specify allowed MAC address separators,
  and also allows you to easily specify if lower/uppercase hex
  characters are allowed.

The latter may seem like a strange 'feature', but various platforms
specify (and require that MAC addresses *be* specified) in a variety
of formats. In my own personal experience, I've seen the following
be considered "valid":

- 01:23:45:67:89:AB
- 01:23:45:67:89:ab
- 01.23.45.67.89.AB
- 01.23.45.67.89.ab
- 01-23-45-67-89-AB
- 01-23-45-67-89-ab
- 01 23 45 67 89 AB
- 01 23 45 67 89 ab
- 0123456789AB
- 0123456789ab
- 0123.4567.89AB
- 0123.4567.89ab

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
