### PR TITLE
Add radiotherm is_on method to return on/off

### DIFF
--- a/homeassistant/components/climate/radiotherm.py
+++ b/homeassistant/components/climate/radiotherm.py
@@ -220,18 +220,9 @@ class RadioThermostat(ClimateDevice):
         return self._away
 
     @property
-    def state(self):
-        """Return the current active state.
-
-        - STATE_OFF : thermostat is off
-        - STATE_IDLE: thermostat is on, but not actively heating or cooling
-        - STATE_HEAT: actively heating
-        - STATE_COOL: actively cooling
-        """
-        if self._tmode == STATE_OFF:
-            return STATE_OFF
-        else:
-            return self._tstate
+    def is_on(self):
+        """Return true if on."""
+        return self._tstate != STATE_IDLE
 
     def update(self):
         """Update and validate the data from the thermostat."""

--- a/homeassistant/components/climate/radiotherm.py
+++ b/homeassistant/components/climate/radiotherm.py
@@ -219,6 +219,20 @@ class RadioThermostat(ClimateDevice):
         """Return true if away mode is on."""
         return self._away
 
+    @property
+    def state(self):
+        """Return the current active state.
+
+        - STATE_OFF : thermostat is off
+        - STATE_IDLE: thermostat is on, but not actively heating or cooling
+        - STATE_HEAT: actively heating
+        - STATE_COOL: actively cooling
+        """
+        if self._tmode == STATE_OFF:
+            return STATE_OFF
+        else:
+            return self._tstate
+
     def update(self):
         """Update and validate the data from the thermostat."""
         # Radio thermostats are very slow, and sometimes don't respond


### PR DESCRIPTION
This fixes issue #18244 for the radiotherm climate component.  It is not a full fix for that issue since it doesn't add similar support for ecobee (which was the original problem report).


## Description:
The radiotherm component did not have a state method so the currently operation state was always reported as the heating/cooling mode in the climate UI which made the plots incorrect.  This adds the state method so that the active mode reports correctly.    With this fix, the plot now highlights the plot only in the areas where active heating or cooling is being done.  
