### PR TITLE
Fix logbook domain filter - alexa, homekit

### DIFF
--- a/homeassistant/components/logbook.py
+++ b/homeassistant/components/logbook.py
@@ -445,6 +445,12 @@ def _exclude_events(events, entities_filter):
             domain = event.data.get(ATTR_DOMAIN)
             entity_id = event.data.get(ATTR_ENTITY_ID)
 
+        elif event.event_type == EVENT_ALEXA_SMART_HOME:
+            domain = 'alexa'
+
+        elif event.event_type == EVENT_HOMEKIT_CHANGED:
+            domain = DOMAIN_HOMEKIT
+
         if not entity_id and domain:
             entity_id = "%s." % (domain, )
 


### PR DESCRIPTION
## Description:
Also the `logbook` does support the `include` / `exlude` filter, this didn't work for `homekit` and `alexa` events. Since they have their own `event_type`. This PR fixes that.

However, due to the nature of those to components, only the `domain` filter is supported.

**Related issue:**  https://community.home-assistant.io/t/homekit-logbook-entries/81554


## Example entry for `configuration.yaml` (if applicable):
```yaml
logbook:
  exclude:   # or include
    domains:
      - alexa
      - homekit
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] Tests have been added to verify that the new code works.