### PR TITLE
Added command_line auth provider that validates credentials by calling a command

### DIFF
--- a/homeassistant/auth/providers/command_line.py
+++ b/homeassistant/auth/providers/command_line.py
@@ -75,11 +75,14 @@ class CommandLineAuthProvider(AuthProvider):
             stdout = (await process.communicate())[0]
         except OSError as err:
             # happens when command doesn't exist or permission is denied
-            _LOGGER.error("Error while authenticating '%s': %s",
-                          username, err)
+            _LOGGER.error("Error while authenticating %s: %s",
+                          repr(username), err)
             raise InvalidAuthError
 
         if process.returncode != 0:
+            _LOGGER.error("User %s failed to authenticate, command exited "
+                          "with code %d.",
+                          repr(username), process.returncode)
             raise InvalidAuthError
 
         if self.config[CONF_META]:

--- a/homeassistant/auth/providers/command_line.py
+++ b/homeassistant/auth/providers/command_line.py
@@ -65,7 +65,7 @@ class CommandLineAuthProvider(AuthProvider):
             "password": password,
         }
         try:
-            process = await asyncio.subprocess.create_subprocess_exec(
+            process = await asyncio.subprocess.create_subprocess_exec(  # pylint: disable=no-member
                 self.config[CONF_COMMAND], *self.config[CONF_ARGS],
                 env=env,
                 stdout=asyncio.subprocess.PIPE

--- a/homeassistant/auth/providers/command_line.py
+++ b/homeassistant/auth/providers/command_line.py
@@ -75,14 +75,14 @@ class CommandLineAuthProvider(AuthProvider):
             stdout = (await process.communicate())[0]
         except OSError as err:
             # happens when command doesn't exist or permission is denied
-            _LOGGER.error("Error while authenticating %s: %s",
-                          repr(username), err)
+            _LOGGER.error("Error while authenticating %r: %s",
+                          username, err)
             raise InvalidAuthError
 
         if process.returncode != 0:
-            _LOGGER.error("User %s failed to authenticate, command exited "
+            _LOGGER.error("User %r failed to authenticate, command exited "
                           "with code %d.",
-                          repr(username), process.returncode)
+                          username, process.returncode)
             raise InvalidAuthError
 
         if self.config[CONF_META]:

--- a/homeassistant/auth/providers/command_line.py
+++ b/homeassistant/auth/providers/command_line.py
@@ -65,7 +65,8 @@ class CommandLineAuthProvider(AuthProvider):
             "password": password,
         }
         try:
-            process = await asyncio.subprocess.create_subprocess_exec(  # pylint: disable=no-member
+            # pylint: disable=no-member
+            process = await asyncio.subprocess.create_subprocess_exec(
                 self.config[CONF_COMMAND], *self.config[CONF_ARGS],
                 env=env,
                 stdout=asyncio.subprocess.PIPE

--- a/homeassistant/auth/providers/command_line.py
+++ b/homeassistant/auth/providers/command_line.py
@@ -29,11 +29,11 @@ class InvalidAuthError(HomeAssistantError):
     """Raised when authentication with given credentials fails."""
 
 
-@AUTH_PROVIDERS.register("external")
-class ExternalAuthProvider(AuthProvider):
-    """External auth provider validating credentials by calling a script."""
+@AUTH_PROVIDERS.register("command_line")
+class CommandLineAuthProvider(AuthProvider):
+    """Auth provider validating credentials by calling a command."""
 
-    DEFAULT_TITLE = "External Authentication"
+    DEFAULT_TITLE = "Command Line Authentication"
 
     # which keys to accept from a program's stdout
     ALLOWED_META_KEYS = ("name",)
@@ -49,7 +49,7 @@ class ExternalAuthProvider(AuthProvider):
 
     async def async_login_flow(self, context: T.Optional[T.Dict]) -> LoginFlow:
         """Return a flow to login."""
-        return ExternalLoginFlow(self)
+        return CommandLineLoginFlow(self)
 
     async def async_validate_login(self, username: str, password: str) -> None:
         """Validate a username and password."""
@@ -116,7 +116,7 @@ class ExternalAuthProvider(AuthProvider):
         )
 
 
-class ExternalLoginFlow(LoginFlow):
+class CommandLineLoginFlow(LoginFlow):
     """Handler for the login flow."""
 
     async def async_step_init(
@@ -127,7 +127,7 @@ class ExternalLoginFlow(LoginFlow):
 
         if user_input is not None:
             try:
-                await T.cast(ExternalAuthProvider, self._auth_provider) \
+                await T.cast(CommandLineAuthProvider, self._auth_provider) \
                         .async_validate_login(
                             user_input["username"], user_input["password"]
                         )

--- a/homeassistant/auth/providers/command_line.py
+++ b/homeassistant/auth/providers/command_line.py
@@ -69,7 +69,7 @@ class CommandLineAuthProvider(AuthProvider):
                 self.config[CONF_COMMAND], *self.config[CONF_ARGS],
                 env=env,
                 stdout=asyncio.subprocess.PIPE
-                       if self.config[CONF_META] else None,
+                if self.config[CONF_META] else None,
             )
             stdout = (await process.communicate())[0]
         except OSError as err:

--- a/homeassistant/auth/providers/command_line.py
+++ b/homeassistant/auth/providers/command_line.py
@@ -1,6 +1,6 @@
 """Auth provider that validates credentials via an external command."""
 
-import typing as T
+from typing import Any, Dict, Optional, cast
 
 import asyncio.subprocess
 import collections
@@ -45,16 +45,16 @@ class CommandLineAuthProvider(AuthProvider):
     # which keys to accept from a program's stdout
     ALLOWED_META_KEYS = ("name",)
 
-    def __init__(self, *args: T.Any, **kwargs: T.Any) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Extend parent's __init__.
 
         Adds self._user_meta dictionary to hold the user-specific
         attributes provided by external programs.
         """
         super().__init__(*args, **kwargs)
-        self._user_meta = {}  # type: T.Dict[str, T.Dict[str, T.Any]]
+        self._user_meta = {}  # type: Dict[str, Dict[str, Any]]
 
-    async def async_login_flow(self, context: T.Optional[T.Dict]) -> LoginFlow:
+    async def async_login_flow(self, context: Optional[dict]) -> LoginFlow:
         """Return a flow to login."""
         return CommandLineLoginFlow(self)
 
@@ -86,7 +86,7 @@ class CommandLineAuthProvider(AuthProvider):
             raise InvalidAuthError
 
         if self.config[CONF_META]:
-            meta = {}  # type: T.Dict[str, str]
+            meta = {}  # type: Dict[str, str]
             for _line in stdout.splitlines():
                 try:
                     line = _line.decode().lstrip()
@@ -103,7 +103,7 @@ class CommandLineAuthProvider(AuthProvider):
             self._user_meta[username] = meta
 
     async def async_get_or_create_credentials(
-            self, flow_result: T.Dict[str, str]
+            self, flow_result: Dict[str, str]
     ) -> Credentials:
         """Get credentials based on the flow result."""
         username = flow_result["username"]
@@ -134,14 +134,14 @@ class CommandLineLoginFlow(LoginFlow):
     """Handler for the login flow."""
 
     async def async_step_init(
-            self, user_input: T.Optional[T.Dict[str, str]] = None
-    ) -> T.Dict[str, T.Any]:
+            self, user_input: Optional[Dict[str, str]] = None
+    ) -> Dict[str, Any]:
         """Handle the step of the form."""
         errors = {}
 
         if user_input is not None:
             try:
-                await T.cast(CommandLineAuthProvider, self._auth_provider) \
+                await cast(CommandLineAuthProvider, self._auth_provider) \
                         .async_validate_login(
                             user_input["username"], user_input["password"]
                         )
@@ -152,7 +152,7 @@ class CommandLineLoginFlow(LoginFlow):
                 user_input.pop("password")
                 return await self.async_finish(user_input)
 
-        schema = collections.OrderedDict()  # type: T.Dict[str, type]
+        schema = collections.OrderedDict()  # type: Dict[str, type]
         schema["username"] = str
         schema["password"] = str
 

--- a/homeassistant/auth/providers/command_line.py
+++ b/homeassistant/auth/providers/command_line.py
@@ -140,6 +140,7 @@ class CommandLineLoginFlow(LoginFlow):
         errors = {}
 
         if user_input is not None:
+            user_input["username"] = user_input["username"].strip()
             try:
                 await cast(CommandLineAuthProvider, self._auth_provider) \
                         .async_validate_login(

--- a/homeassistant/auth/providers/command_line.py
+++ b/homeassistant/auth/providers/command_line.py
@@ -72,7 +72,7 @@ class CommandLineAuthProvider(AuthProvider):
                 stdout=asyncio.subprocess.PIPE
                 if self.config[CONF_META] else None,
             )
-            stdout = (await process.communicate())[0]
+            stdout, _ = (await process.communicate())
         except OSError as err:
             # happens when command doesn't exist or permission is denied
             _LOGGER.error("Error while authenticating %r: %s",

--- a/homeassistant/auth/providers/external.py
+++ b/homeassistant/auth/providers/external.py
@@ -1,0 +1,142 @@
+"""Auth provider that validates credentials via an external script."""
+
+import typing as T
+
+import collections
+
+import asyncio.subprocess
+
+import voluptuous as vol
+
+from homeassistant.exceptions import HomeAssistantError
+
+from . import AuthProvider, AUTH_PROVIDER_SCHEMA, AUTH_PROVIDERS, LoginFlow
+from ..models import Credentials, UserMeta
+
+
+CONF_PROGRAM = "program"
+CONF_ARGS = "args"
+
+CONFIG_SCHEMA = AUTH_PROVIDER_SCHEMA.extend({
+    vol.Required(CONF_PROGRAM): str,
+    vol.Optional(CONF_ARGS, default=None): vol.Any(vol.DefaultTo(list), [str]),
+}, extra=vol.PREVENT_EXTRA)
+
+
+class InvalidAuthError(HomeAssistantError):
+    """Raised when submitting invalid authentication."""
+
+
+@AUTH_PROVIDERS.register("external")
+class ExternalAuthProvider(AuthProvider):
+    """External auth provider validating credentials by calling a script."""
+
+    DEFAULT_TITLE = "External Authentication"
+
+    # which keys to accept from a program's stdout
+    ALLOWED_META_KEYS = ("name",)
+
+    def __init__(self, *args: T.Any, **kwargs: T.Any) -> None:
+        """Extend parent's __init__.
+
+        Adds self._user_meta dictionary to hold the user-specific
+        attributes provided by external programs.
+        """
+        super().__init__(*args, **kwargs)
+        self._user_meta = {}  # type: T.Dict[str, T.Dict[str, T.Any]]
+
+    async def async_login_flow(self, context: T.Optional[T.Dict]) -> LoginFlow:
+        """Return a flow to login."""
+        return ExternalLoginFlow(self)
+
+    async def async_validate_login(self, username: str, password: str) -> None:
+        """Validate a username and password."""
+        env = {
+            "username": username,
+            "password": password,
+        }
+        process = await asyncio.subprocess.create_subprocess_exec(
+            self.config[CONF_PROGRAM], *self.config[CONF_ARGS],
+            env=env,
+            stdout=asyncio.subprocess.PIPE,
+        )
+        stdout = (await process.communicate())[0]
+
+        if process.returncode != 0:
+            raise InvalidAuthError
+
+        meta = {}  # type: T.Dict[str, str]
+        for _line in stdout.splitlines():
+            try:
+                line = _line.decode().lstrip()
+                if line.startswith("#"):
+                    continue
+                key, value = line.split("=", 1)
+            except ValueError:
+                # malformed line
+                continue
+            key = key.strip()
+            value = value.strip()
+            if key in self.ALLOWED_META_KEYS:
+                meta[key] = value
+        self._user_meta[username] = meta
+
+    async def async_get_or_create_credentials(
+            self, flow_result: T.Dict[str, str]
+    ) -> Credentials:
+        """Get credentials based on the flow result."""
+        username = flow_result["username"]
+        for credential in await self.async_credentials():
+            if credential.data["username"] == username:
+                return credential
+
+        # Create new credentials.
+        return self.async_create_credentials({
+            "username": username,
+        })
+
+    async def async_user_meta_for_credentials(
+            self, credentials: Credentials
+    ) -> UserMeta:
+        """Return extra user metadata for credentials.
+
+        Currently, only name is supported.
+        """
+        meta = self._user_meta.get(credentials.data["username"], {})
+        return UserMeta(
+            name=meta.get("name"),
+            is_active=True,
+        )
+
+
+class ExternalLoginFlow(LoginFlow):
+    """Handler for the login flow."""
+
+    async def async_step_init(
+            self, user_input: T.Optional[T.Dict[str, str]] = None
+    ) -> T.Dict[str, T.Any]:
+        """Handle the step of the form."""
+        errors = {}
+
+        if user_input is not None:
+            try:
+                await T.cast(ExternalAuthProvider, self._auth_provider) \
+                        .async_validate_login(
+                            user_input["username"], user_input["password"]
+                        )
+            except InvalidAuthError:
+                errors["base"] = "invalid_auth"
+
+            if not errors:
+                user_input.pop("password")
+                return await self.async_finish(user_input)
+
+        schema = collections.OrderedDict()  # type: T.Dict[str, type]
+        schema["username"] = str
+        schema["password"] = str
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(schema),
+            errors=errors,
+        )

--- a/tests/auth/providers/test_command_line.py
+++ b/tests/auth/providers/test_command_line.py
@@ -1,0 +1,115 @@
+"""Tests for the command_line auth provider."""
+
+from unittest.mock import Mock
+import os
+import uuid
+
+import pytest
+
+from homeassistant.auth import auth_store, models as auth_models, AuthManager
+from homeassistant.auth.providers import command_line
+from homeassistant.const import CONF_TYPE
+
+from tests.common import mock_coro
+
+
+@pytest.fixture
+def store(hass):
+    """Mock store."""
+    return auth_store.AuthStore(hass)
+
+
+@pytest.fixture
+def provider(hass, store):
+    """Mock provider."""
+    return command_line.CommandLineAuthProvider(hass, store, {
+        CONF_TYPE: "command_line",
+        command_line.CONF_COMMAND: os.path.join(
+            os.path.dirname(__file__), "test_command_line_cmd.sh"
+        ),
+        command_line.CONF_ARGS: [],
+        command_line.CONF_META: False,
+    })
+
+
+@pytest.fixture
+def manager(hass, store, provider):
+    """Mock manager."""
+    return AuthManager(hass, store, {
+        (provider.type, provider.id): provider
+    }, {})
+
+
+async def test_create_new_credential(manager, provider):
+    """Test that we create a new credential."""
+    credentials = await provider.async_get_or_create_credentials({
+        "username": "good-user",
+        "password": "good-pass",
+    })
+    assert credentials.is_new is True
+
+    user = await manager.async_get_or_create_user(credentials)
+    assert user.is_active
+
+
+async def test_match_existing_credentials(store, provider):
+    """See if we match existing users."""
+    existing = auth_models.Credentials(
+        id=uuid.uuid4(),
+        auth_provider_type="command_line",
+        auth_provider_id=None,
+        data={
+            "username": "good-user"
+        },
+        is_new=False,
+    )
+    provider.async_credentials = Mock(return_value=mock_coro([existing]))
+    credentials = await provider.async_get_or_create_credentials({
+        "username": "good-user",
+        "password": "irrelevant",
+    })
+    assert credentials is existing
+
+
+async def test_invalid_username(provider):
+    """Test we raise if incorrect user specified."""
+    with pytest.raises(command_line.InvalidAuthError):
+        await provider.async_validate_login("bad-user", "good-pass")
+
+
+async def test_invalid_password(provider):
+    """Test we raise if incorrect password specified."""
+    with pytest.raises(command_line.InvalidAuthError):
+        await provider.async_validate_login("good-user", "bad-pass")
+
+
+async def test_good_auth(provider):
+    """Test nothing is raised with good credentials."""
+    await provider.async_validate_login("good-user", "good-pass")
+
+
+async def test_good_auth_with_meta(manager, provider):
+    """Test metadata is added upon successful authentication."""
+    provider.config[command_line.CONF_ARGS] = ["--with-meta"]
+    provider.config[command_line.CONF_META] = True
+
+    await provider.async_validate_login("good-user", "good-pass")
+
+    credentials = await provider.async_get_or_create_credentials({
+        "username": "good-user",
+        "password": "good-pass",
+    })
+    assert credentials.is_new is True
+
+    user = await manager.async_get_or_create_user(credentials)
+    assert user.name == "Bob"
+    assert user.is_active
+
+
+async def test_utf_8_username_password(provider):
+    """Test that we create a new credential."""
+    credentials = await provider.async_get_or_create_credentials({
+        "username": "ßßß",
+        "password": "äöü",
+    })
+    assert credentials.is_new is True

--- a/tests/auth/providers/test_command_line.py
+++ b/tests/auth/providers/test_command_line.py
@@ -135,3 +135,14 @@ async def test_login_flow_validates(provider):
     })
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["data"]["username"] == "good-user"
+
+
+async def test_strip_username(provider):
+    """Test authentication works with username with whitespace around."""
+    flow = await provider.async_login_flow({})
+    result = await flow.async_step_init({
+        "username": "\t\ngood-user ",
+        "password": "good-pass",
+    })
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["data"]["username"] == "good-user"

--- a/tests/auth/providers/test_command_line_cmd.sh
+++ b/tests/auth/providers/test_command_line_cmd.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+if [ "$username" = "good-user" ] && [ "$password" = "good-pass" ]; then
+	echo "Auth should succeed." >&2
+	if [ "$1" = "--with-meta" ]; then
+		echo "name=Bob"
+	fi
+	exit 0
+fi
+
+echo "Auth should fail." >&2
+exit 1


### PR DESCRIPTION
## Description:

A new authentication provider that checks username/password by calling an external program, passing the values as environment variables. If the program exits with exit code 0, authentication succeeds.

Additionally, the program can print out lines of the form

    KEY=VALUE

to give HA some information about the authenticating user. Currently, only ``name`` is supported, but groups are thinkable as well when there will be an official API for interfacing with HA's group system in the future.

As an example, I wrote a script to do authentication against LDAP, that I'll link here soon.

**Related issue (if applicable):** Closes #19975

**Pull request in home-assistant-polymer:** home-assistant/home-assistant-polymer#2561

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8321

## Example entry for `configuration.yaml` (if applicable):
```yaml
homeassistant:
  auth_providers:
  - type: command_line
    command: /config/auth.sh
    # Optionally, a list of arguments.
    #args: []
    # Optionally, accept meta variables.
    #meta: true
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
