### PR TITLE
Fix CI by pinning IDNA

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -25,3 +25,6 @@ pycrypto==1000000000.0.0
 
 # Contains code to modify Home Assistant to work around our rules
 python-systemair-savecair==1000000000.0.0
+
+# Dec 5, 2018: Request caps idna at <2.8, causing CI to fail
+idna==2.7

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -4,6 +4,7 @@ async_timeout==3.0.1
 attrs==18.2.0
 bcrypt==3.1.4
 certifi>=2018.04.16
+idna==2.7
 jinja2>=2.10
 PyJWT==1.6.4
 cryptography==2.3.1
@@ -25,6 +26,3 @@ pycrypto==1000000000.0.0
 
 # Contains code to modify Home Assistant to work around our rules
 python-systemair-savecair==1000000000.0.0
-
-# Dec 5, 2018: Request caps idna at <2.8, causing CI to fail
-idna==2.7

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -5,6 +5,7 @@ async_timeout==3.0.1
 attrs==18.2.0
 bcrypt==3.1.4
 certifi>=2018.04.16
+idna==2.7
 jinja2>=2.10
 PyJWT==1.6.4
 cryptography==2.3.1

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -149,9 +149,6 @@ pycrypto==1000000000.0.0
 
 # Contains code to modify Home Assistant to work around our rules
 python-systemair-savecair==1000000000.0.0
-
-# Dec 5, 2018: Request caps idna at <2.8, causing CI to fail
-idna==2.7
 """
 
 

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -149,6 +149,9 @@ pycrypto==1000000000.0.0
 
 # Contains code to modify Home Assistant to work around our rules
 python-systemair-savecair==1000000000.0.0
+
+# Dec 5, 2018: Request caps idna at <2.8, causing CI to fail
+idna==2.7
 """
 
 

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,8 @@ REQUIRES = [
     'attrs==18.2.0',
     'bcrypt==3.1.4',
     'certifi>=2018.04.16',
+    # Dec 5, 2018: Idna released 2.8, requests caps idna at <2.8, CI fails
+    'idna==2.7',
     'jinja2>=2.10',
     'PyJWT==1.6.4',
     # PyJWT has loose dependency. We want the latest one.


### PR DESCRIPTION
## Description:
IDNA released 2.8. Requests caps IDNA at <2.8 which causes CI to break. Attempt to pin it.