### PR TITLE
Fix Insteon open/closed sensors

### DIFF
--- a/homeassistant/components/binary_sensor/insteon.py
+++ b/homeassistant/components/binary_sensor/insteon.py
@@ -14,6 +14,7 @@ DEPENDENCIES = ['insteon']
 _LOGGER = logging.getLogger(__name__)
 
 SENSOR_TYPES = {'openClosedSensor': 'opening',
+                'ioLincSensor': 'opening',
                 'motionSensor': 'motion',
                 'doorSensor': 'door',
                 'wetLeakSensor': 'moisture',
@@ -58,7 +59,7 @@ class InsteonBinarySensor(InsteonEntity, BinarySensorDevice):
         on_val = bool(self._insteon_device_state.value)
 
         if self._insteon_device_state.name in ['lightSensor',
-                                               'openClosedSensor']:
+                                               'ioLincSensor']:
             return not on_val
 
         return on_val

--- a/homeassistant/components/insteon/__init__.py
+++ b/homeassistant/components/insteon/__init__.py
@@ -19,7 +19,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers import discovery
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['insteonplm==0.15.1']
+REQUIREMENTS = ['insteonplm==0.15.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -532,7 +532,7 @@ ihcsdk==2.2.0
 influxdb==5.2.0
 
 # homeassistant.components.insteon
-insteonplm==0.15.1
+insteonplm==0.15.2
 
 # homeassistant.components.sensor.iperf3
 iperf3==0.1.10


### PR DESCRIPTION
## Description:
A change made in 0.83.0 created a bug with Insteon Open/closed Binary Sensors. This change fixes that bug.

**Related issue (if applicable):** fixes #18939 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
