### PR TITLE
Upgrade blinkpy and use calibrated temperature for sensor

### DIFF
--- a/homeassistant/components/blink/__init__.py
+++ b/homeassistant/components/blink/__init__.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
     CONF_BINARY_SENSORS, CONF_SENSORS, CONF_FILENAME,
     CONF_MONITORED_CONDITIONS, TEMP_FAHRENHEIT)
 
-REQUIREMENTS = ['blinkpy==0.11.0']
+REQUIREMENTS = ['blinkpy==0.11.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sensor/blink.py
+++ b/homeassistant/components/sensor/blink.py
@@ -44,6 +44,9 @@ class BlinkSensor(Entity):
         self._unit_of_measurement = units
         self._icon = icon
         self._unique_id = "{}-{}".format(self._camera.serial, self._type)
+        self._sensor_key = self._type
+        if self._type == 'temperature':
+            self._sensor_key = 'temperature_calibrated'
 
     @property
     def name(self):
@@ -74,9 +77,9 @@ class BlinkSensor(Entity):
         """Retrieve sensor data from the camera."""
         self.data.refresh()
         try:
-            self._state = self._camera.attributes[self._type]
+            self._state = self._camera.attributes[self._sensor_key]
         except KeyError:
             self._state = None
             _LOGGER.error(
                 "%s not a valid camera attribute. Did the API change?",
-                self._type)
+                self._sensor_key)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -196,7 +196,7 @@ bellows==0.7.0
 bimmer_connected==0.5.3
 
 # homeassistant.components.blink
-blinkpy==0.11.0
+blinkpy==0.11.1
 
 # homeassistant.components.light.blinksticklight
 blinkstick==1.1.8


### PR DESCRIPTION
## Description:
Blink has a separate endpoint for the manually calibrated temperature value.  `blinkpy==0.11.1` adds a calibrated temperature attribute which I now use for the sensor.  This change will be transparent to the end user, no configs or anything need to change 👍.


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
If the code communicates with devices, web services, or third-party tools:
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
