### PR TITLE
Lupupy version push to 0.0.17 - will now transmitted state_alarm_triggered

### DIFF
--- a/homeassistant/components/alarm_control_panel/lupusec.py
+++ b/homeassistant/components/alarm_control_panel/lupusec.py
@@ -13,7 +13,7 @@ from homeassistant.components.lupusec import LupusecDevice
 from homeassistant.const import (STATE_ALARM_ARMED_AWAY,
                                  STATE_ALARM_ARMED_HOME,
                                  STATE_ALARM_DISARMED,
-				 STATE_ALARM_TRIGGERED)
+  				 STATE_ALARM_TRIGGERED)
 
 DEPENDENCIES = ['lupusec']
 

--- a/homeassistant/components/alarm_control_panel/lupusec.py
+++ b/homeassistant/components/alarm_control_panel/lupusec.py
@@ -13,7 +13,7 @@ from homeassistant.components.lupusec import LupusecDevice
 from homeassistant.const import (STATE_ALARM_ARMED_AWAY,
                                  STATE_ALARM_ARMED_HOME,
                                  STATE_ALARM_DISARMED,
-  				                 STATE_ALARM_TRIGGERED)
+                                 STATE_ALARM_TRIGGERED)
 
 DEPENDENCIES = ['lupusec']
 

--- a/homeassistant/components/alarm_control_panel/lupusec.py
+++ b/homeassistant/components/alarm_control_panel/lupusec.py
@@ -13,7 +13,7 @@ from homeassistant.components.lupusec import LupusecDevice
 from homeassistant.const import (STATE_ALARM_ARMED_AWAY,
                                  STATE_ALARM_ARMED_HOME,
                                  STATE_ALARM_DISARMED,
-  				 STATE_ALARM_TRIGGERED)
+  				                 STATE_ALARM_TRIGGERED)
 
 DEPENDENCIES = ['lupusec']
 

--- a/homeassistant/components/alarm_control_panel/lupusec.py
+++ b/homeassistant/components/alarm_control_panel/lupusec.py
@@ -12,7 +12,8 @@ from homeassistant.components.lupusec import DOMAIN as LUPUSEC_DOMAIN
 from homeassistant.components.lupusec import LupusecDevice
 from homeassistant.const import (STATE_ALARM_ARMED_AWAY,
                                  STATE_ALARM_ARMED_HOME,
-                                 STATE_ALARM_DISARMED)
+                                 STATE_ALARM_DISARMED,
+				 STATE_ALARM_TRIGGERED)
 
 DEPENDENCIES = ['lupusec']
 
@@ -50,6 +51,8 @@ class LupusecAlarm(LupusecDevice, AlarmControlPanel):
             state = STATE_ALARM_ARMED_AWAY
         elif self._device.is_home:
             state = STATE_ALARM_ARMED_HOME
+        elif self._device.is_alarm_triggered:
+            state = STATE_ALARM_TRIGGERED
         else:
             state = None
         return state

--- a/homeassistant/components/lupusec.py
+++ b/homeassistant/components/lupusec.py
@@ -16,7 +16,7 @@ from homeassistant.const import (CONF_USERNAME, CONF_PASSWORD,
 from homeassistant.helpers.entity import Entity
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['lupupy==0.0.13']
+REQUIREMENTS = ['lupupy==0.0.17']
 
 DOMAIN = 'lupusec'
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -612,7 +612,7 @@ logi_circle==0.1.7
 luftdaten==0.3.4
 
 # homeassistant.components.lupusec
-lupupy==0.0.13
+lupupy==0.0.17
 
 # homeassistant.components.light.lw12wifi
 lw12==0.9.2


### PR DESCRIPTION
## Description:

Quick Version push of lupupy to 0.0.17. This will now correctly transmit the state alarm_triggered which can be used in automations etc.
