### PR TITLE
Remove spurious libzwave error

### DIFF
--- a/homeassistant/components/zwave/__init__.py
+++ b/homeassistant/components/zwave/__init__.py
@@ -284,7 +284,7 @@ async def async_setup_entry(hass, config_entry):
 
     options.set_console_output(use_debug)
 
-    if CONF_NETWORK_KEY in config_entry.data:
+    if config_entry.data.get(CONF_NETWORK_KEY):
         options.addOption("NetworkKey", config_entry.data[CONF_NETWORK_KEY])
 
     await hass.async_add_executor_job(options.lock)


### PR DESCRIPTION
If a network_key is not configuired, the following error is logged:
TypeError: expected bytes, NoneType found
Exception ignored in: 'libopenzwave.str_to_cppstr'
TypeError: expected bytes, NoneType found

We don't need to set the key if it's None, let's skip in that case.
