### PR TITLE
Relay events for onoff and levelcontrol output clusters in ZHA

### DIFF
--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.entity_component import EntityComponent
 # Loading the config flow file will register the flow
 from . import config_flow  # noqa  # pylint: disable=unused-import
 from . import const as zha_const
-from .event import ZhaEvent
+from .event import ZhaEvent, ZhaRelayEvent
 from .const import (
     COMPONENTS, CONF_BAUDRATE, CONF_DATABASE, CONF_DEVICE_CONFIG,
     CONF_RADIO_TYPE, CONF_USB_PATH, DATA_ZHA, DATA_ZHA_BRIDGE_ID,
@@ -394,6 +394,18 @@ class ApplicationListener:
         if cluster.cluster_id in EVENTABLE_CLUSTERS:
             if cluster.endpoint.device.ieee not in self._events:
                 self._events.update({cluster.endpoint.device.ieee: []})
+            from zigpy.zcl.clusters.general import OnOff, LevelControl
+            if discovery_attr == 'out_clusters' and\
+                    (cluster.cluster_id == OnOff.cluster_id or
+                     cluster.cluster_id == LevelControl.cluster_id):
+                self._events[cluster.endpoint.device.ieee].append(
+                    ZhaRelayEvent(self._hass, cluster)
+                )
+            else:
+                self._events[cluster.endpoint.device.ieee].append(ZhaEvent(
+                    self._hass,
+                    cluster
+                ))
             self._events[cluster.endpoint.device.ieee].append(ZhaEvent(
                 self._hass,
                 cluster

--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -406,10 +406,6 @@ class ApplicationListener:
                     self._hass,
                     cluster
                 ))
-            self._events[cluster.endpoint.device.ieee].append(ZhaEvent(
-                self._hass,
-                cluster
-            ))
 
         if cluster.cluster_id in profile_clusters:
             return

--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -395,7 +395,7 @@ class ApplicationListener:
             if cluster.endpoint.device.ieee not in self._events:
                 self._events.update({cluster.endpoint.device.ieee: []})
             from zigpy.zcl.clusters.general import OnOff, LevelControl
-            if discovery_attr == 'out_clusters' and\
+            if discovery_attr == 'out_clusters' and \
                     (cluster.cluster_id == OnOff.cluster_id or
                      cluster.cluster_id == LevelControl.cluster_id):
                 self._events[cluster.endpoint.device.ieee].append(

--- a/homeassistant/components/zha/event.py
+++ b/homeassistant/components/zha/event.py
@@ -67,3 +67,33 @@ class ZhaEvent():
             },
             EventOrigin.remote
         )
+
+
+class ZhaRelayEvent(ZhaEvent):
+    """A base class for ZHA events."""
+
+    @callback
+    def attribute_updated(self, attribute, value):
+        """Handle an attribute updated on this cluster."""
+        self.zha_send_event(
+            self._cluster,
+            'attribute_updated',
+            {
+                'attribute_id': attribute,
+                'attribute_name': self._cluster.attributes.get(
+                    attribute,
+                    ['Unknown'])[0],
+                'value': value
+            }
+        )
+
+    @callback
+    def cluster_command(self, tsn, command_id, args):
+        """Handle a cluster command received on this cluster."""
+        if self._cluster.server_commands is not None and\
+                self._cluster.server_commands.get(command_id) is not None:
+            self.zha_send_event(
+                self._cluster,
+                self._cluster.server_commands.get(command_id)[0],
+                args
+            )

--- a/homeassistant/components/zha/event.py
+++ b/homeassistant/components/zha/event.py
@@ -70,7 +70,7 @@ class ZhaEvent():
 
 
 class ZhaRelayEvent(ZhaEvent):
-    """A base class for ZHA events."""
+    """Event relay that can be attached to zigbee clusters."""
 
     @callback
     def attribute_updated(self, attribute, value):


### PR DESCRIPTION
This PR will generate ZHA events for any device that has OnOff or LevelControl output clusters. This removes the need for a lot of redundant quirks code.