### PR TITLE
Improve robustness of Weather IPMA

### DIFF
--- a/homeassistant/components/weather/ipma.py
+++ b/homeassistant/components/weather/ipma.py
@@ -92,7 +92,12 @@ class IPMAWeather(WeatherEntity):
     async def async_update(self):
         """Update Condition and Forecast."""
         with async_timeout.timeout(10, loop=self.hass.loop):
-            self._condition = await self._station.observation()
+            _new_condition = await self._station.observation()
+            if _new_condition is None:
+                _LOGGER.warning("Could not update weather conditions")
+                return
+            self._condition = _new_condition
+
             _LOGGER.debug("Updating station %s, condition %s",
                           self._station.local, self._condition)
             self._forecast = await self._station.forecast()


### PR DESCRIPTION
## Description:

Sometimes the upstream API is in an update process and the supporting API returns a None object. This ignores that situation

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
weather:
 - platform: ipma
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54