### PR TITLE
Samsung media played with new TV models

### DIFF
--- a/homeassistant/components/media_player/samsungtv.py
+++ b/homeassistant/components/media_player/samsungtv.py
@@ -22,7 +22,7 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import dt as dt_util
 
-REQUIREMENTS = ['samsungctl[websocket]==0.7.1', 'wakeonlan==1.1.6']
+REQUIREMENTS = ['samsungctl[websocket]', 'wakeonlan==1.1.6']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/media_player/samsungtv.py
+++ b/homeassistant/components/media_player/samsungtv.py
@@ -120,7 +120,7 @@ class SamsungTVDevice(MediaPlayerDevice):
             'timeout': timeout,
         }
 
-        if self._config['port'] == 8001:
+        if self._config['port'] == 8001 or self._config['port'] == 8002:
             self._config['method'] = 'websocket'
         else:
             self._config['method'] = 'legacy'


### PR DESCRIPTION
current code works only with old samsung smart tvs. By manually installing https://github.com/kdschlosser/samsungctl lib enevrything works out of the box.

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>
https://github.com/kdschlosser/samsungctl/issues/36

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>


## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
