### PR TITLE
Add mychevy optional country parameter

### DIFF
--- a/homeassistant/components/mychevy.py
+++ b/homeassistant/components/mychevy.py
@@ -34,12 +34,14 @@ MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=30)
 ERROR_SLEEP_TIME = timedelta(minutes=30)
 
 CONF_COUNTRY = 'country'
+DEFAULT_COUNTRY = 'us'
+
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Required(CONF_USERNAME): cv.string,
         vol.Required(CONF_PASSWORD): cv.string,
-        vol.Optional(CONF_COUNTRY, default='us'): vol.All(
-            cv.string, vol.In(['us', 'ca']))
+        vol.Optional(CONF_COUNTRY, default=DEFAULT_COUNTRY):
+            vol.All(cv.string, vol.In(['us', 'ca']))
     }),
 }, extra=vol.ALLOW_EXTRA)
 

--- a/homeassistant/components/mychevy.py
+++ b/homeassistant/components/mychevy.py
@@ -16,7 +16,7 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import discovery
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ["mychevy==1.1.0"]
+REQUIREMENTS = ["mychevy==1.2.0"]
 
 DOMAIN = 'mychevy'
 UPDATE_TOPIC = DOMAIN
@@ -33,10 +33,13 @@ _LOGGER = logging.getLogger(__name__)
 MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=30)
 ERROR_SLEEP_TIME = timedelta(minutes=30)
 
+CONF_COUNTRY = 'country'
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Required(CONF_USERNAME): cv.string,
         vol.Required(CONF_PASSWORD): cv.string,
+        vol.Optional(CONF_COUNTRY, default='us'): vol.All(
+            cv.string, vol.In(['us', 'ca']))
     }),
 }, extra=vol.ALLOW_EXTRA)
 
@@ -72,7 +75,8 @@ def setup(hass, base_config):
 
     email = config.get(CONF_USERNAME)
     password = config.get(CONF_PASSWORD)
-    hass.data[DOMAIN] = MyChevyHub(mc.MyChevy(email, password), hass,
+    country = config.get(CONF_COUNTRY)
+    hass.data[DOMAIN] = MyChevyHub(mc.MyChevy(email, password, country), hass,
                                    base_config)
     hass.data[DOMAIN].start()
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -680,7 +680,7 @@ motorparts==1.0.2
 mutagen==1.41.1
 
 # homeassistant.components.mychevy
-mychevy==1.1.0
+mychevy==1.2.0
 
 # homeassistant.components.mycroft
 mycroftapi==2.0


### PR DESCRIPTION
mychevy 1.2.0 provides the ability to work in canada as well as the us
(there are different service urls for each region). This creates a new
config option to enable it.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

