### PR TITLE
Fix a bug in Lutron RadioRA2 Scene support

### DIFF
--- a/homeassistant/components/lutron.py
+++ b/homeassistant/components/lutron.py
@@ -68,7 +68,7 @@ def setup(hass, base_config):
                             button.name != 'Unknown Button' and
                             button.button_type in ('SingleAction', 'Toggle')):
                         hass.data[LUTRON_DEVICES]['scene'].append(
-                            (area.name, button, led))
+                            (area.name, keypad.name, button, led))
 
     for component in ('light', 'cover', 'switch', 'scene'):
         discovery.load_platform(hass, component, DOMAIN, None, base_config)


### PR DESCRIPTION
## Description:
The main lutron component was not properly passing the keypad name to the scene component, resulting in a stack trace like so:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/homeassistant/helpers/entity_platform.py", line 128, in _async_setup_platform
    SLOW_SETUP_MAX_WAIT, loop=hass.loop)
  File "/usr/local/lib/python3.6/asyncio/tasks.py", line 358, in wait_for
    return fut.result()
  File "/usr/local/lib/python3.6/concurrent/futures/thread.py", line 56, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/local/lib/python3.6/site-packages/homeassistant/components/scene/lutron.py", line 22, in setup_platform
    (area_name, keypad_name, device, led) = scene_data
ValueError: not enough values to unpack (expected 4, got 3)
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
