### PR TITLE
Fix scrape sensor initial failed setup

### DIFF
--- a/homeassistant/components/sensor/scrape.py
+++ b/homeassistant/components/sensor/scrape.py
@@ -17,6 +17,7 @@ from homeassistant.const import (
     CONF_PASSWORD, CONF_AUTHENTICATION, HTTP_BASIC_AUTHENTICATION,
     HTTP_DIGEST_AUTHENTICATION)
 from homeassistant.helpers.entity import Entity
+from homeassistant.exceptions import PlatformNotReady
 import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['beautifulsoup4==4.6.3']
@@ -73,8 +74,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     rest.update()
 
     if rest.data is None:
-        _LOGGER.error("Unable to fetch data from %s", resource)
-        return False
+        raise PlatformNotReady
 
     add_entities([
         ScrapeSensor(rest, name, select, attr, value_template, unit)], True)


### PR DESCRIPTION
## Description:
Allow scrape sensor to retry setup if initial setup fails (like the rest sensor does).

**Related issue (if applicable):** fixes #19488

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: scrape
    resource: https://www.abcd-home-assistant.io
    select: ".current-version h1"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
