### PR TITLE
Add support for C by GE lights

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -543,6 +543,7 @@ omit =
     homeassistant/components/light/avion.py
     homeassistant/components/light/blinksticklight.py
     homeassistant/components/light/blinkt.py
+    homeassistant/components/light/c_by_ge.py    
     homeassistant/components/light/decora_wifi.py
     homeassistant/components/light/decora.py
     homeassistant/components/light/flux_led.py

--- a/homeassistant/components/light/c_by_ge.py
+++ b/homeassistant/components/light/c_by_ge.py
@@ -8,7 +8,6 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.core import callback
 from homeassistant.const import CONF_NAME, CONF_PASSWORD
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS, SUPPORT_BRIGHTNESS, ATTR_COLOR_TEMP, SUPPORT_COLOR_TEMP,
@@ -30,16 +29,16 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 
 def setup_platform(hass, config, add_entities,
-                               discovery_info=None):
+                   discovery_info=None):
     """Set up the C by GE platform."""
     import laurel
 
-    l = laurel.laurel(config[CONF_NAME], config[CONF_PASSWORD])
-    for network in l.networks:
+    data = laurel.laurel(config[CONF_NAME], config[CONF_PASSWORD])
+    for network in data.networks:
         network.connect()
 
     lights = []
-    for bulb in l.devices:
+    for bulb in data.devices:
         lights.append(GELight(bulb))
 
     add_entities(lights)
@@ -60,7 +59,7 @@ class GELight(Light):
             self._features = SUPPORT_BRIGHTNESS | SUPPORT_COLOR_TEMP
         else:
             self._features = SUPPORT_BRIGHTNESS
-            
+
     def callback(self, args):
         if self.hass is not None:
             self.schedule_update_ha_state()

--- a/homeassistant/components/light/c_by_ge.py
+++ b/homeassistant/components/light/c_by_ge.py
@@ -1,0 +1,132 @@
+"""
+Support for C by GE lights.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/light.c_by_ge/
+"""
+import logging
+
+import voluptuous as vol
+
+from homeassistant.core import callback
+from homeassistant.const import CONF_NAME, CONF_PASSWORD
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS, SUPPORT_BRIGHTNESS, ATTR_COLOR_TEMP, SUPPORT_COLOR_TEMP,
+    Light, PLATFORM_SCHEMA)
+import homeassistant.helpers.config_validation as cv
+from homeassistant.util.color import \
+    color_temperature_kelvin_to_mired as kelvin_to_mired
+from homeassistant.util.color import \
+    color_temperature_mired_to_kelvin as mired_to_kelvin
+
+REQUIREMENTS = ['laurel==0.2']
+
+_LOGGER = logging.getLogger(__name__)
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_NAME): cv.string,
+    vol.Required(CONF_PASSWORD): cv.string,
+})
+
+
+def setup_platform(hass, config, add_entities,
+                               discovery_info=None):
+    """Set up the C by GE platform."""
+    import laurel
+
+    l = laurel.laurel(config[CONF_NAME], config[CONF_PASSWORD])
+    for network in l.networks:
+        network.connect()
+
+    lights = []
+    for bulb in l.devices:
+        lights.append(GELight(bulb))
+
+    add_entities(lights)
+
+
+class GELight(Light):
+    """Representation of a C by GE light."""
+
+    def __init__(self, bulb):
+        """Initialize the light."""
+
+        self._bulb = bulb
+        self._state = False
+        self._brightness = 255
+        bulb.set_callback(self.callback, None)
+
+        if bulb.supports_temperature():
+            self._features = SUPPORT_BRIGHTNESS | SUPPORT_COLOR_TEMP
+        else:
+            self._features = SUPPORT_BRIGHTNESS
+            
+    def callback(self, args):
+        if self.hass is not None:
+            self.schedule_update_ha_state()
+
+    @property
+    def name(self):
+        """Return the name of the device if any."""
+        return self._bulb.name
+
+    @property
+    def is_on(self):
+        """Return true if device is on."""
+        if self._bulb.brightness == 0:
+            return False
+        else:
+            return True
+
+    @property
+    def brightness(self):
+        """Return the brightness of this light between 0..255."""
+        return (self._bulb.brightness * 2.55)
+
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+        return self._features
+
+    @property
+    def color_temp(self):
+        """Return the color temperature of this light."""
+        kelvin = self._bulb.temperature * 50 + 2000
+        return kelvin_to_mired(kelvin)
+
+    @property
+    def min_mireds(self):
+        """Return minimum supported color temperature."""
+        return kelvin_to_mired(7000)
+
+    @property
+    def max_mireds(self):
+        """Return maximum supported color temperature."""
+        return kelvin_to_mired(2000)
+
+    @property
+    def should_poll(self):
+        """Don't need to poll"""
+        return False
+
+    def turn_on(self, **kwargs):
+        """Turn the specified light on."""
+
+        if not self.is_on:
+            self._bulb.set_power(True)
+
+        temperature = kwargs.get(ATTR_COLOR_TEMP)
+        brightness = kwargs.get(ATTR_BRIGHTNESS)
+
+        if temperature is not None:
+            # Colour temperature is a percentage between 2000K and 7000K
+            kelvin = mired_to_kelvin(temperature)
+            percent = int((kelvin - 2000) / 50)
+            self._bulb.set_temperature(percent)
+
+        if brightness is not None:
+            self._bulb.set_brightness(int(brightness/2.55))
+
+    def turn_off(self, **kwargs):
+        """Turn the specified light off."""
+        self._bulb.set_power(False)

--- a/homeassistant/components/light/c_by_ge.py
+++ b/homeassistant/components/light/c_by_ge.py
@@ -49,7 +49,6 @@ class GELight(Light):
 
     def __init__(self, bulb):
         """Initialize the light."""
-
         self._bulb = bulb
         self._state = False
         self._brightness = 255
@@ -61,6 +60,7 @@ class GELight(Light):
             self._features = SUPPORT_BRIGHTNESS
 
     def callback(self, args):
+        """Handle updates from the bulb."""
         if self.hass is not None:
             self.schedule_update_ha_state()
 
@@ -74,13 +74,12 @@ class GELight(Light):
         """Return true if device is on."""
         if self._bulb.brightness == 0:
             return False
-        else:
-            return True
+        return True
 
     @property
     def brightness(self):
         """Return the brightness of this light between 0..255."""
-        return (self._bulb.brightness * 2.55)
+        return self._bulb.brightness * 2.55
 
     @property
     def supported_features(self):
@@ -105,12 +104,11 @@ class GELight(Light):
 
     @property
     def should_poll(self):
-        """Don't need to poll"""
+        """Don't need to poll."""
         return False
 
     def turn_on(self, **kwargs):
         """Turn the specified light on."""
-
         if not self.is_on:
             self._bulb.set_power(True)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -566,6 +566,9 @@ konnected==0.1.4
 # homeassistant.components.eufy
 lakeside==0.11
 
+# homeassistant.components.light.c_by_ge
+laurel==0.2
+
 # homeassistant.components.owntracks
 libnacl==1.6.1
 


### PR DESCRIPTION
## Description:

These are Bluetooth-based bulbs that support mesh networking, allowing
multiple devices to connect to the mesh simultaneously (eg, if you have 3
bulbs, 3 devices can be connected to the mesh to control them at once).
The Sleep models support fairly fine-grained temperatures between 2000K and
7000K, although the shipped app only provides 3 fixed temperatures to
choose from.


**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#7801
## Example entry for `configuration.yaml` (if applicable):
```yaml
light:
  - platform: c_by_ge
    name: email_address
    password: password

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
