### PR TITLE
Optionally disable ssl verification for mjpeg camera

### DIFF
--- a/homeassistant/components/camera/mjpeg.py
+++ b/homeassistant/components/camera/mjpeg.py
@@ -16,7 +16,7 @@ import voluptuous as vol
 
 from homeassistant.const import (
     CONF_NAME, CONF_USERNAME, CONF_PASSWORD, CONF_AUTHENTICATION,
-    HTTP_BASIC_AUTHENTICATION, HTTP_DIGEST_AUTHENTICATION)
+    HTTP_BASIC_AUTHENTICATION, HTTP_DIGEST_AUTHENTICATION, CONF_VERIFY_SSL)
 from homeassistant.components.camera import (PLATFORM_SCHEMA, Camera)
 from homeassistant.helpers.aiohttp_client import (
     async_get_clientsession, async_aiohttp_proxy_web)
@@ -29,6 +29,7 @@ CONF_STILL_IMAGE_URL = 'still_image_url'
 CONTENT_TYPE_HEADER = 'Content-Type'
 
 DEFAULT_NAME = 'Mjpeg Camera'
+DEFAULT_VERIFY_SSL = True
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_MJPEG_URL): cv.url,
@@ -38,6 +39,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_PASSWORD): cv.string,
     vol.Optional(CONF_USERNAME): cv.string,
+    vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): cv.boolean,
 })
 
 
@@ -95,6 +97,7 @@ class MjpegCamera(Camera):
                 self._auth = aiohttp.BasicAuth(
                     self._username, password=self._password
                 )
+        self._verify_ssl = device_info.get(CONF_VERIFY_SSL)
 
     async def async_camera_image(self):
         """Return a still image response from the camera."""
@@ -105,7 +108,10 @@ class MjpegCamera(Camera):
                 self.camera_image)
             return image
 
-        websession = async_get_clientsession(self.hass)
+        websession = async_get_clientsession(
+            self.hass,
+            verify_ssl=self._verify_ssl
+        )
         try:
             with async_timeout.timeout(10, loop=self.hass.loop):
                 response = await websession.get(
@@ -128,7 +134,12 @@ class MjpegCamera(Camera):
             else:
                 auth = HTTPBasicAuth(self._username, self._password)
             req = requests.get(
-                self._mjpeg_url, auth=auth, stream=True, timeout=10)
+                self._mjpeg_url,
+                auth=auth,
+                stream=True,
+                timeout=10,
+                verify=self._verify_ssl
+            )
         else:
             req = requests.get(self._mjpeg_url, stream=True, timeout=10)
 
@@ -144,7 +155,10 @@ class MjpegCamera(Camera):
             return await super().handle_async_mjpeg_stream(request)
 
         # connect to stream
-        websession = async_get_clientsession(self.hass)
+        websession = async_get_clientsession(
+            self.hass,
+            verify_ssl=self._verify_ssl
+        )
         stream_coro = websession.get(self._mjpeg_url, auth=self._auth)
 
         return await async_aiohttp_proxy_web(self.hass, request, stream_coro)

--- a/homeassistant/components/camera/zoneminder.py
+++ b/homeassistant/components/camera/zoneminder.py
@@ -6,7 +6,7 @@ https://home-assistant.io/components/camera.zoneminder/
 """
 import logging
 
-from homeassistant.const import CONF_NAME
+from homeassistant.const import CONF_NAME, CONF_VERIFY_SSL
 from homeassistant.components.camera.mjpeg import (
     CONF_MJPEG_URL, CONF_STILL_IMAGE_URL, MjpegCamera)
 from homeassistant.components.zoneminder import DOMAIN as ZONEMINDER_DOMAIN
@@ -28,19 +28,20 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     cameras = []
     for monitor in monitors:
         _LOGGER.info("Initializing camera %s", monitor.id)
-        cameras.append(ZoneMinderCamera(monitor))
+        cameras.append(ZoneMinderCamera(monitor, zm_client.verify_ssl))
     add_entities(cameras)
 
 
 class ZoneMinderCamera(MjpegCamera):
     """Representation of a ZoneMinder Monitor Stream."""
 
-    def __init__(self, monitor):
+    def __init__(self, monitor, verify_ssl):
         """Initialize as a subclass of MjpegCamera."""
         device_info = {
             CONF_NAME: monitor.name,
             CONF_MJPEG_URL: monitor.mjpeg_image_url,
-            CONF_STILL_IMAGE_URL: monitor.still_image_url
+            CONF_STILL_IMAGE_URL: monitor.still_image_url,
+            CONF_VERIFY_SSL: verify_ssl
         }
         super().__init__(device_info)
         self._is_recording = None

--- a/homeassistant/components/zoneminder/__init__.py
+++ b/homeassistant/components/zoneminder/__init__.py
@@ -15,7 +15,7 @@ import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['zm-py==0.1.0']
+REQUIREMENTS = ['zm-py==0.3.0']
 
 CONF_PATH_ZMS = 'path_zms'
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1689,4 +1689,4 @@ zigpy-xbee==0.1.1
 zigpy==0.2.0
 
 # homeassistant.components.zoneminder
-zm-py==0.1.0
+zm-py==0.3.0


### PR DESCRIPTION
## Description:
Add a configuration option to mjpeg camera to allow disabling ssl certification verification. This is also needed for ZoneMinder cameras (which already provide that option and use it for sensors and switches).

**Related issue (if applicable):** fixes #18418

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#7837

## Example entry for `configuration.yaml` (if applicable):
```yaml
camera:
  - platform: mjpeg
    mjpeg_url: http://192.168.1.92/mjpeg
    verify_ssl: false
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
