### PR TITLE
bump watefurnace version to 1.1.0

### DIFF
--- a/homeassistant/components/waterfurnace.py
+++ b/homeassistant/components/waterfurnace.py
@@ -19,7 +19,7 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import discovery
 
 
-REQUIREMENTS = ["waterfurnace==1.0.0"]
+REQUIREMENTS = ["waterfurnace==1.1.0"]
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1680,7 +1680,7 @@ warrant==0.6.1
 watchdog==0.8.3
 
 # homeassistant.components.waterfurnace
-waterfurnace==1.0.0
+waterfurnace==1.1.0
 
 # homeassistant.components.media_player.gpmdp
 websocket-client==0.54.0


### PR DESCRIPTION
There is better retry logic in the new library to handle login faults.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.