### PR TITLE
Add long click at new Aqara Wireless Remote Switch

### DIFF
--- a/homeassistant/components/binary_sensor/xiaomi_aqara.py
+++ b/homeassistant/components/binary_sensor/xiaomi_aqara.py
@@ -411,8 +411,10 @@ class XiaomiButton(XiaomiBinarySensor):
             click_type = 'both'
         elif value == 'shake':
             click_type = 'shake'
-        elif value in ['long_click', 'long_both_click']:
+        elif value == 'long_click':
             click_type = 'long'
+        elif value == 'long_both_click':
+            return False
         else:
             _LOGGER.warning("Unsupported click_type detected: %s", value)
             return False

--- a/homeassistant/components/binary_sensor/xiaomi_aqara.py
+++ b/homeassistant/components/binary_sensor/xiaomi_aqara.py
@@ -412,7 +412,7 @@ class XiaomiButton(XiaomiBinarySensor):
         elif value == 'shake':
             click_type = 'shake'
         elif value in ['long_click', 'long_both_click']:
-            return False
+            click_type = 'long'
         else:
             _LOGGER.warning("Unsupported click_type detected: %s", value)
             return False


### PR DESCRIPTION
New Aqara Wireless Remote Switch Single supports long click.
Return click_type = 'long' instead of False

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
  trigger:
    - platform: event
      event_type: click
      event_data:
        entity_id: binary_sensor.wall_switch_xxxxx
        click_type: long

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
