### PR TITLE
Reset Brottsplatskartan incident types every day

### DIFF
--- a/homeassistant/components/sensor/brottsplatskartan.py
+++ b/homeassistant/components/sensor/brottsplatskartan.py
@@ -72,7 +72,6 @@ class BrottsplatskartanSensor(Entity):
         self._attributes = dict()
         self._brottsplatskartan = bpk
         self._name = name
-        self._previous_incidents = set()
         self._state = None
 
     @property
@@ -100,13 +99,9 @@ class BrottsplatskartanSensor(Entity):
             _LOGGER.debug("Problems fetching incidents")
             return
 
-        if len(incidents) < len(self._previous_incidents):
-            self._previous_incidents = set()
-
         for incident in incidents:
             incident_type = incident.get('title_type')
             incident_counts[incident_type] += 1
-            self._previous_incidents.add(incident.get('id'))
 
         self._attributes = {ATTR_ATTRIBUTION: brottsplatskartan.ATTRIBUTION}
         self._attributes.update(incident_counts)

--- a/homeassistant/components/sensor/brottsplatskartan.py
+++ b/homeassistant/components/sensor/brottsplatskartan.py
@@ -69,7 +69,7 @@ class BrottsplatskartanSensor(Entity):
 
     def __init__(self, bpk, name):
         """Initialize the Brottsplatskartan sensor."""
-        self._attributes = dict()
+        self._attributes = {}
         self._brottsplatskartan = bpk
         self._name = name
         self._state = None

--- a/homeassistant/components/sensor/brottsplatskartan.py
+++ b/homeassistant/components/sensor/brottsplatskartan.py
@@ -69,8 +69,7 @@ class BrottsplatskartanSensor(Entity):
 
     def __init__(self, bpk, name):
         """Initialize the Brottsplatskartan sensor."""
-        import brottsplatskartan
-        self._attributes = {ATTR_ATTRIBUTION: brottsplatskartan.ATTRIBUTION}
+        self._attributes = dict()
         self._brottsplatskartan = bpk
         self._name = name
         self._previous_incidents = set()
@@ -93,6 +92,7 @@ class BrottsplatskartanSensor(Entity):
 
     def update(self):
         """Update device state."""
+        import brottsplatskartan
         incident_counts = defaultdict(int)
         incidents = self._brottsplatskartan.get_incidents()
 
@@ -108,5 +108,6 @@ class BrottsplatskartanSensor(Entity):
             incident_counts[incident_type] += 1
             self._previous_incidents.add(incident.get('id'))
 
+        self._attributes = {ATTR_ATTRIBUTION: brottsplatskartan.ATTRIBUTION}
         self._attributes.update(incident_counts)
         self._state = len(incidents)


### PR DESCRIPTION
## Description:

Today, only the number of incidents are reset every day at midnight (self._state). But the number of incident types, is always increasing and never reset to zero. After running the plugin for a while I think it would be better if the incident types counters is also reset when the state is reset (once every day), it makes more sense.

This pull request also removes some unused code that was never implemented in the sensor.

**BREAKING CHANGE:** The incident type count is reset every day. Before this change, it didn't reset until you restarted Home assistant.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
