### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -51,6 +51,7 @@ homeassistant/components/alarm_control_panel/egardia.py @jeroenterheerdt
 homeassistant/components/alarm_control_panel/manual_mqtt.py @colinodell
 homeassistant/components/binary_sensor/hikvision.py @mezz64
 homeassistant/components/binary_sensor/threshold.py @fabaff
+homeassistant/components/binary_sensor/uptimerobot.py @ludeeus
 homeassistant/components/camera/yi.py @bachya
 homeassistant/components/climate/ephember.py @ttroy50
 homeassistant/components/climate/eq3btsmart.py @rytilahti
@@ -61,9 +62,11 @@ homeassistant/components/cover/group.py @cdce8p
 homeassistant/components/cover/template.py @PhracturedBlue
 homeassistant/components/device_tracker/asuswrt.py @kennedyshead
 homeassistant/components/device_tracker/automatic.py @armills
+homeassistant/components/device_tracker/googlehome.py @ludeeus
 homeassistant/components/device_tracker/huawei_router.py @abmantis
 homeassistant/components/device_tracker/quantum_gateway.py @cisasteelersfan
 homeassistant/components/device_tracker/tile.py @bachya
+homeassistant/components/device_tracker/traccar.py @ludeeus
 homeassistant/components/device_tracker/bt_smarthub.py @jxwolstenholme
 homeassistant/components/history_graph.py @andrey-git
 homeassistant/components/influx.py @fabaff
@@ -109,6 +112,7 @@ homeassistant/components/sensor/glances.py @fabaff
 homeassistant/components/sensor/gpsd.py @fabaff
 homeassistant/components/sensor/irish_rail_transport.py @ttroy50
 homeassistant/components/sensor/jewish_calendar.py @tsvi
+homeassistant/components/sensor/launch_library.py @ludeeus
 homeassistant/components/sensor/linux_battery.py @fabaff
 homeassistant/components/sensor/miflora.py @danielhiversen @ChristianKuehnel
 homeassistant/components/sensor/min_max.py @fabaff
@@ -119,6 +123,7 @@ homeassistant/components/sensor/pi_hole.py @fabaff
 homeassistant/components/sensor/pollen.py @bachya
 homeassistant/components/sensor/pvoutput.py @fabaff
 homeassistant/components/sensor/qnap.py @colinodell
+homeassistant/components/sensor/ruter.py @ludeeus
 homeassistant/components/sensor/scrape.py @fabaff
 homeassistant/components/sensor/serial.py @fabaff
 homeassistant/components/sensor/seventeentrack.py @bachya
@@ -128,6 +133,7 @@ homeassistant/components/sensor/sql.py @dgomes
 homeassistant/components/sensor/statistics.py @fabaff
 homeassistant/components/sensor/swiss*.py @fabaff
 homeassistant/components/sensor/sytadin.py @gautric
+homeassistant/components/sensor/tautulli.py @ludeeus
 homeassistant/components/sensor/time_data.py @fabaff
 homeassistant/components/sensor/version.py @fabaff
 homeassistant/components/sensor/waqi.py @andrey-git
@@ -157,6 +163,7 @@ homeassistant/components/*/bmw_connected_drive.py @ChristianKuehnel
 homeassistant/components/*/broadlink.py @danielhiversen
 
 # C
+homeassistant/components/cloudflare.py @ludeeus
 homeassistant/components/counter/* @fabaff
 
 # D


### PR DESCRIPTION
## Description:
Adds @ludeeus as codeowner to these files:

- homeassistant/components/binary_sensor/uptimerobot.py
- homeassistant/components/device_tracker/googlehome.py
- homeassistant/components/device_tracker/traccar.py
- homeassistant/components/sensor/launch_library.py
- homeassistant/components/sensor/ruter.py
- homeassistant/components/sensor/tautulli.py
- homeassistant/components/cloudflare.py

<!--
**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
-->
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
