### PR TITLE
Service already discovered log entry

### DIFF
--- a/homeassistant/components/discovery.py
+++ b/homeassistant/components/discovery.py
@@ -134,6 +134,7 @@ async def async_setup(hass, config):
 
         discovery_hash = json.dumps([service, info], sort_keys=True)
         if discovery_hash in already_discovered:
+            logger.debug("Already discoverd service %s %s.", service, info)
             return
 
         already_discovered.add(discovery_hash)


### PR DESCRIPTION
## Description:

Add debug log entry if service is already discovered allowing for better troubleshooting.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

