### PR TITLE
Change log level from error to warning of media_player.plex

### DIFF
--- a/homeassistant/components/media_player/plex.py
+++ b/homeassistant/components/media_player/plex.py
@@ -150,7 +150,7 @@ def setup_plexserver(
             _LOGGER.exception("Error listing plex devices")
             return
         except requests.exceptions.RequestException as ex:
-            _LOGGER.error(
+            _LOGGER.warning(
                 "Could not connect to plex server at http://%s (%s)", host, ex)
             return
 
@@ -218,7 +218,7 @@ def setup_plexserver(
             _LOGGER.exception("Error listing plex sessions")
             return
         except requests.exceptions.RequestException as ex:
-            _LOGGER.error(
+            _LOGGER.warning(
                 "Could not connect to plex server at http://%s (%s)", host, ex)
             return
 


### PR DESCRIPTION
## Description:
Workaround, to avoid filling log with error when Plex server is down

**Related issue (if applicable):** fixes #16653


## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
