### PR TITLE
Bump homekit==0.12.2 + improve controller reliability

### DIFF
--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -13,7 +13,7 @@ from homeassistant.helpers import discovery
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import call_later
 
-REQUIREMENTS = ['homekit==0.12.0']
+REQUIREMENTS = ['homekit==0.12.2']
 
 DOMAIN = 'homekit_controller'
 HOMEKIT_DIR = '.homekit'
@@ -47,10 +47,6 @@ REQUEST_TIMEOUT = 5  # seconds
 RETRY_INTERVAL = 60  # seconds
 
 PAIRING_FILE = "pairing.json"
-
-
-class HomeKitConnectionError(ConnectionError):
-    """Raised when unable to connect to target device."""
 
 
 def get_serial(accessory):
@@ -101,13 +97,14 @@ class HKDevice():
         """Handle setup of a HomeKit accessory."""
         # pylint: disable=import-error
         from homekit.model.services import ServicesTypes
+        from homekit.exceptions import AccessoryDisconnectedError
 
         self.pairing.pairing_data['AccessoryIP'] = self.host
         self.pairing.pairing_data['AccessoryPort'] = self.port
 
         try:
             data = self.pairing.list_accessories_and_characteristics()
-        except HomeKitConnectionError:
+        except AccessoryDisconnectedError:
             call_later(
                 self.hass, RETRY_INTERVAL, lambda _: self.accessory_setup())
             return
@@ -199,10 +196,13 @@ class HomeKitEntity(Entity):
 
     def update(self):
         """Obtain a HomeKit device's state."""
+        # pylint: disable=import-error
+        from homekit.exceptions import AccessoryDisconnectedError
+
         try:
             pairing = self._accessory.pairing
             data = pairing.list_accessories_and_characteristics()
-        except HomeKitConnectionError:
+        except AccessoryDisconnectedError:
             return
         for accessory in data:
             if accessory['aid'] != self._aid:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -523,7 +523,7 @@ home-assistant-frontend==20190121.0
 homeassistant-pyozw==0.1.2
 
 # homeassistant.components.homekit_controller
-# homekit==0.12.0
+# homekit==0.12.2
 
 # homeassistant.components.homematicip_cloud
 homematicip==0.10.3


### PR DESCRIPTION
## Description:

Persistent connections to devices currently time out. HA does not recover from this and must be restarted to make HK controller work again. `homekit==0.12.2` has the fix I got merged upstream to fix this (see [here](https://github.com/jlusiardi/homekit_python/pull/91)). Also fixes an installation issue that is present on some locales.

The upstream exception `AccessoryDisconnectedError` replaces `HomeKitConnectionError` which was no longer raised anywhere anyway, so i've tidied that up.

This release of homekit drops its requirement on `gmpy2` and `py25519` and replaces it with one on `cryptography`. It requires X25519 support in `cryptography`, which has existed since 2.0. HA currently uses 2.3.1. 

**Related issue (if applicable):** fixes #20296  #20115 #18949

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
