### PR TITLE
HomematicIP update version to 0.10.1

### DIFF
--- a/homeassistant/components/homematicip_cloud/__init__.py
+++ b/homeassistant/components/homematicip_cloud/__init__.py
@@ -19,7 +19,7 @@ from .const import (
 from .device import HomematicipGenericDevice  # noqa: F401
 from .hap import HomematicipAuth, HomematicipHAP  # noqa: F401
 
-REQUIREMENTS = ['homematicip==0.9.8']
+REQUIREMENTS = ['homematicip==0.10.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -520,7 +520,7 @@ homeassistant-pyozw==0.1.1
 # homekit==0.12.0
 
 # homeassistant.components.homematicip_cloud
-homematicip==0.9.8
+homematicip==0.10.1
 
 # homeassistant.components.google
 # homeassistant.components.remember_the_milk

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -107,7 +107,7 @@ holidays==0.9.8
 home-assistant-frontend==20181219.0
 
 # homeassistant.components.homematicip_cloud
-homematicip==0.9.8
+homematicip==0.10.1
 
 # homeassistant.components.influxdb
 # homeassistant.components.sensor.influxdb


### PR DESCRIPTION
## Description:
Update rest-api version to 0.10.1.

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
