### PR TITLE
Update locationsharinglib requirement to 3.0.8

### DIFF
--- a/homeassistant/components/device_tracker/google_maps.py
+++ b/homeassistant/components/device_tracker/google_maps.py
@@ -19,7 +19,7 @@ from homeassistant.helpers.event import track_time_interval
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.util import slugify, dt as dt_util
 
-REQUIREMENTS = ['locationsharinglib==3.0.7']
+REQUIREMENTS = ['locationsharinglib==3.0.8']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -594,7 +594,7 @@ liveboxplaytv==2.0.2
 lmnotify==0.0.4
 
 # homeassistant.components.device_tracker.google_maps
-locationsharinglib==3.0.7
+locationsharinglib==3.0.8
 
 # homeassistant.components.logi_circle
 logi_circle==0.1.7


### PR DESCRIPTION
## Description:

Fixes issue with `device_tracker.google_maps`, where the used library stopped providing location data for the owner of the account that was used to query Google's location sharing API.

As far as I can tell, the issue has not been documented in HA's issue tracker, but https://github.com/costastf/locationsharinglib/issues/44 is pointing the issue out.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
