### PR TITLE
0.85.1

### DIFF
--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -24,7 +24,7 @@ from homeassistant.core import callback
 from homeassistant.helpers.translation import async_get_translations
 from homeassistant.loader import bind_hass
 
-REQUIREMENTS = ['home-assistant-frontend==20190109.0']
+REQUIREMENTS = ['home-assistant-frontend==20190109.1']
 
 DOMAIN = 'frontend'
 DEPENDENCIES = ['api', 'websocket_api', 'http', 'system_log',

--- a/homeassistant/components/vacuum/neato.py
+++ b/homeassistant/components/vacuum/neato.py
@@ -82,7 +82,10 @@ class NeatoConnectedVacuum(StateVacuumDevice):
             self._available = False
             return
         _LOGGER.debug('self._state=%s', self._state)
-        robot_alert = ALERTS.get(self._state['alert'])
+        if 'alert' in self._state:
+            robot_alert = ALERTS.get(self._state['alert'])
+        else:
+            robot_alert = None
         if self._state['state'] == 1:
             if self._state['details']['isCharging']:
                 self._clean_state = STATE_DOCKED

--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -95,8 +95,7 @@ async def async_setup(hass, config):
             context={'source': config_entries.SOURCE_IMPORT},
             data={
                 CONF_USB_PATH: conf[CONF_USB_PATH],
-                CONF_RADIO_TYPE: conf.get(CONF_RADIO_TYPE).value,
-                ENABLE_QUIRKS: conf[ENABLE_QUIRKS]
+                CONF_RADIO_TYPE: conf.get(CONF_RADIO_TYPE).value
             }
         ))
     return True
@@ -107,16 +106,16 @@ async def async_setup_entry(hass, config_entry):
 
     Will automatically load components to support devices found on the network.
     """
-    if config_entry.data.get(ENABLE_QUIRKS):
-        # needs to be done here so that the ZHA module is finished loading
-        # before zhaquirks is imported
-        # pylint: disable=W0611, W0612
-        import zhaquirks  # noqa
-
     hass.data[DATA_ZHA] = hass.data.get(DATA_ZHA, {})
     hass.data[DATA_ZHA][DATA_ZHA_DISPATCHERS] = []
 
     config = hass.data[DATA_ZHA].get(DATA_ZHA_CONFIG, {})
+
+    if config.get(ENABLE_QUIRKS, True):
+        # needs to be done here so that the ZHA module is finished loading
+        # before zhaquirks is imported
+        # pylint: disable=W0611, W0612
+        import zhaquirks  # noqa
 
     usb_path = config_entry.data.get(CONF_USB_PATH)
     baudrate = config.get(CONF_BAUDRATE, DEFAULT_BAUDRATE)

--- a/homeassistant/components/zha/const.py
+++ b/homeassistant/components/zha/const.py
@@ -129,7 +129,6 @@ def populate_data():
 
     SINGLE_INPUT_CLUSTER_DEVICE_CLASS.update({
         zcl.clusters.general.OnOff: 'switch',
-        zcl.clusters.general.LevelControl: 'light',
         zcl.clusters.measurement.RelativeHumidity: 'sensor',
         zcl.clusters.measurement.TemperatureMeasurement: 'sensor',
         zcl.clusters.measurement.PressureMeasurement: 'sensor',

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -2,7 +2,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 85
-PATCH_VERSION = '0'
+PATCH_VERSION = '1'
 __short_version__ = '{}.{}'.format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = '{}.{}'.format(__short_version__, PATCH_VERSION)
 REQUIRED_PYTHON_VER = (3, 5, 3)

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -204,8 +204,9 @@ async def entity_service_call(hass, platforms, func, call):
     if ATTR_ENTITY_ID in call.data:
         target_all_entities = call.data[ATTR_ENTITY_ID] == ENTITY_MATCH_ALL
     else:
-        _LOGGER.warning('Not passing an entity ID to a service to target all '
-                        'entities is deprecated. Use instead: entity_id: "*"')
+        _LOGGER.warning(
+            'Not passing an entity ID to a service to target all entities is '
+            'deprecated. Use instead: entity_id: "%s"', ENTITY_MATCH_ALL)
         target_all_entities = True
 
     if not target_all_entities:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -511,7 +511,7 @@ hole==0.3.0
 holidays==0.9.8
 
 # homeassistant.components.frontend
-home-assistant-frontend==20190109.0
+home-assistant-frontend==20190109.1
 
 # homeassistant.components.zwave
 homeassistant-pyozw==0.1.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -104,7 +104,7 @@ hdate==0.7.5
 holidays==0.9.8
 
 # homeassistant.components.frontend
-home-assistant-frontend==20190109.0
+home-assistant-frontend==20190109.1
 
 # homeassistant.components.homematicip_cloud
 homematicip==0.9.8


### PR DESCRIPTION
- check config instead of config_entry for quirks flag ([@dmulcahey] - [#19730]) ([zha docs])
- Don't map LevelControl to light for single cluster devices. ([@Adminiuga] - [#19929]) ([zha docs])
- Fix warning ([@balloob] - [#19946])
- Lovelace: Fix resources being dropped in inline editor

[#19730]: https://github.com/home-assistant/home-assistant/pull/19730
[#19929]: https://github.com/home-assistant/home-assistant/pull/19929
[#19946]: https://github.com/home-assistant/home-assistant/pull/19946
[@Adminiuga]: https://github.com/Adminiuga
[@balloob]: https://github.com/balloob
[@dmulcahey]: https://github.com/dmulcahey
[zha docs]: https://www.home-assistant.io/components/zha/