### PR TITLE
Support for Multiple modbus hubs

### DIFF
--- a/homeassistant/components/climate/flexit.py
+++ b/homeassistant/components/climate/flexit.py
@@ -20,13 +20,14 @@ from homeassistant.const import (
 from homeassistant.components.climate import (
     ClimateDevice, PLATFORM_SCHEMA, SUPPORT_TARGET_TEMPERATURE,
     SUPPORT_FAN_MODE)
-from homeassistant.components import modbus
+from homeassistant.components.modbus import CONF_HUB_NAME, DOMAIN
 import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['pyflexit==0.3']
 DEPENDENCIES = ['modbus']
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_HUB_NAME, default="default"): cv.string,
     vol.Required(CONF_SLAVE): vol.All(int, vol.Range(min=0, max=32)),
     vol.Optional(CONF_NAME, default=DEVICE_DEFAULT_NAME): cv.string
 })
@@ -40,15 +41,18 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Flexit Platform."""
     modbus_slave = config.get(CONF_SLAVE, None)
     name = config.get(CONF_NAME, None)
-    add_entities([Flexit(modbus_slave, name)], True)
+    hub_name = config.get(CONF_HUB_NAME)
+    hub = hass.data[DOMAIN][hub_name]
+    add_entities([Flexit(hub, modbus_slave, name)], True)
 
 
 class Flexit(ClimateDevice):
     """Representation of a Flexit AC unit."""
 
-    def __init__(self, modbus_slave, name):
+    def __init__(self, hub, modbus_slave, name):
         """Initialize the unit."""
         from pyflexit import pyflexit
+        self._hub = hub
         self._name = name
         self._slave = modbus_slave
         self._target_temperature = None
@@ -64,7 +68,7 @@ class Flexit(ClimateDevice):
         self._heating = None
         self._cooling = None
         self._alarm = False
-        self.unit = pyflexit.pyflexit(modbus.HUB, modbus_slave)
+        self.unit = pyflexit.pyflexit(hub, modbus_slave)
 
     @property
     def supported_features(self):

--- a/homeassistant/components/climate/flexit.py
+++ b/homeassistant/components/climate/flexit.py
@@ -20,14 +20,16 @@ from homeassistant.const import (
 from homeassistant.components.climate import (
     ClimateDevice, PLATFORM_SCHEMA, SUPPORT_TARGET_TEMPERATURE,
     SUPPORT_FAN_MODE)
-from homeassistant.components.modbus import CONF_HUB_NAME, DOMAIN
+from homeassistant.components.modbus import DOMAIN
 import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['pyflexit==0.3']
 DEPENDENCIES = ['modbus']
 
+CONF_HUB = 'hub'
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_HUB_NAME, default="default"): cv.string,
+    vol.Required(CONF_HUB, default="default"): cv.string,
     vol.Required(CONF_SLAVE): vol.All(int, vol.Range(min=0, max=32)),
     vol.Optional(CONF_NAME, default=DEVICE_DEFAULT_NAME): cv.string
 })
@@ -41,8 +43,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Flexit Platform."""
     modbus_slave = config.get(CONF_SLAVE, None)
     name = config.get(CONF_NAME, None)
-    hub_name = config.get(CONF_HUB_NAME)
-    hub = hass.data[DOMAIN][hub_name]
+    hub = hass.data[DOMAIN][config.get(CONF_HUB)]
     add_entities([Flexit(hub, modbus_slave, name)], True)
 
 

--- a/homeassistant/components/climate/flexit.py
+++ b/homeassistant/components/climate/flexit.py
@@ -28,7 +28,7 @@ REQUIREMENTS = ['pyflexit==0.3']
 DEPENDENCIES = ['modbus']
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_HUB, default=DEFAULT_HUB): cv.string,
+    vol.Optional(CONF_HUB, default=DEFAULT_HUB): cv.string,
     vol.Required(CONF_SLAVE): vol.All(int, vol.Range(min=0, max=32)),
     vol.Optional(CONF_NAME, default=DEVICE_DEFAULT_NAME): cv.string
 })

--- a/homeassistant/components/climate/flexit.py
+++ b/homeassistant/components/climate/flexit.py
@@ -20,16 +20,15 @@ from homeassistant.const import (
 from homeassistant.components.climate import (
     ClimateDevice, PLATFORM_SCHEMA, SUPPORT_TARGET_TEMPERATURE,
     SUPPORT_FAN_MODE)
-from homeassistant.components.modbus import DOMAIN
+from homeassistant.components.modbus import (
+    CONF_HUB, DEFAULT_HUB, DOMAIN as MODBUS_DOMAIN)
 import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['pyflexit==0.3']
 DEPENDENCIES = ['modbus']
 
-CONF_HUB = 'hub'
-
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_HUB, default="default"): cv.string,
+    vol.Required(CONF_HUB, default=DEFAULT_HUB): cv.string,
     vol.Required(CONF_SLAVE): vol.All(int, vol.Range(min=0, max=32)),
     vol.Optional(CONF_NAME, default=DEVICE_DEFAULT_NAME): cv.string
 })
@@ -43,7 +42,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Flexit Platform."""
     modbus_slave = config.get(CONF_SLAVE, None)
     name = config.get(CONF_NAME, None)
-    hub = hass.data[DOMAIN][config.get(CONF_HUB)]
+    hub = hass.data[MODBUS_DOMAIN][config.get(CONF_HUB)]
     add_entities([Flexit(hub, modbus_slave, name)], True)
 
 

--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -6,151 +6,199 @@ https://home-assistant.io/components/modbus/
 """
 import logging
 import threading
+from typing import TYPE_CHECKING, Any, Dict, List
 
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.const import (
-    EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP,
-    CONF_HOST, CONF_METHOD, CONF_PORT, CONF_TYPE, CONF_TIMEOUT, ATTR_STATE)
+    ATTR_STATE, CONF_HOST, CONF_METHOD, CONF_PORT, CONF_TIMEOUT, CONF_TYPE,
+    EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP)
+
+if TYPE_CHECKING:
+    from pymodbus.client.sync import BaseModbusClient
 
 DOMAIN = 'modbus'
 
 REQUIREMENTS = ['pymodbus==1.5.2']
 
 # Type of network
-CONF_BAUDRATE = 'baudrate'
-CONF_BYTESIZE = 'bytesize'
-CONF_STOPBITS = 'stopbits'
-CONF_PARITY = 'parity'
+CONF_BAUDRATE = "baudrate"
+CONF_BYTESIZE = "bytesize"
+CONF_STOPBITS = "stopbits"
+CONF_PARITY = "parity"
+CONF_HUB_NAME = "hub_name"
 
-SERIAL_SCHEMA = {
+BASE_SCHEMA = vol.Schema({
+    vol.Optional(CONF_HUB_NAME, default="default"): cv.string
+})
+
+SERIAL_SCHEMA = BASE_SCHEMA.extend({
     vol.Required(CONF_BAUDRATE): cv.positive_int,
     vol.Required(CONF_BYTESIZE): vol.Any(5, 6, 7, 8),
-    vol.Required(CONF_METHOD): vol.Any('rtu', 'ascii'),
+    vol.Required(CONF_METHOD): vol.Any("rtu", "ascii"),
     vol.Required(CONF_PORT): cv.string,
-    vol.Required(CONF_PARITY): vol.Any('E', 'O', 'N'),
+    vol.Required(CONF_PARITY): vol.Any("E", "O", "N"),
     vol.Required(CONF_STOPBITS): vol.Any(1, 2),
-    vol.Required(CONF_TYPE): 'serial',
+    vol.Required(CONF_TYPE): "serial",
     vol.Optional(CONF_TIMEOUT, default=3): cv.socket_timeout,
-}
+})
 
-ETHERNET_SCHEMA = {
+ETHERNET_SCHEMA = BASE_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
     vol.Required(CONF_PORT): cv.port,
-    vol.Required(CONF_TYPE): vol.Any('tcp', 'udp', 'rtuovertcp'),
+    vol.Required(CONF_TYPE): vol.Any("tcp", "udp", "rtuovertcp"),
     vol.Optional(CONF_TIMEOUT, default=3): cv.socket_timeout,
-}
+})
 
 
-CONFIG_SCHEMA = vol.Schema({
-    DOMAIN: vol.Any(SERIAL_SCHEMA, ETHERNET_SCHEMA)
-}, extra=vol.ALLOW_EXTRA)
+def check_base_on_type(value: Any) -> Any:
+    """Check modbus component schema base on "type"."""
+    if value[CONF_TYPE] == "serial":
+        return SERIAL_SCHEMA(value)
+    if value[CONF_TYPE] in ("tcp", "udp", "rtuovertcp"):
+        return ETHERNET_SCHEMA(value)
 
+    raise vol.Invalid("%s %s is not supported" % (CONF_TYPE, value[CONF_TYPE]))
+
+CONFIG_SCHEMA = vol.Schema(
+    {
+        DOMAIN:
+            vol.All(cv.ensure_list,
+                    vol.Schema([vol.Any(SERIAL_SCHEMA, ETHERNET_SCHEMA)]))
+    },
+    extra=vol.ALLOW_EXTRA,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
-SERVICE_WRITE_REGISTER = 'write_register'
-SERVICE_WRITE_COIL = 'write_coil'
+SERVICE_WRITE_REGISTER = "write_register"
+SERVICE_WRITE_COIL = "write_coil"
 
-ATTR_ADDRESS = 'address'
-ATTR_UNIT = 'unit'
-ATTR_VALUE = 'value'
+ATTR_ADDRESS = "address"
+ATTR_UNIT = "unit"
+ATTR_VALUE = "value"
 
 SERVICE_WRITE_REGISTER_SCHEMA = vol.Schema({
+    vol.Optional(CONF_HUB_NAME, default="default"): cv.string,
     vol.Required(ATTR_UNIT): cv.positive_int,
     vol.Required(ATTR_ADDRESS): cv.positive_int,
-    vol.Required(ATTR_VALUE): vol.All(cv.ensure_list, [cv.positive_int])
+    vol.Required(ATTR_VALUE): vol.All(cv.ensure_list, [cv.positive_int]),
 })
 
 SERVICE_WRITE_COIL_SCHEMA = vol.Schema({
+    vol.Optional(CONF_HUB_NAME, default="default"): cv.string,
     vol.Required(ATTR_UNIT): cv.positive_int,
     vol.Required(ATTR_ADDRESS): cv.positive_int,
-    vol.Required(ATTR_STATE): cv.boolean
+    vol.Required(ATTR_STATE): cv.boolean,
 })
 
-HUB = None
+HUB = {}  # type: Dict[str, BaseModbusClient]
 
 
-def setup(hass, config):
-    """Set up Modbus component."""
-    # Modbus connection type
-    client_type = config[DOMAIN][CONF_TYPE]
+def setup_client(client_config: dict) -> "BaseModbusClient":
+    """Setup pymodbus client."""
+    from pymodbus.client.sync import (
+        ModbusTcpClient,
+        ModbusUdpClient,
+        ModbusSerialClient,
+    )
+    from pymodbus.transaction import ModbusRtuFramer
+
+    client_type = client_config[CONF_TYPE]
 
     # Connect to Modbus network
     # pylint: disable=import-error
 
-    if client_type == 'serial':
-        from pymodbus.client.sync import ModbusSerialClient as ModbusClient
-        client = ModbusClient(method=config[DOMAIN][CONF_METHOD],
-                              port=config[DOMAIN][CONF_PORT],
-                              baudrate=config[DOMAIN][CONF_BAUDRATE],
-                              stopbits=config[DOMAIN][CONF_STOPBITS],
-                              bytesize=config[DOMAIN][CONF_BYTESIZE],
-                              parity=config[DOMAIN][CONF_PARITY],
-                              timeout=config[DOMAIN][CONF_TIMEOUT])
-    elif client_type == 'rtuovertcp':
-        from pymodbus.client.sync import ModbusTcpClient as ModbusClient
-        from pymodbus.transaction import ModbusRtuFramer as ModbusFramer
-        client = ModbusClient(host=config[DOMAIN][CONF_HOST],
-                              port=config[DOMAIN][CONF_PORT],
-                              framer=ModbusFramer,
-                              timeout=config[DOMAIN][CONF_TIMEOUT])
-    elif client_type == 'tcp':
-        from pymodbus.client.sync import ModbusTcpClient as ModbusClient
-        client = ModbusClient(host=config[DOMAIN][CONF_HOST],
-                              port=config[DOMAIN][CONF_PORT],
-                              timeout=config[DOMAIN][CONF_TIMEOUT])
-    elif client_type == 'udp':
-        from pymodbus.client.sync import ModbusUdpClient as ModbusClient
-        client = ModbusClient(host=config[DOMAIN][CONF_HOST],
-                              port=config[DOMAIN][CONF_PORT],
-                              timeout=config[DOMAIN][CONF_TIMEOUT])
-    else:
-        return False
+    if client_type == "serial":
 
+        return ModbusSerialClient(
+            method=client_config[CONF_METHOD],
+            port=client_config[CONF_PORT],
+            baudrate=client_config[CONF_BAUDRATE],
+            stopbits=client_config[CONF_STOPBITS],
+            bytesize=client_config[CONF_BYTESIZE],
+            parity=client_config[CONF_PARITY],
+            timeout=client_config[CONF_TIMEOUT],
+        )
+    if client_type == "rtuovertcp":
+
+        return ModbusTcpClient(
+            host=client_config[CONF_HOST],
+            port=client_config[CONF_PORT],
+            framer=ModbusRtuFramer,
+            timeout=client_config[CONF_TIMEOUT],
+        )
+    if client_type == "tcp":
+        return ModbusTcpClient(
+            host=client_config[CONF_HOST],
+            port=client_config[CONF_PORT],
+            timeout=client_config[CONF_TIMEOUT],
+        )
+    if client_type == "udp":
+        return ModbusUdpClient(
+            host=client_config[CONF_HOST],
+            port=client_config[CONF_PORT],
+            timeout=client_config[CONF_TIMEOUT],
+        )
+
+    assert False
+
+
+def setup(hass: Any, config: dict) -> bool:
+    """Set up Modbus component."""
+    # Modbus connection type
     global HUB
-    HUB = ModbusHub(client)
 
-    def stop_modbus(event):
+    for client_config in config[DOMAIN]:
+        client = setup_client(client_config)
+        client_name = client_config[CONF_HUB_NAME]
+        HUB[client_name] = ModbusHub(client)
+
+    def stop_modbus(event: Any) -> None:
         """Stop Modbus service."""
-        HUB.close()
+        for client in HUB.values():
+            client.close()
 
-    def start_modbus(event):
+    def start_modbus(event: Any) -> None:
         """Start Modbus service."""
-        HUB.connect()
+        for client in HUB.values():
+            client.connect()
+
         hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, stop_modbus)
 
         # Register services for modbus
         hass.services.register(
-            DOMAIN, SERVICE_WRITE_REGISTER, write_register,
-            schema=SERVICE_WRITE_REGISTER_SCHEMA)
+            DOMAIN,
+            SERVICE_WRITE_REGISTER,
+            write_register,
+            schema=SERVICE_WRITE_REGISTER_SCHEMA,
+        )
         hass.services.register(
-            DOMAIN, SERVICE_WRITE_COIL, write_coil,
+            DOMAIN,
+            SERVICE_WRITE_COIL,
+            write_coil,
             schema=SERVICE_WRITE_COIL_SCHEMA)
 
-    def write_register(service):
+    def write_register(service: Any) -> None:
         """Write modbus registers."""
         unit = int(float(service.data.get(ATTR_UNIT)))
         address = int(float(service.data.get(ATTR_ADDRESS)))
         value = service.data.get(ATTR_VALUE)
+        client_name = service.data.get(CONF_HUB_NAME)
         if isinstance(value, list):
-            HUB.write_registers(
-                unit,
-                address,
-                [int(float(i)) for i in value])
+            HUB[client_name].write_registers(unit, address,
+                                             [int(float(i)) for i in value])
         else:
-            HUB.write_register(
-                unit,
-                address,
-                int(float(value)))
+            HUB[client_name].write_register(unit, address, int(float(value)))
 
-    def write_coil(service):
+    def write_coil(service: Any) -> None:
         """Write modbus coil."""
         unit = service.data.get(ATTR_UNIT)
         address = service.data.get(ATTR_ADDRESS)
         state = service.data.get(ATTR_STATE)
-        HUB.write_coil(unit, address, state)
+        client_name = service.data.get(CONF_HUB_NAME)
+        HUB[client_name].write_coil(unit, address, state)
 
     hass.bus.listen_once(EVENT_HOMEASSISTANT_START, start_modbus)
 
@@ -160,71 +208,56 @@ def setup(hass, config):
 class ModbusHub:
     """Thread safe wrapper class for pymodbus."""
 
-    def __init__(self, modbus_client):
+    def __init__(self, modbus_client: "BaseModbusClient") -> None:
         """Initialize the modbus hub."""
         self._client = modbus_client
         self._lock = threading.Lock()
 
-    def close(self):
+    def close(self) -> None:
         """Disconnect client."""
         with self._lock:
             self._client.close()
 
-    def connect(self):
+    def connect(self) -> None:
         """Connect client."""
         with self._lock:
             self._client.connect()
 
-    def read_coils(self, unit, address, count):
+    def read_coils(self, unit: int, address: int, count: int) -> Any:
         """Read coils."""
         with self._lock:
-            kwargs = {'unit': unit} if unit else {}
-            return self._client.read_coils(
-                address,
-                count,
-                **kwargs)
+            kwargs = {"unit": unit} if unit else {}
+            return self._client.read_coils(address, count, **kwargs)
 
-    def read_input_registers(self, unit, address, count):
+    def read_input_registers(self, unit: int, address: int, count: int) -> Any:
         """Read input registers."""
         with self._lock:
-            kwargs = {'unit': unit} if unit else {}
-            return self._client.read_input_registers(
-                address,
-                count,
-                **kwargs)
+            kwargs = {"unit": unit} if unit else {}
+            return self._client.read_input_registers(address, count, **kwargs)
 
-    def read_holding_registers(self, unit, address, count):
+    def read_holding_registers(self, unit: int, address: int,
+                               count: int) -> Any:
         """Read holding registers."""
         with self._lock:
-            kwargs = {'unit': unit} if unit else {}
-            return self._client.read_holding_registers(
-                address,
-                count,
-                **kwargs)
+            kwargs = {"unit": unit} if unit else {}
+            return self._client.read_holding_registers(address, count,
+                                                       **kwargs)
 
-    def write_coil(self, unit, address, value):
+    def write_coil(self, unit: int, address: int, value: int) -> Any:
         """Write coil."""
         with self._lock:
-            kwargs = {'unit': unit} if unit else {}
-            self._client.write_coil(
-                address,
-                value,
-                **kwargs)
+            kwargs = {"unit": unit} if unit else {}
+            self._client.write_coil(address, value, **kwargs)
 
-    def write_register(self, unit, address, value):
+    def write_register(self, unit: int, address: int, value: int) -> Any:
         """Write register."""
         with self._lock:
-            kwargs = {'unit': unit} if unit else {}
-            self._client.write_register(
-                address,
-                value,
-                **kwargs)
+            kwargs = {"unit": unit} if unit else {}
+            self._client.write_register(address, value, **kwargs)
 
-    def write_registers(self, unit, address, values):
+    def write_registers(self, unit: int, address: int,
+                        values: List[int]) -> Any:
         """Write registers."""
         with self._lock:
-            kwargs = {'unit': unit} if unit else {}
-            self._client.write_registers(
-                address,
-                values,
-                **kwargs)
+            kwargs = {"unit": unit} if unit else {}
+            self._client.write_registers(address, values, **kwargs)

--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -6,7 +6,7 @@ https://home-assistant.io/components/modbus/
 """
 import logging
 import threading
-from typing import TYPE_CHECKING, Any, Dict, List
+from typing import TYPE_CHECKING, Any, List
 
 import voluptuous as vol
 
@@ -16,6 +16,7 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP)
 
 if TYPE_CHECKING:
+    # pylint: disable=unused-import
     from pymodbus.client.sync import BaseModbusClient
 
 DOMAIN = 'modbus'
@@ -61,6 +62,7 @@ def check_base_on_type(value: Any) -> Any:
 
     raise vol.Invalid("%s %s is not supported" % (CONF_TYPE, value[CONF_TYPE]))
 
+
 CONFIG_SCHEMA = vol.Schema(
     {
         DOMAIN:
@@ -92,8 +94,6 @@ SERVICE_WRITE_COIL_SCHEMA = vol.Schema({
     vol.Required(ATTR_ADDRESS): cv.positive_int,
     vol.Required(ATTR_STATE): cv.boolean,
 })
-
-HUB = {}  # type: Dict[str, BaseModbusClient]
 
 
 def setup_client(client_config: dict) -> "BaseModbusClient":
@@ -148,21 +148,21 @@ def setup_client(client_config: dict) -> "BaseModbusClient":
 def setup(hass: Any, config: dict) -> bool:
     """Set up Modbus component."""
     # Modbus connection type
-    global HUB
+    hass.data[DOMAIN] = hub_collect = {}
 
     for client_config in config[DOMAIN]:
         client = setup_client(client_config)
         client_name = client_config[CONF_HUB_NAME]
-        HUB[client_name] = ModbusHub(client)
+        hub_collect[client_name] = ModbusHub(client)
 
     def stop_modbus(event: Any) -> None:
         """Stop Modbus service."""
-        for client in HUB.values():
+        for client in hub_collect.values():
             client.close()
 
     def start_modbus(event: Any) -> None:
         """Start Modbus service."""
-        for client in HUB.values():
+        for client in hub_collect.values():
             client.connect()
 
         hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, stop_modbus)
@@ -187,10 +187,11 @@ def setup(hass: Any, config: dict) -> bool:
         value = service.data.get(ATTR_VALUE)
         client_name = service.data.get(CONF_HUB_NAME)
         if isinstance(value, list):
-            HUB[client_name].write_registers(unit, address,
-                                             [int(float(i)) for i in value])
+            hub_collect[client_name].write_registers(
+                unit, address, [int(float(i)) for i in value])
         else:
-            HUB[client_name].write_register(unit, address, int(float(value)))
+            hub_collect[client_name].write_register(unit, address,
+                                                    int(float(value)))
 
     def write_coil(service: Any) -> None:
         """Write modbus coil."""
@@ -198,7 +199,7 @@ def setup(hass: Any, config: dict) -> bool:
         address = service.data.get(ATTR_ADDRESS)
         state = service.data.get(ATTR_STATE)
         client_name = service.data.get(CONF_HUB_NAME)
-        HUB[client_name].write_coil(unit, address, state)
+        hub_collect[client_name].write_coil(unit, address, state)
 
     hass.bus.listen_once(EVENT_HOMEASSISTANT_START, start_modbus)
 

--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -119,8 +119,8 @@ def setup(hass, config):
 
     for client_config in config[DOMAIN]:
         client = setup_client(client_config)
-        client_name = client_config[CONF_NAME]
-        hub_collect[client_name] = ModbusHub(client)
+        name = client_config[CONF_NAME]
+        hub_collect[name] = ModbusHub(client, name)
         _LOGGER.debug('Setting up hub: %s', client_config)
 
     def stop_modbus(event):
@@ -176,10 +176,16 @@ def setup(hass, config):
 class ModbusHub:
     """Thread safe wrapper class for pymodbus."""
 
-    def __init__(self, modbus_client):
+    def __init__(self, modbus_client, name):
         """Initialize the modbus hub."""
         self._client = modbus_client
         self._lock = threading.Lock()
+        self._name = name
+
+    @property
+    def name(self):
+        """Return the name of this hub."""
+        return self._name
 
     def close(self):
         """Disconnect client."""

--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -65,14 +65,14 @@ ATTR_UNIT = 'unit'
 ATTR_VALUE = 'value'
 
 SERVICE_WRITE_REGISTER_SCHEMA = vol.Schema({
-    vol.Optional(ATTR_HUB, DEFAULT_HUB): cv.string,
+    vol.Optional(ATTR_HUB, default=DEFAULT_HUB): cv.string,
     vol.Required(ATTR_UNIT): cv.positive_int,
     vol.Required(ATTR_ADDRESS): cv.positive_int,
     vol.Required(ATTR_VALUE): vol.All(cv.ensure_list, [cv.positive_int])
 })
 
 SERVICE_WRITE_COIL_SCHEMA = vol.Schema({
-    vol.Optional(ATTR_HUB, DEFAULT_HUB): cv.string,
+    vol.Optional(ATTR_HUB, default=DEFAULT_HUB): cv.string,
     vol.Required(ATTR_UNIT): cv.positive_int,
     vol.Required(ATTR_ADDRESS): cv.positive_int,
     vol.Required(ATTR_STATE): cv.boolean

--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -6,135 +6,111 @@ https://home-assistant.io/components/modbus/
 """
 import logging
 import threading
-from typing import TYPE_CHECKING, Any, List
 
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.const import (
-    ATTR_STATE, CONF_HOST, CONF_METHOD, CONF_PORT, CONF_TIMEOUT, CONF_TYPE,
-    EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP)
-
-if TYPE_CHECKING:
-    # pylint: disable=unused-import
-    from pymodbus.client.sync import BaseModbusClient
+    EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP,
+    CONF_HOST, CONF_METHOD, CONF_PORT, CONF_TYPE, CONF_TIMEOUT, ATTR_STATE)
 
 DOMAIN = 'modbus'
 
 REQUIREMENTS = ['pymodbus==1.5.2']
 
 # Type of network
-CONF_BAUDRATE = "baudrate"
-CONF_BYTESIZE = "bytesize"
-CONF_STOPBITS = "stopbits"
-CONF_PARITY = "parity"
-CONF_HUB_NAME = "hub_name"
+CONF_BAUDRATE = 'baudrate'
+CONF_BYTESIZE = 'bytesize'
+CONF_STOPBITS = 'stopbits'
+CONF_PARITY = 'parity'
+CONF_HUB_NAME = 'hub_name'
 
 BASE_SCHEMA = vol.Schema({
-    vol.Optional(CONF_HUB_NAME, default="default"): cv.string
+    vol.Optional(CONF_HUB_NAME, default='default'): cv.string
 })
 
 SERIAL_SCHEMA = BASE_SCHEMA.extend({
     vol.Required(CONF_BAUDRATE): cv.positive_int,
     vol.Required(CONF_BYTESIZE): vol.Any(5, 6, 7, 8),
-    vol.Required(CONF_METHOD): vol.Any("rtu", "ascii"),
+    vol.Required(CONF_METHOD): vol.Any('rtu', 'ascii'),
     vol.Required(CONF_PORT): cv.string,
-    vol.Required(CONF_PARITY): vol.Any("E", "O", "N"),
+    vol.Required(CONF_PARITY): vol.Any('E', 'O', 'N'),
     vol.Required(CONF_STOPBITS): vol.Any(1, 2),
-    vol.Required(CONF_TYPE): "serial",
+    vol.Required(CONF_TYPE): 'serial',
     vol.Optional(CONF_TIMEOUT, default=3): cv.socket_timeout,
 })
 
 ETHERNET_SCHEMA = BASE_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
     vol.Required(CONF_PORT): cv.port,
-    vol.Required(CONF_TYPE): vol.Any("tcp", "udp", "rtuovertcp"),
+    vol.Required(CONF_TYPE): vol.Any('tcp', 'udp', 'rtuovertcp'),
     vol.Optional(CONF_TIMEOUT, default=3): cv.socket_timeout,
 })
 
-CONFIG_SCHEMA = vol.Schema(
-    {
-        DOMAIN:
-            vol.All(cv.ensure_list,
-                    vol.Schema([vol.Any(SERIAL_SCHEMA, ETHERNET_SCHEMA)]))
-    },
-    extra=vol.ALLOW_EXTRA,
-)
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN:
+        vol.All(cv.ensure_list,
+                vol.Schema([vol.Any(SERIAL_SCHEMA, ETHERNET_SCHEMA)]))
+}, extra=vol.ALLOW_EXTRA,)
 
 _LOGGER = logging.getLogger(__name__)
 
-SERVICE_WRITE_REGISTER = "write_register"
-SERVICE_WRITE_COIL = "write_coil"
+SERVICE_WRITE_REGISTER = 'write_register'
+SERVICE_WRITE_COIL = 'write_coil'
 
-ATTR_ADDRESS = "address"
-ATTR_UNIT = "unit"
-ATTR_VALUE = "value"
+ATTR_ADDRESS = 'address'
+ATTR_UNIT = 'unit'
+ATTR_VALUE = 'value'
 
 SERVICE_WRITE_REGISTER_SCHEMA = vol.Schema({
-    vol.Optional(CONF_HUB_NAME, default="default"): cv.string,
+    vol.Optional(CONF_HUB_NAME, default='default'): cv.string,
     vol.Required(ATTR_UNIT): cv.positive_int,
     vol.Required(ATTR_ADDRESS): cv.positive_int,
-    vol.Required(ATTR_VALUE): vol.All(cv.ensure_list, [cv.positive_int]),
+    vol.Required(ATTR_VALUE): vol.All(cv.ensure_list, [cv.positive_int])
 })
 
 SERVICE_WRITE_COIL_SCHEMA = vol.Schema({
-    vol.Optional(CONF_HUB_NAME, default="default"): cv.string,
+    vol.Optional(CONF_HUB_NAME, default='default'): cv.string,
     vol.Required(ATTR_UNIT): cv.positive_int,
     vol.Required(ATTR_ADDRESS): cv.positive_int,
-    vol.Required(ATTR_STATE): cv.boolean,
+    vol.Required(ATTR_STATE): cv.boolean
 })
 
 
-def setup_client(client_config: dict) -> "BaseModbusClient":
-    """Setup pymodbus client."""
-    from pymodbus.client.sync import (
-        ModbusTcpClient,
-        ModbusUdpClient,
-        ModbusSerialClient,
-    )
-    from pymodbus.transaction import ModbusRtuFramer
-
+def setup_client(client_config):
+    """Set up pymodbus client."""
     client_type = client_config[CONF_TYPE]
 
-    # Connect to Modbus network
-    # pylint: disable=import-error
-
-    if client_type == "serial":
-
-        return ModbusSerialClient(
-            method=client_config[CONF_METHOD],
-            port=client_config[CONF_PORT],
-            baudrate=client_config[CONF_BAUDRATE],
-            stopbits=client_config[CONF_STOPBITS],
-            bytesize=client_config[CONF_BYTESIZE],
-            parity=client_config[CONF_PARITY],
-            timeout=client_config[CONF_TIMEOUT],
-        )
-    if client_type == "rtuovertcp":
-
-        return ModbusTcpClient(
-            host=client_config[CONF_HOST],
-            port=client_config[CONF_PORT],
-            framer=ModbusRtuFramer,
-            timeout=client_config[CONF_TIMEOUT],
-        )
-    if client_type == "tcp":
-        return ModbusTcpClient(
-            host=client_config[CONF_HOST],
-            port=client_config[CONF_PORT],
-            timeout=client_config[CONF_TIMEOUT],
-        )
-    if client_type == "udp":
-        return ModbusUdpClient(
-            host=client_config[CONF_HOST],
-            port=client_config[CONF_PORT],
-            timeout=client_config[CONF_TIMEOUT],
-        )
-
+    if client_type == 'serial':
+        from pymodbus.client.sync import ModbusSerialClient as ModbusClient
+        return ModbusClient(method=client_config[CONF_METHOD],
+                            port=client_config[CONF_PORT],
+                            baudrate=client_config[CONF_BAUDRATE],
+                            stopbits=client_config[CONF_STOPBITS],
+                            bytesize=client_config[CONF_BYTESIZE],
+                            parity=client_config[CONF_PARITY],
+                            timeout=client_config[CONF_TIMEOUT])
+    if client_type == 'rtuovertcp':
+        from pymodbus.client.sync import ModbusTcpClient as ModbusClient
+        from pymodbus.transaction import ModbusRtuFramer
+        return ModbusClient(host=client_config[CONF_HOST],
+                            port=client_config[CONF_PORT],
+                            framer=ModbusRtuFramer,
+                            timeout=client_config[CONF_TIMEOUT])
+    if client_type == 'tcp':
+        from pymodbus.client.sync import ModbusTcpClient as ModbusClient
+        return ModbusClient(host=client_config[CONF_HOST],
+                            port=client_config[CONF_PORT],
+                            timeout=client_config[CONF_TIMEOUT])
+    if client_type == 'udp':
+        from pymodbus.client.sync import ModbusUdpClient as ModbusClient
+        return ModbusClient(host=client_config[CONF_HOST],
+                            port=client_config[CONF_PORT],
+                            timeout=client_config[CONF_TIMEOUT])
     assert False
 
 
-def setup(hass: Any, config: dict) -> bool:
+def setup(hass, config):
     """Set up Modbus component."""
     # Modbus connection type
     hass.data[DOMAIN] = hub_collect = {}
@@ -143,14 +119,14 @@ def setup(hass: Any, config: dict) -> bool:
         client = setup_client(client_config)
         client_name = client_config[CONF_HUB_NAME]
         hub_collect[client_name] = ModbusHub(client)
-        _LOGGER.debug("Setting up hub_client: %s", client_config)
+        _LOGGER.debug('Setting up hub_client: %s', client_config)
 
-    def stop_modbus(event: Any) -> None:
+    def stop_modbus(event):
         """Stop Modbus service."""
         for client in hub_collect.values():
             client.close()
 
-    def start_modbus(event: Any) -> None:
+    def start_modbus(event):
         """Start Modbus service."""
         for client in hub_collect.values():
             client.connect()
@@ -162,15 +138,14 @@ def setup(hass: Any, config: dict) -> bool:
             DOMAIN,
             SERVICE_WRITE_REGISTER,
             write_register,
-            schema=SERVICE_WRITE_REGISTER_SCHEMA,
-        )
+            schema=SERVICE_WRITE_REGISTER_SCHEMA)
         hass.services.register(
             DOMAIN,
             SERVICE_WRITE_COIL,
             write_coil,
             schema=SERVICE_WRITE_COIL_SCHEMA)
 
-    def write_register(service: Any) -> None:
+    def write_register(service):
         """Write modbus registers."""
         unit = int(float(service.data.get(ATTR_UNIT)))
         address = int(float(service.data.get(ATTR_ADDRESS)))
@@ -178,12 +153,16 @@ def setup(hass: Any, config: dict) -> bool:
         client_name = service.data.get(CONF_HUB_NAME)
         if isinstance(value, list):
             hub_collect[client_name].write_registers(
-                unit, address, [int(float(i)) for i in value])
+                unit,
+                address,
+                [int(float(i)) for i in value])
         else:
-            hub_collect[client_name].write_register(unit, address,
-                                                    int(float(value)))
+            hub_collect[client_name].write_register(
+                unit,
+                address,
+                int(float(value)))
 
-    def write_coil(service: Any) -> None:
+    def write_coil(service):
         """Write modbus coil."""
         unit = service.data.get(ATTR_UNIT)
         address = service.data.get(ATTR_ADDRESS)
@@ -199,56 +178,71 @@ def setup(hass: Any, config: dict) -> bool:
 class ModbusHub:
     """Thread safe wrapper class for pymodbus."""
 
-    def __init__(self, modbus_client: "BaseModbusClient") -> None:
+    def __init__(self, modbus_client):
         """Initialize the modbus hub."""
         self._client = modbus_client
         self._lock = threading.Lock()
 
-    def close(self) -> None:
+    def close(self):
         """Disconnect client."""
         with self._lock:
             self._client.close()
 
-    def connect(self) -> None:
+    def connect(self):
         """Connect client."""
         with self._lock:
             self._client.connect()
 
-    def read_coils(self, unit: int, address: int, count: int) -> Any:
+    def read_coils(self, unit, address, count):
         """Read coils."""
         with self._lock:
-            kwargs = {"unit": unit} if unit else {}
-            return self._client.read_coils(address, count, **kwargs)
+            kwargs = {'unit': unit} if unit else {}
+            return self._client.read_coils(
+                address,
+                count,
+                **kwargs)
 
-    def read_input_registers(self, unit: int, address: int, count: int) -> Any:
+    def read_input_registers(self, unit, address, count):
         """Read input registers."""
         with self._lock:
-            kwargs = {"unit": unit} if unit else {}
-            return self._client.read_input_registers(address, count, **kwargs)
+            kwargs = {'unit': unit} if unit else {}
+            return self._client.read_input_registers(
+                address,
+                count,
+                **kwargs)
 
-    def read_holding_registers(self, unit: int, address: int,
-                               count: int) -> Any:
+    def read_holding_registers(self, unit, address, count):
         """Read holding registers."""
         with self._lock:
-            kwargs = {"unit": unit} if unit else {}
-            return self._client.read_holding_registers(address, count,
-                                                       **kwargs)
+            kwargs = {'unit': unit} if unit else {}
+            return self._client.read_holding_registers(
+                address,
+                count,
+                **kwargs)
 
-    def write_coil(self, unit: int, address: int, value: int) -> Any:
+    def write_coil(self, unit, address, value):
         """Write coil."""
         with self._lock:
-            kwargs = {"unit": unit} if unit else {}
-            self._client.write_coil(address, value, **kwargs)
+            kwargs = {'unit': unit} if unit else {}
+            self._client.write_coil(
+                address,
+                value,
+                **kwargs)
 
-    def write_register(self, unit: int, address: int, value: int) -> Any:
+    def write_register(self, unit, address, value):
         """Write register."""
         with self._lock:
-            kwargs = {"unit": unit} if unit else {}
-            self._client.write_register(address, value, **kwargs)
+            kwargs = {'unit': unit} if unit else {}
+            self._client.write_register(
+                address,
+                value,
+                **kwargs)
 
-    def write_registers(self, unit: int, address: int,
-                        values: List[int]) -> Any:
+    def write_registers(self, unit, address, values):
         """Write registers."""
         with self._lock:
-            kwargs = {"unit": unit} if unit else {}
-            self._client.write_registers(address, values, **kwargs)
+            kwargs = {'unit': unit} if unit else {}
+            self._client.write_registers(
+                address,
+                values,
+                **kwargs)

--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -12,7 +12,8 @@ import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
 from homeassistant.const import (
     EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP,
-    CONF_HOST, CONF_METHOD, CONF_PORT, CONF_TYPE, CONF_TIMEOUT, ATTR_STATE)
+    CONF_HOST, CONF_METHOD, CONF_NAME, CONF_PORT, CONF_TYPE, CONF_TIMEOUT, 
+    ATTR_STATE)
 
 DOMAIN = 'modbus'
 
@@ -23,10 +24,9 @@ CONF_BAUDRATE = 'baudrate'
 CONF_BYTESIZE = 'bytesize'
 CONF_STOPBITS = 'stopbits'
 CONF_PARITY = 'parity'
-CONF_HUB_NAME = 'hub_name'
 
 BASE_SCHEMA = vol.Schema({
-    vol.Optional(CONF_HUB_NAME, default='default'): cv.string
+    vol.Optional(CONF_NAME, default='default'): cv.string
 })
 
 SERIAL_SCHEMA = BASE_SCHEMA.extend({
@@ -61,16 +61,17 @@ SERVICE_WRITE_COIL = 'write_coil'
 ATTR_ADDRESS = 'address'
 ATTR_UNIT = 'unit'
 ATTR_VALUE = 'value'
+ATTR_HUB = 'hub'
 
 SERVICE_WRITE_REGISTER_SCHEMA = vol.Schema({
-    vol.Optional(CONF_HUB_NAME, default='default'): cv.string,
+    vol.Optional(ATTR_HUB, default='default'): cv.string,
     vol.Required(ATTR_UNIT): cv.positive_int,
     vol.Required(ATTR_ADDRESS): cv.positive_int,
     vol.Required(ATTR_VALUE): vol.All(cv.ensure_list, [cv.positive_int])
 })
 
 SERVICE_WRITE_COIL_SCHEMA = vol.Schema({
-    vol.Optional(CONF_HUB_NAME, default='default'): cv.string,
+    vol.Optional(ATTR_HUB, default='default'): cv.string,
     vol.Required(ATTR_UNIT): cv.positive_int,
     vol.Required(ATTR_ADDRESS): cv.positive_int,
     vol.Required(ATTR_STATE): cv.boolean
@@ -117,9 +118,9 @@ def setup(hass, config):
 
     for client_config in config[DOMAIN]:
         client = setup_client(client_config)
-        client_name = client_config[CONF_HUB_NAME]
+        client_name = client_config[CONF_NAME]
         hub_collect[client_name] = ModbusHub(client)
-        _LOGGER.debug('Setting up hub_client: %s', client_config)
+        _LOGGER.debug('Setting up hub: %s', client_config)
 
     def stop_modbus(event):
         """Stop Modbus service."""
@@ -150,7 +151,7 @@ def setup(hass, config):
         unit = int(float(service.data.get(ATTR_UNIT)))
         address = int(float(service.data.get(ATTR_ADDRESS)))
         value = service.data.get(ATTR_VALUE)
-        client_name = service.data.get(CONF_HUB_NAME)
+        client_name = service.data.get(ATTR_HUB)
         if isinstance(value, list):
             hub_collect[client_name].write_registers(
                 unit,
@@ -167,7 +168,7 @@ def setup(hass, config):
         unit = service.data.get(ATTR_UNIT)
         address = service.data.get(ATTR_ADDRESS)
         state = service.data.get(ATTR_STATE)
-        client_name = service.data.get(CONF_HUB_NAME)
+        client_name = service.data.get(ATTR_HUB)
         hub_collect[client_name].write_coil(unit, address, state)
 
     hass.bus.listen_once(EVENT_HOMEASSISTANT_START, start_modbus)

--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -154,6 +154,7 @@ def setup(hass: Any, config: dict) -> bool:
         client = setup_client(client_config)
         client_name = client_config[CONF_HUB_NAME]
         hub_collect[client_name] = ModbusHub(client)
+        _LOGGER.debug("Setting up hub_client: %s", client_config)
 
     def stop_modbus(event: Any) -> None:
         """Stop Modbus service."""

--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -12,7 +12,7 @@ import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
 from homeassistant.const import (
     EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP,
-    CONF_HOST, CONF_METHOD, CONF_NAME, CONF_PORT, CONF_TYPE, CONF_TIMEOUT, 
+    CONF_HOST, CONF_METHOD, CONF_NAME, CONF_PORT, CONF_TYPE, CONF_TIMEOUT,
     ATTR_STATE)
 
 DOMAIN = 'modbus'

--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -51,9 +51,7 @@ ETHERNET_SCHEMA = BASE_SCHEMA.extend({
 })
 
 CONFIG_SCHEMA = vol.Schema({
-    DOMAIN:
-        vol.All(cv.ensure_list,
-                vol.Schema([vol.Any(SERIAL_SCHEMA, ETHERNET_SCHEMA)]))
+    DOMAIN: vol.All(cv.ensure_list, [vol.Any(SERIAL_SCHEMA, ETHERNET_SCHEMA)])
 }, extra=vol.ALLOW_EXTRA,)
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -52,17 +52,6 @@ ETHERNET_SCHEMA = BASE_SCHEMA.extend({
     vol.Optional(CONF_TIMEOUT, default=3): cv.socket_timeout,
 })
 
-
-def check_base_on_type(value: Any) -> Any:
-    """Check modbus component schema base on "type"."""
-    if value[CONF_TYPE] == "serial":
-        return SERIAL_SCHEMA(value)
-    if value[CONF_TYPE] in ("tcp", "udp", "rtuovertcp"):
-        return ETHERNET_SCHEMA(value)
-
-    raise vol.Invalid("%s %s is not supported" % (CONF_TYPE, value[CONF_TYPE]))
-
-
 CONFIG_SCHEMA = vol.Schema(
     {
         DOMAIN:

--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -19,14 +19,17 @@ DOMAIN = 'modbus'
 
 REQUIREMENTS = ['pymodbus==1.5.2']
 
+CONF_HUB = 'hub'
 # Type of network
 CONF_BAUDRATE = 'baudrate'
 CONF_BYTESIZE = 'bytesize'
 CONF_STOPBITS = 'stopbits'
 CONF_PARITY = 'parity'
 
+DEFAULT_HUB = 'default'
+
 BASE_SCHEMA = vol.Schema({
-    vol.Optional(CONF_NAME, default='default'): cv.string
+    vol.Optional(CONF_NAME, default=DEFAULT_HUB): cv.string
 })
 
 SERIAL_SCHEMA = BASE_SCHEMA.extend({
@@ -59,19 +62,19 @@ SERVICE_WRITE_REGISTER = 'write_register'
 SERVICE_WRITE_COIL = 'write_coil'
 
 ATTR_ADDRESS = 'address'
+ATTR_HUB = 'hub'
 ATTR_UNIT = 'unit'
 ATTR_VALUE = 'value'
-ATTR_HUB = 'hub'
 
 SERVICE_WRITE_REGISTER_SCHEMA = vol.Schema({
-    vol.Optional(ATTR_HUB, default='default'): cv.string,
+    vol.Optional(ATTR_HUB, DEFAULT_HUB): cv.string,
     vol.Required(ATTR_UNIT): cv.positive_int,
     vol.Required(ATTR_ADDRESS): cv.positive_int,
     vol.Required(ATTR_VALUE): vol.All(cv.ensure_list, [cv.positive_int])
 })
 
 SERVICE_WRITE_COIL_SCHEMA = vol.Schema({
-    vol.Optional(ATTR_HUB, default='default'): cv.string,
+    vol.Optional(ATTR_HUB, DEFAULT_HUB): cv.string,
     vol.Required(ATTR_UNIT): cv.positive_int,
     vol.Required(ATTR_ADDRESS): cv.positive_int,
     vol.Required(ATTR_STATE): cv.boolean
@@ -136,14 +139,10 @@ def setup(hass, config):
 
         # Register services for modbus
         hass.services.register(
-            DOMAIN,
-            SERVICE_WRITE_REGISTER,
-            write_register,
+            DOMAIN, SERVICE_WRITE_REGISTER, write_register,
             schema=SERVICE_WRITE_REGISTER_SCHEMA)
         hass.services.register(
-            DOMAIN,
-            SERVICE_WRITE_COIL,
-            write_coil,
+            DOMAIN, SERVICE_WRITE_COIL, write_coil,
             schema=SERVICE_WRITE_COIL_SCHEMA)
 
     def write_register(service):

--- a/homeassistant/components/modbus/binary_sensor.py
+++ b/homeassistant/components/modbus/binary_sensor.py
@@ -5,13 +5,15 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/binary_sensor.modbus/
 """
 import logging
+
 import voluptuous as vol
 
 from homeassistant.components import modbus
-from homeassistant.const import CONF_NAME, CONF_SLAVE
 from homeassistant.components.binary_sensor import BinarySensorDevice
-from homeassistant.helpers import config_validation as cv
+from homeassistant.components.modbus import CONF_HUB_NAME
 from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import CONF_NAME, CONF_SLAVE
+from homeassistant.helpers import config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 DEPENDENCIES = ['modbus']
@@ -21,6 +23,7 @@ CONF_COILS = 'coils'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_COILS): [{
+        vol.Required(CONF_HUB_NAME, default="default"): cv.string,
         vol.Required(CONF_COIL): cv.positive_int,
         vol.Required(CONF_NAME): cv.string,
         vol.Optional(CONF_SLAVE): cv.positive_int
@@ -32,18 +35,19 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Modbus binary sensors."""
     sensors = []
     for coil in config.get(CONF_COILS):
-        sensors.append(ModbusCoilSensor(
-            coil.get(CONF_NAME),
-            coil.get(CONF_SLAVE),
-            coil.get(CONF_COIL)))
+        sensors.append(
+            ModbusCoilSensor(
+                coil.get(CONF_HUB_NAME), coil.get(CONF_NAME),
+                coil.get(CONF_SLAVE), coil.get(CONF_COIL)))
     add_entities(sensors)
 
 
 class ModbusCoilSensor(BinarySensorDevice):
     """Modbus coil sensor."""
 
-    def __init__(self, name, slave, coil):
+    def __init__(self, hub_name, name, slave, coil):
         """Initialize the modbus coil sensor."""
+        self._hub_name = hub_name
         self._name = name
         self._slave = int(slave) if slave else None
         self._coil = int(coil)
@@ -59,13 +63,16 @@ class ModbusCoilSensor(BinarySensorDevice):
         """Return the state of the sensor."""
         return self._value
 
+    @property
+    def client(self) -> "BaseModbusClient":
+        """Find and return the client from modbus HUB."""
+        return modbus.HUB[self._hub_name]
+
     def update(self):
         """Update the state of the sensor."""
-        result = modbus.HUB.read_coils(self._slave, self._coil, 1)
+        result = self.client.read_coils(self._slave, self._coil, 1)
         try:
             self._value = result.bits[0]
         except AttributeError:
-            _LOGGER.error(
-                'No response from modbus slave %s coil %s',
-                self._slave,
-                self._coil)
+            _LOGGER.error('No response from modbus slave %s coil %s',
+                          self._slave, self._coil)

--- a/homeassistant/components/modbus/binary_sensor.py
+++ b/homeassistant/components/modbus/binary_sensor.py
@@ -39,7 +39,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             ModbusCoilSensor(
                 coil.get(CONF_HUB_NAME), coil.get(CONF_NAME),
                 coil.get(CONF_SLAVE), coil.get(CONF_COIL)))
-    add_entities(sensors)
+    add_entities(sensors, True)
 
 
 class ModbusCoilSensor(BinarySensorDevice):

--- a/homeassistant/components/modbus/binary_sensor.py
+++ b/homeassistant/components/modbus/binary_sensor.py
@@ -5,15 +5,19 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/binary_sensor.modbus/
 """
 import logging
+from typing import TYPE_CHECKING
 
 import voluptuous as vol
 
-from homeassistant.components import modbus
 from homeassistant.components.binary_sensor import BinarySensorDevice
-from homeassistant.components.modbus import CONF_HUB_NAME
+from homeassistant.components.modbus import CONF_HUB_NAME, DOMAIN
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import CONF_NAME, CONF_SLAVE
 from homeassistant.helpers import config_validation as cv
+
+if TYPE_CHECKING:
+    # pylint: disable=unused-import
+    from pymodbus.client.sync import BaseModbusClient
 
 _LOGGER = logging.getLogger(__name__)
 DEPENDENCIES = ['modbus']
@@ -31,23 +35,24 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
+def setup_platform(hass, config, add_devices, discovery_info=None):
     """Set up the Modbus binary sensors."""
     sensors = []
     for coil in config.get(CONF_COILS):
+        hub_name = coil.get(CONF_HUB_NAME)
+        hub = hass.data[DOMAIN][hub_name]
         sensors.append(
-            ModbusCoilSensor(
-                coil.get(CONF_HUB_NAME), coil.get(CONF_NAME),
-                coil.get(CONF_SLAVE), coil.get(CONF_COIL)))
-    add_entities(sensors, True)
+            ModbusCoilSensor(hub, coil.get(CONF_NAME), coil.get(CONF_SLAVE),
+                             coil.get(CONF_COIL)))
+    add_devices(sensors)
 
 
 class ModbusCoilSensor(BinarySensorDevice):
     """Modbus coil sensor."""
 
-    def __init__(self, hub_name, name, slave, coil):
+    def __init__(self, hub, name, slave, coil):
         """Initialize the modbus coil sensor."""
-        self._hub_name = hub_name
+        self._hub: "BaseModbusClient" = hub
         self._name = name
         self._slave = int(slave) if slave else None
         self._coil = int(coil)
@@ -63,14 +68,9 @@ class ModbusCoilSensor(BinarySensorDevice):
         """Return the state of the sensor."""
         return self._value
 
-    @property
-    def client(self) -> "BaseModbusClient":
-        """Find and return the client from modbus HUB."""
-        return modbus.HUB[self._hub_name]
-
     def update(self):
         """Update the state of the sensor."""
-        result = self.client.read_coils(self._slave, self._coil, 1)
+        result = self._hub.read_coils(self._slave, self._coil, 1)
         try:
             self._value = result.bits[0]
         except AttributeError:

--- a/homeassistant/components/modbus/binary_sensor.py
+++ b/homeassistant/components/modbus/binary_sensor.py
@@ -52,7 +52,7 @@ class ModbusCoilSensor(BinarySensorDevice):
 
     def __init__(self, hub, name, slave, coil):
         """Initialize the modbus coil sensor."""
-        self._hub: "BaseModbusClient" = hub
+        self._hub = hub  # type: BaseModbusClient
         self._name = name
         self._slave = int(slave) if slave else None
         self._coil = int(coil)

--- a/homeassistant/components/modbus/binary_sensor.py
+++ b/homeassistant/components/modbus/binary_sensor.py
@@ -5,19 +5,13 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/binary_sensor.modbus/
 """
 import logging
-from typing import TYPE_CHECKING
-
 import voluptuous as vol
 
-from homeassistant.components.binary_sensor import BinarySensorDevice
 from homeassistant.components.modbus import CONF_HUB_NAME, DOMAIN
-from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import CONF_NAME, CONF_SLAVE
+from homeassistant.components.binary_sensor import BinarySensorDevice
 from homeassistant.helpers import config_validation as cv
-
-if TYPE_CHECKING:
-    # pylint: disable=unused-import
-    from pymodbus.client.sync import BaseModbusClient
+from homeassistant.components.sensor import PLATFORM_SCHEMA
 
 _LOGGER = logging.getLogger(__name__)
 DEPENDENCIES = ['modbus']
@@ -27,7 +21,7 @@ CONF_COILS = 'coils'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_COILS): [{
-        vol.Required(CONF_HUB_NAME, default="default"): cv.string,
+        vol.Required(CONF_HUB_NAME, default='default'): cv.string,
         vol.Required(CONF_COIL): cv.positive_int,
         vol.Required(CONF_NAME): cv.string,
         vol.Optional(CONF_SLAVE): cv.positive_int
@@ -35,16 +29,18 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 })
 
 
-def setup_platform(hass, config, add_devices, discovery_info=None):
+def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Modbus binary sensors."""
     sensors = []
     for coil in config.get(CONF_COILS):
         hub_name = coil.get(CONF_HUB_NAME)
         hub = hass.data[DOMAIN][hub_name]
-        sensors.append(
-            ModbusCoilSensor(hub, coil.get(CONF_NAME), coil.get(CONF_SLAVE),
-                             coil.get(CONF_COIL)))
-    add_devices(sensors)
+        sensors.append(ModbusCoilSensor(
+            hub,
+            coil.get(CONF_NAME),
+            coil.get(CONF_SLAVE),
+            coil.get(CONF_COIL)))
+    add_entities(sensors)
 
 
 class ModbusCoilSensor(BinarySensorDevice):
@@ -52,7 +48,7 @@ class ModbusCoilSensor(BinarySensorDevice):
 
     def __init__(self, hub, name, slave, coil):
         """Initialize the modbus coil sensor."""
-        self._hub = hub  # type: BaseModbusClient
+        self._hub = hub
         self._name = name
         self._slave = int(slave) if slave else None
         self._coil = int(coil)

--- a/homeassistant/components/modbus/binary_sensor.py
+++ b/homeassistant/components/modbus/binary_sensor.py
@@ -7,7 +7,7 @@ https://home-assistant.io/components/binary_sensor.modbus/
 import logging
 import voluptuous as vol
 
-from homeassistant.components.modbus import CONF_HUB_NAME, DOMAIN
+from homeassistant.components.modbus import DOMAIN
 from homeassistant.const import CONF_NAME, CONF_SLAVE
 from homeassistant.components.binary_sensor import BinarySensorDevice
 from homeassistant.helpers import config_validation as cv
@@ -16,12 +16,13 @@ from homeassistant.components.sensor import PLATFORM_SCHEMA
 _LOGGER = logging.getLogger(__name__)
 DEPENDENCIES = ['modbus']
 
+CONF_HUB = 'hub'
 CONF_COIL = 'coil'
 CONF_COILS = 'coils'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_COILS): [{
-        vol.Required(CONF_HUB_NAME, default='default'): cv.string,
+        vol.Required(CONF_HUB, default='default'): cv.string,
         vol.Required(CONF_COIL): cv.positive_int,
         vol.Required(CONF_NAME): cv.string,
         vol.Optional(CONF_SLAVE): cv.positive_int
@@ -33,8 +34,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Modbus binary sensors."""
     sensors = []
     for coil in config.get(CONF_COILS):
-        hub_name = coil.get(CONF_HUB_NAME)
-        hub = hass.data[DOMAIN][hub_name]
+        hub = hass.data[DOMAIN][coil.get(CONF_HUB)]
         sensors.append(ModbusCoilSensor(
             hub,
             coil.get(CONF_NAME),

--- a/homeassistant/components/modbus/binary_sensor.py
+++ b/homeassistant/components/modbus/binary_sensor.py
@@ -22,7 +22,7 @@ CONF_COILS = 'coils'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_COILS): [{
-        vol.Required(CONF_HUB, default=DEFAULT_HUB): cv.string,
+        vol.Optional(CONF_HUB, default=DEFAULT_HUB): cv.string,
         vol.Required(CONF_COIL): cv.positive_int,
         vol.Required(CONF_NAME): cv.string,
         vol.Optional(CONF_SLAVE): cv.positive_int

--- a/homeassistant/components/modbus/binary_sensor.py
+++ b/homeassistant/components/modbus/binary_sensor.py
@@ -70,5 +70,5 @@ class ModbusCoilSensor(BinarySensorDevice):
         try:
             self._value = result.bits[0]
         except AttributeError:
-            _LOGGER.error('No response from modbus slave %s coil %s',
-                          self._slave, self._coil)
+            _LOGGER.error('No response from hub %s, slave %s, coil %s',
+                          self._hub.name, self._slave, self._coil)

--- a/homeassistant/components/modbus/binary_sensor.py
+++ b/homeassistant/components/modbus/binary_sensor.py
@@ -7,7 +7,8 @@ https://home-assistant.io/components/binary_sensor.modbus/
 import logging
 import voluptuous as vol
 
-from homeassistant.components.modbus import DOMAIN
+from homeassistant.components.modbus import (
+    CONF_HUB, DEFAULT_HUB, DOMAIN as MODBUS_DOMAIN)
 from homeassistant.const import CONF_NAME, CONF_SLAVE
 from homeassistant.components.binary_sensor import BinarySensorDevice
 from homeassistant.helpers import config_validation as cv
@@ -16,13 +17,12 @@ from homeassistant.components.sensor import PLATFORM_SCHEMA
 _LOGGER = logging.getLogger(__name__)
 DEPENDENCIES = ['modbus']
 
-CONF_HUB = 'hub'
 CONF_COIL = 'coil'
 CONF_COILS = 'coils'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_COILS): [{
-        vol.Required(CONF_HUB, default='default'): cv.string,
+        vol.Required(CONF_HUB, default=DEFAULT_HUB): cv.string,
         vol.Required(CONF_COIL): cv.positive_int,
         vol.Required(CONF_NAME): cv.string,
         vol.Optional(CONF_SLAVE): cv.positive_int
@@ -34,7 +34,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Modbus binary sensors."""
     sensors = []
     for coil in config.get(CONF_COILS):
-        hub = hass.data[DOMAIN][coil.get(CONF_HUB)]
+        hub = hass.data[MODBUS_DOMAIN][coil.get(CONF_HUB)]
         sensors.append(ModbusCoilSensor(
             hub,
             coil.get(CONF_NAME),

--- a/homeassistant/components/modbus/climate.py
+++ b/homeassistant/components/modbus/climate.py
@@ -76,7 +76,7 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     add_devices([
         ModbusThermostat(hub, name, modbus_slave, target_temp_register,
                          current_temp_register, data_type, count, precision)
-    ], True)
+    ])
 
 
 class ModbusThermostat(ClimateDevice):

--- a/homeassistant/components/modbus/climate.py
+++ b/homeassistant/components/modbus/climate.py
@@ -85,7 +85,7 @@ class ModbusThermostat(ClimateDevice):
     def __init__(self, hub, name, modbus_slave, target_temp_register,
                  current_temp_register, data_type, count, precision):
         """Initialize the unit."""
-        self._hub: "BaseModbusClient" = hub
+        self._hub = hub  # type: BaseModbusClient
         self._name = name
         self._slave = modbus_slave
         self._target_temperature_register = target_temp_register

--- a/homeassistant/components/modbus/climate.py
+++ b/homeassistant/components/modbus/climate.py
@@ -35,7 +35,7 @@ DATA_TYPE_UINT = 'uint'
 DATA_TYPE_FLOAT = 'float'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_HUB, default=DEFAULT_HUB): cv.string,
+    vol.Optional(CONF_HUB, default=DEFAULT_HUB): cv.string,
     vol.Required(CONF_NAME): cv.string,
     vol.Required(CONF_SLAVE): cv.positive_int,
     vol.Required(CONF_TARGET_TEMP): cv.positive_int,

--- a/homeassistant/components/modbus/climate.py
+++ b/homeassistant/components/modbus/climate.py
@@ -17,8 +17,8 @@ from homeassistant.const import (
     CONF_NAME, CONF_SLAVE, ATTR_TEMPERATURE)
 from homeassistant.components.climate import (
     ClimateDevice, PLATFORM_SCHEMA, SUPPORT_TARGET_TEMPERATURE)
-
-from homeassistant.components.modbus import DOMAIN
+from homeassistant.components.modbus import (
+    CONF_HUB, DEFAULT_HUB, DOMAIN as MODBUS_DOMAIN)
 import homeassistant.helpers.config_validation as cv
 
 DEPENDENCIES = ['modbus']
@@ -29,14 +29,13 @@ CONF_CURRENT_TEMP = 'current_temp_register'
 CONF_DATA_TYPE = 'data_type'
 CONF_COUNT = 'data_count'
 CONF_PRECISION = 'precision'
-CONF_HUB = 'hub'
 
 DATA_TYPE_INT = 'int'
 DATA_TYPE_UINT = 'uint'
 DATA_TYPE_FLOAT = 'float'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_HUB, default="default"): cv.string,
+    vol.Required(CONF_HUB, default=DEFAULT_HUB): cv.string,
     vol.Required(CONF_NAME): cv.string,
     vol.Required(CONF_SLAVE): cv.positive_int,
     vol.Required(CONF_TARGET_TEMP): cv.positive_int,

--- a/homeassistant/components/modbus/climate.py
+++ b/homeassistant/components/modbus/climate.py
@@ -61,7 +61,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     count = config.get(CONF_COUNT)
     precision = config.get(CONF_PRECISION)
     hub_name = config.get(CONF_HUB)
-    hub = hass.data[DOMAIN][hub_name]
+    hub = hass.data[MODBUS_DOMAIN][hub_name]
 
     add_entities([ModbusThermostat(hub, name, modbus_slave,
                                    target_temp_register, current_temp_register,

--- a/homeassistant/components/modbus/climate.py
+++ b/homeassistant/components/modbus/climate.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
 from homeassistant.components.climate import (
     ClimateDevice, PLATFORM_SCHEMA, SUPPORT_TARGET_TEMPERATURE)
 
-from homeassistant.components.modbus import CONF_HUB_NAME, DOMAIN
+from homeassistant.components.modbus import DOMAIN
 import homeassistant.helpers.config_validation as cv
 
 DEPENDENCIES = ['modbus']
@@ -29,13 +29,14 @@ CONF_CURRENT_TEMP = 'current_temp_register'
 CONF_DATA_TYPE = 'data_type'
 CONF_COUNT = 'data_count'
 CONF_PRECISION = 'precision'
+CONF_HUB = 'hub'
 
 DATA_TYPE_INT = 'int'
 DATA_TYPE_UINT = 'uint'
 DATA_TYPE_FLOAT = 'float'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_HUB_NAME, default="default"): cv.string,
+    vol.Required(CONF_HUB, default="default"): cv.string,
     vol.Required(CONF_NAME): cv.string,
     vol.Required(CONF_SLAVE): cv.positive_int,
     vol.Required(CONF_TARGET_TEMP): cv.positive_int,
@@ -60,7 +61,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     data_type = config.get(CONF_DATA_TYPE)
     count = config.get(CONF_COUNT)
     precision = config.get(CONF_PRECISION)
-    hub_name = config.get(CONF_HUB_NAME)
+    hub_name = config.get(CONF_HUB)
     hub = hass.data[DOMAIN][hub_name]
 
     add_entities([ModbusThermostat(hub, name, modbus_slave,

--- a/homeassistant/components/modbus/sensor.py
+++ b/homeassistant/components/modbus/sensor.py
@@ -16,6 +16,7 @@ from homeassistant.const import (CONF_NAME, CONF_OFFSET, CONF_SLAVE,
                                  CONF_STRUCTURE, CONF_UNIT_OF_MEASUREMENT)
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.restore_state import async_get_last_state
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import
@@ -163,6 +164,13 @@ class ModbusRegisterSensor(Entity):
         self._precision = precision
         self._structure = structure
         self._value: str = None
+
+    async def async_added_to_hass(self):
+        """Handle entity which will be added."""
+        state = await async_get_last_state(self.hass, self.entity_id)
+        if not state:
+            return
+        self._value = state.state
 
     @property
     def state(self) -> str:

--- a/homeassistant/components/modbus/sensor.py
+++ b/homeassistant/components/modbus/sensor.py
@@ -151,7 +151,7 @@ class ModbusRegisterSensor(Entity):
                  unit_of_measurement, count, reverse_order, scale, offset,
                  structure, precision):
         """Initialize the modbus register sensor."""
-        self._hub: "BaseModbusClient" = hub
+        self._hub = hub  # type: BaseModbusClient
         self._name = name
         self._slave = int(slave) if slave else None
         self._register = int(register)

--- a/homeassistant/components/modbus/sensor.py
+++ b/homeassistant/components/modbus/sensor.py
@@ -142,7 +142,7 @@ def setup_platform(hass: Any,
 
     if not sensors:
         return False
-    add_entities(sensors)
+    add_entities(sensors, True)
     return True
 
 

--- a/homeassistant/components/modbus/sensor.py
+++ b/homeassistant/components/modbus/sensor.py
@@ -6,75 +6,104 @@ https://home-assistant.io/components/sensor.modbus/
 """
 import logging
 import struct
+from typing import TYPE_CHECKING, Any
 
 import voluptuous as vol
 
 from homeassistant.components import modbus
-from homeassistant.const import (
-    CONF_NAME, CONF_OFFSET, CONF_UNIT_OF_MEASUREMENT, CONF_SLAVE,
-    CONF_STRUCTURE)
-from homeassistant.helpers.entity import Entity
-from homeassistant.helpers import config_validation as cv
+from homeassistant.components.modbus import CONF_HUB_NAME
 from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import (
+    CONF_NAME,
+    CONF_OFFSET,
+    CONF_SLAVE,
+    CONF_STRUCTURE,
+    CONF_UNIT_OF_MEASUREMENT,
+)
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.entity import Entity
+
+if TYPE_CHECKING:
+    from pymodbus.client.sync import BaseModbusClient
 
 _LOGGER = logging.getLogger(__name__)
 
-DEPENDENCIES = ['modbus']
+DEPENDENCIES = ["modbus"]
 
-CONF_COUNT = 'count'
-CONF_REVERSE_ORDER = 'reverse_order'
-CONF_PRECISION = 'precision'
-CONF_REGISTER = 'register'
-CONF_REGISTERS = 'registers'
-CONF_SCALE = 'scale'
-CONF_DATA_TYPE = 'data_type'
-CONF_REGISTER_TYPE = 'register_type'
+CONF_COUNT = "count"
+CONF_REVERSE_ORDER = "reverse_order"
+CONF_PRECISION = "precision"
+CONF_REGISTER = "register"
+CONF_REGISTERS = "registers"
+CONF_SCALE = "scale"
+CONF_DATA_TYPE = "data_type"
+CONF_REGISTER_TYPE = "register_type"
 
-REGISTER_TYPE_HOLDING = 'holding'
-REGISTER_TYPE_INPUT = 'input'
+REGISTER_TYPE_HOLDING = "holding"
+REGISTER_TYPE_INPUT = "input"
 
-DATA_TYPE_INT = 'int'
-DATA_TYPE_UINT = 'uint'
-DATA_TYPE_FLOAT = 'float'
-DATA_TYPE_CUSTOM = 'custom'
+DATA_TYPE_INT = "int"
+DATA_TYPE_UINT = "uint"
+DATA_TYPE_FLOAT = "float"
+DATA_TYPE_CUSTOM = "custom"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_REGISTERS): [{
-        vol.Required(CONF_NAME): cv.string,
-        vol.Required(CONF_REGISTER): cv.positive_int,
+        vol.Required(CONF_HUB_NAME, default="default"):
+            cv.string,
+        vol.Required(CONF_NAME):
+            cv.string,
+        vol.Required(CONF_REGISTER):
+            cv.positive_int,
         vol.Optional(CONF_REGISTER_TYPE, default=REGISTER_TYPE_HOLDING):
             vol.In([REGISTER_TYPE_HOLDING, REGISTER_TYPE_INPUT]),
-        vol.Optional(CONF_COUNT, default=1): cv.positive_int,
-        vol.Optional(CONF_REVERSE_ORDER, default=False): cv.boolean,
-        vol.Optional(CONF_OFFSET, default=0): vol.Coerce(float),
-        vol.Optional(CONF_PRECISION, default=0): cv.positive_int,
-        vol.Optional(CONF_SCALE, default=1): vol.Coerce(float),
-        vol.Optional(CONF_SLAVE): cv.positive_int,
+        vol.Optional(CONF_COUNT, default=1):
+            cv.positive_int,
+        vol.Optional(CONF_REVERSE_ORDER, default=False):
+            cv.boolean,
+        vol.Optional(CONF_OFFSET, default=0):
+            vol.Coerce(float),
+        vol.Optional(CONF_PRECISION, default=0):
+            cv.positive_int,
+        vol.Optional(CONF_SCALE, default=1):
+            vol.Coerce(float),
+        vol.Optional(CONF_SLAVE):
+            cv.positive_int,
         vol.Optional(CONF_DATA_TYPE, default=DATA_TYPE_INT):
-            vol.In([DATA_TYPE_INT, DATA_TYPE_UINT, DATA_TYPE_FLOAT,
-                    DATA_TYPE_CUSTOM]),
-        vol.Optional(CONF_STRUCTURE): cv.string,
-        vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string
+            vol.In([
+                DATA_TYPE_INT, DATA_TYPE_UINT, DATA_TYPE_FLOAT,
+                DATA_TYPE_CUSTOM
+            ]),
+        vol.Optional(CONF_STRUCTURE):
+            cv.string,
+        vol.Optional(CONF_UNIT_OF_MEASUREMENT):
+            cv.string,
     }]
 })
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
+def setup_platform(hass: Any,
+                   config: dict,
+                   add_entities: Any,
+                   discovery_info: Any = None) -> bool:
     """Set up the Modbus sensors."""
     sensors = []
-    data_types = {DATA_TYPE_INT: {1: 'h', 2: 'i', 4: 'q'}}
-    data_types[DATA_TYPE_UINT] = {1: 'H', 2: 'I', 4: 'Q'}
-    data_types[DATA_TYPE_FLOAT] = {1: 'e', 2: 'f', 4: 'd'}
+    data_types = {DATA_TYPE_INT: {1: "h", 2: "i", 4: "q"}}
+    data_types[DATA_TYPE_UINT] = {1: "H", 2: "I", 4: "Q"}
+    data_types[DATA_TYPE_FLOAT] = {1: "e", 2: "f", 4: "d"}
 
     for register in config.get(CONF_REGISTERS):
-        structure = '>i'
+        structure = ">i"
         if register.get(CONF_DATA_TYPE) != DATA_TYPE_CUSTOM:
             try:
-                structure = '>{}'.format(data_types[
-                    register.get(CONF_DATA_TYPE)][register.get(CONF_COUNT)])
+                structure = ">{}".format(data_types[register.get(
+                    CONF_DATA_TYPE)][register.get(CONF_COUNT)])
             except KeyError:
-                _LOGGER.error("Unable to detect data type for %s sensor, "
-                              "try a custom type.", register.get(CONF_NAME))
+                _LOGGER.error(
+                    "Unable to detect data type for %s sensor, "
+                    "try a custom type.",
+                    register.get(CONF_NAME),
+                )
                 continue
         else:
             structure = register.get(CONF_STRUCTURE)
@@ -82,42 +111,49 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         try:
             size = struct.calcsize(structure)
         except struct.error as err:
-            _LOGGER.error(
-                "Error in sensor %s structure: %s",
-                register.get(CONF_NAME), err)
+            _LOGGER.error("Error in sensor %s structure: %s",
+                          register.get(CONF_NAME), err)
             continue
 
         if register.get(CONF_COUNT) * 2 != size:
             _LOGGER.error(
                 "Structure size (%d bytes) mismatch registers count "
-                "(%d words)", size, register.get(CONF_COUNT))
+                "(%d words)",
+                size,
+                register.get(CONF_COUNT),
+            )
             continue
 
-        sensors.append(ModbusRegisterSensor(
-            register.get(CONF_NAME),
-            register.get(CONF_SLAVE),
-            register.get(CONF_REGISTER),
-            register.get(CONF_REGISTER_TYPE),
-            register.get(CONF_UNIT_OF_MEASUREMENT),
-            register.get(CONF_COUNT),
-            register.get(CONF_REVERSE_ORDER),
-            register.get(CONF_SCALE),
-            register.get(CONF_OFFSET),
-            structure,
-            register.get(CONF_PRECISION)))
+        sensors.append(
+            ModbusRegisterSensor(
+                register.get(CONF_HUB_NAME),
+                register.get(CONF_NAME),
+                register.get(CONF_SLAVE),
+                register.get(CONF_REGISTER),
+                register.get(CONF_REGISTER_TYPE),
+                register.get(CONF_UNIT_OF_MEASUREMENT),
+                register.get(CONF_COUNT),
+                register.get(CONF_REVERSE_ORDER),
+                register.get(CONF_SCALE),
+                register.get(CONF_OFFSET),
+                structure,
+                register.get(CONF_PRECISION),
+            ))
 
     if not sensors:
         return False
     add_entities(sensors)
+    return True
 
 
 class ModbusRegisterSensor(Entity):
     """Modbus register sensor."""
 
-    def __init__(self, name, slave, register, register_type,
+    def __init__(self, hub_name, name, slave, register, register_type,
                  unit_of_measurement, count, reverse_order, scale, offset,
                  structure, precision):
         """Initialize the modbus register sensor."""
+        self._hub_name = hub_name
         self._name = name
         self._slave = int(slave) if slave else None
         self._register = int(register)
@@ -129,35 +165,36 @@ class ModbusRegisterSensor(Entity):
         self._offset = offset
         self._precision = precision
         self._structure = structure
-        self._value = None
+        self._value: str = None
 
     @property
-    def state(self):
+    def state(self) -> str:
         """Return the state of the sensor."""
         return self._value
 
     @property
-    def name(self):
+    def name(self) -> str:
         """Return the name of the sensor."""
         return self._name
 
     @property
-    def unit_of_measurement(self):
+    def unit_of_measurement(self) -> str:
         """Return the unit of measurement."""
         return self._unit_of_measurement
 
-    def update(self):
+    @property
+    def client(self) -> "BaseModbusClient":
+        """Find and return the client from modbus HUB."""
+        return modbus.HUB[self._hub_name]
+
+    def update(self) -> None:
         """Update the state of the sensor."""
         if self._register_type == REGISTER_TYPE_INPUT:
-            result = modbus.HUB.read_input_registers(
-                self._slave,
-                self._register,
-                self._count)
+            result = self.client.read_input_registers(
+                self._slave, self._register, self._count)
         else:
-            result = modbus.HUB.read_holding_registers(
-                self._slave,
-                self._register,
-                self._count)
+            result = self.client.read_holding_registers(
+                self._slave, self._register, self._count)
         val = 0
 
         try:
@@ -165,12 +202,14 @@ class ModbusRegisterSensor(Entity):
             if self._reverse_order:
                 registers.reverse()
         except AttributeError:
-            _LOGGER.error("No response from modbus slave %s, register %s",
-                          self._slave, self._register)
+            _LOGGER.error(
+                "No response from modbus slave %s, register %s",
+                self._slave,
+                self._register,
+            )
             return
-        byte_string = b''.join(
-            [x.to_bytes(2, byteorder='big') for x in registers]
-        )
+        byte_string = b"".join(
+            [x.to_bytes(2, byteorder="big") for x in registers])
         val = struct.unpack(self._structure, byte_string)[0]
-        self._value = format(
-            self._scale * val + self._offset, '.{}f'.format(self._precision))
+        self._value = format(self._scale * val + self._offset,
+                             ".{}f".format(self._precision))

--- a/homeassistant/components/modbus/sensor.py
+++ b/homeassistant/components/modbus/sensor.py
@@ -6,100 +6,76 @@ https://home-assistant.io/components/sensor.modbus/
 """
 import logging
 import struct
-from typing import TYPE_CHECKING, Any
 
 import voluptuous as vol
 
 from homeassistant.components.modbus import CONF_HUB_NAME, DOMAIN
-from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import (CONF_NAME, CONF_OFFSET, CONF_SLAVE,
-                                 CONF_STRUCTURE, CONF_UNIT_OF_MEASUREMENT)
+from homeassistant.const import (
+    CONF_NAME, CONF_OFFSET, CONF_UNIT_OF_MEASUREMENT, CONF_SLAVE,
+    CONF_STRUCTURE)
+from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.entity import Entity
-from homeassistant.helpers.restore_state import async_get_last_state
-
-if TYPE_CHECKING:
-    # pylint: disable=unused-import
-    from pymodbus.client.sync import BaseModbusClient
+from homeassistant.components.sensor import PLATFORM_SCHEMA
 
 _LOGGER = logging.getLogger(__name__)
 
-DEPENDENCIES = ["modbus"]
+DEPENDENCIES = ['modbus']
 
-CONF_COUNT = "count"
-CONF_REVERSE_ORDER = "reverse_order"
-CONF_PRECISION = "precision"
-CONF_REGISTER = "register"
-CONF_REGISTERS = "registers"
-CONF_SCALE = "scale"
-CONF_DATA_TYPE = "data_type"
-CONF_REGISTER_TYPE = "register_type"
+CONF_COUNT = 'count'
+CONF_REVERSE_ORDER = 'reverse_order'
+CONF_PRECISION = 'precision'
+CONF_REGISTER = 'register'
+CONF_REGISTERS = 'registers'
+CONF_SCALE = 'scale'
+CONF_DATA_TYPE = 'data_type'
+CONF_REGISTER_TYPE = 'register_type'
 
-REGISTER_TYPE_HOLDING = "holding"
-REGISTER_TYPE_INPUT = "input"
+REGISTER_TYPE_HOLDING = 'holding'
+REGISTER_TYPE_INPUT = 'input'
 
-DATA_TYPE_INT = "int"
-DATA_TYPE_UINT = "uint"
-DATA_TYPE_FLOAT = "float"
-DATA_TYPE_CUSTOM = "custom"
+DATA_TYPE_INT = 'int'
+DATA_TYPE_UINT = 'uint'
+DATA_TYPE_FLOAT = 'float'
+DATA_TYPE_CUSTOM = 'custom'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_REGISTERS): [{
-        vol.Required(CONF_HUB_NAME, default="default"):
-            cv.string,
-        vol.Required(CONF_NAME):
-            cv.string,
-        vol.Required(CONF_REGISTER):
-            cv.positive_int,
+        vol.Required(CONF_HUB_NAME, default='default'): cv.string,
+        vol.Required(CONF_NAME): cv.string,
+        vol.Required(CONF_REGISTER): cv.positive_int,
         vol.Optional(CONF_REGISTER_TYPE, default=REGISTER_TYPE_HOLDING):
             vol.In([REGISTER_TYPE_HOLDING, REGISTER_TYPE_INPUT]),
-        vol.Optional(CONF_COUNT, default=1):
-            cv.positive_int,
-        vol.Optional(CONF_REVERSE_ORDER, default=False):
-            cv.boolean,
-        vol.Optional(CONF_OFFSET, default=0):
-            vol.Coerce(float),
-        vol.Optional(CONF_PRECISION, default=0):
-            cv.positive_int,
-        vol.Optional(CONF_SCALE, default=1):
-            vol.Coerce(float),
-        vol.Optional(CONF_SLAVE):
-            cv.positive_int,
+        vol.Optional(CONF_COUNT, default=1): cv.positive_int,
+        vol.Optional(CONF_REVERSE_ORDER, default=False): cv.boolean,
+        vol.Optional(CONF_OFFSET, default=0): vol.Coerce(float),
+        vol.Optional(CONF_PRECISION, default=0): cv.positive_int,
+        vol.Optional(CONF_SCALE, default=1): vol.Coerce(float),
+        vol.Optional(CONF_SLAVE): cv.positive_int,
         vol.Optional(CONF_DATA_TYPE, default=DATA_TYPE_INT):
-            vol.In([
-                DATA_TYPE_INT, DATA_TYPE_UINT, DATA_TYPE_FLOAT,
-                DATA_TYPE_CUSTOM
-            ]),
-        vol.Optional(CONF_STRUCTURE):
-            cv.string,
-        vol.Optional(CONF_UNIT_OF_MEASUREMENT):
-            cv.string,
+            vol.In([DATA_TYPE_INT, DATA_TYPE_UINT, DATA_TYPE_FLOAT,
+                    DATA_TYPE_CUSTOM]),
+        vol.Optional(CONF_STRUCTURE): cv.string,
+        vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string
     }]
 })
 
 
-def setup_platform(hass: Any,
-                   config: dict,
-                   add_devices: Any,
-                   discovery_info: Any = None) -> bool:
+def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Modbus sensors."""
     sensors = []
-    data_types = {DATA_TYPE_INT: {1: "h", 2: "i", 4: "q"}}
-    data_types[DATA_TYPE_UINT] = {1: "H", 2: "I", 4: "Q"}
-    data_types[DATA_TYPE_FLOAT] = {1: "e", 2: "f", 4: "d"}
+    data_types = {DATA_TYPE_INT: {1: 'h', 2: 'i', 4: 'q'}}
+    data_types[DATA_TYPE_UINT] = {1: 'H', 2: 'I', 4: 'Q'}
+    data_types[DATA_TYPE_FLOAT] = {1: 'e', 2: 'f', 4: 'd'}
 
-    for register in config.get(CONF_REGISTERS, []):
-        structure = ">i"
+    for register in config.get(CONF_REGISTERS):
+        structure = '>i'
         if register.get(CONF_DATA_TYPE) != DATA_TYPE_CUSTOM:
             try:
-                structure = ">{}".format(data_types[register.get(
+                structure = '>{}'.format(data_types[register.get(
                     CONF_DATA_TYPE)][register.get(CONF_COUNT)])
             except KeyError:
-                _LOGGER.error(
-                    "Unable to detect data type for %s sensor, "
-                    "try a custom type.",
-                    register.get(CONF_NAME),
-                )
+                _LOGGER.error("Unable to detect data type for %s sensor, "
+                              "try a custom type.", register.get(CONF_NAME))
                 continue
         else:
             structure = register.get(CONF_STRUCTURE)
@@ -107,51 +83,46 @@ def setup_platform(hass: Any,
         try:
             size = struct.calcsize(structure)
         except struct.error as err:
-            _LOGGER.error("Error in sensor %s structure: %s",
-                          register.get(CONF_NAME), err)
+            _LOGGER.error(
+                "Error in sensor %s structure: %s",
+                register.get(CONF_NAME), err)
             continue
 
         if register.get(CONF_COUNT) * 2 != size:
             _LOGGER.error(
                 "Structure size (%d bytes) mismatch registers count "
-                "(%d words)",
-                size,
-                register.get(CONF_COUNT),
-            )
+                "(%d words)", size, register.get(CONF_COUNT))
             continue
 
         hub_name = register.get(CONF_HUB_NAME)
         hub = hass.data[DOMAIN][hub_name]
-        sensors.append(
-            ModbusRegisterSensor(
-                hub,
-                register.get(CONF_NAME),
-                register.get(CONF_SLAVE),
-                register.get(CONF_REGISTER),
-                register.get(CONF_REGISTER_TYPE),
-                register.get(CONF_UNIT_OF_MEASUREMENT),
-                register.get(CONF_COUNT),
-                register.get(CONF_REVERSE_ORDER),
-                register.get(CONF_SCALE),
-                register.get(CONF_OFFSET),
-                structure,
-                register.get(CONF_PRECISION),
-            ))
+        sensors.append(ModbusRegisterSensor(
+            hub,
+            register.get(CONF_NAME),
+            register.get(CONF_SLAVE),
+            register.get(CONF_REGISTER),
+            register.get(CONF_REGISTER_TYPE),
+            register.get(CONF_UNIT_OF_MEASUREMENT),
+            register.get(CONF_COUNT),
+            register.get(CONF_REVERSE_ORDER),
+            register.get(CONF_SCALE),
+            register.get(CONF_OFFSET),
+            structure,
+            register.get(CONF_PRECISION)))
 
     if not sensors:
         return False
-    add_devices(sensors)
-    return True
+    add_entities(sensors)
 
 
-class ModbusRegisterSensor(Entity):
+class ModbusRegisterSensor(RestoreEntity):
     """Modbus register sensor."""
 
     def __init__(self, hub, name, slave, register, register_type,
                  unit_of_measurement, count, reverse_order, scale, offset,
                  structure, precision):
         """Initialize the modbus register sensor."""
-        self._hub = hub  # type: BaseModbusClient
+        self._hub = hub
         self._name = name
         self._slave = int(slave) if slave else None
         self._register = int(register)
@@ -163,38 +134,42 @@ class ModbusRegisterSensor(Entity):
         self._offset = offset
         self._precision = precision
         self._structure = structure
-        self._value: str = None
+        self._value = None
 
     async def async_added_to_hass(self):
         """Handle entity which will be added."""
-        state = await async_get_last_state(self.hass, self.entity_id)
+        state = await self.async_get_last_state()
         if not state:
             return
         self._value = state.state
 
     @property
-    def state(self) -> str:
+    def state(self):
         """Return the state of the sensor."""
         return self._value
 
     @property
-    def name(self) -> str:
+    def name(self):
         """Return the name of the sensor."""
         return self._name
 
     @property
-    def unit_of_measurement(self) -> str:
+    def unit_of_measurement(self):
         """Return the unit of measurement."""
         return self._unit_of_measurement
 
-    def update(self) -> None:
+    def update(self):
         """Update the state of the sensor."""
         if self._register_type == REGISTER_TYPE_INPUT:
             result = self._hub.read_input_registers(
-                self._slave, self._register, self._count)
+                self._slave,
+                self._register,
+                self._count)
         else:
             result = self._hub.read_holding_registers(
-                self._slave, self._register, self._count)
+                self._slave,
+                self._register,
+                self._count)
         val = 0
 
         try:
@@ -202,14 +177,12 @@ class ModbusRegisterSensor(Entity):
             if self._reverse_order:
                 registers.reverse()
         except AttributeError:
-            _LOGGER.error(
-                "No response from modbus slave %s, register %s",
-                self._slave,
-                self._register,
-            )
+            _LOGGER.error("No response from modbus slave %s, register %s",
+                          self._slave, self._register)
             return
-        byte_string = b"".join(
-            [x.to_bytes(2, byteorder="big") for x in registers])
+        byte_string = b''.join(
+            [x.to_bytes(2, byteorder='big') for x in registers]
+        )
         val = struct.unpack(self._structure, byte_string)[0]
-        self._value = format(self._scale * val + self._offset,
-                             ".{}f".format(self._precision))
+        self._value = format(
+            self._scale * val + self._offset, '.{}f'.format(self._precision))

--- a/homeassistant/components/modbus/sensor.py
+++ b/homeassistant/components/modbus/sensor.py
@@ -41,7 +41,7 @@ DATA_TYPE_CUSTOM = 'custom'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_REGISTERS): [{
-        vol.Required(CONF_HUB, DEFAULT_HUB): cv.string,
+        vol.Optional(CONF_HUB, default=DEFAULT_HUB): cv.string,
         vol.Required(CONF_NAME): cv.string,
         vol.Required(CONF_REGISTER): cv.positive_int,
         vol.Optional(CONF_REGISTER_TYPE, default=REGISTER_TYPE_HOLDING):

--- a/homeassistant/components/modbus/sensor.py
+++ b/homeassistant/components/modbus/sensor.py
@@ -178,8 +178,8 @@ class ModbusRegisterSensor(RestoreEntity):
             if self._reverse_order:
                 registers.reverse()
         except AttributeError:
-            _LOGGER.error("No response from modbus slave %s, register %s",
-                          self._slave, self._register)
+            _LOGGER.error("No response from hub %s, slave %s, register %s",
+                          self._hub.name, self._slave, self._register)
             return
         byte_string = b''.join(
             [x.to_bytes(2, byteorder='big') for x in registers]

--- a/homeassistant/components/modbus/sensor.py
+++ b/homeassistant/components/modbus/sensor.py
@@ -9,7 +9,7 @@ import struct
 
 import voluptuous as vol
 
-from homeassistant.components.modbus import CONF_HUB_NAME, DOMAIN
+from homeassistant.components.modbus import DOMAIN
 from homeassistant.const import (
     CONF_NAME, CONF_OFFSET, CONF_UNIT_OF_MEASUREMENT, CONF_SLAVE,
     CONF_STRUCTURE)
@@ -21,6 +21,7 @@ _LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = ['modbus']
 
+CONF_HUB = 'hub'
 CONF_COUNT = 'count'
 CONF_REVERSE_ORDER = 'reverse_order'
 CONF_PRECISION = 'precision'
@@ -40,7 +41,7 @@ DATA_TYPE_CUSTOM = 'custom'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_REGISTERS): [{
-        vol.Required(CONF_HUB_NAME, default='default'): cv.string,
+        vol.Required(CONF_HUB, default='default'): cv.string,
         vol.Required(CONF_NAME): cv.string,
         vol.Required(CONF_REGISTER): cv.positive_int,
         vol.Optional(CONF_REGISTER_TYPE, default=REGISTER_TYPE_HOLDING):
@@ -94,7 +95,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                 "(%d words)", size, register.get(CONF_COUNT))
             continue
 
-        hub_name = register.get(CONF_HUB_NAME)
+        hub_name = register.get(CONF_HUB)
         hub = hass.data[DOMAIN][hub_name]
         sensors.append(ModbusRegisterSensor(
             hub,

--- a/homeassistant/components/modbus/sensor.py
+++ b/homeassistant/components/modbus/sensor.py
@@ -9,7 +9,8 @@ import struct
 
 import voluptuous as vol
 
-from homeassistant.components.modbus import DOMAIN
+from homeassistant.components.modbus import (
+    CONF_HUB, DEFAULT_HUB, DOMAIN as MODBUS_DOMAIN)
 from homeassistant.const import (
     CONF_NAME, CONF_OFFSET, CONF_UNIT_OF_MEASUREMENT, CONF_SLAVE,
     CONF_STRUCTURE)
@@ -21,7 +22,6 @@ _LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = ['modbus']
 
-CONF_HUB = 'hub'
 CONF_COUNT = 'count'
 CONF_REVERSE_ORDER = 'reverse_order'
 CONF_PRECISION = 'precision'
@@ -41,7 +41,7 @@ DATA_TYPE_CUSTOM = 'custom'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_REGISTERS): [{
-        vol.Required(CONF_HUB, default='default'): cv.string,
+        vol.Required(CONF_HUB, DEFAULT_HUB): cv.string,
         vol.Required(CONF_NAME): cv.string,
         vol.Required(CONF_REGISTER): cv.positive_int,
         vol.Optional(CONF_REGISTER_TYPE, default=REGISTER_TYPE_HOLDING):
@@ -96,7 +96,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             continue
 
         hub_name = register.get(CONF_HUB)
-        hub = hass.data[DOMAIN][hub_name]
+        hub = hass.data[MODBUS_DOMAIN][hub_name]
         sensors.append(ModbusRegisterSensor(
             hub,
             register.get(CONF_NAME),

--- a/homeassistant/components/modbus/switch.py
+++ b/homeassistant/components/modbus/switch.py
@@ -93,7 +93,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                     register.get(CONF_VERIFY_REGISTER),
                     register.get(CONF_REGISTER_TYPE),
                     register.get(CONF_STATE_ON), register.get(CONF_STATE_OFF)))
-    add_entities(switches)
+    add_entities(switches, True)
 
 
 class ModbusCoilSwitch(ToggleEntity):

--- a/homeassistant/components/modbus/switch.py
+++ b/homeassistant/components/modbus/switch.py
@@ -12,9 +12,10 @@ import voluptuous as vol
 from homeassistant.components.modbus import CONF_HUB_NAME, DOMAIN
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (CONF_COMMAND_OFF, CONF_COMMAND_ON, CONF_NAME,
-                                 CONF_SLAVE)
+                                 CONF_SLAVE, STATE_ON)
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity import ToggleEntity
+from homeassistant.helpers.restore_state import async_get_last_state
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import
@@ -115,6 +116,13 @@ class ModbusCoilSwitch(ToggleEntity):
         self._slave = int(slave) if slave else None
         self._coil = int(coil)
         self._is_on = None
+
+    async def async_added_to_hass(self):
+        """Handle entity which will be added."""
+        state = await async_get_last_state(self.hass, self.entity_id)
+        if not state:
+            return
+        self._is_on = state.state == STATE_ON
 
     @property
     def is_on(self):

--- a/homeassistant/components/modbus/switch.py
+++ b/homeassistant/components/modbus/switch.py
@@ -111,7 +111,7 @@ class ModbusCoilSwitch(ToggleEntity):
 
     def __init__(self, hub, name, slave, coil):
         """Initialize the coil switch."""
-        self._hub: "BaseModbusClient" = hub
+        self._hub = hub  # type: BaseModbusClient
         self._name = name
         self._slave = int(slave) if slave else None
         self._coil = int(coil)
@@ -160,7 +160,7 @@ class ModbusRegisterSwitch(ModbusCoilSwitch):
                  verify_state, verify_register, register_type, state_on,
                  state_off):
         """Initialize the register switch."""
-        self._hub: "BaseModbusClient" = hub
+        self._hub = hub  # type: BaseModbusClient
         self._name = name
         self._slave = slave
         self._register = register

--- a/homeassistant/components/modbus/switch.py
+++ b/homeassistant/components/modbus/switch.py
@@ -5,21 +5,15 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/switch.modbus/
 """
 import logging
-from typing import TYPE_CHECKING
-
 import voluptuous as vol
 
 from homeassistant.components.modbus import CONF_HUB_NAME, DOMAIN
-from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import (CONF_COMMAND_OFF, CONF_COMMAND_ON, CONF_NAME,
-                                 CONF_SLAVE, STATE_ON)
-from homeassistant.helpers import config_validation as cv
+from homeassistant.const import (
+    CONF_NAME, CONF_SLAVE, CONF_COMMAND_ON, CONF_COMMAND_OFF, STATE_ON)
 from homeassistant.helpers.entity import ToggleEntity
-from homeassistant.helpers.restore_state import async_get_last_state
-
-if TYPE_CHECKING:
-    # pylint: disable=unused-import
-    from pymodbus.client.sync import BaseModbusClient
+from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.helpers import config_validation as cv
+from homeassistant.components.sensor import PLATFORM_SCHEMA
 
 _LOGGER = logging.getLogger(__name__)
 DEPENDENCIES = ['modbus']
@@ -38,32 +32,23 @@ REGISTER_TYPE_HOLDING = 'holding'
 REGISTER_TYPE_INPUT = 'input'
 
 REGISTERS_SCHEMA = vol.Schema({
-    vol.Required(CONF_HUB_NAME, default="default"):
-        cv.string,
-    vol.Required(CONF_NAME):
-        cv.string,
-    vol.Optional(CONF_SLAVE):
-        cv.positive_int,
-    vol.Required(CONF_REGISTER):
-        cv.positive_int,
-    vol.Required(CONF_COMMAND_ON):
-        cv.positive_int,
-    vol.Required(CONF_COMMAND_OFF):
-        cv.positive_int,
-    vol.Optional(CONF_VERIFY_STATE, default=True):
-        cv.boolean,
+    vol.Required(CONF_HUB_NAME, default='default'): cv.string,
+    vol.Required(CONF_NAME): cv.string,
+    vol.Optional(CONF_SLAVE): cv.positive_int,
+    vol.Required(CONF_REGISTER): cv.positive_int,
+    vol.Required(CONF_COMMAND_ON): cv.positive_int,
+    vol.Required(CONF_COMMAND_OFF): cv.positive_int,
+    vol.Optional(CONF_VERIFY_STATE, default=True): cv.boolean,
     vol.Optional(CONF_VERIFY_REGISTER):
         cv.positive_int,
     vol.Optional(CONF_REGISTER_TYPE, default=REGISTER_TYPE_HOLDING):
         vol.In([REGISTER_TYPE_HOLDING, REGISTER_TYPE_INPUT]),
-    vol.Optional(CONF_STATE_ON):
-        cv.positive_int,
-    vol.Optional(CONF_STATE_OFF):
-        cv.positive_int,
+    vol.Optional(CONF_STATE_ON): cv.positive_int,
+    vol.Optional(CONF_STATE_OFF): cv.positive_int,
 })
 
 COILS_SCHEMA = vol.Schema({
-    vol.Required(CONF_HUB_NAME, default="default"): cv.string,
+    vol.Required(CONF_HUB_NAME, default='default'): cv.string,
     vol.Required(CONF_COIL): cv.positive_int,
     vol.Required(CONF_NAME): cv.string,
     vol.Required(CONF_SLAVE): cv.positive_int,
@@ -77,41 +62,44 @@ PLATFORM_SCHEMA = vol.All(
     }))
 
 
-def setup_platform(hass, config, add_devices, discovery_info=None):
+def setup_platform(hass, config, add_entities, discovery_info=None):
     """Read configuration and create Modbus devices."""
     switches = []
     if CONF_COILS in config:
         for coil in config.get(CONF_COILS):
             hub_name = coil.get(CONF_HUB_NAME)
             hub = hass.data[DOMAIN][hub_name]
-            switches.append(
-                ModbusCoilSwitch(hub, coil.get(CONF_NAME),
-                                 coil.get(CONF_SLAVE), coil.get(CONF_COIL)))
+            switches.append(ModbusCoilSwitch(
+                hub,
+                coil.get(CONF_NAME),
+                coil.get(CONF_SLAVE),
+                coil.get(CONF_COIL)))
     if CONF_REGISTERS in config:
         for register in config.get(CONF_REGISTERS):
             hub_name = register.get(CONF_HUB_NAME)
             hub = hass.data[DOMAIN][hub_name]
 
-            switches.append(
-                ModbusRegisterSwitch(hub, register.get(CONF_NAME),
-                                     register.get(CONF_SLAVE),
-                                     register.get(CONF_REGISTER),
-                                     register.get(CONF_COMMAND_ON),
-                                     register.get(CONF_COMMAND_OFF),
-                                     register.get(CONF_VERIFY_STATE),
-                                     register.get(CONF_VERIFY_REGISTER),
-                                     register.get(CONF_REGISTER_TYPE),
-                                     register.get(CONF_STATE_ON),
-                                     register.get(CONF_STATE_OFF)))
-    add_devices(switches)
+            switches.append(ModbusRegisterSwitch(
+                hub,
+                register.get(CONF_NAME),
+                register.get(CONF_SLAVE),
+                register.get(CONF_REGISTER),
+                register.get(CONF_COMMAND_ON),
+                register.get(CONF_COMMAND_OFF),
+                register.get(CONF_VERIFY_STATE),
+                register.get(CONF_VERIFY_REGISTER),
+                register.get(CONF_REGISTER_TYPE),
+                register.get(CONF_STATE_ON),
+                register.get(CONF_STATE_OFF)))
+    add_entities(switches)
 
 
-class ModbusCoilSwitch(ToggleEntity):
+class ModbusCoilSwitch(ToggleEntity, RestoreEntity):
     """Representation of a Modbus coil switch."""
 
     def __init__(self, hub, name, slave, coil):
         """Initialize the coil switch."""
-        self._hub = hub  # type: BaseModbusClient
+        self._hub = hub
         self._name = name
         self._slave = int(slave) if slave else None
         self._coil = int(coil)
@@ -119,7 +107,7 @@ class ModbusCoilSwitch(ToggleEntity):
 
     async def async_added_to_hass(self):
         """Handle entity which will be added."""
-        state = await async_get_last_state(self.hass, self.entity_id)
+        state = await self.async_get_last_state()
         if not state:
             return
         self._is_on = state.state == STATE_ON
@@ -148,27 +136,29 @@ class ModbusCoilSwitch(ToggleEntity):
         try:
             self._is_on = bool(result.bits[0])
         except AttributeError:
-            _LOGGER.error('No response from modbus slave %s coil %s',
-                          self._slave, self._coil)
+            _LOGGER.error(
+                'No response from modbus slave %s coil %s',
+                self._slave,
+                self._coil)
 
 
 class ModbusRegisterSwitch(ModbusCoilSwitch):
     """Representation of a Modbus register switch."""
 
     # pylint: disable=super-init-not-called
-    def __init__(self, hub, name, slave, register, command_on, command_off,
-                 verify_state, verify_register, register_type, state_on,
-                 state_off):
+    def __init__(self, hub, name, slave, register, command_on,
+                 command_off, verify_state, verify_register,
+                 register_type, state_on, state_off):
         """Initialize the register switch."""
-        self._hub = hub  # type: BaseModbusClient
+        self._hub = hub
         self._name = name
         self._slave = slave
         self._register = register
         self._command_on = command_on
         self._command_off = command_off
         self._verify_state = verify_state
-        self._verify_register = (verify_register
-                                 if verify_register else self._register)
+        self._verify_register = (
+            verify_register if verify_register else self._register)
         self._register_type = register_type
 
         if state_on is not None:
@@ -185,14 +175,19 @@ class ModbusRegisterSwitch(ModbusCoilSwitch):
 
     def turn_on(self, **kwargs):
         """Set switch on."""
-        self._hub.write_register(self._slave, self._register, self._command_on)
+        self._hub.write_register(
+            self._slave,
+            self._register,
+            self._command_on)
         if not self._verify_state:
             self._is_on = True
 
     def turn_off(self, **kwargs):
         """Set switch off."""
-        self._hub.write_register(self._slave, self._register,
-                                 self._command_off)
+        self._hub.write_register(
+            self._slave,
+            self._register,
+            self._command_off)
         if not self._verify_state:
             self._is_on = False
 
@@ -203,17 +198,23 @@ class ModbusRegisterSwitch(ModbusCoilSwitch):
 
         value = 0
         if self._register_type == REGISTER_TYPE_INPUT:
-            result = self._hub.read_input_registers(self._slave,
-                                                    self._register, 1)
+            result = self._hub.read_input_registers(
+                self._slave,
+                self._register,
+                1)
         else:
-            result = self._hub.read_holding_registers(self._slave,
-                                                      self._register, 1)
+            result = self._hub.read_holding_registers(
+                self._slave,
+                self._register,
+                1)
 
         try:
             value = int(result.registers[0])
         except AttributeError:
-            _LOGGER.error('No response from modbus slave %s register %s',
-                          self._slave, self._verify_register)
+            _LOGGER.error(
+                'No response from modbus slave %s register %s',
+                self._slave,
+                self._verify_register)
 
         if value == self._state_on:
             self._is_on = True
@@ -222,5 +223,7 @@ class ModbusRegisterSwitch(ModbusCoilSwitch):
         else:
             _LOGGER.error(
                 'Unexpected response from modbus slave %s '
-                'register %s, got 0x%2x', self._slave, self._verify_register,
+                'register %s, got 0x%2x',
+                self._slave,
+                self._verify_register,
                 value)

--- a/homeassistant/components/modbus/switch.py
+++ b/homeassistant/components/modbus/switch.py
@@ -7,7 +7,7 @@ https://home-assistant.io/components/switch.modbus/
 import logging
 import voluptuous as vol
 
-from homeassistant.components.modbus import CONF_HUB_NAME, DOMAIN
+from homeassistant.components.modbus import DOMAIN
 from homeassistant.const import (
     CONF_NAME, CONF_SLAVE, CONF_COMMAND_ON, CONF_COMMAND_OFF, STATE_ON)
 from homeassistant.helpers.entity import ToggleEntity
@@ -18,6 +18,7 @@ from homeassistant.components.sensor import PLATFORM_SCHEMA
 _LOGGER = logging.getLogger(__name__)
 DEPENDENCIES = ['modbus']
 
+CONF_HUB = "hub"
 CONF_COIL = "coil"
 CONF_COILS = "coils"
 CONF_REGISTER = "register"
@@ -32,7 +33,7 @@ REGISTER_TYPE_HOLDING = 'holding'
 REGISTER_TYPE_INPUT = 'input'
 
 REGISTERS_SCHEMA = vol.Schema({
-    vol.Required(CONF_HUB_NAME, default='default'): cv.string,
+    vol.Required(CONF_HUB, default='default'): cv.string,
     vol.Required(CONF_NAME): cv.string,
     vol.Optional(CONF_SLAVE): cv.positive_int,
     vol.Required(CONF_REGISTER): cv.positive_int,
@@ -48,7 +49,7 @@ REGISTERS_SCHEMA = vol.Schema({
 })
 
 COILS_SCHEMA = vol.Schema({
-    vol.Required(CONF_HUB_NAME, default='default'): cv.string,
+    vol.Required(CONF_HUB, default='default'): cv.string,
     vol.Required(CONF_COIL): cv.positive_int,
     vol.Required(CONF_NAME): cv.string,
     vol.Required(CONF_SLAVE): cv.positive_int,
@@ -67,7 +68,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     switches = []
     if CONF_COILS in config:
         for coil in config.get(CONF_COILS):
-            hub_name = coil.get(CONF_HUB_NAME)
+            hub_name = coil.get(CONF_HUB)
             hub = hass.data[DOMAIN][hub_name]
             switches.append(ModbusCoilSwitch(
                 hub,
@@ -76,7 +77,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                 coil.get(CONF_COIL)))
     if CONF_REGISTERS in config:
         for register in config.get(CONF_REGISTERS):
-            hub_name = register.get(CONF_HUB_NAME)
+            hub_name = register.get(CONF_HUB)
             hub = hass.data[DOMAIN][hub_name]
 
             switches.append(ModbusRegisterSwitch(

--- a/homeassistant/components/modbus/switch.py
+++ b/homeassistant/components/modbus/switch.py
@@ -7,7 +7,8 @@ https://home-assistant.io/components/switch.modbus/
 import logging
 import voluptuous as vol
 
-from homeassistant.components.modbus import DOMAIN
+from homeassistant.components.modbus import (
+    CONF_HUB, DEFAULT_HUB, DOMAIN as MODBUS_DOMAIN)
 from homeassistant.const import (
     CONF_NAME, CONF_SLAVE, CONF_COMMAND_ON, CONF_COMMAND_OFF, STATE_ON)
 from homeassistant.helpers.entity import ToggleEntity
@@ -18,7 +19,6 @@ from homeassistant.components.sensor import PLATFORM_SCHEMA
 _LOGGER = logging.getLogger(__name__)
 DEPENDENCIES = ['modbus']
 
-CONF_HUB = "hub"
 CONF_COIL = "coil"
 CONF_COILS = "coils"
 CONF_REGISTER = "register"
@@ -33,7 +33,7 @@ REGISTER_TYPE_HOLDING = 'holding'
 REGISTER_TYPE_INPUT = 'input'
 
 REGISTERS_SCHEMA = vol.Schema({
-    vol.Required(CONF_HUB, default='default'): cv.string,
+    vol.Required(CONF_HUB, default=DEFAULT_HUB): cv.string,
     vol.Required(CONF_NAME): cv.string,
     vol.Optional(CONF_SLAVE): cv.positive_int,
     vol.Required(CONF_REGISTER): cv.positive_int,
@@ -49,7 +49,7 @@ REGISTERS_SCHEMA = vol.Schema({
 })
 
 COILS_SCHEMA = vol.Schema({
-    vol.Required(CONF_HUB, default='default'): cv.string,
+    vol.Required(CONF_HUB, default=DEFAULT_HUB): cv.string,
     vol.Required(CONF_COIL): cv.positive_int,
     vol.Required(CONF_NAME): cv.string,
     vol.Required(CONF_SLAVE): cv.positive_int,

--- a/homeassistant/components/modbus/switch.py
+++ b/homeassistant/components/modbus/switch.py
@@ -33,7 +33,7 @@ REGISTER_TYPE_HOLDING = 'holding'
 REGISTER_TYPE_INPUT = 'input'
 
 REGISTERS_SCHEMA = vol.Schema({
-    vol.Required(CONF_HUB, default=DEFAULT_HUB): cv.string,
+    vol.Optional(CONF_HUB, default=DEFAULT_HUB): cv.string,
     vol.Required(CONF_NAME): cv.string,
     vol.Optional(CONF_SLAVE): cv.positive_int,
     vol.Required(CONF_REGISTER): cv.positive_int,
@@ -49,7 +49,7 @@ REGISTERS_SCHEMA = vol.Schema({
 })
 
 COILS_SCHEMA = vol.Schema({
-    vol.Required(CONF_HUB, default=DEFAULT_HUB): cv.string,
+    vol.Optional(CONF_HUB, default=DEFAULT_HUB): cv.string,
     vol.Required(CONF_COIL): cv.positive_int,
     vol.Required(CONF_NAME): cv.string,
     vol.Required(CONF_SLAVE): cv.positive_int,

--- a/homeassistant/components/modbus/switch.py
+++ b/homeassistant/components/modbus/switch.py
@@ -69,7 +69,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     if CONF_COILS in config:
         for coil in config.get(CONF_COILS):
             hub_name = coil.get(CONF_HUB)
-            hub = hass.data[DOMAIN][hub_name]
+            hub = hass.data[MODBUS_DOMAIN][hub_name]
             switches.append(ModbusCoilSwitch(
                 hub,
                 coil.get(CONF_NAME),
@@ -78,7 +78,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     if CONF_REGISTERS in config:
         for register in config.get(CONF_REGISTERS):
             hub_name = register.get(CONF_HUB)
-            hub = hass.data[DOMAIN][hub_name]
+            hub = hass.data[MODBUS_DOMAIN][hub_name]
 
             switches.append(ModbusRegisterSwitch(
                 hub,

--- a/homeassistant/components/modbus/switch.py
+++ b/homeassistant/components/modbus/switch.py
@@ -138,7 +138,8 @@ class ModbusCoilSwitch(ToggleEntity, RestoreEntity):
             self._is_on = bool(result.bits[0])
         except AttributeError:
             _LOGGER.error(
-                'No response from modbus slave %s coil %s',
+                'No response from hub %s, slave %s, coil %s',
+                self._hub.name,
                 self._slave,
                 self._coil)
 
@@ -213,7 +214,8 @@ class ModbusRegisterSwitch(ModbusCoilSwitch):
             value = int(result.registers[0])
         except AttributeError:
             _LOGGER.error(
-                'No response from modbus slave %s register %s',
+                'No response from hub %s, slave %s, register %s',
+                self._hub.name,
                 self._slave,
                 self._verify_register)
 
@@ -223,8 +225,9 @@ class ModbusRegisterSwitch(ModbusCoilSwitch):
             self._is_on = False
         else:
             _LOGGER.error(
-                'Unexpected response from modbus slave %s '
+                'Unexpected response from hub %s, slave %s '
                 'register %s, got 0x%2x',
+                self._hub.name,
                 self._slave,
                 self._verify_register,
                 value)


### PR DESCRIPTION
## Description:

This PR implements support for multiple modbus hubs. It adds new configuration variables to distinguish between different hubs. 

In the modbus section a new variable "name" is introduced. Sensors can then reference this name in a new "hub" variable. Both default to "default" when omitted so existing configuration should continue to work.

This is a continuation of  #17901 with some alterations. The original author indicated that he didn't have time to finish it.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8027

## Example entry for `configuration.yaml` (if applicable):
```yaml
modbus:
  - name: hub1
    type: tcp
    host: 192.168.0.1
    port: 502

  - name: hub2
    type: rtuovertcp
    host: 192.168.0.2
    port: 8887

sensor:
  - platform: modbus
    scan_interval: 5
    registers:
      - name: first_sensor
        hub: hub1
        register: 20
        data_type: uint
      - name: another_sensor
        hub: hub2
        slave: 1
        register: 2
        register_type: holding
        count: 1

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
