### PR TITLE
Update elkm1.py

### DIFF
--- a/homeassistant/components/alarm_control_panel/elkm1.py
+++ b/homeassistant/components/alarm_control_panel/elkm1.py
@@ -116,7 +116,7 @@ class ElkArea(ElkEntity, alarm.AlarmControlPanel):
     @property
     def code_format(self):
         """Return the alarm code format."""
-        return '^[0-9]{4}([0-9]{2})?$'
+        return 'Number'
 
     @property
     def state(self):


### PR DESCRIPTION
Update `code_format` to `return 'Number'` fixes #19983 and now displays the number pad in lovelace-ui as it should.

## Description:


**Related issue:**  fixes #19983


## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`.
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
