### PR TITLE
mqtt_eventstream does not work due to "yield from"

### DIFF
--- a/homeassistant/components/mqtt_eventstream.py
+++ b/homeassistant/components/mqtt_eventstream.py
@@ -38,8 +38,7 @@ CONFIG_SCHEMA = vol.Schema({
 }, extra=vol.ALLOW_EXTRA)
 
 
-@asyncio.coroutine
-def async_setup(hass, config):
+async def async_setup(hass, config):
     """Set up the MQTT eventstream component."""
     mqtt = hass.components.mqtt
     conf = config.get(DOMAIN, {})
@@ -104,6 +103,6 @@ def async_setup(hass, config):
 
     # Only subscribe if you specified a topic.
     if sub_topic:
-        yield from mqtt.async_subscribe(sub_topic, _event_receiver)
+        await mqtt.async_subscribe(sub_topic, _event_receiver)
 
     return True

--- a/homeassistant/components/mqtt_eventstream.py
+++ b/homeassistant/components/mqtt_eventstream.py
@@ -4,7 +4,6 @@ Connect two Home Assistant instances via MQTT.
 For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/mqtt_eventstream/
 """
-import asyncio
 import json
 
 import voluptuous as vol


### PR DESCRIPTION
When running with `PYTHONASYNCIODEBUG=1` the following error is shown:

```python
homeassistant/components/mqtt_eventstream.py:107: RuntimeWarning: coroutine 'async_subscribe' was never awaited
  yield from mqtt.async_subscribe(sub_topic, _event_receiver)

Error during setup of component mqtt_eventstream
Traceback (most recent call last):
  File "homeassistant/setup.py", line 145, in _async_setup_component
    hass, processed_config)
  File "asyncio/coroutines.py", line 110, in __next__
    return self.gen.send(None)
  File "homeassistant/components/mqtt_eventstream.py", line 107, in async_setup
    yield from mqtt.async_subscribe(sub_topic, _event_receiver)
TypeError: cannot 'yield from' a coroutine object in a non-coroutine generator
```

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
