### PR TITLE
Remove creation of geolocation default group

### DIFF
--- a/homeassistant/components/geo_location/__init__.py
+++ b/homeassistant/components/geo_location/__init__.py
@@ -22,15 +22,12 @@ DOMAIN = 'geo_location'
 
 ENTITY_ID_FORMAT = DOMAIN + '.{}'
 
-GROUP_NAME_ALL_EVENTS = 'All Geolocation Events'
-
 SCAN_INTERVAL = timedelta(seconds=60)
 
 
 async def async_setup(hass, config):
     """Set up the Geolocation component."""
-    component = EntityComponent(
-        _LOGGER, DOMAIN, hass, SCAN_INTERVAL, GROUP_NAME_ALL_EVENTS)
+    component = EntityComponent(_LOGGER, DOMAIN, hass, SCAN_INTERVAL)
     await component.async_setup(config)
     return True
 


### PR DESCRIPTION
## Description:
This will remove the creation of a default geolocation group that has so far been used to group any geolocation entities.
The preferred way of displaying geolocation entities in the new Lovelace UI will be the map.

**Breaking change:**
The previously created group (`group.all_geo_location_events` or `group.all_geolocation_events`, depending on which version of HA this was generated) will no longer be created automatically.

**Related issue (if applicable):** as concluded in #20311

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** n/a

## Example entry for `configuration.yaml` (if applicable): n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
