### PR TITLE
Fix hdmi_cec entity race

### DIFF
--- a/homeassistant/components/switch/hdmi_cec.py
+++ b/homeassistant/components/switch/hdmi_cec.py
@@ -9,7 +9,6 @@ import logging
 from homeassistant.components.hdmi_cec import CecDevice, ATTR_NEW
 from homeassistant.components.switch import SwitchDevice, DOMAIN
 from homeassistant.const import STATE_OFF, STATE_STANDBY, STATE_ON
-from homeassistant.core import HomeAssistant
 
 DEPENDENCIES = ['hdmi_cec']
 
@@ -22,20 +21,23 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     """Find and return HDMI devices as switches."""
     if ATTR_NEW in discovery_info:
         _LOGGER.info("Setting up HDMI devices %s", discovery_info[ATTR_NEW])
-        add_entities(CecSwitchDevice(hass, hass.data.get(device),
-                                     hass.data.get(device).logical_address) for
-                     device in discovery_info[ATTR_NEW])
+        entities = []
+        for device in discovery_info[ATTR_NEW]:
+            hdmi_device = hass.data.get(device)
+            entities.append(CecSwitchDevice(
+                hdmi_device, hdmi_device.logical_address,
+            ))
+        add_entities(entities, True)
 
 
 class CecSwitchDevice(CecDevice, SwitchDevice):
     """Representation of a HDMI device as a Switch."""
 
-    def __init__(self, hass: HomeAssistant, device, logical) -> None:
+    def __init__(self, device, logical) -> None:
         """Initialize the HDMI device."""
-        CecDevice.__init__(self, hass, device, logical)
+        CecDevice.__init__(self, device, logical)
         self.entity_id = "%s.%s_%s" % (
             DOMAIN, 'hdmi', hex(self._logical_address)[2:])
-        self.update()
 
     def turn_on(self, **kwargs) -> None:
         """Turn device on."""


### PR DESCRIPTION
Update shouldn't be called before adding the entity.

## Description:

1. `update()` is moved outside of the `__init__()`, otherwise it triggers entity creation with `entity_platform.async_add_entities`, see f241becf7f1976ab148e396e38619542c8a9121d.
2. `add_entities` is now updating those entities instead.
3. Callback is now registered with `async_added_to_hass`.
4. Callback is only schedules update with `self.schedule_update_ha_state(True)`.
5. Added transitional states.

**Related issue:** fixes #12846

## Example entry for `configuration.yaml`:
```yaml
hdmi_cec:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.