### PR TITLE
Bump pynuki to 1.3.2

### DIFF
--- a/homeassistant/components/lock/nuki.py
+++ b/homeassistant/components/lock/nuki.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.service import extract_entity_ids
 
-REQUIREMENTS = ['pynuki==1.3.1']
+REQUIREMENTS = ['pynuki==1.3.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1124,7 +1124,7 @@ pynetgear==0.5.2
 pynetio==0.1.9.1
 
 # homeassistant.components.lock.nuki
-pynuki==1.3.1
+pynuki==1.3.2
 
 # homeassistant.components.sensor.nut
 pynut2==2.1.2


### PR DESCRIPTION
## Description:

Bump pynuki to 1.3.2 which fixes requests timeouts.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.