### PR TITLE
Fix OwnTracks deadlocking

### DIFF
--- a/homeassistant/components/owntracks/__init__.py
+++ b/homeassistant/components/owntracks/__init__.py
@@ -18,7 +18,7 @@ from .config_flow import CONF_SECRET
 
 DOMAIN = "owntracks"
 REQUIREMENTS = ['libnacl==1.6.1']
-DEPENDENCIES = ['device_tracker', 'webhook']
+DEPENDENCIES = ['webhook']
 
 CONF_MAX_GPS_ACCURACY = 'max_gps_accuracy'
 CONF_WAYPOINT_IMPORT = 'waypoints'

--- a/tests/components/device_tracker/test_owntracks.py
+++ b/tests/components/device_tracker/test_owntracks.py
@@ -277,6 +277,8 @@ def setup_comp(hass):
     """Initialize components."""
     mock_component(hass, 'group')
     mock_component(hass, 'zone')
+    hass.loop.run_until_complete(async_setup_component(
+        hass, 'device_tracker', {}))
     hass.loop.run_until_complete(async_mock_mqtt_component(hass))
 
     hass.states.async_set(


### PR DESCRIPTION
## Description:
When people had manually configured the owntracks platform, we got a circular dependency and deadlock.

## Example entry for `configuration.yaml` (if applicable):
```yaml
device_tracker:
  platform: owntracks

# owntracks config entry.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
