### PR TITLE
Add character encoding to MQTT automation.

### DIFF
--- a/homeassistant/components/automation/mqtt.py
+++ b/homeassistant/components/automation/mqtt.py
@@ -15,19 +15,23 @@ import homeassistant.helpers.config_validation as cv
 
 DEPENDENCIES = ['mqtt']
 
+CONF_ENCODING = 'encoding'
 CONF_TOPIC = 'topic'
+DEFAULT_ENCODING = 'utf-8'
 
 TRIGGER_SCHEMA = vol.Schema({
     vol.Required(CONF_PLATFORM): mqtt.DOMAIN,
     vol.Required(CONF_TOPIC): mqtt.valid_subscribe_topic,
     vol.Optional(CONF_PAYLOAD): cv.string,
+    vol.Optional(CONF_ENCODING, default=DEFAULT_ENCODING): cv.string,
 })
 
 
 async def async_trigger(hass, config, action, automation_info):
     """Listen for state changes based on configuration."""
-    topic = config.get(CONF_TOPIC)
+    topic = config[CONF_TOPIC]
     payload = config.get(CONF_PAYLOAD)
+    encoding = config[CONF_ENCODING] or None
 
     @callback
     def mqtt_automation_listener(msg_topic, msg_payload, qos):
@@ -50,5 +54,5 @@ async def async_trigger(hass, config, action, automation_info):
             })
 
     remove = await mqtt.async_subscribe(
-        hass, topic, mqtt_automation_listener)
+        hass, topic, mqtt_automation_listener, encoding=encoding)
     return remove

--- a/tests/components/automation/test_mqtt.py
+++ b/tests/components/automation/test_mqtt.py
@@ -1,5 +1,6 @@
 """The tests for the MQTT automation."""
 import pytest
+from unittest import mock
 
 from homeassistant.setup import async_setup_component
 import homeassistant.components.automation as automation
@@ -92,3 +93,44 @@ async def test_if_not_fires_on_topic_but_no_payload_match(hass, calls):
     async_fire_mqtt_message(hass, 'test-topic', 'no-hello')
     await hass.async_block_till_done()
     assert 0 == len(calls)
+
+
+async def test_encoding_default(hass, calls):
+    """Test default encoding."""
+    mock_mqtt = await async_mock_mqtt_component(hass)
+
+    assert await async_setup_component(hass, automation.DOMAIN, {
+        automation.DOMAIN: {
+            'trigger': {
+                'platform': 'mqtt',
+                'topic': 'test-topic'
+            },
+            'action': {
+                'service': 'test.automation'
+            }
+        }
+    })
+
+    mock_mqtt.async_subscribe.assert_called_once_with(
+        'test-topic', mock.ANY, 0, 'utf-8')
+
+
+async def test_encoding_custom(hass, calls):
+    """Test default encoding."""
+    mock_mqtt = await async_mock_mqtt_component(hass)
+
+    assert await async_setup_component(hass, automation.DOMAIN, {
+        automation.DOMAIN: {
+            'trigger': {
+                'platform': 'mqtt',
+                'topic': 'test-topic',
+                'encoding': ''
+            },
+            'action': {
+                'service': 'test.automation'
+            }
+        }
+    })
+
+    mock_mqtt.async_subscribe.assert_called_once_with(
+        'test-topic', mock.ANY, 0, None)


### PR DESCRIPTION
## Description:
Add support for custom character encoding to MQTT automations.

**Related issue (if applicable):** fixes #16004

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8247

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)