### PR TITLE
Add unnecessary-pass for pylint-update

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -12,6 +12,7 @@
 # abstract-method - with intro of async there are always methods missing
 # inconsistent-return-statements - doesn't handle raise
 # not-an-iterable - https://github.com/PyCQA/pylint/issues/2311
+# unnecessary-pass - readability for functions which only contain pass
 disable=
   abstract-class-little-used,
   abstract-method,
@@ -32,6 +33,7 @@ disable=
   too-many-public-methods,
   too-many-return-statements,
   too-many-statements,
+  unnecessary-pass,
   unused-argument
 
 [REPORTS]


### PR DESCRIPTION
## Description:
As requested for the pylint update to `2.2.1`: https://github.com/home-assistant/home-assistant/pull/18750#discussion_r238351342

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

CC: @scop