### PR TITLE
Bump pybotvac

### DIFF
--- a/homeassistant/components/neato.py
+++ b/homeassistant/components/neato.py
@@ -17,7 +17,7 @@ from homeassistant.util import Throttle
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['pybotvac==0.0.12']
+REQUIREMENTS = ['pybotvac==0.0.13']
 
 DOMAIN = 'neato'
 NEATO_ROBOTS = 'neato_robots'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -919,7 +919,7 @@ pyblackbird==0.5
 # pybluez==0.22
 
 # homeassistant.components.neato
-pybotvac==0.0.12
+pybotvac==0.0.13
 
 # homeassistant.components.cloudflare
 pycfdns==0.0.1


### PR DESCRIPTION
## Description:

Bump pybotvac to support no go lines when available.

**Related issue (if applicable):** fixes # N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
neato:
  username: username
  password: password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
