### PR TITLE
Event not JSON serializable - Recorder

### DIFF
--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -305,7 +305,7 @@ class Recorder(threading.Thread):
                             session.add(dbevent)
                             session.flush()
                         except (TypeError, ValueError):
-                            _LOGGER.warning(
+                            _LOGGER.debug(
                                 "Event is not JSON serializable: %s", event)
 
                         if event.event_type == EVENT_STATE_CHANGED:
@@ -314,7 +314,7 @@ class Recorder(threading.Thread):
                                 dbstate.event_id = dbevent.event_id
                                 session.add(dbstate)
                             except (TypeError, ValueError):
-                                _LOGGER.warning(
+                                _LOGGER.debug(
                                     "State is not JSON serializable: %s",
                                     event.data.get('new_state'))
 


### PR DESCRIPTION
## Description:
Not all events JSON serializable. This mainly applies to service_call events for which `templates` aren't rendered yet. Since the `template` doesn't have knowledge of `hass` yet (at the moment of the service_call), it can't render itself either. See the issue linked below for an example.

Originally I though of rendering it after the serialization failed (https://github.com/home-assistant/home-assistant/commit/a00bd346be5c15bb57e2755b15c758c7e65ce42f), but I think that would overly complicate things. That's why I would propose changing the `warning` message to a `debug` one.

A assume similar chases would apply from `States`.

**Related issue (if applicable):** fixes #18900


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.