### PR TITLE
Fix unused friendly name for SolarEdge sensor

### DIFF
--- a/homeassistant/components/sensor/solaredge.py
+++ b/homeassistant/components/sensor/solaredge.py
@@ -28,14 +28,14 @@ SCAN_INTERVAL = timedelta(minutes=10)
 # Supported sensor types:
 # Key: ['json_key', 'name', unit, icon]
 SENSOR_TYPES = {
-    'life_time_data': ['lifeTimeData', "Lifetime energy", 'Wh',
-                       'mdi:solar-power'],
-    'last_year_data': ['lastYearData', "Energy this year", 'Wh',
-                       'mdi:solar-power'],
-    'last_month_data': ['lastMonthData', "Energy this month", 'Wh',
+    'lifetime_energy': ['lifeTimeData', "Lifetime energy", 'Wh',
                         'mdi:solar-power'],
-    'last_day_data': ['lastDayData', "Energy today", 'Wh',
-                      'mdi:solar-power'],
+    'energy_this_year': ['lastYearData', "Energy this year", 'Wh',
+                         'mdi:solar-power'],
+    'energy_this_month': ['lastMonthData', "Energy this month", 'Wh',
+                          'mdi:solar-power'],
+    'energy_today': ['lastDayData', "Energy today", 'Wh',
+                     'mdi:solar-power'],
     'current_power': ['currentPower', "Current Power", 'W',
                       'mdi:solar-power']
 }
@@ -106,7 +106,8 @@ class SolarEdgeSensor(Entity):
     @property
     def name(self):
         """Return the name."""
-        return "{}_{}".format(self.platform_name, self.sensor_key)
+        return "{} ({})".format(self.platform_name,
+                                SENSOR_TYPES[self.sensor_key][1])
 
     @property
     def unit_of_measurement(self):


### PR DESCRIPTION
## Description:
The SolarEdge component currently creates sensors named like `SolarEdge_current_power` in the front end, while an unused array containing friendly names exists in the code. This PR uses this array to set a friendly name.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8193

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.

## Breaking changes:
This PR changes the **entity names** of this sensor and the **monitoring condition keys** in the configuration:

| Old entity name                    | New entity name                      |
|------------------------------------|--------------------------------------|
| `sensor.solaredge_current_power`   | `sensor.solaredge_current_power`     |
| `sensor.solaredge_last_day_data`   | `sensor.solaredge_energy_today`      |
| `sensor.solaredge_last_month_data` | `sensor.solaredge_energy_this_month` |
| `sensor.solaredge_last_year_data`  | `sensor.solaredge_energy_this_year`  |
| `sensor.solaredge_life_time_data`  | `sensor.solaredge_lifetime_energy`   |

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
