### PR TITLE
Fix not being able to update entities

### DIFF
--- a/homeassistant/components/config/entity_registry.py
+++ b/homeassistant/components/config/entity_registry.py
@@ -104,7 +104,7 @@ async def websocket_update_entity(hass, connection, msg):
     if 'name' in msg:
         changes['name'] = msg['name']
 
-    if 'new_entity_id' in msg:
+    if 'new_entity_id' in msg and msg['new_entity_id'] != msg['entity_id']:
         changes['new_entity_id'] = msg['new_entity_id']
         if hass.states.get(msg['new_entity_id']) is not None:
             connection.send_message(websocket_api.error_message(


### PR DESCRIPTION
## Description:

When editing an entity in the frontend dialog, pressing save causes a "save failed: Entity is already registered" error. This is because the frontend always sets `name` and `new_entity_id` in the websocket command even if they haven't been changed. This adds a check that the `new_entity_id` is actually different from `entity_id` before erroring that the `new_entity_id` is already registered.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
