### PR TITLE
Fix support for base topic for empty values in MQTT discovery msg

### DIFF
--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -196,7 +196,7 @@ async def async_start(hass: HomeAssistantType, discovery_topic, hass_config,
         if TOPIC_BASE in payload:
             base = payload[TOPIC_BASE]
             for key, value in payload.items():
-                if isinstance(value, str) and len(value) > 0:
+                if isinstance(value, str) and value:
                     if value[0] == TOPIC_BASE and key.endswith('_topic'):
                         payload[key] = "{}{}".format(base, value[1:])
                     if value[-1] == TOPIC_BASE and key.endswith('_topic'):

--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -196,7 +196,7 @@ async def async_start(hass: HomeAssistantType, discovery_topic, hass_config,
         if TOPIC_BASE in payload:
             base = payload[TOPIC_BASE]
             for key, value in payload.items():
-                if isinstance(value, str):
+                if isinstance(value, str) and len(value) > 0:
                     if value[0] == TOPIC_BASE and key.endswith('_topic'):
                         payload[key] = "{}{}".format(base, value[1:])
                     if value[-1] == TOPIC_BASE and key.endswith('_topic'):


### PR DESCRIPTION
## Description:
Fix error when discovery message contains empty values and a base topic is defined.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
