### PR TITLE
Bugfix: ADS light breaks if optional parameter adsvar_brightness is not set

### DIFF
--- a/homeassistant/components/light/ads.py
+++ b/homeassistant/components/light/ads.py
@@ -67,11 +67,12 @@ class AdsLight(Light):
             self._ads_hub.add_device_notification,
             self.ads_var_enable, self._ads_hub.PLCTYPE_BOOL, update_on_state
         )
-        self.hass.async_add_job(
-            self._ads_hub.add_device_notification,
-            self.ads_var_brightness, self._ads_hub.PLCTYPE_INT,
-            update_brightness
-        )
+        if self.ads_var_brightness is not None:
+            self.hass.async_add_job(
+                self._ads_hub.add_device_notification,
+                self.ads_var_brightness, self._ads_hub.PLCTYPE_INT,
+                update_brightness
+            )
 
     @property
     def name(self):


### PR DESCRIPTION
## Description:
Just a small change to prevent exception if optional parameter adsvar_brightness is not set

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
