### PR TITLE
Set lock status correctly for Schlage BE469 Z-Wave Locks

### DIFF
--- a/homeassistant/components/lock/zwave.py
+++ b/homeassistant/components/lock/zwave.py
@@ -331,14 +331,14 @@ class ZwaveLock(zwave.ZWaveDeviceEntity, LockDevice):
     def lock(self, **kwargs):
         """Lock the device."""
         if self._clear_alarms_workaround and self.values.alarm_type:
-            self.values.alarm_type.data = None
+            self.values.alarm_type = None
 
         self.values.primary.data = True
 
     def unlock(self, **kwargs):
         """Unlock the device."""
         if self._clear_alarms_workaround and self.values.alarm_type:
-            self.values.alarm_type.data = None
+            self.values.alarm_type = None
 
         self.values.primary.data = False
 

--- a/homeassistant/components/lock/zwave.py
+++ b/homeassistant/components/lock/zwave.py
@@ -29,8 +29,9 @@ SERVICE_CLEAR_USERCODE = 'clear_usercode'
 POLYCONTROL = 0x10E
 DANALOCK_V2_BTZE = 0x2
 POLYCONTROL_DANALOCK_V2_BTZE_LOCK = (POLYCONTROL, DANALOCK_V2_BTZE)
-WORKAROUND_V2BTZE = 'v2btze'
-WORKAROUND_DEVICE_STATE = 'state'
+WORKAROUND_V2BTZE = 1
+WORKAROUND_DEVICE_STATE = 2
+WORKAROUND_CLEAR_ALARMS = 4
 
 DEVICE_MAPPINGS = {
     POLYCONTROL_DANALOCK_V2_BTZE_LOCK: WORKAROUND_V2BTZE,
@@ -43,7 +44,7 @@ DEVICE_MAPPINGS = {
     # Yale YRD220 (as reported by adrum in PR #17386)
     (0x0109, 0x0000): WORKAROUND_DEVICE_STATE,
     # Schlage BE469
-    (0x003B, 0x5044): WORKAROUND_DEVICE_STATE,
+    (0x003B, 0x5044): WORKAROUND_DEVICE_STATE | WORKAROUND_CLEAR_ALARMS,
     # Schlage FE599NX
     (0x003B, 0x504C): WORKAROUND_DEVICE_STATE,
 }
@@ -51,13 +52,15 @@ DEVICE_MAPPINGS = {
 LOCK_NOTIFICATION = {
     '1': 'Manual Lock',
     '2': 'Manual Unlock',
-    '3': 'RF Lock',
-    '4': 'RF Unlock',
     '5': 'Keypad Lock',
     '6': 'Keypad Unlock',
     '11': 'Lock Jammed',
     '254': 'Unknown Event'
 }
+NOTIFICATION_RF_LOCK = '3'
+NOTIFICATION_RF_UNLOCK = '4'
+LOCK_NOTIFICATION[NOTIFICATION_RF_LOCK] = 'RF Lock'
+LOCK_NOTIFICATION[NOTIFICATION_RF_UNLOCK] = 'RF Unlock'
 
 LOCK_ALARM_TYPE = {
     '9': 'Deadbolt Jammed',
@@ -66,8 +69,6 @@ LOCK_ALARM_TYPE = {
     '19': 'Unlocked with Keypad by user ',
     '21': 'Manually Locked ',
     '22': 'Manually Unlocked ',
-    '24': 'Locked by RF',
-    '25': 'Unlocked by RF',
     '27': 'Auto re-lock',
     '33': 'User deleted: ',
     '112': 'Master code changed or User added: ',
@@ -79,6 +80,10 @@ LOCK_ALARM_TYPE = {
     '168': 'Critical Battery Level',
     '169': 'Battery too low to operate'
 }
+ALARM_RF_LOCK = '24'
+ALARM_RF_UNLOCK = '25'
+LOCK_ALARM_TYPE[ALARM_RF_LOCK] = 'Locked by RF'
+LOCK_ALARM_TYPE[ALARM_RF_UNLOCK] = 'Unlocked by RF'
 
 MANUAL_LOCK_ALARM_LEVEL = {
     '1': 'by Key Cylinder or Inside thumb turn',
@@ -229,6 +234,7 @@ class ZwaveLock(zwave.ZWaveDeviceEntity, LockDevice):
         self._lock_status = None
         self._v2btze = None
         self._state_workaround = False
+        self._clear_alarms_workaround = False
 
         # Enable appropriate workaround flags for our device
         # Make sure that we have values for the key before converting to int
@@ -237,15 +243,19 @@ class ZwaveLock(zwave.ZWaveDeviceEntity, LockDevice):
             specific_sensor_key = (int(self.node.manufacturer_id, 16),
                                    int(self.node.product_id, 16))
             if specific_sensor_key in DEVICE_MAPPINGS:
-                if DEVICE_MAPPINGS[specific_sensor_key] == WORKAROUND_V2BTZE:
+                workaround = DEVICE_MAPPINGS[specific_sensor_key]
+                if workaround & WORKAROUND_V2BTZE:
                     self._v2btze = 1
                     _LOGGER.debug("Polycontrol Danalock v2 BTZE "
                                   "workaround enabled")
-                if DEVICE_MAPPINGS[specific_sensor_key] == \
-                        WORKAROUND_DEVICE_STATE:
+                if workaround & WORKAROUND_DEVICE_STATE:
                     self._state_workaround = True
                     _LOGGER.debug(
                         "Notification device state workaround enabled")
+                if workaround & WORKAROUND_CLEAR_ALARMS:
+                    self._clear_alarms_workaround = True
+                    message = "Clear alarms device state workaround enabled"
+                    _LOGGER.debug(message)
         self.update_properties()
 
     def update_properties(self):
@@ -265,16 +275,33 @@ class ZwaveLock(zwave.ZWaveDeviceEntity, LockDevice):
                         "Lock state set from Access Control value and is %s, "
                         "get=%s", str(notification_data), self.state)
 
+        if self._clear_alarms_workaround and \
+                (not self.values.alarm_type or
+                 self.values.alarm_type.data is None):
+
+            self._state = self.values.primary.data
+            if self._state:
+                self._notification = \
+                        LOCK_NOTIFICATION.get(NOTIFICATION_RF_LOCK)
+                self._lock_status = LOCK_ALARM_TYPE[ALARM_RF_LOCK]
+            else:
+                self._notification = LOCK_NOTIFICATION.get(
+                    NOTIFICATION_RF_UNLOCK)
+                self._lock_status = LOCK_ALARM_TYPE[ALARM_RF_UNLOCK]
+
+            message = "Lock state set to %s, notification set to %s, " + \
+                "status set to %s based on cleared alarm workaround"
+            _LOGGER.debug(message, self._state, self._notification,
+                          self._lock_status)
+
         if not self.values.alarm_type:
             return
 
         alarm_type = self.values.alarm_type.data
-        _LOGGER.debug("Lock alarm_type is %s", str(alarm_type))
         if self.values.alarm_level:
             alarm_level = self.values.alarm_level.data
         else:
             alarm_level = None
-        _LOGGER.debug("Lock alarm_level is %s", str(alarm_level))
 
         if not alarm_type:
             return
@@ -303,10 +330,16 @@ class ZwaveLock(zwave.ZWaveDeviceEntity, LockDevice):
 
     def lock(self, **kwargs):
         """Lock the device."""
+        if self._clear_alarms_workaround and self.values.alarm_type:
+            self.values.alarm_type.data = None
+
         self.values.primary.data = True
 
     def unlock(self, **kwargs):
         """Unlock the device."""
+        if self._clear_alarms_workaround and self.values.alarm_type:
+            self.values.alarm_type.data = None
+
         self.values.primary.data = False
 
     @property


### PR DESCRIPTION
Some Z-Wave locks do not send a `DOOR_LOCK_OPERATION_REPORT` after a user
manually manipulates a lock (via key, deadbolt, keypad, etc). Instead,
these locks only send a `DOOR_LOCK_OPERATION_REPORT` in response to Z-Wave
commands such as `DOOR_LOCK_OPERATION_GET` or `DOOR_LOCK_OPERATION_SET`.
Based on my reading of the Z-Wave specification, it could be considered
correct. In fact, OpenZWave seems to know about this, and queues a
`DOOR_LOCK_OPERATION_GET` immediately after a `DOOR_LOCK_OPERATION_SET`:
https://github.com/OpenZWave/open-zwave/blob/master/config/schlage/BE469.xml#L141

We can see that in action here on my own network with this lock:
```
2018-11-25 19:44:52.153 Info, Node019, Value::Set - COMMAND_CLASS_DOOR_LOCK - Locked - 0 - 1 - False
2018-11-25 19:44:52.153 Info, Node019, Value_Lock::Set - Requesting lock to be Unlocked
2018-11-25 19:44:52.153 Detail, Node019, Queuing (Send) DoorLockCmd_Set (Node=19): 0x01, 0x0a, 0x00, 0x13, 0x13, 0x03, 0x62, 0x01, 0x00, 0x25, 0x7b, 0xcb
2018-11-25 19:44:52.153 Detail, Node019, Queuing (Send) DoorLockCmd_Get (Node=19): 0x01, 0x09, 0x00, 0x13, 0x13, 0x02, 0x62, 0x02, 0x25, 0x7c, 0xcd
2018-11-25 19:44:53.718 Detail, Node019, Decrypted Packet: 0x00, 0x62, 0x03, 0x00, 0x00, 0x02, 0xfe, 0xfe
2018-11-25 19:44:53.718 Info, Node019, Received DoorLock report: DoorLock is Unsecure
```

Unfortunately, when we call `update_properties()` for a Z-Wave lock,
we don't really know what property has changed, or what message the Z-Wave
stack received, or even what it plans to do next. So we potentially construct
a state for the device that isn't actually valid. In fact, the right thing
to do here is _nothing_ - ideally the component would wait until the
`DOOR_LOCK_OPERATION_GET` completed, and _then_ update state.

In #17386, we began setting the lock state for certain models of locks
based solely on the Alarm status. This is a good workaround for many models
of locks, but it also depends on a lock *ALWAYS* sending an Alarm after *any*
operation. That is unfortunately not the case for at least the Schlage BE469.
In fact, we get an Alarm notification for every operation _aside_ from RF
locks/unlocks.

Long story short, this PR introduces yet another work around state - this time
one based on clearing alarm status. When a user calls `lock()` or `unlock()`,
we explicitly set any `alarm_type` or `alarm_level` to None. For a normal lock,
this should be fine - we can't always assert that an alarm state will be present
anyways. Moreover, if a user is manipulating a lock via RF we could assert
that they are okay with clearing any alarm statuses - they're working with the
device. But for the BE469, we can look for an enabled workaround flag, and a cleared alarm, and then decide that the value from a received door lock update
is in fact correct, and set flags appropriately.

The PR sets more things manually than I'd really like - it seems that this
model really does send _just_ the bare minimum, and we can't rely on other
things like access_control being set when an RF event happens.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.