### PR TITLE
Support Mijia 1080p camera on HTTP protocol

### DIFF
--- a/homeassistant/components/camera/xiaomi.py
+++ b/homeassistant/components/camera/xiaomi.py
@@ -13,8 +13,9 @@ import voluptuous as vol
 
 from homeassistant.components.camera import Camera, PLATFORM_SCHEMA
 from homeassistant.components.ffmpeg import DATA_FFMPEG
-from homeassistant.const import (CONF_HOST, CONF_NAME, CONF_PATH, CONF_PROTOCOL,
-                                 CONF_PASSWORD, CONF_PORT, CONF_USERNAME)
+from homeassistant.const import (CONF_HOST, CONF_NAME, CONF_PATH,
+                                 CONF_PROTOCOL, CONF_PASSWORD, CONF_PORT,
+                                 CONF_USERNAME)
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_aiohttp_proxy_stream
 
@@ -155,10 +156,8 @@ class XiaomiCamera(Camera):
 
                 # Get second last MP4
                 try:
-                    res = requests.get('http://{0}:{1}{2}/{3}'.format(self.host,
-                                                                      self.port,
-                                                                      self.path,
-                                                                      last_dir))
+                    res = requests.get('http://{0}:{1}{2}/{3}'.format(
+                        self.host, self.port, self.path, last_dir))
                 except Exception as e:
                     _LOGGER.error("Error when making request: %r" % e)
                     return None
@@ -209,7 +208,8 @@ class XiaomiCamera(Camera):
             if self._model == MODEL_XIAOFANG:
                 dirs = [d for d in ftp.nlst() if '.' not in d]
                 if not dirs:
-                    _LOGGER.warning("There don't appear to be any uploaded videos")
+                    _LOGGER.warning("There don't appear to be any uploaded "
+                                    "videos")
                     return False
 
                 latest_dir = dirs[-1]
@@ -217,7 +217,8 @@ class XiaomiCamera(Camera):
 
             videos = [v for v in ftp.nlst() if '.tmp' not in v]
             if not videos:
-                _LOGGER.info('Video folder "%s" is empty; delaying', latest_dir)
+                _LOGGER.info('Video folder "%s" is empty; delaying',
+                             latest_dir)
                 return False
 
             if self._model == MODEL_XIAOFANG:

--- a/homeassistant/components/camera/xiaomi.py
+++ b/homeassistant/components/camera/xiaomi.py
@@ -7,11 +7,13 @@ https://home-assistant.io/components/camera.xiaomi/
 import asyncio
 import logging
 
+from html.parser import HTMLParser
+
 import voluptuous as vol
 
 from homeassistant.components.camera import Camera, PLATFORM_SCHEMA
 from homeassistant.components.ffmpeg import DATA_FFMPEG
-from homeassistant.const import (CONF_HOST, CONF_NAME, CONF_PATH,
+from homeassistant.const import (CONF_HOST, CONF_NAME, CONF_PATH, CONF_PROTOCOL,
                                  CONF_PASSWORD, CONF_PORT, CONF_USERNAME)
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_aiohttp_proxy_stream
@@ -29,12 +31,16 @@ CONF_MODEL = 'model'
 
 MODEL_YI = 'yi'
 MODEL_XIAOFANG = 'xiaofang'
+MODEL_MJ1080 = 'mijia_1080p'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_NAME): cv.string,
     vol.Required(CONF_HOST): cv.string,
     vol.Required(CONF_MODEL): vol.Any(MODEL_YI,
-                                      MODEL_XIAOFANG),
+                                      MODEL_XIAOFANG,
+                                      MODEL_MJ1080),
+    vol.Required(CONF_PROTOCOL, default='ftp'): vol.Any('http',
+                                                        'ftp'),
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
     vol.Optional(CONF_PATH, default=DEFAULT_PATH): cv.string,
     vol.Optional(CONF_USERNAME, default=DEFAULT_USERNAME): cv.string,
@@ -52,6 +58,41 @@ async def async_setup_platform(hass,
     async_add_entities([XiaomiCamera(hass, config)])
 
 
+class Mj1080HtmlParser(HTMLParser):
+    """
+    The HTML Parser satisfy HTTP response from lighttpd on Xiaomi Mijia 1080p
+    """
+    tag_tr = False
+    tag_td = False
+    tag_a = False
+    contents = []
+
+    def handle_starttag(self, tag, attrs):
+        # print("Encountered a start tag:", tag)
+        if tag == 'tr':
+            self.tag_tr = True
+        if tag == 'td':
+            self.tag_td = True
+        if tag == 'a':
+            self.tag_a = True
+
+    def handle_endtag(self, tag):
+        # print("Encountered an end tag :", tag)
+        if tag == 'tr':
+            self.tag_tr = False
+        if tag == 'td':
+            self.tag_td = False
+        if tag == 'a':
+            self.tag_a = False
+
+    def handle_data(self, data):
+        if self.tag_tr and self.tag_td and self.tag_a and data != '..':
+            self.contents.append(data)
+
+    def get_contents(self):
+        return self.contents
+
+
 class XiaomiCamera(Camera):
     """Define an implementation of a Xiaomi Camera."""
 
@@ -63,6 +104,7 @@ class XiaomiCamera(Camera):
         self._last_url = None
         self._manager = hass.data[DATA_FFMPEG]
         self._name = config[CONF_NAME]
+        self.protocol = config[CONF_PROTOCOL]
         self.host = config[CONF_HOST]
         self._model = config[CONF_MODEL]
         self.port = config[CONF_PORT]
@@ -86,55 +128,105 @@ class XiaomiCamera(Camera):
         return self._model
 
     def get_latest_video_url(self):
-        """Retrieve the latest video file from the Xiaomi Camera FTP server."""
+        """
+        Retrieve the latest video file from the Xiaomi Camera FTP/HTTP server.
+        """
         from ftplib import FTP, error_perm
+        import requests
 
-        ftp = FTP(self.host)
-        try:
-            ftp.login(self.user, self.passwd)
-        except error_perm as exc:
-            _LOGGER.error('Camera login failed: %s', exc)
-            return False
+        if self.protocol == 'http':
+            if self.model == MODEL_MJ1080:
+                # Get last dir
+                try:
+                    res = requests.get('http://{0}:{1}{2}'.format(self.host,
+                                                                  self.port,
+                                                                  self.path))
+                except Exception as e:
+                    _LOGGER.error("Error when making request: %r" % e)
+                    return None
+                parser = Mj1080HtmlParser()
+                parser.feed(res.text)
+                try:
+                    last_dir = parser.get_contents()[-1]
+                except IndexError:
+                    _LOGGER.warning("There don't appear to be any uploaded "
+                                    "videos (no folder found)")
+                    return None
 
-        try:
-            ftp.cwd(self.path)
-        except error_perm as exc:
-            _LOGGER.error('Unable to find path: %s - %s', self.path, exc)
-            return False
+                # Get second last MP4
+                try:
+                    res = requests.get('http://{0}:{1}{2}/{3}'.format(self.host,
+                                                                      self.port,
+                                                                      self.path,
+                                                                      last_dir))
+                except Exception as e:
+                    _LOGGER.error("Error when making request: %r" % e)
+                    return None
+                parser.reset()
+                parser.feed(res.text)
+                file_list = parser.get_contents()
 
-        dirs = [d for d in ftp.nlst() if '.' not in d]
-        if not dirs:
-            _LOGGER.warning("There don't appear to be any folders")
-            return False
-
-        first_dir = dirs[-1]
-        try:
-            ftp.cwd(first_dir)
-        except error_perm as exc:
-            _LOGGER.error('Unable to find path: %s - %s', first_dir, exc)
-            return False
-
-        if self._model == MODEL_XIAOFANG:
-            dirs = [d for d in ftp.nlst() if '.' not in d]
-            if not dirs:
-                _LOGGER.warning("There don't appear to be any uploaded videos")
+                # Last MP4 is being ingested, use the second last one.
+                try:
+                    second_last_mp4 = file_list[-3]
+                    if not second_last_mp4.endswith('mp4'):
+                        second_last_mp4 = file_list[-4]
+                except IndexError:
+                    _LOGGER.warning("There don't appear to be any uploaded "
+                                    "videos (no video found)")
+                    return None
+                return 'http://{0}:{1}{2}/{3}/{4}'.format(self.host,
+                                                          self.port,
+                                                          self.path,
+                                                          last_dir,
+                                                          second_last_mp4)
+        if self.protocol == 'ftp':
+            ftp = FTP(self.host)
+            try:
+                ftp.login(self.user, self.passwd)
+            except error_perm as exc:
+                _LOGGER.error('Camera login failed: %s', exc)
                 return False
 
-            latest_dir = dirs[-1]
-            ftp.cwd(latest_dir)
+            try:
+                ftp.cwd(self.path)
+            except error_perm as exc:
+                _LOGGER.error('Unable to find path: %s - %s', self.path, exc)
+                return False
 
-        videos = [v for v in ftp.nlst() if '.tmp' not in v]
-        if not videos:
-            _LOGGER.info('Video folder "%s" is empty; delaying', latest_dir)
-            return False
+            dirs = [d for d in ftp.nlst() if '.' not in d]
+            if not dirs:
+                _LOGGER.warning("There don't appear to be any folders")
+                return False
 
-        if self._model == MODEL_XIAOFANG:
-            video = videos[-2]
-        else:
-            video = videos[-1]
+            first_dir = dirs[-1]
+            try:
+                ftp.cwd(first_dir)
+            except error_perm as exc:
+                _LOGGER.error('Unable to find path: %s - %s', first_dir, exc)
+                return False
 
-        return 'ftp://{0}:{1}@{2}:{3}{4}/{5}'.format(
-            self.user, self.passwd, self.host, self.port, ftp.pwd(), video)
+            if self._model == MODEL_XIAOFANG:
+                dirs = [d for d in ftp.nlst() if '.' not in d]
+                if not dirs:
+                    _LOGGER.warning("There don't appear to be any uploaded videos")
+                    return False
+
+                latest_dir = dirs[-1]
+                ftp.cwd(latest_dir)
+
+            videos = [v for v in ftp.nlst() if '.tmp' not in v]
+            if not videos:
+                _LOGGER.info('Video folder "%s" is empty; delaying', latest_dir)
+                return False
+
+            if self._model == MODEL_XIAOFANG:
+                video = videos[-2]
+            else:
+                video = videos[-1]
+
+            return 'ftp://{0}:{1}@{2}:{3}{4}/{5}'.format(
+                self.user, self.passwd, self.host, self.port, ftp.pwd(), video)
 
     async def async_camera_image(self):
         """Return a still image response from the camera."""


### PR DESCRIPTION
## Description:

The hack: https://github.com/Filipowicz251/mijia-1080P-hacks makes 
Mijia 1080p stream video on RTSP but live streaming causes the recording
video file bad quality.  

This Pull request tend to support image frame capture from Mijia 1080p 
on HTTP protocol since FTP is not support from the hack.

No new dependencies.

Changes:
- Add HTML Parser for HTTP response from Mijia 1080p `lighttpd`
- Add `protocol` parameter in configuration where the value is `ftp`
or `http`.  Default is `ftp` if omitted for backward compatible.
- A new `model = mijia_1080p` for Mijia 1080p.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here> **_(T.B.D)_**

**_(I will make PR for documentation and update this PR later)_**

## Example entry for `configuration.yaml` (if applicable):
```yaml
camera:
  - platform: xiaomi
    model: mijia_1080p
    name: Front door
    host: 192.168.120.120
    port: 8080
    protocol: http
    password: anything
    path: /media
    extra_arguments: -vf scale=800:450
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
