### PR TITLE
HomematicIP add cover FROLL and BROLL devices

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -164,7 +164,6 @@ omit =
     homeassistant/components/homematic/__init__.py
     homeassistant/components/*/homematic.py
 
-    homeassistant/components/homematicip_cloud/__init__.py
     homeassistant/components/homematicip_cloud/hap.py
     homeassistant/components/homematicip_cloud/device.py
     homeassistant/components/*/homematicip_cloud.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -164,7 +164,9 @@ omit =
     homeassistant/components/homematic/__init__.py
     homeassistant/components/*/homematic.py
 
-    homeassistant/components/homematicip_cloud.py
+    homeassistant/components/homematicip_cloud/__init__.py
+    homeassistant/components/homematicip_cloud/hap.py
+    homeassistant/components/homematicip_cloud/device.py
     homeassistant/components/*/homematicip_cloud.py
 
     homeassistant/components/homeworks.py

--- a/homeassistant/components/cover/homematicip_cloud.py
+++ b/homeassistant/components/cover/homematicip_cloud.py
@@ -39,6 +39,10 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class HomematicipCoverShutter(HomematicipGenericDevice, CoverDevice):
     """Representation of a HomematicIP Cloud cover device."""
 
+    def __init__(self, home, device):
+        """Initialize the cover device."""
+        super().__init__(home, device)
+
     @property
     def current_cover_position(self):
         """Return current position of cover."""

--- a/homeassistant/components/cover/homematicip_cloud.py
+++ b/homeassistant/components/cover/homematicip_cloud.py
@@ -38,11 +38,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
 
 class HomematicipCoverShutter(HomematicipGenericDevice, CoverDevice):
-    """representation of a HomematicIP Cloud cover device."""
-
-    def __init__(self, home, device):
-        """Initialize the cover device."""
-        super().__init__(home, device)
+    """Representation of a HomematicIP Cloud cover device."""
 
     @property
     def current_cover_position(self):
@@ -51,10 +47,9 @@ class HomematicipCoverShutter(HomematicipGenericDevice, CoverDevice):
 
     async def async_set_cover_position(self, **kwargs):
         """Move the cover to a specific position."""
-        if ATTR_POSITION in kwargs:
-            position = kwargs[ATTR_POSITION]
-            level = position / 100.0
-            await self._device.set_shutter_level(level)
+        position = kwargs[ATTR_POSITION]
+        level = position / 100.0
+        await self._device.set_shutter_level(level)
 
     @property
     def is_closed(self):

--- a/homeassistant/components/cover/homematicip_cloud.py
+++ b/homeassistant/components/cover/homematicip_cloud.py
@@ -9,8 +9,7 @@ import logging
 from homeassistant.components.cover import (
     ATTR_POSITION, CoverDevice)
 from homeassistant.components.homematicip_cloud import (
-    HMIPC_HAPID, HomematicipGenericDevice)
-from homeassistant.components.homematicip_cloud import DOMAIN as HMIPC_DOMAIN
+    HMIPC_HAPID, HomematicipGenericDevice, DOMAIN as HMIPC_DOMAIN)
 
 DEPENDENCIES = ['homematicip_cloud']
 

--- a/homeassistant/components/cover/homematicip_cloud.py
+++ b/homeassistant/components/cover/homematicip_cloud.py
@@ -49,11 +49,10 @@ class HomematicipCoverShutter(HomematicipGenericDevice, CoverDevice):
         """Return current position of cover."""
         return int(self._device.shutterLevel * 100)
 
-    async def set_cover_position(self, **kwargs):
+    async def async_set_cover_position(self, **kwargs):
         """Move the cover to a specific position."""
         if ATTR_POSITION in kwargs:
-            position = float(kwargs[ATTR_POSITION])
-            position = min(100, max(0, position))
+            position = kwargs[ATTR_POSITION]
             level = position / 100.0
             await self._device.set_shutter_level(level)
 
@@ -62,15 +61,16 @@ class HomematicipCoverShutter(HomematicipGenericDevice, CoverDevice):
         """Return if the cover is closed."""
         if self._device.shutterLevel is not None:
             return self._device.shutterLevel == 0
+        return None
 
-    async def open_cover(self, **kwargs):
+    async def async_open_cover(self, **kwargs):
         """Open the cover."""
         await self._device.set_shutter_level(1)
 
-    async def close_cover(self, **kwargs):
+    async def async_close_cover(self, **kwargs):
         """Close the cover."""
         await self._device.set_shutter_level(0)
 
-    async def stop_cover(self, **kwargs):
+    async def async_stop_cover(self, **kwargs):
         """Stop the device if in motion."""
         await self._device.set_shutter_stop()

--- a/homeassistant/components/cover/homematicip_cloud.py
+++ b/homeassistant/components/cover/homematicip_cloud.py
@@ -25,7 +25,7 @@ async def async_setup_platform(
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the HomematicIP cover from a config entry."""
-    from homematicip.device import AsyncFullFlushShutter
+    from homematicip.aio.device import AsyncFullFlushShutter
 
     home = hass.data[HMIPC_DOMAIN][config_entry.data[HMIPC_HAPID]].home
     devices = []
@@ -49,13 +49,13 @@ class HomematicipCoverShutter(HomematicipGenericDevice, CoverDevice):
         """Return current position of cover."""
         return int(self._device.shutterLevel * 100)
 
-    def set_cover_position(self, **kwargs):
+    async def set_cover_position(self, **kwargs):
         """Move the cover to a specific position."""
         if ATTR_POSITION in kwargs:
             position = float(kwargs[ATTR_POSITION])
             position = min(100, max(0, position))
             level = position / 100.0
-            self._device.set_shutter_level(level)
+            await self._device.set_shutter_level(level)
 
     @property
     def is_closed(self):
@@ -63,14 +63,14 @@ class HomematicipCoverShutter(HomematicipGenericDevice, CoverDevice):
         if self._device.shutterLevel is not None:
             return self._device.shutterLevel == 0
 
-    def open_cover(self, **kwargs):
+    async def open_cover(self, **kwargs):
         """Open the cover."""
-        self._device.set_shutter_level(1)
+        await self._device.set_shutter_level(1)
 
-    def close_cover(self, **kwargs):
+    async def close_cover(self, **kwargs):
         """Close the cover."""
-        self._device.set_shutter_level(0)
+        await self._device.set_shutter_level(0)
 
-    def stop_cover(self, **kwargs):
+    async def stop_cover(self, **kwargs):
         """Stop the device if in motion."""
-        self._device.set_shutter_stop()
+        await self._device.set_shutter_stop()

--- a/homeassistant/components/cover/homematicip_cloud.py
+++ b/homeassistant/components/cover/homematicip_cloud.py
@@ -2,12 +2,12 @@
 Support for HomematicIP Cloud cover.
 
 For more details about this platform, please refer to the documentation at
-https://home-assistant.io/components/switch.homematicip_cloud/
+https://home-assistant.io/components/cover.homematicip_cloud/
 """
 import logging
 
 from homeassistant.components.cover import (
-    ATTR_POSITION, ATTR_TILT_POSITION, CoverDevice)
+    ATTR_POSITION, CoverDevice)
 from homeassistant.components.homematicip_cloud import (
     HMIPC_HAPID, HomematicipGenericDevice)
 from homeassistant.components.homematicip_cloud import DOMAIN as HMIPC_DOMAIN

--- a/homeassistant/components/cover/homematicip_cloud.py
+++ b/homeassistant/components/cover/homematicip_cloud.py
@@ -39,10 +39,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class HomematicipCoverShutter(HomematicipGenericDevice, CoverDevice):
     """Representation of a HomematicIP Cloud cover device."""
 
-    def __init__(self, home, device):
-        """Initialize the cover device."""
-        super().__init__(home, device)
-
     @property
     def current_cover_position(self):
         """Return current position of cover."""

--- a/homeassistant/components/cover/homematicip_cloud.py
+++ b/homeassistant/components/cover/homematicip_cloud.py
@@ -1,5 +1,5 @@
 """
-Support for HomematicIP Cloud cover.
+Support for HomematicIP Cloud cover devices.
 
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/cover.homematicip_cloud/

--- a/homeassistant/components/cover/homematicip_cloud.py
+++ b/homeassistant/components/cover/homematicip_cloud.py
@@ -1,0 +1,76 @@
+"""
+Support for HomematicIP Cloud cover.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/switch.homematicip_cloud/
+"""
+import logging
+
+from homeassistant.components.cover import (
+    ATTR_POSITION, ATTR_TILT_POSITION, CoverDevice)
+from homeassistant.components.homematicip_cloud import (
+    HMIPC_HAPID, HomematicipGenericDevice)
+from homeassistant.components.homematicip_cloud import DOMAIN as HMIPC_DOMAIN
+
+DEPENDENCIES = ['homematicip_cloud']
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_platform(
+        hass, config, async_add_entities, discovery_info=None):
+    """Set up the HomematicIP Cloud cover devices."""
+    pass
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the HomematicIP cover from a config entry."""
+    from homematicip.device import AsyncFullFlushShutter
+
+    home = hass.data[HMIPC_DOMAIN][config_entry.data[HMIPC_HAPID]].home
+    devices = []
+    for device in home.devices:
+        if isinstance(device, AsyncFullFlushShutter):
+            devices.append(HomematicipCoverShutter(home, device))
+
+    if devices:
+        async_add_entities(devices)
+
+
+class HomematicipCoverShutter(HomematicipGenericDevice, CoverDevice):
+    """representation of a HomematicIP Cloud cover device."""
+
+    def __init__(self, home, device):
+        """Initialize the cover device."""
+        super().__init__(home, device)
+
+    @property
+    def current_cover_position(self):
+        """Return current position of cover."""
+        return int(self._device.shutterLevel * 100)
+
+    def set_cover_position(self, **kwargs):
+        """Move the cover to a specific position."""
+        if ATTR_POSITION in kwargs:
+            position = float(kwargs[ATTR_POSITION])
+            position = min(100, max(0, position))
+            level = position / 100.0
+            self._device.set_shutter_level(level)
+
+    @property
+    def is_closed(self):
+        """Return if the cover is closed."""
+        if self._device.shutterLevel is not None:
+            return self._device.shutterLevel == 0
+
+    def open_cover(self, **kwargs):
+        """Open the cover."""
+        self._device.set_shutter_level(1)
+
+    def close_cover(self, **kwargs):
+        """Close the cover."""
+        self._device.set_shutter_level(0)
+
+    def stop_cover(self, **kwargs):
+        """Stop the device if in motion."""
+        self._device.set_shutter_stop()

--- a/homeassistant/components/homematicip_cloud/const.py
+++ b/homeassistant/components/homematicip_cloud/const.py
@@ -9,6 +9,7 @@ COMPONENTS = [
     'alarm_control_panel',
     'binary_sensor',
     'climate',
+    'cover',
     'light',
     'sensor',
     'switch',

--- a/tests/components/homematicip_cloud/test_hap.py
+++ b/tests/components/homematicip_cloud/test_hap.py
@@ -65,7 +65,7 @@ async def test_hap_setup_works(aioclient_mock):
         assert await hap.async_setup() is True
 
     assert hap.home is home
-    assert len(hass.config_entries.async_forward_entry_setup.mock_calls) == 6
+    assert len(hass.config_entries.async_forward_entry_setup.mock_calls) == 7
     assert hass.config_entries.async_forward_entry_setup.mock_calls[0][1] == \
         (entry, 'alarm_control_panel')
     assert hass.config_entries.async_forward_entry_setup.mock_calls[1][1] == \
@@ -107,10 +107,10 @@ async def test_hap_reset_unloads_entry_if_setup():
 
     assert hap.home is home
     assert len(hass.services.async_register.mock_calls) == 0
-    assert len(hass.config_entries.async_forward_entry_setup.mock_calls) == 6
+    assert len(hass.config_entries.async_forward_entry_setup.mock_calls) == 7
 
     hass.config_entries.async_forward_entry_unload.return_value = \
         mock_coro(True)
     await hap.async_reset()
 
-    assert len(hass.config_entries.async_forward_entry_unload.mock_calls) == 6
+    assert len(hass.config_entries.async_forward_entry_unload.mock_calls) == 7


### PR DESCRIPTION
## Description:
Add support for the HmIP-FROLL and HmIP-BROLL devices

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#8170

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
