### PR TITLE
Change state case for rtorrent

### DIFF
--- a/homeassistant/components/sensor/rtorrent.py
+++ b/homeassistant/components/sensor/rtorrent.py
@@ -110,11 +110,11 @@ class RTorrentSensor(Entity):
         if self.type == SENSOR_TYPE_CURRENT_STATUS:
             if self.data:
                 if upload > 0 and download > 0:
-                    self._state = 'Up/Down'
+                    self._state = 'up_down'
                 elif upload > 0 and download == 0:
-                    self._state = 'Seeding'
+                    self._state = 'seeding'
                 elif upload == 0 and download > 0:
-                    self._state = 'Downloading'
+                    self._state = 'downloading'
                 else:
                     self._state = STATE_IDLE
             else:


### PR DESCRIPTION
## Description:
Fixed the case of sensor.rtorrent

## Breaking changes:

Changed the returned states of `sensor.rtorrent` from `Up/Down`,
`Downloading` and `Seeding` to `up_down`, `downloading` and `seeding` to
reflect the guidelines. Hence by automations relying on the state of this
sensor should be updated.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.