### PR TITLE
Use the correct Unicode degree symbol for temperatures and directions

### DIFF
--- a/homeassistant/components/sensor/ambient_station.py
+++ b/homeassistant/components/sensor/ambient_station.py
@@ -32,19 +32,19 @@ UNIT_SYSTEM = {UNITS_US: 0, UNITS_SI: 1}
 SCAN_INTERVAL = timedelta(seconds=300)
 
 SENSOR_TYPES = {
-    'winddir': ['Wind Dir', 'º'],
+    'winddir': ['Wind Dir', '°'],
     'windspeedmph': ['Wind Speed', 'mph'],
     'windgustmph': ['Wind Gust', 'mph'],
     'maxdailygust': ['Max Gust', 'mph'],
-    'windgustdir': ['Gust Dir', 'º'],
+    'windgustdir': ['Gust Dir', '°'],
     'windspdmph_avg2m': ['Wind Avg 2m', 'mph'],
     'winddir_avg2m': ['Wind Dir Avg 2m', 'mph'],
     'windspdmph_avg10m': ['Wind Avg 10m', 'mph'],
-    'winddir_avg10m': ['Wind Dir Avg 10m', 'º'],
+    'winddir_avg10m': ['Wind Dir Avg 10m', '°'],
     'humidity': ['Humidity', '%'],
     'humidityin': ['Humidity In', '%'],
-    'tempf': ['Temp', ['ºF', 'ºC']],
-    'tempinf': ['Inside Temp', ['ºF', 'ºC']],
+    'tempf': ['Temp', ['°F', '°C']],
+    'tempinf': ['Inside Temp', ['°F', '°C']],
     'battout': ['Battery', ''],
     'hourlyrainin': ['Hourly Rain Rate', 'in/hr'],
     'dailyrainin': ['Daily Rain', 'in'],
@@ -60,8 +60,8 @@ SENSOR_TYPES = {
     'solarradiation': ['Solar Rad', 'W/m^2'],
     'co2': ['co2', 'ppm'],
     'lastRain': ['Last Rain', ''],
-    'dewPoint': ['Dew Point', ['ºF', 'ºC']],
-    'feelsLike': ['Feels Like', ['ºF', 'ºC']],
+    'dewPoint': ['Dew Point', ['°F', '°C']],
+    'feelsLike': ['Feels Like', ['°F', '°C']],
 }
 
 _LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION
The previous symbol used for degrees was U+00BA, the "Masculine Ordinal Indicator". This patch changes the symbol to U+00B0, "Degree Sign", to match the rest of the Home Assistant system.

## Description:


**Related issue (if applicable):** N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):

N/A

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
