### PR TITLE
Switch MQTT to asyncio

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -708,7 +708,7 @@ class MQTT:
             if any(other.topic == topic for other in self.subscriptions):
                 # Other subscriptions on topic remaining - don't unsubscribe.
                 return
-            self.hass.async_create_task(self._async_unsubscribe(topic))
+            self.hass.async_add_job(self._async_unsubscribe(topic))
 
         return async_remove
 

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -756,7 +756,7 @@ class MQTT:
 
         if self.birth_message:
             self.hass.add_job(
-                self.async_publish(*attr.astuple(self.birth_message)))
+                self.async_publish, *attr.astuple(self.birth_message))
 
     def _mqtt_on_message(self, _mqttc, _userdata, msg) -> None:
         """Message received callback."""

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -861,7 +861,7 @@ class MQTT:
                 result_code, wait_time)
 
             try:
-                asyncio.sleep(wait_time)
+                await asyncio.sleep(wait_time)
             except asyncio.CancelledError:
                 break
             tries += 1

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -482,8 +482,7 @@ class TestMQTTCallbacks(unittest.TestCase):
         self.hass.data['mqtt']._mqtt_on_disconnect(None, None, 0)
         assert not self.hass.data['mqtt']._mqttc.reconnect.called
 
-    @mock.patch('homeassistant.components.mqtt.asyncio.sleep')
-    def test_mqtt_disconnect_tries_reconnect(self, mock_sleep):
+    def test_mqtt_disconnect_tries_reconnect(self):
         """Test the re-connect tries."""
         self.hass.data['mqtt'].subscriptions = [
             mqtt.Subscription('test/progress', None, 0),
@@ -495,8 +494,6 @@ class TestMQTTCallbacks(unittest.TestCase):
         self.hass.block_till_done()
         assert self.hass.data['mqtt']._mqttc.reconnect.called
         assert 4 == len(self.hass.data['mqtt']._mqttc.reconnect.mock_calls)
-        assert [1, 2, 4] == \
-            [call[1][0] for call in mock_sleep.mock_calls]
 
     def test_retained_message_on_subscribe_received(self):
         """Test every subscriber receives retained message on subscribe."""

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -482,7 +482,7 @@ class TestMQTTCallbacks(unittest.TestCase):
         self.hass.data['mqtt']._mqtt_on_disconnect(None, None, 0)
         assert not self.hass.data['mqtt']._mqttc.reconnect.called
 
-    @mock.patch('homeassistant.components.mqtt.time.sleep')
+    @mock.patch('homeassistant.components.mqtt.asyncio.sleep')
     def test_mqtt_disconnect_tries_reconnect(self, mock_sleep):
         """Test the re-connect tries."""
         self.hass.data['mqtt'].subscriptions = [
@@ -492,6 +492,7 @@ class TestMQTTCallbacks(unittest.TestCase):
         ]
         self.hass.data['mqtt']._mqttc.reconnect.side_effect = [1, 1, 1, 0]
         self.hass.data['mqtt']._mqtt_on_disconnect(None, None, 1)
+        self.hass.block_till_done()
         assert self.hass.data['mqtt']._mqttc.reconnect.called
         assert 4 == len(self.hass.data['mqtt']._mqttc.reconnect.mock_calls)
         assert [1, 2, 4] == \


### PR DESCRIPTION
## Description:
Use external event loop support in paho_mqtt instead of thread.

**Related issue (if applicable):** fixes #16690

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.