### PR TITLE
Making asuswrt sensor optional

### DIFF
--- a/homeassistant/components/asuswrt.py
+++ b/homeassistant/components/asuswrt.py
@@ -60,9 +60,4 @@ async def async_setup(hass, config):
         return False
 
     hass.data[DATA_ASUSWRT] = api
-
-    hass.async_create_task(async_load_platform(
-        hass, 'sensor', DOMAIN, {}, config))
-    hass.async_create_task(async_load_platform(
-        hass, 'device_tracker', DOMAIN, {}, config))
     return True

--- a/homeassistant/components/asuswrt.py
+++ b/homeassistant/components/asuswrt.py
@@ -12,7 +12,6 @@ from homeassistant.const import (
     CONF_HOST, CONF_PASSWORD, CONF_USERNAME, CONF_PORT, CONF_MODE,
     CONF_PROTOCOL)
 from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.discovery import async_load_platform
 
 REQUIREMENTS = ['aioasuswrt==1.1.17']
 


### PR DESCRIPTION
## Description:
This will make the sensor and device_tracker optional.

**Related issue (if applicable):** fixes #18866

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8017

## Example entry for `configuration.yaml` (if applicable):
```yaml
asuswrt:
  host: <ip adress>

sensor:
  - platform: asuswrt

device_tracker:
  - platform: asuswrt
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)