### PR TITLE
Add precision parameter to dsmr sensor

### DIFF
--- a/homeassistant/components/sensor/dsmr.py
+++ b/homeassistant/components/sensor/dsmr.py
@@ -24,9 +24,12 @@ REQUIREMENTS = ['dsmr_parser==0.12']
 
 CONF_DSMR_VERSION = 'dsmr_version'
 CONF_RECONNECT_INTERVAL = 'reconnect_interval'
+CONF_PRECISION = 'precision'
 
 DEFAULT_DSMR_VERSION = '2.2'
 DEFAULT_PORT = '/dev/ttyUSB0'
+DEFAULT_PRECISION = 3
+
 DOMAIN = 'dsmr'
 
 ICON_GAS = 'mdi:fire'
@@ -45,6 +48,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_DSMR_VERSION, default=DEFAULT_DSMR_VERSION): vol.All(
         cv.string, vol.In(['5', '4', '2.2'])),
     vol.Optional(CONF_RECONNECT_INTERVAL, default=30): int,
+    vol.Optional(CONF_PRECISION, default=DEFAULT_PRECISION): vol.Coerce(int),
 })
 
 
@@ -146,7 +150,7 @@ async def async_setup_platform(hass, config, async_add_entities,
     ]
 
     # Generate device entities
-    devices = [DSMREntity(name, obis) for name, obis in obis_mapping]
+    devices = [DSMREntity(name, obis, config) for name, obis in obis_mapping]
 
     # Protocol version specific obis
     if dsmr_version in ('4', '5'):
@@ -156,8 +160,8 @@ async def async_setup_platform(hass, config, async_add_entities,
 
     # Add gas meter reading and derivative for usage
     devices += [
-        DSMREntity('Gas Consumption', gas_obis),
-        DerivativeDSMREntity('Hourly Gas Consumption', gas_obis),
+        DSMREntity('Gas Consumption', gas_obis, config),
+        DerivativeDSMREntity('Hourly Gas Consumption', gas_obis, config),
     ]
 
     async_add_entities(devices)
@@ -224,10 +228,11 @@ async def async_setup_platform(hass, config, async_add_entities,
 class DSMREntity(Entity):
     """Entity reading values from DSMR telegram."""
 
-    def __init__(self, name, obis):
+    def __init__(self, name, obis, config):
         """Initialize entity."""
         self._name = name
         self._obis = obis
+        self._config = config
         self.telegram = {}
 
     def get_dsmr_object_attr(self, attribute):
@@ -266,6 +271,11 @@ class DSMREntity(Entity):
 
         if self._obis == obis.ELECTRICITY_ACTIVE_TARIFF:
             return self.translate_tariff(value)
+
+        try:
+            value = round(float(value),self._config[CONF_PRECISION])
+        except:
+            value = value
 
         if value is not None:
             return value

--- a/homeassistant/components/sensor/dsmr.py
+++ b/homeassistant/components/sensor/dsmr.py
@@ -274,7 +274,7 @@ class DSMREntity(Entity):
 
         try:
             value = round(float(value), self._config[CONF_PRECISION])
-        except:
+        except TypeError:
             value = value
 
         if value is not None:

--- a/homeassistant/components/sensor/dsmr.py
+++ b/homeassistant/components/sensor/dsmr.py
@@ -275,7 +275,7 @@ class DSMREntity(Entity):
         try:
             value = round(float(value), self._config[CONF_PRECISION])
         except TypeError:
-            value = value
+            pass
 
         if value is not None:
             return value

--- a/homeassistant/components/sensor/dsmr.py
+++ b/homeassistant/components/sensor/dsmr.py
@@ -273,7 +273,7 @@ class DSMREntity(Entity):
             return self.translate_tariff(value)
 
         try:
-            value = round(float(value),self._config[CONF_PRECISION])
+            value = round(float(value), self._config[CONF_PRECISION])
         except:
             value = value
 

--- a/tests/components/sensor/test_dsmr.py
+++ b/tests/components/sensor/test_dsmr.py
@@ -96,7 +96,9 @@ def test_derivative():
     """Test calculation of derivative value."""
     from dsmr_parser.objects import MBusObject
 
-    entity = DerivativeDSMREntity('test', '1.0.0')
+    config = {'platform': 'dsmr'}
+
+    entity = DerivativeDSMREntity('test', '1.0.0', config)
     yield from entity.async_update()
 
     assert entity.state == STATE_UNKNOWN, 'initial state not unknown'


### PR DESCRIPTION
## Description:

I was working with the DSMR sensor for reading the power and gas usage.
It uses floats with 3 digits and was filling up the database really quickly.
I've added the precision parameter to make the number of digits configurable.
It works now beter with the value 2.

First I changed it in the file after every update, but I've tried to do my first pull request for this to fix this into the future.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8106

## Example entry for `configuration.yaml` (if applicable):
```yaml
# Power (DSMR)
- platform: dsmr
  port: /dev/ttyUSB1
  dsmr_version: 5
  precision: 2
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54