### PR TITLE
Set unavailable when unreachable

### DIFF
--- a/homeassistant/components/media_player/gpmdp.py
+++ b/homeassistant/components/media_player/gpmdp.py
@@ -219,7 +219,7 @@ class GPMDP(MediaPlayerDevice):
             volume_data = self.send_gpmdp_msg('volume', 'getVolume')
             if volume_data is not None:
                 self._volume = volume_data['value'] / 100
-        except Exception:
+        except OSError:
             self._available = False
 
     @property

--- a/homeassistant/components/media_player/gpmdp.py
+++ b/homeassistant/components/media_player/gpmdp.py
@@ -20,7 +20,7 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util.json import load_json, save_json
 
-REQUIREMENTS = ['websocket-client==0.37.0']
+REQUIREMENTS = ['websocket-client==0.54.0']
 
 _CONFIGURING = {}
 _LOGGER = logging.getLogger(__name__)
@@ -155,6 +155,7 @@ class GPMDP(MediaPlayerDevice):
         self._duration = None
         self._volume = None
         self._request_id = 0
+        self._available = True
 
     def get_ws(self):
         """Check if the websocket is setup and connected."""
@@ -200,22 +201,31 @@ class GPMDP(MediaPlayerDevice):
     def update(self):
         """Get the latest details from the player."""
         time.sleep(1)
-        playstate = self.send_gpmdp_msg('playback', 'getPlaybackState')
-        if playstate is None:
-            return
-        self._status = PLAYBACK_DICT[str(playstate['value'])]
-        time_data = self.send_gpmdp_msg('playback', 'getCurrentTime')
-        if time_data is not None:
-            self._seek_position = int(time_data['value'] / 1000)
-        track_data = self.send_gpmdp_msg('playback', 'getCurrentTrack')
-        if track_data is not None:
-            self._title = track_data['value']['title']
-            self._artist = track_data['value']['artist']
-            self._albumart = track_data['value']['albumArt']
-            self._duration = int(track_data['value']['duration'] / 1000)
-        volume_data = self.send_gpmdp_msg('volume', 'getVolume')
-        if volume_data is not None:
-            self._volume = volume_data['value'] / 100
+        try:
+            self._available = True
+            playstate = self.send_gpmdp_msg('playback', 'getPlaybackState')
+            if playstate is None:
+                return
+            self._status = PLAYBACK_DICT[str(playstate['value'])]
+            time_data = self.send_gpmdp_msg('playback', 'getCurrentTime')
+            if time_data is not None:
+                self._seek_position = int(time_data['value'] / 1000)
+            track_data = self.send_gpmdp_msg('playback', 'getCurrentTrack')
+            if track_data is not None:
+                self._title = track_data['value']['title']
+                self._artist = track_data['value']['artist']
+                self._albumart = track_data['value']['albumArt']
+                self._duration = int(track_data['value']['duration'] / 1000)
+            volume_data = self.send_gpmdp_msg('volume', 'getVolume')
+            if volume_data is not None:
+                self._volume = volume_data['value'] / 100
+        except Exception:
+            self._available = False
+
+    @property
+    def available(self):
+        """Return if media player is available"""
+        return self._available
 
     @property
     def media_content_type(self):

--- a/homeassistant/components/media_player/gpmdp.py
+++ b/homeassistant/components/media_player/gpmdp.py
@@ -224,7 +224,7 @@ class GPMDP(MediaPlayerDevice):
 
     @property
     def available(self):
-        """Return if media player is available"""
+        """Return if media player is available."""
         return self._available
 
     @property

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1620,7 +1620,7 @@ watchdog==0.8.3
 waterfurnace==0.7.0
 
 # homeassistant.components.media_player.gpmdp
-websocket-client==0.37.0
+websocket-client==0.54.0
 
 # homeassistant.components.media_player.webostv
 websockets==6.0


### PR DESCRIPTION
## Description:
Sets the GPMDP component to unavailable when it can't be reached, instead of throwing errors in the logs.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
