### PR TITLE
Add exception handling to ADS shutdown

### DIFF
--- a/homeassistant/components/ads/__init__.py
+++ b/homeassistant/components/ads/__init__.py
@@ -125,16 +125,24 @@ class AdsHub:
 
     def shutdown(self, *args, **kwargs):
         """Shutdown ADS connection."""
+        import pyads
         _LOGGER.debug("Shutting down ADS")
         for notification_item in self._notification_items.values():
-            self._client.del_device_notification(
-                notification_item.hnotify,
-                notification_item.huser
-            )
             _LOGGER.debug(
                 "Deleting device notification %d, %d",
                 notification_item.hnotify, notification_item.huser)
-        self._client.close()
+            try:
+                self._client.del_device_notification(
+                    notification_item.hnotify,
+                    notification_item.huser
+                )
+            except pyads.ADSError as err:
+                _LOGGER.error(err)
+        try:
+            self._client.close()
+        except pyads.ADSError as err:
+            _LOGGER.error(err)
+                
 
     def register_device(self, device):
         """Register a new device."""

--- a/homeassistant/components/ads/__init__.py
+++ b/homeassistant/components/ads/__init__.py
@@ -142,7 +142,7 @@ class AdsHub:
             self._client.close()
         except pyads.ADSError as err:
             _LOGGER.error(err)
-                
+
 
     def register_device(self, device):
         """Register a new device."""

--- a/homeassistant/components/ads/__init__.py
+++ b/homeassistant/components/ads/__init__.py
@@ -143,7 +143,6 @@ class AdsHub:
         except pyads.ADSError as err:
             _LOGGER.error(err)
 
-
     def register_device(self, device):
         """Register a new device."""
         self._devices.append(device)


### PR DESCRIPTION
## Description:
Fixes unhandled exception in shutdown of AdsHub

**Related issue (if applicable):** fixes #18671

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.



[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
