### PR TITLE
Updated Yale Smart Alarm platform to new Yale API

### DIFF
--- a/homeassistant/components/alarm_control_panel/yale_smart_alarm.py
+++ b/homeassistant/components/alarm_control_panel/yale_smart_alarm.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
     STATE_ALARM_ARMED_AWAY, STATE_ALARM_ARMED_HOME, STATE_ALARM_DISARMED)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['yalesmartalarmclient==0.1.4']
+REQUIREMENTS = ['yalesmartalarmclient==0.1.5']
 
 CONF_AREA_ID = 'area_id'
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1652,7 +1652,7 @@ xmltodict==0.11.0
 yahooweather==0.10
 
 # homeassistant.components.alarm_control_panel.yale_smart_alarm
-yalesmartalarmclient==0.1.4
+yalesmartalarmclient==0.1.5
 
 # homeassistant.components.light.yeelight
 yeelight==0.4.3


### PR DESCRIPTION
## Description:
Update Yale Smart Alarm platform to use Yale's new API which replaces the deprecated version.
Interface is unchanged. Bumped yalesmartalarmclient to v0.1.5. 

See: https://github.com/domwillcode/yale-smart-alarm-client/tree/v0.1.5

**Related issue (if applicable):** fixes #17396
https://github.com/home-assistant/home-assistant/issues/17396

## Checklist:
  - [ x ] The code change is tested and works locally.
  - [ x ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ x ] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ N/A ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ x ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ x ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ x ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ N/A ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ N/A ] Tests have been added to verify that the new code works.