### PR TITLE
Fix race in entity_platform.async_add_entities

### DIFF
--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -297,7 +297,8 @@ class EntityPlatform:
                 self.domain, self.platform_name, entity.unique_id,
                 suggested_object_id=suggested_object_id,
                 config_entry_id=config_entry_id,
-                device_id=device_id)
+                device_id=device_id,
+                known_object_ids=self.entities.keys())
 
             if entry.disabled:
                 self.logger.info(

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -117,7 +117,7 @@ class EntityRegistry:
     @callback
     def async_get_or_create(self, domain, platform, unique_id, *,
                             suggested_object_id=None, config_entry_id=None,
-                            device_id=None):
+                            device_id=None, known_object_ids=None):
         """Get entity. Create if it doesn't exist."""
         entity_id = self.async_get_entity_id(domain, platform, unique_id)
         if entity_id:
@@ -126,7 +126,8 @@ class EntityRegistry:
                 device_id=device_id)
 
         entity_id = self.async_generate_entity_id(
-            domain, suggested_object_id or '{}_{}'.format(platform, unique_id))
+            domain, suggested_object_id or '{}_{}'.format(platform, unique_id),
+            known_object_ids)
 
         entity = RegistryEntry(
             entity_id=entity_id,


### PR DESCRIPTION
## Description:
There is a race in entity_platform.async_add_entities() which makes the check for duplicated entity_id fail. This in turns may cause several entities to be created with the same entity_id.
The issue can very easily be reproduced by publishing two persistent MQTT discovery messages with same name before starting hass, one of which has `unique_id` set.

This is a follow-up to #18445, now also fixing the case for entities which are added to the device registry.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.