### PR TITLE
Adds battery_percent which had been introduced with pyatmo 1.4

### DIFF
--- a/homeassistant/components/sensor/netatmo.py
+++ b/homeassistant/components/sensor/netatmo.py
@@ -39,6 +39,7 @@ SENSOR_TYPES = {
     'sum_rain_24': ['sum_rain_24', 'mm', 'mdi:weather-rainy', None],
     'battery_vp': ['Battery', '', 'mdi:battery', None],
     'battery_lvl': ['Battery_lvl', '', 'mdi:battery', None],
+    'battery_percent': ['battery_percent', '%', 'mdi:battery', None],
     'min_temp': ['Min Temp.', TEMP_CELSIUS, 'mdi:thermometer', None],
     'max_temp': ['Max Temp.', TEMP_CELSIUS, 'mdi:thermometer', None],
     'windangle': ['Angle', '', 'mdi:compass', None],
@@ -179,6 +180,8 @@ class NetAtmoSensor(Entity):
             self._state = data['CO2']
         elif self.type == 'pressure':
             self._state = round(data['Pressure'], 1)
+        elif self.type == 'battery_percent':
+            self._state = data['battery_percent']
         elif self.type == 'battery_lvl':
             self._state = data['battery_vp']
         elif (self.type == 'battery_vp' and


### PR DESCRIPTION
## Description:

Adds battery_percent which had been introduced with pyatmo 1.4 and resolves _unknown var_ warning in logging.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#7848

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

