### PR TITLE
Resolves #17196, Resolves #18739 - Hue Beyond light fixture errors

### DIFF
--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -181,7 +181,7 @@ async def async_update_items(hass, bridge, async_add_entities,
 
         for light_id, light in current.items():
             if light_id not in progress_waiting:
-                    light.async_schedule_update_ha_state()   
+                light.async_schedule_update_ha_state()
 
         return
 
@@ -298,7 +298,7 @@ class HueLight(Light):
     @property
     def device_info(self):
         """Return the device info."""
-        if self.light.type in ('LightGroup', 'Room', 
+        if self.light.type in ('LightGroup', 'Room',
                                'Luminaire', 'LightSource'):
             return None
 

--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -181,10 +181,7 @@ async def async_update_items(hass, bridge, async_add_entities,
 
         for light_id, light in current.items():
             if light_id not in progress_waiting:
-                if light.entity_id is None:
-                    _LOGGER.error("ERROR: Light %s has no entity ID. Skipping update.", light.name)
-                else:
-                    light.async_schedule_update_ha_state()
+                    light.async_schedule_update_ha_state()   
 
         return
 
@@ -205,10 +202,7 @@ async def async_update_items(hass, bridge, async_add_entities,
 
             new_lights.append(current[item_id])
         elif item_id not in progress_waiting:
-            if current[item_id].entity_id is None:
-                _LOGGER.error("ERROR: Current Item %s has no entity ID in API type '%s'. Skipping update.", current[item_id].name, api_type)
-            else:
-                current[item_id].async_schedule_update_ha_state()
+            current[item_id].async_schedule_update_ha_state()
 
     if new_lights:
         async_add_entities(new_lights)
@@ -304,7 +298,8 @@ class HueLight(Light):
     @property
     def device_info(self):
         """Return the device info."""
-        if self.light.type in ('LightGroup', 'Room', 'Luminaire', 'LightSource'):
+        if self.light.type in ('LightGroup', 'Room', 
+                               'Luminaire', 'LightSource'):
             return None
 
         return {

--- a/homeassistant/components/light/hue.py
+++ b/homeassistant/components/light/hue.py
@@ -181,7 +181,10 @@ async def async_update_items(hass, bridge, async_add_entities,
 
         for light_id, light in current.items():
             if light_id not in progress_waiting:
-                light.async_schedule_update_ha_state()
+                if light.entity_id is None:
+                    _LOGGER.error("ERROR: Light %s has no entity ID. Skipping update.", light.name)
+                else:
+                    light.async_schedule_update_ha_state()
 
         return
 
@@ -202,7 +205,10 @@ async def async_update_items(hass, bridge, async_add_entities,
 
             new_lights.append(current[item_id])
         elif item_id not in progress_waiting:
-            current[item_id].async_schedule_update_ha_state()
+            if current[item_id].entity_id is None:
+                _LOGGER.error("ERROR: Current Item %s has no entity ID in API type '%s'. Skipping update.", current[item_id].name, api_type)
+            else:
+                current[item_id].async_schedule_update_ha_state()
 
     if new_lights:
         async_add_entities(new_lights)
@@ -298,7 +304,7 @@ class HueLight(Light):
     @property
     def device_info(self):
         """Return the device info."""
-        if self.light.type in ('LightGroup', 'Room'):
+        if self.light.type in ('LightGroup', 'Room', 'Luminaire', 'LightSource'):
             return None
 
         return {


### PR DESCRIPTION
## Description:

Hue Beyond light fixtures report themselves as special groups, that were not correctly recognized by the platform. This lead to various "no entity id" errors amongst others.

This pull adds recognition for the "Luminaire" and "LightGroup" group types, which resolves this error.

**Related issue (if applicable): Fixes #17196, Fixes #18739

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ X] The code change is tested and works locally.
  - [X ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
