### PR TITLE
Fix botvac connected alert retrieval

### DIFF
--- a/homeassistant/components/vacuum/neato.py
+++ b/homeassistant/components/vacuum/neato.py
@@ -82,7 +82,10 @@ class NeatoConnectedVacuum(StateVacuumDevice):
             self._available = False
             return
         _LOGGER.debug('self._state=%s', self._state)
-        robot_alert = ALERTS.get(self._state['alert'])
+        if 'alert' in self._state:
+            robot_alert = ALERTS.get(self._state['alert'])
+        else:
+            robot_alert = None
         if self._state['state'] == 1:
             if self._state['details']['isCharging']:
                 self._clean_state = STATE_DOCKED


### PR DESCRIPTION
## Description:

This PR ensures that the `alert` key first exists before attempting to save the variable.  Only certain botvac's do not have this key the rest of them do.

**Related issue (if applicable):** fixes #19913 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
neato:
  username: username
  password: password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
