### PR TITLE
Fix: Log exceptions thrown by signal callbacks

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -259,9 +259,10 @@ class HomeAssistant:
         """
         task = None
 
+        # Check for partials to properly determine if coroutine function
         check_target = target
-        if isinstance(target, functools.partial):
-            check_target = target.func
+        while isinstance(check_target, functools.partial):
+            check_target = check_target.func
 
         if asyncio.iscoroutine(check_target):
             task = self.loop.create_task(target)  # type: ignore

--- a/homeassistant/util/logging.py
+++ b/homeassistant/util/logging.py
@@ -1,7 +1,7 @@
 """Logging utilities."""
 import asyncio
 from asyncio.events import AbstractEventLoop
-from functools import wraps
+from functools import partial, wraps
 import inspect
 import logging
 import threading
@@ -139,8 +139,13 @@ def catch_log_exception(
         friendly_msg = format_err(*args)
         logging.getLogger(module_name).error('%s\n%s', friendly_msg, exc_msg)
 
+    # Check for partials to properly determine if coroutine function
+    check_func = func
+    while isinstance(check_func, partial):
+        check_func = check_func.func
+
     wrapper_func = None
-    if asyncio.iscoroutinefunction(func):
+    if asyncio.iscoroutinefunction(check_func):
         @wraps(func)
         async def async_wrapper(*args: Any) -> None:
             """Catch and log exception."""


### PR DESCRIPTION
## Description:
Fixed a bug introduced by #20015 where it was not properly detecting coroutine functions wrapped inside a `functools.partial`.  This resulted in `catch_log_exception` wrapping incorrectly, which downstream results in coroutine not being awaited.

This also improved worked done in #20119 so that `async_add_job` now recursively checks for partials to bring it in parity with the work done in `catch_log_exception`.

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.