### PR TITLE
Add verify_ssl to restful_command and switch.rest (#20199)

### DIFF
--- a/homeassistant/components/rest_command.py
+++ b/homeassistant/components/rest_command.py
@@ -14,7 +14,7 @@ import voluptuous as vol
 
 from homeassistant.const import (
     CONF_TIMEOUT, CONF_USERNAME, CONF_PASSWORD, CONF_URL, CONF_PAYLOAD,
-    CONF_METHOD, CONF_HEADERS)
+    CONF_METHOD, CONF_HEADERS, CONF_VERIFY_SSL)
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 
@@ -24,6 +24,7 @@ _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_TIMEOUT = 10
 DEFAULT_METHOD = 'get'
+DEFAULT_VERIFY_SSL = True
 
 SUPPORT_REST_METHODS = [
     'get',
@@ -43,7 +44,8 @@ COMMAND_SCHEMA = vol.Schema({
     vol.Inclusive(CONF_PASSWORD, 'authentication'): cv.string,
     vol.Optional(CONF_PAYLOAD): cv.template,
     vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): vol.Coerce(int),
-    vol.Optional(CONF_CONTENT_TYPE): cv.string
+    vol.Optional(CONF_CONTENT_TYPE): cv.string,
+    vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): cv.boolean,
 })
 
 CONFIG_SCHEMA = vol.Schema({
@@ -55,10 +57,12 @@ CONFIG_SCHEMA = vol.Schema({
 
 async def async_setup(hass, config):
     """Set up the REST command component."""
-    websession = async_get_clientsession(hass)
-
     def async_register_rest_command(name, command_config):
         """Create service for rest command."""
+        websession = async_get_clientsession(
+            hass,
+            command_config.get(CONF_VERIFY_SSL)
+        )
         timeout = command_config[CONF_TIMEOUT]
         method = command_config[CONF_METHOD]
 

--- a/homeassistant/components/switch/rest.py
+++ b/homeassistant/components/switch/rest.py
@@ -14,7 +14,7 @@ import voluptuous as vol
 from homeassistant.components.switch import (SwitchDevice, PLATFORM_SCHEMA)
 from homeassistant.const import (
     CONF_HEADERS, CONF_NAME, CONF_RESOURCE, CONF_TIMEOUT, CONF_METHOD,
-    CONF_USERNAME, CONF_PASSWORD)
+    CONF_USERNAME, CONF_PASSWORD, CONF_VERIFY_SSL)
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 
@@ -29,6 +29,7 @@ DEFAULT_BODY_OFF = 'OFF'
 DEFAULT_BODY_ON = 'ON'
 DEFAULT_NAME = 'REST Switch'
 DEFAULT_TIMEOUT = 10
+DEFAULT_VERIFY_SSL = True
 
 SUPPORT_REST_METHODS = ['post', 'put']
 
@@ -44,6 +45,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int,
     vol.Inclusive(CONF_USERNAME, 'authentication'): cv.string,
     vol.Inclusive(CONF_PASSWORD, 'authentication'): cv.string,
+    vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): cv.boolean,
 })
 
 
@@ -59,6 +61,7 @@ async def async_setup_platform(hass, config, async_add_entities,
     username = config.get(CONF_USERNAME)
     password = config.get(CONF_PASSWORD)
     resource = config.get(CONF_RESOURCE)
+    verify_ssl = config.get(CONF_VERIFY_SSL)
 
     auth = None
     if username:
@@ -74,7 +77,7 @@ async def async_setup_platform(hass, config, async_add_entities,
 
     try:
         switch = RestSwitch(name, resource, method, headers, auth, body_on,
-                            body_off, is_on_template, timeout)
+                            body_off, is_on_template, timeout, verify_ssl)
 
         req = await switch.get_device_state(hass)
         if req.status >= 400:
@@ -92,7 +95,7 @@ class RestSwitch(SwitchDevice):
     """Representation of a switch that can be toggled using REST."""
 
     def __init__(self, name, resource, method, headers, auth, body_on,
-                 body_off, is_on_template, timeout):
+                 body_off, is_on_template, timeout, verify_ssl):
         """Initialize the REST switch."""
         self._state = None
         self._name = name
@@ -104,6 +107,7 @@ class RestSwitch(SwitchDevice):
         self._body_off = body_off
         self._is_on_template = is_on_template
         self._timeout = timeout
+        self._verify_ssl = verify_ssl
 
     @property
     def name(self):
@@ -148,7 +152,7 @@ class RestSwitch(SwitchDevice):
 
     async def set_device_state(self, body):
         """Send a state update to the device."""
-        websession = async_get_clientsession(self.hass)
+        websession = async_get_clientsession(self.hass, self._verify_ssl)
 
         with async_timeout.timeout(self._timeout, loop=self.hass.loop):
             req = await getattr(websession, self._method)(
@@ -167,7 +171,7 @@ class RestSwitch(SwitchDevice):
 
     async def get_device_state(self, hass):
         """Get the latest data from REST API and update the state."""
-        websession = async_get_clientsession(hass)
+        websession = async_get_clientsession(hass, self._verify_ssl)
 
         with async_timeout.timeout(self._timeout, loop=hass.loop):
             req = await websession.get(self._resource, auth=self._auth,

--- a/tests/components/switch/test_rest.py
+++ b/tests/components/switch/test_rest.py
@@ -106,7 +106,7 @@ class TestRestSwitch:
         self.body_off = Template('off', self.hass)
         self.switch = rest.RestSwitch(
             self.name, self.resource, self.method, self.headers, self.auth,
-            self.body_on, self.body_off, None, 10)
+            self.body_on, self.body_off, None, 10, True)
         self.switch.hass = self.hass
 
     def teardown_method(self):


### PR DESCRIPTION
## Description:
Add verify_ssl to restful_command and switch.rest

**Related issue (if applicable):** fixes #20199

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8205

## Example entry for `configuration.yaml` (if applicable):
```yaml
switch:
  - platform: rest
    resource: http://IP_ADDRESS/ENDPOINT
    verify_ssl: true

rest_command:
  example_request:
    url: 'http://example.com/'
    verify_ssl: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
