### PR TITLE
RFC - Defer ZHA component startup until homeassistant is started

### DIFF
--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -173,10 +173,8 @@ async def async_setup_entry(hass, config_entry):
         device_registry.async_get_or_create(
             config_entry_id=config_entry.entry_id,
             connections={(
-                    CONNECTION_ZIGBEE,
-                    str(
-                        APPLICATION_CONTROLLER.ieee
-                    )
+                CONNECTION_ZIGBEE,
+                str(APPLICATION_CONTROLLER.ieee)
             )},
             identifiers={(DOMAIN, str(APPLICATION_CONTROLLER.ieee))},
             name="Zigbee Coordinator",

--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -152,11 +152,12 @@ async def async_setup_entry(hass, config_entry):
         ClusterPersistingListener
     )
 
+    await radio.connect(usb_path, baudrate)
+    hass.data[DATA_ZHA][DATA_ZHA_RADIO] = radio
+    APPLICATION_CONTROLLER = ControllerApplication(radio, database)
+    listener = ApplicationListener(hass, config)
+
     async def async_start_zha(_service_or_event):
-        await radio.connect(usb_path, baudrate)
-        hass.data[DATA_ZHA][DATA_ZHA_RADIO] = radio
-        APPLICATION_CONTROLLER = ControllerApplication(radio, database)
-        listener = ApplicationListener(hass, config)
         APPLICATION_CONTROLLER.add_listener(listener)
         await APPLICATION_CONTROLLER.startup(auto_form=True)
 


### PR DESCRIPTION
Looking for opinions here. This starts ZHA's zigbee network when the component is loaded but defers the handling of entities until HA has completed starting. This is to avoid ZHA causing HA to appear to hang at startup and is similar to what Z-Wave does. Does anyone have any concerns or comments on this?