### PR TITLE
Don't wait for answer for webhook register

### DIFF
--- a/homeassistant/components/cloud/cloudhooks.py
+++ b/homeassistant/components/cloud/cloudhooks.py
@@ -18,7 +18,7 @@ class Cloudhooks:
         await self.cloud.iot.async_send_message('webhook-register', {
             'cloudhook_ids': [info['cloudhook_id'] for info
                               in cloudhooks.values()]
-        })
+        }, expect_answer=False)
 
     async def async_create(self, webhook_id):
         """Create a cloud webhook."""

--- a/tests/components/cloud/test_iot.py
+++ b/tests/components/cloud/test_iot.py
@@ -451,3 +451,51 @@ async def test_webhook_msg(hass):
     assert await received[0].json() == {
         'hello': 'world'
     }
+
+
+async def test_send_message_not_connected(mock_cloud):
+    """Test sending a message that expects no answer."""
+    cloud_iot = iot.CloudIoT(mock_cloud)
+
+    with pytest.raises(iot.NotConnected):
+        await cloud_iot.async_send_message('webhook', {'msg': 'yo'})
+
+
+async def test_send_message_no_answer(mock_cloud):
+    """Test sending a message that expects no answer."""
+    cloud_iot = iot.CloudIoT(mock_cloud)
+    cloud_iot.state = iot.STATE_CONNECTED
+    cloud_iot.client = MagicMock(send_json=MagicMock(return_value=mock_coro()))
+
+    await cloud_iot.async_send_message('webhook', {'msg': 'yo'},
+                                       expect_answer=False)
+    assert not cloud_iot._response_handler
+    assert len(cloud_iot.client.send_json.mock_calls) == 1
+    msg = cloud_iot.client.send_json.mock_calls[0][1][0]
+    assert msg['handler'] == 'webhook'
+    assert msg['payload'] == {'msg': 'yo'}
+
+
+async def test_send_message_answer(loop, mock_cloud):
+    """Test sending a message that expects no answer."""
+    cloud_iot = iot.CloudIoT(mock_cloud)
+    cloud_iot.state = iot.STATE_CONNECTED
+    cloud_iot.client = MagicMock(send_json=MagicMock(return_value=mock_coro()))
+
+    uuid = 5
+
+    with patch('homeassistant.components.cloud.iot.uuid.uuid4',
+               return_value=MagicMock(hex=uuid)):
+        send_task = loop.create_task(cloud_iot.async_send_message(
+            'webhook', {'msg': 'yo'}))
+        await asyncio.sleep(0)
+
+    assert len(cloud_iot.client.send_json.mock_calls) == 1
+    assert len(cloud_iot._response_handler) == 1
+    msg = cloud_iot.client.send_json.mock_calls[0][1][0]
+    assert msg['handler'] == 'webhook'
+    assert msg['payload'] == {'msg': 'yo'}
+
+    cloud_iot._response_handler[uuid].set_result({'response': True})
+    response = await send_task
+    assert response == {'response': True}


### PR DESCRIPTION
## Description:
When registering webhooks with Home Assistant Cloud, don't wait for an answer if it was successful.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
