### PR TITLE
Added triggered condition for NX584 alarm

### DIFF
--- a/homeassistant/components/alarm_control_panel/nx584.py
+++ b/homeassistant/components/alarm_control_panel/nx584.py
@@ -13,7 +13,7 @@ import homeassistant.components.alarm_control_panel as alarm
 from homeassistant.components.alarm_control_panel import PLATFORM_SCHEMA
 from homeassistant.const import (
     CONF_HOST, CONF_NAME, CONF_PORT, STATE_ALARM_ARMED_AWAY,
-    STATE_ALARM_ARMED_HOME, STATE_ALARM_DISARMED, STATE_UNKNOWN)
+    STATE_ALARM_ARMED_HOME, STATE_ALARM_DISARMED, STATE_UNKNOWN, STATE_ALARM_TRIGGERED)
 import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['pynx584==0.4']
@@ -107,6 +107,10 @@ class NX584Alarm(alarm.AlarmControlPanel):
         else:
             self._state = STATE_ALARM_ARMED_AWAY
 
+        for flag in part['condition_flags']:
+            if flag == "Siren on":
+                self._state = STATE_ALARM_TRIGGERED
+            
     def alarm_disarm(self, code=None):
         """Send disarm command."""
         self._alarm.disarm(code)


### PR DESCRIPTION
## Description:

Added ability for NX584 alarm_control_panel to report "triggered" for partition status.  This is sent when the nx584_client sees "Siren on" in the partition status.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ X] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
