### PR TITLE
Bump aioesphomeapi to 1.4.2

### DIFF
--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
         ServiceCall
 
 DOMAIN = 'esphome'
-REQUIREMENTS = ['aioesphomeapi==1.4.1']
+REQUIREMENTS = ['aioesphomeapi==1.4.2']
 
 
 DISPATCHER_UPDATE_ENTITY = 'esphome_{entry_id}_update_{component_key}_{key}'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -96,7 +96,7 @@ aioautomatic==0.6.5
 aiodns==1.1.1
 
 # homeassistant.components.esphome
-aioesphomeapi==1.4.1
+aioesphomeapi==1.4.2
 
 # homeassistant.components.freebox
 aiofreepybox==0.0.6


### PR DESCRIPTION
## Description:

Changelog https://github.com/OttoWinter/aioesphomeapi/compare/9e7c0b9101c42cc9953069dcd7f9add8e3157ac9...master

 * Further improves async handling to hopefully get rid of situations where HA needs to be restarted for an ESP to become online again
 * Fixes error where flash/transition length were 1/millionth of what they should be 😜 
 * Specifies protobuf version restriction. protobuf versions before 3.6 are incompatible.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
