### PR TITLE
Fix statistics for binary sensor

### DIFF
--- a/homeassistant/components/sensor/statistics.py
+++ b/homeassistant/components/sensor/statistics.py
@@ -129,11 +129,17 @@ class StatisticsSensor(Entity):
             EVENT_HOMEASSISTANT_START, async_stats_sensor_startup)
 
     def _add_state_to_queue(self, new_state):
-        try:
-            self.states.append(float(new_state.state))
-            self.ages.append(new_state.last_updated)
-        except ValueError:
-            pass
+        if new_state.state != STATE_UNKNOWN:
+            try:
+                if self.is_binary:
+                    self.states.append(new_state.state)
+                else:
+                    self.states.append(float(new_state.state))
+
+                self.ages.append(new_state.last_updated)
+            except ValueError:
+                _LOGGER.debug("%s: adding state change '%s'", self.entity_id,
+                              new_state.state)
 
     @property
     def name(self):

--- a/homeassistant/components/sensor/statistics.py
+++ b/homeassistant/components/sensor/statistics.py
@@ -129,17 +129,19 @@ class StatisticsSensor(Entity):
             EVENT_HOMEASSISTANT_START, async_stats_sensor_startup)
 
     def _add_state_to_queue(self, new_state):
-        if new_state.state != STATE_UNKNOWN:
-            try:
-                if self.is_binary:
-                    self.states.append(new_state.state)
-                else:
-                    self.states.append(float(new_state.state))
+        if new_state.state == STATE_UNKNOWN:
+            return
 
-                self.ages.append(new_state.last_updated)
-            except ValueError:
-                _LOGGER.debug("%s: adding state change '%s'", self.entity_id,
-                              new_state.state)
+        try:
+            if self.is_binary:
+                self.states.append(new_state.state)
+            else:
+                self.states.append(float(new_state.state))
+
+            self.ages.append(new_state.last_updated)
+        except ValueError:
+            _LOGGER.error("%s: parsing error, expected number and received %s",
+                          self.entity_id, new_state.state)
 
     @property
     def name(self):

--- a/homeassistant/components/sensor/statistics.py
+++ b/homeassistant/components/sensor/statistics.py
@@ -120,7 +120,7 @@ class StatisticsSensor(Entity):
                 self.hass, self._entity_id, async_stats_sensor_state_listener)
 
             if 'recorder' in self.hass.config.components:
-                # only use the database if it's configured
+                # Only use the database if it's configured
                 self.hass.async_create_task(
                     self._async_initialize_from_database()
                 )
@@ -129,6 +129,7 @@ class StatisticsSensor(Entity):
             EVENT_HOMEASSISTANT_START, async_stats_sensor_startup)
 
     def _add_state_to_queue(self, new_state):
+        """Add the state to the queue."""
         if new_state.state == STATE_UNKNOWN:
             return
 

--- a/tests/components/sensor/test_statistics.py
+++ b/tests/components/sensor/test_statistics.py
@@ -40,7 +40,7 @@ class TestStatisticsSensor(unittest.TestCase):
 
     def test_binary_sensor_source(self):
         """Test if source is a sensor."""
-        values = [1, 0, 1, 0, 1, 0, 1]
+        values = ['on', 'off', 'on', 'off', 'on', 'off', 'on']
         assert setup_component(self.hass, 'sensor', {
             'sensor': {
                 'platform': 'statistics',


### PR DESCRIPTION
## Description:

Fix issue where statistics sensor for binary sensors does not work. Also including check to skip unknown states from statistics. Updated test_statistics to provide non-numeric values (on, off) for binary sensor test reflecting true states returned by a binary sensor.

**Related issue (if applicable):** fixes #18158

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.
