### PR TITLE
Implemented v1 and v2 Dialogflow support

### DIFF
--- a/homeassistant/components/dialogflow/__init__.py
+++ b/homeassistant/components/dialogflow/__init__.py
@@ -19,6 +19,9 @@ DOMAIN = 'dialogflow'
 
 SOURCE = "Home Assistant Dialogflow"
 
+V1 = 'V1'
+V2 = 'V2'
+
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: {}
 }, extra=vol.ALLOW_EXTRA)
@@ -99,10 +102,10 @@ config_entry_flow.register_webhook_flow(
 def get_api_version(message):
     """Help determine the version of Dialogflow request."""
     if message.get('id') is not None:
-        return 'V1'
+        return V1
 
     if message.get('responseId') is not None:
-        return 'V2'
+        return V2
 
     return None
 
@@ -112,10 +115,10 @@ def dialogflow_error_response(message, error):
     api_version = get_api_version(message)
     req = {}
 
-    if api_version == 'V2':
+    if api_version == V2:
         req = message.get('queryResult')
 
-    elif api_version == 'V1':
+    elif api_version == V1:
         req = message.get('result')
 
     parameters = req.get('parameters').copy()
@@ -129,12 +132,12 @@ async def async_handle_message(hass, message):
     api_version = get_api_version(message)
     req = {}
 
-    if api_version == 'V2':
+    if api_version == V2:
         req = message.get('queryResult')
         if not req.get('allRequiredParamsPresent', False):
             return None
 
-    elif api_version == 'V1':
+    elif api_version == V1:
         req = message.get('result')
         if req.get('actionIncomplete', True):
             return None
@@ -187,7 +190,7 @@ class DialogflowResponse:
 
     def as_dict(self):
         """Return response in a Dialogflow valid dictionary."""
-        if self.api_version == 'V2':
+        if self.api_version == V2:
             return {
                 'fulfillmentText': self.speech,
                 'fulfillmentMessages': [
@@ -200,7 +203,7 @@ class DialogflowResponse:
                 'source': SOURCE
             }
 
-        if self.api_version == 'V1':
+        if self.api_version == V1:
             return {
                 'speech': self.speech,
                 'displayText': self.speech,

--- a/homeassistant/components/dialogflow/__init__.py
+++ b/homeassistant/components/dialogflow/__init__.py
@@ -130,14 +130,12 @@ async def async_handle_message(hass, message):
 
     if api_version == 'V2':
         req = message.get('queryResult')
-        all_required_parameters_present = req.get('allRequiredParamsPresent', False)
-        if not all_required_parameters_present:
+        if not req.get('allRequiredParamsPresent', False):
             return None
 
     elif api_version == 'V1':
         req = message.get('result')
-        action_incomplete = req.get('actionIncomplete', True)
-        if action_incomplete:
+        if req.get('actionIncomplete', True):
             return None
 
     else:

--- a/homeassistant/components/dialogflow/__init__.py
+++ b/homeassistant/components/dialogflow/__init__.py
@@ -97,6 +97,7 @@ config_entry_flow.register_webhook_flow(
 
 
 def get_api_version(message):
+    """Help determine the version of Dialogflow request."""
     if message.get('id') is not None:
         return 'V1'
 

--- a/homeassistant/components/dialogflow/__init__.py
+++ b/homeassistant/components/dialogflow/__init__.py
@@ -95,13 +95,28 @@ config_entry_flow.register_webhook_flow(
     }
 )
 
+
 def get_api_version(message):
-    return 'V1' if message.get('id') is not None else 'V2'
+    if message.get('id') is not None:
+        return 'V1'
+
+    if message.get('responseId') is not None:
+        return 'V2'
+
+    return None
+
 
 def dialogflow_error_response(message, error):
     """Return a response saying the error message."""
     api_version = get_api_version(message)
-    req = message.get('queryResult') if api_version == 'V2' else message.get('result')
+    req = {}
+
+    if api_version == 'V2':
+        req = message.get('queryResult')
+
+    elif api_version == 'V1':
+        req = message.get('result')
+
     parameters = req.get('parameters').copy()
     dialogflow_response = DialogflowResponse(parameters, api_version)
     dialogflow_response.add_speech(error)


### PR DESCRIPTION
## Description:
Dailogflow v1 implementation being depreciated on Oct 2019 [Notice](https://dialogflow.com/v2-faq#will_api_v1_continue_to_be_supported) this implementation supports both v1 and v2.

Related issue: fixed
- #14343
- #18411 
- #19125 

[Migration Guide](https://dialogflow.com/docs/reference/v1-v2-migration-guide-fulfillment#webhook_responses)

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`.
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.