### PR TITLE
Improve how neato displays alerts and add alerts for persistent maps

### DIFF
--- a/homeassistant/components/neato.py
+++ b/homeassistant/components/neato.py
@@ -143,7 +143,9 @@ ALERTS = {
     'maint_brush_change': 'Change the brush',
     'maint_filter_change': 'Change the filter',
     'clean_completed_to_start': 'Cleaning completed',
-    'nav_floorplan_not_created': 'No floorplan found'
+    'nav_floorplan_not_created': 'No floorplan found',
+    'nav_floorplan_load_fail': 'Failed to load floorplan',
+    'nav_floorplan_localization_fail': 'Failed to load floorplan'
 }
 
 

--- a/homeassistant/components/vacuum/neato.py
+++ b/homeassistant/components/vacuum/neato.py
@@ -67,7 +67,6 @@ class NeatoConnectedVacuum(StateVacuumDevice):
         self._available = False
         self._battery_level = None
         self._robot_serial = self.robot.serial
-        self._robot_alert = None
 
     def update(self):
         """Update the states of Neato Vacuums."""
@@ -83,7 +82,7 @@ class NeatoConnectedVacuum(StateVacuumDevice):
             self._available = False
             return
         _LOGGER.debug('self._state=%s', self._state)
-        self._robot_alert = ALERTS.get(self._state['alert'])
+        robot_alert = ALERTS.get(self._state['alert'])
         if self._state['state'] == 1:
             if self._state['details']['isCharging']:
                 self._clean_state = STATE_DOCKED
@@ -96,16 +95,16 @@ class NeatoConnectedVacuum(StateVacuumDevice):
                 self._clean_state = STATE_IDLE
                 self._status_state = 'Stopped'
 
-            if self._robot_alert is not None:
-                self._status_state = self._robot_alert
+            if robot_alert is not None:
+                self._status_state = robot_alert
         elif self._state['state'] == 2:
-            if self._robot_alert is None:
+            if robot_alert is None:
                 self._clean_state = STATE_CLEANING
                 self._status_state = (
                     MODE.get(self._state['cleaning']['mode'])
                     + ' ' + ACTION.get(self._state['action']))
             else:
-                self._status_state = self._robot_alert
+                self._status_state = robot_alert
         elif self._state['state'] == 3:
             self._clean_state = STATE_PAUSED
             self._status_state = 'Paused'

--- a/homeassistant/components/vacuum/neato.py
+++ b/homeassistant/components/vacuum/neato.py
@@ -67,6 +67,7 @@ class NeatoConnectedVacuum(StateVacuumDevice):
         self._available = False
         self._battery_level = None
         self._robot_serial = self.robot.serial
+        self._robot_alert = None
 
     def update(self):
         """Update the states of Neato Vacuums."""
@@ -82,6 +83,7 @@ class NeatoConnectedVacuum(StateVacuumDevice):
             self._available = False
             return
         _LOGGER.debug('self._state=%s', self._state)
+        self._robot_alert = ALERTS.get(self._state['alert'])
         if self._state['state'] == 1:
             if self._state['details']['isCharging']:
                 self._clean_state = STATE_DOCKED
@@ -93,14 +95,17 @@ class NeatoConnectedVacuum(StateVacuumDevice):
             else:
                 self._clean_state = STATE_IDLE
                 self._status_state = 'Stopped'
+
+            if self._robot_alert is not None:
+                self._status_state = self._robot_alert
         elif self._state['state'] == 2:
-            if ALERTS.get(self._state['error']) is None:
+            if self._robot_alert is None:
                 self._clean_state = STATE_CLEANING
                 self._status_state = (
                     MODE.get(self._state['cleaning']['mode'])
                     + ' ' + ACTION.get(self._state['action']))
             else:
-                self._status_state = ALERTS.get(self._state['error'])
+                self._status_state = self._robot_alert
         elif self._state['state'] == 3:
             self._clean_state = STATE_PAUSED
             self._status_state = 'Paused'


### PR DESCRIPTION
## Description:

The old logic was looking for `alerts` in the wrong location, this PR corrects that.  This PR adds some missing `alerts` and also ensures that alerts are shown even when the vacuum is not cleaning.  Currently they only show up when the vacuum is in the cleaning state but some alerts persist beyond this state.  This is helpful for certain alerts as the botvac may fail and only an alert is shown instead of an error.  Neato defines errors as something that requires the user to press the "start" button on the vacuum, alerts may still require some type of user attention so this will ensure they are not missed.  This is especially useful for when persistent maps are used.

Please note this PR is another attempt at #19238 as I made a mistake submitting the review comments.  This PR also addresses the comments there.

**Related issue (if applicable):** fixes #N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
neato:
  username: username
  password: password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
