### PR TITLE
Bump python_awair to 0.0.3

### DIFF
--- a/homeassistant/components/sensor/awair.py
+++ b/homeassistant/components/sensor/awair.py
@@ -20,7 +20,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle, dt
 
-REQUIREMENTS = ['python_awair==0.0.2']
+REQUIREMENTS = ['python_awair==0.0.3']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1270,7 +1270,7 @@ python-vlc==1.1.2
 python-wink==1.10.1
 
 # homeassistant.components.sensor.awair
-python_awair==0.0.2
+python_awair==0.0.3
 
 # homeassistant.components.sensor.swiss_public_transport
 python_opendata_transport==0.1.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -200,7 +200,7 @@ python-forecastio==1.4.0
 python-nest==4.0.5
 
 # homeassistant.components.sensor.awair
-python_awair==0.0.2
+python_awair==0.0.3
 
 # homeassistant.components.sensor.whois
 pythonwhois==2.4.3


### PR DESCRIPTION
## Description:
This PR bumps the version of python_awair to 0.0.3, which is the library powering the Awair component. The Awair dev team changed their API, and the underlying library needs to send a slightly different UUID parameter to match.

It's rather annoying, and I'm going to find out how to get notified of those updates before they happen. :-/

The component works again with this patch.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
