### PR TITLE
Add LIFX listen port advanced configuration

### DIFF
--- a/homeassistant/components/lifx/__init__.py
+++ b/homeassistant/components/lifx/__init__.py
@@ -3,6 +3,7 @@ import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
 
 from homeassistant import config_entries
+from homeassistant.const import CONF_PORT
 from homeassistant.helpers import config_entry_flow
 from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
 
@@ -15,6 +16,7 @@ CONF_BROADCAST = 'broadcast'
 
 INTERFACE_SCHEMA = vol.Schema({
     vol.Optional(CONF_SERVER): cv.string,
+    vol.Optional(CONF_PORT): cv.port,
     vol.Optional(CONF_BROADCAST): cv.string,
 })
 

--- a/homeassistant/components/light/lifx.py
+++ b/homeassistant/components/light/lifx.py
@@ -22,7 +22,8 @@ from homeassistant.components.light import (
     SUPPORT_TRANSITION, VALID_BRIGHTNESS, VALID_BRIGHTNESS_PCT, Light,
     preprocess_turn_on_alternatives)
 from homeassistant.components.lifx import (
-    DOMAIN as LIFX_DOMAIN, DATA_LIFX_MANAGER, CONF_SERVER, CONF_BROADCAST)
+    DOMAIN as LIFX_DOMAIN, DATA_LIFX_MANAGER, CONF_SERVER, CONF_PORT,
+    CONF_BROADCAST)
 from homeassistant.const import ATTR_ENTITY_ID, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
@@ -230,6 +231,9 @@ class LIFXManager:
         listen_ip = interface.get(CONF_SERVER)
         if listen_ip:
             kwargs['listen_ip'] = listen_ip
+        listen_port = interface.get(CONF_PORT)
+        if listen_port:
+            kwargs['listen_port'] = listen_port
         lifx_discovery.start(**kwargs)
 
         self.discoveries.append(lifx_discovery)


### PR DESCRIPTION
## Description:

This allows the definition of a static port for LIFX discovery responses. We normally use a dynamic port which avoids conflicts with other LIFX controllers but also makes it hard to allow in a firewall.

**Related issue (if applicable):** fixes #20087

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8235

## Example entry for `configuration.yaml` (if applicable):
```yaml
lifx:
 light:
   - server: 10.10.2.14
     port: 56700
     broadcast: 10.10.2.255
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54