### PR TITLE
Expose ZoneMinder availability to Home Assistant

### DIFF
--- a/homeassistant/components/camera/zoneminder.py
+++ b/homeassistant/components/camera/zoneminder.py
@@ -44,6 +44,7 @@ class ZoneMinderCamera(MjpegCamera):
         }
         super().__init__(device_info)
         self._is_recording = None
+        self._is_available = None
         self._monitor = monitor
 
     @property
@@ -55,8 +56,14 @@ class ZoneMinderCamera(MjpegCamera):
         """Update our recording state from the ZM API."""
         _LOGGER.debug("Updating camera state for monitor %i", self._monitor.id)
         self._is_recording = self._monitor.is_recording
+        self._is_available = self._monitor.is_available
 
     @property
     def is_recording(self):
         """Return whether the monitor is in alarm mode."""
         return self._is_recording
+
+    @property
+    def available(self):
+        """Return True if entity is available."""
+        return self._is_available

--- a/homeassistant/components/sensor/zoneminder.py
+++ b/homeassistant/components/sensor/zoneminder.py
@@ -64,7 +64,8 @@ class ZMSensorMonitors(Entity):
     def __init__(self, monitor):
         """Initialize monitor sensor."""
         self._monitor = monitor
-        self._state = monitor.function.value
+        self._state = None
+        self._is_available = None
 
     @property
     def name(self):
@@ -76,6 +77,11 @@ class ZMSensorMonitors(Entity):
         """Return the state of the sensor."""
         return self._state
 
+    @property
+    def available(self):
+        """Return True if Monitor is available."""
+        return self._is_available
+
     def update(self):
         """Update the sensor."""
         state = self._monitor.function
@@ -83,6 +89,7 @@ class ZMSensorMonitors(Entity):
             self._state = None
         else:
             self._state = state.value
+        self._is_available = self._monitor.is_available
 
 
 class ZMSensorEvents(Entity):
@@ -123,6 +130,7 @@ class ZMSensorRunState(Entity):
     def __init__(self, client):
         """Initialize run state sensor."""
         self._state = None
+        self._is_available = None
         self._client = client
 
     @property
@@ -135,6 +143,12 @@ class ZMSensorRunState(Entity):
         """Return the state of the sensor."""
         return self._state
 
+    @property
+    def available(self):
+        """Return True if ZoneMinder is available."""
+        return self._is_available
+
     def update(self):
         """Update the sensor."""
         self._state = self._client.get_active_state()
+        self._is_available = self._client.is_available

--- a/homeassistant/components/zoneminder/__init__.py
+++ b/homeassistant/components/zoneminder/__init__.py
@@ -15,7 +15,7 @@ import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['zm-py==0.1.0']
+REQUIREMENTS = ['zm-py==0.2.0']
 
 CONF_PATH_ZMS = 'path_zms'
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1679,4 +1679,4 @@ zigpy-xbee==0.1.1
 zigpy==0.2.0
 
 # homeassistant.components.zoneminder
-zm-py==0.1.0
+zm-py==0.2.0


### PR DESCRIPTION
## Description:
Ties in the availability from ZoneMinder monitors to the camera and sensor entities created in Home Assistant.

**Related issue (if applicable):** fixes https://github.com/rohankapoorcom/zm-py/issues/20
Depends on https://github.com/rohankapoorcom/zm-py/pull/24

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
