### PR TITLE
Don't set friendly_name device_state_attribute in ZhaEntity. Use `name` property instead

### DIFF
--- a/homeassistant/components/zha/entities/entity.py
+++ b/homeassistant/components/zha/entities/entity.py
@@ -13,7 +13,7 @@ from homeassistant.components.zha.const import (
     ATTR_VALUE, ATTR_MANUFACTURER, ATTR_COMMAND, SERVER, ATTR_COMMAND_TYPE,
     ATTR_ARGS, IN, OUT, CLIENT_COMMANDS, SERVER_COMMANDS)
 from homeassistant.components.zha.helpers import bind_configure_reporting
-from homeassistant.const import ATTR_ENTITY_ID, CONF_FRIENDLY_NAME
+from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import callback
 from homeassistant.helpers import entity
 from homeassistant.helpers.device_registry import CONNECTION_ZIGBEE
@@ -34,6 +34,7 @@ class ZhaEntity(entity.Entity):
                  **kwargs):
         """Init ZHA entity."""
         self._device_state_attributes = {}
+        self._name = None
         ieee = endpoint.device.ieee
         ieeetail = ''.join(['%02x' % (o, ) for o in ieee[-4:]])
         if manufacturer and model is not None:
@@ -45,10 +46,7 @@ class ZhaEntity(entity.Entity):
                 endpoint.endpoint_id,
                 kwargs.get(ENTITY_SUFFIX, ''),
             )
-            self._device_state_attributes[CONF_FRIENDLY_NAME] = "{} {}".format(
-                manufacturer,
-                model,
-            )
+            self._name = "{} {}".format(manufacturer, model)
         else:
             self.entity_id = "{}.zha_{}_{}{}".format(
                 self._domain,
@@ -234,6 +232,11 @@ class ZhaEntity(entity.Entity):
         return cluster
 
     @property
+    def name(self):
+        """Return Entity's default name."""
+        return self._name
+
+    @property
     def zcl_reporting_config(self):
         """Return a dict of ZCL attribute reporting configuration.
 
@@ -302,10 +305,7 @@ class ZhaEntity(entity.Entity):
             'identifiers': {(DOMAIN, ieee)},
             ATTR_MANUFACTURER: self._endpoint.manufacturer,
             'model': self._endpoint.model,
-            'name': self._device_state_attributes.get(
-                CONF_FRIENDLY_NAME,
-                ieee
-            ),
+            'name': self.name or ieee,
             'via_hub': (DOMAIN, self.hass.data[DATA_ZHA][DATA_ZHA_BRIDGE_ID]),
         }
 


### PR DESCRIPTION
## Description:
Use @property name instead of setting friendly_name devices state attribute. Entities shouldn't set friendly_name attributes.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
