### PR TITLE
Fix logbook filtering entities

### DIFF
--- a/homeassistant/components/logbook.py
+++ b/homeassistant/components/logbook.py
@@ -391,9 +391,9 @@ def _get_events(hass, config, start_day, end_day, entity_id=None):
             .filter(Events.event_type.in_(ALL_EVENT_TYPES)) \
             .filter((Events.time_fired > start_day)
                     & (Events.time_fired < end_day)) \
-            .filter((States.last_updated == States.last_changed)
-                    | (States.state_id.is_(None))) \
-            .filter(States.entity_id.in_(entity_ids))
+            .filter(((States.last_updated == States.last_changed) &
+                     States.entity_id.in_(entity_ids))
+                    | (States.state_id.is_(None)))
 
         events = execute(query)
 

--- a/tests/components/test_logbook.py
+++ b/tests/components/test_logbook.py
@@ -72,6 +72,10 @@ class TestComponentLogbook(unittest.TestCase):
         assert 'switch' == last_call.data.get(logbook.ATTR_DOMAIN)
         assert 'switch.test_switch' == last_call.data.get(
             logbook.ATTR_ENTITY_ID)
+        events = list(logbook._get_events(
+            self.hass, {}, dt_util.utcnow() - timedelta(hours=1),
+            dt_util.utcnow() + timedelta(hours=1)))
+        assert len(events) == 1
 
     def test_service_call_create_log_book_entry_no_message(self):
         """Test if service call create log book entry without message."""

--- a/tests/components/test_logbook.py
+++ b/tests/components/test_logbook.py
@@ -62,6 +62,12 @@ class TestComponentLogbook(unittest.TestCase):
         # Our service call will unblock when the event listeners have been
         # scheduled. This means that they may not have been processed yet.
         self.hass.block_till_done()
+        self.hass.data[recorder.DATA_INSTANCE].block_till_done()
+
+        events = list(logbook._get_events(
+            self.hass, {}, dt_util.utcnow() - timedelta(hours=1),
+            dt_util.utcnow() + timedelta(hours=1)))
+        assert len(events) == 2
 
         assert 1 == len(calls)
         last_call = calls[-1]
@@ -72,10 +78,6 @@ class TestComponentLogbook(unittest.TestCase):
         assert 'switch' == last_call.data.get(logbook.ATTR_DOMAIN)
         assert 'switch.test_switch' == last_call.data.get(
             logbook.ATTR_ENTITY_ID)
-        events = list(logbook._get_events(
-            self.hass, {}, dt_util.utcnow() - timedelta(hours=1),
-            dt_util.utcnow() + timedelta(hours=1)))
-        assert len(events) == 1
 
     def test_service_call_create_log_book_entry_no_message(self):
         """Test if service call create log book entry without message."""


### PR DESCRIPTION
## Description:
Fix logbook filtering only events that are related to entities and not logbook_entry events.

Introduced in #18376

Reported by @arsaboo on Discord

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
