### PR TITLE
Set ehendrix23 as owner for harmony platform

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -95,6 +95,7 @@ homeassistant/components/notify/syslog.py @fabaff
 homeassistant/components/notify/xmpp.py @fabaff
 homeassistant/components/notify/yessssms.py @flowolf
 homeassistant/components/plant.py @ChristianKuehnel
+homeassistant/components/remote/harmony.py @ehendrix23
 homeassistant/components/scene/lifx_cloud.py @amelchio
 homeassistant/components/sensor/airvisual.py @bachya
 homeassistant/components/sensor/alpha_vantage.py @fabaff


### PR DESCRIPTION
## Description:

Put myself (ehendrix23) as code owner for remote.harmony platform as the library (aioharmony) used for harmony is now maintained by me and I've been making most changes now.
Currently this platform does not have an owner. 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
