### PR TITLE
Don't map LevelControl to light for single cluster devices.

### DIFF
--- a/homeassistant/components/zha/const.py
+++ b/homeassistant/components/zha/const.py
@@ -129,7 +129,6 @@ def populate_data():
 
     SINGLE_INPUT_CLUSTER_DEVICE_CLASS.update({
         zcl.clusters.general.OnOff: 'switch',
-        zcl.clusters.general.LevelControl: 'light',
         zcl.clusters.measurement.RelativeHumidity: 'sensor',
         zcl.clusters.measurement.TemperatureMeasurement: 'sensor',
         zcl.clusters.measurement.PressureMeasurement: 'sensor',


### PR DESCRIPTION
## Description:
Fixes #19921 
We can't map a `LevelControl` cluster to a light for "single cluster devices". Single cluster devices should operate as single cluster devices. Zha Light however requires the "on_off" cluster with "LevelControl" cluster being optional, so we can't map LevelControl to light, because light won't have the on_off cluster.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
