### PR TITLE
Change state() to try/except to catch KeyError

### DIFF
--- a/homeassistant/components/sensor/tautulli.py
+++ b/homeassistant/components/sensor/tautulli.py
@@ -119,7 +119,10 @@ class TautulliSensor(Entity):
     @property
     def state(self):
         """Return the state of the sensor."""
-        return self.sessions['stream_count']
+        try:
+            return self.sessions['stream_count']
+        except KeyError:
+            return -1
 
     @property
     def icon(self):

--- a/homeassistant/components/sensor/tautulli.py
+++ b/homeassistant/components/sensor/tautulli.py
@@ -119,10 +119,7 @@ class TautulliSensor(Entity):
     @property
     def state(self):
         """Return the state of the sensor."""
-        try:
-            return self.sessions['stream_count']
-        except KeyError:
-            return -1
+        return self.sessions.get('stream_count')
 
     @property
     def icon(self):


### PR DESCRIPTION
## Description:
When Tautulli is up but Plex is down, the API doesn't return a 'stream_count' key. This causes calls to state() to raise KeyError exceptions. The new code includes a try/except to catch the KeyError and return -1 signifying that the Tautulli API cannot talk to Plex

**Related issue (if applicable):** fixes #19849

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: tautulli
    api_key: !secret tautulli_api_key
    host: !secret tautulli_host
    monitored_variables:
      - lan_bandwidth
      - wan_bandwidth
      - total_bandwidth
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
