### PR TITLE
Bump georss_client to 0.5

### DIFF
--- a/homeassistant/components/sensor/geo_rss_events.py
+++ b/homeassistant/components/sensor/geo_rss_events.py
@@ -20,7 +20,7 @@ from homeassistant.const import (
     CONF_LATITUDE, CONF_LONGITUDE, CONF_RADIUS, CONF_URL)
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['georss_client==0.4']
+REQUIREMENTS = ['georss_client==0.5']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -427,7 +427,7 @@ geizhals==0.0.9
 geojson_client==0.3
 
 # homeassistant.components.sensor.geo_rss_events
-georss_client==0.4
+georss_client==0.5
 
 # homeassistant.components.device_tracker.googlehome
 ghlocalapi==0.3.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -83,7 +83,7 @@ gTTS-token==1.1.3
 geojson_client==0.3
 
 # homeassistant.components.sensor.geo_rss_events
-georss_client==0.4
+georss_client==0.5
 
 # homeassistant.components.ffmpeg
 ha-ffmpeg==1.9

--- a/tests/components/sensor/test_geo_rss_events.py
+++ b/tests/components/sensor/test_geo_rss_events.py
@@ -1,10 +1,7 @@
 """The test for the geo rss events sensor platform."""
 import unittest
 from unittest import mock
-import sys
 from unittest.mock import MagicMock, patch
-
-import pytest
 
 from homeassistant.components import sensor
 from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT, ATTR_FRIENDLY_NAME, \
@@ -37,9 +34,6 @@ VALID_CONFIG = {
 }
 
 
-# Until https://github.com/kurtmckee/feedparser/pull/131 is released.
-@pytest.mark.skipif(sys.version_info[:2] >= (3, 7),
-                    reason='Package incompatible with Python 3.7')
 class TestGeoRssServiceUpdater(unittest.TestCase):
     """Test the GeoRss service updater."""
 


### PR DESCRIPTION
## Description:
Version 0.5 of the `georss_client` library now supports Python 3.7. The previous version was depending on the `feedparser` library which has now been replaced with a built-in xml parser.

There is a small chance that some exotic (=non-standaard) GeoRSS feeds are not going to work with the new built-in parser, but I don't think this would justify calling this a breaking change.
All unit tests remained unchanged, i.e. the interface between the library and Home Assistant is fully compatible.

**Related issue (if applicable):** contributes fix to #15479

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable): n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
