### PR TITLE
Cast lametric cycles parameter to int

### DIFF
--- a/homeassistant/components/notify/lametric.py
+++ b/homeassistant/components/notify/lametric.py
@@ -85,7 +85,7 @@ class LaMetricNotificationService(BaseNotificationService):
                     _LOGGER.error("Sound ID %s unknown, ignoring",
                                   data["sound"])
             if "cycles" in data:
-                cycles = data['cycles']
+                cycles = int(data['cycles'])
             if "priority" in data:
                 if data['priority'] in AVAILABLE_PRIORITIES:
                     priority = data['priority']


### PR DESCRIPTION
## Description:

Whenever `cycles` is specified in a lametric data block, it is captured as a string and fed to the lametric python module as such.   The lmnotify python package expects cycles to be an integer value, so the assertion fails, the notification is not sent, and the following appears in the log:

```
  File "/usr/lib/python3.6/site-packages/lmnotify/models.py", line 121, in __init__
    assert(cycles >= 0)
TypeError: '>=' not supported between instances of 'str' and 'int'
```

**Related issue (if applicable):** fixes #14908