### PR TITLE
Update pyhomematic to 0.1.53

### DIFF
--- a/homeassistant/components/homematic/__init__.py
+++ b/homeassistant/components/homematic/__init__.py
@@ -13,12 +13,13 @@ import voluptuous as vol
 
 from homeassistant.const import (
     ATTR_ENTITY_ID, ATTR_NAME, CONF_HOST, CONF_HOSTS, CONF_PASSWORD,
-    CONF_PLATFORM, CONF_USERNAME, EVENT_HOMEASSISTANT_STOP, STATE_UNKNOWN)
+    CONF_PLATFORM, CONF_USERNAME, CONF_SSL, CONF_VERIFY_SSL,
+    EVENT_HOMEASSISTANT_STOP, STATE_UNKNOWN)
 from homeassistant.helpers import discovery
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['pyhomematic==0.1.52']
+REQUIREMENTS = ['pyhomematic==0.1.53']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -77,7 +78,8 @@ HM_DEVICE_TYPES = {
         'IPSmoke', 'RFSiren', 'PresenceIP', 'IPAreaThermostat',
         'IPWeatherSensor', 'RotaryHandleSensorIP', 'IPPassageSensor',
         'IPKeySwitchPowermeter', 'IPThermostatWall230V', 'IPWeatherSensorPlus',
-        'IPWeatherSensorBasic', 'IPBrightnessSensor', 'IPGarage'],
+        'IPWeatherSensorBasic', 'IPBrightnessSensor', 'IPGarage',
+        'UniversalSensor'],
     DISCOVER_CLIMATE: [
         'Thermostat', 'ThermostatWall', 'MAXThermostat', 'ThermostatWall2',
         'MAXWallThermostat', 'IPThermostat', 'IPThermostatWall',
@@ -173,6 +175,9 @@ DEFAULT_PORT = 2001
 DEFAULT_PATH = ''
 DEFAULT_USERNAME = 'Admin'
 DEFAULT_PASSWORD = ''
+DEFAULT_SSL = False
+DEFAULT_VERIFY_SSL = False
+DEFAULT_CHANNEL = 1
 
 
 DEVICE_SCHEMA = vol.Schema({
@@ -180,7 +185,7 @@ DEVICE_SCHEMA = vol.Schema({
     vol.Required(ATTR_NAME): cv.string,
     vol.Required(ATTR_ADDRESS): cv.string,
     vol.Required(ATTR_INTERFACE): cv.string,
-    vol.Optional(ATTR_CHANNEL, default=1): vol.Coerce(int),
+    vol.Optional(ATTR_CHANNEL, default=DEFAULT_CHANNEL): vol.Coerce(int),
     vol.Optional(ATTR_PARAM): cv.string,
     vol.Optional(ATTR_UNIQUE_ID): cv.string,
 })
@@ -198,6 +203,9 @@ CONFIG_SCHEMA = vol.Schema({
             vol.Optional(CONF_PASSWORD, default=DEFAULT_PASSWORD): cv.string,
             vol.Optional(CONF_CALLBACK_IP): cv.string,
             vol.Optional(CONF_CALLBACK_PORT): cv.port,
+            vol.Optional(CONF_SSL, default=DEFAULT_SSL): cv.boolean,
+            vol.Optional(
+                CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): cv.boolean,
         }},
         vol.Optional(CONF_HOSTS, default={}): {cv.match_all: {
             vol.Required(CONF_HOST): cv.string,
@@ -268,6 +276,8 @@ def setup(hass, config):
             'password': rconfig.get(CONF_PASSWORD),
             'callbackip': rconfig.get(CONF_CALLBACK_IP),
             'callbackport': rconfig.get(CONF_CALLBACK_PORT),
+            'ssl': rconfig.get(CONF_SSL),
+            'verify_ssl': rconfig.get(CONF_VERIFY_SSL),
             'connect': True,
         }
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -978,7 +978,7 @@ pyhik==0.1.8
 pyhiveapi==0.2.14
 
 # homeassistant.components.homematic
-pyhomematic==0.1.52
+pyhomematic==0.1.53
 
 # homeassistant.components.sensor.hydroquebec
 pyhydroquebec==2.2.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -169,7 +169,7 @@ pydeconz==47
 pydispatcher==2.0.5
 
 # homeassistant.components.homematic
-pyhomematic==0.1.52
+pyhomematic==0.1.53
 
 # homeassistant.components.litejet
 pylitejet==0.1


### PR DESCRIPTION
## Description:
- Fixes unknown-parameter-errors
- Adds support for SSL connections with CCU3
- Adds support for authentication with CCU3
- Adds support for hostnames as XML-RPC endpoints
- Adds support for devices: HmIP-eTRV-B, HmIP-FDT, HB-UW-Sen-THPL-O, HB-UW-Sen-THPL-I, HmIP-B1

I have set `DEFAULT_VERIFY_SSL` to `False` because I am pretty sure, that at most an insignificant minority of users will have valid certificates configured on their CCU3.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#7750

## Example entry for `configuration.yaml` (if applicable):
```yaml
# Example for connecting to a SSL enabled CCU3 with active authentication
homematic:
  interfaces:
    wireless:
      host: 192.168.1.23
      port: 42001
      ssl: true
      verify_ssl: false # Added for completeness since false is the default
      username: Admin
      password: secret
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
