### PR TITLE
Use manufacturer id in configure_reporting on a per need basis

### DIFF
--- a/homeassistant/components/zha/helpers.py
+++ b/homeassistant/components/zha/helpers.py
@@ -67,10 +67,13 @@ async def configure_reporting(entity_id, cluster, attr, skip_bind=False,
 
     attr_name = cluster.attributes.get(attr, [attr])[0]
     cluster_name = cluster.ep_attribute
+    kwargs = {}
+    if manufacturer:
+        kwargs['manufacturer'] = manufacturer
     try:
         res = await cluster.configure_reporting(attr, min_report,
                                                 max_report, reportable_change,
-                                                manufacturer=manufacturer)
+                                                **kwargs)
         _LOGGER.debug(
             "%s: reporting '%s' attr on '%s' cluster: %d/%d/%d: Result: '%s'",
             entity_id, attr_name, cluster_name, min_report, max_report,


### PR DESCRIPTION
## Description:
If `manufacturer is None` then don't use it in configure reporting Zigpy call

Fixes Zigpy configure reporting exceptions, if using an older zigpy version.
## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
