### PR TITLE
Add timeout to RainMachine login

### DIFF
--- a/homeassistant/components/rainmachine/__init__.py
+++ b/homeassistant/components/rainmachine/__init__.py
@@ -158,18 +158,17 @@ async def async_setup_entry(hass, config_entry):
             websession,
             port=config_entry.data[CONF_PORT],
             ssl=config_entry.data[CONF_SSL])
+        rainmachine = RainMachine(
+            client,
+            config_entry.data.get(CONF_BINARY_SENSORS, {}).get(
+                CONF_MONITORED_CONDITIONS, list(BINARY_SENSORS)),
+            config_entry.data.get(CONF_SENSORS, {}).get(
+                CONF_MONITORED_CONDITIONS, list(SENSORS)),
+            config_entry.data.get(CONF_ZONE_RUN_TIME, DEFAULT_ZONE_RUN))
+        await rainmachine.async_update()
     except RainMachineError as err:
         _LOGGER.error('An error occurred: %s', err)
         raise ConfigEntryNotReady
-
-    rainmachine = RainMachine(
-        client,
-        config_entry.data.get(CONF_BINARY_SENSORS, {}).get(
-            CONF_MONITORED_CONDITIONS, list(BINARY_SENSORS)),
-        config_entry.data.get(CONF_SENSORS, {}).get(
-            CONF_MONITORED_CONDITIONS, list(SENSORS)),
-        config_entry.data.get(CONF_ZONE_RUN_TIME, DEFAULT_ZONE_RUN))
-    await rainmachine.async_update()
 
     hass.data[DOMAIN][DATA_CLIENT][config_entry.entry_id] = rainmachine
 

--- a/homeassistant/components/rainmachine/__init__.py
+++ b/homeassistant/components/rainmachine/__init__.py
@@ -4,11 +4,9 @@ Support for RainMachine devices.
 For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/rainmachine/
 """
-import asyncio
 import logging
 from datetime import timedelta
 
-import async_timeout
 import voluptuous as vol
 
 from homeassistant.config_entries import SOURCE_IMPORT
@@ -26,7 +24,7 @@ from .config_flow import configured_instances
 from .const import (
     DATA_CLIENT, DEFAULT_PORT, DEFAULT_SCAN_INTERVAL, DEFAULT_SSL, DOMAIN)
 
-REQUIREMENTS = ['regenmaschine==1.0.7']
+REQUIREMENTS = ['regenmaschine==1.1.0']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -154,14 +152,13 @@ async def async_setup_entry(hass, config_entry):
     websession = aiohttp_client.async_get_clientsession(hass)
 
     try:
-        with async_timeout.timeout(4):
-            client = await login(
-                config_entry.data[CONF_IP_ADDRESS],
-                config_entry.data[CONF_PASSWORD],
-                websession,
-                port=config_entry.data[CONF_PORT],
-                ssl=config_entry.data[CONF_SSL])
-    except (asyncio.TimeoutError, RainMachineError) as err:
+        client = await login(
+            config_entry.data[CONF_IP_ADDRESS],
+            config_entry.data[CONF_PASSWORD],
+            websession,
+            port=config_entry.data[CONF_PORT],
+            ssl=config_entry.data[CONF_SSL])
+    except RainMachineError as err:
         _LOGGER.error('An error occurred: %s', err)
         raise ConfigEntryNotReady
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1379,7 +1379,7 @@ raincloudy==0.0.5
 # raspihats==2.2.3
 
 # homeassistant.components.rainmachine
-regenmaschine==1.0.7
+regenmaschine==1.1.0
 
 # homeassistant.components.python_script
 restrictedpython==4.0b7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -221,7 +221,7 @@ pyunifi==2.13
 pywebpush==1.6.0
 
 # homeassistant.components.rainmachine
-regenmaschine==1.0.7
+regenmaschine==1.1.0
 
 # homeassistant.components.python_script
 restrictedpython==4.0b7


### PR DESCRIPTION
## Description:

The RainMachine integration didn't use an explicit timeout when logging in, meaning it could potentially hang HASS startup if the RainMachine controller couldn't be reached. This PR fixes that by bumping `regenmaschine` to 1.1.0 (changelog: https://github.com/bachya/regenmaschine/releases/tag/1.1.0).

**Related issue (if applicable):** fixes #19416

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
rainmachine:
  controllers:
    - ip_address: !secret rainmachine_ip_address
      password: !secret rainmachine_password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
