### PR TITLE
Allow emulated hue to set climate component temperature

### DIFF
--- a/homeassistant/components/climate/const.py
+++ b/homeassistant/components/climate/const.py
@@ -1,4 +1,4 @@
-"""Proides the constants needed for component."""
+"""Provides the constants needed for component."""
 
 ATTR_AUX_HEAT = 'aux_heat'
 ATTR_AWAY_MODE = 'away_mode'

--- a/tests/components/emulated_hue/test_hue_api.py
+++ b/tests/components/emulated_hue/test_hue_api.py
@@ -11,7 +11,7 @@ from tests.common import get_test_instance_port
 from homeassistant import core, const, setup
 import homeassistant.components as core_components
 from homeassistant.components import (
-    fan, http, light, script, emulated_hue, media_player, cover)
+    fan, http, light, script, emulated_hue, media_player, cover, climate)
 from homeassistant.components.emulated_hue import Config
 from homeassistant.components.emulated_hue.hue_api import (
     HUE_API_STATE_ON, HUE_API_STATE_BRI, HueUsernameView, HueOneLightStateView,
@@ -78,6 +78,15 @@ def hass_hue(loop, hass):
         }))
 
     loop.run_until_complete(
+        setup.async_setup_component(hass, climate.DOMAIN, {
+            'climate': [
+                {
+                    'platform': 'demo',
+                }
+            ]
+        }))
+
+    loop.run_until_complete(
         setup.async_setup_component(hass, media_player.DOMAIN, {
             'media_player': [
                 {
@@ -136,6 +145,22 @@ def hass_hue(loop, hass):
         cover_entity.entity_id, cover_entity.state, attributes=attrs
     )
 
+    # Expose Hvac
+    hvac_entity = hass.states.get('climate.hvac')
+    attrs = dict(hvac_entity.attributes)
+    attrs[emulated_hue.ATTR_EMULATED_HUE_HIDDEN] = False
+    hass.states.async_set(
+        hvac_entity.entity_id, hvac_entity.state, attributes=attrs
+    )
+
+    # Expose HeatPump
+    hp_entity = hass.states.get('climate.heatpump')
+    attrs = dict(hp_entity.attributes)
+    attrs[emulated_hue.ATTR_EMULATED_HUE_HIDDEN] = False
+    hass.states.async_set(
+        hp_entity.entity_id, hp_entity.state, attributes=attrs
+    )
+
     return hass
 
 
@@ -189,6 +214,9 @@ def test_discover_lights(hue_client):
     assert 'fan.living_room_fan' in devices
     assert 'fan.ceiling_fan' not in devices
     assert 'cover.living_room_window' in devices
+    assert 'climate.hvac' in devices
+    assert 'climate.heatpump' in devices
+    assert 'climate.ecobee' not in devices
 
 
 @asyncio.coroutine
@@ -314,6 +342,84 @@ def test_put_light_state_script(hass_hue, hue_client):
     kitchen_light = hass_hue.states.get('light.kitchen_lights')
     assert kitchen_light.state == 'on'
     assert kitchen_light.attributes[light.ATTR_BRIGHTNESS] == level
+
+
+@asyncio.coroutine
+def test_put_light_state_climate_set_temperature(hass_hue, hue_client):
+    """Test setting climate temperature."""
+    brightness = 19
+    temperature = round(brightness / 255 * 100)
+
+    hvac_result = yield from perform_put_light_state(
+        hass_hue, hue_client,
+        'climate.hvac', True, brightness)
+
+    hvac_result_json = yield from hvac_result.json()
+
+    assert hvac_result.status == 200
+    assert len(hvac_result_json) == 2
+
+    hvac = hass_hue.states.get('climate.hvac')
+    assert hvac.state == climate.const.STATE_COOL
+    assert hvac.attributes[climate.ATTR_TEMPERATURE] == temperature
+    assert hvac.attributes[climate.ATTR_OPERATION_MODE] == \
+        climate.const.STATE_COOL
+
+    # Make sure we can't change the ecobee temperature since it's not exposed
+    ecobee_result = yield from perform_put_light_state(
+        hass_hue, hue_client,
+        'climate.ecobee', True)
+    assert ecobee_result.status == 404
+
+
+@asyncio.coroutine
+def test_put_light_state_climate_turn_on(hass_hue, hue_client):
+    """Test inability to turn climate on."""
+    yield from hass_hue.services.async_call(
+        climate.DOMAIN, const.SERVICE_TURN_OFF,
+        {const.ATTR_ENTITY_ID: 'climate.heatpump'},
+        blocking=True)
+
+    # Somehow after calling the above service the device gets unexposed,
+    # so we need to expose it again
+    hp_entity = hass_hue.states.get('climate.heatpump')
+    attrs = dict(hp_entity.attributes)
+    attrs[emulated_hue.ATTR_EMULATED_HUE_HIDDEN] = False
+    hass_hue.states.async_set(
+        hp_entity.entity_id, hp_entity.state, attributes=attrs
+    )
+
+    hp_result = yield from perform_put_light_state(
+        hass_hue, hue_client,
+        'climate.heatpump', True)
+
+    hp_result_json = yield from hp_result.json()
+
+    assert hp_result.status == 200
+    assert len(hp_result_json) == 1
+
+    hp = hass_hue.states.get('climate.heatpump')
+    assert hp.state == STATE_OFF
+    assert hp.attributes[climate.ATTR_OPERATION_MODE] == \
+        climate.const.STATE_HEAT
+
+
+@asyncio.coroutine
+def test_put_light_state_climate_turn_off(hass_hue, hue_client):
+    """Test inability to turn climate off."""
+    hp_result = yield from perform_put_light_state(
+        hass_hue, hue_client,
+        'climate.heatpump', False)
+
+    hp_result_json = yield from hp_result.json()
+
+    assert hp_result.status == 200
+    assert len(hp_result_json) == 1
+
+    hp = hass_hue.states.get('climate.heatpump')
+    assert hp.state == climate.const.STATE_HEAT
+    assert hp.attributes[climate.ATTR_OPERATION_MODE] == \
+        climate.const.STATE_HEAT
 
 
 @asyncio.coroutine


### PR DESCRIPTION
## Description:
This enables the emulated_hue component to set the temperature of climate devices.

The goal here is not to have the thermostat show up as a thermostat in Alexa, because with emulated hue it will show up as a light. The goal is simply to be able to say “Alexa, set the heater to 66” and have it set the thermostat temperature in that way. Things like “Alexa, raise the temperature” or “Alexa, I’m cold” or “Alexa, turn on the heater” won’t work. Only specifically setting the temperature will work.

This change makes it do the same thing it does for setting media player volume. The emulated_hue will “pretend” the thermostat is a light and use the brightness level as the temperature for the thermostat. This is the same thing it already does to media players. It uses the brightness level as the volume level.

**Related issue (if applicable):** This implements the feature requested here: https://community.home-assistant.io/t/emulated-hue-should-support-climate-thermostats/82702

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** There doesn't seem to be any home-assistant.io changes needed.

## Example entry for `configuration.yaml` (if applicable):
```yaml
emulated_hue:
  host_ip: x.x.x.x
  expose_by_default: false
  entities:
    climate.heater:
      hidden: false
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
