### PR TITLE
Expand the rpi_gpio component to support orangepi as well.

### DIFF
--- a/homeassistant/components/binary_sensor/rpi_gpio.py
+++ b/homeassistant/components/binary_sensor/rpi_gpio.py
@@ -27,8 +27,10 @@ DEFAULT_PULL_MODE = 'UP'
 
 DEPENDENCIES = ['rpi_gpio']
 
+# Note that pin numbers of Raspberry Pis are positive integers, but on
+# OrangePi are strings of the form "PA7".
 _SENSORS_SCHEMA = vol.Schema({
-    cv.positive_int: cv.string,
+    cv.string: cv.string,
 })
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({

--- a/homeassistant/components/rpi_gpio.py
+++ b/homeassistant/components/rpi_gpio.py
@@ -52,10 +52,12 @@ GPIO_LIBRARY = None
 
 class UnknownBoardFamily(Exception):
     """board_family should be 'raspberry_pi' or 'orange_pi'"""
+    pass
 
 
 class UnknownOrangePiBoard(Exception):
-    """'board' config item not set""" 
+    """'board' config item not set"""
+    pass
 
 
 def setup(hass, base_config):

--- a/homeassistant/components/rpi_gpio.py
+++ b/homeassistant/components/rpi_gpio.py
@@ -51,23 +51,22 @@ GPIO_LIBRARY = None
 
 
 class UnknownBoardFamily(Exception):
-    pass
+    """board_family should be 'raspberry_pi' or 'orange_pi'"""
 
 
 class UnknownOrangePiBoard(Exception):
-    pass
+    """'board' config item not set""" 
 
 
 def setup(hass, base_config):
     """Set up the GPIO component."""
-
     global GPIO_LIBRARY
 
     config = base_config.get(DOMAIN)
     family_name = config.get(CONF_BOARD_FAMILY, DEFAULT_FAMILY)
     lib_name = FAMILY_LIBRARIES.get(family_name)
-    _LOGGER.info('Configured to use board family %s' % family_name)
-    _LOGGER.info('Will use %s as GPIO library' % lib_name)
+    _LOGGER.info('Configured to use board family %s', family_name)
+    _LOGGER.info('Will use %s as GPIO library', lib_name)
     if not lib_name:
         raise UnknownBoardFamily('Unknown board family: %s'
                                  % config.get(CONF_BOARD_FAMILY))
@@ -77,7 +76,7 @@ def setup(hass, base_config):
     if family_name == 'orange_pi':
         board_name = config.get(CONF_BOARD)
         board = ORANGEPI_BOARDS.get(board_name)
-        _LOGGER.info('OrangePi %s board specified' % board_name)
+        _LOGGER.info('OrangePi %s board specified', board_name)
 
         if not board_name:
             raise UnknownOrangePiBoard('You must specify a board type '

--- a/homeassistant/components/rpi_gpio.py
+++ b/homeassistant/components/rpi_gpio.py
@@ -14,7 +14,7 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['RPi.GPIO==0.6.5',
-                'OPi.GPIO==0.3.5']
+                'OPi.GPIO==0.3.6']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -65,8 +65,7 @@ def setup(hass, base_config):
     hass.bus.listen_once(EVENT_HOMEASSISTANT_START, prepare_gpio)
 
     if family_name == 'orange_pi':
-        import orangepi.pc
-        hass.data[DOMAIN][LIBRARY].setmode(orangepi.pc.BOARD)
+        hass.data[DOMAIN][LIBRARY].setmode(hass.data[DOMAIN][LIBRARY].SUNXI)
     else:
         hass.data[DOMAIN][LIBRARY].setmode(hass.data[DOMAIN][LIBRARY].BCM)
 

--- a/homeassistant/components/switch/rpi_gpio.py
+++ b/homeassistant/components/switch/rpi_gpio.py
@@ -24,8 +24,10 @@ CONF_INVERT_LOGIC = 'invert_logic'
 
 DEFAULT_INVERT_LOGIC = False
 
+# Note that pin numbers of Raspberry Pis are positive integers, but on
+# OrangePi are strings of the form "PA7".
 _SWITCHES_SCHEMA = vol.Schema({
-    cv.positive_int: cv.string,
+    cv.string: cv.string,
 })
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({

--- a/homeassistant/components/switch/rpi_gpio.py
+++ b/homeassistant/components/switch/rpi_gpio.py
@@ -41,21 +41,23 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     switches = []
     ports = config.get(CONF_PORTS)
     for port, name in ports.items():
-        switches.append(RPiGPIOSwitch(name, port, invert_logic))
+        switches.append(RPiGPIOSwitch(hass, name, port, invert_logic))
     add_entities(switches)
 
 
 class RPiGPIOSwitch(ToggleEntity):
     """Representation of a  Raspberry Pi GPIO."""
 
-    def __init__(self, name, port, invert_logic):
+    def __init__(self, hass, name, port, invert_logic):
         """Initialize the pin."""
+        self._hass = hass
         self._name = name or DEVICE_DEFAULT_NAME
         self._port = port
         self._invert_logic = invert_logic
         self._state = False
-        rpi_gpio.setup_output(self._port)
-        rpi_gpio.write_output(self._port, 1 if self._invert_logic else 0)
+        rpi_gpio.setup_output(self._hass, self._port)
+        rpi_gpio.write_output(self._hass, self._port,
+                              1 if self._invert_logic else 0)
 
     @property
     def name(self):
@@ -74,12 +76,14 @@ class RPiGPIOSwitch(ToggleEntity):
 
     def turn_on(self, **kwargs):
         """Turn the device on."""
-        rpi_gpio.write_output(self._port, 0 if self._invert_logic else 1)
+        rpi_gpio.write_output(self._hass, self._port,
+                              0 if self._invert_logic else 1)
         self._state = True
         self.schedule_update_ha_state()
 
     def turn_off(self, **kwargs):
         """Turn the device off."""
-        rpi_gpio.write_output(self._port, 1 if self._invert_logic else 0)
+        rpi_gpio.write_output(self._hass, self._port,
+                              1 if self._invert_logic else 0)
         self._state = False
         self.schedule_update_ha_state()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -38,6 +38,9 @@ HAP-python==2.4.2
 # homeassistant.components.notify.mastodon
 Mastodon.py==1.3.1
 
+# homeassistant.components.rpi_gpio
+OrangePi.GPIO==0.6.3
+
 # homeassistant.components.isy994
 PyISY==1.1.0
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -39,7 +39,7 @@ HAP-python==2.4.2
 Mastodon.py==1.3.1
 
 # homeassistant.components.rpi_gpio
-OrangePi.GPIO==0.6.3
+OPi.GPIO==0.3.6
 
 # homeassistant.components.isy994
 PyISY==1.1.0


### PR DESCRIPTION
## Description:

Instead of adding a new component for orangepi (which is a raspberry pi clone), let's just extend the existing component to support more than one family of boards.

I have tested this patch on a raspberry pi 3 and an orangepi prime, in both cases with a LED on a GPIO controlled switch. Note that the orangepi GPIO library requires access to /dev/mem, which I have resolved for now by running Home Assistant as root.

I'm holding off on a home-assistant.io pull request to match this until I get a feel for if this approach is acceptable to you.

This code was implemented to support a Home Assistant tutorial running at linux.conf.au 2019 in a couple of weeks, it would be super cool to be able to have this merged by then so that attendees don't need to carry private patches.

## Example entry for `configuration.yaml` (if applicable):
```
rpi_gpio:
  board_family: orange_pi
  board: prime

switch:
 - platform: rpi_gpio
   ports:
     29: LED
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (see PR https://github.com/home-assistant/home-assistant.io/pull/8185)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
