### PR TITLE
Fix lovelace save

### DIFF
--- a/homeassistant/components/lovelace/__init__.py
+++ b/homeassistant/components/lovelace/__init__.py
@@ -101,8 +101,8 @@ class LovelaceStorage:
 
     async def async_save(self, config):
         """Save config."""
-        self._data = {'config': config}
-        await self._store.async_save(config)
+        self._data['config'] = config
+        await self._store.async_save(self._data)
 
 
 class LovelaceYAML:

--- a/tests/components/lovelace/test_init.py
+++ b/tests/components/lovelace/test_init.py
@@ -34,7 +34,7 @@ async def test_lovelace_from_storage(hass, hass_ws_client, hass_storage):
     response = await client.receive_json()
     assert response['success']
     assert hass_storage[lovelace.STORAGE_KEY]['data'] == {
-        'yo': 'hello'
+        'config': {'yo': 'hello'}
     }
 
     # Load new config


### PR DESCRIPTION
## Description:
Fix Lovelace storing the wrong config format due to having a bad check in the test 🤷‍♂️  Due to caching it correctly, only showed up after reboot

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
