### PR TITLE
Add users added via credentials to admin group too

### DIFF
--- a/homeassistant/auth/__init__.py
+++ b/homeassistant/auth/__init__.py
@@ -190,6 +190,7 @@ class AuthManager:
             credentials=credentials,
             name=info.name,
             is_active=info.is_active,
+            group_ids=[GROUP_ID_ADMIN],
         )
 
         self.hass.bus.async_fire(EVENT_USER_ADDED, {

--- a/tests/auth/test_init.py
+++ b/tests/auth/test_init.py
@@ -882,7 +882,6 @@ async def test_new_users_admin(mock_hass):
             'name': 'Test Name'
         }]
     }], [])
-    # mock_hass.auth = manager
     ensure_auth_manager_loaded(manager)
 
     user = await manager.async_create_user('Hello')

--- a/tests/auth/test_init.py
+++ b/tests/auth/test_init.py
@@ -870,3 +870,29 @@ async def test_async_remove_user(hass):
     await hass.async_block_till_done()
     assert len(events) == 1
     assert events[0].data['user_id'] == user.id
+
+
+async def test_new_users_admin(mock_hass):
+    """Test newly created users are admin."""
+    manager = await auth.auth_manager_from_config(mock_hass, [{
+        'type': 'insecure_example',
+        'users': [{
+            'username': 'test-user',
+            'password': 'test-pass',
+            'name': 'Test Name'
+        }]
+    }], [])
+    # mock_hass.auth = manager
+    ensure_auth_manager_loaded(manager)
+
+    user = await manager.async_create_user('Hello')
+    assert user.is_admin
+
+    user_cred = await manager.async_get_or_create_user(auth_models.Credentials(
+        id='mock-id',
+        auth_provider_type='insecure_example',
+        auth_provider_id=None,
+        data={'username': 'test-user'},
+        is_new=True,
+    ))
+    assert user_cred.is_admin


### PR DESCRIPTION
## Description:
If a user was still using API password to authenticate with the Home Assistant API but never logged in with the legacy API user, we would create a new user on the fly. However, this would use `async_get_or_create_user` which did not add the user to the admin group. This PR fixes it.

If you never use the legacy API password to access the UI but still use the legacy API password to authenticate scripts (you really should update to long lived auth tokens), you need to manually add the legacy API user to the Admin group in `<config>/.storage/auth`. Restart Home Assistant after making the change.

```json
            {
                "group_ids": [
                    "system-admin"
                ],
                "id": "<LEGACY USER ID>",
                "is_active": true,
                "is_owner": false,
                "name": "Legacy API password user",
                "system_generated": false
            }
```

And if you are really still using the legacy auth, this is a good reminder to upgrade. It will stop working in the future.

**Related issue (if applicable):** fixes #18885

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
