### PR TITLE
Update Google Assistant services description and request sync timeout

### DIFF
--- a/homeassistant/components/google_assistant/__init__.py
+++ b/homeassistant/components/google_assistant/__init__.py
@@ -67,7 +67,7 @@ async def async_setup(hass: HomeAssistant, yaml_config: Dict[str, Any]):
         """Handle request sync service calls."""
         websession = async_get_clientsession(hass)
         try:
-            with async_timeout.timeout(5, loop=hass.loop):
+            with async_timeout.timeout(15, loop=hass.loop):
                 agent_user_id = call.data.get('agent_user_id') or \
                                 call.context.user_id
                 res = await websession.post(

--- a/homeassistant/components/google_assistant/services.yaml
+++ b/homeassistant/components/google_assistant/services.yaml
@@ -2,4 +2,4 @@ request_sync:
   description: Send a request_sync command to Google.
   fields:
     agent_user_id:
-      description: "Optional. Only needed for automations. Specific Home Assistant user id (not username, ID in configuration > users > under username) to sync with Google Assistant. Do not need when you call this service through Home Assistant front end or API. Used in automation script or other place where context.user_id is missing.
+      description: "Optional. Only needed for automations. Specific Home Assistant user id (not username, ID in configuration > users > under username) to sync with Google Assistant. Do not need when you call this service through Home Assistant front end or API. Used in automation script or other place where context.user_id is missing."

--- a/homeassistant/components/google_assistant/services.yaml
+++ b/homeassistant/components/google_assistant/services.yaml
@@ -2,4 +2,4 @@ request_sync:
   description: Send a request_sync command to Google.
   fields:
     agent_user_id:
-      description: Optional. Only needed for automations. Specific Home Assistant user id to sync with Google Assistant. Do not need when you call this service through Home Assistant front end or API. Used in automation script or other place where context.user_id is missing.
+      description: "Optional. Only needed for automations. Specific Home Assistant user id (not username, ID in configuration > users > under username) to sync with Google Assistant. Do not need when you call this service through Home Assistant front end or API. Used in automation script or other place where context.user_id is missing.


### PR DESCRIPTION
## Description:
https://github.com/home-assistant/home-assistant/pull/17415 was merged to dev but not master.  Since then the __init__.py has been updated to reflect other changes.  This PR brings the previous PR and current together.  Previous https://github.com/home-assistant/home-assistant/pull/17415 was being tested and I can confirm is valid.  @awarecan sorry about the delay and misunderstanding.  I have also updated the services.yaml to reflect the correct ID to use.  I will submit another PR to update documentation.

Also, the request sync timeout was set to 5s.  Routinely the service would sync but throw an error indicating that  "Could not contact Google for request_sync".  This was not the case.  The service did sync and new devices would show up.  However Google was not responding within the 5s timeout threshold.  I tested up to 10s and sometimes the same thing would happen.  A safe value ended up being 15s.  I have a very large amount of devices sync'd to GA (200+) and this is likely the reason for Googles response taking longer than 5s.

**Related issue (if applicable):** fixes #17380

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```
request_sync:
  description: Send a request_sync command to Google.
  fields:
    agent_user_id:
      description: "Optional. Only needed for automations. Specific Home Assistant user id (not username, ID in configuration > users > under username) to sync with Google Assistant. Do not need when you call this service through Home Assistant front end or API. Used in automation script or other place where context.user_id is missing."

```

## Checklist:
  - [x] The code change is tested and works locally.
