### PR TITLE
Updated to support new firmware

### DIFF
--- a/homeassistant/components/media_player/vizio.py
+++ b/homeassistant/components/media_player/vizio.py
@@ -20,7 +20,7 @@ from homeassistant.const import (
     STATE_UNKNOWN)
 from homeassistant.helpers import config_validation as cv
 
-REQUIREMENTS = ['pyvizio==0.0.3']
+REQUIREMENTS = ['pyvizio==0.0.4']
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
Firmware upgrade broke Vizio support. The newer pyvizio fixes this.

Changed version from 0.0.3 to 0.0.4