### PR TITLE
Fix homekit_controller pairing regression

### DIFF
--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -248,7 +248,7 @@ def setup(hass, config):
     if not os.path.isdir(data_dir):
         os.mkdir(data_dir)
 
-    pairing_file = os.path.join(data_dir, 'pairings.json')
+    pairing_file = os.path.join(data_dir, 'pairing.json')
     if os.path.exists(pairing_file):
         controller.load_data(pairing_file)
 

--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -41,6 +41,8 @@ _LOGGER = logging.getLogger(__name__)
 REQUEST_TIMEOUT = 5  # seconds
 RETRY_INTERVAL = 60  # seconds
 
+PAIRING_FILE = "pairing.json"
+
 
 class HomeKitConnectionError(ConnectionError):
     """Raised when unable to connect to target device."""
@@ -150,7 +152,7 @@ class HKDevice():
             pairing_file = os.path.join(
                 self.hass.config.path(),
                 HOMEKIT_DIR,
-                'pairing.json'
+                PAIRING_FILE,
             )
             self.controller.save_data(pairing_file)
             _configurator = self.hass.data[DOMAIN+self.hkid]
@@ -248,7 +250,7 @@ def setup(hass, config):
     if not os.path.isdir(data_dir):
         os.mkdir(data_dir)
 
-    pairing_file = os.path.join(data_dir, 'pairing.json')
+    pairing_file = os.path.join(data_dir, PAIRING_FILE)
     if os.path.exists(pairing_file):
         controller.load_data(pairing_file)
 


### PR DESCRIPTION
## Description:

The upgrade to homekit_controller (#19549)  breaks new pairing (old pairings were migrated fine). Just a typo, which this fixes.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [*] The code change is tested and works locally.
  - [*] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [*] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
