### PR TITLE
Return windspeed and windgust in km/h instead of m/s.

### DIFF
--- a/homeassistant/components/weather/darksky.py
+++ b/homeassistant/components/weather/darksky.py
@@ -71,7 +71,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     units = config.get(CONF_UNITS)
     if not units:
-        units = 'si' if hass.config.units.is_metric else 'us'
+        units = 'ca' if hass.config.units.is_metric else 'us'
 
     dark_sky = DarkSkyData(
         config.get(CONF_API_KEY), latitude, longitude, units)


### PR DESCRIPTION
## Description:

Darksky dev docs state (https://darksky/dev/docs):
`ca: same as si, except that windSpeed and windGust are in kilometers per
hour`

This change will make the output in sync with https://developers.home-assistant.io/docs/en/entity_weather.html when the `unit_system` is `metric`

**Related issue (if applicable):** #16793 


## Example entry for `configuration.yaml` (if applicable):
```yaml
homeassistant:
  latitude: !secret ha_latitude
  longitude: !secret ha_longitude
  elevation: !secret ha_elevation
  unit_system: metric

weather: 
  - platform: darksky
    api_key: !secret darksky_apikey
    mode: daily
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
