### PR TITLE
Fix duplicate luftdaten entities

### DIFF
--- a/homeassistant/components/luftdaten/__init__.py
+++ b/homeassistant/components/luftdaten/__init__.py
@@ -12,13 +12,14 @@ from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import (
     CONF_MONITORED_CONDITIONS, CONF_SCAN_INTERVAL, CONF_SENSORS,
     CONF_SHOW_ON_MAP, TEMP_CELSIUS)
+from homeassistant.core import callback
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.event import async_track_time_interval
 
-from .config_flow import configured_sensors
+from .config_flow import configured_sensors, duplicate_stations
 from .const import CONF_SENSOR_ID, DEFAULT_SCAN_INTERVAL, DOMAIN
 
 REQUIREMENTS = ['luftdaten==0.3.4']
@@ -67,6 +68,14 @@ CONFIG_SCHEMA = vol.Schema({
 }, extra=vol.ALLOW_EXTRA)
 
 
+@callback
+def _async_fixup_sensor_id(hass, config_entry, sensor_id):
+    hass.config_entries.async_update_entry(
+        config_entry, data={
+            **config_entry.data, CONF_SENSOR_ID: int(sensor_id)
+        })
+
+
 async def async_setup(hass, config):
     """Set up the Luftdaten component."""
     hass.data[DOMAIN] = {}
@@ -77,7 +86,7 @@ async def async_setup(hass, config):
         return True
 
     conf = config[DOMAIN]
-    station_id = conf.get(CONF_SENSOR_ID)
+    station_id = conf[CONF_SENSOR_ID]
 
     if station_id not in configured_sensors(hass):
         hass.async_create_task(
@@ -101,6 +110,18 @@ async def async_setup_entry(hass, config_entry):
     """Set up Luftdaten as config entry."""
     from luftdaten import Luftdaten
     from luftdaten.exceptions import LuftdatenError
+
+    if not isinstance(config_entry.data[CONF_SENSOR_ID], int):
+        _async_fixup_sensor_id(hass, config_entry,
+                               config_entry.data[CONF_SENSOR_ID])
+
+    if (config_entry.data[CONF_SENSOR_ID] in
+            duplicate_stations(hass) and config_entry.source == SOURCE_IMPORT):
+        _LOGGER.warning("Removing duplicate sensors for station %s",
+                        config_entry.data[CONF_SENSOR_ID])
+        hass.async_create_task(hass.config_entries.async_remove(
+            config_entry.entry_id))
+        return False
 
     session = async_get_clientsession(hass)
 

--- a/homeassistant/components/luftdaten/config_flow.py
+++ b/homeassistant/components/luftdaten/config_flow.py
@@ -16,8 +16,16 @@ from .const import CONF_SENSOR_ID, DEFAULT_SCAN_INTERVAL, DOMAIN
 def configured_sensors(hass):
     """Return a set of configured Luftdaten sensors."""
     return set(
-        '{0}'.format(entry.data[CONF_SENSOR_ID])
+        entry.data[CONF_SENSOR_ID]
         for entry in hass.config_entries.async_entries(DOMAIN))
+
+
+@callback
+def duplicate_stations(hass):
+    """Return a set of duplicate configured Luftdaten stations."""
+    stations = [int(entry.data[CONF_SENSOR_ID])
+                for entry in hass.config_entries.async_entries(DOMAIN)]
+    return {x for x in stations if stations.count(x) > 1}
 
 
 @config_entries.HANDLERS.register(DOMAIN)

--- a/homeassistant/components/luftdaten/config_flow.py
+++ b/homeassistant/components/luftdaten/config_flow.py
@@ -7,6 +7,7 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_SCAN_INTERVAL, CONF_SHOW_ON_MAP
 from homeassistant.core import callback
 from homeassistant.helpers import aiohttp_client
+import homeassistant.helpers.config_validation as cv
 
 from .const import CONF_SENSOR_ID, DEFAULT_SCAN_INTERVAL, DOMAIN
 
@@ -30,8 +31,8 @@ class LuftDatenFlowHandler(config_entries.ConfigFlow):
     def _show_form(self, errors=None):
         """Show the form to the user."""
         data_schema = OrderedDict()
-        data_schema[vol.Required(CONF_SENSOR_ID)] = str
-        data_schema[vol.Optional(CONF_SHOW_ON_MAP, default=False)] = bool
+        data_schema[vol.Required(CONF_SENSOR_ID)] = cv.positive_int
+        data_schema[vol.Optional(CONF_SHOW_ON_MAP, default=False)] = cv.boolean
 
         return self.async_show_form(
             step_id='user',
@@ -72,4 +73,4 @@ class LuftDatenFlowHandler(config_entries.ConfigFlow):
             CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
         user_input.update({CONF_SCAN_INTERVAL: scan_interval.seconds})
 
-        return self.async_create_entry(title=sensor_id, data=user_input)
+        return self.async_create_entry(title=str(sensor_id), data=user_input)

--- a/homeassistant/components/luftdaten/config_flow.py
+++ b/homeassistant/components/luftdaten/config_flow.py
@@ -40,7 +40,7 @@ class LuftDatenFlowHandler(config_entries.ConfigFlow):
         """Show the form to the user."""
         data_schema = OrderedDict()
         data_schema[vol.Required(CONF_SENSOR_ID)] = cv.positive_int
-        data_schema[vol.Optional(CONF_SHOW_ON_MAP, default=False)] = cv.boolean
+        data_schema[vol.Optional(CONF_SHOW_ON_MAP, default=False)] = bool
 
         return self.async_show_form(
             step_id='user',


### PR DESCRIPTION
## Description:

When using the same sensor_id in the yaml config as in the config_flow, duplicate sensors will be created at every restart of home assistant. The duplicate detection is ineffective because the sensor_id is integer in yaml and string in config_flow. Each sensor will query the luftdaten api and eventually home assistant is banned due to the high load on the api servers. This PR fixes the duplicate detection and removes the duplicate sensors.

**Related issue (if applicable):** fixes #18838, and root cause for  #19622, #19981 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

