### PR TITLE
Add air pollutants component

### DIFF
--- a/homeassistant/components/air_pollutants/__init__.py
+++ b/homeassistant/components/air_pollutants/__init__.py
@@ -1,0 +1,221 @@
+"""
+Component for handling Air Pollutants data for your location.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/air_pollutants/
+"""
+import logging
+
+from homeassistant.helpers.entity_component import EntityComponent
+from homeassistant.helpers.temperature import display_temp as show_temp
+from homeassistant.const import PRECISION_WHOLE, PRECISION_TENTHS, TEMP_CELSIUS
+from homeassistant.helpers.config_validation import PLATFORM_SCHEMA  # noqa
+from homeassistant.helpers.entity import Entity
+
+_LOGGER = logging.getLogger(__name__)
+
+DEPENDENCIES = []
+DOMAIN = 'air_pollutants'
+
+ENTITY_ID_FORMAT = DOMAIN + '.{}'
+
+ATTR_AIR_POLLUTANTS_AQI = 'air_quality_index'
+ATTR_AIR_POLLUTANTS_ATTRIBUTION = 'attribution'
+ATTR_AIR_POLLUTANTS_C02 = 'carbon_dioxide'
+ATTR_AIR_POLLUTANTS_CO = 'carbon_monoxide'
+ATTR_AIR_POLLUTANTS_HUMIDITY = 'humidity'
+ATTR_AIR_POLLUTANTS_N2O = 'nitrogen_oxide'
+ATTR_AIR_POLLUTANTS_NO = 'nitrogen_monoxide'
+ATTR_AIR_POLLUTANTS_NO2 = 'nitrogen_dioxide'
+ATTR_AIR_POLLUTANTS_ORGANIC = 'volatile_organic_compounds'
+ATTR_AIR_POLLUTANTS_OZONE = 'ozone'
+ATTR_AIR_POLLUTANTS_PM = 'particulate_matter'
+ATTR_AIR_POLLUTANTS_PM_0_1 = 'particulate_matter_0_1'
+ATTR_AIR_POLLUTANTS_PM_10 = 'particulate_matter_10'
+ATTR_AIR_POLLUTANTS_PM_2_5 = 'particulate_matter_2_5'
+ATTR_AIR_POLLUTANTS_SO2 = 'sulphur_dioxide'
+ATTR_AIR_POLLUTANTS_TEMPERATURE = 'temperature'
+
+
+async def async_setup(hass, config):
+    """Set up the air pollutants component."""
+    component = hass.data[DOMAIN] = EntityComponent(_LOGGER, DOMAIN, hass)
+    await component.async_setup(config)
+    return True
+
+
+async def async_setup_entry(hass, entry):
+    """Set up a config entry."""
+    return await hass.data[DOMAIN].async_setup_entry(entry)
+
+
+async def async_unload_entry(hass, entry):
+    """Unload a config entry."""
+    return await hass.data[DOMAIN].async_unload_entry(entry)
+
+
+class AirPollutantsEntity(Entity):
+    """ABC for air pollutants data."""
+
+    @property
+    def particulate_matter_2_5(self):
+        """Return the particulate matter 2.5 level."""
+        raise NotImplementedError()
+
+    @property
+    def particulate_matter_10(self):
+        """Return the particulate matter 10 level."""
+        raise NotImplementedError()
+
+    @property
+    def precision(self):
+        """Return the forecast."""
+        return PRECISION_TENTHS if self.temperature_unit == TEMP_CELSIUS \
+            else PRECISION_WHOLE
+
+    @property
+    def humidity(self):
+        """Return the humidity."""
+        return None
+
+    @property
+    def temperature(self):
+        """Return the platform temperature."""
+        return None
+
+    @property
+    def temperature_unit(self):
+        """Return the unit of measurement."""
+        return None
+
+    @property
+    def air_quality_index(self):
+        """Return the Air Quality Index."""
+        return None
+
+    @property
+    def ozone(self):
+        """Return the ozone (O3) level."""
+        return None
+
+    @property
+    def carbon_monoxide(self):
+        """Return the carbon monoxide (CO) level."""
+        return None
+
+    @property
+    def carbon_dioxide(self):
+        """Return the carbon dioxide (CO2) level."""
+        return None
+
+    @property
+    def attribution(self):
+        """Return the attribution."""
+        return None
+
+    @property
+    def particulate_matter(self):
+        """Return the particulate matter level."""
+        return None
+
+    @property
+    def particulate_matter_0_1(self):
+        """Return the particulate matter 0.1 level."""
+        return None
+
+    @property
+    def sulphur_dioxide(self):
+        """Return the sulphur dioxide (SO2) level."""
+        return None
+
+    @property
+    def nitrogen_oxide(self):
+        """Return the nitrogen oxide (NO2) level."""
+        return None
+
+    @property
+    def nitrogen_monoxide(self):
+        """Return the nitrogen monoxide (NO) level."""
+        return None
+
+    @property
+    def nitrogen_dioxide(self):
+        """Return the nitrogen dioxide (NO2) level."""
+        return None
+
+    @property
+    def volatile_organic_compounds(self):
+        """Return the volatile organic compounds level."""
+        return None
+
+    @property
+    def state_attributes(self):
+        """Return the state attributes."""
+        data = {
+            ATTR_AIR_POLLUTANTS_TEMPERATURE: show_temp(
+                self.hass, self.temperature, self.temperature_unit,
+                self.precision),
+        }
+
+        air_quality_index = self.air_quality_index
+        if air_quality_index is not None:
+            data[ATTR_AIR_POLLUTANTS_AQI] = air_quality_index
+
+        humidity = self.humidity
+        if humidity is not None:
+            data[ATTR_AIR_POLLUTANTS_HUMIDITY] = round(humidity)
+
+        ozone = self.ozone
+        if ozone is not None:
+            data[ATTR_AIR_POLLUTANTS_OZONE] = ozone
+
+        particulate_matter = self.particulate_matter
+        if particulate_matter is not None:
+            data[ATTR_AIR_POLLUTANTS_PM] = particulate_matter
+
+        particulate_matter_0_1 = self.particulate_matter_0_1
+        if particulate_matter_0_1 is not None:
+            data[ATTR_AIR_POLLUTANTS_PM_0_1] = particulate_matter_0_1
+
+        particulate_matter_10 = self.particulate_matter_10
+        if particulate_matter_10 is not None:
+            data[ATTR_AIR_POLLUTANTS_PM_10] = particulate_matter_10
+
+        sulphur_dioxide = self.sulphur_dioxide
+        if sulphur_dioxide is not None:
+            data[ATTR_AIR_POLLUTANTS_SO2] = sulphur_dioxide
+
+        nitrogen_oxide = self.nitrogen_oxide
+        if nitrogen_oxide is not None:
+            data[ATTR_AIR_POLLUTANTS_N2O] = nitrogen_oxide
+
+        nitrogen_monoxide = self.nitrogen_monoxide
+        if nitrogen_monoxide is not None:
+            data[ATTR_AIR_POLLUTANTS_NO] = nitrogen_monoxide
+
+        nitrogen_dioxide = self.nitrogen_dioxide
+        if sulphur_dioxide is not None:
+            data[ATTR_AIR_POLLUTANTS_NO2] = nitrogen_dioxide
+
+        carbon_dioxide = self.carbon_dioxide
+        if carbon_dioxide is not None:
+            data[ATTR_AIR_POLLUTANTS_C02] = carbon_dioxide
+
+        carbon_monoxide = self.carbon_monoxide
+        if carbon_monoxide is not None:
+            data[ATTR_AIR_POLLUTANTS_CO] = carbon_monoxide
+
+        volatile_organic_compounds = self.volatile_organic_compounds
+        if volatile_organic_compounds is not None:
+            data[ATTR_AIR_POLLUTANTS_ORGANIC] = volatile_organic_compounds
+
+        attribution = self.attribution
+        if attribution is not None:
+            data[ATTR_AIR_POLLUTANTS_ATTRIBUTION] = attribution
+
+        return data
+
+    @property
+    def state(self):
+        """Return the current state."""
+        return self.particulate_matter_2_5

--- a/homeassistant/components/air_pollutants/__init__.py
+++ b/homeassistant/components/air_pollutants/__init__.py
@@ -12,7 +12,6 @@ from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)
 
-DEPENDENCIES = []
 DOMAIN = 'air_pollutants'
 
 ENTITY_ID_FORMAT = DOMAIN + '.{}'
@@ -59,7 +58,7 @@ class AirPollutantsEntity(Entity):
     @property
     def particulate_matter_10(self):
         """Return the particulate matter 10 level."""
-        raise NotImplementedError()
+        return None
 
     @property
     def particulate_matter_0_1(self):
@@ -150,7 +149,7 @@ class AirPollutantsEntity(Entity):
             data[ATTR_AIR_POLLUTANTS_NO] = nitrogen_monoxide
 
         nitrogen_dioxide = self.nitrogen_dioxide
-        if sulphur_dioxide is not None:
+        if nitrogen_dioxide is not None:
             data[ATTR_AIR_POLLUTANTS_NO2] = nitrogen_dioxide
 
         carbon_dioxide = self.carbon_dioxide

--- a/homeassistant/components/air_pollutants/__init__.py
+++ b/homeassistant/components/air_pollutants/__init__.py
@@ -7,8 +7,6 @@ https://home-assistant.io/components/air_pollutants/
 import logging
 
 from homeassistant.helpers.entity_component import EntityComponent
-from homeassistant.helpers.temperature import display_temp as show_temp
-from homeassistant.const import PRECISION_WHOLE, PRECISION_TENTHS, TEMP_CELSIUS
 from homeassistant.helpers.config_validation import PLATFORM_SCHEMA  # noqa
 from homeassistant.helpers.entity import Entity
 
@@ -23,18 +21,14 @@ ATTR_AIR_POLLUTANTS_AQI = 'air_quality_index'
 ATTR_AIR_POLLUTANTS_ATTRIBUTION = 'attribution'
 ATTR_AIR_POLLUTANTS_C02 = 'carbon_dioxide'
 ATTR_AIR_POLLUTANTS_CO = 'carbon_monoxide'
-ATTR_AIR_POLLUTANTS_HUMIDITY = 'humidity'
 ATTR_AIR_POLLUTANTS_N2O = 'nitrogen_oxide'
 ATTR_AIR_POLLUTANTS_NO = 'nitrogen_monoxide'
 ATTR_AIR_POLLUTANTS_NO2 = 'nitrogen_dioxide'
-ATTR_AIR_POLLUTANTS_ORGANIC = 'volatile_organic_compounds'
 ATTR_AIR_POLLUTANTS_OZONE = 'ozone'
-ATTR_AIR_POLLUTANTS_PM = 'particulate_matter'
 ATTR_AIR_POLLUTANTS_PM_0_1 = 'particulate_matter_0_1'
 ATTR_AIR_POLLUTANTS_PM_10 = 'particulate_matter_10'
 ATTR_AIR_POLLUTANTS_PM_2_5 = 'particulate_matter_2_5'
 ATTR_AIR_POLLUTANTS_SO2 = 'sulphur_dioxide'
-ATTR_AIR_POLLUTANTS_TEMPERATURE = 'temperature'
 
 
 async def async_setup(hass, config):
@@ -68,19 +62,8 @@ class AirPollutantsEntity(Entity):
         raise NotImplementedError()
 
     @property
-    def precision(self):
-        """Return the forecast."""
-        return PRECISION_TENTHS if self.temperature_unit == TEMP_CELSIUS \
-            else PRECISION_WHOLE
-
-    @property
-    def humidity(self):
-        """Return the humidity."""
-        return None
-
-    @property
-    def temperature(self):
-        """Return the platform temperature."""
+    def particulate_matter_0_1(self):
+        """Return the particulate matter 0.1 level."""
         return None
 
     @property
@@ -114,16 +97,6 @@ class AirPollutantsEntity(Entity):
         return None
 
     @property
-    def particulate_matter(self):
-        """Return the general particulate matter level."""
-        return None
-
-    @property
-    def particulate_matter_0_1(self):
-        """Return the particulate matter 0.1 level."""
-        return None
-
-    @property
     def sulphur_dioxide(self):
         """Return the SO2 (sulphur dioxide) level."""
         return None
@@ -144,34 +117,17 @@ class AirPollutantsEntity(Entity):
         return None
 
     @property
-    def volatile_organic_compounds(self):
-        """Return the volatile organic compounds (VOC) level."""
-        return None
-
-    @property
     def state_attributes(self):
         """Return the state attributes."""
-        data = {
-            ATTR_AIR_POLLUTANTS_TEMPERATURE: show_temp(
-                self.hass, self.temperature, self.temperature_unit,
-                self.precision),
-        }
+        data = {}
 
         air_quality_index = self.air_quality_index
         if air_quality_index is not None:
             data[ATTR_AIR_POLLUTANTS_AQI] = air_quality_index
 
-        humidity = self.humidity
-        if humidity is not None:
-            data[ATTR_AIR_POLLUTANTS_HUMIDITY] = round(humidity)
-
         ozone = self.ozone
         if ozone is not None:
             data[ATTR_AIR_POLLUTANTS_OZONE] = ozone
-
-        particulate_matter = self.particulate_matter
-        if particulate_matter is not None:
-            data[ATTR_AIR_POLLUTANTS_PM] = particulate_matter
 
         particulate_matter_0_1 = self.particulate_matter_0_1
         if particulate_matter_0_1 is not None:
@@ -204,10 +160,6 @@ class AirPollutantsEntity(Entity):
         carbon_monoxide = self.carbon_monoxide
         if carbon_monoxide is not None:
             data[ATTR_AIR_POLLUTANTS_CO] = carbon_monoxide
-
-        volatile_organic_compounds = self.volatile_organic_compounds
-        if volatile_organic_compounds is not None:
-            data[ATTR_AIR_POLLUTANTS_ORGANIC] = volatile_organic_compounds
 
         attribution = self.attribution
         if attribution is not None:

--- a/homeassistant/components/air_pollutants/__init__.py
+++ b/homeassistant/components/air_pollutants/__init__.py
@@ -4,6 +4,7 @@ Component for handling Air Pollutants data for your location.
 For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/air_pollutants/
 """
+from datetime import timedelta
 import logging
 
 from homeassistant.helpers.entity_component import EntityComponent
@@ -11,10 +12,6 @@ from homeassistant.helpers.config_validation import PLATFORM_SCHEMA  # noqa
 from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)
-
-DOMAIN = 'air_pollutants'
-
-ENTITY_ID_FORMAT = DOMAIN + '.{}'
 
 ATTR_AIR_POLLUTANTS_AQI = 'air_quality_index'
 ATTR_AIR_POLLUTANTS_ATTRIBUTION = 'attribution'
@@ -29,10 +26,17 @@ ATTR_AIR_POLLUTANTS_PM_10 = 'particulate_matter_10'
 ATTR_AIR_POLLUTANTS_PM_2_5 = 'particulate_matter_2_5'
 ATTR_AIR_POLLUTANTS_SO2 = 'sulphur_dioxide'
 
+DOMAIN = 'air_pollutants'
+
+ENTITY_ID_FORMAT = DOMAIN + '.{}'
+
+SCAN_INTERVAL = timedelta(seconds=30)
+
 
 async def async_setup(hass, config):
     """Set up the air pollutants component."""
-    component = hass.data[DOMAIN] = EntityComponent(_LOGGER, DOMAIN, hass)
+    component = hass.data[DOMAIN] = EntityComponent(
+        _LOGGER, DOMAIN, hass, SCAN_INTERVAL)
     await component.async_setup(config)
     return True
 

--- a/homeassistant/components/air_pollutants/__init__.py
+++ b/homeassistant/components/air_pollutants/__init__.py
@@ -85,27 +85,27 @@ class AirPollutantsEntity(Entity):
 
     @property
     def temperature_unit(self):
-        """Return the unit of measurement."""
+        """Return the unit of measurement of the temperature."""
         return None
 
     @property
     def air_quality_index(self):
-        """Return the Air Quality Index."""
+        """Return the Air Quality Index (AQI)."""
         return None
 
     @property
     def ozone(self):
-        """Return the ozone (O3) level."""
+        """Return the O3 (ozone) level."""
         return None
 
     @property
     def carbon_monoxide(self):
-        """Return the carbon monoxide (CO) level."""
+        """Return the CO (carbon monoxide) level."""
         return None
 
     @property
     def carbon_dioxide(self):
-        """Return the carbon dioxide (CO2) level."""
+        """Return the CO2 (carbon dioxide) level."""
         return None
 
     @property
@@ -115,7 +115,7 @@ class AirPollutantsEntity(Entity):
 
     @property
     def particulate_matter(self):
-        """Return the particulate matter level."""
+        """Return the general particulate matter level."""
         return None
 
     @property
@@ -125,27 +125,27 @@ class AirPollutantsEntity(Entity):
 
     @property
     def sulphur_dioxide(self):
-        """Return the sulphur dioxide (SO2) level."""
+        """Return the SO2 (sulphur dioxide) level."""
         return None
 
     @property
     def nitrogen_oxide(self):
-        """Return the nitrogen oxide (NO2) level."""
+        """Return the N2O (nitrogen oxide) level."""
         return None
 
     @property
     def nitrogen_monoxide(self):
-        """Return the nitrogen monoxide (NO) level."""
+        """Return the NO (nitrogen monoxide) level."""
         return None
 
     @property
     def nitrogen_dioxide(self):
-        """Return the nitrogen dioxide (NO2) level."""
+        """Return the NO2 (nitrogen dioxide) level."""
         return None
 
     @property
     def volatile_organic_compounds(self):
-        """Return the volatile organic compounds level."""
+        """Return the volatile organic compounds (VOC) level."""
         return None
 
     @property

--- a/homeassistant/components/air_pollutants/demo.py
+++ b/homeassistant/components/air_pollutants/demo.py
@@ -5,7 +5,7 @@ For more details about this platform, please refer to the documentation
 https://home-assistant.io/components/demo/
 """
 from homeassistant.components.air_pollutants import AirPollutantsEntity
-from homeassistant.const import (TEMP_CELSIUS, TEMP_FAHRENHEIT)
+from homeassistant.const import (TEMP_CELSIUS, TEMP_FAHRENHEIT, CONF_H)
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):

--- a/homeassistant/components/air_pollutants/demo.py
+++ b/homeassistant/components/air_pollutants/demo.py
@@ -1,0 +1,69 @@
+"""
+Demo platform that offers fake air pollutants data.
+
+For more details about this platform, please refer to the documentation
+https://home-assistant.io/components/demo/
+"""
+from homeassistant.components.air_pollutants import AirPollutantsEntity
+from homeassistant.const import (TEMP_CELSIUS, TEMP_FAHRENHEIT)
+
+
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    """Set up the Air Pollutants."""
+    add_entities([
+        DemoAirPollutants('Home', 14, 23, 100, 12, TEMP_CELSIUS),
+        DemoAirPollutants('Office', 4, 16, None, 4.8, TEMP_FAHRENHEIT)
+    ])
+
+
+class DemoAirPollutants(AirPollutantsEntity):
+    """Representation of Air Pollutants data."""
+
+    def __init__(self, name, pm_2_5, pm_10, n2o, temperature, temperature_unit):
+        """Initialize the Demo Air Pollutants."""
+        self._name = name
+        self._pm_2_5 = pm_2_5
+        self._pm_10 = pm_10
+        self._n2o = n2o
+        self._temperature_unit = temperature_unit
+        self._temperature = temperature
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return '{} {}'.format('Demo Air Pollutants', self._name)
+
+    @property
+    def should_poll(self):
+        """No polling needed for Demo Air Pollutants."""
+        return False
+
+    @property
+    def temperature(self):
+        """Return the temperature."""
+        return self._temperature
+
+    @property
+    def temperature_unit(self):
+        """Return the unit of measurement."""
+        return self._temperature_unit
+
+    @property
+    def particulate_matter_2_5(self):
+        """Return the particulate matter 2.5 level."""
+        return self._pm_2_5
+
+    @property
+    def particulate_matter_10(self):
+        """Return the particulate matter 10 level."""
+        return self._pm_10
+
+    @property
+    def nitrogen_oxide(self):
+        """Return the nitrogen oxide (N2O) level."""
+        return self._n2o
+
+    @property
+    def attribution(self):
+        """Return the attribution."""
+        return 'Powered by Home Assistant'

--- a/homeassistant/components/air_pollutants/demo.py
+++ b/homeassistant/components/air_pollutants/demo.py
@@ -5,7 +5,7 @@ For more details about this platform, please refer to the documentation
 https://home-assistant.io/components/demo/
 """
 from homeassistant.components.air_pollutants import AirPollutantsEntity
-from homeassistant.const import (TEMP_CELSIUS, TEMP_FAHRENHEIT, CONF_H)
+from homeassistant.const import (TEMP_CELSIUS, TEMP_FAHRENHEIT)
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):

--- a/homeassistant/components/air_pollutants/demo.py
+++ b/homeassistant/components/air_pollutants/demo.py
@@ -5,7 +5,6 @@ For more details about this platform, please refer to the documentation
 https://home-assistant.io/components/demo/
 """
 from homeassistant.components.air_pollutants import AirPollutantsEntity
-from homeassistant.const import (TEMP_CELSIUS, TEMP_FAHRENHEIT)
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):

--- a/homeassistant/components/air_pollutants/demo.py
+++ b/homeassistant/components/air_pollutants/demo.py
@@ -11,22 +11,20 @@ from homeassistant.const import (TEMP_CELSIUS, TEMP_FAHRENHEIT)
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Air Pollutants."""
     add_entities([
-        DemoAirPollutants('Home', 14, 23, 100, 12, TEMP_CELSIUS),
-        DemoAirPollutants('Office', 4, 16, None, 4.8, TEMP_FAHRENHEIT)
+        DemoAirPollutants('Home', 14, 23, 100),
+        DemoAirPollutants('Office', 4, 16, None)
     ])
 
 
 class DemoAirPollutants(AirPollutantsEntity):
     """Representation of Air Pollutants data."""
 
-    def __init__(self, name, pm_2_5, pm_10, n2o, temp, temperature_unit):
+    def __init__(self, name, pm_2_5, pm_10, n2o):
         """Initialize the Demo Air Pollutants."""
         self._name = name
         self._pm_2_5 = pm_2_5
         self._pm_10 = pm_10
         self._n2o = n2o
-        self._temperature_unit = temperature_unit
-        self._temperature = temp
 
     @property
     def name(self):
@@ -37,16 +35,6 @@ class DemoAirPollutants(AirPollutantsEntity):
     def should_poll(self):
         """No polling needed for Demo Air Pollutants."""
         return False
-
-    @property
-    def temperature(self):
-        """Return the temperature."""
-        return self._temperature
-
-    @property
-    def temperature_unit(self):
-        """Return the unit of measurement."""
-        return self._temperature_unit
 
     @property
     def particulate_matter_2_5(self):

--- a/homeassistant/components/air_pollutants/demo.py
+++ b/homeassistant/components/air_pollutants/demo.py
@@ -19,14 +19,14 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class DemoAirPollutants(AirPollutantsEntity):
     """Representation of Air Pollutants data."""
 
-    def __init__(self, name, pm_2_5, pm_10, n2o, temperature, temperature_unit):
+    def __init__(self, name, pm_2_5, pm_10, n2o, temp, temperature_unit):
         """Initialize the Demo Air Pollutants."""
         self._name = name
         self._pm_2_5 = pm_2_5
         self._pm_10 = pm_10
         self._n2o = n2o
         self._temperature_unit = temperature_unit
-        self._temperature = temperature
+        self._temperature = temp
 
     @property
     def name(self):

--- a/homeassistant/components/demo.py
+++ b/homeassistant/components/demo.py
@@ -15,6 +15,7 @@ DEPENDENCIES = ['conversation', 'introduction', 'zone']
 DOMAIN = 'demo'
 
 COMPONENTS_WITH_DEMO_PLATFORM = [
+    'air_pollutants',
     'alarm_control_panel',
     'binary_sensor',
     'calendar',

--- a/tests/components/air_pollutants/__init__.py
+++ b/tests/components/air_pollutants/__init__.py
@@ -1,0 +1,1 @@
+"""The tests for Air Pollutants platforms."""

--- a/tests/components/air_pollutants/test_air_pollutants.py
+++ b/tests/components/air_pollutants/test_air_pollutants.py
@@ -1,0 +1,56 @@
+"""The tests for the Air Pollutants component."""
+import unittest
+
+from homeassistant.components import air_pollutants
+from homeassistant.components.air_pollutants import (
+    ATTR_AIR_POLLUTANTS_ATTRIBUTION, ATTR_AIR_POLLUTANTS_N2O,
+    ATTR_AIR_POLLUTANTS_OZONE, ATTR_AIR_POLLUTANTS_PM_10,
+    ATTR_AIR_POLLUTANTS_TEMPERATURE)
+from homeassistant.setup import setup_component
+from homeassistant.util.unit_system import METRIC_SYSTEM
+
+from tests.common import get_test_home_assistant
+
+
+class TestAirPollutants(unittest.TestCase):
+    """Test the Air Pollutants component."""
+
+    def setUp(self):
+        """Set up things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+        self.hass.config.units = METRIC_SYSTEM
+        assert setup_component(self.hass, air_pollutants.DOMAIN, {
+            'air_pollutants': {
+                'platform': 'demo',
+            }
+        })
+
+    def tearDown(self):
+        """Stop down everything that was started."""
+        self.hass.stop()
+
+    def test_attributes(self):
+        """Test Air Pollutants attributes."""
+        state = self.hass.states.get('air_pollutants.demo_air_pollutants_home')
+        assert state is not None
+
+        assert state.state == '14'
+
+        data = state.attributes
+        assert data.get(ATTR_AIR_POLLUTANTS_PM_10) == 23
+        assert data.get(ATTR_AIR_POLLUTANTS_N2O) == 100
+        assert data.get(ATTR_AIR_POLLUTANTS_TEMPERATURE) == 12
+        assert data.get(ATTR_AIR_POLLUTANTS_OZONE) is None
+        assert data.get(ATTR_AIR_POLLUTANTS_ATTRIBUTION) == \
+            'Powered by Home Assistant'
+
+    def test_temperature_convert(self):
+        """Test temperature conversion."""
+        state = self.hass.states.get(
+            'air_pollutants.demo_air_pollutants_office')
+        assert state is not None
+
+        assert state.state == '4'
+
+        data = state.attributes
+        assert data.get(ATTR_AIR_POLLUTANTS_TEMPERATURE) == -15

--- a/tests/components/air_pollutants/test_air_pollutants.py
+++ b/tests/components/air_pollutants/test_air_pollutants.py
@@ -1,43 +1,42 @@
 """The tests for the Air Pollutants component."""
-import unittest
-
-from homeassistant.components import air_pollutants
 from homeassistant.components.air_pollutants import (
     ATTR_AIR_POLLUTANTS_ATTRIBUTION, ATTR_AIR_POLLUTANTS_N2O,
     ATTR_AIR_POLLUTANTS_OZONE, ATTR_AIR_POLLUTANTS_PM_10)
-from homeassistant.setup import setup_component
-from homeassistant.util.unit_system import METRIC_SYSTEM
-
-from tests.common import get_test_home_assistant
+from homeassistant.setup import async_setup_component
 
 
-class TestAirPollutants(unittest.TestCase):
-    """Test the Air Pollutants component."""
+async def test_state(hass):
+    """Test Air Pollutants state."""
+    config = {
+        'air_pollutants': {
+            'platform': 'demo',
+        }
+    }
 
-    def setUp(self):
-        """Set up things to be run when tests are started."""
-        self.hass = get_test_home_assistant()
-        self.hass.config.units = METRIC_SYSTEM
-        assert setup_component(self.hass, air_pollutants.DOMAIN, {
-            'air_pollutants': {
-                'platform': 'demo',
-            }
-        })
+    assert await async_setup_component(hass, 'air_pollutants', config)
 
-    def tearDown(self):
-        """Stop down everything that was started."""
-        self.hass.stop()
+    state = hass.states.get('air_pollutants.demo_air_pollutants_home')
+    assert state is not None
 
-    def test_attributes(self):
-        """Test Air Pollutants attributes."""
-        state = self.hass.states.get('air_pollutants.demo_air_pollutants_home')
-        assert state is not None
+    assert state.state == '14'
 
-        assert state.state == '14'
 
-        data = state.attributes
-        assert data.get(ATTR_AIR_POLLUTANTS_PM_10) == 23
-        assert data.get(ATTR_AIR_POLLUTANTS_N2O) == 100
-        assert data.get(ATTR_AIR_POLLUTANTS_OZONE) is None
-        assert data.get(ATTR_AIR_POLLUTANTS_ATTRIBUTION) == \
-            'Powered by Home Assistant'
+async def test_attributes(hass):
+    """Test Air Pollutants attributes."""
+    config = {
+        'air_pollutants': {
+            'platform': 'demo',
+        }
+    }
+
+    assert await async_setup_component(hass, 'air_pollutants', config)
+
+    state = hass.states.get('air_pollutants.demo_air_pollutants_office')
+    assert state is not None
+
+    data = state.attributes
+    assert data.get(ATTR_AIR_POLLUTANTS_PM_10) == 16
+    assert data.get(ATTR_AIR_POLLUTANTS_N2O) is None
+    assert data.get(ATTR_AIR_POLLUTANTS_OZONE) is None
+    assert data.get(ATTR_AIR_POLLUTANTS_ATTRIBUTION) == \
+        'Powered by Home Assistant'

--- a/tests/components/air_pollutants/test_air_pollutants.py
+++ b/tests/components/air_pollutants/test_air_pollutants.py
@@ -4,8 +4,7 @@ import unittest
 from homeassistant.components import air_pollutants
 from homeassistant.components.air_pollutants import (
     ATTR_AIR_POLLUTANTS_ATTRIBUTION, ATTR_AIR_POLLUTANTS_N2O,
-    ATTR_AIR_POLLUTANTS_OZONE, ATTR_AIR_POLLUTANTS_PM_10,
-    ATTR_AIR_POLLUTANTS_TEMPERATURE)
+    ATTR_AIR_POLLUTANTS_OZONE, ATTR_AIR_POLLUTANTS_PM_10)
 from homeassistant.setup import setup_component
 from homeassistant.util.unit_system import METRIC_SYSTEM
 
@@ -39,18 +38,6 @@ class TestAirPollutants(unittest.TestCase):
         data = state.attributes
         assert data.get(ATTR_AIR_POLLUTANTS_PM_10) == 23
         assert data.get(ATTR_AIR_POLLUTANTS_N2O) == 100
-        assert data.get(ATTR_AIR_POLLUTANTS_TEMPERATURE) == 12
         assert data.get(ATTR_AIR_POLLUTANTS_OZONE) is None
         assert data.get(ATTR_AIR_POLLUTANTS_ATTRIBUTION) == \
             'Powered by Home Assistant'
-
-    def test_temperature_convert(self):
-        """Test temperature conversion."""
-        state = self.hass.states.get(
-            'air_pollutants.demo_air_pollutants_office')
-        assert state is not None
-
-        assert state.state == '4'
-
-        data = state.attributes
-        assert data.get(ATTR_AIR_POLLUTANTS_TEMPERATURE) == -15


### PR DESCRIPTION
## Description:
The `air_pollutants` component (as mentioned in this [arch issue](https://github.com/home-assistant/architecture/issues/109)) should standardized the handling of air quality and pollution details like the `weather` platform does.

**Related issue (if applicable):** fixes https://github.com/home-assistant/architecture/issues/109

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#7645

## Example entry for `configuration.yaml` (if applicable):
```yaml
air_pollutants:
  - platform: demo
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
