### PR TITLE
Remove webhook setup check if base url is local

### DIFF
--- a/homeassistant/helpers/config_entry_flow.py
+++ b/homeassistant/helpers/config_entry_flow.py
@@ -1,10 +1,7 @@
 """Helpers for data entry flows for config entries."""
 from functools import partial
-from ipaddress import ip_address
-from urllib.parse import urlparse
 
 from homeassistant import config_entries
-from homeassistant.util.network import is_local
 
 
 def register_discovery_flow(domain, title, discovery_function,
@@ -114,15 +111,6 @@ class WebhookFlowHandler(config_entries.ConfigFlow):
         """Handle a user initiated set up flow to create a webhook."""
         if not self._allow_multiple and self._async_current_entries():
             return self.async_abort(reason='one_instance_allowed')
-
-        try:
-            url_parts = urlparse(self.hass.config.api.base_url)
-
-            if is_local(ip_address(url_parts.hostname)):
-                return self.async_abort(reason='not_internet_accessible')
-        except ValueError:
-            # If it's not an IP address, it's very likely publicly accessible
-            pass
 
         if user_input is None:
             return self.async_show_form(

--- a/tests/helpers/test_config_entry_flow.py
+++ b/tests/helpers/test_config_entry_flow.py
@@ -183,19 +183,6 @@ async def test_webhook_multiple_entries_allowed(hass, webhook_flow_conf):
     assert result['type'] == data_entry_flow.RESULT_TYPE_FORM
 
 
-async def test_webhook_config_flow_aborts_external_url(hass,
-                                                       webhook_flow_conf):
-    """Test configuring a webhook without an external url."""
-    flow = config_entries.HANDLERS['test_single']()
-    flow.hass = hass
-
-    hass.config.api = Mock(base_url='http://192.168.1.10')
-    result = await flow.async_step_user()
-
-    assert result['type'] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result['reason'] == 'not_internet_accessible'
-
-
 async def test_webhook_config_flow_registers_webhook(hass, webhook_flow_conf):
     """Test setting up an entry creates a webhook."""
     flow = config_entries.HANDLERS['test_single']()


### PR DESCRIPTION
## Description:
Webhook config flow helper had a check that canceled the flow if we detected that we're not internet accessible. However, this breaks if we're integrating with a service with local webhooks (Plex), if the base url is not properly configured or if we're going to make the webhook cloud accessible.

This removes the check.

If you're running into this, a temporary workaround is to set the base url to your hostname in your `configuration.yaml`:

```yaml
http:
  base_url: "hassio:8123"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
