### PR TITLE
Allow using all 4 speeds with the HomeSeer HS-FC200+ fan controller

### DIFF
--- a/homeassistant/components/fan/__init__.py
+++ b/homeassistant/components/fan/__init__.py
@@ -42,6 +42,7 @@ SERVICE_SET_DIRECTION = 'set_direction'
 
 SPEED_OFF = 'off'
 SPEED_LOW = 'low'
+SPEED_MEDIUM_LOW = 'medium-low'
 SPEED_MEDIUM = 'medium'
 SPEED_HIGH = 'high'
 

--- a/homeassistant/components/fan/zwave.py
+++ b/homeassistant/components/fan/zwave.py
@@ -35,7 +35,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     async_dispatcher_connect(hass, 'zwave_new_fan', async_add_fan)
 
 
-def get_device(node, values, node_config, **kwargs):
+def get_device(values, **kwargs):
     """Create Z-Wave entity device."""
     return ZwaveFan(values)
 
@@ -58,7 +58,7 @@ class ZwaveFan(zwave.ZWaveDeviceEntity, FanEntity):
                 "2": range(25, 50),
                 "3": range(50, 75),
                 "4": range(75, 101)
-        }
+            }
         else:
             self._speed_list = [SPEED_OFF, SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH]
             self._speed_to_values = {
@@ -70,8 +70,8 @@ class ZwaveFan(zwave.ZWaveDeviceEntity, FanEntity):
 
         self._value_to_speed = {}
         for speed, values in self._speed_to_values.items():
-              for value in values:
-                    self._value_to_speed[value] = speed
+            for value in values:
+                self._value_to_speed[value] = speed
 
     def _device_id(self):
         if (self.node.manufacturer_id.strip() and

--- a/homeassistant/components/fan/zwave.py
+++ b/homeassistant/components/fan/zwave.py
@@ -74,8 +74,11 @@ class ZwaveFan(zwave.ZWaveDeviceEntity, FanEntity):
                     self._value_to_speed[value] = speed
 
     def _device_id(self):
-        return (int(self.node.manufacturer_id, 16),
-          int(self.node.product_id, 16))
+        if (self.node.manufacturer_id.strip() and
+                self.node.product_id.strip()):
+            return (int(self.node.manufacturer_id, 16),
+                    int(self.node.product_id, 16))
+        return None
 
     def update_properties(self):
         """Handle data changes for node values."""

--- a/homeassistant/components/fan/zwave.py
+++ b/homeassistant/components/fan/zwave.py
@@ -19,6 +19,7 @@ HOMESEER_FC200 = (0x000c, 0x0001)
 
 SUPPORTED_FEATURES = SUPPORT_SET_SPEED
 
+
 async def async_setup_platform(hass, config, async_add_entities,
                                discovery_info=None):
     """Old method of setting up Z-Wave fans."""
@@ -38,6 +39,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 def get_device(values, **kwargs):
     """Create Z-Wave entity device."""
     return ZwaveFan(values)
+
 
 class ZwaveFan(zwave.ZWaveDeviceEntity, FanEntity):
     """Representation of a Z-Wave fan."""

--- a/homeassistant/components/fan/zwave.py
+++ b/homeassistant/components/fan/zwave.py
@@ -8,8 +8,8 @@ import logging
 
 from homeassistant.core import callback
 from homeassistant.components.fan import (
-    DOMAIN, FanEntity, SPEED_OFF, SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH,
-    SUPPORT_SET_SPEED)
+    DOMAIN, FanEntity, SPEED_OFF, SPEED_LOW, SPEED_MEDIUM_LOW,
+    SPEED_MEDIUM, SPEED_HIGH, SUPPORT_SET_SPEED)
 from homeassistant.components import zwave
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
@@ -53,13 +53,19 @@ class ZwaveFan(zwave.ZWaveDeviceEntity, FanEntity):
     def _init_speed_value_mappings(self):
         """Build maps to translate between logical speeds and dimmer values."""
         if self._device_id() == HOMESEER_FC200:
-            self._speed_list = [SPEED_OFF, "1", "2", "3", "4"]
+            self._speed_list = [
+                SPEED_OFF,
+                SPEED_LOW,
+                SPEED_MEDIUM_LOW,
+                SPEED_MEDIUM,
+                SPEED_HIGH
+            ]
             self._speed_to_values = {
                 SPEED_OFF: [0],
-                "1": range(1, 25),
-                "2": range(25, 50),
-                "3": range(50, 75),
-                "4": range(75, 101)
+                SPEED_LOW: range(1, 25),
+                SPEED_MEDIUM_LOW: range(25, 50),
+                SPEED_MEDIUM: range(50, 75),
+                SPEED_HIGH: range(75, 101)
             }
         else:
             self._speed_list = [SPEED_OFF, SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH]

--- a/tests/components/fan/test_zwave.py
+++ b/tests/components/fan/test_zwave.py
@@ -51,7 +51,7 @@ def test_fan_turn_on(mock_openzwave):
     value_id, brightness = node.set_dimmer.mock_calls[0][1]
 
     assert value_id == value.value_id
-    assert brightness == 1
+    assert brightness > 0 and brightness <= 33
 
     node.reset_mock()
 
@@ -61,7 +61,7 @@ def test_fan_turn_on(mock_openzwave):
     value_id, brightness = node.set_dimmer.mock_calls[0][1]
 
     assert value_id == value.value_id
-    assert brightness == 50
+    assert brightness > 33 and brightness <= 66
 
     node.reset_mock()
 
@@ -71,7 +71,7 @@ def test_fan_turn_on(mock_openzwave):
     value_id, brightness = node.set_dimmer.mock_calls[0][1]
 
     assert value_id == value.value_id
-    assert brightness == 99
+    assert brightness > 66 and brightness <= 100
 
 
 def test_fan_turn_off(mock_openzwave):


### PR DESCRIPTION
## Description:
The HomeSeer HS-FC200+ fan controller supports 4 speeds, but the current implementation of the ZWave fan component only allows you to choose 3 of them.

This PR updates the fan component to detect if the device is an FC200+, and if it is, treat it as a 4-speed fan controller with the speeds [off, low, medium-low, medium, high.  Other fan controllers are assumed to be 3-speed only.

Caveat:
The FC200+ can actually be configured in 3-speed mode and 4-speed mode.  I've been working on detecting the device configuration setting during initialization, but I haven't gotten that reliably working (see https://community.home-assistant.io/t/questions-about-updating-the-z-wave-fan-component-for-4-speed-support/80718/2).  I figured that this PR is still a step forward, because users with 3-speed fans on FC200+ controllers will still be able to hit all 3 speeds, they'll just have an extra redundant speed in the middle  (speeds "medium-low" and "medium" will be equivalent), while everything will work perfect for users with FC200+ devices in 4-speed mode.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
