### PR TITLE
Upgrade RPi.GPIO to 0.6.5

### DIFF
--- a/homeassistant/components/rpi_gpio.py
+++ b/homeassistant/components/rpi_gpio.py
@@ -9,7 +9,7 @@ import logging
 from homeassistant.const import (
     EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP)
 
-REQUIREMENTS = ['RPi.GPIO==0.6.1']
+REQUIREMENTS = ['RPi.GPIO==0.6.5']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -64,7 +64,7 @@ PyTransportNSW==0.1.1
 PyXiaomiGateway==0.11.1
 
 # homeassistant.components.rpi_gpio
-# RPi.GPIO==0.6.1
+# RPi.GPIO==0.6.5
 
 # homeassistant.components.remember_the_milk
 RtmAPI==0.7.0


### PR DESCRIPTION
## Description:
Changelog: https://pypi.org/project/RPi.GPIO/

It's unlikely that #19317 will be fixed but worth a try.

The upgrade seems to work on a Raspberry Pi 3 Model B but I'm not an expert on GPIO on a Raspberry Pi.

## Example entry for `configuration.yaml` (if applicable):
```yaml
switch:
  - platform: rpi_gpio
    ports:
      11: Test
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
