### PR TITLE
Set directv unavailable state when errors returned for longer then a minute

### DIFF
--- a/homeassistant/components/media_player/directv.py
+++ b/homeassistant/components/media_player/directv.py
@@ -133,6 +133,7 @@ class DirecTvDevice(MediaPlayerDevice):
         self._is_client = device != '0'
         self._assumed_state = None
         self._available = False
+        self._first_error_timestamp = None
 
         if self._is_client:
             _LOGGER.debug("Created DirecTV client %s for device %s",
@@ -142,7 +143,7 @@ class DirecTvDevice(MediaPlayerDevice):
 
     def update(self):
         """Retrieve latest state."""
-        _LOGGER.debug("Updating status for %s", self._name)
+        _LOGGER.debug("%s: Updating status", self.entity_id)
         try:
             self._available = True
             self._is_standby = self.dtv.get_standby()
@@ -156,6 +157,7 @@ class DirecTvDevice(MediaPlayerDevice):
             else:
                 self._current = self.dtv.get_tuned()
                 if self._current['status']['code'] == 200:
+                    self._first_error_timestamp = None
                     self._is_recorded = self._current.get('uniqueId')\
                         is not None
                     self._paused = self._last_position == \
@@ -165,13 +167,38 @@ class DirecTvDevice(MediaPlayerDevice):
                     self._last_update = dt_util.utcnow() if not self._paused \
                         or self._last_update is None else self._last_update
                 else:
-                    self._available = False
+                    # If an error is received then only set to unavailable if
+                    # this started at least 1 minute ago.
+                    if not self._first_error_timestamp:
+                        self._first_error_timestamp = dt_util.utcnow()
+                    else:
+                        tdelta = dt_util.utcnow() - self._first_error_timestamp
+                        if tdelta.total_seconds() >= 60:
+                            _LOGGER.error("%s: Invalid status %s received",
+                                          self.entity_id,
+                                          self._current['status']['code'])
+                            self._available = False
+                        else:
+                            _LOGGER.debug("%s: Invalid status %s received",
+                                          self.entity_id,
+                                          self._current['status']['code'])
+
         except requests.RequestException as ex:
-            _LOGGER.error("Request error trying to update current status for"
-                          " %s. %s", self._name, ex)
+            _LOGGER.error("%s: Request error trying to update current status: "
+                          "%s", self.entity_id, ex)
+            if not self._first_error_timestamp:
+                self._first_error_timestamp = dt_util.utcnow()
+            else:
+                tdelta = dt_util.utcnow() - self._first_error_timestamp
+                if tdelta.total_seconds() >= 60:
+                    self._available = False
+
+        except Exception as ex:
+            _LOGGER.error("%s: Exception trying to update current status: %s",
+                          self.entity_id, ex)
             self._available = False
-        except Exception:
-            self._available = False
+            if not self._first_error_timestamp:
+                self._first_error_timestamp = dt_util.utcnow()
             raise
 
     @property

--- a/tests/components/media_player/test_directv.py
+++ b/tests/components/media_player/test_directv.py
@@ -515,8 +515,30 @@ async def test_available(hass, platforms, main_dtv, mock_now):
     state = hass.states.get(MAIN_ENTITY_ID)
     assert state.state != STATE_UNAVAILABLE
 
-    # Make update fail (i.e. DVR offline)
+    # Make update fail 1st time
     next_update = next_update + timedelta(minutes=5)
+    with patch.object(
+            main_dtv, 'get_standby', side_effect=requests.RequestException), \
+            patch('homeassistant.util.dt.utcnow', return_value=next_update):
+        async_fire_time_changed(hass, next_update)
+        await hass.async_block_till_done()
+
+    state = hass.states.get(MAIN_ENTITY_ID)
+    assert state.state != STATE_UNAVAILABLE
+
+    # Make update fail 2nd time within 1 minute
+    next_update = next_update + timedelta(seconds=30)
+    with patch.object(
+            main_dtv, 'get_standby', side_effect=requests.RequestException), \
+            patch('homeassistant.util.dt.utcnow', return_value=next_update):
+        async_fire_time_changed(hass, next_update)
+        await hass.async_block_till_done()
+
+    state = hass.states.get(MAIN_ENTITY_ID)
+    assert state.state != STATE_UNAVAILABLE
+
+    # Make update fail 3rd time more then a minute after 1st failure
+    next_update = next_update + timedelta(minutes=1)
     with patch.object(
             main_dtv, 'get_standby', side_effect=requests.RequestException), \
             patch('homeassistant.util.dt.utcnow', return_value=next_update):


### PR DESCRIPTION
## Description:

Change setting to unavailable when getting request exceptions only after 1 minute has past since 1st occurrence, preventing state set to unavailable when powering on/off.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.
