### PR TITLE
Lowercase alarm panel code format

### DIFF
--- a/homeassistant/components/alarm_control_panel/__init__.py
+++ b/homeassistant/components/alarm_control_panel/__init__.py
@@ -21,8 +21,8 @@ from homeassistant.helpers.entity_component import EntityComponent
 DOMAIN = 'alarm_control_panel'
 SCAN_INTERVAL = timedelta(seconds=30)
 ATTR_CHANGED_BY = 'changed_by'
-FORMAT_TEXT = 'Text'
-FORMAT_NUMBER = 'Number'
+FORMAT_TEXT = 'text'
+FORMAT_NUMBER = 'number'
 
 ENTITY_ID_FORMAT = DOMAIN + '.{}'
 


### PR DESCRIPTION
## Description:
We should use lowercase values.

Related to #20037

**Breaking change:** Code format attribute of alarm control panel is now either "text" or "number" instead of a regex.

