### PR TITLE
Use local_ip from config to discover IGD device

### DIFF
--- a/homeassistant/components/media_player/dlna_dmr.py
+++ b/homeassistant/components/media_player/dlna_dmr.py
@@ -26,7 +26,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import get_local_ip
 
-REQUIREMENTS = ['async-upnp-client==0.14.0']
+REQUIREMENTS = ['async-upnp-client==0.14.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/media_player/dlna_dmr.py
+++ b/homeassistant/components/media_player/dlna_dmr.py
@@ -26,7 +26,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import get_local_ip
 
-REQUIREMENTS = ['async-upnp-client==0.14.0.dev0']
+REQUIREMENTS = ['async-upnp-client==0.14.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/media_player/dlna_dmr.py
+++ b/homeassistant/components/media_player/dlna_dmr.py
@@ -26,7 +26,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import get_local_ip
 
-REQUIREMENTS = ['async-upnp-client==0.14.1']
+REQUIREMENTS = ['async-upnp-client==0.14.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/media_player/dlna_dmr.py
+++ b/homeassistant/components/media_player/dlna_dmr.py
@@ -26,7 +26,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import get_local_ip
 
-REQUIREMENTS = ['async-upnp-client==0.14.0']
+REQUIREMENTS = ['async-upnp-client==0.14.0.dev0']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -355,12 +355,12 @@ class DlnaDmrDevice(MediaPlayerDevice):
         if not self._available:
             return STATE_OFF
 
-        from async_upnp_client.profiles import dlna
+        from async_upnp_client.profiles import DeviceState
         if self._device.state is None:
             return STATE_ON
-        if self._device.state == dlna.STATE_PLAYING:
+        if self._device.state == DeviceState.PLAYING:
             return STATE_PLAYING
-        if self._device.state == dlna.STATE_PAUSED:
+        if self._device.state == DeviceState.PAUSED:
             return STATE_PAUSED
 
         return STATE_IDLE

--- a/homeassistant/components/media_player/dlna_dmr.py
+++ b/homeassistant/components/media_player/dlna_dmr.py
@@ -355,7 +355,7 @@ class DlnaDmrDevice(MediaPlayerDevice):
         if not self._available:
             return STATE_OFF
 
-        from async_upnp_client.profiles import DeviceState
+        from async_upnp_client.profiles.dlna import DeviceState
         if self._device.state is None:
             return STATE_ON
         if self._device.state == DeviceState.PLAYING:

--- a/homeassistant/components/media_player/dlna_dmr.py
+++ b/homeassistant/components/media_player/dlna_dmr.py
@@ -26,7 +26,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import get_local_ip
 
-REQUIREMENTS = ['async-upnp-client==0.13.8']
+REQUIREMENTS = ['async-upnp-client==0.14.0']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -145,7 +145,7 @@ async def async_setup_platform(
         raise PlatformNotReady()
 
     # wrap with DmrDevice
-    from async_upnp_client.dlna import DmrDevice
+    from async_upnp_client.profiles.dlna import DmrDevice
     dlna_device = DmrDevice(upnp_device, event_handler)
 
     # create our own device
@@ -314,7 +314,7 @@ class DlnaDmrDevice(MediaPlayerDevice):
         await self._device.async_wait_for_can_play()
 
         # If already playing, no need to call Play
-        from async_upnp_client import dlna
+        from async_upnp_client.profiles import dlna
         if self._device.state == dlna.STATE_PLAYING:
             return
 
@@ -355,7 +355,7 @@ class DlnaDmrDevice(MediaPlayerDevice):
         if not self._available:
             return STATE_OFF
 
-        from async_upnp_client import dlna
+        from async_upnp_client.profiles import dlna
         if self._device.state is None:
             return STATE_ON
         if self._device.state == dlna.STATE_PLAYING:

--- a/homeassistant/components/media_player/dlna_dmr.py
+++ b/homeassistant/components/media_player/dlna_dmr.py
@@ -314,8 +314,8 @@ class DlnaDmrDevice(MediaPlayerDevice):
         await self._device.async_wait_for_can_play()
 
         # If already playing, no need to call Play
-        from async_upnp_client.profiles import dlna
-        if self._device.state == dlna.STATE_PLAYING:
+        from async_upnp_client.profiles.dlna import DeviceState
+        if self._device.state == DeviceState.PLAYING:
             return
 
         # Play it

--- a/homeassistant/components/upnp/__init__.py
+++ b/homeassistant/components/upnp/__init__.py
@@ -29,7 +29,7 @@ from .const import LOGGER as _LOGGER
 from .device import Device
 
 
-REQUIREMENTS = ['async-upnp-client==0.13.8']
+REQUIREMENTS = ['async-upnp-client==0.14.0']
 
 NOTIFICATION_ID = 'upnp_notification'
 NOTIFICATION_TITLE = 'UPnP/IGD Setup'

--- a/homeassistant/components/upnp/__init__.py
+++ b/homeassistant/components/upnp/__init__.py
@@ -29,7 +29,7 @@ from .const import LOGGER as _LOGGER
 from .device import Device
 
 
-REQUIREMENTS = ['async-upnp-client==0.14.0']
+REQUIREMENTS = ['async-upnp-client==0.14.1']
 
 NOTIFICATION_ID = 'upnp_notification'
 NOTIFICATION_TITLE = 'UPnP/IGD Setup'

--- a/homeassistant/components/upnp/__init__.py
+++ b/homeassistant/components/upnp/__init__.py
@@ -29,7 +29,7 @@ from .const import LOGGER as _LOGGER
 from .device import Device
 
 
-REQUIREMENTS = ['async-upnp-client==0.14.0']
+REQUIREMENTS = ['async-upnp-client==0.14.0.dev0']
 
 NOTIFICATION_ID = 'upnp_notification'
 NOTIFICATION_TITLE = 'UPnP/IGD Setup'

--- a/homeassistant/components/upnp/__init__.py
+++ b/homeassistant/components/upnp/__init__.py
@@ -29,7 +29,7 @@ from .const import LOGGER as _LOGGER
 from .device import Device
 
 
-REQUIREMENTS = ['async-upnp-client==0.14.1']
+REQUIREMENTS = ['async-upnp-client==0.14.2']
 
 NOTIFICATION_ID = 'upnp_notification'
 NOTIFICATION_TITLE = 'UPnP/IGD Setup'

--- a/homeassistant/components/upnp/__init__.py
+++ b/homeassistant/components/upnp/__init__.py
@@ -29,7 +29,7 @@ from .const import LOGGER as _LOGGER
 from .device import Device
 
 
-REQUIREMENTS = ['async-upnp-client==0.14.0.dev0']
+REQUIREMENTS = ['async-upnp-client==0.14.0']
 
 NOTIFICATION_ID = 'upnp_notification'
 NOTIFICATION_TITLE = 'UPnP/IGD Setup'

--- a/homeassistant/components/upnp/device.py
+++ b/homeassistant/components/upnp/device.py
@@ -25,11 +25,11 @@ class Device:
         _LOGGER.debug('Discovering UPnP/IGD devices')
         local_ip = hass.data[DOMAIN]['config'].get(CONF_LOCAL_IP)
         if local_ip:
-          local_ip = IPv4Address(local_ip)
+            local_ip = IPv4Address(local_ip)
 
         # discover devices
         from async_upnp_client.profiles.igd import IgdDevice
-        discovery_infos = await IgdDevice.async_search(source_ip = local_ip)
+        discovery_infos = await IgdDevice.async_search(source_ip=local_ip)
 
         # add extra info and store devices
         devices = []

--- a/homeassistant/components/upnp/device.py
+++ b/homeassistant/components/upnp/device.py
@@ -1,7 +1,6 @@
 """Hass representation of an UPnP/IGD."""
 import asyncio
 from ipaddress import IPv4Address
-from typing import Dict
 
 import aiohttp
 
@@ -30,7 +29,7 @@ class Device:
 
         # discover devices
         from async_upnp_client.profiles.igd import IgdDevice
-        discovery_infos = await IgdDevice.async_search( source_ip = local_ip)
+        discovery_infos = await IgdDevice.async_search(source_ip = local_ip)
 
         # add extra info and store devices
         devices = []

--- a/homeassistant/components/upnp/device.py
+++ b/homeassistant/components/upnp/device.py
@@ -9,26 +9,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.typing import HomeAssistantType
 
 from .const import LOGGER as _LOGGER
-from .const import ( DOMAIN, CONF_LOCAL_IP )
-
-from async_upnp_client.igd import IgdDevice
-from async_upnp_client.discovery import async_discover
-
-class IgdDeviceIp(IgdDevice):
-    @classmethod
-    async def async_discover(cls, source_ip: IPv4Address ) -> Dict:
-        """
-        Discovery this device type.
-
-        This only return discovery info, not a profile itself.
-
-        :return:
-        """
-        return [
-            device
-            for device in await async_discover( source_ip = source_ip )
-            if device['st'] in cls.DEVICE_TYPES
-        ]
+from .const import (DOMAIN, CONF_LOCAL_IP)
 
 
 class Device:
@@ -43,13 +24,13 @@ class Device:
     async def async_discover(cls, hass: HomeAssistantType):
         """Discovery UPNP/IGD devices."""
         _LOGGER.debug('Discovering UPnP/IGD devices')
-        local_ip = hass.data[DOMAIN]['local_ip']
         local_ip = hass.data[DOMAIN]['config'].get(CONF_LOCAL_IP)
-#        local_ip = IPv4Address(local_ip)
-        _LOGGER.debug('local_ip = %s',local_ip)
+        if local_ip:
+          local_ip = IPv4Address(local_ip)
 
         # discover devices
-        discovery_infos = await IgdDeviceIp.async_discover( source_ip = local_ip)
+        from async_upnp_client.profiles.igd import IgdDevice
+        discovery_infos = await IgdDevice.async_search( source_ip = local_ip)
 
         # add extra info and store devices
         devices = []
@@ -80,7 +61,7 @@ class Device:
         upnp_device = await factory.async_create_device(ssdp_description)
 
         # wrap with async_upnp_client.IgdDevice
-        from async_upnp_client.igd import IgdDevice
+        from async_upnp_client.profiles.igd import IgdDevice
         igd_device = IgdDevice(upnp_device, None)
 
         return cls(igd_device)

--- a/homeassistant/components/upnp/device.py
+++ b/homeassistant/components/upnp/device.py
@@ -35,7 +35,7 @@ class Device:
         # add extra info and store devices
         devices = []
         for discovery_info in discovery_infos:
-            discovery_info['udn'] = discovery_info['usn'].split('::')[0]
+            discovery_info['udn'] = discovery_info['_udn']
             discovery_info['ssdp_description'] = discovery_info['location']
             discovery_info['source'] = 'async_upnp_client'
             _LOGGER.debug('Discovered device: %s', discovery_info)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -164,7 +164,7 @@ asterisk_mbox==0.5.0
 
 # homeassistant.components.upnp
 # homeassistant.components.media_player.dlna_dmr
-async-upnp-client==0.14.0
+async-upnp-client==0.13.8
 
 # homeassistant.components.light.avion
 # avion==0.10

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -162,11 +162,9 @@ aqualogic==1.0
 # homeassistant.components.asterisk_mbox
 asterisk_mbox==0.5.0
 
+# homeassistant.components.upnp
 # homeassistant.components.media_player.dlna_dmr
 async-upnp-client==0.14.1
-
-# homeassistant.components.upnp
-async-upnp-client==0.41.1
 
 # homeassistant.components.light.avion
 # avion==0.10

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -162,9 +162,11 @@ aqualogic==1.0
 # homeassistant.components.asterisk_mbox
 asterisk_mbox==0.5.0
 
-# homeassistant.components.upnp
 # homeassistant.components.media_player.dlna_dmr
-async-upnp-client==0.14.0
+async-upnp-client==0.14.1
+
+# homeassistant.components.upnp
+async-upnp-client==0.41.1
 
 # homeassistant.components.light.avion
 # avion==0.10

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -164,7 +164,7 @@ asterisk_mbox==0.5.0
 
 # homeassistant.components.upnp
 # homeassistant.components.media_player.dlna_dmr
-async-upnp-client==0.13.8
+async-upnp-client==0.14.0
 
 # homeassistant.components.light.avion
 # avion==0.10

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -164,7 +164,7 @@ asterisk_mbox==0.5.0
 
 # homeassistant.components.upnp
 # homeassistant.components.media_player.dlna_dmr
-async-upnp-client==0.14.1
+async-upnp-client==0.14.2
 
 # homeassistant.components.light.avion
 # avion==0.10


### PR DESCRIPTION
In case of multi-homed server UPNP discovery finds IGD device on some "default" interface. WIth this modification discovery will be performed from 'local_ip'.

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
