### PR TITLE
Add option to specify ip address of Lifx bulb, bypassing discovery

### DIFF
--- a/homeassistant/components/lifx/__init__.py
+++ b/homeassistant/components/lifx/__init__.py
@@ -5,7 +5,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant import config_entries
 from homeassistant.helpers import config_entry_flow
 from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
-
+from homeassistant.const import CONF_HOST, CONF_MAC
 
 DOMAIN = 'lifx'
 REQUIREMENTS = ['aiolifx==0.6.7']
@@ -16,6 +16,8 @@ CONF_BROADCAST = 'broadcast'
 INTERFACE_SCHEMA = vol.Schema({
     vol.Optional(CONF_SERVER): cv.string,
     vol.Optional(CONF_BROADCAST): cv.string,
+    vol.Optional(CONF_HOST): cv.string,
+    vol.Optional(CONF_MAC): cv.string
 })
 
 CONFIG_SCHEMA = vol.Schema({


### PR DESCRIPTION
## Description:

This adds a configuration option for directly specifying IP Addresses of Lifx bulbs, bypassing discovery.

I've tried to retain backwards compatibility with existing config entries, if people were happy breaking backwards compatibility, it might be better to rework this to the config looks like:

```yaml
lifx:
  light:
    discovery:
      - server: IP_ADDRESS
        broadcast: IP_ADDRESS
    hosts:
      - host: IP_ADDRESS
        mac: MAC_ADDRESS
```

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8011

## Example entry for `configuration.yaml` (if applicable):
```yaml
lifx:
  light:
    - server: IP_ADDRESS
      broadcast: IP_ADDRESS
    - host: IP_ADDRESS
      mac: MAC_ADDRESS
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
