### PR TITLE
Bump Python-Nest to 4.0.5

### DIFF
--- a/homeassistant/components/climate/nest.py
+++ b/homeassistant/components/climate/nest.py
@@ -168,18 +168,14 @@ class NestThermostat(ClimateDevice):
     @property
     def target_temperature(self):
         """Return the temperature we try to reach."""
-        if self._mode != NEST_MODE_HEAT_COOL and \
-                self._mode != STATE_ECO and \
-                not self.is_away_mode_on:
+        if self._mode not in (NEST_MODE_HEAT_COOL, STATE_ECO):
             return self._target_temperature
         return None
 
     @property
     def target_temperature_low(self):
         """Return the lower bound temperature we try to reach."""
-        if (self.is_away_mode_on or self._mode == STATE_ECO) and \
-                self._eco_temperature[0]:
-            # eco_temperature is always a low, high tuple
+        if self._mode == STATE_ECO:
             return self._eco_temperature[0]
         if self._mode == NEST_MODE_HEAT_COOL:
             return self._target_temperature[0]
@@ -188,9 +184,7 @@ class NestThermostat(ClimateDevice):
     @property
     def target_temperature_high(self):
         """Return the upper bound temperature we try to reach."""
-        if (self.is_away_mode_on or self._mode == STATE_ECO) and \
-                self._eco_temperature[1]:
-            # eco_temperature is always a low, high tuple
+        if self._mode == STATE_ECO:
             return self._eco_temperature[1]
         if self._mode == NEST_MODE_HEAT_COOL:
             return self._target_temperature[1]

--- a/homeassistant/components/nest/__init__.py
+++ b/homeassistant/components/nest/__init__.py
@@ -27,7 +27,7 @@ from homeassistant.helpers.entity import Entity
 from .const import DOMAIN
 from . import local_auth
 
-REQUIREMENTS = ['python-nest==4.0.4']
+REQUIREMENTS = ['python-nest==4.0.5']
 
 _CONFIGURING = {}
 _LOGGER = logging.getLogger(__name__)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1222,7 +1222,7 @@ python-mpd2==1.0.0
 python-mystrom==0.4.4
 
 # homeassistant.components.nest
-python-nest==4.0.4
+python-nest==4.0.5
 
 # homeassistant.components.device_tracker.nmap_tracker
 python-nmap==0.6.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -196,7 +196,7 @@ pyspcwebgw==0.4.0
 python-forecastio==1.4.0
 
 # homeassistant.components.nest
-python-nest==4.0.4
+python-nest==4.0.5
 
 # homeassistant.components.sensor.whois
 pythonwhois==2.4.3


### PR DESCRIPTION
## Description:
Bump Python-Nest to 4.0.5 to fix #17117

Also fixes target temp based on the [Nest docs](https://developers.nest.com/guides/api/thermostat-guide#how_hvac_mode_and_temperature_values_work_together)

**Related issue (if applicable):** fixes #17117

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
