### PR TITLE
Times of The Day Binary Sensor

### DIFF
--- a/homeassistant/components/binary_sensor/tod.py
+++ b/homeassistant/components/binary_sensor/tod.py
@@ -7,18 +7,19 @@ https://home-assistant.io/components/binary_sensor.tod/
 """
 from datetime import datetime, timedelta
 import logging
+import pytz
 
 import voluptuous as vol
 
 from homeassistant.components.binary_sensor import (
-    ENTITY_ID_FORMAT, PLATFORM_SCHEMA)
+    BinarySensorDevice, ENTITY_ID_FORMAT, PLATFORM_SCHEMA)
 from homeassistant.const import (
-    ATTR_ENTITY_ID, ATTR_FRIENDLY_NAME, CONF_AFTER, CONF_BEFORE, CONF_SENSORS,
-    STATE_OFF, STATE_ON, SUN_EVENT_SUNRISE, SUN_EVENT_SUNSET)
+    ATTR_ENTITY_ID, ATTR_FRIENDLY_NAME, CONF_AFTER, CONF_BEFORE,
+    CONF_SENSORS, SUN_EVENT_SUNRISE, SUN_EVENT_SUNSET)
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.entity import Entity, async_generate_entity_id
-from homeassistant.helpers.event import async_track_point_in_time
+from homeassistant.helpers.entity import async_generate_entity_id
+from homeassistant.helpers.event import async_track_point_in_utc_time
 from homeassistant.helpers.sun import (
     get_astral_event_date, get_astral_event_next)
 from homeassistant.util import dt as dt_util
@@ -33,10 +34,10 @@ ATTR_NEXT_UPDATE = 'next_update'
 
 SENSOR_SCHEMA = vol.Schema({
     vol.Required(CONF_AFTER): vol.Any(cv.time, vol.All(
-        vol.Lower, vol.Any(cv.sun_event))),
+        vol.Lower, cv.sun_event)),
     vol.Optional(CONF_AFTER_OFFSET, default=timedelta(0)): cv.time_period,
     vol.Required(CONF_BEFORE): vol.Any(cv.time, vol.All(
-        vol.Lower, vol.Any(cv.sun_event))),
+        vol.Lower, cv.sun_event)),
     vol.Optional(CONF_BEFORE_OFFSET, default=timedelta(0)): cv.time_period,
     vol.Optional(ATTR_FRIENDLY_NAME): cv.string,
     vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
@@ -52,26 +53,21 @@ async def async_setup_platform(hass, config, async_add_entities,
     """Set up the ToD sensors."""
     if hass.config.time_zone is None:
         _LOGGER.error("Timezone is not set in Home Assistant configuration")
-        return False
+        return
 
     sensors = []
-    for device, device_config in config[CONF_SENSORS].items():
+    for name, device_config in config[CONF_SENSORS].items():
         after = device_config[CONF_AFTER]
         after_offset = device_config[CONF_AFTER_OFFSET]
         before = device_config[CONF_BEFORE]
         before_offset = device_config[CONF_BEFORE_OFFSET]
         sensors.append(
             TodSensor(
-                hass, device, after, after_offset, before, before_offset
+                hass, name, after, after_offset, before, before_offset
             )
         )
 
-    if not sensors:
-        _LOGGER.error("No sensors added")
-        return
-
     async_add_entities(sensors)
-    return
 
 
 def is_sun_event(event):
@@ -79,15 +75,14 @@ def is_sun_event(event):
     return event in (SUN_EVENT_SUNRISE, SUN_EVENT_SUNSET)
 
 
-class TodSensor(Entity):
+class TodSensor(BinarySensorDevice):
     """Time of the Day Sensor."""
 
-    def __init__(self, hass, sensor_name, after, after_offset,
+    def __init__(self, hass, name, after, after_offset,
                  before, before_offset):
         """Init the ToD Sensor..."""
-        self._name = sensor_name
-        self._state = None
         self.hass = hass
+        self._name = name
 
         self._time_before = None
         self._time_after = None
@@ -95,72 +90,18 @@ class TodSensor(Entity):
         self._before_offset = before_offset
         self._before = before
         self._after = after
-
-        self._sunrising = None
-        self._sunsetting = None
-        self._next_sunrising = None
-        self._next_sunsetting = None
+        self._next_update = None
 
         self.entity_id = async_generate_entity_id(
-            ENTITY_ID_FORMAT, 'tod_{}'.format(sensor_name), hass=hass)
+            ENTITY_ID_FORMAT, name, hass=hass)
+
         self._calculate_initial_boudary_time()
+        self._calculate_next_update()
 
-    def _calculate_initial_boudary_time(self):
-        """Calculate internal absolute time boudaries."""
-        today = self.current_datetime
-
-        if is_sun_event(self._after):
-            after_event_date = \
-                get_astral_event_date(
-                    self.hass, self._after, dt_util.as_utc(today)) or \
-                get_astral_event_next(
-                    self.hass, self._after, dt_util.as_utc(today))
-            if after_event_date:
-                self._time_after = dt_util.as_local(after_event_date)
-            else:
-                _LOGGER.error("After event date for %s unknown", self._after)
-        else:
-            self._time_after = datetime.combine(
-                today.date(), self._after, tzinfo=self.hass.config.time_zone)
-
-        if is_sun_event(self._before):
-            before_event_date = get_astral_event_next(
-                self.hass, self._before, dt_util.as_utc(self._time_after))
-            if before_event_date:
-                self._time_before = dt_util.as_local(before_event_date)
-            else:
-                _LOGGER.error("Before event date for %s unknown", self._before)
-        else:
-            self._time_before = datetime.combine(
-                today.date(), self._before, tzinfo=self.hass.config.time_zone)
-            if self._time_after > self._time_before:
-                self._time_before += timedelta(days=1)
-
-        self._time_after += self._after_offset
-        self._time_before += self._before_offset
-
-    def _turn_to_next_day(self):
-        """Turn to to the next day."""
-        if is_sun_event(self._after):
-            self._time_after = dt_util.as_local(get_astral_event_next(
-                self.hass, self._after, dt_util.as_utc(
-                    self._time_after - self._after_offset)))
-            self._time_after += self._after_offset
-        else:
-            # offset is already there
-            self._time_after += timedelta(days=1)
-
-        if is_sun_event(self._before):
-            self._time_before = dt_util.as_local(get_astral_event_next(
-                self.hass, self._before, dt_util.as_utc(
-                    self._time_before - self._before_offset)))
-            self._time_before += self._before_offset
-        else:
-            self._time_before += timedelta(days=1)
-
-    async def async_added_to_hass(self):
-        """Register callbacks."""
-        self.point_in_time_listener(dt_util.now())
+    @property
+    def should_poll(self):
+        """Sensor does not need to be polled."""
+        return False
 
     @property
     def name(self):
@@ -178,44 +119,132 @@ class TodSensor(Entity):
         return self._time_before
 
     @property
-    def state(self):
-        """Return the state of the sensor."""
+    def is_on(self):
+        """Return True is senso is on."""
         if self.after < self.before:
-            if self.after <= self.current_datetime < self.before:
-                return STATE_ON
-        return STATE_OFF
+            return self.after <= self.current_datetime < self.before
+        return False
 
     @property
     def current_datetime(self):
         """Return local current datetime according to hass configuration."""
-        return dt_util.now(self.hass.config.time_zone)
-
-    @property
-    def next_change(self):
-        """Datetime when the next change to the state is."""
-        now = self.current_datetime
-        if now < self.after:
-            return self.after
-        if now < self.before:
-            return self.before
-
-        self._turn_to_next_day()
-        return self.after
+        return dt_util.utcnow()
 
     @property
     def state_attributes(self):
         """Return the state attributes of the sun."""
         return {
-            CONF_AFTER: self.after.isoformat(),
-            CONF_BEFORE: self.before.isoformat(),
-            ATTR_NEXT_UPDATE: self.next_change.isoformat()
+            CONF_AFTER: self.after.astimezone(
+                self.hass.config.time_zone).isoformat(),
+            CONF_BEFORE: self.before.astimezone(
+                self.hass.config.time_zone).isoformat(),
+            ATTR_NEXT_UPDATE: self.next_update.astimezone(
+                self.hass.config.time_zone).isoformat(),
         }
+
+    def _calculate_initial_boudary_time(self):
+        """Calculate internal absolute time boudaries."""
+        nowutc = self.current_datetime
+        # if after value is a sun event instead of absolut time
+        if is_sun_event(self._after):
+            # calculate the today's event utc time or
+            # if not available take next
+            after_event_date = \
+                get_astral_event_date(
+                    self.hass, self._after, nowutc) or \
+                get_astral_event_next(
+                    self.hass, self._after, nowutc)
+        else:
+            # convert local time provided to UTC today
+            # datetime.combine(date, time, tzinfo) is not supported
+            # in python 3.5. The self._after is provided
+            # with hass configured TZ not system wide
+            after_event_date = datetime.combine(
+                nowutc, self._after.replace(
+                    tzinfo=self.hass.config.time_zone)).astimezone(tz=pytz.UTC)
+
+        self._time_after = after_event_date
+
+        # if before value is a sun event instead of absolut time
+        if is_sun_event(self._before):
+            # calculate the today's event utc time or
+            # if not available take next
+            before_event_date = \
+                get_astral_event_date(
+                    self.hass, self._before, nowutc) or \
+                get_astral_event_next(
+                    self.hass, self._before, nowutc)
+            # before is earler than after
+            if before_event_date < after_event_date:
+                # take next day for before
+                before_event_date = get_astral_event_next(
+                    self.hass, self._before, after_event_date)
+        else:
+            # convert local time provided to UTC today,
+            # datetime.combine(date, time, tzinfo) is not supported
+            # in python 3.5. The self._after is provided
+            # with hass configured TZ not system wide
+            before_event_date = datetime.combine(
+                nowutc, self._before.replace(
+                    tzinfo=self.hass.config.time_zone)).astimezone(tz=pytz.UTC)
+
+            # it is safe to add timedelta days=1 to UTC as there is no DST
+            if before_event_date < after_event_date + self._after_offset:
+                before_event_date += timedelta(days=1)
+
+        self._time_before = before_event_date
+
+        # add offset to utc boundries according to the configuration
+        self._time_after += self._after_offset
+        self._time_before += self._before_offset
+
+    def _turn_to_next_day(self):
+        """Turn to to the next day."""
+        if is_sun_event(self._after):
+            self._time_after = get_astral_event_next(
+                self.hass, self._after,
+                self._time_after - self._after_offset)
+            self._time_after += self._after_offset
+        else:
+            # offset is already there
+            self._time_after += timedelta(days=1)
+
+        if is_sun_event(self._before):
+            self._time_before = get_astral_event_next(
+                self.hass, self._before,
+                self._time_before - self._before_offset)
+            self._time_before += self._before_offset
+        else:
+            # offset is already there
+            self._time_before += timedelta(days=1)
+
+    async def async_added_to_hass(self):
+        """Register callbacks."""
+        self.point_in_time_listener(dt_util.now())
+
+    @property
+    def next_update(self):
+        """Return the next update point in the UTC time."""
+        return self._next_update
+
+    def _calculate_next_update(self):
+        """Datetime when the next update to the state."""
+        now = self.current_datetime
+        if now < self.after:
+            self._next_update = self.after
+            return
+        if now < self.before:
+            self._next_update = self.before
+            return
+        self._turn_to_next_day()
+        self._next_update = self.after
 
     @callback
     def point_in_time_listener(self, now):
-        """Run when the state of the sun has changed."""
+        """Run when the state of the sensor should be updated."""
+        self._calculate_next_update()
         self.async_schedule_update_ha_state()
 
-        async_track_point_in_time(
+        async_track_point_in_utc_time(
             self.hass, self.point_in_time_listener,
-            self.next_change)
+            self.next_update)

--- a/homeassistant/components/binary_sensor/tod.py
+++ b/homeassistant/components/binary_sensor/tod.py
@@ -68,10 +68,10 @@ async def async_setup_platform(hass, config, async_add_entities,
 
     if not sensors:
         _LOGGER.error("No sensors added")
-        return False
+        return
 
     async_add_entities(sensors)
-    return True
+    return
 
 
 def is_sun_event(event):
@@ -102,10 +102,8 @@ class TodSensor(Entity):
         self._next_sunsetting = None
 
         self.entity_id = async_generate_entity_id(
-            ENTITY_ID_FORMAT, f'tod_{sensor_name}', hass=hass)
+            ENTITY_ID_FORMAT, 'tod_{}'.format(sensor_name), hass=hass)
         self._calculate_initial_boudary_time()
-        _LOGGER.error(self._time_after.isoformat())
-        _LOGGER.error(self._time_before.isoformat())
 
     def _calculate_initial_boudary_time(self):
         """Calculate internal absolute time boudaries."""

--- a/homeassistant/components/binary_sensor/tod.py
+++ b/homeassistant/components/binary_sensor/tod.py
@@ -14,7 +14,7 @@ import voluptuous as vol
 from homeassistant.components.binary_sensor import (
     BinarySensorDevice, ENTITY_ID_FORMAT, PLATFORM_SCHEMA)
 from homeassistant.const import (
-    CONF_ENTITY_ID, CONF_FRIENDLY_NAME, CONF_AFTER, CONF_BEFORE,
+    CONF_FRIENDLY_NAME, CONF_AFTER, CONF_BEFORE,
     CONF_SENSORS, SUN_EVENT_SUNRISE, SUN_EVENT_SUNSET)
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
@@ -63,7 +63,8 @@ async def async_setup_platform(hass, config, async_add_entities,
         friendly_name = device_config.get(CONF_FRIENDLY_NAME, name)
         sensors.append(
             TodSensor(
-                hass, name, friendly_name, after, after_offset, before, before_offset
+                hass, name, friendly_name,
+                after, after_offset, before, before_offset
             )
         )
 

--- a/homeassistant/components/binary_sensor/tod.py
+++ b/homeassistant/components/binary_sensor/tod.py
@@ -3,23 +3,24 @@ Support for showing the binary sensors represending current time of the day.
 
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/binary_sensor.tod/
+
 """
+from datetime import datetime, timedelta
 import logging
-from datetime import timedelta, datetime,date
-import pytz
 
 import voluptuous as vol
 
-from homeassistant.helpers.entity import (Entity, async_generate_entity_id)
-from homeassistant.components.binary_sensor import PLATFORM_SCHEMA, ENTITY_ID_FORMAT
+from homeassistant.components.binary_sensor import (
+    ENTITY_ID_FORMAT, PLATFORM_SCHEMA)
+from homeassistant.const import (
+    ATTR_ENTITY_ID, ATTR_FRIENDLY_NAME, CONF_AFTER, CONF_BEFORE, CONF_SENSORS,
+    STATE_OFF, STATE_ON, SUN_EVENT_SUNRISE, SUN_EVENT_SUNSET)
 from homeassistant.core import callback
-from homeassistant.const import (CONF_SENSORS, CONF_AFTER, CONF_BEFORE, ATTR_FRIENDLY_NAME, 
-    ATTR_ENTITY_ID, SUN_EVENT_SUNRISE, SUN_EVENT_SUNSET)
-from homeassistant.helpers.event import (
-    async_track_point_in_utc_time, async_track_utc_time_change)
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import Entity, async_generate_entity_id
+from homeassistant.helpers.event import async_track_point_in_time
 from homeassistant.helpers.sun import (
-    get_astral_location, get_astral_event_date, get_astral_event_next)
+    get_astral_event_date, get_astral_event_next)
 from homeassistant.util import dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
@@ -27,20 +28,18 @@ _LOGGER = logging.getLogger(__name__)
 CONF_AFTER_OFFSET = 'after_offset'
 CONF_BEFORE_OFFSET = 'before_offset'
 
+ATTR_NEXT_UPDATE = 'next_update'
 
-utc = pytz.UTC
 
 SENSOR_SCHEMA = vol.Schema({
-    vol.Required(CONF_AFTER): vol.Any(cv.time, vol.All(vol.Lower, vol.Any(cv.sun_event))),
-    vol.Optional(CONF_AFTER_OFFSET, default=timedelta()): cv.time_period,
-    vol.Required(CONF_BEFORE): vol.Any(cv.time, vol.All(vol.Lower, vol.Any(cv.sun_event))),
-    vol.Optional(CONF_BEFORE_OFFSET, default=timedelta()): cv.time_period,
+    vol.Required(CONF_AFTER): vol.Any(cv.time, vol.All(
+        vol.Lower, vol.Any(cv.sun_event))),
+    vol.Optional(CONF_AFTER_OFFSET, default=timedelta(0)): cv.time_period,
+    vol.Required(CONF_BEFORE): vol.Any(cv.time, vol.All(
+        vol.Lower, vol.Any(cv.sun_event))),
+    vol.Optional(CONF_BEFORE_OFFSET, default=timedelta(0)): cv.time_period,
     vol.Optional(ATTR_FRIENDLY_NAME): cv.string,
     vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
-    # vol.Optional(CONF_DELAY_ON):
-    #     vol.All(cv.time_period, cv.positive_timedelta),
-    # vol.Optional(CONF_DELAY_OFF):
-    #     vol.All(cv.time_period, cv.positive_timedelta),
 })
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -55,12 +54,15 @@ async def async_setup_platform(hass, config, async_add_entities,
         _LOGGER.error("Timezone is not set in Home Assistant configuration")
         return False
 
-    _LOGGER.error("Config: %s", config)
     sensors = []
     for device, device_config in config[CONF_SENSORS].items():
+        after = device_config[CONF_AFTER]
+        after_offset = device_config[CONF_AFTER_OFFSET]
+        before = device_config[CONF_BEFORE]
+        before_offset = device_config[CONF_BEFORE_OFFSET]
         sensors.append(
             TodSensor(
-                hass, device, device_config
+                hass, device, after, after_offset, before, before_offset
             )
         )
 
@@ -72,55 +74,95 @@ async def async_setup_platform(hass, config, async_add_entities,
     return True
 
 
+def is_sun_event(event):
+    """Return true if event is sun event not time."""
+    return event in (SUN_EVENT_SUNRISE, SUN_EVENT_SUNSET)
+
+
 class TodSensor(Entity):
     """Time of the Day Sensor."""
-    def __init__(self, hass, sensor_name, config):
+
+    def __init__(self, hass, sensor_name, after, after_offset,
+                 before, before_offset):
+        """Init the ToD Sensor..."""
         self._name = sensor_name
-        self._state = False
+        self._state = None
         self.hass = hass
-        self._config = config
+
+        self._time_before = None
+        self._time_after = None
+        self._after_offset = after_offset
+        self._before_offset = before_offset
+        self._before = before
+        self._after = after
+
         self._sunrising = None
         self._sunsetting = None
         self._next_sunrising = None
         self._next_sunsetting = None
-        
+
         self.entity_id = async_generate_entity_id(
             ENTITY_ID_FORMAT, f'tod_{sensor_name}', hass=hass)
-        after = self._config[CONF_AFTER]
-        before = self._config[CONF_BEFORE]
-        after_offset = self._config[CONF_AFTER_OFFSET]
-        before_offset = self._config[CONF_BEFORE_OFFSET]
-        
-        if after in [SUN_EVENT_SUNRISE, SUN_EVENT_SUNSET]:
-            self._after = get_astral_event_date(
-                self.hass, after, dt_util.utcnow())
-        else:
-            self._after = dt_util.as_utc(datetime.combine(datetime.now(), self._config[CONF_AFTER]))
-        
-        self._after += after_offset
+        self._calculate_initial_boudary_time()
+        _LOGGER.error(self._time_after.isoformat())
+        _LOGGER.error(self._time_before.isoformat())
 
-        if before in [SUN_EVENT_SUNRISE, SUN_EVENT_SUNSET]:
-            self._before = get_astral_event_date(
-                self.hass, before, dt_util.utcnow())
-            self._before += before_offset
-            if self._after > self.before:
-               self._before = get_astral_event_date(
-                self.hass, before, dt_util.utcnow() + timedelta(days=1))
-        else:
-            self._before = dt_util.as_utc(datetime.combine(datetime.now(), self._config[CONF_BEFORE]))
-            self._before += before_offset
-            if self.after > self.before:
-                self._before += timedelta(days=1)
+    def _calculate_initial_boudary_time(self):
+        """Calculate internal absolute time boudaries."""
+        today = self.current_datetime
 
-        
+        if is_sun_event(self._after):
+            after_event_date = \
+                get_astral_event_date(
+                    self.hass, self._after, dt_util.as_utc(today)) or \
+                get_astral_event_next(
+                    self.hass, self._after, dt_util.as_utc(today))
+            if after_event_date:
+                self._time_after = dt_util.as_local(after_event_date)
+            else:
+                _LOGGER.error("After event date for %s unknown", self._after)
+        else:
+            self._time_after = datetime.combine(
+                today.date(), self._after, tzinfo=self.hass.config.time_zone)
+
+        if is_sun_event(self._before):
+            before_event_date = get_astral_event_next(
+                self.hass, self._before, dt_util.as_utc(self._time_after))
+            if before_event_date:
+                self._time_before = dt_util.as_local(before_event_date)
+            else:
+                _LOGGER.error("Before event date for %s unknown", self._before)
+        else:
+            self._time_before = datetime.combine(
+                today.date(), self._before, tzinfo=self.hass.config.time_zone)
+            if self._time_after > self._time_before:
+                self._time_before += timedelta(days=1)
+
+        self._time_after += self._after_offset
+        self._time_before += self._before_offset
+
+    def _turn_to_next_day(self):
+        """Turn to to the next day."""
+        if is_sun_event(self._after):
+            self._time_after = dt_util.as_local(get_astral_event_next(
+                self.hass, self._after, dt_util.as_utc(
+                    self._time_after - self._after_offset)))
+            self._time_after += self._after_offset
+        else:
+            # offset is already there
+            self._time_after += timedelta(days=1)
+
+        if is_sun_event(self._before):
+            self._time_before = dt_util.as_local(get_astral_event_next(
+                self.hass, self._before, dt_util.as_utc(
+                    self._time_before - self._before_offset)))
+            self._time_before += self._before_offset
+        else:
+            self._time_before += timedelta(days=1)
+
     async def async_added_to_hass(self):
         """Register callbacks."""
-        self.point_in_time_listener(dt_util.utcnow())
-    
-    # @property
-    # def unique_id(self) -> str:
-    #     """Return a unique ID."""
-    #     return None
+        self.point_in_time_listener(dt_util.now())
 
     @property
     def name(self):
@@ -129,56 +171,53 @@ class TodSensor(Entity):
 
     @property
     def after(self):
-        """Return the timestamp for the begining of the period"""
-        return self._after
+        """Return the timestamp for the begining of the period."""
+        return self._time_after
 
     @property
     def before(self):
-        """Return the timestamp for the end of the period"""
-        return self._before
+        """Return the timestamp for the end of the period."""
+        return self._time_before
 
     @property
     def state(self):
         """Return the state of the sensor."""
-        return self.after < dt_util.as_utc(datetime.now()) < self.before
-        
+        if self.after < self.before:
+            if self.after <= self.current_datetime < self.before:
+                return STATE_ON
+        return STATE_OFF
+
+    @property
+    def current_datetime(self):
+        """Return local current datetime according to hass configuration."""
+        return dt_util.now(self.hass.config.time_zone)
+
     @property
     def next_change(self):
-        return dt_util.utcnow()
-    
+        """Datetime when the next change to the state is."""
+        now = self.current_datetime
+        if now < self.after:
+            return self.after
+        if now < self.before:
+            return self.before
+
+        self._turn_to_next_day()
+        return self.after
+
     @property
     def state_attributes(self):
         """Return the state attributes of the sun."""
         return {
             CONF_AFTER: self.after.isoformat(),
             CONF_BEFORE: self.before.isoformat(),
-            'sunrise': self._sunrising.isoformat(),
-            'sunset': self._sunsetting.isoformat(),
-            'next_sunrise': self._next_sunrising.isoformat(),
-            'next_sunsetting': self._next_sunsetting.isoformat(),
-            'NOW': dt_util.as_utc(datetime.now()).isoformat()
+            ATTR_NEXT_UPDATE: self.next_change.isoformat()
         }
 
-
-    @callback
-    def update_as_of(self, utc_point_in_time):
-        """Update the sun events."""
-        self._sunrising = get_astral_event_date(
-            self.hass, SUN_EVENT_SUNRISE, utc_point_in_time)
-        self._sunsetting = get_astral_event_date(
-            self.hass, SUN_EVENT_SUNSET, utc_point_in_time)
-        self._next_sunrising = get_astral_event_next(
-            self.hass, SUN_EVENT_SUNRISE, utc_point_in_time)
-        self._next_sunsetting = get_astral_event_next(
-            self.hass, SUN_EVENT_SUNSET, utc_point_in_time)
-    
     @callback
     def point_in_time_listener(self, now):
         """Run when the state of the sun has changed."""
-        self.update_as_of(now)
         self.async_schedule_update_ha_state()
 
-        # Schedule next update at next_change+1 second so sun state has changed
-        async_track_point_in_utc_time(
+        async_track_point_in_time(
             self.hass, self.point_in_time_listener,
-            self.next_change + timedelta(seconds=1))
+            self.next_change)

--- a/homeassistant/components/binary_sensor/tod.py
+++ b/homeassistant/components/binary_sensor/tod.py
@@ -1,0 +1,184 @@
+"""
+Support for showing the binary sensors represending current time of the day.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/binary_sensor.tod/
+"""
+import logging
+from datetime import timedelta, datetime,date
+import pytz
+
+import voluptuous as vol
+
+from homeassistant.helpers.entity import (Entity, async_generate_entity_id)
+from homeassistant.components.binary_sensor import PLATFORM_SCHEMA, ENTITY_ID_FORMAT
+from homeassistant.core import callback
+from homeassistant.const import (CONF_SENSORS, CONF_AFTER, CONF_BEFORE, ATTR_FRIENDLY_NAME, 
+    ATTR_ENTITY_ID, SUN_EVENT_SUNRISE, SUN_EVENT_SUNSET)
+from homeassistant.helpers.event import (
+    async_track_point_in_utc_time, async_track_utc_time_change)
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.sun import (
+    get_astral_location, get_astral_event_date, get_astral_event_next)
+from homeassistant.util import dt as dt_util
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_AFTER_OFFSET = 'after_offset'
+CONF_BEFORE_OFFSET = 'before_offset'
+
+
+utc = pytz.UTC
+
+SENSOR_SCHEMA = vol.Schema({
+    vol.Required(CONF_AFTER): vol.Any(cv.time, vol.All(vol.Lower, vol.Any(cv.sun_event))),
+    vol.Optional(CONF_AFTER_OFFSET, default=timedelta()): cv.time_period,
+    vol.Required(CONF_BEFORE): vol.Any(cv.time, vol.All(vol.Lower, vol.Any(cv.sun_event))),
+    vol.Optional(CONF_BEFORE_OFFSET, default=timedelta()): cv.time_period,
+    vol.Optional(ATTR_FRIENDLY_NAME): cv.string,
+    vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
+    # vol.Optional(CONF_DELAY_ON):
+    #     vol.All(cv.time_period, cv.positive_timedelta),
+    # vol.Optional(CONF_DELAY_OFF):
+    #     vol.All(cv.time_period, cv.positive_timedelta),
+})
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_SENSORS): vol.Schema({cv.slug: SENSOR_SCHEMA}),
+})
+
+
+async def async_setup_platform(hass, config, async_add_entities,
+                               discovery_info=None):
+    """Set up the ToD sensors."""
+    if hass.config.time_zone is None:
+        _LOGGER.error("Timezone is not set in Home Assistant configuration")
+        return False
+
+    _LOGGER.error("Config: %s", config)
+    sensors = []
+    for device, device_config in config[CONF_SENSORS].items():
+        sensors.append(
+            TodSensor(
+                hass, device, device_config
+            )
+        )
+
+    if not sensors:
+        _LOGGER.error("No sensors added")
+        return False
+
+    async_add_entities(sensors)
+    return True
+
+
+class TodSensor(Entity):
+    """Time of the Day Sensor."""
+    def __init__(self, hass, sensor_name, config):
+        self._name = sensor_name
+        self._state = False
+        self.hass = hass
+        self._config = config
+        self._sunrising = None
+        self._sunsetting = None
+        self._next_sunrising = None
+        self._next_sunsetting = None
+        
+        self.entity_id = async_generate_entity_id(
+            ENTITY_ID_FORMAT, f'tod_{sensor_name}', hass=hass)
+        after = self._config[CONF_AFTER]
+        before = self._config[CONF_BEFORE]
+        after_offset = self._config[CONF_AFTER_OFFSET]
+        before_offset = self._config[CONF_BEFORE_OFFSET]
+        
+        if after in [SUN_EVENT_SUNRISE, SUN_EVENT_SUNSET]:
+            self._after = get_astral_event_date(
+                self.hass, after, dt_util.utcnow())
+        else:
+            self._after = dt_util.as_utc(datetime.combine(datetime.now(), self._config[CONF_AFTER]))
+        
+        self._after += after_offset
+
+        if before in [SUN_EVENT_SUNRISE, SUN_EVENT_SUNSET]:
+            self._before = get_astral_event_date(
+                self.hass, before, dt_util.utcnow())
+            self._before += before_offset
+            if self._after > self.before:
+               self._before = get_astral_event_date(
+                self.hass, before, dt_util.utcnow() + timedelta(days=1))
+        else:
+            self._before = dt_util.as_utc(datetime.combine(datetime.now(), self._config[CONF_BEFORE]))
+            self._before += before_offset
+            if self.after > self.before:
+                self._before += timedelta(days=1)
+
+        
+    async def async_added_to_hass(self):
+        """Register callbacks."""
+        self.point_in_time_listener(dt_util.utcnow())
+    
+    # @property
+    # def unique_id(self) -> str:
+    #     """Return a unique ID."""
+    #     return None
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def after(self):
+        """Return the timestamp for the begining of the period"""
+        return self._after
+
+    @property
+    def before(self):
+        """Return the timestamp for the end of the period"""
+        return self._before
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self.after < dt_util.as_utc(datetime.now()) < self.before
+        
+    @property
+    def next_change(self):
+        return dt_util.utcnow()
+    
+    @property
+    def state_attributes(self):
+        """Return the state attributes of the sun."""
+        return {
+            CONF_AFTER: self.after.isoformat(),
+            CONF_BEFORE: self.before.isoformat(),
+            'sunrise': self._sunrising.isoformat(),
+            'sunset': self._sunsetting.isoformat(),
+            'next_sunrise': self._next_sunrising.isoformat(),
+            'next_sunsetting': self._next_sunsetting.isoformat(),
+            'NOW': dt_util.as_utc(datetime.now()).isoformat()
+        }
+
+
+    @callback
+    def update_as_of(self, utc_point_in_time):
+        """Update the sun events."""
+        self._sunrising = get_astral_event_date(
+            self.hass, SUN_EVENT_SUNRISE, utc_point_in_time)
+        self._sunsetting = get_astral_event_date(
+            self.hass, SUN_EVENT_SUNSET, utc_point_in_time)
+        self._next_sunrising = get_astral_event_next(
+            self.hass, SUN_EVENT_SUNRISE, utc_point_in_time)
+        self._next_sunsetting = get_astral_event_next(
+            self.hass, SUN_EVENT_SUNSET, utc_point_in_time)
+    
+    @callback
+    def point_in_time_listener(self, now):
+        """Run when the state of the sun has changed."""
+        self.update_as_of(now)
+        self.async_schedule_update_ha_state()
+
+        # Schedule next update at next_change+1 second so sun state has changed
+        async_track_point_in_utc_time(
+            self.hass, self.point_in_time_listener,
+            self.next_change + timedelta(seconds=1))

--- a/homeassistant/components/binary_sensor/tod.py
+++ b/homeassistant/components/binary_sensor/tod.py
@@ -130,7 +130,7 @@ class TodSensor(BinarySensorDevice):
                 get_astral_event_date(self.hass, self._after, nowutc) or \
                 get_astral_event_next(self.hass, self._after, nowutc)
         else:
-            # Convert local time provided to UTC today 
+            # Convert local time provided to UTC today
             # datetime.combine(date, time, tzinfo) is not supported
             # in python 3.5. The self._after is provided
             # with hass configured TZ not system wide

--- a/homeassistant/components/binary_sensor/tod.py
+++ b/homeassistant/components/binary_sensor/tod.py
@@ -7,15 +7,14 @@ https://home-assistant.io/components/binary_sensor.tod/
 """
 from datetime import datetime, timedelta
 import logging
-import pytz
 
+import pytz
 import voluptuous as vol
 
 from homeassistant.components.binary_sensor import (
-    BinarySensorDevice, PLATFORM_SCHEMA)
+    PLATFORM_SCHEMA, BinarySensorDevice)
 from homeassistant.const import (
-    CONF_NAME, CONF_AFTER, CONF_BEFORE,
-    SUN_EVENT_SUNRISE, SUN_EVENT_SUNSET)
+    CONF_AFTER, CONF_BEFORE, CONF_NAME, SUN_EVENT_SUNRISE, SUN_EVENT_SUNSET)
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import async_track_point_in_utc_time
@@ -25,24 +24,21 @@ from homeassistant.util import dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
 
+ATTR_BEFORE = "before"
+ATTR_AFTER = "after"
+ATTR_NEXT_UPDATE = 'next_update'
+
 CONF_AFTER_OFFSET = 'after_offset'
 CONF_BEFORE_OFFSET = 'before_offset'
 
-ATTR_NEXT_UPDATE = 'next_update'
-
-
-SENSOR_SCHEMA = vol.Schema({
-
-})
-
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_NAME): cv.string,
     vol.Required(CONF_AFTER): vol.Any(cv.time, vol.All(
         vol.Lower, cv.sun_event)),
     vol.Optional(CONF_AFTER_OFFSET, default=timedelta(0)): cv.time_period,
     vol.Required(CONF_BEFORE): vol.Any(cv.time, vol.All(
         vol.Lower, cv.sun_event)),
-    vol.Optional(CONF_BEFORE_OFFSET, default=timedelta(0)): cv.time_period,
-    vol.Required(CONF_NAME): cv.string
+    vol.Optional(CONF_BEFORE_OFFSET, default=timedelta(0)): cv.time_period
 })
 
 
@@ -101,7 +97,7 @@ class TodSensor(BinarySensorDevice):
 
     @property
     def is_on(self):
-        """Return True is senso is on."""
+        """Return True is sensor is on."""
         if self.after < self.before:
             return self.after <= self.current_datetime < self.before
         return False
@@ -117,12 +113,12 @@ class TodSensor(BinarySensorDevice):
         return self._next_update
 
     @property
-    def state_attributes(self):
-        """Return the state attributes of the sun."""
+    def device_state_attributes(self):
+        """Return the state attributes of the sensor."""
         return {
-            CONF_AFTER: self.after.astimezone(
+            ATTR_AFTER: self.after.astimezone(
                 self.hass.config.time_zone).isoformat(),
-            CONF_BEFORE: self.before.astimezone(
+            ATTR_BEFORE: self.before.astimezone(
                 self.hass.config.time_zone).isoformat(),
             ATTR_NEXT_UPDATE: self.next_update.astimezone(
                 self.hass.config.time_zone).isoformat(),

--- a/tests/components/binary_sensor/test_tod.py
+++ b/tests/components/binary_sensor/test_tod.py
@@ -1,0 +1,23 @@
+"""Test Times of the Day Binary Sensor."""
+import unittest
+from unittest import mock
+
+from tests.common import (
+    get_test_home_assistant, assert_setup_component, async_fire_time_changed)
+
+class TestBinarySensorTod(unittest.TestCase):
+    """Test for Binary sensor tod platform."""
+
+    hass = None
+    # pylint: disable=invalid-name
+
+    def setup_method(self, method):
+        """Set up things to be run when tests are started."""
+        self.hass = get_test_home_assistant()
+
+    def teardown_method(self, method):
+        """Stop everything that was started."""
+        self.hass.stop()
+    
+    def test_setup(self):
+        return True

--- a/tests/components/binary_sensor/test_tod.py
+++ b/tests/components/binary_sensor/test_tod.py
@@ -2,6 +2,7 @@
 import unittest
 from unittest.mock import patch
 from datetime import timedelta, datetime
+import pytz
 
 from homeassistant import setup
 import homeassistant.core as ha
@@ -80,12 +81,12 @@ class TestBinarySensorTod(unittest.TestCase):
                 },
             },
         }
-        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.utcnow',
                    return_value=test_time):
             setup_component(self.hass, 'binary_sensor', config)
 
         self.hass.block_till_done()
-        state = self.hass.states.get('binary_sensor.tod_evening')
+        state = self.hass.states.get('binary_sensor.evening')
         assert state.state == STATE_ON
 
     def test_midnight_turnover_before_midnight_inside_period(self):
@@ -104,12 +105,12 @@ class TestBinarySensorTod(unittest.TestCase):
                 },
             },
         }
-        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.utcnow',
                    return_value=test_time):
             setup_component(self.hass, 'binary_sensor', config)
 
         self.hass.block_till_done()
-        state = self.hass.states.get('binary_sensor.tod_night')
+        state = self.hass.states.get('binary_sensor.night')
         assert state.state == STATE_ON
 
     def test_midnight_turnover_after_midnight_inside_period(self):
@@ -128,23 +129,23 @@ class TestBinarySensorTod(unittest.TestCase):
                 },
             },
         }
-        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.utcnow',
                    return_value=test_time):
             setup_component(self.hass, 'binary_sensor', config)
 
-            state = self.hass.states.get('binary_sensor.tod_night')
+            state = self.hass.states.get('binary_sensor.night')
             assert state.state == STATE_OFF
 
             self.hass.block_till_done()
 
-        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
-                   return_value=test_time + timedelta(hours=4)):
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.utcnow',
+                   return_value=test_time + timedelta(hours=1)):
 
             self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
-                ha.ATTR_NOW: test_time + timedelta(hours=4)})
+                ha.ATTR_NOW: test_time + timedelta(hours=1)})
 
             self.hass.block_till_done()
-            state = self.hass.states.get('binary_sensor.tod_night')
+            state = self.hass.states.get('binary_sensor.night')
             assert state.state == STATE_ON
 
     def test_midnight_turnover_before_midnight_outside_period(self):
@@ -163,12 +164,12 @@ class TestBinarySensorTod(unittest.TestCase):
                 },
             },
         }
-        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.utcnow',
                    return_value=test_time):
             setup_component(self.hass, 'binary_sensor', config)
 
         self.hass.block_till_done()
-        state = self.hass.states.get('binary_sensor.tod_night')
+        state = self.hass.states.get('binary_sensor.night')
         assert state.state == STATE_OFF
 
     def test_midnight_turnover_after_midnight_outside_period(self):
@@ -187,26 +188,26 @@ class TestBinarySensorTod(unittest.TestCase):
                 },
             },
         }
-        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.utcnow',
                    return_value=test_time):
             setup_component(self.hass, 'binary_sensor', config)
 
         self.hass.block_till_done()
-        state = self.hass.states.get('binary_sensor.tod_night')
+        state = self.hass.states.get('binary_sensor.night')
         assert state.state == STATE_OFF
 
         switchover_time = datetime(
             2019, 1, 11, 4, 59, 0, tzinfo=self.hass.config.time_zone)
-        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.utcnow',
                    return_value=switchover_time):
 
             self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
                 ha.ATTR_NOW: switchover_time})
             self.hass.block_till_done()
-            state = self.hass.states.get('binary_sensor.tod_night')
+            state = self.hass.states.get('binary_sensor.night')
             assert state.state == STATE_ON
 
-        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.utcnow',
                    return_value=switchover_time + timedelta(
                        minutes=1, seconds=1)):
 
@@ -215,7 +216,7 @@ class TestBinarySensorTod(unittest.TestCase):
                     minutes=1, seconds=1)})
 
             self.hass.block_till_done()
-            state = self.hass.states.get('binary_sensor.tod_night')
+            state = self.hass.states.get('binary_sensor.night')
             assert state.state == STATE_OFF
 
     def test_from_sunrise_to_sunset(self):
@@ -238,9 +239,9 @@ class TestBinarySensorTod(unittest.TestCase):
                 },
             },
         }
-        entity_id = 'binary_sensor.tod_day'
+        entity_id = 'binary_sensor.day'
         testtime = sunrise + timedelta(seconds=-1)
-        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.utcnow',
                    return_value=testtime):
             setup_component(self.hass, 'binary_sensor', config)
 
@@ -249,7 +250,7 @@ class TestBinarySensorTod(unittest.TestCase):
             assert state.state == STATE_OFF
 
         testtime = sunrise
-        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.utcnow',
                    return_value=testtime):
 
             self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
@@ -260,7 +261,7 @@ class TestBinarySensorTod(unittest.TestCase):
             assert state.state == STATE_ON
 
         testtime = sunrise + timedelta(seconds=1)
-        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.utcnow',
                    return_value=testtime):
 
             self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
@@ -273,7 +274,7 @@ class TestBinarySensorTod(unittest.TestCase):
         self.hass.block_till_done()
 
         testtime = sunset + timedelta(seconds=-1)
-        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.utcnow',
                    return_value=testtime):
 
             self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
@@ -286,7 +287,7 @@ class TestBinarySensorTod(unittest.TestCase):
         self.hass.block_till_done()
 
         testtime = sunset
-        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.utcnow',
                    return_value=testtime):
 
             self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
@@ -299,7 +300,7 @@ class TestBinarySensorTod(unittest.TestCase):
         self.hass.block_till_done()
 
         testtime = sunset + timedelta(seconds=1)
-        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.utcnow',
                    return_value=testtime):
 
             self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
@@ -330,9 +331,9 @@ class TestBinarySensorTod(unittest.TestCase):
                 },
             },
         }
-        entity_id = 'binary_sensor.tod_night'
+        entity_id = 'binary_sensor.night'
         testtime = sunset + timedelta(minutes=-1)
-        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.utcnow',
                    return_value=testtime):
             setup_component(self.hass, 'binary_sensor', config)
 
@@ -341,7 +342,7 @@ class TestBinarySensorTod(unittest.TestCase):
             assert state.state == STATE_OFF
 
         testtime = sunset
-        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.utcnow',
                    return_value=testtime):
 
             self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
@@ -352,7 +353,7 @@ class TestBinarySensorTod(unittest.TestCase):
             assert state.state == STATE_ON
 
         testtime = sunset + timedelta(minutes=1)
-        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.utcnow',
                    return_value=testtime):
 
             self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
@@ -363,7 +364,7 @@ class TestBinarySensorTod(unittest.TestCase):
             assert state.state == STATE_ON
 
         testtime = sunrise + timedelta(minutes=-1)
-        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.utcnow',
                    return_value=testtime):
 
             self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
@@ -374,7 +375,7 @@ class TestBinarySensorTod(unittest.TestCase):
             assert state.state == STATE_ON
 
         testtime = sunrise
-        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.utcnow',
                    return_value=testtime):
 
             self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
@@ -387,7 +388,7 @@ class TestBinarySensorTod(unittest.TestCase):
             assert state.state == STATE_OFF
 
         testtime = sunrise + timedelta(minutes=1)
-        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.utcnow',
                    return_value=testtime):
 
             self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
@@ -407,7 +408,7 @@ class TestBinarySensorTod(unittest.TestCase):
             2019, 1, 10, 22, 0, 0,
             tzinfo=self.hass.config.time_zone) + \
             timedelta(hours=1, minutes=45)
-        entity_id = 'binary_sensor.tod_evening'
+        entity_id = 'binary_sensor.evening'
         config = {
             'binary_sensor': {
                 'platform': 'tod',
@@ -423,7 +424,7 @@ class TestBinarySensorTod(unittest.TestCase):
             },
         }
         testtime = after + timedelta(seconds=-1)
-        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.utcnow',
                    return_value=testtime):
             setup_component(self.hass, 'binary_sensor', config)
 
@@ -432,7 +433,7 @@ class TestBinarySensorTod(unittest.TestCase):
         assert state.state == STATE_OFF
 
         testtime = after
-        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.utcnow',
                    return_value=testtime):
             self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
                 ha.ATTR_NOW: testtime})
@@ -442,7 +443,7 @@ class TestBinarySensorTod(unittest.TestCase):
             assert state.state == STATE_ON
 
         testtime = before + timedelta(seconds=-1)
-        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.utcnow',
                    return_value=testtime):
             self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
                 ha.ATTR_NOW: testtime})
@@ -452,7 +453,7 @@ class TestBinarySensorTod(unittest.TestCase):
             assert state.state == STATE_ON
 
         testtime = before
-        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.utcnow',
                    return_value=testtime):
             self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
                 ha.ATTR_NOW: testtime})
@@ -462,7 +463,7 @@ class TestBinarySensorTod(unittest.TestCase):
             assert state.state == STATE_OFF
 
         testtime = before + timedelta(seconds=1)
-        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.utcnow',
                    return_value=testtime):
             self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
                 ha.ATTR_NOW: testtime})
@@ -477,7 +478,7 @@ class TestBinarySensorTod(unittest.TestCase):
             2019, 1, 10, 18, 0, 0,
             tzinfo=self.hass.config.time_zone) + \
             timedelta(hours=1, minutes=34)
-        entity_id = 'binary_sensor.tod_evening'
+        entity_id = 'binary_sensor.evening'
         config = {
             'binary_sensor': {
                 'platform': 'tod',
@@ -493,7 +494,7 @@ class TestBinarySensorTod(unittest.TestCase):
             },
         }
         testtime = after + timedelta(seconds=-1)
-        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.utcnow',
                    return_value=testtime):
             setup_component(self.hass, 'binary_sensor', config)
 
@@ -502,7 +503,7 @@ class TestBinarySensorTod(unittest.TestCase):
         assert state.state == STATE_OFF
 
         testtime = after
-        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.utcnow',
                    return_value=testtime):
             self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
                 ha.ATTR_NOW: testtime})
@@ -533,9 +534,9 @@ class TestBinarySensorTod(unittest.TestCase):
                 },
             },
         }
-        entity_id = 'binary_sensor.tod_day'
+        entity_id = 'binary_sensor.day'
         testtime = test_time
-        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.utcnow',
                    return_value=testtime):
             setup_component(self.hass, 'binary_sensor', config)
 
@@ -544,7 +545,7 @@ class TestBinarySensorTod(unittest.TestCase):
             assert state.state == STATE_OFF
 
         testtime = sunrise + timedelta(seconds=-1)
-        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.utcnow',
                    return_value=testtime):
 
             self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
@@ -555,7 +556,7 @@ class TestBinarySensorTod(unittest.TestCase):
             assert state.state == STATE_OFF
 
         testtime = sunrise
-        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.utcnow',
                    return_value=testtime):
 
             self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
@@ -566,7 +567,7 @@ class TestBinarySensorTod(unittest.TestCase):
             assert state.state == STATE_ON
 
         testtime = sunrise + timedelta(seconds=1)
-        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.utcnow',
                    return_value=testtime):
 
             self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
@@ -579,7 +580,7 @@ class TestBinarySensorTod(unittest.TestCase):
         self.hass.block_till_done()
 
         testtime = sunset + timedelta(seconds=-1)
-        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.utcnow',
                    return_value=testtime):
 
             self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
@@ -592,7 +593,7 @@ class TestBinarySensorTod(unittest.TestCase):
         self.hass.block_till_done()
 
         testtime = sunset
-        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.utcnow',
                    return_value=testtime):
 
             self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
@@ -605,7 +606,7 @@ class TestBinarySensorTod(unittest.TestCase):
         self.hass.block_till_done()
 
         testtime = sunset + timedelta(seconds=1)
-        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.utcnow',
                    return_value=testtime):
 
             self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
@@ -639,9 +640,9 @@ class TestBinarySensorTod(unittest.TestCase):
                 },
             },
         }
-        entity_id = 'binary_sensor.tod_day'
+        entity_id = 'binary_sensor.day'
         testtime = test_time
-        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.utcnow',
                    return_value=testtime):
             setup_component(self.hass, 'binary_sensor', config)
 
@@ -650,7 +651,7 @@ class TestBinarySensorTod(unittest.TestCase):
             assert state.state == STATE_OFF
 
         testtime = sunrise + timedelta(seconds=-1)
-        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.utcnow',
                    return_value=testtime):
 
             self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
@@ -661,7 +662,7 @@ class TestBinarySensorTod(unittest.TestCase):
             assert state.state == STATE_OFF
 
         testtime = sunrise
-        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.utcnow',
                    return_value=testtime):
 
             self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
@@ -672,7 +673,7 @@ class TestBinarySensorTod(unittest.TestCase):
             assert state.state == STATE_ON
 
         testtime = sunrise + timedelta(seconds=1)
-        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.utcnow',
                    return_value=testtime):
 
             self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
@@ -685,7 +686,7 @@ class TestBinarySensorTod(unittest.TestCase):
         self.hass.block_till_done()
 
         testtime = sunset + timedelta(seconds=-1)
-        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.utcnow',
                    return_value=testtime):
 
             self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
@@ -698,7 +699,7 @@ class TestBinarySensorTod(unittest.TestCase):
         self.hass.block_till_done()
 
         testtime = sunset
-        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.utcnow',
                    return_value=testtime):
 
             self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
@@ -711,7 +712,7 @@ class TestBinarySensorTod(unittest.TestCase):
         self.hass.block_till_done()
 
         testtime = sunset + timedelta(seconds=1)
-        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.utcnow',
                    return_value=testtime):
 
             self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
@@ -745,9 +746,9 @@ class TestBinarySensorTod(unittest.TestCase):
                 },
             },
         }
-        entity_id = 'binary_sensor.tod_day'
+        entity_id = 'binary_sensor.day'
         testtime = sunrise + timedelta(seconds=-1)
-        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.utcnow',
                    return_value=testtime):
             setup_component(self.hass, 'binary_sensor', config)
 
@@ -756,7 +757,7 @@ class TestBinarySensorTod(unittest.TestCase):
             assert state.state == STATE_OFF
 
         testtime = sunrise
-        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.utcnow',
                    return_value=testtime):
 
             self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
@@ -767,7 +768,7 @@ class TestBinarySensorTod(unittest.TestCase):
             assert state.state == STATE_ON
 
         testtime = sunrise + timedelta(seconds=1)
-        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.utcnow',
                    return_value=testtime):
 
             self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
@@ -780,7 +781,7 @@ class TestBinarySensorTod(unittest.TestCase):
         self.hass.block_till_done()
 
         testtime = sunset + timedelta(seconds=-1)
-        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.utcnow',
                    return_value=testtime):
 
             self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
@@ -793,7 +794,7 @@ class TestBinarySensorTod(unittest.TestCase):
         self.hass.block_till_done()
 
         testtime = sunset
-        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.utcnow',
                    return_value=testtime):
 
             self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
@@ -806,7 +807,7 @@ class TestBinarySensorTod(unittest.TestCase):
         self.hass.block_till_done()
 
         testtime = sunset + timedelta(seconds=1)
-        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.utcnow',
                    return_value=testtime):
 
             self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
@@ -821,7 +822,7 @@ class TestBinarySensorTod(unittest.TestCase):
             self.hass, 'sunrise', dt_util.as_utc(test_time)) +
             timedelta(hours=-1, minutes=-30))
         testtime = sunrise
-        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.utcnow',
                    return_value=testtime):
 
             self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
@@ -830,3 +831,35 @@ class TestBinarySensorTod(unittest.TestCase):
 
             state = self.hass.states.get(entity_id)
             assert state.state == STATE_ON
+
+    def test_dst(self):
+        """Test sun event with offset."""
+        self.hass.config.time_zone = pytz.timezone('CET')
+        test_time = datetime(
+            2019, 3, 30, 3, 0, 0, tzinfo=self.hass.config.time_zone)
+        config = {
+            'binary_sensor': {
+                'platform': 'tod',
+                'sensors': {
+                    'day': {
+                        'after': '2:30',
+                        'before': '2:40'
+                    },
+                },
+            },
+        }
+        # after 2019-03-30 03:00 CET the next update should ge scheduled
+        # at 3:30 not 2:30 local time
+        # Internally the
+        entity_id = 'binary_sensor.day'
+        testtime = test_time
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.utcnow',
+                   return_value=testtime):
+            setup_component(self.hass, 'binary_sensor', config)
+
+            self.hass.block_till_done()
+            state = self.hass.states.get(entity_id)
+            state.attributes['after'] == '2019-03-31T03:30:00+02:00'
+            state.attributes['before'] == '2019-03-31T03:40:00+02:00'
+            state.attributes['next_update'] == '2019-03-31T03:30:00+02:00'
+            assert state.state == STATE_OFF

--- a/tests/components/binary_sensor/test_tod.py
+++ b/tests/components/binary_sensor/test_tod.py
@@ -34,25 +34,24 @@ class TestBinarySensorTod(unittest.TestCase):
     def test_setup(self):
         """Test the setup."""
         config = {
-            'binary_sensor': {
-                'platform': 'tod',
-                'sensors': {
-                    'early_morning': {
-                        'friendly_name': 'Early Morning',
-                        'after': 'sunrise',
-                        'after_offset': '-02:00',
-                        'before': '7:00',
-                        'before_offset': '1:00'
-                    },
-                    'morning': {
-                        'friendly_name': 'Morning',
-                        'after': 'sunrise',
-                        'before': '12:00'
-                    },
+            'binary_sensor': [
+                {
+                    'platform': 'tod',
+                    'name': 'Early Morning',
+                    'after': 'sunrise',
+                    'after_offset': '-02:00',
+                    'before': '7:00',
+                    'before_offset': '1:00'
                 },
-            },
+                {
+                    'platform': 'tod',
+                    'name': 'Morning',
+                    'after': 'sunrise',
+                    'before': '12:00'
+                }
+            ],
         }
-        with assert_setup_component(1):
+        with assert_setup_component(2):
             assert setup.setup_component(
                 self.hass, 'binary_sensor', config)
 
@@ -70,16 +69,14 @@ class TestBinarySensorTod(unittest.TestCase):
         test_time = datetime(
             2019, 1, 10, 18, 43, 0, tzinfo=self.hass.config.time_zone)
         config = {
-            'binary_sensor': {
-                'platform': 'tod',
-                'sensors': {
-                    'evening': {
-                        'friendly_name': 'Evening',
-                        'after': '18:00',
-                        'before': '22:00'
-                    },
-                },
-            },
+            'binary_sensor': [
+                {
+                    'platform': 'tod',
+                    'name': 'Evening',
+                    'after': '18:00',
+                    'before': '22:00'
+                }
+            ]
         }
         with patch('homeassistant.components.binary_sensor.tod.dt_util.utcnow',
                    return_value=test_time):
@@ -94,16 +91,14 @@ class TestBinarySensorTod(unittest.TestCase):
         test_time = datetime(
             2019, 1, 10, 22, 30, 0, tzinfo=self.hass.config.time_zone)
         config = {
-            'binary_sensor': {
-                'platform': 'tod',
-                'sensors': {
-                    'night': {
-                        'friendly_name': 'Night',
-                        'after': '22:00',
-                        'before': '5:00'
-                    },
+            'binary_sensor': [
+                {
+                    'platform': 'tod',
+                    'name': 'Night',
+                    'after': '22:00',
+                    'before': '5:00'
                 },
-            },
+            ]
         }
         with patch('homeassistant.components.binary_sensor.tod.dt_util.utcnow',
                    return_value=test_time):
@@ -118,16 +113,14 @@ class TestBinarySensorTod(unittest.TestCase):
         test_time = datetime(
             2019, 1, 10, 21, 00, 0, tzinfo=self.hass.config.time_zone)
         config = {
-            'binary_sensor': {
-                'platform': 'tod',
-                'sensors': {
-                    'night': {
-                        'friendly_name': 'Night',
-                        'after': '22:00',
-                        'before': '5:00'
-                    },
+            'binary_sensor': [
+                {
+                    'platform': 'tod',
+                    'name': 'Night',
+                    'after': '22:00',
+                    'before': '5:00'
                 },
-            },
+            ]
         }
         with patch('homeassistant.components.binary_sensor.tod.dt_util.utcnow',
                    return_value=test_time):
@@ -153,16 +146,14 @@ class TestBinarySensorTod(unittest.TestCase):
         test_time = datetime(
             2019, 1, 10, 20, 30, 0, tzinfo=self.hass.config.time_zone)
         config = {
-            'binary_sensor': {
-                'platform': 'tod',
-                'sensors': {
-                    'night': {
-                        'friendly_name': 'Night',
-                        'after': '22:00',
-                        'before': '5:00'
-                    },
-                },
-            },
+            'binary_sensor': [
+                {
+                    'platform': 'tod',
+                    'name': 'Night',
+                    'after': '22:00',
+                    'before': '5:00'
+                }
+            ]
         }
         with patch('homeassistant.components.binary_sensor.tod.dt_util.utcnow',
                    return_value=test_time):
@@ -177,16 +168,14 @@ class TestBinarySensorTod(unittest.TestCase):
         test_time = datetime(
             2019, 1, 10, 20, 0, 0, tzinfo=self.hass.config.time_zone)
         config = {
-            'binary_sensor': {
-                'platform': 'tod',
-                'sensors': {
-                    'night': {
-                        'friendly_name': 'Night',
-                        'after': '22:00',
-                        'before': '5:00'
-                    },
-                },
-            },
+            'binary_sensor': [
+                {
+                    'platform': 'tod',
+                    'name': 'Night',
+                    'after': '22:00',
+                    'before': '5:00'
+                }
+            ]
         }
         with patch('homeassistant.components.binary_sensor.tod.dt_util.utcnow',
                    return_value=test_time):
@@ -228,16 +217,14 @@ class TestBinarySensorTod(unittest.TestCase):
         sunset = dt_util.as_local(get_astral_event_date(
             self.hass, 'sunset', dt_util.as_utc(test_time)))
         config = {
-            'binary_sensor': {
-                'platform': 'tod',
-                'sensors': {
-                    'day': {
-                        'friendly_name': 'Day',
-                        'after': 'sunrise',
-                        'before': 'sunset'
-                    },
-                },
-            },
+            'binary_sensor': [
+                {
+                    'platform': 'tod',
+                    'name': 'Day',
+                    'after': 'sunrise',
+                    'before': 'sunset'
+                }
+            ]
         }
         entity_id = 'binary_sensor.day'
         testtime = sunrise + timedelta(seconds=-1)
@@ -320,16 +307,14 @@ class TestBinarySensorTod(unittest.TestCase):
             self.hass, 'sunrise', sunset))
         # assert sunset == sunrise
         config = {
-            'binary_sensor': {
-                'platform': 'tod',
-                'sensors': {
-                    'night': {
-                        'friendly_name': 'Night',
-                        'after': 'sunset',
-                        'before': 'sunrise'
-                    },
-                },
-            },
+            'binary_sensor': [
+                {
+                    'platform': 'tod',
+                    'name': 'Night',
+                    'after': 'sunset',
+                    'before': 'sunrise'
+                }
+            ]
         }
         entity_id = 'binary_sensor.night'
         testtime = sunset + timedelta(minutes=-1)
@@ -410,18 +395,16 @@ class TestBinarySensorTod(unittest.TestCase):
             timedelta(hours=1, minutes=45)
         entity_id = 'binary_sensor.evening'
         config = {
-            'binary_sensor': {
-                'platform': 'tod',
-                'sensors': {
-                    'evening': {
-                        'friendly_name': 'Evening',
-                        'after': '18:00',
-                        'after_offset': '1:34',
-                        'before': '22:00',
-                        'before_offset': '1:45',
-                    },
-                },
-            },
+            'binary_sensor': [
+                {
+                    'platform': 'tod',
+                    'name': 'Evening',
+                    'after': '18:00',
+                    'after_offset': '1:34',
+                    'before': '22:00',
+                    'before_offset': '1:45'
+                }
+            ]
         }
         testtime = after + timedelta(seconds=-1)
         with patch('homeassistant.components.binary_sensor.tod.dt_util.utcnow',
@@ -480,18 +463,16 @@ class TestBinarySensorTod(unittest.TestCase):
             timedelta(hours=1, minutes=34)
         entity_id = 'binary_sensor.evening'
         config = {
-            'binary_sensor': {
-                'platform': 'tod',
-                'sensors': {
-                    'evening': {
-                        'friendly_name': 'Evening',
-                        'after': '18:00',
-                        'after_offset': '1:34',
-                        'before': '22:00',
-                        'before_offset': '3:00',
-                    },
-                },
-            },
+            'binary_sensor': [
+                {
+                    'platform': 'tod',
+                    'name': 'Evening',
+                    'after': '18:00',
+                    'after_offset': '1:34',
+                    'before': '22:00',
+                    'before_offset': '3:00'
+                }
+            ]
         }
         testtime = after + timedelta(seconds=-1)
         with patch('homeassistant.components.binary_sensor.tod.dt_util.utcnow',
@@ -523,16 +504,14 @@ class TestBinarySensorTod(unittest.TestCase):
         sunset = dt_util.as_local(get_astral_event_next(
             self.hass, 'sunset', dt_util.as_utc(test_time)))
         config = {
-            'binary_sensor': {
-                'platform': 'tod',
-                'sensors': {
-                    'day': {
-                        'friendly_name': 'Day',
-                        'after': 'sunrise',
-                        'before': 'sunset'
-                    },
-                },
-            },
+            'binary_sensor': [
+                {
+                    'platform': 'tod',
+                    'name': 'Day',
+                    'after': 'sunrise',
+                    'before': 'sunset'
+                }
+            ]
         }
         entity_id = 'binary_sensor.day'
         testtime = test_time
@@ -629,16 +608,14 @@ class TestBinarySensorTod(unittest.TestCase):
         print(sunrise)
         print(sunset)
         config = {
-            'binary_sensor': {
-                'platform': 'tod',
-                'sensors': {
-                    'day': {
-                        'friendly_name': 'Day',
-                        'after': 'sunrise',
-                        'before': 'sunset'
-                    },
-                },
-            },
+            'binary_sensor': [
+                {
+                    'platform': 'tod',
+                    'name': 'Day',
+                    'after': 'sunrise',
+                    'before': 'sunset'
+                }
+            ]
         }
         entity_id = 'binary_sensor.day'
         testtime = test_time
@@ -733,18 +710,16 @@ class TestBinarySensorTod(unittest.TestCase):
             self.hass, 'sunset', dt_util.as_utc(test_time)) +
             timedelta(hours=1, minutes=30))
         config = {
-            'binary_sensor': {
-                'platform': 'tod',
-                'sensors': {
-                    'day': {
-                        'friendly_name': 'Day',
-                        'after': 'sunrise',
-                        'after_offset': '-1:30',
-                        'before': 'sunset',
-                        'before_offset': '1:30',
-                    },
-                },
-            },
+            'binary_sensor': [
+                {
+                    'platform': 'tod',
+                    'name': 'Day',
+                    'after': 'sunrise',
+                    'after_offset': '-1:30',
+                    'before': 'sunset',
+                    'before_offset': '1:30'
+                }
+            ]
         }
         entity_id = 'binary_sensor.day'
         testtime = sunrise + timedelta(seconds=-1)
@@ -838,15 +813,14 @@ class TestBinarySensorTod(unittest.TestCase):
         test_time = datetime(
             2019, 3, 30, 3, 0, 0, tzinfo=self.hass.config.time_zone)
         config = {
-            'binary_sensor': {
-                'platform': 'tod',
-                'sensors': {
-                    'day': {
-                        'after': '2:30',
-                        'before': '2:40'
-                    },
-                },
-            },
+            'binary_sensor': [
+                {
+                    'platform': 'tod',
+                    'name': 'Day',
+                    'after': '2:30',
+                    'before': '2:40'
+                }
+            ]
         }
         # after 2019-03-30 03:00 CET the next update should ge scheduled
         # at 3:30 not 2:30 local time

--- a/tests/components/binary_sensor/test_tod.py
+++ b/tests/components/binary_sensor/test_tod.py
@@ -1,9 +1,18 @@
 """Test Times of the Day Binary Sensor."""
 import unittest
-from unittest import mock
+from unittest.mock import patch
+from datetime import timedelta, datetime
 
+from homeassistant import setup
+import homeassistant.core as ha
+from homeassistant.const import STATE_OFF, STATE_ON
+import homeassistant.util.dt as dt_util
+from homeassistant.setup import setup_component
 from tests.common import (
-    get_test_home_assistant, assert_setup_component, async_fire_time_changed)
+    get_test_home_assistant, assert_setup_component)
+from homeassistant.helpers.sun import (
+    get_astral_event_date, get_astral_event_next)
+
 
 class TestBinarySensorTod(unittest.TestCase):
     """Test for Binary sensor tod platform."""
@@ -14,10 +23,810 @@ class TestBinarySensorTod(unittest.TestCase):
     def setup_method(self, method):
         """Set up things to be run when tests are started."""
         self.hass = get_test_home_assistant()
+        self.hass.config.latitute = 50.27583
+        self.hass.config.longitude = 18.98583
 
     def teardown_method(self, method):
         """Stop everything that was started."""
         self.hass.stop()
-    
+
     def test_setup(self):
-        return True
+        """Test the setup."""
+        config = {
+            'binary_sensor': {
+                'platform': 'tod',
+                'sensors': {
+                    'early_morning': {
+                        'friendly_name': 'Early Morning',
+                        'after': 'sunrise',
+                        'after_offset': '-02:00',
+                        'before': '7:00',
+                        'before_offset': '1:00'
+                    },
+                    'morning': {
+                        'friendly_name': 'Morning',
+                        'after': 'sunrise',
+                        'before': '12:00'
+                    },
+                },
+            },
+        }
+        with assert_setup_component(1):
+            assert setup.setup_component(
+                self.hass, 'binary_sensor', config)
+
+    def test_setup_no_sensors(self):
+        """Test setup with no sensors."""
+        with assert_setup_component(0):
+            assert setup.setup_component(self.hass, 'binary_sensor', {
+                'binary_sensor': {
+                    'platform': 'tod'
+                }
+            })
+
+    def test_in_period_on_start(self):
+        """Test simple setting."""
+        test_time = datetime(
+            2019, 1, 10, 18, 43, 0, tzinfo=self.hass.config.time_zone)
+        config = {
+            'binary_sensor': {
+                'platform': 'tod',
+                'sensors': {
+                    'evening': {
+                        'friendly_name': 'Evening',
+                        'after': '18:00',
+                        'before': '22:00'
+                    },
+                },
+            },
+        }
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+                   return_value=test_time):
+            setup_component(self.hass, 'binary_sensor', config)
+
+        self.hass.block_till_done()
+        state = self.hass.states.get('binary_sensor.tod_evening')
+        assert state.state == STATE_ON
+
+    def test_midnight_turnover_before_midnight_inside_period(self):
+        """Test midnight turnover setting before midnight inside period ."""
+        test_time = datetime(
+            2019, 1, 10, 22, 30, 0, tzinfo=self.hass.config.time_zone)
+        config = {
+            'binary_sensor': {
+                'platform': 'tod',
+                'sensors': {
+                    'night': {
+                        'friendly_name': 'Night',
+                        'after': '22:00',
+                        'before': '5:00'
+                    },
+                },
+            },
+        }
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+                   return_value=test_time):
+            setup_component(self.hass, 'binary_sensor', config)
+
+        self.hass.block_till_done()
+        state = self.hass.states.get('binary_sensor.tod_night')
+        assert state.state == STATE_ON
+
+    def test_midnight_turnover_after_midnight_inside_period(self):
+        """Test midnight turnover setting before midnight inside period ."""
+        test_time = datetime(
+            2019, 1, 10, 21, 00, 0, tzinfo=self.hass.config.time_zone)
+        config = {
+            'binary_sensor': {
+                'platform': 'tod',
+                'sensors': {
+                    'night': {
+                        'friendly_name': 'Night',
+                        'after': '22:00',
+                        'before': '5:00'
+                    },
+                },
+            },
+        }
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+                   return_value=test_time):
+            setup_component(self.hass, 'binary_sensor', config)
+
+            state = self.hass.states.get('binary_sensor.tod_night')
+            assert state.state == STATE_OFF
+
+            self.hass.block_till_done()
+
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+                   return_value=test_time + timedelta(hours=4)):
+
+            self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
+                ha.ATTR_NOW: test_time + timedelta(hours=4)})
+
+            self.hass.block_till_done()
+            state = self.hass.states.get('binary_sensor.tod_night')
+            assert state.state == STATE_ON
+
+    def test_midnight_turnover_before_midnight_outside_period(self):
+        """Test midnight turnover setting before midnight outside period."""
+        test_time = datetime(
+            2019, 1, 10, 20, 30, 0, tzinfo=self.hass.config.time_zone)
+        config = {
+            'binary_sensor': {
+                'platform': 'tod',
+                'sensors': {
+                    'night': {
+                        'friendly_name': 'Night',
+                        'after': '22:00',
+                        'before': '5:00'
+                    },
+                },
+            },
+        }
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+                   return_value=test_time):
+            setup_component(self.hass, 'binary_sensor', config)
+
+        self.hass.block_till_done()
+        state = self.hass.states.get('binary_sensor.tod_night')
+        assert state.state == STATE_OFF
+
+    def test_midnight_turnover_after_midnight_outside_period(self):
+        """Test midnight turnover setting before midnight inside period ."""
+        test_time = datetime(
+            2019, 1, 10, 20, 0, 0, tzinfo=self.hass.config.time_zone)
+        config = {
+            'binary_sensor': {
+                'platform': 'tod',
+                'sensors': {
+                    'night': {
+                        'friendly_name': 'Night',
+                        'after': '22:00',
+                        'before': '5:00'
+                    },
+                },
+            },
+        }
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+                   return_value=test_time):
+            setup_component(self.hass, 'binary_sensor', config)
+
+        self.hass.block_till_done()
+        state = self.hass.states.get('binary_sensor.tod_night')
+        assert state.state == STATE_OFF
+
+        switchover_time = datetime(
+            2019, 1, 11, 4, 59, 0, tzinfo=self.hass.config.time_zone)
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+                   return_value=switchover_time):
+
+            self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
+                ha.ATTR_NOW: switchover_time})
+            self.hass.block_till_done()
+            state = self.hass.states.get('binary_sensor.tod_night')
+            assert state.state == STATE_ON
+
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+                   return_value=switchover_time + timedelta(
+                       minutes=1, seconds=1)):
+
+            self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
+                ha.ATTR_NOW: switchover_time + timedelta(
+                    minutes=1, seconds=1)})
+
+            self.hass.block_till_done()
+            state = self.hass.states.get('binary_sensor.tod_night')
+            assert state.state == STATE_OFF
+
+    def test_from_sunrise_to_sunset(self):
+        """Test period from sunrise to sunset."""
+        test_time = datetime(
+            2019, 1, 12, tzinfo=self.hass.config.time_zone)
+        sunrise = dt_util.as_local(get_astral_event_date(
+            self.hass, 'sunrise', dt_util.as_utc(test_time)))
+        sunset = dt_util.as_local(get_astral_event_date(
+            self.hass, 'sunset', dt_util.as_utc(test_time)))
+        config = {
+            'binary_sensor': {
+                'platform': 'tod',
+                'sensors': {
+                    'day': {
+                        'friendly_name': 'Day',
+                        'after': 'sunrise',
+                        'before': 'sunset'
+                    },
+                },
+            },
+        }
+        entity_id = 'binary_sensor.tod_day'
+        testtime = sunrise + timedelta(seconds=-1)
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+                   return_value=testtime):
+            setup_component(self.hass, 'binary_sensor', config)
+
+            self.hass.block_till_done()
+            state = self.hass.states.get(entity_id)
+            assert state.state == STATE_OFF
+
+        testtime = sunrise
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+                   return_value=testtime):
+
+            self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
+                ha.ATTR_NOW: testtime})
+            self.hass.block_till_done()
+
+            state = self.hass.states.get(entity_id)
+            assert state.state == STATE_ON
+
+        testtime = sunrise + timedelta(seconds=1)
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+                   return_value=testtime):
+
+            self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
+                ha.ATTR_NOW: testtime})
+            self.hass.block_till_done()
+
+            state = self.hass.states.get(entity_id)
+            assert state.state == STATE_ON
+
+        self.hass.block_till_done()
+
+        testtime = sunset + timedelta(seconds=-1)
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+                   return_value=testtime):
+
+            self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
+                ha.ATTR_NOW: testtime})
+            self.hass.block_till_done()
+
+            state = self.hass.states.get(entity_id)
+            assert state.state == STATE_ON
+
+        self.hass.block_till_done()
+
+        testtime = sunset
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+                   return_value=testtime):
+
+            self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
+                ha.ATTR_NOW: testtime})
+            self.hass.block_till_done()
+
+            state = self.hass.states.get(entity_id)
+            assert state.state == STATE_OFF
+
+        self.hass.block_till_done()
+
+        testtime = sunset + timedelta(seconds=1)
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+                   return_value=testtime):
+
+            self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
+                ha.ATTR_NOW: testtime})
+            self.hass.block_till_done()
+
+            state = self.hass.states.get(entity_id)
+            assert state.state == STATE_OFF
+
+    def test_from_sunset_to_sunrise(self):
+        """Test period from sunset to sunrise."""
+        test_time = datetime(
+            2019, 1, 12, tzinfo=self.hass.config.time_zone)
+        sunset = dt_util.as_local(get_astral_event_date(
+            self.hass, 'sunset', test_time))
+        sunrise = dt_util.as_local(get_astral_event_next(
+            self.hass, 'sunrise', sunset))
+        # assert sunset == sunrise
+        config = {
+            'binary_sensor': {
+                'platform': 'tod',
+                'sensors': {
+                    'night': {
+                        'friendly_name': 'Night',
+                        'after': 'sunset',
+                        'before': 'sunrise'
+                    },
+                },
+            },
+        }
+        entity_id = 'binary_sensor.tod_night'
+        testtime = sunset + timedelta(minutes=-1)
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+                   return_value=testtime):
+            setup_component(self.hass, 'binary_sensor', config)
+
+            self.hass.block_till_done()
+            state = self.hass.states.get(entity_id)
+            assert state.state == STATE_OFF
+
+        testtime = sunset
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+                   return_value=testtime):
+
+            self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
+                ha.ATTR_NOW: testtime})
+            self.hass.block_till_done()
+
+            state = self.hass.states.get(entity_id)
+            assert state.state == STATE_ON
+
+        testtime = sunset + timedelta(minutes=1)
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+                   return_value=testtime):
+
+            self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
+                ha.ATTR_NOW: testtime})
+            self.hass.block_till_done()
+
+            state = self.hass.states.get(entity_id)
+            assert state.state == STATE_ON
+
+        testtime = sunrise + timedelta(minutes=-1)
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+                   return_value=testtime):
+
+            self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
+                ha.ATTR_NOW: testtime})
+            self.hass.block_till_done()
+
+            state = self.hass.states.get(entity_id)
+            assert state.state == STATE_ON
+
+        testtime = sunrise
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+                   return_value=testtime):
+
+            self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
+                ha.ATTR_NOW: testtime})
+            self.hass.block_till_done()
+
+            state = self.hass.states.get(entity_id)
+            self.hass.block_till_done()
+            # assert state == "dupa"
+            assert state.state == STATE_OFF
+
+        testtime = sunrise + timedelta(minutes=1)
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+                   return_value=testtime):
+
+            self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
+                ha.ATTR_NOW: testtime})
+            self.hass.block_till_done()
+
+            state = self.hass.states.get(entity_id)
+            assert state.state == STATE_OFF
+
+    def test_offset(self):
+        """Test offset."""
+        after = datetime(
+            2019, 1, 10, 18, 0, 0,
+            tzinfo=self.hass.config.time_zone) + \
+            timedelta(hours=1, minutes=34)
+        before = datetime(
+            2019, 1, 10, 22, 0, 0,
+            tzinfo=self.hass.config.time_zone) + \
+            timedelta(hours=1, minutes=45)
+        entity_id = 'binary_sensor.tod_evening'
+        config = {
+            'binary_sensor': {
+                'platform': 'tod',
+                'sensors': {
+                    'evening': {
+                        'friendly_name': 'Evening',
+                        'after': '18:00',
+                        'after_offset': '1:34',
+                        'before': '22:00',
+                        'before_offset': '1:45',
+                    },
+                },
+            },
+        }
+        testtime = after + timedelta(seconds=-1)
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+                   return_value=testtime):
+            setup_component(self.hass, 'binary_sensor', config)
+
+        self.hass.block_till_done()
+        state = self.hass.states.get(entity_id)
+        assert state.state == STATE_OFF
+
+        testtime = after
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+                   return_value=testtime):
+            self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
+                ha.ATTR_NOW: testtime})
+            self.hass.block_till_done()
+
+            state = self.hass.states.get(entity_id)
+            assert state.state == STATE_ON
+
+        testtime = before + timedelta(seconds=-1)
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+                   return_value=testtime):
+            self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
+                ha.ATTR_NOW: testtime})
+            self.hass.block_till_done()
+
+            state = self.hass.states.get(entity_id)
+            assert state.state == STATE_ON
+
+        testtime = before
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+                   return_value=testtime):
+            self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
+                ha.ATTR_NOW: testtime})
+            self.hass.block_till_done()
+
+            state = self.hass.states.get(entity_id)
+            assert state.state == STATE_OFF
+
+        testtime = before + timedelta(seconds=1)
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+                   return_value=testtime):
+            self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
+                ha.ATTR_NOW: testtime})
+            self.hass.block_till_done()
+
+            state = self.hass.states.get(entity_id)
+            assert state.state == STATE_OFF
+
+    def test_offset_overnight(self):
+        """Test offset overnight."""
+        after = datetime(
+            2019, 1, 10, 18, 0, 0,
+            tzinfo=self.hass.config.time_zone) + \
+            timedelta(hours=1, minutes=34)
+        entity_id = 'binary_sensor.tod_evening'
+        config = {
+            'binary_sensor': {
+                'platform': 'tod',
+                'sensors': {
+                    'evening': {
+                        'friendly_name': 'Evening',
+                        'after': '18:00',
+                        'after_offset': '1:34',
+                        'before': '22:00',
+                        'before_offset': '3:00',
+                    },
+                },
+            },
+        }
+        testtime = after + timedelta(seconds=-1)
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+                   return_value=testtime):
+            setup_component(self.hass, 'binary_sensor', config)
+
+        self.hass.block_till_done()
+        state = self.hass.states.get(entity_id)
+        assert state.state == STATE_OFF
+
+        testtime = after
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+                   return_value=testtime):
+            self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
+                ha.ATTR_NOW: testtime})
+            self.hass.block_till_done()
+
+            state = self.hass.states.get(entity_id)
+            assert state.state == STATE_ON
+
+    def test_norwegian_case_winter(self):
+        """Test location in Norway where the sun doesn't set in summer."""
+        self.hass.config.latitude = 69.6
+        self.hass.config.longitude = 18.8
+
+        test_time = datetime(2010, 1, 1, tzinfo=self.hass.config.time_zone)
+        sunrise = dt_util.as_local(get_astral_event_next(
+            self.hass, 'sunrise', dt_util.as_utc(test_time)))
+        sunset = dt_util.as_local(get_astral_event_next(
+            self.hass, 'sunset', dt_util.as_utc(test_time)))
+        config = {
+            'binary_sensor': {
+                'platform': 'tod',
+                'sensors': {
+                    'day': {
+                        'friendly_name': 'Day',
+                        'after': 'sunrise',
+                        'before': 'sunset'
+                    },
+                },
+            },
+        }
+        entity_id = 'binary_sensor.tod_day'
+        testtime = test_time
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+                   return_value=testtime):
+            setup_component(self.hass, 'binary_sensor', config)
+
+            self.hass.block_till_done()
+            state = self.hass.states.get(entity_id)
+            assert state.state == STATE_OFF
+
+        testtime = sunrise + timedelta(seconds=-1)
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+                   return_value=testtime):
+
+            self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
+                ha.ATTR_NOW: testtime})
+            self.hass.block_till_done()
+
+            state = self.hass.states.get(entity_id)
+            assert state.state == STATE_OFF
+
+        testtime = sunrise
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+                   return_value=testtime):
+
+            self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
+                ha.ATTR_NOW: testtime})
+            self.hass.block_till_done()
+
+            state = self.hass.states.get(entity_id)
+            assert state.state == STATE_ON
+
+        testtime = sunrise + timedelta(seconds=1)
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+                   return_value=testtime):
+
+            self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
+                ha.ATTR_NOW: testtime})
+            self.hass.block_till_done()
+
+            state = self.hass.states.get(entity_id)
+            assert state.state == STATE_ON
+
+        self.hass.block_till_done()
+
+        testtime = sunset + timedelta(seconds=-1)
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+                   return_value=testtime):
+
+            self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
+                ha.ATTR_NOW: testtime})
+            self.hass.block_till_done()
+
+            state = self.hass.states.get(entity_id)
+            assert state.state == STATE_ON
+
+        self.hass.block_till_done()
+
+        testtime = sunset
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+                   return_value=testtime):
+
+            self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
+                ha.ATTR_NOW: testtime})
+            self.hass.block_till_done()
+
+            state = self.hass.states.get(entity_id)
+            assert state.state == STATE_OFF
+
+        self.hass.block_till_done()
+
+        testtime = sunset + timedelta(seconds=1)
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+                   return_value=testtime):
+
+            self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
+                ha.ATTR_NOW: testtime})
+            self.hass.block_till_done()
+
+            state = self.hass.states.get(entity_id)
+            assert state.state == STATE_OFF
+
+    def test_norwegian_case_summer(self):
+        """Test location in Norway where the sun doesn't set in summer."""
+        self.hass.config.latitude = 69.6
+        self.hass.config.longitude = 18.8
+
+        test_time = datetime(2010, 6, 1, tzinfo=self.hass.config.time_zone)
+        sunrise = dt_util.as_local(get_astral_event_next(
+            self.hass, 'sunrise', dt_util.as_utc(test_time)))
+        sunset = dt_util.as_local(get_astral_event_next(
+            self.hass, 'sunset', dt_util.as_utc(test_time)))
+        print(sunrise)
+        print(sunset)
+        config = {
+            'binary_sensor': {
+                'platform': 'tod',
+                'sensors': {
+                    'day': {
+                        'friendly_name': 'Day',
+                        'after': 'sunrise',
+                        'before': 'sunset'
+                    },
+                },
+            },
+        }
+        entity_id = 'binary_sensor.tod_day'
+        testtime = test_time
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+                   return_value=testtime):
+            setup_component(self.hass, 'binary_sensor', config)
+
+            self.hass.block_till_done()
+            state = self.hass.states.get(entity_id)
+            assert state.state == STATE_OFF
+
+        testtime = sunrise + timedelta(seconds=-1)
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+                   return_value=testtime):
+
+            self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
+                ha.ATTR_NOW: testtime})
+            self.hass.block_till_done()
+
+            state = self.hass.states.get(entity_id)
+            assert state.state == STATE_OFF
+
+        testtime = sunrise
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+                   return_value=testtime):
+
+            self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
+                ha.ATTR_NOW: testtime})
+            self.hass.block_till_done()
+
+            state = self.hass.states.get(entity_id)
+            assert state.state == STATE_ON
+
+        testtime = sunrise + timedelta(seconds=1)
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+                   return_value=testtime):
+
+            self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
+                ha.ATTR_NOW: testtime})
+            self.hass.block_till_done()
+
+            state = self.hass.states.get(entity_id)
+            assert state.state == STATE_ON
+
+        self.hass.block_till_done()
+
+        testtime = sunset + timedelta(seconds=-1)
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+                   return_value=testtime):
+
+            self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
+                ha.ATTR_NOW: testtime})
+            self.hass.block_till_done()
+
+            state = self.hass.states.get(entity_id)
+            assert state.state == STATE_ON
+
+        self.hass.block_till_done()
+
+        testtime = sunset
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+                   return_value=testtime):
+
+            self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
+                ha.ATTR_NOW: testtime})
+            self.hass.block_till_done()
+
+            state = self.hass.states.get(entity_id)
+            assert state.state == STATE_OFF
+
+        self.hass.block_till_done()
+
+        testtime = sunset + timedelta(seconds=1)
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+                   return_value=testtime):
+
+            self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
+                ha.ATTR_NOW: testtime})
+            self.hass.block_till_done()
+
+            state = self.hass.states.get(entity_id)
+            assert state.state == STATE_OFF
+
+    def test_sun_offset(self):
+        """Test sun event with offset."""
+        test_time = datetime(
+            2019, 1, 12, tzinfo=self.hass.config.time_zone)
+        sunrise = dt_util.as_local(get_astral_event_date(
+            self.hass, 'sunrise', dt_util.as_utc(test_time)) +
+            timedelta(hours=-1, minutes=-30))
+        sunset = dt_util.as_local(get_astral_event_date(
+            self.hass, 'sunset', dt_util.as_utc(test_time)) +
+            timedelta(hours=1, minutes=30))
+        config = {
+            'binary_sensor': {
+                'platform': 'tod',
+                'sensors': {
+                    'day': {
+                        'friendly_name': 'Day',
+                        'after': 'sunrise',
+                        'after_offset': '-1:30',
+                        'before': 'sunset',
+                        'before_offset': '1:30',
+                    },
+                },
+            },
+        }
+        entity_id = 'binary_sensor.tod_day'
+        testtime = sunrise + timedelta(seconds=-1)
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+                   return_value=testtime):
+            setup_component(self.hass, 'binary_sensor', config)
+
+            self.hass.block_till_done()
+            state = self.hass.states.get(entity_id)
+            assert state.state == STATE_OFF
+
+        testtime = sunrise
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+                   return_value=testtime):
+
+            self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
+                ha.ATTR_NOW: testtime})
+            self.hass.block_till_done()
+
+            state = self.hass.states.get(entity_id)
+            assert state.state == STATE_ON
+
+        testtime = sunrise + timedelta(seconds=1)
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+                   return_value=testtime):
+
+            self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
+                ha.ATTR_NOW: testtime})
+            self.hass.block_till_done()
+
+            state = self.hass.states.get(entity_id)
+            assert state.state == STATE_ON
+
+        self.hass.block_till_done()
+
+        testtime = sunset + timedelta(seconds=-1)
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+                   return_value=testtime):
+
+            self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
+                ha.ATTR_NOW: testtime})
+            self.hass.block_till_done()
+
+            state = self.hass.states.get(entity_id)
+            assert state.state == STATE_ON
+
+        self.hass.block_till_done()
+
+        testtime = sunset
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+                   return_value=testtime):
+
+            self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
+                ha.ATTR_NOW: testtime})
+            self.hass.block_till_done()
+
+            state = self.hass.states.get(entity_id)
+            assert state.state == STATE_OFF
+
+        self.hass.block_till_done()
+
+        testtime = sunset + timedelta(seconds=1)
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+                   return_value=testtime):
+
+            self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
+                ha.ATTR_NOW: testtime})
+            self.hass.block_till_done()
+
+            state = self.hass.states.get(entity_id)
+            assert state.state == STATE_OFF
+
+        test_time = test_time + timedelta(days=1)
+        sunrise = dt_util.as_local(get_astral_event_date(
+            self.hass, 'sunrise', dt_util.as_utc(test_time)) +
+            timedelta(hours=-1, minutes=-30))
+        testtime = sunrise
+        with patch('homeassistant.components.binary_sensor.tod.dt_util.now',
+                   return_value=testtime):
+
+            self.hass.bus.fire(ha.EVENT_TIME_CHANGED, {
+                ha.ATTR_NOW: testtime})
+            self.hass.block_till_done()
+
+            state = self.hass.states.get(entity_id)
+            assert state.state == STATE_ON


### PR DESCRIPTION
## Description:
This code provides the new binary sensor platform checking if the current time is within configured time range. The platform allows adding multiple sensor working for different time ranges.

The time ranges can be defined as time format string or sun event (sunset or sunrise). Also for each boundary the offset can be added.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8172

## Example entry for `configuration.yaml` (if applicable):
```yaml
binary_sensor:
  - platform: tod
    sensors:
      early_morning:
        after: sunrise
        after_offset: '-02:00'
        before: '07:00'
      morning:
        after: sunrise
        before: '12:00'
      late_morning:
        after: '10:00'
        before: '12:00'
      early_afternoon:
        after: '12:00'
        before: '15:00'
      afternoon:
        after: '12:00'
        before: '18:00'
      late_afternoon:
        after: '16:00'
        before: '18:0'
      early_evening:
        after: '17:00'
        before: '19:00'
      evening:
        after: '17:00'
        before: '22:00'
      late_evening:
        after: '20:00'
        before: '22:00'
      middle_of_the_night:
        after: '23:00'
        before: sunrise
        before_offset: '-02:00'
      night:
        after: '22:00'
        before: sunrise
      day:
        after: sunrise
        before: sunset
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54