### PR TITLE
Upgrade Adafruit-DHT to 1.4.0 (fixes #15847)

### DIFF
--- a/homeassistant/components/sensor/dht.py
+++ b/homeassistant/components/sensor/dht.py
@@ -17,7 +17,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 from homeassistant.util.temperature import celsius_to_fahrenheit
 
-REQUIREMENTS = ['Adafruit-DHT==1.3.4']
+REQUIREMENTS = ['Adafruit-DHT==1.4.0']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -57,9 +57,9 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     SENSOR_TYPES[SENSOR_TEMPERATURE][1] = hass.config.units.temperature_unit
     available_sensors = {
+        "AM2302": Adafruit_DHT.AM2302,
         "DHT11": Adafruit_DHT.DHT11,
         "DHT22": Adafruit_DHT.DHT22,
-        "AM2302": Adafruit_DHT.AM2302
     }
     sensor = available_sensors.get(config.get(CONF_SENSOR))
     pin = config.get(CONF_PIN)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -20,7 +20,7 @@ voluptuous-serialize==2.0.0
 --only-binary=all nuimo==0.1.0
 
 # homeassistant.components.sensor.dht
-# Adafruit-DHT==1.3.4
+# Adafruit-DHT==1.4.0
 
 # homeassistant.components.sensor.sht31
 Adafruit-GPIO==1.0.3


### PR DESCRIPTION
## Description:
- Support for Pi 3B+

**Related issue (if applicable):** fixes #15847

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  platform: dht
  sensor: DHT22
  pin: 23
  monitored_conditions:
    - temperature
    - humidity
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
