### PR TITLE
Fix pylint issue for helpers/template

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -616,8 +616,9 @@ def base64_decode(value):
 def ordinal(value):
     """Perform ordinal conversion."""
     return str(value) + (list(['th', 'st', 'nd', 'rd'] + ['th'] * 6)
-                         [(int(str(value)[-1])) % 10] if not
-                         int(str(value)[-2:]) % 100 in range(11, 14) else 'th')
+                         [(int(str(value)[-1])) % 10] if
+                         int(str(value)[-2:]) % 100 not in range(11, 14)
+                         else 'th')
 
 
 @contextfilter


### PR DESCRIPTION
## Description:

Travis (Python: 3.5.3 (TOXENV=pylint)) are currently broken from #18125 

With this error:
```
homeassistant/helpers/template.py:619:57: C0113: Consider changing "not int(str(value)[-2:]) % 100 in range(11, 14)" to "int(str(value)[-2:]) % 100 not in range(11, 14)" (unneeded-not)
```

This PR corrects that.
<!--
**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```
-->
## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
<!-- 
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
-->
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
