### PR TITLE
Automatically detect if ipv4/ipv6 is used for cert_expiry

### DIFF
--- a/homeassistant/components/sensor/cert_expiry.py
+++ b/homeassistant/components/sensor/cert_expiry.py
@@ -85,7 +85,8 @@ class SSLCertificate(Entity):
         """Fetch the certificate information."""
         try:
             ctx = ssl.create_default_context()
-            family = socket.getaddrinfo(self.server_name, self.server_port)[0][0]
+            host_info = socket.getaddrinfo(self.server_name, self.server_port)
+            family = host_info[0][0]
             sock = ctx.wrap_socket(
                 socket.socket(family=family), server_hostname=self.server_name)
             sock.settimeout(TIMEOUT)

--- a/homeassistant/components/sensor/cert_expiry.py
+++ b/homeassistant/components/sensor/cert_expiry.py
@@ -85,8 +85,9 @@ class SSLCertificate(Entity):
         """Fetch the certificate information."""
         try:
             ctx = ssl.create_default_context()
+            family = socket.getaddrinfo(self.server_name, self.server_port)[0][0]
             sock = ctx.wrap_socket(
-                socket.socket(), server_hostname=self.server_name)
+                socket.socket(family=family), server_hostname=self.server_name)
             sock.settimeout(TIMEOUT)
             sock.connect((self.server_name, self.server_port))
         except socket.gaierror:


### PR DESCRIPTION
Fixes #18818
Python sockets use ipv4 per default. If the domain which should be checked
only has an ipv6 record, socket creation errors out with
`[Errno -2] Name or service not known`
This fix tries to guess the protocol family and creates the socket
with the correct family type

## Description:


**Related issue (if applicable):** fixes #18818 


## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
