### PR TITLE
add support for Zengge Wi-Fi bulbs

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -582,6 +582,7 @@ omit =
     homeassistant/components/light/yeelight.py
     homeassistant/components/light/yeelightsunflower.py
     homeassistant/components/light/zengge.py
+    homeassistant/components/light/zengge-wifi.py
     homeassistant/components/lirc.py
     homeassistant/components/lock/kiwi.py
     homeassistant/components/lock/lockitron.py

--- a/homeassistant/components/light/zengge-wifi.py
+++ b/homeassistant/components/light/zengge-wifi.py
@@ -12,7 +12,7 @@ import voluptuous as vol
 from homeassistant.components.light import (Light, SUPPORT_COLOR, SUPPORT_WHITE_VALUE,
                                             ATTR_WHITE_VALUE, PLATFORM_SCHEMA,
                                             ATTR_BRIGHTNESS, ATTR_HS_COLOR, SUPPORT_BRIGHTNESS)
-from homeassistant.const import CONF_NAME, CONF_DEVICES
+from homeassistant.const import CONF_NAME, CONF_HOST
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.color as color_util
 
@@ -22,21 +22,15 @@ DEFAULT_NAME = "Zengge Bulb"
 
 _LOGGER = logging.getLogger(__name__)
 
-DEVICE_SCHEMA = vol.Schema({
-    vol.Optional(CONF_NAME): cv.string,
-})
-
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Optional(CONF_DEVICES, default={}): {cv.string: DEVICE_SCHEMA},
+    vol.Required(CONF_HOST): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 })
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Zengge Wi-Fi platform."""
-    lights = []
-    for address, device_config in config[CONF_DEVICES].items():
-        lights.append(ZenggeWifiLight(address, device_config[CONF_NAME]))
-    add_entities(lights)
+    add_entities([ZenggeWifiLight(config[CONF_HOST], config[CONF_NAME])], True)
 
 
 class ZenggeWifiLight(Light):

--- a/homeassistant/components/light/zengge-wifi.py
+++ b/homeassistant/components/light/zengge-wifi.py
@@ -1,0 +1,132 @@
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components.light import Light, SUPPORT_COLOR, SUPPORT_WHITE_VALUE, ATTR_WHITE_VALUE, PLATFORM_SCHEMA, ATTR_BRIGHTNESS, ATTR_HS_COLOR, SUPPORT_BRIGHTNESS
+from homeassistant.const import CONF_HOST, CONF_NAME, STATE_OFF, STATE_ON, CONF_DEVICES
+import homeassistant.helpers.config_validation as cv
+import homeassistant.util.color as color_util
+
+REQUIREMENTS = ["zenggewifi==0.0.3"]
+
+DEFAULT_NAME = "Zengge Bulb"
+
+_LOGGER = logging.getLogger(__name__)
+
+DEVICE_SCHEMA = vol.Schema({
+    vol.Required(CONF_HOST): cv.string,
+    vol.Optional(CONF_NAME): cv.string,
+})
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_DEVICES, default={}): {cv.string: DEVICE_SCHEMA},
+})
+
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    Lights = []
+    for address, device_config in config[CONF_DEVICES].items():
+        Lights.append(ZenggeWifiLight(device_config[CONF_HOST], device_config[CONF_NAME]))
+    add_entities(Lights)
+
+
+class ZenggeWifiLight(Light):
+
+    def __init__(self, host, name):
+        import zenggewifi
+        self._bulb = zenggewifi.ZenggeWifiBulb(host)
+        self._name = name
+        self.is_valid = True
+        self._state = False
+        self._hs_color = (0, 0)
+        self._white = 0
+        self._brightness = 0
+        from datetime import datetime
+        self.update_time = datetime.now()
+        if self._bulb.connect() is False:
+            self.is_valid = False
+            _LOGGER.error("Failed to connect to bulb %s (%s)", name, host)
+            return
+        self.update()
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def is_on(self):
+        return self._state
+    
+    @property
+    def hs_color(self):
+        return self._hs_color
+    
+    @property
+    def brightness(self):
+        return self._brightness
+
+    @property
+    def white_value(self):
+        return self._white
+
+    @property
+    def supported_features(self):
+        return (SUPPORT_COLOR | SUPPORT_BRIGHTNESS | SUPPORT_WHITE_VALUE)
+
+    @property
+    def should_poll(self):
+        return True
+    
+    @property
+    def assumed_state(self):
+        return False
+    
+    def set_rgb(self, red, green, blue):
+        return self._bulb.set_rgb(red, green, blue)
+
+    def set_white(self, white):
+        return self._bulb.set_white(white)
+
+    def turn_on(self, **kwargs):
+        self._bulb.on()
+        self._state = True
+
+        hs_color = kwargs.get(ATTR_HS_COLOR)
+        white = kwargs.get(ATTR_WHITE_VALUE)
+        brightness = kwargs.get(ATTR_BRIGHTNESS)
+
+        if white is not None:
+            self._white = white
+        
+        if hs_color is not None:
+            self._white = 0
+            self._hs_color = hs_color
+        
+        if brightness is not None:
+            self._brightness = brightness
+        
+        if self._white != 0:
+            self.set_white(white)
+        else:
+            rgb = color_util.color_hsv_to_RGB(self._hs_color[0], self._hs_color[1], self._brightness / 255 * 100)
+            self.set_rgb(*rgb)
+        from datetime import datetime
+        self.update_time = datetime.now()
+
+    def turn_off(self):
+        self._state = False
+        self._bulb.off()
+
+    def update(self):
+        from datetime import datetime
+        if (datetime.now() - self.update_time).seconds < 2:
+            from time import sleep
+            sleep(2)
+        status = self._bulb.get_status()
+        if status is False:
+            return False
+        self._state = status.isOn
+        color = status.Color
+        hsv = color_util.color_RGB_to_hsv(color.R, color.G, color.B)
+        self._hs_color = hsv[:2]
+        self._brightness = hsv[2] / 100 * 255
+        self._white = color.W

--- a/homeassistant/components/light/zengge-wifi.py
+++ b/homeassistant/components/light/zengge-wifi.py
@@ -14,7 +14,6 @@ DEFAULT_NAME = "Zengge Bulb"
 _LOGGER = logging.getLogger(__name__)
 
 DEVICE_SCHEMA = vol.Schema({
-    vol.Required(CONF_HOST): cv.string,
     vol.Optional(CONF_NAME): cv.string,
 })
 
@@ -25,7 +24,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 def setup_platform(hass, config, add_entities, discovery_info=None):
     Lights = []
     for address, device_config in config[CONF_DEVICES].items():
-        Lights.append(ZenggeWifiLight(device_config[CONF_HOST], device_config[CONF_NAME]))
+        Lights.append(ZenggeWifiLight(address, device_config[CONF_NAME]))
     add_entities(Lights)
 
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1725,3 +1725,6 @@ zigpy==0.2.0
 
 # homeassistant.components.zoneminder
 zm-py==0.3.0
+
+# homeassistant.components.light.zengge-wifi
+zenggewifi==0.0.3


### PR DESCRIPTION
## Description:
This adds support for Zengge Wi-Fi LED bulbs. They support RGB and Warmwhite, but only one of them at a time. They also support an amount of fix modes like flashing 7 colors, continuous dimming of red, green and so on, but it's not implemented here.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#7947

## Example entry for `configuration.yaml` (if applicable):
```yaml
light:
  - platform: zengge-wifi
    host: IP_ADDRESS
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54