### PR TITLE
Add command to refresh auth

### DIFF
--- a/homeassistant/components/cloud/iot.py
+++ b/homeassistant/components/cloud/iot.py
@@ -2,6 +2,7 @@
 import asyncio
 import logging
 import pprint
+import random
 import uuid
 
 from aiohttp import hdrs, client_exceptions, WSMsgType
@@ -313,15 +314,20 @@ def async_handle_google_actions(hass, cloud, payload):
 
 
 @HANDLERS.register('cloud')
-@asyncio.coroutine
-def async_handle_cloud(hass, cloud, payload):
+async def async_handle_cloud(hass, cloud, payload):
     """Handle an incoming IoT message for cloud component."""
     action = payload['action']
 
     if action == 'logout':
-        yield from cloud.logout()
+        # Log out of Home Assistant Cloud
+        await cloud.logout()
         _LOGGER.error("You have been logged out from Home Assistant cloud: %s",
                       payload['reason'])
+    elif action == 'refresh_auth':
+        # Refresh the auth token between now and payload['seconds']
+        hass.helpers.event.async_call_later(
+            random.randint(0, payload['seconds']),
+            lambda now: auth_api.check_token(cloud))
     else:
         _LOGGER.warning("Received unknown cloud action: %s", action)
 


### PR DESCRIPTION
## Description:
Add a command to the cloud component to refresh the auth token. This can be used before a new cloud is deployed to avoid all clients hitting the token endpoints at the same time.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
