### PR TITLE
Fix creation entity_id for non-english names

### DIFF
--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -102,7 +102,7 @@ class EntityRegistry:
         Conflicts checked against registered and currently existing entities.
         """
         return ensure_unique_string(
-            '{}.{}'.format(domain, slugify(suggested_object_id)),
+            '{}.{}'.format(domain, slugify(suggested_object_id) or domain),
             chain(self.entities.keys(),
                   self.hass.states.async_entity_ids(domain),
                   known_object_ids if known_object_ids else [])


### PR DESCRIPTION
## Description:
My TV is named "Телевизор" and Home Assistant generates invalid entity_id `media_player.` for it.

```
ERROR (MainThread) [homeassistant.core] Error doing job: Task exception was never retrieved
Traceback (most recent call last):
  File "/usr/src/app/homeassistant/helpers/entity_platform.py", line 343, in _async_add_entity
    'Invalid entity id: {}'.format(entity.entity_id))
homeassistant.exceptions.HomeAssistantError: Invalid entity id: media_player.
```

Now default name is used for entity, e.g. `media_player.media_player`.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
