### PR TITLE
Update pygtfs to upstream's 0.1.5

### DIFF
--- a/homeassistant/components/sensor/gtfs.py
+++ b/homeassistant/components/sensor/gtfs.py
@@ -16,7 +16,7 @@ from homeassistant.const import CONF_NAME
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['pygtfs-homeassistant==0.1.3.dev0']
+REQUIREMENTS = ['pygtfs==0.1.5']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -169,9 +169,9 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     import pygtfs
 
-    split_file_name = os.path.splitext(data)
+    (gtfs_root, _) = os.path.splitext(data)
 
-    sqlite_file = "{}.sqlite".format(split_file_name[0])
+    sqlite_file = "{}.sqlite?check_same_thread=False".format(gtfs_root)
     joined_path = os.path.join(gtfs_dir, sqlite_file)
     gtfs = pygtfs.Schedule(joined_path)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -963,7 +963,7 @@ pygatt==3.2.0
 pygogogate2==0.1.1
 
 # homeassistant.components.sensor.gtfs
-pygtfs-homeassistant==0.1.3.dev0
+pygtfs==0.1.5
 
 # homeassistant.components.remote.harmony
 pyharmony==1.0.20


### PR DESCRIPTION
This works by adding `?check_same_thread=False` to the sqlite
connection string, as suggested by robbiet480@.
It upgrades pygtfs from homeassitant's forked 0.1.3 version to 0.1.5.

Fixes #15725

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
