### PR TITLE
Fix error in got_connected for remote.harmony

### DIFF
--- a/homeassistant/components/remote/harmony.py
+++ b/homeassistant/components/remote/harmony.py
@@ -224,12 +224,12 @@ class HarmonyRemote(remote.RemoteDevice):
         self.new_activity(self._client.current_activity)
         await self.hass.async_add_executor_job(self.write_config_file)
 
-    def got_connected(self, _=None):
+    async def got_connected(self, _=None):
         """Notification that we're connected to the HUB."""
         _LOGGER.debug("%s: connected to the HUB.", self._name)
         if not self._available:
             # We were disconnected before.
-            self.new_config()
+            await self.new_config()
         self._available = True
 
     async def got_disconnected(self, _=None):

--- a/homeassistant/components/remote/harmony.py
+++ b/homeassistant/components/remote/harmony.py
@@ -22,7 +22,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.exceptions import PlatformNotReady
 from homeassistant.util import slugify
 
-REQUIREMENTS = ['aioharmony==0.1.1']
+REQUIREMENTS = ['aioharmony==0.1.2']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -216,6 +216,7 @@ class HarmonyRemote(remote.RemoteDevice):
                       activity_name)
         self._current_activity = activity_name
         self._state = bool(activity_id != -1)
+        self._available = True
         self.async_schedule_update_ha_state()
 
     async def new_config(self, _=None):
@@ -230,7 +231,6 @@ class HarmonyRemote(remote.RemoteDevice):
         if not self._available:
             # We were disconnected before.
             await self.new_config()
-        self._available = True
 
     async def got_disconnected(self, _=None):
         """Notification that we're disconnected from the HUB."""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -105,7 +105,7 @@ aiofreepybox==0.0.6
 aioftp==0.12.0
 
 # homeassistant.components.remote.harmony
-aioharmony==0.1.1
+aioharmony==0.1.2
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http


### PR DESCRIPTION
## Description:

Fixed an issue when device is reconnected and race condition for available state

**Related issue (if applicable):** fixes #19657

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

