### PR TITLE
[Fire TV] Catch 'BrokenPipeError' exceptions for ADB commands

### DIFF
--- a/homeassistant/components/media_player/firetv.py
+++ b/homeassistant/components/media_player/firetv.py
@@ -125,7 +125,7 @@ class FireTVDevice(MediaPlayerDevice):
     def __init__(self, ftv, name, get_source, get_sources):
         """Initialize the FireTV device."""
         from adb.adb_protocol import (
-            InvalidCommandError, InvalidResponseError, InvalidChecksumError)
+            InvalidChecksumError, InvalidCommandError, InvalidResponseError)
 
         self.firetv = ftv
 
@@ -137,9 +137,9 @@ class FireTVDevice(MediaPlayerDevice):
         self.adb_lock = threading.Lock()
 
         # ADB exceptions to catch
-        self.exceptions = (TypeError, ValueError, AttributeError,
-                           InvalidCommandError, InvalidResponseError,
-                           InvalidChecksumError)
+        self.exceptions = (AttributeError, BrokenPipeError, TypeError,
+                           ValueError, InvalidChecksumError,
+                           InvalidCommandError, InvalidResponseError)
 
         self._state = None
         self._available = self.firetv.available


### PR DESCRIPTION
## Description:

Some users experience `BrokenPipeError` exceptions when running ADB commands for the Fire TV component. These should be caught and handled appropriately, as the other ADB-related exceptions are. 

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/18826#issuecomment-444116245

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
