### PR TITLE
imap_email_content: allow configuring folder to read.

### DIFF
--- a/homeassistant/components/sensor/imap_email_content.py
+++ b/homeassistant/components/sensor/imap_email_content.py
@@ -45,7 +45,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Email sensor platform."""
     reader = EmailReader(
         config.get(CONF_USERNAME), config.get(CONF_PASSWORD),
-        config.get(CONF_SERVER), config.get(CONF_PORT), config.get(CONF_FOLDER))
+        config.get(CONF_SERVER), config.get(CONF_PORT),
+        config.get(CONF_FOLDER))
 
     value_template = config.get(CONF_VALUE_TEMPLATE)
     if value_template is not None:

--- a/homeassistant/components/sensor/imap_email_content.py
+++ b/homeassistant/components/sensor/imap_email_content.py
@@ -22,6 +22,7 @@ _LOGGER = logging.getLogger(__name__)
 
 CONF_SERVER = 'server'
 CONF_SENDERS = 'senders'
+CONF_FOLDER = 'folder'
 
 ATTR_FROM = 'from'
 ATTR_BODY = 'body'
@@ -36,6 +37,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_SERVER): cv.string,
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
     vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
+    vol.Optional(CONF_FOLDER, default='INBOX'): cv.string,
 })
 
 
@@ -43,7 +45,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Email sensor platform."""
     reader = EmailReader(
         config.get(CONF_USERNAME), config.get(CONF_PASSWORD),
-        config.get(CONF_SERVER), config.get(CONF_PORT))
+        config.get(CONF_SERVER), config.get(CONF_PORT), config.get(CONF_FOLDER))
 
     value_template = config.get(CONF_VALUE_TEMPLATE)
     if value_template is not None:
@@ -61,12 +63,13 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class EmailReader:
     """A class to read emails from an IMAP server."""
 
-    def __init__(self, user, password, server, port):
+    def __init__(self, user, password, server, port, folder):
         """Initialize the Email Reader."""
         self._user = user
         self._password = password
         self._server = server
         self._port = port
+        self._folder = folder
         self._last_id = None
         self._unread_ids = deque([])
         self.connection = None
@@ -97,7 +100,7 @@ class EmailReader:
         """Read the next email from the email server."""
         import imaplib
         try:
-            self.connection.select()
+            self.connection.select(self._folder)
 
             if not self._unread_ids:
                 search = "SINCE {0:%d-%b-%Y}".format(datetime.date.today())


### PR DESCRIPTION
Add configuration for selection of IMAP folder to track

## Description:

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8190

## Example entry for `configuration.yaml` (if applicable):
```yaml
  - platform: imap_email_content
    server: imap.gmail.com
    username: XXXX
    password: XXXX
    folder: Spam
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
