### PR TITLE
Add new fan speed mapping for V2 Roborock Vacuum

### DIFF
--- a/homeassistant/components/vacuum/xiaomi_miio.py
+++ b/homeassistant/components/vacuum/xiaomi_miio.py
@@ -35,7 +35,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
     vol.Required(CONF_TOKEN): vol.All(str, vol.Length(min=32, max=32)),
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional(CONF_NEW_FAN_SPEEDS, default=DEFAULT_NEW_FAN_SPEEDS): cv.boolean,
+    vol.Optional(CONF_NEW_FAN_SPEEDS, default=DEFAULT_NEW_FAN_SPEEDS):
+        cv.boolean,
 }, extra=vol.ALLOW_EXTRA)
 
 SERVICE_MOVE_REMOTE_CONTROL = 'xiaomi_remote_control_move'
@@ -227,7 +228,8 @@ class MiroboVacuum(StateVacuumDevice):
     @property
     def fan_speed_list(self):
         """Get the list of available fan speed steps of the vacuum cleaner."""
-        return list(sorted(self._speed_map.keys(), key=lambda s: self._speed_map[s]))
+        return list(sorted(self._speed_map.keys(),
+                           key=lambda s: self._speed_map[s]))
 
     @property
     def device_state_attributes(self):


### PR DESCRIPTION
## Description:

Update fan speeds to reflect values that Mi Home app is sending to the vacuum. Tested on Roborock S50, this version correctly reflects values set by the app, and the app correctly highlights speeds set by this component.

To keep backwards compatibility, added a new boolean setting to yaml config - `new_fan_speeds` which defaults to the old fan speed mapping. Maybe someone can suggest shorter and more clear name for new variables.

**Related issue (if applicable):** fixes #17695 
Link to an earlier attempt to fix this: #17090

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8233

## Example entry for `configuration.yaml` (if applicable):
```yaml
vacuum:
- platform: xiaomi_miio
  host: <...>
  token: <...>
  new_fan_speeds: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
