### PR TITLE
Geo Location -> Geolocation (comments and default group name)

### DIFF
--- a/homeassistant/components/automation/geo_location.py
+++ b/homeassistant/components/automation/geo_location.py
@@ -3,7 +3,7 @@ Offer geolocation automation rules.
 
 For more details about this automation trigger, please refer to the
 documentation at
-https://home-assistant.io/docs/automation/trigger/#geo-location-trigger
+https://home-assistant.io/docs/automation/trigger/#geolocation-trigger
 """
 import voluptuous as vol
 

--- a/homeassistant/components/automation/geo_location.py
+++ b/homeassistant/components/automation/geo_location.py
@@ -1,5 +1,5 @@
 """
-Offer geo location automation rules.
+Offer geolocation automation rules.
 
 For more details about this automation trigger, please refer to the
 documentation at

--- a/homeassistant/components/geo_location/__init__.py
+++ b/homeassistant/components/geo_location/__init__.py
@@ -1,5 +1,5 @@
 """
-Geo Location component.
+Geolocation component.
 
 For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/geo_location/
@@ -28,7 +28,7 @@ SCAN_INTERVAL = timedelta(seconds=60)
 
 
 async def async_setup(hass, config):
-    """Set up the Geo Location component."""
+    """Set up the Geolocation component."""
     component = EntityComponent(
         _LOGGER, DOMAIN, hass, SCAN_INTERVAL, GROUP_NAME_ALL_EVENTS)
     await component.async_setup(config)
@@ -36,7 +36,7 @@ async def async_setup(hass, config):
 
 
 class GeoLocationEvent(Entity):
-    """This represents an external event with an associated geo location."""
+    """This represents an external event with an associated geolocation."""
 
     @property
     def state(self):

--- a/homeassistant/components/geo_location/__init__.py
+++ b/homeassistant/components/geo_location/__init__.py
@@ -22,7 +22,7 @@ DOMAIN = 'geo_location'
 
 ENTITY_ID_FORMAT = DOMAIN + '.{}'
 
-GROUP_NAME_ALL_EVENTS = 'All Geo Location Events'
+GROUP_NAME_ALL_EVENTS = 'All Geolocation Events'
 
 SCAN_INTERVAL = timedelta(seconds=60)
 

--- a/homeassistant/components/geo_location/demo.py
+++ b/homeassistant/components/geo_location/demo.py
@@ -1,5 +1,5 @@
 """
-Demo platform for the geo location component.
+Demo platform for the geolocation component.
 
 For more details about this platform, please refer to the documentation
 https://home-assistant.io/components/demo/
@@ -30,15 +30,15 @@ SOURCE = 'demo'
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
-    """Set up the Demo geo locations."""
+    """Set up the Demo geolocations."""
     DemoManager(hass, add_entities)
 
 
 class DemoManager:
-    """Device manager for demo geo location events."""
+    """Device manager for demo geolocation events."""
 
     def __init__(self, hass, add_entities):
-        """Initialise the demo geo location event manager."""
+        """Initialise the demo geolocation event manager."""
         self._hass = hass
         self._add_entities = add_entities
         self._managed_devices = []
@@ -91,7 +91,7 @@ class DemoManager:
 
 
 class DemoGeoLocationEvent(GeoLocationEvent):
-    """This represents a demo geo location event."""
+    """This represents a demo geolocation event."""
 
     def __init__(self, name, distance, latitude, longitude,
                  unit_of_measurement):
@@ -114,7 +114,7 @@ class DemoGeoLocationEvent(GeoLocationEvent):
 
     @property
     def should_poll(self):
-        """No polling needed for a demo geo location event."""
+        """No polling needed for a demo geolocation event."""
         return False
 
     @property


### PR DESCRIPTION
## Description:
Fixed all occurrences in the source code comments from "geo location" to "geolocation", as well as in the default group name of the component; as discussed in https://github.com/home-assistant/architecture/issues/42#issuecomment-451145350
Left filenames and source code unchanged.

**Related issue (if applicable):** n/a

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable): n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
