### PR TITLE
Fix for entur sensor exception during setup with quay only config

### DIFF
--- a/homeassistant/components/sensor/entur_public_transport.py
+++ b/homeassistant/components/sensor/entur_public_transport.py
@@ -18,7 +18,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 import homeassistant.util.dt as dt_util
 
-REQUIREMENTS = ['enturclient==0.1.0']
+REQUIREMENTS = ['enturclient==0.1.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -340,7 +340,7 @@ elkm1-lib==0.7.13
 enocean==0.40
 
 # homeassistant.components.sensor.entur_public_transport
-enturclient==0.1.0
+enturclient==0.1.2
 
 # homeassistant.components.sensor.envirophat
 # envirophat==0.0.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -59,7 +59,7 @@ defusedxml==0.5.0
 dsmr_parser==0.12
 
 # homeassistant.components.sensor.entur_public_transport
-enturclient==0.1.0
+enturclient==0.1.2
 
 # homeassistant.components.sensor.season
 ephem==3.7.6.0


### PR DESCRIPTION
## Description:

Upgraded enturclient to 0.1.2 which has fix for an exception raised during setup when only `*:Quay:*` stop ids are given in default config. 

(Temporary fix has been setting `expand_platforms: false` in config. )

**Related issue (if applicable):** fixes #19232 

## Example entry for `configuration.yaml` (if applicable):
```yaml
# This config fails, but will be fixed now. 
- platform: entur_public_transport
  expand_platforms: true
  stop_ids:
    - 'NSR:Quay:12089'
    - 'NSR:Quay:11976'
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
