### PR TITLE
Check configuration.yaml instead of config entry for ZHA enable_quirks flag

### DIFF
--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -95,8 +95,7 @@ async def async_setup(hass, config):
             context={'source': config_entries.SOURCE_IMPORT},
             data={
                 CONF_USB_PATH: conf[CONF_USB_PATH],
-                CONF_RADIO_TYPE: conf.get(CONF_RADIO_TYPE).value,
-                ENABLE_QUIRKS: conf[ENABLE_QUIRKS]
+                CONF_RADIO_TYPE: conf.get(CONF_RADIO_TYPE).value
             }
         ))
     return True
@@ -107,16 +106,16 @@ async def async_setup_entry(hass, config_entry):
 
     Will automatically load components to support devices found on the network.
     """
-    if config_entry.data.get(ENABLE_QUIRKS):
-        # needs to be done here so that the ZHA module is finished loading
-        # before zhaquirks is imported
-        # pylint: disable=W0611, W0612
-        import zhaquirks  # noqa
-
     hass.data[DATA_ZHA] = hass.data.get(DATA_ZHA, {})
     hass.data[DATA_ZHA][DATA_ZHA_DISPATCHERS] = []
 
     config = hass.data[DATA_ZHA].get(DATA_ZHA_CONFIG, {})
+
+    if config.get(ENABLE_QUIRKS, True):
+        # needs to be done here so that the ZHA module is finished loading
+        # before zhaquirks is imported
+        # pylint: disable=W0611, W0612
+        import zhaquirks  # noqa
 
     usb_path = config_entry.data.get(CONF_USB_PATH)
     baudrate = config.get(CONF_BAUDRATE, DEFAULT_BAUDRATE)


### PR DESCRIPTION
The original intent for this was to default the functionality to on and to let users disable it if they chose to for any reason. Moving the check to the configuration.yaml part of the configuration actually allows this to be changed without a user having to remove and re-add an integration. 