### PR TITLE
Fix owntracks topic in encrypted ios

### DIFF
--- a/homeassistant/components/device_tracker/owntracks.py
+++ b/homeassistant/components/device_tracker/owntracks.py
@@ -316,7 +316,11 @@ async def async_handle_waypoints_message(hass, context, message):
 @HANDLERS.register('encrypted')
 async def async_handle_encrypted_message(hass, context, message):
     """Handle an encrypted message."""
-    plaintext_payload = _decrypt_payload(context.secret, message['topic'],
+    if 'topic' not in message and isinstance(context.secret, dict):
+        _LOGGER.error("You cannot set per topic secrets when using HTTP")
+        return
+
+    plaintext_payload = _decrypt_payload(context.secret, message.get('topic'),
                                          message['data'])
 
     if plaintext_payload is None:

--- a/homeassistant/components/device_tracker/owntracks.py
+++ b/homeassistant/components/device_tracker/owntracks.py
@@ -323,7 +323,8 @@ async def async_handle_encrypted_message(hass, context, message):
         return
 
     decrypted = json.loads(plaintext_payload)
-    decrypted['topic'] = message['topic']
+    if 'topic' in message and 'topic' not in decrypted:
+        decrypted['topic'] = message['topic']
 
     await async_handle_message(hass, context, decrypted)
 

--- a/homeassistant/components/owntracks/__init__.py
+++ b/homeassistant/components/owntracks/__init__.py
@@ -137,14 +137,15 @@ async def handle_webhook(hass, webhook_id, request):
         user = headers.get('X-Limit-U')
         device = headers.get('X-Limit-D', user)
 
-        if user is None:
+        if user:
+            topic_base = re.sub('/#$', '', context.mqtt_topic)
+            message['topic'] = '{}/{}/{}'.format(topic_base, user, device)
+
+        elif message['_type'] != 'encrypted':
             _LOGGER.warning('No topic or user found in message. If on Android,'
                             ' set a username in Connection -> Identification')
             # Keep it as a 200 response so the incorrect packet is discarded
             return json_response([])
-
-        topic_base = re.sub('/#$', '', context.mqtt_topic)
-        message['topic'] = '{}/{}/{}'.format(topic_base, user, device)
 
     hass.helpers.dispatcher.async_dispatcher_send(
         DOMAIN, hass, context, message)


### PR DESCRIPTION
## Description:
On iOS, the encrypted payload does not contain a topic. It is available in the decrypted payload.

This adjusts the check to not throw away the message if it's encrypted but process it instead. It will still attach the topic on encrypted messages if it's able to derive it from the Android headers (as Android never includes `topic`)

Thanks to @arsaboo and @bramkragten for helping with testing

**Related issue (if applicable):** fixes #18927

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
