### PR TITLE
Add /sbin to launchd PATH

### DIFF
--- a/homeassistant/scripts/macos/launchd.plist
+++ b/homeassistant/scripts/macos/launchd.plist
@@ -8,7 +8,7 @@
     <key>EnvironmentVariables</key>
     <dict>
       <key>PATH</key>
-      <string>/usr/local/bin/:/usr/bin:/usr/sbin:$PATH</string>
+      <string>/sbin:/usr/local/bin/:/usr/bin:/usr/sbin:$PATH</string>
       <key>LC_CTYPE</key>
       <string>UTF-8</string>
     </dict>

--- a/homeassistant/scripts/macos/launchd.plist
+++ b/homeassistant/scripts/macos/launchd.plist
@@ -8,7 +8,7 @@
     <key>EnvironmentVariables</key>
     <dict>
       <key>PATH</key>
-      <string>/sbin:/usr/local/bin/:/usr/bin:/usr/sbin:$PATH</string>
+      <string>/usr/local/bin/:/usr/bin:/usr/sbin:/sbin:$PATH</string>
       <key>LC_CTYPE</key>
       <string>UTF-8</string>
     </dict>


### PR DESCRIPTION
## Description:
On macOS, ping resides in /sbin, so when running hass with launchd, it needs to be available on the PATH for ping sensors to function 

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
binary_sensor:
  - platform: ping
    host: 192.168.0.1
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
