### PR TITLE
Bump pyflunearyou to 1.0.1

### DIFF
--- a/homeassistant/components/sensor/flunearyou.py
+++ b/homeassistant/components/sensor/flunearyou.py
@@ -18,7 +18,7 @@ from homeassistant.helpers import aiohttp_client
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['pyflunearyou==1.0.0']
+REQUIREMENTS = ['pyflunearyou==1.0.1']
 _LOGGER = logging.getLogger(__name__)
 
 ATTR_CITY = 'city'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -988,7 +988,7 @@ pyflexit==0.3
 pyflic-homeassistant==0.4.dev0
 
 # homeassistant.components.sensor.flunearyou
-pyflunearyou==1.0.0
+pyflunearyou==1.0.1
 
 # homeassistant.components.light.futurenow
 pyfnip==0.2


### PR DESCRIPTION
## Description:
Bumps [`pyflunearyou`](https://github.com/bachya/pyflunearyou) to 1.0.1

**Related issue (if applicable):** fixes https://github.com/home-assistant/home-assistant/issues/19898

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: flunearyou
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
