### PR TITLE
Mqtt alarm added value_template and code_arm_required 

### DIFF
--- a/homeassistant/components/mqtt/alarm_control_panel.py
+++ b/homeassistant/components/mqtt/alarm_control_panel.py
@@ -33,7 +33,7 @@ from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 
 _LOGGER = logging.getLogger(__name__)
 
-CONF_CODE_ARM_REQUIRED='code_arm_required'
+CONF_CODE_ARM_REQUIRED = 'code_arm_required'
 CONF_PAYLOAD_DISARM = 'payload_disarm'
 CONF_PAYLOAD_ARM_HOME = 'payload_arm_home'
 CONF_PAYLOAD_ARM_AWAY = 'payload_arm_away'
@@ -73,7 +73,8 @@ async def async_setup_platform(hass: HomeAssistantType, config: ConfigType,
     await _async_setup_entity(config, value_template, async_add_entities)
 
 
-async def async_setup_entry(hass, config_entry, value_template, async_add_entities):
+async def async_setup_entry(hass, config_entry, value_template,
+                            async_add_entities):
     """Set up MQTT alarm control panel dynamically through MQTT discovery."""
     async def async_discover(discovery_payload):
         """Discover and add an MQTT alarm control panel."""
@@ -132,7 +133,8 @@ class MqttAlarm(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
         @callback
         def message_received(topic, payload, qos):
             if self._value_template is not None:
-                payload = self._value_template.async_render_with_possible_json_value(
+                payload = \
+                    self._value_template.async_render_with_possible_json_value(
                     payload)
 
             """Run when new MQTT message has been received."""

--- a/homeassistant/components/mqtt/alarm_control_panel.py
+++ b/homeassistant/components/mqtt/alarm_control_panel.py
@@ -206,8 +206,8 @@ class MqttAlarm(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
 
         This method is a coroutine.
         """
-        if (self._config.get(CONF_CODE_ARM_REQUIRED) and
-                not self._validate_code(code, 'arming home')):
+        code_required= self._config.get(CONF_CODE_ARM_REQUIRED)
+        if code_required and not self._validate_code(code, 'arming home'):
             return
         mqtt.async_publish(
             self.hass, self._config.get(CONF_COMMAND_TOPIC),
@@ -220,8 +220,8 @@ class MqttAlarm(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
 
         This method is a coroutine.
         """
-        if (self._config.get(CONF_CODE_ARM_REQUIRED) and
-                not self._validate_code(code, 'arming away')):
+        code_required= self._config.get(CONF_CODE_ARM_REQUIRED)
+        if code_required and not self._validate_code(code, 'arming away'):
             return
         mqtt.async_publish(
             self.hass, self._config.get(CONF_COMMAND_TOPIC),

--- a/homeassistant/components/mqtt/alarm_control_panel.py
+++ b/homeassistant/components/mqtt/alarm_control_panel.py
@@ -33,7 +33,7 @@ from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 
 _LOGGER = logging.getLogger(__name__)
 
-CONF_ARM_CODE_REQUIRED='arm_code_required'
+CONF_CODE_ARM_REQUIRED='code_arm_required'
 CONF_PAYLOAD_DISARM = 'payload_disarm'
 CONF_PAYLOAD_ARM_HOME = 'payload_arm_home'
 CONF_PAYLOAD_ARM_AWAY = 'payload_arm_away'
@@ -59,7 +59,7 @@ PLATFORM_SCHEMA = mqtt.MQTT_BASE_PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_UNIQUE_ID): cv.string,
     vol.Optional(CONF_DEVICE): mqtt.MQTT_ENTITY_DEVICE_INFO_SCHEMA,
     vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
-    vol.Optional(CONF_ARM_CODE_REQUIRED, default=True): cv.boolean,
+    vol.Optional(CONF_CODE_ARM_REQUIRED, default=True): cv.boolean,
 }).extend(mqtt.MQTT_AVAILABILITY_SCHEMA.schema)
 
 
@@ -207,7 +207,7 @@ class MqttAlarm(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
 
         This method is a coroutine.
         """
-        if (self._config.get(CONF_ARM_CODE_REQUIRED) and
+        if (self._config.get(CONF_CODE_ARM_REQUIRED) and
                 not self._validate_code(code, 'arming home')):
             return
         mqtt.async_publish(
@@ -221,7 +221,7 @@ class MqttAlarm(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
 
         This method is a coroutine.
         """
-        if (self._config.get(CONF_ARM_CODE_REQUIRED) and
+        if (self._config.get(CONF_CODE_ARM_REQUIRED) and
                 not self._validate_code(code, 'arming away')):
             return
         mqtt.async_publish(

--- a/homeassistant/components/mqtt/alarm_control_panel.py
+++ b/homeassistant/components/mqtt/alarm_control_panel.py
@@ -130,11 +130,11 @@ class MqttAlarm(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
 
         @callback
         def message_received(topic, payload, qos):
+            """Run when new MQTT message has been received."""
             if template is not None:
                 payload = template.async_render_with_possible_json_value(
                     payload)
 
-            """Run when new MQTT message has been received."""
             if payload not in (STATE_ALARM_DISARMED, STATE_ALARM_ARMED_HOME,
                                STATE_ALARM_ARMED_AWAY,
                                STATE_ALARM_ARMED_NIGHT,

--- a/homeassistant/components/mqtt/alarm_control_panel.py
+++ b/homeassistant/components/mqtt/alarm_control_panel.py
@@ -206,7 +206,7 @@ class MqttAlarm(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
 
         This method is a coroutine.
         """
-        code_required= self._config.get(CONF_CODE_ARM_REQUIRED)
+        code_required = self._config.get(CONF_CODE_ARM_REQUIRED)
         if code_required and not self._validate_code(code, 'arming home'):
             return
         mqtt.async_publish(

--- a/homeassistant/components/mqtt/alarm_control_panel.py
+++ b/homeassistant/components/mqtt/alarm_control_panel.py
@@ -220,7 +220,7 @@ class MqttAlarm(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
 
         This method is a coroutine.
         """
-        code_required= self._config.get(CONF_CODE_ARM_REQUIRED)
+        code_required = self._config.get(CONF_CODE_ARM_REQUIRED)
         if code_required and not self._validate_code(code, 'arming away'):
             return
         mqtt.async_publish(

--- a/homeassistant/components/mqtt/alarm_control_panel.py
+++ b/homeassistant/components/mqtt/alarm_control_panel.py
@@ -135,7 +135,7 @@ class MqttAlarm(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
             if self._value_template is not None:
                 payload = \
                     self._value_template.async_render_with_possible_json_value(
-                    payload)
+                        payload)
 
             """Run when new MQTT message has been received."""
             if payload not in (STATE_ALARM_DISARMED, STATE_ALARM_ARMED_HOME,

--- a/tests/components/mqtt/test_alarm_control_panel.py
+++ b/tests/components/mqtt/test_alarm_control_panel.py
@@ -114,15 +114,19 @@ class TestAlarmControlPanelMQTT(unittest.TestCase):
         self.mock_publish.async_publish.assert_called_once_with(
             'alarm/command', 'ARM_HOME', 0, False)
 
-    def test_arm_home_not_publishes_mqtt_with_invalid_code(self):
-        """Test not publishing of MQTT messages with invalid code."""
+    def test_arm_home_not_publishes_mqtt_with_invalid_code_when_required(self):
+        """Test not publishing of MQTT messages with invalid.
+
+        When code_arm_required = True
+        """
         assert setup_component(self.hass, alarm_control_panel.DOMAIN, {
             alarm_control_panel.DOMAIN: {
                 'platform': 'mqtt',
                 'name': 'test',
                 'state_topic': 'alarm/state',
                 'command_topic': 'alarm/command',
-                'code': '1234'
+                'code': '1234',
+                'code_arm_required': True
             }
         })
 
@@ -130,6 +134,24 @@ class TestAlarmControlPanelMQTT(unittest.TestCase):
         common.alarm_arm_home(self.hass, 'abcd')
         self.hass.block_till_done()
         assert call_count == self.mock_publish.call_count
+
+    def test_arm_home_publishes_mqtt_when_code_not_required(self):
+        """Test publishing of MQTT messages when code is not required."""
+        assert setup_component(self.hass, alarm_control_panel.DOMAIN, {
+            alarm_control_panel.DOMAIN: {
+                'platform': 'mqtt',
+                'name': 'test',
+                'state_topic': 'alarm/state',
+                'command_topic': 'alarm/command',
+                'code': '1234',
+                'code_arm_required': False
+            }
+        })
+
+        common.alarm_arm_home(self.hass)
+        self.hass.block_till_done()
+        self.mock_publish.async_publish.assert_called_once_with(
+            'alarm/command', 'ARM_HOME', 0, False)
 
     def test_arm_away_publishes_mqtt(self):
         """Test publishing of MQTT messages while armed."""
@@ -147,15 +169,19 @@ class TestAlarmControlPanelMQTT(unittest.TestCase):
         self.mock_publish.async_publish.assert_called_once_with(
             'alarm/command', 'ARM_AWAY', 0, False)
 
-    def test_arm_away_not_publishes_mqtt_with_invalid_code(self):
-        """Test not publishing of MQTT messages with invalid code."""
+    def test_arm_away_not_publishes_mqtt_with_invalid_code_when_required(self):
+        """Test not publishing of MQTT messages with invalid code.
+
+        When code_arm_required = True
+        """
         assert setup_component(self.hass, alarm_control_panel.DOMAIN, {
             alarm_control_panel.DOMAIN: {
                 'platform': 'mqtt',
                 'name': 'test',
                 'state_topic': 'alarm/state',
                 'command_topic': 'alarm/command',
-                'code': '1234'
+                'code': '1234',
+                'code_arm_required': True
             }
         })
 
@@ -164,38 +190,26 @@ class TestAlarmControlPanelMQTT(unittest.TestCase):
         self.hass.block_till_done()
         assert call_count == self.mock_publish.call_count
 
-    def test_arm_night_publishes_mqtt(self):
-        """Test publishing of MQTT messages while armed."""
+    def test_arm_away_publishes_mqtt_when_code_not_required(self):
+        """Test publishing of MQTT messages.
+
+        When code_arm_required = False
+        """
         assert setup_component(self.hass, alarm_control_panel.DOMAIN, {
             alarm_control_panel.DOMAIN: {
                 'platform': 'mqtt',
                 'name': 'test',
                 'state_topic': 'alarm/state',
                 'command_topic': 'alarm/command',
+                'code': '1234',
+                'code_arm_required': False
             }
         })
 
-        common.alarm_arm_night(self.hass)
+        common.alarm_arm_away(self.hass)
         self.hass.block_till_done()
         self.mock_publish.async_publish.assert_called_once_with(
-            'alarm/command', 'ARM_NIGHT', 0, False)
-
-    def test_arm_night_not_publishes_mqtt_with_invalid_code(self):
-        """Test not publishing of MQTT messages with invalid code."""
-        assert setup_component(self.hass, alarm_control_panel.DOMAIN, {
-            alarm_control_panel.DOMAIN: {
-                'platform': 'mqtt',
-                'name': 'test',
-                'state_topic': 'alarm/state',
-                'command_topic': 'alarm/command',
-                'code': '1234'
-            }
-        })
-
-        call_count = self.mock_publish.call_count
-        common.alarm_arm_night(self.hass, 'abcd')
-        self.hass.block_till_done()
-        assert call_count == self.mock_publish.call_count
+            'alarm/command', 'ARM_AWAY', 0, False)
 
     def test_disarm_publishes_mqtt(self):
         """Test publishing of MQTT messages while disarmed."""

--- a/tests/components/mqtt/test_alarm_control_panel.py
+++ b/tests/components/mqtt/test_alarm_control_panel.py
@@ -114,7 +114,7 @@ class TestAlarmControlPanelMQTT(unittest.TestCase):
         self.mock_publish.async_publish.assert_called_once_with(
             'alarm/command', 'ARM_HOME', 0, False)
 
-    def test_arm_home_not_publishes_mqtt_with_invalid_code_when_required(self):
+    def test_arm_home_not_publishes_mqtt_with_invalid_code_when_req(self):
         """Test not publishing of MQTT messages with invalid.
 
         When code_arm_required = True
@@ -135,24 +135,6 @@ class TestAlarmControlPanelMQTT(unittest.TestCase):
         self.hass.block_till_done()
         assert call_count == self.mock_publish.call_count
 
-    def test_arm_home_publishes_mqtt_when_code_not_required(self):
-        """Test publishing of MQTT messages when code is not required."""
-        assert setup_component(self.hass, alarm_control_panel.DOMAIN, {
-            alarm_control_panel.DOMAIN: {
-                'platform': 'mqtt',
-                'name': 'test',
-                'state_topic': 'alarm/state',
-                'command_topic': 'alarm/command',
-                'code': '1234',
-                'code_arm_required': False
-            }
-        })
-
-        common.alarm_arm_home(self.hass)
-        self.hass.block_till_done()
-        self.mock_publish.async_publish.assert_called_once_with(
-            'alarm/command', 'ARM_HOME', 0, False)
-
     def test_arm_away_publishes_mqtt(self):
         """Test publishing of MQTT messages while armed."""
         assert setup_component(self.hass, alarm_control_panel.DOMAIN, {
@@ -169,7 +151,7 @@ class TestAlarmControlPanelMQTT(unittest.TestCase):
         self.mock_publish.async_publish.assert_called_once_with(
             'alarm/command', 'ARM_AWAY', 0, False)
 
-    def test_arm_away_not_publishes_mqtt_with_invalid_code_when_required(self):
+    def test_arm_away_not_publishes_mqtt_with_invalid_code_when_req(self):
         """Test not publishing of MQTT messages with invalid code.
 
         When code_arm_required = True
@@ -190,7 +172,7 @@ class TestAlarmControlPanelMQTT(unittest.TestCase):
         self.hass.block_till_done()
         assert call_count == self.mock_publish.call_count
 
-    def test_arm_away_publishes_mqtt_when_code_not_required(self):
+    def test_arm_away_publishes_mqtt_when_code_not_req(self):
         """Test publishing of MQTT messages.
 
         When code_arm_required = False
@@ -210,6 +192,43 @@ class TestAlarmControlPanelMQTT(unittest.TestCase):
         self.hass.block_till_done()
         self.mock_publish.async_publish.assert_called_once_with(
             'alarm/command', 'ARM_AWAY', 0, False)
+
+    def test_arm_night_publishes_mqtt(self):
+        """Test publishing of MQTT messages while armed."""
+        assert setup_component(self.hass, alarm_control_panel.DOMAIN, {
+            alarm_control_panel.DOMAIN: {
+                'platform': 'mqtt',
+                'name': 'test',
+                'state_topic': 'alarm/state',
+                'command_topic': 'alarm/command',
+            }
+        })
+
+        common.alarm_arm_night(self.hass)
+        self.hass.block_till_done()
+        self.mock_publish.async_publish.assert_called_once_with(
+            'alarm/command', 'ARM_NIGHT', 0, False)
+
+    def test_arm_night_not_publishes_mqtt_with_invalid_code_when_req(self):
+        """Test not publishing of MQTT messages with invalid code.
+
+        When code_arm_required = True
+        """
+        assert setup_component(self.hass, alarm_control_panel.DOMAIN, {
+            alarm_control_panel.DOMAIN: {
+                'platform': 'mqtt',
+                'name': 'test',
+                'state_topic': 'alarm/state',
+                'command_topic': 'alarm/command',
+                'code': '1234',
+                'code_arm_required': True
+            }
+        })
+
+        call_count = self.mock_publish.call_count
+        common.alarm_arm_night(self.hass, 'abcd')
+        self.hass.block_till_done()
+        assert call_count == self.mock_publish.call_count
 
     def test_disarm_publishes_mqtt(self):
         """Test publishing of MQTT messages while disarmed."""


### PR DESCRIPTION
## Description:
~~Added value_template config option to parse json incoming message.~~
Added code_arm_required config option to avoid code enter on arm.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8822



## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
