### PR TITLE
Added support for triggered state on NX584 alarm.

### DIFF
--- a/homeassistant/components/alarm_control_panel/nx584.py
+++ b/homeassistant/components/alarm_control_panel/nx584.py
@@ -13,8 +13,7 @@ import homeassistant.components.alarm_control_panel as alarm
 from homeassistant.components.alarm_control_panel import PLATFORM_SCHEMA
 from homeassistant.const import (
     CONF_HOST, CONF_NAME, CONF_PORT, STATE_ALARM_ARMED_AWAY,
-    STATE_ALARM_ARMED_HOME, STATE_ALARM_DISARMED, STATE_UNKNOWN,
-    STATE_ALARM_TRIGGERED)
+    STATE_ALARM_ARMED_HOME, STATE_ALARM_DISARMED, STATE_ALARM_TRIGGERED)
 import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['pynx584==0.4']
@@ -44,7 +43,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         add_entities([NX584Alarm(hass, url, name)])
     except requests.exceptions.ConnectionError as ex:
         _LOGGER.error("Unable to connect to NX584: %s", str(ex))
-        return False
+        return
 
 
 class NX584Alarm(alarm.AlarmControlPanel):
@@ -61,7 +60,7 @@ class NX584Alarm(alarm.AlarmControlPanel):
         # talk to the API and trigger a requests exception for setup_platform()
         # to catch
         self._alarm.list_zones()
-        self._state = STATE_UNKNOWN
+        self._state = None
 
     @property
     def name(self):
@@ -86,11 +85,11 @@ class NX584Alarm(alarm.AlarmControlPanel):
         except requests.exceptions.ConnectionError as ex:
             _LOGGER.error("Unable to connect to %(host)s: %(reason)s",
                           dict(host=self._url, reason=ex))
-            self._state = STATE_UNKNOWN
+            self._state = None
             zones = []
         except IndexError:
             _LOGGER.error("NX584 reports no partitions")
-            self._state = STATE_UNKNOWN
+            self._state = None
             zones = []
 
         bypassed = False

--- a/homeassistant/components/alarm_control_panel/nx584.py
+++ b/homeassistant/components/alarm_control_panel/nx584.py
@@ -13,7 +13,8 @@ import homeassistant.components.alarm_control_panel as alarm
 from homeassistant.components.alarm_control_panel import PLATFORM_SCHEMA
 from homeassistant.const import (
     CONF_HOST, CONF_NAME, CONF_PORT, STATE_ALARM_ARMED_AWAY,
-    STATE_ALARM_ARMED_HOME, STATE_ALARM_DISARMED, STATE_UNKNOWN)
+    STATE_ALARM_ARMED_HOME, STATE_ALARM_DISARMED, STATE_UNKNOWN,
+    STATE_ALARM_TRIGGERED)
 import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['pynx584==0.4']
@@ -106,6 +107,10 @@ class NX584Alarm(alarm.AlarmControlPanel):
             self._state = STATE_ALARM_ARMED_HOME
         else:
             self._state = STATE_ALARM_ARMED_AWAY
+
+        for flag in part['condition_flags']:
+            if flag == "Siren on":
+                self._state = STATE_ALARM_TRIGGERED
 
     def alarm_disarm(self, code=None):
         """Send disarm command."""


### PR DESCRIPTION
## Description: 
Added support for NX584 alarm control panel to report a state of triggered.  This state happens when the alarm panel reports the siren is sounding.


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ X] The code change is tested and works locally.
  - [ X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54