### PR TITLE
Add package data attribute to 17track.net summary sensors

### DIFF
--- a/homeassistant/components/sensor/seventeentrack.py
+++ b/homeassistant/components/sensor/seventeentrack.py
@@ -143,9 +143,10 @@ class SeventeenTrackSummarySensor(Entity):
         await self._data.async_update()
 
         package_data = []
-        for package in [
-                p for p in self._data.packages if p.status == self._status
-        ]:
+        for package in self._data.packages:
+            if package.status != self._status:
+                continue
+
             package_data.append({
                 ATTR_FRIENDLY_NAME: package.friendly_name,
                 ATTR_INFO_TEXT: package.info_text,

--- a/homeassistant/components/sensor/seventeentrack.py
+++ b/homeassistant/components/sensor/seventeentrack.py
@@ -21,9 +21,12 @@ REQUIREMENTS = ['py17track==2.1.1']
 _LOGGER = logging.getLogger(__name__)
 
 ATTR_DESTINATION_COUNTRY = 'destination_country'
+ATTR_FRIENDLY_NAME = 'friendly_name'
 ATTR_INFO_TEXT = 'info_text'
 ATTR_ORIGIN_COUNTRY = 'origin_country'
+ATTR_PACKAGES = 'packages'
 ATTR_PACKAGE_TYPE = 'package_type'
+ATTR_STATUS = 'status'
 ATTR_TRACKING_INFO_LANGUAGE = 'tracking_info_language'
 ATTR_TRACKING_NUMBER = 'tracking_number'
 
@@ -117,7 +120,7 @@ class SeventeenTrackSummarySensor(Entity):
     @property
     def name(self):
         """Return the name."""
-        return '17track Packages {0}'.format(self._status)
+        return 'Seventeentrack Packages {0}'.format(self._status)
 
     @property
     def state(self):
@@ -138,6 +141,20 @@ class SeventeenTrackSummarySensor(Entity):
     async def async_update(self):
         """Update the sensor."""
         await self._data.async_update()
+
+        package_data = []
+        for package in [
+                p for p in self._data.packages if p.status == self._status
+        ]:
+            package_data.append({
+                ATTR_FRIENDLY_NAME: package.friendly_name,
+                ATTR_INFO_TEXT: package.info_text,
+                ATTR_STATUS: package.status,
+                ATTR_TRACKING_NUMBER: package.tracking_number,
+            })
+
+        if package_data:
+            self._attrs[ATTR_PACKAGES] = package_data
 
         self._state = self._data.summary.get(self._status)
 
@@ -186,7 +203,7 @@ class SeventeenTrackPackageSensor(Entity):
         name = self._friendly_name
         if not name:
             name = self._tracking_number
-        return '17track Package: {0}'.format(name)
+        return 'Seventeentrack Package: {0}'.format(name)
 
     @property
     def state(self):


### PR DESCRIPTION
## Description:

[From a forum request](https://community.home-assistant.io/t/17track-net/53076): users want 17track.net summary sensors to include a JSON attribute containing the packages applicable to that status (for easier display via a table card in Lovelace). This PR takes care of that.

The PR also fixes an issue wherein 17track.net sensors couldn't be used in Jinja templates because of their entity ID.

**BREAKING CHANGE:** In order to fix the below bug, default entity_ids will change (for example, `sensor.17track_packages_delivered` will change to `sensor.seventeentrack_packages_delivered`).

**Related issue (if applicable):** fixes #19212

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: seventeentrack
    username: !secret 17track_email
    password: !secret 17track_password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
