### PR TITLE
Add brightness command template to MQTT light

### DIFF
--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -64,6 +64,7 @@ ABBREVIATIONS = {
     'away_mode_cmd_t': 'away_mode_command_topic',
     'away_mode_stat_tpl': 'away_mode_state_template',
     'away_mode_stat_t': 'away_mode_state_topic',
+    'bri_cmd_tpl': 'brightness_command_template',
     'bri_cmd_t': 'brightness_command_topic',
     'bri_scl': 'brightness_scale',
     'bri_stat_t': 'brightness_state_topic',


### PR DESCRIPTION
## Description:

Add support for changing the MQTT _brightness command_ with the `brightness_command_template` config option, in the same way as the existing `rgb_command_template` config option. This adds support for devices which expect special payload in command template.

**Related issue (if applicable):** None

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8015

## Example entry for `configuration.yaml` (if applicable):
```yaml
platform: mqtt
brightness_command_template: '{"function": "action_move_level_onoff", "device":"addr", "value": {{brightness}}}'
brightness_command_topic: "command"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
