### PR TITLE
Fix sporadic test failure for test_initialize_from_database_with_maxage

### DIFF
--- a/tests/components/sensor/test_statistics.py
+++ b/tests/components/sensor/test_statistics.py
@@ -305,6 +305,7 @@ class TestStatisticsSensor(unittest.TestCase):
                     'max_age': {'hours': max_age}
                 }
             })
+            self.hass.block_till_done()
 
             self.hass.start()
             self.hass.block_till_done()


### PR DESCRIPTION
## Description:

Fix for sporadic test failure of test test_initialize_from_database_with_maxage in test_statistics

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
