### PR TITLE
[WIP] Create esphomelib component for native API

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -117,6 +117,9 @@ omit =
     homeassistant/components/ecovacs.py
     homeassistant/components/*/ecovacs.py
 
+    homeassistant/components/esphomelib.py
+    homeassistant/components/*/esphomelib.py
+
     homeassistant/components/eufy.py
     homeassistant/components/*/eufy.py
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -184,6 +184,8 @@ homeassistant/components/*/edp_redy.py @abmantis
 homeassistant/components/edp_redy.py @abmantis
 homeassistant/components/eight_sleep.py @mezz64
 homeassistant/components/*/eight_sleep.py @mezz64
+homeassistant/components/esphomelib.py @OttoWinter
+homeassistant/components/*/esphomelib.py @OttoWinter
 
 # H
 homeassistant/components/hive.py @Rendili @KJonline

--- a/homeassistant/components/binary_sensor/esphomelib.py
+++ b/homeassistant/components/binary_sensor/esphomelib.py
@@ -1,0 +1,48 @@
+"""Support for esphomelib binary sensors."""
+import logging
+
+from homeassistant.components.binary_sensor import BinarySensorDevice
+from homeassistant.components.esphomelib import EsphomelibEntity, \
+    platform_async_setup_entry
+
+DEPENDENCIES = ['esphomelib']
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up esphomelib binary sensors based on a config entry."""
+    from aioesphomeapi.client import BinarySensorInfo, BinarySensorState
+
+    await platform_async_setup_entry(
+        hass, entry, async_add_entities,
+        component_key='binary_sensor',
+        info_type=BinarySensorInfo, entity_type=EsphomelibBinarySensor,
+        state_type=BinarySensorState
+    )
+
+
+class EsphomelibBinarySensor(EsphomelibEntity, BinarySensorDevice):
+    """A binary sensor implementation for esphomelib."""
+
+    @property
+    def is_on(self):
+        """Return true if the binary sensor is on."""
+        if self.info.is_status_binary_sensor:
+            # Status binary sensors indicated connected state.
+            # So in their case what's usually _availability_ is now state
+            return self._device_data['available']
+        if self._state is None:
+            return None
+        return self._state.state
+
+    @property
+    def device_class(self):
+        """Return the class of this device, from component DEVICE_CLASSES."""
+        return self.info.device_class
+
+    @property
+    def available(self):
+        """Return True if entity is available."""
+        if self.info.is_status_binary_sensor:
+            return True
+        return super(EsphomelibEntity, self).available

--- a/homeassistant/components/cover/esphomelib.py
+++ b/homeassistant/components/cover/esphomelib.py
@@ -1,0 +1,72 @@
+"""Support for esphomelib covers."""
+import logging
+
+from homeassistant.components.cover import CoverDevice, SUPPORT_CLOSE, \
+    SUPPORT_OPEN, SUPPORT_STOP
+from homeassistant.components.esphomelib import EsphomelibEntity, \
+    platform_async_setup_entry
+from homeassistant.const import STATE_CLOSED, STATE_OPEN
+
+DEPENDENCIES = ['esphomelib']
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up esphomelib covers based on a config entry."""
+    from aioesphomeapi.client import CoverInfo, CoverState
+
+    await platform_async_setup_entry(
+        hass, entry, async_add_entities,
+        component_key='cover',
+        info_type=CoverInfo, entity_type=EsphomelibCover,
+        state_type=CoverState
+    )
+
+
+COVER_STATE_STR_TO_INT = {
+    STATE_OPEN: 0,
+    STATE_CLOSED: 1,
+}
+COVER_STATE_INT_TO_STR = {v: k for k, v in COVER_STATE_STR_TO_INT.items()}
+
+
+class EsphomelibCover(EsphomelibEntity, CoverDevice):
+    """A cover implementation for esphomelib."""
+
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+        return SUPPORT_OPEN | SUPPORT_CLOSE | SUPPORT_STOP
+
+    @property
+    def assumed_state(self):
+        """Return true if we do optimistic updates."""
+        return self.info.is_optimistic
+
+    @property
+    def is_closed(self):
+        """Return if the cover is closed or not."""
+        if self._state is None:
+            return None
+        return COVER_STATE_INT_TO_STR[self._state.state]
+
+    async def async_open_cover(self, **kwargs):
+        """Open the cover."""
+        from aioesphomeapi.client import COVER_COMMAND_OPEN
+
+        await self._client.cover_command(key=self.info.key,
+                                         command=COVER_COMMAND_OPEN)
+
+    async def async_close_cover(self, **kwargs):
+        """Close cover."""
+        from aioesphomeapi.client import COVER_COMMAND_CLOSE
+
+        await self._client.cover_command(key=self.info.key,
+                                         command=COVER_COMMAND_CLOSE)
+
+    async def async_stop_cover(self, **kwargs):
+        """Stop the cover."""
+        from aioesphomeapi.client import COVER_COMMAND_STOP
+
+        await self._client.cover_command(key=self.info.key,
+                                         command=COVER_COMMAND_STOP)

--- a/homeassistant/components/discovery.py
+++ b/homeassistant/components/discovery.py
@@ -52,6 +52,7 @@ CONFIG_ENTRY_HANDLERS = {
     SERVICE_TELLDUSLIVE: 'tellduslive',
     SERVICE_IKEA_TRADFRI: 'tradfri',
     'sonos': 'sonos',
+    'esphomelib': 'esphomelib'
 }
 
 SERVICE_HANDLERS = {

--- a/homeassistant/components/esphomelib/.translations/en.json
+++ b/homeassistant/components/esphomelib/.translations/en.json
@@ -1,0 +1,29 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "ESP is already configured"
+        },
+        "error": {
+            "connection_error": "Can't connect to ESP.\n\nIf this error persists, please set a static IP address: https://esphomelib.com/esphomeyaml/components/wifi.html#manual-ips",
+            "invalid_password": "Invalid password!"
+        },
+        "step": {
+            "user": {
+                "data": {
+                    "host": "Host",
+                    "port": "Port"
+                },
+                "description": "Please enter connection settings of your [esphomelib](https://esphomelib.com/) node.",
+                "title": "esphomelib"
+            },
+            "authenticate": {
+                "data": {
+                    "password": "Password"
+                },
+                "description": "Please enter the password you set in your configuration.",
+                "title": "Enter Password"
+            }
+        },
+        "title": "esphomelib"
+    }
+}

--- a/homeassistant/components/esphomelib/__init__.py
+++ b/homeassistant/components/esphomelib/__init__.py
@@ -227,20 +227,20 @@ async def _setup_auto_reconnect_logic(hass: HomeAssistantType, cli, key,
 
         if tries != 0:
             wait_time = min(2**tries, 300)
-            _LOGGER.info(u"Trying to reconnect in %s seconds.", wait_time)
+            _LOGGER.info("Trying to reconnect in %s seconds.", wait_time)
             await asyncio.sleep(wait_time)
 
         if is_disconnect and tries == 0:
             # This can happen often depending on WiFi strength.
             # Let's make this an info message ("unavailable" state will
             # be set anyway)
-            _LOGGER.info(u"Disconnected from API.")
+            _LOGGER.info("Disconnected from API.")
 
         try:
             await cli.connect()
             await cli.login()
         except APIConnectionError as error:
-            _LOGGER.info(u"Can't connect to esphomelib API for %s (%s).",
+            _LOGGER.info("Can't connect to esphomelib API for %s (%s).",
                          host, error)
             # Schedule re-connect in event loop in order not to delay HA
             # startup. First connect is scheduled in tracked tasks

--- a/homeassistant/components/esphomelib/__init__.py
+++ b/homeassistant/components/esphomelib/__init__.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.typing import HomeAssistantType
 from .config_flow import EsphomelibFlowHandler  # noqa
 
 DOMAIN = 'esphomelib'
-REQUIREMENTS = ['aioesphomeapi']
+REQUIREMENTS = ['aioesphomeapi==1.0.0']
 
 STORAGE_KEY = 'esphomelib.data'
 STORAGE_VERSION = 1

--- a/homeassistant/components/esphomelib/__init__.py
+++ b/homeassistant/components/esphomelib/__init__.py
@@ -1,0 +1,410 @@
+"""Support for esphomelib devices."""
+import asyncio
+import logging
+from typing import Any, Dict, List, Union
+
+import attr
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, \
+    EVENT_HOMEASSISTANT_STOP
+from homeassistant.core import callback
+import homeassistant.helpers.device_registry as dr
+from homeassistant.helpers.dispatcher import async_dispatcher_connect, \
+    async_dispatcher_send
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.json import JSONEncoder
+from homeassistant.helpers.storage import Store
+from homeassistant.helpers.typing import HomeAssistantType
+# Loading the config flow file will register the flow
+from .config_flow import EsphomelibFlowHandler  # noqa
+
+DOMAIN = 'esphomelib'
+REQUIREMENTS = ['aioesphomeapi']
+
+STORAGE_KEY = 'esphomelib.data'
+STORAGE_VERSION = 1
+DATA_STORE = 'esphomelib_store'
+DATA_SERIALIZERS = 'esphomelib_serializers'
+DATA_CLIENT = 'client'
+DATA_RECONNECT_TASK = 'reconnect'
+DATA_AVAILABLE = 'available'
+DATA_DEVICE_INFO = 'device_info'
+DISPATCHER_ON_STATE = 'esphomelib_{}_on_state'
+DISPATCHER_ON_LIST = 'esphomelib_{}_on_list'
+DISPATCHER_ON_DEVICE_UPDATE = 'esphomelib_{}_on_device_update'
+HA_COMPONENTS = ['sensor', 'binary_sensor', 'switch', 'light', 'fan', 'cover']
+
+_LOGGER = logging.getLogger(__name__)
+
+CONFIG_SCHEMA = vol.Schema({}, extra=vol.ALLOW_EXTRA)
+
+
+async def _cleanup_instance(hass: HomeAssistantType, entry: ConfigEntry):
+    data = hass.data[DOMAIN].pop(entry.entry_id)
+    client = data[DATA_CLIENT]
+    if DATA_RECONNECT_TASK in data:
+        data[DATA_RECONNECT_TASK].cancel()
+    await client.stop()
+
+
+def get_or_create_store(hass: HomeAssistantType) -> Store:
+    """Get or create the Store module for retained esphomelib data."""
+    if DATA_STORE not in hass.data:
+        store = Store(hass, STORAGE_VERSION,
+                      STORAGE_KEY, encoder=JSONEncoder)
+        hass.data[DATA_STORE] = store
+    return hass.data[DATA_STORE]
+
+
+async def async_save_store(hass: HomeAssistantType):
+    """Generate dynamic data to store and save it to the filesystem."""
+    from aioesphomeapi.client import COMPONENT_TYPE_TO_INFO
+
+    store = get_or_create_store(hass)
+    all_store_data = {}
+    for entry_id, data in hass.data[DOMAIN].items():
+        store_data = all_store_data[entry_id] = {}
+        store_data[DATA_DEVICE_INFO] = attr.asdict(data[DATA_DEVICE_INFO])
+
+        for key in COMPONENT_TYPE_TO_INFO:
+            if key not in data:
+                continue
+            comp = store_data[key] = []
+            for entity in data[key].values():
+                comp.append(attr.asdict(entity.info))
+
+    await store.async_save(all_store_data)
+
+
+def get_entry_data(hass: HomeAssistantType,
+                   key: Union[ConfigEntry, str]) -> Dict[str, Any]:
+    """Get the per-config entry data dictionary for a key."""
+    if isinstance(key, ConfigEntry):
+        key = key.entry_id
+    return hass.data[DOMAIN].setdefault(key, {})
+
+
+async def async_load_store(hass: HomeAssistantType, entry: ConfigEntry):
+    """Load the retained data from store and return de-serialized data."""
+    from aioesphomeapi.client import COMPONENT_TYPE_TO_INFO, DeviceInfo
+    store = get_or_create_store(hass)
+    restored = await store.async_load()
+    if restored is None or entry.entry_id not in restored:
+        return []
+    restored = restored[entry.entry_id]
+
+    device_info = DeviceInfo(**restored.pop(DATA_DEVICE_INFO))
+    get_entry_data(hass, entry)[DATA_DEVICE_INFO] = device_info
+    infos = []
+    for key, values in restored.items():
+        if key not in COMPONENT_TYPE_TO_INFO:
+            continue
+        for info in values:
+            infos.append(COMPONENT_TYPE_TO_INFO[key](**info))
+    return infos
+
+
+async def _setup_device_registry(hass: HomeAssistantType, entry: ConfigEntry,
+                                 device_info):
+    """Set up device registry feature for a particular config entry."""
+    sw_version = 'esphomelib v' + device_info.esphomelib_version
+    if device_info.compilation_time:
+        sw_version += ' ({})'.format(device_info.compilation_time)
+    device_registry = await dr.async_get_registry(hass)
+    device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        connections={
+            (dr.CONNECTION_NETWORK_MAC, device_info.mac_address)
+        },
+        name=device_info.name,
+        manufacturer='espressif',
+        model=device_info.model,
+        sw_version=sw_version,
+    )
+
+
+async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
+    """Set up the esphomelib component."""
+    from aioesphomeapi.client import APIClient, APIConnectionError
+
+    hass.data.setdefault(DOMAIN, {})
+
+    host = entry.data[CONF_HOST]
+    port = entry.data[CONF_PORT]
+    password = entry.data[CONF_PASSWORD]
+
+    cli = APIClient(hass.loop, host, port, password)
+    await cli.start()
+
+    async def on_stop(event):
+        """Cleanup the socket client on HA stop."""
+        await _cleanup_instance(hass, entry)
+
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, on_stop)
+
+    entry_data = hass.data[DOMAIN].setdefault(entry.entry_id, {})
+    entry_data[DATA_CLIENT] = cli
+    entry_data[DATA_AVAILABLE] = False
+
+    try_connect = await _setup_auto_reconnect_logic(
+        hass, cli, entry.entry_id, host)
+
+    @callback
+    def async_on_state(state):
+        """Send dispatcher updates when a new state is received."""
+        async_dispatcher_send(
+            hass, DISPATCHER_ON_STATE.format(entry.entry_id), state)
+
+    async def on_login():
+        """Subscribe to states and list entities on successful API login."""
+        try:
+            device = entry_data[DATA_DEVICE_INFO] = await cli.device_info()
+            entry_data[DATA_AVAILABLE] = True
+
+            await _setup_device_registry(hass, entry, device)
+
+            entity_infos = await cli.list_entities()
+            async_dispatcher_send(
+                hass, DISPATCHER_ON_LIST.format(entry.entry_id),
+                entity_infos)
+            await cli.subscribe_states(async_on_state)
+
+            hass.async_add_job(async_save_store(hass))
+        except APIConnectionError as err:
+            _LOGGER.warning("Error getting initial data: %s", err)
+            # Re-connection logic will trigger after this
+            await cli.disconnect()
+
+    cli.on_login = on_login
+
+    # This is a bit of a hack. complete_task is not await from this coroutine
+    # but there's a good reason for it:
+    # First, we need to make _sure_ that each platform is fully set up
+    # before doing the initial connection attempt. Otherwise the
+    # dispatcher callbacks will write into the void.
+    # However, we cannot simply await async_forward_entry_setup from within
+    # async_setup_entry as that would result in a recursive await
+    # So workaround is: complete the entry setup + connection
+    # in the pending task queue. It will still be tracked by hass
+    # (_pending_tasks) so startup will be delayed correctly until the
+    # component is ready.
+
+    async def complete_setup():
+        """Complete the config entry setup."""
+        for component in HA_COMPONENTS:
+            await hass.config_entries.async_forward_entry_setup(
+                entry, component)
+
+        infos = await async_load_store(hass, entry)
+        async_dispatcher_send(
+            hass, DISPATCHER_ON_LIST.format(entry.entry_id), infos)
+
+        # If first connect fails, the next re-connect will be scheduled
+        # outside of _pending_task, in order not to delay HA startup
+        # indefinitely
+        await try_connect(is_disconnect=False)
+
+    hass.async_add_job(complete_setup())
+    return True
+
+
+async def _setup_auto_reconnect_logic(hass: HomeAssistantType, cli, key,
+                                      host):
+    """Set up the re-connect logic for the API client."""
+    from aioesphomeapi.client import APIConnectionError
+
+    async def try_connect(tries=0, is_disconnect=True):
+        """Try connecting to the API client. Will retry if not successful."""
+        if key not in hass.data[DOMAIN]:
+            # When removing/disconnecting manually
+            return
+
+        data = get_entry_data(hass, key)
+        data[DATA_AVAILABLE] = False
+        async_dispatcher_send(hass, DISPATCHER_ON_DEVICE_UPDATE.format(key))
+
+        if tries != 0:
+            wait_time = min(2**tries, 300)
+            _LOGGER.info(u"Trying to reconnect in %s seconds.", wait_time)
+            await asyncio.sleep(wait_time)
+
+        if is_disconnect and tries == 0:
+            # This can happen often depending on WiFi strength.
+            # Let's make this an info message ("unavailable" state will
+            # be set anyway)
+            _LOGGER.info(u"Disconnected from API.")
+
+        try:
+            await cli.connect()
+            await cli.login()
+        except APIConnectionError as error:
+            _LOGGER.info(u"Can't connect to esphomelib API for %s (%s).",
+                         host, error)
+            # Schedule re-connect in event loop in order not to delay HA
+            # startup. First connect is scheduled in tracked tasks
+            data['reconnect'] = hass.loop.create_task(
+                try_connect(tries + 1, is_disconnect))
+        else:
+            _LOGGER.info("Successfully connected to %s", host)
+
+    cli.on_disconnect = try_connect
+    return try_connect
+
+
+async def async_unload_entry(hass, config_entry) -> bool:
+    """Unload an esphomelib config entry."""
+    await _cleanup_instance(hass, config_entry)
+
+    for component in HA_COMPONENTS:
+        await hass.config_entries.async_forward_entry_unload(
+            config_entry, component)
+
+    return True
+
+
+async def async_setup(hass, config):
+    """Stub to allow setting up this component.
+
+    Configuration through YAML is not supported at this time.
+    """
+    return True
+
+
+async def platform_async_setup_entry(hass: HomeAssistantType,
+                                     entry: ConfigEntry,
+                                     async_add_entities,
+                                     *,
+                                     component_key,
+                                     info_type,
+                                     entity_type,
+                                     state_type,
+                                     ):
+    """Set up an esphomelib platform."""
+    get_entry_data(hass, entry).setdefault(component_key, {})
+
+    @callback
+    def async_list_entities(infos: List[Any]):
+        """Update entities of this platform when entities are listed."""
+        old_entities = get_entry_data(hass, entry)[component_key]
+        new_entities = {}
+        add_entities = []
+        for info in infos:
+            if not isinstance(info, info_type):
+                continue
+
+            if info.key in old_entities:
+                # Update existing entity
+                entity = old_entities.pop(info.key)
+            else:
+                # Create new entity
+                entity = entity_type(entry.entry_id)
+                add_entities.append(entity)
+            entity.async_info_update(info)
+            new_entities[info.key] = entity
+
+        # Remove old entities
+        for entity in old_entities.values():
+            hass.async_add_job(entity.async_remove())
+
+        get_entry_data(hass, entry)[component_key] = new_entities
+        async_add_entities(add_entities)
+
+    async_dispatcher_connect(
+        hass, DISPATCHER_ON_LIST.format(entry.entry_id), async_list_entities)
+
+    @callback
+    def async_entity_state(state):
+        """Notify the appropriate entity of an updated state."""
+        entities = get_entry_data(hass, entry)[component_key]
+        if not isinstance(state, state_type):
+            return
+        if state.key not in entities:
+            return
+        entity = entities[state.key]
+        entity.async_state_update(state)
+
+    async_dispatcher_connect(
+        hass, DISPATCHER_ON_STATE.format(entry.entry_id), async_entity_state)
+
+    @callback
+    def async_device_state():
+        entities = get_entry_data(hass, entry)[component_key]
+        for entity in entities.values():
+            if entity.hass is not None:
+                entity.async_schedule_update_ha_state()
+
+    async_dispatcher_connect(
+        hass, DISPATCHER_ON_DEVICE_UPDATE.format(entry.entry_id),
+        async_device_state)
+
+
+class EsphomelibEntity(Entity):
+    """Define a generic esphomelib entity."""
+
+    def __init__(self, data_key):
+        """Initialize."""
+        self._data_key = data_key
+        self.info = None
+        self._state = None
+
+    @callback
+    def async_info_update(self, info):
+        """Update the info attribute."""
+        self.info = info
+        if self.hass is not None:
+            self.async_schedule_update_ha_state()
+
+    @callback
+    def async_state_update(self, state):
+        """Update the state attribute."""
+        self._state = state
+        if self.hass is not None:
+            self.async_schedule_update_ha_state()
+
+    @property
+    def _device_data(self):
+        return self.hass.data[DOMAIN][self._data_key]
+
+    @property
+    def _client(self):
+        return self._device_data[DATA_CLIENT]
+
+    @property
+    def device_info(self):
+        """Return device registry information for this entity."""
+        device = self._device_data[DATA_DEVICE_INFO]
+
+        return {
+            'connections': {(dr.CONNECTION_NETWORK_MAC, device.mac_address)}
+        }
+
+    @property
+    def available(self):
+        """Return if the entity is available."""
+        device = self._device_data['device_info']
+
+        if device.has_deep_sleep:
+            # During deep sleep the ESP will not be connectable (by design)
+            # For these cases, show it as available
+            return True
+
+        return self._device_data['available']
+
+    @property
+    def unique_id(self):
+        """Return a unique id identifying the entity."""
+        if not self.info.unique_id:
+            return None
+        return self.info.unique_id
+
+    @property
+    def name(self) -> str:
+        """Return the name of the entity."""
+        return self.info.name
+
+    @property
+    def should_poll(self):
+        """Disable polling."""
+        return False

--- a/homeassistant/components/esphomelib/config_flow.py
+++ b/homeassistant/components/esphomelib/config_flow.py
@@ -1,0 +1,132 @@
+"""Config flow to configure esphomelib component."""
+from collections import OrderedDict
+
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.components.esphomelib import DOMAIN
+
+
+@config_entries.HANDLERS.register(DOMAIN)
+class EsphomelibFlowHandler(config_entries.ConfigFlow):
+    """Handle a esphomelib config flow."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_PUSH
+
+    def __init__(self):
+        """Initialize flow."""
+        self._host = None
+        self._port = None
+        self._password = None
+        self._name = None
+
+    async def fetch_device_info(self):
+        """Fetch device info from API and return any errors."""
+        from aioesphomeapi.client import APIClient, APIConnectionError
+
+        cli = APIClient(self.hass.loop, self._host, self._port, '')
+
+        try:
+            await cli.start()
+            await cli.connect()
+            device_info = await cli.device_info()
+        except APIConnectionError:
+            return 'connection_error', None
+        finally:
+            await cli.stop(True)
+
+        return None, device_info
+
+    async def try_login(self):
+        """Try logging in to device and return any errors."""
+        from aioesphomeapi.client import APIClient, APIConnectionError
+
+        cli = APIClient(self.hass.loop, self._host, self._port, self._password)
+
+        try:
+            await cli.start()
+            await cli.connect()
+        except APIConnectionError:
+            await cli.stop(True)
+            return 'connection_error'
+
+        try:
+            await cli.login()
+        except APIConnectionError:
+            return 'invalid_password'
+
+        return None
+
+    async def async_step_user(self, user_input=None, error=None):
+        """Handle a flow initialized by the user."""
+        if user_input is not None:
+            self._host = user_input['host']
+            self._port = user_input['port']
+            error, device_info = await self.fetch_device_info()
+            if error is not None:
+                return await self.async_step_user(error=error)
+            self._name = device_info.name
+
+            if device_info.uses_password:
+                return await self.async_step_authenticate()
+
+            return self._async_get_entry()
+
+        fields = OrderedDict()
+        fields[vol.Required('host', default=self._host or vol.UNDEFINED)] = str
+        fields[vol.Optional('port', default=self._port or 6053)] = int
+
+        errors = {}
+        if error is not None:
+            errors['base'] = error
+
+        return self.async_show_form(
+            step_id='user',
+            data_schema=vol.Schema(fields),
+            errors=errors
+        )
+
+    def _async_get_entry(self):
+        return self.async_create_entry(
+            title=self._name,
+            data={
+                'host': self._host,
+                'port': self._port,
+                'password': self._password or '',
+            }
+        )
+
+    async def async_step_authenticate(self, user_input=None, error=None):
+        """Handle getting password for authentication."""
+        if user_input is not None:
+            self._password = user_input['password']
+            error = await self.try_login()
+            if error:
+                return await self.async_step_authenticate(error=error)
+            return self._async_get_entry()
+
+        errors = {}
+        if error is not None:
+            errors['base'] = error
+
+        return self.async_show_form(
+            step_id='authenticate',
+            data_schema=vol.Schema({
+                vol.Required('password'): str
+            }),
+            errors=errors
+        )
+
+    async def async_step_discovery(self, user_input):
+        """Handle discovery."""
+        hosts = (user_input['hostname'][:-1], user_input['host'])
+        for entry in self._async_current_entries():
+            if entry.data['host'] in hosts:
+                return self.async_abort(
+                    reason='already_configured'
+                )
+
+        self._host = user_input['hostname'][:-1]
+        self._port = user_input['port']
+        return await self.async_step_user()

--- a/homeassistant/components/esphomelib/config_flow.py
+++ b/homeassistant/components/esphomelib/config_flow.py
@@ -4,10 +4,9 @@ from collections import OrderedDict
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.components.esphomelib import DOMAIN
 
 
-@config_entries.HANDLERS.register(DOMAIN)
+@config_entries.HANDLERS.register('esphomelib')
 class EsphomelibFlowHandler(config_entries.ConfigFlow):
     """Handle a esphomelib config flow."""
 

--- a/homeassistant/components/fan/esphomelib.py
+++ b/homeassistant/components/fan/esphomelib.py
@@ -1,0 +1,100 @@
+"""Support for esphomelib fans."""
+import logging
+from typing import List, Optional
+
+from homeassistant.components.esphomelib import EsphomelibEntity, \
+    platform_async_setup_entry
+from homeassistant.components.fan import FanEntity, SPEED_HIGH, SPEED_LOW, \
+    SPEED_MEDIUM, SUPPORT_OSCILLATE, SUPPORT_SET_SPEED, SPEED_OFF
+
+DEPENDENCIES = ['esphomelib']
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up esphomelib fans based on a config entry."""
+    from aioesphomeapi.client import FanInfo, FanState
+
+    await platform_async_setup_entry(
+        hass, entry, async_add_entities,
+        component_key='fan',
+        info_type=FanInfo, entity_type=EsphomelibFan,
+        state_type=FanState
+    )
+
+
+FAN_SPEED_STR_TO_INT = {
+    SPEED_LOW: 0,
+    SPEED_MEDIUM: 1,
+    SPEED_HIGH: 2
+}
+FAN_SPEED_INT_TO_STR = {v: k for k, v in FAN_SPEED_STR_TO_INT.items()}
+
+
+class EsphomelibFan(EsphomelibEntity, FanEntity):
+    """A fan implementation for esphomelib."""
+
+    async def async_set_speed(self, speed: str):
+        """Set the speed of the fan."""
+        if speed == SPEED_OFF:
+            await self.async_turn_off()
+            return
+        await self._client.fan_command(
+            self.info.key, speed=FAN_SPEED_STR_TO_INT[speed])
+
+    async def async_turn_on(self, speed: Optional[str] = None,
+                            **kwargs) -> None:
+        """Turn on the fan."""
+        if speed == SPEED_OFF:
+            await self.async_turn_off()
+            return
+        data = {'key': self.info.key, 'state': True}
+        if speed is not None:
+            data['speed'] = FAN_SPEED_STR_TO_INT[speed]
+        await self._client.fan_command(**data)
+
+    # pylint: disable=arguments-differ
+    async def async_turn_off(self, **kwargs) -> None:
+        """Turn off the fan."""
+        await self._client.fan_command(key=self.info.key, state=False)
+
+    async def async_oscillate(self, oscillating: bool):
+        """Oscillate the fan."""
+        await self._client.fan_command(key=self.info.key,
+                                       oscillating=oscillating)
+
+    @property
+    def is_on(self) -> Optional[bool]:
+        """Return true if the entity is on."""
+        if self._state is None:
+            return None
+        return self._state.state
+
+    @property
+    def speed(self) -> Optional[str]:
+        """Return the current speed."""
+        if self._state is None:
+            return None
+        return FAN_SPEED_INT_TO_STR[self._state.speed]
+
+    @property
+    def oscillating(self):
+        """Return the oscillation state."""
+        if self._state is None:
+            return None
+        return self._state.oscillating
+
+    @property
+    def speed_list(self) -> List[str]:
+        """Get the list of available speeds."""
+        return [SPEED_OFF, SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH]
+
+    @property
+    def supported_features(self) -> int:
+        """Flag supported features."""
+        flags = 0
+        if self.info.supports_oscillation:
+            flags |= SUPPORT_OSCILLATE
+        if self.info.supports_speed:
+            flags |= SUPPORT_SET_SPEED
+        return flags

--- a/homeassistant/components/light/esphomelib.py
+++ b/homeassistant/components/light/esphomelib.py
@@ -1,0 +1,144 @@
+"""Support for esphomelib lights."""
+import logging
+from typing import Optional, List, Tuple
+
+from homeassistant.components.esphomelib import EsphomelibEntity, \
+    platform_async_setup_entry
+from homeassistant.components.light import Light, SUPPORT_FLASH, \
+    SUPPORT_BRIGHTNESS, SUPPORT_TRANSITION, SUPPORT_COLOR, \
+    SUPPORT_WHITE_VALUE, SUPPORT_COLOR_TEMP, SUPPORT_EFFECT, ATTR_HS_COLOR, \
+    ATTR_FLASH, ATTR_TRANSITION, ATTR_BRIGHTNESS, ATTR_COLOR_TEMP, \
+    ATTR_EFFECT, ATTR_WHITE_VALUE, FLASH_SHORT, FLASH_LONG
+import homeassistant.util.color as color_util
+
+DEPENDENCIES = ['esphomelib']
+_LOGGER = logging.getLogger(__name__)
+
+
+FLASH_LENGTHS = {
+    FLASH_SHORT: 2,
+    FLASH_LONG: 10,
+}
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up esphomelib lights based on a config entry."""
+    from aioesphomeapi.client import LightInfo, LightState
+
+    await platform_async_setup_entry(
+        hass, entry, async_add_entities,
+        component_key='light',
+        info_type=LightInfo, entity_type=EsphomelibLight,
+        state_type=LightState
+    )
+
+
+class EsphomelibLight(EsphomelibEntity, Light):
+    """A switch implementation for esphomelib."""
+
+    @property
+    def is_on(self) -> Optional[bool]:
+        """Return true if the switch is on."""
+        if self._state is None:
+            return None
+        return self._state.state
+
+    async def async_turn_on(self, **kwargs) -> None:
+        """Turn the entity on."""
+        data = {'key': self.info.key, 'state': True}
+        if ATTR_HS_COLOR in kwargs:
+            hue, sat = kwargs[ATTR_HS_COLOR]
+            red, green, blue = color_util.color_hsv_to_RGB(hue, sat, 100)
+            data['rgb'] = (red / 255, green / 255, blue / 255)
+        if ATTR_FLASH in kwargs:
+            data['flash'] = FLASH_LENGTHS[kwargs[ATTR_FLASH]]
+        if ATTR_TRANSITION in kwargs:
+            data['transition_length'] = kwargs[ATTR_TRANSITION]
+        if ATTR_BRIGHTNESS in kwargs:
+            data['brightness'] = kwargs[ATTR_BRIGHTNESS] / 255
+        if ATTR_COLOR_TEMP in kwargs:
+            data['color_temperature'] = kwargs[ATTR_COLOR_TEMP]
+        if ATTR_EFFECT in kwargs:
+            data['effect'] = kwargs[ATTR_EFFECT]
+        if ATTR_WHITE_VALUE in kwargs:
+            data['white'] = kwargs[ATTR_WHITE_VALUE] / 255
+        await self._client.light_command(**data)
+
+    async def async_turn_off(self, **kwargs) -> None:
+        """Turn the entity off."""
+        data = {'key': self.info.key, 'state': False}
+        if ATTR_FLASH in kwargs:
+            data['flash'] = FLASH_LENGTHS[kwargs[ATTR_FLASH]]
+        if ATTR_TRANSITION in kwargs:
+            data['transition_length'] = kwargs[ATTR_TRANSITION]
+        await self._client.light_command(**data)
+
+    @property
+    def brightness(self) -> Optional[int]:
+        """Return the brightness of this light between 0..255."""
+        if self._state is None:
+            return None
+        return round(self._state.brightness * 255)
+
+    @property
+    def hs_color(self) -> Optional[Tuple[float, float]]:
+        """Return the hue and saturation color value [float, float]."""
+        if self._state is None:
+            return None
+        return color_util.color_RGB_to_hs(
+            self._state.red * 255,
+            self._state.green * 255,
+            self._state.blue * 255)
+
+    @property
+    def color_temp(self) -> Optional[float]:
+        """Return the CT color value in mireds."""
+        if self._state is None:
+            return None
+        return self._state.color_temperature
+
+    @property
+    def white_value(self) -> Optional[int]:
+        """Return the white value of this light between 0..255."""
+        if self._state is None:
+            return None
+        return round(self._state.white * 255)
+
+    @property
+    def effect(self) -> Optional[str]:
+        """Return the current effect."""
+        if self._state is None:
+            return None
+        return self._state.effect
+
+    @property
+    def supported_features(self) -> int:
+        """Flag supported features."""
+        flags = SUPPORT_FLASH
+        if self.info.supports_brightness:
+            flags |= SUPPORT_BRIGHTNESS
+            flags |= SUPPORT_TRANSITION
+        if self.info.supports_rgb:
+            flags |= SUPPORT_COLOR
+        if self.info.supports_white_value:
+            flags |= SUPPORT_WHITE_VALUE
+        if self.info.supports_color_temperature:
+            flags |= SUPPORT_COLOR_TEMP
+        if self.info.effects:
+            flags |= SUPPORT_EFFECT
+        return flags
+
+    @property
+    def effect_list(self) -> List[str]:
+        """Return the list of supported effects."""
+        return self.info.effects
+
+    @property
+    def min_mireds(self) -> float:
+        """Return the coldest color_temp that this light supports."""
+        return self.info.min_mireds
+
+    @property
+    def max_mireds(self) -> float:
+        """Return the warmest color_temp that this light supports."""
+        return self.info.max_mireds

--- a/homeassistant/components/sensor/esphomelib.py
+++ b/homeassistant/components/sensor/esphomelib.py
@@ -1,0 +1,69 @@
+"""Support for esphomelib sensors."""
+import logging
+import math
+from typing import Optional
+
+from homeassistant.components.esphomelib import EsphomelibEntity, \
+    platform_async_setup_entry
+
+DEPENDENCIES = ['esphomelib']
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up esphomelib sensors based on a config entry."""
+    from aioesphomeapi.client import SensorInfo, SensorState, TextSensorInfo, \
+        TextSensorState
+
+    await platform_async_setup_entry(
+        hass, entry, async_add_entities,
+        component_key='sensor',
+        info_type=SensorInfo, entity_type=EsphomelibSensor,
+        state_type=SensorState
+    )
+    await platform_async_setup_entry(
+        hass, entry, async_add_entities,
+        component_key='text_sensor',
+        info_type=TextSensorInfo, entity_type=EsphomelibTextSensor,
+        state_type=TextSensorState
+    )
+
+
+class EsphomelibSensor(EsphomelibEntity):
+    """A sensor implementation for esphomelib."""
+
+    @property
+    def icon(self) -> str:
+        """Return the icon."""
+        return self.info.icon
+
+    @property
+    def state(self) -> Optional[str]:
+        """Return the state of the entity."""
+        if self._state is None:
+            return None
+        if math.isnan(self._state.state):
+            return None
+        return '{:.{prec}f}'.format(
+            self._state.state, prec=self.info.accuracy_decimals)
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit the value is expressed in."""
+        return self.info.unit_of_measurement
+
+
+class EsphomelibTextSensor(EsphomelibEntity):
+    """A text sensor implementation for esphomelib."""
+
+    @property
+    def icon(self) -> str:
+        """Return the icon."""
+        return self.info.icon
+
+    @property
+    def state(self) -> Optional[str]:
+        """Return the state of the entity."""
+        if self._state is None:
+            return None
+        return self._state.state

--- a/homeassistant/components/switch/esphomelib.py
+++ b/homeassistant/components/switch/esphomelib.py
@@ -1,0 +1,45 @@
+"""Support for esphomelib switches."""
+import logging
+
+from homeassistant.components.esphomelib import EsphomelibEntity, \
+    platform_async_setup_entry
+from homeassistant.components.switch import SwitchDevice
+
+DEPENDENCIES = ['esphomelib']
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up esphomelib switches based on a config entry."""
+    from aioesphomeapi.client import SwitchInfo, SwitchState
+
+    await platform_async_setup_entry(
+        hass, entry, async_add_entities,
+        component_key='switch',
+        info_type=SwitchInfo, entity_type=EsphomelibSwitch,
+        state_type=SwitchState
+    )
+
+
+class EsphomelibSwitch(EsphomelibEntity, SwitchDevice):
+    """A switch implementation for esphomelib."""
+
+    @property
+    def icon(self) -> str:
+        """Return the icon."""
+        return self.info.icon
+
+    @property
+    def is_on(self):
+        """Return true if the switch is on."""
+        if self._state is None:
+            return None
+        return self._state.state
+
+    async def async_turn_on(self, **kwargs):
+        """Turn the entity on."""
+        await self._client.switch_command(self.info.key, True)
+
+    async def async_turn_off(self, **kwargs):
+        """Turn the entity off."""
+        await self._client.switch_command(self.info.key, False)

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -138,6 +138,7 @@ FLOWS = [
     'cast',
     'deconz',
     'dialogflow',
+    'esphomelib',
     'hangouts',
     'homematicip_cloud',
     'hue',

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -95,6 +95,9 @@ aioautomatic==0.6.5
 # homeassistant.components.sensor.dnsip
 aiodns==1.1.1
 
+# homeassistant.components.esphomelib
+aioesphomeapi==1.0.0
+
 # homeassistant.components.device_tracker.freebox
 aiofreepybox==0.0.5
 


### PR DESCRIPTION
## Description:

This PR creates an "esphomelib" component for directly communicating esphomelib servers.

The architecture of the communication layer is:
 * ESP (microcontroller) is a TCP socket server.
 * HA (client) connects to this server.
 * Communication is done through small protobuf messages. HA side uses protobuf library, ESP uses custom protobuf implementation.

Component supports:

 * Automatic reconnecting with exponential interval (but does not delay HA startup after first unsuccessful connection attempt)
 * Configuration through config entries
 * Automatic discovery via mDNS
 * Marking entities as unavailable if not connected
 * Fully `asyncio`-aware
 * Storing the entities across reboots. So no "entity id x not found"

**Do not merge yet**. This PR is solely to get some initial feedback so that it can hopefully be done for the next release cycle. There's still some things to figure out in the backend PLUS the name of this component.

[aioesphomeapi](https://github.com/OttoWinter/aioesphomeapi) - The python module for the asyncio API
[backend changes](https://github.com/OttoWinter/esphomelib/pull/322) for anybody willing to test. Warning: huge and not 100% stable.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
Not configurable with YAML.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) **This is config entry-only. What to do for docs in this case?**

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
