### PR TITLE
Reintroduce unique_id for Netatmo sensor

### DIFF
--- a/homeassistant/components/sensor/netatmo.py
+++ b/homeassistant/components/sensor/netatmo.py
@@ -63,6 +63,11 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_MODULES): MODULE_SCHEMA,
 })
 
+MODULE_TYPE_OUTDOOR = 'NAModule1'
+MODULE_TYPE_WIND = 'NAModule2'
+MODULE_TYPE_RAIN = 'NAModule3'
+MODULE_TYPE_INDOOR = 'NAModule4'
+
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the available Netatmo weather sensors."""
@@ -74,7 +79,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     try:
         if CONF_MODULES in config:
             # Iterate each module
-            for module_name, monitored_conditions in\
+            for module_name, monitored_conditions in \
                     config[CONF_MODULES].items():
                 # Test if module exists
                 if module_name not in data.get_module_names():
@@ -85,7 +90,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                     dev.append(NetAtmoSensor(data, module_name, variable))
         else:
             for module_name in data.get_module_names():
-                for variable in\
+                for variable in \
                         data.station_data.monitoredConditions(module_name):
                     if variable in SENSOR_TYPES.keys():
                         dev.append(NetAtmoSensor(data, module_name, variable))
@@ -112,9 +117,8 @@ class NetAtmoSensor(Entity):
         self._device_class = SENSOR_TYPES[self.type][3]
         self._icon = SENSOR_TYPES[self.type][2]
         self._unit_of_measurement = SENSOR_TYPES[self.type][1]
-        module_id = self.netatmo_data.\
-            station_data.moduleByName(module=module_name)['_id']
-        self.module_id = module_id[1]
+        self._module_type = self.netatmo_data. \
+            station_data.moduleByName(module=module_name)['type']
 
     @property
     def name(self):
@@ -169,7 +173,7 @@ class NetAtmoSensor(Entity):
             self._state = round(data['Pressure'], 1)
         elif self.type == 'battery_lvl':
             self._state = data['battery_vp']
-        elif self.type == 'battery_vp' and self.module_id == '6':
+        elif self.type == 'battery_vp' and self._module_type == MODULE_TYPE_WIND:
             if data['battery_vp'] >= 5590:
                 self._state = "Full"
             elif data['battery_vp'] >= 5180:
@@ -180,7 +184,7 @@ class NetAtmoSensor(Entity):
                 self._state = "Low"
             elif data['battery_vp'] < 4360:
                 self._state = "Very Low"
-        elif self.type == 'battery_vp' and self.module_id == '5':
+        elif self.type == 'battery_vp' and self._module_type == MODULE_TYPE_RAIN:
             if data['battery_vp'] >= 5500:
                 self._state = "Full"
             elif data['battery_vp'] >= 5000:
@@ -191,7 +195,7 @@ class NetAtmoSensor(Entity):
                 self._state = "Low"
             elif data['battery_vp'] < 4000:
                 self._state = "Very Low"
-        elif self.type == 'battery_vp' and self.module_id == '3':
+        elif self.type == 'battery_vp' and self._module_type == MODULE_TYPE_INDOOR:
             if data['battery_vp'] >= 5640:
                 self._state = "Full"
             elif data['battery_vp'] >= 5280:
@@ -202,7 +206,7 @@ class NetAtmoSensor(Entity):
                 self._state = "Low"
             elif data['battery_vp'] < 4560:
                 self._state = "Very Low"
-        elif self.type == 'battery_vp' and self.module_id == '2':
+        elif self.type == 'battery_vp' and self._module_type == MODULE_TYPE_OUTDOOR:
             if data['battery_vp'] >= 5500:
                 self._state = "Full"
             elif data['battery_vp'] >= 5000:

--- a/homeassistant/components/sensor/netatmo.py
+++ b/homeassistant/components/sensor/netatmo.py
@@ -119,6 +119,9 @@ class NetAtmoSensor(Entity):
         self._unit_of_measurement = SENSOR_TYPES[self.type][1]
         self._module_type = self.netatmo_data. \
             station_data.moduleByName(module=module_name)['type']
+        module_id = self.netatmo_data. \
+            station_data.moduleByName(module=module_name)['_id']
+        self._unique_id = '{}-{}'.format(module_id, self.type)
 
     @property
     def name(self):
@@ -144,6 +147,11 @@ class NetAtmoSensor(Entity):
     def unit_of_measurement(self):
         """Return the unit of measurement of this entity, if any."""
         return self._unit_of_measurement
+
+    @property
+    def unique_id(self):
+        """Return the unique ID for this sensor."""
+        return self._unique_id
 
     def update(self):
         """Get the latest data from NetAtmo API and updates the states."""

--- a/homeassistant/components/sensor/netatmo.py
+++ b/homeassistant/components/sensor/netatmo.py
@@ -181,7 +181,8 @@ class NetAtmoSensor(Entity):
             self._state = round(data['Pressure'], 1)
         elif self.type == 'battery_lvl':
             self._state = data['battery_vp']
-        elif self.type == 'battery_vp' and self._module_type == MODULE_TYPE_WIND:
+        elif (self.type == 'battery_vp' and
+              self._module_type == MODULE_TYPE_WIND):
             if data['battery_vp'] >= 5590:
                 self._state = "Full"
             elif data['battery_vp'] >= 5180:
@@ -192,7 +193,8 @@ class NetAtmoSensor(Entity):
                 self._state = "Low"
             elif data['battery_vp'] < 4360:
                 self._state = "Very Low"
-        elif self.type == 'battery_vp' and self._module_type == MODULE_TYPE_RAIN:
+        elif (self.type == 'battery_vp' and
+              self._module_type == MODULE_TYPE_RAIN):
             if data['battery_vp'] >= 5500:
                 self._state = "Full"
             elif data['battery_vp'] >= 5000:
@@ -203,7 +205,8 @@ class NetAtmoSensor(Entity):
                 self._state = "Low"
             elif data['battery_vp'] < 4000:
                 self._state = "Very Low"
-        elif self.type == 'battery_vp' and self._module_type == MODULE_TYPE_INDOOR:
+        elif (self.type == 'battery_vp' and
+              self._module_type == MODULE_TYPE_INDOOR):
             if data['battery_vp'] >= 5640:
                 self._state = "Full"
             elif data['battery_vp'] >= 5280:
@@ -214,7 +217,8 @@ class NetAtmoSensor(Entity):
                 self._state = "Low"
             elif data['battery_vp'] < 4560:
                 self._state = "Very Low"
-        elif self.type == 'battery_vp' and self._module_type == MODULE_TYPE_OUTDOOR:
+        elif (self.type == 'battery_vp' and
+              self._module_type == MODULE_TYPE_OUTDOOR):
             if data['battery_vp'] >= 5500:
                 self._state = "Full"
             elif data['battery_vp'] >= 5000:


### PR DESCRIPTION
## Description:

### Short:
This commit adds back the unique_id property for Netatmo sensors with a really unique value. Additionally it makes the differentiation of Module Types more intuitive.

### Long:

In commit e51427b28458b86da21f7f317d03c09e5136225a there was already an attempt to add a `unique_id` in the new Entity Registry style to the Netatmo sensor. This assumed, that the value of `self.module_id` was a value unique for each Netatmo Module. (actually it changed from using `module_id` which was unique to `self.module_id` which was not unique for the `unique_id`)

This assumption was wrong as PR #4724 introduced a `self.module_id` which differed from `module_id`
as it was defined like this:
```
module_id = self.netatmo_data.\
            station_data.moduleByName(module=module_name)['_id']
self.module_id = module_id[1]
```

So `self.module_id` was actually only the second char of the `module_id` (which is a MAC Address). This was used in the Battery Code to destinguish between the different types of modules.  So it was actually more representing a `module_type`. 

This led to a unique_id like `2-Temperature` which was pretty obvious to be clashing with other modules.

What this PR now implements:
 * Use the `type` field provided by the Netatmo API to distinguish between module types instead of taking an undocumented Byte from the Module address. This is used for the calculation of the Battery Status.
 * Use the full MAC-Address + SensorType to generate the `unique_id`. So the `unique_id` now looks like `XX:XX:XX:XX:XX:XX-Temperature`

## Example entry for `configuration.yaml` (if applicable):
```yaml
netatmo:
  api_key: YOUR_CLIENT_ID
  secret_key: YOUR_CLIENT_SECRET
  username: YOUR_USERNAME
  password: YOUR_PASSWORD

sensor:
  - platform: netatmo
    station: STATION_NAME
    modules:
      module_name1:
        - temperature
      module_name2:
        - temperature
        - battery_vp
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.


