### PR TITLE
Fix race condition in group.set

### DIFF
--- a/homeassistant/components/group/__init__.py
+++ b/homeassistant/components/group/__init__.py
@@ -207,6 +207,13 @@ async def async_setup(hass, config):
         DOMAIN, SERVICE_RELOAD, reload_service_handler,
         schema=RELOAD_SERVICE_SCHEMA)
 
+    service_lock = asyncio.Lock()
+
+    async def locked_service_handler(service):
+        """Handle a service with an async lock."""
+        async with service_lock:
+            await groups_service_handler(service)
+
     async def groups_service_handler(service):
         """Handle dynamic group service functions."""
         object_id = service.data[ATTR_OBJECT_ID]
@@ -284,7 +291,7 @@ async def async_setup(hass, config):
             await component.async_remove_entity(entity_id)
 
     hass.services.async_register(
-        DOMAIN, SERVICE_SET, groups_service_handler,
+        DOMAIN, SERVICE_SET, locked_service_handler,
         schema=SET_SERVICE_SCHEMA)
 
     hass.services.async_register(


### PR DESCRIPTION
## Description:
Wraps group.set service in an async lock. Group.set contains a few awaits, which can cause a race condition and trying to create a group twice.

**Related issue (if applicable):** fixes #18636

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
