### PR TITLE
Fix waze_travel_time component ERROR on startup

### DIFF
--- a/homeassistant/components/sensor/waze_travel_time.py
+++ b/homeassistant/components/sensor/waze_travel_time.py
@@ -89,7 +89,7 @@ class WazeTravelTime(Entity):
     """Representation of a Waze travel time sensor."""
 
     def __init__(self, name, origin, destination, region,
-                 incl_filter, excl_filter, realtime, interval):
+                incl_filter, excl_filter, realtime, interval):
         """Initialize the Waze travel time sensor."""
         self._name = name
         self._region = region

--- a/homeassistant/components/sensor/waze_travel_time.py
+++ b/homeassistant/components/sensor/waze_travel_time.py
@@ -69,9 +69,9 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     update_interval = config.get(CONF_UPDATE_INTERVAL)
 
     sensor = WazeTravelTime(name, origin, destination, region,
-                            incl_filter, excl_filter, realtime,update_interval)
+                            incl_filter, excl_filter, realtime, update_interval)
 
-    add_entities([sensor],True)
+    add_entities([sensor], True)
 
     # Wait until start event is sent to load this component.
     hass.bus.listen_once(

--- a/homeassistant/components/sensor/waze_travel_time.py
+++ b/homeassistant/components/sensor/waze_travel_time.py
@@ -10,8 +10,8 @@ import logging
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import (ATTR_ATTRIBUTION, CONF_NAME,
-                                 CONF_REGION,EVENT_HOMEASSISTANT_START,
+from homeassistant.const import (ATTR_ATTRIBUTION, CONF_NAME, 
+                                 CONF_REGION,EVENT_HOMEASSISTANT_START, 
                                  ATTR_LATITUDE, ATTR_LONGITUDE)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers import location

--- a/homeassistant/components/sensor/waze_travel_time.py
+++ b/homeassistant/components/sensor/waze_travel_time.py
@@ -10,13 +10,12 @@ import logging
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import (ATTR_ATTRIBUTION, CONF_NAME,
-                                 CONF_REGION, EVENT_HOMEASSISTANT_START,
-                                 ATTR_LATITUDE, ATTR_LONGITUDE)
+from homeassistant.const import (
+    ATTR_ATTRIBUTION, CONF_NAME, CONF_REGION, EVENT_HOMEASSISTANT_START,
+    ATTR_LATITUDE, ATTR_LONGITUDE)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers import location
 from homeassistant.helpers.entity import Entity
-
 from homeassistant.util import Throttle
 
 REQUIREMENTS = ['WazeRouteCalculator==0.6']

--- a/homeassistant/components/sensor/waze_travel_time.py
+++ b/homeassistant/components/sensor/waze_travel_time.py
@@ -69,7 +69,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     update_interval = config.get(CONF_UPDATE_INTERVAL)
 
     sensor = WazeTravelTime(name, origin, destination, region,
-                            incl_filter, excl_filter, realtime, update_interval)
+                            incl_filter, excl_filter, realtime, 
+                            update_interval)
 
     add_entities([sensor], True)
 

--- a/homeassistant/components/sensor/waze_travel_time.py
+++ b/homeassistant/components/sensor/waze_travel_time.py
@@ -10,8 +10,8 @@ import logging
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import (ATTR_ATTRIBUTION, CONF_NAME, 
-                                 CONF_REGION,EVENT_HOMEASSISTANT_START, 
+from homeassistant.const import (ATTR_ATTRIBUTION, CONF_NAME,
+                                 CONF_REGION, EVENT_HOMEASSISTANT_START,
                                  ATTR_LATITUDE, ATTR_LONGITUDE)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers import location

--- a/homeassistant/components/sensor/waze_travel_time.py
+++ b/homeassistant/components/sensor/waze_travel_time.py
@@ -5,18 +5,19 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.waze_travel_time/
 """
 from datetime import timedelta
-from homeassistant.util import Throttle
 import logging
 
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import (
-    ATTR_ATTRIBUTION, CONF_NAME, CONF_REGION, EVENT_HOMEASSISTANT_START,
-    ATTR_LATITUDE, ATTR_LONGITUDE)
+from homeassistant.const import (ATTR_ATTRIBUTION, CONF_NAME,
+                                 CONF_REGION,EVENT_HOMEASSISTANT_START,
+                                 ATTR_LATITUDE, ATTR_LONGITUDE)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers import location
 from homeassistant.helpers.entity import Entity
+
+from homeassistant.util import Throttle
 
 REQUIREMENTS = ['WazeRouteCalculator==0.6']
 
@@ -86,7 +87,7 @@ class WazeTravelTime(Entity):
     """Representation of a Waze travel time sensor."""
 
     def __init__(self, name, origin, destination, region,
-                incl_filter, excl_filter, realtime):
+                 incl_filter, excl_filter, realtime):
         """Initialize the Waze travel time sensor."""
         self._name = name
         self._region = region

--- a/homeassistant/components/sensor/waze_travel_time.py
+++ b/homeassistant/components/sensor/waze_travel_time.py
@@ -13,7 +13,7 @@ import voluptuous as vol
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
     ATTR_ATTRIBUTION, CONF_NAME, CONF_REGION, EVENT_HOMEASSISTANT_START,
-    ATTR_LATITUDE, ATTR_LONGITUDE)
+    ATTR_LATITUDE, ATTR_LONGITUDE, CONF_SCAN_INTERVAL)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers import location
 from homeassistant.helpers.entity import Entity
@@ -40,7 +40,6 @@ ICON = 'mdi:car'
 
 REGIONS = ['US', 'NA', 'EU', 'IL', 'AU']
 
-CONF_UPDATE_INTERVAL = 'update_interval'
 
 TRACKABLE_DOMAINS = ['device_tracker', 'sensor', 'zone']
 
@@ -52,8 +51,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_INCL_FILTER): cv.string,
     vol.Optional(CONF_EXCL_FILTER): cv.string,
     vol.Optional(CONF_REALTIME, default=DEFAULT_REALTIME): cv.boolean,
-    vol.Optional(CONF_UPDATE_INTERVAL, default=timedelta(minutes=5)):
-        vol.All(cv.time_period, cv.positive_timedelta),
+    vol.Optional(CONF_SCAN_INTERVAL, default=timedelta(seconds=300)):
+        cv.time_period,        
 })
 
 
@@ -66,7 +65,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     incl_filter = config.get(CONF_INCL_FILTER)
     excl_filter = config.get(CONF_EXCL_FILTER)
     realtime = config.get(CONF_REALTIME)
-    update_interval = config.get(CONF_UPDATE_INTERVAL)
+    update_interval = config.get(CONF_SCAN_INTERVAL)
 
     sensor = WazeTravelTime(name, origin, destination, region,
                             incl_filter, excl_filter, realtime, 


### PR DESCRIPTION
## Description:
Fix the unhandled exception with Waze Travel Time sensor upon startup,
by adding Throttle before update_interval are starting.

**Related issue (if applicable):**
fixes #16676

Error treated:
```
Error doing job: Future exception was never retrieved
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/concurrent/futures/thread.py", line 56, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/src/app/homeassistant/components/sensor/waze_travel_time.py", line 74, in <lambda>
    EVENT_HOMEASSISTANT_START, lambda _: sensor.update())
  File "/usr/src/app/homeassistant/components/sensor/waze_travel_time.py", line 204, in update
    routes = params.calc_all_routes_info(real_time=self._realtime)
  File "/usr/local/lib/python3.6/site-packages/WazeRouteCalculator/WazeRouteCalculator.py", line 145, in calc_all_routes_info
    routes = self.get_route(npaths, time_delta)
  File "/usr/local/lib/python3.6/site-packages/WazeRouteCalculator/WazeRouteCalculator.py", line 95, in get_route
    response_json = response.json()
  File "/usr/local/lib/python3.6/site-packages/requests/models.py", line 897, in json
    return complexjson.loads(self.text, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/simplejson/__init__.py", line 518, in loads
    return _default_decoder.decode(s)
  File "/usr/local/lib/python3.6/site-packages/simplejson/decoder.py", line 370, in decode
    obj, end = self.raw_decode(s)
  File "/usr/local/lib/python3.6/site-packages/simplejson/decoder.py", line 400, in raw_decode
    return self.scan_once(s, idx=_w(s, idx).end())
simplejson.errors.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```
## Example entry for `configuration.yaml` (if applicable):
```yaml
# Example entry for configuration.yaml
sensor:
  - platform: waze_travel_time
    origin: Montréal, QC
    destination: Québec, QC
    region: 'US'
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

~~If user exposed functionality or configuration variables are added/changed:~~
 ~~- [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)~~

If the code communicates with devices, web services, or third-party tools:
~~- [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).~~
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
~~- [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.~~
~~- [ ] New files were added to `.coveragerc`.~~

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works- Tested on Docker Container 0.85.0 , 0.85.1 , 0.86.0.dev0

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
