### PR TITLE
Downgrade warning to info if a value_template exists of MQTT Binary Sensor

### DIFF
--- a/homeassistant/components/binary_sensor/mqtt.py
+++ b/homeassistant/components/binary_sensor/mqtt.py
@@ -138,10 +138,16 @@ class MqttBinarySensor(MqttAvailability, MqttDiscoveryUpdate,
             elif payload == self._config.get(CONF_PAYLOAD_OFF):
                 self._state = False
             else:  # Payload is not for this entity
-                _LOGGER.warning('No matching payload found'
-                                ' for entity: %s with state_topic: %s',
-                                self._config.get(CONF_NAME),
-                                self._config.get(CONF_STATE_TOPIC))
+                if value_template is not None:
+                    _LOGGER.warning('No matching payload found'
+                                    ' for entity: %s with state_topic: %s',
+                                    self._config.get(CONF_NAME),
+                                    self._config.get(CONF_STATE_TOPIC))
+                else:
+                    _LOGGER.info('No matching payload found'
+                                    ' for entity: %s with state_topic: %s',
+                                    self._config.get(CONF_NAME),
+                                    self._config.get(CONF_STATE_TOPIC))
                 return
 
             if self._delay_listener is not None:

--- a/homeassistant/components/binary_sensor/mqtt.py
+++ b/homeassistant/components/binary_sensor/mqtt.py
@@ -139,15 +139,15 @@ class MqttBinarySensor(MqttAvailability, MqttDiscoveryUpdate,
                 self._state = False
             else:  # Payload is not for this entity
                 if value_template is not None:
-                    _LOGGER.warning('No matching payload found'
-                                    ' for entity: %s with state_topic: %s',
-                                    self._config.get(CONF_NAME),
-                                    self._config.get(CONF_STATE_TOPIC))
-                else:
                     _LOGGER.info('No matching payload found'
                                  ' for entity: %s with state_topic: %s',
                                  self._config.get(CONF_NAME),
                                  self._config.get(CONF_STATE_TOPIC))
+                else:
+                    _LOGGER.warning('No matching payload found'
+                                    ' for entity: %s with state_topic: %s',
+                                    self._config.get(CONF_NAME),
+                                    self._config.get(CONF_STATE_TOPIC))
                 return
 
             if self._delay_listener is not None:

--- a/homeassistant/components/binary_sensor/mqtt.py
+++ b/homeassistant/components/binary_sensor/mqtt.py
@@ -145,9 +145,9 @@ class MqttBinarySensor(MqttAvailability, MqttDiscoveryUpdate,
                                     self._config.get(CONF_STATE_TOPIC))
                 else:
                     _LOGGER.info('No matching payload found'
-                                    ' for entity: %s with state_topic: %s',
-                                    self._config.get(CONF_NAME),
-                                    self._config.get(CONF_STATE_TOPIC))
+                                 ' for entity: %s with state_topic: %s',
+                                 self._config.get(CONF_NAME),
+                                 self._config.get(CONF_STATE_TOPIC))
                 return
 
             if self._delay_listener is not None:


### PR DESCRIPTION
## Description:

With the MQTT `binary_sensor`, there can be a `value_template`. This allows you to parse the JSON of a payload. For example, the sonoff-tasmota firmware with the Sonoff RF bridge sends a payload of:

```json
{"RfReceived":{"Sync":6740,"Low":210,"High":660,"Data":"EE733C","RfKey":"None"}}
```

You can then parse `value_json.RfReceived.Data` using an MQTT `binary_sensor` with a `value_template`. The problem is, this value may not always be correct. This causes a mass of warnings in the logs shown below.

![image](https://user-images.githubusercontent.com/28114703/49343838-d4f9b880-f667-11e8-95fe-f63859a3ef04.png)

This downgrades the warning to info on the logger so that the logs are not flooded with warnings which in the UI are not controllable.

## Example entry for `configuration.yaml` (if applicable):
```yaml
platform: mqtt
name: 'Back Door'
state_topic: 'tele/sonoff-rf/RESULT'
value_template: '{{ value_json.RfReceived.Data }}'
payload_on: '18F10A'
payload_off: '18F10E'
availability_topic: 'tele/sonoff-rf/LWT'
payload_available: 'Online'
payload_not_available: 'Offline'
device_class: door
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
