### PR TITLE
Add device_class property to Systemmonitor sensor

### DIFF
--- a/homeassistant/components/sensor/systemmonitor.py
+++ b/homeassistant/components/sensor/systemmonitor.py
@@ -23,27 +23,27 @@ _LOGGER = logging.getLogger(__name__)
 CONF_ARG = 'arg'
 
 SENSOR_TYPES = {
-    'disk_free': ['Disk free', 'GiB', 'mdi:harddisk'],
-    'disk_use': ['Disk use', 'GiB', 'mdi:harddisk'],
-    'disk_use_percent': ['Disk use (percent)', '%', 'mdi:harddisk'],
-    'ipv4_address': ['IPv4 address', '', 'mdi:server-network'],
-    'ipv6_address': ['IPv6 address', '', 'mdi:server-network'],
-    'last_boot': ['Last boot', '', 'mdi:clock'],
-    'load_15m': ['Load (15m)', ' ', 'mdi:memory'],
-    'load_1m': ['Load (1m)', ' ', 'mdi:memory'],
-    'load_5m': ['Load (5m)', ' ', 'mdi:memory'],
-    'memory_free': ['Memory free', 'MiB', 'mdi:memory'],
-    'memory_use': ['Memory use', 'MiB', 'mdi:memory'],
-    'memory_use_percent': ['Memory use (percent)', '%', 'mdi:memory'],
-    'network_in': ['Network in', 'MiB', 'mdi:server-network'],
-    'network_out': ['Network out', 'MiB', 'mdi:server-network'],
-    'packets_in': ['Packets in', ' ', 'mdi:server-network'],
-    'packets_out': ['Packets out', ' ', 'mdi:server-network'],
-    'process': ['Process', ' ', 'mdi:memory'],
-    'processor_use': ['Processor use', '%', 'mdi:memory'],
-    'swap_free': ['Swap free', 'MiB', 'mdi:harddisk'],
-    'swap_use': ['Swap use', 'MiB', 'mdi:harddisk'],
-    'swap_use_percent': ['Swap use (percent)', '%', 'mdi:harddisk'],
+    'disk_free': ['Disk free', 'GiB', 'mdi:harddisk', None],
+    'disk_use': ['Disk use', 'GiB', 'mdi:harddisk', None],
+    'disk_use_percent': ['Disk use (percent)', '%', 'mdi:harddisk', None],
+    'ipv4_address': ['IPv4 address', '', 'mdi:server-network', None],
+    'ipv6_address': ['IPv6 address', '', 'mdi:server-network', None],
+    'last_boot': ['Last boot', '', 'mdi:clock', 'timestamp'],
+    'load_15m': ['Load (15m)', ' ', 'mdi:memory', None],
+    'load_1m': ['Load (1m)', ' ', 'mdi:memory', None],
+    'load_5m': ['Load (5m)', ' ', 'mdi:memory', None],
+    'memory_free': ['Memory free', 'MiB', 'mdi:memory', None],
+    'memory_use': ['Memory use', 'MiB', 'mdi:memory', None],
+    'memory_use_percent': ['Memory use (percent)', '%', 'mdi:memory', None],
+    'network_in': ['Network in', 'MiB', 'mdi:server-network', None],
+    'network_out': ['Network out', 'MiB', 'mdi:server-network', None],
+    'packets_in': ['Packets in', ' ', 'mdi:server-network', None],
+    'packets_out': ['Packets out', ' ', 'mdi:server-network', None],
+    'process': ['Process', ' ', 'mdi:memory', None],
+    'processor_use': ['Processor use', '%', 'mdi:memory', None],
+    'swap_free': ['Swap free', 'MiB', 'mdi:harddisk', None],
+    'swap_use': ['Swap use', 'MiB', 'mdi:harddisk', None],
+    'swap_use_percent': ['Swap use (percent)', '%', 'mdi:harddisk', None],
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -94,6 +94,11 @@ class SystemMonitorSensor(Entity):
     def name(self):
         """Return the name of the sensor."""
         return self._name.rstrip()
+
+    @property
+    def device_class(self):
+        """Return the class of this sensor."""
+        return SENSOR_TYPES[self.type][3]
 
     @property
     def icon(self):


### PR DESCRIPTION
## Description:
Add the device_class property for the last_boot sensor.

**Related issue (if applicable):** fixes #19325


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
