### PR TITLE
Convert songpal to use asynchronous websocket for state updates

### DIFF
--- a/homeassistant/components/media_player/songpal.py
+++ b/homeassistant/components/media_player/songpal.py
@@ -4,7 +4,9 @@ Support for Songpal-enabled (Sony) media devices.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/media_player.songpal/
 """
+import asyncio
 import logging
+from collections import OrderedDict
 
 import voluptuous as vol
 
@@ -12,15 +14,17 @@ from homeassistant.components.media_player import (
     DOMAIN, PLATFORM_SCHEMA, SUPPORT_SELECT_SOURCE, SUPPORT_TURN_OFF,
     SUPPORT_TURN_ON, SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_SET,
     SUPPORT_VOLUME_STEP, MediaPlayerDevice)
-from homeassistant.const import ATTR_ENTITY_ID, CONF_NAME, STATE_OFF, STATE_ON
+from homeassistant.const import (
+    ATTR_ENTITY_ID, CONF_NAME, STATE_OFF, STATE_ON, EVENT_HOMEASSISTANT_STOP)
 from homeassistant.exceptions import PlatformNotReady
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['python-songpal==0.0.8']
+REQUIREMENTS = ['python-songpal==0.0.9']
 
 _LOGGER = logging.getLogger(__name__)
 
 CONF_ENDPOINT = 'endpoint'
+CONF_POLL = 'poll'
 
 PARAM_NAME = 'name'
 PARAM_VALUE = 'value'
@@ -36,6 +40,7 @@ SUPPORT_SONGPAL = SUPPORT_VOLUME_SET | SUPPORT_VOLUME_STEP | \
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME): cv.string,
     vol.Required(CONF_ENDPOINT): cv.string,
+    vol.Optional(CONF_POLL, default=False): cv.boolean,
 })
 
 SET_SOUND_SCHEMA = vol.Schema({
@@ -62,7 +67,12 @@ async def async_setup_platform(
     else:
         name = config.get(CONF_NAME)
         endpoint = config.get(CONF_ENDPOINT)
-        device = SongpalDevice(name, endpoint)
+        poll = config.get(CONF_POLL)
+        device = SongpalDevice(name, endpoint, poll)
+
+    if endpoint in hass.data[PLATFORM]:
+        _LOGGER.debug("The endpoint exists already, skipping setup.")
+        return
 
     try:
         await device.initialize()
@@ -96,12 +106,13 @@ async def async_setup_platform(
 class SongpalDevice(MediaPlayerDevice):
     """Class representing a Songpal device."""
 
-    def __init__(self, name, endpoint):
+    def __init__(self, name, endpoint, poll):
         """Init."""
-        import songpal
+        from songpal import Device
         self._name = name
-        self.endpoint = endpoint
-        self.dev = songpal.Device(self.endpoint)
+        self._endpoint = endpoint
+        self._poll = poll
+        self.dev = Device(self._endpoint)
         self._sysinfo = None
 
         self._state = False
@@ -114,12 +125,81 @@ class SongpalDevice(MediaPlayerDevice):
         self._volume = 0
         self._is_muted = False
 
-        self._sources = []
+        self._active_source = None
+        self._sources = {}
+
+    @property
+    def should_poll(self):
+        return self._poll
 
     async def initialize(self):
         """Initialize the device."""
         await self.dev.get_supported_methods()
         self._sysinfo = await self.dev.get_system_info()
+
+    async def async_activate_websocket(self):
+        """Activate websocket for listening if wanted."""
+        _LOGGER.info("Activating websocket connection..")
+        from songpal import (VolumeChange, ContentChange,
+                             PowerChange, ConnectChange)
+
+        async def volume_changed(x: VolumeChange):
+            """Volume changed callback."""
+            _LOGGER.debug("Volume changed: %s", x)
+            self._volume = x.volume
+            self._is_muted = x.mute
+            await self.async_update_ha_state()
+
+        async def source_changed(x: ContentChange):
+            """Source changed callback."""
+            _LOGGER.debug("Source changed: %s", x)
+            if x.is_input:
+                self._active_source = self._sources[x.source]
+                _LOGGER.debug("New active source: %s", self._active_source)
+                await self.async_update_ha_state()
+            else:
+                _LOGGER.warning("Got non-handled content change: %s" % x)
+
+        async def power_changed(x: PowerChange):
+            """Power changed callback."""
+            _LOGGER.debug("Power changed: %s", x)
+            self._state = x.status
+            await self.async_update_ha_state()
+
+        async def try_reconnect(x: ConnectChange):
+            """Callback to reconnect back."""
+            _LOGGER.error("Got disconnected with %s, trying to reconnect.",
+                          x.exception)
+            self._available = False
+            self.dev.clear_notification_callbacks()
+            await self.async_update_ha_state()
+
+            # Try to reconnect forever, a successful reconnect will initialize
+            # the websocket connection again.
+            while not self._available:
+                await asyncio.sleep(10)
+                await self.async_update()
+                # We need to inform HA about the state in case we are coming
+                # back from a disconnected state.
+                await self.async_update_ha_state()
+
+        self.dev.on_notification(VolumeChange, volume_changed)
+        self.dev.on_notification(ContentChange, source_changed)
+        self.dev.on_notification(PowerChange, power_changed)
+        self.dev.on_notification(ConnectChange, try_reconnect)
+
+        async def listen_events():
+            await self.dev.listen_notifications()
+
+        async def handle_stop(event):
+            nonlocal remove_hass_stop_listener
+            remove_hass_stop_listener = None
+            await self.dev.stop_listen_notifications()
+
+        remove_hass_stop_listener = self.hass.bus.async_listen_once(
+            EVENT_HOMEASSISTANT_STOP, handle_stop)
+
+        self.hass.loop.create_task(listen_events())
 
     @property
     def name(self):
@@ -169,18 +249,27 @@ class SongpalDevice(MediaPlayerDevice):
 
             inputs = await self.dev.get_inputs()
             _LOGGER.debug("Got ins: %s", inputs)
-            self._sources = inputs
+
+            self._sources = OrderedDict()
+            for input in inputs:
+                self._sources[input.uri] = input
+                if input.active:
+                    self._active_source = input
+
+            _LOGGER.debug("Active source: %s", self._active_source)
 
             self._available = True
+
+            # activate notifications if wanted
+            if not self._poll:
+                await self.hass.async_add_job(self.async_activate_websocket)
         except SongpalException as ex:
-            # if we were available, print out the exception
-            if self._available:
-                _LOGGER.error("Got an exception: %s", ex)
+            _LOGGER.error("Unable to update: %s", ex)
             self._available = False
 
     async def async_select_source(self, source):
         """Select source."""
-        for out in self._sources:
+        for out in self._sources.values():
             if out.title == source:
                 await out.activate()
                 return
@@ -190,7 +279,7 @@ class SongpalDevice(MediaPlayerDevice):
     @property
     def source_list(self):
         """Return list of available sources."""
-        return [x.title for x in self._sources]
+        return [src.title for src in self._sources.values()]
 
     @property
     def state(self):
@@ -202,11 +291,7 @@ class SongpalDevice(MediaPlayerDevice):
     @property
     def source(self):
         """Return currently active source."""
-        for out in self._sources:
-            if out.active:
-                return out.title
-
-        return None
+        return self._active_source.title
 
     @property
     def volume_level(self):

--- a/homeassistant/components/media_player/songpal.py
+++ b/homeassistant/components/media_player/songpal.py
@@ -256,7 +256,8 @@ class SongpalDevice(MediaPlayerDevice):
 
             # activate notifications if wanted
             if not self._poll:
-                await self.hass.async_create_task(self.async_activate_websocket())
+                await self.hass.async_create_task(
+                    self.async_activate_websocket())
         except SongpalException as ex:
             _LOGGER.error("Unable to update: %s", ex)
             self._available = False

--- a/homeassistant/components/media_player/songpal.py
+++ b/homeassistant/components/media_player/songpal.py
@@ -24,7 +24,6 @@ REQUIREMENTS = ['python-songpal==0.0.9']
 _LOGGER = logging.getLogger(__name__)
 
 CONF_ENDPOINT = 'endpoint'
-CONF_POLL = 'poll'
 
 PARAM_NAME = 'name'
 PARAM_VALUE = 'value'
@@ -40,7 +39,6 @@ SUPPORT_SONGPAL = SUPPORT_VOLUME_SET | SUPPORT_VOLUME_STEP | \
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME): cv.string,
     vol.Required(CONF_ENDPOINT): cv.string,
-    vol.Optional(CONF_POLL, default=False): cv.boolean,
 })
 
 SET_SOUND_SCHEMA = vol.Schema({
@@ -67,8 +65,7 @@ async def async_setup_platform(
     else:
         name = config.get(CONF_NAME)
         endpoint = config.get(CONF_ENDPOINT)
-        poll = config.get(CONF_POLL)
-        device = SongpalDevice(name, endpoint, poll)
+        device = SongpalDevice(name, endpoint, poll=False)
 
     if endpoint in hass.data[PLATFORM]:
         _LOGGER.debug("The endpoint exists already, skipping setup.")

--- a/homeassistant/components/media_player/songpal.py
+++ b/homeassistant/components/media_player/songpal.py
@@ -19,7 +19,7 @@ from homeassistant.const import (
 from homeassistant.exceptions import PlatformNotReady
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['python-songpal==0.0.9']
+REQUIREMENTS = ['python-songpal==0.0.9.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1256,7 +1256,7 @@ python-roku==3.1.5
 python-sochain-api==0.0.2
 
 # homeassistant.components.media_player.songpal
-python-songpal==0.0.9
+python-songpal==0.0.9.1
 
 # homeassistant.components.sensor.synologydsm
 python-synology==0.2.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1256,7 +1256,7 @@ python-roku==3.1.5
 python-sochain-api==0.0.2
 
 # homeassistant.components.media_player.songpal
-python-songpal==0.0.8
+python-songpal==0.0.9
 
 # homeassistant.components.sensor.synologydsm
 python-synology==0.2.0


### PR DESCRIPTION
## Description:
This PR converts songpal platform to use the websocket interface for instantaneous updates on state changes.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

## Example entry for `configuration.yaml` (if applicable):

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
