### PR TITLE
Add support for statewide data for Flu Near You

### DIFF
--- a/homeassistant/components/sensor/flunearyou.py
+++ b/homeassistant/components/sensor/flunearyou.py
@@ -118,7 +118,6 @@ class FluNearYouSensor(Entity):
     @property
     def available(self):
         """Return True if entity is available."""
-        _LOGGER.debug(self.fny.data)
         return bool(self.fny.data[self._category])
 
     @property

--- a/homeassistant/components/sensor/flunearyou.py
+++ b/homeassistant/components/sensor/flunearyou.py
@@ -18,13 +18,15 @@ from homeassistant.helpers import aiohttp_client
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['pyflunearyou==0.0.2']
+REQUIREMENTS = ['pyflunearyou==1.0.0']
 _LOGGER = logging.getLogger(__name__)
 
 ATTR_CITY = 'city'
 ATTR_REPORTED_DATE = 'reported_date'
 ATTR_REPORTED_LATITUDE = 'reported_latitude'
 ATTR_REPORTED_LONGITUDE = 'reported_longitude'
+ATTR_STATE_REPORTS_LAST_WEEK = 'state_reports_last_week'
+ATTR_STATE_REPORTS_THIS_WEEK = 'state_reports_this_week'
 ATTR_ZIP_CODE = 'zip_code'
 
 DEFAULT_ATTRIBUTION = 'Data provided by Flu Near You'
@@ -41,9 +43,15 @@ TYPE_USER_CHICK = 'chick'
 TYPE_USER_DENGUE = 'dengue'
 TYPE_USER_FLU = 'flu'
 TYPE_USER_LEPTO = 'lepto'
-TYPE_USER_NO_NONE = 'none'
+TYPE_USER_NO_SYMPTOMS = 'none'
 TYPE_USER_SYMPTOMS = 'symptoms'
 TYPE_USER_TOTAL = 'total'
+
+EXTENDED_TYPE_MAPPING = {
+    'ili': TYPE_USER_SYMPTOMS,
+    'no_symptoms': TYPE_USER_NO_SYMPTOMS,
+    'total': TYPE_USER_TOTAL,
+}
 
 SENSORS = {
     CATEGORY_CDC_REPORT: [
@@ -55,7 +63,7 @@ SENSORS = {
         (TYPE_USER_DENGUE, 'Dengue Fever Symptoms', 'mdi:alert', 'reports'),
         (TYPE_USER_FLU, 'Flu Symptoms', 'mdi:alert', 'reports'),
         (TYPE_USER_LEPTO, 'Leptospirosis Symptoms', 'mdi:alert', 'reports'),
-        (TYPE_USER_NO_NONE, 'No Symptoms', 'mdi:alert', 'reports'),
+        (TYPE_USER_NO_SYMPTOMS, 'No Symptoms', 'mdi:alert', 'reports'),
         (TYPE_USER_SYMPTOMS, 'Flu-like Symptoms', 'mdi:alert', 'reports'),
         (TYPE_USER_TOTAL, 'Total Symptoms', 'mdi:alert', 'reports'),
     ]
@@ -72,26 +80,20 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 async def async_setup_platform(
         hass, config, async_add_entities, discovery_info=None):
     """Configure the platform and add the sensors."""
-    from pyflunearyou import create_client
-    from pyflunearyou.errors import FluNearYouError
+    from pyflunearyou import Client
 
     websession = aiohttp_client.async_get_clientsession(hass)
 
     latitude = config.get(CONF_LATITUDE, hass.config.latitude)
     longitude = config.get(CONF_LONGITUDE, hass.config.longitude)
-    identifier = '{0},{1}'.format(latitude, longitude)
 
-    try:
-        client = await create_client(latitude, longitude, websession)
-    except FluNearYouError as err:
-        _LOGGER.error('There was an error while setting up: %s', err)
-        return
-
-    fny = FluNearYouData(client, config[CONF_MONITORED_CONDITIONS])
+    fny = FluNearYouData(
+        Client(websession), latitude, longitude,
+        config[CONF_MONITORED_CONDITIONS])
     await fny.async_update()
 
     sensors = [
-        FluNearYouSensor(fny, kind, name, identifier, category, icon, unit)
+        FluNearYouSensor(fny, kind, name, category, icon, unit)
         for category in config[CONF_MONITORED_CONDITIONS]
         for kind, name, icon, unit in SENSORS[category]
     ]
@@ -102,12 +104,11 @@ async def async_setup_platform(
 class FluNearYouSensor(Entity):
     """Define a base Flu Near You sensor."""
 
-    def __init__(self, fny, kind, name, identifier, category, icon, unit):
+    def __init__(self, fny, kind, name, category, icon, unit):
         """Initialize the sensor."""
         self._attrs = {ATTR_ATTRIBUTION: DEFAULT_ATTRIBUTION}
         self._category = category
         self._icon = icon
-        self._identifier = identifier
         self._kind = kind
         self._name = name
         self._state = None
@@ -117,6 +118,7 @@ class FluNearYouSensor(Entity):
     @property
     def available(self):
         """Return True if entity is available."""
+        _LOGGER.debug(self.fny.data)
         return bool(self.fny.data[self._category])
 
     @property
@@ -142,7 +144,8 @@ class FluNearYouSensor(Entity):
     @property
     def unique_id(self):
         """Return a unique, HASS-friendly identifier for this entity."""
-        return '{0}_{1}'.format(self._identifier, self._kind)
+        return '{0},{1}_{2}'.format(
+            self.fny.latitude, self.fny.longitude, self._kind)
 
     @property
     def unit_of_measurement(self):
@@ -164,50 +167,56 @@ class FluNearYouSensor(Entity):
             self._state = cdc_data[self._kind]
         elif self._category == CATEGORY_USER_REPORT and user_data:
             self._attrs.update({
-                ATTR_CITY: user_data['city'].split('(')[0],
-                ATTR_REPORTED_LATITUDE: user_data['latitude'],
-                ATTR_REPORTED_LONGITUDE: user_data['longitude'],
-                ATTR_ZIP_CODE: user_data['zip'],
+                ATTR_CITY: user_data['local']['city'].split('(')[0],
+                ATTR_REPORTED_LATITUDE: user_data['local']['latitude'],
+                ATTR_REPORTED_LONGITUDE: user_data['local']['longitude'],
+                ATTR_STATE: user_data['state']['name'],
+                ATTR_ZIP_CODE: user_data['local']['zip'],
             })
+
+            # if self._kind in user_data['state']['data']:
+            #     self._attrs[ATTR_STATE_REPORTS_THIS_WEEK] = user_data['state'][
+            #         'data'][self._kind]
+            # if self._kind in user_data['state']['last_week_data']:
+            #     self._attrs[ATTR_STATE_REPORTS_LAST_WEEK] = user_data['state'][
+            #         'last_week_data'][self._kind]
 
             if self._kind == TYPE_USER_TOTAL:
                 self._state = sum(
-                    v for k, v in user_data.items() if k in (
+                    v for k, v in user_data['local'].items() if k in (
                         TYPE_USER_CHICK, TYPE_USER_DENGUE, TYPE_USER_FLU,
                         TYPE_USER_LEPTO, TYPE_USER_SYMPTOMS))
             else:
-                self._state = user_data[self._kind]
+                self._state = user_data['local'][self._kind]
 
 
 class FluNearYouData:
     """Define a data object to retrieve info from Flu Near You."""
 
-    def __init__(self, client, sensor_types):
+    def __init__(self, client, latitude, longitude, sensor_types):
         """Initialize."""
         self._client = client
         self._sensor_types = sensor_types
         self.data = {}
-
-    async def _get_data(self, category, method):
-        """Get data for a specific category."""
-        from pyflunearyou.errors import FluNearYouError
-
-        try:
-            self.data[category] = await method()
-        except FluNearYouError as err:
-            _LOGGER.error(
-                'There was an error with "%s" data: %s', category, err)
-            self.data[category] = {}
+        self.latitude = latitude
+        self.longitude = longitude
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     async def async_update(self):
         """Update Flu Near You data."""
-        if CATEGORY_CDC_REPORT in self._sensor_types:
-            await self._get_data(
-                CATEGORY_CDC_REPORT, self._client.cdc_reports.status)
+        from pyflunearyou.errors import FluNearYouError
 
-        if CATEGORY_USER_REPORT in self._sensor_types:
-            await self._get_data(
-                CATEGORY_USER_REPORT, self._client.user_reports.status)
+        for key, method in [(CATEGORY_CDC_REPORT,
+                             self._client.cdc_reports.status_by_coordinates),
+                            (CATEGORY_USER_REPORT,
+                             self._client.user_reports.status_by_coordinates)]:
+            if key in self._sensor_types:
+                try:
+                    self.data[key] = await method(
+                        self.latitude, self.longitude)
+                except FluNearYouError as err:
+                    _LOGGER.error(
+                        'There was an error with "%s" data: %s', key, err)
+                    self.data[key] = {}
 
         _LOGGER.debug('New data stored: %s', self.data)

--- a/homeassistant/components/sensor/flunearyou.py
+++ b/homeassistant/components/sensor/flunearyou.py
@@ -48,9 +48,9 @@ TYPE_USER_SYMPTOMS = 'symptoms'
 TYPE_USER_TOTAL = 'total'
 
 EXTENDED_TYPE_MAPPING = {
-    'ili': TYPE_USER_SYMPTOMS,
-    'no_symptoms': TYPE_USER_NO_SYMPTOMS,
-    'total': TYPE_USER_TOTAL,
+    TYPE_USER_FLU: 'ili',
+    TYPE_USER_NO_SYMPTOMS: 'no_symptoms',
+    TYPE_USER_TOTAL: 'total_surveys',
 }
 
 SENSORS = {
@@ -174,12 +174,15 @@ class FluNearYouSensor(Entity):
                 ATTR_ZIP_CODE: user_data['local']['zip'],
             })
 
-            # if self._kind in user_data['state']['data']:
-            #     self._attrs[ATTR_STATE_REPORTS_THIS_WEEK] = user_data['state'][
-            #         'data'][self._kind]
-            # if self._kind in user_data['state']['last_week_data']:
-            #     self._attrs[ATTR_STATE_REPORTS_LAST_WEEK] = user_data['state'][
-            #         'last_week_data'][self._kind]
+            if self._kind in user_data['state']['data']:
+                states_key = self._kind
+            elif self._kind in EXTENDED_TYPE_MAPPING:
+                states_key = EXTENDED_TYPE_MAPPING[self._kind]
+
+            self._attrs[ATTR_STATE_REPORTS_THIS_WEEK] = user_data['state'][
+                'data'][states_key]
+            self._attrs[ATTR_STATE_REPORTS_LAST_WEEK] = user_data['state'][
+                'last_week_data'][states_key]
 
             if self._kind == TYPE_USER_TOTAL:
                 self._state = sum(

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -953,7 +953,7 @@ pyflexit==0.3
 pyflic-homeassistant==0.4.dev0
 
 # homeassistant.components.sensor.flunearyou
-pyflunearyou==0.0.2
+pyflunearyou==1.0.0
 
 # homeassistant.components.light.futurenow
 pyfnip==0.2


### PR DESCRIPTION
## Description:

This PR bumps `pyflunearyou` to 1.0.0, which accomplishes the following:

* Adds new attributes to each disease type sensor that lists statewide reports for that disease, both this week and last week.
* Fixes a bug where certain latitudes/longitudes would throw unhandled exceptions.

**Related issue (if applicable):** fixes #19106

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
   - platform: flunearyou
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
