### PR TITLE
Add HomeKit specific states to fritzbox thermostats

### DIFF
--- a/homeassistant/components/climate/fritzbox.py
+++ b/homeassistant/components/climate/fritzbox.py
@@ -132,7 +132,7 @@ class FritzboxThermostat(ClimateDevice):
         """Set new operation mode."""
         if operation_mode == STATE_HEAT:
             self.set_temperature(temperature=self._comfort_temperature)
-        elif operation_mode == STATE_ECO or operation_mode == STATE_COOL:
+        elif operation_mode in (STATE_ECO, STATE_COOL):
             self.set_temperature(temperature=self._eco_temperature)
         elif operation_mode == STATE_OFF:
             self.set_temperature(temperature=OFF_REPORT_SET_TEMPERATURE)

--- a/homeassistant/components/climate/fritzbox.py
+++ b/homeassistant/components/climate/fritzbox.py
@@ -15,7 +15,7 @@ from homeassistant.components.fritzbox import (
     ATTR_STATE_WINDOW_OPEN)
 from homeassistant.components.climate import (
     ATTR_OPERATION_MODE, ClimateDevice, STATE_ECO, STATE_COOL, STATE_HEAT,
-    STATE_MANUAL, STATE_OFF, STATE_ON, SUPPORT_OPERATION_MODE,
+    STATE_MANUAL, STATE_OFF, STATE_ON, STATE_AUTO, SUPPORT_OPERATION_MODE,
     SUPPORT_TARGET_TEMPERATURE)
 from homeassistant.const import (
     ATTR_BATTERY_LEVEL, ATTR_TEMPERATURE, PRECISION_HALVES, TEMP_CELSIUS)
@@ -130,7 +130,7 @@ class FritzboxThermostat(ClimateDevice):
 
     def set_operation_mode(self, operation_mode):
         """Set new operation mode."""
-        if operation_mode == STATE_HEAT:
+        if operation_mode in (STATE_HEAT, STATE_AUTO):
             self.set_temperature(temperature=self._comfort_temperature)
         elif operation_mode in (STATE_ECO, STATE_COOL):
             self.set_temperature(temperature=self._eco_temperature)

--- a/homeassistant/components/climate/fritzbox.py
+++ b/homeassistant/components/climate/fritzbox.py
@@ -14,8 +14,8 @@ from homeassistant.components.fritzbox import (
     ATTR_STATE_LOCKED, ATTR_STATE_SUMMER_MODE,
     ATTR_STATE_WINDOW_OPEN)
 from homeassistant.components.climate import (
-    ATTR_OPERATION_MODE, ClimateDevice, STATE_ECO, STATE_HEAT, STATE_MANUAL,
-    STATE_OFF, STATE_ON, SUPPORT_OPERATION_MODE,
+    ATTR_OPERATION_MODE, ClimateDevice, STATE_ECO, STATE_COOL, STATE_HEAT,
+    STATE_MANUAL, STATE_OFF, STATE_ON, SUPPORT_OPERATION_MODE,
     SUPPORT_TARGET_TEMPERATURE)
 from homeassistant.const import (
     ATTR_BATTERY_LEVEL, ATTR_TEMPERATURE, PRECISION_HALVES, TEMP_CELSIUS)
@@ -132,7 +132,7 @@ class FritzboxThermostat(ClimateDevice):
         """Set new operation mode."""
         if operation_mode == STATE_HEAT:
             self.set_temperature(temperature=self._comfort_temperature)
-        elif operation_mode == STATE_ECO:
+        elif operation_mode == STATE_ECO or operation_mode == STATE_COOL:
             self.set_temperature(temperature=self._eco_temperature)
         elif operation_mode == STATE_OFF:
             self.set_temperature(temperature=OFF_REPORT_SET_TEMPERATURE)

--- a/tests/components/climate/test_fritzbox.py
+++ b/tests/components/climate/test_fritzbox.py
@@ -122,6 +122,7 @@ class TestFritzboxClimate(unittest.TestCase):
         values = {
             'heat': 22.0,
             'eco': 16.0,
+            'cool': 16.0,
             'on': 30.0,
             'off': 0.0}
         for mode, temp in values.items():


### PR DESCRIPTION
## Description:
Currently fritzbox thermostats exposed to HomeKit do not react to the "Cool" or "Auto" (on) mode. My expectation would be to map "Cool" to the "Eco" temperature and "Auto"/on to the heat temperature, otherwise the usage with HomeKit is pretty cumbersome. This PR implements this mapping.


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
