### PR TITLE
Various enhancements for WeMo component/platforms

### DIFF
--- a/homeassistant/components/binary_sensor/wemo.py
+++ b/homeassistant/components/binary_sensor/wemo.py
@@ -129,3 +129,8 @@ class WemoBinarySensor(BinarySensorDevice):
     def is_on(self):
         """Return true if sensor is on."""
         return self._state
+
+    @property
+    def available(self):
+        """Return true if sensor is available."""
+        return self._available

--- a/homeassistant/components/binary_sensor/wemo.py
+++ b/homeassistant/components/binary_sensor/wemo.py
@@ -55,7 +55,7 @@ class WemoBinarySensor(BinarySensorDevice):
 
     def _subscription_callback(self, _device, _type, _params):
         """Update the state by the Wemo sensor."""
-        _LOGGER.info("Subscription update for %s", self.name)
+        _LOGGER.debug("Subscription update for %s", self.name)
         updated = self.wemo.subscription_update(_type, _params)
         self.hass.add_job(
             self._async_locked_subscription_callback(not updated))

--- a/homeassistant/components/binary_sensor/wemo.py
+++ b/homeassistant/components/binary_sensor/wemo.py
@@ -46,9 +46,6 @@ class WemoBinarySensor(BinarySensorDevice):
         self._state = None
         self._available = True
         self._update_lock = None
-
-        # look up model name, name, and serial number
-        # once as it incurs network traffic
         self._model_name = self.wemo.model_name
         self._name = self.wemo.name
         self._serialnumber = self.wemo.serialnumber

--- a/homeassistant/components/binary_sensor/wemo.py
+++ b/homeassistant/components/binary_sensor/wemo.py
@@ -4,7 +4,10 @@ Support for WeMo sensors.
 For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/binary_sensor.wemo/
 """
+import asyncio
 import logging
+
+import async_timeout
 import requests
 
 from homeassistant.components.binary_sensor import BinarySensorDevice
@@ -41,48 +44,88 @@ class WemoBinarySensor(BinarySensorDevice):
         """Initialize the WeMo sensor."""
         self.wemo = device
         self._state = None
+        self._available = True
+        self._update_lock = None
 
-        wemo = hass.components.wemo
-        wemo.SUBSCRIPTION_REGISTRY.register(self.wemo)
-        wemo.SUBSCRIPTION_REGISTRY.on(self.wemo, None, self._update_callback)
+        # look up model name, name, and serial number
+        # once as it incurs network traffic
+        self._model_name = self.wemo.model_name
+        self._name = self.wemo.name
+        self._serialnumber = self.wemo.serialnumber
 
-    def _update_callback(self, _device, _type, _params):
-        """Handle state changes."""
-        _LOGGER.info("Subscription update for %s", _device)
+    def _subscription_callback(self, _device, _type, _params):
+        """Update the state by the Wemo sensor."""
+        _LOGGER.info("Subscription update for %s", self.name)
         updated = self.wemo.subscription_update(_type, _params)
-        self._update(force_update=(not updated))
+        self.hass.add_job(
+            self._async_locked_subscription_callback(not updated))
 
-        if not hasattr(self, 'hass'):
+    async def _async_locked_subscription_callback(self, force_update):
+        """Handle an update from a subscription."""
+        # If an update is in progress, we don't do anything
+        if self._update_lock.locked():
             return
-        self.schedule_update_ha_state()
 
-    @property
-    def should_poll(self):
-        """No polling needed with subscriptions."""
-        return False
+        await self._async_locked_update(force_update)
+        self.async_schedule_update_ha_state()
+
+    async def async_added_to_hass(self):
+        """Wemo sensor added to HASS."""
+        # Define inside async context so we know our event loop
+        self._update_lock = asyncio.Lock()
+
+        registry = self.hass.components.wemo.SUBSCRIPTION_REGISTRY
+        await self.hass.async_add_executor_job(registry.register, self.wemo)
+        registry.on(self.wemo, None, self._subscription_callback)
+
+    async def async_update(self):
+        """Update WeMo state.
+
+        Wemo has an aggressive retry logic that sometimes can take over a
+        minute to return. If we don't get a state after 5 seconds, assume the
+        Wemo sensor is unreachable. If update goes through, it will be made
+        available again.
+        """
+        # If an update is in progress, we don't do anything
+        if self._update_lock.locked():
+            return
+
+        try:
+            with async_timeout.timeout(5):
+                await asyncio.shield(self._async_locked_update(True))
+        except asyncio.TimeoutError:
+            _LOGGER.warning('Lost connection to %s', self.name)
+            self._available = False
+
+    async def _async_locked_update(self, force_update):
+        """Try updating within an async lock."""
+        async with self._update_lock:
+            await self.hass.async_add_executor_job(self._update, force_update)
+
+    def _update(self, force_update=True):
+        """Update the sensor state."""
+        try:
+            self._state = self.wemo.get_state(force_update)
+
+            if not self._available:
+                _LOGGER.info('Reconnected to %s', self.name)
+                self._available = True
+        except AttributeError as err:
+            _LOGGER.warning("Could not update status for %s (%s)",
+                            self.name, err)
+            self._available = False
 
     @property
     def unique_id(self):
-        """Return the id of this WeMo device."""
-        return self.wemo.serialnumber
+        """Return the id of this WeMo sensor."""
+        return self._serialnumber
 
     @property
     def name(self):
         """Return the name of the service if any."""
-        return self.wemo.name
+        return self._name
 
     @property
     def is_on(self):
         """Return true if sensor is on."""
         return self._state
-
-    def update(self):
-        """Update WeMo state."""
-        self._update(force_update=True)
-
-    def _update(self, force_update=True):
-        try:
-            self._state = self.wemo.get_state(force_update)
-        except AttributeError as err:
-            _LOGGER.warning(
-                "Could not update status for %s (%s)", self.name, err)

--- a/homeassistant/components/discovery.py
+++ b/homeassistant/components/discovery.py
@@ -134,7 +134,7 @@ async def async_setup(hass, config):
 
         discovery_hash = json.dumps([service, info], sort_keys=True)
         if discovery_hash in already_discovered:
-            logger.debug("Already discoverd service %s %s.", service, info)
+            logger.debug("Already discovered service %s %s.", service, info)
             return
 
         already_discovered.add(discovery_hash)

--- a/homeassistant/components/fan/services.yaml
+++ b/homeassistant/components/fan/services.yaml
@@ -209,7 +209,7 @@ wemo_set_humidity:
   description: Set the target humidity of WeMo humidifier devices.
   fields:
     entity_id:
-      description: Names of the WeMo humidifier entities (0 or more entities, if no entity_id is provided, all WeMo humidifiers will have the target humidity set).
+      description: Names of the WeMo humidifier entities (1 or more entity_ids are required).
       example: 'fan.wemo_humidifier'
     target_humidity:
       description: Target humidity. This is a float value between 0 and 100, but will be mapped to the humidity levels that WeMo humidifiers support (45, 50, 55, 60, and 100/Max) by rounding the value down to the nearest supported value.

--- a/homeassistant/components/fan/services.yaml
+++ b/homeassistant/components/fan/services.yaml
@@ -214,3 +214,10 @@ wemo_set_humidity:
     target_humidity:
       description: Target humidity. This is a float value between 0 and 100, but will be mapped to the humidity levels that WeMo humidifiers support (45, 50, 55, 60, and 100/Max) by rounding the value down to the nearest supported value.
       example: 56.5
+
+wemo_reset_filter_life:
+  description: Reset the WeMo Humidifier's filter life to 100%.
+  fields:
+    entity_id:
+      description: Names of the WeMo humidifier entities (1 or more entity_ids are required).
+      example: 'fan.wemo_humidifier'

--- a/homeassistant/components/fan/wemo.py
+++ b/homeassistant/components/fan/wemo.py
@@ -118,25 +118,18 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         """Handle the WeMo humidifier services."""
         entity_ids = service.data.get(ATTR_ENTITY_ID)
 
-        humidifiers = []
+        humidifiers = ([device for device in
+                        hass.data[DATA_KEY].values() if
+                        device.entity_id in entity_ids])
 
-        if entity_ids:
-            humidifiers.extend([device for device in
-                                hass.data[DATA_KEY].values() if
-                                device.entity_id in entity_ids])
+        if service.service == SERVICE_SET_HUMIDITY:
+            target_humidity = service.data.get(ATTR_TARGET_HUMIDITY)
 
-            if service.service == SERVICE_SET_HUMIDITY:
-                target_humidity = service.data.get(ATTR_TARGET_HUMIDITY)
-
-                for humidifier in humidifiers:
-                    humidifier.set_humidity(target_humidity)
-            elif service.service == SERVICE_RESET_FILTER_LIFE:
-                for humidifier in humidifiers:
-                    humidifier.reset_filter_life()
-        else:
-            _LOGGER.error("Unable to execute service %s "
-                          "- entity_ids is a required field.",
-                          service.service)
+            for humidifier in humidifiers:
+                humidifier.set_humidity(target_humidity)
+        elif service.service == SERVICE_RESET_FILTER_LIFE:
+            for humidifier in humidifiers:
+                humidifier.reset_filter_life()
 
     # Register service(s)
     hass.services.register(

--- a/homeassistant/components/fan/wemo.py
+++ b/homeassistant/components/fan/wemo.py
@@ -134,9 +134,9 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                 for humidifier in humidifiers:
                     humidifier.reset_filter_life()
         else:
-            _LOGGER.error("Unable to execute service %s %s",
-                          service.service,
-                          "- entity_ids is a required field.")
+            _LOGGER.error("Unable to execute service %s "
+                          "- entity_ids is a required field.",
+                          service.service)
 
     # Register service(s)
     hass.services.register(
@@ -154,11 +154,9 @@ class WemoHumidifier(FanEntity):
     def __init__(self, device):
         """Initialize the WeMo switch."""
         self.wemo = device
-
         self._state = None
         self._available = True
         self._update_lock = None
-
         self._fan_mode = None
         self._target_humidity = None
         self._current_humidity = None
@@ -166,9 +164,6 @@ class WemoHumidifier(FanEntity):
         self._filter_life = None
         self._filter_expired = None
         self._last_fan_on_mode = WEMO_FAN_MEDIUM
-
-        # look up model name, name, and serial number
-        # once as it incurs network traffic
         self._model_name = self.wemo.model_name
         self._name = self.wemo.name
         self._serialnumber = self.wemo.serialnumber

--- a/homeassistant/components/fan/wemo.py
+++ b/homeassistant/components/fan/wemo.py
@@ -118,9 +118,9 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         """Handle the WeMo humidifier services."""
         entity_ids = service.data.get(ATTR_ENTITY_ID)
 
-        humidifiers = ([device for device in
-                        hass.data[DATA_KEY].values() if
-                        device.entity_id in entity_ids])
+        humidifiers = [device for device in
+                       hass.data[DATA_KEY].values() if
+                       device.entity_id in entity_ids]
 
         if service.service == SERVICE_SET_HUMIDITY:
             target_humidity = service.data.get(ATTR_TARGET_HUMIDITY)

--- a/homeassistant/components/fan/wemo.py
+++ b/homeassistant/components/fan/wemo.py
@@ -78,7 +78,7 @@ HASS_FAN_SPEED_TO_WEMO = {v: k for (k, v) in WEMO_FAN_SPEED_TO_HASS.items()
 SERVICE_SET_HUMIDITY = 'wemo_set_humidity'
 
 SET_HUMIDITY_SCHEMA = vol.Schema({
-    vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
+    vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
     vol.Required(ATTR_TARGET_HUMIDITY):
         vol.All(vol.Coerce(float), vol.Range(min=0, max=100))
 })
@@ -125,21 +125,18 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                                 hass.data[DATA_KEY].values() if
                                 device.entity_id in entity_ids])
 
-        if service.service == SERVICE_SET_HUMIDITY:
-            target_humidity = service.data.get(ATTR_TARGET_HUMIDITY)
+            if service.service == SERVICE_SET_HUMIDITY:
+                target_humidity = service.data.get(ATTR_TARGET_HUMIDITY)
 
-            if not humidifiers:
-                humidifiers.extend(hass.data[DATA_KEY].values())
-
-            for humidifier in humidifiers:
-                humidifier.set_humidity(target_humidity)
-        elif service.service == SERVICE_RESET_FILTER_LIFE:
-            if humidifiers:
+                for humidifier in humidifiers:
+                    humidifier.set_humidity(target_humidity)
+            elif service.service == SERVICE_RESET_FILTER_LIFE:
                 for humidifier in humidifiers:
                     humidifier.reset_filter_life()
-            else:
-                _LOGGER.error("Unable to reset WeMo Humidifier filter life %s",
-                              "- entity_ids is a required field.")
+        else:
+            _LOGGER.error("Unable to execute service %s %s",
+                          service.service,
+                          "- entity_ids is a required field.")
 
     # Register service(s)
     hass.services.register(

--- a/homeassistant/components/fan/wemo.py
+++ b/homeassistant/components/fan/wemo.py
@@ -272,7 +272,6 @@ class WemoHumidifier(FanEntity):
         except asyncio.TimeoutError:
             _LOGGER.warning('Lost connection to %s', self.name)
             self._available = False
-            self.wemo.reconnect_with_device()
 
     async def _async_locked_update(self, force_update):
         """Try updating within an async lock."""

--- a/homeassistant/components/light/wemo.py
+++ b/homeassistant/components/light/wemo.py
@@ -163,7 +163,6 @@ class WemoLight(Light):
         """Turn the light off."""
         transitiontime = int(kwargs.get(ATTR_TRANSITION, 0))
         self.wemo.turn_off(transition=transitiontime)
-        self._is_on = False
 
     def _update(self, force_update=True):
         """Synchronize state with bridge."""

--- a/homeassistant/components/light/wemo.py
+++ b/homeassistant/components/light/wemo.py
@@ -4,9 +4,12 @@ Support for Belkin WeMo lights.
 For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/light.wemo/
 """
+import asyncio
 import logging
 from datetime import timedelta
+
 import requests
+import async_timeout
 
 from homeassistant import util
 from homeassistant.components.light import (
@@ -74,40 +77,56 @@ class WemoLight(Light):
 
     def __init__(self, device, update_lights):
         """Initialize the WeMo light."""
-        self.light_id = device.name
         self.wemo = device
-        self.update_lights = update_lights
+        self._state = None
+        self._update_lights = update_lights
+        self._available = True
+        self._update_lock = None
+
+        self._brightness = None
+        self._hs_color = None
+        self._color_temp = None
+        self._is_on = None
+
+        # look up name and uniqueID
+        # once as it incurs network traffic
+        self._name = self.wemo.name
+        self._unique_id = self.wemo.uniqueID
+
+    async def async_added_to_hass(self):
+        """Wemo light added to HASS."""
+        # Define inside async context so we know our event loop
+        self._update_lock = asyncio.Lock()
 
     @property
     def unique_id(self):
         """Return the ID of this light."""
-        return self.wemo.uniqueID
+        return self._unique_id
 
     @property
     def name(self):
         """Return the name of the light."""
-        return self.wemo.name
+        return self._name
 
     @property
     def brightness(self):
         """Return the brightness of this light between 0..255."""
-        return self.wemo.state.get('level', 255)
+        return self._brightness
 
     @property
     def hs_color(self):
         """Return the hs color values of this light."""
-        xy_color = self.wemo.state.get('color_xy')
-        return color_util.color_xy_to_hs(*xy_color) if xy_color else None
+        return self._hs_color
 
     @property
     def color_temp(self):
         """Return the color temperature of this light in mireds."""
-        return self.wemo.state.get('temperature_mireds')
+        return self._color_temp
 
     @property
     def is_on(self):
         """Return true if device is on."""
-        return self.wemo.state['onoff'] != 0
+        return self._is_on
 
     @property
     def supported_features(self):
@@ -117,7 +136,7 @@ class WemoLight(Light):
     @property
     def available(self):
         """Return if light is available."""
-        return self.wemo.state['available']
+        return self._available
 
     def turn_on(self, **kwargs):
         """Turn the light on."""
@@ -140,14 +159,48 @@ class WemoLight(Light):
         else:
             self.wemo.turn_on(transition=transitiontime)
 
+        self._is_on = True
+
     def turn_off(self, **kwargs):
         """Turn the light off."""
         transitiontime = int(kwargs.get(ATTR_TRANSITION, 0))
         self.wemo.turn_off(transition=transitiontime)
+        self._is_on = False
 
-    def update(self):
+    def _update(self, force_update=True):
         """Synchronize state with bridge."""
-        self.update_lights(no_throttle=True)
+        self._update_lights(no_throttle=force_update)
+        self._state = self.wemo.state
+
+        self._is_on = self._state.get('onoff') != 0
+        self._brightness = self._state.get('level', 255)
+        self._color_temp = self._state.get('temperature_mireds')
+        self._available = True
+
+        xy_color = self._state.get('color_xy')
+
+        if xy_color:
+            self._hs_color = color_util.color_xy_to_hs(*xy_color)
+        else:
+            self._hs_color = None
+
+    async def async_update(self):
+        """Synchronize state with bridge."""
+        # If an update is in progress, we don't do anything
+        if self._update_lock.locked():
+            return
+
+        try:
+            with async_timeout.timeout(5):
+                await asyncio.shield(self._async_locked_update(True))
+        except asyncio.TimeoutError:
+            _LOGGER.warning('Lost connection to %s', self.name)
+            self._available = False
+
+    async def _async_locked_update(self, force_update):
+        """Try updating within an async lock."""
+        async with self._update_lock:
+            await self.hass.async_add_executor_job(self._update, force_update)
 
 
 class WemoDimmer(Light):
@@ -156,45 +209,82 @@ class WemoDimmer(Light):
     def __init__(self, device):
         """Initialize the WeMo dimmer."""
         self.wemo = device
-        self._brightness = None
         self._state = None
+        self._available = True
+        self._update_lock = None
+
+        self._brightness = None
+
+        # look up model name, name, and serial number
+        # once as it incurs network traffic
+        self._model_name = self.wemo.model_name
+        self._name = self.wemo.name
+        self._serialnumber = self.wemo.serialnumber
+
+    def _subscription_callback(self, _device, _type, _params):
+        """Update the state by the Wemo device."""
+        _LOGGER.info("Subscription update for %s", self.name)
+        updated = self.wemo.subscription_update(_type, _params)
+        self.hass.add_job(
+            self._async_locked_subscription_callback(not updated))
+
+    async def _async_locked_subscription_callback(self, force_update):
+        """Handle an update from a subscription."""
+        # If an update is in progress, we don't do anything
+        if self._update_lock.locked():
+            return
+
+        await self._async_locked_update(force_update)
+        self.async_schedule_update_ha_state()
 
     async def async_added_to_hass(self):
-        """Register update callback."""
-        wemo = self.hass.components.wemo
-        # The register method uses a threading condition, so call via executor.
-        # and await to wait until the task is done.
-        await self.hass.async_add_job(
-            wemo.SUBSCRIPTION_REGISTRY.register, self.wemo)
-        # The on method just appends to a defaultdict list.
-        wemo.SUBSCRIPTION_REGISTRY.on(self.wemo, None, self._update_callback)
+        """Wemo dimmer added to HASS."""
+        # Define inside async context so we know our event loop
+        self._update_lock = asyncio.Lock()
 
-    def _update_callback(self, _device, _type, _params):
-        """Update the state by the Wemo device."""
-        _LOGGER.debug("Subscription update for  %s", _device)
-        updated = self.wemo.subscription_update(_type, _params)
-        self._update(force_update=(not updated))
-        self.schedule_update_ha_state()
+        registry = self.hass.components.wemo.SUBSCRIPTION_REGISTRY
+        await self.hass.async_add_executor_job(registry.register, self.wemo)
+        registry.on(self.wemo, None, self._subscription_callback)
+
+    async def async_update(self):
+        """Update WeMo state.
+
+        Wemo has an aggressive retry logic that sometimes can take over a
+        minute to return. If we don't get a state after 5 seconds, assume the
+        Wemo dimmer is unreachable. If update goes through, it will be made
+        available again.
+        """
+        # If an update is in progress, we don't do anything
+        if self._update_lock.locked():
+            return
+
+        try:
+            with async_timeout.timeout(5):
+                await asyncio.shield(self._async_locked_update(True))
+        except asyncio.TimeoutError:
+            _LOGGER.warning('Lost connection to %s', self.name)
+            self._available = False
+            self.wemo.reconnect_with_device()
+
+    async def _async_locked_update(self, force_update):
+        """Try updating within an async lock."""
+        async with self._update_lock:
+            await self.hass.async_add_executor_job(self._update, force_update)
 
     @property
     def unique_id(self):
         """Return the ID of this WeMo dimmer."""
-        return self.wemo.serialnumber
+        return self._serialnumber
 
     @property
     def name(self):
         """Return the name of the dimmer if any."""
-        return self.wemo.name
+        return self._name
 
     @property
     def supported_features(self):
         """Flag supported features."""
         return SUPPORT_BRIGHTNESS
-
-    @property
-    def should_poll(self):
-        """No polling needed with subscriptions."""
-        return False
 
     @property
     def brightness(self):
@@ -210,11 +300,17 @@ class WemoDimmer(Light):
         """Update the device state."""
         try:
             self._state = self.wemo.get_state(force_update)
+
             wemobrightness = int(self.wemo.get_brightness(force_update))
             self._brightness = int((wemobrightness * 255) / 100)
+
+            if not self._available:
+                _LOGGER.info('Reconnected to %s', self.name)
+                self._available = True
         except AttributeError as err:
             _LOGGER.warning("Could not update status for %s (%s)",
                             self.name, err)
+            self._available = False
 
     def turn_on(self, **kwargs):
         """Turn the dimmer on."""
@@ -232,3 +328,8 @@ class WemoDimmer(Light):
     def turn_off(self, **kwargs):
         """Turn the dimmer off."""
         self.wemo.off()
+
+    @property
+    def available(self):
+        """Return if dimmer is available."""
+        return self._available

--- a/homeassistant/components/light/wemo.py
+++ b/homeassistant/components/light/wemo.py
@@ -82,14 +82,10 @@ class WemoLight(Light):
         self._update_lights = update_lights
         self._available = True
         self._update_lock = None
-
         self._brightness = None
         self._hs_color = None
         self._color_temp = None
         self._is_on = None
-
-        # look up name and uniqueID
-        # once as it incurs network traffic
         self._name = self.wemo.name
         self._unique_id = self.wemo.uniqueID
 
@@ -209,11 +205,7 @@ class WemoDimmer(Light):
         self._state = None
         self._available = True
         self._update_lock = None
-
         self._brightness = None
-
-        # look up model name, name, and serial number
-        # once as it incurs network traffic
         self._model_name = self.wemo.model_name
         self._name = self.wemo.name
         self._serialnumber = self.wemo.serialnumber

--- a/homeassistant/components/light/wemo.py
+++ b/homeassistant/components/light/wemo.py
@@ -159,8 +159,6 @@ class WemoLight(Light):
         else:
             self.wemo.turn_on(transition=transitiontime)
 
-        self._is_on = True
-
     def turn_off(self, **kwargs):
         """Turn the light off."""
         transitiontime = int(kwargs.get(ATTR_TRANSITION, 0))
@@ -223,7 +221,7 @@ class WemoDimmer(Light):
 
     def _subscription_callback(self, _device, _type, _params):
         """Update the state by the Wemo device."""
-        _LOGGER.info("Subscription update for %s", self.name)
+        _LOGGER.debug("Subscription update for %s", self.name)
         updated = self.wemo.subscription_update(_type, _params)
         self.hass.add_job(
             self._async_locked_subscription_callback(not updated))

--- a/homeassistant/components/switch/wemo.py
+++ b/homeassistant/components/switch/wemo.py
@@ -64,10 +64,15 @@ class WemoSwitch(SwitchDevice):
         self.maker_params = None
         self.coffeemaker_mode = None
         self._state = None
+        self._mode_string = None
         self._available = True
         self._update_lock = None
-        # look up model name once as it incurs network traffic
+
+        # look up model name, name, and serial number
+        # once as it incurs network traffic
         self._model_name = self.wemo.model_name
+        self._name = self.wemo.name
+        self._serialnumber = self.wemo.serialnumber
 
     def _subscription_callback(self, _device, _type, _params):
         """Update the state by the Wemo device."""
@@ -86,23 +91,14 @@ class WemoSwitch(SwitchDevice):
         self.async_schedule_update_ha_state()
 
     @property
-    def should_poll(self):
-        """Device should poll.
-
-        Subscriptions push the state, however it won't detect if a device
-        is no longer available. Use polling to detect if a device is available.
-        """
-        return True
-
-    @property
     def unique_id(self):
         """Return the ID of this WeMo switch."""
-        return self.wemo.serialnumber
+        return self._serialnumber
 
     @property
     def name(self):
         """Return the name of the switch if any."""
-        return self.wemo.name
+        return self._name
 
     @property
     def device_state_attributes(self):
@@ -169,7 +165,7 @@ class WemoSwitch(SwitchDevice):
     def detail_state(self):
         """Return the state of the device."""
         if self.coffeemaker_mode is not None:
-            return self.wemo.mode_string
+            return self._mode_string
         if self.insight_params:
             standby_state = int(self.insight_params['state'])
             if standby_state == WEMO_ON:
@@ -242,6 +238,7 @@ class WemoSwitch(SwitchDevice):
         """Update the device state."""
         try:
             self._state = self.wemo.get_state(force_update)
+
             if self._model_name == 'Insight':
                 self.insight_params = self.wemo.insight_params
                 self.insight_params['standby_state'] = (
@@ -250,6 +247,7 @@ class WemoSwitch(SwitchDevice):
                 self.maker_params = self.wemo.maker_params
             elif self._model_name == 'CoffeeMaker':
                 self.coffeemaker_mode = self.wemo.mode
+                self._mode_string = self.wemo.mode_string
 
             if not self._available:
                 _LOGGER.info('Reconnected to %s', self.name)

--- a/homeassistant/components/switch/wemo.py
+++ b/homeassistant/components/switch/wemo.py
@@ -67,9 +67,6 @@ class WemoSwitch(SwitchDevice):
         self._mode_string = None
         self._available = True
         self._update_lock = None
-
-        # look up model name, name, and serial number
-        # once as it incurs network traffic
         self._model_name = self.wemo.model_name
         self._name = self.wemo.name
         self._serialnumber = self.wemo.serialnumber

--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -96,7 +96,8 @@ def setup(hass, config):
 
         # Only register a device once
         if serial in KNOWN_DEVICES:
-            _LOGGER.debug('Ignoring known device %s %s', service, discovery_info)
+            _LOGGER.debug('Ignoring known device %s %s',
+                          service, discovery_info)
             return
         _LOGGER.debug('Discovered unique device %s', serial)
         KNOWN_DEVICES.append(serial)

--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -15,7 +15,7 @@ from homeassistant.helpers import config_validation as cv
 
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 
-REQUIREMENTS = ['pywemo==0.4.32']
+REQUIREMENTS = ['pywemo==0.4.33']
 
 DOMAIN = 'wemo'
 

--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -141,7 +141,8 @@ def setup(hass, config):
             _LOGGER.error('Unable to access %s (%s)', url, err)
             continue
 
-        devices.append((url, device))
+        if device not in devices:
+            devices.append((url, device))
 
     if config.get(DOMAIN, {}).get(CONF_DISCOVERY):
         _LOGGER.debug("Scanning for WeMo devices.")

--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -125,27 +125,26 @@ def setup(hass, config):
 
     devices = []
 
-    if config.get(DOMAIN, {}).get(CONF_STATIC, []):
-        _LOGGER.debug("Scanning statically configured WeMo devices...")
-        for host, port in config.get(DOMAIN, {}).get(CONF_STATIC, []):
-            url = setup_url_for_address(host, port)
+    _LOGGER.debug("Scanning statically configured WeMo devices...")
+    for host, port in config.get(DOMAIN, {}).get(CONF_STATIC, []):
+        url = setup_url_for_address(host, port)
 
-            if not url:
-                _LOGGER.error(
-                    'Unable to get description url for %s',
-                    '{}:{}'.format(host, port) if port else host)
-                continue
+        if not url:
+            _LOGGER.error(
+                'Unable to get description url for %s',
+                '{}:{}'.format(host, port) if port else host)
+            continue
 
-            try:
-                device = pywemo.discovery.device_from_description(url, None)
-            except (requests.exceptions.ConnectionError,
-                    requests.exceptions.Timeout) as err:
-                _LOGGER.error('Unable to access %s (%s)', url, err)
-                continue
+        try:
+            device = pywemo.discovery.device_from_description(url, None)
+        except (requests.exceptions.ConnectionError,
+                requests.exceptions.Timeout) as err:
+            _LOGGER.error('Unable to access %s (%s)', url, err)
+            continue
 
-            if not [d[1] for d in devices
-                    if d[1].serialnumber == device.serialnumber]:
-                devices.append((url, device))
+        if not [d[1] for d in devices
+                if d[1].serialnumber == device.serialnumber]:
+            devices.append((url, device))
 
     if config.get(DOMAIN, {}).get(CONF_DISCOVERY):
         _LOGGER.debug("Scanning for WeMo devices...")

--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -143,13 +143,15 @@ def setup(hass, config):
                 _LOGGER.error('Unable to access %s (%s)', url, err)
                 continue
 
-            if not [d[1] for d in devices if d[1].serialnumber == device.serialnumber]:
+            if not [d[1] for d in devices
+                    if d[1].serialnumber == device.serialnumber]:
                 devices.append((url, device))
 
     if config.get(DOMAIN, {}).get(CONF_DISCOVERY):
         _LOGGER.debug("Scanning for WeMo devices...")
         for device in pywemo.discover_devices():
-            if not [d[1] for d in devices if d[1].serialnumber == device.serialnumber]:
+            if not [d[1] for d in devices
+                    if d[1].serialnumber == device.serialnumber]:
                 devices.append((setup_url_for_device(device), device))
 
     for url, device in devices:

--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -15,7 +15,7 @@ from homeassistant.helpers import config_validation as cv
 
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 
-REQUIREMENTS = ['pywemo==0.4.33']
+REQUIREMENTS = ['pywemo==0.4.32']
 
 DOMAIN = 'wemo'
 
@@ -96,6 +96,7 @@ def setup(hass, config):
 
         # Only register a device once
         if serial in KNOWN_DEVICES:
+            _LOGGER.debug('Ignoring known device %s %s', service, discovery_info)
             return
         _LOGGER.debug('Discovered unique device %s', serial)
         KNOWN_DEVICES.append(serial)


### PR DESCRIPTION
## Description:
Various fixes & improvements to the WeMo component/platforms, including:
-- New wemo_reset_filter_life service for the WeMo Humidifier
-- Switched the remainder of the WeMo platforms to async IO
-- Removed any remaining IO in entity properties and moved them to the polling/subscription update process
-- Entity_id is now required on the wemo_set_humidity service

**Breaking change:**
Entity_id is now required for the wemo_set_humidity service.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#7891

## Example entry for `configuration.yaml` (if applicable):
```yaml
wemo:
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)