### PR TITLE
bmw_connected_drive for cars with limited Connected Drive capabilities

### DIFF
--- a/homeassistant/components/binary_sensor/bmw_connected_drive.py
+++ b/homeassistant/components/binary_sensor/bmw_connected_drive.py
@@ -42,15 +42,19 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             if vehicle.has_hv_battery:
                 _LOGGER.debug('BMW with a high voltage battery')
                 for key, value in sorted(SENSOR_TYPES_ELEC.items()):
-                    device = BMWConnectedDriveSensor(account, vehicle, key,
-                                                     value[0], value[1])
-                    devices.append(device)
+                    if value[0] in vehicle.available_attributes:
+                        device = BMWConnectedDriveSensor(account, vehicle,
+                                                         key, value[0],
+                                                         value[1])
+                        devices.append(device)
             elif vehicle.has_internal_combustion_engine:
                 _LOGGER.debug('BMW with an internal combustion engine')
                 for key, value in sorted(SENSOR_TYPES.items()):
-                    device = BMWConnectedDriveSensor(account, vehicle, key,
-                                                     value[0], value[1])
-                    devices.append(device)
+                    if value[0] in vehicle.available_attributes:
+                        device = BMWConnectedDriveSensor(account, vehicle,
+                                                         key, value[0],
+                                                         value[1])
+                        devices.append(device)
     add_entities(devices, True)
 
 

--- a/homeassistant/components/lock/bmw_connected_drive.py
+++ b/homeassistant/components/lock/bmw_connected_drive.py
@@ -24,8 +24,9 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     for account in accounts:
         if not account.read_only:
             for vehicle in account.account.vehicles:
-                device = BMWLock(account, vehicle, 'lock', 'BMW lock')
-                devices.append(device)
+                if 'door_lock_state' in vehicle.available_attributes:
+                    device = BMWLock(account, vehicle, 'lock', 'BMW lock')
+                    devices.append(device)
     add_entities(devices, True)
 
 

--- a/homeassistant/components/sensor/bmw_connected_drive.py
+++ b/homeassistant/components/sensor/bmw_connected_drive.py
@@ -58,10 +58,11 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                     device = BMWConnectedDriveSensor(account, vehicle,
                                                      attribute_name,
                                                      attribute_info)
+                    devices.append(device)
+            if 'mileage' in vehicle.available_attributes:
+                device = BMWConnectedDriveSensor(account, vehicle, 'mileage',
+                                                 attribute_info)
                 devices.append(device)
-            device = BMWConnectedDriveSensor(account, vehicle, 'mileage',
-                                             attribute_info)
-            devices.append(device)
     add_entities(devices, True)
 
 

--- a/homeassistant/components/sensor/bmw_connected_drive.py
+++ b/homeassistant/components/sensor/bmw_connected_drive.py
@@ -54,9 +54,10 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     for account in accounts:
         for vehicle in account.account.vehicles:
             for attribute_name in vehicle.drive_train_attributes:
-                device = BMWConnectedDriveSensor(account, vehicle,
-                                                 attribute_name,
-                                                 attribute_info)
+                if attribute_name in vehicle.available_attributes:
+                    device = BMWConnectedDriveSensor(account, vehicle,
+                                                     attribute_name,
+                                                     attribute_info)
                 devices.append(device)
             device = BMWConnectedDriveSensor(account, vehicle, 'mileage',
                                              attribute_info)


### PR DESCRIPTION
## Description:
Allow usage of the BMW connected drive component for cars with limited connected drive capabilities without showing several sensors etc. that are non-functional and without swamping the log file with error messages trying to pull unavailable data every few seconds. Achieved by skipping creation of binary_sensors / locks / sensors depending on reported vehicle capabilities (available_attributes).

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>
no change in documentation

## Example entry for `configuration.yaml` (if applicable):
no change in configuration

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
