### PR TITLE
Added rudimentary async support for maxcube climate thermostat

### DIFF
--- a/homeassistant/components/climate/maxcube.py
+++ b/homeassistant/components/climate/maxcube.py
@@ -124,6 +124,21 @@ class MaxCubeClimate(ClimateDevice):
                 _LOGGER.error("Setting target temperature failed")
                 return False
 
+    async def async_set_temperature(self, **kwargs):
+        """Set new target temperature."""
+        temp = kwargs.get(ATTR_TEMPERATURE)
+
+        # select device and cube
+        device = self._cubehandle.cube.device_by_rf(self._rf_address)
+        cube = self._cubehandle.cube
+
+        # Set device temperature
+        cube.set_target_temperature(device, temp)
+
+        # call the generic scheduling function,
+        # telling hass to update state in the future
+        self.async_schedule_update_ha_state()
+
     def set_operation_mode(self, operation_mode):
         """Set new operation mode."""
         device = self._cubehandle.cube.device_by_rf(self._rf_address)


### PR DESCRIPTION
## Description:
While I've followed the checklist bellow, and the change is really small, this fix probably needs some more attention. If this is indeed the right way to add syncio to this module, I'll try to add it for other calls as well.

Future candidates include the maxcube platform component (components/maxcube.py) as well as set_operationmode() and update(). Furthermore, I just started reading up on threading Python applications and am still figuring out what threading.Lock does in the original implementation (if this was necessary to not overload the cube) and if this should be replaced by asyncio.Lock

I've only slightly modified the normal set_temperature method. However, I didn't get any messages warning for locked async threads and temperatures update as expected. 

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):
No changes to documentation or website

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [NA] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [NA] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [NA] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [NA] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [NA] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [NA] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
## Description:
While I've followed the checklist bellow, and the change is really small, this fix probably needs some more attention. If this is indeed the right way to add syncio to this module, I'll try to add it for other calls as well.

Future candidates include the maxcube platform component (components/maxcube.py) as well as set_operationmode() and update(). Furthermore, I just started reading up on threading Python applications and am still figuring out what threading.Lock does in the original implementation (if this was necessary to not overload the cube) and if this should be replaced by asyncio.Lock

I've only slightly modified the normal set_temperature method. However, I didn't get any messages warning for locked async threads and temperatures update as expected. 

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):
No changes to documentation or website

## Checklist:
  - [X] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [NA] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [NA] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [NA] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [NA] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [NA] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [NA] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
