### PR TITLE
Don't slugify unique id

### DIFF
--- a/homeassistant/components/xiaomi_aqara.py
+++ b/homeassistant/components/xiaomi_aqara.py
@@ -20,7 +20,6 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import async_track_point_in_utc_time
 from homeassistant.util.dt import utcnow
-from homeassistant.util import slugify
 
 REQUIREMENTS = ['PyXiaomiGateway==0.11.1']
 
@@ -222,11 +221,11 @@ class XiaomiDevice(Entity):
 
         if hasattr(self, '_data_key') \
                 and self._data_key:  # pylint: disable=no-member
-            self._unique_id = slugify("{}-{}".format(
+            self._unique_id = "{}{}".format(
                 self._data_key,  # pylint: disable=no-member
-                self._sid))
+                self._sid)
         else:
-            self._unique_id = slugify("{}-{}".format(self._type, self._sid))
+            self._unique_id = "{}{}".format(self._type, self._sid)
 
     def _add_push_data_job(self, *args):
         self.hass.add_job(self.push_data, *args)


### PR DESCRIPTION
## Description:

```
# homeassistant 0.84.6
>>> from homeassistant.util import slugify
>>> slugify("{}-{}".format("status", "158d0002254951"))
'status158d0002254951'
>>> 
```

```
$ source bin/activate
$ pip3 install -U https://github.com/home-assistant/home-assistant/archive/dev.zip
$ python3
Python 3.5.3 (default, Jan 19 2017, 14:11:04) 
[GCC 6.3.0 20170118] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from homeassistant.util import slugify
>>> slugify("{}-{}".format("status", "158d0002254951"))
'status_158d0002254951'
>>> 
```

This patch will keep the old behavior/format: status158d0002254951

cp. https://github.com/home-assistant/home-assistant/pull/19192#issuecomment-451442301

**Related issue (if applicable):** fixes #13522
