### PR TITLE
Added async locks to Tradfri components

### DIFF
--- a/homeassistant/components/light/tradfri.py
+++ b/homeassistant/components/light/tradfri.py
@@ -4,6 +4,7 @@ Support for the IKEA Tradfri platform.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/light.tradfri/
 """
+import asyncio
 import logging
 
 from homeassistant.core import callback
@@ -63,6 +64,7 @@ class TradfriGroup(Light):
         self._unique_id = "group-{}-{}".format(gateway_id, group.id)
         self._group = group
         self._name = group.name
+        self._lock = asyncio.Lock()
 
         self._refresh(group)
 
@@ -97,22 +99,24 @@ class TradfriGroup(Light):
 
     async def async_turn_off(self, **kwargs):
         """Instruct the group lights to turn off."""
-        await self._api(self._group.set_state(0))
+        async with self._lock:
+            await self._api(self._group.set_state(0))
 
     async def async_turn_on(self, **kwargs):
         """Instruct the group lights to turn on, or dim."""
-        keys = {}
-        if ATTR_TRANSITION in kwargs:
-            keys['transition_time'] = int(kwargs[ATTR_TRANSITION]) * 10
+        async with self._lock:
+            keys = {}
+            if ATTR_TRANSITION in kwargs:
+                keys['transition_time'] = int(kwargs[ATTR_TRANSITION]) * 10
 
-        if ATTR_BRIGHTNESS in kwargs:
-            if kwargs[ATTR_BRIGHTNESS] == 255:
-                kwargs[ATTR_BRIGHTNESS] = 254
+            if ATTR_BRIGHTNESS in kwargs:
+                if kwargs[ATTR_BRIGHTNESS] == 255:
+                    kwargs[ATTR_BRIGHTNESS] = 254
 
-            await self._api(
-                self._group.set_dimmer(kwargs[ATTR_BRIGHTNESS], **keys))
-        else:
-            await self._api(self._group.set_state(1))
+                await self._api(
+                    self._group.set_dimmer(kwargs[ATTR_BRIGHTNESS], **keys))
+            else:
+                await self._api(self._group.set_state(1))
 
     @callback
     def _async_start_observe(self, exc=None):
@@ -140,12 +144,14 @@ class TradfriGroup(Light):
     @callback
     def _observe_update(self, tradfri_device):
         """Receive new state data for this light."""
-        self._refresh(tradfri_device)
-        self.async_schedule_update_ha_state()
+        if not self._lock.locked():
+            self._refresh(tradfri_device)
+            self.async_schedule_update_ha_state()
 
     async def async_update(self):
         """Fetch new state data for the group."""
-        await self._api(self._group.update())
+        async with self._lock:
+            await self._api(self._group.update())
 
 
 class TradfriLight(Light):
@@ -163,6 +169,7 @@ class TradfriLight(Light):
         self._features = SUPPORTED_FEATURES
         self._available = True
         self._gateway_id = gateway_id
+        self._lock = asyncio.Lock()
 
         self._refresh(light)
 
@@ -248,90 +255,96 @@ class TradfriLight(Light):
 
     async def async_turn_off(self, **kwargs):
         """Instruct the light to turn off."""
-        # This allows transitioning to off, but resets the brightness
-        # to 1 for the next set_state(True) command
-        transition_time = None
-        if ATTR_TRANSITION in kwargs:
-            transition_time = int(kwargs[ATTR_TRANSITION]) * 10
+        async with self._lock:
+            # This allows transitioning to off, but resets the brightness
+            # to 1 for the next set_state(True) command
+            transition_time = None
+            if ATTR_TRANSITION in kwargs:
+                transition_time = int(kwargs[ATTR_TRANSITION]) * 10
 
-            dimmer_data = {ATTR_DIMMER: 0, ATTR_TRANSITION_TIME:
-                           transition_time}
-            await self._api(self._light_control.set_dimmer(**dimmer_data))
-        else:
-            await self._api(self._light_control.set_state(False))
+                dimmer_data = {ATTR_DIMMER: 0, ATTR_TRANSITION_TIME:
+                               transition_time}
+                await self._api(self._light_control.set_dimmer(**dimmer_data))
+            else:
+                await self._api(self._light_control.set_state(False))
 
     async def async_turn_on(self, **kwargs):
         """Instruct the light to turn on."""
-        transition_time = None
-        if ATTR_TRANSITION in kwargs:
-            transition_time = int(kwargs[ATTR_TRANSITION]) * 10
-
-        dimmer_command = None
-        if ATTR_BRIGHTNESS in kwargs:
-            brightness = kwargs[ATTR_BRIGHTNESS]
-            if brightness > 254:
-                brightness = 254
-            elif brightness < 0:
-                brightness = 0
-            dimmer_data = {ATTR_DIMMER: brightness, ATTR_TRANSITION_TIME:
-                           transition_time}
-            dimmer_command = self._light_control.set_dimmer(**dimmer_data)
+        async with self._lock:
             transition_time = None
-        else:
-            dimmer_command = self._light_control.set_state(True)
+            if ATTR_TRANSITION in kwargs:
+                transition_time = int(kwargs[ATTR_TRANSITION]) * 10
 
-        color_command = None
-        if ATTR_HS_COLOR in kwargs and self._light_control.can_set_color:
-            hue = int(kwargs[ATTR_HS_COLOR][0] *
-                      (self._light_control.max_hue / 360))
-            sat = int(kwargs[ATTR_HS_COLOR][1] *
-                      (self._light_control.max_saturation / 100))
-            color_data = {ATTR_HUE: hue, ATTR_SAT: sat, ATTR_TRANSITION_TIME:
-                          transition_time}
-            color_command = self._light_control.set_hsb(**color_data)
-            transition_time = None
-
-        temp_command = None
-        if ATTR_COLOR_TEMP in kwargs and (self._light_control.can_set_temp or
-                                          self._light_control.can_set_color):
-            temp = kwargs[ATTR_COLOR_TEMP]
-            # White Spectrum bulb
-            if self._light_control.can_set_temp:
-                if temp > self.max_mireds:
-                    temp = self.max_mireds
-                elif temp < self.min_mireds:
-                    temp = self.min_mireds
-                temp_data = {ATTR_COLOR_TEMP: temp, ATTR_TRANSITION_TIME:
-                             transition_time}
-                temp_command = self._light_control.set_color_temp(**temp_data)
+            dimmer_command = None
+            if ATTR_BRIGHTNESS in kwargs:
+                brightness = kwargs[ATTR_BRIGHTNESS]
+                if brightness > 254:
+                    brightness = 254
+                elif brightness < 0:
+                    brightness = 0
+                dimmer_data = {ATTR_DIMMER: brightness, ATTR_TRANSITION_TIME:
+                               transition_time}
+                dimmer_command = self._light_control.set_dimmer(**dimmer_data)
                 transition_time = None
-            # Color bulb (CWS)
-            # color_temp needs to be set with hue/saturation
-            elif self._light_control.can_set_color:
-                temp_k = color_util.color_temperature_mired_to_kelvin(temp)
-                hs_color = color_util.color_temperature_to_hs(temp_k)
-                hue = int(hs_color[0] * (self._light_control.max_hue / 360))
-                sat = int(hs_color[1] *
+            else:
+                dimmer_command = self._light_control.set_state(True)
+
+            color_command = None
+            if ATTR_HS_COLOR in kwargs and self._light_control.can_set_color:
+                hue = int(kwargs[ATTR_HS_COLOR][0] *
+                          (self._light_control.max_hue / 360))
+                sat = int(kwargs[ATTR_HS_COLOR][1] *
                           (self._light_control.max_saturation / 100))
                 color_data = {ATTR_HUE: hue, ATTR_SAT: sat,
                               ATTR_TRANSITION_TIME: transition_time}
                 color_command = self._light_control.set_hsb(**color_data)
                 transition_time = None
 
-        # HSB can always be set, but color temp + brightness is bulb dependant
-        command = dimmer_command
-        if command is not None:
-            command += color_command
-        else:
-            command = color_command
+            temp_command = None
+            if ATTR_COLOR_TEMP in kwargs and \
+                    (self._light_control.can_set_temp or
+                     self._light_control.can_set_color):
+                temp = kwargs[ATTR_COLOR_TEMP]
+                # White Spectrum bulb
+                if self._light_control.can_set_temp:
+                    if temp > self.max_mireds:
+                        temp = self.max_mireds
+                    elif temp < self.min_mireds:
+                        temp = self.min_mireds
+                    temp_data = {ATTR_COLOR_TEMP: temp, ATTR_TRANSITION_TIME:
+                                 transition_time}
+                    temp_command = self._light_control.set_color_temp(
+                        **temp_data)
+                    transition_time = None
+                # Color bulb (CWS)
+                # color_temp needs to be set with hue/saturation
+                elif self._light_control.can_set_color:
+                    temp_k = color_util.color_temperature_mired_to_kelvin(temp)
+                    hs_color = color_util.color_temperature_to_hs(temp_k)
+                    hue = int(hs_color[0] *
+                              (self._light_control.max_hue / 360))
+                    sat = int(hs_color[1] *
+                              (self._light_control.max_saturation / 100))
+                    color_data = {ATTR_HUE: hue, ATTR_SAT: sat,
+                                  ATTR_TRANSITION_TIME: transition_time}
+                    color_command = self._light_control.set_hsb(**color_data)
+                    transition_time = None
 
-        if self._light_control.can_combine_commands:
-            await self._api(command + temp_command)
-        else:
-            if temp_command is not None:
-                await self._api(temp_command)
+            # HSB can always be set, but color temp + brightness is
+            # bulb dependant
+            command = dimmer_command
             if command is not None:
-                await self._api(command)
+                command += color_command
+            else:
+                command = color_command
+
+            if self._light_control.can_combine_commands:
+                await self._api(command + temp_command)
+            else:
+                if temp_command is not None:
+                    await self._api(temp_command)
+                if command is not None:
+                    await self._api(command)
 
     @callback
     def _async_start_observe(self, exc=None):
@@ -372,5 +385,6 @@ class TradfriLight(Light):
     @callback
     def _observe_update(self, tradfri_device):
         """Receive new state data for this light."""
-        self._refresh(tradfri_device)
-        self.async_schedule_update_ha_state()
+        if not self._lock.locked():
+            self._refresh(tradfri_device)
+            self.async_schedule_update_ha_state()


### PR DESCRIPTION
## Description:

Currently updates to the state of the component and the UI aren't locked when accessed with multiple threads. This can possibly lead to unexpected side effects with multi worker environments, such as Home Assistant.

I suspect this is one of the causes of #14386, because automation updates still come through, but UI updates do not.

This change is based on the [lifx.py](home-assistant/homeassistant/components/light/lifx.py) component, which also contains these locks around the async methods.

I've currently tested this change on my dev and prod environment for about an hour now. Operating both lights and switches. All seems well, even when turning group of devices on or off. Which before caused the above issue for me. 

This is also a far better improvement than my previous improvement of #18497. That's why I closed that one and I am issueing this new PR.

_Note that because of the new formatting, it seems that a lot of code has changed, this is not the case_

**Related issue (if applicable):** fixes #14386 and #9822 __edit__ also partially fixes #17675

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
