### PR TITLE
Make username case-insensitive on login

### DIFF
--- a/homeassistant/auth/providers/homeassistant.py
+++ b/homeassistant/auth/providers/homeassistant.py
@@ -78,7 +78,7 @@ class Data:
 
         # Compare all users to avoid timing attacks.
         for user in self.users:
-            if username == user['username']:
+            if username.casefold() == user['username'].casefold():
                 found = user
 
         if found is None:
@@ -105,7 +105,10 @@ class Data:
 
     def add_auth(self, username: str, password: str) -> None:
         """Add a new authenticated user/pass."""
-        if any(user['username'] == username for user in self.users):
+        if any(
+                user['username'].casefold() == username.casefold()
+                for user in self.users
+        ):
             raise InvalidUser
 
         self.users.append({
@@ -118,7 +121,7 @@ class Data:
         """Remove authentication."""
         index = None
         for i, user in enumerate(self.users):
-            if user['username'] == username:
+            if user['username'].casefold() == username.casefold():
                 index = i
                 break
 
@@ -133,7 +136,7 @@ class Data:
         Raises InvalidUser if user cannot be found.
         """
         for user in self.users:
-            if user['username'] == username:
+            if user['username'].casefold() == username.casefold():
                 user['password'] = self.hash_password(
                     new_password, True).decode()
                 break

--- a/tests/auth/providers/test_homeassistant.py
+++ b/tests/auth/providers/test_homeassistant.py
@@ -31,6 +31,13 @@ async def test_adding_user_duplicate_username(data, hass):
         data.add_auth('test-user', 'other-pass')
 
 
+async def test_adding_user_duplicate_case_insensitive_username(data, hass):
+    """Test adding a user with a duplicate case-insensitve username."""
+    data.add_auth('test-user', 'test-pass')
+    with pytest.raises(hass_auth.InvalidUser):
+        data.add_auth('Test-User', 'test-pass')
+
+
 async def test_validating_password_invalid_user(data, hass):
     """Test validating an invalid user."""
     with pytest.raises(hass_auth.InvalidAuth):
@@ -106,6 +113,16 @@ async def test_saving_loading(data, hass):
     await data.async_load()
     data.validate_login('test-user', 'test-pass')
     data.validate_login('second-user', 'second-pass')
+
+
+async def test_login_case_insensitive_username(data, hass):
+    """Test logging in with a case insensitive username."""
+    data.add_auth('test-user', 'test-pass')
+    await data.async_save()
+
+    data = hass_auth.Data(hass)
+    await data.async_load()
+    data.validate_login('Test-User', 'test-pass')
 
 
 async def test_not_allow_set_id():


### PR DESCRIPTION
Both the username submitted by the user, and the username associated with each user has casefold applied to make the username case-insensitive at login. Using casefold instead of lower to ensure that it works for edge cases in other languages as well as english. 

Casefold was also applied when checking if an existing username already exists at user creation, as well as when doing a password update, as well as when removing a user. This ensures that in all situations, there can only be a single user with a given case-insensitive username.

99% of web logins make the username case-insensitive, and having the login for hassio be case-sensitive can be both confusing and frustrating for admins, and users alike. As case-insensitive usernames are expected by most users, it makes sense to make the login process conform to most users expectations.