### PR TITLE
Filter urllib3.connectionpool warnings in camera.axis and camera.zoneminder

### DIFF
--- a/homeassistant/components/camera/axis.py
+++ b/homeassistant/components/camera/axis.py
@@ -7,7 +7,7 @@ https://home-assistant.io/components/camera.axis/
 import logging
 
 from homeassistant.components.camera.mjpeg import (
-    CONF_MJPEG_URL, CONF_STILL_IMAGE_URL, MjpegCamera)
+    CONF_MJPEG_URL, CONF_STILL_IMAGE_URL, MjpegCamera, filter_urllib3_logging)
 from homeassistant.const import (
     CONF_AUTHENTICATION, CONF_HOST, CONF_NAME, CONF_PASSWORD, CONF_PORT,
     CONF_USERNAME, HTTP_DIGEST_AUTHENTICATION)
@@ -29,6 +29,8 @@ def _get_image_url(host, port, mode):
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Axis camera."""
+    filter_urllib3_logging()
+
     camera_config = {
         CONF_NAME: discovery_info[CONF_NAME],
         CONF_USERNAME: discovery_info[CONF_USERNAME],

--- a/homeassistant/components/camera/mjpeg.py
+++ b/homeassistant/components/camera/mjpeg.py
@@ -46,17 +46,21 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 async def async_setup_platform(hass, config, async_add_entities,
                                discovery_info=None):
     """Set up a MJPEG IP Camera."""
-    # Filter header errors from urllib3 due to a urllib3 bug
+    filter_urllib3_logging()
+
+    if discovery_info:
+        config = PLATFORM_SCHEMA(discovery_info)
+    async_add_entities([MjpegCamera(config)])
+
+
+def filter_urllib3_logging():
+    """Filter header errors from urllib3 due to a urllib3 bug"""
     urllib3_logger = logging.getLogger("urllib3.connectionpool")
     if not any(isinstance(x, NoHeaderErrorFilter)
                for x in urllib3_logger.filters):
         urllib3_logger.addFilter(
             NoHeaderErrorFilter()
         )
-
-    if discovery_info:
-        config = PLATFORM_SCHEMA(discovery_info)
-    async_add_entities([MjpegCamera(config)])
 
 
 def extract_image_from_mjpeg(stream):

--- a/homeassistant/components/camera/mjpeg.py
+++ b/homeassistant/components/camera/mjpeg.py
@@ -54,7 +54,7 @@ async def async_setup_platform(hass, config, async_add_entities,
 
 
 def filter_urllib3_logging():
-    """Filter header errors from urllib3 due to a urllib3 bug"""
+    """Filter header errors from urllib3 due to a urllib3 bug."""
     urllib3_logger = logging.getLogger("urllib3.connectionpool")
     if not any(isinstance(x, NoHeaderErrorFilter)
                for x in urllib3_logger.filters):

--- a/homeassistant/components/camera/zoneminder.py
+++ b/homeassistant/components/camera/zoneminder.py
@@ -8,7 +8,7 @@ import logging
 
 from homeassistant.const import CONF_NAME, CONF_VERIFY_SSL
 from homeassistant.components.camera.mjpeg import (
-    CONF_MJPEG_URL, CONF_STILL_IMAGE_URL, MjpegCamera)
+    CONF_MJPEG_URL, CONF_STILL_IMAGE_URL, MjpegCamera, filter_urllib3_logging)
 from homeassistant.components.zoneminder import DOMAIN as ZONEMINDER_DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
@@ -18,6 +18,7 @@ DEPENDENCIES = ['zoneminder']
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the ZoneMinder cameras."""
+    filter_urllib3_logging()
     zm_client = hass.data[ZONEMINDER_DOMAIN]
 
     monitors = zm_client.get_monitors()


### PR DESCRIPTION
## Description:

There was an existing workaround for this warning in the `camera.mjpeg` platform. This platform is used as a superclass for existing platforms `camera.axis` and `camera.zoneminder`. This PR exposes the workaround via a method and uses it in all platforms that subclass `camera.mjpeg`.

**Related issue (if applicable):** fixes #19600

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
