### PR TITLE
Fix mpd shuffle/random status

### DIFF
--- a/homeassistant/components/media_player/mpd.py
+++ b/homeassistant/components/media_player/mpd.py
@@ -319,7 +319,10 @@ class MpdDevice(MediaPlayerDevice):
     @property
     def shuffle(self):
         """Boolean if shuffle is enabled."""
-        return bool(self._status['random'])
+        if self._status['random'] == '1':
+            return 'true'
+        else:
+            return 'false'
 
     def set_shuffle(self, shuffle):
         """Enable/disable shuffle mode."""

--- a/homeassistant/components/media_player/mpd.py
+++ b/homeassistant/components/media_player/mpd.py
@@ -319,7 +319,7 @@ class MpdDevice(MediaPlayerDevice):
     @property
     def shuffle(self):
         """Boolean if shuffle is enabled."""
-        if self._status['random'] == '1':
+        return bool(int(self._status['random']))
             return 'true'
         else:
             return 'false'

--- a/homeassistant/components/media_player/mpd.py
+++ b/homeassistant/components/media_player/mpd.py
@@ -320,9 +320,6 @@ class MpdDevice(MediaPlayerDevice):
     def shuffle(self):
         """Boolean if shuffle is enabled."""
         return bool(int(self._status['random']))
-            return 'true'
-        else:
-            return 'false'
 
     def set_shuffle(self, shuffle):
         """Enable/disable shuffle mode."""


### PR DESCRIPTION
MPD always shows true for shuffle.  For some reason casting the 0 or 1 as a boolean does not work.  Now returns 'true' or 'false' based on the value of 'random'.

Not sure if there's a better way to do this, but it works.