### PR TITLE
Follow-up: remove pbkdf2 to bcrypt upgrade path

### DIFF
--- a/homeassistant/auth/providers/homeassistant.py
+++ b/homeassistant/auth/providers/homeassistant.py
@@ -1,8 +1,6 @@
 """Home Assistant auth provider."""
 import base64
 from collections import OrderedDict
-import hashlib
-import hmac
 from typing import Any, Dict, List, Optional, cast
 
 import bcrypt
@@ -11,7 +9,6 @@ import voluptuous as vol
 from homeassistant.const import CONF_ID
 from homeassistant.core import callback, HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.util.async_ import run_coroutine_threadsafe
 
 from . import AuthProvider, AUTH_PROVIDER_SCHEMA, AUTH_PROVIDERS, LoginFlow
 
@@ -94,38 +91,10 @@ class Data:
 
         user_hash = base64.b64decode(found['password'])
 
-        # if the hash is not a bcrypt hash...
-        # provide a transparant upgrade for old pbkdf2 hash format
-        if not (user_hash.startswith(b'$2a$')
-                or user_hash.startswith(b'$2b$')
-                or user_hash.startswith(b'$2x$')
-                or user_hash.startswith(b'$2y$')):
-            # IMPORTANT! validate the login, bail if invalid
-            hashed = self.legacy_hash_password(password)
-            if not hmac.compare_digest(hashed, user_hash):
-                raise InvalidAuth
-            # then re-hash the valid password with bcrypt
-            self.change_password(found['username'], password)
-            run_coroutine_threadsafe(
-                self.async_save(), self.hass.loop
-            ).result()
-            user_hash = base64.b64decode(found['password'])
-
         # bcrypt.checkpw is timing-safe
         if not bcrypt.checkpw(password.encode(),
                               user_hash):
             raise InvalidAuth
-
-    def legacy_hash_password(self, password: str,
-                             for_storage: bool = False) -> bytes:
-        """LEGACY password encoding."""
-        # We're no longer storing salts in data, but if one exists we
-        # should be able to retrieve it.
-        salt = self._data['salt'].encode()  # type: ignore
-        hashed = hashlib.pbkdf2_hmac('sha512', password.encode(), salt, 100000)
-        if for_storage:
-            hashed = base64.b64encode(hashed)
-        return hashed
 
     # pylint: disable=no-self-use
     def hash_password(self, password: str, for_storage: bool = False) -> bytes:


### PR DESCRIPTION
## Description:

As discussed in #16071, now 90+ days later, I think it's safe to remove the pbkdf2 -> bcrypt upgrade path. Any users who had the new auth system enabled should at this point now be using bcrypt hashes, thus the upgrade path functionality and related tests should be safe to remove.

**Related issue (if applicable):** Removes legacy upgrade as discussed in #16071

## Example entry for `configuration.yaml` (if applicable):
```yaml
auth_providers:
  - type: homeassistant
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
