### PR TITLE
Add deprecation warning.

### DIFF
--- a/homeassistant/components/sensor/ruter.py
+++ b/homeassistant/components/sensor/ruter.py
@@ -36,8 +36,8 @@ async def async_setup_platform(
         hass, config, async_add_entities, discovery_info=None):
     """Create the sensor."""
     from pyruter.api import Departures
-    _LOGGER.warning("The API used in this sensor is shutting down soon,"
-                    "you should consider starting to use the"
+    _LOGGER.warning("The API used in this sensor is shutting down soon, "
+                    "you should consider starting to use the "
                     "'entur_public_transport' sensor instead")
     stop_id = config[CONF_STOP_ID]
     destination = config.get(CONF_DESTINATION)

--- a/homeassistant/components/sensor/ruter.py
+++ b/homeassistant/components/sensor/ruter.py
@@ -36,7 +36,9 @@ async def async_setup_platform(
         hass, config, async_add_entities, discovery_info=None):
     """Create the sensor."""
     from pyruter.api import Departures
-
+    _LOGGER.warning("The API used in this sensor is shutting down soon,"
+                    "you should consider starting to use the"
+                    "'entur_public_transport' sensor instead")
     stop_id = config[CONF_STOP_ID]
     destination = config.get(CONF_DESTINATION)
     name = config[CONF_NAME]


### PR DESCRIPTION
## Description:

Adds deprecation warning.
<!--
**Related issue (if applicable):** fixes #7924
-->
**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#7924

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  platform: ruter
  stop_id: 387873
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)
<!--
If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
-->
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
