### PR TITLE
Alert repeat can be disabled if repeat set to minus number

### DIFF
--- a/homeassistant/components/alert.py
+++ b/homeassistant/components/alert.py
@@ -218,6 +218,9 @@ class Alert(ToggleEntity):
     async def _schedule_notify(self):
         """Schedule a notification."""
         delay = self._delay[self._next_delay]
+        """Disable alert schedule if repeat contains 0 or minus number"""
+        if delay.days <= 0:
+            return
         next_msg = datetime.now() + delay
         self._cancel = \
             event.async_track_point_in_time(self.hass, self._notify, next_msg)


### PR DESCRIPTION
## Description:
I want to use alert just notify the status change of a sensor or switch, I do not need the alert repeat.

If user set repeat to -1, the alerts will be a bomb all the time.

So If user want to disable alert repeat, just set -1 with this pr.

## Example entry for `configuration.yaml` (if applicable):
```yaml
alert:
  garage_door:
    name: Garage is open
    done_message: Garage is closed
    entity_id: input_boolean.garage_door
    state: 'on'
    repeat: -1
    can_acknowledge: true
    skip_first: true
    notifiers:
      - ryans_phone
      - kristens_phone
```