### PR TITLE
Add a new click_type double_both to improve the support of the new Xi…

### DIFF
--- a/homeassistant/components/binary_sensor/xiaomi_aqara.py
+++ b/homeassistant/components/binary_sensor/xiaomi_aqara.py
@@ -409,6 +409,8 @@ class XiaomiButton(XiaomiBinarySensor):
             click_type = 'double'
         elif value == 'both_click':
             click_type = 'both'
+        elif value == 'double_both_click':
+            click_type = 'double_both'
         elif value == 'shake':
             click_type = 'shake'
         elif value == 'long_click':


### PR DESCRIPTION
…aomi aqara Wireless Wall Switch (remote.b286acn01)

## Description:

The binary_sensor component for xiaomi_qara does not support a click_type `double_both` for WXKG02LM, model b286acn01. This pull request will add the `double_both`.

Not sure how to prepare this pull request (first time for me within this project).
**Related issue (if applicable):** 

https://community.home-assistant.io/t/no-xiaomi-aqara-wireless-switch-long-click-both-double-click-and-both-long-click-support/86746/2

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#7952

## Example entry for `configuration.yaml` (if applicable): 

```yaml
automation:
  - alias: turn off light
    trigger: 
      platform: event
      event_type: xiaomi_aqara.click
      event_data:
        entity_id: binary_sensor.wall_switch_both_158d00027c19e9
        click_type: double_both
    condition:
      - condition: state
        entity_id: light.gateway_light_7c49ebb18b86
        state: 'on'
    action:
      service: light.turn_off
      entity_id: light.gateway_light_7c49ebb18b86
```

## Checklist:
  - [x ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x ] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
