### PR TITLE
Add traccar motion, speed and battery_level attributes

### DIFF
--- a/homeassistant/components/device_tracker/traccar.py
+++ b/homeassistant/components/device_tracker/traccar.py
@@ -93,7 +93,7 @@ class TraccarScanner:
             if device.get('battery') is not None:
                 attr[ATTR_BATTERY_LEVEL] = device.get('battery')
             if device.get('motion') is not None:
-                attr[ATTR_MOTION] = device.get('motion')
+                attr[ATTR_MOTION] = device['motion']
             await self._async_see(
                 dev_id=slugify(device['device_id']),
                 gps=(device.get('latitude'), device.get('longitude')),

--- a/homeassistant/components/device_tracker/traccar.py
+++ b/homeassistant/components/device_tracker/traccar.py
@@ -12,20 +12,22 @@ import voluptuous as vol
 from homeassistant.components.device_tracker import PLATFORM_SCHEMA
 from homeassistant.const import (
     CONF_HOST, CONF_PORT, CONF_SSL, CONF_VERIFY_SSL,
-    CONF_PASSWORD, CONF_USERNAME)
+    CONF_PASSWORD, CONF_USERNAME, ATTR_BATTERY_LEVEL)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.util import slugify
 
 
-REQUIREMENTS = ['pytraccar==0.1.2']
+REQUIREMENTS = ['pytraccar==0.2.0']
 
 _LOGGER = logging.getLogger(__name__)
 
 ATTR_ADDRESS = 'address'
 ATTR_CATEGORY = 'category'
 ATTR_GEOFENCE = 'geofence'
+ATTR_MOTION = 'motion'
+ATTR_SPEED = 'speed'
 ATTR_TRACKER = 'tracker'
 
 DEFAULT_SCAN_INTERVAL = timedelta(seconds=30)
@@ -78,13 +80,21 @@ class TraccarScanner:
         await self._api.get_device_info()
         for devicename in self._api.device_info:
             device = self._api.device_info[devicename]
-            device_attributes = {
-                ATTR_ADDRESS: device['address'],
-                ATTR_GEOFENCE: device['geofence'],
-                ATTR_CATEGORY: device['category'],
-                ATTR_TRACKER: 'traccar'
-                }
+            attr = {}
+            attr[ATTR_TRACKER] = 'traccar'
+            if device.get('address') is not None:
+                attr[ATTR_ADDRESS] = device.get('address')
+            if device.get('geofence') is not None:
+                attr[ATTR_GEOFENCE] = device.get('geofence')
+            if device.get('category') is not None:
+                attr[ATTR_CATEGORY] = device.get('category')
+            if device.get('speed') is not None:
+                attr[ATTR_SPEED] = device.get('speed')
+            if device.get('battery') is not None:
+                attr[ATTR_BATTERY_LEVEL] = device.get('battery')
+            if device.get('motion') is not None:
+                attr[ATTR_MOTION] = device.get('motion')
             await self._async_see(
                 dev_id=slugify(device['device_id']),
-                gps=(device['latitude'], device['longitude']),
-                attributes=device_attributes)
+                gps=(device.get('latitude'), device.get('longitude')),
+                attributes=attr)

--- a/homeassistant/components/device_tracker/traccar.py
+++ b/homeassistant/components/device_tracker/traccar.py
@@ -89,7 +89,7 @@ class TraccarScanner:
             if device.get('category') is not None:
                 attr[ATTR_CATEGORY] = device.get('category')
             if device.get('speed') is not None:
-                attr[ATTR_SPEED] = device.get('speed')
+                attr[ATTR_SPEED] = device['speed']
             if device.get('battery') is not None:
                 attr[ATTR_BATTERY_LEVEL] = device.get('battery')
             if device.get('motion') is not None:

--- a/homeassistant/components/device_tracker/traccar.py
+++ b/homeassistant/components/device_tracker/traccar.py
@@ -83,7 +83,7 @@ class TraccarScanner:
             attr = {}
             attr[ATTR_TRACKER] = 'traccar'
             if device.get('address') is not None:
-                attr[ATTR_ADDRESS] = device.get('address')
+                attr[ATTR_ADDRESS] = device['address']
             if device.get('geofence') is not None:
                 attr[ATTR_GEOFENCE] = device.get('geofence')
             if device.get('category') is not None:

--- a/homeassistant/components/device_tracker/traccar.py
+++ b/homeassistant/components/device_tracker/traccar.py
@@ -87,7 +87,7 @@ class TraccarScanner:
             if device.get('geofence') is not None:
                 attr[ATTR_GEOFENCE] = device['geofence']
             if device.get('category') is not None:
-                attr[ATTR_CATEGORY] = device.get('category')
+                attr[ATTR_CATEGORY] = device['category']
             if device.get('speed') is not None:
                 attr[ATTR_SPEED] = device['speed']
             if device.get('battery') is not None:

--- a/homeassistant/components/device_tracker/traccar.py
+++ b/homeassistant/components/device_tracker/traccar.py
@@ -85,7 +85,7 @@ class TraccarScanner:
             if device.get('address') is not None:
                 attr[ATTR_ADDRESS] = device['address']
             if device.get('geofence') is not None:
-                attr[ATTR_GEOFENCE] = device.get('geofence')
+                attr[ATTR_GEOFENCE] = device['geofence']
             if device.get('category') is not None:
                 attr[ATTR_CATEGORY] = device.get('category')
             if device.get('speed') is not None:

--- a/homeassistant/components/device_tracker/traccar.py
+++ b/homeassistant/components/device_tracker/traccar.py
@@ -91,7 +91,7 @@ class TraccarScanner:
             if device.get('speed') is not None:
                 attr[ATTR_SPEED] = device['speed']
             if device.get('battery') is not None:
-                attr[ATTR_BATTERY_LEVEL] = device.get('battery')
+                attr[ATTR_BATTERY_LEVEL] = device['battery']
             if device.get('motion') is not None:
                 attr[ATTR_MOTION] = device['motion']
             await self._async_see(

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1298,7 +1298,7 @@ pytile==2.0.5
 pytouchline==0.7
 
 # homeassistant.components.device_tracker.traccar
-pytraccar==0.1.2
+pytraccar==0.2.0
 
 # homeassistant.components.device_tracker.trackr
 pytrackr==0.0.5


### PR DESCRIPTION
## Description:

Adds more attributes to Traccar entities (if they are present):
- `battery_level`
- `motion`
- `speed`

Requested here <https://community.home-assistant.io/t/more-traccar-attributes/82779>

## Breaking change
Attributes will only exist if there is data to show for that attribute.

<!--
**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>
-->
## Example entry for `configuration.yaml` (if applicable):
```yaml
device_tracker:
  - platform: traccar
    host: 192.168.2.11
    port: 8072
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
<!--
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)
-->
If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
<!--  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
-->
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54