### PR TITLE
Fix the anthemav component by removing a debugging line.

### DIFF
--- a/homeassistant/components/media_player/anthemav.py
+++ b/homeassistant/components/media_player/anthemav.py
@@ -59,7 +59,6 @@ async def async_setup_platform(hass, config, async_add_entities,
 
     _LOGGER.debug("dump_devicedata: %s", device.dump_avrdata)
     _LOGGER.debug("dump_conndata: %s", avr.dump_conndata)
-    _LOGGER.debug("dump_rawdata: %s", avr.protocol.dump_rawdata)
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, device.avr.close)
     async_add_entities([device])


### PR DESCRIPTION
## Description:

Fix the anthemav component by removing a debugging line.

This line ended up calling vars(transport) on an asyncio Transport
object. In a standard setup, that's a python object provided by asyncio,
and it works. Home Assistant injects uvloop into asyncio, which makes this
a Python C object, and those don't support vars().

**Related issue (if applicable):** fixes #11824


## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
