### PR TITLE
Remove stale user salts

### DIFF
--- a/homeassistant/auth/providers/homeassistant.py
+++ b/homeassistant/auth/providers/homeassistant.py
@@ -13,7 +13,6 @@ from homeassistant.exceptions import HomeAssistantError
 from . import AuthProvider, AUTH_PROVIDER_SCHEMA, AUTH_PROVIDERS, LoginFlow
 
 from ..models import Credentials, UserMeta
-from ..util import generate_secret
 
 
 STORAGE_VERSION = 1
@@ -59,7 +58,6 @@ class Data:
 
         if data is None:
             data = {
-                'salt': generate_secret(),
                 'users': []
             }
 


### PR DESCRIPTION
## Description:

`data['salt']` was originally used as a part of the pbkdf2 implementation.
I failed to remove this as a part of the cleanup in #18736.


## Example entry for `configuration.yaml` (if applicable):
```yaml
auth_providers:
  - type: homeassistant
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
