### PR TITLE
Use async_configure for ZHA IAS binary sensor

### DIFF
--- a/homeassistant/components/binary_sensor/zha.py
+++ b/homeassistant/components/binary_sensor/zha.py
@@ -142,11 +142,10 @@ class IasZoneSensor(RestoreEntity, ZhaEntity, BinarySensorDevice):
 
     async def async_configure(self):
         """Configure IAS device."""
-        _LOGGER.debug("%s: is being configured...", self.entity_id)
         await self._ias_zone_cluster.bind()
         ieee = self._ias_zone_cluster.endpoint.device.application.ieee
         await self._ias_zone_cluster.write_attributes({'cie_addr': ieee})
-        _LOGGER.debug("%s: Finished configuration.", self.entity_id)
+        _LOGGER.debug("%s: finished configuration", self.entity_id)
 
     async def async_update(self):
         """Retrieve latest state."""

--- a/homeassistant/components/binary_sensor/zha.py
+++ b/homeassistant/components/binary_sensor/zha.py
@@ -81,10 +81,6 @@ async def _async_setup_iaszone(discovery_info):
     device_class = None
     from zigpy.zcl.clusters.security import IasZone
     cluster = discovery_info['in_clusters'][IasZone.cluster_id]
-    if discovery_info['new_join']:
-        await cluster.bind()
-        ieee = cluster.endpoint.device.application.ieee
-        await cluster.write_attributes({'cie_addr': ieee})
 
     try:
         zone_type = await cluster['zone_type']
@@ -143,6 +139,14 @@ class IasZoneSensor(RestoreEntity, ZhaEntity, BinarySensorDevice):
             self._state = 3
         else:
             self._state = 0
+
+    async def async_configure(self):
+        """Configure IAS device."""
+        _LOGGER.debug("%s: is being configured...", self.entity_id)
+        await self._ias_zone_cluster.bind()
+        ieee = self._ias_zone_cluster.endpoint.device.application.ieee
+        await self._ias_zone_cluster.write_attributes({'cie_addr': ieee})
+        _LOGGER.debug("%s: Finished configuration.", self.entity_id)
 
     async def async_update(self):
         """Retrieve latest state."""


### PR DESCRIPTION
## Description:
Refactor IAS binary sensor to leverage [async_configure() invocation on new device join](https://github.com/home-assistant/home-assistant/pull/19470)

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
