### PR TITLE
Fixes error with getting attributes from Tautulli

### DIFF
--- a/homeassistant/components/sensor/tautulli.py
+++ b/homeassistant/components/sensor/tautulli.py
@@ -91,7 +91,7 @@ class TautulliSensor(Entity):
         self.home = self.tautulli.api.home_data
         self.sessions = self.tautulli.api.session_data
         self._attributes['Top Movie'] = self.home.get('movie')
-        self._attributes['Top TV Show'] = self.home,get('tv')
+        self._attributes['Top TV Show'] = self.home.get('tv')
         self._attributes['Top User'] = self.home.get('user')
         for key in self.sessions:
             if 'sessions' not in key:

--- a/homeassistant/components/sensor/tautulli.py
+++ b/homeassistant/components/sensor/tautulli.py
@@ -90,9 +90,9 @@ class TautulliSensor(Entity):
         await self.tautulli.async_update()
         self.home = self.tautulli.api.home_data
         self.sessions = self.tautulli.api.session_data
-        self._attributes['Top Movie'] = self.home['movie']
-        self._attributes['Top TV Show'] = self.home['tv']
-        self._attributes['Top User'] = self.home['user']
+        self._attributes['Top Movie'] = self.home.get('movie')
+        self._attributes['Top TV Show'] = self.home,get('tv')
+        self._attributes['Top User'] = self.home.get('user')
         for key in self.sessions:
             if 'sessions' not in key:
                 self._attributes[key] = self.sessions[key]

--- a/homeassistant/components/sensor/tautulli.py
+++ b/homeassistant/components/sensor/tautulli.py
@@ -19,7 +19,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['pytautulli==0.4.0']
+REQUIREMENTS = ['pytautulli==0.4.1']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -90,9 +90,9 @@ class TautulliSensor(Entity):
         await self.tautulli.async_update()
         self.home = self.tautulli.api.home_data
         self.sessions = self.tautulli.api.session_data
-        self._attributes['Top Movie'] = self.home[0]['rows'][0]['title']
-        self._attributes['Top TV Show'] = self.home[3]['rows'][0]['title']
-        self._attributes['Top User'] = self.home[7]['rows'][0]['user']
+        self._attributes['Top Movie'] = self.home['movie']
+        self._attributes['Top TV Show'] = self.home['tv']
+        self._attributes['Top User'] = self.home['user']
         for key in self.sessions:
             if 'sessions' not in key:
                 self._attributes[key] = self.sessions[key]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1158,7 +1158,7 @@ pystride==0.1.7
 pysyncthru==0.3.1
 
 # homeassistant.components.sensor.tautulli
-pytautulli==0.4.0
+pytautulli==0.4.1
 
 # homeassistant.components.media_player.liveboxplaytv
 pyteleloisirs==3.4


### PR DESCRIPTION
## Description:

Did some cleanup in the PyPi package to fix issues getting home statistics.
[changelog](https://github.com/ludeeus/pytautulli/compare/0.4.0...0.4.1)

**Related issue (if applicable):** fixes #18836 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: tautulli
    api_key: TAUTULLI_API_KEY
    host: TAUTULLI_HOST
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
<!--
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]). -->
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
<!--  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
-->
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
