### PR TITLE
Add SCAN_INTERVAL

### DIFF
--- a/homeassistant/components/weather/__init__.py
+++ b/homeassistant/components/weather/__init__.py
@@ -4,6 +4,7 @@ Weather component that handles meteorological data for your location.
 For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/weather/
 """
+from datetime import timedelta
 import logging
 
 from homeassistant.helpers.entity_component import EntityComponent
@@ -14,11 +15,6 @@ from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)
 
-DEPENDENCIES = []
-DOMAIN = 'weather'
-
-ENTITY_ID_FORMAT = DOMAIN + '.{}'
-
 ATTR_CONDITION_CLASS = 'condition_class'
 ATTR_FORECAST = 'forecast'
 ATTR_FORECAST_CONDITION = 'condition'
@@ -26,8 +22,8 @@ ATTR_FORECAST_PRECIPITATION = 'precipitation'
 ATTR_FORECAST_TEMP = 'temperature'
 ATTR_FORECAST_TEMP_LOW = 'templow'
 ATTR_FORECAST_TIME = 'datetime'
-ATTR_FORECAST_WIND_SPEED = 'wind_speed'
 ATTR_FORECAST_WIND_BEARING = 'wind_bearing'
+ATTR_FORECAST_WIND_SPEED = 'wind_speed'
 ATTR_WEATHER_ATTRIBUTION = 'attribution'
 ATTR_WEATHER_HUMIDITY = 'humidity'
 ATTR_WEATHER_OZONE = 'ozone'
@@ -37,10 +33,19 @@ ATTR_WEATHER_VISIBILITY = 'visibility'
 ATTR_WEATHER_WIND_BEARING = 'wind_bearing'
 ATTR_WEATHER_WIND_SPEED = 'wind_speed'
 
+DEPENDENCIES = []
+
+DOMAIN = 'weather'
+
+ENTITY_ID_FORMAT = DOMAIN + '.{}'
+
+SCAN_INTERVAL = timedelta(seconds=30)
+
 
 async def async_setup(hass, config):
     """Set up the weather component."""
-    component = hass.data[DOMAIN] = EntityComponent(_LOGGER, DOMAIN, hass)
+    component = hass.data[DOMAIN] = EntityComponent(
+        _LOGGER, DOMAIN, hass, SCAN_INTERVAL)
     await component.async_setup(config)
     return True
 

--- a/homeassistant/components/weather/__init__.py
+++ b/homeassistant/components/weather/__init__.py
@@ -33,8 +33,6 @@ ATTR_WEATHER_VISIBILITY = 'visibility'
 ATTR_WEATHER_WIND_BEARING = 'wind_bearing'
 ATTR_WEATHER_WIND_SPEED = 'wind_speed'
 
-DEPENDENCIES = []
-
 DOMAIN = 'weather'
 
 ENTITY_ID_FORMAT = DOMAIN + '.{}'


### PR DESCRIPTION
## Description:
Use the same interval as for the sensor. It's a sensor platform and should also behave as one. 

Was spotted during the review of the [`air_pollutants` component](https://github.com/home-assistant/home-assistant/pull/18707#discussion_r240316436) by @MartinHjelmare.

## Example entry for `configuration.yaml` (if applicable):
```yaml
weather:
  - platform: demo
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
