### PR TITLE
Improve Wemo setup speed

### DIFF
--- a/homeassistant/components/binary_sensor/wemo.py
+++ b/homeassistant/components/binary_sensor/wemo.py
@@ -18,7 +18,7 @@ DEPENDENCIES = ['wemo']
 _LOGGER = logging.getLogger(__name__)
 
 
-def setup_platform(hass, config, add_entities_callback, discovery_info=None):
+def setup_platform(hass, config, add_entities, discovery_info=None):
     """Register discovered WeMo binary sensors."""
     from pywemo import discovery
 
@@ -34,7 +34,7 @@ def setup_platform(hass, config, add_entities_callback, discovery_info=None):
             raise PlatformNotReady
 
         if device:
-            add_entities_callback([WemoBinarySensor(hass, device)])
+            add_entities([WemoBinarySensor(hass, device)])
 
 
 class WemoBinarySensor(BinarySensorDevice):

--- a/homeassistant/components/switch/wemo.py
+++ b/homeassistant/components/switch/wemo.py
@@ -35,7 +35,7 @@ WEMO_OFF = 0
 WEMO_STANDBY = 8
 
 
-def setup_platform(hass, config, add_entities_callback, discovery_info=None):
+def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up discovered WeMo switches."""
     from pywemo import discovery
 
@@ -51,7 +51,7 @@ def setup_platform(hass, config, add_entities_callback, discovery_info=None):
             raise PlatformNotReady
 
         if device:
-            add_entities_callback([WemoSwitch(device)])
+            add_entities([WemoSwitch(device)])
 
 
 class WemoSwitch(SwitchDevice):

--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -86,7 +86,7 @@ def setup(hass, config):
 
     def stop_wemo(event):
         """Shutdown Wemo subscriptions and subscription thread on exit."""
-        _LOGGER.debug("Shutting down subscriptions.")
+        _LOGGER.debug("Shutting down WeMo event subscriptions.")
         SUBSCRIPTION_REGISTRY.stop()
 
     hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, stop_wemo)

--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -130,7 +130,8 @@ def setup(hass, config):
     devices = []
 
     async def async_discover_wemo_devices(hass, config):
-        """Run discovery in an async context so initial setup can complete quickly."""
+        """Run discovery in an async context so
+        initial setup can complete quickly."""
         _LOGGER.debug("Scanning statically configured WeMo devices...")
         for host, port in config.get(DOMAIN, {}).get(CONF_STATIC, []):
             url = setup_url_for_address(host, port)
@@ -160,7 +161,8 @@ def setup(hass, config):
                     devices.append((setup_url_for_device(device), device))
 
         for url, device in devices:
-            _LOGGER.debug('Adding WeMo device at %s:%i', device.host, device.port)
+            _LOGGER.debug('Adding WeMo device at %s:%i',
+                          device.host, device.port)
 
             discovery_info = {
                 'model_name': device.model_name,

--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -130,8 +130,7 @@ def setup(hass, config):
     devices = []
 
     async def async_discover_wemo_devices(hass, config):
-        """Run discovery in an async context so
-        initial setup can complete quickly."""
+        """Run discovery in an async context so setup can complete quickly."""
         _LOGGER.debug("Scanning statically configured WeMo devices...")
         for host, port in config.get(DOMAIN, {}).get(CONF_STATIC, []):
             url = setup_url_for_address(host, port)

--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -76,8 +76,6 @@ CONFIG_SCHEMA = vol.Schema({
 
 def setup(hass, config):
     """Set up for WeMo devices."""
-    _LOGGER.debug("Beginning setup of WeMo component...")
-
     import pywemo
 
     # Keep track of WeMo devices
@@ -90,7 +88,7 @@ def setup(hass, config):
 
     def stop_wemo(event):
         """Shutdown Wemo subscriptions and subscription thread on exit."""
-        _LOGGER.debug("Shutting down WeMo event subscriptions.")
+        _LOGGER.debug("Shutting down WeMo event subscriptions")
         SUBSCRIPTION_REGISTRY.stop()
 
     hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, stop_wemo)
@@ -132,7 +130,7 @@ def setup(hass, config):
     discovery.listen(hass, SERVICE_WEMO, discovery_dispatch)
 
     def discover_wemo_devices(now):
-        """Run discovery in an async context so setup can complete quickly."""
+        """Run discovery for WeMo devices."""
         _LOGGER.debug("Beginning WeMo device discovery...")
         _LOGGER.debug("Adding statically configured WeMo devices...")
         for host, port in config.get(DOMAIN, {}).get(CONF_STATIC, []):
@@ -176,11 +174,9 @@ def setup(hass, config):
 
             discovery.discover(hass, SERVICE_WEMO, discovery_info)
 
-        _LOGGER.debug("WeMo device discovery has finished.")
+        _LOGGER.debug("WeMo device discovery has finished")
 
     hass.bus.listen_once(EVENT_HOMEASSISTANT_START,
                          discover_wemo_devices)
-
-    _LOGGER.debug("Setup of WeMo component has finished.")
 
     return True

--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -10,11 +10,8 @@ import requests
 import voluptuous as vol
 
 from homeassistant.components.discovery import SERVICE_WEMO
-from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import discovery
-from homeassistant.helpers.event import async_track_point_in_utc_time
-import homeassistant.util.dt as dt_util
 
 from homeassistant.const import (
     EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP)
@@ -77,7 +74,7 @@ CONFIG_SCHEMA = vol.Schema({
 }, extra=vol.ALLOW_EXTRA)
 
 
-async def async_setup(hass, config):
+def setup(hass, config):
     """Set up for WeMo devices."""
     _LOGGER.debug("Beginning setup of WeMo component...")
 
@@ -91,19 +88,18 @@ async def async_setup(hass, config):
     SUBSCRIPTION_REGISTRY = pywemo.SubscriptionRegistry()
     SUBSCRIPTION_REGISTRY.start()
 
-    @callback
     def stop_wemo(event):
         """Shutdown Wemo subscriptions and subscription thread on exit."""
         _LOGGER.debug("Shutting down WeMo event subscriptions.")
         SUBSCRIPTION_REGISTRY.stop()
 
-    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, stop_wemo)
+    hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, stop_wemo)
 
-    async def setup_url_for_device(device):
+    def setup_url_for_device(device):
         """Determine setup.xml url for given device."""
         return 'http://{}:{}/setup.xml'.format(device.host, device.port)
 
-    async def setup_url_for_address(host, port):
+    def setup_url_for_address(host, port):
         """Determine setup.xml url for given host and port pair."""
         if not port:
             port = pywemo.ouimeaux_device.probe_wemo(host)
@@ -113,7 +109,7 @@ async def async_setup(hass, config):
 
         return 'http://{}:{}/setup.xml'.format(host, port)
 
-    async def discovery_dispatch(service, discovery_info):
+    def discovery_dispatch(service, discovery_info):
         """Dispatcher for incoming WeMo discovery events."""
         # name, model, location, mac
         model_name = discovery_info.get('model_name')
@@ -130,16 +126,17 @@ async def async_setup(hass, config):
 
         component = WEMO_MODEL_DISPATCH.get(model_name, 'switch')
 
-        await discovery.async_load_platform(hass, component, DOMAIN,
-                                            discovery_info, config)
+        discovery.load_platform(hass, component, DOMAIN,
+                                discovery_info, config)
 
-    discovery.async_listen(hass, SERVICE_WEMO, discovery_dispatch)
+    discovery.listen(hass, SERVICE_WEMO, discovery_dispatch)
 
-    async def discover_wemo_devices(now):
+    def discover_wemo_devices(now):
         """Run discovery in an async context so setup can complete quickly."""
-        _LOGGER.debug("Scanning statically configured WeMo devices...")
+        _LOGGER.debug("Beginning WeMo device discovery...")
+        _LOGGER.debug("Adding statically configured WeMo devices...")
         for host, port in config.get(DOMAIN, {}).get(CONF_STATIC, []):
-            url = await setup_url_for_address(host, port)
+            url = setup_url_for_address(host, port)
 
             if not url:
                 _LOGGER.error(
@@ -159,11 +156,11 @@ async def async_setup(hass, config):
                 devices.append((url, device))
 
         if config.get(DOMAIN, {}).get(CONF_DISCOVERY):
-            _LOGGER.debug("Scanning for WeMo devices...")
+            _LOGGER.debug("Scanning network for WeMo devices...")
             for device in pywemo.discover_devices():
                 if not [d[1] for d in devices
                         if d[1].serialnumber == device.serialnumber]:
-                    devices.append((await setup_url_for_device(device),
+                    devices.append((setup_url_for_device(device),
                                     device))
 
         for url, device in devices:
@@ -177,17 +174,12 @@ async def async_setup(hass, config):
                 'ssdp_description': url,
             }
 
-            await discovery.async_discover(hass, SERVICE_WEMO, discovery_info)
+            discovery.discover(hass, SERVICE_WEMO, discovery_info)
 
-    @callback
-    def schedule_first_discovery(event):
-        """Schedule the first discovery when Home Assistant starts up."""
-        async_track_point_in_utc_time(hass,
-                                      discover_wemo_devices,
-                                      dt_util.utcnow())
+        _LOGGER.debug("WeMo device discovery has finished.")
 
-    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START,
-                               schedule_first_discovery)
+    hass.bus.listen_once(EVENT_HOMEASSISTANT_START,
+                         discover_wemo_devices)
 
     _LOGGER.debug("Setup of WeMo component has finished.")
 

--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -163,7 +163,8 @@ async def async_setup(hass, config):
             for device in pywemo.discover_devices():
                 if not [d[1] for d in devices
                         if d[1].serialnumber == device.serialnumber]:
-                    devices.append((await setup_url_for_device(device), device))
+                    devices.append((await setup_url_for_device(device),
+                                    device))
 
         for url, device in devices:
             _LOGGER.debug('Adding WeMo device at %s:%i',
@@ -181,9 +182,12 @@ async def async_setup(hass, config):
     @callback
     def schedule_first_discovery(event):
         """Schedule the first discovery when Home Assistant starts up."""
-        async_track_point_in_utc_time(hass, discover_wemo_devices, dt_util.utcnow())
+        async_track_point_in_utc_time(hass,
+                                      discover_wemo_devices,
+                                      dt_util.utcnow())
 
-    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, schedule_first_discovery)
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START,
+                               schedule_first_discovery)
 
     _LOGGER.debug("Setup of WeMo component has finished.")
 


### PR DESCRIPTION
## Description:

**Breaking change:**
Move WeMo device discovery to run after home assistant start so it won't block initial component setup from completing quickly.

## Example entry for `configuration.yaml` (if applicable):
```yaml
wemo:
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.