### PR TITLE
Add openSenseMap air pollutants platform

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -427,6 +427,7 @@ omit =
     homeassistant/components/spider.py
     homeassistant/components/*/spider.py
 
+    homeassistant/components/air_pollutants/opensensemap.py
     homeassistant/components/alarm_control_panel/alarmdotcom.py
     homeassistant/components/alarm_control_panel/canary.py
     homeassistant/components/alarm_control_panel/concord232.py

--- a/homeassistant/components/air_pollutants/opensensemap.py
+++ b/homeassistant/components/air_pollutants/opensensemap.py
@@ -2,7 +2,7 @@
 Support for openSenseMap Air Pollutants data.
 
 For more details about this platform, please refer to the documentation at
-https://home-assistant.io/components/air_pollutants_opensnesemap/
+https://home-assistant.io/components/air_pollutants_opensensemap/
 """
 from datetime import timedelta
 import logging
@@ -45,12 +45,11 @@ async def async_setup_platform(
 
     await osm_api.async_update()
 
-    try:
-        if name is None:
-            name = osm_api.api.data['name']
-    except KeyError:
-        _LOGGER.error("Station is not available")
-        return
+    if name is None:
+        if 'name' not in osm_api.api.data:
+            _LOGGER.error("Station %s is not available", station_id)
+            return
+        name = osm_api.api.data['name']
 
     async_add_entities([OpenSenseMapPollutants(name, osm_api)], True)
 
@@ -62,7 +61,6 @@ class OpenSenseMapPollutants(AirPollutantsEntity):
         """Initialize the air pollutants entity."""
         self._name = name
         self._osm = osm
-        self.data = None
 
     @property
     def name(self):
@@ -85,7 +83,7 @@ class OpenSenseMapPollutants(AirPollutantsEntity):
         return ATTRIBUTION
 
     async def async_update(self):
-        """Get the latest data from the Pi-hole API."""
+        """Get the latest data from the openSenseMap API."""
         await self._osm.async_update()
 
 
@@ -103,5 +101,5 @@ class OpenSenseMapData:
 
         try:
             await self.api.get_data()
-        except OpenSenseMapError:
-            _LOGGER.error("Unable to fetch data")
+        except OpenSenseMapError as err:
+            _LOGGER.error("Unable to fetch data: %s", err)

--- a/homeassistant/components/air_pollutants/opensensemap.py
+++ b/homeassistant/components/air_pollutants/opensensemap.py
@@ -24,7 +24,7 @@ ATTRIBUTION = 'Data provided by openSenseMap'
 
 CONF_STATION_ID = 'station_id'
 
-MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=10)
+SCAN_INTERVAL = timedelta(minutes=10)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_STATION_ID): cv.string,
@@ -45,13 +45,13 @@ async def async_setup_platform(
 
     await osm_api.async_update()
 
-    if name is None:
-        if 'name' not in osm_api.api.data:
-            _LOGGER.error("Station %s is not available", station_id)
-            return
-        name = osm_api.api.data['name']
+    if 'name' not in osm_api.api.data:
+        _LOGGER.error("Station %s is not available", station_id)
+        return
 
-    async_add_entities([OpenSenseMapPollutants(name, osm_api)], True)
+    station_name = osm_api.api.data['name'] if name is None else name
+
+    async_add_entities([OpenSenseMapPollutants(station_name, osm_api)], True)
 
 
 class OpenSenseMapPollutants(AirPollutantsEntity):
@@ -94,7 +94,7 @@ class OpenSenseMapData:
         """Initialize the data object."""
         self.api = api
 
-    @Throttle(MIN_TIME_BETWEEN_UPDATES)
+    @Throttle(SCAN_INTERVAL)
     async def async_update(self):
         """Get the latest data from the Pi-hole."""
         from opensensemap_api.exceptions import OpenSenseMapError

--- a/homeassistant/components/air_pollutants/opensensemap.py
+++ b/homeassistant/components/air_pollutants/opensensemap.py
@@ -1,0 +1,107 @@
+"""
+Support for openSenseMap Air Pollutants data.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/air_pollutants_opensnesemap/
+"""
+from datetime import timedelta
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components.air_pollutants import (
+    PLATFORM_SCHEMA, AirPollutantsEntity)
+from homeassistant.const import CONF_NAME
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+import homeassistant.helpers.config_validation as cv
+from homeassistant.util import Throttle
+
+REQUIREMENTS = ['opensensemap-api==0.1.3']
+
+_LOGGER = logging.getLogger(__name__)
+
+ATTRIBUTION = 'Data provided by openSenseMap'
+
+CONF_STATION_ID = 'station_id'
+
+MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=10)
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_STATION_ID): cv.string,
+    vol.Optional(CONF_NAME): cv.string,
+})
+
+
+async def async_setup_platform(
+        hass, config, async_add_entities, discovery_info=None):
+    """Set up the openSenseMap air pollutants platform."""
+    from opensensemap_api import OpenSenseMap
+
+    name = config.get(CONF_NAME)
+    station_id = config[CONF_STATION_ID]
+
+    session = async_get_clientsession(hass)
+    osm_api = OpenSenseMapData(OpenSenseMap(station_id, hass.loop, session))
+
+    await osm_api.async_update()
+
+    try:
+        if name is None:
+            name = osm_api.api.data['name']
+    except KeyError:
+        _LOGGER.error("Station is not available")
+        return
+
+    async_add_entities([OpenSenseMapPollutants(name, osm_api)], True)
+
+
+class OpenSenseMapPollutants(AirPollutantsEntity):
+    """Implementation of an openSenseMap air pollutants entity."""
+
+    def __init__(self, name, osm):
+        """Initialize the air pollutants entity."""
+        self._name = name
+        self._osm = osm
+        self.data = None
+
+    @property
+    def name(self):
+        """Return the name of the air pollutants entity."""
+        return self._name
+
+    @property
+    def particulate_matter_2_5(self):
+        """Return the particulate matter 2.5 level."""
+        return self._osm.api.pm2_5
+
+    @property
+    def particulate_matter_10(self):
+        """Return the particulate matter 10 level."""
+        return self._osm.api.pm10
+
+    @property
+    def attribution(self):
+        """Return the attribution."""
+        return ATTRIBUTION
+
+    async def async_update(self):
+        """Get the latest data from the Pi-hole API."""
+        await self._osm.async_update()
+
+
+class OpenSenseMapData:
+    """Get the latest data and update the states."""
+
+    def __init__(self, api):
+        """Initialize the data object."""
+        self.api = api
+
+    @Throttle(MIN_TIME_BETWEEN_UPDATES)
+    async def async_update(self):
+        """Get the latest data from the Pi-hole."""
+        from opensensemap_api.exceptions import OpenSenseMapError
+
+        try:
+            await self.api.get_data()
+        except OpenSenseMapError:
+            _LOGGER.error("Unable to fetch data")

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -725,6 +725,9 @@ openevsewifi==0.4
 # homeassistant.components.media_player.openhome
 openhomedevice==0.4.2
 
+# homeassistant.components.air_pollutants.opensensemap
+opensensemap-api==0.1.3
+
 # homeassistant.components.switch.orvibo
 orvibo==1.1.1
 


### PR DESCRIPTION
## Description:
Support for air pollutants data from [openSenseMap](https://opensensemap.org).

## Example entry for `configuration.yaml` (if applicable):
```yaml
air_pollutants:
  - platform: opensensemap
    station_id: 5bb9e7a3043f3f001b1fa7b3
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
