### PR TITLE
end snips dialogue

### DIFF
--- a/homeassistant/components/snips.py
+++ b/homeassistant/components/snips.py
@@ -148,13 +148,13 @@ async def async_setup(hass, config):
         except intent.IntentError:
             _LOGGER.exception("Error while handling intent: %s.", intent_type)
 
+        notification = {'sessionId': request.get('sessionId', 'default')}
         if snips_response:
-            notification = {'sessionId': request.get('sessionId', 'default'),
-                            'text': snips_response}
+            notification['text'] = snips_response
 
-            _LOGGER.debug("send_response %s", json.dumps(notification))
-            mqtt.async_publish(hass, 'hermes/dialogueManager/endSession',
-                               json.dumps(notification))
+        _LOGGER.debug("end_dialogue %s", json.dumps(notification))
+        mqtt.async_publish(hass, 'hermes/dialogueManager/endSession',
+                           json.dumps(notification))
 
     await hass.components.mqtt.async_subscribe(
         INTENT_TOPIC, message_received)


### PR DESCRIPTION
## Description:

This change will explicitly end the snips dialogue, otherwise the session will be open till timed out. With this change snips will be able to start new dialogues faster after in a row.

snips reference: https://snips.gitbook.io/documentation/ressources/messages-reference#end-session

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
