### PR TITLE
Make variable `entity_id` available to value_template for MQTT binary sensor

### DIFF
--- a/homeassistant/components/binary_sensor/mqtt.py
+++ b/homeassistant/components/binary_sensor/mqtt.py
@@ -135,7 +135,7 @@ class MqttBinarySensor(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
             value_template = self._config.get(CONF_VALUE_TEMPLATE)
             if value_template is not None:
                 payload = value_template.async_render_with_possible_json_value(
-                    payload, entity_id=self.entity_id)
+                    payload, variables={'entity_id': self.entity_id})
             if payload == self._config.get(CONF_PAYLOAD_ON):
                 self._state = True
             elif payload == self._config.get(CONF_PAYLOAD_OFF):

--- a/homeassistant/components/binary_sensor/mqtt.py
+++ b/homeassistant/components/binary_sensor/mqtt.py
@@ -135,7 +135,7 @@ class MqttBinarySensor(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
             value_template = self._config.get(CONF_VALUE_TEMPLATE)
             if value_template is not None:
                 payload = value_template.async_render_with_possible_json_value(
-                    payload)
+                    payload, entity_id=self.entity_id)
             if payload == self._config.get(CONF_PAYLOAD_ON):
                 self._state = True
             elif payload == self._config.get(CONF_PAYLOAD_OFF):

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -149,7 +149,8 @@ class Template:
             error_value).result()
 
     def async_render_with_possible_json_value(self, value,
-                                              error_value=_SENTINEL):
+                                              error_value=_SENTINEL,
+                                              entity_id=None):
         """Render template with value exposed.
 
         If valid JSON will expose value_json too.
@@ -162,6 +163,10 @@ class Template:
         variables = {
             'value': value
         }
+
+        if entity_id:
+            variables['entity_id'] = entity_id
+
         try:
             variables['value_json'] = json.loads(value)
         except ValueError:

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -150,7 +150,7 @@ class Template:
 
     def async_render_with_possible_json_value(self, value,
                                               error_value=_SENTINEL,
-                                              entity_id=None):
+                                              variables=None):
         """Render template with value exposed.
 
         If valid JSON will expose value_json too.
@@ -160,12 +160,8 @@ class Template:
         if self._compiled is None:
             self._ensure_compiled()
 
-        variables = {
-            'value': value
-        }
-
-        if entity_id:
-            variables['entity_id'] = entity_id
+        variables = dict(variables or {})
+        variables['value'] = value
 
         try:
             variables['value_json'] = json.loads(value)


### PR DESCRIPTION
## Description:
#18501, which proposed adding "toggle" functionality to binary sensor, was closed because the same thing should already be possible to achieve with a value template. 

Doing it with a value template however requires hard coding the `entity_id`, which is tedious and error prone in case of manual edit of configuration.yaml, and impossible if the entity is automatically discovered.

This PR makes variable `entity_id` available to the `value_template`, in the same manner as it is already available to automation templates.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8021

## Example entry for `configuration.yaml` (if applicable):
```yaml
# Toggle the binary sensor each time a message is received on state_topic
binary_sensor:
  - platform: mqtt
    state_topic:lab_button/cmnd/POWER"
    value_template:"{%if is_state(entity_id,\"on\")-%}OFF{%-else-%}ON{%-endif%}"}
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.