### PR TITLE
Updated webhook_register, version bump pypoint

### DIFF
--- a/homeassistant/components/binary_sensor/point.py
+++ b/homeassistant/components/binary_sensor/point.py
@@ -7,6 +7,7 @@ https://home-assistant.io/components/binary_sensor.point/
 
 import logging
 
+from homeassistant.components.binary_sensor import BinarySensorDevice
 from homeassistant.components.point import MinutPointEntity
 from homeassistant.components.point.const import (
     DOMAIN as POINT_DOMAIN, NEW_DEVICE, SIGNAL_WEBHOOK)
@@ -45,7 +46,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                         for device_class in EVENTS), True)
 
 
-class MinutPointBinarySensor(MinutPointEntity):
+class MinutPointBinarySensor(MinutPointEntity, BinarySensorDevice):
     """The platform class required by Home Assistant."""
 
     def __init__(self, point_client, device_id, device_class):

--- a/homeassistant/components/point/__init__.py
+++ b/homeassistant/components/point/__init__.py
@@ -25,7 +25,7 @@ from .const import (
     CONF_WEBHOOK_URL, DOMAIN, EVENT_RECEIVED, NEW_DEVICE, SCAN_INTERVAL,
     SIGNAL_UPDATE_ENTITY, SIGNAL_WEBHOOK)
 
-REQUIREMENTS = ['pypoint==1.0.5']
+REQUIREMENTS = ['pypoint==1.0.6']
 DEPENDENCIES = ['webhook']
 
 _LOGGER = logging.getLogger(__name__)
@@ -113,8 +113,8 @@ async def async_setup_webhook(hass: HomeAssistantType, entry: ConfigEntry,
     session.update_webhook(entry.data[CONF_WEBHOOK_URL],
                            entry.data[CONF_WEBHOOK_ID])
 
-    hass.components.webhook.async_register(entry.data[CONF_WEBHOOK_ID],
-                                           handle_webhook)
+    hass.components.webhook.async_register(
+        DOMAIN, 'Point', entry.data[CONF_WEBHOOK_ID], handle_webhook)
 
 
 async def async_unload_entry(hass: HomeAssistantType, entry: ConfigEntry):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1099,7 +1099,7 @@ pyowm==2.9.0
 pypjlink2==1.2.0
 
 # homeassistant.components.point
-pypoint==1.0.5
+pypoint==1.0.6
 
 # homeassistant.components.sensor.pollen
 pypollencom==2.2.2


### PR DESCRIPTION
## Description:

When merged with dev, the `hass.components.webhook.async_register` changed format. 

Pypoint v 1.0.5 had a minor issue.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
