### PR TITLE
Update Z-Wave Tests asyncio/yield from -> async/await

### DIFF
--- a/tests/components/binary_sensor/test_zwave.py
+++ b/tests/components/binary_sensor/test_zwave.py
@@ -1,5 +1,4 @@
 """Test Z-Wave binary sensors."""
-import asyncio
 import datetime
 
 from unittest.mock import patch
@@ -71,8 +70,7 @@ def test_binary_sensor_value_changed(mock_openzwave):
     assert device.is_on
 
 
-@asyncio.coroutine
-def test_trigger_sensor_value_changed(hass, mock_openzwave):
+async def test_trigger_sensor_value_changed(hass, mock_openzwave):
     """Test value changed for trigger sensor."""
     node = MockNode(
         manufacturer_id='013c', product_type='0002', product_id='0002')
@@ -84,13 +82,13 @@ def test_trigger_sensor_value_changed(hass, mock_openzwave):
     assert not device.is_on
 
     value.data = True
-    yield from hass.async_add_job(value_changed, value)
+    await hass.async_add_job(value_changed, value)
     assert device.invalidate_after is None
 
     device.hass = hass
 
     value.data = True
-    yield from hass.async_add_job(value_changed, value)
+    await hass.async_add_job(value_changed, value)
     assert device.is_on
 
     test_time = device.invalidate_after - datetime.timedelta(seconds=1)

--- a/tests/components/zwave/test_init.py
+++ b/tests/components/zwave/test_init.py
@@ -23,36 +23,34 @@ from tests.common import (
 from tests.mock.zwave import MockNetwork, MockNode, MockValue, MockEntityValues
 
 
-@asyncio.coroutine
-def test_valid_device_config(hass, mock_openzwave):
+async def test_valid_device_config(hass, mock_openzwave):
     """Test valid device config."""
     device_config = {
         'light.kitchen': {
             'ignored': 'true'
         }
     }
-    result = yield from async_setup_component(hass, 'zwave', {
+    result = await async_setup_component(hass, 'zwave', {
         'zwave': {
             'device_config': device_config
         }})
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert result
 
 
-@asyncio.coroutine
-def test_invalid_device_config(hass, mock_openzwave):
+async def test_invalid_device_config(hass, mock_openzwave):
     """Test invalid device config."""
     device_config = {
         'light.kitchen': {
             'some_ignored': 'true'
         }
     }
-    result = yield from async_setup_component(hass, 'zwave', {
+    result = await async_setup_component(hass, 'zwave', {
         'zwave': {
             'device_config': device_config
         }})
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert not result
 
@@ -69,15 +67,14 @@ def test_config_access_error():
     assert result is None
 
 
-@asyncio.coroutine
-def test_network_options(hass, mock_openzwave):
+async def test_network_options(hass, mock_openzwave):
     """Test network options."""
-    result = yield from async_setup_component(hass, 'zwave', {
+    result = await async_setup_component(hass, 'zwave', {
         'zwave': {
             'usb_path': 'mock_usb_path',
             'config_path': 'mock_config_path',
         }})
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert result
 
@@ -86,62 +83,59 @@ def test_network_options(hass, mock_openzwave):
     assert network.options.config_path == 'mock_config_path'
 
 
-@asyncio.coroutine
-def test_auto_heal_midnight(hass, mock_openzwave):
+async def test_auto_heal_midnight(hass, mock_openzwave):
     """Test network auto-heal at midnight."""
-    yield from async_setup_component(hass, 'zwave', {
+    await async_setup_component(hass, 'zwave', {
         'zwave': {
             'autoheal': True,
         }})
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     network = hass.data[zwave.DATA_NETWORK]
     assert not network.heal.called
 
     time = utc.localize(datetime(2017, 5, 6, 0, 0, 0))
     async_fire_time_changed(hass, time)
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
     assert network.heal.called
     assert len(network.heal.mock_calls) == 1
 
 
-@asyncio.coroutine
-def test_auto_heal_disabled(hass, mock_openzwave):
+async def test_auto_heal_disabled(hass, mock_openzwave):
     """Test network auto-heal disabled."""
-    yield from async_setup_component(hass, 'zwave', {
+    await async_setup_component(hass, 'zwave', {
         'zwave': {
             'autoheal': False,
         }})
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     network = hass.data[zwave.DATA_NETWORK]
     assert not network.heal.called
 
     time = utc.localize(datetime(2017, 5, 6, 0, 0, 0))
     async_fire_time_changed(hass, time)
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
     assert not network.heal.called
 
 
-@asyncio.coroutine
-def test_setup_platform(hass, mock_openzwave):
+async def test_setup_platform(hass, mock_openzwave):
     """Test invalid device config."""
     mock_device = MagicMock()
     hass.data[DATA_NETWORK] = MagicMock()
     hass.data[zwave.DATA_DEVICES] = {456: mock_device}
     async_add_entities = MagicMock()
 
-    result = yield from zwave.async_setup_platform(
+    result = await zwave.async_setup_platform(
         hass, None, async_add_entities, None)
     assert not result
     assert not async_add_entities.called
 
-    result = yield from zwave.async_setup_platform(
+    result = await zwave.async_setup_platform(
         hass, None, async_add_entities, {const.DISCOVERY_DEVICE: 123})
     assert not result
     assert not async_add_entities.called
 
-    result = yield from zwave.async_setup_platform(
+    result = await zwave.async_setup_platform(
         hass, None, async_add_entities, {const.DISCOVERY_DEVICE: 456})
     assert result
     assert async_add_entities.called
@@ -149,12 +143,11 @@ def test_setup_platform(hass, mock_openzwave):
     assert async_add_entities.mock_calls[0][1][0] == [mock_device]
 
 
-@asyncio.coroutine
-def test_zwave_ready_wait(hass, mock_openzwave):
+async def test_zwave_ready_wait(hass, mock_openzwave):
     """Test that zwave continues after waiting for network ready."""
     # Initialize zwave
-    yield from async_setup_component(hass, 'zwave', {'zwave': {}})
-    yield from hass.async_block_till_done()
+    await async_setup_component(hass, 'zwave', {'zwave': {}})
+    await hass.async_block_till_done()
 
     sleeps = []
 
@@ -163,18 +156,17 @@ def test_zwave_ready_wait(hass, mock_openzwave):
 
     asyncio_sleep = asyncio.sleep
 
-    @asyncio.coroutine
-    def sleep(duration, loop=None):
+    async def sleep(duration, loop=None):
         if duration > 0:
             sleeps.append(duration)
-        yield from asyncio_sleep(0)
+        await asyncio_sleep(0)
 
     with patch('homeassistant.components.zwave.dt_util.utcnow', new=utcnow):
         with patch('asyncio.sleep', new=sleep):
             with patch.object(zwave, '_LOGGER') as mock_logger:
                 hass.data[DATA_NETWORK].state = MockNetwork.STATE_STARTED
                 hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
-                yield from hass.async_block_till_done()
+                await hass.async_block_till_done()
 
                 assert len(sleeps) == const.NETWORK_READY_WAIT_SECS
                 assert mock_logger.warning.called
@@ -183,8 +175,7 @@ def test_zwave_ready_wait(hass, mock_openzwave):
                     const.NETWORK_READY_WAIT_SECS
 
 
-@asyncio.coroutine
-def test_device_entity(hass, mock_openzwave):
+async def test_device_entity(hass, mock_openzwave):
     """Test device entity base class."""
     node = MockNode(node_id='10', name='Mock Node')
     value = MockValue(data=False, node=node, instance=2, object_id='11',
@@ -197,7 +188,7 @@ def test_device_entity(hass, mock_openzwave):
     device.hass = hass
     device.value_added()
     device.update_properties()
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert not device.should_poll
     assert device.unique_id == "10-11"
@@ -205,8 +196,7 @@ def test_device_entity(hass, mock_openzwave):
     assert device.device_state_attributes[zwave.ATTR_POWER] == 50.123
 
 
-@asyncio.coroutine
-def test_node_discovery(hass, mock_openzwave):
+async def test_node_discovery(hass, mock_openzwave):
     """Test discovery of a node."""
     mock_receivers = []
 
@@ -215,14 +205,14 @@ def test_node_discovery(hass, mock_openzwave):
             mock_receivers.append(receiver)
 
     with patch('pydispatch.dispatcher.connect', new=mock_connect):
-        yield from async_setup_component(hass, 'zwave', {'zwave': {}})
-        yield from hass.async_block_till_done()
+        await async_setup_component(hass, 'zwave', {'zwave': {}})
+        await hass.async_block_till_done()
 
     assert len(mock_receivers) == 1
 
     node = MockNode(node_id=14)
     hass.async_add_job(mock_receivers[0], node)
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert hass.states.get('zwave.mock_node').state is 'unknown'
 
@@ -270,8 +260,7 @@ async def test_unparsed_node_discovery(hass, mock_openzwave):
     assert hass.states.get('zwave.unknown_node_14').state is 'unknown'
 
 
-@asyncio.coroutine
-def test_node_ignored(hass, mock_openzwave):
+async def test_node_ignored(hass, mock_openzwave):
     """Test discovery of a node."""
     mock_receivers = []
 
@@ -280,24 +269,23 @@ def test_node_ignored(hass, mock_openzwave):
             mock_receivers.append(receiver)
 
     with patch('pydispatch.dispatcher.connect', new=mock_connect):
-        yield from async_setup_component(hass, 'zwave', {'zwave': {
+        await async_setup_component(hass, 'zwave', {'zwave': {
             'device_config': {
                 'zwave.mock_node': {
                     'ignored': True,
                     }}}})
-        yield from hass.async_block_till_done()
+        await hass.async_block_till_done()
 
     assert len(mock_receivers) == 1
 
     node = MockNode(node_id=14)
     hass.async_add_job(mock_receivers[0], node)
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert hass.states.get('zwave.mock_node') is None
 
 
-@asyncio.coroutine
-def test_value_discovery(hass, mock_openzwave):
+async def test_value_discovery(hass, mock_openzwave):
     """Test discovery of a node."""
     mock_receivers = []
 
@@ -306,8 +294,8 @@ def test_value_discovery(hass, mock_openzwave):
             mock_receivers.append(receiver)
 
     with patch('pydispatch.dispatcher.connect', new=mock_connect):
-        yield from async_setup_component(hass, 'zwave', {'zwave': {}})
-        yield from hass.async_block_till_done()
+        await async_setup_component(hass, 'zwave', {'zwave': {}})
+        await hass.async_block_till_done()
 
     assert len(mock_receivers) == 1
 
@@ -316,14 +304,13 @@ def test_value_discovery(hass, mock_openzwave):
                       command_class=const.COMMAND_CLASS_SENSOR_BINARY,
                       type=const.TYPE_BOOL, genre=const.GENRE_USER)
     hass.async_add_job(mock_receivers[0], node, value)
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert hass.states.get(
         'binary_sensor.mock_node_mock_value').state is 'off'
 
 
-@asyncio.coroutine
-def test_value_discovery_existing_entity(hass, mock_openzwave):
+async def test_value_discovery_existing_entity(hass, mock_openzwave):
     """Test discovery of a node."""
     mock_receivers = []
 
@@ -332,8 +319,8 @@ def test_value_discovery_existing_entity(hass, mock_openzwave):
             mock_receivers.append(receiver)
 
     with patch('pydispatch.dispatcher.connect', new=mock_connect):
-        yield from async_setup_component(hass, 'zwave', {'zwave': {}})
-        yield from hass.async_block_till_done()
+        await async_setup_component(hass, 'zwave', {'zwave': {}})
+        await hass.async_block_till_done()
 
     assert len(mock_receivers) == 1
 
@@ -343,7 +330,7 @@ def test_value_discovery_existing_entity(hass, mock_openzwave):
         command_class=const.COMMAND_CLASS_THERMOSTAT_SETPOINT,
         genre=const.GENRE_USER, units='C')
     hass.async_add_job(mock_receivers[0], node, setpoint)
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert hass.states.get('climate.mock_node_mock_value').attributes[
         'temperature'] == 22.0
@@ -360,7 +347,7 @@ def test_value_discovery_existing_entity(hass, mock_openzwave):
             command_class=const.COMMAND_CLASS_SENSOR_MULTILEVEL,
             genre=const.GENRE_USER, units='C')
         hass.async_add_job(mock_receivers[0], node, temperature)
-        yield from hass.async_block_till_done()
+        await hass.async_block_till_done()
 
     assert hass.states.get('climate.mock_node_mock_value').attributes[
         'temperature'] == 22.0
@@ -368,8 +355,7 @@ def test_value_discovery_existing_entity(hass, mock_openzwave):
         'current_temperature'] == 23.5
 
 
-@asyncio.coroutine
-def test_power_schemes(hass, mock_openzwave):
+async def test_power_schemes(hass, mock_openzwave):
     """Test power attribute."""
     mock_receivers = []
 
@@ -378,8 +364,8 @@ def test_power_schemes(hass, mock_openzwave):
             mock_receivers.append(receiver)
 
     with patch('pydispatch.dispatcher.connect', new=mock_connect):
-        yield from async_setup_component(hass, 'zwave', {'zwave': {}})
-        yield from hass.async_block_till_done()
+        await async_setup_component(hass, 'zwave', {'zwave': {}})
+        await hass.async_block_till_done()
 
     assert len(mock_receivers) == 1
 
@@ -390,7 +376,7 @@ def test_power_schemes(hass, mock_openzwave):
         genre=const.GENRE_USER, type=const.TYPE_BOOL)
     hass.async_add_job(mock_receivers[0], node, switch)
 
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert hass.states.get('switch.mock_node_mock_value').state == 'on'
     assert 'power_consumption' not in hass.states.get(
@@ -405,14 +391,13 @@ def test_power_schemes(hass, mock_openzwave):
             data=23.5, node=node, index=const.INDEX_SENSOR_MULTILEVEL_POWER,
             instance=13, command_class=const.COMMAND_CLASS_SENSOR_MULTILEVEL)
         hass.async_add_job(mock_receivers[0], node, power)
-        yield from hass.async_block_till_done()
+        await hass.async_block_till_done()
 
     assert hass.states.get('switch.mock_node_mock_value').attributes[
         'power_consumption'] == 23.5
 
 
-@asyncio.coroutine
-def test_network_ready(hass, mock_openzwave):
+async def test_network_ready(hass, mock_openzwave):
     """Test Node network ready event."""
     mock_receivers = []
 
@@ -421,8 +406,8 @@ def test_network_ready(hass, mock_openzwave):
             mock_receivers.append(receiver)
 
     with patch('pydispatch.dispatcher.connect', new=mock_connect):
-        yield from async_setup_component(hass, 'zwave', {'zwave': {}})
-        yield from hass.async_block_till_done()
+        await async_setup_component(hass, 'zwave', {'zwave': {}})
+        await hass.async_block_till_done()
 
     assert len(mock_receivers) == 1
 
@@ -434,13 +419,12 @@ def test_network_ready(hass, mock_openzwave):
     hass.bus.async_listen(const.EVENT_NETWORK_COMPLETE, listener)
 
     hass.async_add_job(mock_receivers[0])
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert len(events) == 1
 
 
-@asyncio.coroutine
-def test_network_complete(hass, mock_openzwave):
+async def test_network_complete(hass, mock_openzwave):
     """Test Node network complete event."""
     mock_receivers = []
 
@@ -449,8 +433,8 @@ def test_network_complete(hass, mock_openzwave):
             mock_receivers.append(receiver)
 
     with patch('pydispatch.dispatcher.connect', new=mock_connect):
-        yield from async_setup_component(hass, 'zwave', {'zwave': {}})
-        yield from hass.async_block_till_done()
+        await async_setup_component(hass, 'zwave', {'zwave': {}})
+        await hass.async_block_till_done()
 
     assert len(mock_receivers) == 1
 
@@ -462,13 +446,12 @@ def test_network_complete(hass, mock_openzwave):
     hass.bus.async_listen(const.EVENT_NETWORK_READY, listener)
 
     hass.async_add_job(mock_receivers[0])
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert len(events) == 1
 
 
-@asyncio.coroutine
-def test_network_complete_some_dead(hass, mock_openzwave):
+async def test_network_complete_some_dead(hass, mock_openzwave):
     """Test Node network complete some dead event."""
     mock_receivers = []
 
@@ -477,8 +460,8 @@ def test_network_complete_some_dead(hass, mock_openzwave):
             mock_receivers.append(receiver)
 
     with patch('pydispatch.dispatcher.connect', new=mock_connect):
-        yield from async_setup_component(hass, 'zwave', {'zwave': {}})
-        yield from hass.async_block_till_done()
+        await async_setup_component(hass, 'zwave', {'zwave': {}})
+        await hass.async_block_till_done()
 
     assert len(mock_receivers) == 1
 
@@ -490,7 +473,7 @@ def test_network_complete_some_dead(hass, mock_openzwave):
     hass.bus.async_listen(const.EVENT_NETWORK_COMPLETE_SOME_DEAD, listener)
 
     hass.async_add_job(mock_receivers[0])
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert len(events) == 1
 

--- a/tests/components/zwave/test_node_entity.py
+++ b/tests/components/zwave/test_node_entity.py
@@ -1,5 +1,4 @@
 """Test Z-Wave node entity."""
-import asyncio
 import unittest
 from unittest.mock import patch, MagicMock
 import tests.mock.zwave as mock_zwave
@@ -8,8 +7,7 @@ from homeassistant.components.zwave import node_entity, const
 from homeassistant.const import ATTR_ENTITY_ID
 
 
-@asyncio.coroutine
-def test_maybe_schedule_update(hass, mock_openzwave):
+async def test_maybe_schedule_update(hass, mock_openzwave):
     """Test maybe schedule update."""
     base_entity = node_entity.ZWaveBaseEntity()
     base_entity.hass = hass
@@ -31,8 +29,7 @@ def test_maybe_schedule_update(hass, mock_openzwave):
         assert len(mock_call_later.mock_calls) == 2
 
 
-@asyncio.coroutine
-def test_node_event_activated(hass, mock_openzwave):
+async def test_node_event_activated(hass, mock_openzwave):
     """Test Node event activated event."""
     mock_receivers = []
 
@@ -57,7 +54,7 @@ def test_node_event_activated(hass, mock_openzwave):
     # Test event before entity added to hass
     value = 234
     hass.async_add_job(mock_receivers[0], node, value)
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
     assert len(events) == 0
 
     # Add entity to hass
@@ -66,7 +63,7 @@ def test_node_event_activated(hass, mock_openzwave):
 
     value = 234
     hass.async_add_job(mock_receivers[0], node, value)
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert len(events) == 1
     assert events[0].data[ATTR_ENTITY_ID] == "zwave.mock_node"
@@ -74,8 +71,7 @@ def test_node_event_activated(hass, mock_openzwave):
     assert events[0].data[const.ATTR_BASIC_LEVEL] == value
 
 
-@asyncio.coroutine
-def test_scene_activated(hass, mock_openzwave):
+async def test_scene_activated(hass, mock_openzwave):
     """Test scene activated event."""
     mock_receivers = []
 
@@ -100,7 +96,7 @@ def test_scene_activated(hass, mock_openzwave):
     # Test event before entity added to hass
     scene_id = 123
     hass.async_add_job(mock_receivers[0], node, scene_id)
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
     assert len(events) == 0
 
     # Add entity to hass
@@ -109,7 +105,7 @@ def test_scene_activated(hass, mock_openzwave):
 
     scene_id = 123
     hass.async_add_job(mock_receivers[0], node, scene_id)
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert len(events) == 1
     assert events[0].data[ATTR_ENTITY_ID] == "zwave.mock_node"
@@ -117,8 +113,7 @@ def test_scene_activated(hass, mock_openzwave):
     assert events[0].data[const.ATTR_SCENE_ID] == scene_id
 
 
-@asyncio.coroutine
-def test_central_scene_activated(hass, mock_openzwave):
+async def test_central_scene_activated(hass, mock_openzwave):
     """Test central scene activated event."""
     mock_receivers = []
 
@@ -148,7 +143,7 @@ def test_central_scene_activated(hass, mock_openzwave):
         index=scene_id,
         data=scene_data)
     hass.async_add_job(mock_receivers[0], node, value)
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
     assert len(events) == 0
 
     # Add entity to hass
@@ -162,7 +157,7 @@ def test_central_scene_activated(hass, mock_openzwave):
         index=scene_id,
         data=scene_data)
     hass.async_add_job(mock_receivers[0], node, value)
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert len(events) == 1
     assert events[0].data[ATTR_ENTITY_ID] == "zwave.mock_node"


### PR DESCRIPTION
## Description:
Updates Z-Wave tests to use the async/await syntax instead of asyncio.coroutine and yield from

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
zwave:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
