### PR TITLE
Add huawei_lte notify component

### DIFF
--- a/homeassistant/components/notify/huawei_lte.py
+++ b/homeassistant/components/notify/huawei_lte.py
@@ -1,0 +1,60 @@
+"""Huawei LTE router platform for notify component.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/notify.huawei_lte/
+"""
+
+import logging
+
+import voluptuous as vol
+import attr
+
+from homeassistant.components.notify import (
+    BaseNotificationService, ATTR_TARGET, PLATFORM_SCHEMA)
+from homeassistant.const import CONF_URL
+import homeassistant.helpers.config_validation as cv
+
+from ..huawei_lte import DATA_KEY
+
+
+DEPENDENCIES = ['huawei_lte']
+
+_LOGGER = logging.getLogger(__name__)
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_URL): cv.url,
+    vol.Required(ATTR_TARGET): vol.All(cv.ensure_list, [cv.string]),
+})
+
+
+async def async_get_service(hass, config, discovery_info=None):
+    """Get the notification service."""
+    return HuaweiLteSmsNotificationService(hass, config)
+
+
+@attr.s
+class HuaweiLteSmsNotificationService(BaseNotificationService):
+    """Huawei LTE router SMS notification service."""
+
+    hass = attr.ib()
+    config = attr.ib()
+
+    def send_message(self, message="", **kwargs):
+        """Send message to target numbers."""
+        from huawei_lte_api.exceptions import ResponseErrorException
+
+        targets = kwargs.get(ATTR_TARGET, self.config.get(ATTR_TARGET))
+        if not targets or not message:
+            return
+
+        data = self.hass.data[DATA_KEY].get_data(self.config)
+        if not data:
+            _LOGGER.error("Router not available")
+            return
+
+        try:
+            resp = data.client.sms.send_sms(
+                phone_numbers=targets, message=message)
+            _LOGGER.debug("Sent to %s: %s", targets, resp)
+        except ResponseErrorException as ex:
+            _LOGGER.error("Could not send to %s: %s", targets, ex)

--- a/homeassistant/components/notify/huawei_lte.py
+++ b/homeassistant/components/notify/huawei_lte.py
@@ -11,7 +11,7 @@ import attr
 
 from homeassistant.components.notify import (
     BaseNotificationService, ATTR_TARGET, PLATFORM_SCHEMA)
-from homeassistant.const import CONF_URL
+from homeassistant.const import CONF_RECIPIENT, CONF_URL
 import homeassistant.helpers.config_validation as cv
 
 from ..huawei_lte import DATA_KEY
@@ -23,7 +23,7 @@ _LOGGER = logging.getLogger(__name__)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_URL): cv.url,
-    vol.Required(ATTR_TARGET): vol.All(cv.ensure_list, [cv.string]),
+    vol.Required(CONF_RECIPIENT): vol.All(cv.ensure_list, [cv.string]),
 })
 
 
@@ -43,7 +43,7 @@ class HuaweiLteSmsNotificationService(BaseNotificationService):
         """Send message to target numbers."""
         from huawei_lte_api.exceptions import ResponseErrorException
 
-        targets = kwargs.get(ATTR_TARGET, self.config.get(ATTR_TARGET))
+        targets = kwargs.get(ATTR_TARGET, self.config.get(CONF_RECIPIENT))
         if not targets or not message:
             return
 


### PR DESCRIPTION
## Description:

Add notify component using Huawei LTE router SMS.

**Related issue (if applicable):** https://community.home-assistant.io/t/adding-notification-to-huawei-lte-router/70950

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#7934

## Example entry for `configuration.yaml` (if applicable):
```yaml
notify:
  - platform: huawei_lte
    target: "+15105550123"
```

## Checklist:
  - [x] The code change is tested and works locally. Caveat: tested without an SMS enabled plan, so verified only that the API calls succeed and fail when/like they should, and sent messages end up in the router's SMS outbox.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
