### PR TITLE
Version bump for zha-quirks

### DIFF
--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -37,7 +37,7 @@ REQUIREMENTS = [
     'bellows==0.7.0',
     'zigpy==0.2.0',
     'zigpy-xbee==0.1.1',
-    'zha-quirks==0.0.5'
+    'zha-quirks==0.0.6'
 ]
 
 DEVICE_CONFIG_SCHEMA_ENTRY = vol.Schema({

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1735,7 +1735,7 @@ zengge==0.2
 zeroconf==0.21.3
 
 # homeassistant.components.zha
-zha-quirks==0.0.5
+zha-quirks==0.0.6
 
 # homeassistant.components.climate.zhong_hong
 zhong_hong_hvac==1.0.9


### PR DESCRIPTION
bump version of zha-quirks to 0.0.6

This really should have been done prior to .85 I forgot to release and update it in time.