### PR TITLE
Include Scripts/ directory to .gitignore - this is created by virtualenv on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,7 @@ venv
 .venv
 Pipfile*
 share/*
+Scripts/
 
 # vimmy stuff
 *.swp


### PR DESCRIPTION
## Description:
Include **Scripts/** directory to .gitignore - this is created by virtualenv on Windows

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
