### PR TITLE
Rearchitect the Ambient Weather PWS sensor platform

### DIFF
--- a/homeassistant/components/sensor/ambient_station.py
+++ b/homeassistant/components/sensor/ambient_station.py
@@ -21,16 +21,18 @@ REQUIREMENTS = ['ambient_api==1.5.2']
 _LOGGER = logging.getLogger(__name__)
 
 CONF_APP_KEY = 'app_key'
+CONF_UNITS = 'units'
 
 SENSOR_NAME = 0
 SENSOR_UNITS = 1
 
-CONF_UNITS = 'units'
 UNITS_US = 'us'
 UNITS_SI = 'si'
 UNIT_SYSTEM = {UNITS_US: 0, UNITS_SI: 1}
 
-SCAN_INTERVAL = timedelta(seconds=300)
+DEFAULT_APP_KEY = '32f561c4cb3a400d9c71ae0e96495466beaea220e315403c955b8f2bb' \
+    '12ac9a1'
+DEFAULT_SCAN_INTERVAL = timedelta(seconds=300)
 
 SENSOR_TYPES = {
     '24hourrainin': ['24 Hr Rain', 'in'],
@@ -67,7 +69,6 @@ SENSOR_TYPES = {
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_API_KEY): cv.string,
-    vol.Required(CONF_APP_KEY): cv.string,
     vol.Required(CONF_MONITORED_CONDITIONS, default=list(SENSOR_TYPES)):
         vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
     vol.Optional(CONF_UNITS): vol.In([UNITS_SI, UNITS_US]),
@@ -87,7 +88,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     api = AmbientAPI(
         AMBIENT_API_KEY=config[CONF_API_KEY],
-        AMBIENT_APPLICATION_KEY=config[CONF_APP_KEY],
+        AMBIENT_APPLICATION_KEY=DEFAULT_APP_KEY,
         log_level='DEBUG')
 
     data = AmbientStationData(api)
@@ -161,7 +162,7 @@ class AmbientStationData:
         self.data = {}
         self.stations = []
 
-    @Throttle(SCAN_INTERVAL)
+    @Throttle(DEFAULT_SCAN_INTERVAL)
     def update(self):
         """Get new data for all stations."""
         # Ambient's API has really aggressive rate limiting (no more than 1

--- a/homeassistant/components/sensor/ambient_station.py
+++ b/homeassistant/components/sensor/ambient_station.py
@@ -30,11 +30,6 @@ UNITS_US = 'us'
 UNITS_SI = 'si'
 UNIT_SYSTEM = {UNITS_US: 0, UNITS_SI: 1}
 
-# This is the hardcoded Ambient application key for HASS.
-# https://github.com/ambient-weather/api-docs/issues/14#issuecomment-453263278
-DEFAULT_APP_KEY = '32f561c4cb3a400d9c71ae0e96495466beaea220e315403c955b8f2bb' \
-    '12ac9a1'
-
 DEFAULT_SCAN_INTERVAL = timedelta(minutes=5)
 
 SENSOR_TYPES = {
@@ -71,6 +66,7 @@ SENSOR_TYPES = {
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_APP_KEY): cv.string,
     vol.Required(CONF_API_KEY): cv.string,
     vol.Required(CONF_MONITORED_CONDITIONS, default=list(SENSOR_TYPES)):
         vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
@@ -92,7 +88,7 @@ async def async_setup_platform(
 
     api = AmbientAPI(
         AMBIENT_API_KEY=config[CONF_API_KEY],
-        AMBIENT_APPLICATION_KEY=DEFAULT_APP_KEY,
+        AMBIENT_APPLICATION_KEY=config[CONF_APP_KEY],
         log_level='DEBUG')
 
     data = AmbientStationData(hass, api)

--- a/homeassistant/components/sensor/ambient_station.py
+++ b/homeassistant/components/sensor/ambient_station.py
@@ -68,7 +68,7 @@ SENSOR_TYPES = {
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_APP_KEY): cv.string,
     vol.Required(CONF_API_KEY): cv.string,
-    vol.Required(CONF_MONITORED_CONDITIONS, default=list(SENSOR_TYPES)):
+    vol.Optional(CONF_MONITORED_CONDITIONS, default=list(SENSOR_TYPES)):
         vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
     vol.Optional(CONF_UNITS): vol.In([UNITS_SI, UNITS_US]),
 })

--- a/homeassistant/components/sensor/ambient_station.py
+++ b/homeassistant/components/sensor/ambient_station.py
@@ -150,7 +150,7 @@ class AmbientWeatherSensor(Entity):
         try:
             self._state = latest_data[self._condition]
         except KeyError:
-            _LOGGER.warning('No data for condition: %s', self._condition)
+            return
 
 
 class AmbientStationData:

--- a/homeassistant/components/sensor/ambient_station.py
+++ b/homeassistant/components/sensor/ambient_station.py
@@ -10,9 +10,9 @@ from datetime import timedelta
 
 import voluptuous as vol
 
+import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import CONF_API_KEY, CONF_MONITORED_CONDITIONS
-import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 
@@ -32,7 +32,7 @@ UNIT_SYSTEM = {UNITS_US: 0, UNITS_SI: 1}
 
 DEFAULT_APP_KEY = '32f561c4cb3a400d9c71ae0e96495466beaea220e315403c955b8f2bb' \
     '12ac9a1'
-DEFAULT_SCAN_INTERVAL = timedelta(seconds=300)
+DEFAULT_SCAN_INTERVAL = timedelta(minutes=5)
 
 SENSOR_TYPES = {
     '24hourrainin': ['24 Hr Rain', 'in'],

--- a/homeassistant/components/sensor/ambient_station.py
+++ b/homeassistant/components/sensor/ambient_station.py
@@ -30,8 +30,11 @@ UNITS_US = 'us'
 UNITS_SI = 'si'
 UNIT_SYSTEM = {UNITS_US: 0, UNITS_SI: 1}
 
+# This is the hardcoded Ambient application key for HASS.
+# https://github.com/ambient-weather/api-docs/issues/14#issuecomment-453263278
 DEFAULT_APP_KEY = '32f561c4cb3a400d9c71ae0e96495466beaea220e315403c955b8f2bb' \
     '12ac9a1'
+
 DEFAULT_SCAN_INTERVAL = timedelta(minutes=5)
 
 SENSOR_TYPES = {


### PR DESCRIPTION
## Description:

This PR rearchitects to the Ambient Weather PWS sensor platform to make the following changes:

* Allows for an empty `monitored_conditions` configuration option, which includes every sub-option. Previously, users were required to manually specify each condition manually no matter what.
* Creates sensors for every station associated with the API key. Previously, sensors were only created for the first station.
* Immediately updates data upon platform start. Previously, sensors would show `Unknown` until the first "natural" update.
* Adds unique IDs to each sensor so they can be managed by the entity registry.
* Changes entity IDs to include the station name (so as to not pollute the sensor namespace): `sensor.feels_like` -> `sensor.home_feels_like`
* Removes logic to reconnect to the API with each request, which was originally in place due to Ambient recycling their API servers each night ([they no longer do this](https://github.com/ambient-weather/api-docs/issues/8#issuecomment-445503299)).
* Removes unnecessary code and logging
* Adjusts code style/linting to be more consistent with the rest of HASS.

Although this is a large number of changes for 1 PR, I include them all because (a) this rearchitecture should be equivalent to a new platform and (b) I don't think anything is served by splitting them into multiple PRs (especially considering that the resulting `ambient_station.py` is smaller than what was there before).

**BREAKING CHANGE:** Entity IDs change to include the station name.

**Related issue (if applicable):** fixes N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: ambient_station
    api_key: !secret ambient_api_key
    app_key: !secret ambient_app_key
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
