### PR TITLE
Map person IDs to "friendly" IDs for google_maps tracker

### DIFF
--- a/homeassistant/components/device_tracker/google_maps.py
+++ b/homeassistant/components/device_tracker/google_maps.py
@@ -108,6 +108,7 @@ class GoogleMapsScanner:
             self.see(
                 dev_id=dev_id,
                 gps=(person.latitude, person.longitude),
+                host_name=person.nickname,
                 picture=person.picture_url,
                 source_type=SOURCE_TYPE_GPS,
                 gps_accuracy=person.accuracy,


### PR DESCRIPTION
This is my first PR to home assistant, so go easy on me. Happy to take suggestions 😄

## Description:
Adds a mapping configuration to google maps device tracker.
Currently IDs look like `device_tracker.google_maps_12345678901234567890` which are hard to remember and identify when you have multiple people. This PR allows you to map the Google people IDs to "friendly" IDs. i.e. `device_tracker.carson`.

I'm also passing the google person's nickname as the `host_name` so that the default `friendly_name` for new devices is better. i.e. `Carson` instead of `carson`.

I also thought it would be nice if the entity ID and friendly name could be customized in UI, like other things. But I wasn't exactly sure how to do that - still new to the codebase. The library does give us unique IDs so I think it's possible, but maybe there's something specific to `device_tracker` component preventing this... Insight would be welcomed 😁

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):**
Happy to create once given the thumbs up on direction.

## Example entry for `configuration.yaml` (if applicable):
```yaml
device_tracker:
  platform: google_maps
  devices: # wasn't sure on key here. Happy to change
    12345678901234567890: carson
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)
