### PR TITLE
Improve validation error message

### DIFF
--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -11,7 +11,6 @@ from typing import (  # noqa: F401 pylint: disable=unused-import
     Any, Tuple, Optional, Dict, List, Union, Callable, Sequence, Set)
 from types import ModuleType
 import voluptuous as vol
-from voluptuous.humanize import humanize_error
 
 from homeassistant import auth
 from homeassistant.auth import providers as auth_providers,\

--- a/homeassistant/util/voluptuous.py
+++ b/homeassistant/util/voluptuous.py
@@ -1,0 +1,30 @@
+"""Helpers for dealing with the voluptuous validator."""
+import json
+from typing import Any
+
+import voluptuous as vol
+
+
+def _nested_getitem(data: Any, ex: vol.Invalid) -> Any:
+    """Try to find the configuration of the voluptuous configuration error."""
+    for item_index in ex.path:
+        try:
+            data = data[item_index]
+        except (KeyError, IndexError, TypeError):
+            return None
+    return data
+
+
+def humanize_error(config: Any, ex: vol.Invalid) -> str:
+    """Generate a human-readable representation of the voluptuous exception."""
+    offending_item = _nested_getitem(config, ex)
+    if isinstance(offending_item, dict):
+        try:
+            # Try to use JSON for dictionaries - otherwise
+            # the user will be greeted by a nice "OrderedDict([("key", ...)])
+            # message
+            offending_item = json.dumps(offending_item)
+        except (ValueError, TypeError):
+            # Was not JSON-serializable, fallback to __str__
+            pass
+    return '{}. Got {}'.format(ex, offending_item)


### PR DESCRIPTION
## Description:

Improve the way validation errors are presented to the user. This is a backport of some features in esphomeyaml.

* Replace unreadable `OrderedDict(...)` offending item summaries with JSON encoded ones.
* If multiple validation errors occur, print all of them.
* Print the path to the validation error for all errors
* Better warnings for `vol.Required` validation errors.

Will add tests once this idea is accepted.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
