### PR TITLE
Change event_type column size to 64 characters

### DIFF
--- a/homeassistant/components/recorder/models.py
+++ b/homeassistant/components/recorder/models.py
@@ -27,7 +27,7 @@ class Events(Base):  # type: ignore
 
     __tablename__ = 'events'
     event_id = Column(Integer, primary_key=True)
-    event_type = Column(String(32), index=True)
+    event_type = Column(String(64), index=True)
     event_data = Column(Text)
     origin = Column(String(32))
     time_fired = Column(DateTime(timezone=True), index=True)


### PR DESCRIPTION
## Description:
As both issues above describes. 
Recorder may throw an exception when using MySQL database since `event_type` column is set to 32 char while core may write more.

Too small issue for migration.

**Related issue:** fixes #16074 #15984

## Checklist:
  - [V] The code change is tested and works locally.
  - [V] Local tests pass with `tox`. 
  - [V] There is no commented out code in this PR.

## Manual fix for existing configurations:
Connect to db
```
mysql -u <user> -p
```
Select the db
```
use <db_name>;
```
Change the event_type column in events table to 64 chars long or more
```
ALTER TABLE events MODIFY event_type VARCHAR(64);
```
