### PR TITLE
Add support for unloading entries to device trackers

### DIFF
--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -238,7 +238,7 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType):
 
 async def async_setup_entry(hass, entry):
     """Set up an entry."""
-    await hass.data[DOMAIN].get_async_setup_platform(entry.domain, entry)
+    await hass.data[DOMAIN].get_async_setup_platform()(entry.domain, entry)
     return True
 
 

--- a/homeassistant/components/device_tracker/gpslogger.py
+++ b/homeassistant/components/device_tracker/gpslogger.py
@@ -6,18 +6,22 @@ https://home-assistant.io/components/device_tracker.gpslogger/
 """
 import logging
 
-from homeassistant.components.gpslogger import TRACKER_UPDATE
+from homeassistant.components.device_tracker import DOMAIN as \
+    DEVICE_TRACKER_DOMAIN
+from homeassistant.components.gpslogger import DOMAIN as GPSLOGGER_DOMAIN, \
+    TRACKER_UPDATE
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers.typing import HomeAssistantType, ConfigType
+from homeassistant.helpers.typing import HomeAssistantType
 
 _LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = ['gpslogger']
 
+DATA_KEY = '{}.{}'.format(GPSLOGGER_DOMAIN, DEVICE_TRACKER_DOMAIN)
 
-async def async_setup_scanner(hass: HomeAssistantType, config: ConfigType,
-                              async_see, discovery_info=None):
-    """Set up an endpoint for the GPSLogger device tracker."""
+
+async def async_setup_entry(hass: HomeAssistantType, entry, async_see):
+    """Configure a dispatcher connection based on a config entry."""
     async def _set_location(device, gps_location, battery, accuracy, attrs):
         """Fire HA event to set location."""
         await async_see(
@@ -28,5 +32,13 @@ async def async_setup_scanner(hass: HomeAssistantType, config: ConfigType,
             attributes=attrs
         )
 
-    async_dispatcher_connect(hass, TRACKER_UPDATE, _set_location)
+    hass.data[DATA_KEY] = async_dispatcher_connect(
+        hass, TRACKER_UPDATE, _set_location
+    )
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistantType, entry):
+    """Unload the config entry and remove the dispatcher connection."""
+    hass.data[DATA_KEY]()
     return True

--- a/homeassistant/components/gpslogger/__init__.py
+++ b/homeassistant/components/gpslogger/__init__.py
@@ -15,8 +15,8 @@ from homeassistant.components.device_tracker.tile import ATTR_ALTITUDE
 from homeassistant.const import HTTP_UNPROCESSABLE_ENTITY, \
     HTTP_OK, ATTR_LATITUDE, ATTR_LONGITUDE, CONF_WEBHOOK_ID
 from homeassistant.helpers import config_entry_flow
-from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.components.device_tracker import DOMAIN as DEVICE_TRACKER
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -57,9 +57,6 @@ WEBHOOK_SCHEMA = vol.Schema({
 
 async def async_setup(hass, hass_config):
     """Set up the GPSLogger component."""
-    hass.async_create_task(
-        async_load_platform(hass, 'device_tracker', DOMAIN, {}, hass_config)
-    )
     return True
 
 
@@ -103,12 +100,20 @@ async def async_setup_entry(hass, entry):
     """Configure based on config entry."""
     hass.components.webhook.async_register(
         DOMAIN, 'GPSLogger', entry.data[CONF_WEBHOOK_ID], handle_webhook)
+
+    hass.async_create_task(
+        hass.config_entries.async_forward_entry_setup(entry, DEVICE_TRACKER)
+    )
     return True
 
 
 async def async_unload_entry(hass, entry):
     """Unload a config entry."""
     hass.components.webhook.async_unregister(entry.data[CONF_WEBHOOK_ID])
+
+    hass.async_create_task(
+        hass.config_entries.async_forward_entry_unload(entry, DEVICE_TRACKER)
+    )
     return True
 
 config_entry_flow.register_webhook_flow(

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -1,31 +1,30 @@
 """The tests for the device tracker component."""
 # pylint: disable=protected-access
-import asyncio
 import json
 import logging
-from unittest.mock import call
-from datetime import datetime, timedelta
 import os
-from asynctest import patch
-import pytest
+from datetime import datetime, timedelta
+from unittest.mock import call
 
-from homeassistant.components import zone
-from homeassistant.core import callback, State
-from homeassistant.setup import async_setup_component
-from homeassistant.helpers import discovery
-from homeassistant.loader import get_component
+import pytest
+from asynctest import patch
+
+import homeassistant.components.device_tracker as device_tracker
 import homeassistant.util.dt as dt_util
+from homeassistant.components import zone
 from homeassistant.const import (
     ATTR_ENTITY_ID, ATTR_ENTITY_PICTURE, ATTR_FRIENDLY_NAME, ATTR_HIDDEN,
     STATE_HOME, STATE_NOT_HOME, CONF_PLATFORM, ATTR_ICON)
-import homeassistant.components.device_tracker as device_tracker
-from tests.components.device_tracker import common
+from homeassistant.core import callback, State
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import discovery
 from homeassistant.helpers.json import JSONEncoder
-
+from homeassistant.loader import get_component
+from homeassistant.setup import async_setup_component
 from tests.common import (
     async_fire_time_changed, patch_yaml_files, assert_setup_component,
     mock_restore_cache)
+from tests.components.device_tracker import common
 
 TEST_PLATFORM = {device_tracker.DOMAIN: {CONF_PLATFORM: 'test'}}
 

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -513,8 +513,7 @@ async def test_see_failures(mock_warning, hass, yaml_devices):
     assert len(config) == 4
 
 
-@asyncio.coroutine
-def test_async_added_to_hass(hass):
+async def test_async_added_to_hass(hass):
     """Test restoring state."""
     attr = {
         device_tracker.ATTR_LONGITUDE: 18,
@@ -532,7 +531,7 @@ def test_async_added_to_hass(hass):
         path: 'jk:\n  name: JK Phone\n  track: True',
     }
     with patch_yaml_files(files):
-        yield from device_tracker.async_setup(hass, {})
+        await device_tracker.async_setup(hass, {})
 
     state = hass.states.get('device_tracker.jk')
     assert state
@@ -543,8 +542,7 @@ def test_async_added_to_hass(hass):
         assert atr == val, "{}={} expected: {}".format(key, atr, val)
 
 
-@asyncio.coroutine
-def test_bad_platform(hass):
+async def test_bad_platform(hass):
     """Test bad platform."""
     config = {
         'device_tracker': [{
@@ -552,7 +550,7 @@ def test_bad_platform(hass):
         }]
     }
     with assert_setup_component(0, device_tracker.DOMAIN):
-        assert (yield from device_tracker.async_setup(hass, config))
+        assert await device_tracker.async_setup(hass, config)
 
 
 async def test_adding_unknown_device_to_config(mock_device_tracker_conf, hass):

--- a/tests/components/gpslogger/test_init.py
+++ b/tests/components/gpslogger/test_init.py
@@ -2,15 +2,17 @@
 from unittest.mock import patch, Mock
 
 import pytest
+from homeassistant.helpers.dispatcher import DATA_DISPATCHER
 
 from homeassistant import data_entry_flow
-from homeassistant.components import zone
+from homeassistant.components import zone, gpslogger
 from homeassistant.components.device_tracker import \
     DOMAIN as DEVICE_TRACKER_DOMAIN
-from homeassistant.components.gpslogger import DOMAIN
+from homeassistant.components.gpslogger import DOMAIN, TRACKER_UPDATE
 from homeassistant.const import HTTP_OK, HTTP_UNPROCESSABLE_ENTITY, \
-    STATE_HOME, STATE_NOT_HOME
+    STATE_HOME, STATE_NOT_HOME, CONF_WEBHOOK_ID
 from homeassistant.setup import async_setup_component
+from tests.common import MockConfigEntry
 
 HOME_LATITUDE = 37.239622
 HOME_LONGITUDE = -115.815811
@@ -164,3 +166,18 @@ async def test_enter_with_attrs(hass, gpslogger_client, webhook_id):
     assert 102.0 == state.attributes['altitude']
     assert 'gps' == state.attributes['provider']
     assert 'running' == state.attributes['activity']
+
+
+async def test_load_unload_entry(hass):
+    """Test that the appropriate dispatch signals are added and removed."""
+    entry = MockConfigEntry(domain=DOMAIN, data={
+        CONF_WEBHOOK_ID: 'gpslogger_test'
+    })
+
+    await gpslogger.async_setup_entry(hass, entry)
+    await hass.async_block_till_done()
+    assert 1 == len(hass.data[DATA_DISPATCHER][TRACKER_UPDATE])
+
+    await gpslogger.async_unload_entry(hass, entry)
+    await hass.async_block_till_done()
+    assert 0 == len(hass.data[DATA_DISPATCHER][TRACKER_UPDATE])


### PR DESCRIPTION
## Description:
Device tracker platforms did not support having their entries unloaded. This PR adds support for that and demonstrates how it works with the gpslogger platform. This came out of a couple of discussions with @MartinHjelmare https://github.com/home-assistant/home-assistant/pull/20083#issuecomment-454712408 and https://github.com/home-assistant/home-assistant/pull/20079#discussion_r248505491.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
