### PR TITLE
Better displaying of different periods

### DIFF
--- a/homeassistant/components/sensor/efergy.py
+++ b/homeassistant/components/sensor/efergy.py
@@ -22,7 +22,6 @@ CONF_UTC_OFFSET = 'utc_offset'
 CONF_MONITORED_VARIABLES = 'monitored_variables'
 CONF_SENSOR_TYPE = 'type'
 
-CONF_CURRENCY = 'currency'
 CONF_PERIOD = 'period'
 
 CONF_INSTANT = 'instant_readings'
@@ -147,23 +146,23 @@ class EfergySensor(Entity):
                 response = requests.get(url_string, timeout=10)
                 self._state = response.json()['reading']
             elif self.type == 'amount_day':
-                url_string = '{}getEnergy?token={}&offset={}&period=day'.format(
-                    _RESOURCE, self.app_token, self.utc_offset)
+                url_string = '{}getEnergy?token={}&offset={}&period={}'.format(
+                    _RESOURCE, self.app_token, self.utc_offset, 'day')
                 response = requests.get(url_string, timeout=10)
                 self._state = response.json()['sum']
             elif self.type == 'amount_week':
-                url_string = '{}getEnergy?token={}&offset={}&period=week'.format(
-                    _RESOURCE, self.app_token, self.utc_offset)
+                url_string = '{}getEnergy?token={}&offset={}&period={}'.format(
+                    _RESOURCE, self.app_token, self.utc_offset, 'week')
                 response = requests.get(url_string, timeout=10)
                 self._state = response.json()['sum']
             elif self.type == 'amount_month':
-                url_string = '{}getEnergy?token={}&offset={}&period=month'.format(
-                    _RESOURCE, self.app_token, self.utc_offset)
+                url_string = '{}getEnergy?token={}&offset={}&period={}'.format(
+                    _RESOURCE, self.app_token, self.utc_offset, 'month')
                 response = requests.get(url_string, timeout=10)
                 self._state = response.json()['sum']
             elif self.type == 'amount_year':
-                url_string = '{}getEnergy?token={}&offset={}&period=year'.format(
-                    _RESOURCE, self.app_token, self.utc_offset)
+                url_string = '{}getEnergy?token={}&offset={}&period={}'.format(
+                    _RESOURCE, self.app_token, self.utc_offset, 'year')
                 response = requests.get(url_string, timeout=10)
                 self._state = response.json()['sum']
             elif self.type == 'budget':
@@ -172,23 +171,23 @@ class EfergySensor(Entity):
                 response = requests.get(url_string, timeout=10)
                 self._state = response.json()['status']
             elif self.type == 'cost_day':
-                url_string = '{}getCost?token={}&offset={}&period=day'.format(
-                    _RESOURCE, self.app_token, self.utc_offset)
+                url_string = '{}getCost?token={}&offset={}&period={}'.format(
+                    _RESOURCE, self.app_token, self.utc_offset, 'day')
                 response = requests.get(url_string, timeout=10)
                 self._state = response.json()['sum']
             elif self.type == 'cost_week':
-                url_string = '{}getCost?token={}&offset={}&period=week'.format(
-                    _RESOURCE, self.app_token, self.utc_offset)
+                url_string = '{}getCost?token={}&offset={}&period={}'.format(
+                    _RESOURCE, self.app_token, self.utc_offset, 'week')
                 response = requests.get(url_string, timeout=10)
                 self._state = response.json()['sum']
             elif self.type == 'cost_month':
-                url_string = '{}getCost?token={}&offset={}&period=month'.format(
-                    _RESOURCE, self.app_token, self.utc_offset)
+                url_string = '{}getCost?token={}&offset={}&period={}'.format(
+                    _RESOURCE, self.app_token, self.utc_offset, 'month')
                 response = requests.get(url_string, timeout=10)
                 self._state = response.json()['sum']
             elif self.type == 'cost_year':
-                url_string = '{}getCost?token={}&offset={}&period=year'.format(
-                    _RESOURCE, self.app_token, self.utc_offset)
+                url_string = '{}getCost?token={}&offset={}&period={}'.format(
+                    _RESOURCE, self.app_token, self.utc_offset, 'year')
                 response = requests.get(url_string, timeout=10)
                 self._state = response.json()['sum']
             elif self.type == 'current_values':

--- a/homeassistant/components/sensor/efergy.py
+++ b/homeassistant/components/sensor/efergy.py
@@ -22,12 +22,19 @@ CONF_UTC_OFFSET = 'utc_offset'
 CONF_MONITORED_VARIABLES = 'monitored_variables'
 CONF_SENSOR_TYPE = 'type'
 
+CONF_CURRENCY = 'currency'
 CONF_PERIOD = 'period'
 
 CONF_INSTANT = 'instant_readings'
-CONF_AMOUNT = 'amount'
+CONF_AMOUNT_DAY = 'amount_day'
+CONF_AMOUNT_WEEK = 'amount_week'
+CONF_AMOUNT_MONTH = 'amount_month'
+CONF_AMOUNT_YEAR = 'amount_year'
 CONF_BUDGET = 'budget'
-CONF_COST = 'cost'
+CONF_COST_DAY = 'cost_day'
+CONF_COST_WEEK = 'cost_week'
+CONF_COST_MONTH = 'cost_month'
+CONF_COST_YEAR = 'cost_year'
 CONF_CURRENT_VALUES = 'current_values'
 
 DEFAULT_PERIOD = 'year'
@@ -35,9 +42,15 @@ DEFAULT_UTC_OFFSET = '0'
 
 SENSOR_TYPES = {
     CONF_INSTANT: ['Energy Usage', 'W'],
-    CONF_AMOUNT: ['Energy Consumed', 'kWh'],
+    CONF_AMOUNT_DAY: ['Energy Consumed Today', 'kWh'],
+    CONF_AMOUNT_WEEK: ['Energy Consumed This Week', 'kWh'],
+    CONF_AMOUNT_MONTH: ['Energy Consumed This Month', 'kWh'],
+    CONF_AMOUNT_YEAR: ['Energy Consumed This Year', 'kWh'],
     CONF_BUDGET: ['Energy Budget', None],
-    CONF_COST: ['Energy Cost', None],
+    CONF_COST_DAY: ['Energy Cost Today', None],
+    CONF_COST_WEEK: ['Energy Cost This Week', None],
+    CONF_COST_MONTH: ['Energy Cost This Month', None],
+    CONF_COST_YEAR: ['Energy Cost This Year', None],
     CONF_CURRENT_VALUES: ['Per-Device Usage', 'W']
 }
 
@@ -78,7 +91,6 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     add_entities(dev, True)
 
-
 class EfergySensor(Entity):
     """Implementation of an Efergy sensor."""
 
@@ -96,9 +108,18 @@ class EfergySensor(Entity):
         self._state = None
         self.period = period
         self.currency = currency
-        if self.type == 'cost':
-            self._unit_of_measurement = '{}/{}'.format(
-                self.currency, self.period)
+        if self.type == 'cost_day':
+            self._unit_of_measurement = '{}'.format(
+                self.currency)
+        elif self.type == 'cost_week':
+            self._unit_of_measurement = '{}'.format(
+                    self.currency)
+        elif self.type == 'cost_month':
+            self._unit_of_measurement = '{}'.format(
+                    self.currency)
+        elif self.type == 'cost_year':
+            self._unit_of_measurement = '{}'.format(
+                    self.currency)
         else:
             self._unit_of_measurement = SENSOR_TYPES[sensor_type][1]
 
@@ -125,9 +146,24 @@ class EfergySensor(Entity):
                     _RESOURCE, self.app_token)
                 response = requests.get(url_string, timeout=10)
                 self._state = response.json()['reading']
-            elif self.type == 'amount':
-                url_string = '{}getEnergy?token={}&offset={}&period={}'.format(
-                    _RESOURCE, self.app_token, self.utc_offset, self.period)
+            elif self.type == 'amount_day':
+                url_string = '{}getEnergy?token={}&offset={}&period=day'.format(
+                    _RESOURCE, self.app_token, self.utc_offset)
+                response = requests.get(url_string, timeout=10)
+                self._state = response.json()['sum']
+            elif self.type == 'amount_week':
+                url_string = '{}getEnergy?token={}&offset={}&period=week'.format(
+                    _RESOURCE, self.app_token, self.utc_offset)
+                response = requests.get(url_string, timeout=10)
+                self._state = response.json()['sum']
+            elif self.type == 'amount_month':
+                url_string = '{}getEnergy?token={}&offset={}&period=month'.format(
+                    _RESOURCE, self.app_token, self.utc_offset)
+                response = requests.get(url_string, timeout=10)
+                self._state = response.json()['sum']
+            elif self.type == 'amount_year':
+                url_string = '{}getEnergy?token={}&offset={}&period=year'.format(
+                    _RESOURCE, self.app_token, self.utc_offset)
                 response = requests.get(url_string, timeout=10)
                 self._state = response.json()['sum']
             elif self.type == 'budget':
@@ -135,9 +171,24 @@ class EfergySensor(Entity):
                     _RESOURCE, self.app_token)
                 response = requests.get(url_string, timeout=10)
                 self._state = response.json()['status']
-            elif self.type == 'cost':
-                url_string = '{}getCost?token={}&offset={}&period={}'.format(
-                    _RESOURCE, self.app_token, self.utc_offset, self.period)
+            elif self.type == 'cost_day':
+                url_string = '{}getCost?token={}&offset={}&period=day'.format(
+                    _RESOURCE, self.app_token, self.utc_offset)
+                response = requests.get(url_string, timeout=10)
+                self._state = response.json()['sum']
+            elif self.type == 'cost_week':
+                url_string = '{}getCost?token={}&offset={}&period=week'.format(
+                    _RESOURCE, self.app_token, self.utc_offset)
+                response = requests.get(url_string, timeout=10)
+                self._state = response.json()['sum']
+            elif self.type == 'cost_month':
+                url_string = '{}getCost?token={}&offset={}&period=month'.format(
+                    _RESOURCE, self.app_token, self.utc_offset)
+                response = requests.get(url_string, timeout=10)
+                self._state = response.json()['sum']
+            elif self.type == 'cost_year':
+                url_string = '{}getCost?token={}&offset={}&period=year'.format(
+                    _RESOURCE, self.app_token, self.utc_offset)
                 response = requests.get(url_string, timeout=10)
                 self._state = response.json()['sum']
             elif self.type == 'current_values':


### PR DESCRIPTION
Updated the PY to allow better display of different periods when multiple of same 'type' used.

## Description:

Previously using 'type: cost' or 'amount' more than once with a different 'period' would result in entities being created with a '_#' added.   While this was fine it was inconsistent on reboot and sometimes changed order depending on which 'period' loaded first.

This fixes that by removing the need for 'period' and instead adding more 'types' where the period is defined in the name.

   monitored_variables:
     - type: cost_day
       currency: $
     - type: amount_day
     - type: cost_week
       currency: $
     - type: amount_week
     - type: cost_month
       currency: $
     - type: amount_month
     - type: cost_year
       currency: $
     - type: amount_year

I have also updated the terms used to display the usage or amount to be period specific

Energy Cost Today
Energy Cost This Week
Energy Cost This Month
Energy Cost This Year

Period is now obsolete.  I have not removed it however as it kept kicking out errors when I tried.  At the moment this code is working and displaying correctly.




**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [NA] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [NA] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [NA] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [NA] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
