### PR TITLE
Correct cached stale device tracker handling

### DIFF
--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -533,6 +533,7 @@ class Device(Entity):
             (now or dt_util.utcnow()) - self.last_seen > self.consider_home
             
     def mark_stale(self):
+        """Mark the device state as stale."""
         self._state = STATE_NOT_HOME
         self.gps = None
         self.last_update_home = False

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -531,7 +531,7 @@ class Device(Entity):
         """
         return self.last_seen is None or \
             (now or dt_util.utcnow()) - self.last_seen > self.consider_home
-            
+
     def mark_stale(self):
         """Mark the device state as stale."""
         self._state = STATE_NOT_HOME
@@ -568,7 +568,6 @@ class Device(Entity):
         if not state:
             return
         self._state = state.state
-        
         self.last_update_home = (state.state == STATE_HOME)
 
         for attr, var in (

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -373,6 +373,7 @@ class DeviceTracker:
         for device in self.devices.values():
             if (device.track and device.last_update_home) and \
                device.stale(now):
+                device.mark_stale()
                 self.hass.async_create_task(device.async_update_ha_state(True))
 
     async def async_setup_tracked_device(self):
@@ -528,8 +529,13 @@ class Device(Entity):
 
         Async friendly.
         """
-        return self.last_seen and \
+        return self.last_seen is None or \
             (now or dt_util.utcnow()) - self.last_seen > self.consider_home
+            
+    def mark_stale(self):
+        self._state = STATE_NOT_HOME
+        self.gps = None
+        self.last_update_home = False
 
     async def async_update(self):
         """Update state of entity.
@@ -550,9 +556,7 @@ class Device(Entity):
             else:
                 self._state = zone_state.name
         elif self.stale():
-            self._state = STATE_NOT_HOME
-            self.gps = None
-            self.last_update_home = False
+            self.mark_stale()
         else:
             self._state = STATE_HOME
             self.last_update_home = True
@@ -563,6 +567,8 @@ class Device(Entity):
         if not state:
             return
         self._state = state.state
+        
+        self.last_update_home = (state.state == STATE_HOME)
 
         for attr, var in (
                 (ATTR_SOURCE_TYPE, 'source_type'),


### PR DESCRIPTION
## Description:
It is possible to get a device tracker device into a state where it is cached in the HA db with a state of 'home' yet any future updates (e.g. from a router) don't report a 'last seen' date of the device. Due to a variety of reasons, this causes the device to never get updated again.

This PR handles the case when device.last_seen is None (which causes lots of device.async_update() to be skipped), which thus never updates the staleness state; it also forces async_update_stale() to pay attention to the device by setting device.last_update_home properly when loading from cache (again - that's only set in device.async_update()).

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.
