### PR TITLE
Set lock status correctly for Schlage BE469 Z-Wave locks

### DIFF
--- a/homeassistant/components/lock/zwave.py
+++ b/homeassistant/components/lock/zwave.py
@@ -188,7 +188,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             _LOGGER.info("Usercode at slot %s is: %s", value.index, value.data)
             break
 
-
     def clear_usercode(service):
         """Set usercode to slot X on the lock."""
         node_id = service.data.get(zwave.const.ATTR_NODE_ID)
@@ -285,7 +284,7 @@ class ZwaveLock(zwave.ZWaveDeviceEntity, LockDevice):
                 _LOGGER.debug("set state to %s based on message tracking",
                               self._state)
                 if self._previous_message == \
-                    zwave.const.COMMAND_CLASS_DOOR_LOCK:
+                        zwave.const.COMMAND_CLASS_DOOR_LOCK:
                     if self._state:
                         self._notification = \
                             LOCK_NOTIFICATION[NOTIFICATION_RF_LOCK]

--- a/homeassistant/components/lock/zwave.py
+++ b/homeassistant/components/lock/zwave.py
@@ -29,8 +29,9 @@ SERVICE_CLEAR_USERCODE = 'clear_usercode'
 POLYCONTROL = 0x10E
 DANALOCK_V2_BTZE = 0x2
 POLYCONTROL_DANALOCK_V2_BTZE_LOCK = (POLYCONTROL, DANALOCK_V2_BTZE)
-WORKAROUND_V2BTZE = 'v2btze'
-WORKAROUND_DEVICE_STATE = 'state'
+WORKAROUND_V2BTZE = 1
+WORKAROUND_DEVICE_STATE = 2
+WORKAROUND_TRACK_MESSAGE = 4
 
 DEVICE_MAPPINGS = {
     POLYCONTROL_DANALOCK_V2_BTZE_LOCK: WORKAROUND_V2BTZE,
@@ -43,7 +44,7 @@ DEVICE_MAPPINGS = {
     # Yale YRD220 (as reported by adrum in PR #17386)
     (0x0109, 0x0000): WORKAROUND_DEVICE_STATE,
     # Schlage BE469
-    (0x003B, 0x5044): WORKAROUND_DEVICE_STATE,
+    (0x003B, 0x5044): WORKAROUND_DEVICE_STATE | WORKAROUND_TRACK_MESSAGE,
     # Schlage FE599NX
     (0x003B, 0x504C): WORKAROUND_DEVICE_STATE,
 }
@@ -51,13 +52,15 @@ DEVICE_MAPPINGS = {
 LOCK_NOTIFICATION = {
     '1': 'Manual Lock',
     '2': 'Manual Unlock',
-    '3': 'RF Lock',
-    '4': 'RF Unlock',
     '5': 'Keypad Lock',
     '6': 'Keypad Unlock',
     '11': 'Lock Jammed',
     '254': 'Unknown Event'
 }
+NOTIFICATION_RF_LOCK = '3'
+NOTIFICATION_RF_UNLOCK = '4'
+LOCK_NOTIFICATION[NOTIFICATION_RF_LOCK] = 'RF Lock'
+LOCK_NOTIFICATION[NOTIFICATION_RF_UNLOCK] = 'RF Unlock'
 
 LOCK_ALARM_TYPE = {
     '9': 'Deadbolt Jammed',
@@ -66,8 +69,6 @@ LOCK_ALARM_TYPE = {
     '19': 'Unlocked with Keypad by user ',
     '21': 'Manually Locked ',
     '22': 'Manually Unlocked ',
-    '24': 'Locked by RF',
-    '25': 'Unlocked by RF',
     '27': 'Auto re-lock',
     '33': 'User deleted: ',
     '112': 'Master code changed or User added: ',
@@ -79,6 +80,10 @@ LOCK_ALARM_TYPE = {
     '168': 'Critical Battery Level',
     '169': 'Battery too low to operate'
 }
+ALARM_RF_LOCK = '24'
+ALARM_RF_UNLOCK = '25'
+LOCK_ALARM_TYPE[ALARM_RF_LOCK] = 'Locked by RF'
+LOCK_ALARM_TYPE[ALARM_RF_UNLOCK] = 'Unlocked by RF'
 
 MANUAL_LOCK_ALARM_LEVEL = {
     '1': 'by Key Cylinder or Inside thumb turn',
@@ -183,6 +188,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             _LOGGER.info("Usercode at slot %s is: %s", value.index, value.data)
             break
 
+
     def clear_usercode(service):
         """Set usercode to slot X on the lock."""
         node_id = service.data.get(zwave.const.ATTR_NODE_ID)
@@ -229,6 +235,8 @@ class ZwaveLock(zwave.ZWaveDeviceEntity, LockDevice):
         self._lock_status = None
         self._v2btze = None
         self._state_workaround = False
+        self._track_message_workaround = False
+        self._previous_message = None
 
         # Enable appropriate workaround flags for our device
         # Make sure that we have values for the key before converting to int
@@ -237,26 +245,30 @@ class ZwaveLock(zwave.ZWaveDeviceEntity, LockDevice):
             specific_sensor_key = (int(self.node.manufacturer_id, 16),
                                    int(self.node.product_id, 16))
             if specific_sensor_key in DEVICE_MAPPINGS:
-                if DEVICE_MAPPINGS[specific_sensor_key] == WORKAROUND_V2BTZE:
+                workaround = DEVICE_MAPPINGS[specific_sensor_key]
+                if workaround & WORKAROUND_V2BTZE:
                     self._v2btze = 1
                     _LOGGER.debug("Polycontrol Danalock v2 BTZE "
                                   "workaround enabled")
-                if DEVICE_MAPPINGS[specific_sensor_key] == \
-                        WORKAROUND_DEVICE_STATE:
+                if workaround & WORKAROUND_DEVICE_STATE:
                     self._state_workaround = True
                     _LOGGER.debug(
                         "Notification device state workaround enabled")
+                if workaround & WORKAROUND_TRACK_MESSAGE:
+                    self._track_message_workaround = True
+                    _LOGGER.debug("Message tracking workaround enabled")
         self.update_properties()
 
     def update_properties(self):
         """Handle data changes for node values."""
         self._state = self.values.primary.data
-        _LOGGER.debug("Lock state set from Bool value and is %s", self._state)
+        _LOGGER.debug("lock state set to %s", self._state)
         if self.values.access_control:
             notification_data = self.values.access_control.data
             self._notification = LOCK_NOTIFICATION.get(str(notification_data))
             if self._state_workaround:
                 self._state = LOCK_STATUS.get(str(notification_data))
+                _LOGGER.debug("workaround: lock state set to %s", self._state)
             if self._v2btze:
                 if self.values.v2btze_advanced and \
                         self.values.v2btze_advanced.data == CONFIG_ADVANCED:
@@ -265,16 +277,37 @@ class ZwaveLock(zwave.ZWaveDeviceEntity, LockDevice):
                         "Lock state set from Access Control value and is %s, "
                         "get=%s", str(notification_data), self.state)
 
+        if self._track_message_workaround:
+            this_message = self.node.stats['lastReceivedMessage'][5]
+
+            if this_message == zwave.const.COMMAND_CLASS_DOOR_LOCK:
+                self._state = self.values.primary.data
+                _LOGGER.debug("set state to %s based on message tracking",
+                              self._state)
+                if self._previous_message == \
+                    zwave.const.COMMAND_CLASS_DOOR_LOCK:
+                    if self._state:
+                        self._notification = \
+                            LOCK_NOTIFICATION[NOTIFICATION_RF_LOCK]
+                        self._lock_status = \
+                            LOCK_ALARM_TYPE[ALARM_RF_LOCK]
+                    else:
+                        self._notification = \
+                            LOCK_NOTIFICATION[NOTIFICATION_RF_UNLOCK]
+                        self._lock_status = \
+                            LOCK_ALARM_TYPE[ALARM_RF_UNLOCK]
+                    return
+
+            self._previous_message = this_message
+
         if not self.values.alarm_type:
             return
 
         alarm_type = self.values.alarm_type.data
-        _LOGGER.debug("Lock alarm_type is %s", str(alarm_type))
         if self.values.alarm_level:
             alarm_level = self.values.alarm_level.data
         else:
             alarm_level = None
-        _LOGGER.debug("Lock alarm_level is %s", str(alarm_level))
 
         if not alarm_type:
             return

--- a/tests/components/lock/test_zwave.py
+++ b/tests/components/lock/test_zwave.py
@@ -81,7 +81,7 @@ def test_lock_state_workaround(mock_openzwave):
 def test_track_message_workaround(mock_openzwave):
     """Test value changed for Z-Wave lock by alarm-clearing workaround."""
     node = MockNode(manufacturer_id='003B', product_id='5044',
-                    stats={'lastReceivedMessage':[0] * 6})
+                    stats={'lastReceivedMessage': [0] * 6})
     values = MockEntityValues(
         primary=MockValue(data=True, node=node),
         access_control=None,

--- a/tests/components/lock/test_zwave.py
+++ b/tests/components/lock/test_zwave.py
@@ -62,7 +62,7 @@ def test_lock_value_changed(mock_openzwave):
     assert device.is_locked
 
 
-def test_lock_value_changed_workaround(mock_openzwave):
+def test_lock_state_workaround(mock_openzwave):
     """Test value changed for Z-Wave lock using notification state."""
     node = MockNode(manufacturer_id='0090', product_id='0440')
     values = MockEntityValues(
@@ -76,6 +76,50 @@ def test_lock_value_changed_workaround(mock_openzwave):
     values.access_control.data = 2
     value_changed(values.access_control)
     assert not device.is_locked
+
+
+def test_track_message_workaround(mock_openzwave):
+    """Test value changed for Z-Wave lock by alarm-clearing workaround."""
+    node = MockNode(manufacturer_id='003B', product_id='5044',
+                    stats={'lastReceivedMessage':[0] * 6})
+    values = MockEntityValues(
+        primary=MockValue(data=True, node=node),
+        access_control=None,
+        alarm_type=None,
+        alarm_level=None,
+    )
+
+    # Here we simulate an RF lock. The first zwave.get_device will call
+    # update properties, simulating the first DoorLock report. We then trigger
+    # a change, simulating the openzwave automatic refreshing behavior (which
+    # is enabled for at least the lock that needs this workaround)
+    node.stats['lastReceivedMessage'][5] = const.COMMAND_CLASS_DOOR_LOCK
+    device = zwave.get_device(node=node, values=values)
+    value_changed(values.primary)
+    assert device.is_locked
+    assert device.device_state_attributes[zwave.ATTR_NOTIFICATION] == 'RF Lock'
+
+    # Simulate a keypad unlock. We trigger a value_changed() which simulates
+    # the Alarm notification received from the lock. Then, we trigger
+    # value_changed() to simulate the automatic refreshing behavior.
+    values.access_control = MockValue(data=6, node=node)
+    values.alarm_type = MockValue(data=19, node=node)
+    values.alarm_level = MockValue(data=3, node=node)
+    node.stats['lastReceivedMessage'][5] = const.COMMAND_CLASS_ALARM
+    value_changed(values.access_control)
+    node.stats['lastReceivedMessage'][5] = const.COMMAND_CLASS_DOOR_LOCK
+    values.primary.data = False
+    value_changed(values.primary)
+    assert not device.is_locked
+    assert device.device_state_attributes[zwave.ATTR_LOCK_STATUS] == \
+        'Unlocked with Keypad by user 3'
+
+    # Again, simulate an RF lock.
+    device.lock()
+    node.stats['lastReceivedMessage'][5] = const.COMMAND_CLASS_DOOR_LOCK
+    value_changed(values.primary)
+    assert device.is_locked
+    assert device.device_state_attributes[zwave.ATTR_NOTIFICATION] == 'RF Lock'
 
 
 def test_v2btze_value_changed(mock_openzwave):


### PR DESCRIPTION
PR #17386 attempted to improve the state of z-wave lock tracking for
some problematic models. However, it operated under flawed
assumptions. Namely, that we can always trust `self.values` to have
fresh data, and that the Schlage BE469 sends alarm reports after every
lock event. We can't trust `self.values`, and the Schlage is very
broken. But popular, so we should fix it! :)

When we receive a notification from the driver about a state change,
we call `update_properties` - but we can (and do!) have _stale_
properties left over from previous updates. #17386 really works best
if you start from a clean slate each time. However, `update_properties`
is called on every value update, and we don't get a reason why.
Moreover, values that weren't _just_ refreshed are not removed. So blindly
looking at something like `self.values.access_control` when deciding to
apply a workaround is not going to always be correct - it may or may not
be, depending on what happened in the past.

For the sad case of the BE469, here are the Z-Wave events that happen
under various circumstances:

RF Lock / Unlock:
- Send: door lock command set
- Receive: door lock report
- Send: door lock command get
- Receive: door lock report

Manual lock / Unlock:
- Receive: alarm
- Send: door lock command get
- Receive: door lock report

Keypad lock / Unlock:
- Receive: alarm
- Send: door lock command get
- Receive: door lock report

Thus, this PR introduces yet another work around - we track the current
and last z-wave command that the driver saw, and make assumptions based
on the sequence of events. This seems to be the most reliable way to go - simply asking the driver to refresh various states doesn't clear out
alarms the way you would expect; this model doesn't support the access
control logging commands; and trying to manually clear out alarm state
when calling RF lock/unlock was tricky.

The lock state, when the z-wave network restarts, may look out of sync
for a few minutes. However, after the full network restart is complete,
everything looks good in my testing.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

