### PR TITLE
Drop bme680 os_lookup for temp_offset

### DIFF
--- a/homeassistant/components/sensor/bme680.py
+++ b/homeassistant/components/sensor/bme680.py
@@ -145,7 +145,7 @@ def _setup_bme680(config):
             os_lookup[config.get(CONF_OVERSAMPLING_TEMP)]
         )
         sensor.set_temp_offset(
-            os_lookup[config.get(CONF_TEMP_OFFSET)]
+            config.get(CONF_TEMP_OFFSET)
         )
         sensor.set_humidity_oversample(
             os_lookup[config.get(CONF_OVERSAMPLING_HUM)]


### PR DESCRIPTION
## Description:
Drops os_lookup, as it isn't needed to set the temperature offset.

**Related issue (if applicable):** 
fixes: https://github.com/home-assistant/home-assistant/pull/19684#discussion_r244905843


## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)



[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
