### PR TITLE
RFC: Add service to remove an IP from the ban list

### DIFF
--- a/homeassistant/components/http/const.py
+++ b/homeassistant/components/http/const.py
@@ -1,3 +1,4 @@
 """HTTP specific constants."""
+DOMAIN = 'http'
 KEY_AUTHENTICATED = 'ha_authenticated'
 KEY_REAL_IP = 'ha_real_ip'


### PR DESCRIPTION
## Description:

This PR seeks to add a service to the `http` domain that removes a ban from `ip_bans.yaml` and reloads the middleware so that the IP is unblocked without a HASS restart. Request taken from here: https://community.home-assistant.io/t/service-or-ui-to-remove-banned-ip-addresses/81590. The ultimate goal would be to (a) complete this service and (b) add a UI to on top of it.

Because I have no experience in this subsystem, submitting this as an RFC; will avoid tests/etc. until this is confirmed as a good idea. Thus far, I have a service in place to remove a banned IP; however, I could use guidance on how to dynamically reload/replace the middleware so that the results go into effect immedately.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** TBD

## Example entry for `configuration.yaml` (if applicable):
```yaml
http:
  ip_ban_enabled: true
  login_attempts_threshold: 5
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
