### PR TITLE
Fix deprecation warning

### DIFF
--- a/homeassistant/helpers/aiohttp_client.py
+++ b/homeassistant/helpers/aiohttp_client.py
@@ -155,10 +155,9 @@ def _async_get_connector(hass, verify_ssl=True):
     connector = aiohttp.TCPConnector(loop=hass.loop, ssl=ssl_context)
     hass.data[key] = connector
 
-    @callback
-    def _async_close_connector(event):
+    async def _async_close_connector(event):
         """Close connector pool."""
-        connector.close()
+        await connector.close()
 
     hass.bus.async_listen_once(
         EVENT_HOMEASSISTANT_CLOSE, _async_close_connector)


### PR DESCRIPTION
## Description:
Our tests have been printing [a lot of deprecation warnings](https://travis-ci.org/home-assistant/home-assistant/jobs/477049733#L1509) after a recent aiohttp upgrade. This fixes it.


