### PR TITLE
remove the need to have query feature support

### DIFF
--- a/homeassistant/components/influxdb.py
+++ b/homeassistant/components/influxdb.py
@@ -136,7 +136,7 @@ def setup(hass, config):
 
     try:
         influx = InfluxDBClient(**kwargs)
-        influx.query("SHOW SERIES LIMIT 1;", database=conf[CONF_DB_NAME])
+        influx.write_points([])
     except (exceptions.InfluxDBClientError,
             requests.exceptions.ConnectionError) as exc:
         _LOGGER.error("Database host is not accessible due to '%s', please "

--- a/tests/components/test_influxdb.py
+++ b/tests/components/test_influxdb.py
@@ -3,8 +3,6 @@ import datetime
 import unittest
 from unittest import mock
 
-import influxdb as influx_client
-
 from homeassistant.setup import setup_component
 import homeassistant.components.influxdb as influxdb
 from homeassistant.const import EVENT_STATE_CHANGED, STATE_OFF, STATE_ON, \

--- a/tests/components/test_influxdb.py
+++ b/tests/components/test_influxdb.py
@@ -82,19 +82,6 @@ class TestInfluxDB(unittest.TestCase):
 
         assert not setup_component(self.hass, influxdb.DOMAIN, config)
 
-    def test_setup_query_fail(self, mock_client):
-        """Test the setup for query failures."""
-        config = {
-            'influxdb': {
-                'host': 'host',
-                'username': 'user',
-                'password': 'pass',
-            }
-        }
-        mock_client.return_value.query.side_effect = \
-            influx_client.exceptions.InfluxDBClientError('fake')
-        assert not setup_component(self.hass, influxdb.DOMAIN, config)
-
     def _setup(self, **kwargs):
         """Set up the client."""
         config = {

--- a/tests/components/test_influxdb.py
+++ b/tests/components/test_influxdb.py
@@ -48,7 +48,7 @@ class TestInfluxDB(unittest.TestCase):
         assert self.hass.bus.listen.called
         assert \
             EVENT_STATE_CHANGED == self.hass.bus.listen.call_args_list[0][0][0]
-        assert mock_client.return_value.query.called
+        assert mock_client.return_value.write_points.call_count == 1
 
     def test_setup_config_defaults(self, mock_client):
         """Test the setup with default configuration."""

--- a/tests/components/test_influxdb.py
+++ b/tests/components/test_influxdb.py
@@ -323,6 +323,7 @@ class TestInfluxDB(unittest.TestCase):
         }
         assert setup_component(self.hass, influxdb.DOMAIN, config)
         self.handler_method = self.hass.bus.listen.call_args_list[0][0][1]
+        mock_client.return_value.write_points.reset_mock()
 
         for entity_id in ('included', 'default'):
             state = mock.MagicMock(
@@ -364,6 +365,7 @@ class TestInfluxDB(unittest.TestCase):
         }
         assert setup_component(self.hass, influxdb.DOMAIN, config)
         self.handler_method = self.hass.bus.listen.call_args_list[0][0][1]
+        mock_client.return_value.write_points.reset_mock()
 
         for domain in ('fake', 'another_fake'):
             state = mock.MagicMock(
@@ -456,6 +458,7 @@ class TestInfluxDB(unittest.TestCase):
         }
         assert setup_component(self.hass, influxdb.DOMAIN, config)
         self.handler_method = self.hass.bus.listen.call_args_list[0][0][1]
+        mock_client.return_value.write_points.reset_mock()
 
         for entity_id in ('ok', 'blacklisted'):
             state = mock.MagicMock(
@@ -495,6 +498,7 @@ class TestInfluxDB(unittest.TestCase):
         }
         assert setup_component(self.hass, influxdb.DOMAIN, config)
         self.handler_method = self.hass.bus.listen.call_args_list[0][0][1]
+        mock_client.return_value.write_points.reset_mock()
 
         attrs = {
             'unit_of_measurement': 'foobars',
@@ -534,6 +538,7 @@ class TestInfluxDB(unittest.TestCase):
         }
         assert setup_component(self.hass, influxdb.DOMAIN, config)
         self.handler_method = self.hass.bus.listen.call_args_list[0][0][1]
+        mock_client.return_value.write_points.reset_mock()
 
         attrs = {
             'friendly_fake': 'tag_str',
@@ -590,6 +595,7 @@ class TestInfluxDB(unittest.TestCase):
         }
         assert setup_component(self.hass, influxdb.DOMAIN, config)
         self.handler_method = self.hass.bus.listen.call_args_list[0][0][1]
+        mock_client.return_value.write_points.reset_mock()
 
         test_components = [
             {'domain': 'sensor', 'id': 'fake_humidity', 'res': 'humidity'},
@@ -633,6 +639,7 @@ class TestInfluxDB(unittest.TestCase):
         }
         assert setup_component(self.hass, influxdb.DOMAIN, config)
         self.handler_method = self.hass.bus.listen.call_args_list[0][0][1]
+        mock_client.return_value.write_points.reset_mock()
 
         state = mock.MagicMock(
             state=1, domain='fake', entity_id='entity.id', object_id='entity',


### PR DESCRIPTION
## Description:

Some InfluxDB servers don't have /query support feature but are still valid servers for storing data.
Usually those servers are proxies to others timeseries databases.
Exemple of OVH Metrics https://docs.ovh.com/gb/en/metrics/protocol-overview/ where data can be pushed with InfluxDB and query with OpenTSdB/Graphite/Prometeus/...

The proposal still validates the configuration but with less feature requirements on the server side.

## Example entry for `configuration.yaml` (if applicable):
Regular Influxdb yaml configuration.

```yaml
influxdb:
  host: influxdb.gra1.metrics.ovh.net
  port: 443
  database: homeassistant
  username: token
  password: verylongtoken
  ssl: true
  verify_ssl: true
  max_retries: 3
  default_measurement: state
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.
