### PR TITLE
Adds ability to calibrate temperature for BME680

### DIFF
--- a/homeassistant/components/sensor/bme680.py
+++ b/homeassistant/components/sensor/bme680.py
@@ -51,7 +51,7 @@ DEFAULT_GAS_HEATER_DURATION = 150  # Heater duration in ms 1 - 4032
 DEFAULT_AQ_BURN_IN_TIME = 300  # 300 second burn in time for AQ gas measurement
 DEFAULT_AQ_HUM_BASELINE = 40  # 40%, an optimal indoor humidity.
 DEFAULT_AQ_HUM_WEIGHTING = 25  # 25% Weighting of humidity to gas in AQ score
-DEFAULT_TEMP_OFFSET = 0 # No calibration out of the box.
+DEFAULT_TEMP_OFFSET = 0  # No calibration out of the box.
 
 SENSOR_TEMP = 'temperature'
 SENSOR_HUMID = 'humidity'

--- a/homeassistant/components/sensor/bme680.py
+++ b/homeassistant/components/sensor/bme680.py
@@ -20,7 +20,7 @@ from homeassistant.const import (
 from homeassistant.helpers.entity import Entity
 from homeassistant.util.temperature import celsius_to_fahrenheit
 
-REQUIREMENTS = ['bme680==1.0.4',
+REQUIREMENTS = ['bme680==1.0.5',
                 'smbus-cffi==0.5.1']
 
 _LOGGER = logging.getLogger(__name__)
@@ -36,6 +36,7 @@ CONF_GAS_HEATER_DURATION = 'gas_heater_duration'
 CONF_AQ_BURN_IN_TIME = 'aq_burn_in_time'
 CONF_AQ_HUM_BASELINE = 'aq_humidity_baseline'
 CONF_AQ_HUM_WEIGHTING = 'aq_humidity_bias'
+CONF_TEMP_OFFSET = 'temp_offset'
 
 
 DEFAULT_NAME = 'BME680 Sensor'
@@ -50,6 +51,7 @@ DEFAULT_GAS_HEATER_DURATION = 150  # Heater duration in ms 1 - 4032
 DEFAULT_AQ_BURN_IN_TIME = 300  # 300 second burn in time for AQ gas measurement
 DEFAULT_AQ_HUM_BASELINE = 40  # 40%, an optimal indoor humidity.
 DEFAULT_AQ_HUM_WEIGHTING = 25  # 25% Weighting of humidity to gas in AQ score
+DEFAULT_TEMP_OFFSET = 0 # No calibration out of the box.
 
 SENSOR_TEMP = 'temperature'
 SENSOR_HUMID = 'humidity'
@@ -93,6 +95,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
         vol.All(vol.Coerce(int), vol.Range(1, 100)),
     vol.Optional(CONF_AQ_HUM_WEIGHTING, default=DEFAULT_AQ_HUM_WEIGHTING):
         vol.All(vol.Coerce(int), vol.Range(1, 100)),
+    vol.Optional(CONF_TEMP_OFFSET, default=DEFAULT_TEMP_OFFSET):
+        vol.All(vol.Coerce(float), vol.Range(-100.0, 100.0)),
 })
 
 
@@ -139,6 +143,9 @@ def _setup_bme680(config):
         }
         sensor.set_temperature_oversample(
             os_lookup[config.get(CONF_OVERSAMPLING_TEMP)]
+        )
+        sensor.set_temp_offset(
+            os_lookup[config.get(CONF_TEMP_OFFSET)]
         )
         sensor.set_humidity_oversample(
             os_lookup[config.get(CONF_OVERSAMPLING_HUM)]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -211,7 +211,7 @@ blockchain==1.4.4
 # bluepy==1.1.4
 
 # homeassistant.components.sensor.bme680
-# bme680==1.0.4
+# bme680==1.0.5
 
 # homeassistant.components.route53
 # homeassistant.components.notify.aws_lambda


### PR DESCRIPTION
## Description:
Out of the box the BME680 runs too hot.   This change version bumps the bme680 package to allow for a temperature offset.

Further reading:

> Looking at a reference thermometer, we can see that our temperature is indeed a few degrees to high. Does that mean the temperature sensor inside the BME680 is inaccurate?
> Actually no, it very accurately measures the temperature exactly where it is located on the board. But there also is the issue: our board as most devices contains some heat sources (e.g., MCU, WiFi chip, display, …). This means the temperature on our board is actually higher than the ambient temperature. Since the absolute amount of water in the air is approximately constant, this also causes the relative humidity to be lower on our board than elsewhere in the room.
> As BSEC cannot know in which kind of device the sensor is integrated, we have provide some information to the algorithm to enable it to compensate this offset. In the simplest case, we have to deal with an embedded device with a constant workload and approximately constant self-heating. In such a case, we can simply supply a temperature offset to BSEC which will be subtracted from the temperature and will be used to correct the humidity reading as well.

from the Integration Guide - Bosch Software Environmental Cluster (BSEC)

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** https://github.com/home-assistant/home-assistant.io/pull/8004

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: bme680
    temp_offset: -5
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
