### PR TITLE
Fix errors in ESPHome integration

### DIFF
--- a/homeassistant/components/cover/esphome.py
+++ b/homeassistant/components/cover/esphome.py
@@ -8,7 +8,6 @@ from homeassistant.components.cover import CoverDevice, SUPPORT_CLOSE, \
 from homeassistant.components.esphome import EsphomeEntity, \
     platform_async_setup_entry
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import STATE_CLOSED, STATE_OPEN
 from homeassistant.helpers.typing import HomeAssistantType
 
 if TYPE_CHECKING:
@@ -31,12 +30,6 @@ async def async_setup_entry(hass: HomeAssistantType,
         info_type=CoverInfo, entity_type=EsphomeCover,
         state_type=CoverState
     )
-
-
-COVER_STATE_INT_TO_STR = {
-    0: STATE_OPEN,
-    1: STATE_CLOSED
-}
 
 
 class EsphomeCover(EsphomeEntity, CoverDevice):
@@ -65,7 +58,7 @@ class EsphomeCover(EsphomeEntity, CoverDevice):
         """Return if the cover is closed or not."""
         if self._state is None:
             return None
-        return COVER_STATE_INT_TO_STR[self._state.state]
+        return bool(self._state.state)
 
     async def async_open_cover(self, **kwargs) -> None:
         """Open the cover."""

--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -481,7 +481,7 @@ class EsphomeEntity(Entity):
         self._remove_callbacks.append(
             async_dispatcher_connect(self.hass,
                                      DISPATCHER_REMOVE_ENTITY.format(**kwargs),
-                                     self.async_schedule_update_ha_state)
+                                     self.async_remove)
         )
 
         self._remove_callbacks.append(

--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -10,7 +10,7 @@ from homeassistant import const
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, \
     EVENT_HOMEASSISTANT_STOP
-from homeassistant.core import callback, Event
+from homeassistant.core import callback, Event, State
 import homeassistant.helpers.device_registry as dr
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers import template
@@ -208,11 +208,11 @@ async def async_setup_entry(hass: HomeAssistantType,
             domain, service_name, service_data, blocking=True))
 
     async def send_home_assistant_state(entity_id: str, _,
-                                        new_state: Optional[str]) -> None:
+                                        new_state: Optional[State]) -> None:
         """Forward Home Assistant states to ESPHome."""
         if new_state is None:
             return
-        await cli.send_home_assistant_state(entity_id, new_state)
+        await cli.send_home_assistant_state(entity_id, new_state.state)
 
     @callback
     def async_on_state_subscription(entity_id: str) -> None:

--- a/homeassistant/components/fan/esphome.py
+++ b/homeassistant/components/fan/esphome.py
@@ -91,6 +91,8 @@ class EsphomeFan(EsphomeEntity, FanEntity):
         """Return the current speed."""
         if self._state is None:
             return None
+        if not self._static_info.supports_speed:
+            return None
         return FAN_SPEED_INT_TO_STR[self._state.speed]
 
     @property
@@ -98,11 +100,15 @@ class EsphomeFan(EsphomeEntity, FanEntity):
         """Return the oscillation state."""
         if self._state is None:
             return None
+        if not self._static_info.supports_oscillation:
+            return None
         return self._state.oscillating
 
     @property
-    def speed_list(self) -> List[str]:
+    def speed_list(self) -> Optional[List[str]]:
         """Get the list of available speeds."""
+        if not self._static_info.supports_speed:
+            return None
         return [SPEED_OFF, SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH]
 
     @property


### PR DESCRIPTION
## Description:

Some errors popped up in my bug tracker:

 - Covers are always shown as CLOSED. This is because `is_closed` should return a bool, not a string 🤕 
 - Fans always show oscillating & speed in frontend, even if the corresponding supported features flags are not set. So the `supported_features` field **is not** used by the frontend! (https://github.com/home-assistant/home-assistant-polymer/blob/a58a3240738929cf8b915e638fd16a2a6a1f298f/src/dialogs/more-info/controls/more-info-fan.js#L143). 

  - Workaround is returning `None` in the properties. Maybe this is more of a frontend issue?

 - `send_home_assistant_state`'s call signate was wrong, we need to send `.state`, not the whole state object. I swear this worked before, somehow I think I messed it up while adding type annotations.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
