### PR TITLE
Adjust OpenUV integration for upcoming API limit changes

### DIFF
--- a/homeassistant/components/openuv/__init__.py
+++ b/homeassistant/components/openuv/__init__.py
@@ -20,6 +20,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import (
     async_track_sunrise, async_track_sunset, async_track_time_interval)
+from homeassistant.helpers.sun import is_up
 
 from .config_flow import configured_instances
 from .const import DEFAULT_SCAN_INTERVAL, DOMAIN
@@ -171,6 +172,10 @@ async def async_setup_entry(hass, config_entry):
         hass.async_create_task(
             hass.config_entries.async_forward_entry_setup(
                 config_entry, component))
+
+    # Check for whether it's nighttime upon startup:
+    if not is_up(hass):
+        openuv.is_nighttime = True
 
     async def refresh(event_time):
         """Refresh OpenUV data."""

--- a/homeassistant/components/openuv/__init__.py
+++ b/homeassistant/components/openuv/__init__.py
@@ -196,7 +196,7 @@ async def async_setup_entry(hass, config_entry):
         _LOGGER.debug('Stopping API polling at sunset')
         openuv.is_nighttime = True
 
-    hass.data[DOMAIN][DATA_OPENUV_LISTENER_SUNRISE][
+    hass.data[DOMAIN][DATA_OPENUV_LISTENER_SUNSET][
         config_entry.entry_id] = async_track_sunset(hass, set_sunset)
 
     return True

--- a/homeassistant/components/openuv/__init__.py
+++ b/homeassistant/components/openuv/__init__.py
@@ -12,14 +12,14 @@ from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import (
     ATTR_ATTRIBUTION, CONF_API_KEY, CONF_BINARY_SENSORS, CONF_ELEVATION,
     CONF_LATITUDE, CONF_LONGITUDE, CONF_MONITORED_CONDITIONS,
-    CONF_SCAN_INTERVAL, CONF_SENSORS)
+    CONF_SENSORS)
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import aiohttp_client, config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.entity import Entity
 
 from .config_flow import configured_instances
-from .const import DEFAULT_SCAN_INTERVAL, DOMAIN
+from .const import DOMAIN
 
 REQUIREMENTS = ['pyopenuv==1.0.4']
 _LOGGER = logging.getLogger(__name__)
@@ -91,8 +91,6 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(CONF_BINARY_SENSORS, default={}):
             BINARY_SENSOR_SCHEMA,
         vol.Optional(CONF_SENSORS, default={}): SENSOR_SCHEMA,
-        vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL):
-            cv.time_period,
     })
 }, extra=vol.ALLOW_EXTRA)
 
@@ -118,7 +116,6 @@ async def async_setup(hass, config):
         CONF_API_KEY: conf[CONF_API_KEY],
         CONF_BINARY_SENSORS: conf[CONF_BINARY_SENSORS],
         CONF_SENSORS: conf[CONF_SENSORS],
-        CONF_SCAN_INTERVAL: conf[CONF_SCAN_INTERVAL],
     }
 
     if CONF_LATITUDE in conf:

--- a/homeassistant/components/openuv/__init__.py
+++ b/homeassistant/components/openuv/__init__.py
@@ -18,7 +18,8 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import aiohttp_client, config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.entity import Entity
-from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.helpers.event import (
+    async_track_sunrise, async_track_sunset, async_track_time_interval)
 
 from .config_flow import configured_instances
 from .const import DEFAULT_SCAN_INTERVAL, DOMAIN
@@ -27,7 +28,9 @@ REQUIREMENTS = ['pyopenuv==1.0.4']
 _LOGGER = logging.getLogger(__name__)
 
 DATA_OPENUV_CLIENT = 'data_client'
-DATA_OPENUV_LISTENER = 'data_listener'
+DATA_OPENUV_LISTENER_REFRESH = 'data_listener_refresh'
+DATA_OPENUV_LISTENER_SUNRISE = 'data_listener_sunrise'
+DATA_OPENUV_LISTENER_SUNSET = 'data_listener_sunset'
 DATA_PROTECTION_WINDOW = 'protection_window'
 DATA_UV = 'uv'
 
@@ -103,7 +106,9 @@ async def async_setup(hass, config):
     """Set up the OpenUV component."""
     hass.data[DOMAIN] = {}
     hass.data[DOMAIN][DATA_OPENUV_CLIENT] = {}
-    hass.data[DOMAIN][DATA_OPENUV_LISTENER] = {}
+    hass.data[DOMAIN][DATA_OPENUV_LISTENER_REFRESH] = {}
+    hass.data[DOMAIN][DATA_OPENUV_LISTENER_SUNRISE] = {}
+    hass.data[DOMAIN][DATA_OPENUV_LISTENER_SUNSET] = {}
 
     if DOMAIN not in config:
         return True
@@ -173,11 +178,26 @@ async def async_setup_entry(hass, config_entry):
         await openuv.async_update()
         async_dispatcher_send(hass, TOPIC_UPDATE)
 
-    hass.data[DOMAIN][DATA_OPENUV_LISTENER][
+    hass.data[DOMAIN][DATA_OPENUV_LISTENER_REFRESH][
         config_entry.entry_id] = async_track_time_interval(
-            hass,
-            refresh,
+            hass, refresh,
             timedelta(seconds=config_entry.data[CONF_SCAN_INTERVAL]))
+
+    async def set_sunrise():
+        _LOGGER.debug('Starting API polling at sunrise')
+        openuv.is_nighttime = False
+        await openuv.async_update()
+        async_dispatcher_send(hass, TOPIC_UPDATE)
+
+    hass.data[DOMAIN][DATA_OPENUV_LISTENER_SUNRISE][
+        config_entry.entry_id] = async_track_sunrise(hass, set_sunrise)
+
+    async def set_sunset():
+        _LOGGER.debug('Stopping API polling at sunset')
+        openuv.is_nighttime = True
+
+    hass.data[DOMAIN][DATA_OPENUV_LISTENER_SUNRISE][
+        config_entry.entry_id] = async_track_sunset(hass, set_sunset)
 
     return True
 
@@ -186,9 +206,10 @@ async def async_unload_entry(hass, config_entry):
     """Unload an OpenUV config entry."""
     hass.data[DOMAIN][DATA_OPENUV_CLIENT].pop(config_entry.entry_id)
 
-    remove_listener = hass.data[DOMAIN][DATA_OPENUV_LISTENER].pop(
-        config_entry.entry_id)
-    remove_listener()
+    for key in (DATA_OPENUV_LISTENER_REFRESH, DATA_OPENUV_LISTENER_SUNRISE,
+                DATA_OPENUV_LISTENER_SUNSET):
+        remove_listener = hass.data[DOMAIN][key].pop(config_entry.entry_id)
+        remove_listener()
 
     for component in ('binary_sensor', 'sensor'):
         await hass.config_entries.async_forward_entry_unload(
@@ -205,10 +226,14 @@ class OpenUV:
         self.binary_sensor_conditions = binary_sensor_conditions
         self.client = client
         self.data = {}
+        self.is_nighttime = False
         self.sensor_conditions = sensor_conditions
 
     async def async_update(self):
         """Update sensor/binary sensor data."""
+        if self.is_nighttime:
+            return
+
         if TYPE_PROTECTION_WINDOW in self.binary_sensor_conditions:
             resp = await self.client.uv_protection_window()
             data = resp['result']

--- a/homeassistant/components/openuv/config_flow.py
+++ b/homeassistant/components/openuv/config_flow.py
@@ -5,11 +5,10 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.core import callback
 from homeassistant.const import (
-    CONF_API_KEY, CONF_ELEVATION, CONF_LATITUDE, CONF_LONGITUDE,
-    CONF_SCAN_INTERVAL)
+    CONF_API_KEY, CONF_ELEVATION, CONF_LATITUDE, CONF_LONGITUDE)
 from homeassistant.helpers import aiohttp_client, config_validation as cv
 
-from .const import DEFAULT_SCAN_INTERVAL, DOMAIN
+from .const import DOMAIN
 
 
 @callback
@@ -73,9 +72,5 @@ class OpenUvFlowHandler(config_entries.ConfigFlow):
             await client.uv_index()
         except OpenUvError:
             return await self._show_form({CONF_API_KEY: 'invalid_api_key'})
-
-        scan_interval = user_input.get(
-            CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
-        user_input[CONF_SCAN_INTERVAL] = scan_interval.seconds
 
         return self.async_create_entry(title=identifier, data=user_input)

--- a/homeassistant/components/openuv/const.py
+++ b/homeassistant/components/openuv/const.py
@@ -1,6 +1,2 @@
 """Define constants for the OpenUV component."""
-from datetime import timedelta
-
 DOMAIN = 'openuv'
-
-DEFAULT_SCAN_INTERVAL = timedelta(minutes=30)

--- a/homeassistant/components/openuv/services.yaml
+++ b/homeassistant/components/openuv/services.yaml
@@ -1,0 +1,5 @@
+# Describes the format for available OpenUV services
+
+---
+update_data:
+  description: Request new data from OpenUV.

--- a/tests/components/openuv/test_config_flow.py
+++ b/tests/components/openuv/test_config_flow.py
@@ -2,8 +2,6 @@
 from unittest.mock import patch
 
 import pytest
-
-import pyopenuv
 from pyopenuv.errors import OpenUvError
 
 from homeassistant import data_entry_flow

--- a/tests/components/openuv/test_config_flow.py
+++ b/tests/components/openuv/test_config_flow.py
@@ -1,6 +1,4 @@
 """Define tests for the OpenUV config flow."""
-from unittest.mock import patch
-
 import pytest
 from pyopenuv.errors import OpenUvError
 

--- a/tests/components/openuv/test_config_flow.py
+++ b/tests/components/openuv/test_config_flow.py
@@ -30,6 +30,9 @@ async def test_duplicate_error(hass):
 
 async def test_invalid_api_key(hass):
     """Test that an invalid API key throws an error."""
+    import pyopenuv
+    from pyopenuv.errors import OpenUvError
+
     conf = {
         CONF_API_KEY: '12345abcde',
         CONF_ELEVATION: 59.1234,
@@ -40,8 +43,8 @@ async def test_invalid_api_key(hass):
     flow = config_flow.OpenUvFlowHandler()
     flow.hass = hass
 
-    with patch('pyopenuv.util.validate_api_key',
-               return_value=mock_coro(False)):
+    with patch.object(pyopenuv.Client, 'uv_index',
+                      return_value=mock_coro(exception=OpenUvError)):
         result = await flow.async_step_user(user_input=conf)
         assert result['errors'] == {CONF_API_KEY: 'invalid_api_key'}
 
@@ -59,6 +62,8 @@ async def test_show_form(hass):
 
 async def test_step_import(hass):
     """Test that the import step works."""
+    import pyopenuv
+
     conf = {
         CONF_API_KEY: '12345abcde',
         CONF_ELEVATION: 59.1234,
@@ -69,8 +74,7 @@ async def test_step_import(hass):
     flow = config_flow.OpenUvFlowHandler()
     flow.hass = hass
 
-    with patch('pyopenuv.util.validate_api_key',
-               return_value=mock_coro(True)):
+    with patch.object(pyopenuv.Client, 'uv_index', return_value=mock_coro()):
         result = await flow.async_step_import(import_config=conf)
 
         assert result['type'] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
@@ -86,6 +90,8 @@ async def test_step_import(hass):
 
 async def test_step_user(hass):
     """Test that the user step works."""
+    import pyopenuv
+
     conf = {
         CONF_API_KEY: '12345abcde',
         CONF_ELEVATION: 59.1234,
@@ -97,8 +103,7 @@ async def test_step_user(hass):
     flow = config_flow.OpenUvFlowHandler()
     flow.hass = hass
 
-    with patch('pyopenuv.util.validate_api_key',
-               return_value=mock_coro(True)):
+    with patch.object(pyopenuv.Client, 'uv_index', return_value=mock_coro()):
         result = await flow.async_step_user(user_input=conf)
 
         assert result['type'] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY

--- a/tests/components/openuv/test_config_flow.py
+++ b/tests/components/openuv/test_config_flow.py
@@ -1,12 +1,10 @@
 """Define tests for the OpenUV config flow."""
-from datetime import timedelta
 from unittest.mock import patch
 
 from homeassistant import data_entry_flow
 from homeassistant.components.openuv import DOMAIN, config_flow
 from homeassistant.const import (
-    CONF_API_KEY, CONF_ELEVATION, CONF_LATITUDE, CONF_LONGITUDE,
-    CONF_SCAN_INTERVAL)
+    CONF_API_KEY, CONF_ELEVATION, CONF_LATITUDE, CONF_LONGITUDE)
 
 from tests.common import MockConfigEntry, mock_coro
 
@@ -84,7 +82,6 @@ async def test_step_import(hass):
             CONF_ELEVATION: 59.1234,
             CONF_LATITUDE: 39.128712,
             CONF_LONGITUDE: -104.9812612,
-            CONF_SCAN_INTERVAL: 1800,
         }
 
 
@@ -97,7 +94,6 @@ async def test_step_user(hass):
         CONF_ELEVATION: 59.1234,
         CONF_LATITUDE: 39.128712,
         CONF_LONGITUDE: -104.9812612,
-        CONF_SCAN_INTERVAL: timedelta(minutes=5)
     }
 
     flow = config_flow.OpenUvFlowHandler()
@@ -113,5 +109,4 @@ async def test_step_user(hass):
             CONF_ELEVATION: 59.1234,
             CONF_LATITUDE: 39.128712,
             CONF_LONGITUDE: -104.9812612,
-            CONF_SCAN_INTERVAL: 300,
         }

--- a/tests/components/openuv/test_config_flow.py
+++ b/tests/components/openuv/test_config_flow.py
@@ -1,6 +1,9 @@
 """Define tests for the OpenUV config flow."""
 from unittest.mock import patch
 
+import pyopenuv
+from pyopenuv.errors import OpenUvError
+
 from homeassistant import data_entry_flow
 from homeassistant.components.openuv import DOMAIN, config_flow
 from homeassistant.const import (
@@ -28,9 +31,6 @@ async def test_duplicate_error(hass):
 
 async def test_invalid_api_key(hass):
     """Test that an invalid API key throws an error."""
-    import pyopenuv
-    from pyopenuv.errors import OpenUvError
-
     conf = {
         CONF_API_KEY: '12345abcde',
         CONF_ELEVATION: 59.1234,
@@ -60,8 +60,6 @@ async def test_show_form(hass):
 
 async def test_step_import(hass):
     """Test that the import step works."""
-    import pyopenuv
-
     conf = {
         CONF_API_KEY: '12345abcde',
         CONF_ELEVATION: 59.1234,
@@ -87,8 +85,6 @@ async def test_step_import(hass):
 
 async def test_step_user(hass):
     """Test that the user step works."""
-    import pyopenuv
-
     conf = {
         CONF_API_KEY: '12345abcde',
         CONF_ELEVATION: 59.1234,


### PR DESCRIPTION
## Description:

Starting February 1st, OpenUV will be reducing the free tier of its API to 50 requests per day. The current integration will likely overrun this. To accommodate all possible scenarios, this PR removes automatic polling of the API and, instead, gives users the ability to update sensors manually via the `openuv.update_data` service.

Additionally, this PR fixes a bug (caused by a recent OpenUV change) where users would see "Invalid API Key" when configuring the component, even if the API key was valid.

**BREAKING CHANGE:** users will now need to use the `openuv.update_data` service to request new data from the API.

**Related issue (if applicable):** fixes #19931 and fixes #19950

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** https://github.com/home-assistant/home-assistant.io/pull/8127

## Example entry for `configuration.yaml` (if applicable):
```yaml
openuv:
  api_key: !secret openuv_api_key
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
