### PR TITLE
Add MVP person component

### DIFF
--- a/homeassistant/components/person/__init__.py
+++ b/homeassistant/components/person/__init__.py
@@ -42,7 +42,7 @@ CONFIG_SCHEMA = vol.Schema({
 
 async def async_setup(hass, config):
     """Set up the Person component."""
-    component = hass.data[DOMAIN] = EntityComponent(_LOGGER, DOMAIN, hass)
+    component = EntityComponent(_LOGGER, DOMAIN, hass)
     conf = config[DOMAIN]
     entities = []
     for person_conf in conf:
@@ -140,6 +140,9 @@ class Person(RestoreEntity):
         state = await self.async_get_last_state()
         if state:
             self._parse_source_state(state)
+
+        if not self._trackers:
+            return
 
         @callback
         def async_handle_tracker_update(entity, old_state, new_state):

--- a/homeassistant/components/person/__init__.py
+++ b/homeassistant/components/person/__init__.py
@@ -38,7 +38,7 @@ CONFIG_SCHEMA = vol.Schema({
 
 
 async def async_setup(hass, config):
-    """Set up the Person component."""
+    """Set up the person component."""
     component = EntityComponent(_LOGGER, DOMAIN, hass)
     conf = config[DOMAIN]
     entities = []
@@ -58,7 +58,7 @@ async def async_setup(hass, config):
 
 
 class Person(RestoreEntity):
-    """Represent a tracked Person."""
+    """Represent a tracked person."""
 
     def __init__(self, config, user_id):
         """Set up person."""
@@ -131,7 +131,7 @@ class Person(RestoreEntity):
                 self.hass, tracker, async_handle_tracker_update)
 
     def _parse_source_state(self, state):
-        """Parse source state and set Person attributes."""
+        """Parse source state and set person attributes."""
         self._state = state.state
         self._source = state.entity_id
         self._latitude = state.attributes.get(ATTR_LATITUDE)

--- a/homeassistant/components/person/__init__.py
+++ b/homeassistant/components/person/__init__.py
@@ -95,6 +95,7 @@ class Person(RestoreEntity):
             name = '{} {}'.format(self.first_name, self.last_name)
         return name
 
+    @property
     def should_poll(self):
         """Return True if entity has to be polled for state.
 

--- a/homeassistant/components/person/__init__.py
+++ b/homeassistant/components/person/__init__.py
@@ -139,7 +139,7 @@ class Person(RestoreEntity):
         await super().async_added_to_hass()
         state = await self.async_get_last_state()
         if state:
-            self._state = state.state
+            self._parse_source_state(state)
 
         @callback
         def async_handle_tracker_update(entity, old_state, new_state):

--- a/homeassistant/components/person/__init__.py
+++ b/homeassistant/components/person/__init__.py
@@ -1,0 +1,162 @@
+"""
+Support for tracking people.
+
+For more details about this component, please refer to the documentation.
+https://home-assistant.io/components/person/
+"""
+import logging
+
+import voluptuous as vol
+
+from homeassistant.const import ATTR_LATITUDE, ATTR_LONGITUDE
+from homeassistant.core import callback
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity_component import EntityComponent
+from homeassistant.helpers.event import async_track_state_change
+from homeassistant.helpers.restore_state import RestoreEntity
+
+_LOGGER = logging.getLogger(__name__)
+ATTR_FIRST_NAME = 'first_name'
+ATTR_LAST_NAME = 'last_name'
+ATTR_SOURCE = 'source'
+ATTR_USER_ID = 'user_id'
+CONF_DEVICE_TRACKERS = 'device_trackers'
+CONF_FIRST_NAME = 'first_name'
+CONF_LAST_NAME = 'last_name'
+CONF_USER_ID = 'user_id'
+DOMAIN = 'person'
+ENTITY_ID_FORMAT = DOMAIN + '.{}'
+
+PERSON_SCHEMA = vol.Schema({
+    vol.Required(CONF_FIRST_NAME): cv.string,
+    vol.Optional(CONF_LAST_NAME): cv.string,
+    vol.Optional(CONF_USER_ID): cv.string,
+    vol.Optional(CONF_DEVICE_TRACKERS, default=[]): vol.All(
+        cv.ensure_list, cv.entity_ids),
+})
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.All(cv.ensure_list, [PERSON_SCHEMA])
+}, extra=vol.ALLOW_EXTRA)
+
+
+async def async_setup(hass, config):
+    """Set up the Person component."""
+    component = hass.data[DOMAIN] = EntityComponent(_LOGGER, DOMAIN, hass)
+    conf = config[DOMAIN]
+    entities = []
+    for person_conf in conf:
+        entities.append(Person(person_conf))
+
+    await component.async_add_entities(entities)
+
+    return True
+
+
+class Person(RestoreEntity):
+    """Represent a tracked Person."""
+
+    def __init__(self, config):
+        """Set up person."""
+        self._first_name = config[CONF_FIRST_NAME]
+        self._last_name = config.get(CONF_LAST_NAME)
+        self._latitude = None
+        self._longitude = None
+        self._source = None
+        self._state = None
+        self._trackers = config.get(CONF_DEVICE_TRACKERS)
+        self._user_id = config.get(CONF_USER_ID)
+
+    @property
+    def first_name(self):
+        """Return the first name of the person."""
+        return self._first_name
+
+    @property
+    def last_name(self):
+        """Return the last name of the person."""
+        return self._last_name
+
+    @property
+    def latitude(self):
+        """Return latitude value of the person."""
+        return self._latitude
+
+    @property
+    def longitude(self):
+        """Return longitude value of the person."""
+        return self._longitude
+
+    @property
+    def name(self):
+        """Return the name of the entity."""
+        name = self.first_name
+        if self.last_name:
+            name = '{} {}'.format(self.first_name, self.last_name)
+        return name
+
+    def should_poll(self):
+        """Return True if entity has to be polled for state.
+
+        False if entity pushes its state to HA.
+        """
+        return False
+
+    @property
+    def source(self):
+        """Return source entity_id that provides the state of the person."""
+        return self._source
+
+    @property
+    def state(self):
+        """Return the state of the person."""
+        return self._state
+
+    @property
+    def state_attributes(self):
+        """Return the state attributes of the person."""
+        data = {}
+        data[ATTR_FIRST_NAME] = self.first_name
+        if self.last_name is not None:
+            data[ATTR_LAST_NAME] = self.last_name
+        if self.latitude is not None:
+            data[ATTR_LATITUDE] = round(self.latitude, 5)
+        if self.longitude is not None:
+            data[ATTR_LONGITUDE] = round(self.longitude, 5)
+        if self.source is not None:
+            data[ATTR_SOURCE] = self.source
+        if self.user_id is not None:
+            data[ATTR_USER_ID] = self.user_id
+        return data
+
+    @property
+    def user_id(self):
+        """Return the user id of the person."""
+        return self._user_id
+
+    async def async_added_to_hass(self):
+        """Register device trackers."""
+        await super().async_added_to_hass()
+        state = await self.async_get_last_state()
+        if state:
+            self._state = state.state
+
+        @callback
+        def async_handle_tracker_update(entity, old_state, new_state):
+            """Handle the device tracker state changes."""
+            self._parse_source_state(new_state)
+            self.async_schedule_update_ha_state()
+
+        _LOGGER.debug(
+            "Subscribe to device trackers for %s", self.entity_id)
+
+        for tracker in self._trackers:
+            async_track_state_change(
+                self.hass, tracker, async_handle_tracker_update)
+
+    def _parse_source_state(self, state):
+        """Parse source state and set Person attributes."""
+        self._state = state.state
+        self._source = state.entity_id
+        self._latitude = state.attributes.get(ATTR_LATITUDE)
+        self._longitude = state.attributes.get(ATTR_LONGITUDE)

--- a/homeassistant/components/person/__init__.py
+++ b/homeassistant/components/person/__init__.py
@@ -10,7 +10,8 @@ import voluptuous as vol
 
 from homeassistant.components.device_tracker import (
     DOMAIN as DEVICE_TRACKER_DOMAIN)
-from homeassistant.const import ATTR_LATITUDE, ATTR_LONGITUDE, CONF_NAME
+from homeassistant.const import (
+    ATTR_ID, ATTR_LATITUDE, ATTR_LONGITUDE, CONF_ID, CONF_NAME)
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_component import EntityComponent
@@ -26,6 +27,7 @@ DOMAIN = 'person'
 ENTITY_ID_FORMAT = DOMAIN + '.{}'
 
 PERSON_SCHEMA = vol.Schema({
+    vol.Required(CONF_ID): cv.string,
     vol.Required(CONF_NAME): cv.string,
     vol.Optional(CONF_USER_ID): cv.string,
     vol.Optional(CONF_DEVICE_TRACKERS, default=[]): vol.All(
@@ -66,9 +68,10 @@ class Person(RestoreEntity):
 
     def __init__(self, config, user_id):
         """Set up person."""
-        self._name = config[CONF_NAME]
+        self._id = config[CONF_ID]
         self._latitude = None
         self._longitude = None
+        self._name = config[CONF_NAME]
         self._source = None
         self._state = None
         self._trackers = config.get(CONF_DEVICE_TRACKERS)
@@ -96,6 +99,7 @@ class Person(RestoreEntity):
     def state_attributes(self):
         """Return the state attributes of the person."""
         data = {}
+        data[ATTR_ID] = self._id
         if self._latitude is not None:
             data[ATTR_LATITUDE] = round(self._latitude, 5)
         if self._longitude is not None:
@@ -109,7 +113,7 @@ class Person(RestoreEntity):
     @property
     def unique_id(self):
         """Return a unique ID for the person."""
-        return self._user_id
+        return self._id
 
     async def async_added_to_hass(self):
         """Register device trackers."""

--- a/homeassistant/components/person/__init__.py
+++ b/homeassistant/components/person/__init__.py
@@ -8,6 +8,8 @@ import logging
 
 import voluptuous as vol
 
+from homeassistant.components.device_tracker import (
+    DOMAIN as DEVICE_TRACKER_DOMAIN)
 from homeassistant.const import ATTR_LATITUDE, ATTR_LONGITUDE
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
@@ -32,7 +34,7 @@ PERSON_SCHEMA = vol.Schema({
     vol.Optional(CONF_LAST_NAME): cv.string,
     vol.Optional(CONF_USER_ID): cv.string,
     vol.Optional(CONF_DEVICE_TRACKERS, default=[]): vol.All(
-        cv.ensure_list, cv.entity_ids),
+        cv.ensure_list, cv.entities_domain(DEVICE_TRACKER_DOMAIN)),
 })
 
 CONFIG_SCHEMA = vol.Schema({

--- a/homeassistant/components/person/__init__.py
+++ b/homeassistant/components/person/__init__.py
@@ -24,7 +24,6 @@ ATTR_USER_ID = 'user_id'
 CONF_DEVICE_TRACKERS = 'device_trackers'
 CONF_USER_ID = 'user_id'
 DOMAIN = 'person'
-ENTITY_ID_FORMAT = DOMAIN + '.{}'
 
 PERSON_SCHEMA = vol.Schema({
     vol.Required(CONF_ID): cv.string,

--- a/homeassistant/components/person/__init__.py
+++ b/homeassistant/components/person/__init__.py
@@ -10,7 +10,7 @@ import voluptuous as vol
 
 from homeassistant.components.device_tracker import (
     DOMAIN as DEVICE_TRACKER_DOMAIN)
-from homeassistant.const import ATTR_LATITUDE, ATTR_LONGITUDE
+from homeassistant.const import ATTR_LATITUDE, ATTR_LONGITUDE, CONF_NAME
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_component import EntityComponent
@@ -18,20 +18,15 @@ from homeassistant.helpers.event import async_track_state_change
 from homeassistant.helpers.restore_state import RestoreEntity
 
 _LOGGER = logging.getLogger(__name__)
-ATTR_FIRST_NAME = 'first_name'
-ATTR_LAST_NAME = 'last_name'
 ATTR_SOURCE = 'source'
 ATTR_USER_ID = 'user_id'
 CONF_DEVICE_TRACKERS = 'device_trackers'
-CONF_FIRST_NAME = 'first_name'
-CONF_LAST_NAME = 'last_name'
 CONF_USER_ID = 'user_id'
 DOMAIN = 'person'
 ENTITY_ID_FORMAT = DOMAIN + '.{}'
 
 PERSON_SCHEMA = vol.Schema({
-    vol.Required(CONF_FIRST_NAME): cv.string,
-    vol.Optional(CONF_LAST_NAME): cv.string,
+    vol.Required(CONF_NAME): cv.string,
     vol.Optional(CONF_USER_ID): cv.string,
     vol.Optional(CONF_DEVICE_TRACKERS, default=[]): vol.All(
         cv.ensure_list, cv.entities_domain(DEVICE_TRACKER_DOMAIN)),
@@ -60,24 +55,13 @@ class Person(RestoreEntity):
 
     def __init__(self, config):
         """Set up person."""
-        self._first_name = config[CONF_FIRST_NAME]
-        self._last_name = config.get(CONF_LAST_NAME)
+        self._name = config[CONF_NAME]
         self._latitude = None
         self._longitude = None
         self._source = None
         self._state = None
         self._trackers = config.get(CONF_DEVICE_TRACKERS)
         self._user_id = config.get(CONF_USER_ID)
-
-    @property
-    def first_name(self):
-        """Return the first name of the person."""
-        return self._first_name
-
-    @property
-    def last_name(self):
-        """Return the last name of the person."""
-        return self._last_name
 
     @property
     def latitude(self):
@@ -92,10 +76,7 @@ class Person(RestoreEntity):
     @property
     def name(self):
         """Return the name of the entity."""
-        name = self.first_name
-        if self.last_name:
-            name = '{} {}'.format(self.first_name, self.last_name)
-        return name
+        return self._name
 
     @property
     def should_poll(self):
@@ -119,9 +100,6 @@ class Person(RestoreEntity):
     def state_attributes(self):
         """Return the state attributes of the person."""
         data = {}
-        data[ATTR_FIRST_NAME] = self.first_name
-        if self.last_name is not None:
-            data[ATTR_LAST_NAME] = self.last_name
         if self.latitude is not None:
             data[ATTR_LATITUDE] = round(self.latitude, 5)
         if self.longitude is not None:

--- a/homeassistant/components/person/__init__.py
+++ b/homeassistant/components/person/__init__.py
@@ -71,16 +71,6 @@ class Person(RestoreEntity):
         self._user_id = user_id
 
     @property
-    def latitude(self):
-        """Return latitude value of the person."""
-        return self._latitude
-
-    @property
-    def longitude(self):
-        """Return longitude value of the person."""
-        return self._longitude
-
-    @property
     def name(self):
         """Return the name of the entity."""
         return self._name
@@ -94,11 +84,6 @@ class Person(RestoreEntity):
         return False
 
     @property
-    def source(self):
-        """Return source entity_id that provides the state of the person."""
-        return self._source
-
-    @property
     def state(self):
         """Return the state of the person."""
         return self._state
@@ -107,24 +92,19 @@ class Person(RestoreEntity):
     def state_attributes(self):
         """Return the state attributes of the person."""
         data = {}
-        if self.latitude is not None:
-            data[ATTR_LATITUDE] = round(self.latitude, 5)
-        if self.longitude is not None:
-            data[ATTR_LONGITUDE] = round(self.longitude, 5)
-        if self.source is not None:
-            data[ATTR_SOURCE] = self.source
-        if self.user_id is not None:
-            data[ATTR_USER_ID] = self.user_id
+        if self._latitude is not None:
+            data[ATTR_LATITUDE] = round(self._latitude, 5)
+        if self._longitude is not None:
+            data[ATTR_LONGITUDE] = round(self._longitude, 5)
+        if self._source is not None:
+            data[ATTR_SOURCE] = self._source
+        if self._user_id is not None:
+            data[ATTR_USER_ID] = self._user_id
         return data
 
     @property
     def unique_id(self):
         """Return a unique ID for the person."""
-        return self._user_id
-
-    @property
-    def user_id(self):
-        """Return the user id of the person."""
         return self._user_id
 
     async def async_added_to_hass(self):

--- a/homeassistant/components/person/__init__.py
+++ b/homeassistant/components/person/__init__.py
@@ -52,6 +52,10 @@ async def async_setup(hass, config):
             continue
         entities.append(Person(person_conf, user_id))
 
+    if not entities:
+        _LOGGER.error("No persons could be set up")
+        return False
+
     await component.async_add_entities(entities)
 
     return True

--- a/homeassistant/components/person/__init__.py
+++ b/homeassistant/components/person/__init__.py
@@ -118,6 +118,11 @@ class Person(RestoreEntity):
         return data
 
     @property
+    def unique_id(self):
+        """Return a unique ID for the person."""
+        return self._user_id
+
+    @property
     def user_id(self):
         """Return the user id of the person."""
         return self._user_id

--- a/tests/components/person/__init__.py
+++ b/tests/components/person/__init__.py
@@ -1,0 +1,1 @@
+"""The tests for the person component."""

--- a/tests/components/person/test_init.py
+++ b/tests/components/person/test_init.py
@@ -1,0 +1,160 @@
+"""The tests for the person component."""
+from homeassistant.components.person import ATTR_SOURCE, ATTR_USER_ID, DOMAIN
+from homeassistant.setup import async_setup_component
+from homeassistant.const import ATTR_LATITUDE, ATTR_LONGITUDE, STATE_UNKNOWN
+from homeassistant.core import State, CoreState
+from tests.common import mock_component, mock_restore_cache
+
+DEVICE_TRACKER = 'device_tracker.test_tracker'
+DEVICE_TRACKER_2 = 'device_tracker.test_tracker_2'
+
+
+async def test_minimal_setup(hass):
+    """Test minimal config with only name."""
+    config = {DOMAIN: {'name': 'test person'}}
+    assert await async_setup_component(hass, DOMAIN, config)
+
+    state = hass.states.get('person.test_person')
+    assert state.state == STATE_UNKNOWN
+    assert state.attributes.get(ATTR_LATITUDE) is None
+    assert state.attributes.get(ATTR_LONGITUDE) is None
+    assert state.attributes.get(ATTR_SOURCE) is None
+    assert state.attributes.get(ATTR_USER_ID) is None
+
+
+async def test_setup_user_id(hass, hass_owner_user):
+    """Test config with user id."""
+    user_id = hass_owner_user.id
+    config = {DOMAIN: {'name': 'test person', 'user_id': user_id}}
+    assert await async_setup_component(hass, DOMAIN, config)
+
+    state = hass.states.get('person.test_person')
+    assert state.state == STATE_UNKNOWN
+    assert state.attributes.get(ATTR_LATITUDE) is None
+    assert state.attributes.get(ATTR_LONGITUDE) is None
+    assert state.attributes.get(ATTR_SOURCE) is None
+    assert state.attributes.get(ATTR_USER_ID) == user_id
+
+
+async def test_setup_invalid_user_id(hass):
+    """Test config with invalid user id."""
+    config = {DOMAIN: {'name': 'test bad user', 'user_id': 'bad_user_id'}}
+    assert not await async_setup_component(hass, DOMAIN, config)
+
+
+async def test_valid_invalid_user_ids(hass, hass_owner_user):
+    """Test a person with valid user id and a person with invalid user id ."""
+    user_id = hass_owner_user.id
+    config = {DOMAIN: [
+        {'name': 'test valid user', 'user_id': user_id},
+        {'name': 'test bad user', 'user_id': 'bad_user_id'}]}
+    assert await async_setup_component(hass, DOMAIN, config)
+
+    state = hass.states.get('person.test_valid_user')
+    assert state.state == STATE_UNKNOWN
+    assert state.attributes.get(ATTR_LATITUDE) is None
+    assert state.attributes.get(ATTR_LONGITUDE) is None
+    assert state.attributes.get(ATTR_SOURCE) is None
+    assert state.attributes.get(ATTR_USER_ID) == user_id
+    state = hass.states.get('person.test_bad_user')
+    assert state is None
+
+
+async def test_setup_tracker(hass, hass_owner_user):
+    """Test set up person with one device tracker."""
+    user_id = hass_owner_user.id
+    config = {DOMAIN: {
+        'name': 'tracked person', 'user_id': user_id,
+        'device_trackers': DEVICE_TRACKER}}
+    assert await async_setup_component(hass, DOMAIN, config)
+
+    state = hass.states.get('person.tracked_person')
+    assert state.state == STATE_UNKNOWN
+    assert state.attributes.get(ATTR_LATITUDE) is None
+    assert state.attributes.get(ATTR_LONGITUDE) is None
+    assert state.attributes.get(ATTR_SOURCE) is None
+    assert state.attributes.get(ATTR_USER_ID) == user_id
+
+    hass.states.async_set(DEVICE_TRACKER, 'home')
+    await hass.async_block_till_done()
+
+    state = hass.states.get('person.tracked_person')
+    assert state.state == 'home'
+    assert state.attributes.get(ATTR_LATITUDE) is None
+    assert state.attributes.get(ATTR_LONGITUDE) is None
+    assert state.attributes.get(ATTR_SOURCE) == DEVICE_TRACKER
+    assert state.attributes.get(ATTR_USER_ID) == user_id
+
+    hass.states.async_set(
+        DEVICE_TRACKER, 'not_home',
+        {ATTR_LATITUDE: 10.123456, ATTR_LONGITUDE: 11.123456})
+    await hass.async_block_till_done()
+
+    state = hass.states.get('person.tracked_person')
+    assert state.state == 'not_home'
+    assert state.attributes.get(ATTR_LATITUDE) == 10.12346
+    assert state.attributes.get(ATTR_LONGITUDE) == 11.12346
+    assert state.attributes.get(ATTR_SOURCE) == DEVICE_TRACKER
+    assert state.attributes.get(ATTR_USER_ID) == user_id
+
+
+async def test_setup_two_trackers(hass, hass_owner_user):
+    """Test set up person with two device trackers."""
+    user_id = hass_owner_user.id
+    config = {DOMAIN: {
+        'name': 'tracked person', 'user_id': user_id,
+        'device_trackers': [DEVICE_TRACKER, DEVICE_TRACKER_2]}}
+    assert await async_setup_component(hass, DOMAIN, config)
+
+    state = hass.states.get('person.tracked_person')
+    assert state.state == STATE_UNKNOWN
+    assert state.attributes.get(ATTR_LATITUDE) is None
+    assert state.attributes.get(ATTR_LONGITUDE) is None
+    assert state.attributes.get(ATTR_SOURCE) is None
+    assert state.attributes.get(ATTR_USER_ID) == user_id
+
+    hass.states.async_set(DEVICE_TRACKER, 'home')
+    await hass.async_block_till_done()
+
+    state = hass.states.get('person.tracked_person')
+    assert state.state == 'home'
+    assert state.attributes.get(ATTR_LATITUDE) is None
+    assert state.attributes.get(ATTR_LONGITUDE) is None
+    assert state.attributes.get(ATTR_SOURCE) == DEVICE_TRACKER
+    assert state.attributes.get(ATTR_USER_ID) == user_id
+
+    hass.states.async_set(
+        DEVICE_TRACKER_2, 'not_home',
+        {ATTR_LATITUDE: 12.123456, ATTR_LONGITUDE: 13.123456})
+    await hass.async_block_till_done()
+
+    state = hass.states.get('person.tracked_person')
+    assert state.state == 'not_home'
+    assert state.attributes.get(ATTR_LATITUDE) == 12.12346
+    assert state.attributes.get(ATTR_LONGITUDE) == 13.12346
+    assert state.attributes.get(ATTR_SOURCE) == DEVICE_TRACKER_2
+    assert state.attributes.get(ATTR_USER_ID) == user_id
+
+
+async def test_restore_home_state(hass, hass_owner_user):
+    """Test that the state is restored for a person on startup."""
+    attrs = {
+        ATTR_LATITUDE: 10.12346, ATTR_LONGITUDE: 11.12346,
+        ATTR_SOURCE: DEVICE_TRACKER}
+    state = State('person.tracked_person', 'home', attrs)
+    mock_restore_cache(hass, (state, ))
+    hass.state = CoreState.starting
+    mock_component(hass, 'recorder')
+    user_id = hass_owner_user.id
+    config = {DOMAIN: {
+        'name': 'tracked person', 'user_id': user_id,
+        'device_trackers': DEVICE_TRACKER}}
+    assert await async_setup_component(hass, DOMAIN, config)
+
+    state = hass.states.get('person.tracked_person')
+    assert state.state == 'home'
+    assert state.attributes.get(ATTR_LATITUDE) == 10.12346
+    assert state.attributes.get(ATTR_LONGITUDE) == 11.12346
+    # When restoring state the entity_id of the person will be used as source.
+    assert state.attributes.get(ATTR_SOURCE) == 'person.tracked_person'
+    assert state.attributes.get(ATTR_USER_ID) == user_id

--- a/tests/components/person/test_init.py
+++ b/tests/components/person/test_init.py
@@ -1,8 +1,10 @@
 """The tests for the person component."""
 from homeassistant.components.person import ATTR_SOURCE, ATTR_USER_ID, DOMAIN
+from homeassistant.const import (
+    ATTR_ID, ATTR_LATITUDE, ATTR_LONGITUDE, STATE_UNKNOWN)
+from homeassistant.core import CoreState, State
 from homeassistant.setup import async_setup_component
-from homeassistant.const import ATTR_LATITUDE, ATTR_LONGITUDE, STATE_UNKNOWN
-from homeassistant.core import State, CoreState
+
 from tests.common import mock_component, mock_restore_cache
 
 DEVICE_TRACKER = 'device_tracker.test_tracker'
@@ -11,7 +13,7 @@ DEVICE_TRACKER_2 = 'device_tracker.test_tracker_2'
 
 async def test_minimal_setup(hass):
     """Test minimal config with only name."""
-    config = {DOMAIN: {'name': 'test person'}}
+    config = {DOMAIN: {'id': '1234', 'name': 'test person'}}
     assert await async_setup_component(hass, DOMAIN, config)
 
     state = hass.states.get('person.test_person')
@@ -22,14 +24,28 @@ async def test_minimal_setup(hass):
     assert state.attributes.get(ATTR_USER_ID) is None
 
 
+async def test_setup_no_id(hass):
+    """Test config with no id."""
+    config = {DOMAIN: {'name': 'test user'}}
+    assert not await async_setup_component(hass, DOMAIN, config)
+
+
+async def test_setup_no_name(hass):
+    """Test config with no name."""
+    config = {DOMAIN: {'id': '1234'}}
+    assert not await async_setup_component(hass, DOMAIN, config)
+
+
 async def test_setup_user_id(hass, hass_owner_user):
     """Test config with user id."""
     user_id = hass_owner_user.id
-    config = {DOMAIN: {'name': 'test person', 'user_id': user_id}}
+    config = {
+        DOMAIN: {'id': '1234', 'name': 'test person', 'user_id': user_id}}
     assert await async_setup_component(hass, DOMAIN, config)
 
     state = hass.states.get('person.test_person')
     assert state.state == STATE_UNKNOWN
+    assert state.attributes.get(ATTR_ID) == '1234'
     assert state.attributes.get(ATTR_LATITUDE) is None
     assert state.attributes.get(ATTR_LONGITUDE) is None
     assert state.attributes.get(ATTR_SOURCE) is None
@@ -38,7 +54,9 @@ async def test_setup_user_id(hass, hass_owner_user):
 
 async def test_setup_invalid_user_id(hass):
     """Test config with invalid user id."""
-    config = {DOMAIN: {'name': 'test bad user', 'user_id': 'bad_user_id'}}
+    config = {
+        DOMAIN: {
+            'id': '1234', 'name': 'test bad user', 'user_id': 'bad_user_id'}}
     assert not await async_setup_component(hass, DOMAIN, config)
 
 
@@ -46,12 +64,13 @@ async def test_valid_invalid_user_ids(hass, hass_owner_user):
     """Test a person with valid user id and a person with invalid user id ."""
     user_id = hass_owner_user.id
     config = {DOMAIN: [
-        {'name': 'test valid user', 'user_id': user_id},
-        {'name': 'test bad user', 'user_id': 'bad_user_id'}]}
+        {'id': '1234', 'name': 'test valid user', 'user_id': user_id},
+        {'id': '5678', 'name': 'test bad user', 'user_id': 'bad_user_id'}]}
     assert await async_setup_component(hass, DOMAIN, config)
 
     state = hass.states.get('person.test_valid_user')
     assert state.state == STATE_UNKNOWN
+    assert state.attributes.get(ATTR_ID) == '1234'
     assert state.attributes.get(ATTR_LATITUDE) is None
     assert state.attributes.get(ATTR_LONGITUDE) is None
     assert state.attributes.get(ATTR_SOURCE) is None
@@ -64,12 +83,13 @@ async def test_setup_tracker(hass, hass_owner_user):
     """Test set up person with one device tracker."""
     user_id = hass_owner_user.id
     config = {DOMAIN: {
-        'name': 'tracked person', 'user_id': user_id,
+        'id': '1234', 'name': 'tracked person', 'user_id': user_id,
         'device_trackers': DEVICE_TRACKER}}
     assert await async_setup_component(hass, DOMAIN, config)
 
     state = hass.states.get('person.tracked_person')
     assert state.state == STATE_UNKNOWN
+    assert state.attributes.get(ATTR_ID) == '1234'
     assert state.attributes.get(ATTR_LATITUDE) is None
     assert state.attributes.get(ATTR_LONGITUDE) is None
     assert state.attributes.get(ATTR_SOURCE) is None
@@ -80,6 +100,7 @@ async def test_setup_tracker(hass, hass_owner_user):
 
     state = hass.states.get('person.tracked_person')
     assert state.state == 'home'
+    assert state.attributes.get(ATTR_ID) == '1234'
     assert state.attributes.get(ATTR_LATITUDE) is None
     assert state.attributes.get(ATTR_LONGITUDE) is None
     assert state.attributes.get(ATTR_SOURCE) == DEVICE_TRACKER
@@ -92,6 +113,7 @@ async def test_setup_tracker(hass, hass_owner_user):
 
     state = hass.states.get('person.tracked_person')
     assert state.state == 'not_home'
+    assert state.attributes.get(ATTR_ID) == '1234'
     assert state.attributes.get(ATTR_LATITUDE) == 10.12346
     assert state.attributes.get(ATTR_LONGITUDE) == 11.12346
     assert state.attributes.get(ATTR_SOURCE) == DEVICE_TRACKER
@@ -102,12 +124,13 @@ async def test_setup_two_trackers(hass, hass_owner_user):
     """Test set up person with two device trackers."""
     user_id = hass_owner_user.id
     config = {DOMAIN: {
-        'name': 'tracked person', 'user_id': user_id,
+        'id': '1234', 'name': 'tracked person', 'user_id': user_id,
         'device_trackers': [DEVICE_TRACKER, DEVICE_TRACKER_2]}}
     assert await async_setup_component(hass, DOMAIN, config)
 
     state = hass.states.get('person.tracked_person')
     assert state.state == STATE_UNKNOWN
+    assert state.attributes.get(ATTR_ID) == '1234'
     assert state.attributes.get(ATTR_LATITUDE) is None
     assert state.attributes.get(ATTR_LONGITUDE) is None
     assert state.attributes.get(ATTR_SOURCE) is None
@@ -118,6 +141,7 @@ async def test_setup_two_trackers(hass, hass_owner_user):
 
     state = hass.states.get('person.tracked_person')
     assert state.state == 'home'
+    assert state.attributes.get(ATTR_ID) == '1234'
     assert state.attributes.get(ATTR_LATITUDE) is None
     assert state.attributes.get(ATTR_LONGITUDE) is None
     assert state.attributes.get(ATTR_SOURCE) == DEVICE_TRACKER
@@ -130,6 +154,7 @@ async def test_setup_two_trackers(hass, hass_owner_user):
 
     state = hass.states.get('person.tracked_person')
     assert state.state == 'not_home'
+    assert state.attributes.get(ATTR_ID) == '1234'
     assert state.attributes.get(ATTR_LATITUDE) == 12.12346
     assert state.attributes.get(ATTR_LONGITUDE) == 13.12346
     assert state.attributes.get(ATTR_SOURCE) == DEVICE_TRACKER_2
@@ -138,21 +163,22 @@ async def test_setup_two_trackers(hass, hass_owner_user):
 
 async def test_restore_home_state(hass, hass_owner_user):
     """Test that the state is restored for a person on startup."""
+    user_id = hass_owner_user.id
     attrs = {
-        ATTR_LATITUDE: 10.12346, ATTR_LONGITUDE: 11.12346,
-        ATTR_SOURCE: DEVICE_TRACKER}
+        ATTR_ID: '1234', ATTR_LATITUDE: 10.12346, ATTR_LONGITUDE: 11.12346,
+        ATTR_SOURCE: DEVICE_TRACKER, ATTR_USER_ID: user_id}
     state = State('person.tracked_person', 'home', attrs)
     mock_restore_cache(hass, (state, ))
     hass.state = CoreState.starting
     mock_component(hass, 'recorder')
-    user_id = hass_owner_user.id
     config = {DOMAIN: {
-        'name': 'tracked person', 'user_id': user_id,
+        'id': '1234', 'name': 'tracked person', 'user_id': user_id,
         'device_trackers': DEVICE_TRACKER}}
     assert await async_setup_component(hass, DOMAIN, config)
 
     state = hass.states.get('person.tracked_person')
     assert state.state == 'home'
+    assert state.attributes.get(ATTR_ID) == '1234'
     assert state.attributes.get(ATTR_LATITUDE) == 10.12346
     assert state.attributes.get(ATTR_LONGITUDE) == 11.12346
     # When restoring state the entity_id of the person will be used as source.


### PR DESCRIPTION
## Description:
This aims to solve MVP as specified here:
https://github.com/home-assistant/architecture/issues/72#issuecomment-430173862

* Required name.
* Required id. Id will set unique id.
* Optional user id.
* Optionally track device trackers. Last device tracker state change will set state.
* Set device tracker state entity_id as source attribute.
* Set coordinates of device tracker state as state attributes.
* Restore state.

If we think this is the right direction, I'll finish up and add tests.

**Related issue (if applicable):**
https://github.com/home-assistant/architecture/issues/72

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):**
WIP

## Example entry for `configuration.yaml` (if applicable):
```yaml
person:
  - name: Martin Hjelmare
    user_id: 12345678912345678912345678912345
    device_trackers:
      - device_tracker.demo_paulus
      - device_tracker.demo_anne_therese

device_tracker:
  - platform: demo
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.