### PR TITLE
Bump py17track to 2.1.1

### DIFF
--- a/homeassistant/components/sensor/seventeentrack.py
+++ b/homeassistant/components/sensor/seventeentrack.py
@@ -17,7 +17,7 @@ from homeassistant.helpers import aiohttp_client, config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle, slugify
 
-REQUIREMENTS = ['py17track==2.1.0']
+REQUIREMENTS = ['py17track==2.1.1']
 _LOGGER = logging.getLogger(__name__)
 
 ATTR_DESTINATION_COUNTRY = 'destination_country'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -808,7 +808,7 @@ py-melissa-climate==2.0.0
 py-synology==0.2.0
 
 # homeassistant.components.sensor.seventeentrack
-py17track==2.1.0
+py17track==2.1.1
 
 # homeassistant.components.hdmi_cec
 pyCEC==0.4.13


### PR DESCRIPTION
## Description:

This PR bumps `py17track` to 2.1.1. Changelog: https://github.com/bachya/py17track/releases/tag/2.1.1

This fixes an issue where the platform would incorrectly compare its current entity set to the incoming entity set and create sensors that already exist.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: seventeentrack
    username: !secret 17track_user
    password: !secret 17track_password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
