### PR TITLE
Configure ZHA entity on new ZHA device join

### DIFF
--- a/homeassistant/components/fan/zha.py
+++ b/homeassistant/components/fan/zha.py
@@ -70,10 +70,7 @@ async def _async_setup_entities(hass, config_entry, async_add_entities,
     """Set up the ZHA fans."""
     entities = []
     for discovery_info in discovery_infos:
-        fan = ZhaFan(**discovery_info)
-        if discovery_info['new_join']:
-            await fan.async_configure()
-        entities.append(fan)
+        entities.append(ZhaFan(**discovery_info))
 
     async_add_entities(entities, update_before_add=True)
 

--- a/homeassistant/components/light/zha.py
+++ b/homeassistant/components/light/zha.py
@@ -75,8 +75,6 @@ async def _async_setup_entities(hass, config_entry, async_add_entities,
                     discovery_info['color_capabilities'] |= \
                         CAPABILITIES_COLOR_TEMP
         zha_light = Light(**discovery_info)
-        if discovery_info['new_join']:
-            await zha_light.async_configure()
         entities.append(zha_light)
 
     async_add_entities(entities, update_before_add=True)

--- a/homeassistant/components/sensor/zha.py
+++ b/homeassistant/components/sensor/zha.py
@@ -84,8 +84,6 @@ async def make_sensor(discovery_info):
     else:
         sensor = Sensor(**discovery_info)
 
-    if discovery_info['new_join']:
-        await sensor.async_configure()
     return sensor
 
 

--- a/homeassistant/components/switch/zha.py
+++ b/homeassistant/components/switch/zha.py
@@ -46,10 +46,7 @@ async def _async_setup_entities(hass, config_entry, async_add_entities,
     """Set up the ZHA switches."""
     entities = []
     for discovery_info in discovery_infos:
-        switch = Switch(**discovery_info)
-        if discovery_info['new_join']:
-            await switch.async_configure()
-        entities.append(switch)
+        entities.append(Switch(**discovery_info))
 
     async_add_entities(entities, update_before_add=True)
 
@@ -124,7 +121,7 @@ class Switch(ZhaEntity, SwitchDevice):
 
     async def async_update(self):
         """Retrieve latest state."""
-        result = await helpers.safe_read(self._endpoint.on_off,
+        result = await helpers.safe_read(self.cluster,
                                          ['on_off'],
                                          allow_cache=False,
                                          only_cache=(not self._initialized))

--- a/homeassistant/components/zha/entities/entity.py
+++ b/homeassistant/components/zha/entities/entity.py
@@ -4,7 +4,7 @@ Entity for Zigbee Home Automation.
 For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/zha/
 """
-from asyncio import sleep
+import asyncio
 import logging
 from random import uniform
 
@@ -104,7 +104,7 @@ class ZhaEntity(entity.Entity):
                     manufacturer=manufacturer
                 )
                 skip_bind = True
-                await sleep(uniform(0.1, 0.5))
+                await asyncio.sleep(uniform(0.1, 0.5))
         _LOGGER.debug("%s: finished configuration", self.entity_id)
 
     def _get_cluster_from_report_config(self, cluster_key):
@@ -152,7 +152,7 @@ class ZhaEntity(entity.Entity):
             }
         }
         """
-        return dict()
+        return {}
 
     @property
     def unique_id(self) -> str:

--- a/homeassistant/components/zha/entities/entity.py
+++ b/homeassistant/components/zha/entities/entity.py
@@ -25,7 +25,8 @@ class ZhaEntity(entity.Entity):
     _domain = None  # Must be overridden by subclasses
 
     def __init__(self, endpoint, in_clusters, out_clusters, manufacturer,
-                 model, application_listener, unique_id, **kwargs):
+                 model, application_listener, unique_id, new_join=False,
+                 **kwargs):
         """Init ZHA entity."""
         self._device_state_attributes = {}
         ieee = endpoint.device.ieee
@@ -54,6 +55,7 @@ class ZhaEntity(entity.Entity):
         self._endpoint = endpoint
         self._in_clusters = in_clusters
         self._out_clusters = out_clusters
+        self._new_join = new_join
         self._state = None
         self._unique_id = unique_id
 
@@ -78,6 +80,9 @@ class ZhaEntity(entity.Entity):
             cluster.add_listener(self._out_listeners.get(cluster_id, self))
 
         self._endpoint.device.zdo.add_listener(self)
+
+        if self._new_join:
+            self.hass.async_create_task(self.async_configure())
 
         self._initialized = True
 


### PR DESCRIPTION
## Description:
address #19177 comments
make `new_join` part of `ZhaEntity` and automatically call `async_configure()` if this entity of a freshly joined ZHA device

There's some duplicated code in zha platform for different components, this PR removes unnecessary code duplication

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
