### PR TITLE
Add camera selection config to skybell camera

### DIFF
--- a/homeassistant/components/camera/skybell.py
+++ b/homeassistant/components/camera/skybell.py
@@ -8,6 +8,11 @@ from datetime import timedelta
 import logging
 
 import requests
+import voluptuous as vol
+
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import CONF_MONITORED_CONDITIONS
+import homeassistant.helpers.config_validation as cv
 
 from homeassistant.components.camera import Camera
 from homeassistant.components.skybell import (
@@ -19,14 +24,32 @@ _LOGGER = logging.getLogger(__name__)
 
 SCAN_INTERVAL = timedelta(seconds=90)
 
+IMAGE_AVATAR = 'avatar'
+IMAGE_ACTIVITY = 'activity'
+
+CONF_ACTIVITY_NAME = 'activity_name'
+CONF_AVATAR_NAME = 'avatar_name'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_MONITORED_CONDITIONS, default=[IMAGE_AVATAR]):
+        vol.All(cv.ensure_list, [vol.In([IMAGE_AVATAR, IMAGE_ACTIVITY])]),
+    vol.Optional(CONF_ACTIVITY_NAME, default=""): cv.string,
+    vol.Optional(CONF_AVATAR_NAME, default=""): cv.string,
+})
+
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the platform for a Skybell device."""
+    cond = config[CONF_MONITORED_CONDITIONS]
+    names = {}
+    names[IMAGE_ACTIVITY] = config[CONF_ACTIVITY_NAME]
+    names[IMAGE_AVATAR] = config[CONF_AVATAR_NAME]
     skybell = hass.data.get(SKYBELL_DOMAIN)
 
     sensors = []
     for device in skybell.get_devices():
-        sensors.append(SkybellCamera(device))
+        for camera_type in cond:
+            sensors.append(SkybellCamera(device, type, names[camera_type]))
 
     add_entities(sensors, True)
 
@@ -34,11 +57,15 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class SkybellCamera(SkybellDevice, Camera):
     """A camera implementation for Skybell devices."""
 
-    def __init__(self, device):
+    def __init__(self, device, camera_type, name=""):
         """Initialize a camera for a Skybell device."""
+        self._type = camera_type
         SkybellDevice.__init__(self, device)
         Camera.__init__(self)
-        self._name = self._device.name
+        if name != "":
+            self._name = self._device.name + " " + name
+        else:
+            self._name = self._device.name
         self._url = None
         self._response = None
 
@@ -47,12 +74,19 @@ class SkybellCamera(SkybellDevice, Camera):
         """Return the name of the sensor."""
         return self._name
 
+    @property
+    def image_url(self):
+        """Get the camera image url based on type."""
+        if self._type == IMAGE_ACTIVITY:
+            return self._device.activity_image
+        return self._device.image
+
     def camera_image(self):
         """Get the latest camera image."""
         super().update()
 
-        if self._url != self._device.image:
-            self._url = self._device.image
+        if self._url != self.image_url:
+            self._url = self.image_url
 
             try:
                 self._response = requests.get(

--- a/homeassistant/components/skybell.py
+++ b/homeassistant/components/skybell.py
@@ -14,7 +14,7 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['skybellpy==0.2.0']
+REQUIREMENTS = ['skybellpy==0.3.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1440,7 +1440,7 @@ simplisafe-python==3.1.14
 sisyphus-control==2.1
 
 # homeassistant.components.skybell
-skybellpy==0.2.0
+skybellpy==0.3.0
 
 # homeassistant.components.notify.slack
 slacker==0.12.0


### PR DESCRIPTION
## Description:
Ongoing conversation in https://github.com/home-assistant/home-assistant/issues/17617 resulted in a better fix. Some people liked the image we used when the original broke, so I am adding a config to let you choose which image to use in Skybell Camera.

**Related issue (if applicable):** fixes #17617

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#7849

## Example entry for `configuration.yaml` (if applicable):
```yaml
camera:
  - platform: skybell
    monitored_conditions:
    - avatar
    - activity
    activity_name: "Last Activity"
    avatar_name: "Current"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
