### PR TITLE
Update launch library to use datetime

### DIFF
--- a/homeassistant/components/sensor/launch_library.py
+++ b/homeassistant/components/sensor/launch_library.py
@@ -63,7 +63,8 @@ class LaunchLibrarySensor(Entity):
         try:
             data = self.launches.launches[0]
             self._state = data['name']
-            self._attributes['launch_time'] = template_help.timestamp_local(data['wsstamp'])
+            self._attributes['launch_time'] = template_help.timestamp_local(
+                data['wsstamp'])
             self._attributes['agency'] = data['agency']
             agency_country_code = data['agency_country_code']
             self._attributes['agency_country_code'] = agency_country_code

--- a/homeassistant/components/sensor/launch_library.py
+++ b/homeassistant/components/sensor/launch_library.py
@@ -10,6 +10,7 @@ import logging
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
+import homeassistant.helpers.template as template_help
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import ATTR_ATTRIBUTION, CONF_NAME
 from homeassistant.helpers.entity import Entity
@@ -62,7 +63,7 @@ class LaunchLibrarySensor(Entity):
         try:
             data = self.launches.launches[0]
             self._state = data['name']
-            self._attributes['launch_time'] = data['start']
+            self._attributes['launch_time'] = template_help.timestamp_local(data['wsstamp'])
             self._attributes['agency'] = data['agency']
             agency_country_code = data['agency_country_code']
             self._attributes['agency_country_code'] = agency_country_code


### PR DESCRIPTION
Previous version used "start" from pylaunches which is a string that is not parsed by home assistant into a datetime. This change updates launch library to use the timestamp from pylaunches and parses it to make the launch_time attribute easier to template and automate with.

## Description:
Modified launch library to pass datetime-parsable string instead of string.

**Related issue (if applicable): None


## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [Not done] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [N/A] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools: N/A
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
