### PR TITLE
0.84.3

### DIFF
--- a/homeassistant/components/alarm_control_panel/manual.py
+++ b/homeassistant/components/alarm_control_panel/manual.py
@@ -310,7 +310,15 @@ class ManualAlarm(alarm.AlarmControlPanel, RestoreEntity):
 
     async def async_added_to_hass(self):
         """Run when entity about to be added to hass."""
+        await super().async_added_to_hass()
         state = await self.async_get_last_state()
         if state:
-            self._state = state.state
-            self._state_ts = state.last_updated
+            if state.state == STATE_ALARM_PENDING and \
+                    hasattr(state, 'attributes') and \
+                    state.attributes['pre_pending_state']:
+                # If in pending state, we return to the pre_pending_state
+                self._state = state.attributes['pre_pending_state']
+                self._state_ts = dt_util.utcnow()
+            else:
+                self._state = state.state
+                self._state_ts = state.last_updated

--- a/homeassistant/components/config/entity_registry.py
+++ b/homeassistant/components/config/entity_registry.py
@@ -104,7 +104,7 @@ async def websocket_update_entity(hass, connection, msg):
     if 'name' in msg:
         changes['name'] = msg['name']
 
-    if 'new_entity_id' in msg:
+    if 'new_entity_id' in msg and msg['new_entity_id'] != msg['entity_id']:
         changes['new_entity_id'] = msg['new_entity_id']
         if hass.states.get(msg['new_entity_id']) is not None:
             connection.send_message(websocket_api.error_message(

--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -24,7 +24,7 @@ from homeassistant.core import callback
 from homeassistant.helpers.translation import async_get_translations
 from homeassistant.loader import bind_hass
 
-REQUIREMENTS = ['home-assistant-frontend==20181211.0']
+REQUIREMENTS = ['home-assistant-frontend==20181211.1']
 
 DOMAIN = 'frontend'
 DEPENDENCIES = ['api', 'websocket_api', 'http', 'system_log',

--- a/homeassistant/components/lock/zwave.py
+++ b/homeassistant/components/lock/zwave.py
@@ -29,8 +29,9 @@ SERVICE_CLEAR_USERCODE = 'clear_usercode'
 POLYCONTROL = 0x10E
 DANALOCK_V2_BTZE = 0x2
 POLYCONTROL_DANALOCK_V2_BTZE_LOCK = (POLYCONTROL, DANALOCK_V2_BTZE)
-WORKAROUND_V2BTZE = 'v2btze'
-WORKAROUND_DEVICE_STATE = 'state'
+WORKAROUND_V2BTZE = 1
+WORKAROUND_DEVICE_STATE = 2
+WORKAROUND_TRACK_MESSAGE = 4
 
 DEVICE_MAPPINGS = {
     POLYCONTROL_DANALOCK_V2_BTZE_LOCK: WORKAROUND_V2BTZE,
@@ -43,7 +44,7 @@ DEVICE_MAPPINGS = {
     # Yale YRD220 (as reported by adrum in PR #17386)
     (0x0109, 0x0000): WORKAROUND_DEVICE_STATE,
     # Schlage BE469
-    (0x003B, 0x5044): WORKAROUND_DEVICE_STATE,
+    (0x003B, 0x5044): WORKAROUND_DEVICE_STATE | WORKAROUND_TRACK_MESSAGE,
     # Schlage FE599NX
     (0x003B, 0x504C): WORKAROUND_DEVICE_STATE,
 }
@@ -51,13 +52,15 @@ DEVICE_MAPPINGS = {
 LOCK_NOTIFICATION = {
     '1': 'Manual Lock',
     '2': 'Manual Unlock',
-    '3': 'RF Lock',
-    '4': 'RF Unlock',
     '5': 'Keypad Lock',
     '6': 'Keypad Unlock',
     '11': 'Lock Jammed',
     '254': 'Unknown Event'
 }
+NOTIFICATION_RF_LOCK = '3'
+NOTIFICATION_RF_UNLOCK = '4'
+LOCK_NOTIFICATION[NOTIFICATION_RF_LOCK] = 'RF Lock'
+LOCK_NOTIFICATION[NOTIFICATION_RF_UNLOCK] = 'RF Unlock'
 
 LOCK_ALARM_TYPE = {
     '9': 'Deadbolt Jammed',
@@ -66,8 +69,6 @@ LOCK_ALARM_TYPE = {
     '19': 'Unlocked with Keypad by user ',
     '21': 'Manually Locked ',
     '22': 'Manually Unlocked ',
-    '24': 'Locked by RF',
-    '25': 'Unlocked by RF',
     '27': 'Auto re-lock',
     '33': 'User deleted: ',
     '112': 'Master code changed or User added: ',
@@ -79,6 +80,10 @@ LOCK_ALARM_TYPE = {
     '168': 'Critical Battery Level',
     '169': 'Battery too low to operate'
 }
+ALARM_RF_LOCK = '24'
+ALARM_RF_UNLOCK = '25'
+LOCK_ALARM_TYPE[ALARM_RF_LOCK] = 'Locked by RF'
+LOCK_ALARM_TYPE[ALARM_RF_UNLOCK] = 'Unlocked by RF'
 
 MANUAL_LOCK_ALARM_LEVEL = {
     '1': 'by Key Cylinder or Inside thumb turn',
@@ -229,6 +234,8 @@ class ZwaveLock(zwave.ZWaveDeviceEntity, LockDevice):
         self._lock_status = None
         self._v2btze = None
         self._state_workaround = False
+        self._track_message_workaround = False
+        self._previous_message = None
 
         # Enable appropriate workaround flags for our device
         # Make sure that we have values for the key before converting to int
@@ -237,26 +244,30 @@ class ZwaveLock(zwave.ZWaveDeviceEntity, LockDevice):
             specific_sensor_key = (int(self.node.manufacturer_id, 16),
                                    int(self.node.product_id, 16))
             if specific_sensor_key in DEVICE_MAPPINGS:
-                if DEVICE_MAPPINGS[specific_sensor_key] == WORKAROUND_V2BTZE:
+                workaround = DEVICE_MAPPINGS[specific_sensor_key]
+                if workaround & WORKAROUND_V2BTZE:
                     self._v2btze = 1
                     _LOGGER.debug("Polycontrol Danalock v2 BTZE "
                                   "workaround enabled")
-                if DEVICE_MAPPINGS[specific_sensor_key] == \
-                        WORKAROUND_DEVICE_STATE:
+                if workaround & WORKAROUND_DEVICE_STATE:
                     self._state_workaround = True
                     _LOGGER.debug(
                         "Notification device state workaround enabled")
+                if workaround & WORKAROUND_TRACK_MESSAGE:
+                    self._track_message_workaround = True
+                    _LOGGER.debug("Message tracking workaround enabled")
         self.update_properties()
 
     def update_properties(self):
         """Handle data changes for node values."""
         self._state = self.values.primary.data
-        _LOGGER.debug("Lock state set from Bool value and is %s", self._state)
+        _LOGGER.debug("lock state set to %s", self._state)
         if self.values.access_control:
             notification_data = self.values.access_control.data
             self._notification = LOCK_NOTIFICATION.get(str(notification_data))
             if self._state_workaround:
                 self._state = LOCK_STATUS.get(str(notification_data))
+                _LOGGER.debug("workaround: lock state set to %s", self._state)
             if self._v2btze:
                 if self.values.v2btze_advanced and \
                         self.values.v2btze_advanced.data == CONFIG_ADVANCED:
@@ -265,16 +276,37 @@ class ZwaveLock(zwave.ZWaveDeviceEntity, LockDevice):
                         "Lock state set from Access Control value and is %s, "
                         "get=%s", str(notification_data), self.state)
 
+        if self._track_message_workaround:
+            this_message = self.node.stats['lastReceivedMessage'][5]
+
+            if this_message == zwave.const.COMMAND_CLASS_DOOR_LOCK:
+                self._state = self.values.primary.data
+                _LOGGER.debug("set state to %s based on message tracking",
+                              self._state)
+                if self._previous_message == \
+                        zwave.const.COMMAND_CLASS_DOOR_LOCK:
+                    if self._state:
+                        self._notification = \
+                            LOCK_NOTIFICATION[NOTIFICATION_RF_LOCK]
+                        self._lock_status = \
+                            LOCK_ALARM_TYPE[ALARM_RF_LOCK]
+                    else:
+                        self._notification = \
+                            LOCK_NOTIFICATION[NOTIFICATION_RF_UNLOCK]
+                        self._lock_status = \
+                            LOCK_ALARM_TYPE[ALARM_RF_UNLOCK]
+                    return
+
+            self._previous_message = this_message
+
         if not self.values.alarm_type:
             return
 
         alarm_type = self.values.alarm_type.data
-        _LOGGER.debug("Lock alarm_type is %s", str(alarm_type))
         if self.values.alarm_level:
             alarm_level = self.values.alarm_level.data
         else:
             alarm_level = None
-        _LOGGER.debug("Lock alarm_level is %s", str(alarm_level))
 
         if not alarm_type:
             return

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -2,7 +2,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 84
-PATCH_VERSION = '2'
+PATCH_VERSION = '3'
 __short_version__ = '{}.{}'.format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = '{}.{}'.format(__short_version__, PATCH_VERSION)
 REQUIRED_PYTHON_VER = (3, 5, 3)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -493,7 +493,7 @@ hole==0.3.0
 holidays==0.9.8
 
 # homeassistant.components.frontend
-home-assistant-frontend==20181211.0
+home-assistant-frontend==20181211.1
 
 # homeassistant.components.zwave
 homeassistant-pyozw==0.1.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -101,7 +101,7 @@ hdate==0.7.5
 holidays==0.9.8
 
 # homeassistant.components.frontend
-home-assistant-frontend==20181211.0
+home-assistant-frontend==20181211.1
 
 # homeassistant.components.homematicip_cloud
 homematicip==0.9.8


### PR DESCRIPTION
- Set lock status correctly for Schlage BE469 Z-Wave locks ([@ahayworth] - [#18737]) ([lock.zwave docs])
- Fix restore state for manual alarm control panel ([@liaanvdm] - [#19284]) ([alarm_control_panel.manual docs])
- Fix not being able to update entities ([@glentakahashi] - [#19344]) ([config docs])

Frontend: 

- Fix setting aspect ratio in percentage ([#2289](https://github.com/home-assistant/home-assistant-polymer/pull/2289)) [@balloob]
- Fix opening edit dialog twice when closed by clicking on overlay ([#2290](https://github.com/home-assistant/home-assistant-polymer/pull/2290)) [@balloob]
- Fix translations not loading on first load ([#2293](https://github.com/home-assistant/home-assistant-polymer/pull/2293)) [@balloob]
- remove Animation for thermostat and light ([#2303](https://github.com/home-assistant/home-assistant-polymer/pull/2303)) [@zsarnett]
- Fix for picture element positioning ([#2335](https://github.com/home-assistant/home-assistant-polymer/pull/2335)) [@iantrich]
- Fix undefined on plant/weather card ([#2339](https://github.com/home-assistant/home-assistant-polymer/pull/2339)) [@balloob]
- Fix service button element ([#2343](https://github.com/home-assistant/home-assistant-polymer/pull/2343)) [@balloob]


[#18737]: https://github.com/home-assistant/home-assistant/pull/18737
[#19284]: https://github.com/home-assistant/home-assistant/pull/19284
[#19344]: https://github.com/home-assistant/home-assistant/pull/19344
[@balloob]: https://github.com/balloob
[@ahayworth]: https://github.com/ahayworth
[@glentakahashi]: https://github.com/glentakahashi
[@zsarnett]: https://github.com/zsarnett
[@iantrich]: https://github.com/iantrich
[@liaanvdm]: https://github.com/liaanvdm
[alarm_control_panel.manual docs]: https://www.home-assistant.io/components/alarm_control_panel.manual/
[config docs]: https://www.home-assistant.io/components/config/
[lock.zwave docs]: https://www.home-assistant.io/components/lock.zwave/