### PR TITLE
Geo Location -> Geolocation (class names and unit test comments)

### DIFF
--- a/homeassistant/components/geo_location/__init__.py
+++ b/homeassistant/components/geo_location/__init__.py
@@ -35,7 +35,7 @@ async def async_setup(hass, config):
     return True
 
 
-class GeoLocationEvent(Entity):
+class GeolocationEvent(Entity):
     """This represents an external event with an associated geolocation."""
 
     @property

--- a/homeassistant/components/geo_location/demo.py
+++ b/homeassistant/components/geo_location/demo.py
@@ -10,7 +10,7 @@ from math import cos, pi, radians, sin
 import random
 from typing import Optional
 
-from homeassistant.components.geo_location import GeoLocationEvent
+from homeassistant.components.geo_location import GeolocationEvent
 from homeassistant.helpers.event import track_time_interval
 
 _LOGGER = logging.getLogger(__name__)
@@ -62,7 +62,7 @@ class DemoManager:
             cos(radians(home_latitude))
 
         event_name = random.choice(EVENT_NAMES)
-        return DemoGeoLocationEvent(event_name, radius_in_km, latitude,
+        return DemoGeolocationEvent(event_name, radius_in_km, latitude,
                                     longitude, DEFAULT_UNIT_OF_MEASUREMENT)
 
     def _init_regular_updates(self):
@@ -90,7 +90,7 @@ class DemoManager:
         self._add_entities(new_devices)
 
 
-class DemoGeoLocationEvent(GeoLocationEvent):
+class DemoGeolocationEvent(GeolocationEvent):
     """This represents a demo geolocation event."""
 
     def __init__(self, name, distance, latitude, longitude,

--- a/homeassistant/components/geo_location/geo_json_events.py
+++ b/homeassistant/components/geo_location/geo_json_events.py
@@ -11,7 +11,7 @@ from typing import Optional
 import voluptuous as vol
 
 from homeassistant.components.geo_location import (
-    PLATFORM_SCHEMA, GeoLocationEvent)
+    PLATFORM_SCHEMA, GeolocationEvent)
 from homeassistant.const import (
     CONF_RADIUS, CONF_SCAN_INTERVAL, CONF_URL, EVENT_HOMEASSISTANT_START,
     CONF_LATITUDE, CONF_LONGITUDE)
@@ -108,7 +108,7 @@ class GeoJsonFeedEntityManager:
         dispatcher_send(self._hass, SIGNAL_DELETE_ENTITY.format(external_id))
 
 
-class GeoJsonLocationEvent(GeoLocationEvent):
+class GeoJsonLocationEvent(GeolocationEvent):
     """This represents an external event with GeoJSON data."""
 
     def __init__(self, feed_manager, external_id):

--- a/homeassistant/components/geo_location/nsw_rural_fire_service_feed.py
+++ b/homeassistant/components/geo_location/nsw_rural_fire_service_feed.py
@@ -11,7 +11,7 @@ from typing import Optional
 import voluptuous as vol
 
 from homeassistant.components.geo_location import (
-    PLATFORM_SCHEMA, GeoLocationEvent)
+    PLATFORM_SCHEMA, GeolocationEvent)
 from homeassistant.const import (
     ATTR_ATTRIBUTION, ATTR_LOCATION, CONF_RADIUS, CONF_SCAN_INTERVAL,
     EVENT_HOMEASSISTANT_START, CONF_LATITUDE, CONF_LONGITUDE)
@@ -129,7 +129,7 @@ class NswRuralFireServiceFeedEntityManager:
         dispatcher_send(self._hass, SIGNAL_DELETE_ENTITY.format(external_id))
 
 
-class NswRuralFireServiceLocationEvent(GeoLocationEvent):
+class NswRuralFireServiceLocationEvent(GeolocationEvent):
     """This represents an external event with NSW Rural Fire Service data."""
 
     def __init__(self, feed_manager, external_id):

--- a/homeassistant/components/geo_location/usgs_earthquakes_feed.py
+++ b/homeassistant/components/geo_location/usgs_earthquakes_feed.py
@@ -11,7 +11,7 @@ from typing import Optional
 import voluptuous as vol
 
 from homeassistant.components.geo_location import (
-    PLATFORM_SCHEMA, GeoLocationEvent)
+    PLATFORM_SCHEMA, GeolocationEvent)
 from homeassistant.const import (
     ATTR_ATTRIBUTION, CONF_RADIUS, CONF_SCAN_INTERVAL,
     EVENT_HOMEASSISTANT_START, CONF_LATITUDE, CONF_LONGITUDE)
@@ -148,7 +148,7 @@ class UsgsEarthquakesFeedEntityManager:
         dispatcher_send(self._hass, SIGNAL_DELETE_ENTITY.format(external_id))
 
 
-class UsgsEarthquakesEvent(GeoLocationEvent):
+class UsgsEarthquakesEvent(GeolocationEvent):
     """This represents an external event with USGS Earthquake data."""
 
     def __init__(self, feed_manager, external_id):

--- a/tests/components/automation/test_geo_location.py
+++ b/tests/components/automation/test_geo_location.py
@@ -1,4 +1,4 @@
-"""The tests for the geo location trigger."""
+"""The tests for the geolocation trigger."""
 import pytest
 
 from homeassistant.components import automation, zone

--- a/tests/components/geo_location/test_demo.py
+++ b/tests/components/geo_location/test_demo.py
@@ -39,7 +39,7 @@ class TestDemoPlatform(unittest.TestCase):
             with assert_setup_component(1, geo_location.DOMAIN):
                 assert setup_component(self.hass, geo_location.DOMAIN, CONFIG)
 
-            # In this test, only entities of the geo location domain have been
+            # In this test, only entities of the geolocation domain have been
             # generated.
             all_states = self.hass.states.all()
             assert len(all_states) == NUMBER_OF_DEMO_DEVICES

--- a/tests/components/geo_location/test_init.py
+++ b/tests/components/geo_location/test_init.py
@@ -1,4 +1,4 @@
-"""The tests for the geo location component."""
+"""The tests for the geolocation component."""
 import pytest
 
 from homeassistant.components import geo_location
@@ -13,7 +13,7 @@ async def test_setup_component(hass):
 
 
 async def test_event(hass):
-    """Simple test of the geo location event class."""
+    """Simple test of the geolocation event class."""
     entity = GeolocationEvent()
 
     assert entity.state is None

--- a/tests/components/geo_location/test_init.py
+++ b/tests/components/geo_location/test_init.py
@@ -2,7 +2,7 @@
 import pytest
 
 from homeassistant.components import geo_location
-from homeassistant.components.geo_location import GeoLocationEvent
+from homeassistant.components.geo_location import GeolocationEvent
 from homeassistant.setup import async_setup_component
 
 
@@ -14,7 +14,7 @@ async def test_setup_component(hass):
 
 async def test_event(hass):
     """Simple test of the geo location event class."""
-    entity = GeoLocationEvent()
+    entity = GeolocationEvent()
 
     assert entity.state is None
     assert entity.distance is None


### PR DESCRIPTION
## Description:
Fixed all occurrences in class names from "GeoLocation..." to "Geolocation..." and in unit test comments from "geo location" to "geolocation"; as discussed in https://github.com/home-assistant/architecture/issues/42#issuecomment-451145350
Left any user-exposed code and configuration as-is to avoid breaking changes.

**Related issue (if applicable):** n/a

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable): n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
