### PR TITLE
Add automation and script events to logbook filter events

### DIFF
--- a/homeassistant/components/logbook.py
+++ b/homeassistant/components/logbook.py
@@ -472,11 +472,11 @@ def _exclude_events(events, entities_filter):
         elif event.event_type == EVENT_AUTOMATION_TRIGGERED:
             domain = event.data.get(ATTR_DOMAIN)
             entity_id = event.data.get(ATTR_ENTITY_ID)
-           
+
         elif event.event_type == EVENT_SCRIPT_STARTED:
             domain = event.data.get(ATTR_DOMAIN)
             entity_id = event.data.get(ATTR_ENTITY_ID)
-            
+
         elif event.event_type == EVENT_ALEXA_SMART_HOME:
             domain = 'alexa'
 

--- a/homeassistant/components/logbook.py
+++ b/homeassistant/components/logbook.py
@@ -470,11 +470,11 @@ def _exclude_events(events, entities_filter):
             entity_id = event.data.get(ATTR_ENTITY_ID)
 
         elif event.event_type == EVENT_AUTOMATION_TRIGGERED:
-            domain = event.data.get(ATTR_DOMAIN)
+            domain = 'automation'
             entity_id = event.data.get(ATTR_ENTITY_ID)
 
         elif event.event_type == EVENT_SCRIPT_STARTED:
-            domain = event.data.get(ATTR_DOMAIN)
+            domain = 'script'
             entity_id = event.data.get(ATTR_ENTITY_ID)
 
         elif event.event_type == EVENT_ALEXA_SMART_HOME:

--- a/homeassistant/components/logbook.py
+++ b/homeassistant/components/logbook.py
@@ -469,6 +469,14 @@ def _exclude_events(events, entities_filter):
             domain = event.data.get(ATTR_DOMAIN)
             entity_id = event.data.get(ATTR_ENTITY_ID)
 
+        elif event.event_type == EVENT_AUTOMATION_TRIGGERED:
+            domain = event.data.get(ATTR_DOMAIN)
+            entity_id = event.data.get(ATTR_ENTITY_ID)
+           
+        elif event.event_type == EVENT_SCRIPT_STARTED:
+            domain = event.data.get(ATTR_DOMAIN)
+            entity_id = event.data.get(ATTR_ENTITY_ID)
+            
         elif event.event_type == EVENT_ALEXA_SMART_HOME:
             domain = 'alexa'
 

--- a/tests/components/test_logbook.py
+++ b/tests/components/test_logbook.py
@@ -265,7 +265,6 @@ class TestComponentLogbook(unittest.TestCase):
     def test_exclude_automation_events(self):
         """Test if automation entries can be excluded by entity_id."""
         name = 'My Automation Rule'
-        message = 'has been triggered'
         domain = 'automation'
         entity_id = 'automation.my_automation_rule'
         entity_id2 = 'automation.my_automation_rule_2'

--- a/tests/components/test_logbook.py
+++ b/tests/components/test_logbook.py
@@ -271,13 +271,13 @@ class TestComponentLogbook(unittest.TestCase):
         entity_id2 = 'automation.my_automation_rule_2'
         entity_id2 = 'sensor.blu'
 
-        eventA = ha.Event(logbook.EVENT_LOGBOOK_ENTRY, {
+        eventA = ha.Event(logbook.EVENT_AUTOMATION_TRIGGERED, {
             logbook.ATTR_NAME: name,
             logbook.ATTR_MESSAGE: message,
             logbook.ATTR_DOMAIN: domain,
             logbook.ATTR_ENTITY_ID: entity_id,
         })
-        eventB = ha.Event(logbook.EVENT_LOGBOOK_ENTRY, {
+        eventB = ha.Event(logbook.EVENT_AUTOMATION_TRIGGERED, {
             logbook.ATTR_NAME: name,
             logbook.ATTR_MESSAGE: message,
             logbook.ATTR_DOMAIN: domain,
@@ -299,6 +299,44 @@ class TestComponentLogbook(unittest.TestCase):
             domain=ha.DOMAIN)
         self.assert_entry(
             entries[1], name=name, domain=domain, entity_id=entity_id2)
+
+    def test_exclude_script_events(self):
+        """Test if script start can be excluded by entity_id."""
+        name = 'My Script Rule'
+        message = 'started'
+        domain = 'script'
+        entity_id = 'script.my_script'
+        entity_id2 = 'script.my_script_2'
+        entity_id2 = 'sensor.blu'
+
+        eventA = ha.Event(logbook.EVENT_SCRIPT_STARTED, {
+            logbook.ATTR_NAME: name,
+            logbook.ATTR_MESSAGE: message,
+            logbook.ATTR_DOMAIN: domain,
+            logbook.ATTR_ENTITY_ID: entity_id,
+        })
+        eventB = ha.Event(logbook.EVENT_SCRIPT_STARTED, {
+            logbook.ATTR_NAME: name,
+            logbook.ATTR_MESSAGE: message,
+            logbook.ATTR_DOMAIN: domain,
+            logbook.ATTR_ENTITY_ID: entity_id2,
+        })
+
+        config = logbook.CONFIG_SCHEMA({
+            ha.DOMAIN: {},
+            logbook.DOMAIN: {logbook.CONF_EXCLUDE: {
+                logbook.CONF_ENTITIES: [entity_id, ]}}})
+        events = logbook._exclude_events(
+            (ha.Event(EVENT_HOMEASSISTANT_STOP), eventA, eventB),
+            logbook._generate_filter_from_config(config[logbook.DOMAIN]))
+        entries = list(logbook.humanify(self.hass, events))
+
+        assert 2 == len(entries)
+        self.assert_entry(
+            entries[0], name='Home Assistant', message='stopped',
+            domain=ha.DOMAIN)
+        self.assert_entry(
+            entries[1], name=name, domain=domain, entity_id=entity_id2)        
 
     def test_include_events_entity(self):
         """Test if events are filtered if entity is included in config."""

--- a/tests/components/test_logbook.py
+++ b/tests/components/test_logbook.py
@@ -336,7 +336,7 @@ class TestComponentLogbook(unittest.TestCase):
             entries[0], name='Home Assistant', message='stopped',
             domain=ha.DOMAIN)
         self.assert_entry(
-            entries[1], name=name, domain=domain, entity_id=entity_id2)        
+            entries[1], name=name, domain=domain, entity_id=entity_id2)
 
     def test_include_events_entity(self):
         """Test if events are filtered if entity is included in config."""

--- a/tests/components/test_logbook.py
+++ b/tests/components/test_logbook.py
@@ -299,7 +299,6 @@ class TestComponentLogbook(unittest.TestCase):
     def test_exclude_script_events(self):
         """Test if script start can be excluded by entity_id."""
         name = 'My Script Rule'
-        message = 'started'
         domain = 'script'
         entity_id = 'script.my_script'
         entity_id2 = 'script.my_script_2'

--- a/tests/components/test_logbook.py
+++ b/tests/components/test_logbook.py
@@ -273,14 +273,10 @@ class TestComponentLogbook(unittest.TestCase):
 
         eventA = ha.Event(logbook.EVENT_AUTOMATION_TRIGGERED, {
             logbook.ATTR_NAME: name,
-            logbook.ATTR_MESSAGE: message,
-            logbook.ATTR_DOMAIN: domain,
             logbook.ATTR_ENTITY_ID: entity_id,
         })
         eventB = ha.Event(logbook.EVENT_AUTOMATION_TRIGGERED, {
             logbook.ATTR_NAME: name,
-            logbook.ATTR_MESSAGE: message,
-            logbook.ATTR_DOMAIN: domain,
             logbook.ATTR_ENTITY_ID: entity_id2,
         })
 
@@ -311,14 +307,10 @@ class TestComponentLogbook(unittest.TestCase):
 
         eventA = ha.Event(logbook.EVENT_SCRIPT_STARTED, {
             logbook.ATTR_NAME: name,
-            logbook.ATTR_MESSAGE: message,
-            logbook.ATTR_DOMAIN: domain,
             logbook.ATTR_ENTITY_ID: entity_id,
         })
         eventB = ha.Event(logbook.EVENT_SCRIPT_STARTED, {
             logbook.ATTR_NAME: name,
-            logbook.ATTR_MESSAGE: message,
-            logbook.ATTR_DOMAIN: domain,
             logbook.ATTR_ENTITY_ID: entity_id2,
         })
 


### PR DESCRIPTION
## Description:
Logbook was not filtering out automation and script events that were filtered by user config.
Related to  #19220


## Example entry for `configuration.yaml` (if applicable):
```yaml
logbook:
  exclude:
    entities:
      - automation.aut1
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
