### PR TITLE
Increase pyatv to 0.3.11

### DIFF
--- a/homeassistant/components/apple_tv.py
+++ b/homeassistant/components/apple_tv.py
@@ -16,7 +16,7 @@ from homeassistant.helpers import discovery
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['pyatv==0.3.10']
+REQUIREMENTS = ['pyatv==0.3.11']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -851,7 +851,7 @@ pyarlo==0.2.2
 pyatmo==1.3
 
 # homeassistant.components.apple_tv
-pyatv==0.3.10
+pyatv==0.3.11
 
 # homeassistant.components.device_tracker.bbox
 # homeassistant.components.sensor.bbox


### PR DESCRIPTION
## Description:

Increase pyatv requirement to 0.3.11; providing support for Python 3.7.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
