### PR TITLE
Set cover level using emulated_hue

### DIFF
--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -19,6 +19,12 @@ from homeassistant.components.fan import (
     ATTR_SPEED, SUPPORT_SET_SPEED, SPEED_OFF, SPEED_LOW,
     SPEED_MEDIUM, SPEED_HIGH
 )
+
+from homeassistant.components.cover import (
+    ATTR_CURRENT_POSITION, ATTR_POSITION, SERVICE_SET_COVER_POSITION,
+    SUPPORT_SET_POSITION
+)
+
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.components.http.const import KEY_REAL_IP
 from homeassistant.util.network import is_local
@@ -246,8 +252,14 @@ class HueOneLightChangeView(HomeAssistantView):
             domain = entity.domain
             if service == SERVICE_TURN_ON:
                 service = SERVICE_OPEN_COVER
-            else:
+            elif service == SERVICE_TURN_OFF:
                 service = SERVICE_CLOSE_COVER
+
+            if entity_features & SUPPORT_SET_POSITION:
+                if brightness is not None:
+                    domain = entity.domain
+                    service = SERVICE_SET_COVER_POSITION
+                    data[ATTR_POSITION] = brightness
 
         # If the requested entity is a fan, convert to speed
         elif entity.domain == "fan":
@@ -334,7 +346,8 @@ def parse_hue_api_put_light_body(request_json, entity):
 
         elif (entity.domain == "script" or
               entity.domain == "media_player" or
-              entity.domain == "fan"):
+              entity.domain == "fan" or
+              entity.domain == "cover"):
             # Convert 0-255 to 0-100
             level = brightness / 255 * 100
             brightness = round(level)
@@ -375,6 +388,9 @@ def get_entity_state(config, entity):
                 final_brightness = 170
             elif speed == SPEED_HIGH:
                 final_brightness = 255
+        elif entity.domain == "cover":
+            level = entity.attributes.get(ATTR_CURRENT_POSITION, 0)
+            final_brightness = round(level / 100 * 255)
     else:
         final_state, final_brightness = cached_state
         # Make sure brightness is valid

--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -25,7 +25,8 @@ from homeassistant.components.cover import (
     SUPPORT_SET_POSITION
 )
 
-from homeassistant.components import cover, fan, media_player, light, script, scene
+from homeassistant.components import (cover, fan, media_player, light, 
+    script, scene)
 
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.components.http.const import KEY_REAL_IP
@@ -346,7 +347,8 @@ def parse_hue_api_put_light_body(request_json, entity):
             report_brightness = False
             result = True
 
-        elif entity.domain in [script.DOMAIN, media_player.DOMAIN, fan.DOMAIN, cover.DOMAIN]:
+        elif entity.domain in [script.DOMAIN, media_player.DOMAIN,
+            fan.DOMAIN, cover.DOMAIN]:
             # Convert 0-255 to 0-100
             level = brightness / 255 * 100
             brightness = round(level)

--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -344,7 +344,7 @@ def parse_hue_api_put_light_body(request_json, entity):
             report_brightness = False
             result = True
 
-        elif entity.domain in [ "script", "media_player", "fan", "cover"]:
+        elif entity.domain in ["script", "media_player", "fan", "cover"]:
             # Convert 0-255 to 0-100
             level = brightness / 255 * 100
             brightness = round(level)

--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -25,8 +25,9 @@ from homeassistant.components.cover import (
     SUPPORT_SET_POSITION
 )
 
-from homeassistant.components import (cover, fan, media_player, light, 
-    script, scene)
+from homeassistant.components import (
+    cover, fan, media_player, light, script, scene
+)
 
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.components.http.const import KEY_REAL_IP
@@ -347,8 +348,10 @@ def parse_hue_api_put_light_body(request_json, entity):
             report_brightness = False
             result = True
 
-        elif entity.domain in [script.DOMAIN, media_player.DOMAIN,
-            fan.DOMAIN, cover.DOMAIN]:
+        elif entity.domain in [
+                script.DOMAIN, media_player.DOMAIN,
+                fan.DOMAIN, cover.DOMAIN
+            ]:
             # Convert 0-255 to 0-100
             level = brightness / 255 * 100
             brightness = round(level)

--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -350,8 +350,7 @@ def parse_hue_api_put_light_body(request_json, entity):
 
         elif entity.domain in [
                 script.DOMAIN, media_player.DOMAIN,
-                fan.DOMAIN, cover.DOMAIN
-            ]:
+                fan.DOMAIN, cover.DOMAIN]:
             # Convert 0-255 to 0-100
             level = brightness / 255 * 100
             brightness = round(level)

--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -252,7 +252,7 @@ class HueOneLightChangeView(HomeAssistantView):
             domain = entity.domain
             if service == SERVICE_TURN_ON:
                 service = SERVICE_OPEN_COVER
-            elif service == SERVICE_TURN_OFF:
+            else:
                 service = SERVICE_CLOSE_COVER
 
             if entity_features & SUPPORT_SET_POSITION:
@@ -344,10 +344,7 @@ def parse_hue_api_put_light_body(request_json, entity):
             report_brightness = False
             result = True
 
-        elif (entity.domain == "script" or
-              entity.domain == "media_player" or
-              entity.domain == "fan" or
-              entity.domain == "cover"):
+        elif entity.domain in [ "script", "media_player", "fan", "cover"]:
             # Convert 0-255 to 0-100
             level = brightness / 255 * 100
             brightness = round(level)

--- a/tests/components/emulated_hue/test_hue_api.py
+++ b/tests/components/emulated_hue/test_hue_api.py
@@ -11,12 +11,16 @@ from tests.common import get_test_instance_port
 from homeassistant import core, const, setup
 import homeassistant.components as core_components
 from homeassistant.components import (
-    fan, http, light, script, emulated_hue, media_player)
+    fan, http, light, script, emulated_hue, media_player, cover)
 from homeassistant.components.emulated_hue import Config
 from homeassistant.components.emulated_hue.hue_api import (
     HUE_API_STATE_ON, HUE_API_STATE_BRI, HueUsernameView, HueOneLightStateView,
     HueAllLightsStateView, HueOneLightChangeView)
 from homeassistant.const import STATE_ON, STATE_OFF
+
+import homeassistant.util.dt as dt_util
+from datetime import timedelta
+from tests.common import async_fire_time_changed
 
 HTTP_SERVER_PORT = get_test_instance_port()
 BRIDGE_SERVER_PORT = get_test_instance_port()
@@ -91,6 +95,15 @@ def hass_hue(loop, hass):
             ]
         }))
 
+    loop.run_until_complete(
+        setup.async_setup_component(hass, cover.DOMAIN, {
+            'cover': [
+                {
+                    'platform': 'demo',
+                }
+            ]
+        }))
+
     # Kitchen light is explicitly excluded from being exposed
     kitchen_light_entity = hass.states.get('light.kitchen_lights')
     attrs = dict(kitchen_light_entity.attributes)
@@ -115,6 +128,14 @@ def hass_hue(loop, hass):
         script_entity.entity_id, script_entity.state, attributes=attrs
     )
 
+    # Expose cover
+    cover_entity = hass.states.get('cover.living_room_window')
+    attrs = dict(cover_entity.attributes)
+    attrs[emulated_hue.ATTR_EMULATED_HUE_HIDDEN] = False
+    hass.states.async_set(
+        cover_entity.entity_id, cover_entity.state, attributes=attrs
+    )
+
     return hass
 
 
@@ -127,7 +148,11 @@ def hue_client(loop, hass_hue, aiohttp_client):
         emulated_hue.CONF_ENTITIES: {
             'light.bed_light': {
                 emulated_hue.CONF_ENTITY_HIDDEN: True
+            },
+            'cover.living_room_window': {
+                emulated_hue.CONF_ENTITY_HIDDEN: False
             }
+
         }
     })
 
@@ -162,6 +187,7 @@ def test_discover_lights(hue_client):
     assert 'media_player.lounge_room' in devices
     assert 'fan.living_room_fan' in devices
     assert 'fan.ceiling_fan' not in devices
+    assert 'cover.living_room_window' in devices
 
 
 @asyncio.coroutine
@@ -314,6 +340,98 @@ def test_put_light_state_media_player(hass_hue, hue_client):
     walkman = hass_hue.states.get('media_player.walkman')
     assert walkman.state == 'playing'
     assert walkman.attributes[media_player.ATTR_MEDIA_VOLUME_LEVEL] == level
+
+
+async def test_close_cover(hass_hue, hue_client):
+    """Test opening cover ."""
+    COVER_ID = "cover.living_room_window"
+    # Turn the office light off first
+    await hass_hue.services.async_call(
+        cover.DOMAIN, const.SERVICE_CLOSE_COVER,
+        {const.ATTR_ENTITY_ID: COVER_ID},
+        blocking=True)
+
+    cover_test = hass_hue.states.get(COVER_ID)
+    assert cover_test.state == 'closing'
+
+    for _ in range(7):
+        future = dt_util.utcnow() + timedelta(seconds=1)
+        async_fire_time_changed(hass_hue, future)
+        await hass_hue.async_block_till_done()
+
+    cover_test = hass_hue.states.get(COVER_ID)
+    assert cover_test.state == 'closed'
+
+    # Go through the API to turn it on
+    cover_result = await perform_put_light_state(
+        hass_hue, hue_client,
+        COVER_ID, True, 100)
+
+    assert cover_result.status == 200
+    assert 'application/json' in cover_result.headers['content-type']
+
+    for _ in range(7):
+        future = dt_util.utcnow() + timedelta(seconds=1)
+        async_fire_time_changed(hass_hue, future)
+        await hass_hue.async_block_till_done()
+
+    cover_result_json = await cover_result.json()
+
+    assert len(cover_result_json) == 2
+
+    # Check to make sure the state changed
+    cover_test_2 = hass_hue.states.get(COVER_ID)
+    assert cover_test_2.state == 'open'
+
+
+async def test_set_position_cover(hass_hue, hue_client):
+    """Test setting postion cover ."""
+    COVER_ID = "cover.living_room_window"
+    # Turn the office light off first
+    await hass_hue.services.async_call(
+        cover.DOMAIN, const.SERVICE_CLOSE_COVER,
+        {const.ATTR_ENTITY_ID: COVER_ID},
+        blocking=True)
+
+    cover_test = hass_hue.states.get(COVER_ID)
+    assert cover_test.state == 'closing'
+
+    for _ in range(7):
+        future = dt_util.utcnow() + timedelta(seconds=1)
+        async_fire_time_changed(hass_hue, future)
+        await hass_hue.async_block_till_done()
+
+    cover_test = hass_hue.states.get(COVER_ID)
+    assert cover_test.state == 'closed'
+
+    level = 20
+    brightness = round(level/100*255)
+
+    # Go through the API to open
+    cover_result = await perform_put_light_state(
+        hass_hue, hue_client,
+        COVER_ID, False, brightness)
+
+    assert cover_result.status == 200
+    assert 'application/json' in cover_result.headers['content-type']
+
+    cover_result_json = await cover_result.json()
+
+    assert len(cover_result_json) == 2
+    assert True, cover_result_json[0]['success'][
+        '/lights/cover.living_room_window/state/on']
+    assert cover_result_json[1]['success'][
+        '/lights/cover.living_room_window/state/bri'] == level
+
+    for _ in range(100):
+        future = dt_util.utcnow() + timedelta(seconds=1)
+        async_fire_time_changed(hass_hue, future)
+        await hass_hue.async_block_till_done()
+
+    # Check to make sure the state changed
+    cover_test_2 = hass_hue.states.get(COVER_ID)
+    assert cover_test_2.state == 'open'
+    assert cover_test_2.attributes.get('current_position') == level
 
 
 @asyncio.coroutine


### PR DESCRIPTION
## Description:
implemented support to set cover level using emulated_hue.
Added missing tests for cover in emulated_hue component. 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
