### PR TITLE
Add native ESPHome API binary sensor

### DIFF
--- a/homeassistant/components/binary_sensor/esphome.py
+++ b/homeassistant/components/binary_sensor/esphome.py
@@ -1,35 +1,35 @@
-"""Support for esphomelib binary sensors."""
+"""Support for ESPHome binary sensors."""
 import logging
 
 from typing import TYPE_CHECKING, Optional
 
 from homeassistant.components.binary_sensor import BinarySensorDevice
-from homeassistant.components.esphomelib import EsphomelibEntity, \
+from homeassistant.components.esphome import EsphomeEntity, \
     platform_async_setup_entry
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import
-    from aioesphomeapi.client import BinarySensorInfo, BinarySensorState
+    from aioesphomeapi import BinarySensorInfo, BinarySensorState
 
-DEPENDENCIES = ['esphomelib']
+DEPENDENCIES = ['esphome']
 _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass, entry, async_add_entities):
-    """Set up esphomelib binary sensors based on a config entry."""
+    """Set up ESPHome binary sensors based on a config entry."""
     # pylint: disable=redefined-outer-name
-    from aioesphomeapi.client import BinarySensorInfo, BinarySensorState
+    from aioesphomeapi import BinarySensorInfo, BinarySensorState
 
     await platform_async_setup_entry(
         hass, entry, async_add_entities,
         component_key='binary_sensor',
-        info_type=BinarySensorInfo, entity_type=EsphomelibBinarySensor,
+        info_type=BinarySensorInfo, entity_type=EsphomeBinarySensor,
         state_type=BinarySensorState
     )
 
 
-class EsphomelibBinarySensor(EsphomelibEntity, BinarySensorDevice):
-    """A binary sensor implementation for esphomelib."""
+class EsphomeBinarySensor(EsphomeEntity, BinarySensorDevice):
+    """A binary sensor implementation for ESPHome."""
 
     @property
     def _static_info(self) -> 'BinarySensorInfo':
@@ -60,4 +60,4 @@ class EsphomelibBinarySensor(EsphomelibEntity, BinarySensorDevice):
         """Return True if entity is available."""
         if self._static_info.is_status_binary_sensor:
             return True
-        return super(EsphomelibEntity, self).available
+        return super(EsphomeEntity, self).available

--- a/homeassistant/components/binary_sensor/esphome.py
+++ b/homeassistant/components/binary_sensor/esphome.py
@@ -9,7 +9,7 @@ from homeassistant.components.esphome import EsphomeEntity, \
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import
-    from aioesphomeapi import BinarySensorInfo, BinarySensorState
+    from aioesphomeapi import BinarySensorInfo, BinarySensorState  # noqa
 
 DEPENDENCIES = ['esphome']
 _LOGGER = logging.getLogger(__name__)
@@ -18,7 +18,7 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up ESPHome binary sensors based on a config entry."""
     # pylint: disable=redefined-outer-name
-    from aioesphomeapi import BinarySensorInfo, BinarySensorState
+    from aioesphomeapi import BinarySensorInfo, BinarySensorState  # noqa
 
     await platform_async_setup_entry(
         hass, entry, async_add_entities,

--- a/homeassistant/components/binary_sensor/esphomelib.py
+++ b/homeassistant/components/binary_sensor/esphomelib.py
@@ -1,0 +1,63 @@
+"""Support for esphomelib binary sensors."""
+import logging
+
+from typing import TYPE_CHECKING, Optional
+
+from homeassistant.components.binary_sensor import BinarySensorDevice
+from homeassistant.components.esphomelib import EsphomelibEntity, \
+    platform_async_setup_entry
+
+if TYPE_CHECKING:
+    # pylint: disable=unused-import
+    from aioesphomeapi.client import BinarySensorInfo, BinarySensorState
+
+DEPENDENCIES = ['esphomelib']
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up esphomelib binary sensors based on a config entry."""
+    # pylint: disable=redefined-outer-name
+    from aioesphomeapi.client import BinarySensorInfo, BinarySensorState
+
+    await platform_async_setup_entry(
+        hass, entry, async_add_entities,
+        component_key='binary_sensor',
+        info_type=BinarySensorInfo, entity_type=EsphomelibBinarySensor,
+        state_type=BinarySensorState
+    )
+
+
+class EsphomelibBinarySensor(EsphomelibEntity, BinarySensorDevice):
+    """A binary sensor implementation for esphomelib."""
+
+    @property
+    def _static_info(self) -> 'BinarySensorInfo':
+        return super()._static_info
+
+    @property
+    def _state(self) -> Optional['BinarySensorState']:
+        return super()._state
+
+    @property
+    def is_on(self):
+        """Return true if the binary sensor is on."""
+        if self._static_info.is_status_binary_sensor:
+            # Status binary sensors indicated connected state.
+            # So in their case what's usually _availability_ is now state
+            return self._entry_data.available
+        if self._state is None:
+            return None
+        return self._state.state
+
+    @property
+    def device_class(self):
+        """Return the class of this device, from component DEVICE_CLASSES."""
+        return self._static_info.device_class
+
+    @property
+    def available(self):
+        """Return True if entity is available."""
+        if self._static_info.is_status_binary_sensor:
+            return True
+        return super(EsphomelibEntity, self).available

--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -31,7 +31,10 @@ DISPATCHER_ON_LIST = 'esphome_{entry_id}_on_list'
 DISPATCHER_ON_DEVICE_UPDATE = 'esphome_{entry_id}_on_device_update'
 DISPATCHER_ON_STATE = 'esphome_{entry_id}_on_state'
 # The HA component types this integration supports
-HA_COMPONENTS = ['sensor']
+HA_COMPONENTS = [
+    'sensor',
+    'binary_sensor'
+]
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Description:

There will be a couple of PRs like this one for different platforms. And all of them need to edit the same file: `esphome/__init__.py` to register the platform.

To save all the "please rebase on dev" stuff, I would propose the following: First review as usual, but I'll do the merging - so then I can go through all PRs in order, rebase them and click merge myself (saves the entire delay of GH communication).

Also, please post all review comments that affect all ESPHome platform here.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
