### PR TITLE
Fix temperature updates via automation overriding away temperature

### DIFF
--- a/homeassistant/components/climate/generic_thermostat.py
+++ b/homeassistant/components/climate/generic_thermostat.py
@@ -276,7 +276,10 @@ class GenericThermostat(ClimateDevice, RestoreEntity):
         temperature = kwargs.get(ATTR_TEMPERATURE)
         if temperature is None:
             return
-        self._target_temp = temperature
+        if self._is_away:
+            self._saved_target_temp = temperature
+        else:
+            self._target_temp = temperature
         await self._async_control_heating(force=True)
         await self.async_update_ha_state()
 

--- a/tests/components/climate/test_generic_thermostat.py
+++ b/tests/components/climate/test_generic_thermostat.py
@@ -223,6 +223,27 @@ async def test_set_away_mode_twice_and_restore_prev_temp(hass, setup_comp_2):
     assert 23 == state.attributes.get('temperature')
 
 
+async def test_change_temp_when_away_and_restore_prev_temp(hass, setup_comp_2):
+    """Test that setting a temperature in away mode updates stored temperature.
+
+    Verify new temperature is restored.
+    """
+    common.async_set_temperature(hass, 23)
+    await hass.async_block_till_done()
+    common.async_set_away_mode(hass, True)
+    await hass.async_block_till_done()
+    state = hass.states.get(ENTITY)
+    assert 16 == state.attributes.get('temperature')
+    common.async_set_temperature(hass, 30)
+    await hass.async_block_till_done()
+    state = hass.states.get(ENTITY)
+    assert 16 == state.attributes.get('temperature')
+    common.async_set_away_mode(hass, False)
+    await hass.async_block_till_done()
+    state = hass.states.get(ENTITY)
+    assert 30 == state.attributes.get('temperature')
+
+
 async def test_sensor_bad_value(hass, setup_comp_2):
     """Test sensor that have None as state."""
     state = hass.states.get(ENTITY)


### PR DESCRIPTION
## Description:
Fix for temperature updates via Automation overriding 'permanent' Away temperature when in Away mode. Now updates the Stored temperature, not the target temperature, when in Away mode.

**Related issue (if applicable):** fixes #20154

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
