### PR TITLE
Fix Pollen sensor to work in 0.86: Removed the & to work with new slug

### DIFF
--- a/homeassistant/components/sensor/pollen.py
+++ b/homeassistant/components/sensor/pollen.py
@@ -73,7 +73,7 @@ SENSORS = {
     TYPE_ASTHMA_HISTORIC: (
         'HistoricalSensor', 'Asthma Index: Historical Average', 'mdi:flower'),
     TYPE_DISEASE_FORECAST: (
-        'ForecastSensor', 'Cold & Flu: Forecasted Average', 'mdi:snowflake')
+        'ForecastSensor', 'Cold Flu: Forecasted Average', 'mdi:snowflake')
 }
 
 RATING_MAPPING = [{


### PR DESCRIPTION
The `&` in the sensor name created `__` which does not work in 0.86.