### PR TITLE
Set tradfri unavailable on communication error

### DIFF
--- a/homeassistant/components/light/tradfri.py
+++ b/homeassistant/components/light/tradfri.py
@@ -339,6 +339,8 @@ class TradfriLight(Light):
         # pylint: disable=import-error
         from pytradfri.error import PytradfriError
         if exc:
+            self._available = False
+            self.async_schedule_update_ha_state()
             _LOGGER.warning("Observation failed for %s", self._name,
                             exc_info=exc)
 

--- a/homeassistant/components/switch/tradfri.py
+++ b/homeassistant/components/switch/tradfri.py
@@ -108,6 +108,8 @@ class TradfriSwitch(SwitchDevice):
         """Start observation of switch."""
         from pytradfri.error import PytradfriError
         if exc:
+            self._available = False
+            self.async_schedule_update_ha_state()
             _LOGGER.warning("Observation failed for %s", self._name,
                             exc_info=exc)
 


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes #17675

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
