### PR TITLE
Use intended display unit for thermostat

### DIFF
--- a/homeassistant/components/homekit/type_thermostats.py
+++ b/homeassistant/components/homekit/type_thermostats.py
@@ -89,7 +89,7 @@ class Thermostat(HomeAccessory):
 
         # Display units characteristic
         self.char_display_units = serv_thermostat.configure_char(
-            CHAR_TEMP_DISPLAY_UNITS, value=0)
+            CHAR_TEMP_DISPLAY_UNITS, value=UNIT_HASS_TO_HOMEKIT[self._unit])
 
         # If the device supports it: high and low temperature characteristics
         self.char_cooling_thresh_temp = None


### PR DESCRIPTION
## Description:
Use intended display unit for thermostat so that it follows the hass global setting.

Looks like the display unit of homekit thermostat is hard coded to be Celsius. This PR makes it follow homeassistant config setting.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.