### PR TITLE
Show persistent notification on Doorbird schedule failure

### DIFF
--- a/homeassistant/components/doorbird.py
+++ b/homeassistant/components/doorbird.py
@@ -113,7 +113,16 @@ def setup(hass, config):
 
         # Subscribe to doorbell or motion events
         if events:
-            doorstation.update_schedule(hass)
+            try:
+                doorstation.update_schedule(hass)
+            except:
+                hass.components.persistent_notification.create(
+                    'Doorbird configuration failed.  Please verify that API '
+                    'Operator permission is enabled for the Doorbird user. '
+                    'A restart will be required once permissions have been '
+                    'verified.',
+                    title='Doorbird Configuration Failure',
+                    notification_id='doorbird_schedule_error')
 
     hass.data[DOMAIN] = doorstations
 
@@ -230,6 +239,7 @@ class ConfiguredDoorBird():
         if not self.webhook_is_registered(hass_url):
             self.device.change_favorite('http', 'Home Assistant ({} events)'
                                         .format(event), hass_url)
+
         fav_id = self.get_webhook_id(hass_url)
 
         if not fav_id:
@@ -253,8 +263,6 @@ class ConfiguredDoorBird():
             for relay in self._relay_nums:
                 entry = self.device.get_schedule_entry(event, str(relay))
                 entry.output.append(output)
-                resp = self.device.change_schedule(entry)
-                return resp
         else:
             entry = self.device.get_schedule_entry(event)
             entry.output.append(output)

--- a/homeassistant/components/doorbird.py
+++ b/homeassistant/components/doorbird.py
@@ -7,6 +7,7 @@ https://home-assistant.io/components/doorbird/
 import logging
 
 import voluptuous as vol
+from urllib.error import HTTPError
 
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.const import CONF_HOST, CONF_USERNAME, \
@@ -115,7 +116,7 @@ def setup(hass, config):
         if events:
             try:
                 doorstation.update_schedule(hass)
-            except:
+            except HTTPError:
                 hass.components.persistent_notification.create(
                     'Doorbird configuration failed.  Please verify that API '
                     'Operator permission is enabled for the Doorbird user. '

--- a/homeassistant/components/doorbird.py
+++ b/homeassistant/components/doorbird.py
@@ -125,6 +125,8 @@ def setup(hass, config):
                     title='Doorbird Configuration Failure',
                     notification_id='doorbird_schedule_error')
 
+                return False
+
     hass.data[DOMAIN] = doorstations
 
     def _reset_device_favorites_handler(event):

--- a/homeassistant/components/doorbird.py
+++ b/homeassistant/components/doorbird.py
@@ -6,8 +6,8 @@ https://home-assistant.io/components/doorbird/
 """
 import logging
 
-import voluptuous as vol
 from urllib.error import HTTPError
+import voluptuous as vol
 
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.const import CONF_HOST, CONF_USERNAME, \

--- a/homeassistant/components/doorbird.py
+++ b/homeassistant/components/doorbird.py
@@ -14,7 +14,7 @@ from homeassistant.const import CONF_HOST, CONF_USERNAME, \
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import slugify, dt as dt_util
 
-REQUIREMENTS = ['doorbirdpy==2.0.4']
+REQUIREMENTS = ['doorbirdpy==2.0.5']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/doorbird.py
+++ b/homeassistant/components/doorbird.py
@@ -15,7 +15,7 @@ from homeassistant.const import CONF_HOST, CONF_USERNAME, \
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import slugify, dt as dt_util
 
-REQUIREMENTS = ['doorbirdpy==2.0.5']
+REQUIREMENTS = ['doorbirdpy==2.0.6']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -327,7 +327,7 @@ distro==1.3.0
 dlipower==0.7.165
 
 # homeassistant.components.doorbird
-doorbirdpy==2.0.5
+doorbirdpy==2.0.6
 
 # homeassistant.components.sensor.dovado
 dovado==0.4.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -327,7 +327,7 @@ distro==1.3.0
 dlipower==0.7.165
 
 # homeassistant.components.doorbird
-doorbirdpy==2.0.4
+doorbirdpy==2.0.5
 
 # homeassistant.components.sensor.dovado
 dovado==0.4.1


### PR DESCRIPTION
## Description:
Cleanup unnecessary return inside of loop.  Adds persistent notification for failed schedule setup.

**Related issue (if applicable):** fixes #19661

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
