### PR TITLE
Reconnect and device name fix for harmony platform

### DIFF
--- a/homeassistant/components/remote/harmony.py
+++ b/homeassistant/components/remote/harmony.py
@@ -28,8 +28,6 @@ _LOGGER = logging.getLogger(__name__)
 
 ATTR_CHANNEL = 'channel'
 ATTR_CURRENT_ACTIVITY = 'current_activity'
-ATTR_CONFIG_VERSION = 'config_version'
-ATTR_FIRMWARE_VERSION = 'firmware_version'
 
 DEFAULT_PORT = 8088
 DEVICES = []
@@ -221,11 +219,7 @@ class HarmonyRemote(remote.RemoteDevice):
     @property
     def device_state_attributes(self):
         """Add platform specific attributes."""
-        return {
-            ATTR_CURRENT_ACTIVITY: self._current_activity,
-            ATTR_FIRMWARE_VERSION: self._client.fw_version,
-            ATTR_CONFIG_VERSION: self._client.hub_config.config_version
-        }
+        return {ATTR_CURRENT_ACTIVITY: self._current_activity}
 
     @property
     def is_on(self):

--- a/homeassistant/components/remote/harmony.py
+++ b/homeassistant/components/remote/harmony.py
@@ -28,6 +28,8 @@ _LOGGER = logging.getLogger(__name__)
 
 ATTR_CHANNEL = 'channel'
 ATTR_CURRENT_ACTIVITY = 'current_activity'
+ATTR_CONFIG_VERSION = 'config_version'
+ATTR_FIRMWARE_VERSION = 'firmware_version'
 
 DEFAULT_PORT = 8088
 DEVICES = []
@@ -213,7 +215,11 @@ class HarmonyRemote(remote.RemoteDevice):
     @property
     def device_state_attributes(self):
         """Add platform specific attributes."""
-        return {ATTR_CURRENT_ACTIVITY: self._current_activity}
+        return {
+            ATTR_CURRENT_ACTIVITY: self._current_activity,
+            ATTR_FIRMWARE_VERSION: self._client.fw_version,
+            ATTR_CONFIG_VERSION: self._client.hub_config.config_version
+        }
 
     @property
     def is_on(self):

--- a/homeassistant/components/remote/harmony.py
+++ b/homeassistant/components/remote/harmony.py
@@ -157,7 +157,6 @@ class HarmonyRemote(remote.RemoteDevice):
         """Initialize HarmonyRemote class."""
         from aioharmony.harmonyapi import HarmonyAPI as HarmonyClient
 
-        _LOGGER.debug("%s: Device init started", name)
         self._name = name
         self.host = host
         self.port = port

--- a/homeassistant/components/remote/harmony.py
+++ b/homeassistant/components/remote/harmony.py
@@ -346,7 +346,7 @@ class HarmonyRemote(remote.RemoteDevice):
         for _ in range(num_repeats):
             for single_command in command:
                 send_command = SendCommandDevice(
-                    device=device,
+                    device=device_id,
                     command=single_command,
                     delay=0
                 )

--- a/homeassistant/components/remote/harmony.py
+++ b/homeassistant/components/remote/harmony.py
@@ -22,7 +22,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.exceptions import PlatformNotReady
 from homeassistant.util import slugify
 
-REQUIREMENTS = ['aioharmony==0.1.3']
+REQUIREMENTS = ['aioharmony==0.1.4']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/remote/harmony.py
+++ b/homeassistant/components/remote/harmony.py
@@ -22,7 +22,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.exceptions import PlatformNotReady
 from homeassistant.util import slugify
 
-REQUIREMENTS = ['aioharmony==0.1.2']
+REQUIREMENTS = ['aioharmony==0.1.3']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/remote/harmony.py
+++ b/homeassistant/components/remote/harmony.py
@@ -22,7 +22,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.exceptions import PlatformNotReady
 from homeassistant.util import slugify
 
-REQUIREMENTS = ['aioharmony==0.1.4']
+REQUIREMENTS = ['aioharmony==0.1.5']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -107,9 +107,6 @@ aioftp==0.12.0
 # homeassistant.components.remote.harmony
 aioharmony==0.1.2
 
-# homeassistant.components.remote.harmony
-aioharmony==0.1.1
-
 # homeassistant.components.emulated_hue
 # homeassistant.components.http
 aiohttp_cors==0.7.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -105,7 +105,7 @@ aiofreepybox==0.0.6
 aioftp==0.12.0
 
 # homeassistant.components.remote.harmony
-aioharmony==0.1.4
+aioharmony==0.1.5
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -108,7 +108,7 @@ aioftp==0.12.0
 aioharmony==0.1.2
 
 # homeassistant.components.remote.harmony
-aioharmony==0.1.00
+aioharmony==0.1.1
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -105,7 +105,7 @@ aiofreepybox==0.0.6
 aioftp==0.12.0
 
 # homeassistant.components.remote.harmony
-aioharmony==0.1.2
+aioharmony==0.1.4
 
 # homeassistant.components.emulated_hue
 # homeassistant.components.http

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -107,6 +107,9 @@ aioftp==0.12.0
 # homeassistant.components.remote.harmony
 aioharmony==0.1.2
 
+# homeassistant.components.remote.harmony
+aioharmony==0.1.00
+
 # homeassistant.components.emulated_hue
 # homeassistant.components.http
 aiohttp_cors==0.7.0


### PR DESCRIPTION
## Description:

-) Increase aioharmony to 0.1.4 (fixes reconnect issue if connection lost)
-) Set PlatformNotReady if unable to connect to HUB on startup.
-) Fix when providing device name instead of id.

**Related issue (if applicable):** fixes #20010 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.