### PR TITLE
Round illumination and lux value to one for xiaomi_aqara

### DIFF
--- a/homeassistant/components/sensor/xiaomi_aqara.py
+++ b/homeassistant/components/sensor/xiaomi_aqara.py
@@ -107,5 +107,8 @@ class XiaomiSensor(XiaomiDevice):
             return False
         if self._data_key == 'pressure' and value == 0:
             return False
-        self._state = round(value, 1)
+        if self._data_key in ['illumination', 'lux']:
+            self._state = round(value)
+        else:
+            self._state = round(value, 1)
         return True


### PR DESCRIPTION
## Description:
The Xiaomi Aqara gateway sends illumination and lux values as rounded to one and HA should display these in the same way. Now it's always zero as a decimal place.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

