### PR TITLE
Initialise plant attributes at startup

### DIFF
--- a/homeassistant/components/plant.py
+++ b/homeassistant/components/plant.py
@@ -105,9 +105,6 @@ async def async_setup(hass, config):
     for plant_name, plant_config in config[DOMAIN].items():
         _LOGGER.info("Added plant %s", plant_name)
         entity = Plant(plant_name, plant_config)
-        sensor_entity_ids = list(plant_config[CONF_SENSORS].values())
-        _LOGGER.debug("Subscribing to entity_ids %s", sensor_entity_ids)
-        async_track_state_change(hass, sensor_entity_ids, entity.state_changed)
         entities.append(entity)
 
     await component.async_add_entities(entities)
@@ -249,6 +246,9 @@ class Plant(Entity):
         if ENABLE_LOAD_HISTORY and 'recorder' in self.hass.config.components:
             # only use the database if it's configured
             self.hass.async_add_job(self._load_history_from_db)
+
+        async_track_state_change(self.hass, list(self._sensormap),
+                                 self.state_changed)
 
         for entity in self._sensormap:
             state = self.hass.states.get(entity)

--- a/homeassistant/components/plant.py
+++ b/homeassistant/components/plant.py
@@ -250,6 +250,11 @@ class Plant(Entity):
             # only use the database if it's configured
             self.hass.async_add_job(self._load_history_from_db)
 
+        for entity in self._sensormap:
+            state = self.hass.states.get(entity)
+            if state is not None:
+                self.state_changed(entity, None, state)
+
     async def _load_history_from_db(self):
         """Load the history of the brightness values from the database.
 

--- a/homeassistant/components/plant.py
+++ b/homeassistant/components/plant.py
@@ -250,10 +250,10 @@ class Plant(Entity):
         async_track_state_change(self.hass, list(self._sensormap),
                                  self.state_changed)
 
-        for entity in self._sensormap:
-            state = self.hass.states.get(entity)
+        for entity_id in self._sensormap:
+            state = self.hass.states.get(entity_id)
             if state is not None:
-                self.state_changed(entity, None, state)
+                self.state_changed(entity_id, None, state)
 
     async def _load_history_from_db(self):
         """Load the history of the brightness values from the database.

--- a/tests/components/test_plant.py
+++ b/tests/components/test_plant.py
@@ -86,6 +86,20 @@ class TestPlant(unittest.TestCase):
         assert sensor.state == 'problem'
         assert sensor.state_attributes['problem'] == 'battery low'
 
+    def test_initial_states(self):
+        """Test plant initialises attributes if sensor already exists."""
+        self.hass.states.set(MOISTURE_ENTITY, 5,
+                             {ATTR_UNIT_OF_MEASUREMENT: 'us/cm'})
+        plant_name = 'some_plant'
+        assert setup_component(self.hass, plant.DOMAIN, {
+            plant.DOMAIN: {
+                plant_name: GOOD_CONFIG
+            }
+        })
+        self.hass.block_till_done()
+        state = self.hass.states.get('plant.'+plant_name)
+        assert 5 == state.attributes[plant.READING_MOISTURE]
+
     def test_update_states(self):
         """Test updating the state of a sensor.
 


### PR DESCRIPTION
## Description:
The plant component tracks selected sensor entities and displays an aggregated view of a plant in the front-end. This PR is to resolve an issue that after restarting home assistant, there are often missing values in the plant cards even though the underlying sensors are present, e.g. in the card on the left the values are missing even though the underlying sensors exists and have valid values.

![image](https://user-images.githubusercontent.com/16738570/50042004-68ae8a00-0055-11e9-81be-93803b411388.png)


This is due to a timing issue on start-up where sensors created before the plant entity will not be displayed until their value is updated. This is due to the initial state change event of the sensor being sent before the plant entity has been created and is able to listen for the event. Thus the plant entity has to wait until the next sensor event is generated before being able to populate its attribute (this could be hours or more if the sensor is slow moving). This PR adds initialization logic to work around this timing problem.

@ChristianKuehnel , this as as per our discussion in the related issue and includes the improvements you suggested. Appreciate any thoughts / view on the PR.

**Related issue (if applicable):** fixes #18574

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
