### PR TITLE
Forbid float NaN in JSON

### DIFF
--- a/homeassistant/components/http/view.py
+++ b/homeassistant/components/http/view.py
@@ -45,8 +45,9 @@ class HomeAssistantView:
         """Return a JSON response."""
         try:
             msg = json.dumps(
-                result, sort_keys=True, cls=JSONEncoder).encode('UTF-8')
-        except TypeError as err:
+                result, sort_keys=True, cls=JSONEncoder, allow_nan=False
+            ).encode('UTF-8')
+        except (ValueError, TypeError) as err:
             _LOGGER.error('Unable to serialize to JSON: %s\n%s', err, result)
             raise HTTPInternalServerError
         response = web.Response(

--- a/tests/components/http/test_view.py
+++ b/tests/components/http/test_view.py
@@ -10,6 +10,6 @@ async def test_invalid_json(caplog):
     view = HomeAssistantView()
 
     with pytest.raises(HTTPInternalServerError):
-        view.json(object)
+        view.json(float("NaN"))
 
-    assert str(object) in caplog.text
+    assert str(float("NaN")) in caplog.text

--- a/tests/components/websocket_api/test_commands.py
+++ b/tests/components/websocket_api/test_commands.py
@@ -300,3 +300,19 @@ async def test_states_filters_visible(hass, hass_admin_user, websocket_client):
 
     assert len(msg['result']) == 1
     assert msg['result'][0]['entity_id'] == 'test.entity'
+
+
+async def test_get_states_not_allows_nan(hass, websocket_client):
+    """Test get_states command not allows NaN floats."""
+    hass.states.async_set('greeting.hello', 'world', {
+        'hello': float("NaN")
+    })
+
+    await websocket_client.send_json({
+        'id': 5,
+        'type': commands.TYPE_GET_STATES,
+    })
+
+    msg = await websocket_client.receive_json()
+    assert not msg['success']
+    assert msg['error']['code'] == const.ERR_UNKNOWN_ERROR


### PR DESCRIPTION
## Description:
This forbids float NaN and Inifinity values to be JSON encoded as browsers don't like this.

**Related issue (if applicable):** #18710

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
