### PR TITLE
Add missing async_start_pause

### DIFF
--- a/homeassistant/components/vacuum/xiaomi_miio.py
+++ b/homeassistant/components/vacuum/xiaomi_miio.py
@@ -291,6 +291,14 @@ class MiroboVacuum(StateVacuumDevice):
             await self._try_command(
                 "Unable to set start/pause: %s", self._vacuum.pause)
 
+    async def async_start_pause(self):
+        """Pause the cleaning task."""
+        if self.state == STATE_CLEANING:
+            async_pause()
+        else:
+            """Start or resume the cleaning task."""
+            async_start()
+
     async def async_stop(self, **kwargs):
         """Stop the vacuum cleaner."""
         await self._try_command(


### PR DESCRIPTION
closes #18771

## Description: Add missing async_start_pause def into xiaomi_miio.py


**Related issue (if applicable):** fixes #18771

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
