### PR TITLE
Cleanup if discovered mqtt binary_sensor can't be added

### DIFF
--- a/homeassistant/components/binary_sensor/mqtt.py
+++ b/homeassistant/components/binary_sensor/mqtt.py
@@ -20,7 +20,8 @@ from homeassistant.components.mqtt import (
     CONF_PAYLOAD_AVAILABLE, CONF_PAYLOAD_NOT_AVAILABLE, CONF_QOS,
     MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
     MqttEntityDeviceInfo, subscription)
-from homeassistant.components.mqtt.discovery import MQTT_DISCOVERY_NEW
+from homeassistant.components.mqtt.discovery import (
+    ALREADY_DISCOVERED, MQTT_DISCOVERY_NEW)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 import homeassistant.helpers.event as evt
@@ -63,9 +64,15 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up MQTT binary sensor dynamically through MQTT discovery."""
     async def async_discover(discovery_payload):
         """Discover and add a MQTT binary sensor."""
-        config = PLATFORM_SCHEMA(discovery_payload)
-        await _async_setup_entity(config, async_add_entities,
-                                  discovery_payload[ATTR_DISCOVERY_HASH])
+        try:
+            discovery_hash = discovery_payload[ATTR_DISCOVERY_HASH]
+            config = PLATFORM_SCHEMA(discovery_payload)
+            await _async_setup_entity(config, async_add_entities,
+                                      discovery_hash)
+        except:  # noqa: E722
+            if discovery_hash:
+                del hass.data[ALREADY_DISCOVERED][discovery_hash]
+            raise
 
     async_dispatcher_connect(
         hass, MQTT_DISCOVERY_NEW.format(binary_sensor.DOMAIN, 'mqtt'),

--- a/homeassistant/components/binary_sensor/mqtt.py
+++ b/homeassistant/components/binary_sensor/mqtt.py
@@ -69,7 +69,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             config = PLATFORM_SCHEMA(discovery_payload)
             await _async_setup_entity(config, async_add_entities,
                                       discovery_hash)
-        except:  # noqa: E722
+        except Exception:
             if discovery_hash:
                 del hass.data[ALREADY_DISCOVERED][discovery_hash]
             raise

--- a/homeassistant/components/binary_sensor/mqtt.py
+++ b/homeassistant/components/binary_sensor/mqtt.py
@@ -21,7 +21,7 @@ from homeassistant.components.mqtt import (
     MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
     MqttEntityDeviceInfo, subscription)
 from homeassistant.components.mqtt.discovery import (
-    ALREADY_DISCOVERED, MQTT_DISCOVERY_NEW)
+    MQTT_DISCOVERY_NEW, clear_discovery_hash)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 import homeassistant.helpers.event as evt
@@ -71,7 +71,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                                       discovery_hash)
         except Exception:
             if discovery_hash:
-                del hass.data[ALREADY_DISCOVERED][discovery_hash]
+                clear_discovery_hash(hass, discovery_hash)
             raise
 
     async_dispatcher_connect(


### PR DESCRIPTION
## Description:
If a discovered MQTT binary_sensor fails to be added, make sure the discovery hash is cleaned up from the `ALREADY_DISCOVERED` list. (Same as #19721)

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.
