### PR TITLE
Make Netatmo able to discover both Weather station and Health Coach

### DIFF
--- a/homeassistant/components/netatmo/sensor.py
+++ b/homeassistant/components/netatmo/sensor.py
@@ -134,11 +134,13 @@ def auto_config(netatmo, config, dev):
         except pyatmo.NoDevice:
             continue
 
+
 def all_product_classes():
     """Returns all handled Netatmo product classes."""
     import pyatmo
 
     return [pyatmo.WeatherStationData, pyatmo.HomeCoachData]
+
 
 class NetAtmoSensor(Entity):
     """Implementation of a Netatmo sensor."""

--- a/homeassistant/components/netatmo/sensor.py
+++ b/homeassistant/components/netatmo/sensor.py
@@ -136,7 +136,7 @@ def auto_config(netatmo, config, dev):
 
 
 def all_product_classes():
-    """Returns all handled Netatmo product classes."""
+    """Provide all handled Netatmo product classes."""
     import pyatmo
 
     return [pyatmo.WeatherStationData, pyatmo.HomeCoachData]

--- a/homeassistant/components/netatmo/sensor.py
+++ b/homeassistant/components/netatmo/sensor.py
@@ -17,8 +17,6 @@ from homeassistant.const import (
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 
-import pyatmo
-
 _LOGGER = logging.getLogger(__name__)
 
 CONF_MODULES = 'modules'
@@ -72,8 +70,6 @@ MODULE_TYPE_WIND = 'NAModule2'
 MODULE_TYPE_RAIN = 'NAModule3'
 MODULE_TYPE_INDOOR = 'NAModule4'
 
-ALL_PRODUCT_CLASSES = [pyatmo.WeatherStationData, pyatmo.HomeCoachData]
-
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the available Netatmo weather sensors."""
@@ -91,9 +87,11 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
 def manual_config(netatmo, config, dev):
     """Handle manual configuration."""
+    import pyatmo
 
+    all_classes = all_product_classes()
     not_handled = {}
-    for data_class in ALL_PRODUCT_CLASSES:
+    for data_class in all_classes:
         data = NetAtmoData(netatmo.NETATMO_AUTH, data_class,
                            config.get(CONF_STATION))
         try:
@@ -113,14 +111,15 @@ def manual_config(netatmo, config, dev):
             continue
 
     for module_name, count in not_handled.items():
-        if count == len(ALL_PRODUCT_CLASSES):
+        if count == len(all_classes):
             _LOGGER.error('Module name: "%s" not found', module_name)
 
 
 def auto_config(netatmo, config, dev):
     """Handle auto configuration."""
+    import pyatmo
 
-    for data_class in ALL_PRODUCT_CLASSES:
+    for data_class in all_product_classes():
         data = NetAtmoData(netatmo.NETATMO_AUTH, data_class,
                            config.get(CONF_STATION))
         try:
@@ -135,6 +134,11 @@ def auto_config(netatmo, config, dev):
         except pyatmo.NoDevice:
             continue
 
+def all_product_classes():
+    """Returns all handled Netatmo product classes."""
+    import pyatmo
+
+    return [pyatmo.WeatherStationData, pyatmo.HomeCoachData]
 
 class NetAtmoSensor(Entity):
     """Implementation of a Netatmo sensor."""


### PR DESCRIPTION
## Description:

Netatmo is now able to discover both Weather Station and Health Coach devices at the same time.
Before it would only discover one of the types. If you had both types not all devices would be found.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54