### PR TITLE
support lists and dicts in secrets.yaml

### DIFF
--- a/homeassistant/util/yaml.py
+++ b/homeassistant/util/yaml.py
@@ -283,7 +283,7 @@ def secret_yaml(loader: SafeLineLoader,
         if node.value in secrets:
             _LOGGER.debug("Secret %s retrieved from secrets.yaml in "
                           "folder %s", node.value, secret_path)
-            # return a deepcopy so users can't corrupt the internal secret cache
+            # return a deepcopy so the internal cache can't be corrupted
             return copy.deepcopy(secrets[node.value])
 
         if secret_path == os.path.dirname(sys.path[0]):

--- a/homeassistant/util/yaml.py
+++ b/homeassistant/util/yaml.py
@@ -3,6 +3,7 @@ import logging
 import os
 import sys
 import fnmatch
+import copy
 from collections import OrderedDict
 from typing import Union, List, Dict, Iterator, overload, TypeVar
 
@@ -282,7 +283,8 @@ def secret_yaml(loader: SafeLineLoader,
         if node.value in secrets:
             _LOGGER.debug("Secret %s retrieved from secrets.yaml in "
                           "folder %s", node.value, secret_path)
-            return secrets[node.value]
+            # return a deepcopy so users can't corrupt the internal secret cache
+            return copy.deepcopy(secrets[node.value])
 
         if secret_path == os.path.dirname(sys.path[0]):
             break  # sys.path[0] set to config/deps folder by bootstrap


### PR DESCRIPTION
## Description:
The secrets implementation maintains an internal cache. If an entry is a complex data type (list or dict), it is returned by reference in the `secret_yaml` implementation. When parsing the config yaml, that reference is placed into the configuration object. The configuration object is modified in place sometimes (for instance strings can be turned into Template objects). This becomes an issue when reloading the configuration at run time as the cache has now been modified and can produce unexpected behavior or errors.

To get fix this, the secret_yaml loader should return a deep copy of it's cached value. This way, the downstream consumer of this config entry cannot modify and corrupt the internal secret cache. `copy.deepcopy` is used rather than just `copy.copy` to support arbitrarily nested data structures in secrets.yaml.

My use case for this was maintaining a list of notification emails in secrets.yaml for use in automations. Below is an example that will now work using the pushbullet notifier which before would corrupt the secret cache by turning each entry in the `default_notify` list into a Template object.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>
_I don't think the docs need to be updated to reflect this as I'd call this just intuitive behavior. I'm happy to open a PR for the docs showing an example of this if people think that's a good idea._

## YAML configuration example
**secrets.yaml**
```yaml
# default notifier  target
default_notify: 
  - 'email/foo@bar.com'
  - 'email/biz@baz.com'
```

**automations.yaml**
```yaml
- alias: 'example pushbullet notification'
  trigger:
    platform: event
    event_type: state_changed
    entity_id: light.some_light
    to_state: on
  action:
    - service: notify.pushbullet
      data_template:
        message: 'This is an example'
        target: !secret default_notify
```
## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] ~~Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)~~
_Assuming this isn't needed based on the content of this PR, unless people think otherwise_