### PR TITLE
Specifying a device name in lost_iphone now works

### DIFF
--- a/homeassistant/components/device_tracker/icloud.py
+++ b/homeassistant/components/device_tracker/icloud.py
@@ -443,7 +443,8 @@ class Icloud(DeviceScanner):
         self.api.authenticate()
 
         for device in self.api.devices:
-            if devicename is None or device == self.devices[devicename]:
+            if devicename is None or \
+               str(device) == str(self.devices[devicename]):
                 device.play_sound()
 
     def update_icloud(self, devicename=None):


### PR DESCRIPTION
## Description:

Specifying a device name in lost_iphone now works

**Related issue:** fixes #11419

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.
  - [X] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
