### PR TITLE
Adding support for FRITZ DECT 100 (temp sensor)

### DIFF
--- a/homeassistant/components/fritzbox.py
+++ b/homeassistant/components/fritzbox.py
@@ -18,7 +18,7 @@ _LOGGER = logging.getLogger(__name__)
 
 REQUIREMENTS = ['pyfritzhome==0.4.0']
 
-SUPPORTED_DOMAINS = ['binary_sensor', 'climate', 'switch']
+SUPPORTED_DOMAINS = ['binary_sensor', 'climate', 'switch', 'sensor']
 
 DOMAIN = 'fritzbox'
 

--- a/homeassistant/components/sensor/fritzbox.py
+++ b/homeassistant/components/sensor/fritzbox.py
@@ -1,0 +1,77 @@
+"""
+Support for AVM Fritz!Box smarthome temperature sensor only devices.
+
+For more details about this component, please refer to the documentation at
+http://home-assistant.io/components/sensor.fritzbox/
+"""
+import logging
+
+import requests
+
+from homeassistant.components.fritzbox import DOMAIN as FRITZBOX_DOMAIN
+from homeassistant.components.fritzbox import (
+    ATTR_STATE_DEVICE_LOCKED, ATTR_STATE_LOCKED)
+from homeassistant.helpers.entity import Entity
+from homeassistant.const import TEMP_CELSIUS
+
+DEPENDENCIES = ['fritzbox']
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    """Set up the Fritzbox smarthome sensor platform."""
+    _LOGGER.debug("Initializing fritzbox temperature sensors")
+    devices = []
+    fritz_list = hass.data[FRITZBOX_DOMAIN]
+
+    for fritz in fritz_list:
+        device_list = fritz.get_devices()
+        for device in device_list:
+            if (device.has_temperature_sensor
+                    and not device.has_switch
+                    and not device.has_thermostat):
+                devices.append(FritzBoxTempSensor(device, fritz))
+
+    add_entities(devices)
+
+
+class FritzBoxTempSensor(Entity):
+    """The entity class for Fritzbox temperature sensors."""
+
+    def __init__(self, device, fritz):
+        """Initialize the switch."""
+        self._device = device
+        self._fritz = fritz
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return self._device.name
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._device.temperature
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement."""
+        return TEMP_CELSIUS
+
+    def update(self):
+        """Get latest data and states from the device."""
+        try:
+            self._device.update()
+        except requests.exceptions.HTTPError as ex:
+            _LOGGER.warning("Fritzhome connection error: %s", ex)
+            self._fritz.login()
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes of the device."""
+        attrs = {
+            ATTR_STATE_DEVICE_LOCKED: self._device.device_lock,
+            ATTR_STATE_LOCKED: self._device.lock,
+        }
+        return attrs


### PR DESCRIPTION
## Description:

Added automatic setup of fritz!box components which are temperature sensors only. 

**Related issue (if applicable):** n/a

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8242

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
