### PR TITLE
WIP - Update device registry of MQTT cover

### DIFF
--- a/homeassistant/components/cover/mqtt.py
+++ b/homeassistant/components/cover/mqtt.py
@@ -137,6 +137,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     async def async_discover(discovery_payload):
         """Discover and add an MQTT cover."""
         config = PLATFORM_SCHEMA(discovery_payload)
+        config['config_entry'] = config_entry
         await _async_setup_entity(config, async_add_entities,
                                   discovery_payload[ATTR_DISCOVERY_HASH])
 
@@ -173,12 +174,13 @@ class MqttCover(MqttAvailability, MqttDiscoveryUpdate, MqttEntityDeviceInfo,
         payload_not_available = config.get(CONF_PAYLOAD_NOT_AVAILABLE)
         qos = config.get(CONF_QOS)
         device_config = config.get(CONF_DEVICE)
+        config_entry = config.get('config_entry')
 
         MqttAvailability.__init__(self, availability_topic, qos,
                                   payload_available, payload_not_available)
         MqttDiscoveryUpdate.__init__(self, discovery_hash,
                                      self.discovery_update)
-        MqttEntityDeviceInfo.__init__(self, device_config)
+        MqttEntityDeviceInfo.__init__(self, device_config, config_entry)
 
     async def async_added_to_hass(self):
         """Subscribe MQTT events."""
@@ -190,6 +192,7 @@ class MqttCover(MqttAvailability, MqttDiscoveryUpdate, MqttEntityDeviceInfo,
         config = PLATFORM_SCHEMA(discovery_payload)
         self._setup_from_config(config)
         await self.availability_discovery_update(config)
+        await self.device_info_discovery_update(config)
         await self._subscribe_topics()
         self.async_schedule_update_ha_state()
 

--- a/homeassistant/components/cover/mqtt.py
+++ b/homeassistant/components/cover/mqtt.py
@@ -137,8 +137,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     async def async_discover(discovery_payload):
         """Discover and add an MQTT cover."""
         config = PLATFORM_SCHEMA(discovery_payload)
-        config['config_entry'] = config_entry
-        await _async_setup_entity(config, async_add_entities,
+        await _async_setup_entity(config, async_add_entities, config_entry,
                                   discovery_payload[ATTR_DISCOVERY_HASH])
 
     async_dispatcher_connect(
@@ -146,16 +145,17 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         async_discover)
 
 
-async def _async_setup_entity(config, async_add_entities, discovery_hash=None):
+async def _async_setup_entity(config, async_add_entities, config_entry=None,
+                              discovery_hash=None):
     """Set up the MQTT Cover."""
-    async_add_entities([MqttCover(config, discovery_hash)])
+    async_add_entities([MqttCover(config, config_entry, discovery_hash)])
 
 
 class MqttCover(MqttAvailability, MqttDiscoveryUpdate, MqttEntityDeviceInfo,
                 CoverDevice):
     """Representation of a cover that can be controlled using MQTT."""
 
-    def __init__(self, config, discovery_hash):
+    def __init__(self, config, config_entry, discovery_hash):
         """Initialize the cover."""
         self._unique_id = config.get(CONF_UNIQUE_ID)
         self._position = None
@@ -174,7 +174,6 @@ class MqttCover(MqttAvailability, MqttDiscoveryUpdate, MqttEntityDeviceInfo,
         payload_not_available = config.get(CONF_PAYLOAD_NOT_AVAILABLE)
         qos = config.get(CONF_QOS)
         device_config = config.get(CONF_DEVICE)
-        config_entry = config.get('config_entry')
 
         MqttAvailability.__init__(self, availability_topic, qos,
                                   payload_available, payload_not_available)

--- a/homeassistant/components/switch/mqtt.py
+++ b/homeassistant/components/switch/mqtt.py
@@ -62,6 +62,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     async def async_discover(discovery_payload):
         """Discover and add a MQTT switch."""
         config = PLATFORM_SCHEMA(discovery_payload)
+        config['config_entry'] = config_entry
         await _async_setup_entity(config, async_add_entities,
                                   discovery_payload[ATTR_DISCOVERY_HASH])
 
@@ -99,12 +100,13 @@ class MqttSwitch(MqttAvailability, MqttDiscoveryUpdate, MqttEntityDeviceInfo,
         payload_not_available = config.get(CONF_PAYLOAD_NOT_AVAILABLE)
         qos = config.get(CONF_QOS)
         device_config = config.get(CONF_DEVICE)
+        config_entry = config.get('config_entry')
 
         MqttAvailability.__init__(self, availability_topic, qos,
                                   payload_available, payload_not_available)
         MqttDiscoveryUpdate.__init__(self, discovery_hash,
                                      self.discovery_update)
-        MqttEntityDeviceInfo.__init__(self, device_config)
+        MqttEntityDeviceInfo.__init__(self, device_config, config_entry)
 
     async def async_added_to_hass(self):
         """Subscribe to MQTT events."""
@@ -116,6 +118,7 @@ class MqttSwitch(MqttAvailability, MqttDiscoveryUpdate, MqttEntityDeviceInfo,
         config = PLATFORM_SCHEMA(discovery_payload)
         self._setup_from_config(config)
         await self.availability_discovery_update(config)
+        await self.device_info_discovery_update(config)
         await self._subscribe_topics()
         self.async_schedule_update_ha_state()
 

--- a/tests/components/cover/test_mqtt.py
+++ b/tests/components/cover/test_mqtt.py
@@ -1160,6 +1160,53 @@ async def test_entity_device_info_with_identifier(hass, mqtt_mock):
     assert device.sw_version == '0.1-beta'
 
 
+async def test_entity_device_info_update(hass, mqtt_mock):
+    """Test device registry update."""
+    entry = MockConfigEntry(domain=mqtt.DOMAIN)
+    entry.add_to_hass(hass)
+    await async_start(hass, 'homeassistant', {}, entry)
+    registry = await hass.helpers.device_registry.async_get_registry()
+
+    config = {
+        'platform': 'mqtt',
+        'name': 'Test 1',
+        'state_topic': 'test-topic',
+        'command_topic': 'test-command-topic',
+        'device': {
+            'identifiers': ['helloworld'],
+            'connections': [
+                ["mac", "02:5b:26:a8:dc:12"],
+            ],
+            'manufacturer': 'Whatever',
+            'name': 'Beer',
+            'model': 'Glass',
+            'sw_version': '0.1-beta',
+        },
+        'unique_id': 'veryunique'
+    }
+
+    data = json.dumps(config)
+    async_fire_mqtt_message(hass, 'homeassistant/cover/bla/config',
+                            data)
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+
+    device = registry.async_get_device({('mqtt', 'helloworld')}, set())
+    assert device is not None
+    assert device.name == 'Beer'
+
+    config['device']['name'] = 'Milk'
+    data = json.dumps(config)
+    async_fire_mqtt_message(hass, 'homeassistant/cover/bla/config',
+                            data)
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+
+    device = registry.async_get_device({('mqtt', 'helloworld')}, set())
+    assert device is not None
+    assert device.name == 'Milk'
+
+
 async def test_entity_id_update(hass, mqtt_mock):
     """Test MQTT subscriptions are managed when entity_id is updated."""
     registry = mock_registry(hass, {})

--- a/tests/components/cover/test_mqtt.py
+++ b/tests/components/cover/test_mqtt.py
@@ -758,6 +758,7 @@ class TestCoverMQTT(unittest.TestCase):
                 'set_position_topic': None, 'set_position_template': None,
                 'unique_id': None, 'device_config': None,
             },
+            None,
             None)
 
         assert 44 == mqtt_cover.find_percentage_in_range(44)
@@ -788,6 +789,7 @@ class TestCoverMQTT(unittest.TestCase):
                 'set_position_topic': None, 'set_position_template': None,
                 'unique_id': None, 'device_config': None,
             },
+            None,
             None)
 
         assert 40 == mqtt_cover.find_percentage_in_range(120)
@@ -818,6 +820,7 @@ class TestCoverMQTT(unittest.TestCase):
                 'set_position_topic': None, 'set_position_template': None,
                 'unique_id': None, 'device_config': None,
             },
+            None,
             None)
 
         assert 56 == mqtt_cover.find_percentage_in_range(44)
@@ -848,6 +851,7 @@ class TestCoverMQTT(unittest.TestCase):
                 'set_position_topic': None, 'set_position_template': None,
                 'unique_id': None, 'device_config': None,
             },
+            None,
             None)
 
         assert 60 == mqtt_cover.find_percentage_in_range(120)
@@ -878,6 +882,7 @@ class TestCoverMQTT(unittest.TestCase):
                 'set_position_topic': None, 'set_position_template': None,
                 'unique_id': None, 'device_config': None,
             },
+            None,
             None)
 
         assert 44 == mqtt_cover.find_in_range_from_percent(44)
@@ -908,6 +913,7 @@ class TestCoverMQTT(unittest.TestCase):
                 'set_position_topic': None, 'set_position_template': None,
                 'unique_id': None, 'device_config': None,
             },
+            None,
             None)
 
         assert 120 == mqtt_cover.find_in_range_from_percent(40)
@@ -938,6 +944,7 @@ class TestCoverMQTT(unittest.TestCase):
                 'set_position_topic': None, 'set_position_template': None,
                 'unique_id': None, 'device_config': None,
             },
+            None,
             None)
 
         assert 44 == mqtt_cover.find_in_range_from_percent(56)
@@ -968,6 +975,7 @@ class TestCoverMQTT(unittest.TestCase):
                 'set_position_topic': None, 'set_position_template': None,
                 'unique_id': None, 'device_config': None,
             },
+            None,
             None)
 
         assert 120 == mqtt_cover.find_in_range_from_percent(60)

--- a/tests/components/switch/test_mqtt.py
+++ b/tests/components/switch/test_mqtt.py
@@ -399,7 +399,7 @@ async def test_discovery_update_switch(hass, mqtt_mock, caplog):
 
 
 async def test_entity_device_info_with_identifier(hass, mqtt_mock):
-    """Test MQTT switch device registry integration."""
+    """Test device registry integration."""
     entry = MockConfigEntry(domain=mqtt.DOMAIN)
     entry.add_to_hass(hass)
     await async_start(hass, 'homeassistant', {}, entry)
@@ -435,6 +435,53 @@ async def test_entity_device_info_with_identifier(hass, mqtt_mock):
     assert device.name == 'Beer'
     assert device.model == 'Glass'
     assert device.sw_version == '0.1-beta'
+
+
+async def test_entity_device_info_update(hass, mqtt_mock):
+    """Test device registry update."""
+    entry = MockConfigEntry(domain=mqtt.DOMAIN)
+    entry.add_to_hass(hass)
+    await async_start(hass, 'homeassistant', {}, entry)
+    registry = await hass.helpers.device_registry.async_get_registry()
+
+    config = {
+        'platform': 'mqtt',
+        'name': 'Test 1',
+        'state_topic': 'test-topic',
+        'command_topic': 'test-command-topic',
+        'device': {
+            'identifiers': ['helloworld'],
+            'connections': [
+                ["mac", "02:5b:26:a8:dc:12"],
+            ],
+            'manufacturer': 'Whatever',
+            'name': 'Beer',
+            'model': 'Glass',
+            'sw_version': '0.1-beta',
+        },
+        'unique_id': 'veryunique'
+    }
+
+    data = json.dumps(config)
+    async_fire_mqtt_message(hass, 'homeassistant/switch/bla/config',
+                            data)
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+
+    device = registry.async_get_device({('mqtt', 'helloworld')}, set())
+    assert device is not None
+    assert device.name == 'Beer'
+
+    config['device']['name'] = 'Milk'
+    data = json.dumps(config)
+    async_fire_mqtt_message(hass, 'homeassistant/switch/bla/config',
+                            data)
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+
+    device = registry.async_get_device({('mqtt', 'helloworld')}, set())
+    assert device is not None
+    assert device.name == 'Milk'
 
 
 async def test_entity_id_update(hass, mqtt_mock):


### PR DESCRIPTION
## Description:
Support update of device registry so Hass doesn't need to be restarted to, for example, show updated firmware version of the device.
(Same as #19540)

WIP: Based on #19540, will be rebased once that is merged.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.