### PR TITLE
Add support for connecting to multiple zoneminder instances

### DIFF
--- a/homeassistant/components/camera/zoneminder.py
+++ b/homeassistant/components/camera/zoneminder.py
@@ -22,7 +22,9 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     for zm_client in hass.data[ZONEMINDER_DOMAIN].values():
         monitors = zm_client.get_monitors()
         if not monitors:
-            _LOGGER.warning("Could not fetch monitors from ZoneMinder host: %s")
+            _LOGGER.warning(
+                "Could not fetch monitors from ZoneMinder host: %s"
+            )
             return
 
         cameras = []

--- a/homeassistant/components/camera/zoneminder.py
+++ b/homeassistant/components/camera/zoneminder.py
@@ -19,18 +19,17 @@ DEPENDENCIES = ['zoneminder']
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the ZoneMinder cameras."""
     filter_urllib3_logging()
-    zm_client = hass.data[ZONEMINDER_DOMAIN]
+    for zm_client in hass.data[ZONEMINDER_DOMAIN].values():
+        monitors = zm_client.get_monitors()
+        if not monitors:
+            _LOGGER.warning("Could not fetch monitors from ZoneMinder host: %s")
+            return
 
-    monitors = zm_client.get_monitors()
-    if not monitors:
-        _LOGGER.warning("Could not fetch monitors from ZoneMinder")
-        return
-
-    cameras = []
-    for monitor in monitors:
-        _LOGGER.info("Initializing camera %s", monitor.id)
-        cameras.append(ZoneMinderCamera(monitor, zm_client.verify_ssl))
-    add_entities(cameras)
+        cameras = []
+        for monitor in monitors:
+            _LOGGER.info("Initializing camera %s", monitor.id)
+            cameras.append(ZoneMinderCamera(monitor, zm_client.verify_ssl))
+        add_entities(cameras)
 
 
 class ZoneMinderCamera(MjpegCamera):

--- a/homeassistant/components/camera/zoneminder.py
+++ b/homeassistant/components/camera/zoneminder.py
@@ -19,6 +19,7 @@ DEPENDENCIES = ['zoneminder']
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the ZoneMinder cameras."""
     filter_urllib3_logging()
+    cameras = []
     for zm_client in hass.data[ZONEMINDER_DOMAIN].values():
         monitors = zm_client.get_monitors()
         if not monitors:
@@ -27,11 +28,10 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             )
             return
 
-        cameras = []
         for monitor in monitors:
             _LOGGER.info("Initializing camera %s", monitor.id)
             cameras.append(ZoneMinderCamera(monitor, zm_client.verify_ssl))
-        add_entities(cameras)
+    add_entities(cameras)
 
 
 class ZoneMinderCamera(MjpegCamera):

--- a/homeassistant/components/sensor/zoneminder.py
+++ b/homeassistant/components/sensor/zoneminder.py
@@ -52,7 +52,9 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             sensors.append(ZMSensorMonitors(monitor))
 
             for sensor in config[CONF_MONITORED_CONDITIONS]:
-                sensors.append(ZMSensorEvents(monitor, include_archived, sensor))
+                sensors.append(
+                    ZMSensorEvents(monitor, include_archived, sensor)
+                )
 
         sensors.append(ZMSensorRunState(zm_client))
         add_entities(sensors)

--- a/homeassistant/components/sensor/zoneminder.py
+++ b/homeassistant/components/sensor/zoneminder.py
@@ -42,12 +42,12 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the ZoneMinder sensor platform."""
     include_archived = config.get(CONF_INCLUDE_ARCHIVED)
 
+    sensors = []
     for zm_client in hass.data[ZONEMINDER_DOMAIN].values():
         monitors = zm_client.get_monitors()
         if not monitors:
             _LOGGER.warning('Could not fetch any monitors from ZoneMinder')
 
-        sensors = []
         for monitor in monitors:
             sensors.append(ZMSensorMonitors(monitor))
 
@@ -57,7 +57,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                 )
 
         sensors.append(ZMSensorRunState(zm_client))
-        add_entities(sensors)
+    add_entities(sensors)
 
 
 class ZMSensorMonitors(Entity):

--- a/homeassistant/components/sensor/zoneminder.py
+++ b/homeassistant/components/sensor/zoneminder.py
@@ -42,20 +42,20 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the ZoneMinder sensor platform."""
     include_archived = config.get(CONF_INCLUDE_ARCHIVED)
 
-    zm_client = hass.data[ZONEMINDER_DOMAIN]
-    monitors = zm_client.get_monitors()
-    if not monitors:
-        _LOGGER.warning('Could not fetch any monitors from ZoneMinder')
+    for zm_client in hass.data[ZONEMINDER_DOMAIN].values():
+        monitors = zm_client.get_monitors()
+        if not monitors:
+            _LOGGER.warning('Could not fetch any monitors from ZoneMinder')
 
-    sensors = []
-    for monitor in monitors:
-        sensors.append(ZMSensorMonitors(monitor))
+        sensors = []
+        for monitor in monitors:
+            sensors.append(ZMSensorMonitors(monitor))
 
-        for sensor in config[CONF_MONITORED_CONDITIONS]:
-            sensors.append(ZMSensorEvents(monitor, include_archived, sensor))
+            for sensor in config[CONF_MONITORED_CONDITIONS]:
+                sensors.append(ZMSensorEvents(monitor, include_archived, sensor))
 
-    sensors.append(ZMSensorRunState(zm_client))
-    add_entities(sensors)
+        sensors.append(ZMSensorRunState(zm_client))
+        add_entities(sensors)
 
 
 class ZMSensorMonitors(Entity):

--- a/homeassistant/components/switch/zoneminder.py
+++ b/homeassistant/components/switch/zoneminder.py
@@ -29,16 +29,16 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     on_state = MonitorState(config.get(CONF_COMMAND_ON))
     off_state = MonitorState(config.get(CONF_COMMAND_OFF))
 
+    switches = []
     for zm_client in hass.data[ZONEMINDER_DOMAIN].values():
         monitors = zm_client.get_monitors()
         if not monitors:
             _LOGGER.warning('Could not fetch monitors from ZoneMinder')
             return
 
-        switches = []
         for monitor in monitors:
             switches.append(ZMSwitchMonitors(monitor, on_state, off_state))
-        add_entities(switches)
+    add_entities(switches)
 
 
 class ZMSwitchMonitors(SwitchDevice):

--- a/homeassistant/components/switch/zoneminder.py
+++ b/homeassistant/components/switch/zoneminder.py
@@ -29,17 +29,16 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     on_state = MonitorState(config.get(CONF_COMMAND_ON))
     off_state = MonitorState(config.get(CONF_COMMAND_OFF))
 
-    zm_client = hass.data[ZONEMINDER_DOMAIN]
+    for zm_client in hass.data[ZONEMINDER_DOMAIN].values():
+        monitors = zm_client.get_monitors()
+        if not monitors:
+            _LOGGER.warning('Could not fetch monitors from ZoneMinder')
+            return
 
-    monitors = zm_client.get_monitors()
-    if not monitors:
-        _LOGGER.warning('Could not fetch monitors from ZoneMinder')
-        return
-
-    switches = []
-    for monitor in monitors:
-        switches.append(ZMSwitchMonitors(monitor, on_state, off_state))
-    add_entities(switches)
+        switches = []
+        for monitor in monitors:
+            switches.append(ZMSwitchMonitors(monitor, on_state, off_state))
+        add_entities(switches)
 
 
 class ZMSwitchMonitors(SwitchDevice):

--- a/homeassistant/components/zoneminder/__init__.py
+++ b/homeassistant/components/zoneminder/__init__.py
@@ -8,10 +8,10 @@ import logging
 
 import voluptuous as vol
 
+import homeassistant.helpers.config_validation as cv
 from homeassistant.const import (
     CONF_HOST, CONF_PASSWORD, CONF_PATH, CONF_SSL, CONF_USERNAME,
-    CONF_VERIFY_SSL, ATTR_NAME, CONF_HOSTS, ATTR_ID)
-import homeassistant.helpers.config_validation as cv
+    CONF_VERIFY_SSL, ATTR_NAME, ATTR_ID)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/zoneminder/__init__.py
+++ b/homeassistant/components/zoneminder/__init__.py
@@ -37,7 +37,7 @@ HOST_CONFIG_SCHEMA = vol.Schema({
 })
 
 CONFIG_SCHEMA = vol.Schema({
-    DOMAIN: cv.ensure_list(HOST_CONFIG_SCHEMA)
+    DOMAIN: vol.All(cv.ensure_list, [HOST_CONFIG_SCHEMA])
 }, extra=vol.ALLOW_EXTRA)
 
 SERVICE_SET_RUN_STATE = 'set_run_state'

--- a/homeassistant/components/zoneminder/__init__.py
+++ b/homeassistant/components/zoneminder/__init__.py
@@ -10,7 +10,7 @@ import voluptuous as vol
 
 from homeassistant.const import (
     CONF_HOST, CONF_PASSWORD, CONF_PATH, CONF_SSL, CONF_USERNAME,
-    CONF_VERIFY_SSL, ATTR_NAME)
+    CONF_VERIFY_SSL, ATTR_NAME, CONF_HOSTS, ATTR_ID)
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
@@ -26,20 +26,23 @@ DEFAULT_TIMEOUT = 10
 DEFAULT_VERIFY_SSL = True
 DOMAIN = 'zoneminder'
 
+HOST_CONFIG_SCHEMA = vol.Schema({
+    vol.Required(CONF_HOST): cv.string,
+    vol.Optional(CONF_PASSWORD): cv.string,
+    vol.Optional(CONF_PATH, default=DEFAULT_PATH): cv.string,
+    vol.Optional(CONF_PATH_ZMS, default=DEFAULT_PATH_ZMS): cv.string,
+    vol.Optional(CONF_SSL, default=DEFAULT_SSL): cv.boolean,
+    vol.Optional(CONF_USERNAME): cv.string,
+    vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): cv.boolean,
+})
+
 CONFIG_SCHEMA = vol.Schema({
-    DOMAIN: vol.Schema({
-        vol.Required(CONF_HOST): cv.string,
-        vol.Optional(CONF_PASSWORD): cv.string,
-        vol.Optional(CONF_PATH, default=DEFAULT_PATH): cv.string,
-        vol.Optional(CONF_PATH_ZMS, default=DEFAULT_PATH_ZMS): cv.string,
-        vol.Optional(CONF_SSL, default=DEFAULT_SSL): cv.boolean,
-        vol.Optional(CONF_USERNAME): cv.string,
-        vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): cv.boolean,
-    })
+    DOMAIN: cv.ensure_list([HOST_CONFIG_SCHEMA])
 }, extra=vol.ALLOW_EXTRA)
 
 SERVICE_SET_RUN_STATE = 'set_run_state'
 SET_RUN_STATE_SCHEMA = vol.Schema({
+    vol.Required(ATTR_ID): cv.string,
     vol.Required(ATTR_NAME): cv.string
 })
 
@@ -48,27 +51,40 @@ def setup(hass, config):
     """Set up the ZoneMinder component."""
     from zoneminder.zm import ZoneMinder
 
-    conf = config[DOMAIN]
-    if conf[CONF_SSL]:
-        schema = 'https'
-    else:
-        schema = 'http'
+    hass.data[DOMAIN] = {}
 
-    server_origin = '{}://{}'.format(schema, conf[CONF_HOST])
-    hass.data[DOMAIN] = ZoneMinder(server_origin,
-                                   conf.get(CONF_USERNAME),
-                                   conf.get(CONF_PASSWORD),
-                                   conf.get(CONF_PATH),
-                                   conf.get(CONF_PATH_ZMS),
-                                   conf.get(CONF_VERIFY_SSL))
+    success = True
+
+    for conf in config[DOMAIN]:
+        if conf[CONF_SSL]:
+            schema = 'https'
+        else:
+            schema = 'http'
+
+        host_name = conf[CONF_HOST]
+        server_origin = '{}://{}'.format(schema, host_name)
+        hass.data[DOMAIN][host_name] = ZoneMinder(
+            server_origin,
+            conf.get(CONF_USERNAME),
+            conf.get(CONF_PASSWORD),
+            conf.get(CONF_PATH),
+            conf.get(CONF_PATH_ZMS),
+            conf.get(CONF_VERIFY_SSL)
+        )
+
+        success = hass.data[DOMAIN][host_name].login() and success
 
     def set_active_state(call):
         """Set the ZoneMinder run state to the given state name."""
-        return hass.data[DOMAIN].set_active_state(call.data[ATTR_NAME])
+        zm_id = call.data[ATTR_ID]
+        if zm_id not in hass.data[DOMAIN]:
+            _LOGGER.error('Invalid ZoneMinder host provided: %s', zm_id)
+            return False
+        return hass.data[DOMAIN][zm_id].set_active_state(call.data[ATTR_NAME])
 
     hass.services.register(
         DOMAIN, SERVICE_SET_RUN_STATE, set_active_state,
         schema=SET_RUN_STATE_SCHEMA
     )
 
-    return hass.data[DOMAIN].login()
+    return success

--- a/homeassistant/components/zoneminder/__init__.py
+++ b/homeassistant/components/zoneminder/__init__.py
@@ -63,7 +63,7 @@ def setup(hass, config):
 
         host_name = conf[CONF_HOST]
         server_origin = '{}://{}'.format(schema, host_name)
-        zm = ZoneMinder(
+        zm_client = ZoneMinder(
             server_origin,
             conf.get(CONF_USERNAME),
             conf.get(CONF_PASSWORD),
@@ -71,9 +71,9 @@ def setup(hass, config):
             conf.get(CONF_PATH_ZMS),
             conf.get(CONF_VERIFY_SSL)
         )
-        hass.data[DOMAIN][host_name] = zm
+        hass.data[DOMAIN][host_name] = zm_client
 
-        success = zm.login() and success
+        success = zm_client.login() and success
 
     def set_active_state(call):
         """Set the ZoneMinder run state to the given state name."""


### PR DESCRIPTION
## Description:

**Breaking Change**: The service `zoneminder.set_run_state` now requires an attribute `id` to be set to the `host` of the ZoneMinder instance you would like to control.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8129

## Example entry for `configuration.yaml` (if applicable):
```yaml
zoneminder:
  - host: ZM_HOST
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
