### PR TITLE
Fix unique_id for Tellduslive sensors

### DIFF
--- a/homeassistant/components/sensor/tellduslive.py
+++ b/homeassistant/components/sensor/tellduslive.py
@@ -146,4 +146,4 @@ class TelldusLiveSensor(TelldusLiveEntity):
     @property
     def unique_id(self) -> str:
         """Return a unique ID."""
-        return "-".join(self._id[0:2])
+        return "-".join(map(str, self._id))


### PR DESCRIPTION
## Description:

Some sensors reports the same id, this fixes that.

**Related issue (if applicable):** fixes #19300

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
