### PR TITLE
Make auth backwards compat again

### DIFF
--- a/homeassistant/auth/auth_store.py
+++ b/homeassistant/auth/auth_store.py
@@ -462,10 +462,11 @@ class AuthStore:
         for group in self._groups.values():
             g_dict = {
                 'id': group.id,
+                # Name not read for sys groups. Kept here for backwards compat
+                'name': group.name
             }  # type: Dict[str, Any]
 
             if group.id not in (GROUP_ID_READ_ONLY, GROUP_ID_ADMIN):
-                g_dict['name'] = group.name
                 g_dict['policy'] = group.policy
 
             groups.append(g_dict)

--- a/tests/auth/test_auth_store.py
+++ b/tests/auth/test_auth_store.py
@@ -199,13 +199,22 @@ async def test_loading_empty_data(hass, hass_storage):
     assert len(users) == 0
 
 
-async def test_system_groups_only_store_id(hass, hass_storage):
-    """Test that for system groups we only store the ID."""
+async def test_system_groups_store_id_and_name(hass, hass_storage):
+    """Test that for system groups we store the ID and name.
+
+    Name is stored so that we remain backwards compat with < 0.82.
+    """
     store = auth_store.AuthStore(hass)
     await store._async_load()
     data = store._data_to_save()
     assert len(data['users']) == 0
     assert data['groups'] == [
-        {'id': auth_store.GROUP_ID_ADMIN},
-        {'id': auth_store.GROUP_ID_READ_ONLY},
+        {
+            'id': auth_store.GROUP_ID_ADMIN,
+            'name': auth_store.GROUP_NAME_ADMIN,
+        },
+        {
+            'id': auth_store.GROUP_ID_READ_ONLY,
+            'name': auth_store.GROUP_NAME_READ_ONLY,
+        },
     ]


### PR DESCRIPTION
## Description:
This makes the auth storage backwards compatible with 0.82 and before so people can rollback.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
