### PR TITLE
Add JSON attributes to MQTT binary sensor

### DIFF
--- a/homeassistant/components/binary_sensor/mqtt.py
+++ b/homeassistant/components/binary_sensor/mqtt.py
@@ -16,9 +16,9 @@ from homeassistant.const import (
     CONF_FORCE_UPDATE, CONF_NAME, CONF_VALUE_TEMPLATE, CONF_PAYLOAD_ON,
     CONF_PAYLOAD_OFF, CONF_DEVICE_CLASS, CONF_DEVICE)
 from homeassistant.components.mqtt import (
-    ATTR_DISCOVERY_HASH, CONF_AVAILABILITY_TOPIC, CONF_JSON_ATTRS,
-    CONF_STATE_TOPIC, CONF_PAYLOAD_AVAILABLE, CONF_PAYLOAD_NOT_AVAILABLE,
-    CONF_QOS, MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
+    ATTR_DISCOVERY_HASH, CONF_AVAILABILITY_TOPIC, CONF_STATE_TOPIC,
+    CONF_PAYLOAD_AVAILABLE, CONF_PAYLOAD_NOT_AVAILABLE, CONF_QOS,
+    MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
     MqttEntityDeviceInfo, subscription)
 from homeassistant.components.mqtt.discovery import MQTT_DISCOVERY_NEW
 import homeassistant.helpers.config_validation as cv
@@ -45,12 +45,12 @@ PLATFORM_SCHEMA = mqtt.MQTT_RO_PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_FORCE_UPDATE, default=DEFAULT_FORCE_UPDATE): cv.boolean,
     vol.Optional(CONF_OFF_DELAY):
         vol.All(vol.Coerce(int), vol.Range(min=0)),
-    vol.Optional(CONF_JSON_ATTRS, default=[]): cv.ensure_list_csv,
     # Integrations should never expose unique_id through configuration.
     # This is an exception because MQTT is a message transport, not a protocol
     vol.Optional(CONF_UNIQUE_ID): cv.string,
     vol.Optional(CONF_DEVICE): mqtt.MQTT_ENTITY_DEVICE_INFO_SCHEMA,
-}).extend(mqtt.MQTT_AVAILABILITY_SCHEMA.schema)
+}).extend(mqtt.MQTT_AVAILABILITY_SCHEMA.schema).extend(
+    mqtt.MQTT_JSON_ATTRS_SCHEMA.schema)
 
 
 async def async_setup_platform(hass: HomeAssistantType, config: ConfigType,
@@ -90,14 +90,12 @@ class MqttBinarySensor(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
         self._delay_listener = None
 
         availability_topic = config.get(CONF_AVAILABILITY_TOPIC)
-        state_topic = config.get(CONF_STATE_TOPIC)
         payload_available = config.get(CONF_PAYLOAD_AVAILABLE)
         payload_not_available = config.get(CONF_PAYLOAD_NOT_AVAILABLE)
         qos = config.get(CONF_QOS)
         device_config = config.get(CONF_DEVICE)
-        json_attributes = config.get(CONF_JSON_ATTRS)
 
-        MqttAttributes.__init__(self, state_topic, qos, json_attributes)
+        MqttAttributes.__init__(self, config)
         MqttAvailability.__init__(self, availability_topic, qos,
                                   payload_available, payload_not_available)
         MqttDiscoveryUpdate.__init__(self, discovery_hash,

--- a/tests/components/binary_sensor/test_mqtt.py
+++ b/tests/components/binary_sensor/test_mqtt.py
@@ -264,11 +264,11 @@ class TestSensorMQTT(unittest.TestCase):
                 'platform': 'mqtt',
                 'name': 'test',
                 'state_topic': 'test-topic',
-                'json_attributes': 'val'
+                'json_attributes_topic': 'attr-topic'
             }
         })
 
-        fire_mqtt_message(self.hass, 'test-topic', '{ "val": "100" }')
+        fire_mqtt_message(self.hass, 'attr-topic', '{ "val": "100" }')
         self.hass.block_till_done()
         state = self.hass.states.get('binary_sensor.test')
 
@@ -284,16 +284,17 @@ class TestSensorMQTT(unittest.TestCase):
                 'platform': 'mqtt',
                 'name': 'test',
                 'state_topic': 'test-topic',
-                'json_attributes': 'val'
+                'json_attributes_topic': 'attr-topic'
             }
         })
 
-        fire_mqtt_message(self.hass, 'test-topic', '[ "list", "of", "things"]')
+        fire_mqtt_message(self.hass, 'attr-topic', '[ "list", "of", "things"]')
         self.hass.block_till_done()
         state = self.hass.states.get('binary_sensor.test')
 
         assert state.attributes.get('val') is None
-        assert mock_logger.warning.called
+        mock_logger.debug.assert_called_with(
+            'JSON result was not a dictionary')
 
     @patch('homeassistant.components.mqtt._LOGGER')
     def test_update_with_json_attrs_bad_JSON(self, mock_logger):
@@ -304,38 +305,17 @@ class TestSensorMQTT(unittest.TestCase):
                 'platform': 'mqtt',
                 'name': 'test',
                 'state_topic': 'test-topic',
-                'json_attributes': 'val'
+                'json_attributes_topic': 'attr-topic'
             }
         })
 
-        fire_mqtt_message(self.hass, 'test-topic', 'This is not JSON')
+        fire_mqtt_message(self.hass, 'attr-topic', 'This is not JSON')
         self.hass.block_till_done()
 
         state = self.hass.states.get('binary_sensor.test')
         assert state.attributes.get('val') is None
-        assert mock_logger.warning.called
-        assert mock_logger.debug.called
-
-    def test_update_with_json_attrs_and_template(self):
-        """Test attributes get extracted from a JSON result."""
-        mock_component(self.hass, 'mqtt')
-        assert setup_component(self.hass, binary_sensor.DOMAIN, {
-            binary_sensor.DOMAIN: {
-                'platform': 'mqtt',
-                'name': 'test',
-                'state_topic': 'test-topic',
-                'value_template': '{{ value_json.val }}',
-                'json_attributes': 'val'
-            }
-        })
-
-        fire_mqtt_message(self.hass, 'test-topic', '{ "val": "ON" }')
-        self.hass.block_till_done()
-        state = self.hass.states.get('binary_sensor.test')
-
-        assert 'ON' == \
-            state.attributes.get('val')
-        assert STATE_ON == state.state
+        mock_logger.debug.assert_called_with(
+            'Erroneous JSON: %s', 'This is not JSON')
 
 
 async def test_unique_id(hass):


### PR DESCRIPTION
## Description:
Add JSON attributes to MQTT binary sensor in same way as already supported by MQTT sensor
Add MqttAttributes mixin to simplify adding JSON attributes to other MQTT components.

Note:
MQTT Sensor should be refactored to use the mixin, but waiting for merge of #18178 first

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation:** home-assistant/home-assistant.io#TODO

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)