### PR TITLE
Add brightness control and proper state handling for x10 cm11a

### DIFF
--- a/homeassistant/components/light/x10.py
+++ b/homeassistant/components/light/x10.py
@@ -61,6 +61,7 @@ class X10Light(Light):
         self._brightness = 0
         self._state = False
         self._is_cm11a = is_cm11a
+        self.update()
 
     @property
     def name(self):

--- a/homeassistant/components/light/x10.py
+++ b/homeassistant/components/light/x10.py
@@ -36,12 +36,14 @@ def x10_command(command):
 def get_unit_status(code):
     """Get on/off status for given unit."""
     output = check_output('heyu onstate ' + code, shell=True)
+    _LOGGER.debug("unit on/off status %d", int(output))
     return int(output.decode('utf-8')[0])
 
 
 def get_raw_brightness(code):
     """Get current raw brightness for given unit."""
     output = check_output('heyu rawlevel ' + code, shell=True).rstrip()
+    _LOGGER.debug("raw brightness value %d", int(output))
     return int(output)
 
 


### PR DESCRIPTION
## Description:
Resubmitted my changes from before now that I have time

Our platform stated we had support for this but really it did nothing now it actually works.

You can't tell original protocol devices a brightness to go to so you must figure out the proper brightness needed and how many steps
it will take to get you there.

I do not own cm17a so I do not know if it has support for brightness control so I limited it to cm11a.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.