### PR TITLE
Default to on if logged in

### DIFF
--- a/homeassistant/components/cloud/__init__.py
+++ b/homeassistant/components/cloud/__init__.py
@@ -253,7 +253,7 @@ class Cloud:
 
         info = await self.hass.async_add_job(load_config)
 
-        await self.prefs.async_initialize(not info)
+        await self.prefs.async_initialize(bool(info))
 
         if info is None:
             return

--- a/homeassistant/components/cloud/prefs.py
+++ b/homeassistant/components/cloud/prefs.py
@@ -28,6 +28,7 @@ class CloudPreferences:
                 PREF_GOOGLE_ALLOW_UNLOCK: False,
                 PREF_CLOUDHOOKS: {}
             }
+            await self._store.async_save(prefs)
 
         self._prefs = prefs
 


### PR DESCRIPTION
## Description:
Backwards compat gone wrong -> if no prefs are stored, we should default to turning ON, not OFF, to make it backwards compatible with before we could turn toggles on and off.
