### PR TITLE
[Breaking Change] Cleanup Lutron light component

### DIFF
--- a/homeassistant/components/light/lutron.py
+++ b/homeassistant/components/light/lutron.py
@@ -24,7 +24,6 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         devs.append(dev)
 
     add_entities(devs, True)
-    return True
 
 
 def to_lutron_level(level):
@@ -43,7 +42,7 @@ class LutronLight(LutronDevice, Light):
     def __init__(self, area_name, lutron_device, controller):
         """Initialize the light."""
         self._prev_brightness = None
-        LutronDevice.__init__(self, area_name, lutron_device, controller)
+        super().__init__(self, area_name, lutron_device, controller)
 
     @property
     def supported_features(self):
@@ -77,7 +76,7 @@ class LutronLight(LutronDevice, Light):
     def device_state_attributes(self):
         """Return the state attributes."""
         attr = {}
-        attr['Lutron Integration ID'] = self._lutron_device.id
+        attr['lutron_integration_id'] = self._lutron_device.id
         return attr
 
     @property


### PR DESCRIPTION
## Description:
Remove the return value from setup_platform
Convert LutronLight.__init__ to use super() when referencing the parent class.
Change device_state_attributes() to use lowercase snakecase (Rename 'Lutron Integration ID' to 'lutron_integration_id')


## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
