### PR TITLE
Emulated hue component now correctly reports non-dimmable entities

### DIFF
--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -381,6 +381,7 @@ def get_entity_state(config, entity):
 
     return (final_state, final_brightness)
 
+
 def entity_to_json(config, entity, is_on=None, brightness=None):
     """Convert an entity to its Hue bridge JSON representation."""
     state = {

--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -29,6 +29,9 @@ _LOGGER = logging.getLogger(__name__)
 HUE_API_STATE_ON = 'on'
 HUE_API_STATE_BRI = 'bri'
 
+HUE_API_TYPE_ON_OFF = 'On/Off light'
+HUE_API_TYPE_DIMMABLE = "Dimmable light"
+
 
 class HueUsernameView(HomeAssistantView):
     """Handle requests to create a username for the emulated hue bridge."""
@@ -391,9 +394,9 @@ def entity_to_json(config, entity, is_on=None, brightness=None):
 
     if brightness is not None:
         state[HUE_API_STATE_BRI] = brightness
-        light_type = 'Dimmable light'
+        light_type = HUE_API_TYPE_DIMMABLE
     else:
-        light_type = 'On/Off light'
+        light_type = HUE_API_TYPE_ON_OFF
 
     return {
         'state': state,

--- a/homeassistant/components/light/demo.py
+++ b/homeassistant/components/light/demo.py
@@ -200,10 +200,11 @@ class BasicDemoLight(Light):
 
     @property
     def supported_features(self) -> int:
-        """Light does not support any extra features"""
+        """Light does not support any extra features."""
         return 0
 
     def turn_on(self, **kwargs) -> None:
+        """Turn the light on."""
         self._state = True
 
         # As we have disabled polling, we need to inform

--- a/tests/scripts/test_check_config.py
+++ b/tests/scripts/test_check_config.py
@@ -73,7 +73,7 @@ class TestCheckConfig(unittest.TestCase):
         with patch_yaml_files(files):
             res = check_config.check(get_test_config_dir())
             assert res['components'].keys() == {'homeassistant', 'light'}
-            assert res['components']['light'] == [{'platform': 'demo'}]
+            assert res['components']['light'] == [{'platform': 'demo'}, {'demo_with_basic': False}]
             assert res['except'] == {}
             assert res['secret_cache'] == {}
             assert res['secrets'] == {}

--- a/tests/scripts/test_check_config.py
+++ b/tests/scripts/test_check_config.py
@@ -73,7 +73,8 @@ class TestCheckConfig(unittest.TestCase):
         with patch_yaml_files(files):
             res = check_config.check(get_test_config_dir())
             assert res['components'].keys() == {'homeassistant', 'light'}
-            assert res['components']['light'] == [{'platform': 'demo'}, {'demo_with_basic': False}]
+            assert res['components']['light'] == \
+                [{'platform': 'demo', 'demo_with_basic': False}]
             assert res['except'] == {}
             assert res['secret_cache'] == {}
             assert res['secrets'] == {}


### PR DESCRIPTION
## Description:

This is required as 3rd generation echo dot devices will first
attempt to turn a device to full brightness *and* turn it on if
it is seen as a dimmable light.

Instead, we should report non-dimmable devices as on/off only,
meaning that the echo dot will only attempt to turn the device on
and off, instead of dimming it.

**Related issue (if applicable):** fixes #13296

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
