### PR TITLE
Fix the Xiaomi Aqara Cube rotate event of the LAN protocol 2.0

### DIFF
--- a/homeassistant/components/binary_sensor/xiaomi_aqara.py
+++ b/homeassistant/components/binary_sensor/xiaomi_aqara.py
@@ -467,4 +467,12 @@ class XiaomiCube(XiaomiBinarySensor):
             })
             self._last_action = 'rotate'
 
+        if 'rotate_degree' in data:
+            self._hass.bus.fire('xiaomi_aqara.cube_action', {
+                'entity_id': self.entity_id,
+                'action_type': 'rotate',
+                'action_value': float(data['rotate_degree'].replace(",", "."))
+            })
+            self._last_action = 'rotate'
+
         return True


### PR DESCRIPTION
## Description:

The payload of the LAN protocol v2 has changed a bit.

**Related issue (if applicable):** fixes #18199

