### PR TITLE
Bump pyEmby to 1.6, add channel media type mapping

### DIFF
--- a/homeassistant/components/media_player/emby.py
+++ b/homeassistant/components/media_player/emby.py
@@ -9,9 +9,9 @@ import logging
 import voluptuous as vol
 
 from homeassistant.components.media_player import (
-    MEDIA_TYPE_MOVIE, MEDIA_TYPE_MUSIC, MEDIA_TYPE_TVSHOW, PLATFORM_SCHEMA,
-    SUPPORT_NEXT_TRACK, SUPPORT_PAUSE, SUPPORT_PLAY, SUPPORT_PREVIOUS_TRACK,
-    SUPPORT_SEEK, SUPPORT_STOP, MediaPlayerDevice)
+    MEDIA_TYPE_CHANNEL, MEDIA_TYPE_MOVIE, MEDIA_TYPE_MUSIC, MEDIA_TYPE_TVSHOW,
+    PLATFORM_SCHEMA, SUPPORT_NEXT_TRACK, SUPPORT_PAUSE, SUPPORT_PLAY,
+    SUPPORT_PREVIOUS_TRACK, SUPPORT_SEEK, SUPPORT_STOP, MediaPlayerDevice)
 from homeassistant.const import (
     CONF_API_KEY, CONF_HOST, CONF_PORT, CONF_SSL, DEVICE_DEFAULT_NAME,
     EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP, STATE_IDLE, STATE_OFF,
@@ -20,7 +20,7 @@ from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.dt as dt_util
 
-REQUIREMENTS = ['pyemby==1.5']
+REQUIREMENTS = ['pyemby==1.6']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -237,6 +237,8 @@ class EmbyDevice(MediaPlayerDevice):
             return MEDIA_TYPE_GENERIC_VIDEO
         if media_type == 'Audio':
             return MEDIA_TYPE_MUSIC
+        if media_type == 'TvChannel':
+            return MEDIA_TYPE_CHANNEL
         return None
 
     @property

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -935,7 +935,7 @@ pyedimax==0.1
 pyeight==0.0.9
 
 # homeassistant.components.media_player.emby
-pyemby==1.5
+pyemby==1.6
 
 # homeassistant.components.envisalink
 pyenvisalink==3.7


### PR DESCRIPTION
## Description:

Increase pyEmby library version and add channel media type mapping.

**Related issue (if applicable):** 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** 

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
