### PR TITLE
Silent duplicate key error in yaml loader

### DIFF
--- a/homeassistant/util/yaml.py
+++ b/homeassistant/util/yaml.py
@@ -219,9 +219,9 @@ def _ordered_dict(loader: SafeLineLoader,
 
         if key in seen:
             fname = getattr(loader.stream, 'name', '')
-            _LOGGER.error(
-                'YAML file %s contains duplicate key "%s". '
-                'Check lines %d and %d.', fname, key, seen[key], line)
+            raise HomeAssistantError(
+                'YAML file {} contains duplicate key "{}". '
+                'Check lines {} and {}.'.format(fname, key, seen[key], line))
         seen[key] = line
 
     return _add_reference(OrderedDict(nodes), loader, node)

--- a/tests/util/test_yaml.py
+++ b/tests/util/test_yaml.py
@@ -1,15 +1,16 @@
 """Test Home Assistant yaml loader."""
 import io
+import logging
 import os
 import unittest
-import logging
 from unittest.mock import patch
 
 import pytest
 
+from homeassistant.config import YAML_CONFIG_FILE, load_yaml_config_file
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.util import yaml
-from homeassistant.config import YAML_CONFIG_FILE, load_yaml_config_file
+
 from tests.common import get_test_config_dir, patch_yaml_files
 
 
@@ -437,9 +438,9 @@ def test_representing_yaml_loaded_data():
     assert yaml.dump(data) == "key:\n- 1\n- '2'\n- 3\n"
 
 
-def test_duplicate_key(caplog):
+def test_duplicate_key():
     """Test duplicate dict keys."""
     files = {YAML_CONFIG_FILE: 'key: thing1\nkey: thing2'}
-    with patch_yaml_files(files):
-        load_yaml_config_file(YAML_CONFIG_FILE)
-    assert 'contains duplicate key' in caplog.text
+    with pytest.raises(HomeAssistantError):
+        with patch_yaml_files(files):
+            load_yaml_config_file(YAML_CONFIG_FILE)


### PR DESCRIPTION
## Description:
Changes a silent duplicate key error in yaml loader to raise an Exception

**Related issue (if applicable):** fixes #18547 home-assistant/home-assistant-polymer#2066

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  # Weather prediction
  - platform: yr
  - platform: random
    maximum: 255

sensor:
  - platform: buienradar
    monitored_conditions:
      - symbol
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
