### PR TITLE
Don't avoid async_schedule_update_ha_state by returning false

### DIFF
--- a/homeassistant/components/binary_sensor/xiaomi_aqara.py
+++ b/homeassistant/components/binary_sensor/xiaomi_aqara.py
@@ -423,9 +423,7 @@ class XiaomiButton(XiaomiBinarySensor):
         })
         self._last_action = click_type
 
-        if value in ['long_click_press', 'long_click_release']:
-            return True
-        return False
+        return True
 
 
 class XiaomiCube(XiaomiBinarySensor):


### PR DESCRIPTION
## Description:

If `parse_data` returns true `async_schedule_update_ha_state` is triggered. At the moment some attribute updates doesn't propagate because update_ha_state isn't called often enough. 

**Related issue (if applicable):** fixes #19089

https://community.home-assistant.io/t/xiaomi-button-no-longer-registers-single-or-double-press/83129
