### PR TITLE
Don't truncate brightness and white_value of MQTT light

### DIFF
--- a/homeassistant/components/light/mqtt/schema_basic.py
+++ b/homeassistant/components/light/mqtt/schema_basic.py
@@ -305,7 +305,7 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, MqttEntityDeviceInfo,
             device_value = float(payload)
             percent_bright = \
                 device_value / self._config.get(CONF_BRIGHTNESS_SCALE)
-            self._brightness = int(percent_bright * 255)
+            self._brightness = percent_bright * 255
             self.async_schedule_update_ha_state()
 
         if self._topic[CONF_BRIGHTNESS_STATE_TOPIC] is not None:
@@ -335,7 +335,7 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, MqttEntityDeviceInfo,
             if self._topic[CONF_BRIGHTNESS_STATE_TOPIC] is None:
                 percent_bright = \
                     float(color_util.color_RGB_to_hsv(*rgb)[2]) / 100.0
-                self._brightness = int(percent_bright * 255)
+                self._brightness = round(percent_bright * 255)
             self.async_schedule_update_ha_state()
 
         if self._topic[CONF_RGB_STATE_TOPIC] is not None:
@@ -441,7 +441,7 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, MqttEntityDeviceInfo,
             device_value = float(payload)
             percent_white = \
                 device_value / self._config.get(CONF_WHITE_VALUE_SCALE)
-            self._white_value = int(percent_white * 255)
+            self._white_value = percent_white * 255
             self.async_schedule_update_ha_state()
 
         if self._topic[CONF_WHITE_VALUE_STATE_TOPIC] is not None:
@@ -496,7 +496,10 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, MqttEntityDeviceInfo,
     @property
     def brightness(self):
         """Return the brightness of this light between 0..255."""
-        return self._brightness
+        brightness = self._brightness
+        if brightness:
+            brightness = round(brightness)
+        return brightness
 
     @property
     def hs_color(self):
@@ -511,7 +514,10 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, MqttEntityDeviceInfo,
     @property
     def white_value(self):
         """Return the white property."""
-        return self._white_value
+        white_value = self._white_value
+        if white_value:
+            white_value = round(white_value)
+        return white_value
 
     @property
     def should_poll(self):
@@ -640,7 +646,7 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, MqttEntityDeviceInfo,
            self._topic[CONF_BRIGHTNESS_COMMAND_TOPIC] is not None:
             percent_bright = float(kwargs[ATTR_BRIGHTNESS]) / 255
             device_brightness = \
-                int(percent_bright * self._config.get(CONF_BRIGHTNESS_SCALE))
+                round(percent_bright * self._config.get(CONF_BRIGHTNESS_SCALE))
             mqtt.async_publish(
                 self.hass, self._topic[CONF_BRIGHTNESS_COMMAND_TOPIC],
                 device_brightness, self._config.get(CONF_QOS),
@@ -701,7 +707,7 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, MqttEntityDeviceInfo,
            self._topic[CONF_WHITE_VALUE_COMMAND_TOPIC] is not None:
             percent_white = float(kwargs[ATTR_WHITE_VALUE]) / 255
             device_white_value = \
-                int(percent_white * self._config.get(CONF_WHITE_VALUE_SCALE))
+                round(percent_white * self._config.get(CONF_WHITE_VALUE_SCALE))
             mqtt.async_publish(
                 self.hass, self._topic[CONF_WHITE_VALUE_COMMAND_TOPIC],
                 device_white_value, self._config.get(CONF_QOS),

--- a/homeassistant/components/light/mqtt/schema_basic.py
+++ b/homeassistant/components/light/mqtt/schema_basic.py
@@ -335,7 +335,7 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, MqttEntityDeviceInfo,
             if self._topic[CONF_BRIGHTNESS_STATE_TOPIC] is None:
                 percent_bright = \
                     float(color_util.color_RGB_to_hsv(*rgb)[2]) / 100.0
-                self._brightness = round(percent_bright * 255)
+                self._brightness = percent_bright * 255
             self.async_schedule_update_ha_state()
 
         if self._topic[CONF_RGB_STATE_TOPIC] is not None:
@@ -498,7 +498,7 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, MqttEntityDeviceInfo,
         """Return the brightness of this light between 0..255."""
         brightness = self._brightness
         if brightness:
-            brightness = round(brightness)
+            brightness = min(round(brightness), 255)
         return brightness
 
     @property
@@ -516,7 +516,7 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, MqttEntityDeviceInfo,
         """Return the white property."""
         white_value = self._white_value
         if white_value:
-            white_value = round(white_value)
+            white_value = min(round(white_value), 255)
         return white_value
 
     @property
@@ -645,8 +645,9 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, MqttEntityDeviceInfo,
         if ATTR_BRIGHTNESS in kwargs and \
            self._topic[CONF_BRIGHTNESS_COMMAND_TOPIC] is not None:
             percent_bright = float(kwargs[ATTR_BRIGHTNESS]) / 255
+            brightness_scale = self._config.get(CONF_BRIGHTNESS_SCALE)
             device_brightness = \
-                round(percent_bright * self._config.get(CONF_BRIGHTNESS_SCALE))
+                min(round(percent_bright * brightness_scale), brightness_scale)
             mqtt.async_publish(
                 self.hass, self._topic[CONF_BRIGHTNESS_COMMAND_TOPIC],
                 device_brightness, self._config.get(CONF_QOS),
@@ -706,8 +707,9 @@ class MqttLight(MqttAvailability, MqttDiscoveryUpdate, MqttEntityDeviceInfo,
         if ATTR_WHITE_VALUE in kwargs and \
            self._topic[CONF_WHITE_VALUE_COMMAND_TOPIC] is not None:
             percent_white = float(kwargs[ATTR_WHITE_VALUE]) / 255
+            white_scale = self._config.get(CONF_WHITE_VALUE_SCALE)
             device_white_value = \
-                round(percent_white * self._config.get(CONF_WHITE_VALUE_SCALE))
+                min(round(percent_white * white_scale), white_scale)
             mqtt.async_publish(
                 self.hass, self._topic[CONF_WHITE_VALUE_COMMAND_TOPIC],
                 device_white_value, self._config.get(CONF_QOS),


### PR DESCRIPTION
## Description:
Round instead of truncating brightness and white_value.

When truncating, a light with `on_command_type` = `'brightness'` and `brightness_scale` = `100` will have its brightness lowered by one step each time the light is turned on.
Fix by storing the brightness in the entity with full precision, and rounding instead of truncating, when getting the property or communicating with HW.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.