### PR TITLE
 Fix false log message on CAPsMAN only devices 

### DIFF
--- a/homeassistant/components/device_tracker/mikrotik.py
+++ b/homeassistant/components/device_tracker/mikrotik.py
@@ -129,7 +129,7 @@ class MikrotikScanner(DeviceScanner):
                     self.wireless_exist = False
 
                 if not self.wireless_exist and not self.capsman_exist \
-                or self.method == 'ip':
+                   or self.method == 'ip':
                     _LOGGER.info(
                         "Mikrotik %s: Wireless adapters not found. Try to "
                         "use DHCP lease table as presence tracker source. "

--- a/homeassistant/components/device_tracker/mikrotik.py
+++ b/homeassistant/components/device_tracker/mikrotik.py
@@ -128,7 +128,8 @@ class MikrotikScanner(DeviceScanner):
                         librouteros.exceptions.ConnectionError):
                     self.wireless_exist = False
 
-                if not self.wireless_exist or self.method == 'ip':
+                if not self.wireless_exist and not self.capsman_exist \
+                or self.method == 'ip':
                     _LOGGER.info(
                         "Mikrotik %s: Wireless adapters not found. Try to "
                         "use DHCP lease table as presence tracker source. "


### PR DESCRIPTION
## Description:
False debug log message appeared on CAPsMAN only devices without physichal wireless interfaces. This fix eliminates them.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
