### PR TITLE
Fixed doorbird config without events (empty list)

### DIFF
--- a/homeassistant/components/doorbird.py
+++ b/homeassistant/components/doorbird.py
@@ -104,7 +104,7 @@ def setup(hass, config):
             return False
 
         # Subscribe to doorbell or motion events
-        if events is not None:
+        if events:
             doorstation.update_schedule(hass)
 
     hass.data[DOMAIN] = doorstations


### PR DESCRIPTION
## Description:
When not specifying any doorbird events the events variable is a empty list.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
When `events` is a empty list:
```yaml
doorbird:
  token: !secret doorbird_token
  devices:
    name: Frontdoor
    host: 1.2.3.4
    username: !secret doorbird_username
    password: !secret doorbird_password
```
So without:
```yaml
    monitored_conditions:
      - doorbell
      - motion
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
