### PR TITLE
Lovelace fix: no ordered dict

### DIFF
--- a/homeassistant/components/lovelace/__init__.py
+++ b/homeassistant/components/lovelace/__init__.py
@@ -271,7 +271,6 @@ def add_card(fname: str, view_id: str, card_config: str,
             card_config = yaml.yaml_to_object(card_config)
         if 'id' not in card_config:
             card_config['id'] = uuid.uuid4().hex
-            card_config.move_to_end('id', last=False)
         if position is None:
             cards.append(card_config)
         else:
@@ -396,7 +395,6 @@ def add_view(fname: str, view_config: str,
         view_config = yaml.yaml_to_object(view_config)
     if 'id' not in view_config:
         view_config['id'] = uuid.uuid4().hex
-        view_config.move_to_end('id', last=False)
     if position is None:
         views.append(view_config)
     else:


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
