### PR TITLE
Improve handling of shared state topic

### DIFF
--- a/homeassistant/components/light/mqtt/schema_basic.py
+++ b/homeassistant/components/light/mqtt/schema_basic.py
@@ -242,7 +242,7 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, Light, RestoreEntity):
         templates = {}
         for key, tpl in list(self._templates.items()):
             if tpl is None:
-                templates[key] = lambda value: value
+                templates[key] = lambda value, error_value: value
             else:
                 tpl.hass = self.hass
                 templates[key] = tpl.async_render_with_possible_json_value
@@ -252,7 +252,7 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, Light, RestoreEntity):
         @callback
         def state_received(topic, payload, qos):
             """Handle new MQTT messages."""
-            payload = templates[CONF_STATE](payload)
+            payload = templates[CONF_STATE](payload, None)
             if not payload:
                 _LOGGER.debug("Ignoring empty state message from '%s'", topic)
                 return
@@ -273,7 +273,7 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, Light, RestoreEntity):
         @callback
         def brightness_received(topic, payload, qos):
             """Handle new MQTT messages for the brightness."""
-            payload = templates[CONF_BRIGHTNESS](payload)
+            payload = templates[CONF_BRIGHTNESS](payload, None)
             if not payload:
                 _LOGGER.debug("Ignoring empty brightness message from '%s'",
                               topic)
@@ -300,7 +300,7 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, Light, RestoreEntity):
         @callback
         def rgb_received(topic, payload, qos):
             """Handle new MQTT messages for RGB."""
-            payload = templates[CONF_RGB](payload)
+            payload = templates[CONF_RGB](payload, None)
             if not payload:
                 _LOGGER.debug("Ignoring empty rgb message from '%s'", topic)
                 return
@@ -327,7 +327,7 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, Light, RestoreEntity):
         @callback
         def color_temp_received(topic, payload, qos):
             """Handle new MQTT messages for color temperature."""
-            payload = templates[CONF_COLOR_TEMP](payload)
+            payload = templates[CONF_COLOR_TEMP](payload, None)
             if not payload:
                 _LOGGER.debug("Ignoring empty color temp message from '%s'",
                               topic)
@@ -352,7 +352,7 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, Light, RestoreEntity):
         @callback
         def effect_received(topic, payload, qos):
             """Handle new MQTT messages for effect."""
-            payload = templates[CONF_EFFECT](payload)
+            payload = templates[CONF_EFFECT](payload, None)
             if not payload:
                 _LOGGER.debug("Ignoring empty effect message from '%s'", topic)
                 return
@@ -376,7 +376,7 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, Light, RestoreEntity):
         @callback
         def hs_received(topic, payload, qos):
             """Handle new MQTT messages for hs color."""
-            payload = templates[CONF_HS](payload)
+            payload = templates[CONF_HS](payload, None)
             if not payload:
                 _LOGGER.debug("Ignoring empty hs message from '%s'", topic)
                 return
@@ -403,7 +403,7 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, Light, RestoreEntity):
         @callback
         def white_value_received(topic, payload, qos):
             """Handle new MQTT messages for white value."""
-            payload = templates[CONF_WHITE_VALUE](payload)
+            payload = templates[CONF_WHITE_VALUE](payload, None)
             if not payload:
                 _LOGGER.debug("Ignoring empty white value message from '%s'",
                               topic)
@@ -430,7 +430,7 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, Light, RestoreEntity):
         @callback
         def xy_received(topic, payload, qos):
             """Handle new MQTT messages for xy color."""
-            payload = templates[CONF_XY](payload)
+            payload = templates[CONF_XY](payload, None)
             if not payload:
                 _LOGGER.debug("Ignoring empty xy-color message from '%s'",
                               topic)


### PR DESCRIPTION
## Description:
Improve handling of shared state topic when some states are not always present in the MQTT message (follow-up to #16720).

### Example:
Discovery message sent by the device, `tasmota/sonoff_0FDD9A/stat/RESULT` is shared by several states:
Topic: `homeassistant/light/sonoff_0FDD9A_1/config`
Message:
``` json
{  
   "name":"Kitchen Sink",
   "command_topic":"tasmota/sonoff_0FDD9A/cmnd/POWER",
   "state_topic":"tasmota/sonoff_0FDD9A/stat/RESULT",
   "value_template":"{{value_json.POWER}}",
   "payload_off":"OFF",
   "payload_on":"ON",
   "availability_topic":"tasmota/sonoff_0FDD9A/tele/LWT",
   "payload_available":"Online",
   "payload_not_available":"Offline",
   "brightness_command_topic":"tasmota/sonoff_0FDD9A/cmnd/Dimmer",
   "brightness_state_topic":"tasmota/sonoff_0FDD9A/stat/RESULT",
   "brightness_scale":100,
    "rgb_command_topic": "tasmota/sonoff_0FDD9A/cmnd/Color2",
    "rgb_state_topic": "tasmota/sonoff_0FDD9A/stat/RESULT",
    "rgb_value_template": "{{value_json.Color.split(',')[0:3]|join(',')}}",
   "on_command_type":"brightness",
   "brightness_value_template":"{{value_json.Dimmer}}"
}
```

Change color update:
Topic: `tasmota/sonoff_0FDD9A/stat/RESULT` Message: `{"POWER":"ON","Dimmer":66,"Color":"1,2,3,4,5"}`

Turn off update - this will fail in `rgb_received` because there is no Color:
Topic: `tasmota/sonoff_0FDD9A/stat/RESULT` Message: `{"POWER":"OFF"}`

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.