### PR TITLE
Fix remote.harmony_change_channel services.yaml indentation

### DIFF
--- a/homeassistant/components/remote/services.yaml
+++ b/homeassistant/components/remote/services.yaml
@@ -52,13 +52,13 @@ harmony_sync:
 
 harmony_change_channel:
   description: Sends change channel command to the Harmony HUB
-    fields:
-      entity_id:
-        description: Name(s) of Harmony remote entities to send change channel command to
-        example: 'remote.family_room'
-      channel:
-        description: Channel number to change to
-        example: '200'
+  fields:
+    entity_id:
+      description: Name(s) of Harmony remote entities to send change channel command to
+      example: 'remote.family_room'
+    channel:
+      description: Channel number to change to
+      example: '200'
 
 xiaomi_miio_learn_command:
   description: 'Learn an IR command, press "Call Service", point the remote at the IR device, and the learned command will be shown as a notification in Overview.'


### PR DESCRIPTION
## Description:

This was introduced in #20031.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.
  - [X] There is no commented out code in this PR.
