### PR TITLE
Resolve update took to long for denon and entity not added when receiver is powered off

### DIFF
--- a/homeassistant/components/media_player/denon.py
+++ b/homeassistant/components/media_player/denon.py
@@ -140,6 +140,7 @@ class DenonDevice(MediaPlayerDevice):
         except OSError as exc:
             _LOGGER.debug("%s: Opening telnet for update failed: %s",
                           self.entity_id, exc)
+            self._pwstate = 'PWSTANDBY'
             return False
 
         if self._should_setup_sources:


### PR DESCRIPTION
## Description:

Fix for update timeout issue when the receiver is powered off and to still add the entity for HASS on startup even if the receiver is powered off.
Added debug log entries as well.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

