### PR TITLE
Rename IOLinc sensor due to conflict with Open/Closed sensors

### DIFF
--- a/homeassistant/components/binary_sensor/insteon.py
+++ b/homeassistant/components/binary_sensor/insteon.py
@@ -58,7 +58,7 @@ class InsteonBinarySensor(InsteonEntity, BinarySensorDevice):
         on_val = bool(self._insteon_device_state.value)
 
         if self._insteon_device_state.name in ['lightSensor',
-                                               'openClosedSensor']:
+                                               'ioLincSensor']:
             return not on_val
 
         return on_val

--- a/homeassistant/components/insteon/__init__.py
+++ b/homeassistant/components/insteon/__init__.py
@@ -19,7 +19,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers import discovery
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['insteonplm==0.15.1']
+REQUIREMENTS = ['insteonplm==0.15.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -4,6 +4,7 @@ async_timeout==3.0.1
 attrs==18.2.0
 bcrypt==3.1.4
 certifi>=2018.04.16
+idna=2.7
 jinja2>=2.10
 PyJWT==1.6.4
 cryptography==2.3.1

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -4,7 +4,7 @@ async_timeout==3.0.1
 attrs==18.2.0
 bcrypt==3.1.4
 certifi>=2018.04.16
-idna=2.7
+idna==2.7
 jinja2>=2.10
 PyJWT==1.6.4
 cryptography==2.3.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -5,6 +5,7 @@ async_timeout==3.0.1
 attrs==18.2.0
 bcrypt==3.1.4
 certifi>=2018.04.16
+idna=2.7
 jinja2>=2.10
 PyJWT==1.6.4
 cryptography==2.3.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -5,7 +5,7 @@ async_timeout==3.0.1
 attrs==18.2.0
 bcrypt==3.1.4
 certifi>=2018.04.16
-idna=2.7
+idna==2.7
 jinja2>=2.10
 PyJWT==1.6.4
 cryptography==2.3.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -532,7 +532,7 @@ ihcsdk==2.2.0
 influxdb==5.2.0
 
 # homeassistant.components.insteon
-insteonplm==0.15.1
+insteonplm==0.15.2
 
 # homeassistant.components.sensor.iperf3
 iperf3==0.1.10

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ REQUIRES = [
     'attrs==18.2.0',
     'bcrypt==3.1.4',
     'certifi>=2018.04.16',
+    'idna=2.7',
     'jinja2>=2.10',
     'PyJWT==1.6.4',
     # PyJWT has loose dependency. We want the latest one.

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ REQUIRES = [
     'attrs==18.2.0',
     'bcrypt==3.1.4',
     'certifi>=2018.04.16',
-    'idna=2.7',
+    'idna==2.7',
     'jinja2>=2.10',
     'PyJWT==1.6.4',
     # PyJWT has loose dependency. We want the latest one.


### PR DESCRIPTION
## Description:
The Insteon IOLinc device internal open/closed sensor works different than the standalone open/closed sensor. A change made in version 0.83.0 introduced a bug that fixed IOLinc but broke the other open/closed sensors. 

**Related issue (if applicable):** fixes #18939 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
