### PR TITLE
Handle non-string values in JSON template renderer

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -165,7 +165,7 @@ class Template:
 
         try:
             variables['value_json'] = json.loads(value)
-        except ValueError:
+        except (ValueError, TypeError):
             pass
 
         try:

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -4,6 +4,7 @@ from datetime import datetime
 import unittest
 import random
 import math
+import pytz
 from unittest.mock import patch
 
 from homeassistant.components import group
@@ -421,6 +422,16 @@ class TestHelpersTemplate(unittest.TestCase):
         tpl = template.Template('{{ value_json.bye|is_defined }}', self.hass)
         assert '' == \
             tpl.render_with_possible_json_value('{"hello": "world"}', '')
+
+    def test_render_with_possible_json_value_non_string_value(self):
+        """Render with possible JSON value with non-string value."""
+        tpl = template.Template("""
+{{ strptime(value~'+0000', '%Y-%m-%d %H:%M:%S%z') }}
+            """, self.hass)
+        value = datetime(2019, 1, 18, 12, 13, 14)
+        expected = str(pytz.utc.localize(value))
+        assert expected == \
+            tpl.render_with_possible_json_value(value)
 
     def test_raise_exception_on_error(self):
         """Test raising an exception on error."""


### PR DESCRIPTION
## Description:
Using the [SQL Sensor](https://www.home-assistant.io/components/sensor.sql/) to extract a datetime value for a state (such as last_changed), and using value_template to convert that datetime to another format, was resulting in a TypeError being thrown by json.loads, indirectly called by async_render_with_possible_json_value in homeassistant.helpers.template. This error should be ignored so that the template can be rendered without value_json (just like what happens with a malformed JSON string.)

This change fixes that problem by catching TypeError in addition to ValueError.

Example error from log:
```
sql: Error on device update!
Traceback (most recent call last):
  File "/srv/homeassistant/lib/python3.5/site-packages/homeassistant/helpers/entity_platform.py", line 248, in _async_add_entity
    await entity.async_device_update(warning=False)
  File "/srv/homeassistant/lib/python3.5/site-packages/homeassistant/helpers/entity.py", line 349, in async_device_update
    await self.hass.async_add_executor_job(self.update)
  File "/usr/lib/python3.5/asyncio/futures.py", line 380, in __iter__
    yield self  # This tells Task to wait for completion.
  File "/usr/lib/python3.5/asyncio/tasks.py", line 304, in _wakeup
    future.result()
  File "/usr/lib/python3.5/asyncio/futures.py", line 293, in result
    raise self._exception
  File "/usr/lib/python3.5/concurrent/futures/thread.py", line 55, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/srv/homeassistant/lib/python3.5/site-packages/homeassistant/components/sensor/sql.py", line 160, in update
    data, None)
  File "/srv/homeassistant/lib/python3.5/site-packages/homeassistant/helpers/template.py", line 166, in async_render_with_possible_json_value
    variables['value_json'] = json.loads(value)
  File "/usr/lib/python3.5/json/__init__.py", line 312, in loads
    s.__class__.__name__))
TypeError: the JSON object must be str, not 'datetime'
```

**Related issue (if applicable):** none

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** none

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: sql
    db_url: !secret db_url
    queries:
      - name: Get last_changed in local time
        query: "SELECT last_changed FROM states WHERE entity_id = 'domain.object_id' ORDER BY state_id DESC LIMIT 1;"
        column: last_changed
        value_template: "{{ strptime(value~'+0000', '%Y-%m-%d %H:%M:%S%z').astimezone(now().tzinfo) }}"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
