### PR TITLE
Add MANUAL state of HM-IP-ETRV-2 to supported modes

### DIFF
--- a/homeassistant/components/alexa/smart_home.py
+++ b/homeassistant/components/alexa/smart_home.py
@@ -48,6 +48,7 @@ API_TEMP_UNITS = {
 # back to HA state.
 API_THERMOSTAT_MODES = OrderedDict([
     (climate.STATE_HEAT, 'HEAT'),
+    (climate.STATE_MANUAL, 'HEAT'),
     (climate.STATE_COOL, 'COOL'),
     (climate.STATE_AUTO, 'AUTO'),
     (climate.STATE_ECO, 'ECO'),


### PR DESCRIPTION
## Description:

This fix fixes the problem when a thermostat is in manual mode,
to prevent overwriting the settings made within Homeassistant,
Alexa was not able to get/set the status anymore.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

