### PR TITLE
Always use datetime and timedelta in camera.proxy instead of int/float

### DIFF
--- a/homeassistant/components/camera/proxy.py
+++ b/homeassistant/components/camera/proxy.py
@@ -206,7 +206,7 @@ class ProxyCamera(Camera):
         self._cache_images = bool(
             config.get(CONF_IMAGE_REFRESH_RATE)
             or config.get(CONF_CACHE_IMAGES))
-        self._last_image_time = 0
+        self._last_image_time = self._last_image_time = dt_util.utc_from_timestamp(0)
         self._last_image = None
         self._headers = (
             {HTTP_HEADER_HA_AUTH: self.hass.config.api.api_password}
@@ -223,7 +223,8 @@ class ProxyCamera(Camera):
         now = dt_util.utcnow()
 
         if (self._image_refresh_rate and
-                now < self._last_image_time + self._image_refresh_rate):
+                now < self._last_image_time +
+                dt.timedelta(seconds=self._image_refresh_rate)):
             return self._last_image
 
         self._last_image_time = now


### PR DESCRIPTION
## Description:

The camera proxy module compares a float with a `datetime` object, and also attempts to add a float to a datetime. This is not valid, and produces the following error:
```
Dec 11 07:11:09 raspberrypi hass[3669]: 2018-12-11 07:11:09 ERROR (MainThread) [homeassistant.components.websocket_api.decorators] Unexpected exception
Dec 11 07:11:09 raspberrypi hass[3669]: Traceback (most recent call last):
Dec 11 07:11:09 raspberrypi hass[3669]:   File "/home/pi/.local/lib/python3.5/site-packages/homeassistant/components/websocket_api/decorators.py", line 16, in _handle_async_response
Dec 11 07:11:09 raspberrypi hass[3669]:     await func(hass, connection, msg)
Dec 11 07:11:09 raspberrypi hass[3669]:   File "/home/pi/.local/lib/python3.5/site-packages/homeassistant/components/camera/__init__.py", line 463, in websocket_camera_thumbnail
Dec 11 07:11:09 raspberrypi hass[3669]:     image = await async_get_image(hass, msg['entity_id'])
Dec 11 07:11:09 raspberrypi hass[3669]:   File "/home/pi/.local/lib/python3.5/site-packages/homeassistant/components/camera/__init__.py", line 93, in async_get_image
Dec 11 07:11:09 raspberrypi hass[3669]:     image = await camera.async_camera_image()
Dec 11 07:11:09 raspberrypi hass[3669]:   File "/home/pi/.local/lib/python3.5/site-packages/homeassistant/components/camera/proxy.py", line 155, in async_camera_image
Dec 11 07:11:09 raspberrypi hass[3669]:     now < self._last_image_time + self._image_refresh_rate):
Dec 11 07:11:09 raspberrypi hass[3669]: TypeError: unorderable types: datetime.datetime() < float()
```

I'm actually not sure how it ever worked, unless `image_refresh_rate` is not set... :-/

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
