### PR TITLE
Remove colorlog dep if available

### DIFF
--- a/homeassistant/scripts/check_config.py
+++ b/homeassistant/scripts/check_config.py
@@ -5,7 +5,6 @@ import logging
 import os
 from collections import OrderedDict, namedtuple
 from glob import glob
-from platform import system
 from typing import Dict, List, Sequence
 from unittest.mock import patch
 
@@ -21,9 +20,10 @@ from homeassistant.config import (
 from homeassistant.util import yaml
 from homeassistant.exceptions import HomeAssistantError
 
-REQUIREMENTS = ('colorlog==4.0.2',)
-if system() == 'Windows':  # Ensure colorama installed for colorlog on Windows
-    REQUIREMENTS += ('colorama<=1',)
+try:
+    import colorlog.escape_codes  # noqa # pylint: disable=unused-import
+except ImportError:
+    REQUIREMENTS = ('colorlog==4.0.2',)
 
 _LOGGER = logging.getLogger(__name__)
 # pylint: disable=protected-access

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -261,9 +261,6 @@ coinbase==2.1.0
 # homeassistant.components.sensor.coinmarketcap
 coinmarketcap==5.0.3
 
-# homeassistant.scripts.check_config
-colorlog==4.0.2
-
 # homeassistant.components.alarm_control_panel.concord232
 # homeassistant.components.binary_sensor.concord232
 concord232==0.15


### PR DESCRIPTION
## Description:
Removed colorlog REQUIREMENT if this is already present
There are multiple reports of colorlog installing everytime on config_check execution — I am seeing this in the dev docker image as well

**Another approach would be to make this part of the core requirements... (would prefer this to be honest)**

**Related issue (if applicable):** fixes #18651

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54