### PR TITLE
Fix for Volumio str/int issue #19086

### DIFF
--- a/homeassistant/components/media_player/volumio.py
+++ b/homeassistant/components/media_player/volumio.py
@@ -189,7 +189,7 @@ class Volumio(MediaPlayerDevice):
         """Volume level of the media player (0..1)."""
         volume = self._state.get('volume', None)
         if volume is not None and volume != "":
-            volume = volume / 100
+            volume = int(volume) / 100
         return volume
 
     @property


### PR DESCRIPTION
## Description:
Casting added to volume calculation to avoid type mismatch error.

**Related issue (if applicable):** fixes #19086

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>


## Checklist:
  - [Y] The code change is tested and works locally.
  - [Y] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [Y] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [N] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [N] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [N] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [N] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [N] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [N] Tests have been added to verify that the new code works.