### PR TITLE
Fix 17track.net sensor issues

### DIFF
--- a/homeassistant/components/sensor/seventeentrack.py
+++ b/homeassistant/components/sensor/seventeentrack.py
@@ -25,6 +25,7 @@ ATTR_INFO_TEXT = 'info_text'
 ATTR_ORIGIN_COUNTRY = 'origin_country'
 ATTR_PACKAGE_TYPE = 'package_type'
 ATTR_TRACKING_INFO_LANGUAGE = 'tracking_info_language'
+ATTR_TRACKING_NUMBER = 'tracking_number'
 
 CONF_SHOW_ARCHIVED = 'show_archived'
 CONF_SHOW_DELIVERED = 'show_delivered'
@@ -116,7 +117,7 @@ class SeventeenTrackSummarySensor(Entity):
     @property
     def name(self):
         """Return the name."""
-        return 'Packages {0}'.format(self._status)
+        return '17track Packages {0}'.format(self._status)
 
     @property
     def state(self):
@@ -154,8 +155,10 @@ class SeventeenTrackPackageSensor(Entity):
             ATTR_ORIGIN_COUNTRY: package.origin_country,
             ATTR_PACKAGE_TYPE: package.package_type,
             ATTR_TRACKING_INFO_LANGUAGE: package.tracking_info_language,
+            ATTR_TRACKING_NUMBER: package.tracking_number,
         }
         self._data = data
+        self._friendly_name = package.friendly_name
         self._state = package.status
         self._tracking_number = package.tracking_number
 
@@ -180,7 +183,10 @@ class SeventeenTrackPackageSensor(Entity):
     @property
     def name(self):
         """Return the name."""
-        return self._tracking_number
+        name = self._friendly_name
+        if not name:
+            name = self._tracking_number
+        return '17track Package: {0}'.format(name)
 
     @property
     def state(self):


### PR DESCRIPTION
## Description:

Currently, the 17track.net integration has two issues with its sensor names:

- Names are too generic, which pollutes the sensor namespace
- Friendly names (if they exist in the data) aren't properly shown.

This PR addresses both issues by making the following changes:

1. Summary sensors will now be prefixed with `17track_` (e.g., `sensor.17track_packages_delivered` instead of `sensor.packages_delivered`).
2. Individual package sensors will now have sensor names that include the friendly name and are prefixed with `17track_` (e.g., `sensor.17track_package_playstation_4`).
3. If a package doesn't have a 17track.net friendly name, the tracking number will be used (e.g., `sensor.17track_package_4tukql2580046`).
4. Since tracking numbers may or may not be part of package sensor names, these sensors now have a `tracking_number` attribute.

**Breaking Changes:** sensor names will change based on the above rules.

**Related issue (if applicable):** fixes #18840 and #18842

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: seventeentrack
    username: !secret 17track_user
    password: !secret 17track_password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
