### PR TITLE
Remove MQTT sensor attribute picking

### DIFF
--- a/tests/components/sensor/test_mqtt.py
+++ b/tests/components/sensor/test_mqtt.py
@@ -257,7 +257,6 @@ class TestSensorMQTT(unittest.TestCase):
                 'name': 'test',
                 'state_topic': 'test-topic',
                 'unit_of_measurement': 'fav unit',
-                'json_attributes': 'val'
             }
         })
 
@@ -268,8 +267,7 @@ class TestSensorMQTT(unittest.TestCase):
         assert '100' == \
             state.attributes.get('val')
 
-    @patch('homeassistant.components.sensor.mqtt._LOGGER')
-    def test_update_with_json_attrs_not_dict(self, mock_logger):
+    def test_update_with_json_attrs_not_dict(self):
         """Test attributes get extracted from a JSON result."""
         mock_component(self.hass, 'mqtt')
         assert setup_component(self.hass, sensor.DOMAIN, {
@@ -278,7 +276,6 @@ class TestSensorMQTT(unittest.TestCase):
                 'name': 'test',
                 'state_topic': 'test-topic',
                 'unit_of_measurement': 'fav unit',
-                'json_attributes': 'val'
             }
         })
 
@@ -287,7 +284,6 @@ class TestSensorMQTT(unittest.TestCase):
         state = self.hass.states.get('sensor.test')
 
         assert state.attributes.get('val') is None
-        assert mock_logger.warning.called
 
     @patch('homeassistant.components.sensor.mqtt._LOGGER')
     def test_update_with_json_attrs_bad_JSON(self, mock_logger):
@@ -299,7 +295,6 @@ class TestSensorMQTT(unittest.TestCase):
                 'name': 'test',
                 'state_topic': 'test-topic',
                 'unit_of_measurement': 'fav unit',
-                'json_attributes': 'val'
             }
         })
 
@@ -308,7 +303,6 @@ class TestSensorMQTT(unittest.TestCase):
 
         state = self.hass.states.get('sensor.test')
         assert state.attributes.get('val') is None
-        assert mock_logger.warning.called
         assert mock_logger.debug.called
 
     def test_update_with_json_attrs_and_template(self):
@@ -321,7 +315,6 @@ class TestSensorMQTT(unittest.TestCase):
                 'state_topic': 'test-topic',
                 'unit_of_measurement': 'fav unit',
                 'value_template': '{{ value_json.val }}',
-                'json_attributes': 'val'
             }
         })
 


### PR DESCRIPTION
## Description:
Remove MQTT sensor attribute picking.

We might want to consider looking into having a different topic be specified for just the attributes. Right now we just want to get this functionality out.

**Related issue (if applicable):** ##18726

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
