### PR TITLE
Remove marking device tracker stale if state is stale

### DIFF
--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -373,7 +373,6 @@ class DeviceTracker:
         for device in self.devices.values():
             if (device.track and device.last_update_home) and \
                device.stale(now):
-                device.mark_stale()
                 self.hass.async_create_task(device.async_update_ha_state(True))
 
     async def async_setup_tracked_device(self):


### PR DESCRIPTION
## Description:
Fix issues reported in 
#18999
#18930
#18662

introduced in https://github.com/home-assistant/home-assistant/pull/18572

by no longer marking devices as stale. This will fix the issue, however the "true" fix is probably to get the devices configured with a more appropriate "consider_home" value.

I didn't notice these because I was testing on an AsusWrt device tracker with Android; I didn't realize iOS devices will periodically just hang off the network and there needs to be more "leeway". This basically reverts the functionality introduced earlier to more aggressively mark stale nodes as stale.

**Related issue (if applicable):** fixes #18999, #18930, #18662 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
