### PR TITLE
Fix bug when trying to read states of MQTT light when it is off.

### DIFF
--- a/homeassistant/components/light/mqtt/schema_basic.py
+++ b/homeassistant/components/light/mqtt/schema_basic.py
@@ -291,17 +291,18 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, Light, RestoreEntity):
         @callback
         def brightness_received(topic, payload, qos):
             """Handle new MQTT messages for the brightness."""
-            payload = templates[CONF_BRIGHTNESS](payload)
-            if not payload:
-                _LOGGER.debug("Ignoring empty brightness message from '%s'",
-                              topic)
-                return
+            if self._state:
+                payload = templates[CONF_BRIGHTNESS](payload)
+                if not payload:
+                    _LOGGER.debug("Ignoring empty brightness message from \
+                                    '%s'", topic)
+                    return
 
-            device_value = float(payload)
-            percent_bright = \
-                device_value / self._config.get(CONF_BRIGHTNESS_SCALE)
-            self._brightness = int(percent_bright * 255)
-            self.async_schedule_update_ha_state()
+                device_value = float(payload)
+                percent_bright = \
+                    device_value / self._config.get(CONF_BRIGHTNESS_SCALE)
+                self._brightness = int(percent_bright * 255)
+                self.async_schedule_update_ha_state()
 
         if self._topic[CONF_BRIGHTNESS_STATE_TOPIC] is not None:
             topics[CONF_BRIGHTNESS_STATE_TOPIC] = {
@@ -320,18 +321,20 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, Light, RestoreEntity):
         @callback
         def rgb_received(topic, payload, qos):
             """Handle new MQTT messages for RGB."""
-            payload = templates[CONF_RGB](payload)
-            if not payload:
-                _LOGGER.debug("Ignoring empty rgb message from '%s'", topic)
-                return
+            if self._state:
+                payload = templates[CONF_RGB](payload)
+                if not payload:
+                    _LOGGER.debug("Ignoring empty rgb message from \
+                                  '%s'", topic)
+                    return
 
-            rgb = [int(val) for val in payload.split(',')]
-            self._hs = color_util.color_RGB_to_hs(*rgb)
-            if self._topic[CONF_BRIGHTNESS_STATE_TOPIC] is None:
-                percent_bright = \
-                    float(color_util.color_RGB_to_hsv(*rgb)[2]) / 100.0
-                self._brightness = int(percent_bright * 255)
-            self.async_schedule_update_ha_state()
+                rgb = [int(val) for val in payload.split(',')]
+                self._hs = color_util.color_RGB_to_hs(*rgb)
+                if self._topic[CONF_BRIGHTNESS_STATE_TOPIC] is None:
+                    percent_bright = \
+                        float(color_util.color_RGB_to_hsv(*rgb)[2]) / 100.0
+                    self._brightness = int(percent_bright * 255)
+                self.async_schedule_update_ha_state()
 
         if self._topic[CONF_RGB_STATE_TOPIC] is not None:
             topics[CONF_RGB_STATE_TOPIC] = {
@@ -348,14 +351,15 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, Light, RestoreEntity):
         @callback
         def color_temp_received(topic, payload, qos):
             """Handle new MQTT messages for color temperature."""
-            payload = templates[CONF_COLOR_TEMP](payload)
-            if not payload:
-                _LOGGER.debug("Ignoring empty color temp message from '%s'",
-                              topic)
-                return
+            if self._state:
+                payload = templates[CONF_COLOR_TEMP](payload)
+                if not payload:
+                    _LOGGER.debug("Ignoring empty color temp message from \
+                                  '%s'", topic)
+                    return
 
-            self._color_temp = int(payload)
-            self.async_schedule_update_ha_state()
+                self._color_temp = int(payload)
+                self.async_schedule_update_ha_state()
 
         if self._topic[CONF_COLOR_TEMP_STATE_TOPIC] is not None:
             topics[CONF_COLOR_TEMP_STATE_TOPIC] = {
@@ -374,13 +378,15 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, Light, RestoreEntity):
         @callback
         def effect_received(topic, payload, qos):
             """Handle new MQTT messages for effect."""
-            payload = templates[CONF_EFFECT](payload)
-            if not payload:
-                _LOGGER.debug("Ignoring empty effect message from '%s'", topic)
-                return
+            if self._state:
+                payload = templates[CONF_EFFECT](payload)
+                if not payload:
+                    _LOGGER.debug("Ignoring empty effect message from\
+                                  '%s'", topic)
+                    return
 
-            self._effect = payload
-            self.async_schedule_update_ha_state()
+                self._effect = payload
+                self.async_schedule_update_ha_state()
 
         if self._topic[CONF_EFFECT_STATE_TOPIC] is not None:
             topics[CONF_EFFECT_STATE_TOPIC] = {
@@ -399,18 +405,19 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, Light, RestoreEntity):
         @callback
         def hs_received(topic, payload, qos):
             """Handle new MQTT messages for hs color."""
-            payload = templates[CONF_HS](payload)
-            if not payload:
-                _LOGGER.debug("Ignoring empty hs message from '%s'", topic)
-                return
+            if self._state:
+                payload = templates[CONF_HS](payload)
+                if not payload:
+                    _LOGGER.debug("Ignoring empty hs message from '%s'", topic)
+                    return
 
-            try:
-                hs_color = [float(val) for val in payload.split(',', 2)]
-                self._hs = hs_color
-                self.async_schedule_update_ha_state()
-            except ValueError:
-                _LOGGER.debug("Failed to parse hs state update: '%s'",
-                              payload)
+                try:
+                    hs_color = [float(val) for val in payload.split(',', 2)]
+                    self._hs = hs_color
+                    self.async_schedule_update_ha_state()
+                except ValueError:
+                    _LOGGER.debug("Failed to parse hs state update: '%s'",
+                                  payload)
 
         if self._topic[CONF_HS_STATE_TOPIC] is not None:
             topics[CONF_HS_STATE_TOPIC] = {
@@ -427,17 +434,18 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, Light, RestoreEntity):
         @callback
         def white_value_received(topic, payload, qos):
             """Handle new MQTT messages for white value."""
-            payload = templates[CONF_WHITE_VALUE](payload)
-            if not payload:
-                _LOGGER.debug("Ignoring empty white value message from '%s'",
-                              topic)
-                return
+            if self._state:
+                payload = templates[CONF_WHITE_VALUE](payload)
+                if not payload:
+                    _LOGGER.debug("Ignoring empty white value message from\
+                                  '%s'", topic)
+                    return
 
-            device_value = float(payload)
-            percent_white = \
-                device_value / self._config.get(CONF_WHITE_VALUE_SCALE)
-            self._white_value = int(percent_white * 255)
-            self.async_schedule_update_ha_state()
+                device_value = float(payload)
+                percent_white = \
+                    device_value / self._config.get(CONF_WHITE_VALUE_SCALE)
+                self._white_value = int(percent_white * 255)
+                self.async_schedule_update_ha_state()
 
         if self._topic[CONF_WHITE_VALUE_STATE_TOPIC] is not None:
             topics[CONF_WHITE_VALUE_STATE_TOPIC] = {
@@ -456,15 +464,16 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, Light, RestoreEntity):
         @callback
         def xy_received(topic, payload, qos):
             """Handle new MQTT messages for xy color."""
-            payload = templates[CONF_XY](payload)
-            if not payload:
-                _LOGGER.debug("Ignoring empty xy-color message from '%s'",
-                              topic)
-                return
+            if self._state:
+                payload = templates[CONF_XY](payload)
+                if not payload:
+                    _LOGGER.debug("Ignoring empty xy-color message from '%s'",
+                                  topic)
+                    return
 
-            xy_color = [float(val) for val in payload.split(',')]
-            self._hs = color_util.color_xy_to_hs(*xy_color)
-            self.async_schedule_update_ha_state()
+                xy_color = [float(val) for val in payload.split(',')]
+                self._hs = color_util.color_xy_to_hs(*xy_color)
+                self.async_schedule_update_ha_state()
 
         if self._topic[CONF_XY_STATE_TOPIC] is not None:
             topics[CONF_XY_STATE_TOPIC] = {

--- a/tests/components/light/test_mqtt.py
+++ b/tests/components/light/test_mqtt.py
@@ -523,10 +523,10 @@ async def test_controlling_state_via_topic_with_templates(hass, mqtt_mock):
     assert state.attributes.get('brightness') is None
     assert state.attributes.get('rgb_color') is None
 
-    async_fire_mqtt_message(hass, 'test_light_rgb/rgb/status',
-                            '{"hello": [1, 2, 3]}')
     async_fire_mqtt_message(hass, 'test_light_rgb/status',
                             '{"hello": "ON"}')
+    async_fire_mqtt_message(hass, 'test_light_rgb/rgb/status',
+                            '{"hello": [1, 2, 3]}')
     async_fire_mqtt_message(hass, 'test_light_rgb/brightness/status',
                             '{"hello": "50"}')
     async_fire_mqtt_message(hass, 'test_light_rgb/color_temp/status',


### PR DESCRIPTION
## Description:

This week I started to using RGB MQTT light and found a bug in mqtt light implementation.
When I call to turn off light, it tried to read rgb state when light is already off.
It occurs if state topic and brightness/color topic etc. are the same.

Exception thrown:
```
2018-12-11 15:15:07 ERROR (MainThread) [homeassistant.helpers.template] Error parsing value: 'dict object' has no attribute 'Color' (value: {"POWER":"OFF"}, template: {{value_json.Color.split(',')[0:3]|join(',')}})                                                         
2018-12-11 15:15:07 ERROR (MainThread) [homeassistant.core] Error doing job: Exception in callback MQTT._mqtt_handle_message(<paho.mqtt.cl...x7fb43fb67dd8>)                                                                                                                   
Traceback (most recent call last):
  File "/usr/lib/python3.6/asyncio/events.py", line 145, in _run
    self._callback(*self._args)
  File "/root/homeassistant/lib/python3.6/site-packages/homeassistant/components/mqtt/__init__.py", line 775, in _mqtt_handle_message
    subscription.callback, msg.topic, payload, msg.qos)
  File "/root/homeassistant/lib/python3.6/site-packages/homeassistant/core.py", line 327, in async_run_job
    target(*args)
  File "/root/homeassistant/lib/python3.6/site-packages/homeassistant/components/light/mqtt.py", line 331, in rgb_received
    rgb = [int(val) for val in payload.split(',')]
  File "/root/homeassistant/lib/python3.6/site-packages/homeassistant/components/light/mqtt.py", line 331, in <listcomp>
    rgb = [int(val) for val in payload.split(',')]
ValueError: invalid literal for int() with base 10: '{"POWER":"OFF"}'
```

**Related issue (if applicable): couldn't find any.

## Example entry for `configuration.yaml` (if applicable):
Config which threw error:
```yaml
- platform: mqtt
  name: "LED light"
  command_topic: "cmnd/led/POWER"
  state_topic: "stat/led/RESULT"
  state_value_template: "{{value_json.POWER}}"
  availability_topic: "tele/led/LWT"
  brightness_command_topic: "cmnd/led/Dimmer"
  brightness_state_topic: "stat/led/RESULT"
  brightness_scale: 100
  on_command_type: "brightness"
  brightness_value_template: "{{value_json.Dimmer}}"
  color_temp_command_topic: "cmnd/led/CT"
  color_temp_state_topic: "stat/led/RESULT"
  color_temp_value_template: "{{value_json.CT}}"
  rgb_command_topic: "cmnd/led/Color2"
  rgb_state_topic: "stat/led/RESULT"
  rgb_value_template: "{{value_json.Color.split(',')[0:3]|join(',')}}"
  effect_command_topic: "cmnd/led/Scheme"
  effect_state_topic: "stat/led/RESULT"
  effect_value_template: "{{value_json.Scheme}}"
  effect_list:
    - 0
    - 1
    - 2
    - 3
    - 4
  payload_on: "ON"
  payload_off: "OFF"
  payload_available: "Online"
  payload_not_available: "Offline"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] Tests have been changed to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
