### PR TITLE
Add device_info to Daikin

### DIFF
--- a/homeassistant/components/climate/daikin.py
+++ b/homeassistant/components/climate/daikin.py
@@ -266,3 +266,8 @@ class DaikinClimate(ClimateDevice):
     def update(self):
         """Retrieve latest state."""
         self._api.update()
+
+    @property
+    def device_info(self):
+        """Return a device description for device registry."""
+        return self._api.device_info

--- a/homeassistant/components/daikin/__init__.py
+++ b/homeassistant/components/daikin/__init__.py
@@ -130,3 +130,16 @@ class DaikinApi:
     def mac(self):
         """Return mac-address of device."""
         return self.device.values.get('mac')
+
+    @property
+    def device_info(self):
+        """Return a device description for device registry."""
+        info = self.device.values
+        return {
+            'connections': {('mac', self.mac)},
+            'identifieres': self.mac,
+            'manufacturer': 'Daikin',
+            'model': info.get('model'),
+            'name': info.get('name'),
+            'sw_version': info.get('ver').replace('_', '.'),
+        }

--- a/homeassistant/components/daikin/__init__.py
+++ b/homeassistant/components/daikin/__init__.py
@@ -15,6 +15,7 @@ import voluptuous as vol
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOSTS
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.util import Throttle
 
@@ -129,14 +130,14 @@ class DaikinApi:
     @property
     def mac(self):
         """Return mac-address of device."""
-        return self.device.values.get('mac')
+        return self.device.values.get(CONNECTION_NETWORK_MAC)
 
     @property
     def device_info(self):
         """Return a device description for device registry."""
         info = self.device.values
         return {
-            'connections': {('mac', self.mac)},
+            'connections': {(CONNECTION_NETWORK_MAC, self.mac)},
             'identifieres': self.mac,
             'manufacturer': 'Daikin',
             'model': info.get('model'),

--- a/homeassistant/components/sensor/daikin.py
+++ b/homeassistant/components/sensor/daikin.py
@@ -104,3 +104,8 @@ class DaikinClimateSensor(Entity):
     def update(self):
         """Retrieve latest state."""
         self._api.update()
+
+    @property
+    def device_info(self):
+        """Return a device description for device registry."""
+        return self._api.device_info


### PR DESCRIPTION
## Description:

Adds device_info for Daikin


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
