### PR TITLE
Rename ocr.png to ssocr-(entity_name).png to allow multiple instances

### DIFF
--- a/homeassistant/components/image_processing/seven_segments.py
+++ b/homeassistant/components/image_processing/seven_segments.py
@@ -69,7 +69,8 @@ class ImageProcessingSsocr(ImageProcessingEntity):
                 split_entity_id(camera_entity)[1])
         self._state = None
 
-        self.filepath = os.path.join(self.hass.config.config_dir, 'ssocr-' + self._name.replace(' ','_') + '.png')
+        self.filepath = os.path.join(self.hass.config.config_dir, 'ssocr-' + 
+                                     self._name.replace(' ', '_') + '.png')
         crop = ['crop', str(config[CONF_X_POS]), str(config[CONF_Y_POS]),
                 str(config[CONF_WIDTH]), str(config[CONF_HEIGHT])]
         digits = ['-d', str(config.get(CONF_DIGITS, -1))]

--- a/homeassistant/components/image_processing/seven_segments.py
+++ b/homeassistant/components/image_processing/seven_segments.py
@@ -69,7 +69,7 @@ class ImageProcessingSsocr(ImageProcessingEntity):
                 split_entity_id(camera_entity)[1])
         self._state = None
 
-        self.filepath = os.path.join(self.hass.config.config_dir, 'ssocr-' + 
+        self.filepath = os.path.join(self.hass.config.config_dir, 'ssocr-' +
                                      self._name.replace(' ', '_') + '.png')
         crop = ['crop', str(config[CONF_X_POS]), str(config[CONF_Y_POS]),
                 str(config[CONF_WIDTH]), str(config[CONF_HEIGHT])]

--- a/homeassistant/components/image_processing/seven_segments.py
+++ b/homeassistant/components/image_processing/seven_segments.py
@@ -69,8 +69,9 @@ class ImageProcessingSsocr(ImageProcessingEntity):
                 split_entity_id(camera_entity)[1])
         self._state = None
 
-        self.filepath = os.path.join(self.hass.config.config_dir, 'ssocr-' +
-                                     self._name.replace(' ', '_') + '.png')
+        self.filepath = os.path.join(self.hass.config.config_dir,
+                                     'ssocr-{0}.png'.format(
+                                         self._name.replace(' ', '_')))
         crop = ['crop', str(config[CONF_X_POS]), str(config[CONF_Y_POS]),
                 str(config[CONF_WIDTH]), str(config[CONF_HEIGHT])]
         digits = ['-d', str(config.get(CONF_DIGITS, -1))]

--- a/homeassistant/components/image_processing/seven_segments.py
+++ b/homeassistant/components/image_processing/seven_segments.py
@@ -69,7 +69,7 @@ class ImageProcessingSsocr(ImageProcessingEntity):
                 split_entity_id(camera_entity)[1])
         self._state = None
 
-        self.filepath = os.path.join(self.hass.config.config_dir, 'ocr.png')
+        self.filepath = os.path.join(self.hass.config.config_dir, 'ssocr-' + self._name.replace(' ','_') + '.png')
         crop = ['crop', str(config[CONF_X_POS]), str(config[CONF_Y_POS]),
                 str(config[CONF_WIDTH]), str(config[CONF_HEIGHT])]
         digits = ['-d', str(config.get(CONF_DIGITS, -1))]


### PR DESCRIPTION
A patch that addresses #18633, allowing multiple seven segments instances to have their own uniquely named ocr.png files.

**Description**
Have Seven Segments use a unique file name instead of `home-assistant-config-dir/ocr.png` to allow multiple instances to run without constantly overwriting each other's ssocr image input data.

**Breaking Change**
seven_segments will incorporate the entity name into the file name changing from former hardcoded `ocr.png` to `ssocr-(ss_entity_name).png` to make each ssocr input data file unique.