### PR TITLE
Synology chat add verify ssl

### DIFF
--- a/homeassistant/components/notify/synology_chat.py
+++ b/homeassistant/components/notify/synology_chat.py
@@ -1,5 +1,6 @@
 """
 SynologyChat platform for notify component.
+
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/notify.synology_chat/
 """

--- a/homeassistant/components/notify/synology_chat.py
+++ b/homeassistant/components/notify/synology_chat.py
@@ -1,6 +1,5 @@
 """
 SynologyChat platform for notify component.
-
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/notify.synology_chat/
 """
@@ -12,13 +11,14 @@ import voluptuous as vol
 
 from homeassistant.components.notify import (
     BaseNotificationService, PLATFORM_SCHEMA, ATTR_DATA)
-from homeassistant.const import CONF_RESOURCE
+from homeassistant.const import CONF_RESOURCE, CONF_VERIFY_SSL
 import homeassistant.helpers.config_validation as cv
 
 ATTR_FILE_URL = 'file_url'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_RESOURCE): cv.url,
+    vol.Optional(CONF_VERIFY_SSL, default=True): cv.boolean,
 })
 
 _LOGGER = logging.getLogger(__name__)
@@ -27,16 +27,18 @@ _LOGGER = logging.getLogger(__name__)
 def get_service(hass, config, discovery_info=None):
     """Get the Synology Chat notification service."""
     resource = config.get(CONF_RESOURCE)
+    verify_ssl = config.get(CONF_VERIFY_SSL)
 
-    return SynologyChatNotificationService(resource)
+    return SynologyChatNotificationService(resource, verify_ssl)
 
 
 class SynologyChatNotificationService(BaseNotificationService):
     """Implementation of a notification service for Synology Chat."""
 
-    def __init__(self, resource):
+    def __init__(self, resource, verify_ssl):
         """Initialize the service."""
         self._resource = resource
+        self._verify_ssl = verify_ssl
 
     def send_message(self, message="", **kwargs):
         """Send a message to a user."""
@@ -52,7 +54,8 @@ class SynologyChatNotificationService(BaseNotificationService):
 
         to_send = 'payload={}'.format(json.dumps(data))
 
-        response = requests.post(self._resource, data=to_send, timeout=10)
+        response = requests.post(self._resource, data=to_send, timeout=10,
+                                 verify=self._verify_ssl)
 
         if response.status_code not in (200, 201):
             _LOGGER.exception(


### PR DESCRIPTION
## Description:
Added verify_ssl option into synology_chat to allow users to disable ssl verification for self signed certs or direct IP address in the url.

**Related issue (if applicable):** fixes # Not applicable

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#7833

## Example entry for `configuration.yaml` (if applicable):
```yaml
notify:
  - platform: synology_chat
    name: hass_synchat
    verify_ssl: True
    resource: https://example.your.synology.com/webapi/entry.cgi?api=SYNO.Chat.External&method=incoming&version=1&token=ABCDEFG
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
