### PR TITLE
Add support for multiple RainMachine controllers

### DIFF
--- a/homeassistant/components/rainmachine/__init__.py
+++ b/homeassistant/components/rainmachine/__init__.py
@@ -117,7 +117,7 @@ CONTROLLER_SCHEMA = vol.Schema({
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
-        vol.Optional(CONF_CONTROLLERS):
+        vol.Required(CONF_CONTROLLERS):
             vol.All(cv.ensure_list, [CONTROLLER_SCHEMA]),
     }),
 }, extra=vol.ALLOW_EXTRA)

--- a/homeassistant/components/rainmachine/__init__.py
+++ b/homeassistant/components/rainmachine/__init__.py
@@ -104,7 +104,8 @@ CONTROLLER_SCHEMA = vol.Schema({
     vol.Required(CONF_PASSWORD): cv.string,
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
     vol.Optional(CONF_SSL, default=DEFAULT_SSL): cv.boolean,
-    vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL): cv.time_period,
+    vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL):
+        cv.time_period,
     vol.Optional(CONF_BINARY_SENSORS, default={}): BINARY_SENSOR_SCHEMA,
     vol.Optional(CONF_SENSORS, default={}): SENSOR_SCHEMA,
     vol.Optional(CONF_SWITCHES, default={}): SWITCH_SCHEMA,

--- a/homeassistant/components/rainmachine/__init__.py
+++ b/homeassistant/components/rainmachine/__init__.py
@@ -100,19 +100,15 @@ SWITCH_SCHEMA = vol.Schema({vol.Optional(CONF_ZONE_RUN_TIME): cv.positive_int})
 
 
 CONTROLLER_SCHEMA = vol.Schema({
-    DOMAIN: vol.Schema({
-        vol.Required(CONF_IP_ADDRESS): cv.string,
-        vol.Required(CONF_PASSWORD): cv.string,
-        vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
-        vol.Optional(CONF_SSL, default=DEFAULT_SSL): cv.boolean,
-        vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL):
-            cv.time_period,
-        vol.Optional(CONF_BINARY_SENSORS, default={}):
-            BINARY_SENSOR_SCHEMA,
-        vol.Optional(CONF_SENSORS, default={}): SENSOR_SCHEMA,
-        vol.Optional(CONF_SWITCHES, default={}): SWITCH_SCHEMA,
-    })
-}, extra=vol.ALLOW_EXTRA)
+    vol.Required(CONF_IP_ADDRESS): cv.string,
+    vol.Required(CONF_PASSWORD): cv.string,
+    vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+    vol.Optional(CONF_SSL, default=DEFAULT_SSL): cv.boolean,
+    vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL): cv.time_period,
+    vol.Optional(CONF_BINARY_SENSORS, default={}): BINARY_SENSOR_SCHEMA,
+    vol.Optional(CONF_SENSORS, default={}): SENSOR_SCHEMA,
+    vol.Optional(CONF_SWITCHES, default={}): SWITCH_SCHEMA,
+})
 
 
 CONFIG_SCHEMA = vol.Schema({

--- a/homeassistant/components/rainmachine/config_flow.py
+++ b/homeassistant/components/rainmachine/config_flow.py
@@ -7,7 +7,7 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.core import callback
 from homeassistant.const import (
-    CONF_IP_ADDRESS, CONF_PASSWORD, CONF_PORT, CONF_SSL, CONF_SCAN_INTERVAL)
+    CONF_IP_ADDRESS, CONF_PASSWORD, CONF_PORT, CONF_SCAN_INTERVAL, CONF_SSL)
 from homeassistant.helpers import aiohttp_client
 
 from .const import DEFAULT_PORT, DEFAULT_SCAN_INTERVAL, DEFAULT_SSL, DOMAIN
@@ -74,6 +74,12 @@ class RainMachineFlowHandler(config_entries.ConfigFlow):
                 CONF_PASSWORD: 'invalid_credentials'
             })
 
+        # Since the config entry doesn't allow for configuration of SSL, make
+        # sure it's set:
+        if not user_input.get(CONF_SSL):
+            user_input[CONF_SSL] = DEFAULT_SSL
+
+        # Timedeltas are easily serializable, so store the seconds instead:
         scan_interval = user_input.get(
             CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
         user_input[CONF_SCAN_INTERVAL] = scan_interval.seconds

--- a/homeassistant/components/rainmachine/config_flow.py
+++ b/homeassistant/components/rainmachine/config_flow.py
@@ -76,16 +76,10 @@ class RainMachineFlowHandler(config_entries.ConfigFlow):
 
         scan_interval = user_input.get(
             CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+        user_input[CONF_SCAN_INTERVAL] = scan_interval.seconds
 
         # Unfortunately, RainMachine doesn't provide a way to refresh the
         # access token without using the IP address and password, so we have to
         # store it:
         return self.async_create_entry(
-            title=user_input[CONF_IP_ADDRESS],
-            data={
-                CONF_IP_ADDRESS: user_input[CONF_IP_ADDRESS],
-                CONF_PASSWORD: user_input[CONF_PASSWORD],
-                CONF_PORT: user_input.get(CONF_PORT, DEFAULT_PORT),
-                CONF_SCAN_INTERVAL: scan_interval.seconds,
-                CONF_SSL: user_input.get(CONF_SSL, DEFAULT_SSL),
-            })
+            title=user_input[CONF_IP_ADDRESS], data=user_input)

--- a/homeassistant/components/rainmachine/config_flow.py
+++ b/homeassistant/components/rainmachine/config_flow.py
@@ -76,7 +76,7 @@ class RainMachineFlowHandler(config_entries.ConfigFlow):
 
         # Since the config entry doesn't allow for configuration of SSL, make
         # sure it's set:
-        if not user_input.get(CONF_SSL):
+        if user_input.get(CONF_SSL) is None:
             user_input[CONF_SSL] = DEFAULT_SSL
 
         # Timedeltas are easily serializable, so store the seconds instead:

--- a/homeassistant/components/rainmachine/config_flow.py
+++ b/homeassistant/components/rainmachine/config_flow.py
@@ -7,10 +7,10 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.core import callback
 from homeassistant.const import (
-    CONF_IP_ADDRESS, CONF_PASSWORD, CONF_PORT, CONF_SCAN_INTERVAL)
+    CONF_IP_ADDRESS, CONF_PASSWORD, CONF_PORT, CONF_SSL, CONF_SCAN_INTERVAL)
 from homeassistant.helpers import aiohttp_client
 
-from .const import DEFAULT_PORT, DEFAULT_SCAN_INTERVAL, DOMAIN
+from .const import DEFAULT_PORT, DEFAULT_SCAN_INTERVAL, DEFAULT_SSL, DOMAIN
 
 
 @callback
@@ -76,10 +76,16 @@ class RainMachineFlowHandler(config_entries.ConfigFlow):
 
         scan_interval = user_input.get(
             CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
-        user_input[CONF_SCAN_INTERVAL] = scan_interval.seconds
 
         # Unfortunately, RainMachine doesn't provide a way to refresh the
         # access token without using the IP address and password, so we have to
         # store it:
         return self.async_create_entry(
-            title=user_input[CONF_IP_ADDRESS], data=user_input)
+            title=user_input[CONF_IP_ADDRESS],
+            data={
+                CONF_IP_ADDRESS: user_input[CONF_IP_ADDRESS],
+                CONF_PASSWORD: user_input[CONF_PASSWORD],
+                CONF_PORT: user_input.get(CONF_PORT, DEFAULT_PORT),
+                CONF_SCAN_INTERVAL: scan_interval.seconds,
+                CONF_SSL: user_input.get(CONF_SSL, DEFAULT_SSL),
+            })

--- a/homeassistant/components/rainmachine/const.py
+++ b/homeassistant/components/rainmachine/const.py
@@ -10,5 +10,6 @@ DATA_CLIENT = 'client'
 
 DEFAULT_PORT = 8080
 DEFAULT_SCAN_INTERVAL = timedelta(seconds=60)
+DEFAULT_SSL = True
 
 TOPIC_UPDATE = 'update_{0}'


### PR DESCRIPTION
## Description:

Even though multiple RainMachine controllers can be added via config UI, the same use case can't be accommodated via `configuration.yaml`. This PR rectifies that.

**BREAKING CHANGE:** the `configuration.yaml` format changes to the below.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** https://github.com/home-assistant/home-assistant.io/pull/7721

## Example entry for `configuration.yaml` (if applicable):
```yaml
rainmachine:
  controllers:
    - ip_address: !secret rainmachine_ip_address
      password: !secret rainmachine_password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
