### PR TITLE
Use capability of sensor if present to fix multisensor Wink devices

### DIFF
--- a/homeassistant/components/wink/__init__.py
+++ b/homeassistant/components/wink/__init__.py
@@ -690,6 +690,10 @@ class WinkDevice(Entity):
     @property
     def unique_id(self):
         """Return the unique id of the Wink device."""
+        if hasattr(self.wink, 'capability') and \
+                self.wink.capability() is not None:
+            return "{}_{}".format(self.wink.object_id(),
+                                  self.wink.capability())
         return self.wink.object_id()
 
     @property


### PR DESCRIPTION
## Description:
Unique ID support was added, but didn't account for Wink devices that are broken out in to several sensors in HA. For example the Wink relay and Wink smoke detectors which show up in Home Assistant as multiple sensors even though they are only one device. 

**Related issue (if applicable):** fixes https://community.home-assistant.io/t/wink-relay-problem-after-upgrade/82269


## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
