### PR TITLE
Add service change_channel to Harmony component

### DIFF
--- a/homeassistant/components/remote/harmony.py
+++ b/homeassistant/components/remote/harmony.py
@@ -27,6 +27,8 @@ REQUIREMENTS = ['aioharmony==0.1.2']
 _LOGGER = logging.getLogger(__name__)
 
 ATTR_CURRENT_ACTIVITY = 'current_activity'
+ATTR_CONFIG_VERSION = 'config_version'
+ATTR_FIRMWARE_VERSION = 'firmware_version'
 
 DEFAULT_PORT = 8088
 DEVICES = []
@@ -197,7 +199,11 @@ class HarmonyRemote(remote.RemoteDevice):
     @property
     def device_state_attributes(self):
         """Add platform specific attributes."""
-        return {ATTR_CURRENT_ACTIVITY: self._current_activity}
+        return {
+            ATTR_CURRENT_ACTIVITY: self._current_activity,
+            ATTR_FIRMWARE_VERSION: self._client.fw_version,
+            ATTR_CONFIG_VERSION: self._client.hub_config.config_version
+        }
 
     @property
     def is_on(self):

--- a/homeassistant/components/remote/harmony.py
+++ b/homeassistant/components/remote/harmony.py
@@ -26,8 +26,8 @@ REQUIREMENTS = ['aioharmony==0.1.2']
 
 _LOGGER = logging.getLogger(__name__)
 
-ATTR_CURRENT_ACTIVITY = 'current_activity'
 ATTR_CONFIG_VERSION = 'config_version'
+ATTR_CURRENT_ACTIVITY = 'current_activity'
 ATTR_FIRMWARE_VERSION = 'firmware_version'
 
 DEFAULT_PORT = 8088

--- a/homeassistant/components/remote/harmony.py
+++ b/homeassistant/components/remote/harmony.py
@@ -34,7 +34,7 @@ DEVICES = []
 CONF_DEVICE_CACHE = 'harmony_device_cache'
 
 SERVICE_SYNC = 'harmony_sync'
-SERVICE_CHANGE_CHANNEL = 'change_channel'
+SERVICE_CHANGE_CHANNEL = 'harmony_change_channel'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(ATTR_ACTIVITY): cv.string,
@@ -50,7 +50,7 @@ HARMONY_SYNC_SCHEMA = vol.Schema({
 })
 
 HARMONY_CHANGE_CHANNEL_SCHEMA = vol.Schema({
-    vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
+    vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
     vol.Required(ATTR_CHANNEL): cv.positive_int
 })
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -107,9 +107,6 @@ aioftp==0.12.0
 # homeassistant.components.remote.harmony
 aioharmony==0.1.2
 
-# homeassistant.components.remote.harmony
-aioharmony==0.1.1
-
 # homeassistant.components.emulated_hue
 # homeassistant.components.http
 aiohttp_cors==0.7.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -108,7 +108,7 @@ aioftp==0.12.0
 aioharmony==0.1.2
 
 # homeassistant.components.remote.harmony
-aioharmony==0.1.00
+aioharmony==0.1.1
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -107,6 +107,9 @@ aioftp==0.12.0
 # homeassistant.components.remote.harmony
 aioharmony==0.1.2
 
+# homeassistant.components.remote.harmony
+aioharmony==0.1.00
+
 # homeassistant.components.emulated_hue
 # homeassistant.components.http
 aiohttp_cors==0.7.0


### PR DESCRIPTION
## Description:
Adding the service change_channel to the Harmony component supporting changing channels through the Harmony HUB.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#7984

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)