### PR TITLE
Use xml.etree through defusedxml

### DIFF
--- a/homeassistant/components/ihc/__init__.py
+++ b/homeassistant/components/ihc/__init__.py
@@ -6,7 +6,6 @@ https://home-assistant.io/components/ihc/
 """
 import logging
 import os.path
-import xml.etree.ElementTree
 
 import voluptuous as vol
 
@@ -24,7 +23,7 @@ from homeassistant.helpers import discovery
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import HomeAssistantType
 
-REQUIREMENTS = ['ihcsdk==2.2.0']
+REQUIREMENTS = ['ihcsdk==2.2.0', 'defusedxml==0.5.0']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -217,11 +216,13 @@ def get_manual_configuration(
 def autosetup_ihc_products(hass: HomeAssistantType, config, ihc_controller,
                            controller_id):
     """Auto setup of IHC products from the IHC project file."""
+    from defusedxml import ElementTree
+
     project_xml = ihc_controller.get_project()
     if not project_xml:
         _LOGGER.error("Unable to read project from IHC controller")
         return False
-    project = xml.etree.ElementTree.fromstring(project_xml)
+    project = ElementTree.fromstring(project_xml)
 
     # if an auto setup file exist in the configuration it will override
     yaml_path = hass.config.path(AUTO_SETUP_YAML)

--- a/homeassistant/components/namecheapdns.py
+++ b/homeassistant/components/namecheapdns.py
@@ -14,6 +14,8 @@ from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_DOMAIN
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
+REQUIREMENTS = ['defusedxml==0.5.0']
+
 _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = 'namecheapdns'
@@ -55,7 +57,7 @@ async def async_setup(hass, config):
 
 async def _update_namecheapdns(session, host, domain, password):
     """Update namecheap DNS entry."""
-    import xml.etree.ElementTree as ET
+    import defusedxml.ElementTree as ET
 
     params = {
         'host': host,

--- a/homeassistant/components/sensor/ohmconnect.py
+++ b/homeassistant/components/sensor/ohmconnect.py
@@ -6,7 +6,6 @@ https://home-assistant.io/components/sensor.ohmconnect/
 """
 import logging
 from datetime import timedelta
-import xml.etree.ElementTree as ET
 
 import requests
 import voluptuous as vol
@@ -16,6 +15,8 @@ from homeassistant.const import CONF_NAME
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import Throttle
 from homeassistant.helpers.entity import Entity
+
+REQUIREMENTS = ['defusedxml==0.5.0']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -68,6 +69,8 @@ class OhmconnectSensor(Entity):
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
         """Get the latest data from OhmConnect."""
+        import defusedxml.ElementTree as ET
+
         try:
             url = ("https://login.ohmconnect.com"
                    "/verify-ohm-hour/{}").format(self._ohmid)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -295,7 +295,10 @@ datapoint==0.4.3
 # homeassistant.components.light.decora_wifi
 # decora_wifi==1.3
 
+# homeassistant.components.ihc
+# homeassistant.components.namecheapdns
 # homeassistant.components.device_tracker.upc_connect
+# homeassistant.components.sensor.ohmconnect
 defusedxml==0.5.0
 
 # homeassistant.components.sensor.deluge

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -52,7 +52,10 @@ caldav==0.5.0
 # homeassistant.components.sensor.coinmarketcap
 coinmarketcap==5.0.3
 
+# homeassistant.components.ihc
+# homeassistant.components.namecheapdns
 # homeassistant.components.device_tracker.upc_connect
+# homeassistant.components.sensor.ohmconnect
 defusedxml==0.5.0
 
 # homeassistant.components.sensor.dsmr


### PR DESCRIPTION
## Description:

...for security reasons. Untested apart from tox/Travis, I don't have these devices around.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
