### PR TITLE
Fix ADS light when parameter adsvar_brightness is not set

### DIFF
--- a/homeassistant/components/light/ads.py
+++ b/homeassistant/components/light/ads.py
@@ -1,7 +1,9 @@
 """
 Support for ADS light sources.
+
 For more details about this platform, please refer to the documentation.
 https://home-assistant.io/components/light.ads/
+
 """
 import logging
 import voluptuous as vol

--- a/homeassistant/components/light/ads.py
+++ b/homeassistant/components/light/ads.py
@@ -1,9 +1,7 @@
 """
 Support for ADS light sources.
-
 For more details about this platform, please refer to the documentation.
 https://home-assistant.io/components/light.ads/
-
 """
 import logging
 import voluptuous as vol
@@ -63,15 +61,16 @@ class AdsLight(Light):
             self._brightness = value
             self.schedule_update_ha_state()
 
-        self.hass.async_add_job(
+        self.hass.async_add_executor_job(
             self._ads_hub.add_device_notification,
             self.ads_var_enable, self._ads_hub.PLCTYPE_BOOL, update_on_state
         )
-        self.hass.async_add_job(
-            self._ads_hub.add_device_notification,
-            self.ads_var_brightness, self._ads_hub.PLCTYPE_INT,
-            update_brightness
-        )
+        if self.ads_var_brightness is not None:
+            self.hass.async_add_executor_job(
+                self._ads_hub.add_device_notification,
+                self.ads_var_brightness, self._ads_hub.PLCTYPE_INT,
+                update_brightness
+            )
 
     @property
     def name(self):
@@ -96,8 +95,10 @@ class AdsLight(Light):
     @property
     def supported_features(self):
         """Flag supported features."""
+        support = 0
         if self.ads_var_brightness is not None:
-            return SUPPORT_BRIGHTNESS
+            support = SUPPORT_BRIGHTNESS
+        return support
 
     def turn_on(self, **kwargs):
         """Turn the light on or set a specific dimmer value."""


### PR DESCRIPTION
## Description:
Just a small change to prevent exception if optional parameter adsvar_brightness is not set. 
(replaces #19423)

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
