### PR TITLE
Mock out device tracker configuration loading funcs in Geofency + OwnTracks

### DIFF
--- a/tests/components/geofency/test_init.py
+++ b/tests/components/geofency/test_init.py
@@ -104,6 +104,11 @@ BEACON_EXIT_CAR = {
 }
 
 
+@pytest.fixture(autouse=True)
+def mock_dev_track(mock_device_tracker_conf):
+    pass
+
+
 @pytest.fixture
 def geofency_client(loop, hass, hass_client):
     """Geofency mock client."""

--- a/tests/components/geofency/test_init.py
+++ b/tests/components/geofency/test_init.py
@@ -106,6 +106,7 @@ BEACON_EXIT_CAR = {
 
 @pytest.fixture(autouse=True)
 def mock_dev_track(mock_device_tracker_conf):
+    """Mock device tracker config loading."""
     pass
 
 

--- a/tests/components/owntracks/test_init.py
+++ b/tests/components/owntracks/test_init.py
@@ -33,6 +33,11 @@ LOCATION_MESSAGE = {
 }
 
 
+@pytest.fixture(autouse=True)
+def mock_dev_track(mock_device_tracker_conf):
+    pass
+
+
 @pytest.fixture
 def mock_client(hass, aiohttp_client):
     """Start the Hass HTTP component."""

--- a/tests/components/owntracks/test_init.py
+++ b/tests/components/owntracks/test_init.py
@@ -35,6 +35,7 @@ LOCATION_MESSAGE = {
 
 @pytest.fixture(autouse=True)
 def mock_dev_track(mock_device_tracker_conf):
+    """Mock device tracker config loading."""
     pass
 
 


### PR DESCRIPTION
## Description:
Mock out the device tracker conf loading/saving funcs during tests.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
