### PR TITLE
Allow 'all' entity_id in service schema

### DIFF
--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -517,7 +517,7 @@ SERVICE_SCHEMA = vol.All(vol.Schema({
     vol.Exclusive('service_template', 'service name'): template,
     vol.Optional('data'): dict,
     vol.Optional('data_template'): {match_all: template_complex},
-    vol.Optional(CONF_ENTITY_ID): entity_ids,
+    vol.Optional(CONF_ENTITY_ID): comp_entity_ids,
 }), has_at_least_one_key('service', 'service_template'))
 
 NUMERIC_STATE_CONDITION_SCHEMA = vol.All(vol.Schema({

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -333,6 +333,10 @@ def test_service_schema():
             'entity_id': 'light.kitchen',
         },
         {
+            'service': 'light.turn_on',
+            'entity_id': 'all',
+        },
+        {
             'service': 'homeassistant.turn_on',
             'entity_id': ['light.kitchen', 'light.ceiling'],
         },


### PR DESCRIPTION
## Description:

Following #19006, I was updating an automation from:

```yaml
    action:
      - service: light.turn_off
```
to
```yaml
    action:
      - service: light.turn_off
        entity_id: all
```
but that failed and I had to use
```yaml
    action:
      - service: light.turn_off
        data:
          entity_id: all
```

I assume that to be unintended and this is the fix.

CC @balloob 

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.
  - [X] There is no commented out code in this PR.

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.
