### PR TITLE
Add btle_name attribute to devices

### DIFF
--- a/homeassistant/components/device_tracker/googlehome.py
+++ b/homeassistant/components/device_tracker/googlehome.py
@@ -89,6 +89,7 @@ class GoogleHomeDeviceScanner(DeviceScanner):
                 devices[uuid]['btle_mac_address'] = device['mac_address']
                 devices[uuid]['ghname'] = ghname
                 devices[uuid]['source_type'] = 'bluetooth'
-                devices[uuid]['btle_name'] = device['name']
+                if device['name']:
+                    devices[uuid]['btle_name'] = device['name']
         await self.scanner.clear_scan_result()
         self.last_results = devices

--- a/homeassistant/components/device_tracker/googlehome.py
+++ b/homeassistant/components/device_tracker/googlehome.py
@@ -89,5 +89,6 @@ class GoogleHomeDeviceScanner(DeviceScanner):
                 devices[uuid]['btle_mac_address'] = device['mac_address']
                 devices[uuid]['ghname'] = ghname
                 devices[uuid]['source_type'] = 'bluetooth'
+                devices[uuid]['btle_name'] = device['name']
         await self.scanner.clear_scan_result()
         self.last_results = devices


### PR DESCRIPTION
Added name from bluetooth device to attributes

## Description:
The advertised name of the bluetooth device was missing from the attributes, so I added it.

## Checklist:
  - [X] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
