### PR TITLE
Removed mkdir, If the WORKDIR doesn’t exist, it will be created.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,6 @@ LABEL maintainer="Paulus Schoutsen <Paulus@PaulusSchoutsen.nl>"
 
 VOLUME /config
 
-RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
 # Copy build scripts

--- a/virtualization/Docker/Dockerfile.dev
+++ b/virtualization/Docker/Dockerfile.dev
@@ -17,7 +17,6 @@ LABEL maintainer="Paulus Schoutsen <Paulus@PaulusSchoutsen.nl>"
 
 VOLUME /config
 
-RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
 # Copy build scripts


### PR DESCRIPTION
## Description:

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

Referring documentation https://docs.docker.com/engine/reference/builder/#workdir, no need to use `mkdir`, before `WORKDIR`, because new directory will be created by `WORKDIR`