### PR TITLE
Improve handling of MQTT light discovery

### DIFF
--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -41,9 +41,10 @@ CONFIG_ENTRY_COMPONENTS = [
 ]
 
 DEPRECATED_PLATFORM_TO_SCHEMA = {
-    'mqtt': 'basic',
-    'mqtt_json': 'json',
-    'mqtt_template': 'template',
+    'light': {
+        'mqtt_json': 'json',
+        'mqtt_template': 'template',
+    }
 }
 
 
@@ -207,10 +208,11 @@ async def async_start(hass: HomeAssistantType, discovery_topic, hass_config,
         discovery_hash = (component, discovery_id)
 
         if payload:
-            if CONF_PLATFORM in payload:
+            if CONF_PLATFORM in payload and 'schema' not in payload:
                 platform = payload[CONF_PLATFORM]
-                if platform in DEPRECATED_PLATFORM_TO_SCHEMA:
-                    schema = DEPRECATED_PLATFORM_TO_SCHEMA[platform]
+                if (component in DEPRECATED_PLATFORM_TO_SCHEMA and
+                        platform in DEPRECATED_PLATFORM_TO_SCHEMA[component]):
+                    schema = DEPRECATED_PLATFORM_TO_SCHEMA[component][platform]
                     payload['schema'] = schema
                     _LOGGER.warning('"platform": "%s" is deprecated, '
                                     'replace with "schema":"%s"',


### PR DESCRIPTION
## Description:
Improve handling of MQTT light discovery message.

When refactoring the mqtt_json and mqtt_template lights, backwards compatibility was added for MQTT discovery messages such that discovery messages setting  `"platform":"mqtt_json"`, `"platform":"mqtt"` or `"platform":"mqtt_template"` would still work by translating to the new `schema` configuration variable.

This PR makes the backwards compatibility more intuitive and less error prone by:
 - Not setting the `schema` configuration variable unless platform is `light`
 - Not overwriting the `schema` configuration variable if it is set
 - Not setting the `schema` configuration varible if `platform` is set to `mqtt`

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
