### PR TITLE
Allow webhooks that support GET

### DIFF
--- a/homeassistant/components/webhook.py
+++ b/homeassistant/components/webhook.py
@@ -101,10 +101,18 @@ class WebhookView(HomeAssistantView):
     name = "api:webhook"
     requires_auth = False
 
-    async def post(self, request, webhook_id):
+    async def handle(self, request, webhook_id):
         """Handle webhook call."""
         hass = request.app['hass']
         return await async_handle_webhook(hass, webhook_id, request)
+
+    async def post(self, request, webhook_id):
+        """Handle webhook POST call."""
+        await self.handle(request, webhook_id)
+
+    async def get(self, request, webhook_id):
+        """Handle webhook GET call."""
+        await self.handle(request, webhook_id)
 
 
 @callback

--- a/homeassistant/components/webhook.py
+++ b/homeassistant/components/webhook.py
@@ -108,11 +108,11 @@ class WebhookView(HomeAssistantView):
 
     async def post(self, request, webhook_id):
         """Handle webhook POST call."""
-        await self.handle(request, webhook_id)
+        return await self.handle(request, webhook_id)
 
     async def get(self, request, webhook_id):
         """Handle webhook GET call."""
-        await self.handle(request, webhook_id)
+        return await self.handle(request, webhook_id)
 
 
 @callback

--- a/tests/components/test_webhook.py
+++ b/tests/components/test_webhook.py
@@ -125,13 +125,13 @@ async def test_listing_webhook(hass, hass_ws_client, hass_access_token):
 
 
 async def test_getting_webhook_nonexisting(hass, mock_client):
-    """Test posting to a nonexisting webhook."""
+    """Test getting a nonexisting webhook."""
     resp = await mock_client.get('/api/webhook/non-existing')
     assert resp.status == 200
 
 
 async def test_getting_webhook(hass, mock_client):
-    """Test posting a webhook with no data."""
+    """Test getting a webhook with no data."""
     hooks = []
     webhook_id = hass.components.webhook.async_generate_id()
 

--- a/tests/components/test_webhook.py
+++ b/tests/components/test_webhook.py
@@ -122,3 +122,27 @@ async def test_listing_webhook(hass, hass_ws_client, hass_access_token):
             'name': 'Test hook'
         }
     ]
+
+
+async def test_getting_webhook_nonexisting(hass, mock_client):
+    """Test posting to a nonexisting webhook."""
+    resp = await mock_client.get('/api/webhook/non-existing')
+    assert resp.status == 200
+
+
+async def test_getting_webhook(hass, mock_client):
+    """Test posting a webhook with no data."""
+    hooks = []
+    webhook_id = hass.components.webhook.async_generate_id()
+
+    async def handle(*args):
+        """Handle webhook."""
+        hooks.append(args)
+
+    hass.components.webhook.async_register(webhook_id, handle)
+
+    resp = await mock_client.get('/api/webhook/{}'.format(webhook_id))
+    assert resp.status == 200
+    assert len(hooks) == 1
+    assert hooks[0][0] is hass
+    assert hooks[0][1] == webhook_id

--- a/tests/components/test_webhook.py
+++ b/tests/components/test_webhook.py
@@ -139,7 +139,8 @@ async def test_getting_webhook(hass, mock_client):
         """Handle webhook."""
         hooks.append(args)
 
-    hass.components.webhook.async_register(webhook_id, handle)
+    hass.components.webhook.async_register(
+        'test', "Test hook", webhook_id, handle)
 
     resp = await mock_client.get('/api/webhook/{}'.format(webhook_id))
     assert resp.status == 200


### PR DESCRIPTION
## Description:

We talked about this once before in #17782 and at the time it didn't make sense. Since then, we've run into at least one device (#19523) where the device only can make `GET` calls. Rather than making it configurable on a per webhook basis, I think it makes sense for all webhooks to respond with the same behavior whether it's a `GET` or `POST` call.

**Related issue (if applicable):** fixes #19523

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
