### PR TITLE
Hass.io config check

### DIFF
--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -18,6 +18,7 @@ from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.loader import bind_hass
 from homeassistant.util.dt import utcnow
+from homeassistant.exceptions import HomeAssistantError
 
 from .auth import async_setup_auth
 from .handler import HassIO, HassioAPIError
@@ -143,6 +144,7 @@ async def async_check_config(hass):
         result = await hassio.check_homeassistant_config()
     except HassioAPIError as err:
         _LOGGER.error("Error on Hass.io API: %s", err)
+        raise HomeAssistantError() from None
     else:
         if result['result'] == "error":
             return result['message']


### PR DESCRIPTION
## Description:

You can only run once config check at once, or it raises an error on the interface. Some user can't wait and press again to button what will not fail currently.
