### PR TITLE
Add ability to set temperature to a given fan_mode

### DIFF
--- a/homeassistant/components/climate/__init__.py
+++ b/homeassistant/components/climate/__init__.py
@@ -112,6 +112,7 @@ SET_TEMPERATURE_SCHEMA = vol.Schema(vol.All(
         vol.Inclusive(ATTR_TARGET_TEMP_LOW, 'temperature'): vol.Coerce(float),
         vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
         vol.Optional(ATTR_OPERATION_MODE): cv.string,
+        vol.Optional(ATTR_FAN_MODE): cv.string,
     }
 ))
 SET_FAN_MODE_SCHEMA = vol.Schema({

--- a/homeassistant/components/climate/mqtt.py
+++ b/homeassistant/components/climate/mqtt.py
@@ -14,9 +14,10 @@ from homeassistant.components import mqtt, climate
 from homeassistant.components.climate import (
     STATE_HEAT, STATE_COOL, STATE_DRY, STATE_FAN_ONLY, ClimateDevice,
     PLATFORM_SCHEMA as CLIMATE_PLATFORM_SCHEMA, STATE_AUTO,
-    ATTR_OPERATION_MODE, SUPPORT_TARGET_TEMPERATURE, SUPPORT_OPERATION_MODE,
-    SUPPORT_SWING_MODE, SUPPORT_FAN_MODE, SUPPORT_AWAY_MODE, SUPPORT_HOLD_MODE,
-    SUPPORT_AUX_HEAT, DEFAULT_MIN_TEMP, DEFAULT_MAX_TEMP)
+    ATTR_OPERATION_MODE, ATTR_FAN_MODE, SUPPORT_TARGET_TEMPERATURE,
+    SUPPORT_OPERATION_MODE, SUPPORT_SWING_MODE, SUPPORT_FAN_MODE,
+    SUPPORT_AWAY_MODE, SUPPORT_HOLD_MODE, SUPPORT_AUX_HEAT, DEFAULT_MIN_TEMP,
+    DEFAULT_MAX_TEMP)
 from homeassistant.const import (
     STATE_ON, STATE_OFF, ATTR_TEMPERATURE, CONF_NAME, CONF_VALUE_TEMPLATE)
 from homeassistant.components.mqtt import (
@@ -523,6 +524,10 @@ class MqttClimate(MqttAvailability, MqttDiscoveryUpdate, ClimateDevice):
 
     async def async_set_temperature(self, **kwargs):
         """Set new target temperatures."""
+        if kwargs.get(ATTR_FAN_MODE) is not None:
+            fan_mode = kwargs.get(ATTR_FAN_MODE)
+            await self.async_set_fan_mode(fan_mode)
+
         if kwargs.get(ATTR_OPERATION_MODE) is not None:
             operation_mode = kwargs.get(ATTR_OPERATION_MODE)
             await self.async_set_operation_mode(operation_mode)

--- a/homeassistant/components/climate/services.yaml
+++ b/homeassistant/components/climate/services.yaml
@@ -45,6 +45,9 @@ set_temperature:
     operation_mode:
       description: Operation mode to set temperature to. This defaults to current_operation mode if not set, or set incorrectly.
       example: 'Heat'
+    fan_mode:
+      description: Fan mode to set temperature to. This defaults to current_fan_mode if not set, or set incorrectly.
+      example: 'low'
 set_humidity:
   description: Set target humidity of climate device.
   fields:

--- a/tests/components/climate/test_init.py
+++ b/tests/components/climate/test_init.py
@@ -34,7 +34,7 @@ def test_set_temp_schema(hass, caplog):
 
     data = {
         'temperature': 20.0, 'operation_mode': 'test',
-        'entity_id': ['climate.test_id']}
+        'entity_id': ['climate.test_id'], 'fan_mode': 'low'}
     yield from hass.services.async_call(domain, service, data)
     yield from hass.async_block_till_done()
 


### PR DESCRIPTION
## Description:

Allows setting the temperature with a specific fan mode. I personally have an automation that triggers once a day to turn on the AC but I wanted it always set to `low`, regardless of what the previous setting was.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation:** home-assistant/home-assistant.io#7769

## Example service call:
```js
{
  "entity_id": "climate.living_room_ac",
  "temperature": 23,
  "operation_mode": "Heat",
  "fan_mode": "low"
}
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)
  - [x] Tests have been added to verify that the new code works.