### PR TITLE
Add LCN cover platform

### DIFF
--- a/homeassistant/components/cover/lcn.py
+++ b/homeassistant/components/cover/lcn.py
@@ -1,0 +1,94 @@
+"""
+Support for LCN covers.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/cover.lcn/
+"""
+
+from homeassistant.components.cover import CoverDevice
+from homeassistant.components.lcn import (
+    CONF_CONNECTIONS, CONF_MOTOR, DATA_LCN, LcnDevice, get_connection)
+from homeassistant.const import CONF_ADDRESS
+
+DEPENDENCIES = ['lcn']
+
+
+async def async_setup_platform(hass, hass_config, async_add_entities,
+                               discovery_info=None):
+    """Setups the LCN cover platform."""
+    if discovery_info is None:
+        return
+
+    import pypck
+
+    devices = []
+    for config in discovery_info:
+        address, connection_id = config[CONF_ADDRESS]
+        addr = pypck.lcn_addr.LcnAddr(*address)
+        connections = hass.data[DATA_LCN][CONF_CONNECTIONS]
+        connection = get_connection(connections, connection_id)
+        address_connection = connection.get_address_conn(addr)
+
+        devices.append(LcnCover(config, address_connection))
+
+    async_add_entities(devices)
+
+
+class LcnCover(LcnDevice, CoverDevice):
+    """Representation of a LCN cover."""
+
+    def __init__(self, config, address_connection):
+        """Initialize the LCN cover."""
+        super().__init__(config, address_connection)
+
+        self.motor = self.pypck.lcn_defs.MotorPort[config[CONF_MOTOR]]
+        self.motor_port_onoff = self.motor.value * 2
+        self.motor_port_updown = self.motor_port_onoff + 1
+
+        self._closed = None
+
+    async def async_added_to_hass(self):
+        """Run when entity about to be added to hass."""
+        await super().async_added_to_hass()
+        self.hass.async_create_task(
+            self.address_connection.activate_status_request_handler(
+                self.motor))
+
+    @property
+    def is_closed(self):
+        """Return if the cover is closed."""
+        return self._closed
+
+    async def async_close_cover(self, **kwargs):
+        """Close the cover."""
+        self._closed = False
+        states = [self.pypck.lcn_defs.MotorStateModifier.NOCHANGE] * 4
+        states[self.motor.value] = self.pypck.lcn_defs.MotorStateModifier.DOWN
+        self.address_connection.control_motors(states)
+        await self.async_update_ha_state()
+
+    async def async_open_cover(self, **kwargs):
+        """Open the cover."""
+        self._closed = True
+        states = [self.pypck.lcn_defs.MotorStateModifier.NOCHANGE] * 4
+        states[self.motor.value] = self.pypck.lcn_defs.MotorStateModifier.UP
+        self.address_connection.control_motors(states)
+        await self.async_update_ha_state()
+
+    async def async_stop_cover(self, **kwargs):
+        """Stop the cover."""
+        states = [self.pypck.lcn_defs.MotorStateModifier.NOCHANGE] * 4
+        states[self.motor.value] = self.pypck.lcn_defs.MotorStateModifier.STOP
+        self.address_connection.control_motors(states)
+        await self.async_update_ha_state()
+
+    def input_received(self, input_obj):
+        """Set cover states when LCN input object (command) is received."""
+        if not isinstance(input_obj, self.pypck.inputs.ModStatusRelays):
+            return
+
+        states = input_obj.states  # list of boolean values (relay on/off)
+        if states[self.motor_port_onoff]:  # motor is on
+            self._closed = states[self.motor_port_updown]  # set direction
+
+        self.async_schedule_update_ha_state()

--- a/homeassistant/components/lcn/__init__.py
+++ b/homeassistant/components/lcn/__init__.py
@@ -181,15 +181,12 @@ async def async_setup(hass, config):
     hass.data[DATA_LCN][CONF_CONNECTIONS] = connections
 
     # load platforms
-    hass.async_create_task(
-        async_load_platform(hass, 'cover', DOMAIN,
-                            config[DOMAIN][CONF_COVERS], config))
-    hass.async_create_task(
-        async_load_platform(hass, 'light', DOMAIN,
-                            config[DOMAIN][CONF_LIGHTS], config))
-    hass.async_create_task(
-        async_load_platform(hass, 'switch', DOMAIN,
-                            config[DOMAIN][CONF_SWITCHES], config))
+    for component, conf_key in (('cover', CONF_COVERS),
+                                ('light', CONF_LIGHTS),
+                                ('switch', CONF_SWITCHES)):
+        hass.async_create_task(
+            async_load_platform(hass, component, DOMAIN,
+                                config[DOMAIN][conf_key], config))
 
     return True
 

--- a/homeassistant/components/lcn/__init__.py
+++ b/homeassistant/components/lcn/__init__.py
@@ -121,7 +121,7 @@ CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Required(CONF_CONNECTIONS): vol.All(
             cv.ensure_list, has_unique_connection_names, [CONNECTION_SCHEMA]),
-        vol.Optional(CONF_COVERS, default=[]): vol.All(
+        vol.Optional(CONF_COVERS): vol.All(
             cv.ensure_list, [COVERS_SCHEMA]),
         vol.Optional(CONF_LIGHTS): vol.All(
             cv.ensure_list, [LIGHTS_SCHEMA]),

--- a/homeassistant/components/lcn/cover.py
+++ b/homeassistant/components/lcn/cover.py
@@ -1,10 +1,4 @@
-"""
-Support for LCN covers.
-
-For more details about this platform, please refer to the documentation at
-https://home-assistant.io/components/cover.lcn/
-"""
-
+"""Support for LCN covers."""
 from homeassistant.components.cover import CoverDevice
 from homeassistant.components.lcn import (
     CONF_CONNECTIONS, CONF_MOTOR, DATA_LCN, LcnDevice, get_connection)
@@ -61,7 +55,6 @@ class LcnCover(LcnDevice, CoverDevice):
 
     async def async_close_cover(self, **kwargs):
         """Close the cover."""
-        self._closed = False
         states = [self.pypck.lcn_defs.MotorStateModifier.NOCHANGE] * 4
         states[self.motor.value] = self.pypck.lcn_defs.MotorStateModifier.DOWN
         self.address_connection.control_motors(states)
@@ -69,7 +62,6 @@ class LcnCover(LcnDevice, CoverDevice):
 
     async def async_open_cover(self, **kwargs):
         """Open the cover."""
-        self._closed = True
         states = [self.pypck.lcn_defs.MotorStateModifier.NOCHANGE] * 4
         states[self.motor.value] = self.pypck.lcn_defs.MotorStateModifier.UP
         self.address_connection.control_motors(states)

--- a/homeassistant/components/lcn/cover.py
+++ b/homeassistant/components/lcn/cover.py
@@ -55,6 +55,7 @@ class LcnCover(LcnDevice, CoverDevice):
 
     async def async_close_cover(self, **kwargs):
         """Close the cover."""
+        self._closed = True
         states = [self.pypck.lcn_defs.MotorStateModifier.NOCHANGE] * 4
         states[self.motor.value] = self.pypck.lcn_defs.MotorStateModifier.DOWN
         self.address_connection.control_motors(states)
@@ -62,6 +63,7 @@ class LcnCover(LcnDevice, CoverDevice):
 
     async def async_open_cover(self, **kwargs):
         """Open the cover."""
+        self._closed = False
         states = [self.pypck.lcn_defs.MotorStateModifier.NOCHANGE] * 4
         states[self.motor.value] = self.pypck.lcn_defs.MotorStateModifier.UP
         self.address_connection.control_motors(states)
@@ -69,6 +71,7 @@ class LcnCover(LcnDevice, CoverDevice):
 
     async def async_stop_cover(self, **kwargs):
         """Stop the cover."""
+        self._closed = None
         states = [self.pypck.lcn_defs.MotorStateModifier.NOCHANGE] * 4
         states[self.motor.value] = self.pypck.lcn_defs.MotorStateModifier.STOP
         self.address_connection.control_motors(states)


### PR DESCRIPTION
## Description:
This adds the LCN cover platform. The implementation follows the already merged LCN light and switch platforms.

**Related issue (if applicable):**

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8234

## Example entry for `configuration.yaml` (if applicable):
```yaml
lcn:
  connections:
    - name: myhome
      host: 192.168.2.41
      port: 4114
      username: !secret lcn_username
      password: !secret lcn_password

  covers:
    - name: Living room cover
      address: myhome.0.7
      motor: motor1
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
