### PR TITLE
Change return text code for alarm control panels

### DIFF
--- a/homeassistant/components/alarm_control_panel/alarmdotcom.py
+++ b/homeassistant/components/alarm_control_panel/alarmdotcom.py
@@ -82,7 +82,7 @@ class AlarmDotCom(alarm.AlarmControlPanel):
             return None
         if isinstance(self._code, str) and re.search('^\\d+$', self._code):
             return alarm.FORMAT_NUMBER
-        return 'Any'
+        return alarm.FORMAT_TEXT
 
     @property
     def state(self):

--- a/homeassistant/components/alarm_control_panel/ialarm.py
+++ b/homeassistant/components/alarm_control_panel/ialarm.py
@@ -83,7 +83,7 @@ class IAlarmPanel(alarm.AlarmControlPanel):
             return None
         if isinstance(self._code, str) and re.search('^\\d+$', self._code):
             return alarm.FORMAT_NUMBER
-        return 'Any'
+        return alarm.FORMAT_TEXT
 
     @property
     def state(self):

--- a/homeassistant/components/alarm_control_panel/ifttt.py
+++ b/homeassistant/components/alarm_control_panel/ifttt.py
@@ -130,7 +130,7 @@ class IFTTTAlarmPanel(alarm.AlarmControlPanel):
             return None
         if isinstance(self._code, str) and re.search('^\\d+$', self._code):
             return alarm.FORMAT_NUMBER
-        return 'Any'
+        return alarm.FORMAT_TEXT
 
     def alarm_disarm(self, code=None):
         """Send disarm command."""

--- a/homeassistant/components/alarm_control_panel/manual.py
+++ b/homeassistant/components/alarm_control_panel/manual.py
@@ -208,7 +208,7 @@ class ManualAlarm(alarm.AlarmControlPanel, RestoreEntity):
             return None
         if isinstance(self._code, str) and re.search('^\\d+$', self._code):
             return alarm.FORMAT_NUMBER
-        return 'Any'
+        return alarm.FORMAT_TEXT
 
     def alarm_disarm(self, code=None):
         """Send disarm command."""

--- a/homeassistant/components/alarm_control_panel/manual_mqtt.py
+++ b/homeassistant/components/alarm_control_panel/manual_mqtt.py
@@ -242,7 +242,7 @@ class ManualMQTTAlarm(alarm.AlarmControlPanel):
             return None
         if isinstance(self._code, str) and re.search('^\\d+$', self._code):
             return alarm.FORMAT_NUMBER
-        return 'Any'
+        return alarm.FORMAT_TEXT
 
     def alarm_disarm(self, code=None):
         """Send disarm command."""

--- a/homeassistant/components/alarm_control_panel/mqtt.py
+++ b/homeassistant/components/alarm_control_panel/mqtt.py
@@ -173,7 +173,7 @@ class MqttAlarm(MqttAvailability, MqttDiscoveryUpdate, MqttEntityDeviceInfo,
             return None
         if isinstance(code, str) and re.search('^\\d+$', code):
             return alarm.FORMAT_NUMBER
-        return 'Any'
+        return alarm.FORMAT_TEXT
 
     async def async_alarm_disarm(self, code=None):
         """Send disarm command.

--- a/homeassistant/components/alarm_control_panel/simplisafe.py
+++ b/homeassistant/components/alarm_control_panel/simplisafe.py
@@ -65,7 +65,7 @@ class SimpliSafeAlarm(alarm.AlarmControlPanel):
             return None
         if isinstance(self._code, str) and re.search('^\\d+$', self._code):
             return alarm.FORMAT_NUMBER
-        return 'Any'
+        return alarm.FORMAT_TEXT
 
     @property
     def state(self):


### PR DESCRIPTION
Follow up to https://github.com/home-assistant/home-assistant/pull/20037. This PR standardizes the return text to `alarm.FORMAT_TEXT`. 


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
