### PR TITLE
min_max sensor support for STATE_UNAVAILABLE

### DIFF
--- a/homeassistant/components/sensor/min_max.py
+++ b/homeassistant/components/sensor/min_max.py
@@ -11,7 +11,8 @@ import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
-    CONF_NAME, STATE_UNKNOWN, CONF_TYPE, ATTR_UNIT_OF_MEASUREMENT)
+    CONF_NAME, STATE_UNKNOWN, STATE_UNAVAILABLE, CONF_TYPE,
+    ATTR_UNIT_OF_MEASUREMENT)
 from homeassistant.core import callback
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import async_track_state_change
@@ -125,7 +126,8 @@ class MinMaxSensor(Entity):
         @callback
         def async_min_max_sensor_state_listener(entity, old_state, new_state):
             """Handle the sensor state changes."""
-            if new_state.state is None or new_state.state in STATE_UNKNOWN:
+            if (new_state.state is None
+                    or new_state.state in [STATE_UNKNOWN, STATE_UNAVAILABLE]):
                 self.states[entity] = STATE_UNKNOWN
                 hass.async_add_job(self.async_update_ha_state, True)
                 return

--- a/tests/components/sensor/test_min_max.py
+++ b/tests/components/sensor/test_min_max.py
@@ -3,7 +3,8 @@ import unittest
 
 from homeassistant.setup import setup_component
 from homeassistant.const import (
-    STATE_UNKNOWN, ATTR_UNIT_OF_MEASUREMENT, TEMP_CELSIUS, TEMP_FAHRENHEIT)
+    STATE_UNKNOWN, STATE_UNAVAILABLE, ATTR_UNIT_OF_MEASUREMENT, TEMP_CELSIUS,
+    TEMP_FAHRENHEIT)
 from tests.common import get_test_home_assistant
 
 
@@ -209,7 +210,7 @@ class TestMinMaxSensor(unittest.TestCase):
         state = self.hass.states.get('sensor.test_max')
         assert STATE_UNKNOWN != state.state
 
-        self.hass.states.set(entity_ids[1], STATE_UNKNOWN)
+        self.hass.states.set(entity_ids[1], STATE_UNAVAILABLE)
         self.hass.block_till_done()
 
         state = self.hass.states.get('sensor.test_max')


### PR DESCRIPTION
## Description:
The `min_max` sensor platform doesn't work anymore if one of the monitored entity_id is in the `unavailable` state (MQTT sensors for example).

This PR fixes this issue and considers `STATE_UNAVAILABLE` as `STATE_UNKNOWN`.

## Example entry for `configuration.yaml` (if applicable):
```yaml
- platform: min_max
  name: test_max
  type: max
  entity_ids:
    - sensor.mqtt_sensor1
    - sensor.mqtt_sensor2
    - sensor.mqtt_sensor3
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
