### PR TITLE
Fix entity unavailable after reconfiguring MQTT availability

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -852,7 +852,8 @@ class MqttAvailability(Entity):
         """(Re)Setup."""
         self._availability_topic = config.get(CONF_AVAILABILITY_TOPIC)
         self._availability_qos = config.get(CONF_QOS)
-        self._available = self._availability_topic is None  # type: bool
+        if self._availability_topic is None:
+            self._available = True
         self._payload_available = config.get(CONF_PAYLOAD_AVAILABLE)
         self._payload_not_available = config.get(CONF_PAYLOAD_NOT_AVAILABLE)
 

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -828,10 +828,10 @@ class MqttAvailability(Entity):
                  payload_not_available: Optional[str]) -> None:
         """Initialize the availability mixin."""
         self._availability_sub_state = None
+        self._available = False  # type: bool
 
         self._availability_topic = availability_topic
         self._availability_qos = qos
-        self._available = self._availability_topic is None  # type: bool
         self._payload_available = payload_available
         self._payload_not_available = payload_not_available
 
@@ -852,8 +852,6 @@ class MqttAvailability(Entity):
         """(Re)Setup."""
         self._availability_topic = config.get(CONF_AVAILABILITY_TOPIC)
         self._availability_qos = config.get(CONF_QOS)
-        if self._availability_topic is None:
-            self._available = True
         self._payload_available = config.get(CONF_PAYLOAD_AVAILABLE)
         self._payload_not_available = config.get(CONF_PAYLOAD_NOT_AVAILABLE)
 
@@ -888,7 +886,7 @@ class MqttAvailability(Entity):
     @property
     def available(self) -> bool:
         """Return if the device is available."""
-        return self._available
+        return self._availability_topic is None or self._available
 
 
 class MqttDiscoveryUpdate(Entity):


### PR DESCRIPTION
## Description:

Fix bug when reconfiguring MQTT availability caused by overwriting self._available making the entity incorrectly appear unavailable.

**Related issue (if applicable):** Additional fix related to #18909

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.