### PR TITLE
Added device tracker support for Ubee Router

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -536,6 +536,7 @@ omit =
     homeassistant/components/device_tracker/tplink.py
     homeassistant/components/device_tracker/traccar.py
     homeassistant/components/device_tracker/trackr.py
+    homeassistant/components/device_tracker/ubee.py
     homeassistant/components/device_tracker/ubus.py
     homeassistant/components/downloader.py
     homeassistant/components/emoncms_history.py

--- a/homeassistant/components/device_tracker/ubee.py
+++ b/homeassistant/components/device_tracker/ubee.py
@@ -1,0 +1,127 @@
+"""
+Support for Ubee router.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/device_tracker.ubee/
+"""
+import logging
+import re
+
+import requests
+import voluptuous as vol
+
+from homeassistant.components.device_tracker import (
+    DOMAIN, PLATFORM_SCHEMA, DeviceScanner)
+from homeassistant.const import (
+    CONF_HOST, CONF_PASSWORD, CONF_USERNAME)
+import homeassistant.helpers.config_validation as cv
+
+_LOGGER = logging.getLogger(__name__)
+
+_ROUTER_REGEX = re.compile(
+    r'<tr bgcolor=#[0-9a-fA-F]+>'
+    r'<td>([0-9a-fA-F]{2}:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}:'
+    r'[0-9a-fA-F]{2}:[0-9a-fA-F]{2})</td>'
+    r'<td>\d+</td><td>.+</td><td>\d+\.\d+\.\d+\.\d+</td><td>(.+)</td>'
+    r'<td>.+</td><td>\d+</td></tr>'
+)
+_MAC_REGEX = re.compile(r'(([0-9A-Fa-f]{1,2}\:){5}[0-9A-Fa-f]{1,2})')
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_HOST): cv.string,
+    vol.Required(CONF_PASSWORD): cv.string,
+    vol.Required(CONF_USERNAME): cv.string,
+})
+
+
+def get_scanner(hass, config):
+    """Validate the configuration and return a Ubee scanner."""
+    try:
+        return UbeeRouterDeviceScanner(config[DOMAIN])
+    except ConnectionError:
+        return None
+
+
+class UbeeRouterDeviceScanner(DeviceScanner):
+    """This class queries a wireless Ubee router."""
+    def __init__(self, config):
+        """Initialize the Ubee scanner."""
+        self.host = config[CONF_HOST]
+        self.username = config[CONF_USERNAME]
+        self.password = config[CONF_PASSWORD]
+        self.login_url = 'http://{}/goform/login'.format(self.host)
+        self.status_url = 'http://{}/UbeeAdvConnectedDevicesList.asp'.format(
+            self.host
+        )
+
+        self.last_results = {}
+        self.mac2name = {}
+
+        # Test the router is accessible
+        payload = {
+            'loginUsername': self.username,
+            'loginPassword': self.password
+        }
+        try:
+            response = requests.post(self.login_url, data=payload, timeout=4)
+        except requests.exceptions.Timeout:
+            print('Connection to the router timed out')
+            return
+        data = response.text
+        if not data:
+            raise ConnectionError('Cannot connect to Ubee router')
+
+    def scan_devices(self):
+        """Scan for new devices and return a list
+        with found device MAC address."""
+        self._update_info()
+
+        return self.last_results
+
+    def get_device_name(self, device):
+        """Return the name of the given device or None if we don't know."""
+        if device in self.mac2name:
+            return self.mac2name.get(device)
+
+        return None
+
+    def _update_info(self):
+        """Ensure the information from the router is up to date.
+        Return boolean if scanning successful.
+        """
+        _LOGGER.info("Loading wireless clients...")
+
+        data = self.get_router_data()
+
+        if not data:
+            return False
+
+        self.mac2name = data
+        self.last_results = []
+        self.last_results.extend(item for item in data
+                                 if _MAC_REGEX.match(item))
+
+        return True
+
+    def get_router_data(self):
+        """Retrieve data from Router and return parsed result."""
+        try:
+            response = requests.get(self.status_url, timeout=4)
+        except requests.exceptions.Timeout:
+            _LOGGER.exception("Connection to the router timed out")
+            return
+
+        if response.status_code == 200:
+            return _parse_router_response(response.text)
+        if response.status_code == 401:
+            # Authentication error
+            _LOGGER.exception("Failed to authenticate, "
+                              "check your username and password")
+            return
+        _LOGGER.error("Invalid response from Router: %s", response)
+
+def _parse_router_response(data_str):
+    """Parse the Router response."""
+    return {
+        key: val for key, val in _ROUTER_REGEX.findall(data_str)
+    }

--- a/homeassistant/components/device_tracker/ubee.py
+++ b/homeassistant/components/device_tracker/ubee.py
@@ -88,7 +88,6 @@ class UbeeDeviceScanner(DeviceScanner):
 
     def get_connected_devices(self):
         """List connected devices with pyubee."""
-
         if not self.ubee.session_active():
             self.ubee.login()
 

--- a/homeassistant/components/device_tracker/ubee.py
+++ b/homeassistant/components/device_tracker/ubee.py
@@ -48,11 +48,8 @@ class UbeeDeviceScanner(DeviceScanner):
         self.mac2name = {}
 
         self.ubee = Ubee(self.host, self.username, self.password)
-
         _LOGGER.info("Logging in")
-
         results = self.get_connected_devices()
-
         self.success_init = results is not None
 
         if self.success_init:
@@ -83,7 +80,6 @@ class UbeeDeviceScanner(DeviceScanner):
             return
 
         _LOGGER.info("Scanning")
-
         results = self.get_connected_devices()
 
         if results is None:

--- a/homeassistant/components/device_tracker/ubee.py
+++ b/homeassistant/components/device_tracker/ubee.py
@@ -57,7 +57,6 @@ class UbeeDeviceScanner(DeviceScanner):
         else:
             _LOGGER.error("Failed to login")
 
-
     def scan_devices(self):
         """Scan for new devices and return a list with found device IDs."""
         self._update_info()

--- a/homeassistant/components/device_tracker/ubee.py
+++ b/homeassistant/components/device_tracker/ubee.py
@@ -71,23 +71,18 @@ class UbeeDeviceScanner(DeviceScanner):
         return None
 
     def _update_info(self):
-        """Retrieve latest information from the Ubee router.
-
-        Returns boolean if scanning successful.
-        """
+        """Retrieve latest information from the Ubee router."""
         if not self.success_init:
-            return False
+            return
 
-        _LOGGER.info("Scanning")
+        _LOGGER.debug("Scanning")
         results = self.get_connected_devices()
 
         if results is None:
             _LOGGER.warning("Error scanning devices")
-            return False
+            return
 
         self.last_results = results or []
-
-        return True
 
     def get_connected_devices(self):
         """List connected devices with pyubee."""

--- a/homeassistant/components/device_tracker/ubee.py
+++ b/homeassistant/components/device_tracker/ubee.py
@@ -55,7 +55,7 @@ class UbeeDeviceScanner(DeviceScanner):
         if self.success_init:
             self.last_results = results
         else:
-            _LOGGER.error("Failed to login")
+            _LOGGER.error("Login failed")
 
     def scan_devices(self):
         """Scan for new devices and return a list with found device IDs."""

--- a/homeassistant/components/device_tracker/ubee.py
+++ b/homeassistant/components/device_tracker/ubee.py
@@ -14,7 +14,7 @@ from homeassistant.const import (
     CONF_HOST, CONF_PASSWORD, CONF_USERNAME)
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['pyubee==0.1']
+REQUIREMENTS = ['pyubee==0.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/device_tracker/ubee.py
+++ b/homeassistant/components/device_tracker/ubee.py
@@ -4,10 +4,8 @@ Support for Ubee router.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/device_tracker.ubee/
 """
-import logging
-import re
 
-import requests
+import logging
 import voluptuous as vol
 
 from homeassistant.components.device_tracker import (
@@ -16,16 +14,9 @@ from homeassistant.const import (
     CONF_HOST, CONF_PASSWORD, CONF_USERNAME)
 import homeassistant.helpers.config_validation as cv
 
-_LOGGER = logging.getLogger(__name__)
+REQUIREMENTS = ['pyubee==0.1']
 
-_ROUTER_REGEX = re.compile(
-    r'<tr bgcolor=#[0-9a-fA-F]+>'
-    r'<td>([0-9a-fA-F]{2}:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}:'
-    r'[0-9a-fA-F]{2}:[0-9a-fA-F]{2})</td>'
-    r'<td>\d+</td><td>.+</td><td>\d+\.\d+\.\d+\.\d+</td><td>(.+)</td>'
-    r'<td>.+</td><td>\d+</td></tr>'
-)
-_MAC_REGEX = re.compile(r'(([0-9A-Fa-f]{1,2}\:){5}[0-9A-Fa-f]{1,2})')
+_LOGGER = logging.getLogger(__name__)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
@@ -37,43 +28,41 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 def get_scanner(hass, config):
     """Validate the configuration and return a Ubee scanner."""
     try:
-        return UbeeRouterDeviceScanner(config[DOMAIN])
+        return UbeeDeviceScanner(config[DOMAIN])
     except ConnectionError:
         return None
 
 
-class UbeeRouterDeviceScanner(DeviceScanner):
+class UbeeDeviceScanner(DeviceScanner):
     """This class queries a wireless Ubee router."""
+
     def __init__(self, config):
         """Initialize the Ubee scanner."""
+        from pyubee import Ubee
+
         self.host = config[CONF_HOST]
         self.username = config[CONF_USERNAME]
         self.password = config[CONF_PASSWORD]
-        self.login_url = 'http://{}/goform/login'.format(self.host)
-        self.status_url = 'http://{}/UbeeAdvConnectedDevicesList.asp'.format(
-            self.host
-        )
 
         self.last_results = {}
         self.mac2name = {}
 
-        # Test the router is accessible
-        payload = {
-            'loginUsername': self.username,
-            'loginPassword': self.password
-        }
-        try:
-            response = requests.post(self.login_url, data=payload, timeout=4)
-        except requests.exceptions.Timeout:
-            print('Connection to the router timed out')
-            return
-        data = response.text
-        if not data:
-            raise ConnectionError('Cannot connect to Ubee router')
+        self.ubee = Ubee(self.host, self.username, self.password)
+
+        _LOGGER.info("Logging in")
+
+        results = self.get_connected_devices()
+
+        self.success_init = results is not None
+
+        if self.success_init:
+            self.last_results = results
+        else:
+            _LOGGER.error("Failed to login")
+
 
     def scan_devices(self):
-        """Scan for new devices and return a list
-        with found device MAC address."""
+        """Scan for new devices and return a list with found device IDs."""
         self._update_info()
 
         return self.last_results
@@ -86,42 +75,26 @@ class UbeeRouterDeviceScanner(DeviceScanner):
         return None
 
     def _update_info(self):
-        """Ensure the information from the router is up to date.
-        Return boolean if scanning successful.
+        """Retrieve latest information from the Ubee router.
+
+        Returns boolean if scanning successful.
         """
-        _LOGGER.info("Loading wireless clients...")
-
-        data = self.get_router_data()
-
-        if not data:
-            return False
-
-        self.mac2name = data
-        self.last_results = []
-        self.last_results.extend(item for item in data
-                                 if _MAC_REGEX.match(item))
-
-        return True
-
-    def get_router_data(self):
-        """Retrieve data from Router and return parsed result."""
-        try:
-            response = requests.get(self.status_url, timeout=4)
-        except requests.exceptions.Timeout:
-            _LOGGER.exception("Connection to the router timed out")
+        if not self.success_init:
             return
 
-        if response.status_code == 200:
-            return _parse_router_response(response.text)
-        if response.status_code == 401:
-            # Authentication error
-            _LOGGER.exception("Failed to authenticate, "
-                              "check your username and password")
-            return
-        _LOGGER.error("Invalid response from Router: %s", response)
+        _LOGGER.info("Scanning")
 
-def _parse_router_response(data_str):
-    """Parse the Router response."""
-    return {
-        key: val for key, val in _ROUTER_REGEX.findall(data_str)
-    }
+        results = self.get_connected_devices()
+
+        if results is None:
+            _LOGGER.warning("Error scanning devices")
+
+        self.last_results = results or []
+
+    def get_connected_devices(self):
+        """List connected devices with pyubee."""
+
+        if not self.ubee.session_active():
+            self.ubee.login()
+
+        return self.ubee.get_connected_devices()

--- a/homeassistant/components/device_tracker/ubee.py
+++ b/homeassistant/components/device_tracker/ubee.py
@@ -76,15 +76,18 @@ class UbeeDeviceScanner(DeviceScanner):
         Returns boolean if scanning successful.
         """
         if not self.success_init:
-            return
+            return False
 
         _LOGGER.info("Scanning")
         results = self.get_connected_devices()
 
         if results is None:
             _LOGGER.warning("Error scanning devices")
+            return False
 
         self.last_results = results or []
+
+        return True
 
     def get_connected_devices(self):
         """List connected devices with pyubee."""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1344,6 +1344,9 @@ pytradfri[async]==6.0.1
 # homeassistant.components.sensor.trafikverket_weatherstation
 pytrafikverket==0.1.5.8
 
+# homeassistant.components.device_tracker.ubee
+pyubee==0.1
+
 # homeassistant.components.device_tracker.unifi
 pyunifi==2.13
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1345,7 +1345,7 @@ pytradfri[async]==6.0.1
 pytrafikverket==0.1.5.8
 
 # homeassistant.components.device_tracker.ubee
-pyubee==0.1
+pyubee==0.2
 
 # homeassistant.components.device_tracker.unifi
 pyunifi==2.13


### PR DESCRIPTION
## Description:

Added [Ubee](http://www.ubeeinteractive.com/products) device tracker.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#7955

## Example entry for `configuration.yaml` (if applicable):
```yaml
device_tracker:
  - platform: ubee
    host: 192.168.1.1
    username: admin
    password: somepassword
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
