### PR TITLE
Fixed wording that may confuse user inside logs.

### DIFF
--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -29,7 +29,7 @@ def migrate_schema(instance):
         with open(progress_path, 'w'):
             pass
 
-        _LOGGER.warning("Database requires upgrade. Schema version: %s",
+        _LOGGER.warning("Database is about to upgrade. Schema version: %s",
                         current_version)
 
         if current_version is None:


### PR DESCRIPTION
## Description:
Fixed wording on the recorder component. 
Changed from "Database requires upgrade. Schema version: ..." to "Database is about to upgrade. Schema version: ..."

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.