### PR TITLE
Trusted Network Auth: only authenticate request when owner can be found

### DIFF
--- a/homeassistant/components/http/auth.py
+++ b/homeassistant/components/http/auth.py
@@ -92,8 +92,8 @@ def setup_auth(app, trusted_networks, api_password):
             for user in users:
                 if user.is_owner:
                     request['hass_user'] = user
+                    authenticated = True
                     break
-            authenticated = True
 
         request[KEY_AUTHENTICATED] = authenticated
         return await handler(request)


### PR DESCRIPTION
## Description:
Only authenticate request when owner can be found in trusted network.

It will request system on-board has to be finished or user be created manual before any http request can be authenticated even in trusted network. Otherwise HTTP 401 will be return instead of 500

**Related issue (if applicable):** fixes #19576

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
