### PR TITLE
Add fan_on as a climate attribute for Wink thermostats

### DIFF
--- a/homeassistant/components/climate/wink.py
+++ b/homeassistant/components/climate/wink.py
@@ -29,6 +29,7 @@ ATTR_SMART_TEMPERATURE = 'smart_temperature'
 ATTR_TOTAL_CONSUMPTION = 'total_consumption'
 ATTR_HEAT_ON = 'heat_on'
 ATTR_COOL_ON = 'cool_on'
+ATTR_FAN_ON = 'fan_on'
 
 DEPENDENCIES = ['wink']
 
@@ -122,6 +123,9 @@ class WinkThermostat(WinkDevice, ClimateDevice):
         if self.cool_on is not None:
             data[ATTR_COOL_ON] = self.cool_on
 
+        if self.fan_on is not None:
+            data[ATTR_FAN_ON] = self.fan_on
+
         current_humidity = self.current_humidity
         if current_humidity is not None:
             data[ATTR_CURRENT_HUMIDITY] = current_humidity
@@ -172,8 +176,13 @@ class WinkThermostat(WinkDevice, ClimateDevice):
 
     @property
     def cool_on(self):
-        """Return whether or not the heat is actually heating."""
+        """Return whether or not the cooler is actually cooling."""
         return self.wink.cool_on()
+
+    @property
+    def fan_on(self):
+        """Return whether or not the fan is actually running."""
+        return self.wink.fan_on()
 
     @property
     def current_operation(self):


### PR DESCRIPTION
## Description:

Add `fan_on` as an optional attribute of the climate entity for Wink thermostats. This is similar to the existing attributes `heat_on` and `cool_on`. It's possible to run fans independently of heating or cooling, so this allows tracking of fan run-time separately. For example, some thermostats have a fan circulation feature which runs the fan X minutes per hour, w/o heating or cooling necessarily being on, and it would be useful to monitor that.

Example attributes while system is idle and fan was manually turned on:
```json
{
  "current_temperature": 68,
  "min_temp": 50,
  "max_temp": 99,
  "temperature": 68,
  "target_temp_high": null,
  "target_temp_low": null,
  "current_humidity": 32,
  "fan_mode": "on",
  "fan_list": [
    "auto",
    "on"
  ],
  "operation_mode": "heat",
  "operation_list": [
    "off",
    "heat",
    "cool",
    "auto"
  ],
  "away_mode": "off",
  "aux_heat": "off",
  "heat_on": false,
  "cool_on": false,
  "fan_on": true,
  "friendly_name": "Home",
  "supported_features": 3271
}
```
Example attributes while system is completely idle:
```json
{
  "current_temperature": 68,
  "min_temp": 50,
  "max_temp": 99,
  "temperature": 68,
  "target_temp_high": null,
  "target_temp_low": null,
  "current_humidity": 32,
  "fan_mode": "auto",
  "fan_list": [
    "auto",
    "on"
  ],
  "operation_mode": "heat",
  "operation_list": [
    "off",
    "heat",
    "cool",
    "auto"
  ],
  "away_mode": "off",
  "aux_heat": "off",
  "heat_on": false,
  "cool_on": false,
  "fan_on": false,
  "friendly_name": "Home",
  "supported_features": 3271
}
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.