### PR TITLE
ESPHome Native API Restore Entities on startup

### DIFF
--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -13,6 +13,8 @@ from homeassistant.core import callback, Event
 from homeassistant.helpers.dispatcher import async_dispatcher_connect, \
     async_dispatcher_send
 from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.json import JSONEncoder
+from homeassistant.helpers.storage import Store
 from homeassistant.helpers.typing import HomeAssistantType, ConfigType
 
 # Import config flow so that it's added to the registry
@@ -30,6 +32,10 @@ DISPATCHER_REMOVE_ENTITY = 'esphome_{entry_id}_remove_{component_key}_{key}'
 DISPATCHER_ON_LIST = 'esphome_{entry_id}_on_list'
 DISPATCHER_ON_DEVICE_UPDATE = 'esphome_{entry_id}_on_device_update'
 DISPATCHER_ON_STATE = 'esphome_{entry_id}_on_state'
+
+STORAGE_KEY = 'esphome.{}'
+STORAGE_VERSION = 1
+
 # The HA component types this integration supports
 HA_COMPONENTS = ['sensor']
 
@@ -45,6 +51,7 @@ class RuntimeEntryData:
 
     entry_id = attr.ib(type=str)
     client = attr.ib(type='APIClient')
+    store = attr.ib(type=Store)
     reconnect_task = attr.ib(type=Optional[asyncio.Task], default=None)
     state = attr.ib(type=Dict[str, Dict[str, Any]], factory=dict)
     info = attr.ib(type=Dict[str, Dict[str, Any]], factory=dict)
@@ -83,6 +90,36 @@ class RuntimeEntryData:
         signal = DISPATCHER_ON_DEVICE_UPDATE.format(entry_id=self.entry_id)
         async_dispatcher_send(hass, signal)
 
+    async def async_load_from_store(self) -> List['EntityInfo']:
+        """Load the retained data from store and return de-serialized data."""
+        # pylint: disable= redefined-outer-name
+        from aioesphomeapi import COMPONENT_TYPE_TO_INFO, DeviceInfo
+
+        restored = await self.store.async_load()
+        if restored is None:
+            return []
+
+        device_info = DeviceInfo(**restored.pop('device_info'))
+        self.device_info = device_info
+        infos = []
+        for comp_type, restored_infos in restored.items():
+            if comp_type not in COMPONENT_TYPE_TO_INFO:
+                continue
+            for info in restored_infos:
+                infos.append(COMPONENT_TYPE_TO_INFO[comp_type](**info))
+        return infos
+
+    async def async_save_to_store(self) -> None:
+        """Generate dynamic data to store and save it to the filesystem."""
+        store_data = {
+            'device_info': attr.asdict(self.device_info)
+        }
+
+        for comp_type, infos in self.info.items():
+            store_data[comp_type] = [attr.asdict(info) for info in infos]
+
+        await self.store.async_save(store_data)
+
 
 async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
     """Stub to allow setting up this component.
@@ -108,9 +145,12 @@ async def async_setup_entry(hass: HomeAssistantType,
     await cli.start()
 
     # Store client in per-config-entry hass.data
+    store = Store(hass, STORAGE_VERSION, STORAGE_KEY.format(entry.entry_id),
+                  encoder=JSONEncoder)
     entry_data = hass.data[DOMAIN][entry.entry_id] = RuntimeEntryData(
         client=cli,
-        entry_id=entry.entry_id
+        entry_id=entry.entry_id,
+        store=store,
     )
 
     async def on_stop(event: Event) -> None:
@@ -138,6 +178,8 @@ async def async_setup_entry(hass: HomeAssistantType,
             entity_infos = await cli.list_entities()
             entry_data.async_update_static_infos(hass, entity_infos)
             await cli.subscribe_states(async_on_state)
+
+            hass.async_create_task(entry_data.async_save_to_store())
         except APIConnectionError as err:
             _LOGGER.warning("Error getting initial data: %s", err)
             # Re-connection logic will trigger after this
@@ -172,6 +214,9 @@ async def async_setup_entry(hass: HomeAssistantType,
             tasks.append(hass.config_entries.async_forward_entry_setup(
                 entry, component))
         await asyncio.wait(tasks)
+
+        infos = await entry_data.async_load_from_store()
+        entry_data.async_update_static_infos(hass, infos)
 
         # If first connect fails, the next re-connect will be scheduled
         # outside of _pending_task, in order not to delay HA startup


### PR DESCRIPTION
## Description:

This brings back a nice feature that existed in the MQTT discovery protocol: Entities are re-created even if the ESP is not reachable. So lovelace & co don't freak out when an entity is missing.

They will be shown as `unavailable` as long as they're not reachable.

This creates a separate Store for each config entry. I also have code that has a global store that's shared between all config entries, but that's not _as_ nice because it breaks the abstraction of "all config entries don't need to know about each other" (and the code is a bit less nice).

The store is only updated on successful login. So usually around once every few days (or hours, depending on WiFi signal). That shouldn't be an issue for the FS.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
