### PR TITLE
Added support for Somfy RTS wireless power socket and

### DIFF
--- a/homeassistant/components/cover/tahoma.py
+++ b/homeassistant/components/cover/tahoma.py
@@ -145,6 +145,14 @@ class TahomaCover(TahomaDevice, CoverDevice):
         if self.tahoma_device.type != \
             'rts:RollerShutterRTSComponent':
             self.apply_action('setPosition', 100 - kwargs.get(ATTR_POSITION))
+        else:
+            if kwargs.get(ATTR_POSITION) == 100:
+               self.open_cover()
+            elif kwargs.get(ATTR_POSITION) == 0:
+               self.close_cover()
+            else:
+               self.stop_cover()
+
 
     @property
     def is_closed(self):

--- a/homeassistant/components/cover/tahoma.py
+++ b/homeassistant/components/cover/tahoma.py
@@ -42,7 +42,7 @@ class TahomaCover(TahomaDevice, CoverDevice):
 
         self._closure = 0
         # 100 equals open
-        self._position = 100
+        self._position = 50
         self._closed = False
         self._rssi_level = None
         self._icon = None
@@ -123,13 +123,15 @@ class TahomaCover(TahomaDevice, CoverDevice):
                 self._position = 100
             self._closed = self._position == 0
         else:
-            self._position = None
-            if 'core:OpenClosedState' in self.tahoma_device.active_states:
-                self._closed = \
-                    self.tahoma_device.active_states['core:OpenClosedState']\
-                    == 'closed'
-            else:
-                self._closed = False
+            if self.tahoma_device.type != \
+            'rts:RollerShutterRTSComponent':
+                self._position = None
+                if 'core:OpenClosedState' in self.tahoma_device.active_states:
+                    self._closed = \
+                        self.tahoma_device.active_states['core:OpenClosedState']\
+                        == 'closed'
+                else:
+                    self._closed = False
 
         _LOGGER.debug("Update %s, position: %d", self._name, self._position)
 
@@ -140,7 +142,9 @@ class TahomaCover(TahomaDevice, CoverDevice):
 
     def set_cover_position(self, **kwargs):
         """Move the cover to a specific position."""
-        self.apply_action('setPosition', 100 - kwargs.get(ATTR_POSITION))
+        if self.tahoma_device.type != \
+            'rts:RollerShutterRTSComponent':
+            self.apply_action('setPosition', 100 - kwargs.get(ATTR_POSITION))
 
     @property
     def is_closed(self):
@@ -188,6 +192,8 @@ class TahomaCover(TahomaDevice, CoverDevice):
             self.apply_action('close')
         else:
             self.apply_action('open')
+        if self.tahoma_device.type == 'rts:RollerShutterRTSComponent':
+            self._position = 100
 
     def close_cover(self, **kwargs):
         """Close the cover."""
@@ -195,6 +201,8 @@ class TahomaCover(TahomaDevice, CoverDevice):
             self.apply_action('open')
         else:
             self.apply_action('close')
+        if self.tahoma_device.type == 'rts:RollerShutterRTSComponent':
+            self._position = 0
 
     def stop_cover(self, **kwargs):
         """Stop the cover."""
@@ -214,5 +222,9 @@ class TahomaCover(TahomaDevice, CoverDevice):
                  'io:RollerShutterGenericIOComponent',
                  'io:VerticalExteriorAwningIOComponent'):
             self.apply_action('stop')
+        elif self.tahoma_device.type == \
+            'rts:RollerShutterRTSComponent':
+            self.apply_action('my')
+            self._position = 50
         else:
             self.apply_action('stopIdentify')

--- a/homeassistant/components/sensor/tahoma.py
+++ b/homeassistant/components/sensor/tahoma.py
@@ -48,8 +48,8 @@ class TahomaSensor(TahomaDevice, Entity):
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement of this entity, if any."""
-        if self.tahoma_device.type == 'Temperature Sensor':
-            return None
+        if self.tahoma_device.type == 'io:TemperatureIOSystemSensor':
+            return '°C'
         if self.tahoma_device.type == 'io:SomfyContactIOSystemSensor':
             return None
         if self.tahoma_device.type == 'io:LightIOSystemSensor':
@@ -81,6 +81,11 @@ class TahomaSensor(TahomaDevice, Entity):
         if self.tahoma_device.type == 'rtds:RTDSMotionSensor':
             self.current_value = self.tahoma_device.active_states[
                 'core:OccupancyState']
+            self._available = True
+        if self.tahoma_device.type == 'io:TemperatureIOSystemSensor':
+            """ round the temperature value, otherwise, it will show up as 13.4999999999999 """
+            self.current_value = float("{:.2f}".format(self.tahoma_device.active_states[
+                'core:TemperatureState']))
             self._available = True
 
         _LOGGER.debug("Update %s, value: %d", self._name, self.current_value)

--- a/homeassistant/components/sensor/tahoma.py
+++ b/homeassistant/components/sensor/tahoma.py
@@ -83,9 +83,10 @@ class TahomaSensor(TahomaDevice, Entity):
                 'core:OccupancyState']
             self._available = True
         if self.tahoma_device.type == 'io:TemperatureIOSystemSensor':
-            """ round the temperature value, otherwise, it will show up as 13.4999999999999 """
-            self.current_value = float("{:.2f}".format(self.tahoma_device.active_states[
-                'core:TemperatureState']))
+            """ round the temperature value, otherwise, it will"""
+            """ show up as 13.4999999999999 """
+            self.current_value = float("{:.2f}".format(
+                self.tahoma_device.active_states['core:TemperatureState']))
             self._available = True
 
         _LOGGER.debug("Update %s, value: %d", self._name, self.current_value)

--- a/homeassistant/components/switch/tahoma.py
+++ b/homeassistant/components/switch/tahoma.py
@@ -54,9 +54,14 @@ class TahomaSwitch(TahomaDevice, SwitchDevice):
                 self._state = STATE_ON
             else:
                 self._state = STATE_OFF
-
-        self._available = bool(self.tahoma_device.active_states.get(
-            'core:StatusState') == 'available')
+        
+        """ A RTS power socket doesn't have a feedback channel, so we must assume the
+            socket is available. If not, the signal is lost in the endless expanse of the universe """
+        if self.tahoma_device.type == 'rts:OnOffRTSComponent':
+            self._available = True
+        else:
+            self._available = bool(self.tahoma_device.active_states.get(
+                'core:StatusState') == 'available')
 
         _LOGGER.debug("Update %s, state: %s", self._name, self._state)
 

--- a/homeassistant/components/switch/tahoma.py
+++ b/homeassistant/components/switch/tahoma.py
@@ -54,9 +54,10 @@ class TahomaSwitch(TahomaDevice, SwitchDevice):
                 self._state = STATE_ON
             else:
                 self._state = STATE_OFF
-        
-        """ A RTS power socket doesn't have a feedback channel, so we must assume the
-            socket is available. If not, the signal is lost in the endless expanse of the universe """
+
+        """ A RTS power socket doesn't have a feedback channel, 
+            so we must assume the socket is available. If not, the signal 
+            is lost in the endless expanse of the universe """
         if self.tahoma_device.type == 'rts:OnOffRTSComponent':
             self._available = True
         else:

--- a/homeassistant/components/tahoma.py
+++ b/homeassistant/components/tahoma.py
@@ -39,6 +39,7 @@ TAHOMA_TYPES = {
     'io:ExteriorVenetianBlindIOComponent': 'cover',
     'io:HorizontalAwningIOComponent': 'cover',
     'io:LightIOSystemSensor': 'sensor',
+    'io:TemperatureIOSystemSensor': 'sensor',
     'io:OnOffIOComponent': 'switch',
     'io:OnOffLightIOComponent': 'switch',
     'io:RollerShutterGenericIOComponent': 'cover',
@@ -57,7 +58,8 @@ TAHOMA_TYPES = {
     'rts:ExteriorVenetianBlindRTSComponent': 'cover',
     'rts:GarageDoor4TRTSComponent': 'switch',
     'rts:RollerShutterRTSComponent': 'cover',
-    'rts:VenetianBlindRTSComponent': 'cover'
+    'rts:VenetianBlindRTSComponent': 'cover',
+    'rts:OnOffRTSComponent': 'switch'
 }
 
 


### PR DESCRIPTION
Somfy Temperature Sensore Thermos Wirefree io

## Description:
Added support for Somfy RTS wireless power socket and Somfy Temperature Sensore Thermos Wirefree io

**Related issue (if applicable):** n/a

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable): n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

