### PR TITLE
Fixed the range filter unknown argument precision

### DIFF
--- a/homeassistant/components/sensor/filter.py
+++ b/homeassistant/components/sensor/filter.py
@@ -79,7 +79,7 @@ FILTER_LOWPASS_SCHEMA = FILTER_SCHEMA.extend({
                  default=DEFAULT_FILTER_TIME_CONSTANT): vol.Coerce(int),
 })
 
-FILTER_RANGE_SCHEMA = FILTER_SCHEMA.extend({
+FILTER_RANGE_SCHEMA = vol.Schema({
     vol.Required(CONF_FILTER_NAME): FILTER_NAME_RANGE,
     vol.Optional(CONF_FILTER_LOWER_BOUND): vol.Coerce(float),
     vol.Optional(CONF_FILTER_UPPER_BOUND): vol.Coerce(float),


### PR DESCRIPTION
In HomeAssistant 0.84.3, the range filter would not work due to the unexpected precision filter parameter. 
The default range scheme has been edited to remove the unexpected precision parameter.

Verified and tested.

## Description:

A bug that caused the filter platform to crash when using the range filter.

**Related issue (if applicable):** fixes #0.84.3 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#19428

## Example entry for `configuration.yaml` (if applicable):
```yaml
  - platform: filter
    name: "Test"
    entity_id: sensor.test_sensor
    filters:
      - filter: range
        lower_bound: 0
        upper_bound: 1187
      - filter: lowpass
        precision: 1
        time_constant: 10
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
