### PR TITLE
Add Repetier-Server sensor platform

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -844,6 +844,7 @@ omit =
     homeassistant/components/sensor/xbox_live.py
     homeassistant/components/sensor/zamg.py
     homeassistant/components/sensor/zestimate.py
+    homeassistant/components/sensor/repetier.py
     homeassistant/components/shiftr.py
     homeassistant/components/spc.py
     homeassistant/components/switch/acer_projector.py

--- a/homeassistant/components/sensor/repetier.py
+++ b/homeassistant/components/sensor/repetier.py
@@ -1,0 +1,196 @@
+"""
+Sensor for retrieving Repetier Server status.
+
+by Morten Trab - 2018
+"""
+import logging
+from datetime import timedelta
+
+import requests
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import (CONF_URL,
+                                 CONF_API_KEY,
+                                 CONF_PORT,
+                                 STATE_IDLE,
+                                 STATE_ON,
+                                 STATE_OFF)
+from homeassistant.helpers.entity import Entity
+from homeassistant.util import Throttle
+
+__version__ = '0.2'
+
+_LOGGER = logging.getLogger(__name__)
+
+SCAN_INTERVAL = timedelta(seconds=5)
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_URL): cv.string,
+    vol.Required(CONF_API_KEY): cv.string,
+    vol.Optional(CONF_PORT, default='3344'): cv.string,
+    vol.Optional('decimals', default=1): int,
+    vol.Optional('state_percent', default=False): bool,
+})
+
+DEC_NUM = 0
+SHOW_PCT = True
+
+
+def parse_repetier_api_response(response):
+    """Parse the Repetier Server API json response."""
+    data_dict = {}
+
+    i = 0
+    for printer in response['data']:
+        _key = i
+        i += 1
+        if _key not in data_dict.keys():
+            data_dict[_key] = printer
+        else:
+            data_dict[_key].update(printer)
+    return data_dict
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    """Set up the Repetier sensors."""
+    try:
+        global DEC_NUM
+        global SHOW_PCT
+        DEC_NUM = config.get("decimals")
+        SHOW_PCT = config.get("state_percent")
+
+        data = RepetierData(parse_repetier_api_response, config)
+        data.update()
+        sensors = []
+        for key in data.data.keys():
+            sensors.append(RepetierSensor(key, data))
+        add_devices(sensors, True)
+    except (RuntimeError, TypeError, NameError):
+        _LOGGER.warning("Cannot setup Repetier sensors, check your config")
+
+
+def format_data(self):
+    """Format output data."""
+
+    self._name = self._data.data[self._repetier_id]['name']
+
+    if self._data.data[self._repetier_id]['online'] == 1:
+        if self._data.data[self._repetier_id]['job'] != "none":
+            if SHOW_PCT:
+                self._state = round(self._data.data[self._repetier_id]['done'], DEC_NUM)
+                self._units = '%'
+            else:
+                self._state = STATE_ON
+                self._units = None
+            self._attributes = {
+                'active': self._data.data[self._repetier_id]['active'],
+                'analysed': self._data.data[self._repetier_id]['analysed'],
+                'done': self._data.data[self._repetier_id]['done'],
+                'job': self._data.data[self._repetier_id]['job'],
+                'jobid': self._data.data[self._repetier_id]['jobid'],
+                'linesSend': self._data.data[self._repetier_id]['linesSend'],
+                'ofLayer': self._data.data[self._repetier_id]['ofLayer'],
+                'pauseState': self._data.data[self._repetier_id]['pauseState'],
+                'paused': self._data.data[self._repetier_id]['paused'],
+                'printTime': self._data.data[self._repetier_id]['printTime'],
+                'printedTimeComp': self._data.data[self._repetier_id]['printedTimeComp'],
+                'start': self._data.data[self._repetier_id]['start'],
+                'totalLines': self._data.data[self._repetier_id]['totalLines'],
+                'online': self._data.data[self._repetier_id]['online'],
+            }
+        else:
+            if SHOW_PCT:
+                self._state = STATE_IDLE
+            else:
+                self._state = STATE_ON
+            self._attributes = {
+                'active': self._data.data[self._repetier_id]['active'],
+                'job': self._data.data[self._repetier_id]['job'],
+                'pauseState': self._data.data[self._repetier_id]['pauseState'],
+                'paused': self._data.data[self._repetier_id]['paused'],
+                'online': self._data.data[self._repetier_id]['online'],
+            }
+            self._units = None
+    else:
+        self._state = STATE_OFF
+        self._attributes = {
+            'active': self._data.data[self._repetier_id]['active'],
+            'job': self._data.data[self._repetier_id]['job'],
+            'pauseState': self._data.data[self._repetier_id]['pauseState'],
+            'paused': self._data.data[self._repetier_id]['paused'],
+            'online': self._data.data[self._repetier_id]['online'],
+        }
+        self._units = None
+
+
+class RepetierData(object):
+    """Get the latest sensor data."""
+
+    def __init__(self, parse_repetier_api_response, config):
+        """Initialize the data object."""
+        self.url = self._build_url(config)
+        self.data = None
+        self.parse_repetier_api_response = parse_repetier_api_response
+
+    """Update only once in scan interval."""
+    @Throttle(SCAN_INTERVAL)
+    def update(self):
+        """Get the latest data."""
+        response = requests.get(self.url)
+        if response.status_code != 200:
+            _LOGGER.warning("Invalid response from API")
+        else:
+            self.data = self.parse_repetier_api_response(response.json())
+
+    def _build_url(self, config):
+        url = config.get(CONF_URL)
+        port = config.get(CONF_PORT)
+        api_key = config.get(CONF_API_KEY)
+
+        return url + ":" + port + "/printer/list/?apikey=" + api_key
+
+
+class RepetierSensor(Entity):
+    """Class to hold Repetier Sensor basic info."""
+
+    def __init__(self, repetier_id, data):
+        """Initialize the sensor object."""
+        self._repetier_id = repetier_id
+        self._data = data    # data is in .data
+        self._icon = 'mdi:printer-3d'
+        format_data(self)
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def icon(self):
+        """Icon to use in the frontend, if any."""
+        return self._icon
+
+    @property
+    def unit_of_measurement(self):
+        """Set units of measurement."""
+        return self._units
+
+    @property
+    def device_state_attributes(self):
+        """Attributes."""
+        return self._attributes
+
+    def update(self):
+        """Update the sensor."""
+        try:
+            self._data.update()
+            format_data(self)
+        except (RuntimeError, TypeError, NameError):
+            _LOGGER.error("Error updating Repetier Server sensors")

--- a/homeassistant/components/sensor/repetier.py
+++ b/homeassistant/components/sensor/repetier.py
@@ -62,7 +62,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         DEC_NUM = config.get("decimals")
         SHOW_PCT = config.get("state_percent")
 
-        data = RepetierData(config)
+        data = RepetierData(parse_repetier_api_response, config)
         data.update()
         sensors = []
         for key in data.data.keys():
@@ -154,16 +154,14 @@ def format_data(self):
 class RepetierData():
     """Get the latest sensor data."""
 
-    global parse_repetier_api_response
-
-    def __init__(self, config):
+    def __init__(self, parser, config):
         """Initialize the data object."""
         url = config.get(CONF_URL)
         port = config.get(CONF_PORT)
         api_key = config.get(CONF_API_KEY)
         self.url = url + ":" + port + "/printer/list/?apikey=" + api_key
         self.data = None
-        self.repetier_api_response = parse_repetier_api_response
+        self.repetier_api_response = parser
 
     @Throttle(SCAN_INTERVAL)
     def update(self):

--- a/homeassistant/components/sensor/repetier.py
+++ b/homeassistant/components/sensor/repetier.py
@@ -185,6 +185,10 @@ class RepetierSensor(Entity):
         self._repetier_id = repetier_id
         self._data = data    # data is in .data
         self._icon = 'mdi:printer-3d'
+        self._name = None
+        self._state = STATE_UNKNOWN
+        self._units = None
+        self._attributes = None
         format_data(self)
 
     @property

--- a/homeassistant/components/sensor/repetier.py
+++ b/homeassistant/components/sensor/repetier.py
@@ -15,7 +15,6 @@ from homeassistant.const import (CONF_URL,
                                  CONF_API_KEY,
                                  CONF_PORT,
                                  STATE_IDLE,
-                                 STATE_ON,
                                  STATE_OFF,
                                  STATE_UNKNOWN)
 from homeassistant.helpers.entity import Entity

--- a/homeassistant/components/sensor/repetier.py
+++ b/homeassistant/components/sensor/repetier.py
@@ -153,6 +153,7 @@ def format_data(self):
 
 class RepetierData():
     """Get the latest sensor data."""
+
     global parse_repetier_api_response
 
     def __init__(self, config):

--- a/homeassistant/components/sensor/repetier.py
+++ b/homeassistant/components/sensor/repetier.py
@@ -1,8 +1,8 @@
 """
 Sensor for retrieving Repetier-Server device status.
-Creates one sensor for each device attached to Repetier-Server
 
-by Morten Trab - 2018
+Creates one sensor for each device attached to Repetier-Server
+Created by Morten Trab (morten@trab.dk) - 2018
 """
 from datetime import timedelta
 import logging

--- a/homeassistant/components/sensor/repetier.py
+++ b/homeassistant/components/sensor/repetier.py
@@ -57,12 +57,12 @@ def parse_repetier_api_response(response):
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Repetier sensors."""
     try:
-        global DEC_NUM
+	global DEC_NUM
         global SHOW_PCT
         DEC_NUM = config.get("decimals")
         SHOW_PCT = config.get("state_percent")
 
-        data = RepetierData(parse_repetier_api_response, config)
+        data = RepetierData(config)
         data.update()
         sensors = []
         for key in data.data.keys():
@@ -153,9 +153,11 @@ def format_data(self):
 
 class RepetierData():
     """Get the latest sensor data."""
+    global parse_repetier_api_response
 
-    def __init__(self, parse_repetier_api_response, config):
+    def __init__(self, config):
         """Initialize the data object."""
+        #global parse_repetier_api_response
         url = config.get(CONF_URL)
         port = config.get(CONF_PORT)
         api_key = config.get(CONF_API_KEY)

--- a/homeassistant/components/sensor/repetier.py
+++ b/homeassistant/components/sensor/repetier.py
@@ -1,26 +1,29 @@
 """
-Sensor for retrieving Repetier Server status.
+Sensor for retrieving Repetier-Server device status.
+Creates one sensor for each device attached to Repetier-Server
 
 by Morten Trab - 2018
 """
-import logging
 from datetime import timedelta
+import logging
 
 import requests
 import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import (CONF_URL,
-                                 CONF_API_KEY,
-                                 CONF_PORT,
-                                 STATE_IDLE,
-                                 STATE_OFF,
-                                 STATE_UNKNOWN)
+from homeassistant.const import (
+    CONF_API_KEY,
+    CONF_PORT,
+    CONF_URL,
+    STATE_IDLE,
+    STATE_OFF,
+    STATE_ON,
+    STATE_UNKNOWN)
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 
-__version__ = '0.4'
+__version__ = '0.5'
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -36,7 +39,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 DEC_NUM = 0
 SHOW_PCT = True
-STATE_PRINTING = "printing"
 
 
 def parse_repetier_api_response(response):
@@ -59,8 +61,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     try:
         global DEC_NUM
         global SHOW_PCT
-        DEC_NUM = config.get("decimals")
-        SHOW_PCT = config.get("state_percent")
+        DEC_NUM = config.get('decimals')
+        SHOW_PCT = config.get('state_percent')
 
         data = RepetierData(parse_repetier_api_response, config)
         data.update()
@@ -77,14 +79,14 @@ def format_data(self):
     self._name = self._data.data[self._repetier_id]['name']
 
     if self._data.data[self._repetier_id]['online'] == 1:
-        if self._data.data[self._repetier_id]['job'] != "none":
+        if self._data.data[self._repetier_id]['job'] != 'none':
             if SHOW_PCT:
                 self._state = round(
                     self._data.data[self._repetier_id]['done'],
                     DEC_NUM)
                 self._units = '%'
             else:
-                self._state = STATE_PRINTING
+                self._state = STATE_ON
                 self._units = None
             self._attributes = {
                 'active':
@@ -159,7 +161,7 @@ class RepetierData():
         url = config.get(CONF_URL)
         port = config.get(CONF_PORT)
         api_key = config.get(CONF_API_KEY)
-        self.url = url + ":" + port + "/printer/list/?apikey=" + api_key
+        self.url = url + ':' + port + '/printer/list/?apikey=' + api_key
         self.data = None
         self.repetier_api_response = parser
 

--- a/homeassistant/components/sensor/repetier.py
+++ b/homeassistant/components/sensor/repetier.py
@@ -16,7 +16,8 @@ from homeassistant.const import (CONF_URL,
                                  CONF_PORT,
                                  STATE_IDLE,
                                  STATE_ON,
-                                 STATE_OFF)
+                                 STATE_OFF,
+                                 STATE_UNKNOWN)
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 

--- a/homeassistant/components/sensor/repetier.py
+++ b/homeassistant/components/sensor/repetier.py
@@ -79,8 +79,8 @@ def format_data(self):
         if self._data.data[self._repetier_id]['job'] != "none":
             if SHOW_PCT:
                 self._state = round(
-                        self._data.data[self._repetier_id]['done'],
-                        DEC_NUM)
+                    self._data.data[self._repetier_id]['done'],
+                    DEC_NUM)
                 self._units = '%'
             else:
                 self._state = STATE_ON

--- a/homeassistant/components/sensor/repetier.py
+++ b/homeassistant/components/sensor/repetier.py
@@ -57,7 +57,7 @@ def parse_repetier_api_response(response):
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Repetier sensors."""
     try:
-	global DEC_NUM
+        global DEC_NUM
         global SHOW_PCT
         DEC_NUM = config.get("decimals")
         SHOW_PCT = config.get("state_percent")
@@ -157,7 +157,6 @@ class RepetierData():
 
     def __init__(self, config):
         """Initialize the data object."""
-        #global parse_repetier_api_response
         url = config.get(CONF_URL)
         port = config.get(CONF_PORT)
         api_key = config.get(CONF_API_KEY)

--- a/homeassistant/components/sensor/repetier.py
+++ b/homeassistant/components/sensor/repetier.py
@@ -37,8 +37,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 DEC_NUM = 0
 SHOW_PCT = True
-
 STATE_PRINTING = "printing"
+
 
 def parse_repetier_api_response(response):
     """Parse the Repetier Server API json response."""

--- a/homeassistant/components/sensor/repetier.py
+++ b/homeassistant/components/sensor/repetier.py
@@ -20,7 +20,7 @@ from homeassistant.const import (CONF_URL,
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 
-__version__ = '0.2'
+__version__ = '0.3'
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -73,54 +73,79 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
 def format_data(self):
     """Format output data."""
-
     self._name = self._data.data[self._repetier_id]['name']
 
     if self._data.data[self._repetier_id]['online'] == 1:
         if self._data.data[self._repetier_id]['job'] != "none":
             if SHOW_PCT:
-                self._state = round(self._data.data[self._repetier_id]['done'], DEC_NUM)
+                self._state = round(
+                        self._data.data[self._repetier_id]['done'],
+                        DEC_NUM)
                 self._units = '%'
             else:
                 self._state = STATE_ON
                 self._units = None
             self._attributes = {
-                'active': self._data.data[self._repetier_id]['active'],
-                'analysed': self._data.data[self._repetier_id]['analysed'],
-                'done': self._data.data[self._repetier_id]['done'],
-                'job': self._data.data[self._repetier_id]['job'],
-                'jobid': self._data.data[self._repetier_id]['jobid'],
-                'linesSend': self._data.data[self._repetier_id]['linesSend'],
-                'ofLayer': self._data.data[self._repetier_id]['ofLayer'],
-                'pauseState': self._data.data[self._repetier_id]['pauseState'],
-                'paused': self._data.data[self._repetier_id]['paused'],
-                'printTime': self._data.data[self._repetier_id]['printTime'],
-                'printedTimeComp': self._data.data[self._repetier_id]['printedTimeComp'],
-                'start': self._data.data[self._repetier_id]['start'],
-                'totalLines': self._data.data[self._repetier_id]['totalLines'],
-                'online': self._data.data[self._repetier_id]['online'],
+                'active':
+                    self._data.data[self._repetier_id]['active'],
+                'analysed':
+                    self._data.data[self._repetier_id]['analysed'],
+                'done':
+                    self._data.data[self._repetier_id]['done'],
+                'job':
+                    self._data.data[self._repetier_id]['job'],
+                'jobid':
+                    self._data.data[self._repetier_id]['jobid'],
+                'linesSend':
+                    self._data.data[self._repetier_id]['linesSend'],
+                'ofLayer':
+                    self._data.data[self._repetier_id]['ofLayer'],
+                'pauseState':
+                    self._data.data[self._repetier_id]['pauseState'],
+                'paused':
+                    self._data.data[self._repetier_id]['paused'],
+                'printTime':
+                    self._data.data[self._repetier_id]['printTime'],
+                'printedTimeComp':
+                    self._data.data[self._repetier_id]['printedTimeComp'],
+                'start':
+                    self._data.data[self._repetier_id]['start'],
+                'totalLines':
+                    self._data.data[self._repetier_id]['totalLines'],
+                'online':
+                    self._data.data[self._repetier_id]['online'],
             }
         else:
             if SHOW_PCT:
                 self._state = STATE_IDLE
             else:
-                self._state = STATE_ON
+                self._state = STATE_IDLE
             self._attributes = {
-                'active': self._data.data[self._repetier_id]['active'],
-                'job': self._data.data[self._repetier_id]['job'],
-                'pauseState': self._data.data[self._repetier_id]['pauseState'],
-                'paused': self._data.data[self._repetier_id]['paused'],
-                'online': self._data.data[self._repetier_id]['online'],
+                'active':
+                    self._data.data[self._repetier_id]['active'],
+                'job':
+                    self._data.data[self._repetier_id]['job'],
+                'pauseState':
+                    self._data.data[self._repetier_id]['pauseState'],
+                'paused':
+                    self._data.data[self._repetier_id]['paused'],
+                'online':
+                    self._data.data[self._repetier_id]['online'],
             }
             self._units = None
     else:
         self._state = STATE_OFF
         self._attributes = {
-            'active': self._data.data[self._repetier_id]['active'],
-            'job': self._data.data[self._repetier_id]['job'],
-            'pauseState': self._data.data[self._repetier_id]['pauseState'],
-            'paused': self._data.data[self._repetier_id]['paused'],
-            'online': self._data.data[self._repetier_id]['online'],
+            'active':
+                self._data.data[self._repetier_id]['active'],
+            'job':
+                self._data.data[self._repetier_id]['job'],
+            'pauseState':
+                self._data.data[self._repetier_id]['pauseState'],
+            'paused':
+                self._data.data[self._repetier_id]['paused'],
+            'online':
+                self._data.data[self._repetier_id]['online'],
         }
         self._units = None
 

--- a/man/man1/nosetests.1
+++ b/man/man1/nosetests.1
@@ -1,0 +1,581 @@
+.\" Man page generated from reStructuredText.
+.
+.TH "NOSETESTS" "1" "April 04, 2015" "1.3" "nose"
+.SH NAME
+nosetests \- Nicer testing for Python
+.
+.nr rst2man-indent-level 0
+.
+.de1 rstReportMargin
+\\$1 \\n[an-margin]
+level \\n[rst2man-indent-level]
+level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
+-
+\\n[rst2man-indent0]
+\\n[rst2man-indent1]
+\\n[rst2man-indent2]
+..
+.de1 INDENT
+.\" .rstReportMargin pre:
+. RS \\$1
+. nr rst2man-indent\\n[rst2man-indent-level] \\n[an-margin]
+. nr rst2man-indent-level +1
+.\" .rstReportMargin post:
+..
+.de UNINDENT
+. RE
+.\" indent \\n[an-margin]
+.\" old: \\n[rst2man-indent\\n[rst2man-indent-level]]
+.nr rst2man-indent-level -1
+.\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
+.in \\n[rst2man-indent\\n[rst2man-indent-level]]u
+..
+.SH NICER TESTING FOR PYTHON
+.SS SYNOPSIS
+.INDENT 0.0
+.INDENT 3.5
+nosetests [options] [names]
+.UNINDENT
+.UNINDENT
+.SS DESCRIPTION
+.sp
+nose collects tests automatically from python source files,
+directories and packages found in its working directory (which
+defaults to the current working directory). Any python source file,
+directory or package that matches the testMatch regular expression
+(by default: \fI(?:^|[b_.\-])[Tt]est)\fP will be collected as a test (or
+source for collection of tests). In addition, all other packages
+found in the working directory will be examined for python source files
+or directories that match testMatch. Package discovery descends all
+the way down the tree, so package.tests and package.sub.tests and
+package.sub.sub2.tests will all be collected.
+.sp
+Within a test directory or package, any python source file matching
+testMatch will be examined for test cases. Within a test module,
+functions and classes whose names match testMatch and TestCase
+subclasses with any name will be loaded and executed as tests. Tests
+may use the assert keyword or raise AssertionErrors to indicate test
+failure. TestCase subclasses may do the same or use the various
+TestCase methods available.
+.sp
+\fBIt is important to note that the default behavior of nose is to
+not include tests from files which are executable.\fP  To include
+tests from such files, remove their executable bit or use
+the \-\-exe flag (see \(aqOptions\(aq section below).
+.SS Selecting Tests
+.sp
+To specify which tests to run, pass test names on the command line:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+nosetests only_test_this.py
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Test names specified may be file or module names, and may optionally
+indicate the test case to run by separating the module or file name
+from the test case name with a colon. Filenames may be relative or
+absolute. Examples:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+nosetests test.module
+nosetests another.test:TestCase.test_method
+nosetests a.test:TestCase
+nosetests /path/to/test/file.py:test_function
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+You may also change the working directory where nose looks for tests
+by using the \-w switch:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+nosetests \-w /path/to/tests
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Note, however, that support for multiple \-w arguments is now deprecated
+and will be removed in a future release. As of nose 0.10, you can get
+the same behavior by specifying the target directories \fIwithout\fP
+the \-w switch:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+nosetests /path/to/tests /another/path/to/tests
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+Further customization of test selection and loading is possible
+through the use of plugins.
+.sp
+Test result output is identical to that of unittest, except for
+the additional features (error classes, and plugin\-supplied
+features such as output capture and assert introspection) detailed
+in the options below.
+.SS Configuration
+.sp
+In addition to passing command\-line options, you may also put
+configuration options in your project\(aqs \fIsetup.cfg\fP file, or a .noserc
+or nose.cfg file in your home directory. In any of these standard
+ini\-style config files, you put your nosetests configuration in a
+\fB[nosetests]\fP section. Options are the same as on the command line,
+with the \-\- prefix removed. For options that are simple switches, you
+must supply a value:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+[nosetests]
+verbosity=3
+with\-doctest=1
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+All configuration files that are found will be loaded and their
+options combined. You can override the standard config file loading
+with the \fB\-c\fP option.
+.SS Using Plugins
+.sp
+There are numerous nose plugins available via easy_install and
+elsewhere. To use a plugin, just install it. The plugin will add
+command line options to nosetests. To verify that the plugin is installed,
+run:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+nosetests \-\-plugins
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
+.sp
+You can add \-v or \-vv to that command to show more information
+about each plugin.
+.sp
+If you are running nose.main() or nose.run() from a script, you
+can specify a list of plugins to use by passing a list of plugins
+with the plugins keyword argument.
+.SS 0.9 plugins
+.sp
+nose 1.0 can use SOME plugins that were written for nose 0.9. The
+default plugin manager inserts a compatibility wrapper around 0.9
+plugins that adapts the changed plugin api calls. However, plugins
+that access nose internals are likely to fail, especially if they
+attempt to access test case or test suite classes. For example,
+plugins that try to determine if a test passed to startTest is an
+individual test or a suite will fail, partly because suites are no
+longer passed to startTest and partly because it\(aqs likely that the
+plugin is trying to find out if the test is an instance of a class
+that no longer exists.
+.SS 0.10 and 0.11 plugins
+.sp
+All plugins written for nose 0.10 and 0.11 should work with nose 1.0.
+.SS Options
+.INDENT 0.0
+.TP
+.B \-V, \-\-version
+Output nose version and exit
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-p, \-\-plugins
+Output list of available plugins and exit. Combine with higher verbosity for greater detail
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-v=DEFAULT, \-\-verbose=DEFAULT
+Be more verbose. [NOSE_VERBOSE]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-verbosity=VERBOSITY
+Set verbosity; \-\-verbosity=2 is the same as \-v
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-q=DEFAULT, \-\-quiet=DEFAULT
+Be less verbose
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-c=FILES, \-\-config=FILES
+Load configuration from config file(s). May be specified multiple times; in that case, all config files will be loaded and combined
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-w=WHERE, \-\-where=WHERE
+Look for tests in this directory. May be specified multiple times. The first directory passed will be used as the working directory, in place of the current working directory, which is the default. Others will be added to the list of tests to execute. [NOSE_WHERE]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-py3where=PY3WHERE
+Look for tests in this directory under Python 3.x. Functions the same as \(aqwhere\(aq, but only applies if running under Python 3.x or above.  Note that, if present under 3.x, this option completely replaces any directories specified with \(aqwhere\(aq, so the \(aqwhere\(aq option becomes ineffective. [NOSE_PY3WHERE]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-m=REGEX, \-\-match=REGEX, \-\-testmatch=REGEX
+Files, directories, function names, and class names that match this regular expression are considered tests.  Default: (?:^|[b_./\-])[Tt]est [NOSE_TESTMATCH]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-tests=NAMES
+Run these tests (comma\-separated list). This argument is useful mainly from configuration files; on the command line, just pass the tests to run as additional arguments with no switch.
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-l=DEFAULT, \-\-debug=DEFAULT
+Activate debug logging for one or more systems. Available debug loggers: nose, nose.importer, nose.inspector, nose.plugins, nose.result and nose.selector. Separate multiple names with a comma.
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-debug\-log=FILE
+Log debug messages to this file (default: sys.stderr)
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-logging\-config=FILE, \-\-log\-config=FILE
+Load logging config from this file \-\- bypasses all other logging config settings.
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-I=REGEX, \-\-ignore\-files=REGEX
+Completely ignore any file that matches this regular expression. Takes precedence over any other settings or plugins. Specifying this option will replace the default setting. Specify this option multiple times to add more regular expressions [NOSE_IGNORE_FILES]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-e=REGEX, \-\-exclude=REGEX
+Don\(aqt run tests that match regular expression [NOSE_EXCLUDE]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-i=REGEX, \-\-include=REGEX
+This regular expression will be applied to files, directories, function names, and class names for a chance to include additional tests that do not match TESTMATCH.  Specify this option multiple times to add more regular expressions [NOSE_INCLUDE]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-x, \-\-stop
+Stop running tests after the first error or failure
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-P, \-\-no\-path\-adjustment
+Don\(aqt make any changes to sys.path when loading tests [NOSE_NOPATH]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-exe
+Look for tests in python modules that are executable. Normal behavior is to exclude executable modules, since they may not be import\-safe [NOSE_INCLUDE_EXE]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-noexe
+DO NOT look for tests in python modules that are executable. (The default on the windows platform is to do so.)
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-traverse\-namespace
+Traverse through all path entries of a namespace package
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-first\-package\-wins, \-\-first\-pkg\-wins, \-\-1st\-pkg\-wins
+nose\(aqs importer will normally evict a package from sys.modules if it sees a package with the same name in a different location. Set this option to disable that behavior.
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-no\-byte\-compile
+Prevent nose from byte\-compiling the source into .pyc files while nose is scanning for and running tests.
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-a=ATTR, \-\-attr=ATTR
+Run only tests that have attributes specified by ATTR [NOSE_ATTR]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-A=EXPR, \-\-eval\-attr=EXPR
+Run only tests for whose attributes the Python expression EXPR evaluates to True [NOSE_EVAL_ATTR]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-s, \-\-nocapture
+Don\(aqt capture stdout (any stdout output will be printed immediately) [NOSE_NOCAPTURE]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-nologcapture
+Disable logging capture plugin. Logging configuration will be left intact. [NOSE_NOLOGCAPTURE]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-logging\-format=FORMAT
+Specify custom format to print statements. Uses the same format as used by standard logging handlers. [NOSE_LOGFORMAT]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-logging\-datefmt=FORMAT
+Specify custom date/time format to print statements. Uses the same format as used by standard logging handlers. [NOSE_LOGDATEFMT]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-logging\-filter=FILTER
+Specify which statements to filter in/out. By default, everything is captured. If the output is too verbose,
+use this option to filter out needless output.
+Example: filter=foo will capture statements issued ONLY to
+ foo or foo.what.ever.sub but not foobar or other logger.
+Specify multiple loggers with comma: filter=foo,bar,baz.
+If any logger name is prefixed with a minus, eg filter=\-foo,
+it will be excluded rather than included. Default: exclude logging messages from nose itself (\-nose). [NOSE_LOGFILTER]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-logging\-clear\-handlers
+Clear all other logging handlers
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-logging\-level=DEFAULT
+Set the log level to capture
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-with\-coverage
+Enable plugin Coverage: 
+Activate a coverage report using Ned Batchelder\(aqs coverage module.
+ [NOSE_WITH_COVERAGE]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-cover\-package=PACKAGE
+Restrict coverage output to selected packages [NOSE_COVER_PACKAGE]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-cover\-erase
+Erase previously collected coverage statistics before run
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-cover\-tests
+Include test modules in coverage report [NOSE_COVER_TESTS]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-cover\-min\-percentage=DEFAULT
+Minimum percentage of coverage for tests to pass [NOSE_COVER_MIN_PERCENTAGE]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-cover\-inclusive
+Include all python files under working directory in coverage report.  Useful for discovering holes in test coverage if not all files are imported by the test suite. [NOSE_COVER_INCLUSIVE]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-cover\-html
+Produce HTML coverage information
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-cover\-html\-dir=DIR
+Produce HTML coverage information in dir
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-cover\-branches
+Include branch coverage in coverage report [NOSE_COVER_BRANCHES]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-cover\-xml
+Produce XML coverage information
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-cover\-xml\-file=FILE
+Produce XML coverage information in file
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-pdb
+Drop into debugger on failures or errors
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-pdb\-failures
+Drop into debugger on failures
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-pdb\-errors
+Drop into debugger on errors
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-no\-deprecated
+Disable special handling of DeprecatedTest exceptions.
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-with\-doctest
+Enable plugin Doctest: 
+Activate doctest plugin to find and run doctests in non\-test modules.
+ [NOSE_WITH_DOCTEST]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-doctest\-tests
+Also look for doctests in test modules. Note that classes, methods and functions should have either doctests or non\-doctest tests, not both. [NOSE_DOCTEST_TESTS]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-doctest\-extension=EXT
+Also look for doctests in files with this extension [NOSE_DOCTEST_EXTENSION]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-doctest\-result\-variable=VAR
+Change the variable name set to the result of the last interpreter command from the default \(aq_\(aq. Can be used to avoid conflicts with the _() function used for text translation. [NOSE_DOCTEST_RESULT_VAR]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-doctest\-fixtures=SUFFIX
+Find fixtures for a doctest file in module with this name appended to the base name of the doctest file
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-doctest\-options=OPTIONS
+Specify options to pass to doctest. Eg. \(aq+ELLIPSIS,+NORMALIZE_WHITESPACE\(aq
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-with\-isolation
+Enable plugin IsolationPlugin: 
+Activate the isolation plugin to isolate changes to external
+modules to a single test module or package. The isolation plugin
+resets the contents of sys.modules after each test module or
+package runs to its state before the test. PLEASE NOTE that this
+plugin should not be used with the coverage plugin, or in any other case
+where module reloading may produce undesirable side\-effects.
+ [NOSE_WITH_ISOLATION]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-d, \-\-detailed\-errors, \-\-failure\-detail
+Add detail to error output by attempting to evaluate failed asserts [NOSE_DETAILED_ERRORS]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-with\-profile
+Enable plugin Profile: 
+Use this plugin to run tests using the hotshot profiler. 
+ [NOSE_WITH_PROFILE]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-profile\-sort=SORT
+Set sort order for profiler output
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-profile\-stats\-file=FILE
+Profiler stats file; default is a new temp file on each run
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-profile\-restrict=RESTRICT
+Restrict profiler output. See help for pstats.Stats for details
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-no\-skip
+Disable special handling of SkipTest exceptions.
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-with\-id
+Enable plugin TestId: 
+Activate to add a test id (like #1) to each test name output. Activate
+with \-\-failed to rerun failing tests only.
+ [NOSE_WITH_ID]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-id\-file=FILE
+Store test ids found in test runs in this file. Default is the file .noseids in the working directory.
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-failed
+Run the tests that failed in the last test run.
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-processes=NUM
+Spread test run among this many processes. Set a number equal to the number of processors or cores in your machine for best results. Pass a negative number to have the number of processes automatically set to the number of cores. Passing 0 means to disable parallel testing. Default is 0 unless NOSE_PROCESSES is set. [NOSE_PROCESSES]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-process\-timeout=SECONDS
+Set timeout for return of results from each test runner process. Default is 10. [NOSE_PROCESS_TIMEOUT]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-process\-restartworker
+If set, will restart each worker process once their tests are done, this helps control memory leaks from killing the system. [NOSE_PROCESS_RESTARTWORKER]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-with\-xunit
+Enable plugin Xunit: This plugin provides test results in the standard XUnit XML format. [NOSE_WITH_XUNIT]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-xunit\-file=FILE
+Path to xml file to store the xunit report in. Default is nosetests.xml in the working directory [NOSE_XUNIT_FILE]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-xunit\-testsuite\-name=PACKAGE
+Name of the testsuite in the xunit xml, generated by plugin. Default test suite name is nosetests.
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-all\-modules
+Enable plugin AllModules: Collect tests from all python modules.
+ [NOSE_ALL_MODULES]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-collect\-only
+Enable collect\-only: 
+Collect and output test names only, don\(aqt run any tests.
+ [COLLECT_ONLY]
+.UNINDENT
+.SH AUTHOR
+Nose developers
+.SH COPYRIGHT
+2009, Jason Pellerin
+.\" Generated by docutils manpage writer.
+.


### PR DESCRIPTION
## Description:
Adding Repetier-Server sensor for each device in your Repetier-Server

## Example entry for `configuration.yaml` (if applicable):
```yaml
# Example configuration.yaml entry
sensor:
  - platform: repetier
    url: http://IP_ADDRESS
    port: PORT
    api_key: YOUR_API_KEY
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New files were added to `.coveragerc`.
