### PR TITLE
Add a new click_type "long_both"

### DIFF
--- a/homeassistant/components/binary_sensor/xiaomi_aqara.py
+++ b/homeassistant/components/binary_sensor/xiaomi_aqara.py
@@ -414,7 +414,7 @@ class XiaomiButton(XiaomiBinarySensor):
         elif value == 'long_click':
             click_type = 'long'
         elif value == 'long_both_click':
-            return False
+            click_type = 'long_both'
         else:
             _LOGGER.warning("Unsupported click_type detected: %s", value)
             return False


### PR DESCRIPTION
to improve the support of the new Xiaomi Wireless Wall Switch (remote.b286acn01).

**Related issue (if applicable):** fixes https://community.home-assistant.io/t/no-xiaomi-aqara-wireless-switch-long-click-both-double-click-and-both-long-click-support/86746/2

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#7949