### PR TITLE
Fix saving YAML as JSON with empty array

### DIFF
--- a/homeassistant/components/lovelace/__init__.py
+++ b/homeassistant/components/lovelace/__init__.py
@@ -267,6 +267,8 @@ def add_card(fname: str, view_id: str, card_config: str,
         if str(view.get('id', '')) != view_id:
             continue
         cards = view.get('cards', [])
+        if len(cards) == 0 and 'cards' in view:
+            del view['cards']
         if data_format == FORMAT_YAML:
             card_config = yaml.yaml_to_object(card_config)
         if 'id' not in card_config:
@@ -275,6 +277,8 @@ def add_card(fname: str, view_id: str, card_config: str,
             cards.append(card_config)
         else:
             cards.insert(position, card_config)
+        if 'cards' not in view:
+            view['cards'] = cards
         yaml.save_yaml(fname, config)
         return
 
@@ -402,6 +406,8 @@ def add_view(fname: str, view_config: str,
         views.append(view_config)
     else:
         views.insert(position, view_config)
+    if 'views' not in config:
+        config['views'] = views
     yaml.save_yaml(fname, config)
 
 

--- a/homeassistant/components/lovelace/__init__.py
+++ b/homeassistant/components/lovelace/__init__.py
@@ -267,7 +267,7 @@ def add_card(fname: str, view_id: str, card_config: str,
         if str(view.get('id', '')) != view_id:
             continue
         cards = view.get('cards', [])
-        if len(cards) == 0 and 'cards' in view:
+        if not cards and 'cards' in view:
             del view['cards']
         if data_format == FORMAT_YAML:
             card_config = yaml.yaml_to_object(card_config)


### PR DESCRIPTION
## Description: 
It is kinda dirty... 
It looks like ruamel stores if it was a JSON array and keeps it that way? Removing it if it was empty and recreating it fixes it.

Before:
```yaml
  - id: test2
    title: Test2
    badges:
      - a.demo_mode
      - alarm_control_panel.alarm
    cards: [{type: entities, id: 43e603545e138c7f9689, entities: [entity: a.demo_mode]},
       {type: glance, id: 0be5f165b9d7fd604a4d, entities: [entity: alarm_control_panel.alarm]},
       {type: alarm-panel, id: 2904d6f2cd37b5df460a}]
```

After:
```yaml
  - title: test3
    badges: []
    id: ac02c1c87bb64763a27cb73e61474ae9
    cards:
      - type: entities
        id: 0d87ab625fa8ff155eb4
        entities: []
      - type: horizontal-graph
        id: ed2be2ea0e7c5e0faeaf
      - type: sensor
        id: 326a13fd673886baede4
```