### PR TITLE
Adding IPv6 to fail2ban sensor

### DIFF
--- a/homeassistant/components/sensor/fail2ban.py
+++ b/homeassistant/components/sensor/fail2ban.py
@@ -65,7 +65,7 @@ class BanSensor(Entity):
         self.last_ban = None
         self.log_parser = log_parser
         self.log_parser.ip_regex[self.jail] = re.compile(
-            r"\[{}\].(Ban|Unban) ([\w+\.]{{3,}})".format(re.escape(self.jail))
+            r"\[{}\]\s*(Ban|Unban) (.*)".format(re.escape(self.jail))
         )
         _LOGGER.debug("Setting up jail %s", self.jail)
 

--- a/tests/components/sensor/test_fail2ban.py
+++ b/tests/components/sensor/test_fail2ban.py
@@ -130,7 +130,7 @@ class TestBanSensor(unittest.TestCase):
         assert sensor.state == '2607:f0d0:1002:51::4'
         assert \
             sensor.state_attributes[STATE_CURRENT_BANS] == \
-                ['2607:f0d0:1002:51::4']
+            ['2607:f0d0:1002:51::4']
         assert \
             sensor.state_attributes[STATE_ALL_BANS] == ['2607:f0d0:1002:51::4']
 

--- a/tests/components/sensor/test_fail2ban.py
+++ b/tests/components/sensor/test_fail2ban.py
@@ -129,8 +129,8 @@ class TestBanSensor(unittest.TestCase):
 
         assert sensor.state == '2607:f0d0:1002:51::4'
         assert \
-            sensor.state_attributes[STATE_CURRENT_BANS] == 
-            ['2607:f0d0:1002:51::4']
+            sensor.state_attributes[STATE_CURRENT_BANS] == \
+                ['2607:f0d0:1002:51::4']
         assert \
             sensor.state_attributes[STATE_ALL_BANS] == ['2607:f0d0:1002:51::4']
 

--- a/tests/components/sensor/test_fail2ban.py
+++ b/tests/components/sensor/test_fail2ban.py
@@ -116,7 +116,7 @@ class TestBanSensor(unittest.TestCase):
             sensor.state_attributes[STATE_CURRENT_BANS] == ['111.111.111.111']
         assert \
             sensor.state_attributes[STATE_ALL_BANS] == ['111.111.111.111']
-        
+
     def test_ipv6_ban(self):
         """Test that log is parsed correctly for IPV6 bans."""
         log_parser = BanLogParser(timedelta(seconds=-1), '/tmp')
@@ -129,10 +129,11 @@ class TestBanSensor(unittest.TestCase):
 
         assert sensor.state == '2607:f0d0:1002:51::4'
         assert \
-            sensor.state_attributes[STATE_CURRENT_BANS] == ['2607:f0d0:1002:51::4']
+            sensor.state_attributes[STATE_CURRENT_BANS] == 
+            ['2607:f0d0:1002:51::4']
         assert \
             sensor.state_attributes[STATE_ALL_BANS] == ['2607:f0d0:1002:51::4']
-        
+
     def test_multiple_ban(self):
         """Test that log is parsed correctly for multiple ban."""
         log_parser = BanLogParser(timedelta(seconds=-1), '/tmp')

--- a/tests/components/sensor/test_fail2ban.py
+++ b/tests/components/sensor/test_fail2ban.py
@@ -20,6 +20,10 @@ def fake_log(log_key):
             '2017-01-01 12:23:35 fail2ban.actions [111]: '
             'NOTICE [jail_one] Ban 111.111.111.111'
         ),
+        'ipv6_ban': (
+             '2017-01-01 12:23:35 fail2ban.actions [111]: '
+             'NOTICE [jail_one] Ban 2607:f0d0:1002:51::4'
+         ),
         'multi_ban': (
             '2017-01-01 12:23:35 fail2ban.actions [111]: '
             'NOTICE [jail_one] Ban 111.111.111.111\n'
@@ -112,7 +116,23 @@ class TestBanSensor(unittest.TestCase):
             sensor.state_attributes[STATE_CURRENT_BANS] == ['111.111.111.111']
         assert \
             sensor.state_attributes[STATE_ALL_BANS] == ['111.111.111.111']
+        
+    def test_ipv6_ban(self):
+        """Test that log is parsed correctly for IPV6 bans."""
+        log_parser = BanLogParser(timedelta(seconds=-1), '/tmp')
+        sensor = BanSensor('fail2ban', 'jail_one', log_parser)
+        assert sensor.name == 'fail2ban jail_one'
+        mock_fh = MockOpen(read_data=fake_log('ipv6_ban'))
+        with patch('homeassistant.components.sensor.fail2ban.open', mock_fh,
+                   create=True):
+            sensor.update()
 
+        assert sensor.state == '2607:f0d0:1002:51::4'
+        assert \
+            sensor.state_attributes[STATE_CURRENT_BANS] == ['2607:f0d0:1002:51::4']
+        assert \
+            sensor.state_attributes[STATE_ALL_BANS] == ['2607:f0d0:1002:51::4']
+        
     def test_multiple_ban(self):
         """Test that log is parsed correctly for multiple ban."""
         log_parser = BanLogParser(timedelta(seconds=-1), '/tmp')


### PR DESCRIPTION
## Description:
Spliting contributions from #17612. Adding regex changes and tests for IPv6 in the fail2ban sensor

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
