### PR TITLE
Implemented unique ID support for Fibaro hub integration

### DIFF
--- a/homeassistant/components/fibaro.py
+++ b/homeassistant/components/fibaro.py
@@ -392,7 +392,5 @@ class FibaroDevice(Entity):
         except (ValueError, KeyError):
             pass
 
-        attr['room'] = self.fibaro_device.room_name
         attr['fibaro_id'] = self.fibaro_device.id
-        attr['fibaro_hub'] = self.controller.hub_serial
         return attr


### PR DESCRIPTION
## Description:

Implemented unique ID support for Fibaro hub integration
The unique ID is generated from the hub's serial number and the device's permanent ID

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
