### PR TITLE
Fix mychevy wrong attribute on battery level selector

### DIFF
--- a/homeassistant/components/sensor/mychevy.py
+++ b/homeassistant/components/sensor/mychevy.py
@@ -144,7 +144,7 @@ class EVSensor(Entity):
     def icon(self):
         """Return the icon."""
         if self._attr == BATTERY_SENSOR:
-            charging = self.state_attributes.get("charging", False)
+            charging = self._state_attributes.get("charging", False)
             return icon_for_battery_level(self.state, charging)
         return self._icon
 


### PR DESCRIPTION
The battery level sensor is broken because the logic for determining
if the battery is charged accessed the wrong variable. This one
character fix makes it work again.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
