### PR TITLE
catch TypeError's in addition to ValueError's for unifi direct device tracker

### DIFF
--- a/homeassistant/components/device_tracker/unifi_direct.py
+++ b/homeassistant/components/device_tracker/unifi_direct.py
@@ -131,6 +131,6 @@ def _response_to_json(response):
                 active_clients[client.get("mac")] = client
 
         return active_clients
-    except ValueError, TypeError:
+    except (ValueError, TypeError):
         _LOGGER.error("Failed to decode response from AP.")
         return {}

--- a/homeassistant/components/device_tracker/unifi_direct.py
+++ b/homeassistant/components/device_tracker/unifi_direct.py
@@ -131,6 +131,6 @@ def _response_to_json(response):
                 active_clients[client.get("mac")] = client
 
         return active_clients
-    except ValueError:
+    except ValueError, TypeError:
         _LOGGER.error("Failed to decode response from AP.")
         return {}


### PR DESCRIPTION
Sometimes Unifi's access point returns incomplete json which results in a TypeError because ssid_table is None

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.