### PR TITLE
Support for multiple Fibaro gateways

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -124,7 +124,7 @@ omit =
     homeassistant/components/eufy.py
     homeassistant/components/*/eufy.py
 
-    homeassistant/components/fibaro.py
+    homeassistant/components/fibaro/__init__.py
     homeassistant/components/*/fibaro.py
 
     homeassistant/components/gc100.py

--- a/homeassistant/components/binary_sensor/fibaro.py
+++ b/homeassistant/components/binary_sensor/fibaro.py
@@ -9,7 +9,7 @@ import logging
 from homeassistant.components.binary_sensor import (
     BinarySensorDevice, ENTITY_ID_FORMAT)
 from homeassistant.components.fibaro import (
-    FIBARO_CONTROLLER, FIBARO_DEVICES, FibaroDevice)
+    FIBARO_DEVICES, FibaroDevice)
 from homeassistant.const import (CONF_DEVICE_CLASS, CONF_ICON)
 
 DEPENDENCIES = ['fibaro']
@@ -33,17 +33,17 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         return
 
     add_entities(
-        [FibaroBinarySensor(device, hass.data[FIBARO_CONTROLLER])
+        [FibaroBinarySensor(device)
          for device in hass.data[FIBARO_DEVICES]['binary_sensor']], True)
 
 
 class FibaroBinarySensor(FibaroDevice, BinarySensorDevice):
     """Representation of a Fibaro Binary Sensor."""
 
-    def __init__(self, fibaro_device, controller):
+    def __init__(self, fibaro_device):
         """Initialize the binary_sensor."""
         self._state = None
-        super().__init__(fibaro_device, controller)
+        super().__init__(fibaro_device)
         self.entity_id = ENTITY_ID_FORMAT.format(self.ha_id)
         stype = None
         devconf = fibaro_device.device_config

--- a/homeassistant/components/cover/fibaro.py
+++ b/homeassistant/components/cover/fibaro.py
@@ -9,7 +9,7 @@ import logging
 from homeassistant.components.cover import (
     CoverDevice, ENTITY_ID_FORMAT, ATTR_POSITION, ATTR_TILT_POSITION)
 from homeassistant.components.fibaro import (
-    FIBARO_CONTROLLER, FIBARO_DEVICES, FibaroDevice)
+    FIBARO_DEVICES, FibaroDevice)
 
 DEPENDENCIES = ['fibaro']
 
@@ -22,16 +22,16 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         return
 
     add_entities(
-        [FibaroCover(device, hass.data[FIBARO_CONTROLLER]) for
+        [FibaroCover(device) for
          device in hass.data[FIBARO_DEVICES]['cover']], True)
 
 
 class FibaroCover(FibaroDevice, CoverDevice):
     """Representation a Fibaro Cover."""
 
-    def __init__(self, fibaro_device, controller):
+    def __init__(self, fibaro_device):
         """Initialize the Vera device."""
-        super().__init__(fibaro_device, controller)
+        super().__init__(fibaro_device)
         self.entity_id = ENTITY_ID_FORMAT.format(self.ha_id)
 
     @staticmethod

--- a/homeassistant/components/fibaro/__init__.py
+++ b/homeassistant/components/fibaro/__init__.py
@@ -67,20 +67,18 @@ DEVICE_CONFIG_SCHEMA_ENTRY = vol.Schema({
 FIBARO_ID_LIST_SCHEMA = vol.Schema([cv.string])
 
 GATEWAY_CONFIG = vol.Schema({
-    DOMAIN: vol.Schema({
-        vol.Required(CONF_PASSWORD): cv.string,
-        vol.Required(CONF_USERNAME): cv.string,
-        vol.Required(CONF_URL): cv.url,
-        vol.Optional(CONF_PLUGINS, default=False): cv.boolean,
-        vol.Optional(CONF_EXCLUDE, default=[]): FIBARO_ID_LIST_SCHEMA,
-        vol.Optional(CONF_DEVICE_CONFIG, default={}):
-            vol.Schema({cv.string: DEVICE_CONFIG_SCHEMA_ENTRY})
-    })
+    vol.Required(CONF_PASSWORD): cv.string,
+    vol.Required(CONF_USERNAME): cv.string,
+    vol.Required(CONF_URL): cv.url,
+    vol.Optional(CONF_PLUGINS, default=False): cv.boolean,
+    vol.Optional(CONF_EXCLUDE, default=[]): FIBARO_ID_LIST_SCHEMA,
+    vol.Optional(CONF_DEVICE_CONFIG, default={}):
+        vol.Schema({cv.string: DEVICE_CONFIG_SCHEMA_ENTRY})
 }, extra=vol.ALLOW_EXTRA)
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
-        vol.Optional(CONF_GATEWAYS, default={}):
+        vol.Optional(CONF_GATEWAYS, default=[{}]):
             vol.All(cv.ensure_list, [GATEWAY_CONFIG])
     })
 }, extra=vol.ALLOW_EXTRA)
@@ -255,10 +253,10 @@ class FibaroController():
                         self.hub_serial, device.id)
                     self._device_map[device.id] = device
                     self.fibaro_devices[device.mapped_type].append(device)
-                else:
-                    _LOGGER.debug("%s (%s, %s) not used",
-                                  device.ha_id, device.type,
-                                  device.baseType)
+                _LOGGER.debug("%s (%s, %s) -> %s. Prop: %s Actions: %s",
+                              device.ha_id, device.type,
+                              device.baseType, device.mapped_type,
+                              str(device.properties), str(device.actions))
             except (KeyError, ValueError):
                 pass
 

--- a/homeassistant/components/fibaro/__init__.py
+++ b/homeassistant/components/fibaro/__init__.py
@@ -270,7 +270,6 @@ def setup(hass, base_config):
         _LOGGER.info("Shutting down Fibaro connection")
         for controller in hass.data[FIBARO_CONTROLLERS].values():
             controller.disable_state_handler()
-        hass.data[FIBARO_CONTROLLERS] = {}
 
     hass.data[FIBARO_DEVICES] = {}
     for component in FIBARO_COMPONENTS:

--- a/homeassistant/components/fibaro/__init__.py
+++ b/homeassistant/components/fibaro/__init__.py
@@ -262,8 +262,7 @@ class FibaroController():
 
 def setup(hass, base_config):
     """Set up the Fibaro Component."""
-    config = base_config.get(DOMAIN)
-    gateways = config.get(CONF_GATEWAYS)
+    gateways = base_config[DOMAIN][CONF_GATEWAYS]
     hass.data[FIBARO_CONTROLLERS] = {}
 
     def stop_fibaro(event):

--- a/homeassistant/components/fibaro/__init__.py
+++ b/homeassistant/components/fibaro/__init__.py
@@ -287,7 +287,7 @@ def setup(hass, base_config):
     if hass.data[FIBARO_CONTROLLERS]:
         for component in FIBARO_COMPONENTS:
             discovery.load_platform(hass, component, DOMAIN, {},
-                                    base_config[DOMAIN])
+                                    base_config)
         for controller in hass.data[FIBARO_CONTROLLERS].values():
             controller.enable_state_handler()
         hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, stop_fibaro)

--- a/homeassistant/components/fibaro/__init__.py
+++ b/homeassistant/components/fibaro/__init__.py
@@ -286,7 +286,8 @@ def setup(hass, base_config):
 
     if hass.data[FIBARO_CONTROLLERS]:
         for component in FIBARO_COMPONENTS:
-            discovery.load_platform(hass, component, DOMAIN, {}, base_config[DOMAIN])
+            discovery.load_platform(hass, component, DOMAIN, {},
+                                    base_config[DOMAIN])
         for controller in hass.data[FIBARO_CONTROLLERS].values():
             controller.enable_state_handler()
         hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, stop_fibaro)

--- a/homeassistant/components/fibaro/__init__.py
+++ b/homeassistant/components/fibaro/__init__.py
@@ -78,7 +78,7 @@ GATEWAY_CONFIG = vol.Schema({
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
-        vol.Optional(CONF_GATEWAYS, default=[{}]):
+        vol.Required(CONF_GATEWAYS):
             vol.All(cv.ensure_list, [GATEWAY_CONFIG])
     })
 }, extra=vol.ALLOW_EXTRA)
@@ -91,19 +91,19 @@ class FibaroController():
         """Initialize the Fibaro controller."""
         from fiblary3.client.v4.client import Client as FibaroClient
 
-        self._client = FibaroClient(config.get(CONF_URL),
-                                    config.get(CONF_USERNAME),
-                                    config.get(CONF_PASSWORD))
+        self._client = FibaroClient(config[CONF_URL],
+                                    config[CONF_USERNAME],
+                                    config[CONF_PASSWORD])
         self._scene_map = None
         # Whether to import devices from plugins
-        self._import_plugins = config.get(CONF_PLUGINS, False)
-        self._device_config = config.get(CONF_DEVICE_CONFIG, {})
+        self._import_plugins = config[CONF_PLUGINS]
+        self._device_config = config[CONF_DEVICE_CONFIG]
         self._room_map = None         # Mapping roomId to room object
         self._device_map = None       # Mapping deviceId to device object
         self.fibaro_devices = None    # List of devices by type
         self._callbacks = {}          # Update value callbacks by deviceId
         self._state_handler = None    # Fiblary's StateHandler object
-        self._excluded_devices = config.get(CONF_EXCLUDE, [])
+        self._excluded_devices = config[CONF_EXCLUDE]
         self.hub_serial = None          # Unique serial number of the hub
 
     def connect(self):
@@ -176,12 +176,11 @@ class FibaroController():
     def _map_device_to_type(device):
         """Map device to HA device type."""
         # Use our lookup table to identify device type
+        device_type = None
         if 'type' in device:
             device_type = FIBARO_TYPEMAP.get(device.type)
-        elif 'baseType' in device:
+        if device_type is None and 'baseType' in device:
             device_type = FIBARO_TYPEMAP.get(device.baseType)
-        else:
-            device_type = None
 
         # We can also identify device type by its capabilities
         if device_type is None:

--- a/homeassistant/components/fibaro/__init__.py
+++ b/homeassistant/components/fibaro/__init__.py
@@ -286,7 +286,7 @@ def setup(hass, base_config):
 
     if hass.data[FIBARO_CONTROLLERS]:
         for component in FIBARO_COMPONENTS:
-            discovery.load_platform(hass, component, DOMAIN, {}, config)
+            discovery.load_platform(hass, component, DOMAIN, {}, base_config[DOMAIN])
         for controller in hass.data[FIBARO_CONTROLLERS].values():
             controller.enable_state_handler()
         hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, stop_fibaro)

--- a/homeassistant/components/light/fibaro.py
+++ b/homeassistant/components/light/fibaro.py
@@ -12,7 +12,7 @@ from functools import partial
 from homeassistant.const import (
     CONF_WHITE_VALUE)
 from homeassistant.components.fibaro import (
-    FIBARO_CONTROLLER, FIBARO_DEVICES, FibaroDevice,
+    FIBARO_DEVICES, FibaroDevice,
     CONF_DIMMING, CONF_COLOR, CONF_RESET_COLOR)
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS, ATTR_HS_COLOR, ATTR_WHITE_VALUE, ENTITY_ID_FORMAT,
@@ -50,14 +50,14 @@ async def async_setup_platform(hass,
         return
 
     async_add_entities(
-        [FibaroLight(device, hass.data[FIBARO_CONTROLLER])
+        [FibaroLight(device)
          for device in hass.data[FIBARO_DEVICES]['light']], True)
 
 
 class FibaroLight(FibaroDevice, Light):
     """Representation of a Fibaro Light, including dimmable."""
 
-    def __init__(self, fibaro_device, controller):
+    def __init__(self, fibaro_device):
         """Initialize the light."""
         self._brightness = None
         self._color = (0, 0)
@@ -81,7 +81,7 @@ class FibaroLight(FibaroDevice, Light):
         if devconf.get(CONF_WHITE_VALUE, supports_white_v):
             self._supported_flags |= SUPPORT_WHITE_VALUE
 
-        super().__init__(fibaro_device, controller)
+        super().__init__(fibaro_device)
         self.entity_id = ENTITY_ID_FORMAT.format(self.ha_id)
 
     @property

--- a/homeassistant/components/scene/fibaro.py
+++ b/homeassistant/components/scene/fibaro.py
@@ -9,7 +9,7 @@ import logging
 from homeassistant.components.scene import (
     Scene)
 from homeassistant.components.fibaro import (
-    FIBARO_CONTROLLER, FIBARO_DEVICES, FibaroDevice)
+    FIBARO_DEVICES, FibaroDevice)
 
 DEPENDENCIES = ['fibaro']
 
@@ -23,7 +23,7 @@ async def async_setup_platform(hass, config, async_add_entities,
         return
 
     async_add_entities(
-        [FibaroScene(scene, hass.data[FIBARO_CONTROLLER])
+        [FibaroScene(scene)
          for scene in hass.data[FIBARO_DEVICES]['scene']], True)
 
 

--- a/homeassistant/components/sensor/fibaro.py
+++ b/homeassistant/components/sensor/fibaro.py
@@ -12,7 +12,7 @@ from homeassistant.const import (
 from homeassistant.helpers.entity import Entity
 from homeassistant.components.sensor import ENTITY_ID_FORMAT
 from homeassistant.components.fibaro import (
-    FIBARO_CONTROLLER, FIBARO_DEVICES, FibaroDevice)
+    FIBARO_DEVICES, FibaroDevice)
 
 SENSOR_TYPES = {
     'com.fibaro.temperatureSensor':
@@ -37,18 +37,18 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         return
 
     add_entities(
-        [FibaroSensor(device, hass.data[FIBARO_CONTROLLER])
+        [FibaroSensor(device)
          for device in hass.data[FIBARO_DEVICES]['sensor']], True)
 
 
 class FibaroSensor(FibaroDevice, Entity):
     """Representation of a Fibaro Sensor."""
 
-    def __init__(self, fibaro_device, controller):
+    def __init__(self, fibaro_device):
         """Initialize the sensor."""
         self.current_value = None
         self.last_changed_time = None
-        super().__init__(fibaro_device, controller)
+        super().__init__(fibaro_device)
         self.entity_id = ENTITY_ID_FORMAT.format(self.ha_id)
         if fibaro_device.type in SENSOR_TYPES:
             self._unit = SENSOR_TYPES[fibaro_device.type][1]

--- a/homeassistant/components/switch/fibaro.py
+++ b/homeassistant/components/switch/fibaro.py
@@ -9,7 +9,7 @@ import logging
 from homeassistant.util import convert
 from homeassistant.components.switch import ENTITY_ID_FORMAT, SwitchDevice
 from homeassistant.components.fibaro import (
-    FIBARO_CONTROLLER, FIBARO_DEVICES, FibaroDevice)
+    FIBARO_DEVICES, FibaroDevice)
 
 DEPENDENCIES = ['fibaro']
 _LOGGER = logging.getLogger(__name__)
@@ -21,17 +21,17 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         return
 
     add_entities(
-        [FibaroSwitch(device, hass.data[FIBARO_CONTROLLER]) for
+        [FibaroSwitch(device) for
          device in hass.data[FIBARO_DEVICES]['switch']], True)
 
 
 class FibaroSwitch(FibaroDevice, SwitchDevice):
     """Representation of a Fibaro Switch."""
 
-    def __init__(self, fibaro_device, controller):
+    def __init__(self, fibaro_device):
         """Initialize the Fibaro device."""
         self._state = False
-        super().__init__(fibaro_device, controller)
+        super().__init__(fibaro_device)
         self.entity_id = ENTITY_ID_FORMAT.format(self.ha_id)
 
     def turn_on(self, **kwargs):


### PR DESCRIPTION
## Description:
Fibaro component now supports multiple Fibaro HC gateways.

- Added multiple gateway support.
- Reworked parameter flow to platforms to enable multiple controllers.

**Breaking change:**
A list of gateways is expected instead of a single config.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
fibaro:
    gateways:
      - url: http://your.fibaro.url/api
        username: username
        password: password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io/pull/8140) PR 8140

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
