### PR TITLE
Add raw service data to event

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1098,9 +1098,11 @@ class ServiceRegistry:
             raise ServiceNotFound(domain, service) from None
 
         if handler.schema:
-            service_data = handler.schema(service_data)
+            processed_data = handler.schema(service_data)
+        else:
+            processed_data = service_data
 
-        service_call = ServiceCall(domain, service, service_data, context)
+        service_call = ServiceCall(domain, service, processed_data, context)
 
         self._hass.bus.async_fire(EVENT_CALL_SERVICE, {
             ATTR_DOMAIN: domain.lower(),

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8,6 +8,7 @@ from unittest.mock import patch, MagicMock
 from datetime import datetime, timedelta
 from tempfile import TemporaryDirectory
 
+import voluptuous as vol
 import pytz
 import pytest
 
@@ -21,7 +22,7 @@ from homeassistant.const import (
     __version__, EVENT_STATE_CHANGED, ATTR_FRIENDLY_NAME, CONF_UNIT_SYSTEM,
     ATTR_NOW, EVENT_TIME_CHANGED, EVENT_TIMER_OUT_OF_SYNC, ATTR_SECONDS,
     EVENT_HOMEASSISTANT_STOP, EVENT_HOMEASSISTANT_CLOSE,
-    EVENT_SERVICE_REGISTERED, EVENT_SERVICE_REMOVED)
+    EVENT_SERVICE_REGISTERED, EVENT_SERVICE_REMOVED, EVENT_CALL_SERVICE)
 
 from tests.common import get_test_home_assistant, async_mock_service
 
@@ -1000,3 +1001,27 @@ async def test_service_executed_with_subservices(hass):
     assert len(calls) == 4
     assert [call.service for call in calls] == [
         'outer', 'inner', 'inner', 'outer']
+
+
+async def test_service_call_event_contains_original_data(hass):
+    """Test that service call event contains original data."""
+    events = []
+
+    @ha.callback
+    def callback(event):
+        events.append(event)
+
+    hass.bus.async_listen(EVENT_CALL_SERVICE, callback)
+
+    calls = async_mock_service(hass, 'test', 'service', vol.Schema({
+        'number': vol.Coerce(int)
+    }))
+
+    await hass.services.async_call('test', 'service', {
+        'number': '23'
+    }, blocking=True)
+    await hass.async_block_till_done()
+    assert len(events) == 1
+    assert events[0].data['service_data']['number'] == '23'
+    assert len(calls) == 1
+    assert calls[0].data['number'] == 23


### PR DESCRIPTION
## Description:

When we changed service handling, we ended up sending processed service data over the event bus. This caused issues with templates, as they are not JSON serializable. This changes it so that we send unprocessed service data over event bus.

**Related issue (if applicable):** fixes #18900

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
