### PR TITLE
WIP Add Twinkly platform in light component with discovery

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -566,6 +566,7 @@ omit =
     homeassistant/components/light/tikteck.py
     homeassistant/components/light/tplink.py
     homeassistant/components/light/tradfri.py
+    homeassistant/components/light/twinkly.py
     homeassistant/components/light/x10.py
     homeassistant/components/light/yeelight.py
     homeassistant/components/light/yeelightsunflower.py

--- a/homeassistant/components/discovery.py
+++ b/homeassistant/components/discovery.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.event import async_track_point_in_utc_time
 from homeassistant.helpers.discovery import async_load_platform, async_discover
 import homeassistant.util.dt as dt_util
 
-REQUIREMENTS = ['netdisco==2.2.0']
+REQUIREMENTS = ['netdisco==2.3.0']
 
 DOMAIN = 'discovery'
 
@@ -44,6 +44,7 @@ SERVICE_SABNZBD = 'sabnzbd'
 SERVICE_SAMSUNG_PRINTER = 'samsung_printer'
 SERVICE_HOMEKIT = 'homekit'
 SERVICE_OCTOPRINT = 'octoprint'
+SERVICE_TWINKLY = 'twinkly'
 
 CONFIG_ENTRY_HANDLERS = {
     SERVICE_DECONZ: 'deconz',
@@ -63,6 +64,7 @@ SERVICE_HANDLERS = {
     SERVICE_WINK: ('wink', None),
     SERVICE_XIAOMI_GW: ('xiaomi_aqara', None),
     SERVICE_TELLDUSLIVE: ('tellduslive', None),
+    SERVICE_TWINKLY: ('light', 'twinkly'),
     SERVICE_DAIKIN: ('daikin', None),
     SERVICE_SABNZBD: ('sabnzbd', None),
     SERVICE_SAMSUNG_PRINTER: ('sensor', 'syncthru'),

--- a/homeassistant/components/light/twinkly.py
+++ b/homeassistant/components/light/twinkly.py
@@ -41,8 +41,21 @@ async def async_setup_platform(hass, config, async_add_entities,
     if DOMAIN not in hass.data:
         hass.data[DOMAIN] = {}
 
-    if discovery_info is None:
+    if discovery_info is not None:
+        async_add_entities_discovery(hass, discovery_info, async_add_entities)
+    else:
         async_add_entities_config(hass, config, async_add_entities)
+
+
+@callback
+def async_add_entities_discovery(hass, discovery_info, async_add_entities):
+    """Set up Twinkly lights discovered automatically."""
+    _LOGGER.debug("Parsing %s", discovery_info)
+    host = discovery_info[CONF_HOST]
+    _LOGGER.debug("Adding autodetected %s", host)
+    device_id = discovery_info[CONF_NAME]
+    entity = TwinklyLight(host, device_id)
+    async_add_entities([entity])
 
 
 @callback

--- a/homeassistant/components/light/twinkly.py
+++ b/homeassistant/components/light/twinkly.py
@@ -1,0 +1,114 @@
+"""
+Support for LEDWORKS Twinkly.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/light.twinkly/
+"""
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components.light import (
+    ATTR_HS_COLOR, PLATFORM_SCHEMA, SUPPORT_COLOR, Light)
+from homeassistant.const import CONF_DEVICES, CONF_HOST, CONF_NAME
+from homeassistant.core import callback
+import homeassistant.helpers.config_validation as cv
+import homeassistant.util.color as color_util
+
+REQUIREMENTS = ['xled==0.5.0']
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = 'twinkly'
+
+DEFAULT_NAME = "Twinkly Lights"
+
+DEVICE_SCHEMA = vol.Schema({
+    vol.Required(CONF_HOST): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+})
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_DEVICES, default={}): {cv.string: DEVICE_SCHEMA},
+})
+
+SUPPORT_TWINKLY = SUPPORT_COLOR
+
+
+async def async_setup_platform(hass, config, async_add_entities,
+                               discovery_info=None):
+    """Set up Twinkly lights."""
+    if DOMAIN not in hass.data:
+        hass.data[DOMAIN] = {}
+
+    if discovery_info is None:
+        async_add_entities_config(hass, config, async_add_entities)
+
+
+@callback
+def async_add_entities_config(hass, config, async_add_entities):
+    """Set up Twinkly lights configured within platform."""
+    devices = []
+    for device_id, device_config in config[CONF_DEVICES].items():
+        host = device_config[CONF_HOST]
+        _LOGGER.debug("Adding configured %s (host %s)", device_id, host)
+        name = device_config.get(CONF_NAME)
+
+        light = TwinklyLight(host, device_id, name)
+        devices.append(light)
+        hass.data[DOMAIN][name] = light
+    async_add_entities(devices)
+
+
+class TwinklyLight(Light):
+    """Representation of an Twinkly lights."""
+
+    def __init__(self, host, device_id, name=None):
+        """Initialize the Twinkly lights."""
+        import xled
+
+        self._control = xled.control.HighControlInterface(host)
+        self._state = None
+        self._device_id = device_id
+        if name:
+            self._name = name
+        else:
+            self._name = device_id
+
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+        return SUPPORT_TWINKLY
+
+    @property
+    def name(self):
+        """Return a name for the device."""
+        return self._name
+
+    @property
+    def unique_id(self):
+        """Return the ID of this light."""
+        return self._device_id
+
+    @property
+    def is_on(self):
+        """Return true if device is on."""
+        return bool(self._state)
+
+    def turn_on(self, **kwargs):
+        """Turn the specified light on."""
+        self._state = True
+
+        if ATTR_HS_COLOR in kwargs:
+            rgb = color_util.color_hs_to_RGB(*kwargs[ATTR_HS_COLOR])
+            self._control.set_static_color(*rgb)
+        self._control.turn_on()
+
+    def turn_off(self, **kwargs):
+        """Turn the specified light off."""
+        self._state = False
+        self._control.turn_off()
+
+    def update(self):
+        """Synchronise internal state with the actual light state."""
+        self._state = self._control.is_on()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -678,7 +678,7 @@ ndms2_client==0.0.5
 netdata==0.1.2
 
 # homeassistant.components.discovery
-netdisco==2.2.0
+netdisco==2.3.0
 
 # homeassistant.components.sensor.neurio_energy
 neurio==0.3.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1641,6 +1641,9 @@ xboxapi==0.1.1
 # homeassistant.components.knx
 xknx==0.9.1
 
+# homeassistant.components.light.twinkly
+xled==0.5.0
+
 # homeassistant.components.media_player.bluesound
 # homeassistant.components.sensor.startca
 # homeassistant.components.sensor.ted5000


### PR DESCRIPTION
## Description:
Adds support for controlling LEDWORKS [Twinkly](https://twinkly.com) - Smart LED Christmas lights and uses XLED discovery method to find these. Discovery part depends on https://github.com/home-assistant/netdisco/pull/227.

For more information see [documentation of Twinkly protocol](https://xled-docs.readthedocs.io/en/latest/). There is also [python library and command line interface](https://xled.readthedocs.io/en/latest/).

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation:** home-assistant/home-assistant.io#7789

## Example entry for `configuration.yaml` (if applicable):
```yaml
light:
  - platform: twinkly
    devices:
      Twinkly_33AAFF:
        name: Christmas Tree
        host: 192.168.4.1
```

or just enable discovery:

```yaml
discovery:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54