### PR TITLE
Fix 'all' entity_id in service call extraction

### DIFF
--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -7,7 +7,8 @@ import logging
 from homeassistant import config as conf_util
 from homeassistant.setup import async_prepare_setup_platform
 from homeassistant.const import (
-    ATTR_ENTITY_ID, CONF_SCAN_INTERVAL, CONF_ENTITY_NAMESPACE, MATCH_ALL)
+    ATTR_ENTITY_ID, CONF_SCAN_INTERVAL, CONF_ENTITY_NAMESPACE,
+    ENTITY_MATCH_ALL)
 from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_per_platform, discovery
@@ -163,7 +164,7 @@ class EntityComponent:
         """
         data_ent_id = service.data.get(ATTR_ENTITY_ID)
 
-        if data_ent_id in (None, MATCH_ALL):
+        if data_ent_id in (None, ENTITY_MATCH_ALL):
             if data_ent_id is None:
                 self.logger.warning(
                     'Not passing an entity ID to a service to target all '

--- a/tests/helpers/test_entity_component.py
+++ b/tests/helpers/test_entity_component.py
@@ -479,7 +479,7 @@ async def test_extract_all_use_match_all(hass, caplog):
         MockEntity(name='test_2'),
     ])
 
-    call = ha.ServiceCall('test', 'service', {'entity_id': '*'})
+    call = ha.ServiceCall('test', 'service', {'entity_id': 'all'})
 
     assert ['test_domain.test_1', 'test_domain.test_2'] == \
         sorted(ent.entity_id for ent in


### PR DESCRIPTION
## Description:

In #19006 we introduced the `*` entity_id but then changed to `all`. It seems that this piece was missed.

CC @balloob 

## Example entry for `configuration.yaml` (if applicable):
```yaml
script:
  all_off:
    sequence:
      - service: automation.turn_off
        data:
          entity_id: all
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.
  - [X] There is no commented out code in this PR.

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.
