### PR TITLE
Add support for deconz radios to zha component

### DIFF
--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -37,7 +37,8 @@ REQUIREMENTS = [
     'bellows==0.7.0',
     'zigpy==0.2.0',
     'zigpy-xbee==0.1.1',
-    'zha-quirks==0.0.6'
+    'zha-quirks==0.0.6',
+    'zigpy-deconz==0.0.1'
 ]
 
 DEVICE_CONFIG_SCHEMA_ENTRY = vol.Schema({
@@ -117,6 +118,11 @@ async def async_setup_entry(hass, config_entry):
         from zigpy_xbee.zigbee.application import ControllerApplication
         radio = zigpy_xbee.api.XBee()
         radio_description = "XBee"
+    elif radio_type == RadioType.deconz.name:
+        import zigpy_deconz.api
+        from zigpy_deconz.zigbee.application import ControllerApplication
+        radio = zigpy_deconz.api.Deconz()
+        radio_description = "Deconz"
 
     await radio.connect(usb_path, baudrate)
     hass.data[DATA_ZHA][DATA_ZHA_RADIO] = radio

--- a/homeassistant/components/zha/const.py
+++ b/homeassistant/components/zha/const.py
@@ -57,6 +57,7 @@ class RadioType(enum.Enum):
 
     ezsp = 'ezsp'
     xbee = 'xbee'
+    deconz = 'deconz'
 
     @classmethod
     def list(cls):

--- a/homeassistant/components/zha/helpers.py
+++ b/homeassistant/components/zha/helpers.py
@@ -118,6 +118,10 @@ async def check_zigpy_connection(usb_path, radio_type, database_path):
         import zigpy_xbee.api
         from zigpy_xbee.zigbee.application import ControllerApplication
         radio = zigpy_xbee.api.XBee()
+    elif radio_type == RadioType.deconz.name:
+        import zigpy_deconz.api
+        from zigpy_deconz.zigbee.application import ControllerApplication
+        radio = zigpy_deconz.api.Deconz()
     try:
         await radio.connect(usb_path, DEFAULT_BAUDRATE)
         controller = ControllerApplication(radio, database_path)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1744,6 +1744,9 @@ zhong_hong_hvac==1.0.9
 ziggo-mediabox-xl==1.1.0
 
 # homeassistant.components.zha
+zigpy-deconz==0.0.1
+
+# homeassistant.components.zha
 zigpy-xbee==0.1.1
 
 # homeassistant.components.zha


### PR DESCRIPTION
## Description:

Add support for ConBee and RaspBee devices to zha component. 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8189

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable.
  - [x] New dependencies are only imported inside functions that use them.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.