### PR TITLE
Log exceptions thrown by signal callbacks

### DIFF
--- a/homeassistant/helpers/dispatcher.py
+++ b/homeassistant/helpers/dispatcher.py
@@ -30,9 +30,9 @@ def dispatcher_connect(hass: HomeAssistantType, signal: str,
     return remove_dispatcher
 
 
-def wrap_callback(func):
+def wrap_callback(func: Callable[..., Any]) -> Callable[[], None]:
     """Decorate a signal callback to catch and log exceptions."""
-    def log_exception(signal, *args):
+    def log_exception(signal: str, *args: Any) -> None:
         module_name = inspect.getmodule(inspect.trace()[1][0]).__name__
         # Do not print the wrapper in the traceback
         frames = len(inspect.trace()) - 1
@@ -44,16 +44,16 @@ def wrap_callback(func):
     wrapper_func = None
     if asyncio.iscoroutinefunction(func):
         @wraps(func)
-        async def wrapper(signal, *args):
+        async def async_wrapper(signal: str, *args: Any) -> None:
             """Catch and log exception."""
             try:
                 await func(*args)
             except Exception:  # pylint: disable=broad-except
                 log_exception(signal, *args)
-        wrapper_func = wrapper
+        wrapper_func = async_wrapper
     else:
         @wraps(func)
-        def wrapper(signal, *args):
+        def wrapper(signal: str, *args: Any) -> None:
             """Catch and log exception."""
             try:
                 func(*args)

--- a/homeassistant/helpers/dispatcher.py
+++ b/homeassistant/helpers/dispatcher.py
@@ -38,8 +38,8 @@ def wrap_callback(func: Callable[..., Any]) -> Callable[[], None]:
         frames = len(inspect.trace()) - 1
         err = traceback.format_exc(-frames)
         logging.getLogger(module_name).error(
-            "Exception in %s when dispatching '%s': '%s'\n%s",
-            func.__name__, signal, *args, err)
+            "Exception in %s when dispatching '%s': %s\n%s",
+            func.__name__, signal, args, err)
 
     wrapper_func = None
     if asyncio.iscoroutinefunction(func):

--- a/homeassistant/helpers/dispatcher.py
+++ b/homeassistant/helpers/dispatcher.py
@@ -79,13 +79,15 @@ def async_dispatcher_connect(hass: HomeAssistantType, signal: str,
     if signal not in hass.data[DATA_DISPATCHER]:
         hass.data[DATA_DISPATCHER][signal] = []
 
-    hass.data[DATA_DISPATCHER][signal].append(wrap_callback(target))
+    wrapped_target = wrap_callback(target)
+
+    hass.data[DATA_DISPATCHER][signal].append(wrapped_target)
 
     @callback
     def async_remove_dispatcher() -> None:
         """Remove signal listener."""
         try:
-            hass.data[DATA_DISPATCHER][signal].remove(target)
+            hass.data[DATA_DISPATCHER][signal].remove(wrapped_target)
         except (KeyError, ValueError):
             # KeyError is key target listener did not exist
             # ValueError if listener did not exist within signal

--- a/homeassistant/helpers/dispatcher.py
+++ b/homeassistant/helpers/dispatcher.py
@@ -3,7 +3,6 @@ import asyncio
 import inspect
 from functools import wraps
 import logging
-import sys
 import traceback
 from typing import Any, Callable
 
@@ -35,13 +34,12 @@ def wrap_callback(func):
     """Decorate a signal callback to catch and log exceptions."""
     def log_exception(signal, *args):
         module_name = inspect.getmodule(inspect.trace()[1][0]).__name__
-        exc_type, exc_value, exc_tb = sys.exc_info()
         # Do not print the wrapper in the traceback
-        exc_tb = exc_tb.tb_next
-        err = traceback.format_exception(exc_type, exc_value, exc_tb)
+        frames = len(inspect.trace()) - 1
+        err = traceback.format_exc(-frames)
         logging.getLogger(module_name).error(
             "Exception in %s when dispatching '%s': '%s'\n%s",
-            func.__name__, signal, *args, ''.join(err))
+            func.__name__, signal, *args, err)
 
     wrapper_func = None
     if asyncio.iscoroutinefunction(func):

--- a/homeassistant/helpers/dispatcher.py
+++ b/homeassistant/helpers/dispatcher.py
@@ -79,4 +79,4 @@ def async_dispatcher_send(
     target_list = hass.data.get(DATA_DISPATCHER, {}).get(signal, [])
 
     for target in target_list:
-        hass.async_add_job(target, signal, *args)
+        hass.async_add_job(target, *args)

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -13,10 +13,10 @@ from homeassistant.components import mqtt
 from homeassistant.const import (EVENT_CALL_SERVICE, ATTR_DOMAIN, ATTR_SERVICE,
                                  EVENT_HOMEASSISTANT_STOP)
 
-from tests.common import (get_test_home_assistant, mock_coro,
-                          mock_mqtt_component,
-                          threadsafe_coroutine_factory, fire_mqtt_message,
-                          async_fire_mqtt_message, MockConfigEntry)
+from tests.common import (
+    MockConfigEntry, async_fire_mqtt_message, async_mock_mqtt_component,
+    fire_mqtt_message, get_test_home_assistant, mock_coro, mock_mqtt_component,
+    threadsafe_coroutine_factory)
 
 
 @pytest.fixture
@@ -295,23 +295,6 @@ class TestMQTTCallbacks(unittest.TestCase):
             assert \
                 "WARNING:homeassistant.components.mqtt:Can't decode payload " \
                 "b'\\x9a' on test-topic with encoding utf-8" in \
-                test_handle.output[0]
-
-    def test_message_callback_exception_gets_logged(self):
-        """Test exception raised by message handler."""
-        @callback
-        def bad_handler(*args):
-            """Record calls."""
-            raise Exception('This is a bad message callback')
-        mqtt.subscribe(self.hass, 'test-topic', bad_handler)
-
-        with self.assertLogs(level='WARNING') as test_handle:
-            fire_mqtt_message(self.hass, 'test-topic', 'test')
-
-            self.hass.block_till_done()
-            assert \
-                "Exception in bad_handler when handling msg on 'test-topic':" \
-                " 'test'" in \
                 test_handle.output[0]
 
     def test_all_subscriptions_run_when_decode_fails(self):
@@ -766,3 +749,21 @@ def test_mqtt_subscribes_topics_on_connect(hass):
 async def test_setup_fails_without_config(hass):
     """Test if the MQTT component fails to load with no config."""
     assert not await async_setup_component(hass, mqtt.DOMAIN, {})
+
+
+async def test_message_callback_exception_gets_logged(hass, caplog):
+    """Test exception raised by message handler."""
+    await async_mock_mqtt_component(hass)
+
+    @callback
+    def bad_handler(*args):
+        """Record calls."""
+        raise Exception('This is a bad message callback')
+
+    await mqtt.async_subscribe(hass, 'test-topic', bad_handler)
+    async_fire_mqtt_message(hass, 'test-topic', 'test')
+    await hass.async_block_till_done()
+
+    assert \
+        "Exception in bad_handler when handling msg on 'test-topic':" \
+        " 'test'" in caplog.text

--- a/tests/helpers/test_dispatcher.py
+++ b/tests/helpers/test_dispatcher.py
@@ -149,5 +149,5 @@ class TestHelpersDispatcher(unittest.TestCase):
 
             self.hass.block_till_done()
             assert \
-                "Exception in bad_handler when dispatching 'test': ('bad',)" in \
-                test_handle.output[0]
+                "Exception in bad_handler when dispatching 'test': ('bad',)" \
+                in test_handle.output[0]


### PR DESCRIPTION
## Description:
Improve logging of exceptions thrown by MQTT message callbacks as discussed in #15446

Example of improved logging:
```
ERROR:homeassistant.components.lock.mqtt:Exception in async_discover when dispatching 'mqtt_discovery_new_lock_mqtt': '{'name': 'Beer', 'platform': 'mqtt', 'state_topic': 'homeassistant/lock/bla/state', 'discovery_hash': ('lock', 'bla')}'
Traceback (most recent call last):
  File "/mnt/d/development/github/home-assistant_fork/homeassistant/components/lock/mqtt.py", line 63, in async_discover
    config = PLATFORM_SCHEMA(discovery_payload)
  File "/mnt/d/development/github/home-assistant_fork/lib/python3.6/site-packages/voluptuous/schema_builder.py", line 267, in __call__
    return self._compiled([], data)
  File "/mnt/d/development/github/home-assistant_fork/lib/python3.6/site-packages/voluptuous/schema_builder.py", line 589, in validate_dict
    return base_validate(path, iteritems(data), out)
  File "/mnt/d/development/github/home-assistant_fork/lib/python3.6/site-packages/voluptuous/schema_builder.py", line 427, in validate_mapping
    raise er.MultipleInvalid(errors)
voluptuous.error.MultipleInvalid: required key not provided @ data['command_topic']
```

Example of improved logging if not skipping the wrapper:
```
ERROR:homeassistant.components.lock.mqtt:Exception in async_discover when dispatching 'mqtt_discovery_new_lock_mqtt': '{'name': 'Beer', 'platform': 'mqtt', 'state_topic': 'homeassistant/lock/bla/state', 'discovery_hash': ('lock', 'bla')}'
Traceback (most recent call last):
  File "/mnt/d/development/github/home-assistant_fork/homeassistant/helpers/dispatcher.py", line 51, in wrapper
    await func(*args)
  File "/mnt/d/development/github/home-assistant_fork/homeassistant/components/lock/mqtt.py", line 63, in async_discover
    config = PLATFORM_SCHEMA(discovery_payload)
  File "/mnt/d/development/github/home-assistant_fork/lib/python3.6/site-packages/voluptuous/schema_builder.py", line 267, in __call__
    return self._compiled([], data)
  File "/mnt/d/development/github/home-assistant_fork/lib/python3.6/site-packages/voluptuous/schema_builder.py", line 589, in validate_dict
    return base_validate(path, iteritems(data), out)
  File "/mnt/d/development/github/home-assistant_fork/lib/python3.6/site-packages/voluptuous/schema_builder.py", line 427, in validate_mapping
    raise er.MultipleInvalid(errors)
voluptuous.error.MultipleInvalid: required key not provided @ data['command_topic']
```

Example of old error message:
```
ERROR:homeassistant.core:Error doing job: Task exception was never retrieved
Traceback (most recent call last):
  File "/mnt/d/development/github/home-assistant_fork/homeassistant/components/lock/mqtt.py", line 63, in async_discover
    config = PLATFORM_SCHEMA(discovery_payload)
  File "/mnt/d/development/github/home-assistant_fork/lib/python3.6/site-packages/voluptuous/schema_builder.py", line 267, in __call__
    return self._compiled([], data)
  File "/mnt/d/development/github/home-assistant_fork/lib/python3.6/site-packages/voluptuous/schema_builder.py", line 589, in validate_dict
    return base_validate(path, iteritems(data), out)
  File "/mnt/d/development/github/home-assistant_fork/lib/python3.6/site-packages/voluptuous/schema_builder.py", line 427, in validate_mapping
    raise er.MultipleInvalid(errors)
voluptuous.error.MultipleInvalid: required key not provided @ data['command_topic']
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
