### PR TITLE
Fix error when trying to log used UPnP device, if multiple found

### DIFF
--- a/homeassistant/components/upnp/__init__.py
+++ b/homeassistant/components/upnp/__init__.py
@@ -102,8 +102,10 @@ async def async_discover_and_construct(hass, udn=None) -> Device:
         # get the first/any
         discovery_info = discovery_infos[0]
         if len(discovery_infos) > 1:
+            device_name = discovery_info.get(
+                'usn', discovery_info.get('ssdp_description', ''))
             _LOGGER.info('Detected multiple UPnP/IGD devices, using: %s',
-                         discovery_info['igd_name'])
+                         device_name)
 
     ssdp_description = discovery_info['ssdp_description']
     return await Device.async_create_device(hass, ssdp_description)


### PR DESCRIPTION
## Description:

Fix an error when reporting which UPnP/IGD device is added, when multiple UPnP/IGD devices were found.

**Related issue (if applicable):** fixes #19862

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** -

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
