### PR TITLE
Add discoverability and deviceinfo to mqtt-vacuum

### DIFF
--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -25,7 +25,7 @@ TOPIC_MATCHER = re.compile(
 SUPPORTED_COMPONENTS = [
     'binary_sensor', 'camera', 'cover', 'fan',
     'light', 'sensor', 'switch', 'lock', 'climate',
-    'alarm_control_panel']
+    'alarm_control_panel', 'vacuum']
 
 CONFIG_ENTRY_COMPONENTS = [
     'binary_sensor',
@@ -38,6 +38,7 @@ CONFIG_ENTRY_COMPONENTS = [
     'climate',
     'alarm_control_panel',
     'fan',
+    'vacuum'
 ]
 
 DEPRECATED_PLATFORM_TO_SCHEMA = {
@@ -67,12 +68,25 @@ ABBREVIATIONS = {
     'bri_scl': 'brightness_scale',
     'bri_stat_t': 'brightness_state_topic',
     'bri_val_tpl': 'brightness_value_template',
+    'bat_lev_t': 'battery_level_topic',
+    'bat_lev_tpl': 'battery_level_template',
+    'chrg_t': 'charging_topic',
+    'chrg_tpl': 'chargin_template',
     'clr_temp_cmd_t': 'color_temp_command_topic',
     'clr_temp_stat_t': 'color_temp_state_topic',
     'clr_temp_val_tpl': 'color_temp_value_template',
+    'cln_t': 'cleaning_topic',
+    'cln_tpl': 'cleaning_template',
     'cmd_t': 'command_topic',
     'curr_temp_t': 'current_temperature_topic',
     'dev_cla': 'device_class',
+    'dock_t': 'docked_topic',
+    'dock_tpl': 'docked_template',
+    'err_t': 'error_topic',
+    'err_tpl': 'error_template',
+    'fanspd_t': 'fan_speed_topic',
+    'fanspd_tpl': 'fan_speed_template',
+    'fanspd_lst': 'fan_speed_list',
     'fx_cmd_t': 'effect_command_topic',
     'fx_list': 'effect_list',
     'fx_stat_t': 'effect_state_topic',
@@ -122,6 +136,7 @@ ABBREVIATIONS = {
     'rgb_cmd_t': 'rgb_command_topic',
     'rgb_stat_t': 'rgb_state_topic',
     'rgb_val_tpl': 'rgb_value_template',
+    'send_cmd_t': 'send_command_topic',
     'send_if_off': 'send_if_off',
     'set_pos_tpl': 'set_position_template',
     'set_pos_t': 'set_position_topic',
@@ -135,6 +150,7 @@ ABBREVIATIONS = {
     'stat_open': 'state_open',
     'stat_t': 'state_topic',
     'stat_val_tpl': 'state_value_template',
+    'sup_feat': 'supported_features',
     'swing_mode_cmd_t': 'swing_mode_command_topic',
     'swing_mode_stat_tpl': 'swing_mode_state_template',
     'swing_mode_stat_t': 'swing_mode_state_topic',

--- a/homeassistant/components/vacuum/__init__.py
+++ b/homeassistant/components/vacuum/__init__.py
@@ -49,7 +49,7 @@ SERVICE_PAUSE = 'pause'
 SERVICE_STOP = 'stop'
 
 VACUUM_SERVICE_SCHEMA = vol.Schema({
-    vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
+    vol.Optional(ATTR_ENTITY_ID): cv.comp_entity_ids,
 })
 
 VACUUM_SET_FAN_SPEED_SERVICE_SCHEMA = VACUUM_SERVICE_SCHEMA.extend({

--- a/homeassistant/components/vacuum/__init__.py
+++ b/homeassistant/components/vacuum/__init__.py
@@ -49,7 +49,7 @@ SERVICE_PAUSE = 'pause'
 SERVICE_STOP = 'stop'
 
 VACUUM_SERVICE_SCHEMA = vol.Schema({
-    vol.Optional(ATTR_ENTITY_ID): cv.comp_entity_ids,
+    vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
 })
 
 VACUUM_SET_FAN_SPEED_SERVICE_SCHEMA = VACUUM_SERVICE_SCHEMA.extend({
@@ -95,7 +95,7 @@ def is_on(hass, entity_id=None):
 
 async def async_setup(hass, config):
     """Set up the vacuum component."""
-    component = EntityComponent(
+    component = hass.data[DOMAIN] = EntityComponent(
         _LOGGER, DOMAIN, hass, SCAN_INTERVAL, GROUP_NAME_ALL_VACUUMS)
 
     await component.async_setup(config)
@@ -150,6 +150,16 @@ async def async_setup(hass, config):
     )
 
     return True
+
+
+async def async_setup_entry(hass, entry):
+    """Set up a config entry."""
+    return await hass.data[DOMAIN].async_setup_entry(entry)
+
+
+async def async_unload_entry(hass, entry):
+    """Unload a config entry."""
+    return await hass.data[DOMAIN].async_unload_entry(entry)
 
 
 class _BaseVacuum(Entity):

--- a/homeassistant/components/vacuum/mqtt.py
+++ b/homeassistant/components/vacuum/mqtt.py
@@ -234,8 +234,7 @@ class MqttVacuum(MqttAvailability, MqttDiscoveryUpdate, MqttEntityDeviceInfo, Va
                 CONF_PAYLOAD_STOP,
                 CONF_PAYLOAD_CLEAN_SPOT,
                 CONF_PAYLOAD_LOCATE,
-                CONF_PAYLOAD_START_PAUSE,
-                CONF_PAYLOAD_PAUSE
+                CONF_PAYLOAD_START_PAUSE
             )
         }
         self._topics = {

--- a/homeassistant/components/vacuum/mqtt.py
+++ b/homeassistant/components/vacuum/mqtt.py
@@ -13,8 +13,8 @@ from homeassistant.components.mqtt import (
     ATTR_DISCOVERY_HASH, MqttAvailability, MqttDiscoveryUpdate,
     MqttEntityDeviceInfo, subscription)
 from homeassistant.components.mqtt.discovery import MQTT_DISCOVERY_NEW
-from homeassistant.components.vacuum import (	
-    SUPPORT_BATTERY, SUPPORT_CLEAN_SPOT, SUPPORT_FAN_SPEED,    
+from homeassistant.components.vacuum import (
+    SUPPORT_BATTERY, SUPPORT_CLEAN_SPOT, SUPPORT_FAN_SPEED,
     SUPPORT_LOCATE, SUPPORT_PAUSE, SUPPORT_RETURN_HOME, SUPPORT_SEND_COMMAND,
     SUPPORT_STATUS, SUPPORT_STOP, SUPPORT_TURN_OFF, SUPPORT_TURN_ON,
     VacuumDevice, DOMAIN)
@@ -158,7 +158,7 @@ async def async_setup_platform(hass, config, async_add_entities,
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
-    """Set up MQTT vacuum dynamically through MQTT discovery."""    
+    """Set up MQTT vacuum dynamically through MQTT discovery."""
     async def async_discover(discovery_payload):
         """Discover and add a MQTT vacuum."""
         config = PLATFORM_SCHEMA(discovery_payload)
@@ -168,7 +168,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     async_dispatcher_connect(
         hass, MQTT_DISCOVERY_NEW.format(DOMAIN, 'mqtt'), async_discover)
 
-    
+
 async def _async_setup_entity(config, async_add_entities,
                               discovery_hash=None):
     """Set up the MQTT vacuum."""
@@ -335,12 +335,13 @@ class MqttVacuum(MqttAvailability, MqttDiscoveryUpdate, MqttEntityDeviceInfo,
 
         topics_list = set([topic for topic in self._topics.values() if topic])
         self._sub_state = await subscription.async_subscribe_topics(
-            self.hass, self._sub_state,
-            { "topic{}".format(i): {
+            self.hass, self._sub_state, {
+              "topic{}".format(i): {
                 "topic": topic,
                 "msg_callback": message_received,
                 "qos": self._qos
-              } for i, topic in enumerate(topics_list) }
+              } for i, topic in enumerate(topics_list)
+            }
         )
         for topic in set(topics_list):
             await self.hass.components.mqtt.async_subscribe(

--- a/homeassistant/components/vacuum/mqtt.py
+++ b/homeassistant/components/vacuum/mqtt.py
@@ -9,15 +9,20 @@ import logging
 import voluptuous as vol
 
 from homeassistant.components import mqtt
-from homeassistant.components.mqtt import MqttAvailability
-from homeassistant.components.vacuum import (
-    SUPPORT_BATTERY, SUPPORT_CLEAN_SPOT, SUPPORT_FAN_SPEED,
+from homeassistant.components.mqtt import (
+    ATTR_DISCOVERY_HASH, MqttAvailability, MqttDiscoveryUpdate, 
+    MqttEntityDeviceInfo, subscription)
+from homeassistant.components.mqtt.discovery import MQTT_DISCOVERY_NEW
+from homeassistant.components.vacuum import (	
+    SUPPORT_BATTERY, SUPPORT_CLEAN_SPOT, SUPPORT_FAN_SPEED,    
     SUPPORT_LOCATE, SUPPORT_PAUSE, SUPPORT_RETURN_HOME, SUPPORT_SEND_COMMAND,
     SUPPORT_STATUS, SUPPORT_STOP, SUPPORT_TURN_OFF, SUPPORT_TURN_ON,
-    VacuumDevice)
-from homeassistant.const import ATTR_SUPPORTED_FEATURES, CONF_NAME
+    VacuumDevice, DOMAIN)
+from homeassistant.const import (
+    ATTR_SUPPORTED_FEATURES, CONF_NAME, CONF_DEVICE)
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.icon import icon_for_battery_level
 
 _LOGGER = logging.getLogger(__name__)
@@ -89,6 +94,7 @@ CONF_FAN_SPEED_TEMPLATE = 'fan_speed_template'
 CONF_SET_FAN_SPEED_TOPIC = 'set_fan_speed_topic'
 CONF_FAN_SPEED_LIST = 'fan_speed_list'
 CONF_SEND_COMMAND_TOPIC = 'send_command_topic'
+CONF_UNIQUE_ID = 'unique_id'
 
 DEFAULT_NAME = 'MQTT Vacuum'
 DEFAULT_RETAIN = False
@@ -139,137 +145,41 @@ PLATFORM_SCHEMA = mqtt.MQTT_BASE_PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_FAN_SPEED_LIST, default=[]):
         vol.All(cv.ensure_list, [cv.string]),
     vol.Optional(CONF_SEND_COMMAND_TOPIC): mqtt.valid_publish_topic,
+    vol.Optional(CONF_UNIQUE_ID): cv.string,
+    vol.Optional(CONF_DEVICE): mqtt.MQTT_ENTITY_DEVICE_INFO_SCHEMA
 }).extend(mqtt.MQTT_AVAILABILITY_SCHEMA.schema)
 
 
 async def async_setup_platform(hass, config, async_add_entities,
                                discovery_info=None):
-    """Set up the vacuum."""
-    name = config.get(CONF_NAME)
-    supported_feature_strings = config.get(CONF_SUPPORTED_FEATURES)
-    supported_features = strings_to_services(supported_feature_strings)
-
-    qos = config.get(mqtt.CONF_QOS)
-    retain = config.get(mqtt.CONF_RETAIN)
-
-    command_topic = config.get(mqtt.CONF_COMMAND_TOPIC)
-    payload_turn_on = config.get(CONF_PAYLOAD_TURN_ON)
-    payload_turn_off = config.get(CONF_PAYLOAD_TURN_OFF)
-    payload_return_to_base = config.get(CONF_PAYLOAD_RETURN_TO_BASE)
-    payload_stop = config.get(CONF_PAYLOAD_STOP)
-    payload_clean_spot = config.get(CONF_PAYLOAD_CLEAN_SPOT)
-    payload_locate = config.get(CONF_PAYLOAD_LOCATE)
-    payload_start_pause = config.get(CONF_PAYLOAD_START_PAUSE)
-
-    battery_level_topic = config.get(CONF_BATTERY_LEVEL_TOPIC)
-    battery_level_template = config.get(CONF_BATTERY_LEVEL_TEMPLATE)
-    if battery_level_template:
-        battery_level_template.hass = hass
-
-    charging_topic = config.get(CONF_CHARGING_TOPIC)
-    charging_template = config.get(CONF_CHARGING_TEMPLATE)
-    if charging_template:
-        charging_template.hass = hass
-
-    cleaning_topic = config.get(CONF_CLEANING_TOPIC)
-    cleaning_template = config.get(CONF_CLEANING_TEMPLATE)
-    if cleaning_template:
-        cleaning_template.hass = hass
-
-    docked_topic = config.get(CONF_DOCKED_TOPIC)
-    docked_template = config.get(CONF_DOCKED_TEMPLATE)
-    if docked_template:
-        docked_template.hass = hass
-
-    error_topic = config.get(CONF_ERROR_TOPIC)
-    error_template = config.get(CONF_ERROR_TEMPLATE)
-    if error_template:
-        error_template.hass = hass
-
-    fan_speed_topic = config.get(CONF_FAN_SPEED_TOPIC)
-    fan_speed_template = config.get(CONF_FAN_SPEED_TEMPLATE)
-    if fan_speed_template:
-        fan_speed_template.hass = hass
-
-    set_fan_speed_topic = config.get(CONF_SET_FAN_SPEED_TOPIC)
-    fan_speed_list = config.get(CONF_FAN_SPEED_LIST)
-
-    send_command_topic = config.get(CONF_SEND_COMMAND_TOPIC)
-
-    availability_topic = config.get(mqtt.CONF_AVAILABILITY_TOPIC)
-    payload_available = config.get(mqtt.CONF_PAYLOAD_AVAILABLE)
-    payload_not_available = config.get(mqtt.CONF_PAYLOAD_NOT_AVAILABLE)
-
-    async_add_entities([
-        MqttVacuum(
-            name, supported_features, qos, retain, command_topic,
-            payload_turn_on, payload_turn_off, payload_return_to_base,
-            payload_stop, payload_clean_spot, payload_locate,
-            payload_start_pause, battery_level_topic, battery_level_template,
-            charging_topic, charging_template, cleaning_topic,
-            cleaning_template, docked_topic, docked_template,
-            error_topic, error_template, fan_speed_topic,
-            fan_speed_template, set_fan_speed_topic, fan_speed_list,
-            send_command_topic, availability_topic, payload_available,
-            payload_not_available
-        ),
-    ])
+    """Set up MQTT vacuum through configuration.yaml."""
+    await _async_setup_entity(config, async_add_entities,
+                              discovery_info)
 
 
-class MqttVacuum(MqttAvailability, VacuumDevice):
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up MQTT vacuum dynamically through MQTT discovery."""    
+    async def async_discover(discovery_payload):
+        """Discover and add a MQTT vacuum."""
+        config = PLATFORM_SCHEMA(discovery_payload)
+        await _async_setup_entity(config, async_add_entities,
+                                  discovery_payload[ATTR_DISCOVERY_HASH])
+
+    async_dispatcher_connect(
+        hass, MQTT_DISCOVERY_NEW.format(DOMAIN, 'mqtt'), async_discover)
+
+    
+async def _async_setup_entity(config, async_add_entities,
+                              discovery_hash=None):
+    """Set up the MQTT vacuum."""
+    async_add_entities([MqttVacuum(config, discovery_hash)])
+
+
+class MqttVacuum(MqttAvailability, MqttDiscoveryUpdate, MqttEntityDeviceInfo, VacuumDevice):
     """Representation of a MQTT-controlled vacuum."""
 
-    def __init__(
-            self, name, supported_features, qos, retain, command_topic,
-            payload_turn_on, payload_turn_off, payload_return_to_base,
-            payload_stop, payload_clean_spot, payload_locate,
-            payload_start_pause, battery_level_topic, battery_level_template,
-            charging_topic, charging_template, cleaning_topic,
-            cleaning_template, docked_topic, docked_template,
-            error_topic, error_template, fan_speed_topic,
-            fan_speed_template, set_fan_speed_topic, fan_speed_list,
-            send_command_topic, availability_topic, payload_available,
-            payload_not_available):
+    def __init__(self, config, discovery_hash):
         """Initialize the vacuum."""
-        super().__init__(availability_topic, qos, payload_available,
-                         payload_not_available)
-
-        self._name = name
-        self._supported_features = supported_features
-        self._qos = qos
-        self._retain = retain
-
-        self._command_topic = command_topic
-        self._payload_turn_on = payload_turn_on
-        self._payload_turn_off = payload_turn_off
-        self._payload_return_to_base = payload_return_to_base
-        self._payload_stop = payload_stop
-        self._payload_clean_spot = payload_clean_spot
-        self._payload_locate = payload_locate
-        self._payload_start_pause = payload_start_pause
-
-        self._battery_level_topic = battery_level_topic
-        self._battery_level_template = battery_level_template
-
-        self._charging_topic = charging_topic
-        self._charging_template = charging_template
-
-        self._cleaning_topic = cleaning_topic
-        self._cleaning_template = cleaning_template
-
-        self._docked_topic = docked_topic
-        self._docked_template = docked_template
-
-        self._error_topic = error_topic
-        self._error_template = error_template
-
-        self._fan_speed_topic = fan_speed_topic
-        self._fan_speed_template = fan_speed_template
-
-        self._set_fan_speed_topic = set_fan_speed_topic
-        self._fan_speed_list = fan_speed_list
-        self._send_command_topic = send_command_topic
-
         self._cleaning = False
         self._charging = False
         self._docked = False
@@ -277,45 +187,125 @@ class MqttVacuum(MqttAvailability, VacuumDevice):
         self._status = 'Unknown'
         self._battery_level = 0
         self._fan_speed = 'unknown'
+        self._unique_id = config.get(CONF_UNIQUE_ID)
+        self._sub_state = None
+
+        # Load config
+        self._setup_from_config(config)
+
+        qos = config.get(mqtt.CONF_QOS)
+        availability_topic = config.get(mqtt.CONF_AVAILABILITY_TOPIC)
+        payload_available = config.get(mqtt.CONF_PAYLOAD_AVAILABLE)
+        payload_not_available = config.get(mqtt.CONF_PAYLOAD_NOT_AVAILABLE)
+        device_config = config.get(CONF_DEVICE)
+
+        MqttAvailability.__init__(self, availability_topic, qos,
+                                  payload_available, payload_not_available)
+        MqttDiscoveryUpdate.__init__(self, discovery_hash, 
+                                     self.discovery_update)
+        MqttEntityDeviceInfo.__init__(self, device_config)
+        
 
     async def async_added_to_hass(self):
-        """Subscribe MQTT events."""
+        """Subscribe to MQTT events."""
         await super().async_added_to_hass()
+        await self._subscribe_topics()
+
+    async def discovery_update(self, discovery_payload):
+        """Handle updated discovery message."""
+        config = PLATFORM_SCHEMA(discovery_payload)
+        self._setup_from_config(config)
+        await self.availability_discovery_update(config)
+        await self._subscribe_topics()
+        self.async_schedule_update_ha_state()
+
+    def _setup_from_config(self, config):
+        self._name = config.get(CONF_NAME)
+        supported_feature_strings = config.get(CONF_SUPPORTED_FEATURES)
+        self._supported_features = strings_to_services(supported_feature_strings)
+        self._qos = config.get(mqtt.CONF_QOS)
+        self._retain = config.get(mqtt.CONF_RETAIN)
+
+        self._payloads = {
+            key: config.get(key) for key in (
+                CONF_PAYLOAD_TURN_ON,
+                CONF_PAYLOAD_TURN_OFF,
+                CONF_PAYLOAD_RETURN_TO_BASE,
+                CONF_PAYLOAD_STOP,
+                CONF_PAYLOAD_CLEAN_SPOT,
+                CONF_PAYLOAD_LOCATE,
+                CONF_PAYLOAD_START_PAUSE,
+                CONF_PAYLOAD_PAUSE
+            )
+        }
+        self._topics = {
+            key: config.get(key) for key in (
+                mqtt.CONF_COMMAND_TOPIC,
+                CONF_BATTERY_LEVEL_TOPIC,
+                CONF_CHARGING_TOPIC,
+                CONF_CLEANING_TOPIC,
+                CONF_DOCKED_TOPIC,
+                CONF_ERROR_TOPIC,
+                CONF_FAN_SPEED_TOPIC,
+                CONF_SEND_COMMAND_TOPIC
+            )
+        }
+        self._templates = {
+            key: config.get(key) for key in (
+                CONF_BATTERY_LEVEL_TEMPLATE,
+                CONF_CHARGING_TEMPLATE,
+                CONF_CLEANING_TEMPLATE,
+                CONF_DOCKED_TEMPLATE,
+                CONF_ERROR_TEMPLATE,
+                CONF_FAN_SPEED_TEMPLATE,
+                CONF_SEND_COMMAND_TOPIC
+            )
+        }
+
+    async def _subscribe_topics(self):
+        """(Re)Subscribe to topics."""
+        for tpl in self._templates.values():
+            if tpl is not None:
+                tpl.hass = self.hass
 
         @callback
         def message_received(topic, payload, qos):
             """Handle new MQTT message."""
-            if topic == self._battery_level_topic and \
-                    self._battery_level_template:
-                battery_level = self._battery_level_template\
+            if topic == self._topics[CONF_BATTERY_LEVEL_TOPIC] and \
+                    self._templates[CONF_BATTERY_LEVEL_TEMPLATE]:
+                battery_level = self._templates[CONF_BATTERY_LEVEL_TEMPLATE]\
                     .async_render_with_possible_json_value(
                         payload, error_value=None)
                 if battery_level is not None:
                     self._battery_level = int(battery_level)
 
-            if topic == self._charging_topic and self._charging_template:
-                charging = self._charging_template\
+            if topic == self._topics[CONF_CHARGING_TOPIC] and \
+                    self._templates[CONF_CHARGING_TEMPLATE]:
+                charging = self._templates[CONF_CHARGING_TEMPLATE]\
                     .async_render_with_possible_json_value(
                         payload, error_value=None)
                 if charging is not None:
                     self._charging = cv.boolean(charging)
 
-            if topic == self._cleaning_topic and self._cleaning_template:
-                cleaning = self._cleaning_template \
+            if topic == self._topics[CONF_CLEANING_TOPIC] and \
+                    self._templates[CONF_CLEANING_TEMPLATE]:
+                cleaning = self._templates[CONF_CLEANING_TEMPLATE]\
                     .async_render_with_possible_json_value(
                         payload, error_value=None)
                 if cleaning is not None:
                     self._cleaning = cv.boolean(cleaning)
 
-            if topic == self._docked_topic and self._docked_template:
-                docked = self._docked_template \
+            if topic == self._topics[CONF_DOCKED_TOPIC] and \
+                    self._templates[CONF_DOCKED_TEMPLATE]:
+                docked = self._templates[CONF_DOCKED_TEMPLATE]\
                     .async_render_with_possible_json_value(
                         payload, error_value=None)
                 if docked is not None:
                     self._docked = cv.boolean(docked)
 
-            if topic == self._error_topic and self._error_template:
-                error = self._error_template \
+            if topic == self._topics[CONF_ERROR_TOPIC] and \
+                    self._templates[CONF_ERROR_TEMPLATE]:
+                error = self._templates[CONF_ERROR_TEMPLATE]\
                     .async_render_with_possible_json_value(
                         payload, error_value=None)
                 if error is not None:
@@ -333,8 +323,9 @@ class MqttVacuum(MqttAvailability, VacuumDevice):
             else:
                 self._status = "Stopped"
 
-            if topic == self._fan_speed_topic and self._fan_speed_template:
-                fan_speed = self._fan_speed_template\
+            if topic == self._topics[CONF_FAN_SPEED_TOPIC] and \
+                    self._templates[CONF_FAN_SPEED_TEMPLATE]:
+                fan_speed = self._templates[CONF_FAN_SPEED_TEMPLATE]\
                     .async_render_with_possible_json_value(
                         payload, error_value=None)
                 if fan_speed is not None:
@@ -342,14 +333,23 @@ class MqttVacuum(MqttAvailability, VacuumDevice):
 
             self.async_schedule_update_ha_state()
 
-        topics_list = [topic for topic in (self._battery_level_topic,
-                                           self._charging_topic,
-                                           self._cleaning_topic,
-                                           self._docked_topic,
-                                           self._fan_speed_topic) if topic]
+        topics_list = set([topic for topic in self._topics.values() if topic])
+        self._sub_state = await subscription.async_subscribe_topics(
+            self.hass, self._sub_state, 
+            { "topic{}".format(i):{ 
+                "topic": topic,
+                "msg_callback": message_received,
+                "qos": self._qos
+              } for i, topic in enumerate(topics_list) }
+        )
         for topic in set(topics_list):
             await self.hass.components.mqtt.async_subscribe(
                 topic, message_received, self._qos)
+
+    async def async_will_remove_from_hass(self):
+        """Unsubscribe when removed."""
+        await subscription.async_unsubscribe_topics(self.hass, self._sub_state)
+        await MqttAvailability.async_will_remove_from_hass(self)
 
     @property
     def name(self):
@@ -365,6 +365,11 @@ class MqttVacuum(MqttAvailability, VacuumDevice):
     def is_on(self):
         """Return true if vacuum is on."""
         return self._cleaning
+
+    @property
+    def unique_id(self):
+        """Return a unique ID."""
+        return self._unique_id
 
     @property
     def status(self):
@@ -417,7 +422,8 @@ class MqttVacuum(MqttAvailability, VacuumDevice):
             return
 
         mqtt.async_publish(self.hass, self._command_topic,
-                           self._payload_turn_on, self._qos, self._retain)
+                           self._payloads[CONF_PAYLOAD_TURN_ON], 
+                           self._qos, self._retain)
         self._status = 'Cleaning'
         self.async_schedule_update_ha_state()
 
@@ -427,7 +433,8 @@ class MqttVacuum(MqttAvailability, VacuumDevice):
             return
 
         mqtt.async_publish(self.hass, self._command_topic,
-                           self._payload_turn_off, self._qos, self._retain)
+                           self._payloads[CONF_PAYLOAD_TURN_OFF], 
+                           self._qos, self._retain)
         self._status = 'Turning Off'
         self.async_schedule_update_ha_state()
 
@@ -436,7 +443,8 @@ class MqttVacuum(MqttAvailability, VacuumDevice):
         if self.supported_features & SUPPORT_STOP == 0:
             return
 
-        mqtt.async_publish(self.hass, self._command_topic, self._payload_stop,
+        mqtt.async_publish(self.hass, self._command_topic, 
+                           self._payloads[CONF_PAYLOAD_STOP],
                            self._qos, self._retain)
         self._status = 'Stopping the current task'
         self.async_schedule_update_ha_state()
@@ -447,7 +455,8 @@ class MqttVacuum(MqttAvailability, VacuumDevice):
             return
 
         mqtt.async_publish(self.hass, self._command_topic,
-                           self._payload_clean_spot, self._qos, self._retain)
+                           self._payloads[CONF_PAYLOAD_CLEAN_SPOT], 
+                           self._qos, self._retain)
         self._status = "Cleaning spot"
         self.async_schedule_update_ha_state()
 
@@ -457,7 +466,8 @@ class MqttVacuum(MqttAvailability, VacuumDevice):
             return
 
         mqtt.async_publish(self.hass, self._command_topic,
-                           self._payload_locate, self._qos, self._retain)
+                           self._payloads[CONF_PAYLOAD_LOCATE], 
+                           self._qos, self._retain)
         self._status = "Hi, I'm over here!"
         self.async_schedule_update_ha_state()
 
@@ -467,7 +477,8 @@ class MqttVacuum(MqttAvailability, VacuumDevice):
             return
 
         mqtt.async_publish(self.hass, self._command_topic,
-                           self._payload_start_pause, self._qos, self._retain)
+                           self._payloads[CONF_PAYLOAD_START_PAUSE], 
+                           self._qos, self._retain)
         self._status = 'Pausing/Resuming cleaning...'
         self.async_schedule_update_ha_state()
 
@@ -477,8 +488,8 @@ class MqttVacuum(MqttAvailability, VacuumDevice):
             return
 
         mqtt.async_publish(self.hass, self._command_topic,
-                           self._payload_return_to_base, self._qos,
-                           self._retain)
+                           self._payloads[CONF_PAYLOAD_RETURN_TO_BASE], 
+                           self._qos, self._retain)
         self._status = 'Returning home...'
         self.async_schedule_update_ha_state()
 
@@ -489,9 +500,8 @@ class MqttVacuum(MqttAvailability, VacuumDevice):
         if not self._fan_speed_list or fan_speed not in self._fan_speed_list:
             return
 
-        mqtt.async_publish(
-            self.hass, self._set_fan_speed_topic, fan_speed, self._qos,
-            self._retain)
+        mqtt.async_publish(self.hass, self._set_fan_speed_topic, 
+                           fan_speed, self._qos, self._retain)
         self._status = "Setting fan to {}...".format(fan_speed)
         self.async_schedule_update_ha_state()
 
@@ -500,8 +510,7 @@ class MqttVacuum(MqttAvailability, VacuumDevice):
         if self.supported_features & SUPPORT_SEND_COMMAND == 0:
             return
 
-        mqtt.async_publish(
-            self.hass, self._send_command_topic, command, self._qos,
-            self._retain)
+        mqtt.async_publish(self.hass, self._send_command_topic, 
+                           command, self._qos, self._retain)
         self._status = "Sending command {}...".format(command)
         self.async_schedule_update_ha_state()

--- a/homeassistant/components/vacuum/mqtt.py
+++ b/homeassistant/components/vacuum/mqtt.py
@@ -10,7 +10,7 @@ import voluptuous as vol
 
 from homeassistant.components import mqtt
 from homeassistant.components.mqtt import (
-    ATTR_DISCOVERY_HASH, MqttAvailability, MqttDiscoveryUpdate, 
+    ATTR_DISCOVERY_HASH, MqttAvailability, MqttDiscoveryUpdate,
     MqttEntityDeviceInfo, subscription)
 from homeassistant.components.mqtt.discovery import MQTT_DISCOVERY_NEW
 from homeassistant.components.vacuum import (	
@@ -175,7 +175,8 @@ async def _async_setup_entity(config, async_add_entities,
     async_add_entities([MqttVacuum(config, discovery_hash)])
 
 
-class MqttVacuum(MqttAvailability, MqttDiscoveryUpdate, MqttEntityDeviceInfo, VacuumDevice):
+class MqttVacuum(MqttAvailability, MqttDiscoveryUpdate, MqttEntityDeviceInfo,
+                 VacuumDevice):
     """Representation of a MQTT-controlled vacuum."""
 
     def __init__(self, config, discovery_hash):
@@ -201,10 +202,9 @@ class MqttVacuum(MqttAvailability, MqttDiscoveryUpdate, MqttEntityDeviceInfo, Va
 
         MqttAvailability.__init__(self, availability_topic, qos,
                                   payload_available, payload_not_available)
-        MqttDiscoveryUpdate.__init__(self, discovery_hash, 
+        MqttDiscoveryUpdate.__init__(self, discovery_hash,
                                      self.discovery_update)
         MqttEntityDeviceInfo.__init__(self, device_config)
-        
 
     async def async_added_to_hass(self):
         """Subscribe to MQTT events."""
@@ -222,7 +222,8 @@ class MqttVacuum(MqttAvailability, MqttDiscoveryUpdate, MqttEntityDeviceInfo, Va
     def _setup_from_config(self, config):
         self._name = config.get(CONF_NAME)
         supported_feature_strings = config.get(CONF_SUPPORTED_FEATURES)
-        self._supported_features = strings_to_services(supported_feature_strings)
+        self._supported_features = strings_to_services(
+          supported_feature_strings)
         self._qos = config.get(mqtt.CONF_QOS)
         self._retain = config.get(mqtt.CONF_RETAIN)
 
@@ -334,8 +335,8 @@ class MqttVacuum(MqttAvailability, MqttDiscoveryUpdate, MqttEntityDeviceInfo, Va
 
         topics_list = set([topic for topic in self._topics.values() if topic])
         self._sub_state = await subscription.async_subscribe_topics(
-            self.hass, self._sub_state, 
-            { "topic{}".format(i):{ 
+            self.hass, self._sub_state,
+            { "topic{}".format(i): {
                 "topic": topic,
                 "msg_callback": message_received,
                 "qos": self._qos
@@ -421,7 +422,7 @@ class MqttVacuum(MqttAvailability, MqttDiscoveryUpdate, MqttEntityDeviceInfo, Va
             return
 
         mqtt.async_publish(self.hass, self._command_topic,
-                           self._payloads[CONF_PAYLOAD_TURN_ON], 
+                           self._payloads[CONF_PAYLOAD_TURN_ON],
                            self._qos, self._retain)
         self._status = 'Cleaning'
         self.async_schedule_update_ha_state()
@@ -432,7 +433,7 @@ class MqttVacuum(MqttAvailability, MqttDiscoveryUpdate, MqttEntityDeviceInfo, Va
             return
 
         mqtt.async_publish(self.hass, self._command_topic,
-                           self._payloads[CONF_PAYLOAD_TURN_OFF], 
+                           self._payloads[CONF_PAYLOAD_TURN_OFF],
                            self._qos, self._retain)
         self._status = 'Turning Off'
         self.async_schedule_update_ha_state()
@@ -442,7 +443,7 @@ class MqttVacuum(MqttAvailability, MqttDiscoveryUpdate, MqttEntityDeviceInfo, Va
         if self.supported_features & SUPPORT_STOP == 0:
             return
 
-        mqtt.async_publish(self.hass, self._command_topic, 
+        mqtt.async_publish(self.hass, self._command_topic,
                            self._payloads[CONF_PAYLOAD_STOP],
                            self._qos, self._retain)
         self._status = 'Stopping the current task'
@@ -454,7 +455,7 @@ class MqttVacuum(MqttAvailability, MqttDiscoveryUpdate, MqttEntityDeviceInfo, Va
             return
 
         mqtt.async_publish(self.hass, self._command_topic,
-                           self._payloads[CONF_PAYLOAD_CLEAN_SPOT], 
+                           self._payloads[CONF_PAYLOAD_CLEAN_SPOT],
                            self._qos, self._retain)
         self._status = "Cleaning spot"
         self.async_schedule_update_ha_state()
@@ -465,7 +466,7 @@ class MqttVacuum(MqttAvailability, MqttDiscoveryUpdate, MqttEntityDeviceInfo, Va
             return
 
         mqtt.async_publish(self.hass, self._command_topic,
-                           self._payloads[CONF_PAYLOAD_LOCATE], 
+                           self._payloads[CONF_PAYLOAD_LOCATE],
                            self._qos, self._retain)
         self._status = "Hi, I'm over here!"
         self.async_schedule_update_ha_state()
@@ -476,7 +477,7 @@ class MqttVacuum(MqttAvailability, MqttDiscoveryUpdate, MqttEntityDeviceInfo, Va
             return
 
         mqtt.async_publish(self.hass, self._command_topic,
-                           self._payloads[CONF_PAYLOAD_START_PAUSE], 
+                           self._payloads[CONF_PAYLOAD_START_PAUSE],
                            self._qos, self._retain)
         self._status = 'Pausing/Resuming cleaning...'
         self.async_schedule_update_ha_state()
@@ -487,7 +488,7 @@ class MqttVacuum(MqttAvailability, MqttDiscoveryUpdate, MqttEntityDeviceInfo, Va
             return
 
         mqtt.async_publish(self.hass, self._command_topic,
-                           self._payloads[CONF_PAYLOAD_RETURN_TO_BASE], 
+                           self._payloads[CONF_PAYLOAD_RETURN_TO_BASE],
                            self._qos, self._retain)
         self._status = 'Returning home...'
         self.async_schedule_update_ha_state()
@@ -499,7 +500,7 @@ class MqttVacuum(MqttAvailability, MqttDiscoveryUpdate, MqttEntityDeviceInfo, Va
         if not self._fan_speed_list or fan_speed not in self._fan_speed_list:
             return
 
-        mqtt.async_publish(self.hass, self._set_fan_speed_topic, 
+        mqtt.async_publish(self.hass, self._set_fan_speed_topic,
                            fan_speed, self._qos, self._retain)
         self._status = "Setting fan to {}...".format(fan_speed)
         self.async_schedule_update_ha_state()
@@ -509,7 +510,7 @@ class MqttVacuum(MqttAvailability, MqttDiscoveryUpdate, MqttEntityDeviceInfo, Va
         if self.supported_features & SUPPORT_SEND_COMMAND == 0:
             return
 
-        mqtt.async_publish(self.hass, self._send_command_topic, 
+        mqtt.async_publish(self.hass, self._send_command_topic,
                            command, self._qos, self._retain)
         self._status = "Sending command {}...".format(command)
         self.async_schedule_update_ha_state()


### PR DESCRIPTION
## Description:
Adds discoverability for mqtt-vacuum and enables deviceinfo if supplied.

I can't figure out the testing, need help/guidance ...
```
assert setup_component(self.hass, vacuum.DOMAIN, {  vacuum.DOMAIN: self.default_config })
entity = self.hass.states.get('vacuum.mqtttest')
```
yields NoneType, but the tests for mqtt cover is "the same" and it seems to work.



**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
