### PR TITLE
Geolocation dependent on group

### DIFF
--- a/homeassistant/components/geo_location/__init__.py
+++ b/homeassistant/components/geo_location/__init__.py
@@ -19,6 +19,7 @@ ATTR_DISTANCE = 'distance'
 ATTR_SOURCE = 'source'
 
 DOMAIN = 'geo_location'
+DEPENDENCIES = ['group']
 
 ENTITY_ID_FORMAT = DOMAIN + '.{}'
 

--- a/homeassistant/components/geo_location/__init__.py
+++ b/homeassistant/components/geo_location/__init__.py
@@ -18,8 +18,8 @@ _LOGGER = logging.getLogger(__name__)
 ATTR_DISTANCE = 'distance'
 ATTR_SOURCE = 'source'
 
-DOMAIN = 'geo_location'
 DEPENDENCIES = ['group']
+DOMAIN = 'geo_location'
 
 ENTITY_ID_FORMAT = DOMAIN + '.{}'
 

--- a/tests/components/geo_location/test_demo.py
+++ b/tests/components/geo_location/test_demo.py
@@ -39,10 +39,10 @@ class TestDemoPlatform(unittest.TestCase):
             with assert_setup_component(1, geo_location.DOMAIN):
                 assert setup_component(self.hass, geo_location.DOMAIN, CONFIG)
 
-            # In this test, only entities of the geolocation domain have been
-            # generated.
+            # In this test, only entities of the geolocation domain and
+            # one group have been generated.
             all_states = self.hass.states.all()
-            assert len(all_states) == NUMBER_OF_DEMO_DEVICES
+            assert len(all_states) == NUMBER_OF_DEMO_DEVICES + 1
 
             # Check a single device's attributes.
             state_first_entry = all_states[0]
@@ -62,5 +62,5 @@ class TestDemoPlatform(unittest.TestCase):
             # Get all states again, ensure that the number of states is still
             # the same, but the lists are different.
             all_states_updated = self.hass.states.all()
-            assert len(all_states_updated) == NUMBER_OF_DEMO_DEVICES
+            assert len(all_states_updated) == NUMBER_OF_DEMO_DEVICES + 1
             assert all_states != all_states_updated

--- a/tests/components/geo_location/test_nsw_rural_fire_service_feed.py
+++ b/tests/components/geo_location/test_nsw_rural_fire_service_feed.py
@@ -208,7 +208,3 @@ async def test_setup_with_custom_location(hass):
 
             assert mock_feed.call_args == call(
                 (15.1, 25.2), filter_categories=[], filter_radius=200.0)
-
-
-# async def test_group_updates(hass):
-#     """Test the behavior of the catch-all group."""

--- a/tests/components/geo_location/test_usgs_earthquakes_feed.py
+++ b/tests/components/geo_location/test_usgs_earthquakes_feed.py
@@ -97,7 +97,7 @@ async def test_setup(hass):
             await hass.async_block_till_done()
 
             all_states = hass.states.async_all()
-            assert len(all_states) == 3
+            assert len(all_states) == 4
 
             state = hass.states.get("geo_location.title_1")
             assert state is not None
@@ -139,15 +139,21 @@ async def test_setup(hass):
                 ATTR_SOURCE: 'usgs_earthquakes_feed'}
             assert round(abs(float(state.state)-25.5), 7) == 0
 
+            # Now check if all entities are found in the component's group.
+            group_state = hass.states.get("group.all_geolocation_events")
+            assert group_state.attributes['entity_id'] == (
+                'geo_location.title_1', 'geo_location.title_2',
+                'geo_location.title_3')
+
             # Simulate an update - one existing, one new entry,
-            # one outdated entry
+            # one outdated entry.
             mock_feed.return_value.update.return_value = 'OK', [
                 mock_entry_1, mock_entry_4, mock_entry_3]
             async_fire_time_changed(hass, utcnow + SCAN_INTERVAL)
             await hass.async_block_till_done()
 
             all_states = hass.states.async_all()
-            assert len(all_states) == 3
+            assert len(all_states) == 4
 
             # Simulate an update - empty data, but successful update,
             # so no changes to entities.
@@ -156,15 +162,16 @@ async def test_setup(hass):
             await hass.async_block_till_done()
 
             all_states = hass.states.async_all()
-            assert len(all_states) == 3
+            assert len(all_states) == 4
 
-            # Simulate an update - empty data, removes all entities
+            # Simulate an update - empty data, removes all entities, except
+            # for the group.
             mock_feed.return_value.update.return_value = 'ERROR', None
             async_fire_time_changed(hass, utcnow + 3 * SCAN_INTERVAL)
             await hass.async_block_till_done()
 
             all_states = hass.states.async_all()
-            assert len(all_states) == 0
+            assert len(all_states) == 1
 
 
 async def test_setup_with_custom_location(hass):
@@ -187,7 +194,7 @@ async def test_setup_with_custom_location(hass):
             await hass.async_block_till_done()
 
             all_states = hass.states.async_all()
-            assert len(all_states) == 1
+            assert len(all_states) == 2
 
             assert mock_feed.call_args == call(
                 (15.1, 25.2), 'past_hour_m25_earthquakes',


### PR DESCRIPTION
## Description:
The `geo_location` component automatically sets up a catch-all group for its entities. This PR defines the missing `DEPENDENCIES = ['group']` and adds a couple of lines to existing unit tests to make sure that entities become member of that catch-all group.

This PR is required in preparation to test a fix of an issue when entities are not correctly removed from that group (#20236).

**Related issue (if applicable):** prerequisite for #20236

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable): n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
