### PR TITLE
Allow multiple accounts for Google Maps device tracker

### DIFF
--- a/homeassistant/components/device_tracker/google_maps.py
+++ b/homeassistant/components/device_tracker/google_maps.py
@@ -61,8 +61,9 @@ class GoogleMapsScanner:
         self.max_gps_accuracy = config[CONF_MAX_GPS_ACCURACY]
 
         try:
-            self.service = Service(self.username, self.password,
-                                   hass.config.path(CREDENTIALS_FILE))
+            credfile = "{}.{}".format(hass.config.path(CREDENTIALS_FILE),
+                                      slugify(self.username))
+            self.service = Service(self.username, self.password, credfile)
             self._update_info()
 
             track_time_interval(


### PR DESCRIPTION
## Description:
Adding multi-account capability for the google maps device-tracker component. This is a redo of #19716 due to issues with the fork.
It might be a good idea to wait with merging until the [NoneType upstream issue](https://github.com/costastf/locationsharinglib/issues/42) is fixed as the change will trigger re-fetching the cookies into the new file name even for users with only one account. This is causing issues in HA right now as well and won't get better or worse with this change but would affect more folks that currently still have a valid cookies file: #17410 #19356 

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8020

## Example entry for `configuration.yaml` (if applicable):
no change, just allowing multiple entries instead of just one

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
