### PR TITLE
Allow checking entity permissions based on devices

### DIFF
--- a/homeassistant/auth/models.py
+++ b/homeassistant/auth/models.py
@@ -31,6 +31,9 @@ class User:
     """A user."""
 
     name = attr.ib(type=str)  # type: Optional[str]
+    perm_lookup = attr.ib(
+        type=perm_mdl.PermissionLookup, cmp=False,
+    )  # type: perm_mdl.PermissionLookup
     id = attr.ib(type=str, factory=lambda: uuid.uuid4().hex)
     is_owner = attr.ib(type=bool, default=False)
     is_active = attr.ib(type=bool, default=False)
@@ -66,7 +69,8 @@ class User:
 
         self._permissions = perm_mdl.PolicyPermissions(
             perm_mdl.merge_policies([
-                group.policy for group in self.groups]))
+                group.policy for group in self.groups]),
+            self.perm_lookup)
 
         return self._permissions
 

--- a/homeassistant/auth/permissions/__init__.py
+++ b/homeassistant/auth/permissions/__init__.py
@@ -1,14 +1,17 @@
 """Permissions for Home Assistant."""
 import logging
 from typing import (  # noqa: F401
-    cast, Any, Callable, Dict, List, Mapping, Set, Tuple, Union)
+    cast, Any, Callable, Dict, List, Mapping, Set, Tuple, Union,
+    TYPE_CHECKING)
 
 import voluptuous as vol
 
 from .const import CAT_ENTITIES
+from .models import PermissionLookup
 from .types import PolicyType
 from .entities import ENTITY_POLICY_SCHEMA, compile_entities
 from .merge import merge_policies  # noqa
+
 
 POLICY_SCHEMA = vol.Schema({
     vol.Optional(CAT_ENTITIES): ENTITY_POLICY_SCHEMA
@@ -39,13 +42,16 @@ class AbstractPermissions:
 class PolicyPermissions(AbstractPermissions):
     """Handle permissions."""
 
-    def __init__(self, policy: PolicyType) -> None:
+    def __init__(self, policy: PolicyType,
+                 perm_lookup: PermissionLookup) -> None:
         """Initialize the permission class."""
         self._policy = policy
+        self._perm_lookup = perm_lookup
 
     def _entity_func(self) -> Callable[[str, str], bool]:
         """Return a function that can test entity access."""
-        return compile_entities(self._policy.get(CAT_ENTITIES))
+        return compile_entities(self._policy.get(CAT_ENTITIES),
+                                self._perm_lookup)
 
     def __eq__(self, other: Any) -> bool:
         """Equals check."""

--- a/homeassistant/auth/permissions/entities.py
+++ b/homeassistant/auth/permissions/entities.py
@@ -5,6 +5,7 @@ from typing import Callable, List, Union  # noqa: F401
 import voluptuous as vol
 
 from .const import SUBCAT_ALL, POLICY_READ, POLICY_CONTROL, POLICY_EDIT
+from .models import PermissionLookup
 from .types import CategoryType, ValueType
 
 SINGLE_ENTITY_SCHEMA = vol.Any(True, vol.Schema({
@@ -14,6 +15,7 @@ SINGLE_ENTITY_SCHEMA = vol.Any(True, vol.Schema({
 }))
 
 ENTITY_DOMAINS = 'domains'
+ENTITY_DEVICE_IDS = 'device_ids'
 ENTITY_ENTITY_IDS = 'entity_ids'
 
 ENTITY_VALUES_SCHEMA = vol.Any(True, vol.Schema({
@@ -22,6 +24,7 @@ ENTITY_VALUES_SCHEMA = vol.Any(True, vol.Schema({
 
 ENTITY_POLICY_SCHEMA = vol.Any(True, vol.Schema({
     vol.Optional(SUBCAT_ALL): SINGLE_ENTITY_SCHEMA,
+    vol.Optional(ENTITY_DEVICE_IDS): ENTITY_VALUES_SCHEMA,
     vol.Optional(ENTITY_DOMAINS): ENTITY_VALUES_SCHEMA,
     vol.Optional(ENTITY_ENTITY_IDS): ENTITY_VALUES_SCHEMA,
 }))
@@ -36,7 +39,7 @@ def _entity_allowed(schema: ValueType, key: str) \
     return schema.get(key)
 
 
-def compile_entities(policy: CategoryType) \
+def compile_entities(policy: CategoryType, perm_lookup: PermissionLookup) \
         -> Callable[[str, str], bool]:
     """Compile policy into a function that tests policy."""
     # None, Empty Dict, False
@@ -57,6 +60,7 @@ def compile_entities(policy: CategoryType) \
     assert isinstance(policy, dict)
 
     domains = policy.get(ENTITY_DOMAINS)
+    device_ids = policy.get(ENTITY_DEVICE_IDS)
     entity_ids = policy.get(ENTITY_ENTITY_IDS)
     all_entities = policy.get(SUBCAT_ALL)
 
@@ -83,6 +87,29 @@ def compile_entities(policy: CategoryType) \
                 entity_ids.get(entity_id), key)  # type: ignore
 
         funcs.append(allowed_entity_id_dict)
+
+    if isinstance(device_ids, bool):
+        def allowed_device_id_bool(entity_id: str, key: str) \
+                -> Union[None, bool]:
+            """Test if allowed device_id."""
+            return device_ids
+
+        funcs.append(allowed_device_id_bool)
+
+    elif device_ids is not None:
+        def allowed_device_id_dict(entity_id: str, key: str) \
+                -> Union[None, bool]:
+            """Test if allowed device_id."""
+            entity_entry = perm_lookup.entity_registry.async_get(entity_id)
+
+            if entity_entry is None or entity_entry.device_id is None:
+                return None
+
+            return _entity_allowed(
+                device_ids.get(entity_entry.device_id), key   # type: ignore
+            )
+
+        funcs.append(allowed_device_id_dict)
 
     if isinstance(domains, bool):
         def allowed_domain_bool(entity_id: str, key: str) \

--- a/homeassistant/auth/permissions/models.py
+++ b/homeassistant/auth/permissions/models.py
@@ -1,0 +1,17 @@
+"""Models for permissions."""
+from typing import TYPE_CHECKING
+
+import attr
+
+if TYPE_CHECKING:
+    # pylint: disable=unused-import
+    from homeassistant.helpers import (  # noqa
+        entity_registry as ent_reg,
+    )
+
+
+@attr.s(slots=True)
+class PermissionLookup:
+    """Class to hold data for permission lookups."""
+
+    entity_registry = attr.ib(type='ent_reg.EntityRegistry')

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -10,6 +10,7 @@ timer.
 from collections import OrderedDict
 from itertools import chain
 import logging
+from typing import Optional
 import weakref
 
 import attr
@@ -84,6 +85,11 @@ class EntityRegistry:
     def async_is_registered(self, entity_id):
         """Check if an entity_id is currently registered."""
         return entity_id in self.entities
+
+    @callback
+    def async_get(self, entity_id: str) -> Optional[RegistryEntry]:
+        """Get EntityEntry for an entity_id."""
+        return self.entities.get(entity_id)
 
     @callback
     def async_get_entity_id(self, domain: str, platform: str, unique_id: str):

--- a/tests/auth/permissions/test_system_policies.py
+++ b/tests/auth/permissions/test_system_policies.py
@@ -8,7 +8,7 @@ def test_admin_policy():
     # Make sure it's valid
     POLICY_SCHEMA(system_policies.ADMIN_POLICY)
 
-    perms = PolicyPermissions(system_policies.ADMIN_POLICY)
+    perms = PolicyPermissions(system_policies.ADMIN_POLICY, None)
     assert perms.check_entity('light.kitchen', 'read')
     assert perms.check_entity('light.kitchen', 'control')
     assert perms.check_entity('light.kitchen', 'edit')
@@ -19,7 +19,7 @@ def test_read_only_policy():
     # Make sure it's valid
     POLICY_SCHEMA(system_policies.READ_ONLY_POLICY)
 
-    perms = PolicyPermissions(system_policies.READ_ONLY_POLICY)
+    perms = PolicyPermissions(system_policies.READ_ONLY_POLICY, None)
     assert perms.check_entity('light.kitchen', 'read')
     assert not perms.check_entity('light.kitchen', 'control')
     assert not perms.check_entity('light.kitchen', 'edit')

--- a/tests/auth/test_models.py
+++ b/tests/auth/test_models.py
@@ -5,7 +5,12 @@ from homeassistant.auth import models, permissions
 def test_owner_fetching_owner_permissions():
     """Test we fetch the owner permissions for an owner user."""
     group = models.Group(name="Test Group", policy={})
-    owner = models.User(name="Test User", groups=[group], is_owner=True)
+    owner = models.User(
+        name="Test User",
+        perm_lookup=None,
+        groups=[group],
+        is_owner=True
+    )
     assert owner.permissions is permissions.OwnerPermissions
 
 
@@ -25,7 +30,11 @@ def test_permissions_merged():
             }
         }
     })
-    user = models.User(name="Test User", groups=[group, group2])
+    user = models.User(
+        name="Test User",
+        perm_lookup=None,
+        groups=[group, group2]
+    )
     # Make sure we cache instance
     assert user.permissions is user.permissions
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -384,6 +384,7 @@ class MockUser(auth_models.User):
             'name': name,
             'system_generated': system_generated,
             'groups': groups or [],
+            'perm_lookup': None,
         }
         if id is not None:
             kwargs['id'] = id
@@ -401,7 +402,8 @@ class MockUser(auth_models.User):
 
     def mock_policy(self, policy):
         """Mock a policy for a user."""
-        self._permissions = auth_permissions.PolicyPermissions(policy)
+        self._permissions = auth_permissions.PolicyPermissions(
+            policy, self.perm_lookup)
 
 
 async def register_auth_provider(hass, config):

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -232,7 +232,7 @@ async def test_call_context_target_all(hass, mock_service_platform_call,
                            'light.kitchen': True
                        }
                    }
-               })))):
+               }, None)))):
         await service.entity_service_call(hass, [
             Mock(entities=mock_entities)
         ], Mock(), ha.ServiceCall('test_domain', 'test_service',
@@ -253,7 +253,7 @@ async def test_call_context_target_specific(hass, mock_service_platform_call,
                            'light.kitchen': True
                        }
                    }
-               })))):
+               }, None)))):
         await service.entity_service_call(hass, [
             Mock(entities=mock_entities)
         ], Mock(), ha.ServiceCall('test_domain', 'test_service', {
@@ -271,7 +271,7 @@ async def test_call_context_target_specific_no_auth(
     with pytest.raises(exceptions.Unauthorized) as err:
         with patch('homeassistant.auth.AuthManager.async_get_user',
                    return_value=mock_coro(Mock(
-                       permissions=PolicyPermissions({})))):
+                       permissions=PolicyPermissions({}, None)))):
             await service.entity_service_call(hass, [
                 Mock(entities=mock_entities)
             ], Mock(), ha.ServiceCall('test_domain', 'test_service', {


### PR DESCRIPTION
## Description:
Add support for checking entity permissions based on device they belong to.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
