### PR TITLE
Log exceptions thrown by MQTT message callbacks

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -5,7 +5,9 @@ For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/mqtt/
 """
 import asyncio
+import inspect
 from itertools import groupby
+from functools import wraps
 import json
 import logging
 from operator import attrgetter
@@ -13,6 +15,7 @@ import os
 import socket
 import ssl
 import time
+import traceback
 from typing import Any, Callable, List, Optional, Union, cast  # noqa: F401
 
 import attr
@@ -301,6 +304,36 @@ def publish_template(hass: HomeAssistantType, topic, payload_template,
     hass.services.call(DOMAIN, SERVICE_PUBLISH, data)
 
 
+def wrap_callback(func):
+    """Decorate an MQTT message callback to catch and log exceptions."""
+    def log_exception(topic, payload):
+        module_name = inspect.getmodule(inspect.trace()[1][0]).__name__
+        logging.getLogger(module_name).error(
+            "Exception in %s when handling msg on '%s': '%s'\n%s",
+            func.__name__, topic, payload, traceback.format_exc(limit=-1))
+
+    wrapper_func = None
+    if asyncio.iscoroutinefunction(func):
+        @wraps(func)
+        async def wrapper(topic, payload, qos):
+            """Catch and log exception."""
+            try:
+                await func(topic, payload, qos)
+            except Exception:  # pylint: disable=broad-except
+                log_exception(topic, payload)
+        wrapper_func = wrapper
+    else:
+        @wraps(func)
+        def wrapper(topic, payload, qos):
+            """Catch and log exception."""
+            try:
+                func(topic, payload, qos)
+            except Exception:  # pylint: disable=broad-except
+                log_exception(topic, payload)
+        wrapper_func = wrapper
+    return wrapper_func
+
+
 @bind_hass
 async def async_subscribe(hass: HomeAssistantType, topic: str,
                           msg_callback: MessageCallbackType,
@@ -311,7 +344,7 @@ async def async_subscribe(hass: HomeAssistantType, topic: str,
     Call the return value to unsubscribe.
     """
     async_remove = await hass.data[DATA_MQTT].async_subscribe(
-        topic, msg_callback, qos, encoding)
+        topic, wrap_callback(msg_callback), qos, encoding)
     return async_remove
 
 

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -14,6 +14,7 @@ from operator import attrgetter
 import os
 import socket
 import ssl
+import sys
 import time
 import traceback
 from typing import Any, Callable, List, Optional, Union, cast  # noqa: F401
@@ -308,9 +309,13 @@ def wrap_callback(func):
     """Decorate an MQTT message callback to catch and log exceptions."""
     def log_exception(topic, payload):
         module_name = inspect.getmodule(inspect.trace()[1][0]).__name__
+        exc_type, exc_value, exc_tb = sys.exc_info()
+        # Do not print the wrapper in the traceback
+        exc_tb = exc_tb.tb_next
+        err = traceback.format_exception(exc_type, exc_value, exc_tb)
         logging.getLogger(module_name).error(
             "Exception in %s when handling msg on '%s': '%s'\n%s",
-            func.__name__, topic, payload, traceback.format_exc(limit=-1))
+            func.__name__, topic, payload, ''.join(err))
 
     wrapper_func = None
     if asyncio.iscoroutinefunction(func):

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -14,7 +14,6 @@ from operator import attrgetter
 import os
 import socket
 import ssl
-from sys import exc_info
 import time
 import traceback
 from typing import Any, Callable, List, Optional, Union, cast  # noqa: F401
@@ -309,13 +308,12 @@ def wrap_callback(func):
     """Decorate an MQTT message callback to catch and log exceptions."""
     def log_exception(topic, payload):
         module_name = inspect.getmodule(inspect.trace()[1][0]).__name__
-        exc_type, exc_value, exc_tb = exc_info()
         # Do not print the wrapper in the traceback
-        exc_tb = exc_tb.tb_next
-        err = traceback.format_exception(exc_type, exc_value, exc_tb)
+        frames = len(inspect.trace()) - 1
+        err = traceback.format_exc(-frames)
         logging.getLogger(module_name).error(
             "Exception in %s when handling msg on '%s': '%s'\n%s",
-            func.__name__, topic, payload, ''.join(err))
+            func.__name__, topic, payload, err)
 
     wrapper_func = None
     if asyncio.iscoroutinefunction(func):

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -14,7 +14,7 @@ from operator import attrgetter
 import os
 import socket
 import ssl
-import sys
+from sys import exc_info
 import time
 import traceback
 from typing import Any, Callable, List, Optional, Union, cast  # noqa: F401
@@ -309,7 +309,7 @@ def wrap_callback(func):
     """Decorate an MQTT message callback to catch and log exceptions."""
     def log_exception(topic, payload):
         module_name = inspect.getmodule(inspect.trace()[1][0]).__name__
-        exc_type, exc_value, exc_tb = sys.exc_info()
+        exc_type, exc_value, exc_tb = exc_info()
         # Do not print the wrapper in the traceback
         exc_tb = exc_tb.tb_next
         err = traceback.format_exception(exc_type, exc_value, exc_tb)

--- a/homeassistant/util/logging.py
+++ b/homeassistant/util/logging.py
@@ -126,7 +126,10 @@ class AsyncHandler:
         self.handler.set_name(name)  # type: ignore
 
 
-def catch_log_exception(func: Callable[..., Any], format_err: Callable[..., Any], *args: Any) -> Callable[[], None]:
+def catch_log_exception(
+        func: Callable[..., Any],
+        format_err: Callable[..., Any],
+        *args: Any) -> Callable[[], None]:
     """Decorate an callback to catch and log exceptions."""
     def log_exception(*args: Any) -> None:
         module_name = inspect.getmodule(inspect.trace()[1][0]).__name__

--- a/homeassistant/util/logging.py
+++ b/homeassistant/util/logging.py
@@ -6,7 +6,7 @@ import inspect
 import logging
 import threading
 import traceback
-from typing import Optional
+from typing import Any, Callable, Optional
 
 from .async_ import run_coroutine_threadsafe
 
@@ -126,9 +126,9 @@ class AsyncHandler:
         self.handler.set_name(name)  # type: ignore
 
 
-def catch_log_exception(func, format_err, *args):
+def catch_log_exception(func: Callable[..., Any], format_err: Callable[..., Any], *args: Any) -> Callable[[], None]:
     """Decorate an callback to catch and log exceptions."""
-    def log_exception(*args):
+    def log_exception(*args: Any) -> None:
         module_name = inspect.getmodule(inspect.trace()[1][0]).__name__
         # Do not print the wrapper in the traceback
         frames = len(inspect.trace()) - 1
@@ -139,16 +139,16 @@ def catch_log_exception(func, format_err, *args):
     wrapper_func = None
     if asyncio.iscoroutinefunction(func):
         @wraps(func)
-        async def wrapper(*args):
+        async def async_wrapper(*args: Any) -> None:
             """Catch and log exception."""
             try:
                 await func(*args)
             except Exception:  # pylint: disable=broad-except
                 log_exception(*args)
-        wrapper_func = wrapper
+        wrapper_func = async_wrapper
     else:
         @wraps(func)
-        def wrapper(*args):
+        def wrapper(*args: Any) -> None:
             """Catch and log exception."""
             try:
                 func(*args)

--- a/tests/components/mqtt/test_subscription.py
+++ b/tests/components/mqtt/test_subscription.py
@@ -1,4 +1,6 @@
 """The tests for the MQTT subscription component."""
+from unittest import mock
+
 from homeassistant.core import callback
 from homeassistant.components.mqtt.subscription import (
     async_subscribe_topics, async_unsubscribe_topics)
@@ -135,7 +137,7 @@ async def test_qos_encoding_default(hass, mqtt_mock, caplog):
         {'test_topic1': {'topic': 'test-topic1',
                          'msg_callback': msg_callback}})
     mock_mqtt.async_subscribe.assert_called_once_with(
-        'test-topic1', msg_callback, 0, 'utf-8')
+        'test-topic1', mock.ANY, 0, 'utf-8')
 
 
 async def test_qos_encoding_custom(hass, mqtt_mock, caplog):
@@ -155,7 +157,7 @@ async def test_qos_encoding_custom(hass, mqtt_mock, caplog):
                          'qos': 1,
                          'encoding': 'utf-16'}})
     mock_mqtt.async_subscribe.assert_called_once_with(
-        'test-topic1', msg_callback, 1, 'utf-16')
+        'test-topic1', mock.ANY, 1, 'utf-16')
 
 
 async def test_no_change(hass, mqtt_mock, caplog):


### PR DESCRIPTION
## Description:
Improve logging of exceptions thrown by MQTT message callbacks as discussed in #15446

Example of improved logging:
```
2019-01-11 14:30:43 ERROR (MainThread) [homeassistant.components.mqtt.discovery] Exception in async_device_message_received when handling msg on 'homeassistant/sensor/BC5316_COUNTER_C1/config': '{"name":"Sonoff COUNTER C1","state_topic":"tasmota/sonoff_BC5316/tele/SENSOR","availability_topic":"tasmota/sonoff_BC5316/tele/LWT","payload_available":"Online","payload_not_available":"Offline","value_template":"{{value_json['COUNTER'].C1}}"}'
Traceback (most recent call last):
  File "/mnt/d/development/github/home-assistant_fork/homeassistant/components/mqtt/discovery.py", line 265, in async_device_message_received
    hass.data['ALREADY_DISCOVERED'][discovery_hash] = None
KeyError: 'ALREADY_DISCOVERED'
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
