### PR TITLE
Whitelisting of lines on entur sensor

### DIFF
--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -349,7 +349,7 @@ elkm1-lib==0.7.13
 enocean==0.40
 
 # homeassistant.components.sensor.entur_public_transport
-enturclient==0.1.2
+enturclient==0.1.3
 
 # homeassistant.components.sensor.envirophat
 # envirophat==0.0.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -59,7 +59,7 @@ defusedxml==0.5.0
 dsmr_parser==0.12
 
 # homeassistant.components.sensor.entur_public_transport
-enturclient==0.1.2
+enturclient==0.1.3
 
 # homeassistant.components.sensor.season
 ephem==3.7.6.0


### PR DESCRIPTION
## Description:

A requested feature from users, that has come in from multiple channels, is to filter out unwanted lines from the stop places on their sensors. This update will support a whitelisting of public transport lines that should be the only ones that show up on the sensors. 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#7932

## Example entry for `configuration.yaml` (if applicable):
```yaml
# Example configuration.yaml entry
sensor:
  - platform: entur_public_transport
    stop_ids:
      - 'NSR:Quay:7333'
      - 'NSR:Quay:48550'
      - 'NSR:StopPlace:596'
    line_whitelist:
      - 'RUT:Line:1'
      - 'KOL:Line:1000_236'
      - 'NSB:Line:59'
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
