### PR TITLE
Fix fail2ban by removal of internal timer logic

### DIFF
--- a/homeassistant/components/sensor/fail2ban.py
+++ b/homeassistant/components/sensor/fail2ban.py
@@ -7,8 +7,6 @@ https://home-assistant.io/components/sensor.fail2ban/
 import os
 import logging
 
-from datetime import timedelta
-
 import re
 import voluptuous as vol
 

--- a/homeassistant/components/sensor/fail2ban.py
+++ b/homeassistant/components/sensor/fail2ban.py
@@ -7,6 +7,8 @@ https://home-assistant.io/components/sensor.fail2ban/
 import os
 import logging
 
+from datetime import timedelta
+
 import re
 import voluptuous as vol
 
@@ -26,6 +28,7 @@ DEFAULT_LOG = '/var/log/fail2ban.log'
 
 STATE_CURRENT_BANS = 'current_bans'
 STATE_ALL_BANS = 'total_bans'
+SCAN_INTERVAL = timedelta(seconds=120)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_JAILS): vol.All(cv.ensure_list, vol.Length(min=1)),

--- a/homeassistant/components/sensor/fail2ban.py
+++ b/homeassistant/components/sensor/fail2ban.py
@@ -3,6 +3,7 @@ Support for displaying IPs banned by fail2ban.
 
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.fail2ban/
+
 """
 import os
 import logging

--- a/homeassistant/components/sensor/fail2ban.py
+++ b/homeassistant/components/sensor/fail2ban.py
@@ -13,10 +13,9 @@ import re
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
-import homeassistant.util.dt as dt_util
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
-    CONF_NAME, CONF_SCAN_INTERVAL, CONF_FILE_PATH
+    CONF_NAME, CONF_FILE_PATH
 )
 from homeassistant.helpers.entity import Entity
 
@@ -26,7 +25,6 @@ CONF_JAILS = 'jails'
 
 DEFAULT_NAME = 'fail2ban'
 DEFAULT_LOG = '/var/log/fail2ban.log'
-SCAN_INTERVAL = timedelta(seconds=120)
 
 STATE_CURRENT_BANS = 'current_bans'
 STATE_ALL_BANS = 'total_bans'
@@ -43,11 +41,10 @@ async def async_setup_platform(hass, config, async_add_entities,
     """Set up the fail2ban sensor."""
     name = config.get(CONF_NAME)
     jails = config.get(CONF_JAILS)
-    scan_interval = config.get(CONF_SCAN_INTERVAL)
     log_file = config.get(CONF_FILE_PATH, DEFAULT_LOG)
 
     device_list = []
-    log_parser = BanLogParser(scan_interval, log_file)
+    log_parser = BanLogParser(log_file)
     for jail in jails:
         device_list.append(BanSensor(name, jail, log_parser))
 
@@ -86,8 +83,7 @@ class BanSensor(Entity):
 
     def update(self):
         """Update the list of banned ips."""
-        if self.log_parser.timer():
-            self.log_parser.read_log(self.jail)
+        self.log_parser.read_log(self.jail)
 
         if self.log_parser.data:
             for entry in self.log_parser.data:
@@ -114,21 +110,11 @@ class BanSensor(Entity):
 class BanLogParser:
     """Class to parse fail2ban logs."""
 
-    def __init__(self, interval, log_file):
+    def __init__(self, log_file):
         """Initialize the parser."""
-        self.interval = interval
         self.log_file = log_file
         self.data = list()
-        self.last_update = dt_util.now()
         self.ip_regex = dict()
-
-    def timer(self):
-        """Check if we are allowed to update."""
-        boundary = dt_util.now() - self.interval
-        if boundary > self.last_update:
-            self.last_update = dt_util.now()
-            return True
-        return False
 
     def read_log(self, jail):
         """Read the fail2ban log and find entries for jail."""

--- a/tests/components/sensor/test_fail2ban.py
+++ b/tests/components/sensor/test_fail2ban.py
@@ -100,120 +100,99 @@ class TestBanSensor(unittest.TestCase):
         """Test that log is parsed correctly for single ban."""
         log_parser = BanLogParser('/tmp')
         sensor = BanSensor('fail2ban', 'jail_one', log_parser)
-        self.assertEqual(sensor.name, 'fail2ban jail_one')
+        assert sensor.name == 'fail2ban jail_one'
         mock_fh = MockOpen(read_data=fake_log('single_ban'))
         with patch('homeassistant.components.sensor.fail2ban.open', mock_fh,
                    create=True):
             sensor.update()
 
-        self.assertEqual(sensor.state, '111.111.111.111')
-        self.assertEqual(
-            sensor.state_attributes[STATE_CURRENT_BANS], ['111.111.111.111']
-        )
-        self.assertEqual(
-            sensor.state_attributes[STATE_ALL_BANS], ['111.111.111.111']
-        )
+        assert sensor.state == '111.111.111.111'
+        assert \
+            sensor.state_attributes[STATE_CURRENT_BANS] == ['111.111.111.111']
+        assert \
+            sensor.state_attributes[STATE_ALL_BANS] == ['111.111.111.111']
 
     def test_multiple_ban(self):
         """Test that log is parsed correctly for multiple ban."""
         log_parser = BanLogParser('/tmp')
         sensor = BanSensor('fail2ban', 'jail_one', log_parser)
-        self.assertEqual(sensor.name, 'fail2ban jail_one')
+        assert sensor.name == 'fail2ban jail_one'
         mock_fh = MockOpen(read_data=fake_log('multi_ban'))
         with patch('homeassistant.components.sensor.fail2ban.open', mock_fh,
                    create=True):
             sensor.update()
 
-        self.assertEqual(sensor.state, '222.222.222.222')
-        self.assertEqual(
-            sensor.state_attributes[STATE_CURRENT_BANS],
+        assert sensor.state == '222.222.222.222'
+        assert sensor.state_attributes[STATE_CURRENT_BANS] == \
             ['111.111.111.111', '222.222.222.222']
-        )
-        self.assertEqual(
-            sensor.state_attributes[STATE_ALL_BANS],
+        assert sensor.state_attributes[STATE_ALL_BANS] == \
             ['111.111.111.111', '222.222.222.222']
-        )
 
     def test_unban_all(self):
         """Test that log is parsed correctly when unbanning."""
         log_parser = BanLogParser('/tmp')
         sensor = BanSensor('fail2ban', 'jail_one', log_parser)
-        self.assertEqual(sensor.name, 'fail2ban jail_one')
+        assert sensor.name == 'fail2ban jail_one'
         mock_fh = MockOpen(read_data=fake_log('unban_all'))
         with patch('homeassistant.components.sensor.fail2ban.open', mock_fh,
                    create=True):
             sensor.update()
 
-        self.assertEqual(sensor.state, 'None')
-        self.assertEqual(sensor.state_attributes[STATE_CURRENT_BANS], [])
-        self.assertEqual(
-            sensor.state_attributes[STATE_ALL_BANS],
+        assert sensor.state == 'None'
+        assert sensor.state_attributes[STATE_CURRENT_BANS] == []
+        assert sensor.state_attributes[STATE_ALL_BANS] == \
             ['111.111.111.111', '222.222.222.222']
-        )
 
     def test_unban_one(self):
         """Test that log is parsed correctly when unbanning one ip."""
         log_parser = BanLogParser('/tmp')
         sensor = BanSensor('fail2ban', 'jail_one', log_parser)
-        self.assertEqual(sensor.name, 'fail2ban jail_one')
+        assert sensor.name == 'fail2ban jail_one'
         mock_fh = MockOpen(read_data=fake_log('unban_one'))
         with patch('homeassistant.components.sensor.fail2ban.open', mock_fh,
                    create=True):
             sensor.update()
 
-        self.assertEqual(sensor.state, '222.222.222.222')
-        self.assertEqual(
-            sensor.state_attributes[STATE_CURRENT_BANS],
+        assert sensor.state == '222.222.222.222'
+        assert sensor.state_attributes[STATE_CURRENT_BANS] == \
             ['222.222.222.222']
-        )
-        self.assertEqual(
-            sensor.state_attributes[STATE_ALL_BANS],
+        assert sensor.state_attributes[STATE_ALL_BANS] == \
             ['111.111.111.111', '222.222.222.222']
-        )
 
     def test_multi_jail(self):
         """Test that log is parsed correctly when using multiple jails."""
         log_parser = BanLogParser('/tmp')
         sensor1 = BanSensor('fail2ban', 'jail_one', log_parser)
         sensor2 = BanSensor('fail2ban', 'jail_two', log_parser)
-        self.assertEqual(sensor1.name, 'fail2ban jail_one')
-        self.assertEqual(sensor2.name, 'fail2ban jail_two')
+        assert sensor1.name == 'fail2ban jail_one'
+        assert sensor2.name == 'fail2ban jail_two'
         mock_fh = MockOpen(read_data=fake_log('multi_jail'))
         with patch('homeassistant.components.sensor.fail2ban.open', mock_fh,
                    create=True):
             sensor1.update()
             sensor2.update()
 
-        self.assertEqual(sensor1.state, '111.111.111.111')
-        self.assertEqual(
-            sensor1.state_attributes[STATE_CURRENT_BANS], ['111.111.111.111']
-        )
-        self.assertEqual(
-            sensor1.state_attributes[STATE_ALL_BANS], ['111.111.111.111']
-        )
-        self.assertEqual(sensor2.state, '222.222.222.222')
-        self.assertEqual(
-            sensor2.state_attributes[STATE_CURRENT_BANS], ['222.222.222.222']
-        )
-        self.assertEqual(
-            sensor2.state_attributes[STATE_ALL_BANS], ['222.222.222.222']
-        )
+        assert sensor1.state == '111.111.111.111'
+        assert \
+            sensor1.state_attributes[STATE_CURRENT_BANS] == ['111.111.111.111']
+        assert sensor1.state_attributes[STATE_ALL_BANS] == ['111.111.111.111']
+        assert sensor2.state == '222.222.222.222'
+        assert \
+            sensor2.state_attributes[STATE_CURRENT_BANS] == ['222.222.222.222']
+        assert sensor2.state_attributes[STATE_ALL_BANS] == ['222.222.222.222']
 
     def test_ban_active_after_update(self):
         """Test that ban persists after subsequent update."""
         log_parser = BanLogParser('/tmp')
         sensor = BanSensor('fail2ban', 'jail_one', log_parser)
-        self.assertEqual(sensor.name, 'fail2ban jail_one')
+        assert sensor.name == 'fail2ban jail_one'
         mock_fh = MockOpen(read_data=fake_log('single_ban'))
         with patch('homeassistant.components.sensor.fail2ban.open', mock_fh,
                    create=True):
             sensor.update()
-            self.assertEqual(sensor.state, '111.111.111.111')
+            assert sensor.state == '111.111.111.111'
             sensor.update()
-            self.assertEqual(sensor.state, '111.111.111.111')
-        self.assertEqual(
-            sensor.state_attributes[STATE_CURRENT_BANS], ['111.111.111.111']
-        )
-        self.assertEqual(
-            sensor.state_attributes[STATE_ALL_BANS], ['111.111.111.111']
-        )
+            assert sensor.state == '111.111.111.111'
+        assert \
+            sensor.state_attributes[STATE_CURRENT_BANS] == ['111.111.111.111']
+        assert sensor.state_attributes[STATE_ALL_BANS] == ['111.111.111.111']

--- a/tests/components/sensor/test_fail2ban.py
+++ b/tests/components/sensor/test_fail2ban.py
@@ -2,7 +2,6 @@
 import unittest
 from unittest.mock import Mock, patch
 
-from datetime import timedelta
 from mock_open import MockOpen
 
 from homeassistant.setup import setup_component
@@ -99,101 +98,122 @@ class TestBanSensor(unittest.TestCase):
 
     def test_single_ban(self):
         """Test that log is parsed correctly for single ban."""
-        log_parser = BanLogParser(timedelta(seconds=-1), '/tmp')
+        log_parser = BanLogParser('/tmp')
         sensor = BanSensor('fail2ban', 'jail_one', log_parser)
-        assert sensor.name == 'fail2ban jail_one'
+        self.assertEqual(sensor.name, 'fail2ban jail_one')
         mock_fh = MockOpen(read_data=fake_log('single_ban'))
         with patch('homeassistant.components.sensor.fail2ban.open', mock_fh,
                    create=True):
             sensor.update()
 
-        assert sensor.state == '111.111.111.111'
-        assert \
-            sensor.state_attributes[STATE_CURRENT_BANS] == ['111.111.111.111']
-        assert \
-            sensor.state_attributes[STATE_ALL_BANS] == ['111.111.111.111']
+        self.assertEqual(sensor.state, '111.111.111.111')
+        self.assertEqual(
+            sensor.state_attributes[STATE_CURRENT_BANS], ['111.111.111.111']
+        )
+        self.assertEqual(
+            sensor.state_attributes[STATE_ALL_BANS], ['111.111.111.111']
+        )
 
     def test_multiple_ban(self):
         """Test that log is parsed correctly for multiple ban."""
-        log_parser = BanLogParser(timedelta(seconds=-1), '/tmp')
+        log_parser = BanLogParser('/tmp')
         sensor = BanSensor('fail2ban', 'jail_one', log_parser)
-        assert sensor.name == 'fail2ban jail_one'
+        self.assertEqual(sensor.name, 'fail2ban jail_one')
         mock_fh = MockOpen(read_data=fake_log('multi_ban'))
         with patch('homeassistant.components.sensor.fail2ban.open', mock_fh,
                    create=True):
             sensor.update()
 
-        assert sensor.state == '222.222.222.222'
-        assert sensor.state_attributes[STATE_CURRENT_BANS] == \
+        self.assertEqual(sensor.state, '222.222.222.222')
+        self.assertEqual(
+            sensor.state_attributes[STATE_CURRENT_BANS],
             ['111.111.111.111', '222.222.222.222']
-        assert sensor.state_attributes[STATE_ALL_BANS] == \
+        )
+        self.assertEqual(
+            sensor.state_attributes[STATE_ALL_BANS],
             ['111.111.111.111', '222.222.222.222']
+        )
 
     def test_unban_all(self):
         """Test that log is parsed correctly when unbanning."""
-        log_parser = BanLogParser(timedelta(seconds=-1), '/tmp')
+        log_parser = BanLogParser('/tmp')
         sensor = BanSensor('fail2ban', 'jail_one', log_parser)
-        assert sensor.name == 'fail2ban jail_one'
+        self.assertEqual(sensor.name, 'fail2ban jail_one')
         mock_fh = MockOpen(read_data=fake_log('unban_all'))
         with patch('homeassistant.components.sensor.fail2ban.open', mock_fh,
                    create=True):
             sensor.update()
 
-        assert sensor.state == 'None'
-        assert sensor.state_attributes[STATE_CURRENT_BANS] == []
-        assert sensor.state_attributes[STATE_ALL_BANS] == \
+        self.assertEqual(sensor.state, 'None')
+        self.assertEqual(sensor.state_attributes[STATE_CURRENT_BANS], [])
+        self.assertEqual(
+            sensor.state_attributes[STATE_ALL_BANS],
             ['111.111.111.111', '222.222.222.222']
+        )
 
     def test_unban_one(self):
         """Test that log is parsed correctly when unbanning one ip."""
-        log_parser = BanLogParser(timedelta(seconds=-1), '/tmp')
+        log_parser = BanLogParser('/tmp')
         sensor = BanSensor('fail2ban', 'jail_one', log_parser)
-        assert sensor.name == 'fail2ban jail_one'
+        self.assertEqual(sensor.name, 'fail2ban jail_one')
         mock_fh = MockOpen(read_data=fake_log('unban_one'))
         with patch('homeassistant.components.sensor.fail2ban.open', mock_fh,
                    create=True):
             sensor.update()
 
-        assert sensor.state == '222.222.222.222'
-        assert sensor.state_attributes[STATE_CURRENT_BANS] == \
+        self.assertEqual(sensor.state, '222.222.222.222')
+        self.assertEqual(
+            sensor.state_attributes[STATE_CURRENT_BANS],
             ['222.222.222.222']
-        assert sensor.state_attributes[STATE_ALL_BANS] == \
+        )
+        self.assertEqual(
+            sensor.state_attributes[STATE_ALL_BANS],
             ['111.111.111.111', '222.222.222.222']
+        )
 
     def test_multi_jail(self):
         """Test that log is parsed correctly when using multiple jails."""
-        log_parser = BanLogParser(timedelta(seconds=-1), '/tmp')
+        log_parser = BanLogParser('/tmp')
         sensor1 = BanSensor('fail2ban', 'jail_one', log_parser)
         sensor2 = BanSensor('fail2ban', 'jail_two', log_parser)
-        assert sensor1.name == 'fail2ban jail_one'
-        assert sensor2.name == 'fail2ban jail_two'
+        self.assertEqual(sensor1.name, 'fail2ban jail_one')
+        self.assertEqual(sensor2.name, 'fail2ban jail_two')
         mock_fh = MockOpen(read_data=fake_log('multi_jail'))
         with patch('homeassistant.components.sensor.fail2ban.open', mock_fh,
                    create=True):
             sensor1.update()
             sensor2.update()
 
-        assert sensor1.state == '111.111.111.111'
-        assert \
-            sensor1.state_attributes[STATE_CURRENT_BANS] == ['111.111.111.111']
-        assert sensor1.state_attributes[STATE_ALL_BANS] == ['111.111.111.111']
-        assert sensor2.state == '222.222.222.222'
-        assert \
-            sensor2.state_attributes[STATE_CURRENT_BANS] == ['222.222.222.222']
-        assert sensor2.state_attributes[STATE_ALL_BANS] == ['222.222.222.222']
+        self.assertEqual(sensor1.state, '111.111.111.111')
+        self.assertEqual(
+            sensor1.state_attributes[STATE_CURRENT_BANS], ['111.111.111.111']
+        )
+        self.assertEqual(
+            sensor1.state_attributes[STATE_ALL_BANS], ['111.111.111.111']
+        )
+        self.assertEqual(sensor2.state, '222.222.222.222')
+        self.assertEqual(
+            sensor2.state_attributes[STATE_CURRENT_BANS], ['222.222.222.222']
+        )
+        self.assertEqual(
+            sensor2.state_attributes[STATE_ALL_BANS], ['222.222.222.222']
+        )
 
     def test_ban_active_after_update(self):
         """Test that ban persists after subsequent update."""
-        log_parser = BanLogParser(timedelta(seconds=-1), '/tmp')
+        log_parser = BanLogParser('/tmp')
         sensor = BanSensor('fail2ban', 'jail_one', log_parser)
-        assert sensor.name == 'fail2ban jail_one'
+        self.assertEqual(sensor.name, 'fail2ban jail_one')
         mock_fh = MockOpen(read_data=fake_log('single_ban'))
         with patch('homeassistant.components.sensor.fail2ban.open', mock_fh,
                    create=True):
             sensor.update()
-            assert sensor.state == '111.111.111.111'
+            self.assertEqual(sensor.state, '111.111.111.111')
             sensor.update()
-            assert sensor.state == '111.111.111.111'
-        assert \
-            sensor.state_attributes[STATE_CURRENT_BANS] == ['111.111.111.111']
-        assert sensor.state_attributes[STATE_ALL_BANS] == ['111.111.111.111']
+            self.assertEqual(sensor.state, '111.111.111.111')
+        self.assertEqual(
+            sensor.state_attributes[STATE_CURRENT_BANS], ['111.111.111.111']
+        )
+        self.assertEqual(
+            sensor.state_attributes[STATE_ALL_BANS], ['111.111.111.111']
+        )


### PR DESCRIPTION
## Description:
As asked in #17612, I split the different contribuitions.

**Related issue (if applicable):**
fixes #10497

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
