### PR TITLE
Fixed temp scale unit when state unknown or unavailable

### DIFF
--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -287,18 +287,22 @@ class Entity:
             attr.update(self.hass.data[DATA_CUSTOMIZE].get(self.entity_id))
 
         # Convert temperature if we detect one
-        try:
-            unit_of_measure = attr.get(ATTR_UNIT_OF_MEASUREMENT)
-            units = self.hass.config.units
-            if (unit_of_measure in (TEMP_CELSIUS, TEMP_FAHRENHEIT) and
-                    unit_of_measure != units.temperature_unit):
-                prec = len(state) - state.index('.') - 1 if '.' in state else 0
-                temp = units.temperature(float(state), unit_of_measure)
-                state = str(round(temp) if prec == 0 else round(temp, prec))
+
+        unit_of_measure = attr.get(ATTR_UNIT_OF_MEASUREMENT)
+        units = self.hass.config.units
+        if (unit_of_measure in (TEMP_CELSIUS, TEMP_FAHRENHEIT) and
+                unit_of_measure != units.temperature_unit):
+            try:
+                if state not in [STATE_UNAVAILABLE, STATE_UNKNOWN]:
+                    prec = len(state) - state.index('.') - 1 \
+                        if '.' in state else 0
+                    temp = units.temperature(float(state), unit_of_measure)
+                    state = str(
+                        round(temp) if prec == 0 else round(temp, prec))
                 attr[ATTR_UNIT_OF_MEASUREMENT] = units.temperature_unit
-        except ValueError:
-            # Could not convert state to float
-            pass
+            except ValueError:
+                # Could not convert state to float
+                pass
 
         if (self._context is not None and
                 dt_util.utcnow() - self._context_set >


### PR DESCRIPTION
## Description:
When the state of an entity is `unknown` or `unavailable` and has a different temperature scale than what the user has configured, the original scale is not updated, resulting in an inconsistently reported scale when a device transitions to/from `unavailable`/`unknown`.  This change ensures that the target temperature scale is still set when the state is `unknown` or `unavailable` and maintains the behavior that if conversion fails, the entities's reported scale is unchanged.

New tests have been added to describe these conditions.

**Related issue (if applicable):** fixes #20331 (secondary issue)

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.
 
If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.