### PR TITLE
'latest_dir' referenced before assignment

### DIFF
--- a/homeassistant/components/camera/xiaomi.py
+++ b/homeassistant/components/camera/xiaomi.py
@@ -125,7 +125,7 @@ class XiaomiCamera(Camera):
 
         videos = [v for v in ftp.nlst() if '.tmp' not in v]
         if not videos:
-            _LOGGER.info('Video folder "%s" is empty; delaying', latest_dir)
+            _LOGGER.info('Video folder "%s" is empty; delaying', first_dir)
             return False
 
         if self._model == MODEL_XIAOFANG:

--- a/homeassistant/components/camera/xiaomi.py
+++ b/homeassistant/components/camera/xiaomi.py
@@ -107,7 +107,7 @@ class XiaomiCamera(Camera):
             _LOGGER.warning("There don't appear to be any folders")
             return False
 
-        first_dir = dirs[-1]
+        first_dir = latest_dir = dirs[-1]
         try:
             ftp.cwd(first_dir)
         except error_perm as exc:
@@ -125,7 +125,7 @@ class XiaomiCamera(Camera):
 
         videos = [v for v in ftp.nlst() if '.tmp' not in v]
         if not videos:
-            _LOGGER.info('Video folder "%s" is empty; delaying', first_dir)
+            _LOGGER.info('Video folder "%s" is empty; delaying', latest_dir)
             return False
 
         if self._model == MODEL_XIAOFANG:


### PR DESCRIPTION
local variable 'latest_dir' referenced before assignment

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
