### PR TITLE
Add sunrise and sunset to Darksky weather sensor

### DIFF
--- a/homeassistant/components/sensor/darksky.py
+++ b/homeassistant/components/sensor/darksky.py
@@ -23,11 +23,12 @@ REQUIREMENTS = ['python-forecastio==1.4.0']
 
 _LOGGER = logging.getLogger(__name__)
 
-CONF_ATTRIBUTION = "Powered by Dark Sky"
-CONF_UNITS = 'units'
-CONF_UPDATE_INTERVAL = 'update_interval'
+ATTRIBUTION = "Powered by Dark Sky"
+
 CONF_FORECAST = 'forecast'
 CONF_LANGUAGE = 'language'
+CONF_UNITS = 'units'
+CONF_UPDATE_INTERVAL = 'update_interval'
 
 DEFAULT_LANGUAGE = 'en'
 
@@ -129,6 +130,10 @@ SENSOR_TYPES = {
                  UNIT_UV_INDEX, UNIT_UV_INDEX, 'mdi:weather-sunny',
                  ['currently', 'hourly', 'daily']],
     'moon_phase': ['Moon Phase', None, None, None, None, None,
+                   'mdi:weather-night', ['daily']],
+    'sunrise_time': ['Sunrise', None, None, None, None, None,
+                   'mdi:white-balance-sunny', ['daily']],
+    'sunset_time': ['Sunset', None, None, None, None, None,
                    'mdi:weather-night', ['daily']],
 }
 
@@ -296,7 +301,7 @@ class DarkSkySensor(Entity):
     def device_state_attributes(self):
         """Return the state attributes."""
         return {
-            ATTR_ATTRIBUTION: CONF_ATTRIBUTION,
+            ATTR_ATTRIBUTION: ATTRIBUTION,
         }
 
     def update(self):

--- a/homeassistant/components/sensor/darksky.py
+++ b/homeassistant/components/sensor/darksky.py
@@ -132,9 +132,9 @@ SENSOR_TYPES = {
     'moon_phase': ['Moon Phase', None, None, None, None, None,
                    'mdi:weather-night', ['daily']],
     'sunrise_time': ['Sunrise', None, None, None, None, None,
-                   'mdi:white-balance-sunny', ['daily']],
+                     'mdi:white-balance-sunny', ['daily']],
     'sunset_time': ['Sunset', None, None, None, None, None,
-                   'mdi:weather-night', ['daily']],
+                    'mdi:weather-night', ['daily']],
 }
 
 CONDITION_PICTURES = {


### PR DESCRIPTION
## Description:
Add sunrise and sunset to Darksky weather sensor.

**Related issue (if applicable):** fixes [85438](https://community.home-assistant.io/t/darksky-sensor-add-sunrise-sunset-to-monitored-conditions/85438)

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#7917

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: darksky
    api_key: !secret darksky_api
    forecast:
      - 0
    monitored_conditions:
      - sunrise_time
      - sunset_time
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)
