### PR TITLE
Raise NotImplementedError

### DIFF
--- a/homeassistant/components/owntracks/__init__.py
+++ b/homeassistant/components/owntracks/__init__.py
@@ -191,7 +191,7 @@ class OwnTracksContext:
 
     async def async_see(self, **data):
         """Send a see message to the device tracker."""
-        await self.hass.components.device_tracker.async_see(**data)
+        raise NotImplementedError
 
     async def async_see_beacons(self, hass, dev_id, kwargs_param):
         """Set active beacons to the current location."""


### PR DESCRIPTION
## Description:
This method is overriden during setup. We need to raise an error if it's not. It was not containing an implementation that never made it online :)

**Related issue (if applicable):** https://github.com/home-assistant/home-assistant/pull/18759#discussion_r237332987


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
