### PR TITLE
Fix missing colorTemperatureInKelvin from Alexa responses

### DIFF
--- a/homeassistant/components/alexa/smart_home.py
+++ b/homeassistant/components/alexa/smart_home.py
@@ -504,6 +504,20 @@ class _AlexaColorTemperatureController(_AlexaInterface):
     def name(self):
         return 'Alexa.ColorTemperatureController'
 
+    def properties_supported(self):
+        return [{'name': 'colorTemperatureInKelvin'}]
+
+    def properties_retrievable(self):
+        return True
+
+    def get_property(self, name):
+        if name != 'colorTemperatureInKelvin':
+            raise _UnsupportedProperty(name)
+        if 'color_temp' in self.entity.attributes:
+            return color_util.color_temperature_mired_to_kelvin(
+                    self.entity.attributes['color_temp'])
+        return 0
+
 
 class _AlexaPercentageController(_AlexaInterface):
     """Implements Alexa.PercentageController.

--- a/homeassistant/components/alexa/smart_home.py
+++ b/homeassistant/components/alexa/smart_home.py
@@ -515,7 +515,7 @@ class _AlexaColorTemperatureController(_AlexaInterface):
             raise _UnsupportedProperty(name)
         if 'color_temp' in self.entity.attributes:
             return color_util.color_temperature_mired_to_kelvin(
-                    self.entity.attributes['color_temp'])
+                self.entity.attributes['color_temp'])
         return 0
 
 

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -1354,6 +1354,25 @@ async def test_report_colored_light_state(hass):
     })
 
 
+async def test_report_colored_temp_light_state(hass):
+    """Test ColorTemperatureController reports color temp correctly."""
+    hass.states.async_set(
+        'light.test_on', 'on', {'friendly_name': "Test light On",
+                                'color_temp': 240,
+                                'supported_features': 2})
+    hass.states.async_set(
+        'light.test_off', 'off', {'friendly_name': "Test light Off",
+                                  'supported_features': 2})
+
+    properties = await reported_properties(hass, 'light.test_on')
+    properties.assert_equal('Alexa.ColorTemperatureController',
+                            'colorTemperatureInKelvin', 4166)
+
+    properties = await reported_properties(hass, 'light.test_off')
+    properties.assert_equal('Alexa.ColorTemperatureController',
+                            'colorTemperatureInKelvin', 0)
+
+
 async def reported_properties(hass, endpoint):
     """Use ReportState to get properties and return them.
 


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes #18827

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54