### PR TITLE
Fix MQTT async_added_to_hass

### DIFF
--- a/homeassistant/components/alarm_control_panel/manual_mqtt.py
+++ b/homeassistant/components/alarm_control_panel/manual_mqtt.py
@@ -336,10 +336,7 @@ class ManualMQTTAlarm(alarm.AlarmControlPanel):
         return state_attr
 
     async def async_added_to_hass(self):
-        """Subscribe to MQTT events.
-
-        This method must be run in the event loop and returns a coroutine.
-        """
+        """Subscribe to MQTT events."""
         async_track_state_change(
             self.hass, self.entity_id, self._async_state_changed_listener
         )

--- a/homeassistant/components/alarm_control_panel/manual_mqtt.py
+++ b/homeassistant/components/alarm_control_panel/manual_mqtt.py
@@ -335,7 +335,7 @@ class ManualMQTTAlarm(alarm.AlarmControlPanel):
 
         return state_attr
 
-    def async_added_to_hass(self):
+    async def async_added_to_hass(self):
         """Subscribe to MQTT events.
 
         This method must be run in the event loop and returns a coroutine.
@@ -359,7 +359,7 @@ class ManualMQTTAlarm(alarm.AlarmControlPanel):
                 _LOGGER.warning("Received unexpected payload: %s", payload)
                 return
 
-        return mqtt.async_subscribe(
+        await mqtt.async_subscribe(
             self.hass, self._command_topic, message_received, self._qos)
 
     async def _async_state_changed_listener(self, entity_id, old_state,

--- a/homeassistant/components/camera/mqtt.py
+++ b/homeassistant/components/camera/mqtt.py
@@ -89,13 +89,12 @@ class MqttCamera(Camera):
         """Return a unique ID."""
         return self._unique_id
 
-    @asyncio.coroutine
-    def async_added_to_hass(self):
+    async def async_added_to_hass(self):
         """Subscribe MQTT events."""
         @callback
         def message_received(topic, payload, qos):
             """Handle new MQTT messages."""
             self._last_image = payload
 
-        return mqtt.async_subscribe(
+        await mqtt.async_subscribe(
             self.hass, self._topic, message_received, self._qos, None)


### PR DESCRIPTION
## Description:
We were not calling async_added_to_hass correctly. It would return a coroutine but with a hackish approach in one and the other was just broken.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
