### PR TITLE
Bump skybellpy version to fix api issue

### DIFF
--- a/homeassistant/components/skybell.py
+++ b/homeassistant/components/skybell.py
@@ -14,7 +14,7 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['skybellpy==0.1.2']
+REQUIREMENTS = ['skybellpy==0.2.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1431,7 +1431,7 @@ simplisafe-python==3.1.14
 sisyphus-control==2.1
 
 # homeassistant.components.skybell
-skybellpy==0.1.2
+skybellpy==0.2.0
 
 # homeassistant.components.notify.slack
 slacker==0.11.0


### PR DESCRIPTION
## Description:
Increase skybellpy version number to version with fixes for API changes.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>
fixes https://github.com/home-assistant/home-assistant/issues/17617

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>
n/a

## Example entry for `configuration.yaml` (if applicable):
```yaml
n/a
```

## Checklist:
  - [ x ] The code change is tested and works locally.
  - [ x ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ x ] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ x ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ x ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ x ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ x ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ x ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ x ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
