### PR TITLE
Add native ESPHome API device registry feature

### DIFF
--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -235,7 +235,7 @@ async def _async_setup_device_registry(hass: HomeAssistantType,
                                        entry: ConfigEntry,
                                        device_info: 'DeviceInfo'):
     """Set up device registry feature for a particular config entry."""
-    sw_version = 'ESPHome v' + device_info.esphome_core_version
+    sw_version = device_info.esphome_core_version
     if device_info.compilation_time:
         sw_version += ' ({})'.format(device_info.compilation_time)
     device_registry = await dr.async_get_registry(hass)

--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -134,6 +134,8 @@ async def async_setup_entry(hass: HomeAssistantType,
         try:
             entry_data.device_info = await cli.device_info()
             entry_data.available = True
+            await _async_setup_device_registry(hass, entry,
+                                               entry_data.device_info)
             entry_data.async_update_device_state(hass)
 
             entity_infos = await cli.list_entities()

--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -10,6 +10,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, \
     EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import callback, Event
+import homeassistant.helpers.device_registry as dr
 from homeassistant.helpers.dispatcher import async_dispatcher_connect, \
     async_dispatcher_send
 from homeassistant.helpers.entity import Entity
@@ -22,7 +23,7 @@ if TYPE_CHECKING:
     from aioesphomeapi import APIClient, EntityInfo, EntityState, DeviceInfo
 
 DOMAIN = 'esphome'
-REQUIREMENTS = ['aioesphomeapi==1.1.0']
+REQUIREMENTS = ['aioesphomeapi==1.2.0']
 
 
 DISPATCHER_UPDATE_ENTITY = 'esphome_{entry_id}_update_{component_key}_{key}'
@@ -228,6 +229,26 @@ async def _setup_auto_reconnect_logic(hass: HomeAssistantType,
     return try_connect
 
 
+async def _async_setup_device_registry(hass: HomeAssistantType,
+                                       entry: ConfigEntry,
+                                       device_info: 'DeviceInfo'):
+    """Set up device registry feature for a particular config entry."""
+    sw_version = 'ESPHome v' + device_info.esphome_core_version
+    if device_info.compilation_time:
+        sw_version += ' ({})'.format(device_info.compilation_time)
+    device_registry = await dr.async_get_registry(hass)
+    device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        connections={
+            (dr.CONNECTION_NETWORK_MAC, device_info.mac_address)
+        },
+        name=device_info.name,
+        manufacturer='espressif',
+        model=device_info.model,
+        sw_version=sw_version,
+    )
+
+
 async def _cleanup_instance(hass: HomeAssistantType,
                             entry: ConfigEntry) -> None:
     """Cleanup the esphome client if it exists."""
@@ -397,6 +418,14 @@ class EsphomeEntity(Entity):
         if not self._static_info.unique_id:
             return None
         return self._static_info.unique_id
+
+    @property
+    def device_info(self):
+        """Return device registry information for this entity."""
+        return {
+            'connections': {(dr.CONNECTION_NETWORK_MAC,
+                             self._device_info.mac_address)}
+        }
 
     @property
     def name(self) -> str:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -97,7 +97,7 @@ aioautomatic==0.6.5
 aiodns==1.1.1
 
 # homeassistant.components.esphome
-aioesphomeapi==1.1.0
+aioesphomeapi==1.2.0
 
 # homeassistant.components.device_tracker.freebox
 aiofreepybox==0.0.5


### PR DESCRIPTION
## Description:

The title says it all.

The 1.2.0 update is required for the `esphome_core_version` field (previously it was called `esphomelib_version`)

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
