### PR TITLE
Upgrade greeneye_monitor to 1.0

### DIFF
--- a/homeassistant/components/greeneye_monitor.py
+++ b/homeassistant/components/greeneye_monitor.py
@@ -81,7 +81,14 @@ CHANNEL_SCHEMA = vol.Schema({
 CHANNELS_SCHEMA = vol.All(cv.ensure_list, [CHANNEL_SCHEMA])
 
 MONITOR_SCHEMA = vol.Schema({
-    vol.Required(CONF_SERIAL_NUMBER): cv.positive_int,
+    vol.Required(CONF_SERIAL_NUMBER):
+        vol.All(
+            cv.string,
+            vol.Length(
+                min=8,
+                max=8,
+                msg="GEM serial number must be specified as an 8-character "
+                    "string (including leading zeroes).")),
     vol.Optional(CONF_CHANNELS, default=[]): CHANNELS_SCHEMA,
     vol.Optional(
         CONF_TEMPERATURE_SENSORS,

--- a/homeassistant/components/greeneye_monitor.py
+++ b/homeassistant/components/greeneye_monitor.py
@@ -16,7 +16,7 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.discovery import async_load_platform
 
-REQUIREMENTS = ['greeneye_monitor==0.1']
+REQUIREMENTS = ['greeneye_monitor==1.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/greeneye_monitor.py
+++ b/homeassistant/components/greeneye_monitor.py
@@ -88,7 +88,8 @@ MONITOR_SCHEMA = vol.Schema({
                 min=8,
                 max=8,
                 msg="GEM serial number must be specified as an 8-character "
-                    "string (including leading zeroes).")),
+                    "string (including leading zeroes)."),
+            vol.Coerce(int)),
     vol.Optional(CONF_CHANNELS, default=[]): CHANNELS_SCHEMA,
     vol.Optional(
         CONF_TEMPERATURE_SENSORS,

--- a/homeassistant/components/sensor/greeneye_monitor.py
+++ b/homeassistant/components/sensor/greeneye_monitor.py
@@ -127,7 +127,7 @@ class GEMSensor(Entity):
             monitors.remove_listener(self._on_new_monitor)
 
     def _try_connect_to_monitor(self, monitors):
-        monitor = monitors.monitors.get(int(self._monitor_serial_number))
+        monitor = monitors.monitors.get(self._monitor_serial_number)
         if not monitor:
             return False
 

--- a/homeassistant/components/sensor/greeneye_monitor.py
+++ b/homeassistant/components/sensor/greeneye_monitor.py
@@ -127,7 +127,7 @@ class GEMSensor(Entity):
             monitors.remove_listener(self._on_new_monitor)
 
     def _try_connect_to_monitor(self, monitors):
-        monitor = monitors.monitors.get(self._monitor_serial_number)
+        monitor = monitors.monitors.get(int(self._monitor_serial_number))
         if not monitor:
             return False
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -457,7 +457,7 @@ googlemaps==2.5.1
 gps3==0.33.3
 
 # homeassistant.components.greeneye_monitor
-greeneye_monitor==0.1
+greeneye_monitor==1.0
 
 # homeassistant.components.light.greenwave
 greenwavereality==0.5.1


### PR DESCRIPTION
## Description:

This is a breaking change; it causes the `serial_number` field in
configuration to be treated as the full 8-digit serial number rather
than the last 5 digits as was previously done, which results in the unique
identifiers for the sensors being different. (Fixing them up in
`config/.storage/core.entity_registry` before rebooting into the updated
version seems to prevent any weirdness.)

The last-5-digits behavior was a result of me misunderstanding the packet
format docs and not realizing that the true serial number was split across
two fields. In addition to being confusing (see
https://community.home-assistant.io/t/brultech-greeneye-issues/86852), it
was technically incorrect. The `greeneye_monitor` platform was just introduced
in 0.82, so it seems like the kind of thing that's best to fix now while
adoption is relatively low rather than later when somebody runs into it
as more than just a point of confusion.

**Related issue (if applicable):** https://community.home-assistant.io/t/brultech-greeneye-issues/86852

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#7976

## Example entry for `configuration.yaml` (if applicable):
N/A

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
