### PR TITLE
Implement RVU Genie client device discovery

### DIFF
--- a/homeassistant/components/media_player/directv.py
+++ b/homeassistant/components/media_player/directv.py
@@ -591,24 +591,3 @@ class DirecTvDevice(MediaPlayerDevice):
 
         _LOGGER.debug("Changing channel on %s to %s", self._name, media_id)
         self.dtv.tune_channel(media_id)
-
-    def mute_volume(self, mute):
-        pass
-
-    def set_volume_level(self, volume):
-        pass
-
-    def media_seek(self, position):
-        pass
-
-    def select_source(self, source):
-        pass
-
-    def select_sound_mode(self, sound_mode):
-        pass
-
-    def clear_playlist(self):
-        pass
-
-    def set_shuffle(self, shuffle):
-        pass

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -321,7 +321,7 @@ deluge-client==1.4.0
 denonavr==0.7.8
 
 # homeassistant.components.media_player.directv
-directpy==0.5
+directpy==0.6
 
 # homeassistant.components.sensor.discogs
 discogs_client==2.2.1

--- a/tests/components/media_player/test_directv.py
+++ b/tests/components/media_player/test_directv.py
@@ -15,7 +15,8 @@ from homeassistant.components.media_player.const import (
     SUPPORT_PREVIOUS_TRACK, SUPPORT_PLAY)
 from homeassistant.components.media_player.directv import (
     ATTR_MEDIA_CURRENTLY_RECORDING, ATTR_MEDIA_RATING, ATTR_MEDIA_RECORDED,
-    ATTR_MEDIA_START_TIME, DEFAULT_DEVICE, DEFAULT_PORT)
+    ATTR_MEDIA_START_TIME, DEFAULT_CLIENT_DISCOVER_INTERVAL, DEFAULT_DEVICE,
+    DEFAULT_PORT)
 from homeassistant.const import (
     ATTR_ENTITY_ID, CONF_DEVICE, CONF_HOST, CONF_NAME, CONF_PORT,
     SERVICE_MEDIA_NEXT_TRACK, SERVICE_MEDIA_PAUSE, SERVICE_MEDIA_PLAY,
@@ -29,11 +30,12 @@ from tests.common import MockDependency, async_fire_time_changed
 
 CLIENT_ENTITY_ID = 'media_player.client_dvr'
 MAIN_ENTITY_ID = 'media_player.main_dvr'
+HOST_NAME = 'localhost'
 IP_ADDRESS = '127.0.0.1'
 
 DISCOVERY_INFO = {
     'host': IP_ADDRESS,
-    'serial': 1234
+    'serial': 'RID-123456789012'
 }
 
 LIVE = {
@@ -86,7 +88,7 @@ RECORDING = {
 WORKING_CONFIG = {
     'media_player': {
         'platform': 'directv',
-        CONF_HOST: IP_ADDRESS,
+        CONF_HOST: HOST_NAME,
         CONF_NAME: 'Main DVR',
         CONF_PORT: DEFAULT_PORT,
         CONF_DEVICE: DEFAULT_DEVICE
@@ -251,7 +253,7 @@ class MockDirectvClass:
     def get_tuned(self):
         """Mock for get_tuned method."""
         if self._play:
-            self.attributes['offset'] = self.attributes['offset']+1
+            self.attributes['offset'] = self.attributes['offset'] + 1
 
         test_attributes = self.attributes
         test_attributes['status'] = {
@@ -279,6 +281,24 @@ class MockDirectvClass:
         """Mock for tune_channel method."""
         self.attributes['major'] = int(source)
 
+    def get_version(self):
+        """Mock for get_version method."""
+        test_version = {
+            'accessCardId': '0011-1265-7890',
+            'receiverId': '1234 5678 9012',
+            'status': {
+                'code': 200,
+                'commandResult': 0,
+                'msg': 'OK.',
+                'query': '/info/getVersion'
+            },
+            'stbSoftwareVersion': '0x1234',
+            'systemTime': 1543947120,
+            'version': '2.1'
+        }
+
+        return test_version
+
 
 async def test_setup_platform_config(hass):
     """Test setting up the platform from configuration."""
@@ -295,18 +315,29 @@ async def test_setup_platform_config(hass):
 
 async def test_setup_platform_discover(hass):
     """Test setting up the platform from discovery."""
+    LOCATIONS.append({
+        'locationName': 'Client 1',
+        'clientAddr': '1'
+    })
+
     with MockDependency('DirectPy'), \
             patch('DirectPy.DIRECTV', new=MockDirectvClass):
 
+        await hass.async_start()
+        await hass.async_block_till_done()
         hass.async_create_task(
             async_load_platform(hass, DOMAIN, 'directv', DISCOVERY_INFO,
                                 {'media_player': {}})
         )
         await hass.async_block_till_done()
 
+    del LOCATIONS[-1]
+
     state = hass.states.get(MAIN_ENTITY_ID)
     assert state
-    assert len(hass.states.async_entity_ids('media_player')) == 1
+    state = hass.states.get('media_player.client_1')
+    assert state
+    assert len(hass.states.async_entity_ids('media_player')) == 2
 
 
 async def test_setup_platform_discover_duplicate(hass):
@@ -327,15 +358,15 @@ async def test_setup_platform_discover_duplicate(hass):
     assert len(hass.states.async_entity_ids('media_player')) == 1
 
 
-async def test_setup_platform_discover_client(hass):
-    """Test setting up the platform from discovery."""
+async def test_setup_platform_discover_client(hass, mock_now):
+    """Test setting up the platform from discovery.
+
+    First client should be added upon initialization of the platform.
+    Second client should be added by the scheduled discovery task.
+    """
     LOCATIONS.append({
         'locationName': 'Client 1',
         'clientAddr': '1'
-    })
-    LOCATIONS.append({
-        'locationName': 'Client 2',
-        'clientAddr': '2'
     })
 
     with MockDependency('DirectPy'), \
@@ -343,19 +374,41 @@ async def test_setup_platform_discover_client(hass):
 
         await async_setup_component(hass, DOMAIN, WORKING_CONFIG)
         await hass.async_block_till_done()
+        await hass.async_start()
+        await hass.async_block_till_done()
 
-        hass.async_create_task(
-            async_load_platform(hass, DOMAIN, 'directv', DISCOVERY_INFO,
-                                {'media_player': {}})
-        )
+    state = hass.states.get(MAIN_ENTITY_ID)
+    assert state
+    assert len(hass.states.async_entity_ids('media_player')) == 1
+
+    next_update = mock_now + DEFAULT_CLIENT_DISCOVER_INTERVAL + \
+        timedelta(seconds=1)
+    with MockDependency('DirectPy'), \
+            patch('DirectPy.DIRECTV', new=MockDirectvClass), \
+            patch('homeassistant.util.dt.utcnow', return_value=next_update):
+        async_fire_time_changed(hass, next_update)
+        await hass.async_block_till_done()
+
+    state = hass.states.get('media_player.client_1')
+    assert state
+    assert len(hass.states.async_entity_ids('media_player')) == 2
+
+    LOCATIONS.append({
+        'locationName': 'Client 2',
+        'clientAddr': '2'
+    })
+
+    next_update = next_update + DEFAULT_CLIENT_DISCOVER_INTERVAL + \
+        timedelta(seconds=1)
+    with MockDependency('DirectPy'), \
+            patch('DirectPy.DIRECTV', new=MockDirectvClass), \
+            patch('homeassistant.util.dt.utcnow', return_value=next_update):
+        async_fire_time_changed(hass, next_update)
         await hass.async_block_till_done()
 
     del LOCATIONS[-1]
     del LOCATIONS[-1]
-    state = hass.states.get(MAIN_ENTITY_ID)
-    assert state
-    state = hass.states.get('media_player.client_1')
-    assert state
+
     state = hass.states.get('media_player.client_2')
     assert state
 


### PR DESCRIPTION
## Description:

Perform discovery of RVU Genie client devices allowing them to be discovered even when they are offline upon discovery of the main Genie DVR.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#7768

## Example entry for `configuration.yaml` (if applicable):
```yaml
media_player:
  - platform: directv
    host: 192.168.1.2
    port: 8080
    name: Family_Room
    device: 0
    discover_clients: true
    client_discover_interval: 20
  - platform: directv
    host: 192.168.1.2
    port: 8080
    name: Master Bedroom
    device: 0
    discover_clients: false
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.

