### PR TITLE
Add ability to monitor relay events

### DIFF
--- a/homeassistant/components/doorbird.py
+++ b/homeassistant/components/doorbird.py
@@ -112,7 +112,7 @@ def setup(hass, config):
             return False
 
         # Subscribe to doorbell or motion events
-        if events is not None:
+        if events:
             doorstation.update_schedule(hass)
 
     hass.data[DOMAIN] = doorstations


### PR DESCRIPTION
## Description:
Enables ability to trigger actions in Home Assistant when Doorbird relay is triggered.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#7648

## Example entry for `configuration.yaml` (if applicable):
```yaml
doorbird:
  token: YOUR_DOORBIRD_TOKEN
  devices:
    - host: DOORBIRD_IP_OR_HOSTNAME
      username: YOUR_USERNAME
      password: YOUR_PASSWORD
      name: Driveway Gate
      monitored_conditions:
        - doorbell
        - motion
        - relay
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
