### PR TITLE
Update pylaunches dependency to 0.2.0

### DIFF
--- a/homeassistant/components/sensor/launch_library.py
+++ b/homeassistant/components/sensor/launch_library.py
@@ -15,7 +15,7 @@ from homeassistant.const import ATTR_ATTRIBUTION, CONF_NAME
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-REQUIREMENTS = ['pylaunches==0.1.2']
+REQUIREMENTS = ['pylaunches==0.2.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1046,7 +1046,7 @@ pylacrosse==0.3.1
 pylast==2.4.0
 
 # homeassistant.components.sensor.launch_library
-pylaunches==0.1.2
+pylaunches==0.2.0
 
 # homeassistant.components.media_player.lg_netcast
 pylgnetcast-homeassistant==0.2.0.dev0


### PR DESCRIPTION
**Breaking change**
The launch_time sensor attribute will now be a datetime which can be used in templates, as opposed to a written word string. 

## Description:
Update launch library to use pylaunches 0.2.0 as a dependency. launch_time sensor attribute will now be passed in ISO format, allowing for templating/easier automating with this attribute.
Bump [Space Launch Sensor](https://www.home-assistant.io/components/sensor.launch_library/) to pylaunches 0.2.0. 



**Related issue (if applicable): None

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
