### PR TITLE
Support for mulitple Blink sync modules

### DIFF
--- a/homeassistant/components/alarm_control_panel/blink.py
+++ b/homeassistant/components/alarm_control_panel/blink.py
@@ -25,21 +25,19 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         return
     data = hass.data[BLINK_DATA]
 
-    # Current version of blinkpy API only supports one sync module.  When
-    # support for additional models is added, the sync module name should
-    # come from the API.
     sync_modules = []
-    sync_modules.append(BlinkSyncModule(data, 'sync'))
+    for sync_name, sync_module in data.sync.items():
+        sync_modules.append(BlinkSyncModule(data, sync_name, sync_module))
     add_entities(sync_modules, True)
 
 
 class BlinkSyncModule(AlarmControlPanel):
     """Representation of a Blink Alarm Control Panel."""
 
-    def __init__(self, data, name):
+    def __init__(self, data, name, sync):
         """Initialize the alarm control panel."""
         self.data = data
-        self.sync = data.sync
+        self.sync = sync
         self._name = name
         self._state = None
 
@@ -68,6 +66,7 @@ class BlinkSyncModule(AlarmControlPanel):
         """Return the state attributes."""
         attr = self.sync.attributes
         attr['network_info'] = self.data.networks
+        attr['associated_cameras'] = list(self.sync.cameras.keys())
         attr[ATTR_ATTRIBUTION] = DEFAULT_ATTRIBUTION
         return attr
 

--- a/homeassistant/components/binary_sensor/blink.py
+++ b/homeassistant/components/binary_sensor/blink.py
@@ -18,7 +18,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     data = hass.data[BLINK_DATA]
 
     devs = []
-    for camera in data.sync.cameras:
+    for camera in data.cameras:
         for sensor_type in discovery_info[CONF_MONITORED_CONDITIONS]:
             devs.append(BlinkBinarySensor(data, camera, sensor_type))
     add_entities(devs, True)
@@ -34,7 +34,7 @@ class BlinkBinarySensor(BinarySensorDevice):
         name, icon = BINARY_SENSORS[sensor_type]
         self._name = "{} {} {}".format(BLINK_DATA, camera, name)
         self._icon = icon
-        self._camera = data.sync.cameras[camera]
+        self._camera = data.cameras[camera]
         self._state = None
         self._unique_id = "{}-{}".format(self._camera.serial, self._type)
 

--- a/homeassistant/components/blink/__init__.py
+++ b/homeassistant/components/blink/__init__.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
     CONF_BINARY_SENSORS, CONF_SENSORS, CONF_FILENAME,
     CONF_MONITORED_CONDITIONS, TEMP_FAHRENHEIT)
 
-REQUIREMENTS = ['blinkpy==0.10.3']
+REQUIREMENTS = ['blinkpy==0.11.0']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -111,7 +111,7 @@ def setup(hass, config):
 
     def trigger_camera(call):
         """Trigger a camera."""
-        cameras = hass.data[BLINK_DATA].sync.cameras
+        cameras = hass.data[BLINK_DATA].cameras
         name = call.data[CONF_NAME]
         if name in cameras:
             cameras[name].snap_picture()
@@ -148,7 +148,7 @@ async def async_handle_save_video_service(hass, call):
 
     def _write_video(camera_name, video_path):
         """Call video write."""
-        all_cameras = hass.data[BLINK_DATA].sync.cameras
+        all_cameras = hass.data[BLINK_DATA].cameras
         if camera_name in all_cameras:
             all_cameras[camera_name].video_to_file(video_path)
 

--- a/homeassistant/components/camera/blink.py
+++ b/homeassistant/components/camera/blink.py
@@ -23,7 +23,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         return
     data = hass.data[BLINK_DATA]
     devs = []
-    for name, camera in data.sync.cameras.items():
+    for name, camera in data.cameras.items():
         devs.append(BlinkCamera(data, name, camera))
 
     add_entities(devs)

--- a/homeassistant/components/sensor/blink.py
+++ b/homeassistant/components/sensor/blink.py
@@ -21,7 +21,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         return
     data = hass.data[BLINK_DATA]
     devs = []
-    for camera in data.sync.cameras:
+    for camera in data.cameras:
         for sensor_type in discovery_info[CONF_MONITORED_CONDITIONS]:
             devs.append(BlinkSensor(data, camera, sensor_type))
 
@@ -39,7 +39,7 @@ class BlinkSensor(Entity):
         self._camera_name = name
         self._type = sensor_type
         self.data = data
-        self._camera = data.sync.cameras[camera]
+        self._camera = data.cameras[camera]
         self._state = None
         self._unit_of_measurement = units
         self._icon = icon

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -186,7 +186,7 @@ bellows==0.7.0
 bimmer_connected==0.5.3
 
 # homeassistant.components.blink
-blinkpy==0.10.3
+blinkpy==0.11.0
 
 # homeassistant.components.light.blinksticklight
 blinkstick==1.1.8


### PR DESCRIPTION
## Description:
The `blinkpy` library added support for multiple sync modules with the most recent release, so I rolled those changes in here. 

## Example entry for `configuration.yaml` (if applicable):
```yaml
blink:
  username: <username>
  password: <password>
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
