### PR TITLE
Fix pulling cpu_temp issue on Odroid

### DIFF
--- a/homeassistant/components/sensor/glances.py
+++ b/homeassistant/components/sensor/glances.py
@@ -180,7 +180,8 @@ class GlancesSensor(Entity):
             elif self.type == 'cpu_temp':
                 for sensor in value['sensors']:
                     if sensor['label'] in ['CPU', "Package id 0",
-                                           "Physical id 0", "cpu-thermal 1"]:
+                                           "Physical id 0", "cpu-thermal 1",
+                                           "exynos-therm 1"]:
                         self._state = sensor['value']
             elif self.type == 'docker_active':
                 count = 0


### PR DESCRIPTION
## Description:

This is basically a similar fix as in PR #19404 but for Odroid (at least for Odroid U2 which I have). Similarly to `cpu-thermal 1` on Raspberry Pi, termal sensor on Odroid is called `exynos-therm 1`, so I added it to the Glances component.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.