### PR TITLE
Add timeout option to sensor.rest and binary_sensor.rest.

### DIFF
--- a/homeassistant/components/binary_sensor/rest.py
+++ b/homeassistant/components/binary_sensor/rest.py
@@ -14,7 +14,7 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.components.sensor.rest import RestData
 from homeassistant.const import (
     CONF_PAYLOAD, CONF_NAME, CONF_VALUE_TEMPLATE, CONF_METHOD, CONF_RESOURCE,
-    CONF_VERIFY_SSL, CONF_USERNAME, CONF_PASSWORD,
+    CONF_VERIFY_SSL, CONF_USERNAME, CONF_PASSWORD, CONF_TIMEOUT,
     CONF_HEADERS, CONF_AUTHENTICATION, HTTP_BASIC_AUTHENTICATION,
     HTTP_DIGEST_AUTHENTICATION, CONF_DEVICE_CLASS)
 import homeassistant.helpers.config_validation as cv
@@ -25,6 +25,7 @@ _LOGGER = logging.getLogger(__name__)
 DEFAULT_METHOD = 'GET'
 DEFAULT_NAME = 'REST Binary Sensor'
 DEFAULT_VERIFY_SSL = True
+DEFAULT_TIMEOUT = 10
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_RESOURCE): cv.url,
@@ -39,6 +40,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_USERNAME): cv.string,
     vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
     vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): cv.boolean,
+    vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int,
 })
 
 
@@ -49,6 +51,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     method = config.get(CONF_METHOD)
     payload = config.get(CONF_PAYLOAD)
     verify_ssl = config.get(CONF_VERIFY_SSL)
+    timeout = config.get(CONF_TIMEOUT)
     username = config.get(CONF_USERNAME)
     password = config.get(CONF_PASSWORD)
     headers = config.get(CONF_HEADERS)
@@ -65,7 +68,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     else:
         auth = None
 
-    rest = RestData(method, resource, auth, headers, payload, verify_ssl)
+    rest = RestData(method, resource, auth, headers, payload, verify_ssl,
+                    timeout)
     rest.update()
     if rest.data is None:
         raise PlatformNotReady

--- a/tests/components/sensor/test_rest.py
+++ b/tests/components/sensor/test_rest.py
@@ -89,6 +89,7 @@ class TestRestSensorSetup(unittest.TestCase):
                     'name': 'foo',
                     'unit_of_measurement': 'MB',
                     'verify_ssl': 'true',
+                    'timeout': 30,
                     'authentication': 'basic',
                     'username': 'my username',
                     'password': 'my password',
@@ -112,6 +113,7 @@ class TestRestSensorSetup(unittest.TestCase):
                     'name': 'foo',
                     'unit_of_measurement': 'MB',
                     'verify_ssl': 'true',
+                    'timeout': 30,
                     'authentication': 'basic',
                     'username': 'my username',
                     'password': 'my password',
@@ -280,8 +282,10 @@ class TestRestData(unittest.TestCase):
         self.method = "GET"
         self.resource = "http://localhost"
         self.verify_ssl = True
+        self.timeout = 10
         self.rest = rest.RestData(
-            self.method, self.resource, None, None, None, self.verify_ssl)
+            self.method, self.resource, None, None, None, self.verify_ssl,
+            self.timeout)
 
     @requests_mock.Mocker()
     def test_update(self, mock_req):


### PR DESCRIPTION
## Description:

Adds user adjustable timeout for the REST sensor request. Defaults to 10 seconds 


**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8161

## Example entry for `configuration.yaml` (if applicable):
```yaml
  - platform: rest
    resource: http://example.com/status/
    value_template: '{{ value_json.status }}'
    timeout: 30
    name: status

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
