### PR TITLE
Remove .isort because we use the config from setup.cfg

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,0 @@
-[settings]
-multi_line_output=4


### PR DESCRIPTION
## Description:

small cleanup
