### PR TITLE
Force recent pubnub version to make it compatible with python 3.7

### DIFF
--- a/homeassistant/components/wink/__init__.py
+++ b/homeassistant/components/wink/__init__.py
@@ -25,7 +25,7 @@ from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.event import track_time_interval
 from homeassistant.util.json import load_json, save_json
 
-REQUIREMENTS = ['python-wink==1.10.1', 'pubnubsub-handler==1.0.2']
+REQUIREMENTS = ['python-wink==1.10.1', 'pubnubsub-handler==1.0.3']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -829,7 +829,7 @@ protobuf==3.6.1
 psutil==5.4.8
 
 # homeassistant.components.wink
-pubnubsub-handler==1.0.2
+pubnubsub-handler==1.0.3
 
 # homeassistant.components.notify.pushbullet
 # homeassistant.components.sensor.pushbullet


### PR DESCRIPTION
## Description:
**Related issue (if applicable):** fixes #16118

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** None

## Example entry for `configuration.yaml` (if applicable):
No change

## Checklist:
  - [X] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  ☝️See open question 1
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)
  🚫 Not needed

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  ☝️See open question 2
  - [X] New files were added to `.coveragerc`.
  🚫 Not needed

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.
  🚫 Not needed

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54

## Open Questions:
1. `tox` does not appear to work on macOS, is there a way to run it inside Docker?
2. I feel that running `script/gen_requirements_all.py` should add my new dependency, but all I get is:
```
******* ERROR
Errors while importing:  homeassistant.components.climate.econet, homeassistant.components.google_assistant.auth
Make sure you import 3rd party libraries inside methods.
```