### PR TITLE
Upgade colorlog to 4.0.2

### DIFF
--- a/homeassistant/scripts/check_config.py
+++ b/homeassistant/scripts/check_config.py
@@ -21,7 +21,7 @@ from homeassistant.config import (
 from homeassistant.util import yaml
 from homeassistant.exceptions import HomeAssistantError
 
-REQUIREMENTS = ('colorlog==3.1.4',)
+REQUIREMENTS = ('colorlog==4.0.2',)
 if system() == 'Windows':  # Ensure colorama installed for colorlog on Windows
     REQUIREMENTS += ('colorama<=1',)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -260,7 +260,7 @@ coinbase==2.1.0
 coinmarketcap==5.0.3
 
 # homeassistant.scripts.check_config
-colorlog==3.1.4
+colorlog==4.0.2
 
 # homeassistant.components.alarm_control_panel.concord232
 # homeassistant.components.binary_sensor.concord232


### PR DESCRIPTION
## Description:
Changelog: https://github.com/borntyping/python-colorlog/commits/master

## Example entry for `configuration.yaml` (if applicable):
```bash
$ hass --script check_config
INFO:homeassistant.util.package:Attempting install of colorlog==4.0.2
Testing configuration at /home/fab/.homeassistant
ERROR:homeassistant.util.yaml:mapping values are not allowed here
  in "/home/test/.homeassistant/configuration.yaml", line 117, column 13
Failed config
  General Errors: 
    - Error loading /home/test/.homeassistant/configuration.yaml: mapping values are not allowed here
  in "/home/test/.homeassistant/configuration.yaml", line 117, column 13

Successful config (partial)
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
