### PR TITLE
Simplify data_key for a stable unique_id

### DIFF
--- a/homeassistant/components/cover/xiaomi_aqara.py
+++ b/homeassistant/components/cover/xiaomi_aqara.py
@@ -18,9 +18,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             model = device['model']
             if model == 'curtain':
                 devices.append(XiaomiGenericCover(device, "Curtain",
-                                                  {'status': 'status',
-                                                   'pos': 'curtain_level'},
-                                                  gateway))
+                                                  'status', gateway))
     add_entities(devices)
 
 
@@ -45,20 +43,20 @@ class XiaomiGenericCover(XiaomiDevice, CoverDevice):
 
     def close_cover(self, **kwargs):
         """Close the cover."""
-        self._write_to_hub(self._sid, **{self._data_key['status']: 'close'})
+        self._write_to_hub(self._sid, **{self._data_key: 'close'})
 
     def open_cover(self, **kwargs):
         """Open the cover."""
-        self._write_to_hub(self._sid, **{self._data_key['status']: 'open'})
+        self._write_to_hub(self._sid, **{self._data_key: 'open'})
 
     def stop_cover(self, **kwargs):
         """Stop the cover."""
-        self._write_to_hub(self._sid, **{self._data_key['status']: 'stop'})
+        self._write_to_hub(self._sid, **{self._data_key: 'stop'})
 
     def set_cover_position(self, **kwargs):
         """Move the cover to a specific position."""
         position = kwargs.get(ATTR_POSITION)
-        self._write_to_hub(self._sid, **{self._data_key['pos']: str(position)})
+        self._write_to_hub(self._sid, **{ATTR_CURTAIN_LEVEL: str(position)})
 
     def parse_data(self, data, raw_data):
         """Parse data sent by gateway."""


### PR DESCRIPTION
Simplify data_key for a stable unique_id because the order of the dict will not be preserved.

Without this patch the unique_id of the cover entity can be `status158d0002254951` or `pos158d0002254951` and flips probably on each restart. 

## Description:

**Related issue (if applicable):** fixes #13522
