### PR TITLE
Optionally do not log template rendering errors

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -169,8 +169,10 @@ class Template:
         try:
             return self._compiled.render(variables).strip()
         except jinja2.TemplateError as ex:
-            _LOGGER.error("Error parsing value: %s (value: %s, template: %s)",
-                          ex, value, self.template)
+            if error_value is _SENTINEL:
+                _LOGGER.error(
+                    "Error parsing value: %s (value: %s, template: %s)",
+                    ex, value, self.template)
             return value if error_value is _SENTINEL else error_value
 
     def _ensure_compiled(self):


### PR DESCRIPTION
## Description:
Unlike `async_render`, `async_render_with_possible_json_value` prints an angry error message if the template could not be rendered.
This PR disables logging if `error_value` (default value in case the template can't be rendered) has been set.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.