### PR TITLE
Replace MyChevy persistant_notification with error log entry

### DIFF
--- a/homeassistant/components/sensor/mychevy.py
+++ b/homeassistant/components/sensor/mychevy.py
@@ -75,8 +75,8 @@ class MyChevyStatus(Entity):
     def error(self):
         """Update state, trigger updates."""
         if self._state != MYCHEVY_ERROR:
-            _LOGGER.exception(
-                "Error:<br/>Connection to mychevy website failed. "
+            _LOGGER.error(
+                "Error: Connection to mychevy website failed. "
                 "This probably means the mychevy to OnStar link is down.")
             self._state = MYCHEVY_ERROR
         self.async_schedule_update_ha_state()

--- a/homeassistant/components/sensor/mychevy.py
+++ b/homeassistant/components/sensor/mychevy.py
@@ -74,11 +74,10 @@ class MyChevyStatus(Entity):
     @callback
     def error(self):
         """Update state, trigger updates."""
-        if self._state != MYCHEVY_ERROR:
-            _LOGGER.error(
-                "Error: Connection to mychevy website failed. "
-                "This probably means the mychevy to OnStar link is down.")
-            self._state = MYCHEVY_ERROR
+        _LOGGER.error(
+            "Connection to mychevy website failed. "
+            "This probably means the mychevy to OnStar link is down")
+        self._state = MYCHEVY_ERROR
         self.async_schedule_update_ha_state()
 
     @property

--- a/homeassistant/components/sensor/mychevy.py
+++ b/homeassistant/components/sensor/mychevy.py
@@ -75,11 +75,9 @@ class MyChevyStatus(Entity):
     def error(self):
         """Update state, trigger updates."""
         if self._state != MYCHEVY_ERROR:
-            self.hass.components.persistent_notification.create(
+            _LOGGER.exception(
                 "Error:<br/>Connection to mychevy website failed. "
-                "This probably means the mychevy to OnStar link is down.",
-                title=NOTIFICATION_TITLE,
-                notification_id=NOTIFICATION_ID)
+                "This probably means the mychevy to OnStar link is down.")
             self._state = MYCHEVY_ERROR
         self.async_schedule_update_ha_state()
 

--- a/homeassistant/components/sensor/mychevy.py
+++ b/homeassistant/components/sensor/mychevy.py
@@ -8,7 +8,7 @@ import logging
 
 from homeassistant.components.mychevy import (
     EVSensorConfig, DOMAIN as MYCHEVY_DOMAIN, MYCHEVY_ERROR, MYCHEVY_SUCCESS,
-    NOTIFICATION_ID, NOTIFICATION_TITLE, UPDATE_TOPIC, ERROR_TOPIC
+    UPDATE_TOPIC, ERROR_TOPIC
 )
 from homeassistant.components.sensor import ENTITY_ID_FORMAT
 from homeassistant.core import callback


### PR DESCRIPTION
## Description:
The mychevy component creates a persistant_notifocation on each new connection error. This PR is replacing the persistant_notification with a log error message. 

**Related issue (if applicable):** fixes #19785

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
