### PR TITLE
Updated sense library to 0.6.0

### DIFF
--- a/homeassistant/components/sense.py
+++ b/homeassistant/components/sense.py
@@ -12,7 +12,7 @@ from homeassistant.const import CONF_EMAIL, CONF_PASSWORD, CONF_TIMEOUT
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.discovery import load_platform
 
-REQUIREMENTS = ['sense_energy==0.5.1']
+REQUIREMENTS = ['sense_energy==0.6.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1478,7 +1478,7 @@ sendgrid==5.6.0
 sense-hat==2.2.0
 
 # homeassistant.components.sense
-sense_energy==0.5.1
+sense_energy==0.6.0
 
 # homeassistant.components.media_player.aquostv
 sharp_aquos_rc==0.3.2


### PR DESCRIPTION
## Description:
Updated the sense-api to version 0.6.0.  The new version uses the "websockets" library rather than the "websocket-client" library which is more reliable.
