### PR TITLE
Link to dicttoxml excessive INFO logging issue

### DIFF
--- a/homeassistant/components/huawei_lte.py
+++ b/homeassistant/components/huawei_lte.py
@@ -22,6 +22,7 @@ from homeassistant.util import Throttle
 _LOGGER = logging.getLogger(__name__)
 
 # dicttoxml (used by huawei-lte-api) has uselessly verbose INFO level.
+# https://github.com/quandyfactory/dicttoxml/issues/60
 logging.getLogger('dicttoxml').setLevel(logging.WARNING)
 
 REQUIREMENTS = ['huawei-lte-api==1.0.16']


### PR DESCRIPTION
## Description:

Just a comment with a link to dicttoxml upstream issue.

## Checklist:
  - [N/A] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
