### PR TITLE
Update radiotherm to 2.0.0 and handle change in tstat error detection

### DIFF
--- a/homeassistant/components/climate/radiotherm.py
+++ b/homeassistant/components/climate/radiotherm.py
@@ -235,13 +235,15 @@ class RadioThermostat(ClimateDevice):
             self._name = self.device.name['raw']
 
         # Request the current state from the thermostat.
-        data = self.device.tstat['raw']
+        import radiotherm
+        try:
+            data = self.device.tstat['raw']
+        except radiotherm.validate.RadiothermTstatError:
+            _LOGGER.error('%s (%s) was busy (invalid value returned)',
+                          self._name, self.device.host)
+            return
 
         current_temp = data['temp']
-        if current_temp == -1:
-            _LOGGER.error('%s (%s) was busy (temp == -1)', self._name,
-                          self.device.host)
-            return
 
         # Map thermostat values into various STATE_ flags.
         self._current_temperature = current_temp

--- a/homeassistant/components/climate/radiotherm.py
+++ b/homeassistant/components/climate/radiotherm.py
@@ -17,7 +17,7 @@ from homeassistant.const import (
     CONF_HOST, TEMP_FAHRENHEIT, ATTR_TEMPERATURE, PRECISION_HALVES)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['radiotherm==1.4.1']
+REQUIREMENTS = ['radiotherm==2.0.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1352,7 +1352,7 @@ quantum-gateway==0.0.3
 rachiopy==0.1.3
 
 # homeassistant.components.climate.radiotherm
-radiotherm==1.4.1
+radiotherm==2.0.0
 
 # homeassistant.components.raincloud
 raincloudy==0.0.5


### PR DESCRIPTION
## Description:
Updates the radiotherm module version to 2.0.0 and changes how errors from the tstat are handled to be in line with the change in API in radiothermm 2.0.0.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.


If the code communicates with devices, web services, or third-party tools:
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
