### PR TITLE
Add minimum/maximum to counter

### DIFF
--- a/homeassistant/components/counter/services.yaml
+++ b/homeassistant/components/counter/services.yaml
@@ -18,3 +18,18 @@ reset:
     entity_id:
       description: Entity id of the counter to reset.
       example: 'counter.count0'
+setup:
+  description: Change counter paramters
+  fields:
+    entity_id:
+      description: Entity id of the counter to change.
+      example: 'counter.count0'
+    minimum:
+      description: New minimum value for the counter or None to remove minimum
+      example: 0
+    maximum:
+      description: New maximum value for the counter or None to remove maximum
+      example: 100
+    step:
+      description: New value for step
+      example: 2


### PR DESCRIPTION
Docs: https://github.com/home-assistant/home-assistant.io/pull/6802
OldPR: https://github.com/home-assistant/home-assistant/pull/17440

## Description:

## Example entry for `configuration.yaml` (if applicable):
```yaml

counter:
  my_counter:
    initial: 0
    step : 1
    minimum: 0
    maximum: 10
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.
