### PR TITLE
SSL verification bypass for Plex thumbnails if necessary

### DIFF
--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -779,7 +779,7 @@ class MediaPlayerDevice(Entity):
         return state_attr
 
 
-async def _async_fetch_image(hass, url):
+async def _async_fetch_image(hass, url, verify_ssl=True):
     """Fetch image.
 
     Images are cached in memory (the images are typically 10-100kB in size).
@@ -798,7 +798,7 @@ async def _async_fetch_image(hass, url):
             return cache_images[url][CACHE_CONTENT]
 
         content, content_type = (None, None)
-        websession = async_get_clientsession(hass)
+        websession = async_get_clientsession(hass, verify_ssl)
         try:
             with async_timeout.timeout(10, loop=hass.loop):
                 response = await websession.get(url)

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -779,7 +779,10 @@ class MediaPlayerDevice(Entity):
         return state_attr
 
 
-async def _async_fetch_image(hass, url, verify_ssl=True):
+# This method has been copied into components.media_player.plex, to support
+# skipping SSL verification. If you need to do this again, please consider
+# changing the base class to support this instead.
+async def _async_fetch_image(hass, url):
     """Fetch image.
 
     Images are cached in memory (the images are typically 10-100kB in size).
@@ -798,7 +801,7 @@ async def _async_fetch_image(hass, url, verify_ssl=True):
             return cache_images[url][CACHE_CONTENT]
 
         content, content_type = (None, None)
-        websession = async_get_clientsession(hass, verify_ssl)
+        websession = async_get_clientsession(hass)
         try:
             with async_timeout.timeout(10, loop=hass.loop):
                 response = await websession.get(url)


### PR DESCRIPTION
## Description:
Allows SSL verification bypass, for Plex media players specifically, but adds allows other media player entities to support it too.

Relates: #19676

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - **N/A** Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)
