### PR TITLE
Show ANSI color codes in logs in Hass.io

### DIFF
--- a/homeassistant/components/hassio/http.py
+++ b/homeassistant/components/hassio/http.py
@@ -15,7 +15,6 @@ from aiohttp import web
 from aiohttp.hdrs import CONTENT_TYPE
 from aiohttp.web_exceptions import HTTPBadGateway
 
-from homeassistant.const import CONTENT_TYPE_TEXT_PLAIN
 from homeassistant.components.http import KEY_AUTHENTICATED, HomeAssistantView
 
 from .const import X_HASSIO

--- a/homeassistant/components/hassio/http.py
+++ b/homeassistant/components/hassio/http.py
@@ -63,8 +63,6 @@ class HassIOView(HomeAssistantView):
         client = await self._command_proxy(path, request)
 
         data = await client.read()
-        if path.endswith('/logs'):
-            return _create_response_log(client, data)
         return _create_response(client, data)
 
     get = _handle
@@ -111,18 +109,6 @@ def _create_response(client, data):
         body=data,
         status=client.status,
         content_type=client.content_type,
-    )
-
-
-def _create_response_log(client, data):
-    """Convert a response from client request."""
-    # Remove color codes
-    log = re.sub(r"\x1b(\[.*?[@-~]|\].*?(\x07|\x1b\\))", "", data.decode())
-
-    return web.Response(
-        text=log,
-        status=client.status,
-        content_type=CONTENT_TYPE_TEXT_PLAIN,
     )
 
 

--- a/tests/components/hassio/test_http.py
+++ b/tests/components/hassio/test_http.py
@@ -108,8 +108,8 @@ def test_forward_log_request(hassio_client):
 
     with patch('homeassistant.components.hassio.HassIOView._command_proxy',
                Mock(return_value=mock_coro(response))), \
-         patch('homeassistant.components.hassio.http'
-               '._create_response') as mresp:
+            patch('homeassistant.components.hassio.http.'
+                  '_create_response') as mresp:
         mresp.return_value = '\033[32mresponse\033[0m'
         resp = yield from hassio_client.get('/api/hassio/beer/logs', headers={
                 HTTP_HEADER_HA_AUTH: API_PASSWORD

--- a/tests/components/hassio/test_http.py
+++ b/tests/components/hassio/test_http.py
@@ -102,15 +102,15 @@ def test_forward_request_no_auth_for_logo(hassio_client):
 
 @asyncio.coroutine
 def test_forward_log_request(hassio_client):
-    """Test fetching normal log path."""
+    """Test fetching normal log path doesn't remove ANSI color escape codes."""
     response = MagicMock()
     response.read.return_value = mock_coro('data')
 
     with patch('homeassistant.components.hassio.HassIOView._command_proxy',
                Mock(return_value=mock_coro(response))), \
-            patch('homeassistant.components.hassio.http.'
-                  '_create_response_log') as mresp:
-        mresp.return_value = 'response'
+         patch('homeassistant.components.hassio.http'
+               '._create_response') as mresp:
+        mresp.return_value = '\033[32mresponse\033[0m'
         resp = yield from hassio_client.get('/api/hassio/beer/logs', headers={
                 HTTP_HEADER_HA_AUTH: API_PASSWORD
             })
@@ -118,7 +118,7 @@ def test_forward_log_request(hassio_client):
     # Check we got right response
     assert resp.status == 200
     body = yield from resp.text()
-    assert body == 'response'
+    assert body == '\033[32mresponse\033[0m'
 
     # Check we forwarded command
     assert len(mresp.mock_calls) == 1


### PR DESCRIPTION
## Description:


**Pull request in [home-assistant-polymer](https://github.com/home-assistant/home-assistant-polymer):** https://github.com/home-assistant/home-assistant-polymer/pull/2155

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
