### PR TITLE
Don't fail on empty top movie/tv show/user node

### DIFF
--- a/homeassistant/components/sensor/tautulli.py
+++ b/homeassistant/components/sensor/tautulli.py
@@ -90,9 +90,20 @@ class TautulliSensor(Entity):
         await self.tautulli.async_update()
         self.home = self.tautulli.api.home_data
         self.sessions = self.tautulli.api.session_data
-        self._attributes['Top Movie'] = self.home[0]['rows'][0]['title']
-        self._attributes['Top TV Show'] = self.home[3]['rows'][0]['title']
-        self._attributes['Top User'] = self.home[7]['rows'][0]['user']
+
+        try:
+            self._attributes['Top Movie'] = self.home[0]['rows'][0]['title']
+        except (KeyError, TypeError):
+            self._attributes['Top Movie'] = ''
+        try:
+            self._attributes['Top TV Show'] = self.home[3]['rows'][0]['title']
+        except (KeyError, TypeError):
+            self._attributes['Top TV Show'] = ''
+        try:
+            self._attributes['Top User'] = self.home[7]['rows'][0]['user']
+        except (KeyError, TypeError):
+            self._attributes['Top User'] = ''
+
         for key in self.sessions:
             if 'sessions' not in key:
                 self._attributes[key] = self.sessions[key]


### PR DESCRIPTION
## Description:

When querying the Tautulli API it is perfectly valid that no results are returned for "Top Movie", "Top TV Show" and "Top User". This patch ensures that HA doesn't throw an error in that case but instead just leaves the values blank.

**Related issue:** fixes #18836

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`.
  - [x] There is no commented out code in this PR.
