### PR TITLE
Add verify_ssl option to Splunk component

### DIFF
--- a/homeassistant/components/splunk.py
+++ b/homeassistant/components/splunk.py
@@ -12,7 +12,8 @@ import requests
 import voluptuous as vol
 
 from homeassistant.const import (
-    CONF_SSL, CONF_HOST, CONF_NAME, CONF_PORT, CONF_TOKEN, EVENT_STATE_CHANGED)
+    CONF_SSL, CONF_VERIFY_SSL, CONF_HOST, CONF_NAME,
+    CONF_PORT, CONF_TOKEN, EVENT_STATE_CHANGED)
 from homeassistant.helpers import state as state_helper
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.json import JSONEncoder
@@ -32,6 +33,7 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
         vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
         vol.Optional(CONF_SSL, default=False): cv.boolean,
+        vol.Optional(CONF_VERIFY_SSL, default=True): cv.boolean,
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     }),
 }, extra=vol.ALLOW_EXTRA)
@@ -44,6 +46,7 @@ def setup(hass, config):
     port = conf.get(CONF_PORT)
     token = conf.get(CONF_TOKEN)
     use_ssl = conf.get(CONF_SSL)
+    verify_ssl = conf.get(CONF_VERIFY_SSL)
     name = conf.get(CONF_NAME)
 
     if use_ssl:
@@ -85,7 +88,7 @@ def setup(hass, config):
             }
             requests.post(event_collector,
                           data=json.dumps(payload, cls=JSONEncoder),
-                          headers=headers, timeout=10)
+                          headers=headers, timeout=10, verify=verify_ssl)
         except requests.exceptions.RequestException as error:
             _LOGGER.exception("Error saving event to Splunk: %s", error)
 

--- a/tests/components/test_splunk.py
+++ b/tests/components/test_splunk.py
@@ -31,6 +31,7 @@ class TestSplunk(unittest.TestCase):
                 'port': 123,
                 'token': 'secret',
                 'ssl': 'False',
+                'ssl_verify': 'True',
                 'name': 'hostname',
             }
         }

--- a/tests/components/test_splunk.py
+++ b/tests/components/test_splunk.py
@@ -89,10 +89,9 @@ class TestSplunk(unittest.TestCase):
         }
 
         for in_, out in valid.items():
-            state = mock.MagicMock(state=in_,
-                                   domain='fake',
-                                   object_id='entity',
-                                   attributes={'datetime_attr': now})
+            state = mock.MagicMock(
+                state=in_, domain='fake', object_id='entity',
+                attributes={'datetime_attr': now})
             event = mock.MagicMock(data={'new_state': state}, time_fired=12345)
 
             try:
@@ -119,6 +118,5 @@ class TestSplunk(unittest.TestCase):
                 mock.call(
                     payload['host'], data=json.dumps(payload),
                     headers={'Authorization': 'Splunk secret'},
-                    timeout=10
-                )
+                    timeout=10, verify=True)
             self.mock_post.reset_mock()

--- a/tests/components/test_splunk.py
+++ b/tests/components/test_splunk.py
@@ -31,7 +31,7 @@ class TestSplunk(unittest.TestCase):
                 'port': 123,
                 'token': 'secret',
                 'ssl': 'False',
-                'ssl_verify': 'True',
+                'verify_ssl': 'True',
                 'name': 'hostname',
             }
         }


### PR DESCRIPTION
## Description:
Adds the verify_ssl option to the Splunk component. Defaults to True.

**Related issue:** fixes #11151

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation:** home-assistant/home-assistant.io#7770

## Example entry for `configuration.yaml`:
```yaml
splunk:
  token: df881b2b-579d-47ef-8458-0e1111111115
  host: 192.168.1.2
  ssl: True
  verify_ssl: False
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ *] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54