### PR TITLE
Skip state update on null or NaN payload of MQTT Sensor

### DIFF
--- a/homeassistant/components/sensor/mqtt.py
+++ b/homeassistant/components/sensor/mqtt.py
@@ -172,9 +172,10 @@ class MqttSensor(MqttAvailability, MqttDiscoveryUpdate, MqttEntityDeviceInfo,
                     payload, self._state)
 
             # If payload is null or a varient of null, skip update
-            if payload is None or payload.lower() == 'nan':
+            if payload is None or str(payload).lower() == 'nan':
                 _LOGGER.warning(
-                    "%s value for %s. Skipping state update. Current state: %s",
+                    "%s value for %s. Skipping state update. "
+                    + "Current state: %s",
                     payload, self._name, self._state)
             else:
                 self._state = payload

--- a/homeassistant/components/sensor/mqtt.py
+++ b/homeassistant/components/sensor/mqtt.py
@@ -174,8 +174,7 @@ class MqttSensor(MqttAvailability, MqttDiscoveryUpdate, MqttEntityDeviceInfo,
             # If payload is null or a varient of null, skip update
             if payload is None or str(payload).lower() == 'nan':
                 _LOGGER.warning(
-                    "%s value for %s. Skipping state update. "
-                    + "Current state: %s",
+                    "%s value for %s. Skipping update. Current state: %s",
                     payload, self._name, self._state)
             else:
                 self._state = payload

--- a/homeassistant/components/sensor/mqtt.py
+++ b/homeassistant/components/sensor/mqtt.py
@@ -170,8 +170,15 @@ class MqttSensor(MqttAvailability, MqttDiscoveryUpdate, MqttEntityDeviceInfo,
             if self._template is not None:
                 payload = self._template.async_render_with_possible_json_value(
                     payload, self._state)
-            self._state = payload
-            self.async_schedule_update_ha_state()
+
+            # If payload is null or a varient of null, skip update
+            if payload is None or payload.lower() == 'nan':
+                _LOGGER.warning(
+                    "%s value for %s. Skipping state update. Current state: %s",
+                    payload, self._name, self._state)
+            else:
+                self._state = payload
+                self.async_schedule_update_ha_state()
 
         await mqtt.async_subscribe(self.hass, self._state_topic,
                                    message_received, self._qos)

--- a/tests/components/sensor/test_mqtt.py
+++ b/tests/components/sensor/test_mqtt.py
@@ -133,6 +133,27 @@ class TestSensorMQTT(unittest.TestCase):
 
         assert '100' == state.state
 
+    def test_nan_payload_from_mqtt_json_message(self):
+        """Test using MQTT with JSON payload with a NaN value."""
+        mock_component(self.hass, 'mqtt')
+        assert setup_component(self.hass, sensor.DOMAIN, {
+            sensor.DOMAIN: {
+                'platform': 'mqtt',
+                'name': 'test',
+                'state_topic': 'test-topic',
+                'unit_of_measurement': 'fav unit',
+                'value_template': '{{ value_json.val }}'
+            }
+        })
+
+        fire_mqtt_message(self.hass, 'test-topic', '{ "val": 21.4 }')
+        self.hass.block_till_done()
+        fire_mqtt_message(self.hass, 'test-topic', '{ "val": NaN }')
+        self.hass.block_till_done()
+        state = self.hass.states.get('sensor.test')
+
+        assert '21.4' == state.state
+
     def test_force_update_disabled(self):
         """Test force update option."""
         mock_component(self.hass, 'mqtt')


### PR DESCRIPTION
## Description:

As suggested [here](https://github.com/home-assistant/home-assistant-js-websocket/issues/80#issuecomment-441465754) on the `home-assistant-js-websocket` repo, updating state to `NaN` / `null` causes bad JSON data to be sent to the websocket, causing masses of logs in any app subscribed to the entity:

![image](https://user-images.githubusercontent.com/28114703/48984853-20a4e300-f0f9-11e8-8a57-b53209f89dd8.png)

This change sends out a warning to the log and prevents the entity's state from being updated if the payload is `NaN` / `null`.

```bash
2018-11-25 21:24:03 DEBUG (MainThread) [homeassistant.components.mqtt] Received message on test/temperature: b'{\n  "temperature": 21.2\n}'
2018-11-25 21:24:03 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event state_changed[L]: entity_id=sensor.test_temperature, old_state=<state sensor.test_temperature=21.3; unit_of_measurement=°C, friendly_name=Test Temperature @ 2018-11-25T21:22:35.421243+00:00>, new_state=<state sensor.test_temperature=21.2; unit_of_measurement=°C, friendly_name=Test Temperature @ 2018-11-25T21:24:03.634209+00:00>>
2018-11-25 21:24:03 DEBUG (MainThread) [homeassistant.components.websocket_api.http.connection.140146265594232] Sending {'id': 2, 'type': 'event', 'event': {'event_type': 'state_changed', 'data': {'entity_id': 'sensor.test_temperature', 'old_state': <state sensor.test_temperature=21.3; unit_of_measurement=°C, friendly_name=Test Temperature @ 2018-11-25T21:22:35.421243+00:00>, 'new_state': <state sensor.test_temperature=21.2; unit_of_measurement=°C, friendly_name=Test Temperature @ 2018-11-25T21:24:03.634209+00:00>}, 'origin': 'LOCAL', 'time_fired': datetime.datetime(2018, 11, 25, 21, 24, 3, 634237, tzinfo=<UTC>), 'context': {'id': 'ebd10947ac844244af6611192c68a498', 'user_id': None}}}
2018-11-25 21:24:08 DEBUG (MainThread) [homeassistant.components.websocket_api.http.connection.140146265594232] Received {'type': 'config/entity_registry/get', 'entity_id': 'sensor.test_temperature', 'id': 17}
2018-11-25 21:24:08 DEBUG (MainThread) [homeassistant.components.websocket_api.http.connection.140146265594232] Sending {'id': 17, 'type': 'result', 'success': False, 'error': {'code': 3, 'message': 'Entity not found'}}
2018-11-25 21:24:08 INFO (MainThread) [homeassistant.components.http.view] Serving /api/history/period/2018-11-24T21:24:08.106Z to 127.0.0.1 (auth: True)
2018-11-25 21:24:08 DEBUG (SyncWorker_0) [homeassistant.components.recorder.util] converting 42 rows to native objects took 0.007657s
2018-11-25 21:24:08 DEBUG (SyncWorker_0) [homeassistant.components.history] get_significant_states took 0.015944s
2018-11-25 21:24:08 DEBUG (SyncWorker_0) [homeassistant.components.history] getting 0 first datapoints took 0.001683s
2018-11-25 21:24:08 DEBUG (MainThread) [homeassistant.components.history] Extracted 42 states in 0.018604s
2018-11-25 21:24:15 DEBUG (MainThread) [homeassistant.components.mqtt] Received message on test/temperature: b'{\n  "temperature": NaN\n}'
2018-11-25 21:24:15 WARNING (MainThread) [homeassistant.components.sensor.mqtt] nan value for Test Temperature. Skipping state update. Current state: 21.2
```

![image](https://user-images.githubusercontent.com/28114703/48984895-95781d00-f0f9-11e8-8678-51684035edef.png)

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
