### PR TITLE
adding ssl-cert-check package to base image to allow automations that…

### DIFF
--- a/virtualization/Docker/setup_docker_prereqs
+++ b/virtualization/Docker/setup_docker_prereqs
@@ -30,6 +30,8 @@ PACKAGES=(
   ffmpeg
   # homeassistant.components.sensor.iperf3
   iperf3
+  # To allow automations that evaluate ssl cert status
+  ssl-cert-check
 )
 
 # Required debian packages for building dependencies


### PR DESCRIPTION
… can check ssl cert status

## Description:
Simple addition to the base image that allows command-line use of `ssl-cert-check` package to check on ssl status. 

Most duckdns-like tutorials/examples seem to use this method and thus require manually installing `ssl-cert-check` (which can be clumsy in a docker image). This becomes tedious when upgrading docker images since your sensor will stop working unless you manually reinstall this package. (or if you're like me, you have to create a post-install script so you don't forget)

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

Example sensor: 
platform: command_line
   name: SSL Cert Expiry
   unit_of_measurement: days
   scan_interval: 10800
   command: "ssl-cert-check -b -c /etc/bla/bla/bla/cert.pem | awk '{ print $NF }'"
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
