### PR TITLE
Geo Location platform code clean up

### DIFF
--- a/tests/components/geo_location/test_geo_json_events.py
+++ b/tests/components/geo_location/test_geo_json_events.py
@@ -187,8 +187,7 @@ async def test_setup_race_condition(hass):
             assert await async_setup_component(
                 hass, geo_location.DOMAIN, CONFIG)
 
-            mock_feed.return_value.update.return_value = 'OK', [
-                mock_entry_1]
+            mock_feed.return_value.update.return_value = 'OK', [mock_entry_1]
 
             # Artificially trigger update.
             hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
@@ -211,8 +210,7 @@ async def test_setup_race_condition(hass):
             assert len(hass.data[DATA_DISPATCHER][update_signal]) == 0
 
             # Simulate an update - 1 entry
-            mock_feed.return_value.update.return_value = 'OK', [
-                mock_entry_1]
+            mock_feed.return_value.update.return_value = 'OK', [mock_entry_1]
             async_fire_time_changed(hass, utcnow + 2 * SCAN_INTERVAL)
             await hass.async_block_till_done()
 
@@ -222,8 +220,7 @@ async def test_setup_race_condition(hass):
             assert len(hass.data[DATA_DISPATCHER][update_signal]) == 1
 
             # Simulate an update - 1 entry
-            mock_feed.return_value.update.return_value = 'OK', [
-                mock_entry_1]
+            mock_feed.return_value.update.return_value = 'OK', [mock_entry_1]
             async_fire_time_changed(hass, utcnow + 3 * SCAN_INTERVAL)
             await hass.async_block_till_done()
 

--- a/tests/components/geo_location/test_geo_json_events.py
+++ b/tests/components/geo_location/test_geo_json_events.py
@@ -1,7 +1,5 @@
 """The tests for the geojson platform."""
-import unittest
-from unittest import mock
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, call
 
 import homeassistant
 from homeassistant.components import geo_location
@@ -10,10 +8,9 @@ from homeassistant.components.geo_location.geo_json_events import \
     SCAN_INTERVAL, ATTR_EXTERNAL_ID
 from homeassistant.const import CONF_URL, EVENT_HOMEASSISTANT_START, \
     CONF_RADIUS, ATTR_LATITUDE, ATTR_LONGITUDE, ATTR_FRIENDLY_NAME, \
-    ATTR_UNIT_OF_MEASUREMENT
-from homeassistant.setup import setup_component
-from tests.common import get_test_home_assistant, assert_setup_component, \
-    fire_time_changed
+    ATTR_UNIT_OF_MEASUREMENT, CONF_LATITUDE, CONF_LONGITUDE
+from homeassistant.setup import async_setup_component
+from tests.common import assert_setup_component, async_fire_time_changed
 import homeassistant.util.dt as dt_util
 
 URL = 'http://geo.json.local/geo_json_events.json'
@@ -27,200 +24,228 @@ CONFIG = {
     ]
 }
 
+CONFIG_WITH_CUSTOM_LOCATION = {
+    geo_location.DOMAIN: [
+        {
+            'platform': 'geo_json_events',
+            CONF_URL: URL,
+            CONF_RADIUS: 200,
+            CONF_LATITUDE: 15.1,
+            CONF_LONGITUDE: 25.2
+        }
+    ]
+}
 
-class TestGeoJsonPlatform(unittest.TestCase):
-    """Test the geojson platform."""
 
-    def setUp(self):
-        """Initialize values for this testcase class."""
-        self.hass = get_test_home_assistant()
+def _generate_mock_feed_entry(external_id, title, distance_to_home,
+                              coordinates):
+    """Construct a mock feed entry for testing purposes."""
+    feed_entry = MagicMock()
+    feed_entry.external_id = external_id
+    feed_entry.title = title
+    feed_entry.distance_to_home = distance_to_home
+    feed_entry.coordinates = coordinates
+    return feed_entry
 
-    def tearDown(self):
-        """Stop everything that was started."""
-        self.hass.stop()
 
-    @staticmethod
-    def _generate_mock_feed_entry(external_id, title, distance_to_home,
-                                  coordinates):
-        """Construct a mock feed entry for testing purposes."""
-        feed_entry = MagicMock()
-        feed_entry.external_id = external_id
-        feed_entry.title = title
-        feed_entry.distance_to_home = distance_to_home
-        feed_entry.coordinates = coordinates
-        return feed_entry
+async def test_setup(hass):
+    """Test the general setup of the platform."""
+    # Set up some mock feed entries for this test.
+    mock_entry_1 = _generate_mock_feed_entry('1234', 'Title 1', 15.5,
+                                                  (-31.0, 150.0))
+    mock_entry_2 = _generate_mock_feed_entry('2345', 'Title 2', 20.5,
+                                                  (-31.1, 150.1))
+    mock_entry_3 = _generate_mock_feed_entry('3456', 'Title 3', 25.5,
+                                                  (-31.2, 150.2))
+    mock_entry_4 = _generate_mock_feed_entry('4567', 'Title 4', 12.5,
+                                                  (-31.3, 150.3))
 
-    @mock.patch('geojson_client.generic_feed.GenericFeed')
-    def test_setup(self, mock_feed):
-        """Test the general setup of the platform."""
-        # Set up some mock feed entries for this test.
-        mock_entry_1 = self._generate_mock_feed_entry('1234', 'Title 1', 15.5,
-                                                      (-31.0, 150.0))
-        mock_entry_2 = self._generate_mock_feed_entry('2345', 'Title 2', 20.5,
-                                                      (-31.1, 150.1))
-        mock_entry_3 = self._generate_mock_feed_entry('3456', 'Title 3', 25.5,
-                                                      (-31.2, 150.2))
-        mock_entry_4 = self._generate_mock_feed_entry('4567', 'Title 4', 12.5,
-                                                      (-31.3, 150.3))
+    # Patching 'utcnow' to gain more control over the timed update.
+    utcnow = dt_util.utcnow()
+    with patch('homeassistant.util.dt.utcnow', return_value=utcnow), \
+         patch('geojson_client.generic_feed.GenericFeed') as mock_feed:
         mock_feed.return_value.update.return_value = 'OK', [mock_entry_1,
                                                             mock_entry_2,
                                                             mock_entry_3]
+        with assert_setup_component(1, geo_location.DOMAIN):
+            assert await async_setup_component(
+                hass, geo_location.DOMAIN, CONFIG)
+            # Artificially trigger update.
+            hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+            # Collect events.
+            await hass.async_block_till_done()
 
-        utcnow = dt_util.utcnow()
-        # Patching 'utcnow' to gain more control over the timed update.
-        with patch('homeassistant.util.dt.utcnow', return_value=utcnow):
-            with assert_setup_component(1, geo_location.DOMAIN):
-                assert setup_component(self.hass, geo_location.DOMAIN, CONFIG)
-                # Artificially trigger update.
-                self.hass.bus.fire(EVENT_HOMEASSISTANT_START)
-                # Collect events.
-                self.hass.block_till_done()
+            all_states = hass.states.async_all()
+            assert len(all_states) == 3
 
-                all_states = self.hass.states.all()
-                assert len(all_states) == 3
+            state = hass.states.get("geo_location.title_1")
+            assert state is not None
+            assert state.name == "Title 1"
+            assert state.attributes == {
+                ATTR_EXTERNAL_ID: "1234", ATTR_LATITUDE: -31.0,
+                ATTR_LONGITUDE: 150.0, ATTR_FRIENDLY_NAME: "Title 1",
+                ATTR_UNIT_OF_MEASUREMENT: "km",
+                ATTR_SOURCE: 'geo_json_events'}
+            assert round(abs(float(state.state)-15.5), 7) == 0
 
-                state = self.hass.states.get("geo_location.title_1")
-                assert state is not None
-                assert state.name == "Title 1"
-                assert state.attributes == {
-                    ATTR_EXTERNAL_ID: "1234", ATTR_LATITUDE: -31.0,
-                    ATTR_LONGITUDE: 150.0, ATTR_FRIENDLY_NAME: "Title 1",
-                    ATTR_UNIT_OF_MEASUREMENT: "km",
-                    ATTR_SOURCE: 'geo_json_events'}
-                assert round(abs(float(state.state)-15.5), 7) == 0
+            state = hass.states.get("geo_location.title_2")
+            assert state is not None
+            assert state.name == "Title 2"
+            assert state.attributes == {
+                ATTR_EXTERNAL_ID: "2345", ATTR_LATITUDE: -31.1,
+                ATTR_LONGITUDE: 150.1, ATTR_FRIENDLY_NAME: "Title 2",
+                ATTR_UNIT_OF_MEASUREMENT: "km",
+                ATTR_SOURCE: 'geo_json_events'}
+            assert round(abs(float(state.state)-20.5), 7) == 0
 
-                state = self.hass.states.get("geo_location.title_2")
-                assert state is not None
-                assert state.name == "Title 2"
-                assert state.attributes == {
-                    ATTR_EXTERNAL_ID: "2345", ATTR_LATITUDE: -31.1,
-                    ATTR_LONGITUDE: 150.1, ATTR_FRIENDLY_NAME: "Title 2",
-                    ATTR_UNIT_OF_MEASUREMENT: "km",
-                    ATTR_SOURCE: 'geo_json_events'}
-                assert round(abs(float(state.state)-20.5), 7) == 0
+            state = hass.states.get("geo_location.title_3")
+            assert state is not None
+            assert state.name == "Title 3"
+            assert state.attributes == {
+                ATTR_EXTERNAL_ID: "3456", ATTR_LATITUDE: -31.2,
+                ATTR_LONGITUDE: 150.2, ATTR_FRIENDLY_NAME: "Title 3",
+                ATTR_UNIT_OF_MEASUREMENT: "km",
+                ATTR_SOURCE: 'geo_json_events'}
+            assert round(abs(float(state.state)-25.5), 7) == 0
 
-                state = self.hass.states.get("geo_location.title_3")
-                assert state is not None
-                assert state.name == "Title 3"
-                assert state.attributes == {
-                    ATTR_EXTERNAL_ID: "3456", ATTR_LATITUDE: -31.2,
-                    ATTR_LONGITUDE: 150.2, ATTR_FRIENDLY_NAME: "Title 3",
-                    ATTR_UNIT_OF_MEASUREMENT: "km",
-                    ATTR_SOURCE: 'geo_json_events'}
-                assert round(abs(float(state.state)-25.5), 7) == 0
+            # Simulate an update - one existing, one new entry,
+            # one outdated entry
+            mock_feed.return_value.update.return_value = 'OK', [
+                mock_entry_1, mock_entry_4, mock_entry_3]
+            async_fire_time_changed(hass, utcnow + SCAN_INTERVAL)
+            await hass.async_block_till_done()
 
-                # Simulate an update - one existing, one new entry,
-                # one outdated entry
+            all_states = hass.states.async_all()
+            assert len(all_states) == 3
+
+            # Simulate an update - empty data, but successful update,
+            # so no changes to entities.
+            mock_feed.return_value.update.return_value = 'OK_NO_DATA', None
+            async_fire_time_changed(hass, utcnow + 2 * SCAN_INTERVAL)
+            await hass.async_block_till_done()
+
+            all_states = hass.states.async_all()
+            assert len(all_states) == 3
+
+            # Simulate an update - empty data, removes all entities
+            mock_feed.return_value.update.return_value = 'ERROR', None
+            async_fire_time_changed(hass, utcnow + 3 * SCAN_INTERVAL)
+            await hass.async_block_till_done()
+
+            all_states = hass.states.async_all()
+            assert len(all_states) == 0
+
+
+async def test_setup_with_custom_location(hass):
+    """Test the setup with a custom location."""
+    # Set up some mock feed entries for this test.
+    mock_entry_1 = _generate_mock_feed_entry(
+        '1234', 'Title 1', 2000.5, (-31.1, 150.1))
+
+    with patch('geojson_client.generic_feed.GenericFeed') as mock_feed:
+        mock_feed.return_value.update.return_value = 'OK', [mock_entry_1]
+
+        with assert_setup_component(1, geo_location.DOMAIN):
+            assert await async_setup_component(
+                hass, geo_location.DOMAIN, CONFIG_WITH_CUSTOM_LOCATION)
+
+            # Artificially trigger update.
+            hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+            # Collect events.
+            await hass.async_block_till_done()
+
+            all_states = hass.states.async_all()
+            assert len(all_states) == 1
+
+            assert mock_feed.call_args == call(
+                (15.1, 25.2), URL, filter_radius=200.0)
+
+
+async def test_setup_race_condition(hass):
+    """Test a particular race condition experienced."""
+    # 1. Feed returns 1 entry -> Feed manager creates 1 entity.
+    # 2. Feed returns error -> Feed manager removes 1 entity.
+    #    However, this stayed on and kept listening for dispatcher signals.
+    # 3. Feed returns 1 entry -> Feed manager creates 1 entity.
+    # 4. Feed returns 1 entry -> Feed manager updates 1 entity.
+    #    Internally, the previous entity is updating itself, too.
+    # 5. Feed returns error -> Feed manager removes 1 entity.
+    #    There are now 2 entities trying to remove themselves from HA, but
+    #    the second attempt fails of course.
+
+    # Set up some mock feed entries for this test.
+    mock_entry_1 = _generate_mock_feed_entry(
+        '1234', 'Title 1', 15.5, (-31.0, 150.0))
+
+    # Patching 'utcnow' to gain more control over the timed update.
+    utcnow = dt_util.utcnow()
+    with patch('homeassistant.util.dt.utcnow', return_value=utcnow), \
+        patch('geojson_client.generic_feed.GenericFeed') as mock_feed:
+        with assert_setup_component(1, geo_location.DOMAIN):
+            assert await async_setup_component(
+                hass, geo_location.DOMAIN, CONFIG)
+
+            # This gives us the ability to assert the '_delete_callback'
+            # has been called while still executing it.
+            original_delete_callback = homeassistant.components\
+                .geo_location.geo_json_events.GeoJsonLocationEvent\
+                ._delete_callback
+
+            def mock_delete_callback(entity):
+                original_delete_callback(entity)
+
+            with patch('homeassistant.components.geo_location'
+                       '.geo_json_events.GeoJsonLocationEvent'
+                       '._delete_callback',
+                       side_effect=mock_delete_callback,
+                       autospec=True) as mocked_delete_callback:
+
                 mock_feed.return_value.update.return_value = 'OK', [
-                    mock_entry_1, mock_entry_4, mock_entry_3]
-                fire_time_changed(self.hass, utcnow + SCAN_INTERVAL)
-                self.hass.block_till_done()
+                    mock_entry_1]
 
-                all_states = self.hass.states.all()
-                assert len(all_states) == 3
+                # Artificially trigger update.
+                hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+                # Collect events.
+                await hass.async_block_till_done()
 
-                # Simulate an update - empty data, but successful update,
-                # so no changes to entities.
-                mock_feed.return_value.update.return_value = 'OK_NO_DATA', None
-                # mock_restdata.return_value.data = None
-                fire_time_changed(self.hass, utcnow +
-                                  2 * SCAN_INTERVAL)
-                self.hass.block_till_done()
-
-                all_states = self.hass.states.all()
-                assert len(all_states) == 3
+                all_states = hass.states.async_all()
+                assert len(all_states) == 1
 
                 # Simulate an update - empty data, removes all entities
                 mock_feed.return_value.update.return_value = 'ERROR', None
-                fire_time_changed(self.hass, utcnow +
-                                  2 * SCAN_INTERVAL)
-                self.hass.block_till_done()
+                async_fire_time_changed(hass, utcnow + SCAN_INTERVAL)
+                await hass.async_block_till_done()
 
-                all_states = self.hass.states.all()
+                assert mocked_delete_callback.call_count == 1
+                all_states = hass.states.async_all()
                 assert len(all_states) == 0
 
-    @mock.patch('geojson_client.generic_feed.GenericFeed')
-    def test_setup_race_condition(self, mock_feed):
-        """Test a particular race condition experienced."""
-        # 1. Feed returns 1 entry -> Feed manager creates 1 entity.
-        # 2. Feed returns error -> Feed manager removes 1 entity.
-        #    However, this stayed on and kept listening for dispatcher signals.
-        # 3. Feed returns 1 entry -> Feed manager creates 1 entity.
-        # 4. Feed returns 1 entry -> Feed manager updates 1 entity.
-        #    Internally, the previous entity is updating itself, too.
-        # 5. Feed returns error -> Feed manager removes 1 entity.
-        #    There are now 2 entities trying to remove themselves from HA, but
-        #    the second attempt fails of course.
+                # Simulate an update - 1 entry
+                mock_feed.return_value.update.return_value = 'OK', [
+                    mock_entry_1]
+                async_fire_time_changed(hass, utcnow + 2 * SCAN_INTERVAL)
+                await hass.async_block_till_done()
 
-        # Set up some mock feed entries for this test.
-        mock_entry_1 = self._generate_mock_feed_entry('1234', 'Title 1', 15.5,
-                                                      (-31.0, 150.0))
-        mock_feed.return_value.update.return_value = 'OK', [mock_entry_1]
+                all_states = hass.states.async_all()
+                assert len(all_states) == 1
 
-        utcnow = dt_util.utcnow()
-        # Patching 'utcnow' to gain more control over the timed update.
-        with patch('homeassistant.util.dt.utcnow', return_value=utcnow):
-            with assert_setup_component(1, geo_location.DOMAIN):
-                assert setup_component(self.hass, geo_location.DOMAIN, CONFIG)
+                # Simulate an update - 1 entry
+                mock_feed.return_value.update.return_value = 'OK', [
+                    mock_entry_1]
+                async_fire_time_changed(hass, utcnow + 3 * SCAN_INTERVAL)
+                await hass.async_block_till_done()
 
-                # This gives us the ability to assert the '_delete_callback'
-                # has been called while still executing it.
-                original_delete_callback = homeassistant.components\
-                    .geo_location.geo_json_events.GeoJsonLocationEvent\
-                    ._delete_callback
+                all_states = hass.states.async_all()
+                assert len(all_states) == 1
 
-                def mock_delete_callback(entity):
-                    original_delete_callback(entity)
+                # Reset mocked method for the next test.
+                mocked_delete_callback.reset_mock()
 
-                with patch('homeassistant.components.geo_location'
-                           '.geo_json_events.GeoJsonLocationEvent'
-                           '._delete_callback',
-                           side_effect=mock_delete_callback,
-                           autospec=True) as mocked_delete_callback:
+                # Simulate an update - empty data, removes all entities
+                mock_feed.return_value.update.return_value = 'ERROR', None
+                async_fire_time_changed(hass, utcnow + 4 * SCAN_INTERVAL)
+                await hass.async_block_till_done()
 
-                    # Artificially trigger update.
-                    self.hass.bus.fire(EVENT_HOMEASSISTANT_START)
-                    # Collect events.
-                    self.hass.block_till_done()
-
-                    all_states = self.hass.states.all()
-                    assert len(all_states) == 1
-
-                    # Simulate an update - empty data, removes all entities
-                    mock_feed.return_value.update.return_value = 'ERROR', None
-                    fire_time_changed(self.hass, utcnow + SCAN_INTERVAL)
-                    self.hass.block_till_done()
-
-                    assert mocked_delete_callback.call_count == 1
-                    all_states = self.hass.states.all()
-                    assert len(all_states) == 0
-
-                    # Simulate an update - 1 entry
-                    mock_feed.return_value.update.return_value = 'OK', [
-                        mock_entry_1]
-                    fire_time_changed(self.hass, utcnow + 2 * SCAN_INTERVAL)
-                    self.hass.block_till_done()
-
-                    all_states = self.hass.states.all()
-                    assert len(all_states) == 1
-
-                    # Simulate an update - 1 entry
-                    mock_feed.return_value.update.return_value = 'OK', [
-                        mock_entry_1]
-                    fire_time_changed(self.hass, utcnow + 3 * SCAN_INTERVAL)
-                    self.hass.block_till_done()
-
-                    all_states = self.hass.states.all()
-                    assert len(all_states) == 1
-
-                    # Reset mocked method for the next test.
-                    mocked_delete_callback.reset_mock()
-
-                    # Simulate an update - empty data, removes all entities
-                    mock_feed.return_value.update.return_value = 'ERROR', None
-                    fire_time_changed(self.hass, utcnow + 4 * SCAN_INTERVAL)
-                    self.hass.block_till_done()
-
-                    assert mocked_delete_callback.call_count == 1
-                    all_states = self.hass.states.all()
-                    assert len(all_states) == 0
+                assert mocked_delete_callback.call_count == 1
+                all_states = hass.states.async_all()
+                assert len(all_states) == 0

--- a/tests/components/geo_location/test_geo_json_events.py
+++ b/tests/components/geo_location/test_geo_json_events.py
@@ -51,19 +51,19 @@ def _generate_mock_feed_entry(external_id, title, distance_to_home,
 async def test_setup(hass):
     """Test the general setup of the platform."""
     # Set up some mock feed entries for this test.
-    mock_entry_1 = _generate_mock_feed_entry('1234', 'Title 1', 15.5,
-                                                  (-31.0, 150.0))
-    mock_entry_2 = _generate_mock_feed_entry('2345', 'Title 2', 20.5,
-                                                  (-31.1, 150.1))
-    mock_entry_3 = _generate_mock_feed_entry('3456', 'Title 3', 25.5,
-                                                  (-31.2, 150.2))
-    mock_entry_4 = _generate_mock_feed_entry('4567', 'Title 4', 12.5,
-                                                  (-31.3, 150.3))
+    mock_entry_1 = _generate_mock_feed_entry(
+        '1234', 'Title 1', 15.5, (-31.0, 150.0))
+    mock_entry_2 = _generate_mock_feed_entry(
+        '2345', 'Title 2', 20.5, (-31.1, 150.1))
+    mock_entry_3 = _generate_mock_feed_entry(
+        '3456', 'Title 3', 25.5, (-31.2, 150.2))
+    mock_entry_4 = _generate_mock_feed_entry(
+        '4567', 'Title 4', 12.5, (-31.3, 150.3))
 
     # Patching 'utcnow' to gain more control over the timed update.
     utcnow = dt_util.utcnow()
     with patch('homeassistant.util.dt.utcnow', return_value=utcnow), \
-         patch('geojson_client.generic_feed.GenericFeed') as mock_feed:
+            patch('geojson_client.generic_feed.GenericFeed') as mock_feed:
         mock_feed.return_value.update.return_value = 'OK', [mock_entry_1,
                                                             mock_entry_2,
                                                             mock_entry_3]
@@ -180,7 +180,7 @@ async def test_setup_race_condition(hass):
     # Patching 'utcnow' to gain more control over the timed update.
     utcnow = dt_util.utcnow()
     with patch('homeassistant.util.dt.utcnow', return_value=utcnow), \
-        patch('geojson_client.generic_feed.GenericFeed') as mock_feed:
+            patch('geojson_client.generic_feed.GenericFeed') as mock_feed:
         with assert_setup_component(1, geo_location.DOMAIN):
             assert await async_setup_component(
                 hass, geo_location.DOMAIN, CONFIG)

--- a/tests/components/geo_location/test_nsw_rural_fire_service_feed.py
+++ b/tests/components/geo_location/test_nsw_rural_fire_service_feed.py
@@ -1,6 +1,6 @@
 """The tests for the geojson platform."""
 import datetime
-from unittest.mock import patch, MagicMock, call
+from asynctest.mock import patch, MagicMock, call
 
 from homeassistant.components import geo_location
 from homeassistant.components.geo_location import ATTR_SOURCE
@@ -79,8 +79,8 @@ async def test_setup(hass):
     mock_entry_4 = _generate_mock_feed_entry('4567', 'Title 4', 12.5,
                                              (-31.3, 150.3))
 
-    # Patching 'utcnow' to gain more control over the timed update.
     utcnow = dt_util.utcnow()
+    # Patching 'utcnow' to gain more control over the timed update.
     with patch('homeassistant.util.dt.utcnow', return_value=utcnow), \
             patch('geojson_client.nsw_rural_fire_service_feed.'
                   'NswRuralFireServiceFeed') as mock_feed:

--- a/tests/components/geo_location/test_nsw_rural_fire_service_feed.py
+++ b/tests/components/geo_location/test_nsw_rural_fire_service_feed.py
@@ -1,6 +1,6 @@
 """The tests for the geojson platform."""
 import datetime
-from asynctest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, call
 
 from homeassistant.components import geo_location
 from homeassistant.components.geo_location import ATTR_SOURCE
@@ -10,18 +10,27 @@ from homeassistant.components.geo_location.nsw_rural_fire_service_feed import \
     ATTR_RESPONSIBLE_AGENCY, ATTR_PUBLICATION_DATE
 from homeassistant.const import CONF_URL, EVENT_HOMEASSISTANT_START, \
     CONF_RADIUS, ATTR_LATITUDE, ATTR_LONGITUDE, ATTR_FRIENDLY_NAME, \
-    ATTR_UNIT_OF_MEASUREMENT, ATTR_ATTRIBUTION
+    ATTR_UNIT_OF_MEASUREMENT, ATTR_ATTRIBUTION, CONF_LATITUDE, CONF_LONGITUDE
 from homeassistant.setup import async_setup_component
 from tests.common import assert_setup_component, async_fire_time_changed
 import homeassistant.util.dt as dt_util
 
-URL = 'http://geo.json.local/geo_json_events.json'
 CONFIG = {
     geo_location.DOMAIN: [
         {
             'platform': 'nsw_rural_fire_service_feed',
-            CONF_URL: URL,
             CONF_RADIUS: 200
+        }
+    ]
+}
+
+CONFIG_WITH_CUSTOM_LOCATION = {
+    geo_location.DOMAIN: [
+        {
+            'platform': 'nsw_rural_fire_service_feed',
+            CONF_RADIUS: 200,
+            CONF_LATITUDE: 15.1,
+            CONF_LONGITUDE: 25.2
         }
     ]
 }
@@ -55,107 +64,130 @@ def _generate_mock_feed_entry(external_id, title, distance_to_home,
 async def test_setup(hass):
     """Test the general setup of the platform."""
     # Set up some mock feed entries for this test.
-    with patch('geojson_client.nsw_rural_fire_service_feed.'
+    mock_entry_1 = _generate_mock_feed_entry(
+        '1234', 'Title 1', 15.5, (-31.0, 150.0), category='Category 1',
+        location='Location 1', attribution='Attribution 1',
+        publication_date=datetime.datetime(2018, 9, 22, 8, 0,
+                                           tzinfo=datetime.timezone.utc),
+        council_area='Council Area 1', status='Status 1',
+        entry_type='Type 1', size='Size 1', responsible_agency='Agency 1')
+    mock_entry_2 = _generate_mock_feed_entry('2345', 'Title 2', 20.5,
+                                             (-31.1, 150.1),
+                                             fire=False)
+    mock_entry_3 = _generate_mock_feed_entry('3456', 'Title 3', 25.5,
+                                             (-31.2, 150.2))
+    mock_entry_4 = _generate_mock_feed_entry('4567', 'Title 4', 12.5,
+                                             (-31.3, 150.3))
+
+    # Patching 'utcnow' to gain more control over the timed update.
+    utcnow = dt_util.utcnow()
+    with patch('homeassistant.util.dt.utcnow', return_value=utcnow), \
+        patch('geojson_client.nsw_rural_fire_service_feed.'
                'NswRuralFireServiceFeed') as mock_feed:
-        mock_entry_1 = _generate_mock_feed_entry(
-            '1234', 'Title 1', 15.5, (-31.0, 150.0), category='Category 1',
-            location='Location 1', attribution='Attribution 1',
-            publication_date=datetime.datetime(2018, 9, 22, 8, 0,
-                                               tzinfo=datetime.timezone.utc),
-            council_area='Council Area 1', status='Status 1',
-            entry_type='Type 1', size='Size 1', responsible_agency='Agency 1')
-        mock_entry_2 = _generate_mock_feed_entry('2345', 'Title 2', 20.5,
-                                                 (-31.1, 150.1),
-                                                 fire=False)
-        mock_entry_3 = _generate_mock_feed_entry('3456', 'Title 3', 25.5,
-                                                 (-31.2, 150.2))
-        mock_entry_4 = _generate_mock_feed_entry('4567', 'Title 4', 12.5,
-                                                 (-31.3, 150.3))
         mock_feed.return_value.update.return_value = 'OK', [mock_entry_1,
                                                             mock_entry_2,
                                                             mock_entry_3]
+        with assert_setup_component(1, geo_location.DOMAIN):
+            assert await async_setup_component(
+                hass, geo_location.DOMAIN, CONFIG)
+            # Artificially trigger update.
+            hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+            # Collect events.
+            await hass.async_block_till_done()
 
-        utcnow = dt_util.utcnow()
-        # Patching 'utcnow' to gain more control over the timed update.
-        with patch('homeassistant.util.dt.utcnow', return_value=utcnow):
-            with assert_setup_component(1, geo_location.DOMAIN):
-                assert await async_setup_component(
-                    hass, geo_location.DOMAIN, CONFIG)
-                # Artificially trigger update.
-                hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
-                # Collect events.
-                await hass.async_block_till_done()
+            all_states = hass.states.async_all()
+            assert len(all_states) == 3
 
-                all_states = hass.states.async_all()
-                assert len(all_states) == 3
+            state = hass.states.get("geo_location.title_1")
+            assert state is not None
+            assert state.name == "Title 1"
+            assert state.attributes == {
+                ATTR_EXTERNAL_ID: "1234", ATTR_LATITUDE: -31.0,
+                ATTR_LONGITUDE: 150.0, ATTR_FRIENDLY_NAME: "Title 1",
+                ATTR_CATEGORY: "Category 1", ATTR_LOCATION: "Location 1",
+                ATTR_ATTRIBUTION: "Attribution 1",
+                ATTR_PUBLICATION_DATE:
+                    datetime.datetime(2018, 9, 22, 8, 0,
+                                      tzinfo=datetime.timezone.utc),
+                ATTR_FIRE: True,
+                ATTR_COUNCIL_AREA: 'Council Area 1',
+                ATTR_STATUS: 'Status 1', ATTR_TYPE: 'Type 1',
+                ATTR_SIZE: 'Size 1', ATTR_RESPONSIBLE_AGENCY: 'Agency 1',
+                ATTR_UNIT_OF_MEASUREMENT: "km",
+                ATTR_SOURCE: 'nsw_rural_fire_service_feed'}
+            assert round(abs(float(state.state)-15.5), 7) == 0
 
-                state = hass.states.get("geo_location.title_1")
-                assert state is not None
-                assert state.name == "Title 1"
-                assert state.attributes == {
-                    ATTR_EXTERNAL_ID: "1234", ATTR_LATITUDE: -31.0,
-                    ATTR_LONGITUDE: 150.0, ATTR_FRIENDLY_NAME: "Title 1",
-                    ATTR_CATEGORY: "Category 1", ATTR_LOCATION: "Location 1",
-                    ATTR_ATTRIBUTION: "Attribution 1",
-                    ATTR_PUBLICATION_DATE:
-                        datetime.datetime(2018, 9, 22, 8, 0,
-                                          tzinfo=datetime.timezone.utc),
-                    ATTR_FIRE: True,
-                    ATTR_COUNCIL_AREA: 'Council Area 1',
-                    ATTR_STATUS: 'Status 1', ATTR_TYPE: 'Type 1',
-                    ATTR_SIZE: 'Size 1', ATTR_RESPONSIBLE_AGENCY: 'Agency 1',
-                    ATTR_UNIT_OF_MEASUREMENT: "km",
-                    ATTR_SOURCE: 'nsw_rural_fire_service_feed'}
-                assert round(abs(float(state.state)-15.5), 7) == 0
+            state = hass.states.get("geo_location.title_2")
+            assert state is not None
+            assert state.name == "Title 2"
+            assert state.attributes == {
+                ATTR_EXTERNAL_ID: "2345", ATTR_LATITUDE: -31.1,
+                ATTR_LONGITUDE: 150.1, ATTR_FRIENDLY_NAME: "Title 2",
+                ATTR_FIRE: False,
+                ATTR_UNIT_OF_MEASUREMENT: "km",
+                ATTR_SOURCE: 'nsw_rural_fire_service_feed'}
+            assert round(abs(float(state.state)-20.5), 7) == 0
 
-                state = hass.states.get("geo_location.title_2")
-                assert state is not None
-                assert state.name == "Title 2"
-                assert state.attributes == {
-                    ATTR_EXTERNAL_ID: "2345", ATTR_LATITUDE: -31.1,
-                    ATTR_LONGITUDE: 150.1, ATTR_FRIENDLY_NAME: "Title 2",
-                    ATTR_FIRE: False,
-                    ATTR_UNIT_OF_MEASUREMENT: "km",
-                    ATTR_SOURCE: 'nsw_rural_fire_service_feed'}
-                assert round(abs(float(state.state)-20.5), 7) == 0
+            state = hass.states.get("geo_location.title_3")
+            assert state is not None
+            assert state.name == "Title 3"
+            assert state.attributes == {
+                ATTR_EXTERNAL_ID: "3456", ATTR_LATITUDE: -31.2,
+                ATTR_LONGITUDE: 150.2, ATTR_FRIENDLY_NAME: "Title 3",
+                ATTR_FIRE: True,
+                ATTR_UNIT_OF_MEASUREMENT: "km",
+                ATTR_SOURCE: 'nsw_rural_fire_service_feed'}
+            assert round(abs(float(state.state)-25.5), 7) == 0
 
-                state = hass.states.get("geo_location.title_3")
-                assert state is not None
-                assert state.name == "Title 3"
-                assert state.attributes == {
-                    ATTR_EXTERNAL_ID: "3456", ATTR_LATITUDE: -31.2,
-                    ATTR_LONGITUDE: 150.2, ATTR_FRIENDLY_NAME: "Title 3",
-                    ATTR_FIRE: True,
-                    ATTR_UNIT_OF_MEASUREMENT: "km",
-                    ATTR_SOURCE: 'nsw_rural_fire_service_feed'}
-                assert round(abs(float(state.state)-25.5), 7) == 0
+            # Simulate an update - one existing, one new entry,
+            # one outdated entry
+            mock_feed.return_value.update.return_value = 'OK', [
+                mock_entry_1, mock_entry_4, mock_entry_3]
+            async_fire_time_changed(hass, utcnow + SCAN_INTERVAL)
+            await hass.async_block_till_done()
 
-                # Simulate an update - one existing, one new entry,
-                # one outdated entry
-                mock_feed.return_value.update.return_value = 'OK', [
-                    mock_entry_1, mock_entry_4, mock_entry_3]
-                async_fire_time_changed(hass, utcnow + SCAN_INTERVAL)
-                await hass.async_block_till_done()
+            all_states = hass.states.async_all()
+            assert len(all_states) == 3
 
-                all_states = hass.states.async_all()
-                assert len(all_states) == 3
+            # Simulate an update - empty data, but successful update,
+            # so no changes to entities.
+            mock_feed.return_value.update.return_value = 'OK_NO_DATA', None
+            async_fire_time_changed(hass, utcnow + 2 * SCAN_INTERVAL)
+            await hass.async_block_till_done()
 
-                # Simulate an update - empty data, but successful update,
-                # so no changes to entities.
-                mock_feed.return_value.update.return_value = 'OK_NO_DATA', None
-                # mock_restdata.return_value.data = None
-                async_fire_time_changed(hass, utcnow +
-                                        2 * SCAN_INTERVAL)
-                await hass.async_block_till_done()
+            all_states = hass.states.async_all()
+            assert len(all_states) == 3
 
-                all_states = hass.states.async_all()
-                assert len(all_states) == 3
+            # Simulate an update - empty data, removes all entities
+            mock_feed.return_value.update.return_value = 'ERROR', None
+            async_fire_time_changed(hass, utcnow + 3 * SCAN_INTERVAL)
+            await hass.async_block_till_done()
 
-                # Simulate an update - empty data, removes all entities
-                mock_feed.return_value.update.return_value = 'ERROR', None
-                async_fire_time_changed(hass, utcnow +
-                                        2 * SCAN_INTERVAL)
-                await hass.async_block_till_done()
+            all_states = hass.states.async_all()
+            assert len(all_states) == 0
 
-                all_states = hass.states.async_all()
-                assert len(all_states) == 0
+
+async def test_setup_with_custom_location(hass):
+    """Test the setup with a custom location."""
+    # Set up some mock feed entries for this test.
+    mock_entry_1 = _generate_mock_feed_entry(
+        '1234', 'Title 1', 20.5, (-31.1, 150.1))
+
+    with patch('geojson_client.nsw_rural_fire_service_feed.'
+               'NswRuralFireServiceFeed') as mock_feed:
+        mock_feed.return_value.update.return_value = 'OK', [mock_entry_1]
+
+        with assert_setup_component(1, geo_location.DOMAIN):
+            assert await async_setup_component(
+                hass, geo_location.DOMAIN, CONFIG_WITH_CUSTOM_LOCATION)
+
+            # Artificially trigger update.
+            hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+            # Collect events.
+            await hass.async_block_till_done()
+
+            all_states = hass.states.async_all()
+            assert len(all_states) == 1
+
+            assert mock_feed.call_args == call(
+                (15.1, 25.2), filter_categories=[], filter_radius=200.0)

--- a/tests/components/geo_location/test_nsw_rural_fire_service_feed.py
+++ b/tests/components/geo_location/test_nsw_rural_fire_service_feed.py
@@ -8,9 +8,9 @@ from homeassistant.components.geo_location.nsw_rural_fire_service_feed import \
     ATTR_EXTERNAL_ID, SCAN_INTERVAL, ATTR_CATEGORY, ATTR_FIRE, ATTR_LOCATION, \
     ATTR_COUNCIL_AREA, ATTR_STATUS, ATTR_TYPE, ATTR_SIZE, \
     ATTR_RESPONSIBLE_AGENCY, ATTR_PUBLICATION_DATE
-from homeassistant.const import CONF_URL, EVENT_HOMEASSISTANT_START, \
-    CONF_RADIUS, ATTR_LATITUDE, ATTR_LONGITUDE, ATTR_FRIENDLY_NAME, \
-    ATTR_UNIT_OF_MEASUREMENT, ATTR_ATTRIBUTION, CONF_LATITUDE, CONF_LONGITUDE
+from homeassistant.const import ATTR_ATTRIBUTION, ATTR_FRIENDLY_NAME, \
+    ATTR_LATITUDE, ATTR_LONGITUDE, ATTR_UNIT_OF_MEASUREMENT, CONF_LATITUDE, \
+    CONF_LONGITUDE, CONF_RADIUS, EVENT_HOMEASSISTANT_START
 from homeassistant.setup import async_setup_component
 from tests.common import assert_setup_component, async_fire_time_changed
 import homeassistant.util.dt as dt_util
@@ -82,8 +82,8 @@ async def test_setup(hass):
     # Patching 'utcnow' to gain more control over the timed update.
     utcnow = dt_util.utcnow()
     with patch('homeassistant.util.dt.utcnow', return_value=utcnow), \
-        patch('geojson_client.nsw_rural_fire_service_feed.'
-               'NswRuralFireServiceFeed') as mock_feed:
+            patch('geojson_client.nsw_rural_fire_service_feed.'
+                  'NswRuralFireServiceFeed') as mock_feed:
         mock_feed.return_value.update.return_value = 'OK', [mock_entry_1,
                                                             mock_entry_2,
                                                             mock_entry_3]


### PR DESCRIPTION
## Description:
This changes the level of integration of the `geo_json_events` and `nsw_rural_fire_service_feed` platforms to align them with https://github.com/home-assistant/home-assistant/pull/18207.
* More entity management code has been moved into the third-party library.
* Cleaned up unit tests.
* Transformed `geo_json_events` tests to async.
* Support for custom latitude/longitude.

**Related issue (if applicable):** n/a

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#7654

## Example entry for `configuration.yaml` (if applicable):
```yaml
geo_location:
  - platform: nsw_rural_fire_service_feed
    latitude: -36.666667
    longitude: 149.833333
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
