### PR TITLE
Bump pyvizio version in vizio.py

### DIFF
--- a/homeassistant/components/media_player/vizio.py
+++ b/homeassistant/components/media_player/vizio.py
@@ -20,7 +20,7 @@ from homeassistant.const import (
     STATE_UNKNOWN)
 from homeassistant.helpers import config_validation as cv
 
-REQUIREMENTS = ['pyvizio==0.0.3']
+REQUIREMENTS = ['pyvizio==0.0.4']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1325,7 +1325,7 @@ pyvera==0.2.45
 pyvesync==0.1.1
 
 # homeassistant.components.media_player.vizio
-pyvizio==0.0.3
+pyvizio==0.0.4
 
 # homeassistant.components.velux
 pyvlx==0.1.3


### PR DESCRIPTION
Bump pyvizio version to resolve get volume call and component setup failures

## Description:

**Related issue (if applicable):** fixes #18577

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
