### PR TITLE
Use web sockets for Harmony HUB

### DIFF
--- a/homeassistant/components/remote/harmony.py
+++ b/homeassistant/components/remote/harmony.py
@@ -22,7 +22,9 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.exceptions import PlatformNotReady
 from homeassistant.util import slugify
 
-REQUIREMENTS = ['pyharmony==1.0.22']
+# REQUIREMENTS = ['pyharmony==1.0.22']
+REQUIREMENTS = ['https://github.com/ehendrix23/pyharmony/archive/websockets.zip'
+ '#pyharmony==1.0.22']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/remote/harmony.py
+++ b/homeassistant/components/remote/harmony.py
@@ -24,7 +24,8 @@ from homeassistant.util import slugify
 
 # REQUIREMENTS = ['pyharmony==1.0.22']
 REQUIREMENTS = [
-    'https://github.com/ehendrix23/pyharmony/archive/websockets.zip'
+    'https://github.com/ehendrix23/pyharmony/archive/'
+    '10d58ad8c89047f6278f559cced5cfbeac4b305f.zip'
     '#pyharmony==1.0.22'
 ]
 

--- a/homeassistant/components/remote/harmony.py
+++ b/homeassistant/components/remote/harmony.py
@@ -24,9 +24,9 @@ from homeassistant.util import slugify
 
 # REQUIREMENTS = ['pyharmony==1.0.22']
 REQUIREMENTS = [
-    'https://github.com/ehendrix23/pyharmony/archive/'
-    '10d58ad8c89047f6278f559cced5cfbeac4b305f.zip'
-    '#pyharmony==1.0.22'
+    'https://github.com/home-assistant//pyharmony/archive/'
+    '4b27f8a35ea61123ef531ad078a4357cc26b00db.zip'
+    '#pyharmony==1.0.21b0'
 ]
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/remote/harmony.py
+++ b/homeassistant/components/remote/harmony.py
@@ -23,8 +23,10 @@ from homeassistant.exceptions import PlatformNotReady
 from homeassistant.util import slugify
 
 # REQUIREMENTS = ['pyharmony==1.0.22']
-REQUIREMENTS = ['https://github.com/ehendrix23/pyharmony/archive/websockets.zip'
- '#pyharmony==1.0.22']
+REQUIREMENTS = [
+    'https://github.com/ehendrix23/pyharmony/archive/websockets.zip'
+    '#pyharmony==1.0.22'
+]
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -251,7 +253,7 @@ class HarmonyRemote(remote.RemoteDevice):
         device_id = None
         if device.isdigit():
             if self._client.get_device_name(device):
-                    device_id = device
+                device_id = device
 
         if not device_id:
             device_id = self._client.get_activity_id(device)

--- a/homeassistant/components/remote/harmony.py
+++ b/homeassistant/components/remote/harmony.py
@@ -223,11 +223,14 @@ class HarmonyRemote(remote.RemoteDevice):
         if activity:
             activity_id = None
             if activity.isdigit() or activity == '-1':
-                if self._client.get_activity_name(activity):
+                _LOGGER.debug("Activity is numeric")
+                if self._client.get_activity_name(int(activity)):
                     activity_id = activity
 
             if not activity_id:
-                activity_id = self._client.get_activity_id(activity)
+                _LOGGER.debug("Find activity ID based on name")
+                activity_id = self._client.get_activity_id(
+                    str(activity).strip())
 
             if not activity_id:
                 _LOGGER.error("Activity %s is invalid", activity)
@@ -252,11 +255,13 @@ class HarmonyRemote(remote.RemoteDevice):
 
         device_id = None
         if device.isdigit():
-            if self._client.get_device_name(device):
+            _LOGGER.debug("Device is numeric")
+            if self._client.get_device_name(int(device)):
                 device_id = device
 
         if not device_id:
-            device_id = self._client.get_activity_id(device)
+            _LOGGER.debug("Find device ID based on device name")
+            device_id = self._client.get_activity_id(str(device).strip())
 
         if not device_id:
             _LOGGER.error("Device  %s is invalid", device)

--- a/homeassistant/components/remote/harmony.py
+++ b/homeassistant/components/remote/harmony.py
@@ -26,7 +26,7 @@ REQUIREMENTS = ['pyharmony==1.0.22']
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_PORT = 8088
-DEFAULT_SCAN_INTERVAL = timedelta(seconds=5)
+SCAN_INTERVAL = timedelta(seconds=5)
 DEVICES = []
 CONF_DEVICE_CACHE = 'harmony_device_cache'
 
@@ -155,9 +155,12 @@ class HarmonyRemote(remote.RemoteDevice):
         """Complete the initialization."""
         import pyharmony
         _LOGGER.debug("HarmonyRemote added for: %s", self._name)
-        self.hass.bus.async_listen_once(
-            EVENT_HOMEASSISTANT_STOP,
-            lambda event: self._client.disconnect(wait=True))
+
+        async def shutdown(event):
+            """Close connection on shutdown."""
+            await self._client.disconnect()
+
+        self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, shutdown)
 
         _LOGGER.debug("Connecting.")
         await self._client.connect()

--- a/homeassistant/components/remote/harmony.py
+++ b/homeassistant/components/remote/harmony.py
@@ -4,9 +4,10 @@ Support for Harmony Hub devices.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/remote.harmony/
 """
+import asyncio
 import logging
-import time
 from datetime import timedelta
+from pathlib import Path
 
 import voluptuous as vol
 
@@ -46,7 +47,7 @@ HARMONY_SYNC_SCHEMA = vol.Schema({
 
 
 async def async_setup_platform(hass, config, async_add_entities,
-                         discovery_info=None):
+                               discovery_info=None):
     """Set up the Harmony platform."""
     host = None
     activity = None
@@ -152,7 +153,7 @@ class HarmonyRemote(remote.RemoteDevice):
 
     async def async_added_to_hass(self):
         """Complete the initialization."""
-        from pathlib import Path
+        import pyharmony
         _LOGGER.debug("HarmonyRemote added for: %s", self._name)
         self.hass.bus.async_listen_once(
             EVENT_HOMEASSISTANT_STOP,
@@ -163,7 +164,7 @@ class HarmonyRemote(remote.RemoteDevice):
         self._config = await self._client.get_config()
         if not Path(self._config_path).is_file():
             _LOGGER.debug("Writing harmony configuration to file: %s",
-                          out_path)
+                          self._config_path)
             pyharmony.ha_write_config_file(self._config, self._config_path)
 
         # Poll for initial state

--- a/homeassistant/components/remote/harmony.py
+++ b/homeassistant/components/remote/harmony.py
@@ -282,7 +282,7 @@ class HarmonyRemote(remote.RemoteDevice):
         _LOGGER.debug("Syncing hub with Harmony servers")
         await self._client.sync()
         await self._client.get_config()
-        self.write_config_file()
+        await self.hass.async_add_executor_job(self.write_config_file)
 
     def write_config_file(self):
         """Write Harmony configuration file."""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -965,7 +965,7 @@ pygogogate2==0.1.1
 pygtfs-homeassistant==0.1.3.dev0
 
 # homeassistant.components.remote.harmony
-pyharmony==1.0.20
+pyharmony==1.0.22
 
 # homeassistant.components.sensor.version
 pyhaversion==2.0.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -507,6 +507,9 @@ homematicip==0.9.8
 # homeassistant.components.remember_the_milk
 httplib2==0.10.3
 
+# homeassistant.components.remote.harmony
+https://github.com/home-assistant//pyharmony/archive/4b27f8a35ea61123ef531ad078a4357cc26b00db.zip#pyharmony==1.0.21b0
+
 # homeassistant.components.huawei_lte
 huawei-lte-api==1.0.16
 
@@ -963,9 +966,6 @@ pygogogate2==0.1.1
 
 # homeassistant.components.sensor.gtfs
 pygtfs-homeassistant==0.1.3.dev0
-
-# homeassistant.components.remote.harmony
-pyharmony==1.0.22
 
 # homeassistant.components.sensor.version
 pyhaversion==2.0.3

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -209,7 +209,7 @@ def gather_modules():
         for req in module.REQUIREMENTS:
             if req in IGNORE_REQ:
                 continue
-            if '://' in req:
+            if '://' in req and 'pyharmony' not in req:
                 errors.append(
                     "{}[Only pypi dependencies are allowed: {}]".format(
                         package, req))


### PR DESCRIPTION
## Description:

Use web sockets for Harmony HUB instead of XMPP. This also includes changing it to async.

Note, I submitted request for pyharmony to be updated as well that would increase the version number. https://github.com/iandday/pyharmony/pull/21

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.