### PR TITLE
Fix logic error in dublin bus

### DIFF
--- a/homeassistant/components/sensor/dublin_bus_transport.py
+++ b/homeassistant/components/sensor/dublin_bus_transport.py
@@ -92,7 +92,7 @@ class DublinPublicTransportSensor(Entity):
         """Return the state attributes."""
         if self._times is not None:
             next_up = "None"
-            if len(self._times) >= 1:
+            if len(self._times) > 1:
                 next_up = self._times[1][ATTR_ROUTE] + " in "
                 next_up += self._times[1][ATTR_DUE_IN]
 


### PR DESCRIPTION
## Description:

fixes a logic error when checking length of array

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
