### PR TITLE
Make ZHA entities non-polled by default

### DIFF
--- a/homeassistant/components/binary_sensor/zha.py
+++ b/homeassistant/components/binary_sensor/zha.py
@@ -122,11 +122,6 @@ class IasZoneSensor(RestoreEntity, ZhaEntity, BinarySensorDevice):
         self._ias_zone_cluster = self._in_clusters[IasZone.cluster_id]
 
     @property
-    def should_poll(self) -> bool:
-        """Let zha handle polling."""
-        return False
-
-    @property
     def is_on(self) -> bool:
         """Return True if entity is on."""
         if self._state is None:
@@ -262,11 +257,6 @@ class Remote(RestoreEntity, ZhaEntity, BinarySensorDevice):
             self._zcl_reporting[cluster] = {0: REPORT_CONFIG_IMMEDIATE}
 
     @property
-    def should_poll(self) -> bool:
-        """Let zha handle polling."""
-        return False
-
-    @property
     def is_on(self) -> bool:
         """Return true if the binary sensor is on."""
         return self._state
@@ -358,11 +348,6 @@ class BinarySensor(RestoreEntity, ZhaEntity, BinarySensorDevice):
 
         _LOGGER.debug("%s restoring old state: %s", self.entity_id, old_state)
         self._state = old_state.state == STATE_ON
-
-    @property
-    def should_poll(self) -> bool:
-        """Let zha handle polling."""
-        return False
 
     @property
     def cluster(self):

--- a/homeassistant/components/fan/zha.py
+++ b/homeassistant/components/fan/zha.py
@@ -151,14 +151,6 @@ class ZhaFan(ZhaEntity, FanEntity):
         new_value = result.get('fan_mode', None)
         self._state = VALUE_TO_SPEED.get(new_value, None)
 
-    @property
-    def should_poll(self) -> bool:
-        """Return True if entity has to be polled for state.
-
-        False if entity pushes its state to HA.
-        """
-        return False
-
     def attribute_updated(self, attribute, value):
         """Handle attribute update from device."""
         attr_name = self.cluster.attributes.get(attribute, [attribute])[0]

--- a/homeassistant/components/light/zha.py
+++ b/homeassistant/components/light/zha.py
@@ -266,11 +266,3 @@ class Light(ZhaEntity, light.Light):
                 xy_color = (round(result['current_x']/65535, 3),
                             round(result['current_y']/65535, 3))
                 self._hs_color = color_util.color_xy_to_hs(*xy_color)
-
-    @property
-    def should_poll(self) -> bool:
-        """Return True if entity has to be polled for state.
-
-        False if entity pushes its state to HA.
-        """
-        return False

--- a/homeassistant/components/sensor/zha.py
+++ b/homeassistant/components/sensor/zha.py
@@ -118,11 +118,6 @@ class Sensor(ZhaEntity):
         return self._cluster
 
     @property
-    def should_poll(self) -> bool:
-        """State gets pushed from device."""
-        return False
-
-    @property
     def state(self) -> str:
         """Return the state of the entity."""
         if isinstance(self._state, float):

--- a/homeassistant/components/switch/zha.py
+++ b/homeassistant/components/switch/zha.py
@@ -83,11 +83,6 @@ class Switch(ZhaEntity, SwitchDevice):
         return self._endpoint.on_off
 
     @property
-    def should_poll(self) -> bool:
-        """Let zha handle polling."""
-        return False
-
-    @property
     def is_on(self) -> bool:
         """Return if the switch is on based on the statemachine."""
         if self._state is None:

--- a/homeassistant/components/zha/entities/entity.py
+++ b/homeassistant/components/zha/entities/entity.py
@@ -164,6 +164,11 @@ class ZhaEntity(entity.Entity):
         """Return device specific state attributes."""
         return self._device_state_attributes
 
+    @property
+    def should_poll(self) -> bool:
+        """Let ZHA handle polling."""
+        return False
+
     @callback
     def attribute_updated(self, attribute, value):
         """Handle an attribute updated on this cluster."""


### PR DESCRIPTION
## Description:
Most of ZHA entities are ~~polled~~ non-polled by default anyway, so move `def should_poll(self)` to ZhaEntity class definition, allowing override on per entity basis.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
