### PR TITLE
Add mitemp bt sensor device class

### DIFF
--- a/homeassistant/components/sensor/mitemp_bt.py
+++ b/homeassistant/components/sensor/mitemp_bt.py
@@ -12,7 +12,7 @@ from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 from homeassistant.const import (
-    CONF_FORCE_UPDATE, CONF_MONITORED_CONDITIONS, CONF_NAME, CONF_MAC, DEVICE_CLASS_HUMIDITY, DEVICE_CLASS_TEMPERATURE
+    CONF_FORCE_UPDATE, CONF_MONITORED_CONDITIONS, CONF_NAME, CONF_MAC, DEVICE_CLASS_HUMIDITY, DEVICE_CLASS_TEMPERATURE, DEVICE_CLASS_BATTERY
 )
 
 
@@ -39,7 +39,7 @@ DEFAULT_TIMEOUT = 10
 SENSOR_TYPES = {
     'temperature': [DEVICE_CLASS_TEMPERATURE, 'Temperature', '°C'],
     'humidity': [DEVICE_CLASS_HUMIDITY, 'Humidity', '%'],
-    'battery': ['Battery', '%'],
+    'battery': [DEVICE_CLASS_BATTERY, 'Battery', '%'],
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({

--- a/homeassistant/components/sensor/mitemp_bt.py
+++ b/homeassistant/components/sensor/mitemp_bt.py
@@ -12,7 +12,7 @@ from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 from homeassistant.const import (
-    CONF_FORCE_UPDATE, CONF_MONITORED_CONDITIONS, CONF_NAME, CONF_MAC
+    CONF_FORCE_UPDATE, CONF_MONITORED_CONDITIONS, CONF_NAME, CONF_MAC, DEVICE_CLASS_HUMIDITY, DEVICE_CLASS_TEMPERATURE
 )
 
 
@@ -37,8 +37,8 @@ DEFAULT_TIMEOUT = 10
 
 # Sensor types are defined like: Name, units
 SENSOR_TYPES = {
-    'temperature': ['Temperature', '°C'],
-    'humidity': ['Humidity', '%'],
+    'temperature': [DEVICE_CLASS_TEMPERATURE, 'Temperature', '°C'],
+    'humidity': [DEVICE_CLASS_HUMIDITY, 'Humidity', '%'],
     'battery': ['Battery', '%'],
 }
 
@@ -80,15 +80,16 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     devs = []
 
     for parameter in config[CONF_MONITORED_CONDITIONS]:
-        name = SENSOR_TYPES[parameter][0]
-        unit = SENSOR_TYPES[parameter][1]
+        device = SENSOR_TYPES[parameter][0]
+        name = SENSOR_TYPES[parameter][1]
+        unit = SENSOR_TYPES[parameter][2]
 
         prefix = config.get(CONF_NAME)
         if prefix:
             name = "{} {}".format(prefix, name)
 
         devs.append(MiTempBtSensor(
-            poller, parameter, name, unit, force_update, median))
+            poller, parameter, device, name, unit, force_update, median))
 
     add_entities(devs)
 
@@ -96,10 +97,11 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class MiTempBtSensor(Entity):
     """Implementing the MiTempBt sensor."""
 
-    def __init__(self, poller, parameter, name, unit, force_update, median):
+    def __init__(self, poller, parameter, device, name, unit, force_update, median):
         """Initialize the sensor."""
         self.poller = poller
         self.parameter = parameter
+        self._device = device
         self._unit = unit
         self._name = name
         self._state = None
@@ -124,6 +126,10 @@ class MiTempBtSensor(Entity):
     def unit_of_measurement(self):
         """Return the units of measurement."""
         return self._unit
+
+    @property
+    def device_class(self):
+        return self._device
 
     @property
     def force_update(self):

--- a/homeassistant/components/sensor/mitemp_bt.py
+++ b/homeassistant/components/sensor/mitemp_bt.py
@@ -12,7 +12,8 @@ from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 from homeassistant.const import (
-    CONF_FORCE_UPDATE, CONF_MONITORED_CONDITIONS, CONF_NAME, CONF_MAC, DEVICE_CLASS_HUMIDITY, DEVICE_CLASS_TEMPERATURE, DEVICE_CLASS_BATTERY
+    CONF_FORCE_UPDATE, CONF_MONITORED_CONDITIONS, CONF_NAME, CONF_MAC,
+    DEVICE_CLASS_HUMIDITY, DEVICE_CLASS_TEMPERATURE, DEVICE_CLASS_BATTERY
 )
 
 
@@ -97,7 +98,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class MiTempBtSensor(Entity):
     """Implementing the MiTempBt sensor."""
 
-    def __init__(self, poller, parameter, device, name, unit, force_update, median):
+    def __init__(self, poller, parameter, device, name, unit,
+                 force_update, median):
         """Initialize the sensor."""
         self.poller = poller
         self.parameter = parameter

--- a/homeassistant/components/sensor/mitemp_bt.py
+++ b/homeassistant/components/sensor/mitemp_bt.py
@@ -131,6 +131,7 @@ class MiTempBtSensor(Entity):
 
     @property
     def device_class(self):
+        """Device class of this entity."""
         return self._device
 
     @property


### PR DESCRIPTION
When using HomeKit components, MiTemp BT's humidity state will not display in Home.app.
After Added home-assistant device class into property, this problem is solved.

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
