### PR TITLE
Fix broken deprecation message

### DIFF
--- a/homeassistant/components/sensor/mqtt.py
+++ b/homeassistant/components/sensor/mqtt.py
@@ -100,7 +100,7 @@ class MqttSensor(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
         qos = config.get(CONF_QOS)
         device_config = config.get(CONF_DEVICE)
 
-        if CONF_JSON_ATTRS in config:
+        if config.get(CONF_JSON_ATTRS):
             _LOGGER.warning('configuration variable "json_attributes" is '
                             'deprecated, replace with "json_attributes_topic"')
 


### PR DESCRIPTION
## Description:
Fix broken check for deprecated `json_attributes` configuration variable.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
