### PR TITLE
Revert change to MQTT discovery_hash introduced in #18169

### DIFF
--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -202,11 +202,8 @@ async def async_start(hass: HomeAssistantType, discovery_topic, hass_config,
                     if value[-1] == TOPIC_BASE and key.endswith('_topic'):
                         payload[key] = "{}{}".format(value[:-1], base)
 
-        # If present, unique_id is used as the discovered object id. Otherwise,
-        # if present, the node_id will be included in the discovered object id
-        discovery_id = payload.get(
-            'unique_id', ' '.join(
-                (node_id, object_id)) if node_id else object_id)
+        # If present, the node_id will be included in the discovered object id
+        discovery_id = ' '.join((node_id, object_id)) if node_id else object_id
         discovery_hash = (component, discovery_id)
 
         if payload:

--- a/tests/components/binary_sensor/test_mqtt.py
+++ b/tests/components/binary_sensor/test_mqtt.py
@@ -333,39 +333,6 @@ async def test_discovery_update_binary_sensor(hass, mqtt_mock, caplog):
     assert state is None
 
 
-async def test_discovery_unique_id(hass, mqtt_mock, caplog):
-    """Test unique id option only creates one sensor per unique_id."""
-    entry = MockConfigEntry(domain=mqtt.DOMAIN)
-    await async_start(hass, 'homeassistant', {}, entry)
-    data1 = (
-        '{ "name": "Beer",'
-        '  "state_topic": "test_topic",'
-        '  "unique_id": "TOTALLY_UNIQUE" }'
-    )
-    data2 = (
-        '{ "name": "Milk",'
-        '  "state_topic": "test_topic",'
-        '  "unique_id": "TOTALLY_DIFFERENT" }'
-    )
-    async_fire_mqtt_message(hass, 'homeassistant/binary_sensor/bla/config',
-                            data1)
-    await hass.async_block_till_done()
-    state = hass.states.get('binary_sensor.beer')
-    assert state is not None
-    assert state.name == 'Beer'
-    async_fire_mqtt_message(hass, 'homeassistant/binary_sensor/bla/config',
-                            data2)
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
-    state = hass.states.get('binary_sensor.beer')
-    assert state is not None
-    assert state.name == 'Beer'
-
-    state = hass.states.get('binary_sensor.milk')
-    assert state is not None
-    assert state.name == 'Milk'
-
-
 async def test_entity_device_info_with_identifier(hass, mqtt_mock):
     """Test MQTT binary sensor device registry integration."""
     entry = MockConfigEntry(domain=mqtt.DOMAIN)


### PR DESCRIPTION
## Description:
discovery_hash was changed in #18169 to be unique_id if present in the configuration.
This breaks the possibility to remove a previously discovered entity by sending an empty discovery update.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`.
  - [x] There is no commented out code in this PR.