### PR TITLE
Add device registry to MQTT lock

### DIFF
--- a/tests/components/lock/test_mqtt.py
+++ b/tests/components/lock/test_mqtt.py
@@ -1,11 +1,14 @@
 """The tests for the MQTT lock platform."""
+import json
+
 from homeassistant.setup import async_setup_component
 from homeassistant.const import (
     STATE_LOCKED, STATE_UNLOCKED, STATE_UNAVAILABLE, ATTR_ASSUMED_STATE)
 from homeassistant.components import lock, mqtt
 from homeassistant.components.mqtt.discovery import async_start
 
-from tests.common import async_fire_mqtt_message, MockConfigEntry
+from tests.common import (
+    async_fire_mqtt_message, async_mock_mqtt_component, MockConfigEntry)
 
 
 async def test_controlling_state_via_topic(hass, mqtt_mock):
@@ -134,6 +137,29 @@ async def test_custom_availability_payload(hass, mqtt_mock):
     assert state.state is STATE_UNAVAILABLE
 
 
+async def test_unique_id(hass):
+    """Test unique id option only creates one light per unique_id."""
+    await async_mock_mqtt_component(hass)
+    assert await async_setup_component(hass, lock.DOMAIN, {
+        lock.DOMAIN: [{
+            'platform': 'mqtt',
+            'name': 'Test 1',
+            'status_topic': 'test-topic',
+            'command_topic': 'test_topic',
+            'unique_id': 'TOTALLY_UNIQUE'
+        }, {
+            'platform': 'mqtt',
+            'name': 'Test 2',
+            'status_topic': 'test-topic',
+            'command_topic': 'test_topic',
+            'unique_id': 'TOTALLY_UNIQUE'
+        }]
+    })
+    async_fire_mqtt_message(hass, 'test-topic', 'payload')
+    await hass.async_block_till_done()
+    assert len(hass.states.async_entity_ids(lock.DOMAIN)) == 1
+
+
 async def test_discovery_removal_lock(hass, mqtt_mock, caplog):
     """Test removal of discovered lock."""
     entry = MockConfigEntry(domain=mqtt.DOMAIN)
@@ -154,3 +180,42 @@ async def test_discovery_removal_lock(hass, mqtt_mock, caplog):
     await hass.async_block_till_done()
     state = hass.states.get('lock.beer')
     assert state is None
+
+
+async def test_entity_device_info_with_identifier(hass, mqtt_mock):
+    """Test MQTT lock device registry integration."""
+    entry = MockConfigEntry(domain=mqtt.DOMAIN)
+    entry.add_to_hass(hass)
+    await async_start(hass, 'homeassistant', {}, entry)
+    registry = await hass.helpers.device_registry.async_get_registry()
+
+    data = json.dumps({
+        'platform': 'mqtt',
+        'name': 'Test 1',
+        'state_topic': 'test-topic',
+        'command_topic': 'test-topic',
+        'device': {
+            'identifiers': ['helloworld'],
+            'connections': [
+                ["mac", "02:5b:26:a8:dc:12"],
+            ],
+            'manufacturer': 'Whatever',
+            'name': 'Beer',
+            'model': 'Glass',
+            'sw_version': '0.1-beta',
+        },
+        'unique_id': 'veryunique'
+    })
+    async_fire_mqtt_message(hass, 'homeassistant/lock/bla/config',
+                            data)
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+
+    device = registry.async_get_device({('mqtt', 'helloworld')}, set())
+    assert device is not None
+    assert device.identifiers == {('mqtt', 'helloworld')}
+    assert device.connections == {('mac', "02:5b:26:a8:dc:12")}
+    assert device.manufacturer == 'Whatever'
+    assert device.name == 'Beer'
+    assert device.model == 'Glass'
+    assert device.sw_version == '0.1-beta'


### PR DESCRIPTION
## Description:

Implements #16943 for `lock.mqtt`

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#7865

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.