### PR TITLE
Accept both domains and entities in influxdb include

### DIFF
--- a/homeassistant/components/influxdb.py
+++ b/homeassistant/components/influxdb.py
@@ -154,8 +154,9 @@ def setup(hass, config):
             return
 
         try:
-            if (whitelist_e and state.entity_id not in whitelist_e) or \
-                    (whitelist_d and state.domain not in whitelist_d):
+            if ((whitelist_e or whitelist_d)
+                    and state.entity_id not in whitelist_e
+                    and state.domain not in whitelist_d):
                 return
 
             _include_state = _include_value = False

--- a/tests/components/test_influxdb.py
+++ b/tests/components/test_influxdb.py
@@ -360,7 +360,6 @@ class TestInfluxDB(unittest.TestCase):
                 'password': 'pass',
                 'include': {
                     'domains': ['fake'],
-                    'entities': ['some.other'],
                 }
             }
         }
@@ -394,6 +393,77 @@ class TestInfluxDB(unittest.TestCase):
             else:
                 assert not mock_client.return_value.write_points.called
             mock_client.return_value.write_points.reset_mock()
+
+    def test_event_listener_whitelist_domain_and_entities(self, mock_client):
+        """Test the event listener against a whitelist."""
+        config = {
+            'influxdb': {
+                'host': 'host',
+                'username': 'user',
+                'password': 'pass',
+                'include': {
+                    'domains': ['fake'],
+                    'entities': ['other.one'],
+                }
+            }
+        }
+        assert setup_component(self.hass, influxdb.DOMAIN, config)
+        self.handler_method = self.hass.bus.listen.call_args_list[0][0][1]
+        mock_client.return_value.write_points.reset_mock()
+
+        for domain in ('fake', 'another_fake'):
+            state = mock.MagicMock(
+                state=1, domain=domain,
+                entity_id='{}.something'.format(domain),
+                object_id='something', attributes={})
+            event = mock.MagicMock(data={'new_state': state}, time_fired=12345)
+            body = [{
+                'measurement': '{}.something'.format(domain),
+                'tags': {
+                    'domain': domain,
+                    'entity_id': 'something',
+                },
+                'time': 12345,
+                'fields': {
+                    'value': 1,
+                },
+            }]
+            self.handler_method(event)
+            self.hass.data[influxdb.DOMAIN].block_till_done()
+            if domain == 'fake':
+                assert mock_client.return_value.write_points.call_count == 1
+                assert mock_client.return_value.write_points.call_args == \
+                    mock.call(body)
+            else:
+                assert not mock_client.return_value.write_points.called
+            mock_client.return_value.write_points.reset_mock()
+
+        for entity_id in ('one', 'two'):
+            state = mock.MagicMock(
+                state=1, domain='other', entity_id='other.{}'.format(entity_id),
+                object_id=entity_id, attributes={})
+            event = mock.MagicMock(data={'new_state': state}, time_fired=12345)
+            body = [{
+                'measurement': 'other.{}'.format(entity_id),
+                'tags': {
+                    'domain': 'other',
+                    'entity_id': entity_id,
+                },
+                'time': 12345,
+                'fields': {
+                    'value': 1,
+                },
+            }]
+            self.handler_method(event)
+            self.hass.data[influxdb.DOMAIN].block_till_done()
+            if entity_id == 'one':
+                assert mock_client.return_value.write_points.call_count == 1
+                assert mock_client.return_value.write_points.call_args == \
+                    mock.call(body)
+            else:
+                assert not mock_client.return_value.write_points.called
+            mock_client.return_value.write_points.reset_mock()
+
 
     def test_event_listener_invalid_type(self, mock_client):
         """Test the event listener when an attribute has an invalid type."""

--- a/tests/components/test_influxdb.py
+++ b/tests/components/test_influxdb.py
@@ -360,6 +360,7 @@ class TestInfluxDB(unittest.TestCase):
                 'password': 'pass',
                 'include': {
                     'domains': ['fake'],
+                    'entities': ['some.other'],
                 }
             }
         }

--- a/tests/components/test_influxdb.py
+++ b/tests/components/test_influxdb.py
@@ -440,7 +440,8 @@ class TestInfluxDB(unittest.TestCase):
 
         for entity_id in ('one', 'two'):
             state = mock.MagicMock(
-                state=1, domain='other', entity_id='other.{}'.format(entity_id),
+                state=1, domain='other',
+                entity_id='other.{}'.format(entity_id),
                 object_id=entity_id, attributes={})
             event = mock.MagicMock(data={'new_state': state}, time_fired=12345)
             body = [{
@@ -463,7 +464,6 @@ class TestInfluxDB(unittest.TestCase):
             else:
                 assert not mock_client.return_value.write_points.called
             mock_client.return_value.write_points.reset_mock()
-
 
     def test_event_listener_invalid_type(self, mock_client):
         """Test the event listener when an attribute has an invalid type."""


### PR DESCRIPTION
## Description:

Whitelisting both domains and entities would require both to match for an event to be passed to InfluxDB. This PR changes the condition so matching one or the other is enough.

**Related issue (if applicable):** fixes [forum issue](https://community.home-assistant.io/t/influxdb-certain-combinations-of-entities-and-domains-prevent-writes-to-the-db/90239)

## Example entry for `configuration.yaml` (if applicable):
```yaml
influxdb:
  host: !secret influx_host
  username: !secret influx_user
  password: !secret influx_pass
  default_measurement: state
  include:
    domains:
      - sensor
    entities:
      - climate.hallway
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.
  - [X] There is no commented out code in this PR.

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.
