### PR TITLE
Switch geofency tests to using an unauthenticated HTTP client

### DIFF
--- a/tests/components/geofency/test_init.py
+++ b/tests/components/geofency/test_init.py
@@ -112,8 +112,8 @@ def mock_dev_track(mock_device_tracker_conf):
 
 
 @pytest.fixture
-def geofency_client(loop, hass, hass_client):
-    """Geofency mock client."""
+def geofency_client(loop, hass, aiohttp_client):
+    """Geofency mock client (unauthenticated)."""
     assert loop.run_until_complete(async_setup_component(
         hass, 'persistent_notification', {}))
 
@@ -126,7 +126,7 @@ def geofency_client(loop, hass, hass_client):
     loop.run_until_complete(hass.async_block_till_done())
 
     with patch('homeassistant.components.device_tracker.update_config'):
-        yield loop.run_until_complete(hass_client())
+        yield loop.run_until_complete(aiohttp_client(hass.http.app))
 
 
 @pytest.fixture(autouse=True)
@@ -146,7 +146,7 @@ def setup_zones(loop, hass):
 async def webhook_id(hass, geofency_client):
     """Initialize the Geofency component and get the webhook_id."""
     hass.config.api = Mock(base_url='http://example.com')
-    result = await hass.config_entries.flow.async_init('geofency', context={
+    result = await hass.config_entries.flow.async_init(DOMAIN, context={
         'source': 'user'
     })
     assert result['type'] == data_entry_flow.RESULT_TYPE_FORM, result


### PR DESCRIPTION
## Description:
Geofency uses a webhook integration. This does not require being logged in. Switch the tests over to using an unauthenticated HTTP client as well to make sure that everything works in the intended environment.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
