### PR TITLE
Correctly map Nest hvac_state to Home Assistant states.

### DIFF
--- a/homeassistant/components/sensor/nest.py
+++ b/homeassistant/components/sensor/nest.py
@@ -6,11 +6,13 @@ https://home-assistant.io/components/sensor.nest/
 """
 import logging
 
+from homeassistant.components.climate import (
+    STATE_COOL, STATE_HEAT)
 from homeassistant.components.nest import (
     DATA_NEST, DATA_NEST_CONFIG, CONF_SENSORS, NestSensorDevice)
 from homeassistant.const import (
     TEMP_CELSIUS, TEMP_FAHRENHEIT, CONF_MONITORED_CONDITIONS,
-    DEVICE_CLASS_TEMPERATURE, DEVICE_CLASS_HUMIDITY)
+    DEVICE_CLASS_TEMPERATURE, DEVICE_CLASS_HUMIDITY, STATE_OFF)
 
 DEPENDENCIES = ['nest']
 
@@ -38,6 +40,10 @@ SENSOR_UNITS = {'humidity': '%'}
 SENSOR_DEVICE_CLASSES = {'humidity': DEVICE_CLASS_HUMIDITY}
 
 VARIABLE_NAME_MAPPING = {'eta': 'eta_begin', 'operation_mode': 'mode'}
+
+VALUE_MAPPING = {
+    'hvac_state': {
+        'heating': STATE_HEAT, 'cooling': STATE_COOL, 'off': STATE_OFF}}
 
 SENSOR_TYPES_DEPRECATED = ['last_ip',
                            'local_ip',
@@ -142,6 +148,9 @@ class NestBasicSensor(NestSensorDevice):
         if self.variable in VARIABLE_NAME_MAPPING:
             self._state = getattr(self.device,
                                   VARIABLE_NAME_MAPPING[self.variable])
+        elif self.variable in VALUE_MAPPING:
+            state = getattr(self.device, self.variable)
+            self._state = VALUE_MAPPING[self.variable].get(state, state)
         elif self.variable in PROTECT_SENSOR_TYPES \
                 and self.variable != 'color_status':
             # keep backward compatibility


### PR DESCRIPTION
## Description:
Currently, the value for the `hvac_state` sensor [returned from Nest](https://developers.nest.com/reference/api-thermostat#hvac_state) is a string value that does not map correctly to one of Home Assistant's internal values ("heating" instead of "heat", "cooling" instead of "cool"). For 90% of people's use cases this has probably caused no issues, and they're close enough that it's not been spotted.

Not mapping to internal state constants does have some downfalls however. Like when `helpers.state. state_as_number` is called by the Prometheus component. In this case, the value for the `hvac_state` sensor is always reported as zero, instead of zero or one.

This _does_ however introduce a **backwards incompatibility** for anyone using these existing values to compare state. If you really don't want to introduce this backwards incompatibility, there are two alternatives I considered:

1. introduce a new (effectively duplicate) `STATE_HEATING` and make sure it's also used everywhere where comparisons are made to the current `STATE_HEAT`;
2. change `STATE_HEAT` to be a custom string type that also compares true to the value "heating" - rather unintuitive for someone trying to debug something.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io): home-assistant/home-assistant.io#8114.