### PR TITLE
Fritzbox Wifi as Switch

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -874,6 +874,7 @@ omit =
     homeassistant/components/switch/dlink.py
     homeassistant/components/switch/edimax.py
     homeassistant/components/switch/fritzdect.py
+    homeassistant/components/switch/fritzbox_wifi.py
     homeassistant/components/switch/hikvisioncam.py
     homeassistant/components/switch/hook.py
     homeassistant/components/switch/kankun.py

--- a/homeassistant/components/switch/fritzbox_wifi.py
+++ b/homeassistant/components/switch/fritzbox_wifi.py
@@ -1,5 +1,5 @@
 """
-Fritzbox (Guest) WiFi Switch
+Fritzbox (Guest) WiFi Switch.
 
 Support for switching Fritzbox (Guest) Wifi on and off.
 For more details about this platform, please refer to the documentation at
@@ -86,14 +86,14 @@ class FritzBoxWifiSwitch(SwitchDevice):
         return self._state
 
     def turn_on(self, **kwargs):
-        """Turning on guest Wifi"""
+        """Turn the specified Wifi on."""
         self._conn.call_action(
             'WLANConfiguration:{}'.format(self._interface),
             'SetEnable', NewEnable=1)
         self._state = True
 
     def turn_off(self, **kwargs):
-        """Turning off guest WiFI"""
+        """Turn the specified WiFI off."""
         self._conn.call_action(
             'WLANConfiguration:{}'.format(self._interface),
             'SetEnable', NewEnable=0)

--- a/homeassistant/components/switch/fritzbox_wifi.py
+++ b/homeassistant/components/switch/fritzbox_wifi.py
@@ -57,6 +57,8 @@ class FritzBoxWifiSwitch(SwitchDevice):
     """The switch class for Fritzbox WiFi switches."""
 
     def __init__(self, conn, name, interface):
+        """Init individual Fritzbox WiFi switches."""
+
         self._conn = conn
         self._name = name
         self._interface = interface
@@ -66,10 +68,12 @@ class FritzBoxWifiSwitch(SwitchDevice):
 
     @property
     def name(self):
+        """Return the name of the wifi switch."""
         return self._name
 
     @property
     def is_on(self):
+        """Return true if switch is on."""
         self._info = self._conn.call_action(
             'WLANConfiguration:{}'.format(self._interface), 'GetInfo')
         info = self._info.get('NewEnable')
@@ -82,14 +86,16 @@ class FritzBoxWifiSwitch(SwitchDevice):
         return self._state
 
     def turn_on(self, **kwargs):
-        _LOGGER.info('Turning on guest Wifi')
+        """Turning on guest Wifi"""
+
         self._conn.call_action(
             'WLANConfiguration:{}'.format(self._interface),
             'SetEnable', NewEnable=1)
         self._state = True
 
     def turn_off(self, **kwargs):
-        _LOGGER.info('Turning off guest WiFI')
+        """Turning off guest WiFI"""
+
         self._conn.call_action(
             'WLANConfiguration:{}'.format(self._interface),
             'SetEnable', NewEnable=0)

--- a/homeassistant/components/switch/fritzbox_wifi.py
+++ b/homeassistant/components/switch/fritzbox_wifi.py
@@ -1,4 +1,6 @@
 """
+Fritzbox (Guest) WiFi Switch
+
 Support for switching Fritzbox (Guest) Wifi on and off.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/switch.fritzbox_wifi/
@@ -35,7 +37,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Fritzbox WiFi switch platform."""
-
     import fritzconnection as fc
     host = config.get(CONF_HOST)
     port = config.get(CONF_PORT)
@@ -58,7 +59,6 @@ class FritzBoxWifiSwitch(SwitchDevice):
 
     def __init__(self, conn, name, interface):
         """Init individual Fritzbox WiFi switches."""
-
         self._conn = conn
         self._name = name
         self._interface = interface
@@ -87,7 +87,6 @@ class FritzBoxWifiSwitch(SwitchDevice):
 
     def turn_on(self, **kwargs):
         """Turning on guest Wifi"""
-
         self._conn.call_action(
             'WLANConfiguration:{}'.format(self._interface),
             'SetEnable', NewEnable=1)
@@ -95,7 +94,6 @@ class FritzBoxWifiSwitch(SwitchDevice):
 
     def turn_off(self, **kwargs):
         """Turning off guest WiFI"""
-
         self._conn.call_action(
             'WLANConfiguration:{}'.format(self._interface),
             'SetEnable', NewEnable=0)

--- a/homeassistant/components/switch/fritzbox_wifi.py
+++ b/homeassistant/components/switch/fritzbox_wifi.py
@@ -1,0 +1,87 @@
+"""
+Support for switching Fritzbox (Guest) Wifi on and off.
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/switch.fritzbox_wifi/
+"""
+# pylint: disable=import-error
+
+import logging
+import voluptuous as vol
+
+from homeassistant.components.switch import (SwitchDevice, PLATFORM_SCHEMA)
+from homeassistant.const import (CONF_HOST, CONF_PORT, CONF_NAME, CONF_USERNAME, CONF_PASSWORD)
+import homeassistant.helpers.config_validation as cv
+
+REQUIREMENTS = ['fritzconnection==0.6.5']
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_NAME = 'Guest Wifi'
+DEFAULT_HOST = '169.254.1.1'
+DEFAULT_PORT = 49000
+DEFAULT_INTERFACE = 3
+
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string,
+    vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.positive_int,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_USERNAME): cv.string,
+    vol.Required(CONF_PASSWORD): cv.string,
+    vol.Optional('interface', DEFAULT_INTERFACE): cv.positive_int
+})
+
+
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    import fritzconnection as fc
+    host = config.get(CONF_HOST)
+    port = config.get(CONF_PORT)
+    name = config.get(CONF_NAME)
+    username = config.get(CONF_USERNAME)
+    password = config.get(CONF_PASSWORD)
+    interface = config.get('interface')
+
+    conn = fc.FritzConnection(
+        address=host,
+        port=port,
+        user=username,
+        password=password
+    )
+    add_entities([FritzBoxWifiSwitch(conn, name, interface)], True)
+
+class FritzBoxWifiSwitch(SwitchDevice):
+    def __init__(self, conn, name, interface):
+        self._conn = conn
+        self._name = name
+        self._interface = interface
+        self._state = None
+        self._available = True
+        self._info = None
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def is_on(self):
+        self._info = self._conn.call_action('WLANConfiguration:{}'.format(self._interface), 'GetInfo')
+        info = self._info.get('NewEnable')
+        if info == '1':
+            _LOGGER.info('Guest Wifi On')
+            self._state = True
+        elif info == '0':
+            _LOGGER.info('Guest WiFi Off')
+            self._state = False
+        return self._state
+
+    def turn_on(self, **kwargs):
+        _LOGGER.info('Turning on guest Wifi')
+        self._conn.call_action('WLANConfiguration:{}'.format(self._interface), 'SetEnable', NewEnable=1)
+        self._state = True
+
+
+    def turn_off(self, **kwargs):
+        _LOGGER.info('Turning off guest WiFI')
+        self._conn.call_action('WLANConfiguration:{}'.format(self._interface), 'SetEnable', NewEnable=0)
+        self._state = False
+

--- a/homeassistant/components/switch/fritzbox_wifi.py
+++ b/homeassistant/components/switch/fritzbox_wifi.py
@@ -9,7 +9,8 @@ import logging
 import voluptuous as vol
 
 from homeassistant.components.switch import (SwitchDevice, PLATFORM_SCHEMA)
-from homeassistant.const import (CONF_HOST, CONF_PORT, CONF_NAME, CONF_USERNAME, CONF_PASSWORD)
+from homeassistant.const import (
+    CONF_HOST, CONF_PORT, CONF_NAME, CONF_USERNAME, CONF_PASSWORD)
 import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['fritzconnection==0.6.5']
@@ -33,6 +34,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
+    """Set up the Fritzbox WiFi switch platform."""
+
     import fritzconnection as fc
     host = config.get(CONF_HOST)
     port = config.get(CONF_PORT)
@@ -49,7 +52,10 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     )
     add_entities([FritzBoxWifiSwitch(conn, name, interface)], True)
 
+
 class FritzBoxWifiSwitch(SwitchDevice):
+    """The switch class for Fritzbox WiFi switches."""
+
     def __init__(self, conn, name, interface):
         self._conn = conn
         self._name = name
@@ -64,7 +70,8 @@ class FritzBoxWifiSwitch(SwitchDevice):
 
     @property
     def is_on(self):
-        self._info = self._conn.call_action('WLANConfiguration:{}'.format(self._interface), 'GetInfo')
+        self._info = self._conn.call_action(
+            'WLANConfiguration:{}'.format(self._interface), 'GetInfo')
         info = self._info.get('NewEnable')
         if info == '1':
             _LOGGER.info('Guest Wifi On')
@@ -76,12 +83,14 @@ class FritzBoxWifiSwitch(SwitchDevice):
 
     def turn_on(self, **kwargs):
         _LOGGER.info('Turning on guest Wifi')
-        self._conn.call_action('WLANConfiguration:{}'.format(self._interface), 'SetEnable', NewEnable=1)
+        self._conn.call_action(
+            'WLANConfiguration:{}'.format(self._interface),
+            'SetEnable', NewEnable=1)
         self._state = True
-
 
     def turn_off(self, **kwargs):
         _LOGGER.info('Turning off guest WiFI')
-        self._conn.call_action('WLANConfiguration:{}'.format(self._interface), 'SetEnable', NewEnable=0)
+        self._conn.call_action(
+            'WLANConfiguration:{}'.format(self._interface),
+            'SetEnable', NewEnable=0)
         self._state = False
-

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -414,7 +414,7 @@ freesms==0.1.2
 # homeassistant.components.sensor.fritzbox_callmonitor
 # homeassistant.components.sensor.fritzbox_netmonitor
 # homeassistant.components.switch.fritzbox_wifi
-fritzconnection==0.6.5
+# fritzconnection==0.6.5
 
 # homeassistant.components.switch.fritzdect
 fritzhome==1.0.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -413,7 +413,8 @@ freesms==0.1.2
 # homeassistant.components.device_tracker.fritz
 # homeassistant.components.sensor.fritzbox_callmonitor
 # homeassistant.components.sensor.fritzbox_netmonitor
-# fritzconnection==0.6.5
+# homeassistant.components.switch.fritzbox_wifi
+fritzconnection==0.6.5
 
 # homeassistant.components.switch.fritzdect
 fritzhome==1.0.4


### PR DESCRIPTION
## Description:

Please be kind. It is my first OpenSource Pull request.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable): https://github.com/home-assistant/home-assistant.io/pull/7935

## Example entry for `configuration.yaml` (if applicable):
```yaml
switch:
   - platform: fritzbox_wifi
     host: 192.168.XXX.XXX
     password: "YOURPASSWORD"
     name: "NAME_OF_THE_SWITCH_SHOW_UP_IN_HA"
     interface: 3
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

This has nothing to do with the plugin i think, but how can i fix it:
```
SKIPPED:  py35: InterpreterNotFound: python3.5 (ok i can install Python 3.5&3.6&3.8 with homebrew)
SKIPPED:  py36: InterpreterNotFound: python3.6
  py37: commands succeeded
SKIPPED:  py38: InterpreterNotFound: python3.8
ERROR:   lint: commands failed
ERROR:   pylint: could not install deps [-r/Users/user/Documents/GitHub/home-assistant/requirements_all.txt, -r/Users/user/Documents/GitHub/home-assistant/requirements_test.txt, -c/Users/user/Documents/GitHub/home-assistant/homeassistant/package_constraints.txt]; v = InvocationError('/usr/bin/env LANG=C.UTF-8 pip install -r/Users/user/Documents/GitHub/home-assistant/requirements_all.txt -r/Users/user/Documents/GitHub/home-assistant/requirements_test.txt -c/Users/user/Documents/GitHub/home-assistant/homeassistant/package_constraints.txt (see /Users/user/Documents/GitHub/home-assistant/.tox/pylint/log/pylint-1.log)', 1)
ERROR:   typing: commands failed
  cov: commands succeeded
```
P.S. Not sure how to fix this. Running a mac

  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
