### PR TITLE
Prevent error when octoprint server auto detectedd but no configuration present.

### DIFF
--- a/homeassistant/components/octoprint.py
+++ b/homeassistant/components/octoprint.py
@@ -92,6 +92,10 @@ def setup(hass, config):
 
     discovery.listen(hass, SERVICE_OCTOPRINT, device_discovered)
 
+    if DOMAIN not in config:
+        # Skip the setup if there is no configuration present
+        return True
+
     for printer in config[DOMAIN]:
         name = printer[CONF_NAME]
         ssl = 's' if printer[CONF_SSL] else ''


### PR DESCRIPTION
## Description:

Bugfix for an issue a user reported: when there is no octoprint component configuration present but an octoprint server gets auto-detected, an error pop-ups in the persistent notifications.

**Related issue (if applicable):** fixes #18627
Here is the relevant traceback:

```
2019-01-21 22:30:56 ERROR (MainThread) [homeassistant.setup] Error during setup of component octoprint
Traceback (most recent call last):
  File "/Users/reefab/Projects/Public/home-assistant/homeassistant/setup.py", line 148, in _async_setup_component
    component.setup, hass, processed_config)  # type: ignore
  File "/usr/local/Cellar/python/3.7.2/Frameworks/Python.framework/Versions/3.7/lib/python3.7/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/Users/reefab/Projects/Public/home-assistant/homeassistant/components/octoprint.py", line 95, in setup
    for printer in config[DOMAIN]:
KeyError: 'octoprint'
```

This PR disable the loading of the component if no configuration is already present and thus there is no error messages.

This is a band-aid fix until the auto discovery and configuration for the octoprint platform gets implemented. As of now, the auto discovery doesn't do anything (except for this error message actually).

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
