### PR TITLE
Fix typo C02 to CO2

### DIFF
--- a/homeassistant/components/air_quality/__init__.py
+++ b/homeassistant/components/air_quality/__init__.py
@@ -46,7 +46,6 @@ PROP_TO_ATTR = {
     'particulate_matter_10': ATTR_PM_10,
     'particulate_matter_2_5': ATTR_PM_2_5,
     'sulphur_dioxide': ATTR_SO2,
-    'volatile_organic_compound': ATTR_VOC,
 }
 
 

--- a/homeassistant/components/air_quality/__init__.py
+++ b/homeassistant/components/air_quality/__init__.py
@@ -25,7 +25,6 @@ ATTR_PM_0_1 = 'particulate_matter_0_1'
 ATTR_PM_10 = 'particulate_matter_10'
 ATTR_PM_2_5 = 'particulate_matter_2_5'
 ATTR_SO2 = 'sulphur_dioxide'
-ATTR_VOC = 'volatile_organic_compound'
 
 DOMAIN = 'air_quality'
 

--- a/homeassistant/components/air_quality/__init__.py
+++ b/homeassistant/components/air_quality/__init__.py
@@ -132,11 +132,6 @@ class AirQualityEntity(Entity):
         return None
 
     @property
-    def volatile_organic_compound(self):
-        """Return the VOC (volatile organic compound) level."""
-        return None
-
-    @property
     def state_attributes(self):
         """Return the state attributes."""
         data = {}

--- a/homeassistant/components/air_quality/__init__.py
+++ b/homeassistant/components/air_quality/__init__.py
@@ -15,7 +15,7 @@ _LOGGER = logging.getLogger(__name__)
 
 ATTR_AQI = 'air_quality_index'
 ATTR_ATTRIBUTION = 'attribution'
-ATTR_C02 = 'carbon_dioxide'
+ATTR_CO2 = 'carbon_dioxide'
 ATTR_CO = 'carbon_monoxide'
 ATTR_N2O = 'nitrogen_oxide'
 ATTR_NO = 'nitrogen_monoxide'
@@ -25,6 +25,7 @@ ATTR_PM_0_1 = 'particulate_matter_0_1'
 ATTR_PM_10 = 'particulate_matter_10'
 ATTR_PM_2_5 = 'particulate_matter_2_5'
 ATTR_SO2 = 'sulphur_dioxide'
+ATTR_VOC = 'volatile_organic_compounds'
 
 DOMAIN = 'air_quality'
 
@@ -35,7 +36,7 @@ SCAN_INTERVAL = timedelta(seconds=30)
 PROP_TO_ATTR = {
     'air_quality_index': ATTR_AQI,
     'attribution': ATTR_ATTRIBUTION,
-    'carbon_dioxide': ATTR_C02,
+    'carbon_dioxide': ATTR_CO2,
     'carbon_monoxide': ATTR_CO,
     'nitrogen_oxide': ATTR_N2O,
     'nitrogen_monoxide': ATTR_NO,
@@ -45,6 +46,7 @@ PROP_TO_ATTR = {
     'particulate_matter_10': ATTR_PM_10,
     'particulate_matter_2_5': ATTR_PM_2_5,
     'sulphur_dioxide': ATTR_SO2,
+    'volatile_organic_compounds': ATTR_VOC,
 }
 
 
@@ -127,6 +129,11 @@ class AirQualityEntity(Entity):
     @property
     def nitrogen_dioxide(self):
         """Return the NO2 (nitrogen dioxide) level."""
+        return None
+
+    @property
+    def volatile_organic_compounds(self):
+        """Return the VOC (volatile organic compounds) level."""
         return None
 
     @property

--- a/homeassistant/components/air_quality/__init__.py
+++ b/homeassistant/components/air_quality/__init__.py
@@ -25,7 +25,7 @@ ATTR_PM_0_1 = 'particulate_matter_0_1'
 ATTR_PM_10 = 'particulate_matter_10'
 ATTR_PM_2_5 = 'particulate_matter_2_5'
 ATTR_SO2 = 'sulphur_dioxide'
-ATTR_VOC = 'volatile_organic_compounds'
+ATTR_VOC = 'volatile_organic_compound'
 
 DOMAIN = 'air_quality'
 
@@ -46,7 +46,7 @@ PROP_TO_ATTR = {
     'particulate_matter_10': ATTR_PM_10,
     'particulate_matter_2_5': ATTR_PM_2_5,
     'sulphur_dioxide': ATTR_SO2,
-    'volatile_organic_compounds': ATTR_VOC,
+    'volatile_organic_compound': ATTR_VOC,
 }
 
 
@@ -132,8 +132,8 @@ class AirQualityEntity(Entity):
         return None
 
     @property
-    def volatile_organic_compounds(self):
-        """Return the VOC (volatile organic compounds) level."""
+    def volatile_organic_compound(self):
+        """Return the VOC (volatile organic compound) level."""
         return None
 
     @property


### PR DESCRIPTION
## Description:

There was a typo in the air quality platform, ATTR_CO2 was spelled ATTR_C02, zero instead of big o.

This attribute wasn't used anywhere so no other files needed to be changed.

I took this opportunity to add VOC, Volatile Organic Compounds to the attributes list. 
Considering many, if not most, indoor air quality devices derives their CO2 measurement from a VOC sensor.

Context: I'm migrating the foobot component from sensor to the air quality platform.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
