### PR TITLE
Don't setup device_tracker twice

### DIFF
--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -201,8 +201,10 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType):
 
     hass.data[DOMAIN] = async_setup_platform
 
+    tracker_platforms = dict(config_per_platform(config, DOMAIN))
+
     setup_tasks = [async_setup_platform(p_type, p_config) for p_type, p_config
-                   in config_per_platform(config, DOMAIN)]
+                   in tracker_platforms.items()]
     if setup_tasks:
         await asyncio.wait(setup_tasks, loop=hass.loop)
 
@@ -210,7 +212,8 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType):
 
     async def async_platform_discovered(platform, info):
         """Load a platform."""
-        await async_setup_platform(platform, {}, disc_info=info)
+        if platform not in tracker_platforms:
+            await async_setup_platform(platform, {}, disc_info=info)
 
     discovery.async_listen_platform(hass, DOMAIN, async_platform_discovered)
 

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -191,15 +191,13 @@ async def test_discover_platform(mock_demo_setup_scanner, mock_see, hass):
 
 
 @patch(
-    'homeassistant.components.device_tracker.DeviceTracker.see')
-@patch(
     'homeassistant.components.device_tracker.demo.setup_scanner',
     autospec=True)
-async def test_discover_platform_configured(mock_demo_setup_scanner, mock_see, hass):
+async def test_discover_platform_configured(mock_demo_setup_scanner, hass):
     """Test discovery of device_tracker demo platform."""
-    assert await async_setup_component(hass, device_tracker.DOMAIN,
-                                       {device_tracker.DOMAIN: {CONF_PLATFORM:
-                                           'demo'}})
+    assert await async_setup_component(
+        hass, device_tracker.DOMAIN,
+        {device_tracker.DOMAIN: {CONF_PLATFORM: 'demo'}})
     assert device_tracker.DOMAIN in hass.config.components
     await discovery.async_load_platform(
         hass, device_tracker.DOMAIN, 'demo', {'test_key': 'test_val'},

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -190,6 +190,25 @@ async def test_discover_platform(mock_demo_setup_scanner, mock_see, hass):
         hass, {}, mock_see, {'test_key': 'test_val'})
 
 
+@patch(
+    'homeassistant.components.device_tracker.DeviceTracker.see')
+@patch(
+    'homeassistant.components.device_tracker.demo.setup_scanner',
+    autospec=True)
+async def test_discover_platform_configured(mock_demo_setup_scanner, mock_see, hass):
+    """Test discovery of device_tracker demo platform."""
+    assert await async_setup_component(hass, device_tracker.DOMAIN,
+                                       {device_tracker.DOMAIN: {CONF_PLATFORM:
+                                           'demo'}})
+    assert device_tracker.DOMAIN in hass.config.components
+    await discovery.async_load_platform(
+        hass, device_tracker.DOMAIN, 'demo', {'test_key': 'test_val'},
+        {'demo': {}})
+    await hass.async_block_till_done()
+    assert mock_demo_setup_scanner.called
+    assert mock_demo_setup_scanner.call_count == 1
+
+
 async def test_update_stale(hass):
     """Test stalled update."""
     scanner = get_component(hass, 'device_tracker.test').SCANNER


### PR DESCRIPTION
## Description:

When a device_tracker with a platform is explicitely configured (for
example to specify query interval), it's overriden later on when the
platform is discovered, without the proper configuration. Let's ignore
the second call in that cases.

fixes #19848 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.
