### PR TITLE
Update Doorbird events to include event_data

### DIFF
--- a/homeassistant/components/binary_sensor/point.py
+++ b/homeassistant/components/binary_sensor/point.py
@@ -7,8 +7,7 @@ https://home-assistant.io/components/binary_sensor.point/
 
 import logging
 
-from homeassistant.components.binary_sensor import (
-    DOMAIN as PARENT_DOMAIN, BinarySensorDevice)
+from homeassistant.components.binary_sensor import DOMAIN, BinarySensorDevice
 from homeassistant.components.point import MinutPointEntity
 from homeassistant.components.point.const import (
     DOMAIN as POINT_DOMAIN, POINT_DISCOVERY_NEW, SIGNAL_WEBHOOK)
@@ -49,7 +48,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
              for device_class in EVENTS), True)
 
     async_dispatcher_connect(
-        hass, POINT_DISCOVERY_NEW.format(PARENT_DOMAIN, POINT_DOMAIN),
+        hass, POINT_DISCOVERY_NEW.format(DOMAIN, POINT_DOMAIN),
         async_discover_sensor)
 
 

--- a/homeassistant/components/sensor/point.py
+++ b/homeassistant/components/sensor/point.py
@@ -6,10 +6,10 @@ https://home-assistant.io/components/sensor.point/
 """
 import logging
 
-from homeassistant.components.point import (
-    DOMAIN as PARENT_DOMAIN, MinutPointEntity)
+from homeassistant.components.point import MinutPointEntity
 from homeassistant.components.point.const import (
     DOMAIN as POINT_DOMAIN, POINT_DISCOVERY_NEW)
+from homeassistant.components.sensor import DOMAIN
 from homeassistant.const import (
     DEVICE_CLASS_HUMIDITY, DEVICE_CLASS_PRESSURE, DEVICE_CLASS_TEMPERATURE,
     TEMP_CELSIUS)
@@ -38,7 +38,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                             for sensor_type in SENSOR_TYPES), True)
 
     async_dispatcher_connect(
-        hass, POINT_DISCOVERY_NEW.format(PARENT_DOMAIN, POINT_DOMAIN),
+        hass, POINT_DISCOVERY_NEW.format(DOMAIN, POINT_DOMAIN),
         async_discover_sensor)
 
 


### PR DESCRIPTION
## Description:
This is a change that was missed on a previous PR.  Adds stream URLs to event_data to allow use in automations.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
