### PR TITLE
Add webhook as a dependency to cloud component

### DIFF
--- a/homeassistant/components/cloud/__init__.py
+++ b/homeassistant/components/cloud/__init__.py
@@ -24,6 +24,7 @@ from . import http_api, iot, auth_api, prefs, cloudhooks
 from .const import CONFIG_DIR, DOMAIN, SERVERS
 
 REQUIREMENTS = ['warrant==0.6.1']
+DEPENDENCIES = ['webhook']
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Description:
The cloud component relies on the webhook component being loaded for the frontend to function.

**Related issue (if applicable):** reported in #beta

## Example entry for `configuration.yaml` (if applicable):
```yaml
cloud:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
