### PR TITLE
Baidu tts

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -624,6 +624,7 @@ omit =
     homeassistant/components/telegram_bot/*
     homeassistant/components/thingspeak.py
     homeassistant/components/tts/amazon_polly.py
+    homeassistant/components/tts/baidu.py
     homeassistant/components/tts/microsoft.py
     homeassistant/components/tts/picotts.py
     homeassistant/components/vacuum/roomba.py

--- a/homeassistant/components/tts/baidu.py
+++ b/homeassistant/components/tts/baidu.py
@@ -5,7 +5,6 @@ For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/tts.baidu/
 """
 
-import asyncio
 import logging
 import voluptuous as vol
 
@@ -48,8 +47,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-@asyncio.coroutine
-def async_get_engine(hass, config):
+def get_engine(hass, config):
     """Set up Baidu TTS component."""
     return BaiduTTSProvider(hass, config)
 
@@ -87,8 +85,7 @@ class BaiduTTSProvider(Provider):
         """Return list of supported languages."""
         return SUPPORT_LANGUAGES
 
-    @asyncio.coroutine
-    def async_get_tts_audio(self, message, language, options=None):
+    def get_tts_audio(self, message, language, options=None):
         """Load TTS from BaiduTTS."""
         from aip import AipSpeech
         aip_speech = AipSpeech(

--- a/homeassistant/components/tts/baidu.py
+++ b/homeassistant/components/tts/baidu.py
@@ -1,0 +1,111 @@
+"""
+Support for the baidu speech service.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/tts.baidu/
+"""
+
+import asyncio
+import logging
+import voluptuous as vol
+
+from homeassistant.components.tts import Provider, PLATFORM_SCHEMA, CONF_LANG
+import homeassistant.helpers.config_validation as cv
+
+
+REQUIREMENTS = ["baidu-aip==1.6.6"]
+
+_LOGGER = logging.getLogger(__name__)
+
+
+SUPPORT_LANGUAGES = [
+    'zh',
+]
+DEFAULT_LANG = 'zh'
+
+
+CONF_APPID = 'appid'
+CONF_APIKEY = 'apikey'
+CONF_SECRETKEY = 'secretkey'
+CONF_SPEED = 'speed'
+CONF_PITCH = 'pitch'
+CONF_VOLUME = 'volume'
+CONF_PERSON = 'person'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_LANG, default=DEFAULT_LANG): vol.In(SUPPORT_LANGUAGES),
+    vol.Required(CONF_APPID): cv.string,
+    vol.Required(CONF_APIKEY): cv.string,
+    vol.Required(CONF_SECRETKEY): cv.string,
+    vol.Optional(CONF_SPEED, default=5): vol.All(
+        vol.Coerce(int), vol.Range(min=0, max=9)),
+    vol.Optional(CONF_PITCH, default=5): vol.All(
+        vol.Coerce(int), vol.Range(min=0, max=9)),
+    vol.Optional(CONF_VOLUME, default=5): vol.All(
+        vol.Coerce(int), vol.Range(min=0, max=15)),
+    vol.Optional(CONF_PERSON, default=0): vol.All(
+        vol.Coerce(int), vol.Range(min=0, max=4)),
+})
+
+
+@asyncio.coroutine
+def async_get_engine(hass, config):
+    """Set up Baidu TTS component."""
+    return BaiduTTSProvider(hass, config)
+
+
+class BaiduTTSProvider(Provider):
+    """Baidu TTS speech api provider."""
+
+    def __init__(self, hass, conf):
+        """Init Baidu TTS service."""
+        self.hass = hass
+        self._lang = conf.get(CONF_LANG)
+        self._codec = 'mp3'
+        self.name = 'BaiduTTS'
+
+        self._app_data = {
+            'appid': conf.get(CONF_APPID),
+            'apikey': conf.get(CONF_APIKEY),
+            'secretkey': conf.get(CONF_SECRETKEY),
+            }
+
+        self._speech_conf_data = {
+            'spd': conf.get(CONF_SPEED),
+            'pit': conf.get(CONF_PITCH),
+            'vol': conf.get(CONF_VOLUME),
+            'per': conf.get(CONF_PERSON),
+            }
+
+    @property
+    def default_language(self):
+        """Return the default language."""
+        return self._lang
+
+    @property
+    def supported_languages(self):
+        """Return list of supported languages."""
+        return SUPPORT_LANGUAGES
+
+    @asyncio.coroutine
+    def async_get_tts_audio(self, message, language, options=None):
+        """Load TTS from BaiduTTS."""
+        from aip import AipSpeech
+        aip_speech = AipSpeech(
+            self._app_data['appid'],
+            self._app_data['apikey'],
+            self._app_data['secretkey']
+            )
+
+        result = aip_speech.synthesis(
+            message, language, 1, self._speech_conf_data)
+
+        if isinstance(result, dict):
+            _LOGGER.error(
+                "Baidu TTS error-- err_no:%d; err_msg:%s; err_detail:%s",
+                result['err_no'],
+                result['err_msg'],
+                result['err_detail'])
+            return (None, None)
+
+        return (self._codec, result)

--- a/homeassistant/components/tts/baidu.py
+++ b/homeassistant/components/tts/baidu.py
@@ -9,6 +9,7 @@ import asyncio
 import logging
 import voluptuous as vol
 
+from homeassistant.const import CONF_API_KEY
 from homeassistant.components.tts import Provider, PLATFORM_SCHEMA, CONF_LANG
 import homeassistant.helpers.config_validation as cv
 
@@ -24,9 +25,8 @@ SUPPORT_LANGUAGES = [
 DEFAULT_LANG = 'zh'
 
 
-CONF_APPID = 'appid'
-CONF_APIKEY = 'apikey'
-CONF_SECRETKEY = 'secretkey'
+CONF_APP_ID = 'app_id'
+CONF_SECRET_KEY = 'secret_key'
 CONF_SPEED = 'speed'
 CONF_PITCH = 'pitch'
 CONF_VOLUME = 'volume'
@@ -34,9 +34,9 @@ CONF_PERSON = 'person'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_LANG, default=DEFAULT_LANG): vol.In(SUPPORT_LANGUAGES),
-    vol.Required(CONF_APPID): cv.string,
-    vol.Required(CONF_APIKEY): cv.string,
-    vol.Required(CONF_SECRETKEY): cv.string,
+    vol.Required(CONF_APP_ID): cv.string,
+    vol.Required(CONF_API_KEY): cv.string,
+    vol.Required(CONF_SECRET_KEY): cv.string,
     vol.Optional(CONF_SPEED, default=5): vol.All(
         vol.Coerce(int), vol.Range(min=0, max=9)),
     vol.Optional(CONF_PITCH, default=5): vol.All(
@@ -65,9 +65,9 @@ class BaiduTTSProvider(Provider):
         self.name = 'BaiduTTS'
 
         self._app_data = {
-            'appid': conf.get(CONF_APPID),
-            'apikey': conf.get(CONF_APIKEY),
-            'secretkey': conf.get(CONF_SECRETKEY),
+            'appid': conf.get(CONF_APP_ID),
+            'apikey': conf.get(CONF_API_KEY),
+            'secretkey': conf.get(CONF_SECRET_KEY),
             }
 
         self._speech_conf_data = {

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -107,6 +107,9 @@ asterisk_mbox==0.4.0
 # homeassistant.components.axis
 axis==14
 
+# homeassistant.components.tts.baidu
+baidu-aip==1.6.6
+
 # homeassistant.components.sensor.modem_callerid
 basicmodem==0.7
 


### PR DESCRIPTION
## Description:
1. Update the requirement version, from baidu-aip==1.6.6 to baidu-aip==2.2.8
2. the option range for speed&pitch, from[0..9] to [0..15]
3. use the options input in get_tts_audio, to support input options from service tts.baidu_say

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
