### PR TITLE
Use aioharmony for remote.harmony platform

### DIFF
--- a/homeassistant/components/remote/harmony.py
+++ b/homeassistant/components/remote/harmony.py
@@ -25,7 +25,7 @@ from homeassistant.util import slugify
 # REQUIREMENTS = ['aioharmony==0.1.00']
 REQUIREMENTS = [
     'https://github.com/ehendrix23/aioharmony/archive/dev.zip#aioharmony==0'
-    '.0.6'
+    '.0.7'
 ]
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/remote/harmony.py
+++ b/homeassistant/components/remote/harmony.py
@@ -22,10 +22,10 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.exceptions import PlatformNotReady
 from homeassistant.util import slugify
 
-# REQUIREMENTS = ['pyharmony==1.0.22']
+# REQUIREMENTS = ['aioharmony==0.1.00']
 REQUIREMENTS = [
     'https://github.com/ehendrix23/aioharmony/archive/dev.zip#aioharmony==0'
-    '.0.5'
+    '.0.6'
 ]
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/remote/harmony.py
+++ b/homeassistant/components/remote/harmony.py
@@ -24,9 +24,8 @@ from homeassistant.util import slugify
 
 # REQUIREMENTS = ['pyharmony==1.0.22']
 REQUIREMENTS = [
-    'https://github.com/home-assistant/pyharmony/archive/'
-    '31efd339a3c39e7b8f58e823a0eddb59013e03ae.zip'
-    '#pyharmony==1.0.21b1'
+    'https://github.com/ehendrix23/aioharmony/archive/dev.zip#aioharmony==0'
+    '.0.5'
 ]
 
 _LOGGER = logging.getLogger(__name__)
@@ -142,7 +141,9 @@ class HarmonyRemote(remote.RemoteDevice):
 
     def __init__(self, name, host, port, activity, out_path, delay_secs):
         """Initialize HarmonyRemote class."""
-        import pyharmony.client as harmony_client
+        from aioharmony.harmonyapi import (
+            HarmonyAPI as harmony_client, ClientCallbackType)
+
 
         _LOGGER.debug("HarmonyRemote device init started for: %s", name)
         self._name = name
@@ -151,10 +152,18 @@ class HarmonyRemote(remote.RemoteDevice):
         self._state = None
         self._current_activity = None
         self._default_activity = activity
-        # self._client = pyharmony.get_client(host, port, self.new_activity)
-        self._client = harmony_client.HarmonyClient(host)
+        self._client = harmony_client(
+            ip_address=host,
+            callbacks=ClientCallbackType(
+                new_activity=self.new_activity,
+                config_updated=self.new_config,
+                connect=self.got_connected,
+                disconnect=self.got_disconnected
+            )
+        )
         self._config_path = out_path
         self._delay_secs = delay_secs
+        self._available = True
         _LOGGER.debug("HarmonyRemote device init completed for: %s", name)
 
     async def async_added_to_hass(self):
@@ -163,18 +172,17 @@ class HarmonyRemote(remote.RemoteDevice):
 
         async def shutdown(event):
             """Close connection on shutdown."""
-            await self._client.disconnect()
+            await self._client.close()
 
         self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, shutdown)
 
         _LOGGER.debug("Connecting.")
         await self._client.connect()
-        await self._client.get_config()
         if not Path(self._config_path).is_file():
-            self.write_config_file()
+            await self.hass.async_add_executor_job(self.write_config_file)
 
         # Poll for initial state
-        self.new_activity(await self._client.get_current_activity())
+        self.new_activity(self._client.current_activity)
 
     @property
     def name(self):
@@ -184,7 +192,7 @@ class HarmonyRemote(remote.RemoteDevice):
     @property
     def should_poll(self):
         """Return the fact that we should not be polled."""
-        return True
+        return False
 
     @property
     def device_state_attributes(self):
@@ -196,101 +204,161 @@ class HarmonyRemote(remote.RemoteDevice):
         """Return False if PowerOff is the current activity, otherwise True."""
         return self._current_activity not in [None, 'PowerOff']
 
+    @property
+    def available(self):
+        return self._available
+
     async def async_update(self):
         """Retrieve current activity from Hub."""
         _LOGGER.debug("Updating Harmony.")
         if not self._client.config:
             await self._client.get_config()
 
-        activity_id = await self._client.get_current_activity()
-        activity_name = self._client.get_activity_name(activity_id)
+        activity_id, activity_name = self._client.current_activity
         _LOGGER.debug("%s activity reported as: %s", self._name, activity_name)
         self._current_activity = activity_name
         self._state = bool(self._current_activity != 'PowerOff')
         return
 
-    def new_activity(self, activity_id):
+    def new_activity(self, activity_info):
         """Call for updating the current activity."""
-        activity_name = self._client.get_activity_name(activity_id)
+        activity_id, activity_name = activity_info
         _LOGGER.debug("%s activity reported as: %s", self._name, activity_name)
         self._current_activity = activity_name
         self._state = bool(self._current_activity != 'PowerOff')
         self.schedule_update_ha_state()
 
+    def new_config(self, _ = None):
+        """Call for updating the current activity."""
+        _LOGGER.debug("%s configuration has been updated", self._name)
+        self.new_activity(self._client.current_activity)
+
+        _, self._current_activity = self._client.current_activity
+        self._state = bool(self._current_activity != 'PowerOff')
+        self.schedule_update_ha_state()
+        self.write_config_file()
+
+    def got_connected(self, _ = None):
+        """Notification that we're connected to the HUB."""
+        _LOGGER.debug("%s connected to the HUB.", self._name)
+        if not self._available:
+            # We were disconnected before.
+            self.new_config()
+        self._available = True
+
+    async def got_disconnected(self, _ = None):
+        """Notification that we're disconnected from the HUB."""
+        _LOGGER.debug("%s disconnected from the HUB.", self._name)
+        self._available = False
+        # We're going to wait for 10 seconds before announcing we're
+        # unavailable, this to allow a reconnection to happen.
+        await asyncio.sleep(10)
+
+        if not self._available:
+            # Still disconnected. Let the state engine know.
+            self.schedule_update_ha_state()
+
     async def async_turn_on(self, **kwargs):
         """Start an activity from the Harmony device."""
+        _LOGGER.debug("%s: Turn On", self.name)
         activity = kwargs.get(ATTR_ACTIVITY, self._default_activity)
 
         if activity:
             activity_id = None
             if activity.isdigit() or activity == '-1':
-                _LOGGER.debug("Activity is numeric")
+                _LOGGER.debug("%s: Activity is numeric", self.name)
                 if self._client.get_activity_name(int(activity)):
                     activity_id = activity
 
-            if not activity_id:
-                _LOGGER.debug("Find activity ID based on name")
+            if activity_id is None:
+                _LOGGER.debug("%s: Find activity ID based on name", self.name)
                 activity_id = self._client.get_activity_id(
                     str(activity).strip())
 
-            if not activity_id:
-                _LOGGER.error("Activity %s is invalid", activity)
+            if activity_id is None:
+                _LOGGER.error("%s: Activity %s is invalid",
+                              self.name, activity)
                 return
 
             await self._client.start_activity(activity_id)
             self._state = True
         else:
-            _LOGGER.error("No activity specified with turn_on service")
+            _LOGGER.error("%s: No activity specified with turn_on service",
+                          self.name)
 
     async def async_turn_off(self, **kwargs):
         """Start the PowerOff activity."""
+        _LOGGER.debug("%s: Turn Off", self.name)
         await self._client.power_off()
 
     # pylint: disable=arguments-differ
     async def async_send_command(self, command, **kwargs):
         """Send a list of commands to one device."""
+        from aioharmony.harmonyapi import SendCommandDevice
+        _LOGGER.debug("%s: Send Command", self.name)
         device = kwargs.get(ATTR_DEVICE)
         if device is None:
-            _LOGGER.error("Missing required argument: device")
+            _LOGGER.error("%s: Missing required argument: device", self.name)
             return
 
         device_id = None
         if device.isdigit():
-            _LOGGER.debug("Device is numeric")
+            _LOGGER.debug("%s: Device %s is numeric",
+                          self.name, device)
             if self._client.get_device_name(int(device)):
                 device_id = device
 
-        if not device_id:
-            _LOGGER.debug("Find device ID based on device name")
-            device_id = self._client.get_activity_id(str(device).strip())
+        if device_id is None:
+            _LOGGER.debug("%s: Find device ID %s based on device name",
+                          self.name, device)
+            device_id = self._client.get_device_id(str(device).strip())
 
-        if not device_id:
-            _LOGGER.error("Device  %s is invalid", device)
+        if device_id is None:
+            _LOGGER.error("%s: Device %s is invalid", self.name, device)
             return
 
         num_repeats = kwargs.get(ATTR_NUM_REPEATS)
         delay_secs = kwargs.get(ATTR_DELAY_SECS, self._delay_secs)
 
+        # Creating list of commands to send.
+        snd_cmnd_list = []
         for _ in range(num_repeats):
             for single_command in command:
-                _LOGGER.debug("Sending command %s", single_command)
-                await self._client.send_command(device, single_command)
-                await asyncio.sleep(delay_secs)
+                send_command = SendCommandDevice(
+                    device=device,
+                    command=single_command,
+                    delay=0
+                )
+                snd_cmnd_list.append(send_command)
+                if delay_secs > 0:
+                    snd_cmnd_list.append(float(delay_secs))
+
+        _LOGGER.debug("%s: Sending commands", self.name)
+        result_list = await self._client.send_commands(snd_cmnd_list)
+        for result in result_list:
+            _LOGGER.warning("Sending command %s to device %s failed with code "
+                            "%s: %s",
+                            result.command.command,
+                            result.command.device,
+                            result.command.code,
+                            result.command.msg
+                            )
 
     async def sync(self):
         """Sync the Harmony device with the web service."""
-        _LOGGER.debug("Syncing hub with Harmony servers")
+        _LOGGER.debug("%s: Syncing hub with Harmony servers", self.name)
         await self._client.sync()
-        await self._client.get_config()
         await self.hass.async_add_executor_job(self.write_config_file)
 
     def write_config_file(self):
         """Write Harmony configuration file."""
-        _LOGGER.debug("Writing hub config to file: %s", self._config_path)
+        _LOGGER.debug("%s: Writing hub config to file: %s",
+                      self.name,
+                      self._config_path)
         try:
             with open(self._config_path, 'w+', encoding='utf-8') as file_out:
                 json.dump(self._client.json_config, file_out,
                           sort_keys=True, indent=4)
         except IOError as exc:
-            _LOGGER.error("Unable to write HUB configuration to %s: %s",
-                          self._config_path, exc)
+            _LOGGER.error("%s: Unable to write HUB configuration to %s: %s",
+                          self.name, self._config_path, exc)

--- a/homeassistant/components/remote/harmony.py
+++ b/homeassistant/components/remote/harmony.py
@@ -22,7 +22,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.exceptions import PlatformNotReady
 from homeassistant.util import slugify
 
-REQUIREMENTS = ['aioharmony==0.1.00']
+REQUIREMENTS = ['aioharmony==0.1.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/remote/harmony.py
+++ b/homeassistant/components/remote/harmony.py
@@ -206,6 +206,7 @@ class HarmonyRemote(remote.RemoteDevice):
 
     @property
     def available(self):
+        """Return True if connected to Hub, otherwise False."""
         return self._available
 
     def new_activity(self, activity_info: tuple) -> None:

--- a/homeassistant/components/remote/harmony.py
+++ b/homeassistant/components/remote/harmony.py
@@ -137,7 +137,7 @@ class HarmonyRemote(remote.RemoteDevice):
     def __init__(self, name, host, port, activity, out_path, delay_secs):
         """Initialize HarmonyRemote class."""
         from aioharmony.harmonyapi import (
-            HarmonyAPI as Harmony_Client, ClientCallbackType
+            HarmonyAPI as HarmonyClient, ClientCallbackType
         )
 
         _LOGGER.debug("%s: Device init started", name)
@@ -147,7 +147,7 @@ class HarmonyRemote(remote.RemoteDevice):
         self._state = None
         self._current_activity = None
         self._default_activity = activity
-        self._client = Harmony_Client(
+        self._client = HarmonyClient(
             ip_address=host,
             callbacks=ClientCallbackType(
                 new_activity=self.new_activity,
@@ -358,7 +358,8 @@ class HarmonyRemote(remote.RemoteDevice):
         except aioexc.TimeOut:
             _LOGGER.error("%s: Syncing hub with Harmony cloud timed-out",
                           self.name)
-        await self.hass.async_add_executor_job(self.write_config_file)
+        else:
+            await self.hass.async_add_executor_job(self.write_config_file)
 
     def write_config_file(self):
         """Write Harmony configuration file."""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -104,6 +104,9 @@ aiofreepybox==0.0.5
 # homeassistant.components.camera.yi
 aioftp==0.10.1
 
+# homeassistant.components.remote.harmony
+aioharmony==0.1.00
+
 # homeassistant.components.emulated_hue
 # homeassistant.components.http
 aiohttp_cors==0.7.0
@@ -519,9 +522,6 @@ homematicip==0.9.8
 # homeassistant.components.google
 # homeassistant.components.remember_the_milk
 httplib2==0.10.3
-
-# homeassistant.components.remote.harmony
-https://github.com/home-assistant/pyharmony/archive/31efd339a3c39e7b8f58e823a0eddb59013e03ae.zip#pyharmony==1.0.21b1
 
 # homeassistant.components.huawei_lte
 huawei-lte-api==1.0.16

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -105,7 +105,7 @@ aiofreepybox==0.0.5
 aioftp==0.10.1
 
 # homeassistant.components.remote.harmony
-aioharmony==0.1.00
+aioharmony==0.1.1
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http


### PR DESCRIPTION
## Description:

Use new aioharmony instead of pyharmony. This provides the following benefits:
- Full async support
- No more polling for updates, when an activity is changed from another source (i.e. remote) then HASS will be updated through a notification
- Set available state if for some reason disconnected from HUB.
- Automatic reconnect to HUB if disconnected
- When sending a command with repeat it will be send done as 1 "transaction" preventing anything else from HASS to send a command in the middle.
- Automatic config update. If anything is changed on the HUB (i.e. device added, rename, ...) then it is detected and configuration is updated. The Harmony files with the configuration are automatically updates as well then.
- Unique message identifications ensuring that HUB responses are correctly identified and processed

**Related issue (if applicable):**
fixes #19465, fixes #19466 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#7982

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

