### PR TITLE
Homekit controller garage cover support

### DIFF
--- a/homeassistant/components/cover/homekit_controller.py
+++ b/homeassistant/components/cover/homekit_controller.py
@@ -3,7 +3,6 @@
 Support for Homekit Garage Covers.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/cover.homekit_controller/
-https://developer.apple.com/documentation/homekit/hmservicetypegaragedooropener
 """
 import logging
 
@@ -39,7 +38,6 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         accessory = hass.data[KNOWN_ACCESSORIES][discovery_info['serial']]
         add_entities([HomeKitCover(accessory, discovery_info)], True)
 
-
 class HomeKitCover(HomeKitEntity, CoverDevice):
     """Representation of a Homekit cover."""
 
@@ -73,12 +71,6 @@ class HomeKitCover(HomeKitEntity, CoverDevice):
             elif ctype == "name":
                 self._chars['name'] = characteristic['iid']
                 self._name = characteristic['value']
-            elif ctype == "position.hold":
-                _LOGGER.debug(" position.hold %s", characteristic)
-                # position.hold {'iid': 14, 'type': '0000006F-0000-1000-8000-0026BB765***', 'perms': ['pw'], 'format': 'bool'}
-                # https://developer.apple.com/documentation/homekit/hmcharacteristictypeholdposition
-                # self._chars['position.hold'] = characteristic['iid']
-                # self._position_hold = characteristic['value']
 
     @property
     def is_closed(self):

--- a/homeassistant/components/cover/homekit_controller.py
+++ b/homeassistant/components/cover/homekit_controller.py
@@ -6,9 +6,10 @@ https://home-assistant.io/components/cover.homekit_controller/
 """
 import logging
 
-from homeassistant.components.homekit_controller import (HomeKitEntity,
-                                                         KNOWN_ACCESSORIES)
-from homeassistant.components.cover import (CoverDevice, SUPPORT_OPEN, SUPPORT_CLOSE, SUPPORT_STOP)
+from homeassistant.components.homekit_controller import (
+    HomeKitEntity, KNOWN_ACCESSORIES)
+from homeassistant.components.cover import (
+    CoverDevice, SUPPORT_OPEN, SUPPORT_CLOSE, SUPPORT_STOP)
 from homeassistant.const import (
     STATE_UNKNOWN, STATE_CLOSED, STATE_OPEN, STATE_CLOSING, STATE_OPENING)
     

--- a/homeassistant/components/cover/homekit_controller.py
+++ b/homeassistant/components/cover/homekit_controller.py
@@ -119,7 +119,6 @@ class HomeKitCover(HomeKitEntity, CoverDevice):
                                 'value': MODE_HASS_TO_HOMEKIT[STATE_STOPPED]}]
             self.put_characteristics(characteristics)
 
-
     @property
     def name(self):
         """Return the name of the cover."""

--- a/homeassistant/components/cover/homekit_controller.py
+++ b/homeassistant/components/cover/homekit_controller.py
@@ -127,7 +127,7 @@ class HomeKitCover(HomeKitEntity, CoverDevice):
     @property
     def available(self):
         """Return True if entity is available."""
-        return not self._door_state_current in [STATE_UNKNOWN]
+        return self._door_state_current not in [STATE_UNKNOWN]
 
     @property
     def device_state_attributes(self):

--- a/homeassistant/components/cover/homekit_controller.py
+++ b/homeassistant/components/cover/homekit_controller.py
@@ -39,6 +39,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         accessory = hass.data[KNOWN_ACCESSORIES][discovery_info['serial']]
         add_entities([HomeKitCover(accessory, discovery_info)], True)
 
+
 class HomeKitCover(HomeKitEntity, CoverDevice):
     """Representation of a Homekit cover."""
 

--- a/homeassistant/components/cover/homekit_controller.py
+++ b/homeassistant/components/cover/homekit_controller.py
@@ -1,0 +1,159 @@
+
+"""
+Support for Homekit Garage Covers.
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/cover.homekit_controller/
+https://developer.apple.com/documentation/homekit/hmservicetypegaragedooropener
+"""
+import logging
+
+from homeassistant.components.homekit_controller import (HomeKitEntity,
+                                                         KNOWN_ACCESSORIES)
+from homeassistant.components.cover import (CoverDevice, SUPPORT_OPEN, SUPPORT_CLOSE, SUPPORT_STOP)
+from homeassistant.const import (
+    STATE_UNKNOWN, STATE_CLOSED, STATE_OPEN, STATE_CLOSING, STATE_OPENING)
+    
+DEPENDENCIES = ['homekit_controller']
+
+_LOGGER = logging.getLogger(__name__)
+
+ATTR_DOOR_STATE = 'door_state'
+
+STATE_STOPPED = 'stopped'
+
+# Map of Homekit operation modes to hass modes
+MODE_HOMEKIT_TO_HASS = {
+    0: STATE_OPEN,
+    1: STATE_CLOSED,
+    2: STATE_OPENING,
+    3: STATE_CLOSING,
+    4: STATE_STOPPED,
+}
+
+# Map of hass operation modes to homekit modes
+MODE_HASS_TO_HOMEKIT = {v: k for k, v in MODE_HOMEKIT_TO_HASS.items()}
+
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    """Set up Homekit switch support."""
+    if discovery_info is not None:
+        accessory = hass.data[KNOWN_ACCESSORIES][discovery_info['serial']]
+        add_entities([HomeKitCover(accessory, discovery_info)], True)
+
+
+class HomeKitCover(HomeKitEntity, CoverDevice):
+    """Representation of a Homekit cover."""
+
+    def __init__(self, *args):
+        """Initialise the cover."""
+        super().__init__(*args)
+
+        self._door_state_current = None
+        self._door_state_target = None
+        self._obstruction_detected = None
+        self._name = None
+        self._position_hold = None
+
+    def update_characteristics(self, characteristics):
+        """Synchronise the cover state with Home Assistant."""
+        import homekit  # pylint: disable=import-error
+
+        for characteristic in characteristics:
+            ctype = characteristic['type']
+            ctype = homekit.CharacteristicsTypes.get_short(ctype)
+
+            if ctype == "door-state.current":
+                self._chars['door-state.current'] = characteristic['iid']
+                self._door_state_current = MODE_HOMEKIT_TO_HASS.get(characteristic['value'])
+            elif ctype == "door-state.target":
+                self._chars['door-state.target'] = characteristic['iid']
+                self._door_state_target = MODE_HOMEKIT_TO_HASS.get(characteristic['value'])
+            elif ctype == "obstruction-detected":
+                self._chars['obstruction-detected'] = characteristic['iid']
+                self._obstruction_detected = characteristic['value']
+            elif ctype == "name":
+                self._chars['name'] = characteristic['iid']
+                self._name = characteristic['value']
+            elif ctype == "position.hold":
+                _LOGGER.debug(" position.hold %s", characteristic)
+                # position.hold {'iid': 14, 'type': '0000006F-0000-1000-8000-0026BB765***', 'perms': ['pw'], 'format': 'bool'}
+                # https://developer.apple.com/documentation/homekit/hmcharacteristictypeholdposition
+                # self._chars['position.hold'] = characteristic['iid']
+                # self._position_hold = characteristic['value']
+
+    @property
+    def is_closed(self):
+        """Return if the cover is closed."""
+        if self._door_state_current in [STATE_UNKNOWN]:
+            return None
+        return self._door_state_current in [STATE_CLOSED]
+    
+    @property
+    def is_opening(self):
+        """Return if the cover is opening or not."""
+        return self._door_state_current in [STATE_OPENING]
+
+    @property
+    def is_closing(self):
+        """Return if the cover is closing or not."""
+        return self._door_state_current in [STATE_CLOSING]
+
+    def close_cover(self, **kwargs):
+        """Close the cover."""
+        if self._door_state_current not in [STATE_CLOSED, STATE_CLOSING]:
+            self._door_state_target = STATE_CLOSED
+            self._door_state_current = STATE_CLOSING
+            characteristics = [{'aid': self._aid,
+                                'iid': self._chars['door-state.target'],
+                                'value': MODE_HASS_TO_HOMEKIT[STATE_CLOSED]}]
+            self.put_characteristics(characteristics)
+
+    def open_cover(self, **kwargs):
+        """Open the cover."""
+        if self._door_state_current not in [STATE_OPEN, STATE_OPENING]:
+            self._door_state_target = STATE_OPEN
+            self._door_state_current = STATE_OPENING
+            characteristics = [{'aid': self._aid,
+                                'iid': self._chars['door-state.target'],
+                                'value': MODE_HASS_TO_HOMEKIT[STATE_OPEN]}]
+            self.put_characteristics(characteristics)
+
+    def stop_cover(self, **kwargs):
+        """Stop the cover."""
+        if self._door_state_current not in [STATE_STOPPED, STATE_OPEN, STATE_CLOSED]:
+            self._door_state_target = STATE_STOPPED
+            self._door_state_current = STATE_STOPPED
+            characteristics = [{'aid': self._aid,
+                                'iid': self._chars['door-state.target'],
+                                'value': MODE_HASS_TO_HOMEKIT[STATE_STOPPED]}]
+            self.put_characteristics(characteristics)
+
+
+    @property
+    def name(self):
+        """Return the name of the cover."""
+        return self._name
+
+    @property
+    def available(self):
+        """Return True if entity is available."""
+        return not self._door_state_current in [STATE_UNKNOWN]
+
+    @property
+    def device_state_attributes(self):
+        """Return the device state attributes."""
+        data = {}
+
+        if self._door_state_current is not None:
+            data[ATTR_DOOR_STATE] = self._door_state_current
+
+        return data
+
+    @property
+    def device_class(self):
+        """Return the class of this device, from component DEVICE_CLASSES."""
+        return 'garage'
+
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+        return SUPPORT_OPEN | SUPPORT_CLOSE | SUPPORT_STOP

--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -24,6 +24,7 @@ HOMEKIT_ACCESSORY_DISPATCH = {
     'outlet': 'switch',
     'switch': 'switch',
     'thermostat': 'climate',
+    'garage-door-opener': 'cover',
 }
 
 HOMEKIT_IGNORE = [


### PR DESCRIPTION
## Description:

https://community.home-assistant.io/t/control-homekit-enabled-garage-door-from-homeassistant/87722
https://community.home-assistant.io/t/add-garage-door-opener-device-type-support-to-homekit-controller/87723

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
not applicable
```

## Checklist:
  - [x] The code change is tested and works locally. > tested with Nice Control SPA SpeedGate
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass** > sorry newbie here, don't know how to run the tests yet :)
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
