### PR TITLE
Support for relay ports for LCN light platform

### DIFF
--- a/homeassistant/components/lcn.py
+++ b/homeassistant/components/lcn.py
@@ -34,6 +34,8 @@ CONF_CONNECTIONS = 'connections'
 
 DIM_MODES = ['steps50', 'steps200']
 OUTPUT_PORTS = ['output1', 'output2', 'output3', 'output4']
+RELAY_PORTS = ['relay1', 'relay2', 'relay3', 'relay4',
+               'relay5', 'relay6', 'relay7', 'relay8']
 
 # Regex for address validation
 PATTERN_ADDRESS = re.compile('^((?P<conn_id>\\w+)\\.)?s?(?P<seg_id>\\d+)'
@@ -85,7 +87,8 @@ def is_address(value):
 LIGHTS_SCHEMA = vol.Schema({
     vol.Required(CONF_NAME): cv.string,
     vol.Required(CONF_ADDRESS): is_address,
-    vol.Required(CONF_OUTPUT): vol.All(vol.In(OUTPUT_PORTS), vol.Upper),
+    vol.Required(CONF_OUTPUT): vol.All(vol.In(OUTPUT_PORTS + RELAY_PORTS),
+                                       vol.Upper),
     vol.Optional(CONF_DIMMABLE, default=False): vol.Coerce(bool),
     vol.Optional(CONF_TRANSITION, default=0):
         vol.All(vol.Coerce(float), vol.Range(min=0., max=486.),

--- a/homeassistant/components/lcn.py
+++ b/homeassistant/components/lcn.py
@@ -183,11 +183,11 @@ class LcnDevice(Entity):
         self._name = config[CONF_NAME]
 
     @property
-    def should_poll(self) -> bool:
+    def should_poll(self):
         """Lcn device entity pushes its state to HA."""
         return False
 
-    async def async_added_to_hass(self) -> None:
+    async def async_added_to_hass(self):
         """Run when entity about to be added to hass."""
         self.address_connection.register_for_inputs(
             self.input_received)

--- a/homeassistant/components/lcn.py
+++ b/homeassistant/components/lcn.py
@@ -32,10 +32,10 @@ CONF_TRANSITION = 'transition'
 CONF_DIMMABLE = 'dimmable'
 CONF_CONNECTIONS = 'connections'
 
-DIM_MODES = ['steps50', 'steps200']
-OUTPUT_PORTS = ['output1', 'output2', 'output3', 'output4']
-RELAY_PORTS = ['relay1', 'relay2', 'relay3', 'relay4',
-               'relay5', 'relay6', 'relay7', 'relay8']
+DIM_MODES = ['STEPS50', 'STEPS200']
+OUTPUT_PORTS = ['OUTPUT1', 'OUTPUT2', 'OUTPUT3', 'OUTPUT4']
+RELAY_PORTS = ['RELAY1', 'RELAY2', 'RELAY3', 'RELAY4',
+               'RELAY5', 'RELAY6', 'RELAY7', 'RELAY8']
 
 # Regex for address validation
 PATTERN_ADDRESS = re.compile('^((?P<conn_id>\\w+)\\.)?s?(?P<seg_id>\\d+)'
@@ -87,8 +87,8 @@ def is_address(value):
 LIGHTS_SCHEMA = vol.Schema({
     vol.Required(CONF_NAME): cv.string,
     vol.Required(CONF_ADDRESS): is_address,
-    vol.Required(CONF_OUTPUT): vol.All(vol.In(OUTPUT_PORTS + RELAY_PORTS),
-                                       vol.Upper),
+    vol.Required(CONF_OUTPUT): vol.All(vol.Upper,
+                                       vol.In(OUTPUT_PORTS + RELAY_PORTS)),
     vol.Optional(CONF_DIMMABLE, default=False): vol.Coerce(bool),
     vol.Optional(CONF_TRANSITION, default=0):
         vol.All(vol.Coerce(float), vol.Range(min=0., max=486.),
@@ -101,8 +101,8 @@ CONNECTION_SCHEMA = vol.Schema({
     vol.Required(CONF_USERNAME): cv.string,
     vol.Required(CONF_PASSWORD): cv.string,
     vol.Optional(CONF_SK_NUM_TRIES, default=3): cv.positive_int,
-    vol.Optional(CONF_DIM_MODE, default='steps50'): vol.All(vol.In(DIM_MODES),
-                                                            vol.Upper),
+    vol.Optional(CONF_DIM_MODE, default='steps50'): vol.All(vol.Upper,
+                                                            vol.In(DIM_MODES)),
     vol.Optional(CONF_NAME): cv.string
 })
 

--- a/homeassistant/components/light/lcn.py
+++ b/homeassistant/components/light/lcn.py
@@ -56,7 +56,7 @@ class LcnOutputLight(LcnDevice, Light):
         self._is_on = None
         self._is_dimming_to_zero = False
 
-    async def async_added_to_hass(self) -> None:
+    async def async_added_to_hass(self):
         """Run when entity about to be added to hass."""
         await super().async_added_to_hass()
         self.hass.async_create_task(
@@ -138,7 +138,7 @@ class LcnRelayLight(LcnDevice, Light):
 
         self._is_on = None
 
-    async def async_added_to_hass(self) -> None:
+    async def async_added_to_hass(self):
         """Run when entity about to be added to hass."""
         await super().async_added_to_hass()
         self.hass.async_create_task(

--- a/homeassistant/components/light/lcn.py
+++ b/homeassistant/components/light/lcn.py
@@ -146,11 +146,6 @@ class LcnRelayLight(LcnDevice, Light):
                 self.output))
 
     @property
-    def supported_features(self):
-        """Flag supported features."""
-        return 0
-
-    @property
     def is_on(self):
         """Return True if entity is on."""
         return self._is_on

--- a/homeassistant/components/light/lcn.py
+++ b/homeassistant/components/light/lcn.py
@@ -29,10 +29,9 @@ async def async_setup_platform(hass, hass_config, async_add_entities,
         connection = get_connection(connections, connection_id)
         address_connection = connection.get_address_conn(addr)
 
-        output = config[CONF_OUTPUT].lower()
-        if output in OUTPUT_PORTS:
+        if config[CONF_OUTPUT] in OUTPUT_PORTS:
             device = LcnOutputLight(config, address_connection)
-        else:
+        else:  # in RELAY_PORTS
             device = LcnRelayLight(config, address_connection)
 
         devices.append(device)

--- a/homeassistant/components/light/lcn.py
+++ b/homeassistant/components/light/lcn.py
@@ -7,7 +7,7 @@ https://home-assistant.io/components/light.lcn/
 
 from homeassistant.components.lcn import (
     CONF_CONNECTIONS, CONF_DIMMABLE, CONF_OUTPUT, CONF_TRANSITION, DATA_LCN,
-    LcnDevice, get_connection)
+    OUTPUT_PORTS, LcnDevice, get_connection)
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS, ATTR_TRANSITION, SUPPORT_BRIGHTNESS, SUPPORT_TRANSITION,
     Light)
@@ -29,7 +29,14 @@ async def async_setup_platform(hass, hass_config, async_add_entities,
         connection = get_connection(connections, connection_id)
         address_connection = connection.get_address_conn(addr)
 
-        devices.append(LcnOutputLight(config, address_connection))
+        output = config[CONF_OUTPUT].lower()
+        if output in OUTPUT_PORTS:
+            device = LcnOutputLight(config, address_connection)
+        else:
+            device = LcnRelayLight(config, address_connection)
+
+        devices.append(device)
+
     async_add_entities(devices)
 
 
@@ -118,4 +125,61 @@ class LcnOutputLight(LcnDevice, Light):
             self._is_dimming_to_zero = False
         if not self._is_dimming_to_zero:
             self._is_on = self.brightness > 0
+        self.async_schedule_update_ha_state()
+
+
+class LcnRelayLight(LcnDevice, Light):
+    """Representation of a LCN light for relay ports."""
+
+    def __init__(self, config, address_connection):
+        """Initialize the LCN light."""
+        super().__init__(config, address_connection)
+
+        self.output = self.pypck.lcn_defs.RelayPort[config[CONF_OUTPUT]]
+
+        self._is_on = None
+
+    async def async_added_to_hass(self) -> None:
+        """Run when entity about to be added to hass."""
+        await super().async_added_to_hass()
+        self.hass.async_create_task(
+            self.address_connection.activate_status_request_handler(
+                self.output))
+
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+        return 0
+
+    @property
+    def is_on(self):
+        """Return True if entity is on."""
+        return self._is_on
+
+    async def async_turn_on(self, **kwargs):
+        """Turn the entity on."""
+        self._is_on = True
+
+        states = [self.pypck.lcn_defs.RelayStateModifier.NOCHANGE] * 8
+        states[self.output.value] = self.pypck.lcn_defs.RelayStateModifier.ON
+        self.address_connection.control_relays(states)
+
+        await self.async_update_ha_state()
+
+    async def async_turn_off(self, **kwargs):
+        """Turn the entity off."""
+        self._is_on = False
+
+        states = [self.pypck.lcn_defs.RelayStateModifier.NOCHANGE] * 8
+        states[self.output.value] = self.pypck.lcn_defs.RelayStateModifier.OFF
+        self.address_connection.control_relays(states)
+
+        await self.async_update_ha_state()
+
+    def input_received(self, input_obj):
+        """Set light state when LCN input object (command) is received."""
+        if not isinstance(input_obj, self.pypck.inputs.ModStatusRelays):
+            return
+
+        self._is_on = input_obj.get_state(self.output.value)
         self.async_schedule_update_ha_state()


### PR DESCRIPTION
## Description:
Support is added for lights which are connected to the relays of LCN hardware devices.

**Related issue (if applicable):**

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#7977

## Example entry for `configuration.yaml` (if applicable):
```yaml
lcn:
  connections:
    - name: myhome
      host: 192.168.2.41
      port: 4114
      username: !secret lcn_username
      password: !secret lcn_password

  lights:
    - name: Living room
      address: myhome.0.7
      output: relay1
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
