### PR TITLE
Clean up RFLink tests and add two tests

### DIFF
--- a/tests/components/binary_sensor/test_rflink.py
+++ b/tests/components/binary_sensor/test_rflink.py
@@ -7,7 +7,6 @@ automatic sensor creation.
 from datetime import timedelta
 from unittest.mock import patch
 
-from ..test_rflink import mock_rflink
 from homeassistant.components.rflink import (
     CONF_RECONNECT_INTERVAL)
 
@@ -17,6 +16,7 @@ from homeassistant.const import (
 import homeassistant.util.dt as dt_util
 
 from tests.common import async_fire_time_changed
+from ..test_rflink import mock_rflink
 
 DOMAIN = 'binary_sensor'
 
@@ -46,7 +46,7 @@ CONFIG = {
 async def test_default_setup(hass, monkeypatch):
     """Test all basic functionality of the rflink sensor component."""
     # setup mocking rflink module
-    event_callback, create, _, disconnect_callback = await mock_rflink(
+    event_callback, create, _, _ = await mock_rflink(
         hass, CONFIG, DOMAIN, monkeypatch)
 
     # make sure arguments are passed
@@ -86,7 +86,7 @@ async def test_entity_availability(hass, monkeypatch):
     config[CONF_RECONNECT_INTERVAL] = 60
 
     # Create platform and entities
-    event_callback, create, _, disconnect_callback = await mock_rflink(
+    _, _, _, disconnect_callback = await mock_rflink(
         hass, config, DOMAIN, monkeypatch, failures=failures)
 
     # Entities are available by default
@@ -114,7 +114,7 @@ async def test_entity_availability(hass, monkeypatch):
 async def test_off_delay(hass, monkeypatch):
     """Test off_delay option."""
     # setup mocking rflink module
-    event_callback, create, _, disconnect_callback = await mock_rflink(
+    event_callback, create, _, _ = await mock_rflink(
         hass, CONFIG, DOMAIN, monkeypatch)
 
     # make sure arguments are passed

--- a/tests/components/light/test_rflink.py
+++ b/tests/components/light/test_rflink.py
@@ -5,8 +5,6 @@ control of RFLink switch devices.
 
 """
 
-import asyncio
-
 from homeassistant.components.light import ATTR_BRIGHTNESS
 from homeassistant.components.rflink import EVENT_BUTTON_PRESSED
 from homeassistant.const import (
@@ -43,11 +41,10 @@ CONFIG = {
 }
 
 
-@asyncio.coroutine
-def test_default_setup(hass, monkeypatch):
+async def test_default_setup(hass, monkeypatch):
     """Test all basic functionality of the RFLink switch component."""
     # setup mocking rflink module
-    event_callback, create, protocol, _ = yield from mock_rflink(
+    event_callback, create, protocol, _ = await mock_rflink(
         hass, CONFIG, DOMAIN, monkeypatch)
 
     # make sure arguments are passed
@@ -66,7 +63,7 @@ def test_default_setup(hass, monkeypatch):
         'id': 'protocol_0_0',
         'command': 'on',
     })
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     light_after_first_command = hass.states.get(DOMAIN + '.test')
     assert light_after_first_command.state == 'on'
@@ -78,26 +75,26 @@ def test_default_setup(hass, monkeypatch):
         'id': 'protocol_0_0',
         'command': 'off',
     })
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert hass.states.get(DOMAIN + '.test').state == 'off'
 
-    # should repond to group command
+    # should respond to group command
     event_callback({
         'id': 'protocol_0_0',
         'command': 'allon',
     })
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     light_after_first_command = hass.states.get(DOMAIN + '.test')
     assert light_after_first_command.state == 'on'
 
-    # should repond to group command
+    # should respond to group command
     event_callback({
         'id': 'protocol_0_0',
         'command': 'alloff',
     })
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert hass.states.get(DOMAIN + '.test').state == 'off'
 
@@ -107,7 +104,7 @@ def test_default_setup(hass, monkeypatch):
         'id': 'test_alias_0_0',
         'command': 'on',
     })
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert hass.states.get(DOMAIN + '.test').state == 'on'
 
@@ -116,23 +113,23 @@ def test_default_setup(hass, monkeypatch):
         'id': 'protocol2_0_1',
         'command': 'on',
     })
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert hass.states.get(DOMAIN + '.protocol2_0_1').state == 'on'
 
     # test changing state from HA propagates to RFLink
-    hass.async_add_job(
+    hass.async_create_task(
         hass.services.async_call(DOMAIN, SERVICE_TURN_OFF,
                                  {ATTR_ENTITY_ID: DOMAIN + '.test'}))
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
     assert hass.states.get(DOMAIN + '.test').state == 'off'
     assert protocol.send_command_ack.call_args_list[0][0][0] == 'protocol_0_0'
     assert protocol.send_command_ack.call_args_list[0][0][1] == 'off'
 
-    hass.async_add_job(
+    hass.async_create_task(
         hass.services.async_call(DOMAIN, SERVICE_TURN_ON,
                                  {ATTR_ENTITY_ID: DOMAIN + '.test'}))
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
     assert hass.states.get(DOMAIN + '.test').state == 'on'
     assert protocol.send_command_ack.call_args_list[1][0][1] == 'on'
 
@@ -141,11 +138,11 @@ def test_default_setup(hass, monkeypatch):
         'id': 'newkaku_0_1',
         'command': 'off',
     })
-    yield from hass.async_block_till_done()
-    hass.async_add_job(
+    await hass.async_block_till_done()
+    hass.async_create_task(
         hass.services.async_call(DOMAIN, SERVICE_TURN_ON,
                                  {ATTR_ENTITY_ID: DOMAIN + '.newkaku_0_1'}))
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     # dimmable should send highest dim level when turning on
     assert protocol.send_command_ack.call_args_list[2][0][1] == '15'
@@ -153,29 +150,28 @@ def test_default_setup(hass, monkeypatch):
     # and send on command for fallback
     assert protocol.send_command_ack.call_args_list[3][0][1] == 'on'
 
-    hass.async_add_job(
+    hass.async_create_task(
         hass.services.async_call(DOMAIN, SERVICE_TURN_ON,
                                  {
                                      ATTR_ENTITY_ID: DOMAIN + '.newkaku_0_1',
                                      ATTR_BRIGHTNESS: 128,
                                  }))
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert protocol.send_command_ack.call_args_list[4][0][1] == '7'
 
-    hass.async_add_job(
+    hass.async_create_task(
         hass.services.async_call(DOMAIN, SERVICE_TURN_ON,
                                  {
                                      ATTR_ENTITY_ID: DOMAIN + '.dim_test',
                                      ATTR_BRIGHTNESS: 128,
                                  }))
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert protocol.send_command_ack.call_args_list[5][0][1] == '7'
 
 
-@asyncio.coroutine
-def test_firing_bus_event(hass, monkeypatch):
+async def test_firing_bus_event(hass, monkeypatch):
     """Incoming RFLink command events should be put on the HA event bus."""
     config = {
         'rflink': {
@@ -194,7 +190,7 @@ def test_firing_bus_event(hass, monkeypatch):
     }
 
     # setup mocking rflink module
-    event_callback, _, _, _ = yield from mock_rflink(
+    event_callback, _, _, _ = await mock_rflink(
         hass, config, DOMAIN, monkeypatch)
 
     calls = []
@@ -209,13 +205,12 @@ def test_firing_bus_event(hass, monkeypatch):
         'id': 'protocol_0_0',
         'command': 'off',
     })
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert calls[0].data == {'state': 'off', 'entity_id': DOMAIN + '.test'}
 
 
-@asyncio.coroutine
-def test_signal_repetitions(hass, monkeypatch):
+async def test_signal_repetitions(hass, monkeypatch):
     """Command should be sent amount of configured repetitions."""
     config = {
         'rflink': {
@@ -242,26 +237,26 @@ def test_signal_repetitions(hass, monkeypatch):
     }
 
     # setup mocking rflink module
-    event_callback, _, protocol, _ = yield from mock_rflink(
+    event_callback, _, protocol, _ = await mock_rflink(
         hass, config, DOMAIN, monkeypatch)
 
     # test if signal repetition is performed according to configuration
-    hass.async_add_job(
+    hass.async_create_task(
         hass.services.async_call(DOMAIN, SERVICE_TURN_OFF,
                                  {ATTR_ENTITY_ID: DOMAIN + '.test'}))
 
     # wait for commands and repetitions to finish
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert protocol.send_command_ack.call_count == 2
 
     # test if default apply to configured devices
-    hass.async_add_job(
+    hass.async_create_task(
         hass.services.async_call(DOMAIN, SERVICE_TURN_OFF,
                                  {ATTR_ENTITY_ID: DOMAIN + '.test1'}))
 
     # wait for commands and repetitions to finish
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert protocol.send_command_ack.call_count == 5
 
@@ -272,20 +267,19 @@ def test_signal_repetitions(hass, monkeypatch):
     })
 
     # make sure entity is created before setting state
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
-    hass.async_add_job(
+    hass.async_create_task(
         hass.services.async_call(DOMAIN, SERVICE_TURN_OFF,
                                  {ATTR_ENTITY_ID: DOMAIN + '.protocol_0_2'}))
 
     # wait for commands and repetitions to finish
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert protocol.send_command_ack.call_count == 8
 
 
-@asyncio.coroutine
-def test_signal_repetitions_alternation(hass, monkeypatch):
+async def test_signal_repetitions_alternation(hass, monkeypatch):
     """Simultaneously switching entities must alternate repetitions."""
     config = {
         'rflink': {
@@ -307,17 +301,17 @@ def test_signal_repetitions_alternation(hass, monkeypatch):
     }
 
     # setup mocking rflink module
-    _, _, protocol, _ = yield from mock_rflink(
+    _, _, protocol, _ = await mock_rflink(
         hass, config, DOMAIN, monkeypatch)
 
-    hass.async_add_job(
+    hass.async_create_task(
         hass.services.async_call(DOMAIN, SERVICE_TURN_OFF,
                                  {ATTR_ENTITY_ID: DOMAIN + '.test'}))
-    hass.async_add_job(
+    hass.async_create_task(
         hass.services.async_call(DOMAIN, SERVICE_TURN_OFF,
                                  {ATTR_ENTITY_ID: DOMAIN + '.test1'}))
 
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert protocol.send_command_ack.call_args_list[0][0][0] == 'protocol_0_0'
     assert protocol.send_command_ack.call_args_list[1][0][0] == 'protocol_0_1'
@@ -325,8 +319,7 @@ def test_signal_repetitions_alternation(hass, monkeypatch):
     assert protocol.send_command_ack.call_args_list[3][0][0] == 'protocol_0_1'
 
 
-@asyncio.coroutine
-def test_signal_repetitions_cancelling(hass, monkeypatch):
+async def test_signal_repetitions_cancelling(hass, monkeypatch):
     """Cancel outstanding repetitions when state changed."""
     config = {
         'rflink': {
@@ -344,18 +337,18 @@ def test_signal_repetitions_cancelling(hass, monkeypatch):
     }
 
     # setup mocking rflink module
-    _, _, protocol, _ = yield from mock_rflink(
+    _, _, protocol, _ = await mock_rflink(
         hass, config, DOMAIN, monkeypatch)
 
-    hass.async_add_job(
+    hass.async_create_task(
         hass.services.async_call(DOMAIN, SERVICE_TURN_OFF,
                                  {ATTR_ENTITY_ID: DOMAIN + '.test'}))
 
-    hass.async_add_job(
+    hass.async_create_task(
         hass.services.async_call(DOMAIN, SERVICE_TURN_ON,
                                  {ATTR_ENTITY_ID: DOMAIN + '.test'}))
 
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert protocol.send_command_ack.call_args_list[0][0][1] == 'on'
     assert protocol.send_command_ack.call_args_list[1][0][1] == 'off'
@@ -363,8 +356,7 @@ def test_signal_repetitions_cancelling(hass, monkeypatch):
     assert protocol.send_command_ack.call_args_list[3][0][1] == 'off'
 
 
-@asyncio.coroutine
-def test_type_toggle(hass, monkeypatch):
+async def test_type_toggle(hass, monkeypatch):
     """Test toggle type lights (on/on)."""
     config = {
         'rflink': {
@@ -382,7 +374,7 @@ def test_type_toggle(hass, monkeypatch):
     }
 
     # setup mocking rflink module
-    event_callback, _, _, _ = yield from mock_rflink(
+    event_callback, _, _, _ = await mock_rflink(
         hass, config, DOMAIN, monkeypatch)
 
     assert hass.states.get(DOMAIN + '.toggle_test').state == 'off'
@@ -392,7 +384,7 @@ def test_type_toggle(hass, monkeypatch):
         'id': 'toggle_0_0',
         'command': 'on',
     })
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert hass.states.get(DOMAIN + '.toggle_test').state == 'on'
 
@@ -401,13 +393,12 @@ def test_type_toggle(hass, monkeypatch):
         'id': 'toggle_0_0',
         'command': 'on',
     })
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert hass.states.get(DOMAIN + '.toggle_test').state == 'off'
 
 
-@asyncio.coroutine
-def test_group_alias(hass, monkeypatch):
+async def test_group_alias(hass, monkeypatch):
     """Group aliases should only respond to group commands (allon/alloff)."""
     config = {
         'rflink': {
@@ -425,7 +416,7 @@ def test_group_alias(hass, monkeypatch):
     }
 
     # setup mocking rflink module
-    event_callback, _, _, _ = yield from mock_rflink(
+    event_callback, _, _, _ = await mock_rflink(
         hass, config, DOMAIN, monkeypatch)
 
     assert hass.states.get(DOMAIN + '.test').state == 'off'
@@ -435,7 +426,7 @@ def test_group_alias(hass, monkeypatch):
         'id': 'test_group_0_0',
         'command': 'allon',
     })
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert hass.states.get(DOMAIN + '.test').state == 'on'
 
@@ -444,13 +435,12 @@ def test_group_alias(hass, monkeypatch):
         'id': 'test_group_0_0',
         'command': 'off',
     })
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert hass.states.get(DOMAIN + '.test').state == 'on'
 
 
-@asyncio.coroutine
-def test_nogroup_alias(hass, monkeypatch):
+async def test_nogroup_alias(hass, monkeypatch):
     """Non group aliases should not respond to group commands."""
     config = {
         'rflink': {
@@ -468,7 +458,7 @@ def test_nogroup_alias(hass, monkeypatch):
     }
 
     # setup mocking rflink module
-    event_callback, _, _, _ = yield from mock_rflink(
+    event_callback, _, _, _ = await mock_rflink(
         hass, config, DOMAIN, monkeypatch)
 
     assert hass.states.get(DOMAIN + '.test').state == 'off'
@@ -478,7 +468,7 @@ def test_nogroup_alias(hass, monkeypatch):
         'id': 'test_nogroup_0_0',
         'command': 'allon',
     })
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
     # should not affect state
     assert hass.states.get(DOMAIN + '.test').state == 'off'
 
@@ -487,13 +477,12 @@ def test_nogroup_alias(hass, monkeypatch):
         'id': 'test_nogroup_0_0',
         'command': 'on',
     })
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
     # should affect state
     assert hass.states.get(DOMAIN + '.test').state == 'on'
 
 
-@asyncio.coroutine
-def test_nogroup_device_id(hass, monkeypatch):
+async def test_nogroup_device_id(hass, monkeypatch):
     """Device id that do not respond to group commands (allon/alloff)."""
     config = {
         'rflink': {
@@ -511,7 +500,7 @@ def test_nogroup_device_id(hass, monkeypatch):
     }
 
     # setup mocking rflink module
-    event_callback, _, _, _ = yield from mock_rflink(
+    event_callback, _, _, _ = await mock_rflink(
         hass, config, DOMAIN, monkeypatch)
 
     assert hass.states.get(DOMAIN + '.test').state == 'off'
@@ -521,7 +510,7 @@ def test_nogroup_device_id(hass, monkeypatch):
         'id': 'test_nogroup_0_0',
         'command': 'allon',
     })
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
     # should not affect state
     assert hass.states.get(DOMAIN + '.test').state == 'off'
 
@@ -530,13 +519,12 @@ def test_nogroup_device_id(hass, monkeypatch):
         'id': 'test_nogroup_0_0',
         'command': 'on',
     })
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
     # should affect state
     assert hass.states.get(DOMAIN + '.test').state == 'on'
 
 
-@asyncio.coroutine
-def test_disable_automatic_add(hass, monkeypatch):
+async def test_disable_automatic_add(hass, monkeypatch):
     """If disabled new devices should not be automatically added."""
     config = {
         'rflink': {
@@ -549,7 +537,7 @@ def test_disable_automatic_add(hass, monkeypatch):
     }
 
     # setup mocking rflink module
-    event_callback, _, _, _ = yield from mock_rflink(
+    event_callback, _, _, _ = await mock_rflink(
         hass, config, DOMAIN, monkeypatch)
 
     # test event for new unconfigured sensor
@@ -557,14 +545,13 @@ def test_disable_automatic_add(hass, monkeypatch):
         'id': 'protocol_0_0',
         'command': 'off',
     })
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     # make sure new device is not added
     assert not hass.states.get(DOMAIN + '.protocol_0_0')
 
 
-@asyncio.coroutine
-def test_restore_state(hass, monkeypatch):
+async def test_restore_state(hass, monkeypatch):
     """Ensure states are restored on startup."""
     config = {
         'rflink': {
@@ -583,6 +570,10 @@ def test_restore_state(hass, monkeypatch):
                 'test_restore_3': {
                     'name': 'l3',
                 },
+                'test_restore_4': {
+                    'name': 'l4',
+                    'type': 'dimmable',
+                },
             },
         },
     }
@@ -596,7 +587,7 @@ def test_restore_state(hass, monkeypatch):
     hass.state = CoreState.starting
 
     # setup mocking rflink module
-    _, _, _, _ = yield from mock_rflink(hass, config, DOMAIN, monkeypatch)
+    _, _, _, _ = await mock_rflink(hass, config, DOMAIN, monkeypatch)
 
     # dimmable light must restore brightness
     state = hass.states.get(DOMAIN + '.l1')
@@ -614,3 +605,10 @@ def test_restore_state(hass, monkeypatch):
     state = hass.states.get(DOMAIN + '.l3')
     assert state
     assert state.state == STATE_OFF
+
+    # not cached light must default values
+    state = hass.states.get(DOMAIN + '.l4')
+    assert state
+    assert state.state == STATE_OFF
+    assert not state.attributes.get(ATTR_BRIGHTNESS)
+    assert state.attributes['assumed_state']

--- a/tests/components/sensor/test_rflink.py
+++ b/tests/components/sensor/test_rflink.py
@@ -7,10 +7,10 @@ automatic sensor creation.
 
 import asyncio
 
-from ..test_rflink import mock_rflink
 from homeassistant.components.rflink import (
     CONF_RECONNECT_INTERVAL)
 from homeassistant.const import STATE_UNKNOWN
+from ..test_rflink import mock_rflink
 
 DOMAIN = 'sensor'
 
@@ -31,11 +31,10 @@ CONFIG = {
 }
 
 
-@asyncio.coroutine
-def test_default_setup(hass, monkeypatch):
+async def test_default_setup(hass, monkeypatch):
     """Test all basic functionality of the rflink sensor component."""
     # setup mocking rflink module
-    event_callback, create, _, disconnect_callback = yield from mock_rflink(
+    event_callback, create, _, _ = await mock_rflink(
         hass, CONFIG, DOMAIN, monkeypatch)
 
     # make sure arguments are passed
@@ -54,7 +53,7 @@ def test_default_setup(hass, monkeypatch):
         'value': 1,
         'unit': '°C',
     })
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert hass.states.get('sensor.test').state == '1'
 
@@ -65,7 +64,7 @@ def test_default_setup(hass, monkeypatch):
         'value': 0,
         'unit': '°C',
     })
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     # test  state of new sensor
     new_sensor = hass.states.get('sensor.test2')
@@ -75,8 +74,7 @@ def test_default_setup(hass, monkeypatch):
     assert new_sensor.attributes['icon'] == 'mdi:thermometer'
 
 
-@asyncio.coroutine
-def test_disable_automatic_add(hass, monkeypatch):
+async def test_disable_automatic_add(hass, monkeypatch):
     """If disabled new devices should not be automatically added."""
     config = {
         'rflink': {
@@ -89,7 +87,7 @@ def test_disable_automatic_add(hass, monkeypatch):
     }
 
     # setup mocking rflink module
-    event_callback, _, _, _ = yield from mock_rflink(
+    event_callback, _, _, _ = await mock_rflink(
         hass, config, DOMAIN, monkeypatch)
 
     # test event for new unconfigured sensor
@@ -99,14 +97,13 @@ def test_disable_automatic_add(hass, monkeypatch):
         'value': 0,
         'unit': '°C',
     })
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     # make sure new device is not added
     assert not hass.states.get('sensor.test2')
 
 
-@asyncio.coroutine
-def test_entity_availability(hass, monkeypatch):
+async def test_entity_availability(hass, monkeypatch):
     """If Rflink device is disconnected, entities should become unavailable."""
     # Make sure Rflink mock does not 'recover' to quickly from the
     # disconnect or else the unavailability cannot be measured
@@ -115,7 +112,7 @@ def test_entity_availability(hass, monkeypatch):
     config[CONF_RECONNECT_INTERVAL] = 60
 
     # Create platform and entities
-    event_callback, create, _, disconnect_callback = yield from mock_rflink(
+    _, _, _, disconnect_callback = await mock_rflink(
         hass, config, DOMAIN, monkeypatch, failures=failures)
 
     # Entities are available by default
@@ -125,7 +122,7 @@ def test_entity_availability(hass, monkeypatch):
     disconnect_callback()
 
     # Wait for dispatch events to propagate
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     # Entity should be unavailable
     assert hass.states.get('sensor.test').state == 'unavailable'
@@ -134,7 +131,7 @@ def test_entity_availability(hass, monkeypatch):
     disconnect_callback()
 
     # Wait for dispatch events to propagate
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     # Entities should be available again
     assert hass.states.get('sensor.test').state == STATE_UNKNOWN

--- a/tests/components/sensor/test_rflink.py
+++ b/tests/components/sensor/test_rflink.py
@@ -5,8 +5,6 @@ automatic sensor creation.
 
 """
 
-import asyncio
-
 from homeassistant.components.rflink import (
     CONF_RECONNECT_INTERVAL)
 from homeassistant.const import STATE_UNKNOWN

--- a/tests/components/switch/test_rflink.py
+++ b/tests/components/switch/test_rflink.py
@@ -5,8 +5,6 @@ control of Rflink switch devices.
 
 """
 
-import asyncio
-
 from homeassistant.components.rflink import EVENT_BUTTON_PRESSED
 from homeassistant.const import (
     ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON, STATE_ON, STATE_OFF)
@@ -34,11 +32,10 @@ CONFIG = {
 }
 
 
-@asyncio.coroutine
-def test_default_setup(hass, monkeypatch):
+async def test_default_setup(hass, monkeypatch):
     """Test all basic functionality of the rflink switch component."""
     # setup mocking rflink module
-    event_callback, create, protocol, _ = yield from mock_rflink(
+    event_callback, create, protocol, _ = await mock_rflink(
         hass, CONFIG, DOMAIN, monkeypatch)
 
     # make sure arguments are passed
@@ -57,7 +54,7 @@ def test_default_setup(hass, monkeypatch):
         'id': 'protocol_0_0',
         'command': 'on',
     })
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     switch_after_first_command = hass.states.get('switch.test')
     assert switch_after_first_command.state == 'on'
@@ -69,7 +66,7 @@ def test_default_setup(hass, monkeypatch):
         'id': 'protocol_0_0',
         'command': 'off',
     })
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert hass.states.get('switch.test').state == 'off'
 
@@ -79,7 +76,7 @@ def test_default_setup(hass, monkeypatch):
         'id': 'test_alias_0_0',
         'command': 'on',
     })
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert hass.states.get('switch.test').state == 'on'
 
@@ -87,24 +84,23 @@ def test_default_setup(hass, monkeypatch):
     # events because every new unknown device is added as a light by default.
 
     # test changing state from HA propagates to Rflink
-    hass.async_add_job(
+    hass.async_create_task(
         hass.services.async_call(DOMAIN, SERVICE_TURN_OFF,
                                  {ATTR_ENTITY_ID: DOMAIN + '.test'}))
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
     assert hass.states.get(DOMAIN + '.test').state == 'off'
     assert protocol.send_command_ack.call_args_list[0][0][0] == 'protocol_0_0'
     assert protocol.send_command_ack.call_args_list[0][0][1] == 'off'
 
-    hass.async_add_job(
+    hass.async_create_task(
         hass.services.async_call(DOMAIN, SERVICE_TURN_ON,
                                  {ATTR_ENTITY_ID: DOMAIN + '.test'}))
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
     assert hass.states.get(DOMAIN + '.test').state == 'on'
     assert protocol.send_command_ack.call_args_list[1][0][1] == 'on'
 
 
-@asyncio.coroutine
-def test_group_alias(hass, monkeypatch):
+async def test_group_alias(hass, monkeypatch):
     """Group aliases should only respond to group commands (allon/alloff)."""
     config = {
         'rflink': {
@@ -122,7 +118,7 @@ def test_group_alias(hass, monkeypatch):
     }
 
     # setup mocking rflink module
-    event_callback, _, _, _ = yield from mock_rflink(
+    event_callback, _, _, _ = await mock_rflink(
         hass, config, DOMAIN, monkeypatch)
 
     assert hass.states.get(DOMAIN + '.test').state == 'off'
@@ -132,7 +128,7 @@ def test_group_alias(hass, monkeypatch):
         'id': 'test_group_0_0',
         'command': 'allon',
     })
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert hass.states.get(DOMAIN + '.test').state == 'on'
 
@@ -141,13 +137,12 @@ def test_group_alias(hass, monkeypatch):
         'id': 'test_group_0_0',
         'command': 'off',
     })
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert hass.states.get(DOMAIN + '.test').state == 'on'
 
 
-@asyncio.coroutine
-def test_nogroup_alias(hass, monkeypatch):
+async def test_nogroup_alias(hass, monkeypatch):
     """Non group aliases should not respond to group commands."""
     config = {
         'rflink': {
@@ -165,7 +160,7 @@ def test_nogroup_alias(hass, monkeypatch):
     }
 
     # setup mocking rflink module
-    event_callback, _, _, _ = yield from mock_rflink(
+    event_callback, _, _, _ = await mock_rflink(
         hass, config, DOMAIN, monkeypatch)
 
     assert hass.states.get(DOMAIN + '.test').state == 'off'
@@ -175,7 +170,7 @@ def test_nogroup_alias(hass, monkeypatch):
         'id': 'test_nogroup_0_0',
         'command': 'allon',
     })
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
     # should not affect state
     assert hass.states.get(DOMAIN + '.test').state == 'off'
 
@@ -184,13 +179,12 @@ def test_nogroup_alias(hass, monkeypatch):
         'id': 'test_nogroup_0_0',
         'command': 'on',
     })
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
     # should affect state
     assert hass.states.get(DOMAIN + '.test').state == 'on'
 
 
-@asyncio.coroutine
-def test_nogroup_device_id(hass, monkeypatch):
+async def test_nogroup_device_id(hass, monkeypatch):
     """Device id that do not respond to group commands (allon/alloff)."""
     config = {
         'rflink': {
@@ -208,7 +202,7 @@ def test_nogroup_device_id(hass, monkeypatch):
     }
 
     # setup mocking rflink module
-    event_callback, _, _, _ = yield from mock_rflink(
+    event_callback, _, _, _ = await mock_rflink(
         hass, config, DOMAIN, monkeypatch)
 
     assert hass.states.get(DOMAIN + '.test').state == 'off'
@@ -218,7 +212,7 @@ def test_nogroup_device_id(hass, monkeypatch):
         'id': 'test_nogroup_0_0',
         'command': 'allon',
     })
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
     # should not affect state
     assert hass.states.get(DOMAIN + '.test').state == 'off'
 
@@ -227,13 +221,12 @@ def test_nogroup_device_id(hass, monkeypatch):
         'id': 'test_nogroup_0_0',
         'command': 'on',
     })
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
     # should affect state
     assert hass.states.get(DOMAIN + '.test').state == 'on'
 
 
-@asyncio.coroutine
-def test_device_defaults(hass, monkeypatch):
+async def test_device_defaults(hass, monkeypatch):
     """Event should fire if device_defaults config says so."""
     config = {
         'rflink': {
@@ -254,7 +247,7 @@ def test_device_defaults(hass, monkeypatch):
     }
 
     # setup mocking rflink module
-    event_callback, _, _, _ = yield from mock_rflink(
+    event_callback, _, _, _ = await mock_rflink(
         hass, config, DOMAIN, monkeypatch)
 
     calls = []
@@ -269,13 +262,12 @@ def test_device_defaults(hass, monkeypatch):
         'id': 'protocol_0_0',
         'command': 'off',
     })
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert calls[0].data == {'state': 'off', 'entity_id': DOMAIN + '.test'}
 
 
-@asyncio.coroutine
-def test_not_firing_default(hass, monkeypatch):
+async def test_not_firing_default(hass, monkeypatch):
     """By default no bus events should be fired."""
     config = {
         'rflink': {
@@ -293,7 +285,7 @@ def test_not_firing_default(hass, monkeypatch):
     }
 
     # setup mocking rflink module
-    event_callback, _, _, _ = yield from mock_rflink(
+    event_callback, _, _, _ = await mock_rflink(
         hass, config, DOMAIN, monkeypatch)
 
     calls = []
@@ -308,13 +300,12 @@ def test_not_firing_default(hass, monkeypatch):
         'id': 'protocol_0_0',
         'command': 'off',
     })
-    yield from hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert not calls, 'an event has been fired'
 
 
-@asyncio.coroutine
-def test_restore_state(hass, monkeypatch):
+async def test_restore_state(hass, monkeypatch):
     """Ensure states are restored on startup."""
     config = {
         'rflink': {
@@ -329,6 +320,9 @@ def test_restore_state(hass, monkeypatch):
                 },
                 'switch_test': {
                     'name': 's2',
+                },
+                'switch_s3': {
+                    'name': 's3',
                 }
             }
         }
@@ -342,7 +336,7 @@ def test_restore_state(hass, monkeypatch):
     hass.state = CoreState.starting
 
     # setup mocking rflink module
-    _, _, _, _ = yield from mock_rflink(hass, config, DOMAIN, monkeypatch)
+    _, _, _, _ = await mock_rflink(hass, config, DOMAIN, monkeypatch)
 
     state = hass.states.get(DOMAIN + '.s1')
     assert state
@@ -351,3 +345,9 @@ def test_restore_state(hass, monkeypatch):
     state = hass.states.get(DOMAIN + '.s2')
     assert state
     assert state.state == STATE_OFF
+
+    # not cached switch must default values
+    state = hass.states.get(DOMAIN + '.s3')
+    assert state
+    assert state.state == STATE_OFF
+    assert state.attributes['assumed_state']

--- a/tests/components/test_rflink.py
+++ b/tests/components/test_rflink.py
@@ -97,8 +97,8 @@ def test_send_no_wait(hass, monkeypatch):
             'platform': 'rflink',
             'devices': {
                 'protocol_0_0': {
-                        'name': 'test',
-                        'aliases': ['test_alias_0_0'],
+                    'name': 'test',
+                    'aliases': ['test_alias_0_0'],
                 },
             },
         },
@@ -129,8 +129,8 @@ def test_cover_send_no_wait(hass, monkeypatch):
             'platform': 'rflink',
             'devices': {
                 'RTS_0100F2_0': {
-                        'name': 'test',
-                        'aliases': ['test_alias_0_0'],
+                    'name': 'test',
+                    'aliases': ['test_alias_0_0'],
                 },
             },
         },
@@ -274,8 +274,8 @@ def test_error_when_not_connected(hass, monkeypatch):
             'platform': 'rflink',
             'devices': {
                 'protocol_0_0': {
-                        'name': 'test',
-                        'aliases': ['test_alias_0_0'],
+                    'name': 'test',
+                    'aliases': ['test_alias_0_0'],
                 },
             },
         },
@@ -285,7 +285,7 @@ def test_error_when_not_connected(hass, monkeypatch):
     failures = [False, True, False]
 
     # setup mocking rflink module
-    _, mock_create, _, disconnect_callback = yield from mock_rflink(
+    _, _, _, disconnect_callback = yield from mock_rflink(
         hass, config, domain, monkeypatch, failures=failures)
 
     # rflink initiated disconnect


### PR DESCRIPTION
## Description:
After releasing the PR #18816, I made some additional changes in the tests to make them homogeneous with the other changes applied.
This PR contains small refactorings and some additional tests.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) **N/A**

If the code communicates with devices, web services, or third-party tools:
  - New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]). **N/A**
  - New dependencies are only imported inside functions that use them ([example][ex-import]). **N/A**
  - New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`. **N/A**
  - New files were added to `.coveragerc`. **N/A**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
