### PR TITLE
BUGFIX: handle extra fan speeds.

### DIFF
--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -714,7 +714,7 @@ class FanSpeedTrait(_Trait):
         modes = self.state.attributes.get(fan.ATTR_SPEED_LIST, [])
         speeds = []
         for mode in modes:
-            if mode not in speed_synonyms.keys():
+            if mode not in self.speed_synonyms:
                 continue
             speed = {
                 "speed_name": mode,

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -714,10 +714,12 @@ class FanSpeedTrait(_Trait):
         modes = self.state.attributes.get(fan.ATTR_SPEED_LIST, [])
         speeds = []
         for mode in modes:
+            if mode not in speed_synonyms.keys():
+                continue
             speed = {
                 "speed_name": mode,
                 "speed_values": [{
-                    "speed_synonym": self.speed_synonyms.get(mode, [mode]),
+                    "speed_synonym": self.speed_synonyms.get(mode),
                     "lang": 'en'
                 }]
             }

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -717,7 +717,7 @@ class FanSpeedTrait(_Trait):
             speed = {
                 "speed_name": mode,
                 "speed_values": [{
-                    "speed_synonym": self.speed_synonyms.get(mode),
+                    "speed_synonym": self.speed_synonyms.get(mode, [mode]),
                     "lang": 'en'
                 }]
             }


### PR DESCRIPTION
## Description:
mqtt and zha fans either have or can have extra speed modes other than the default 4 [off, low, medium, high]
When these are present, it was breaking the payload sent to GA.
Added support for these additional speeds but they will not have additional aliases.

**Related issue (if applicable):** fixes #18798

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable): Not Applicable

## Example entry for `configuration.yaml` (if applicable):
Not Applicable

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)
Not applicable

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.
Not applicable

If the code does not interact with devices:
  - [z] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
