### PR TITLE
Fix default fail2ban scan interval

### DIFF
--- a/homeassistant/components/sensor/fail2ban.py
+++ b/homeassistant/components/sensor/fail2ban.py
@@ -43,7 +43,7 @@ async def async_setup_platform(hass, config, async_add_entities,
     """Set up the fail2ban sensor."""
     name = config.get(CONF_NAME)
     jails = config.get(CONF_JAILS)
-    scan_interval = config.get(CONF_SCAN_INTERVAL)
+    scan_interval = config.get(CONF_SCAN_INTERVAL, SCAN_INTERVAL)
     log_file = config.get(CONF_FILE_PATH, DEFAULT_LOG)
 
     device_list = []


### PR DESCRIPTION
## Description:
The fail2ban sensor specified a default scan interval but didn't actually use it. This fixes it to use the default if one is not specified in the config.

**Related issue (if applicable):** fixes #10497

## Checklist:
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
