### PR TITLE
assign user to websocket connection when using legacy_api_password

### DIFF
--- a/homeassistant/components/websocket_api/auth.py
+++ b/homeassistant/components/websocket_api/auth.py
@@ -6,6 +6,7 @@ from homeassistant.const import __version__
 from homeassistant.components.http.auth import validate_password
 from homeassistant.components.http.ban import process_wrong_login, \
     process_success_login
+from homeassistant.auth.providers import legacy_api_password
 
 from .connection import ActiveConnection
 from .error import Disconnect
@@ -81,7 +82,8 @@ class AuthPhase:
         elif self._hass.auth.support_legacy and 'api_password' in msg:
             self._logger.debug("Received api_password")
             if validate_password(self._request, msg['api_password']):
-                return await self._async_finish_auth(None, None)
+                user = await legacy_api_password.async_get_user(self._hass)
+                return await self._async_finish_auth(user, None)
 
         self._send_message(auth_invalid_message(
             'Invalid access token or password'))

--- a/tests/components/websocket_api/test_auth.py
+++ b/tests/components/websocket_api/test_auth.py
@@ -132,7 +132,8 @@ async def test_auth_active_with_password_not_allow(hass, aiohttp_client):
         assert auth_msg['type'] == TYPE_AUTH_INVALID
 
 
-async def test_auth_legacy_support_with_password(hass, aiohttp_client):
+async def test_auth_legacy_support_with_password(hass, aiohttp_client,
+                                                 legacy_auth):
     """Test authenticating with a token."""
     assert await async_setup_component(hass, 'websocket_api', {
         'http': {


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #19522

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
