### PR TITLE
Add native ESPHome API service call feature

### DIFF
--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -1,5 +1,6 @@
 """Support for esphome devices."""
 import asyncio
+import copy
 import logging
 from typing import Any, Dict, List, Optional, TYPE_CHECKING, Callable
 
@@ -11,6 +12,8 @@ from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, \
     EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import callback, Event
 import homeassistant.helpers.device_registry as dr
+from homeassistant.exceptions import TemplateError
+from homeassistant.helpers import template
 from homeassistant.helpers.dispatcher import async_dispatcher_connect, \
     async_dispatcher_send
 from homeassistant.helpers.entity import Entity
@@ -22,7 +25,8 @@ from homeassistant.helpers.typing import HomeAssistantType, ConfigType
 from .config_flow import EsphomeFlowHandler  # noqa
 
 if TYPE_CHECKING:
-    from aioesphomeapi import APIClient, EntityInfo, EntityState, DeviceInfo
+    from aioesphomeapi import APIClient, EntityInfo, EntityState, DeviceInfo, \
+        ServiceCall
 
 DOMAIN = 'esphome'
 REQUIREMENTS = ['aioesphomeapi==1.2.0']
@@ -182,6 +186,25 @@ async def async_setup_entry(hass: HomeAssistantType,
         """Send dispatcher updates when a new state is received."""
         entry_data.async_update_state(hass, state)
 
+    @callback
+    def async_on_service_call(service: 'ServiceCall') -> None:
+        """Call service when user automation in ESPHome config is triggered."""
+        domain, service_name = service.service.split('.', 1)
+        service_data = service.data
+
+        if service.data_template:
+            try:
+                data_template = copy.deepcopy(service.data_template)
+                template.attach(hass, data_template)
+                service_data.update(template.render_complex(
+                    data_template, service.variables))
+            except TemplateError as ex:
+                _LOGGER.error('Error rendering data template: %s', ex)
+                return
+
+        hass.async_create_task(hass.services.async_call(
+            domain, service_name, service_data, blocking=True))
+
     async def on_login() -> None:
         """Subscribe to states and list entities on successful API login."""
         try:
@@ -194,6 +217,7 @@ async def async_setup_entry(hass: HomeAssistantType,
             entity_infos = await cli.list_entities()
             entry_data.async_update_static_infos(hass, entity_infos)
             await cli.subscribe_states(async_on_state)
+            await cli.subscribe_service_calls(async_on_service_call)
 
             hass.async_create_task(entry_data.async_save_to_store())
         except APIConnectionError as err:

--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -1,6 +1,5 @@
 """Support for esphome devices."""
 import asyncio
-import copy
 import logging
 from typing import Any, Dict, List, Optional, TYPE_CHECKING, Callable
 
@@ -17,6 +16,7 @@ from homeassistant.helpers import template
 from homeassistant.helpers.dispatcher import async_dispatcher_connect, \
     async_dispatcher_send
 from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.template import Template
 from homeassistant.helpers.json import JSONEncoder
 from homeassistant.helpers.storage import Store
 from homeassistant.helpers.typing import HomeAssistantType, ConfigType
@@ -194,7 +194,8 @@ async def async_setup_entry(hass: HomeAssistantType,
 
         if service.data_template:
             try:
-                data_template = copy.deepcopy(service.data_template)
+                data_template = {key: Template(value) for key, value in
+                                 service.data_template.items()}
                 template.attach(hass, data_template)
                 service_data.update(template.render_complex(
                     data_template, service.variables))


### PR DESCRIPTION
## Description:

One of the features that ESPHome will finally be able to solve with the native API is the problem of inter-device automations. Up until now, if the user wanted an automation that interacts with anything else the user would have to use HA automations for this.

With this change, users can add something like this to their ESPHome automations:

```yaml
binary_sensor:
- platform: gpio
  pin: D1
  on_press:
  # On-device automation
  - switch.turn_on: my_switch
  - delay: 1s
  # HA service call
  - homeassistant.service:
      service: notify.html5
      data:
        title: Button was pressed
      data_template:
        message: The humidity is {{ my_variable }}%.
      variables:
        my_variable: 'return id(my_sensor).state;'
```

TODO:

 - This calls services directly using `hass.services.async_call`. I've seen the `Context` class used in several places in the HA codebase. Should this integration also use `Context`s? If so, how should that be done? CC @balloob 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
