### PR TITLE
Update tautulli to use a path

### DIFF
--- a/homeassistant/components/sensor/tautulli.py
+++ b/homeassistant/components/sensor/tautulli.py
@@ -12,7 +12,7 @@ import voluptuous as vol
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
     CONF_API_KEY, CONF_HOST, CONF_MONITORED_CONDITIONS, CONF_NAME, CONF_PORT,
-    CONF_SSL, CONF_VERIFY_SSL)
+    CONF_PATH, CONF_SSL, CONF_VERIFY_SSL)
 from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
@@ -27,6 +27,7 @@ CONF_MONITORED_USERS = 'monitored_users'
 
 DEFAULT_NAME = 'Tautulli'
 DEFAULT_PORT = '8181'
+DEFAULT_PATH = ''
 DEFAULT_SSL = False
 DEFAULT_VERIFY_SSL = True
 
@@ -40,6 +41,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_MONITORED_USERS): vol.All(cv.ensure_list, [cv.string]),
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.string,
+    vol.Optional(CONF_PATH, default=DEFAULT_PATH): cv.string,
     vol.Optional(CONF_SSL, default=DEFAULT_SSL): cv.boolean,
     vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): cv.boolean,
 })
@@ -52,7 +54,7 @@ async def async_setup_platform(
 
     name = config.get(CONF_NAME)
     host = config[CONF_HOST]
-    port = config.get(CONF_PORT)
+    port = config.get(CONF_PORT) + config.get(CONF_PATH)
     api_key = config[CONF_API_KEY]
     monitored_conditions = config.get(CONF_MONITORED_CONDITIONS)
     user = config.get(CONF_MONITORED_USERS)


### PR DESCRIPTION
This will add an optional config entry and the possibility to have Tautulli behind a reverse proxy while using URL/Path instead of only domain.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)