### PR TITLE
Remove unsupported strong mode of the Xiaomi Air Humidifier CA1

### DIFF
--- a/homeassistant/components/fan/xiaomi_miio.py
+++ b/homeassistant/components/fan/xiaomi_miio.py
@@ -756,12 +756,12 @@ class XiaomiAirHumidifier(XiaomiGenericDevice):
             self._device_features = FEATURE_FLAGS_AIRHUMIDIFIER_CA
             self._available_attributes = AVAILABLE_ATTRIBUTES_AIRHUMIDIFIER_CA
             self._speed_list = [mode.name for mode in OperationMode if
-                                mode.name != 'Strong']
+                                mode is not OperationMode.Strong]
         else:
             self._device_features = FEATURE_FLAGS_AIRHUMIDIFIER
             self._available_attributes = AVAILABLE_ATTRIBUTES_AIRHUMIDIFIER
             self._speed_list = [mode.name for mode in OperationMode if
-                                mode.name != 'Auto']
+                                mode is not OperationMode.Auto]
 
         self._state_attrs.update(
             {attribute: None for attribute in self._available_attributes})

--- a/homeassistant/components/fan/xiaomi_miio.py
+++ b/homeassistant/components/fan/xiaomi_miio.py
@@ -755,7 +755,8 @@ class XiaomiAirHumidifier(XiaomiGenericDevice):
         if self._model == MODEL_AIRHUMIDIFIER_CA:
             self._device_features = FEATURE_FLAGS_AIRHUMIDIFIER_CA
             self._available_attributes = AVAILABLE_ATTRIBUTES_AIRHUMIDIFIER_CA
-            self._speed_list = [mode.name for mode in OperationMode]
+            self._speed_list = [mode.name for mode in OperationMode if
+                                mode.name != 'Strong']
         else:
             self._device_features = FEATURE_FLAGS_AIRHUMIDIFIER
             self._available_attributes = AVAILABLE_ATTRIBUTES_AIRHUMIDIFIER


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** https://community.home-assistant.io/t/xiaomi-humidifier-support/35672/77?u=syssi

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** https://github.com/home-assistant/home-assistant.io/pull/7710
