### PR TITLE
Add native ESPHome API text sensor

### DIFF
--- a/homeassistant/components/sensor/esphome.py
+++ b/homeassistant/components/sensor/esphome.py
@@ -10,7 +10,8 @@ from homeassistant.helpers.typing import HomeAssistantType
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import
-    from aioesphomeapi import SensorInfo, SensorState  # noqa
+    from aioesphomeapi import SensorInfo, SensorState, TextSensorInfo, \
+        TextSensorState
 
 DEPENDENCIES = ['esphome']
 _LOGGER = logging.getLogger(__name__)
@@ -20,13 +21,20 @@ async def async_setup_entry(hass: HomeAssistantType,
                             entry: ConfigEntry, async_add_entities) -> None:
     """Set up esphome sensors based on a config entry."""
     # pylint: disable=redefined-outer-name
-    from aioesphomeapi import SensorInfo, SensorState  # noqa
+    from aioesphomeapi import SensorInfo, SensorState, TextSensorInfo, \
+        TextSensorState
 
     await platform_async_setup_entry(
         hass, entry, async_add_entities,
         component_key='sensor',
         info_type=SensorInfo, entity_type=EsphomeSensor,
         state_type=SensorState
+    )
+    await platform_async_setup_entry(
+        hass, entry, async_add_entities,
+        component_key='text_sensor',
+        info_type=TextSensorInfo, entity_type=EsphomeTextSensor,
+        state_type=TextSensorState
     )
 
 
@@ -60,3 +68,27 @@ class EsphomeSensor(EsphomeEntity):
     def unit_of_measurement(self) -> str:
         """Return the unit the value is expressed in."""
         return self._static_info.unit_of_measurement
+
+
+class EsphomeTextSensor(EsphomeEntity):
+    """A text sensor implementation for ESPHome."""
+
+    @property
+    def _static_info(self) -> 'TextSensorInfo':
+        return super()._static_info
+
+    @property
+    def _state(self) -> Optional['TextSensorState']:
+        return super()._state
+
+    @property
+    def icon(self) -> str:
+        """Return the icon."""
+        return self._static_info.icon
+
+    @property
+    def state(self) -> Optional[str]:
+        """Return the state of the entity."""
+        if self._state is None:
+            return None
+        return self._state.state

--- a/homeassistant/components/sensor/esphome.py
+++ b/homeassistant/components/sensor/esphome.py
@@ -10,8 +10,8 @@ from homeassistant.helpers.typing import HomeAssistantType
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import
-    from aioesphomeapi import SensorInfo, SensorState, TextSensorInfo, \
-        TextSensorState
+    from aioesphomeapi import ( # noqa
+        SensorInfo, SensorState, TextSensorInfo, TextSensorState)
 
 DEPENDENCIES = ['esphome']
 _LOGGER = logging.getLogger(__name__)
@@ -21,8 +21,8 @@ async def async_setup_entry(hass: HomeAssistantType,
                             entry: ConfigEntry, async_add_entities) -> None:
     """Set up esphome sensors based on a config entry."""
     # pylint: disable=redefined-outer-name
-    from aioesphomeapi import SensorInfo, SensorState, TextSensorInfo, \
-        TextSensorState
+    from aioesphomeapi import (  # noqa
+        SensorInfo, SensorState, TextSensorInfo, TextSensorState)
 
     await platform_async_setup_entry(
         hass, entry, async_add_entities,


### PR DESCRIPTION
## Description:

## Read #19371 first

Text sensors are like sensors in ESPHome, just for text-based data. Distinguishing between text data and floating point data in statically typed languages is important

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
