### PR TITLE
Bump aioesphomeapi

### DIFF
--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
         ServiceCall
 
 DOMAIN = 'esphome'
-REQUIREMENTS = ['aioesphomeapi==1.4.0']
+REQUIREMENTS = ['aioesphomeapi==1.4.1']
 
 
 DISPATCHER_UPDATE_ENTITY = 'esphome_{entry_id}_update_{component_key}_{key}'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -96,7 +96,7 @@ aioautomatic==0.6.5
 aiodns==1.1.1
 
 # homeassistant.components.esphome
-aioesphomeapi==1.4.0
+aioesphomeapi==1.4.1
 
 # homeassistant.components.freebox
 aiofreepybox==0.0.6


### PR DESCRIPTION
## Description:

Fixes "Error doing job: Task exception was never retrieved" sporadic info logs. 

And implements a proper watchdog - some users reported that Home Assistant would sometimes not realize the connection was closed (I assume due to race condition). The watchdog checks if everything's fine and recreates the connection if there's been an issue somewhere.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

