### PR TITLE
Fix geizhals crash if no price found

### DIFF
--- a/homeassistant/components/sensor/geizhals.py
+++ b/homeassistant/components/sensor/geizhals.py
@@ -82,8 +82,8 @@ class Geizwatch(Entity):
         """Return the best price of the selected product."""
         if not self._device.prices:
             return None
-        else:
-            return self._device.prices[0]
+        
+        return self._device.prices[0]
 
     @property
     def device_state_attributes(self):

--- a/homeassistant/components/sensor/geizhals.py
+++ b/homeassistant/components/sensor/geizhals.py
@@ -82,7 +82,7 @@ class Geizwatch(Entity):
         """Return the best price of the selected product."""
         if not self._device.prices:
             return None
-        
+
         return self._device.prices[0]
 
     @property

--- a/homeassistant/components/sensor/geizhals.py
+++ b/homeassistant/components/sensor/geizhals.py
@@ -13,7 +13,7 @@ from homeassistant.components.sensor import PLATFORM_SCHEMA
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import Throttle
 from homeassistant.helpers.entity import Entity
-from homeassistant.const import CONF_NAME, STATE_UNKNOWN
+from homeassistant.const import CONF_NAME
 
 REQUIREMENTS = ['geizhals==0.0.9']
 
@@ -81,7 +81,7 @@ class Geizwatch(Entity):
     def state(self):
         """Return the best price of the selected product."""
         if not self._device.prices:
-            return STATE_UNKNOWN
+            return None
         else:
             return self._device.prices[0]
 

--- a/homeassistant/components/sensor/geizhals.py
+++ b/homeassistant/components/sensor/geizhals.py
@@ -13,7 +13,7 @@ from homeassistant.components.sensor import PLATFORM_SCHEMA
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import Throttle
 from homeassistant.helpers.entity import Entity
-from homeassistant.const import CONF_NAME
+from homeassistant.const import CONF_NAME, STATE_UNKNOWN
 
 REQUIREMENTS = ['geizhals==0.0.9']
 
@@ -80,7 +80,10 @@ class Geizwatch(Entity):
     @property
     def state(self):
         """Return the best price of the selected product."""
-        return self._device.prices[0]
+        if not self._device.prices:
+            return STATE_UNKNOWN
+        else:
+            return self._device.prices[0]
 
     @property
     def device_state_attributes(self):


### PR DESCRIPTION
## Description:

Currently, if the `geizhals` package can't find a price for a product (because the Geizhals website can't find a price…), that produces a crash, as an empty list is returned. This change fixes that.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.