### PR TITLE
Add notify.html5_dismiss service

### DIFF
--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -151,8 +151,7 @@ async def async_setup(hass, config):
             SERVICE_NOTIFY)
         platform_name_slug = slugify(platform_name)
 
-        if hasattr(notify_service, 'can_dismiss') and \
-           notify_service.can_dismiss:
+        if getattr(notify_service, 'can_dismiss', False):
             hass.services.async_register(
                 DOMAIN, '{}_{}'.format(platform_name_slug, SERVICE_DISMISS),
                 async_dismiss_message, schema=DISMISS_SERVICE_SCHEMA)

--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -187,12 +187,12 @@ class BaseNotificationService:
         """Dismisses a notifaction."""
         raise NotImplementedError()
 
-    def async_dismiss(self, **kwargs):
+    async def async_dismiss(self, **kwargs):
         """Dismisses a notification.
 
-        This method must be run in the event loop and returns a coroutine.
+        This method must be run in the event loop.
         """
-        return self.hass.async_add_job(
+        await self.hass.async_add_executor_job(
             partial(self.dismiss, **kwargs))
 
     def send_message(self, message, **kwargs):

--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -151,9 +151,11 @@ async def async_setup(hass, config):
             SERVICE_NOTIFY)
         platform_name_slug = slugify(platform_name)
 
-        hass.services.async_register(
-            DOMAIN, '{}_{}'.format(platform_name_slug, SERVICE_DISMISS),
-            async_dismiss_message, schema=DISMISS_SERVICE_SCHEMA)
+        if hasattr(notify_service, 'can_dismiss') and \
+           notify_service.can_dismiss:
+            hass.services.async_register(
+                DOMAIN, '{}_{}'.format(platform_name_slug, SERVICE_DISMISS),
+                async_dismiss_message, schema=DISMISS_SERVICE_SCHEMA)
         hass.services.async_register(
             DOMAIN, platform_name_slug, async_notify_message,
             schema=NOTIFY_SERVICE_SCHEMA)

--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -35,11 +35,17 @@ ATTR_TITLE_DEFAULT = "Home Assistant"
 DOMAIN = 'notify'
 
 SERVICE_NOTIFY = 'notify'
+SERVICE_DISMISS = 'dismiss'
 
 PLATFORM_SCHEMA = vol.Schema({
     vol.Required(CONF_PLATFORM): cv.string,
     vol.Optional(CONF_NAME): cv.string,
 }, extra=vol.ALLOW_EXTRA)
+
+DISMISS_SERVICE_SCHEMA = vol.Schema({
+    vol.Optional(ATTR_TARGET): vol.All(cv.ensure_list, [cv.string]),
+    vol.Optional(ATTR_DATA): dict,
+})
 
 NOTIFY_SERVICE_SCHEMA = vol.Schema({
     vol.Required(ATTR_MESSAGE): cv.template,
@@ -95,6 +101,19 @@ async def async_setup(hass, config):
         if discovery_info is None:
             discovery_info = {}
 
+        async def async_dismiss_message(service):
+            """Handle dismissing notification message service calls."""
+            kwargs = {}
+
+            if targets.get(service.service) is not None:
+                kwargs[ATTR_TARGET] = [targets[service.service]]
+            elif service.data.get(ATTR_TARGET) is not None:
+                kwargs[ATTR_TARGET] = service.data.get(ATTR_TARGET)
+
+            kwargs[ATTR_DATA] = service.data.get(ATTR_DATA)
+
+            await notify_service.async_dismiss(**kwargs)
+
         async def async_notify_message(service):
             """Handle sending notification message service calls."""
             kwargs = {}
@@ -133,6 +152,9 @@ async def async_setup(hass, config):
         platform_name_slug = slugify(platform_name)
 
         hass.services.async_register(
+            DOMAIN, '{}_{}'.format(platform_name_slug, SERVICE_DISMISS),
+            async_dismiss_message, schema=DISMISS_SERVICE_SCHEMA)
+        hass.services.async_register(
             DOMAIN, platform_name_slug, async_notify_message,
             schema=NOTIFY_SERVICE_SCHEMA)
 
@@ -159,6 +181,18 @@ class BaseNotificationService:
     """An abstract class for notification services."""
 
     hass = None
+
+    def dismiss(self, **kwargs):
+        """Dismisses a notifaction."""
+        raise NotImplementedError()
+
+    def async_dismiss(self, **kwargs):
+        """Dismisses a notification.
+
+        This method must be run in the event loop and returns a coroutine.
+        """
+        return self.hass.async_add_job(
+            partial(self.dismiss, **kwargs))
 
     def send_message(self, message, **kwargs):
         """Send a message.

--- a/homeassistant/components/notify/html5.py
+++ b/homeassistant/components/notify/html5.py
@@ -129,7 +129,8 @@ def get_service(hass, config, discovery_info=None):
         add_manifest_json_key(
             ATTR_GCM_SENDER_ID, config.get(ATTR_GCM_SENDER_ID))
 
-    return HTML5NotificationService(hass, gcm_api_key, registrations, json_path)
+    return HTML5NotificationService(
+        hass, gcm_api_key, registrations, json_path)
 
 
 def _load_config(filename):

--- a/homeassistant/components/notify/html5.py
+++ b/homeassistant/components/notify/html5.py
@@ -56,6 +56,7 @@ ATTR_ACTION = 'action'
 ATTR_ACTIONS = 'actions'
 ATTR_TYPE = 'type'
 ATTR_URL = 'url'
+ATTR_DISMISS = 'dismiss'
 
 ATTR_JWT = 'jwt'
 
@@ -334,12 +335,18 @@ class HTML5NotificationService(BaseNotificationService):
             targets[registration] = registration
         return targets
 
+    def dismiss(self, **kwargs):
+        """Dismisses a notification."""
+        payload = {
+            ATTR_TAG: kwargs.get(ATTR_DATA, {}).get(ATTR_TAG),
+            ATTR_DISMISS: True,
+            ATTR_DATA: {}
+        }
+
+        self._push_message(payload, **kwargs)
+
     def send_message(self, message="", **kwargs):
         """Send a message to a user."""
-        import jwt
-        from pywebpush import WebPusher
-
-        timestamp = int(time.time())
         tag = str(uuid.uuid4())
 
         payload = {
@@ -348,7 +355,6 @@ class HTML5NotificationService(BaseNotificationService):
             ATTR_DATA: {},
             'icon': '/static/icons/favicon-192x192.png',
             ATTR_TAG: tag,
-            'timestamp': (timestamp*1000),  # Javascript ms since epoch
             ATTR_TITLE: kwargs.get(ATTR_TITLE, ATTR_TITLE_DEFAULT)
         }
 
@@ -371,6 +377,17 @@ class HTML5NotificationService(BaseNotificationService):
         if (payload[ATTR_DATA].get(ATTR_URL) is None and
                 payload.get(ATTR_ACTIONS) is None):
             payload[ATTR_DATA][ATTR_URL] = URL_ROOT
+
+        self._push_message(payload, **kwargs)
+
+    def _push_message(self, payload, **kwargs):
+        """Send the message."""
+        import jwt
+        from pywebpush import WebPusher
+
+        timestamp = int(time.time())
+
+        payload['timestamp'] = (timestamp*1000)  # Javascript ms since epoch
 
         targets = kwargs.get(ATTR_TARGET)
 

--- a/homeassistant/components/notify/html5.py
+++ b/homeassistant/components/notify/html5.py
@@ -335,6 +335,11 @@ class HTML5NotificationService(BaseNotificationService):
             targets[registration] = registration
         return targets
 
+    @property
+    def can_dismiss(self):
+        """Return true if dismiss is supported."""
+        return True
+
     def dismiss(self, **kwargs):
         """Dismisses a notification."""
         payload = {

--- a/homeassistant/components/notify/html5.py
+++ b/homeassistant/components/notify/html5.py
@@ -342,8 +342,10 @@ class HTML5NotificationService(BaseNotificationService):
 
     def dismiss(self, **kwargs):
         """Dismisses a notification."""
+        data = kwargs.get(ATTR_DATA)
+        tag = data.get(ATTR_TAG) if data else ""
         payload = {
-            ATTR_TAG: kwargs.get(ATTR_DATA, {}).get(ATTR_TAG),
+            ATTR_TAG: tag,
             ATTR_DISMISS: True,
             ATTR_DATA: {}
         }

--- a/homeassistant/components/notify/services.yaml
+++ b/homeassistant/components/notify/services.yaml
@@ -16,15 +16,15 @@ notify:
       description: Extended information for notification. Optional depending on the platform.
       example: platform specific
 
-dismiss:
-  description: Dismiss a notification.
+html5_dismiss:
+  description: Dismiss a html5 notification.
   fields:
     target:
-      description: An array of targets to send the notification to. Optional depending on the platform.
-      example: platform specific
+      description: An array of targets. Optional.
+      example: ['my_phone', 'my_tablet']
     data:
-      description: Extended information of notification.
-      example: platform specific
+      description: Extended information of notification. Supports tag. Optional.
+      example: '{ "tag": "tagname" }'
 
 apns_register:
   description: Registers a device to receive push notifications.

--- a/homeassistant/components/notify/services.yaml
+++ b/homeassistant/components/notify/services.yaml
@@ -16,6 +16,16 @@ notify:
       description: Extended information for notification. Optional depending on the platform.
       example: platform specific
 
+dismiss:
+  description: Dismiss a notification.
+  fields:
+    target:
+      description: An array of targets to send the notification to. Optional depending on the platform.
+      example: platform specific
+    data:
+      description: Extended information of notification.
+      example: platform specific
+
 apns_register:
   description: Registers a device to receive push notifications.
   fields:

--- a/tests/components/notify/test_html5.py
+++ b/tests/components/notify/test_html5.py
@@ -82,6 +82,40 @@ class TestHtml5Notify:
         assert service is not None
 
     @patch('pywebpush.WebPusher')
+    def test_dismissing_message(self, mock_wp):
+        """Test dismissing message."""
+        hass = MagicMock()
+
+        data = {
+            'device': SUBSCRIPTION_1
+        }
+
+        m = mock_open(read_data=json.dumps(data))
+        with patch(
+            'homeassistant.util.json.open',
+            m, create=True
+        ):
+            service = html5.get_service(hass, {'gcm_sender_id': '100'})
+
+        assert service is not None
+
+        service.dismiss(target=['device', 'non_existing'],
+                        data={'tag': 'test'})
+
+        assert len(mock_wp.mock_calls) == 3
+
+        # WebPusher constructor
+        assert mock_wp.mock_calls[0][1][0] == SUBSCRIPTION_1['subscription']
+        # Third mock_call checks the status_code of the response.
+        assert mock_wp.mock_calls[2][0] == '().send().status_code.__eq__'
+
+        # Call to send
+        payload = json.loads(mock_wp.mock_calls[1][1][0])
+
+        assert payload['dismiss'] == True
+        assert payload['tag'] == 'test'
+
+    @patch('pywebpush.WebPusher')
     def test_sending_message(self, mock_wp):
         """Test sending message."""
         hass = MagicMock()

--- a/tests/components/notify/test_html5.py
+++ b/tests/components/notify/test_html5.py
@@ -112,7 +112,7 @@ class TestHtml5Notify:
         # Call to send
         payload = json.loads(mock_wp.mock_calls[1][1][0])
 
-        assert payload['dismiss'] == True
+        assert payload['dismiss'] is True
         assert payload['tag'] == 'test'
 
     @patch('pywebpush.WebPusher')


### PR DESCRIPTION
## Description:
Add dismiss to html5 notifications.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8121
**Pull request in [home-assistant-polymer](https://github.com/home-assistant/home-assistant-polymer) (if applicable):** https://github.com/home-assistant/home-assistant-polymer/pull/2435

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
