### PR TITLE
Satel integra monitor outputs

### DIFF
--- a/homeassistant/components/binary_sensor/satel_integra.py
+++ b/homeassistant/components/binary_sensor/satel_integra.py
@@ -8,9 +8,11 @@ import logging
 
 from homeassistant.components.binary_sensor import BinarySensorDevice
 from homeassistant.components.satel_integra import (CONF_ZONES,
+                                                    CONF_OUTPUTS,
                                                     CONF_ZONE_NAME,
                                                     CONF_ZONE_TYPE,
-                                                    SIGNAL_ZONES_UPDATED)
+                                                    SIGNAL_ZONES_UPDATED,
+                                                    SIGNAL_OUTPUTS_UPDATED)
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
@@ -32,7 +34,17 @@ async def async_setup_platform(hass, config, async_add_entities,
     for zone_num, device_config_data in configured_zones.items():
         zone_type = device_config_data[CONF_ZONE_TYPE]
         zone_name = device_config_data[CONF_ZONE_NAME]
-        device = SatelIntegraBinarySensor(zone_num, zone_name, zone_type)
+        device = SatelIntegraBinarySensor(zone_num, zone_name, zone_type,
+                                          SIGNAL_ZONES_UPDATED)
+        devices.append(device)
+
+    configured_outputs = discovery_info[CONF_OUTPUTS]
+
+    for zone_num, device_config_data in configured_outputs.items():
+        zone_type = device_config_data[CONF_ZONE_TYPE]
+        zone_name = device_config_data[CONF_ZONE_NAME]
+        device = SatelIntegraBinarySensor(zone_num, zone_name, zone_type,
+                                          SIGNAL_OUTPUTS_UPDATED)
         devices.append(device)
 
     async_add_entities(devices)
@@ -41,17 +53,18 @@ async def async_setup_platform(hass, config, async_add_entities,
 class SatelIntegraBinarySensor(BinarySensorDevice):
     """Representation of an Satel Integra binary sensor."""
 
-    def __init__(self, zone_number, zone_name, zone_type):
+    def __init__(self, device_number, device_name, zone_type, react_to_signal):
         """Initialize the binary_sensor."""
-        self._zone_number = zone_number
-        self._name = zone_name
+        self._device_number = device_number
+        self._name = device_name
         self._zone_type = zone_type
         self._state = 0
+        self._react_to_signal = react_to_signal
 
     async def async_added_to_hass(self):
         """Register callbacks."""
         async_dispatcher_connect(
-            self.hass, SIGNAL_ZONES_UPDATED, self._zones_updated)
+            self.hass, self._react_to_signal, self._devices_updated)
 
     @property
     def name(self):
@@ -80,9 +93,9 @@ class SatelIntegraBinarySensor(BinarySensorDevice):
         return self._zone_type
 
     @callback
-    def _zones_updated(self, zones):
+    def _devices_updated(self, zones):
         """Update the zone's state, if needed."""
-        if self._zone_number in zones \
-                and self._state != zones[self._zone_number]:
-            self._state = zones[self._zone_number]
+        if self._device_number in zones \
+                and self._state != zones[self._device_number]:
+            self._state = zones[self._device_number]
             self.async_schedule_update_ha_state()

--- a/homeassistant/components/satel_integra.py
+++ b/homeassistant/components/satel_integra.py
@@ -64,8 +64,10 @@ CONFIG_SCHEMA = vol.Schema({
                      default=DEFAULT_DEVICE_PARTITION): cv.positive_int,
         vol.Optional(CONF_ARM_HOME_MODE,
                      default=DEFAULT_CONF_ARM_HOME_MODE): vol.In([1, 2, 3]),
-        vol.Optional(CONF_ZONES): {vol.Coerce(int): ZONE_SCHEMA},
-        vol.Optional(CONF_OUTPUTS): {vol.Coerce(int): ZONE_SCHEMA},
+        vol.Optional(CONF_ZONES,
+                     default={}): {vol.Coerce(int): ZONE_SCHEMA},
+        vol.Optional(CONF_OUTPUTS,
+                     default={}): {vol.Coerce(int): ZONE_SCHEMA},
     }),
 }, extra=vol.ALLOW_EXTRA)
 
@@ -74,9 +76,8 @@ async def async_setup(hass, config):
     """Set up the Satel Integra component."""
     conf = config.get(DOMAIN)
 
-    zones = conf.get(CONF_ZONES) if conf.get(CONF_ZONES) is not None else []
-    outputs = \
-        conf.get(CONF_OUTPUTS) if conf.get(CONF_OUTPUTS) is not None else []
+    zones = conf.get(CONF_ZONES)
+    outputs = conf.get(CONF_OUTPUTS)
     host = conf.get(CONF_DEVICE_HOST)
     port = conf.get(CONF_DEVICE_PORT)
     partition = conf.get(CONF_DEVICE_PARTITION)

--- a/homeassistant/components/satel_integra.py
+++ b/homeassistant/components/satel_integra.py
@@ -40,6 +40,7 @@ CONF_ARM_HOME_MODE = 'arm_home_mode'
 CONF_ZONE_NAME = 'name'
 CONF_ZONE_TYPE = 'type'
 CONF_ZONES = 'zones'
+CONF_OUTPUTS = 'outputs'
 
 ZONES = 'zones'
 
@@ -49,6 +50,7 @@ SIGNAL_PANEL_ARM_HOME = 'satel_integra.panel_arm_home'
 SIGNAL_PANEL_DISARM = 'satel_integra.panel_disarm'
 
 SIGNAL_ZONES_UPDATED = 'satel_integra.zones_updated'
+SIGNAL_OUTPUTS_UPDATED = 'satel_integra.outputs_updated'
 
 ZONE_SCHEMA = vol.Schema({
     vol.Required(CONF_ZONE_NAME): cv.string,
@@ -63,6 +65,7 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(CONF_ARM_HOME_MODE,
                      default=DEFAULT_CONF_ARM_HOME_MODE): vol.In([1, 2, 3]),
         vol.Optional(CONF_ZONES): {vol.Coerce(int): ZONE_SCHEMA},
+        vol.Optional(CONF_OUTPUTS): {vol.Coerce(int): ZONE_SCHEMA},
     }),
 }, extra=vol.ALLOW_EXTRA)
 
@@ -71,14 +74,16 @@ async def async_setup(hass, config):
     """Set up the Satel Integra component."""
     conf = config.get(DOMAIN)
 
-    zones = conf.get(CONF_ZONES)
+    zones = conf.get(CONF_ZONES) if conf.get(CONF_ZONES) is not None else []
+    outputs = \
+        conf.get(CONF_OUTPUTS) if conf.get(CONF_OUTPUTS) is not None else []
     host = conf.get(CONF_DEVICE_HOST)
     port = conf.get(CONF_DEVICE_PORT)
     partition = conf.get(CONF_DEVICE_PARTITION)
 
     from satel_integra.satel_integra import AsyncSatel, AlarmState
 
-    controller = AsyncSatel(host, port, hass.loop, zones, [], partition)
+    controller = AsyncSatel(host, port, hass.loop, zones, outputs, partition)
 
     hass.data[DATA_SATEL] = controller
 
@@ -101,7 +106,8 @@ async def async_setup(hass, config):
 
     task_zones = hass.async_create_task(
         async_load_platform(hass, 'binary_sensor', DOMAIN,
-                            {CONF_ZONES: zones}, config))
+                            {CONF_ZONES: zones, CONF_OUTPUTS: outputs}, config)
+        )
 
     await asyncio.wait([task_control_panel, task_zones], loop=hass.loop)
 
@@ -134,8 +140,14 @@ async def async_setup(hass, config):
     @callback
     def zones_update_callback(status):
         """Update zone objects as per notification from the alarm."""
-        _LOGGER.debug("Zones callback , status: %s", status)
+        _LOGGER.debug("Zones callback, status: %s", status)
         async_dispatcher_send(hass, SIGNAL_ZONES_UPDATED, status[ZONES])
+
+    @callback
+    def outputs_update_callback(status):
+        """Update zone objects as per notification from the alarm."""
+        _LOGGER.debug("Outputs updated callback , status: %s", status)
+        async_dispatcher_send(hass, SIGNAL_OUTPUTS_UPDATED, status["outputs"])
 
     # Create a task instead of adding a tracking job, since this task will
     # run until the connection to satel_integra is closed.
@@ -143,7 +155,8 @@ async def async_setup(hass, config):
     hass.loop.create_task(
         controller.monitor_status(
             alarm_status_update_callback,
-            zones_update_callback)
+            zones_update_callback,
+            outputs_update_callback)
     )
 
     return True

--- a/homeassistant/components/satel_integra.py
+++ b/homeassistant/components/satel_integra.py
@@ -19,7 +19,7 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
-REQUIREMENTS = ['satel_integra==0.1.0']
+REQUIREMENTS = ['satel_integra==0.2.0']
 
 DEFAULT_ALARM_NAME = 'satel_integra'
 DEFAULT_PORT = 7094
@@ -78,7 +78,7 @@ async def async_setup(hass, config):
 
     from satel_integra.satel_integra import AsyncSatel, AlarmState
 
-    controller = AsyncSatel(host, port, zones, hass.loop, partition)
+    controller = AsyncSatel(host, port, hass.loop, zones, [], partition)
 
     hass.data[DATA_SATEL] = controller
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1397,7 +1397,7 @@ rxv==0.5.1
 samsungctl[websocket]==0.7.1
 
 # homeassistant.components.satel_integra
-satel_integra==0.1.0
+satel_integra==0.2.0
 
 # homeassistant.components.sensor.deutsche_bahn
 schiene==0.22


### PR DESCRIPTION
## Description:

Added support for output monitoring for Satel Integra alarm.
Fixed initialization issue that prevented component from asking Satel about its state during start.

**Related issue (if applicable):** relates to: #10616

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#7785

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
