### PR TITLE
Drop OwnTracks bad packets

### DIFF
--- a/tests/components/owntracks/test_init.py
+++ b/tests/components/owntracks/test_init.py
@@ -110,7 +110,7 @@ def test_handle_value_error(mock_client):
 
 
 @asyncio.coroutine
-def test_returns_error_missing_username(mock_client):
+def test_returns_error_missing_username(mock_client, caplog):
     """Test that an error is returned when username is missing."""
     resp = yield from mock_client.post(
         '/api/webhook/owntracks_test',
@@ -120,10 +120,29 @@ def test_returns_error_missing_username(mock_client):
         }
     )
 
-    assert resp.status == 400
-
+    # Needs to be 200 or OwnTracks keeps retrying bad packet.
+    assert resp.status == 200
     json = yield from resp.json()
-    assert json == {'error': 'You need to supply username.'}
+    assert json == []
+    assert 'No topic or user found' in caplog.text
+
+
+@asyncio.coroutine
+def test_returns_error_incorrect_json(mock_client, caplog):
+    """Test that an error is returned when username is missing."""
+    resp = yield from mock_client.post(
+        '/api/webhook/owntracks_test',
+        data='not json',
+        headers={
+            'X-Limit-d': 'Pixel',
+        }
+    )
+
+    # Needs to be 200 or OwnTracks keeps retrying bad packet.
+    assert resp.status == 200
+    json = yield from resp.json()
+    assert json == []
+    assert 'invalid JSON' in caplog.text
 
 
 @asyncio.coroutine


### PR DESCRIPTION
## Description:
We were returning 400 to OwnTracks when receiving bad packets, which meant that OwnTracks kept trying to repost the same bad packet. Now we return 200 and hope the next packet is better!

**Related issue (if applicable):** #18927

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
