### PR TITLE
Bug: fix google_assistant 'allow_unlock' config option

### DIFF
--- a/homeassistant/components/cloud/__init__.py
+++ b/homeassistant/components/cloud/__init__.py
@@ -191,9 +191,9 @@ class Cloud:
 
             self._gactions_config = ga_h.Config(
                 should_expose=should_expose,
+                allow_unlock=self.prefs.google_allow_unlock,
                 agent_user_id=self.claims['cognito:username'],
                 entity_config=conf.get(CONF_ENTITY_CONFIG),
-                allow_unlock=self.prefs.google_allow_unlock,
             )
 
         return self._gactions_config

--- a/homeassistant/components/google_assistant/helpers.py
+++ b/homeassistant/components/google_assistant/helpers.py
@@ -16,8 +16,8 @@ class SmartHomeError(Exception):
 class Config:
     """Hold the configuration for Google Assistant."""
 
-    def __init__(self, should_expose, agent_user_id, entity_config=None,
-                 allow_unlock=False):
+    def __init__(self, should_expose, allow_unlock, agent_user_id,
+                 entity_config=None):
         """Initialize the configuration."""
         self.should_expose = should_expose
         self.agent_user_id = agent_user_id

--- a/homeassistant/components/google_assistant/http.py
+++ b/homeassistant/components/google_assistant/http.py
@@ -15,6 +15,7 @@ from homeassistant.const import CLOUD_NEVER_EXPOSED_ENTITIES
 
 from .const import (
     GOOGLE_ASSISTANT_API_ENDPOINT,
+    CONF_ALLOW_UNLOCK,
     CONF_EXPOSE_BY_DEFAULT,
     CONF_EXPOSED_DOMAINS,
     CONF_ENTITY_CONFIG,
@@ -32,6 +33,7 @@ def async_register_http(hass, cfg):
     expose_by_default = cfg.get(CONF_EXPOSE_BY_DEFAULT)
     exposed_domains = cfg.get(CONF_EXPOSED_DOMAINS)
     entity_config = cfg.get(CONF_ENTITY_CONFIG) or {}
+    allow_unlock = cfg.get(CONF_ALLOW_UNLOCK, False)
 
     def is_exposed(entity) -> bool:
         """Determine if an entity should be exposed to Google Assistant."""
@@ -57,7 +59,7 @@ def async_register_http(hass, cfg):
         return is_default_exposed or explicit_expose
 
     hass.http.register_view(
-        GoogleAssistantView(is_exposed, entity_config))
+        GoogleAssistantView(is_exposed, entity_config, allow_unlock))
 
 
 class GoogleAssistantView(HomeAssistantView):
@@ -67,15 +69,17 @@ class GoogleAssistantView(HomeAssistantView):
     name = 'api:google_assistant'
     requires_auth = True
 
-    def __init__(self, is_exposed, entity_config):
+    def __init__(self, is_exposed, entity_config, allow_unlock):
         """Initialize the Google Assistant request handler."""
         self.is_exposed = is_exposed
         self.entity_config = entity_config
+        self.allow_unlock = allow_unlock
 
     async def post(self, request: Request) -> Response:
         """Handle Google Assistant requests."""
         message = await request.json()  # type: dict
         config = Config(self.is_exposed,
+                        self.allow_unlock,
                         request['hass_user'].id,
                         self.entity_config)
         result = await async_handle_message(

--- a/tests/components/google_assistant/test_smart_home.py
+++ b/tests/components/google_assistant/test_smart_home.py
@@ -11,6 +11,7 @@ from homeassistant.components.light.demo import DemoLight
 
 BASIC_CONFIG = helpers.Config(
     should_expose=lambda state: True,
+    allow_unlock=False,
     agent_user_id='test-agent',
 )
 REQ_ID = 'ff36a3cc-ec34-11e6-b1a0-64510650abcf'
@@ -35,6 +36,7 @@ async def test_sync_message(hass):
 
     config = helpers.Config(
         should_expose=lambda state: state.entity_id != 'light.not_expose',
+        allow_unlock=False,
         agent_user_id='test-agent',
         entity_config={
             'light.demo_light': {

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -25,6 +25,7 @@ from tests.common import async_mock_service
 
 BASIC_CONFIG = helpers.Config(
     should_expose=lambda state: True,
+    allow_unlock=False,
     agent_user_id='test-agent',
 )
 


### PR DESCRIPTION
## Description

I failed to thread the `allow_unlock` preference down from where we actually read the `google_assistant` preferences, through to the `Config` object that holds preferences in the http view. This was done correctly for the `cloud` component, but I missed it here. This PR also removes the default value for this parameter on the `Config` object, which is how it was missed before. As a required param, future refactoring will not miss it.
 
**Related issue (if applicable):** fixes #18848

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
