### PR TITLE
UniFi - Fix issue when controlling POE

### DIFF
--- a/homeassistant/components/unifi/__init__.py
+++ b/homeassistant/components/unifi/__init__.py
@@ -22,7 +22,7 @@ DEFAULT_PORT = 8443
 DEFAULT_SITE_ID = 'default'
 DEFAULT_VERIFY_SSL = False
 
-REQUIREMENTS = ['aiounifi==3']
+REQUIREMENTS = ['aiounifi==4']
 
 
 async def async_setup(hass, config):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -127,7 +127,7 @@ aiolifx_effects==0.2.1
 aiopvapi==1.6.14
 
 # homeassistant.components.unifi
-aiounifi==3
+aiounifi==4
 
 # homeassistant.components.cover.aladdin_connect
 aladdin_connect==0.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -41,7 +41,7 @@ aiohttp_cors==0.7.0
 aiohue==1.5.0
 
 # homeassistant.components.unifi
-aiounifi==3
+aiounifi==4
 
 # homeassistant.components.notify.apns
 apns2==0.3.0

--- a/tests/components/switch/test_unifi.py
+++ b/tests/components/switch/test_unifi.py
@@ -109,7 +109,7 @@ DEVICE_1 = {
     'mac': '00:00:00:00:01:01',
     'type': 'usw',
     'name': 'mock-name',
-    'portconf_id': '',
+    'port_overrides': [],
     'port_table': [
         {
             'media': 'GE',


### PR DESCRIPTION
Controlling POE would reset configuration for all other ports on device

**Related issue (if applicable):** fixes #18267

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
