### PR TITLE
Make Netatmo battery_percent icon dynamic

### DIFF
--- a/homeassistant/components/sensor/netatmo.py
+++ b/homeassistant/components/sensor/netatmo.py
@@ -13,7 +13,7 @@ import voluptuous as vol
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
     TEMP_CELSIUS, DEVICE_CLASS_HUMIDITY, DEVICE_CLASS_TEMPERATURE,
-    STATE_UNKNOWN)
+    DEVICE_CLASS_BATTERY, STATE_UNKNOWN)
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 
@@ -39,7 +39,7 @@ SENSOR_TYPES = {
     'sum_rain_24': ['sum_rain_24', 'mm', 'mdi:weather-rainy', None],
     'battery_vp': ['Battery', '', 'mdi:battery', None],
     'battery_lvl': ['Battery_lvl', '', 'mdi:battery', None],
-    'battery_percent': ['battery_percent', '%', 'mdi:battery', None],
+    'battery_percent': ['battery_percent', '%', None, DEVICE_CLASS_BATTERY],
     'min_temp': ['Min Temp.', TEMP_CELSIUS, 'mdi:thermometer', None],
     'max_temp': ['Max Temp.', TEMP_CELSIUS, 'mdi:thermometer', None],
     'windangle': ['Angle', '', 'mdi:compass', None],


### PR DESCRIPTION
## Description:
This change makes the icon for the Netatmo battery_percent sensors dynamic by setting device_class on the sensors instead of hard coding the icon.

**Related issue (if applicable):** fixes N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
netatmo:
  api_key: YOUR_CLIENT_ID
  secret_key: YOUR_CLIENT_SECRET
  username: YOUR_USERNAME
  password: YOUR_PASSWORD
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
