### PR TITLE
Freebox sensor async_add_entities

### DIFF
--- a/homeassistant/components/sensor/freebox.py
+++ b/homeassistant/components/sensor/freebox.py
@@ -15,13 +15,13 @@ _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_platform(
-        hass, config, add_entities, discovery_info=None):
+        hass, config, async_add_entities, discovery_info=None):
     """Set up the sensors."""
     fbx = hass.data[DATA_FREEBOX]
-    add_entities([
+    async_add_entities([
         FbxRXSensor(fbx),
         FbxTXSensor(fbx)
-    ])
+    ], True)
 
 
 class FbxSensor(Entity):


### PR DESCRIPTION
## Description:
Changing add_entities to async and get better state at Home Assistant startup.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.