### PR TITLE
Add zone attributes if user has a persistent map to use in zone cleaning

### DIFF
--- a/homeassistant/components/neato.py
+++ b/homeassistant/components/neato.py
@@ -23,6 +23,7 @@ DOMAIN = 'neato'
 NEATO_ROBOTS = 'neato_robots'
 NEATO_LOGIN = 'neato_login'
 NEATO_MAP_DATA = 'neato_map_data'
+NEATO_PERSISTENT_MAPS = 'neato_persistent_maps'
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
@@ -202,6 +203,7 @@ class NeatoHub:
             domain_config[CONF_USERNAME],
             domain_config[CONF_PASSWORD])
         self._hass.data[NEATO_ROBOTS] = self.my_neato.robots
+        self._hass.data[NEATO_PERSISTENT_MAPS] = self.my_neato.persistent_maps
         self._hass.data[NEATO_MAP_DATA] = self.my_neato.maps
 
     def login(self):
@@ -221,6 +223,7 @@ class NeatoHub:
         _LOGGER.debug("Running HUB.update_robots %s",
                       self._hass.data[NEATO_ROBOTS])
         self._hass.data[NEATO_ROBOTS] = self.my_neato.robots
+        self._hass.data[NEATO_PERSISTENT_MAPS] = self.my_neato.persistent_maps
         self._hass.data[NEATO_MAP_DATA] = self.my_neato.maps
 
     def download_map(self, url):

--- a/homeassistant/components/vacuum/neato.py
+++ b/homeassistant/components/vacuum/neato.py
@@ -148,7 +148,6 @@ class NeatoConnectedVacuum(StateVacuumDevice):
             self._robot_map_id = self._robot_maps[self._robot_serial][0]['id']
             self._robot_boundaries = (self.robot.get_map_boundaries(
                 self._robot_map_id).json())
-             
             zones = range(len(self._robot_boundaries['data']['boundaries']))
 
             for boundary in zones:

--- a/homeassistant/components/vacuum/neato.py
+++ b/homeassistant/components/vacuum/neato.py
@@ -150,8 +150,8 @@ class NeatoConnectedVacuum(StateVacuumDevice):
                 self._robot_map_id).json())
 
             for boundary in (range(
-                             len(self._robot_boundaries['data']
-                             ['boundaries']))):
+                             len(self._robot_boundaries['data']['boundaries']))
+                             ):
                 self._boundary_name[boundary] = (
                     self._robot_boundaries['data']['boundaries'][boundary]
                     ['name'])

--- a/homeassistant/components/vacuum/neato.py
+++ b/homeassistant/components/vacuum/neato.py
@@ -150,7 +150,8 @@ class NeatoConnectedVacuum(StateVacuumDevice):
                 self._robot_map_id).json())
 
             for boundary in (range(
-                             len(self._robot_boundaries['data']['boundaries']))):
+                             len(self._robot_boundaries['data']
+                             ['boundaries']))):
                 self._boundary_name[boundary] = (
                     self._robot_boundaries['data']['boundaries'][boundary]
                     ['name'])

--- a/homeassistant/components/vacuum/neato.py
+++ b/homeassistant/components/vacuum/neato.py
@@ -148,10 +148,10 @@ class NeatoConnectedVacuum(StateVacuumDevice):
             self._robot_map_id = self._robot_maps[self._robot_serial][0]['id']
             self._robot_boundaries = (self.robot.get_map_boundaries(
                 self._robot_map_id).json())
+             
+            zones = range(len(self._robot_boundaries['data']['boundaries']))
 
-            for boundary in (range(
-                             len(self._robot_boundaries['data']['boundaries']))
-                             ):
+            for boundary in zones:
                 self._boundary_name[boundary] = (
                     self._robot_boundaries['data']['boundaries'][boundary]
                     ['name'])

--- a/homeassistant/components/vacuum/neato.py
+++ b/homeassistant/components/vacuum/neato.py
@@ -149,12 +149,11 @@ class NeatoConnectedVacuum(StateVacuumDevice):
             self._robot_boundaries = (self.robot.get_map_boundaries(
                 self._robot_map_id).json())
 
-            for boundary in range(len(self._robot_boundaries['data']
-                ['boundaries'])):
-                self._boundary_name[boundary] = (self._robot_boundaries['data']
-                    ['boundaries'][boundary]['name'])
-                self._boundary_id[boundary] = (self._robot_boundaries['data']
-                    ['boundaries'][boundary]['id'])
+            for boundary in range(len(self._robot_boundaries['data']['boundaries'])):
+                self._boundary_name[boundary] = (
+                    self._robot_boundaries['data']['boundaries'][boundary]['name'])
+                self._boundary_id[boundary] = (
+                    self._robot_boundaries['data']['boundaries'][boundary]['id'])
 
     @property
     def name(self):

--- a/homeassistant/components/vacuum/neato.py
+++ b/homeassistant/components/vacuum/neato.py
@@ -149,7 +149,8 @@ class NeatoConnectedVacuum(StateVacuumDevice):
             self._robot_boundaries = (self.robot.get_map_boundaries(
                 self._robot_map_id).json())
 
-            for boundary in range(len(self._robot_boundaries['data']['boundaries'])):
+            for boundary in (range(
+                             len(self._robot_boundaries['data']['boundaries']))):
                 self._boundary_name[boundary] = (
                     self._robot_boundaries['data']['boundaries'][boundary]
                     ['name'])

--- a/homeassistant/components/vacuum/neato.py
+++ b/homeassistant/components/vacuum/neato.py
@@ -151,9 +151,11 @@ class NeatoConnectedVacuum(StateVacuumDevice):
 
             for boundary in range(len(self._robot_boundaries['data']['boundaries'])):
                 self._boundary_name[boundary] = (
-                    self._robot_boundaries['data']['boundaries'][boundary]['name'])
+                    self._robot_boundaries['data']['boundaries'][boundary]
+                    ['name'])
                 self._boundary_id[boundary] = (
-                    self._robot_boundaries['data']['boundaries'][boundary]['id'])
+                    self._robot_boundaries['data']['boundaries'][boundary]
+                    ['id'])
 
     @property
     def name(self):

--- a/homeassistant/components/vacuum/neato.py
+++ b/homeassistant/components/vacuum/neato.py
@@ -146,11 +146,15 @@ class NeatoConnectedVacuum(StateVacuumDevice):
 
         if self._robot_has_map:
             self._robot_map_id = self._robot_maps[self._robot_serial][0]['id']
-            self._robot_boundaries = self.robot.get_map_boundaries(self._robot_map_id).json()
+            self._robot_boundaries = (self.robot.get_map_boundaries(
+                self._robot_map_id).json())
 
-            for boundary in range(len(self._robot_boundaries['data']['boundaries'])):
-               self._boundary_name[boundary] = self._robot_boundaries['data']['boundaries'][boundary]['name']
-               self._boundary_id[boundary] = self._robot_boundaries['data']['boundaries'][boundary]['id']
+            for boundary in range(len(self._robot_boundaries['data']
+                ['boundaries'])):
+                self._boundary_name[boundary] = (self._robot_boundaries['data']
+                    ['boundaries'][boundary]['name'])
+                self._boundary_id[boundary] = (self._robot_boundaries['data']
+                    ['boundaries'][boundary]['id'])
 
     @property
     def name(self):
@@ -211,8 +215,9 @@ class NeatoConnectedVacuum(StateVacuumDevice):
             data[ATTR_CLEAN_BATTERY_END] = self.clean_battery_end
 
         if self._boundary_name is not None:
-           for boundary in self._boundary_name:
-               data[self._boundary_name[boundary]] = self._boundary_id[boundary]
+            for boundary in self._boundary_name:
+                data[self._boundary_name[boundary]] = (
+                    self._boundary_id[boundary])
 
         return data
 


### PR DESCRIPTION
## Description:

In preparation of adding zone cleaning this PR adds zone names and their respective ID from the persistent map to the device attributes.  This is useful as the user will need to know the zone ID to perform the cleaning action.  There is no easy way for most users to grab this information as it is not available in the app.  If the user changes the map they may need to retrieve the ID again.  There will be a follow up PR that will contain the new service call.

**Related issue (if applicable):** fixes # N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io# N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
neato:
  username: username
  password: password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
