### PR TITLE
Render the OwnTracks secret during setup

### DIFF
--- a/homeassistant/components/owntracks/config_flow.py
+++ b/homeassistant/components/owntracks/config_flow.py
@@ -40,8 +40,8 @@ class OwnTracksFlow(config_entries.ConfigFlow):
 
         if supports_encryption():
             secret_desc = (
-                "The encryption key is {secret} "
-                "(on Android under preferences -> advanced)")
+                "The encryption key is {} "
+                "(on Android under preferences -> advanced)".format(secret))
         else:
             secret_desc = (
                 "Encryption is not supported because libsodium is not "


### PR DESCRIPTION
## Description:
We were not rendering the secret correctly, causing people to not know what the secret was.
