### PR TITLE
Fix ffmpeg v4 stream issue

### DIFF
--- a/homeassistant/components/amcrest/camera.py
+++ b/homeassistant/components/amcrest/camera.py
@@ -82,7 +82,7 @@ class AmcrestCam(Camera):
         try:
             return await async_aiohttp_proxy_stream(
                 self.hass, request, stream,
-                'multipart/x-mixed-replace;boundary=ffserver')
+                await self._manager.async_get_ffmpeg_stream_content_type())
         finally:
             await stream.close()
 

--- a/homeassistant/components/amcrest/camera.py
+++ b/homeassistant/components/amcrest/camera.py
@@ -82,7 +82,7 @@ class AmcrestCam(Camera):
         try:
             return await async_aiohttp_proxy_stream(
                 self.hass, request, stream,
-                await self._manager.async_get_ffmpeg_stream_content_type())
+                await self._ffmpeg.async_get_ffmpeg_stream_content_type())
         finally:
             await stream.close()
 

--- a/homeassistant/components/amcrest/camera.py
+++ b/homeassistant/components/amcrest/camera.py
@@ -82,7 +82,7 @@ class AmcrestCam(Camera):
         try:
             return await async_aiohttp_proxy_stream(
                 self.hass, request, stream,
-                await self._ffmpeg.async_get_ffmpeg_stream_content_type())
+                self._ffmpeg.ffmpeg_stream_content_type)
         finally:
             await stream.close()
 

--- a/homeassistant/components/arlo/camera.py
+++ b/homeassistant/components/arlo/camera.py
@@ -104,7 +104,7 @@ class ArloCam(Camera):
         try:
             return await async_aiohttp_proxy_stream(
                 self.hass, request, stream,
-                'multipart/x-mixed-replace;boundary=ffserver')
+                await self._manager.async_get_ffmpeg_stream_content_type())
         finally:
             await stream.close()
 

--- a/homeassistant/components/arlo/camera.py
+++ b/homeassistant/components/arlo/camera.py
@@ -104,7 +104,7 @@ class ArloCam(Camera):
         try:
             return await async_aiohttp_proxy_stream(
                 self.hass, request, stream,
-                await self._ffmpeg.async_get_ffmpeg_stream_content_type())
+                self._ffmpeg.ffmpeg_stream_content_type)
         finally:
             await stream.close()
 

--- a/homeassistant/components/arlo/camera.py
+++ b/homeassistant/components/arlo/camera.py
@@ -104,7 +104,7 @@ class ArloCam(Camera):
         try:
             return await async_aiohttp_proxy_stream(
                 self.hass, request, stream,
-                await self._manager.async_get_ffmpeg_stream_content_type())
+                await self._ffmpeg.async_get_ffmpeg_stream_content_type())
         finally:
             await stream.close()
 

--- a/homeassistant/components/camera/canary.py
+++ b/homeassistant/components/camera/canary.py
@@ -101,7 +101,7 @@ class CanaryCamera(Camera):
         try:
             return await async_aiohttp_proxy_stream(
                 self.hass, request, stream,
-                await self._ffmpeg.async_get_ffmpeg_stream_content_type())
+                self._ffmpeg.ffmpeg_stream_content_type)
         finally:
             await stream.close()
 

--- a/homeassistant/components/camera/canary.py
+++ b/homeassistant/components/camera/canary.py
@@ -101,7 +101,7 @@ class CanaryCamera(Camera):
         try:
             return await async_aiohttp_proxy_stream(
                 self.hass, request, stream,
-                await self._manager.async_get_ffmpeg_stream_content_type())
+                await self._ffmpeg.async_get_ffmpeg_stream_content_type())
         finally:
             await stream.close()
 

--- a/homeassistant/components/camera/canary.py
+++ b/homeassistant/components/camera/canary.py
@@ -101,7 +101,7 @@ class CanaryCamera(Camera):
         try:
             return await async_aiohttp_proxy_stream(
                 self.hass, request, stream,
-                'multipart/x-mixed-replace;boundary=ffserver')
+                await self._manager.async_get_ffmpeg_stream_content_type())
         finally:
             await stream.close()
 

--- a/homeassistant/components/camera/ffmpeg.py
+++ b/homeassistant/components/camera/ffmpeg.py
@@ -60,7 +60,7 @@ class FFmpegCamera(Camera):
     async def handle_async_mjpeg_stream(self, request):
         """Generate an HTTP MJPEG stream from the camera."""
         from haffmpeg import CameraMjpeg
-        
+
         stream = CameraMjpeg(self._manager.binary, loop=self.hass.loop)
         await stream.open_camera(
             self._input, extra_cmd=self._extra_arguments)

--- a/homeassistant/components/camera/ffmpeg.py
+++ b/homeassistant/components/camera/ffmpeg.py
@@ -68,7 +68,7 @@ class FFmpegCamera(Camera):
         try:
             return await async_aiohttp_proxy_stream(
                 self.hass, request, stream,
-                await self._manager.async_get_ffmpeg_stream_content_type())
+                self._manager.ffmpeg_stream_content_type)
         finally:
             await stream.close()
 

--- a/homeassistant/components/camera/ffmpeg.py
+++ b/homeassistant/components/camera/ffmpeg.py
@@ -61,8 +61,6 @@ class FFmpegCamera(Camera):
         """Generate an HTTP MJPEG stream from the camera."""
         from haffmpeg import CameraMjpeg
         
-        content_type = await self._manager.async_get_ffmpeg_stream_content_type()
-
         stream = CameraMjpeg(self._manager.binary, loop=self.hass.loop)
         await stream.open_camera(
             self._input, extra_cmd=self._extra_arguments)
@@ -70,7 +68,7 @@ class FFmpegCamera(Camera):
         try:
             return await async_aiohttp_proxy_stream(
                 self.hass, request, stream,
-                content_type)
+                await self._manager.async_get_ffmpeg_stream_content_type())
         finally:
             await stream.close()
 

--- a/homeassistant/components/camera/ffmpeg.py
+++ b/homeassistant/components/camera/ffmpeg.py
@@ -60,6 +60,8 @@ class FFmpegCamera(Camera):
     async def handle_async_mjpeg_stream(self, request):
         """Generate an HTTP MJPEG stream from the camera."""
         from haffmpeg import CameraMjpeg
+        
+        content_type = await self._manager.async_get_ffmpeg_stream_content_type()
 
         stream = CameraMjpeg(self._manager.binary, loop=self.hass.loop)
         await stream.open_camera(
@@ -68,7 +70,7 @@ class FFmpegCamera(Camera):
         try:
             return await async_aiohttp_proxy_stream(
                 self.hass, request, stream,
-                'multipart/x-mixed-replace;boundary=ffserver')
+                content_type)
         finally:
             await stream.close()
 

--- a/homeassistant/components/camera/onvif.py
+++ b/homeassistant/components/camera/onvif.py
@@ -221,7 +221,7 @@ class ONVIFHassCamera(Camera):
         try:
             return await async_aiohttp_proxy_stream(
                 self.hass, request, stream,
-                'multipart/x-mixed-replace;boundary=ffserver')
+                await self._manager.async_get_ffmpeg_stream_content_type())
         finally:
             await stream.close()
 

--- a/homeassistant/components/camera/onvif.py
+++ b/homeassistant/components/camera/onvif.py
@@ -221,7 +221,8 @@ class ONVIFHassCamera(Camera):
         try:
             return await async_aiohttp_proxy_stream(
                 self.hass, request, stream,
-                await self._manager.async_get_ffmpeg_stream_content_type())
+                await self.hass.data[DATA_FFMPEG]
+                    .async_get_ffmpeg_stream_content_type())
         finally:
             await stream.close()
 

--- a/homeassistant/components/camera/onvif.py
+++ b/homeassistant/components/camera/onvif.py
@@ -222,7 +222,7 @@ class ONVIFHassCamera(Camera):
         try:
             return await async_aiohttp_proxy_stream(
                 self.hass, request, stream,
-                await ffmpeg_manager.async_get_ffmpeg_stream_content_type())
+                ffmpeg_manager.ffmpeg_stream_content_type)
         finally:
             await stream.close()
 

--- a/homeassistant/components/camera/onvif.py
+++ b/homeassistant/components/camera/onvif.py
@@ -213,7 +213,8 @@ class ONVIFHassCamera(Camera):
             if not self._input:
                 return None
 
-        stream = CameraMjpeg(self.hass.data[DATA_FFMPEG].binary,
+        ffmpeg_manager = self.hass.data[DATA_FFMPEG]
+        stream = CameraMjpeg(ffmpeg_manager.binary,
                              loop=self.hass.loop)
         await stream.open_camera(
             self._input, extra_cmd=self._ffmpeg_arguments)
@@ -221,8 +222,7 @@ class ONVIFHassCamera(Camera):
         try:
             return await async_aiohttp_proxy_stream(
                 self.hass, request, stream,
-                await self.hass.data[DATA_FFMPEG]
-                    .async_get_ffmpeg_stream_content_type())
+                await ffmpeg_manager.async_get_ffmpeg_stream_content_type())
         finally:
             await stream.close()
 

--- a/homeassistant/components/camera/ring.py
+++ b/homeassistant/components/camera/ring.py
@@ -142,7 +142,7 @@ class RingCam(Camera):
         try:
             return await async_aiohttp_proxy_stream(
                 self.hass, request, stream,
-                await self._manager.async_get_ffmpeg_stream_content_type())
+                await self._ffmpeg.async_get_ffmpeg_stream_content_type())
         finally:
             await stream.close()
 

--- a/homeassistant/components/camera/ring.py
+++ b/homeassistant/components/camera/ring.py
@@ -142,7 +142,7 @@ class RingCam(Camera):
         try:
             return await async_aiohttp_proxy_stream(
                 self.hass, request, stream,
-                await self._ffmpeg.async_get_ffmpeg_stream_content_type())
+                self._ffmpeg.ffmpeg_stream_content_type)
         finally:
             await stream.close()
 

--- a/homeassistant/components/camera/ring.py
+++ b/homeassistant/components/camera/ring.py
@@ -142,7 +142,7 @@ class RingCam(Camera):
         try:
             return await async_aiohttp_proxy_stream(
                 self.hass, request, stream,
-                'multipart/x-mixed-replace;boundary=ffserver')
+                await self._manager.async_get_ffmpeg_stream_content_type())
         finally:
             await stream.close()
 

--- a/homeassistant/components/camera/xiaomi.py
+++ b/homeassistant/components/camera/xiaomi.py
@@ -161,6 +161,6 @@ class XiaomiCamera(Camera):
         try:
             return await async_aiohttp_proxy_stream(
                 self.hass, request, stream,
-                await self._manager.async_get_ffmpeg_stream_content_type())
+                self._manager.ffmpeg_stream_content_type)
         finally:
             await stream.close()

--- a/homeassistant/components/camera/xiaomi.py
+++ b/homeassistant/components/camera/xiaomi.py
@@ -161,6 +161,6 @@ class XiaomiCamera(Camera):
         try:
             return await async_aiohttp_proxy_stream(
                 self.hass, request, stream,
-                'multipart/x-mixed-replace;boundary=ffserver')
+                await self._manager.async_get_ffmpeg_stream_content_type())
         finally:
             await stream.close()

--- a/homeassistant/components/camera/yi.py
+++ b/homeassistant/components/camera/yi.py
@@ -147,6 +147,6 @@ class YiCamera(Camera):
         try:
             return await async_aiohttp_proxy_stream(
                 self.hass, request, stream,
-                await self._manager.async_get_ffmpeg_stream_content_type())
+                self._manager.ffmpeg_stream_content_type)
         finally:
             await stream.close()

--- a/homeassistant/components/camera/yi.py
+++ b/homeassistant/components/camera/yi.py
@@ -147,6 +147,6 @@ class YiCamera(Camera):
         try:
             return await async_aiohttp_proxy_stream(
                 self.hass, request, stream,
-                'multipart/x-mixed-replace;boundary=ffserver')
+                await self._manager.async_get_ffmpeg_stream_content_type())
         finally:
             await stream.close()

--- a/homeassistant/components/ffmpeg.py
+++ b/homeassistant/components/ffmpeg.py
@@ -18,7 +18,7 @@ from homeassistant.helpers.dispatcher import (
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['ha-ffmpeg==1.9']
+REQUIREMENTS = ['ha-ffmpeg==1.11']
 
 DOMAIN = 'ffmpeg'
 
@@ -107,19 +107,11 @@ class FFmpegManager:
 
     async def async_get_version(self):
         """Return ffmpeg version."""
+        from haffmpeg.tools import FFVersion
+
         if self._version is None:
-            proc = await asyncio.create_subprocess_exec(
-                self._bin, "-version",
-                loop=self.hass.loop,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE)
-
-            first_line = (await proc.stdout.readline()).decode()
-            _LOGGER.debug(first_line)
-
-            result = re.search(r"ffmpeg version (\S*)", first_line)
-            if result is not None:
-                self._version = result.group(1)
+            ffversion = FFVersion(self._bin, self.hass.loop)
+            self._version = await ffversion.get_version()
 
         return self._version
 

--- a/homeassistant/components/ffmpeg.py
+++ b/homeassistant/components/ffmpeg.py
@@ -110,9 +110,9 @@ class FFmpegManager:
         if self._version is None:
             proc = await asyncio.create_subprocess_exec(
                 self._bin, "-version",
-                loop = self.hass.loop,
-                stdout = asyncio.subprocess.PIPE,
-                stderr = asyncio.subprocess.PIPE)
+                loop=self.hass.loop,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE)
             
             first_line = (await proc.stdout.readline()).decode()
             _LOGGER.debug(first_line)

--- a/homeassistant/components/ffmpeg.py
+++ b/homeassistant/components/ffmpeg.py
@@ -125,9 +125,10 @@ class FFmpegManager:
     
     async def async_get_ffmpeg_stream_content_type(self):
         """Return HTTP content type for ffmpeg stream."""
+        major_version = 3
+
         version_string = await self.async_get_version()
         result = re.search(r"(\d+)\.", version_string)
-        major_version = 3
         if result is not None:
             major_version = int(result.group(0))
         

--- a/homeassistant/components/ffmpeg.py
+++ b/homeassistant/components/ffmpeg.py
@@ -4,7 +4,6 @@ Component that will help set the FFmpeg component.
 For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/ffmpeg/
 """
-import asyncio
 import logging
 import re
 

--- a/homeassistant/components/ffmpeg.py
+++ b/homeassistant/components/ffmpeg.py
@@ -119,7 +119,7 @@ class FFmpegManager:
 
             result = re.search(r"ffmpeg version (\S*)", first_line)
             if result is not None:
-                self._version = result.group(0)
+                self._version = result.group(1)
 
         return self._version
 

--- a/homeassistant/components/ffmpeg.py
+++ b/homeassistant/components/ffmpeg.py
@@ -131,7 +131,7 @@ class FFmpegManager:
         if version_string is not None:
             result = re.search(r"(\d+)\.", version_string)
             if result is not None:
-                major_version = int(result.group(0))
+                major_version = int(result.group(1))
 
         if major_version > 3:
             return 'multipart/x-mixed-replace;boundary=ffmpeg'

--- a/homeassistant/components/ffmpeg.py
+++ b/homeassistant/components/ffmpeg.py
@@ -104,7 +104,7 @@ class FFmpegManager:
     def binary(self):
         """Return ffmpeg binary from config."""
         return self._bin
-    
+
     async def async_get_version(self):
         """Return ffmpeg version."""
         if self._version is None:
@@ -113,16 +113,16 @@ class FFmpegManager:
                 loop=self.hass.loop,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE)
-            
+
             first_line = (await proc.stdout.readline()).decode()
             _LOGGER.debug(first_line)
 
             result = re.search(r"ffmpeg version (\S*)", first_line)
             if result is not None:
                 self._version = result.group(0)
-            
+
         return self._version
-    
+
     async def async_get_ffmpeg_stream_content_type(self):
         """Return HTTP content type for ffmpeg stream."""
         major_version = 3
@@ -131,10 +131,10 @@ class FFmpegManager:
         result = re.search(r"(\d+)\.", version_string)
         if result is not None:
             major_version = int(result.group(0))
-        
+
         if major_version > 3:
             return 'multipart/x-mixed-replace;boundary=ffmpeg'
-        
+
         return 'multipart/x-mixed-replace;boundary=ffserver'
 
 

--- a/homeassistant/components/ffmpeg.py
+++ b/homeassistant/components/ffmpeg.py
@@ -122,6 +122,19 @@ class FFmpegManager:
                 self._version = result.group(0)
             
         return self._version
+    
+    async def async_get_ffmpeg_stream_content_type(self):
+        """Return HTTP content type for ffmpeg stream."""
+        version_string = await self.async_get_version()
+        result = re.search(r"(\d+)\.", version_string)
+        major_version = 3
+        if result is not None:
+            major_version = int(result.group(0))
+        
+        if major_version > 3:
+            return 'multipart/x-mixed-replace;boundary=ffmpeg'
+        
+        return 'multipart/x-mixed-replace;boundary=ffserver'
 
 
 class FFmpegBase(Entity):

--- a/homeassistant/components/ffmpeg.py
+++ b/homeassistant/components/ffmpeg.py
@@ -128,9 +128,10 @@ class FFmpegManager:
         major_version = 3
 
         version_string = await self.async_get_version()
-        result = re.search(r"(\d+)\.", version_string)
-        if result is not None:
-            major_version = int(result.group(0))
+        if version_string is not None:
+            result = re.search(r"(\d+)\.", version_string)
+            if result is not None:
+                major_version = int(result.group(0))
 
         if major_version > 3:
             return 'multipart/x-mixed-replace;boundary=ffmpeg'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -487,7 +487,7 @@ greenwavereality==0.5.1
 gstreamer-player==1.1.2
 
 # homeassistant.components.ffmpeg
-ha-ffmpeg==1.9
+ha-ffmpeg==1.11
 
 # homeassistant.components.media_player.philips_js
 ha-philipsjs==0.0.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -101,7 +101,7 @@ geojson_client==0.3
 georss_client==0.5
 
 # homeassistant.components.ffmpeg
-ha-ffmpeg==1.9
+ha-ffmpeg==1.11
 
 # homeassistant.components.hangouts
 hangups==0.4.6


### PR DESCRIPTION
## Description:

Since ffmpeg version 4, the HTTP stream multi-part indicator used by ffmpeg changed. This fix use version-aware content type string to resolve the issue #18056  

Upgrade ha-ffmpeg to 1.11 at the same time.

**Related issue (if applicable):** fixes #18056 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
