### PR TITLE
Add parameter hold_secs for Harmony remote send command

### DIFF
--- a/homeassistant/components/harmony/remote.py
+++ b/homeassistant/components/harmony/remote.py
@@ -8,8 +8,8 @@ import voluptuous as vol
 from homeassistant.components import remote
 from homeassistant.components.remote import (
     ATTR_ACTIVITY, ATTR_DELAY_SECS, ATTR_DEVICE, ATTR_NUM_REPEATS,
-    DEFAULT_DELAY_SECS, DOMAIN, PLATFORM_SCHEMA
-)
+    DEFAULT_DELAY_SECS, ATTR_HOLD_SECS, DEFAULT_HOLD_SECS,
+    DOMAIN, PLATFORM_SCHEMA)
 from homeassistant.const import (
     ATTR_ENTITY_ID, CONF_HOST, CONF_NAME, CONF_PORT, EVENT_HOMEASSISTANT_STOP
 )
@@ -35,6 +35,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(ATTR_ACTIVITY): cv.string,
     vol.Required(CONF_NAME): cv.string,
     vol.Optional(ATTR_DELAY_SECS, default=DEFAULT_DELAY_SECS):
+        vol.Coerce(float),
+    vol.Optional(ATTR_HOLD_SECS, default=DEFAULT_HOLD_SECS):
         vol.Coerce(float),
     vol.Optional(CONF_HOST): cv.string,
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
@@ -342,6 +344,9 @@ class HarmonyRemote(remote.RemoteDevice):
 
         num_repeats = kwargs.get(ATTR_NUM_REPEATS)
         delay_secs = kwargs.get(ATTR_DELAY_SECS, self._delay_secs)
+        hold_secs = kwargs.get(ATTR_HOLD_SECS)
+        _LOGGER.debug("Sending commands to device %s holding for %s seconds",
+                      device, hold_secs)
 
         # Creating list of commands to send.
         snd_cmnd_list = []
@@ -350,7 +355,7 @@ class HarmonyRemote(remote.RemoteDevice):
                 send_command = SendCommandDevice(
                     device=device_id,
                     command=single_command,
-                    delay=0
+                    delay=hold_secs
                 )
                 snd_cmnd_list.append(send_command)
                 if delay_secs > 0:

--- a/homeassistant/components/harmony/remote.py
+++ b/homeassistant/components/harmony/remote.py
@@ -23,8 +23,6 @@ _LOGGER = logging.getLogger(__name__)
 
 ATTR_CHANNEL = 'channel'
 ATTR_CURRENT_ACTIVITY = 'current_activity'
-ATTR_CONFIG_VERSION = 'config_version'
-ATTR_FIRMWARE_VERSION = 'firmware_version'
 
 DEFAULT_PORT = 8088
 DEVICES = []
@@ -207,11 +205,7 @@ class HarmonyRemote(remote.RemoteDevice):
     @property
     def device_state_attributes(self):
         """Add platform specific attributes."""
-        return {
-            ATTR_CURRENT_ACTIVITY: self._current_activity,
-            ATTR_FIRMWARE_VERSION: self._client.fw_version,
-            ATTR_CONFIG_VERSION: self._client.hub_config.config_version
-        }
+        return {ATTR_CURRENT_ACTIVITY: self._current_activity}
 
     @property
     def is_on(self):

--- a/homeassistant/components/harmony/remote.py
+++ b/homeassistant/components/harmony/remote.py
@@ -23,6 +23,8 @@ _LOGGER = logging.getLogger(__name__)
 
 ATTR_CHANNEL = 'channel'
 ATTR_CURRENT_ACTIVITY = 'current_activity'
+ATTR_CONFIG_VERSION = 'config_version'
+ATTR_FIRMWARE_VERSION = 'firmware_version'
 
 DEFAULT_PORT = 8088
 DEVICES = []
@@ -205,7 +207,11 @@ class HarmonyRemote(remote.RemoteDevice):
     @property
     def device_state_attributes(self):
         """Add platform specific attributes."""
-        return {ATTR_CURRENT_ACTIVITY: self._current_activity}
+        return {
+            ATTR_CURRENT_ACTIVITY: self._current_activity,
+            ATTR_FIRMWARE_VERSION: self._client.fw_version,
+            ATTR_CONFIG_VERSION: self._client.hub_config.config_version
+        }
 
     @property
     def is_on(self):

--- a/homeassistant/components/harmony/remote.py
+++ b/homeassistant/components/harmony/remote.py
@@ -7,9 +7,8 @@ import voluptuous as vol
 
 from homeassistant.components import remote
 from homeassistant.components.remote import (
-    ATTR_ACTIVITY, ATTR_DELAY_SECS, ATTR_DEVICE, ATTR_NUM_REPEATS,
-    DEFAULT_DELAY_SECS, ATTR_HOLD_SECS, DEFAULT_HOLD_SECS,
-    DOMAIN, PLATFORM_SCHEMA)
+    ATTR_ACTIVITY, ATTR_DELAY_SECS, ATTR_DEVICE, ATTR_HOLD_SECS,
+    ATTR_NUM_REPEATS, DEFAULT_DELAY_SECS, DOMAIN, PLATFORM_SCHEMA)
 from homeassistant.const import (
     ATTR_ENTITY_ID, CONF_HOST, CONF_NAME, CONF_PORT, EVENT_HOMEASSISTANT_STOP
 )
@@ -35,8 +34,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(ATTR_ACTIVITY): cv.string,
     vol.Required(CONF_NAME): cv.string,
     vol.Optional(ATTR_DELAY_SECS, default=DEFAULT_DELAY_SECS):
-        vol.Coerce(float),
-    vol.Optional(ATTR_HOLD_SECS, default=DEFAULT_HOLD_SECS):
         vol.Coerce(float),
     vol.Optional(CONF_HOST): cv.string,
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
@@ -342,11 +339,12 @@ class HarmonyRemote(remote.RemoteDevice):
             _LOGGER.error("%s: Device %s is invalid", self.name, device)
             return
 
-        num_repeats = kwargs.get(ATTR_NUM_REPEATS)
+        num_repeats = kwargs[ATTR_NUM_REPEATS]
         delay_secs = kwargs.get(ATTR_DELAY_SECS, self._delay_secs)
-        hold_secs = kwargs.get(ATTR_HOLD_SECS)
-        _LOGGER.debug("Sending commands to device %s holding for %s seconds",
-                      device, hold_secs)
+        hold_secs = kwargs[ATTR_HOLD_SECS]
+        _LOGGER.debug("Sending commands to device %s holding for %s seconds "
+                      "with a delay of %s seconds",
+                      device, hold_secs, delay_secs)
 
         # Creating list of commands to send.
         snd_cmnd_list = []

--- a/homeassistant/components/remote/__init__.py
+++ b/homeassistant/components/remote/__init__.py
@@ -23,6 +23,7 @@ ATTR_COMMAND = 'command'
 ATTR_DEVICE = 'device'
 ATTR_NUM_REPEATS = 'num_repeats'
 ATTR_DELAY_SECS = 'delay_secs'
+ATTR_HOLD_SECS = 'hold_secs'
 
 DOMAIN = 'remote'
 DEPENDENCIES = ['group']
@@ -40,6 +41,7 @@ SERVICE_SYNC = 'sync'
 
 DEFAULT_NUM_REPEATS = 1
 DEFAULT_DELAY_SECS = 0.4
+DEFAULT_HOLD_SECS = 0
 
 REMOTE_SERVICE_SCHEMA = vol.Schema({
     vol.Optional(ATTR_ENTITY_ID): cv.comp_entity_ids,
@@ -55,6 +57,7 @@ REMOTE_SERVICE_SEND_COMMAND_SCHEMA = REMOTE_SERVICE_SCHEMA.extend({
     vol.Optional(
         ATTR_NUM_REPEATS, default=DEFAULT_NUM_REPEATS): cv.positive_int,
     vol.Optional(ATTR_DELAY_SECS): vol.Coerce(float),
+    vol.Optional(ATTR_HOLD_SECS, default=DEFAULT_HOLD_SECS): vol.Coerce(float),
 })
 
 

--- a/homeassistant/components/remote/services.yaml
+++ b/homeassistant/components/remote/services.yaml
@@ -42,6 +42,10 @@ send_command:
     delay_secs:
       description: An optional value that specifies that number of seconds you want to wait in between repeated commands. If not specified, the default of 0.4 seconds will be used.
       example: '0.75'
+    hold_secs:
+      description: An optional value that specifies that number of seconds you want to have it held before the release is send. If not specified, the release will be send immediately after the press.
+      example: '2.5'
+
 
 harmony_sync:
   description: Syncs the remote's configuration.

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -113,9 +113,6 @@ aioftp==0.12.0
 # homeassistant.components.harmony.remote
 aioharmony==0.1.8
 
-# homeassistant.components.remote.harmony
-aioharmony==0.1.1
-
 # homeassistant.components.emulated_hue
 # homeassistant.components.http
 aiohttp_cors==0.7.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -113,6 +113,9 @@ aioftp==0.12.0
 # homeassistant.components.harmony.remote
 aioharmony==0.1.8
 
+# homeassistant.components.remote.harmony
+aioharmony==0.1.00
+
 # homeassistant.components.emulated_hue
 # homeassistant.components.http
 aiohttp_cors==0.7.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -114,7 +114,7 @@ aioftp==0.12.0
 aioharmony==0.1.8
 
 # homeassistant.components.remote.harmony
-aioharmony==0.1.00
+aioharmony==0.1.1
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http


### PR DESCRIPTION
## Description:
Add optional parameter to specify how long the remote should "hold" a pressed button before releasing it.

Architecture issue home-assistant/architecture#90 was originally opened for adding this parameter as well.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#7985

## Example entry for `configuration.yaml` (if applicable):
```yaml
- platform: harmony
  name: Living Room 
  activity: Watch TV
  hold_secs: 1
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

