### PR TITLE
Support ZHA light turn_off transition

### DIFF
--- a/homeassistant/components/light/zha.py
+++ b/homeassistant/components/light/zha.py
@@ -198,8 +198,15 @@ class Light(ZhaEntity, light.Light):
     async def async_turn_off(self, **kwargs):
         """Turn the entity off."""
         from zigpy.exceptions import DeliveryError
+        duration = kwargs.get(light.ATTR_TRANSITION)
         try:
-            res = await self._endpoint.on_off.off()
+            supports_level = self.supported_features & light.SUPPORT_BRIGHTNESS
+            if duration and supports_level:
+                res = await self._endpoint.level.move_to_level_with_on_off(
+                    0, duration*10
+                )
+            else:
+                res = await self._endpoint.on_off.off()
             _LOGGER.debug("%s was turned off: %s", self.entity_id, res)
         except DeliveryError as ex:
             _LOGGER.error("%s: Unable to turn the light off: %s",


### PR DESCRIPTION
## Description:
Support transition attribute for ZHA `light.turn_off` service call. If no transition attribute is specified, then send ZCL "off" command, otherwise send ZCL "move_to_level_with_on_off" command and change brightness to level 0 over duration = transition * 10, as ZCL duration command option is 1/10s units

**Related issue (if applicable):** fixes #17040 
## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
