### PR TITLE
Add support for restoring state to rpi_gpio_pwm

### DIFF
--- a/homeassistant/components/light/rpi_gpio_pwm.py
+++ b/homeassistant/components/light/rpi_gpio_pwm.py
@@ -8,14 +8,15 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.const import CONF_NAME, CONF_TYPE
+from homeassistant.const import CONF_NAME, CONF_TYPE, STATE_ON
 from homeassistant.components.light import (
     Light, ATTR_BRIGHTNESS, ATTR_HS_COLOR, ATTR_TRANSITION,
     SUPPORT_BRIGHTNESS, SUPPORT_COLOR, SUPPORT_TRANSITION, PLATFORM_SCHEMA)
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.color as color_util
+from homeassistant.helpers.restore_state import RestoreEntity
 
-REQUIREMENTS = ['pwmled==1.4.0']
+REQUIREMENTS = ['pwmled==1.4.1']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -34,6 +35,7 @@ CONF_LED_TYPE_RGB = 'rgb'
 CONF_LED_TYPE_RGBW = 'rgbw'
 CONF_LED_TYPES = [CONF_LED_TYPE_SIMPLE, CONF_LED_TYPE_RGB, CONF_LED_TYPE_RGBW]
 
+DEFAULT_BRIGHTNESS = 255
 DEFAULT_COLOR = [0, 0]
 
 SUPPORT_SIMPLE_LED = (SUPPORT_BRIGHTNESS | SUPPORT_TRANSITION)
@@ -95,7 +97,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     add_entities(leds)
 
 
-class PwmSimpleLed(Light):
+class PwmSimpleLed(Light, RestoreEntity):
     """Representation of a simple one-color PWM LED."""
 
     def __init__(self, led, name):
@@ -103,7 +105,18 @@ class PwmSimpleLed(Light):
         self._led = led
         self._name = name
         self._is_on = False
-        self._brightness = 255
+        self._brightness = DEFAULT_BRIGHTNESS
+
+    async def async_added_to_hass(self):
+        """Handle entity about to be added to hass event."""
+        await super().async_added_to_hass()
+        last_state = await self.async_get_last_state()
+        if last_state:
+            self._is_on = (last_state.state == STATE_ON)
+            self._brightness = last_state.attributes.get('brightness',
+                                                         DEFAULT_BRIGHTNESS)
+            self._led.set(is_on=self._is_on,
+                          brightness=_from_hass_brightness(self._brightness))
 
     @property
     def should_poll(self):
@@ -168,6 +181,14 @@ class PwmRgbLed(PwmSimpleLed):
         """Initialize a RGB(W) PWM LED."""
         super().__init__(led, name)
         self._color = DEFAULT_COLOR
+
+    async def async_added_to_hass(self):
+        """Handle entity about to be added to hass event."""
+        await super().async_added_to_hass()
+        last_state = await self.async_get_last_state()
+        if last_state:
+            self._color = last_state.attributes.get('hs_color', DEFAULT_COLOR)
+            self._led.set(color=_from_hass_color(self._color))
 
     @property
     def hs_color(self):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -839,7 +839,7 @@ pushbullet.py==0.11.0
 pushetta==1.0.15
 
 # homeassistant.components.light.rpi_gpio_pwm
-pwmled==1.4.0
+pwmled==1.4.1
 
 # homeassistant.components.august
 py-august==0.7.0


### PR DESCRIPTION
## Description:
Bumps version of `pwmled` and implements restoring of last state for `rpi_gpio_pwm` lights.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
