### PR TITLE
Fix Daikin Component Not Loading

### DIFF
--- a/homeassistant/components/daikin/__init__.py
+++ b/homeassistant/components/daikin/__init__.py
@@ -12,7 +12,7 @@ from socket import timeout
 import async_timeout
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import CONF_HOSTS
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
@@ -51,12 +51,12 @@ async def async_setup(hass, config):
     if not hosts:
         hass.async_create_task(
             hass.config_entries.flow.async_init(
-                DOMAIN, context={'source': config.SOURCE_IMPORT}))
+                DOMAIN, context={'source': SOURCE_IMPORT}))
     for host in hosts:
         hass.async_create_task(
             hass.config_entries.flow.async_init(
                 DOMAIN,
-                context={'source': config.SOURCE_IMPORT},
+                context={'source': SOURCE_IMPORT},
                 data={
                     KEY_HOST: host,
                 }))


### PR DESCRIPTION
## Description:

There is a missing import and typo in the Daikin setup, this fixes that.

**Related issue (if applicable):** fixes #19814, Daikin config setting

## Example entry for `configuration.yaml` (if applicable):
```yaml
daikin:
  hosts:
    - 10.10.3.163
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

