### PR TITLE
Fix MQTT re-subscription logic

### DIFF
--- a/homeassistant/components/mqtt/subscription.py
+++ b/homeassistant/components/mqtt/subscription.py
@@ -34,6 +34,11 @@ class EntitySubscription:
 
         if other is not None and other.unsubscribe_callback is not None:
             other.unsubscribe_callback()
+
+        if self.topic is None:
+            # We were asked to remove the subscription or not to create it
+            return
+
         self.unsubscribe_callback = await mqtt.async_subscribe(
             hass, self.topic, self.message_callback,
             self.qos, self.encoding

--- a/homeassistant/components/mqtt/subscription.py
+++ b/homeassistant/components/mqtt/subscription.py
@@ -5,45 +5,75 @@ For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/mqtt/
 """
 import logging
+from typing import Any, Callable, Dict, Optional
+
+import attr
 
 from homeassistant.components import mqtt
-from homeassistant.components.mqtt import DEFAULT_QOS
-from homeassistant.loader import bind_hass
+from homeassistant.components.mqtt import DEFAULT_QOS, MessageCallbackType
 from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.loader import bind_hass
 
 _LOGGER = logging.getLogger(__name__)
 
 
+@attr.s(slots=True)
+class EntitySubscription:
+    """Class to hold data about an active entity topic subscription."""
+
+    topic = attr.ib(type=str)
+    message_callback = attr.ib(type=MessageCallbackType)
+    unsubscribe_callback = attr.ib(type=Optional[Callable[[], None]])
+    qos = attr.ib(type=int, default=0)
+    encoding = attr.ib(type=str, default='utf-8')
+
+    def should_resubscribe(self, other):
+        """Check if we should re-subscribe to the topic using the old state."""
+        if other is None:
+            return True
+
+        return self.topic != other.topic or self.qos != other.qos or \
+            self.encoding != other.encoding
+
+
 @bind_hass
-async def async_subscribe_topics(hass: HomeAssistantType, sub_state: dict,
-                                 topics: dict):
+async def async_subscribe_topics(hass: HomeAssistantType,
+                                 new_state: Optional[Dict[str,
+                                                          EntitySubscription]],
+                                 topics: Dict[str, Any]):
     """(Re)Subscribe to a set of MQTT topics.
 
-    State is kept in sub_state.
+    State is kept in sub_state and a dictionary mapping from the subscription
+    key to the subscription state
     """
-    cur_state = sub_state if sub_state is not None else {}
-    sub_state = {}
-    for key in topics:
-        topic = topics[key].get('topic', None)
-        msg_callback = topics[key].get('msg_callback', None)
-        qos = topics[key].get('qos', DEFAULT_QOS)
-        encoding = topics[key].get('encoding', 'utf-8')
-        topic = (topic, msg_callback, qos, encoding)
-        (cur_topic, unsub) = cur_state.pop(
-            key, ((None, None, None, None), None))
+    current_subscriptions = new_state if new_state is not None else {}
+    new_state = {}
+    for key, value in topics.items():
+        # Extract the new requested subscription
+        requested = EntitySubscription(
+            topic=value.get('topic', None),
+            message_callback=value.get('msg_callback', None),
+            unsubscribe_callback=None,
+            qos=value.get('qos', DEFAULT_QOS),
+            encoding=value.get('encoding', 'utf-8'),
+        )
+        # Get the current subscription state
+        current = current_subscriptions.pop(key, None)
 
-        if topic != cur_topic and topic[0] is not None:
-            if unsub is not None:
-                unsub()
-            unsub = await mqtt.async_subscribe(
-                hass, topic[0], topic[1], topic[2], topic[3])
-        sub_state[key] = (topic, unsub)
+        # Re-subscribe if we need to
+        if requested.should_resubscribe(current):
+            if requested.unsubscribe_callback is not None:
+                requested.unsubscribe_callback()
+            requested.unsubscribe_callback = await mqtt.async_subscribe(
+                hass, requested.topic, requested.message_callback,
+                requested.qos, requested.encoding)
+        new_state[key] = requested
 
-    for key, (topic, unsub) in list(cur_state.items()):
-        if unsub is not None:
-            unsub()
+    for remaining in current_subscriptions.values():
+        if remaining.unsubscribe_callback is not None:
+            remaining.unsubscribe_callback()
 
-    return sub_state
+    return new_state
 
 
 @bind_hass

--- a/homeassistant/components/mqtt/subscription.py
+++ b/homeassistant/components/mqtt/subscription.py
@@ -28,6 +28,7 @@ class EntitySubscription:
     encoding = attr.ib(type=str, default='utf-8')
 
     async def resubscribe_if_necessary(self, hass, other):
+        """Re-subscribe to the new topic if necessary."""
         if not self._should_resubscribe(other):
             return
 

--- a/tests/components/mqtt/test_subscription.py
+++ b/tests/components/mqtt/test_subscription.py
@@ -99,15 +99,15 @@ async def test_modify_topics(hass, mqtt_mock, caplog):
     async_fire_mqtt_message(hass, 'test-topic2', 'test-payload')
     await hass.async_block_till_done()
     await hass.async_block_till_done()
-    assert 1 == len(calls1)
+    assert 2 == len(calls1)
     assert 1 == len(calls2)
 
     async_fire_mqtt_message(hass, 'test-topic1_1', 'test-payload')
     await hass.async_block_till_done()
     await hass.async_block_till_done()
-    assert 2 == len(calls1)
-    assert 'test-topic1_1' == calls1[1][0]
-    assert 'test-payload' == calls1[1][1]
+    assert 3 == len(calls1)
+    assert 'test-topic1_1' == calls1[2][0]
+    assert 'test-payload' == calls1[2][1]
     assert 1 == len(calls2)
 
     await async_unsubscribe_topics(hass, sub_state)
@@ -116,7 +116,7 @@ async def test_modify_topics(hass, mqtt_mock, caplog):
     async_fire_mqtt_message(hass, 'test-topic2', 'test-payload')
 
     await hass.async_block_till_done()
-    assert 2 == len(calls1)
+    assert 3 == len(calls1)
     assert 1 == len(calls2)
 
 

--- a/tests/components/mqtt/test_subscription.py
+++ b/tests/components/mqtt/test_subscription.py
@@ -99,15 +99,15 @@ async def test_modify_topics(hass, mqtt_mock, caplog):
     async_fire_mqtt_message(hass, 'test-topic2', 'test-payload')
     await hass.async_block_till_done()
     await hass.async_block_till_done()
-    assert 2 == len(calls1)
+    assert 1 == len(calls1)
     assert 1 == len(calls2)
 
     async_fire_mqtt_message(hass, 'test-topic1_1', 'test-payload')
     await hass.async_block_till_done()
     await hass.async_block_till_done()
-    assert 3 == len(calls1)
-    assert 'test-topic1_1' == calls1[2][0]
-    assert 'test-payload' == calls1[2][1]
+    assert 2 == len(calls1)
+    assert 'test-topic1_1' == calls1[1][0]
+    assert 'test-payload' == calls1[1][1]
     assert 1 == len(calls2)
 
     await async_unsubscribe_topics(hass, sub_state)
@@ -116,7 +116,7 @@ async def test_modify_topics(hass, mqtt_mock, caplog):
     async_fire_mqtt_message(hass, 'test-topic2', 'test-payload')
 
     await hass.async_block_till_done()
-    assert 3 == len(calls1)
+    assert 2 == len(calls1)
     assert 1 == len(calls2)
 
 


### PR DESCRIPTION
## Description:

The old re-subscription logic was wrong and re-subscribing when the topic _didn't_ change (see log in attached issue). I didn't step through the old code to figure out what the issue was because it was quite messy and hard to understand. But I suspect it's two things combined:
* the comparison of the message callback (will never be the same if an anonymous method)
* the unsub() *callback* directly followed by the re-subscribe *coroutine* (a race condition)

Instead, I rewrote the code to be (I think) easier to understand using some nice attr data classes.
Using some quick testing I was able to confirm that the issue is resolved with this.

~~Also, the tests seem to be incorrect. I manually stepped through them and couldn't understand why the previous checks were there. The new comparisons look more correct to me when manually stepping through.~~ Nevermind (the tests are way too long and should probably be split up at some point)

(if there's another patch release, it would be great to include it there)

**Related issue (if applicable):** fixes #18909

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

CC: @emontnemery @balloob 