### PR TITLE
Only bind clusters in ZHA remote entity

### DIFF
--- a/homeassistant/components/binary_sensor/zha.py
+++ b/homeassistant/components/binary_sensor/zha.py
@@ -176,12 +176,6 @@ class Remote(RestoreEntity, ZhaEntity, BinarySensorDevice):
 
         out_clusters = kwargs.get('out_clusters')
         self._zcl_reporting = {}
-        for cluster_id in [general.OnOff.cluster_id,
-                           general.LevelControl.cluster_id]:
-            if cluster_id not in out_clusters:
-                continue
-            cluster = out_clusters[cluster_id]
-            self._zcl_reporting[cluster] = {0: REPORT_CONFIG_IMMEDIATE}
 
         if general.LevelControl.cluster_id in out_clusters:
             self._out_listeners.update({
@@ -229,6 +223,19 @@ class Remote(RestoreEntity, ZhaEntity, BinarySensorDevice):
         if self._level == 0:
             self._level = 255
         self.async_schedule_update_ha_state()
+
+    async def async_configure(self):
+        """Bind clusters."""
+        from zigpy.zcl.clusters import general
+        await helpers.bind_cluster(
+            self.entity_id,
+            self._out_clusters[general.OnOff.cluster_id]
+        )
+        if general.LevelControl.cluster_id in self._out_clusters:
+            await helpers.bind_cluster(
+                self.entity_id,
+                self._out_clusters[general.LevelControl.cluster_id]
+            )
 
     async def async_added_to_hass(self):
         """Run when about to be added to hass."""

--- a/homeassistant/components/zha/entities/entity.py
+++ b/homeassistant/components/zha/entities/entity.py
@@ -10,7 +10,7 @@ from random import uniform
 
 from homeassistant.components.zha.const import (
     DATA_ZHA, DATA_ZHA_BRIDGE_ID, DOMAIN)
-from homeassistant.components.zha.helpers import configure_reporting
+from homeassistant.components.zha.helpers import bind_configure_reporting
 from homeassistant.core import callback
 from homeassistant.helpers import entity
 from homeassistant.helpers.device_registry import CONNECTION_ZIGBEE
@@ -100,7 +100,7 @@ class ZhaEntity(entity.Entity):
             skip_bind = False  # bind cluster only for the 1st configured attr
             for attr, details in attrs.items():
                 min_report_interval, max_report_interval, change = details
-                await configure_reporting(
+                await bind_configure_reporting(
                     self.entity_id, cluster, attr,
                     min_report=min_report_interval,
                     max_report=max_report_interval,

--- a/homeassistant/components/zha/helpers.py
+++ b/homeassistant/components/zha/helpers.py
@@ -33,7 +33,11 @@ async def safe_read(cluster, attributes, allow_cache=True, only_cache=False):
 
 
 async def bind_cluster(entity_id, cluster):
-    """Bind a zigbee cluster."""
+    """Bind a zigbee cluster.
+
+    This also swallows DeliveryError exceptions that are thrown when devices
+    are unreachable.
+    """
     from zigpy.exceptions import DeliveryError
 
     cluster_name = cluster.ep_attribute
@@ -56,8 +60,8 @@ async def configure_reporting(entity_id, cluster, attr, skip_bind=False,
                               manufacturer=None):
     """Configure attribute reporting for a cluster.
 
-    while swallowing the DeliverError exceptions in case of unreachable
-    devices.
+    This also swallows DeliveryError exceptions that are thrown when devices
+    are unreachable.
     """
     from zigpy.exceptions import DeliveryError
 
@@ -84,10 +88,10 @@ async def bind_configure_reporting(entity_id, cluster, attr, skip_bind=False,
                                    max_report=REPORT_CONFIG_MAX_INT,
                                    reportable_change=REPORT_CONFIG_RPT_CHANGE,
                                    manufacturer=None):
-    """Bind cluster and configure attribute reporting for a cluster.
+    """Bind and configure zigbee attribute reporting for a cluster.
 
-    while swallowing the DeliverError exceptions in case of unreachable
-    devices.
+    This also swallows DeliveryError exceptions that are thrown when devices
+    are unreachable.
     """
     if not skip_bind:
         await bind_cluster(entity_id, cluster)


### PR DESCRIPTION
Previously we were configuring reporting on output clusters in the "remote" entity in ZHA. This is unnecessary because all of the functionality occurs over cluster commands which only require binding. This PR does the following:

1. Splits bind and configure reporting functionality into separate helpers
2. Creates an aggregate helper that calls the previously mentioned helpers in sequence
3. Overrides async_configure in the remote entity so that it only calls bind
