### PR TITLE
Zha light.turn_on service fixes.

### DIFF
--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -155,7 +155,8 @@ class Light(ZhaEntity, light.Light):
 
         duration = kwargs.get(light.ATTR_TRANSITION, DEFAULT_DURATION)
         duration = duration * 10  # tenths of s
-        if light.ATTR_COLOR_TEMP in kwargs:
+        if light.ATTR_COLOR_TEMP in kwargs and \
+                self.supported_features & light.SUPPORT_COLOR_TEMP:
             temperature = kwargs[light.ATTR_COLOR_TEMP]
             try:
                 res = await self._endpoint.light_color.move_to_color_temp(
@@ -168,7 +169,8 @@ class Light(ZhaEntity, light.Light):
                 return
             self._color_temp = temperature
 
-        if light.ATTR_HS_COLOR in kwargs:
+        if light.ATTR_HS_COLOR in kwargs and \
+                self.supported_features & light.SUPPORT_COLOR:
             self._hs_color = kwargs[light.ATTR_HS_COLOR]
             xy_color = color_util.color_hs_to_xy(*self._hs_color)
             try:
@@ -187,7 +189,6 @@ class Light(ZhaEntity, light.Light):
         if self._brightness is not None:
             brightness = kwargs.get(
                 light.ATTR_BRIGHTNESS, self._brightness or 255)
-            self._brightness = brightness
             # Move to level with on/off:
             try:
                 res = await self._endpoint.level.move_to_level_with_on_off(
@@ -201,6 +202,7 @@ class Light(ZhaEntity, light.Light):
                               self.entity_id, ex)
                 return
             self._state = 1
+            self._brightness = brightness
             self.async_schedule_update_ha_state()
             return
 


### PR DESCRIPTION
Set color only if light supports color mode.
Set color temp only light supports color temp.
Update entity's brightness only if Zigbee command to set the brightness was sent successfully.

## Description:
Zha light issues different ZCL commands based on `light.turn_on` service attributes presence, which causes issues for example when service call contains attributes related to color, but light doesn't support any color operations. This PR checks for actual supported features, before issuing related ZCL commands.

Example: Setting a color on a light which doesn't support colors:
```
2019-01-13 22:23:19 ERROR (MainThread) [homeassistant.components.websocket_api.http.connection.139778305736040] Error handling message: {'domain': 'light', 'service': 'turn_on', 'service_data': {'entity_id': 'light.jasco_products_45857_001b94bb_1', 'color_name': 'red'}, 'type': 'call_service', 'id': 14}
Traceback (most recent call last):
  File "/home/lex/lex/src/zigpy/zigpy/endpoint.py", line 222, in __getattr__
    return self._cluster_attr[name]
KeyError: 'light_color'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/lex/lex/src/ac-hass/homeassistant/components/websocket_api/decorators.py", line 17, in _handle_async_response
    await func(hass, connection, msg)
  File "/home/lex/lex/src/ac-hass/homeassistant/components/websocket_api/commands.py", line 148, in handle_call_service
    connection.context(msg))
  File "/home/lex/lex/src/ac-hass/homeassistant/core.py", line 1121, in async_call
    self._execute_service(handler, service_call))
  File "/usr/lib/python3.5/asyncio/futures.py", line 380, in __iter__
    yield self  # This tells Task to wait for completion.
  File "/usr/lib/python3.5/asyncio/tasks.py", line 304, in _wakeup
    future.result()
  File "/usr/lib/python3.5/asyncio/futures.py", line 293, in result
    raise self._exception
  File "/usr/lib/python3.5/asyncio/tasks.py", line 239, in _step
    result = coro.send(None)
  File "/home/lex/lex/src/ac-hass/homeassistant/core.py", line 1143, in _execute_service
    await handler.func(service_call)
  File "/home/lex/lex/src/ac-hass/homeassistant/components/light/__init__.py", line 287, in async_handle_light_on_service
    await light.async_turn_on(**pars)
  File "/home/lex/lex/src/ac-hass/homeassistant/components/zha/light.py", line 175, in async_turn_on
    res = await self._endpoint.light_color.move_to_color(
  File "/home/lex/lex/src/zigpy/zigpy/endpoint.py", line 224, in __getattr__
    raise AttributeError
AttributeError
```
## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
