### PR TITLE
Add LCN switch platform

### DIFF
--- a/homeassistant/components/lcn.py
+++ b/homeassistant/components/lcn.py
@@ -12,7 +12,7 @@ import voluptuous as vol
 
 from homeassistant.const import (
     CONF_ADDRESS, CONF_HOST, CONF_LIGHTS, CONF_NAME, CONF_PASSWORD, CONF_PORT,
-    CONF_USERNAME)
+    CONF_SWITCHES, CONF_USERNAME)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.entity import Entity
@@ -95,6 +95,13 @@ LIGHTS_SCHEMA = vol.Schema({
                 lambda value: value * 1000),
 })
 
+SWITCHES_SCHEMA = vol.Schema({
+    vol.Required(CONF_NAME): cv.string,
+    vol.Required(CONF_ADDRESS): is_address,
+    vol.Required(CONF_OUTPUT): vol.All(vol.Upper,
+                                       vol.In(OUTPUT_PORTS + RELAY_PORTS))
+})
+
 CONNECTION_SCHEMA = vol.Schema({
     vol.Required(CONF_HOST): cv.string,
     vol.Required(CONF_PORT): cv.port,
@@ -110,7 +117,8 @@ CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Required(CONF_CONNECTIONS): vol.All(
             cv.ensure_list, has_unique_connection_names, [CONNECTION_SCHEMA]),
-        vol.Required(CONF_LIGHTS): vol.All(cv.ensure_list, [LIGHTS_SCHEMA])
+        vol.Optional(CONF_LIGHTS): vol.All(cv.ensure_list, [LIGHTS_SCHEMA]),
+        vol.Optional(CONF_SWITCHES): vol.All(cv.ensure_list, [SWITCHES_SCHEMA])
     })
 }, extra=vol.ALLOW_EXTRA)
 
@@ -167,6 +175,10 @@ async def async_setup(hass, config):
     hass.async_create_task(
         async_load_platform(hass, 'light', DOMAIN,
                             config[DOMAIN][CONF_LIGHTS], config))
+
+    hass.async_create_task(
+        async_load_platform(hass, 'switch', DOMAIN,
+                            config[DOMAIN][CONF_SWITCHES], config))
 
     return True
 

--- a/homeassistant/components/switch/lcn.py
+++ b/homeassistant/components/switch/lcn.py
@@ -17,6 +17,9 @@ DEPENDENCIES = ['lcn']
 async def async_setup_platform(hass, hass_config, async_add_entities,
                                discovery_info=None):
     """Set up the LCN switch platform."""
+    if discovery_info is None:
+        return
+
     import pypck
 
     devices = []
@@ -78,7 +81,7 @@ class LcnOutputSwitch(LcnDevice, SwitchDevice):
                 input_obj.get_output_id() != self.output.value:
             return
 
-        self._is_on = (input_obj.get_percent() > 0)
+        self._is_on = input_obj.get_percent() > 0
         self.async_schedule_update_ha_state()
 
 

--- a/homeassistant/components/switch/lcn.py
+++ b/homeassistant/components/switch/lcn.py
@@ -1,0 +1,132 @@
+"""
+Support for LCN switches.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/switch.lcn/
+"""
+
+from homeassistant.components.lcn import (
+    CONF_CONNECTIONS, CONF_OUTPUT, DATA_LCN, OUTPUT_PORTS, LcnDevice,
+    get_connection)
+from homeassistant.components.switch import SwitchDevice
+from homeassistant.const import CONF_ADDRESS
+
+DEPENDENCIES = ['lcn']
+
+
+async def async_setup_platform(hass, hass_config, async_add_entities,
+                               discovery_info=None):
+    """Set up the LCN switch platform."""
+    import pypck
+
+    devices = []
+    for config in discovery_info:
+        address, connection_id = config[CONF_ADDRESS]
+        addr = pypck.lcn_addr.LcnAddr(*address)
+        connections = hass.data[DATA_LCN][CONF_CONNECTIONS]
+        connection = get_connection(connections, connection_id)
+        address_connection = connection.get_address_conn(addr)
+
+        if config[CONF_OUTPUT] in OUTPUT_PORTS:
+            device = LcnOutputSwitch(config, address_connection)
+        else:  # in RELAY_PORTS
+            device = LcnRelaySwitch(config, address_connection)
+
+        devices.append(device)
+
+    async_add_entities(devices)
+
+
+class LcnOutputSwitch(LcnDevice, SwitchDevice):
+    """Representation of a LCN switch for output ports."""
+
+    def __init__(self, config, address_connection):
+        """Initialize the LCN switch."""
+        super().__init__(config, address_connection)
+
+        self.output = self.pypck.lcn_defs.OutputPort[config[CONF_OUTPUT]]
+
+        self._is_on = None
+
+    async def async_added_to_hass(self):
+        """Run when entity about to be added to hass."""
+        await super().async_added_to_hass()
+        self.hass.async_create_task(
+            self.address_connection.activate_status_request_handler(
+                self.output))
+
+    @property
+    def is_on(self):
+        """Return True if entity is on."""
+        return self._is_on
+
+    async def async_turn_on(self, **kwargs):
+        """Turn the entity on."""
+        self._is_on = True
+        self.address_connection.dim_output(self.output.value, 100, 0)
+        await self.async_update_ha_state()
+
+    async def async_turn_off(self, **kwargs):
+        """Turn the entity off."""
+        self._is_on = False
+        self.address_connection.dim_output(self.output.value, 0, 0)
+        await self.async_update_ha_state()
+
+    def input_received(self, input_obj):
+        """Set switch state when LCN input object (command) is received."""
+        if not isinstance(input_obj, self.pypck.inputs.ModStatusOutput) or \
+                input_obj.get_output_id() != self.output.value:
+            return
+
+        self._is_on = (input_obj.get_percent() > 0)
+        self.async_schedule_update_ha_state()
+
+
+class LcnRelaySwitch(LcnDevice, SwitchDevice):
+    """Representation of a LCN switch for relay ports."""
+
+    def __init__(self, config, address_connection):
+        """Initialize the LCN switch."""
+        super().__init__(config, address_connection)
+
+        self.output = self.pypck.lcn_defs.RelayPort[config[CONF_OUTPUT]]
+
+        self._is_on = None
+
+    async def async_added_to_hass(self):
+        """Run when entity about to be added to hass."""
+        await super().async_added_to_hass()
+        self.hass.async_create_task(
+            self.address_connection.activate_status_request_handler(
+                self.output))
+
+    @property
+    def is_on(self):
+        """Return True if entity is on."""
+        return self._is_on
+
+    async def async_turn_on(self, **kwargs):
+        """Turn the entity on."""
+        self._is_on = True
+
+        states = [self.pypck.lcn_defs.RelayStateModifier.NOCHANGE] * 8
+        states[self.output.value] = self.pypck.lcn_defs.RelayStateModifier.ON
+        self.address_connection.control_relays(states)
+        await self.async_update_ha_state()
+
+    async def async_turn_off(self, **kwargs):
+        """Turn the entity off."""
+        self._is_on = False
+
+        states = [self.pypck.lcn_defs.RelayStateModifier.NOCHANGE] * 8
+        states[self.output.value] = self.pypck.lcn_defs.RelayStateModifier.OFF
+        self.address_connection.control_relays(states)
+        await self.async_update_ha_state()
+
+    def input_received(self, input_obj):
+        """Set switch state when LCN input object (command) is received."""
+        if not isinstance(input_obj, self.pypck.inputs.ModStatusRelays):
+            return
+
+        self._is_on = input_obj.get_state(self.output.value)
+        self.async_schedule_update_ha_state()


### PR DESCRIPTION
## Description:
The LCN switch platform is added. The implementation follows the already merged LCN light platform.

**Related issue (if applicable):**

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8223

## Example entry for `configuration.yaml` (if applicable):
```yaml
lcn:
  connections:
    - name: myhome
      host: 192.168.2.41
      port: 4114
      username: !secret lcn_username
      password: !secret lcn_password

  switches:
    - name: Sprinkler switch
      address: myhome.0.7
      output: relay1
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
