### PR TITLE
Small refactoring of MQTT light

### DIFF
--- a/homeassistant/components/light/mqtt/schema_basic.py
+++ b/homeassistant/components/light/mqtt/schema_basic.py
@@ -131,11 +131,7 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, Light, RestoreEntity):
         self._white_value = None
         self._supported_features = 0
 
-        self._name = None
-        self._effect_list = None
         self._topic = None
-        self._qos = None
-        self._retain = None
         self._payload = None
         self._templates = None
         self._optimistic = False
@@ -146,9 +142,6 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, Light, RestoreEntity):
         self._optimistic_hs = False
         self._optimistic_white_value = False
         self._optimistic_xy = False
-        self._brightness_scale = None
-        self._white_value_scale = None
-        self._on_command_type = None
         self._unique_id = config.get(CONF_UNIQUE_ID)
 
         # Load config
@@ -157,8 +150,9 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, Light, RestoreEntity):
         availability_topic = config.get(CONF_AVAILABILITY_TOPIC)
         payload_available = config.get(CONF_PAYLOAD_AVAILABLE)
         payload_not_available = config.get(CONF_PAYLOAD_NOT_AVAILABLE)
+        qos = config.get(CONF_QOS)
 
-        MqttAvailability.__init__(self, availability_topic, self._qos,
+        MqttAvailability.__init__(self, availability_topic, qos,
                                   payload_available, payload_not_available)
         MqttDiscoveryUpdate.__init__(self, discovery_hash,
                                      self.discovery_update)
@@ -178,8 +172,8 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, Light, RestoreEntity):
 
     def _setup_from_config(self, config):
         """(Re)Setup the entity."""
-        self._name = config.get(CONF_NAME)
-        self._effect_list = config.get(CONF_EFFECT_LIST)
+        self._config = config
+
         topic = {
             key: config.get(key) for key in (
                 CONF_BRIGHTNESS_COMMAND_TOPIC,
@@ -201,8 +195,6 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, Light, RestoreEntity):
             )
         }
         self._topic = topic
-        self._qos = config.get(CONF_QOS)
-        self._retain = config.get(CONF_RETAIN)
         self._payload = {
             'on': config.get(CONF_PAYLOAD_ON),
             'off': config.get(CONF_PAYLOAD_OFF),
@@ -239,10 +231,6 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, Light, RestoreEntity):
             optimistic or topic[CONF_WHITE_VALUE_STATE_TOPIC] is None)
         self._optimistic_xy = \
             optimistic or topic[CONF_XY_STATE_TOPIC] is None
-
-        self._brightness_scale = config.get(CONF_BRIGHTNESS_SCALE)
-        self._white_value_scale = config.get(CONF_WHITE_VALUE_SCALE)
-        self._on_command_type = config.get(CONF_ON_COMMAND_TYPE)
 
         self._supported_features = 0
         self._supported_features |= (
@@ -296,7 +284,7 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, Light, RestoreEntity):
             topics[CONF_STATE_TOPIC] = {
                 'topic': self._topic[CONF_STATE_TOPIC],
                 'msg_callback': state_received,
-                'qos': self._qos}
+                'qos': self._config.get(CONF_QOS)}
         elif self._optimistic and last_state:
             self._state = last_state.state == STATE_ON
 
@@ -310,7 +298,8 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, Light, RestoreEntity):
                 return
 
             device_value = float(payload)
-            percent_bright = device_value / self._brightness_scale
+            percent_bright = \
+                device_value / self._config.get(CONF_BRIGHTNESS_SCALE)
             self._brightness = int(percent_bright * 255)
             self.async_schedule_update_ha_state()
 
@@ -318,7 +307,7 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, Light, RestoreEntity):
             topics[CONF_BRIGHTNESS_STATE_TOPIC] = {
                 'topic': self._topic[CONF_BRIGHTNESS_STATE_TOPIC],
                 'msg_callback': brightness_received,
-                'qos': self._qos}
+                'qos': self._config.get(CONF_QOS)}
             self._brightness = 255
         elif self._optimistic_brightness and last_state\
                 and last_state.attributes.get(ATTR_BRIGHTNESS):
@@ -348,7 +337,7 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, Light, RestoreEntity):
             topics[CONF_RGB_STATE_TOPIC] = {
                 'topic': self._topic[CONF_RGB_STATE_TOPIC],
                 'msg_callback': rgb_received,
-                'qos': self._qos}
+                'qos': self._config.get(CONF_QOS)}
             self._hs = (0, 0)
         if self._optimistic_rgb and last_state\
                 and last_state.attributes.get(ATTR_HS_COLOR):
@@ -372,7 +361,7 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, Light, RestoreEntity):
             topics[CONF_COLOR_TEMP_STATE_TOPIC] = {
                 'topic': self._topic[CONF_COLOR_TEMP_STATE_TOPIC],
                 'msg_callback': color_temp_received,
-                'qos': self._qos}
+                'qos': self._config.get(CONF_QOS)}
             self._color_temp = 150
         if self._optimistic_color_temp and last_state\
                 and last_state.attributes.get(ATTR_COLOR_TEMP):
@@ -397,7 +386,7 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, Light, RestoreEntity):
             topics[CONF_EFFECT_STATE_TOPIC] = {
                 'topic': self._topic[CONF_EFFECT_STATE_TOPIC],
                 'msg_callback': effect_received,
-                'qos': self._qos}
+                'qos': self._config.get(CONF_QOS)}
             self._effect = 'none'
         if self._optimistic_effect and last_state\
                 and last_state.attributes.get(ATTR_EFFECT):
@@ -427,7 +416,7 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, Light, RestoreEntity):
             topics[CONF_HS_STATE_TOPIC] = {
                 'topic': self._topic[CONF_HS_STATE_TOPIC],
                 'msg_callback': hs_received,
-                'qos': self._qos}
+                'qos': self._config.get(CONF_QOS)}
             self._hs = (0, 0)
         if self._optimistic_hs and last_state\
                 and last_state.attributes.get(ATTR_HS_COLOR):
@@ -445,7 +434,8 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, Light, RestoreEntity):
                 return
 
             device_value = float(payload)
-            percent_white = device_value / self._white_value_scale
+            percent_white = \
+                device_value / self._config.get(CONF_WHITE_VALUE_SCALE)
             self._white_value = int(percent_white * 255)
             self.async_schedule_update_ha_state()
 
@@ -453,7 +443,7 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, Light, RestoreEntity):
             topics[CONF_WHITE_VALUE_STATE_TOPIC] = {
                 'topic': self._topic[CONF_WHITE_VALUE_STATE_TOPIC],
                 'msg_callback': white_value_received,
-                'qos': self._qos}
+                'qos': self._config.get(CONF_QOS)}
             self._white_value = 255
         elif self._optimistic_white_value and last_state\
                 and last_state.attributes.get(ATTR_WHITE_VALUE):
@@ -480,7 +470,7 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, Light, RestoreEntity):
             topics[CONF_XY_STATE_TOPIC] = {
                 'topic': self._topic[CONF_XY_STATE_TOPIC],
                 'msg_callback': xy_received,
-                'qos': self._qos}
+                'qos': self._config.get(CONF_QOS)}
             self._hs = (0, 0)
         if self._optimistic_xy and last_state\
                 and last_state.attributes.get(ATTR_HS_COLOR):
@@ -525,7 +515,7 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, Light, RestoreEntity):
     @property
     def name(self):
         """Return the name of the device if any."""
-        return self._name
+        return self._config.get(CONF_NAME)
 
     @property
     def unique_id(self):
@@ -545,7 +535,7 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, Light, RestoreEntity):
     @property
     def effect_list(self):
         """Return the list of supported effects."""
-        return self._effect_list
+        return self._config.get(CONF_EFFECT_LIST)
 
     @property
     def effect(self):
@@ -563,17 +553,19 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, Light, RestoreEntity):
         This method is a coroutine.
         """
         should_update = False
+        on_command_type = self._config.get(CONF_ON_COMMAND_TYPE)
 
-        if self._on_command_type == 'first':
+        if on_command_type == 'first':
             mqtt.async_publish(
                 self.hass, self._topic[CONF_COMMAND_TOPIC],
-                self._payload['on'], self._qos, self._retain)
+                self._payload['on'], self._config.get(CONF_QOS),
+                self._config.get(CONF_RETAIN))
             should_update = True
 
         # If brightness is being used instead of an on command, make sure
         # there is a brightness input.  Either set the brightness to our
         # saved value or the maximum value if this is the first call
-        elif self._on_command_type == 'brightness':
+        elif on_command_type == 'brightness':
             if ATTR_BRIGHTNESS not in kwargs:
                 kwargs[ATTR_BRIGHTNESS] = self._brightness if \
                                           self._brightness else 255
@@ -605,7 +597,8 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, Light, RestoreEntity):
 
             mqtt.async_publish(
                 self.hass, self._topic[CONF_RGB_COMMAND_TOPIC],
-                rgb_color_str, self._qos, self._retain)
+                rgb_color_str, self._config.get(CONF_QOS),
+                self._config.get(CONF_RETAIN))
 
             if self._optimistic_rgb:
                 self._hs = kwargs[ATTR_HS_COLOR]
@@ -617,8 +610,8 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, Light, RestoreEntity):
             hs_color = kwargs[ATTR_HS_COLOR]
             mqtt.async_publish(
                 self.hass, self._topic[CONF_HS_COMMAND_TOPIC],
-                '{},{}'.format(*hs_color), self._qos,
-                self._retain)
+                '{},{}'.format(*hs_color), self._config.get(CONF_QOS),
+                self._config.get(CONF_RETAIN))
 
             if self._optimistic_hs:
                 self._hs = kwargs[ATTR_HS_COLOR]
@@ -630,8 +623,8 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, Light, RestoreEntity):
             xy_color = color_util.color_hs_to_xy(*kwargs[ATTR_HS_COLOR])
             mqtt.async_publish(
                 self.hass, self._topic[CONF_XY_COMMAND_TOPIC],
-                '{},{}'.format(*xy_color), self._qos,
-                self._retain)
+                '{},{}'.format(*xy_color), self._config.get(CONF_QOS),
+                self._config.get(CONF_RETAIN))
 
             if self._optimistic_xy:
                 self._hs = kwargs[ATTR_HS_COLOR]
@@ -640,10 +633,12 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, Light, RestoreEntity):
         if ATTR_BRIGHTNESS in kwargs and \
            self._topic[CONF_BRIGHTNESS_COMMAND_TOPIC] is not None:
             percent_bright = float(kwargs[ATTR_BRIGHTNESS]) / 255
-            device_brightness = int(percent_bright * self._brightness_scale)
+            device_brightness = \
+                int(percent_bright * self._config.get(CONF_BRIGHTNESS_SCALE))
             mqtt.async_publish(
                 self.hass, self._topic[CONF_BRIGHTNESS_COMMAND_TOPIC],
-                device_brightness, self._qos, self._retain)
+                device_brightness, self._config.get(CONF_QOS),
+                self._config.get(CONF_RETAIN))
 
             if self._optimistic_brightness:
                 self._brightness = kwargs[ATTR_BRIGHTNESS]
@@ -664,7 +659,8 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, Light, RestoreEntity):
 
             mqtt.async_publish(
                 self.hass, self._topic[CONF_RGB_COMMAND_TOPIC],
-                rgb_color_str, self._qos, self._retain)
+                rgb_color_str, self._config.get(CONF_QOS),
+                self._config.get(CONF_RETAIN))
 
             if self._optimistic_brightness:
                 self._brightness = kwargs[ATTR_BRIGHTNESS]
@@ -675,7 +671,8 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, Light, RestoreEntity):
             color_temp = int(kwargs[ATTR_COLOR_TEMP])
             mqtt.async_publish(
                 self.hass, self._topic[CONF_COLOR_TEMP_COMMAND_TOPIC],
-                color_temp, self._qos, self._retain)
+                color_temp, self._config.get(CONF_QOS),
+                self._config.get(CONF_RETAIN))
 
             if self._optimistic_color_temp:
                 self._color_temp = kwargs[ATTR_COLOR_TEMP]
@@ -684,10 +681,11 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, Light, RestoreEntity):
         if ATTR_EFFECT in kwargs and \
            self._topic[CONF_EFFECT_COMMAND_TOPIC] is not None:
             effect = kwargs[ATTR_EFFECT]
-            if effect in self._effect_list:
+            if effect in self._config.get(CONF_EFFECT_LIST):
                 mqtt.async_publish(
                     self.hass, self._topic[CONF_EFFECT_COMMAND_TOPIC],
-                    effect, self._qos, self._retain)
+                    effect, self._config.get(CONF_QOS),
+                    self._config.get(CONF_RETAIN))
 
                 if self._optimistic_effect:
                     self._effect = kwargs[ATTR_EFFECT]
@@ -696,18 +694,21 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, Light, RestoreEntity):
         if ATTR_WHITE_VALUE in kwargs and \
            self._topic[CONF_WHITE_VALUE_COMMAND_TOPIC] is not None:
             percent_white = float(kwargs[ATTR_WHITE_VALUE]) / 255
-            device_white_value = int(percent_white * self._white_value_scale)
+            device_white_value = \
+                int(percent_white * self._config.get(CONF_WHITE_VALUE_SCALE))
             mqtt.async_publish(
                 self.hass, self._topic[CONF_WHITE_VALUE_COMMAND_TOPIC],
-                device_white_value, self._qos, self._retain)
+                device_white_value, self._config.get(CONF_QOS),
+                self._config.get(CONF_RETAIN))
 
             if self._optimistic_white_value:
                 self._white_value = kwargs[ATTR_WHITE_VALUE]
                 should_update = True
 
-        if self._on_command_type == 'last':
+        if on_command_type == 'last':
             mqtt.async_publish(self.hass, self._topic[CONF_COMMAND_TOPIC],
-                               self._payload['on'], self._qos, self._retain)
+                               self._payload['on'], self._config.get(CONF_QOS),
+                               self._config.get(CONF_RETAIN))
             should_update = True
 
         if self._optimistic:
@@ -725,7 +726,7 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, Light, RestoreEntity):
         """
         mqtt.async_publish(
             self.hass, self._topic[CONF_COMMAND_TOPIC], self._payload['off'],
-            self._qos, self._retain)
+            self._config.get(CONF_QOS), self._config.get(CONF_RETAIN))
 
         if self._optimistic:
             # Optimistically assume that the light has changed state.

--- a/homeassistant/components/light/mqtt/schema_json.py
+++ b/homeassistant/components/light/mqtt/schema_json.py
@@ -99,22 +99,14 @@ class MqttLightJson(MqttAvailability, MqttDiscoveryUpdate, Light,
         self._sub_state = None
         self._supported_features = 0
 
-        self._name = None
-        self._effect_list = None
         self._topic = None
-        self._qos = None
-        self._retain = None
         self._optimistic = False
-        self._rgb = False
-        self._xy = False
-        self._hs_support = False
         self._brightness = None
         self._color_temp = None
         self._effect = None
         self._hs = None
         self._white_value = None
         self._flash_times = None
-        self._brightness_scale = None
         self._unique_id = config.get(CONF_UNIQUE_ID)
 
         # Load config
@@ -123,8 +115,9 @@ class MqttLightJson(MqttAvailability, MqttDiscoveryUpdate, Light,
         availability_topic = config.get(CONF_AVAILABILITY_TOPIC)
         payload_available = config.get(CONF_PAYLOAD_AVAILABLE)
         payload_not_available = config.get(CONF_PAYLOAD_NOT_AVAILABLE)
+        qos = config.get(CONF_QOS)
 
-        MqttAvailability.__init__(self, availability_topic, self._qos,
+        MqttAvailability.__init__(self, availability_topic, qos,
                                   payload_available, payload_not_available)
         MqttDiscoveryUpdate.__init__(self, discovery_hash,
                                      self.discovery_update)
@@ -144,16 +137,14 @@ class MqttLightJson(MqttAvailability, MqttDiscoveryUpdate, Light,
 
     def _setup_from_config(self, config):
         """(Re)Setup the entity."""
-        self._name = config.get(CONF_NAME)
-        self._effect_list = config.get(CONF_EFFECT_LIST)
+        self._config = config
+
         self._topic = {
             key: config.get(key) for key in (
                 CONF_STATE_TOPIC,
                 CONF_COMMAND_TOPIC
             )
         }
-        self._qos = config.get(CONF_QOS)
-        self._retain = config.get(CONF_RETAIN)
         optimistic = config.get(CONF_OPTIMISTIC)
         self._optimistic = optimistic or self._topic[CONF_STATE_TOPIC] is None
 
@@ -181,11 +172,7 @@ class MqttLightJson(MqttAvailability, MqttDiscoveryUpdate, Light,
         else:
             self._white_value = None
 
-        self._rgb = config.get(CONF_RGB)
-        self._xy = config.get(CONF_XY)
-        self._hs_support = config.get(CONF_HS)
-
-        if self._hs_support or self._rgb or self._xy:
+        if config.get(CONF_HS) or config.get(CONF_RGB) or config.get(CONF_XY):
             self._hs = [0, 0]
         else:
             self._hs = None
@@ -196,16 +183,15 @@ class MqttLightJson(MqttAvailability, MqttDiscoveryUpdate, Light,
                 CONF_FLASH_TIME_LONG
             )
         }
-        self._brightness_scale = config.get(CONF_BRIGHTNESS_SCALE)
 
         self._supported_features = (SUPPORT_TRANSITION | SUPPORT_FLASH)
-        self._supported_features |= (self._rgb and SUPPORT_COLOR)
+        self._supported_features |= (config.get(CONF_RGB) and SUPPORT_COLOR)
         self._supported_features |= (brightness and SUPPORT_BRIGHTNESS)
         self._supported_features |= (color_temp and SUPPORT_COLOR_TEMP)
         self._supported_features |= (effect and SUPPORT_EFFECT)
         self._supported_features |= (white_value and SUPPORT_WHITE_VALUE)
-        self._supported_features |= (self._xy and SUPPORT_COLOR)
-        self._supported_features |= (self._hs_support and SUPPORT_COLOR)
+        self._supported_features |= (config.get(CONF_XY) and SUPPORT_COLOR)
+        self._supported_features |= (config.get(CONF_HS) and SUPPORT_COLOR)
 
     async def _subscribe_topics(self):
         """(Re)Subscribe to topics."""
@@ -255,9 +241,9 @@ class MqttLightJson(MqttAvailability, MqttDiscoveryUpdate, Light,
 
             if self._brightness is not None:
                 try:
-                    self._brightness = int(values['brightness'] /
-                                           float(self._brightness_scale) *
-                                           255)
+                    self._brightness = int(
+                        values['brightness'] /
+                        float(self._config.get(CONF_BRIGHTNESS_SCALE)) * 255)
                 except KeyError:
                     pass
                 except ValueError:
@@ -294,7 +280,7 @@ class MqttLightJson(MqttAvailability, MqttDiscoveryUpdate, Light,
                 self.hass, self._sub_state,
                 {'state_topic': {'topic': self._topic[CONF_STATE_TOPIC],
                                  'msg_callback': state_received,
-                                 'qos': self._qos}})
+                                 'qos': self._config.get(CONF_QOS)}})
 
         if self._optimistic and last_state:
             self._state = last_state.state == STATE_ON
@@ -332,7 +318,7 @@ class MqttLightJson(MqttAvailability, MqttDiscoveryUpdate, Light,
     @property
     def effect_list(self):
         """Return the list of supported effects."""
-        return self._effect_list
+        return self._config.get(CONF_EFFECT_LIST)
 
     @property
     def hs_color(self):
@@ -352,7 +338,7 @@ class MqttLightJson(MqttAvailability, MqttDiscoveryUpdate, Light,
     @property
     def name(self):
         """Return the name of the device if any."""
-        return self._name
+        return self._config.get(CONF_NAME)
 
     @property
     def unique_id(self):
@@ -383,11 +369,12 @@ class MqttLightJson(MqttAvailability, MqttDiscoveryUpdate, Light,
 
         message = {'state': 'ON'}
 
-        if ATTR_HS_COLOR in kwargs and (self._hs_support
-                                        or self._rgb or self._xy):
+        if ATTR_HS_COLOR in kwargs and (
+                self._config.get(CONF_HS) or self._config.get(CONF_RGB)
+                or self._config.get(CONF_XY)):
             hs_color = kwargs[ATTR_HS_COLOR]
             message['color'] = {}
-            if self._rgb:
+            if self._config.get(CONF_RGB):
                 # If there's a brightness topic set, we don't want to scale the
                 # RGB values given using the brightness.
                 if self._brightness is not None:
@@ -401,11 +388,11 @@ class MqttLightJson(MqttAvailability, MqttDiscoveryUpdate, Light,
                 message['color']['r'] = rgb[0]
                 message['color']['g'] = rgb[1]
                 message['color']['b'] = rgb[2]
-            if self._xy:
+            if self._config.get(CONF_XY):
                 xy_color = color_util.color_hs_to_xy(*kwargs[ATTR_HS_COLOR])
                 message['color']['x'] = xy_color[0]
                 message['color']['y'] = xy_color[1]
-            if self._hs_support:
+            if self._config.get(CONF_HS):
                 message['color']['h'] = hs_color[0]
                 message['color']['s'] = hs_color[1]
 
@@ -425,9 +412,9 @@ class MqttLightJson(MqttAvailability, MqttDiscoveryUpdate, Light,
             message['transition'] = int(kwargs[ATTR_TRANSITION])
 
         if ATTR_BRIGHTNESS in kwargs:
-            message['brightness'] = int(kwargs[ATTR_BRIGHTNESS] /
-                                        float(DEFAULT_BRIGHTNESS_SCALE) *
-                                        self._brightness_scale)
+            message['brightness'] = int(
+                kwargs[ATTR_BRIGHTNESS] / float(DEFAULT_BRIGHTNESS_SCALE) *
+                self._config.get(CONF_BRIGHTNESS_SCALE))
 
             if self._optimistic:
                 self._brightness = kwargs[ATTR_BRIGHTNESS]
@@ -456,7 +443,7 @@ class MqttLightJson(MqttAvailability, MqttDiscoveryUpdate, Light,
 
         mqtt.async_publish(
             self.hass, self._topic[CONF_COMMAND_TOPIC], json.dumps(message),
-            self._qos, self._retain)
+            self._config.get(CONF_QOS), self._config.get(CONF_RETAIN))
 
         if self._optimistic:
             # Optimistically assume that the light has changed state.
@@ -478,7 +465,7 @@ class MqttLightJson(MqttAvailability, MqttDiscoveryUpdate, Light,
 
         mqtt.async_publish(
             self.hass, self._topic[CONF_COMMAND_TOPIC], json.dumps(message),
-            self._qos, self._retain)
+            self._config.get(CONF_QOS), self._config.get(CONF_RETAIN))
 
         if self._optimistic:
             # Optimistically assume that the light has changed state.


### PR DESCRIPTION
## Description:
Small refactoring of MQTT light as proposed in #18174:
- Just store config instead of every variable since the configuration values are just copied.

(Follow-up to #18674)

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.