### PR TITLE
Add Repetier Server sensor

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -876,6 +876,7 @@ omit =
     homeassistant/components/sensor/xbox_live.py
     homeassistant/components/sensor/zamg.py
     homeassistant/components/sensor/zestimate.py
+    homeassistant/components/sensor/repetier.py
     homeassistant/components/shiftr.py
     homeassistant/components/spc.py
     homeassistant/components/switch/acer_projector.py

--- a/homeassistant/components/sensor/repetier.py
+++ b/homeassistant/components/sensor/repetier.py
@@ -1,0 +1,199 @@
+"""
+Sensor for retrieving Repetier-Server device status.
+
+Creates one sensor for each device attached to Repetier-Server
+Created by Morten Trab (morten@trab.dk) - 2018
+"""
+from datetime import timedelta
+import logging
+
+import requests
+import voluptuous as vol
+
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import (
+    CONF_API_KEY,
+    CONF_PORT,
+    CONF_URL,
+    STATE_IDLE,
+    STATE_OFF,
+    STATE_ON,
+    STATE_UNKNOWN)
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import Entity
+from homeassistant.util import Throttle
+
+REQUIREMENTS = ['pyrepetier==1.4.1']
+
+__version__ = '0.5.1'
+
+_LOGGER = logging.getLogger(__name__)
+
+SCAN_INTERVAL = timedelta(seconds=5)
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_URL): cv.string,
+    vol.Required(CONF_API_KEY): cv.string,
+    vol.Optional(CONF_PORT, default='3344'): cv.string,
+    vol.Optional('decimals', default=1): int,
+    vol.Optional('state_percent', default=False): bool,
+})
+
+
+def parse_repetier_api_response(response):
+    """Parse the Repetier Server API json response."""
+    data_dict = {}
+
+    i = 0
+    for printer in response['data']:
+        _key = i
+        i += 1
+        if _key not in data_dict.keys():
+            data_dict[_key] = printer
+        else:
+            data_dict[_key].update(printer)
+    return data_dict
+
+
+def setup_platform(hass, config, add_devices, discovery_info=None):
+    import pyrepetier
+    """Set up the Repetier sensors."""
+    try:
+        data = pyrepetier.RepetierData(parse_repetier_api_response,url=config.get(CONF_URL), port=config.get(CONF_PORT), api_key=config.get(CONF_API_KEY))
+        data.update()
+        sensors = []
+        for key in data.data.keys():
+            sensors.append(RepetierSensor(config, key, data))
+        add_devices(sensors, True)
+    except (RuntimeError, TypeError, NameError):
+        _LOGGER.warning("Cannot setup Repetier sensors, check your config")
+
+
+class RepetierSensor(Entity):
+    """Class to hold Repetier Sensor basic info."""
+
+    def __init__(self, config, repetier_id, data):
+        """Initialize the sensor object."""
+        self._repetier_id = repetier_id
+        self._data = data
+        self._icon = 'mdi:printer-3d'
+        self._name = None
+        self._state = STATE_UNKNOWN
+        self._units = None
+        self._attributes = None
+        self._decimals = config.get('decimals')
+        self._show_pct = config.get('state_percent')
+        self.format_data()
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def icon(self):
+        """Icon to use in the frontend, if any."""
+        return self._icon
+
+    @property
+    def unit_of_measurement(self):
+        """Set units of measurement."""
+        return self._units
+
+    @property
+    def device_state_attributes(self):
+        """Attributes."""
+        return self._attributes
+
+    @Throttle(SCAN_INTERVAL)
+    def update(self):
+        """Update the sensor."""
+        try:
+            self._data.update()
+            self.format_data()
+        except (RuntimeError, TypeError, NameError):
+            _LOGGER.error("Error updating Repetier Server sensors")
+
+    def format_data(self):
+        """Format output data."""
+        self._name = self._data.data[self._repetier_id]['name']
+
+        if self._data.data[self._repetier_id]['online'] == 1:
+            if self._data.data[self._repetier_id]['job'] != 'none':
+                if self._show_pct:
+                    self._state = round(
+                        self._data.data[self._repetier_id]['done'],
+                        self._decimals)
+                    self._units = '%'
+                else:
+                    self._state = STATE_ON
+                    self._units = None
+                self._attributes = {
+                    'active':
+                        self._data.data[self._repetier_id]['active'],
+                    'analysed':
+                        self._data.data[self._repetier_id]['analysed'],
+                    'done':
+                        self._data.data[self._repetier_id]['done'],
+                    'job':
+                        self._data.data[self._repetier_id]['job'],
+                    'jobid':
+                        self._data.data[self._repetier_id]['jobid'],
+                    'linesSend':
+                        self._data.data[self._repetier_id]['linesSend'],
+                    'ofLayer':
+                        self._data.data[self._repetier_id]['ofLayer'],
+                    'pauseState':
+                        self._data.data[self._repetier_id]['pauseState'],
+                    'paused':
+                        self._data.data[self._repetier_id]['paused'],
+                    'printTime':
+                        self._data.data[self._repetier_id]['printTime'],
+                    'printedTimeComp':
+                        self._data.data[self._repetier_id]['printedTimeComp'],
+                    'start':
+                        self._data.data[self._repetier_id]['start'],
+                    'totalLines':
+                        self._data.data[self._repetier_id]['totalLines'],
+                    'online':
+                        self._data.data[self._repetier_id]['online'],
+                }
+            else:
+                if SHOW_PCT:
+                    self._state = STATE_IDLE
+                else:
+                    self._state = STATE_IDLE
+                self._attributes = {
+                    'active':
+                        self._data.data[self._repetier_id]['active'],
+                    'job':
+                        self._data.data[self._repetier_id]['job'],
+                    'pauseState':
+                        self._data.data[self._repetier_id]['pauseState'],
+                    'paused':
+                        self._data.data[self._repetier_id]['paused'],
+                    'online':
+                        self._data.data[self._repetier_id]['online'],
+                }
+                self._units = None
+        else:
+            self._state = STATE_OFF
+            self._attributes = {
+                'active':
+                    self._data.data[self._repetier_id]['active'],
+                'job':
+                    self._data.data[self._repetier_id]['job'],
+                'pauseState':
+                    self._data.data[self._repetier_id]['pauseState'],
+                'paused':
+                    self._data.data[self._repetier_id]['paused'],
+                'online':
+                    self._data.data[self._repetier_id]['online'],
+            }
+            self._units = None
+

--- a/homeassistant/components/sensor/repetier.py
+++ b/homeassistant/components/sensor/repetier.py
@@ -164,7 +164,7 @@ class RepetierSensor(Entity):
                         self._data.data[self._repetier_id]['online'],
                 }
             else:
-                if SHOW_PCT:
+                if self._show_pct:
                     self._state = STATE_IDLE
                 else:
                     self._state = STATE_IDLE
@@ -196,4 +196,3 @@ class RepetierSensor(Entity):
                     self._data.data[self._repetier_id]['online'],
             }
             self._units = None
-

--- a/homeassistant/components/sensor/repetier.py
+++ b/homeassistant/components/sensor/repetier.py
@@ -2,12 +2,11 @@
 Sensor for retrieving Repetier-Server device status.
 
 Creates one sensor for each device attached to Repetier-Server
-Created by Morten Trab (morten@trab.dk) - 2018
+Created by Morten Trab (morten@trab.dk) - 2019
 """
 from datetime import timedelta
 import logging
 
-import requests
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
@@ -59,7 +58,11 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     import pyrepetier
     """Set up the Repetier sensors."""
     try:
-        data = pyrepetier.RepetierData(parse_repetier_api_response,url=config.get(CONF_URL), port=config.get(CONF_PORT), api_key=config.get(CONF_API_KEY))
+        data = pyrepetier.RepetierData(
+            parse_repetier_api_response,
+            url=config.get(CONF_URL),
+            port=config.get(CONF_PORT),
+            api_key=config.get(CONF_API_KEY))
         data.update()
         sensors = []
         for key in data.data.keys():

--- a/homeassistant/components/sensor/repetier.py
+++ b/homeassistant/components/sensor/repetier.py
@@ -16,8 +16,7 @@ from homeassistant.const import (
     CONF_URL,
     STATE_IDLE,
     STATE_OFF,
-    STATE_ON,
-    STATE_UNKNOWN)
+    STATE_ON)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle

--- a/homeassistant/components/sensor/repetier.py
+++ b/homeassistant/components/sensor/repetier.py
@@ -55,8 +55,8 @@ def parse_repetier_api_response(response):
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
-    import pyrepetier
     """Set up the Repetier sensors."""
+    import pyrepetier
     try:
         data = pyrepetier.RepetierData(
             parse_repetier_api_response,

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1749,3 +1749,6 @@ zigpy==0.2.0
 
 # homeassistant.components.zoneminder
 zm-py==0.3.0
+
+# homeassistant.components.sensor.repetier
+pyrepetier==1.4.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1176,6 +1176,9 @@ pyrainbird==0.1.6
 # homeassistant.components.switch.recswitch
 pyrecswitch==1.0.2
 
+# homeassistant.components.sensor.repetier
+pyrepetier==1.4.1
+
 # homeassistant.components.sensor.ruter
 pyruter==1.1.0
 
@@ -1749,6 +1752,3 @@ zigpy==0.2.0
 
 # homeassistant.components.zoneminder
 zm-py==0.3.0
-
-# homeassistant.components.sensor.repetier
-pyrepetier==1.4.1


### PR DESCRIPTION
## Description:
Adding Repetier-Server sensor for each device in your Repetier-Server

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#7712

## Example entry for `configuration.yaml` (if applicable):
```yaml
# Example configuration.yaml entry
sensor:
  - platform: repetier
    url: http://IP_ADDRESS
    port: PORT
    api_key: YOUR_API_KEY
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

Previous PR: https://github.com/home-assistant/home-assistant/pull/18941