### PR TITLE
Should require the 'GATTOOL' setup extras which includes pexpect.

### DIFF
--- a/homeassistant/components/device_tracker/bluetooth_le_tracker.py
+++ b/homeassistant/components/device_tracker/bluetooth_le_tracker.py
@@ -15,7 +15,7 @@ import homeassistant.util.dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['pygatt==3.2.0']
+REQUIREMENTS = ['pygatt[GATTTOOL]==3.2.0']
 
 BLE_PREFIX = 'BLE_'
 MIN_SEEN_NEW = 5

--- a/homeassistant/components/sensor/skybeacon.py
+++ b/homeassistant/components/sensor/skybeacon.py
@@ -16,7 +16,7 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['pygatt==3.2.0']
+REQUIREMENTS = ['pygatt[GATTTOOL]==3.2.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1004,7 +1004,7 @@ pyfttt==0.3
 
 # homeassistant.components.device_tracker.bluetooth_le_tracker
 # homeassistant.components.sensor.skybeacon
-pygatt==3.2.0
+pygatt[GATTTOOL]==3.2.0
 
 # homeassistant.components.cover.gogogate2
 pygogogate2==0.1.1


### PR DESCRIPTION
## Description:
This home assistant component always uses the gattool backend of pygatt. This backend in turn requires `pexpect`, but to install it as a dependency means specifying the extras requirement here.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.