### PR TITLE
Remove double logging of automation action

### DIFF
--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -375,8 +375,6 @@ def _async_get_action(hass, config, name):
     async def action(entity_id, variables, context):
         """Execute an action."""
         _LOGGER.info('Executing %s', name)
-        hass.components.logbook.async_log_entry(
-            name, 'has been triggered', DOMAIN, entity_id)
 
         try:
             await script_obj.async_run(variables, context)


### PR DESCRIPTION
## Description:

This was removed in #18765 but then returned in #18965 (due to a merge conflict, I assume).

**Related issue (if applicable):** fixes #19970

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
