### PR TITLE
ChromeCast custom name support

### DIFF
--- a/homeassistant/components/media_player/cast.py
+++ b/homeassistant/components/media_player/cast.py
@@ -19,8 +19,8 @@ from homeassistant.components.media_player import (
     SUPPORT_PREVIOUS_TRACK, SUPPORT_STOP, SUPPORT_TURN_OFF, SUPPORT_TURN_ON,
     SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_SET, MediaPlayerDevice)
 from homeassistant.const import (
-    CONF_HOST, EVENT_HOMEASSISTANT_STOP, STATE_IDLE, STATE_OFF, STATE_PAUSED,
-    STATE_PLAYING)
+    CONF_HOST, CONF_NAME, EVENT_HOMEASSISTANT_STOP,
+    STATE_IDLE, STATE_OFF, STATE_PAUSED, STATE_PLAYING)
 from homeassistant.core import callback
 from homeassistant.exceptions import PlatformNotReady
 import homeassistant.helpers.config_validation as cv
@@ -57,6 +57,7 @@ SIGNAL_CAST_DISCOVERED = 'cast_discovered'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_HOST): cv.string,
+    vol.Optional(CONF_NAME): cv.string,
     vol.Optional(CONF_IGNORE_CEC, default=[]):
         vol.All(cv.ensure_list, [cv.string]),
 })
@@ -236,7 +237,8 @@ async def _async_setup_platform(hass: HomeAssistantType, config: ConfigType,
                               port=discovery_info['port'])
     elif CONF_HOST in config:
         info = ChromecastInfo(host=config[CONF_HOST],
-                              port=DEFAULT_PORT)
+                              port=DEFAULT_PORT,
+                              friendly_name=config.get(CONF_NAME, None))
 
     @callback
     def async_cast_discovered(discover: ChromecastInfo) -> None:

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -113,25 +113,29 @@ class EntityRegistry:
                             suggested_object_id=None, config_entry_id=None,
                             device_id=None):
         """Get entity. Create if it doesn't exist."""
-        entity_id = self.async_get_entity_id(domain, platform, unique_id)
+        entity_id = new_entity_id = \
+            self.async_get_entity_id(domain, platform, unique_id)
+
+        if not entity_id or not valid_entity_id(entity_id):
+            new_entity_id = self.async_generate_entity_id(
+                domain, suggested_object_id
+                        or '{}_{}'.format(platform, unique_id))
+
         if entity_id:
             return self._async_update_entity(
                 entity_id, config_entry_id=config_entry_id,
-                device_id=device_id)
-
-        entity_id = self.async_generate_entity_id(
-            domain, suggested_object_id or '{}_{}'.format(platform, unique_id))
+                device_id=device_id, new_entity_id=new_entity_id)
 
         entity = RegistryEntry(
-            entity_id=entity_id,
+            entity_id=new_entity_id,
             config_entry_id=config_entry_id,
             device_id=device_id,
             unique_id=unique_id,
             platform=platform,
         )
-        self.entities[entity_id] = entity
+        self.entities[new_entity_id] = entity
         _LOGGER.info('Registered new %s.%s entity: %s',
-                     domain, platform, entity_id)
+                     domain, platform, new_entity_id)
         self.async_schedule_save()
         return entity
 

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -118,8 +118,9 @@ class EntityRegistry:
 
         if not entity_id or not valid_entity_id(entity_id):
             new_entity_id = self.async_generate_entity_id(
-                domain, suggested_object_id
-                        or '{}_{}'.format(platform, unique_id))
+                domain,
+                suggested_object_id or '{}_{}'.format(platform, unique_id)
+            )
 
         if entity_id:
             return self._async_update_entity(


### PR DESCRIPTION
## Description:
My TV is named "Телевизор" and Home Assistant generates invalid entity_id `media_player.` for it.
Now i can set custom name for cast-device and entity_id is generated correctly.

```
ERROR (MainThread) [homeassistant.core] Error doing job: Task exception was never retrieved
Traceback (most recent call last):
  File "/usr/src/app/homeassistant/helpers/entity_platform.py", line 343, in _async_add_entity
    'Invalid entity id: {}'.format(entity.entity_id))
homeassistant.exceptions.HomeAssistantError: Invalid entity id: media_player.
```

## Example entry for `configuration.yaml` (if applicable):
```yaml
cast:
  media_player:
    - host: 192.168.10.101
      name: My ChromeCast
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.