### PR TITLE
Split locative to a separate component

### DIFF
--- a/homeassistant/components/device_tracker/locative.py
+++ b/homeassistant/components/device_tracker/locative.py
@@ -4,106 +4,25 @@ Support for the Locative platform.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/device_tracker.locative/
 """
-from functools import partial
 import logging
 
-from homeassistant.const import (
-    ATTR_LATITUDE, ATTR_LONGITUDE, STATE_NOT_HOME, HTTP_UNPROCESSABLE_ENTITY)
-from homeassistant.components.http import HomeAssistantView
-# pylint: disable=unused-import
-from homeassistant.components.device_tracker import (  # NOQA
-    DOMAIN, PLATFORM_SCHEMA)
+from homeassistant.components.locative import TRACKER_UPDATE
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 _LOGGER = logging.getLogger(__name__)
 
-DEPENDENCIES = ['http']
-URL = '/api/locative'
+DEPENDENCIES = ['locative']
 
 
-def setup_scanner(hass, config, see, discovery_info=None):
-    """Set up an endpoint for the Locative application."""
-    hass.http.register_view(LocativeView(see))
+async def async_setup_scanner(hass, config, async_see, discovery_info=None):
+    """Set up an endpoint for the Locative device tracker."""
+    async def _set_location(device, gps_location, location_name):
+        """Fire HA event to set location."""
+        await async_see(
+            dev_id=device,
+            gps=gps_location,
+            location_name=location_name
+        )
 
+    async_dispatcher_connect(hass, TRACKER_UPDATE, _set_location)
     return True
-
-
-class LocativeView(HomeAssistantView):
-    """View to handle Locative requests."""
-
-    url = URL
-    name = 'api:locative'
-
-    def __init__(self, see):
-        """Initialize Locative URL endpoints."""
-        self.see = see
-
-    async def get(self, request):
-        """Locative message received as GET."""
-        res = await self._handle(request.app['hass'], request.query)
-        return res
-
-    async def post(self, request):
-        """Locative message received."""
-        data = await request.post()
-        res = await self._handle(request.app['hass'], data)
-        return res
-
-    async def _handle(self, hass, data):
-        """Handle locative request."""
-        if 'latitude' not in data or 'longitude' not in data:
-            return ('Latitude and longitude not specified.',
-                    HTTP_UNPROCESSABLE_ENTITY)
-
-        if 'device' not in data:
-            _LOGGER.error('Device id not specified.')
-            return ('Device id not specified.',
-                    HTTP_UNPROCESSABLE_ENTITY)
-
-        if 'trigger' not in data:
-            _LOGGER.error('Trigger is not specified.')
-            return ('Trigger is not specified.',
-                    HTTP_UNPROCESSABLE_ENTITY)
-
-        if 'id' not in data and data['trigger'] != 'test':
-            _LOGGER.error('Location id not specified.')
-            return ('Location id not specified.',
-                    HTTP_UNPROCESSABLE_ENTITY)
-
-        device = data['device'].replace('-', '')
-        location_name = data.get('id', data['trigger']).lower()
-        direction = data['trigger']
-        gps_location = (data[ATTR_LATITUDE], data[ATTR_LONGITUDE])
-
-        if direction == 'enter':
-            await hass.async_add_job(
-                partial(self.see, dev_id=device, location_name=location_name,
-                        gps=gps_location))
-            return 'Setting location to {}'.format(location_name)
-
-        if direction == 'exit':
-            current_state = hass.states.get(
-                '{}.{}'.format(DOMAIN, device))
-
-            if current_state is None or current_state.state == location_name:
-                location_name = STATE_NOT_HOME
-                await hass.async_add_job(
-                    partial(self.see, dev_id=device,
-                            location_name=location_name, gps=gps_location))
-                return 'Setting location to not home'
-
-            # Ignore the message if it is telling us to exit a zone that we
-            # aren't currently in. This occurs when a zone is entered
-            # before the previous zone was exited. The enter message will
-            # be sent first, then the exit message will be sent second.
-            return 'Ignoring exit from {} (already in {})'.format(
-                location_name, current_state)
-
-        if direction == 'test':
-            # In the app, a test message can be sent. Just return something to
-            # the user to let them know that it works.
-            return 'Received test message.'
-
-        _LOGGER.error('Received unidentified message from Locative: %s',
-                      direction)
-        return ('Received unidentified message: {}'.format(direction),
-                HTTP_UNPROCESSABLE_ENTITY)

--- a/homeassistant/components/locative/__init__.py
+++ b/homeassistant/components/locative/__init__.py
@@ -1,0 +1,120 @@
+"""
+Support for Locative.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/locative/
+"""
+import logging
+
+from homeassistant.components.device_tracker import \
+    DOMAIN as DEVICE_TRACKER_DOMAIN
+from homeassistant.components.http import HomeAssistantView
+from homeassistant.const import HTTP_UNPROCESSABLE_ENTITY, ATTR_LATITUDE, \
+    ATTR_LONGITUDE, STATE_NOT_HOME
+from homeassistant.helpers.discovery import async_load_platform
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = 'locative'
+DEPENDENCIES = ['http']
+
+URL = '/api/locative'
+
+TRACKER_UPDATE = '{}_tracker_update'.format(DOMAIN)
+
+
+async def async_setup(hass, hass_config):
+    """Set up the Locative component."""
+    hass.http.register_view(LocativeView)
+    hass.async_create_task(
+        async_load_platform(hass, 'device_tracker', DOMAIN, {}, hass_config)
+    )
+    return True
+
+
+class LocativeView(HomeAssistantView):
+    """View to handle Locative requests."""
+
+    url = URL
+    name = 'api:locative'
+
+    def __init__(self):
+        """Initialize Locative URL endpoints."""
+
+    async def get(self, request):
+        """Locative message received as GET."""
+        return await self._handle(request.app['hass'], request.query)
+
+    async def post(self, request):
+        """Locative message received."""
+        data = await request.post()
+        return await self._handle(request.app['hass'], data)
+
+    async def _handle(self, hass, data):
+        """Handle locative request."""
+        if 'latitude' not in data or 'longitude' not in data:
+            return ('Latitude and longitude not specified.',
+                    HTTP_UNPROCESSABLE_ENTITY)
+
+        if 'device' not in data:
+            _LOGGER.error('Device id not specified.')
+            return ('Device id not specified.',
+                    HTTP_UNPROCESSABLE_ENTITY)
+
+        if 'trigger' not in data:
+            _LOGGER.error('Trigger is not specified.')
+            return ('Trigger is not specified.',
+                    HTTP_UNPROCESSABLE_ENTITY)
+
+        if 'id' not in data and data['trigger'] != 'test':
+            _LOGGER.error('Location id not specified.')
+            return ('Location id not specified.',
+                    HTTP_UNPROCESSABLE_ENTITY)
+
+        device = data['device'].replace('-', '')
+        location_name = data.get('id', data['trigger']).lower()
+        direction = data['trigger']
+        gps_location = (data[ATTR_LATITUDE], data[ATTR_LONGITUDE])
+
+        if direction == 'enter':
+            async_dispatcher_send(
+                hass,
+                TRACKER_UPDATE,
+                device,
+                gps_location,
+                location_name
+            )
+            return 'Setting location to {}'.format(location_name)
+
+        if direction == 'exit':
+            current_state = hass.states.get(
+                '{}.{}'.format(DEVICE_TRACKER_DOMAIN, device))
+
+            if current_state is None or current_state.state == location_name:
+                location_name = STATE_NOT_HOME
+                async_dispatcher_send(
+                    hass,
+                    TRACKER_UPDATE,
+                    device,
+                    gps_location,
+                    location_name
+                )
+                return 'Setting location to not home'
+
+            # Ignore the message if it is telling us to exit a zone that we
+            # aren't currently in. This occurs when a zone is entered
+            # before the previous zone was exited. The enter message will
+            # be sent first, then the exit message will be sent second.
+            return 'Ignoring exit from {} (already in {})'.format(
+                location_name, current_state)
+
+        if direction == 'test':
+            # In the app, a test message can be sent. Just return something to
+            # the user to let them know that it works.
+            return 'Received test message.'
+
+        _LOGGER.error('Received unidentified message from Locative: %s',
+                      direction)
+        return ('Received unidentified message: {}'.format(direction),
+                HTTP_UNPROCESSABLE_ENTITY)

--- a/tests/components/locative/__init__.py
+++ b/tests/components/locative/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Locative component."""

--- a/tests/components/locative/test_init.py
+++ b/tests/components/locative/test_init.py
@@ -18,6 +18,12 @@ def _url(data=None):
     return "{}?{}".format(URL, data)
 
 
+@pytest.fixture(autouse=True)
+def mock_dev_track(mock_device_tracker_conf):
+    """Mock device tracker config loading."""
+    pass
+
+
 @pytest.fixture
 def locative_client(loop, hass, hass_client):
     """Locative mock client."""

--- a/tests/components/locative/test_locative.py
+++ b/tests/components/locative/test_locative.py
@@ -6,7 +6,7 @@ import pytest
 from homeassistant.components.device_tracker import \
     DOMAIN as DEVICE_TRACKER_DOMAIN
 from homeassistant.components.locative import URL, DOMAIN
-from homeassistant.const import HTTP_OK
+from homeassistant.const import HTTP_OK, HTTP_UNPROCESSABLE_ENTITY
 from homeassistant.setup import async_setup_component
 
 
@@ -42,31 +42,31 @@ async def test_missing_data(locative_client):
 
     # No data
     req = await locative_client.get(_url({}))
-    assert req.status == 422
+    assert req.status == HTTP_UNPROCESSABLE_ENTITY
 
     # No latitude
     copy = data.copy()
     del copy['latitude']
     req = await locative_client.get(_url(copy))
-    assert req.status == 422
+    assert req.status == HTTP_UNPROCESSABLE_ENTITY
 
     # No device
     copy = data.copy()
     del copy['device']
     req = await locative_client.get(_url(copy))
-    assert req.status == 422
+    assert req.status == HTTP_UNPROCESSABLE_ENTITY
 
     # No location
     copy = data.copy()
     del copy['id']
     req = await locative_client.get(_url(copy))
-    assert req.status == 422
+    assert req.status == HTTP_UNPROCESSABLE_ENTITY
 
     # No trigger
     copy = data.copy()
     del copy['trigger']
     req = await locative_client.get(_url(copy))
-    assert req.status == 422
+    assert req.status == HTTP_UNPROCESSABLE_ENTITY
 
     # Test message
     copy = data.copy()
@@ -85,7 +85,7 @@ async def test_missing_data(locative_client):
     copy = data.copy()
     copy['trigger'] = 'foobar'
     req = await locative_client.get(_url(copy))
-    assert req.status == 422
+    assert req.status == HTTP_UNPROCESSABLE_ENTITY
 
 
 async def test_enter_and_exit(hass, locative_client):


### PR DESCRIPTION
## Description:
Splits the locative device tracker to be a component in addition to the device_tracker platform. This is required to migrate it over to use the webhook.

**Breaking Change**: The locative device_tracker platform no longer takes any configuration. The configuration needs to be applied to the component locative instead. The platform will be automatically loaded with the component and should not be specified in configuration.yaml.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8150

## Example entry for `configuration.yaml` (if applicable):
```yaml
locative:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
