### PR TITLE
Update requirement btsmarthub_devicelist==0.1.3

### DIFF
--- a/homeassistant/components/device_tracker/bt_smarthub.py
+++ b/homeassistant/components/device_tracker/bt_smarthub.py
@@ -13,7 +13,7 @@ from homeassistant.components.device_tracker import (
     DOMAIN, PLATFORM_SCHEMA, DeviceScanner)
 from homeassistant.const import CONF_HOST
 
-REQUIREMENTS = ['btsmarthub_devicelist>=0.1.3']
+REQUIREMENTS = ['btsmarthub_devicelist==0.1.3']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/device_tracker/bt_smarthub.py
+++ b/homeassistant/components/device_tracker/bt_smarthub.py
@@ -13,7 +13,7 @@ from homeassistant.components.device_tracker import (
     DOMAIN, PLATFORM_SCHEMA, DeviceScanner)
 from homeassistant.const import CONF_HOST
 
-REQUIREMENTS = ['btsmarthub_devicelist==0.1.1']
+REQUIREMENTS = ['btsmarthub_devicelist==0.1.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/device_tracker/bt_smarthub.py
+++ b/homeassistant/components/device_tracker/bt_smarthub.py
@@ -13,7 +13,7 @@ from homeassistant.components.device_tracker import (
     DOMAIN, PLATFORM_SCHEMA, DeviceScanner)
 from homeassistant.const import CONF_HOST
 
-REQUIREMENTS = ['btsmarthub_devicelist==0.1.2']
+REQUIREMENTS = ['btsmarthub_devicelist>=0.1.3']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -230,7 +230,7 @@ bt_proximity==0.1.2
 bthomehub5-devicelist==0.1.1
 
 # homeassistant.components.device_tracker.bt_smarthub
-btsmarthub_devicelist==0.1.1
+btsmarthub_devicelist==0.1.2
 
 # homeassistant.components.sensor.buienradar
 # homeassistant.components.weather.buienradar

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -230,7 +230,7 @@ bt_proximity==0.1.2
 bthomehub5-devicelist==0.1.1
 
 # homeassistant.components.device_tracker.bt_smarthub
-btsmarthub_devicelist==0.1.2
+btsmarthub_devicelist==0.1.3
 
 # homeassistant.components.sensor.buienradar
 # homeassistant.components.weather.buienradar


### PR DESCRIPTION
## Description:
Updated to require btsmarthub_devicelist 1.1.2 to fix keyerror logs

**Related issue (if applicable):** fixes issue where unnecessary keyerrors would be displayed in the HA log 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
