### PR TITLE
Add HomematicIP Cloud SMI55 device

### DIFF
--- a/homeassistant/components/binary_sensor/homematicip_cloud.py
+++ b/homeassistant/components/binary_sensor/homematicip_cloud.py
@@ -28,14 +28,16 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the HomematicIP Cloud binary sensor from a config entry."""
     from homematicip.aio.device import (
         AsyncShutterContact, AsyncMotionDetectorIndoor, AsyncSmokeDetector,
-        AsyncWaterSensor, AsyncRotaryHandleSensor)
+        AsyncWaterSensor, AsyncRotaryHandleSensor,
+        AsyncMotionDetectorPushButton)
 
     home = hass.data[HMIPC_DOMAIN][config_entry.data[HMIPC_HAPID]].home
     devices = []
     for device in home.devices:
         if isinstance(device, (AsyncShutterContact, AsyncRotaryHandleSensor)):
             devices.append(HomematicipShutterContact(home, device))
-        elif isinstance(device, AsyncMotionDetectorIndoor):
+        elif isinstance(device, (AsyncMotionDetectorIndoor,
+                                 AsyncMotionDetectorPushButton)):
             devices.append(HomematicipMotionDetector(home, device))
         elif isinstance(device, AsyncSmokeDetector):
             devices.append(HomematicipSmokeDetector(home, device))

--- a/homeassistant/components/sensor/homematicip_cloud.py
+++ b/homeassistant/components/sensor/homematicip_cloud.py
@@ -35,7 +35,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     from homematicip.aio.device import (
         AsyncHeatingThermostat, AsyncTemperatureHumiditySensorWithoutDisplay,
         AsyncTemperatureHumiditySensorDisplay, AsyncMotionDetectorIndoor,
-        AsyncTemperatureHumiditySensorOutdoor)
+        AsyncTemperatureHumiditySensorOutdoor,
+        AsyncMotionDetectorPushButton)
 
     home = hass.data[HMIPC_DOMAIN][config_entry.data[HMIPC_HAPID]].home
     devices = [HomematicipAccesspointStatus(home)]
@@ -47,7 +48,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                                AsyncTemperatureHumiditySensorOutdoor)):
             devices.append(HomematicipTemperatureSensor(home, device))
             devices.append(HomematicipHumiditySensor(home, device))
-        if isinstance(device, AsyncMotionDetectorIndoor):
+        if isinstance(device, (AsyncMotionDetectorIndoor,
+                               AsyncMotionDetectorPushButton)):
             devices.append(HomematicipIlluminanceSensor(home, device))
 
     if devices:


### PR DESCRIPTION
## Description:
Add support for the motion and illuminance sensor of the SMI55 device.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
