### PR TITLE
Add Synology SRM device tracker

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -552,6 +552,7 @@ omit =
     homeassistant/components/device_tracker/sky_hub.py
     homeassistant/components/device_tracker/snmp.py
     homeassistant/components/device_tracker/swisscom.py
+    homeassistant/components/device_tracker/synology_srm.py
     homeassistant/components/device_tracker/tado.py
     homeassistant/components/device_tracker/thomson.py
     homeassistant/components/device_tracker/tile.py

--- a/homeassistant/components/device_tracker/synology_srm.py
+++ b/homeassistant/components/device_tracker/synology_srm.py
@@ -1,0 +1,100 @@
+"""Device tracker for Synology SRM routers.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/device_tracker.synology_srm/
+"""
+import logging
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.device_tracker import (
+    DOMAIN, PLATFORM_SCHEMA, DeviceScanner)
+from homeassistant.const import (
+    CONF_HOST, CONF_USERNAME, CONF_PASSWORD,
+    CONF_PORT, CONF_SSL, CONF_VERIFY_SSL)
+
+REQUIREMENTS = ['synology-srm==0.0.3']
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_USERNAME = 'admin'
+DEFAULT_PORT = 8001
+DEFAULT_SSL = True
+DEFAULT_VERIFY_SSL = False
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_HOST): cv.string,
+    vol.Required(CONF_USERNAME, default=DEFAULT_USERNAME): cv.string,
+    vol.Required(CONF_PASSWORD): cv.string,
+    vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+    vol.Optional(CONF_SSL, default=DEFAULT_SSL): cv.boolean,
+    vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): cv.boolean,
+})
+
+
+def get_scanner(hass, config):
+    """Validate the configuration and return Synology SRM scanner."""
+    scanner = SynologySrmDeviceScanner(config[DOMAIN])
+
+    return scanner if scanner.success_init else None
+
+
+class SynologySrmDeviceScanner(DeviceScanner):
+    """This class scans for devices connected to a Synology SRM router."""
+
+    def __init__(self, config):
+        """Initialize the scanner."""
+        import synology_srm
+
+        self.client = synology_srm.Client(
+            host=config[CONF_HOST],
+            port=config[CONF_PORT],
+            username=config[CONF_USERNAME],
+            password=config[CONF_PASSWORD],
+            https=config[CONF_SSL]
+        )
+
+        if not config[CONF_VERIFY_SSL]:
+            self.client.http.disable_https_verify()
+
+        self.last_results = []
+        self.success_init = self._update_info()
+
+        _LOGGER.info("Synology SRM scanner initialized")
+
+    def scan_devices(self):
+        """Scan for new devices and return a list with found device IDs."""
+        self._update_info()
+
+        return [device['mac'] for device in self.last_results]
+
+    def get_device_name(self, device):
+        """Return the name of the given device or None if we don't know."""
+        filter_named = [result['hostname'] for result in self.last_results if
+                        result['mac'] == device]
+
+        if filter_named:
+            return filter_named[0]
+
+        return None
+
+    def _update_info(self):
+        """Check the router for connected devices."""
+        _LOGGER.debug("Scanning for connected devices")
+
+        devices = self.client.mesh.network_wifidevice()
+        last_results = []
+
+        for device in devices:
+            last_results.append({
+                'mac': device['mac'],
+                'hostname': device['hostname']
+            })
+
+        _LOGGER.debug(
+            "Found %d device(s) connected to the router",
+            len(devices)
+        )
+
+        self.last_results = last_results
+        return True

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1582,6 +1582,9 @@ suds-py3==1.3.3.0
 # homeassistant.components.sensor.swiss_hydrological_data
 swisshydrodata==0.0.3
 
+# homeassistant.components.device_tracker.synology_srm
+synology-srm==0.0.3
+
 # homeassistant.components.tahoma
 tahoma-api==0.0.14
 


### PR DESCRIPTION
## Description

This PR adds the device tracker for [Synology SRM routers](https://www.synology.com/en-us/srm).

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8240

## Example entry for `configuration.yaml` (if applicable):
```yaml
device_tracker:
  - platform: synology_srm
    host: 10.10.10.254
    password: !secret synology_srm_password
    new_device_defaults:
      track_new_devices: false
      hide_if_away: true
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
