### PR TITLE
Upgrade pyatv to 0.3.12

### DIFF
--- a/homeassistant/components/apple_tv.py
+++ b/homeassistant/components/apple_tv.py
@@ -16,7 +16,7 @@ from homeassistant.helpers import discovery
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['pyatv==0.3.11']
+REQUIREMENTS = ['pyatv==0.3.12']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -861,7 +861,7 @@ pyarlo==0.2.2
 pyatmo==1.4
 
 # homeassistant.components.apple_tv
-pyatv==0.3.11
+pyatv==0.3.12
 
 # homeassistant.components.device_tracker.bbox
 # homeassistant.components.sensor.bbox


### PR DESCRIPTION
## Description:

Bump pyatv to 0.3.12 with the following changes:

* Fix breaking change in tvOS 12.1.1 (details in postlund/pyatv#158)
* Manually paired remotes are no longer removed when rebooting Apple TV (postlund/pyatv#127)
* Handle leading zeros when pairing (postlund/pyatv#163)
* Improved error when using AirPlay without credentials
* Fixed bug introduced in 0.3.11 where a status code was not handled properly when no artwork was available (seen as an exception)

**Related issue (if applicable):** fixes #18325

## Checklist:

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
