### PR TITLE
Fix cpu_temp issue on Vero 4K

### DIFF
--- a/homeassistant/components/sensor/glances.py
+++ b/homeassistant/components/sensor/glances.py
@@ -181,7 +181,7 @@ class GlancesSensor(Entity):
                 for sensor in value['sensors']:
                     if sensor['label'] in ['CPU', "Package id 0",
                                            "Physical id 0", "cpu-thermal 1",
-                                           "exynos-therm 1"]:
+                                           "exynos-therm 1", "soc_thermal 1"]:
                         self._state = sensor['value']
             elif self.type == 'docker_active':
                 count = 0


### PR DESCRIPTION
## Description:
Fix pulling the temperature info for the Vero 4K.  The  thermal sensor is called `soc_thermal 1`

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.