### PR TITLE
Restore states for RFLink devices

### DIFF
--- a/homeassistant/components/cover/rflink.py
+++ b/homeassistant/components/cover/rflink.py
@@ -18,7 +18,6 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.const import CONF_NAME, STATE_OPEN
 
-
 DEPENDENCIES = ['rflink']
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/cover/rflink.py
+++ b/homeassistant/components/cover/rflink.py
@@ -15,7 +15,8 @@ from homeassistant.components.rflink import (
 from homeassistant.components.cover import (
     CoverDevice, PLATFORM_SCHEMA)
 import homeassistant.helpers.config_validation as cv
-from homeassistant.const import CONF_NAME
+from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.const import CONF_NAME, STATE_OPEN
 
 
 DEPENDENCIES = ['rflink']
@@ -60,8 +61,16 @@ async def async_setup_platform(hass, config, async_add_entities,
     async_add_entities(devices_from_config(config))
 
 
-class RflinkCover(RflinkCommand, CoverDevice):
+class RflinkCover(RflinkCommand, CoverDevice, RestoreEntity):
     """Rflink entity which can switch on/stop/off (eg: cover)."""
+
+    async def async_added_to_hass(self):
+        """Restore RFLink cover state (OPEN/CLOSE)."""
+        await super().async_added_to_hass()
+
+        old_state = await self.async_get_last_state()
+        if old_state is not None:
+            self._state = old_state.state == STATE_OPEN
 
     def _handle_event(self, event):
         """Adjust state if Rflink picks up a remote command for this device."""

--- a/homeassistant/components/light/rflink.py
+++ b/homeassistant/components/light/rflink.py
@@ -18,7 +18,6 @@ from homeassistant.components.rflink import (
     EVENT_KEY_COMMAND, EVENT_KEY_ID, SwitchableRflinkDevice,
     remove_deprecated)
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.const import (CONF_NAME, CONF_TYPE)
 
 DEPENDENCIES = ['rflink']
@@ -155,7 +154,7 @@ class RflinkLight(SwitchableRflinkDevice, Light):
     pass
 
 
-class DimmableRflinkLight(SwitchableRflinkDevice, Light, RestoreEntity):
+class DimmableRflinkLight(SwitchableRflinkDevice, Light):
     """Rflink light device that support dimming."""
 
     _brightness = 255
@@ -189,7 +188,7 @@ class DimmableRflinkLight(SwitchableRflinkDevice, Light, RestoreEntity):
         return SUPPORT_BRIGHTNESS
 
 
-class HybridRflinkLight(SwitchableRflinkDevice, Light, RestoreEntity):
+class HybridRflinkLight(SwitchableRflinkDevice, Light):
     """Rflink light device that sends out both dim and on/off commands.
 
     Used for protocols which support lights that are not exclusively on/off

--- a/homeassistant/components/light/rflink.py
+++ b/homeassistant/components/light/rflink.py
@@ -168,6 +168,7 @@ class DimmableRflinkLight(SwitchableRflinkDevice, Light):
         old_state = await self.async_get_last_state()
         if old_state is not None and \
                 old_state.attributes.get(ATTR_BRIGHTNESS) is not None:
+            # restore also brightness in dimmables devices
             self._brightness = int(old_state.attributes.get(ATTR_BRIGHTNESS))
 
     async def async_turn_on(self, **kwargs):
@@ -215,6 +216,7 @@ class HybridRflinkLight(SwitchableRflinkDevice, Light):
         old_state = await self.async_get_last_state()
         if old_state is not None and \
                 old_state.attributes.get(ATTR_BRIGHTNESS) is not None:
+            # restore also brightness in dimmables devices
             self._brightness = int(old_state.attributes.get(ATTR_BRIGHTNESS))
 
     async def async_turn_on(self, **kwargs):

--- a/homeassistant/components/light/rflink.py
+++ b/homeassistant/components/light/rflink.py
@@ -210,7 +210,7 @@ class HybridRflinkLight(SwitchableRflinkDevice, Light, RestoreEntity):
         """Restore RFLink light brightness attribute."""
         await super().async_added_to_hass()
 
-        old_state = await async_get_last_state(self.hass, self.entity_id)
+        old_state = await self.async_get_last_state()
         if old_state is not None and \
                 old_state.attributes.get(ATTR_BRIGHTNESS) is not None:
             self._brightness = int(old_state.attributes.get(ATTR_BRIGHTNESS))

--- a/homeassistant/components/light/rflink.py
+++ b/homeassistant/components/light/rflink.py
@@ -169,7 +169,7 @@ class DimmableRflinkLight(SwitchableRflinkDevice, Light):
         if old_state is not None and \
                 old_state.attributes.get(ATTR_BRIGHTNESS) is not None:
             # restore also brightness in dimmables devices
-            self._brightness = int(old_state.attributes.get(ATTR_BRIGHTNESS))
+            self._brightness = int(old_state.attributes[ATTR_BRIGHTNESS])
 
     async def async_turn_on(self, **kwargs):
         """Turn the device on."""
@@ -217,7 +217,7 @@ class HybridRflinkLight(SwitchableRflinkDevice, Light):
         if old_state is not None and \
                 old_state.attributes.get(ATTR_BRIGHTNESS) is not None:
             # restore also brightness in dimmables devices
-            self._brightness = int(old_state.attributes.get(ATTR_BRIGHTNESS))
+            self._brightness = int(old_state.attributes[ATTR_BRIGHTNESS])
 
     async def async_turn_on(self, **kwargs):
         """Turn the device on and set dim level."""

--- a/homeassistant/components/light/rflink.py
+++ b/homeassistant/components/light/rflink.py
@@ -148,12 +148,14 @@ async def async_setup_platform(hass, config, async_add_entities,
         hass.data[DATA_DEVICE_REGISTER][EVENT_KEY_COMMAND] = add_new_device
 
 
+# pylint: disable=too-many-ancestors
 class RflinkLight(SwitchableRflinkDevice, Light):
     """Representation of a Rflink light."""
 
     pass
 
 
+# pylint: disable=too-many-ancestors
 class DimmableRflinkLight(SwitchableRflinkDevice, Light):
     """Rflink light device that support dimming."""
 
@@ -188,6 +190,7 @@ class DimmableRflinkLight(SwitchableRflinkDevice, Light):
         return SUPPORT_BRIGHTNESS
 
 
+# pylint: disable=too-many-ancestors
 class HybridRflinkLight(SwitchableRflinkDevice, Light):
     """Rflink light device that sends out both dim and on/off commands.
 
@@ -240,6 +243,7 @@ class HybridRflinkLight(SwitchableRflinkDevice, Light):
         return SUPPORT_BRIGHTNESS
 
 
+# pylint: disable=too-many-ancestors
 class ToggleRflinkLight(SwitchableRflinkDevice, Light):
     """Rflink light device which sends out only 'on' commands.
 

--- a/homeassistant/components/rflink.py
+++ b/homeassistant/components/rflink.py
@@ -13,7 +13,7 @@ import voluptuous as vol
 
 from homeassistant.const import (
     ATTR_ENTITY_ID, CONF_COMMAND, CONF_HOST, CONF_PORT,
-    EVENT_HOMEASSISTANT_STOP)
+    STATE_ON, EVENT_HOMEASSISTANT_STOP)
 from homeassistant.core import CoreState, callback
 from homeassistant.exceptions import HomeAssistantError
 import homeassistant.helpers.config_validation as cv
@@ -21,7 +21,7 @@ from homeassistant.helpers.deprecation import get_deprecated
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_send, async_dispatcher_connect)
-
+from homeassistant.helpers.restore_state import RestoreEntity
 
 REQUIREMENTS = ['rflink==0.0.37']
 
@@ -499,8 +499,16 @@ class RflinkCommand(RflinkDevice):
                 self._async_send_command(cmd, repetitions - 1))
 
 
-class SwitchableRflinkDevice(RflinkCommand):
+class SwitchableRflinkDevice(RflinkCommand, RestoreEntity):
     """Rflink entity which can switch on/off (eg: light, switch)."""
+
+    async def async_added_to_hass(self):
+        """Restore RFLink device state (ON/OFF)."""
+        await super().async_added_to_hass()
+
+        old_state = await self.async_added_to_hass()
+        if old_state is not None:
+            self._state = old_state.state == STATE_ON
 
     def _handle_event(self, event):
         """Adjust state if Rflink picks up a remote command for this device."""

--- a/homeassistant/components/rflink.py
+++ b/homeassistant/components/rflink.py
@@ -506,7 +506,7 @@ class SwitchableRflinkDevice(RflinkCommand, RestoreEntity):
         """Restore RFLink device state (ON/OFF)."""
         await super().async_added_to_hass()
 
-        old_state = await self.async_added_to_hass()
+        old_state = await self.async_get_last_state()
         if old_state is not None:
             self._state = old_state.state == STATE_ON
 

--- a/homeassistant/components/switch/rflink.py
+++ b/homeassistant/components/switch/rflink.py
@@ -67,6 +67,7 @@ async def async_setup_platform(hass, config, async_add_entities,
     async_add_entities(devices_from_config(config))
 
 
+# pylint: disable=too-many-ancestors
 class RflinkSwitch(SwitchableRflinkDevice, SwitchDevice):
     """Representation of a Rflink switch."""
 

--- a/homeassistant/components/switch/rflink.py
+++ b/homeassistant/components/switch/rflink.py
@@ -67,7 +67,6 @@ async def async_setup_platform(hass, config, async_add_entities,
     async_add_entities(devices_from_config(config))
 
 
-# pylint: disable=too-many-ancestors
 class RflinkSwitch(SwitchableRflinkDevice, SwitchDevice):
     """Representation of a Rflink switch."""
 

--- a/tests/components/light/test_rflink.py
+++ b/tests/components/light/test_rflink.py
@@ -596,22 +596,21 @@ def test_restore_state(hass, monkeypatch):
     hass.state = CoreState.starting
 
     # setup mocking rflink module
-    event_callback, _, _, _ = yield from mock_rflink(
-        hass, config, DOMAIN, monkeypatch)
+    _, _, _, _ = yield from mock_rflink(hass, config, DOMAIN, monkeypatch)
 
     # dimmable light must restore brightness
     state = hass.states.get(DOMAIN + '.l1')
     assert state
-    assert(state.state == STATE_ON)
-    assert(state.attributes[ATTR_BRIGHTNESS] == 123)
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_BRIGHTNESS] == 123
 
     # normal light do NOT must restore brightness
     state = hass.states.get(DOMAIN + '.l2')
     assert state
-    assert(state.state == STATE_ON)
-    assert not (state.attributes.get(ATTR_BRIGHTNESS))
+    assert state.state == STATE_ON
+    assert not state.attributes.get(ATTR_BRIGHTNESS)
 
     # OFF state also restores (or not)
     state = hass.states.get(DOMAIN + '.l3')
     assert state
-    assert(state.state == STATE_OFF)
+    assert state.state == STATE_OFF


### PR DESCRIPTION
## Description:
This PR aims to add the ability to recover the previous state to RFLink devices.
RFLink devices do not have the ability to ask for their status, so in the reboots, the previous state is lost. This delivery gives these devices the ability to 'remember' the status on the reboots.
This PR comes from the failed PR #18208

Some of the points to review:
- I don't think that will be a breaking change
- If the PR goes live I will adjust the documentation to the new behavior (on reboots)
- Sugestions and improvement proposals

My intention would be to release an initial version 'as is' and then work on some of the points of improvement:
1. How to disable the behavior? My approach would be to make use of a new 'initial_value' attribute that, if informed, prevails over the previous value. I don't like the option to define a flag attribute to modify the behavior and I think that 'initial_value' is already used in other cases.
2. The new behavior does not apply to devices of the `sensor` and `binary_sensor` type. In my opinion, I do not believe that the previous state should be restored in these cases, in the next update the correct state will be restored, regardless of the previous state.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]). **N/A**
  - New dependencies are only imported inside functions that use them ([example][ex-import]). **N/A**
  - New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`. **N/A**
  - New files were added to `.coveragerc`. **N/A**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
