### PR TITLE
Remove color call to set lights to black when turning hyperion lights off.

### DIFF
--- a/homeassistant/components/light/hyperion.py
+++ b/homeassistant/components/light/hyperion.py
@@ -177,11 +177,6 @@ class Hyperion(Light):
     def turn_off(self, **kwargs):
         """Disconnect all remotes."""
         self.json_request({'command': 'clearall'})
-        self.json_request({
-            'command': 'color',
-            'priority': self._priority,
-            'color': [0, 0, 0]
-        })
 
     def update(self):
         """Get the lights status."""


### PR DESCRIPTION
## Description:

Calling clear all is enough to turn off the hyperion light.  Calling the color
command after calling clear all makes the light no longer function until clear all is called
again.  The component calls clear all before turning the light on, which is
why it works through home assistant.  However if you try to control the
light via the hyperion app, kodi, or it's JSON API after it has been turned off
via home assistant it will not function until you call clear all again through an app or it's JSON API.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

