### PR TITLE
Reduce log noise from Envisalink component

### DIFF
--- a/homeassistant/components/envisalink/__init__.py
+++ b/homeassistant/components/envisalink/__init__.py
@@ -146,19 +146,19 @@ async def async_setup(hass, config):
     @callback
     def zones_updated_callback(data):
         """Handle zone timer updates."""
-        _LOGGER.info("Envisalink sent a zone update event. Updating zones...")
+        _LOGGER.debug("Envisalink sent a zone update event. Updating zones...")
         async_dispatcher_send(hass, SIGNAL_ZONE_UPDATE, data)
 
     @callback
     def alarm_data_updated_callback(data):
         """Handle non-alarm based info updates."""
-        _LOGGER.info("Envisalink sent new alarm info. Updating alarms...")
+        _LOGGER.debug("Envisalink sent new alarm info. Updating alarms...")
         async_dispatcher_send(hass, SIGNAL_KEYPAD_UPDATE, data)
 
     @callback
     def partition_updated_callback(data):
         """Handle partition changes thrown by evl (including alarms)."""
-        _LOGGER.info("The envisalink sent a partition update event")
+        _LOGGER.debug("The envisalink sent a partition update event")
         async_dispatcher_send(hass, SIGNAL_PARTITION_UPDATE, data)
 
     @callback


### PR DESCRIPTION
## Description:

The Envisalink component was logging messages whenever it got state updates from the device. But the device sends state updates every few seconds, so this was causing my HA logs to fill up with messages like

```
2019-01-20 13:18:49 INFO (MainThread) [homeassistant.components.envisalink] Envisalink sent a zone update event. Updating zones...
2019-01-20 13:18:52 INFO (MainThread) [homeassistant.components.envisalink] Envisalink sent new alarm info. Updating alarms...
```

Reduce the log level to DEBUG so the messages are suppressed by default.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
