### PR TITLE
This makes the vasttrafik platform stop spamming the logs with warnings

### DIFF
--- a/homeassistant/components/sensor/vasttrafik.py
+++ b/homeassistant/components/sensor/vasttrafik.py
@@ -116,7 +116,7 @@ class VasttrafikDepartureSensor(Entity):
     def state(self):
         """Return the next departure time."""
         if not self._departureboard:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "No departures from %s heading %s",
                 self._departure['name'],
                 self._heading['name'] if self._heading else 'ANY')
@@ -143,5 +143,5 @@ class VasttrafikDepartureSensor(Entity):
                 direction=self._heading['id'] if self._heading else None,
                 date=datetime.now()+self._delay)
         except self._vasttrafik.Error:
-            _LOGGER.warning("Unable to read departure board, updating token")
+            _LOGGER.debug("Unable to read departure board, updating token")
             self._planner.update_token()

--- a/homeassistant/components/sensor/vasttrafik.py
+++ b/homeassistant/components/sensor/vasttrafik.py
@@ -59,6 +59,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     planner = vasttrafik.JournyPlanner(
         config.get(CONF_KEY), config.get(CONF_SECRET))
     sensors = []
+
     for departure in config.get(CONF_DEPARTURES):
         sensors.append(
             VasttrafikDepartureSensor(


### PR DESCRIPTION
## Description:
My log was filling up with "no departures message, I do not have bus departures on all weekdays

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.