### PR TITLE
Version bump pydaikin

### DIFF
--- a/homeassistant/components/climate/daikin.py
+++ b/homeassistant/components/climate/daikin.py
@@ -22,7 +22,6 @@ from homeassistant.const import (
     ATTR_TEMPERATURE, CONF_HOST, CONF_NAME, TEMP_CELSIUS)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['pydaikin==0.9']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/climate/daikin.py
+++ b/homeassistant/components/climate/daikin.py
@@ -22,7 +22,7 @@ from homeassistant.const import (
     ATTR_TEMPERATURE, CONF_HOST, CONF_NAME, TEMP_CELSIUS)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['pydaikin==0.8']
+REQUIREMENTS = ['pydaikin==0.9']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/daikin/__init__.py
+++ b/homeassistant/components/daikin/__init__.py
@@ -21,7 +21,7 @@ from homeassistant.util import Throttle
 from . import config_flow  # noqa  pylint_disable=unused-import
 from .const import KEY_HOST
 
-REQUIREMENTS = ['pydaikin==0.8']
+REQUIREMENTS = ['pydaikin==0.9']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -910,7 +910,6 @@ pycsspeechtts==1.0.2
 # pycups==1.9.73
 
 # homeassistant.components.daikin
-# homeassistant.components.climate.daikin
 pydaikin==0.9
 
 # homeassistant.components.deconz

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -911,7 +911,7 @@ pycsspeechtts==1.0.2
 
 # homeassistant.components.daikin
 # homeassistant.components.climate.daikin
-pydaikin==0.8
+pydaikin==0.9
 
 # homeassistant.components.deconz
 pydeconz==47


### PR DESCRIPTION
## Description:

Pydaikin have a new version. Fixes support for devices with **fan rate** but not **fan direction**.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
