### PR TITLE
Add support for zigbee binding and unbinding to ZHA

### DIFF
--- a/homeassistant/components/zha/entities/entity.py
+++ b/homeassistant/components/zha/entities/entity.py
@@ -70,7 +70,7 @@ class ZhaEntity(entity.Entity):
 
         self._initialized = False
         self.manufacturer_code = None
-        application_listener.register_entity(ieee, self)
+        self._application_listener = application_listener
 
     async def get_clusters(self):
         """Get zigbee clusters from this entity."""
@@ -171,6 +171,8 @@ class ZhaEntity(entity.Entity):
 
         It is now safe to update the entity state
         """
+        self._application_listener.register_entity(self._endpoint.device.ieee,
+                                                   self)
         for cluster_id, cluster in self._in_clusters.items():
             cluster.add_listener(self._in_listeners.get(cluster_id, self))
         for cluster_id, cluster in self._out_clusters.items():
@@ -265,6 +267,11 @@ class ZhaEntity(entity.Entity):
     def unique_id(self) -> str:
         """Return a unique ID."""
         return self._unique_id
+
+    @property
+    def ieee(self):
+        """Return ieee."""
+        return self._endpoint.device.ieee
 
     @property
     def device_state_attributes(self):

--- a/homeassistant/components/zha/services.yaml
+++ b/homeassistant/components/zha/services.yaml
@@ -14,16 +14,28 @@ remove:
       description: IEEE address of the node to remove
       example: "00:0d:6f:00:05:7d:2d:34"
 
-reconfigure_device:
+issue_direct_zigbee_bind:
   description: >- 
-    Reconfigure ZHA device (heal device). Use this if you are having issues 
-    with the device. If the device in question is a battery powered device
-    please ensure it is awake and accepting commands when you use this
-    service. 
+    Directly bind 2 zigbee devices. This is useful when you want to bind
+    a remote like device directly to a light.  
   fields:
-    ieee_address:
-      description: IEEE address of the device to reconfigure
-      example: "00:0d:6f:00:05:7d:2d:34"
+    source_entity_id:
+      description: Entity id
+      example: "binary_sensor.centralite_3130_00e8fb4e_1"
+    target_entity_id:
+      description: Entity id
+      example: "light.sengled_z01a19nae26_03011d28_1"
+
+issue_direct_zigbee_unbind:
+  description: >- 
+    Remove a direct binding between to zigbee devices.  
+  fields:
+    source_entity_id:
+      description: Entity id
+      example: "binary_sensor.centralite_3130_00e8fb4e_1"
+    target_entity_id:
+      description: Entity id
+      example: "light.sengled_z01a19nae26_03011d28_1"
 
 set_zigbee_cluster_attribute:
   description: >- 


### PR DESCRIPTION
This PR adds initial support for zigbee device binding and unbinding to ZHA.

Currently it is just an MVP and it isn't very smart. It will attempt to bind all compatible clusters between 2 entities. In the future it will support device / entity binding and individual cluster binding.  

I set these up as services for now so that users have a way to use the functionality until I have time to create a configuration panel that exposes the functionality. When I create the panel I will convert these to web socket commands.