### PR TITLE
aioasuswrt sometimes return empty lists

### DIFF
--- a/homeassistant/components/asuswrt.py
+++ b/homeassistant/components/asuswrt.py
@@ -14,7 +14,7 @@ from homeassistant.const import (
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.discovery import async_load_platform
 
-REQUIREMENTS = ['aioasuswrt==1.1.11']
+REQUIREMENTS = ['aioasuswrt==1.1.12']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sensor/asuswrt.py
+++ b/homeassistant/components/sensor/asuswrt.py
@@ -68,7 +68,7 @@ class AsuswrtRXSensor(AsuswrtSensor):
     async def async_update(self):
         """Fetch new state data for the sensor."""
         await super().async_update()
-        if self._speed is not None:
+        if self._speed:
             self._state = round(self._speed[0] / 125000, 2)
 
 
@@ -86,7 +86,7 @@ class AsuswrtTXSensor(AsuswrtSensor):
     async def async_update(self):
         """Fetch new state data for the sensor."""
         await super().async_update()
-        if self._speed is not None:
+        if self._speed:
             self._state = round(self._speed[1] / 125000, 2)
 
 
@@ -104,7 +104,7 @@ class AsuswrtTotalRXSensor(AsuswrtSensor):
     async def async_update(self):
         """Fetch new state data for the sensor."""
         await super().async_update()
-        if self._rates is not None:
+        if self._rates:
             self._state = round(self._rates[0] / 1000000000, 1)
 
 
@@ -122,5 +122,5 @@ class AsuswrtTotalTXSensor(AsuswrtSensor):
     async def async_update(self):
         """Fetch new state data for the sensor."""
         await super().async_update()
-        if self._rates is not None:
+        if self._rates:
             self._state = round(self._rates[1] / 1000000000, 1)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -86,7 +86,7 @@ abodepy==0.14.0
 afsapi==0.0.4
 
 # homeassistant.components.asuswrt
-aioasuswrt==1.1.11
+aioasuswrt==1.1.12
 
 # homeassistant.components.device_tracker.automatic
 aioautomatic==0.6.5


### PR DESCRIPTION
## Description:
* If there is no data available it will be an empy list rather than None.
* Bumping version to take care of telnet reconnect.

**Related issue (if applicable):** fixes #18728 fixes #18735

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
