### PR TITLE
Update pyhomematic 0.1.54 + small fixes

### DIFF
--- a/homeassistant/components/homematic/__init__.py
+++ b/homeassistant/components/homematic/__init__.py
@@ -799,8 +799,6 @@ class HMDevice(Entity):
         """Handle all pyhomematic device events."""
         _LOGGER.debug("%s received event '%s' value: %s", self._name,
                       attribute, value)
-        if int(device.split(':')[-1]) != int(self._channel):
-            return
         has_changed = False
 
         # Is data needed for this instance?

--- a/homeassistant/components/homematic/__init__.py
+++ b/homeassistant/components/homematic/__init__.py
@@ -19,7 +19,7 @@ from homeassistant.helpers import discovery
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['pyhomematic==0.1.53']
+REQUIREMENTS = ['pyhomematic==0.1.54']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -79,7 +79,7 @@ HM_DEVICE_TYPES = {
         'IPWeatherSensor', 'RotaryHandleSensorIP', 'IPPassageSensor',
         'IPKeySwitchPowermeter', 'IPThermostatWall230V', 'IPWeatherSensorPlus',
         'IPWeatherSensorBasic', 'IPBrightnessSensor', 'IPGarage',
-        'UniversalSensor'],
+        'UniversalSensor', 'MotionIPV2'],
     DISCOVER_CLIMATE: [
         'Thermostat', 'ThermostatWall', 'MAXThermostat', 'ThermostatWall2',
         'MAXWallThermostat', 'IPThermostat', 'IPThermostatWall',
@@ -89,7 +89,7 @@ HM_DEVICE_TYPES = {
         'MotionIP', 'RemoteMotion', 'WeatherSensor', 'TiltSensor',
         'IPShutterContact', 'HMWIOSwitch', 'MaxShutterContact', 'Rain',
         'WiredSensor', 'PresenceIP', 'IPWeatherSensor', 'IPPassageSensor',
-        'SmartwareMotion', 'IPWeatherSensorPlus'],
+        'SmartwareMotion', 'IPWeatherSensorPlus', 'MotionIPV2'],
     DISCOVER_COVER: ['Blind', 'KeyBlind', 'IPKeyBlind', 'IPKeyBlindTilt'],
     DISCOVER_LOCKS: ['KeyMatic']
 }
@@ -799,6 +799,8 @@ class HMDevice(Entity):
         """Handle all pyhomematic device events."""
         _LOGGER.debug("%s received event '%s' value: %s", self._name,
                       attribute, value)
+        if int(device.split(':')[-1]) != int(self._channel):
+            return
         has_changed = False
 
         # Is data needed for this instance?

--- a/homeassistant/components/sensor/homematic.py
+++ b/homeassistant/components/sensor/homematic.py
@@ -48,6 +48,7 @@ HM_UNIT_HA_CAST = {
     'GAS_POWER': 'm3',
     'GAS_ENERGY_COUNTER': 'm3',
     'LUX': 'lx',
+    'ILLUMINATION': 'lx',
     'CURRENT_ILLUMINATION': 'lx',
     'AVERAGE_ILLUMINATION': 'lx',
     'LOWEST_ILLUMINATION': 'lx',

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1016,7 +1016,7 @@ pyhik==0.1.9
 pyhiveapi==0.2.14
 
 # homeassistant.components.homematic
-pyhomematic==0.1.53
+pyhomematic==0.1.54
 
 # homeassistant.components.homeworks
 pyhomeworks==0.0.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -175,7 +175,7 @@ pydeconz==47
 pydispatcher==2.0.5
 
 # homeassistant.components.homematic
-pyhomematic==0.1.53
+pyhomematic==0.1.54
 
 # homeassistant.components.litejet
 pylitejet==0.1


### PR DESCRIPTION
## Description:
In pyhomematic:
- Set SABOTAGE helper for HmIP devices to channel 0
- Fix log-message for callbacks
- Add support for HmIP-FBL, HmIP-SWDM, HmIP-SMI55

In Home Assistant:
- Fix #19619 
- Ensure that the event we are processing is handeled by the correct entity. See this issue for further details: https://github.com/danielperna84/pyhomematic/issues/193
@pvizeli do you see anything wrong with this approach? So far it seems to work.

**Related issue (if applicable):** fixes #19619 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
