### PR TITLE
Add save command to lovelace

### DIFF
--- a/homeassistant/components/lovelace/__init__.py
+++ b/homeassistant/components/lovelace/__init__.py
@@ -57,7 +57,7 @@ SCHEMA_MIGRATE_CONFIG = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend({
 SCHEMA_SAVE_CONFIG = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend({
     vol.Required('type'): WS_TYPE_SAVE_CONFIG,
     vol.Required('config'): vol.Any(str, Dict),
-    vol.Optional('format', default=FORMAT_YAML):
+    vol.Optional('format', default=FORMAT_JSON):
         vol.Any(FORMAT_JSON, FORMAT_YAML),
 })
 
@@ -212,7 +212,7 @@ def migrate_config(fname: str) -> None:
         yaml.save_yaml(fname, config)
 
 
-def save_config(fname: str, config, data_format: str = FORMAT_YAML) -> None:
+def save_config(fname: str, config, data_format: str = FORMAT_JSON) -> None:
     """Save config to file."""
     if data_format == FORMAT_YAML:
         config = yaml.yaml_to_object(config)
@@ -541,7 +541,7 @@ async def websocket_lovelace_save_config(hass, connection, msg):
     """Save Lovelace UI configuration."""
     return await hass.async_add_executor_job(
         save_config, hass.config.path(LOVELACE_CONFIG_FILE), msg['config'],
-        msg.get('format', FORMAT_YAML))
+        msg.get('format', FORMAT_JSON))
 
 
 @websocket_api.async_response

--- a/homeassistant/components/lovelace/__init__.py
+++ b/homeassistant/components/lovelace/__init__.py
@@ -31,6 +31,7 @@ FORMAT_JSON = 'json'
 OLD_WS_TYPE_GET_LOVELACE_UI = 'frontend/lovelace_config'
 WS_TYPE_GET_LOVELACE_UI = 'lovelace/config'
 WS_TYPE_MIGRATE_CONFIG = 'lovelace/config/migrate'
+WS_TYPE_SAVE_CONFIG = 'lovelace/config/save'
 
 WS_TYPE_GET_CARD = 'lovelace/config/card/get'
 WS_TYPE_UPDATE_CARD = 'lovelace/config/card/update'
@@ -51,6 +52,13 @@ SCHEMA_GET_LOVELACE_UI = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend({
 
 SCHEMA_MIGRATE_CONFIG = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend({
     vol.Required('type'): WS_TYPE_MIGRATE_CONFIG,
+})
+
+SCHEMA_SAVE_CONFIG = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend({
+    vol.Required('type'): WS_TYPE_SAVE_CONFIG,
+    vol.Required('config'): vol.Any(str, Dict),
+    vol.Optional('format', default=FORMAT_YAML):
+        vol.Any(FORMAT_JSON, FORMAT_YAML),
 })
 
 SCHEMA_GET_CARD = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend({
@@ -202,6 +210,13 @@ def migrate_config(fname: str) -> None:
         index += 1
     if updated:
         yaml.save_yaml(fname, config)
+
+
+def save_config(fname: str, config, data_format: str = FORMAT_YAML) -> None:
+    """Save config to file."""
+    if data_format == FORMAT_YAML:
+        config = yaml.yaml_to_object(config)
+    yaml.save_yaml(fname, config)
 
 
 def get_card(fname: str, card_id: str, data_format: str = FORMAT_YAML)\
@@ -423,12 +438,16 @@ async def async_setup(hass, config):
         SCHEMA_GET_LOVELACE_UI)
 
     hass.components.websocket_api.async_register_command(
+        WS_TYPE_GET_LOVELACE_UI, websocket_lovelace_config,
+        SCHEMA_GET_LOVELACE_UI)
+
+    hass.components.websocket_api.async_register_command(
         WS_TYPE_MIGRATE_CONFIG, websocket_lovelace_migrate_config,
         SCHEMA_MIGRATE_CONFIG)
 
     hass.components.websocket_api.async_register_command(
-        WS_TYPE_GET_LOVELACE_UI, websocket_lovelace_config,
-        SCHEMA_GET_LOVELACE_UI)
+        WS_TYPE_SAVE_CONFIG, websocket_lovelace_save_config,
+        SCHEMA_SAVE_CONFIG)
 
     hass.components.websocket_api.async_register_command(
         WS_TYPE_GET_CARD, websocket_lovelace_get_card, SCHEMA_GET_CARD)
@@ -514,6 +533,15 @@ async def websocket_lovelace_migrate_config(hass, connection, msg):
     """Migrate Lovelace UI configuration."""
     return await hass.async_add_executor_job(
         migrate_config, hass.config.path(LOVELACE_CONFIG_FILE))
+
+
+@websocket_api.async_response
+@handle_yaml_errors
+async def websocket_lovelace_save_config(hass, connection, msg):
+    """Save Lovelace UI configuration."""
+    return await hass.async_add_executor_job(
+        save_config, hass.config.path(LOVELACE_CONFIG_FILE), msg['config'],
+        msg.get('format', FORMAT_YAML))
 
 
 @websocket_api.async_response

--- a/homeassistant/util/ruamel_yaml.py
+++ b/homeassistant/util/ruamel_yaml.py
@@ -104,13 +104,18 @@ def save_yaml(fname: str, data: JSON_TYPE) -> None:
     yaml.indent(sequence=4, offset=2)
     tmp_fname = fname + "__TEMP__"
     try:
-        file_stat = os.stat(fname)
+        try:
+            file_stat = os.stat(fname)
+            st_mode = file_stat.st_mode
+        except OSError:
+            file_stat = None
+            st_mode = 0o644
         with open(os.open(tmp_fname, O_WRONLY | O_CREAT | O_TRUNC,
-                          file_stat.st_mode), 'w', encoding='utf-8') \
+                          st_mode), 'w', encoding='utf-8') \
                 as temp_file:
             yaml.dump(data, temp_file)
         os.replace(tmp_fname, fname)
-        if hasattr(os, 'chown'):
+        if hasattr(os, 'chown') and file_stat:
             try:
                 os.chown(fname, file_stat.st_uid, file_stat.st_gid)
             except OSError:


### PR DESCRIPTION
## Description:
Adds save command to save the automatically created config to file.

https://github.com/home-assistant/home-assistant-polymer/pull/2091

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
