### PR TITLE
HomeKit controller refactoring (towards BLE support) [DO NOT MERGE]

### DIFF
--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -68,6 +68,11 @@ def get_serial(accessory):
     return None
 
 
+def escape_characteristic_name(char_name):
+    """Escape any dash or dots in a characteristics name."""
+    return char_name.replace('-', '_').replace('.', '_')
+
+
 class HKDevice():
     """HomeKit device."""
 
@@ -193,25 +198,82 @@ class HomeKitEntity(Entity):
         self._address = "homekit-{}-{}".format(devinfo['serial'], self._iid)
         self._features = 0
         self._chars = {}
+        self.setup()
+
+    def setup(self):
+        """Configure an entity baed on its HomeKit characterstics metadata."""
+        # pylint: disable=import-error
+        from homekit.model.characteristics import CharacteristicsTypes
+
+        pairing_data = self._accessory.pairing.pairing_data
+
+        get_uuid = CharacteristicsTypes.get_uuid
+        characteristic_types = [
+            get_uuid(c) for c in self.get_characteristic_types()
+        ]
+
+        self._chars_to_poll = []
+        self._chars = {}
+        self._char_names = {}
+
+        for accessory in pairing_data.get('accessories', []):
+            if accessory['aid'] != self._aid:
+                continue
+            for service in accessory['services']:
+                if service['iid'] != self._iid:
+                    continue
+                for char in service['characteristics']:
+                    uuid = CharacteristicsTypes.get_uuid(char['type'])
+                    if uuid not in characteristic_types:
+                        continue
+                    self._setup_characteristic(char)
+
+    def _setup_characteristic(self, char):
+        """Configure an entity based on a HomeKit characteristics metadata."""
+        # pylint: disable=import-error
+        from homekit.model.characteristics import CharacteristicsTypes
+
+        # Build up a list of (aid, iid) tuples to poll on update()
+        self._chars_to_poll.append((self._aid, char['iid']))
+
+        # Build a map of ctype -> iid
+        short_name = CharacteristicsTypes.get_short(char['type'])
+        self._chars[short_name] = char['iid']
+        self._char_names[char['iid']] = short_name
+
+        # Callback to allow entity to configure itself based on this
+        # characteristics metadata (valid values, value ranges, features, etc)
+        setup_fn_name = escape_characteristic_name(short_name)
+        setup_fn = getattr(self, '_setup_{}'.format(setup_fn_name), None)
+        if not setup_fn:
+            return
+        # pylint: disable=E1102
+        setup_fn(char)
 
     def update(self):
         """Obtain a HomeKit device's state."""
         # pylint: disable=import-error
         from homekit.exceptions import AccessoryDisconnectedError
 
+        pairing = self._accessory.pairing
+
         try:
-            pairing = self._accessory.pairing
-            data = pairing.list_accessories_and_characteristics()
+            new_values_dict = pairing.get_characteristics(self._chars_to_poll)
         except AccessoryDisconnectedError:
             return
-        for accessory in data:
-            if accessory['aid'] != self._aid:
+
+        for (_, iid), result in new_values_dict.items():
+            # Did not get a new value for this characteristic - skip
+            if 'value' not in result:
                 continue
-            for service in accessory['services']:
-                if service['iid'] != self._iid:
-                    continue
-                self.update_characteristics(service['characteristics'])
-                break
+
+            # Callback to update the entity with this characteristic value
+            char_name = escape_characteristic_name(self._char_names[iid])
+            update_fn = getattr(self, '_update_{}'.format(char_name), None)
+            if not update_fn:
+                continue
+            # pylint: disable=E1102
+            update_fn(result['value'])
 
     @property
     def unique_id(self):
@@ -228,8 +290,8 @@ class HomeKitEntity(Entity):
         """Return True if entity is available."""
         return self._accessory.pairing is not None
 
-    def update_characteristics(self, characteristics):
-        """Synchronise a HomeKit device state with Home Assistant."""
+    def get_characteristic_types(self):
+        """Return a list of characteristic types that this entity uses."""
         raise NotImplementedError
 
     def put_characteristics(self, characteristics):

--- a/homeassistant/components/homekit_controller/alarm_control_panel.py
+++ b/homeassistant/components/homekit_controller/alarm_control_panel.py
@@ -54,24 +54,21 @@ class HomeKitAlarmControlPanel(HomeKitEntity, AlarmControlPanel):
         self._state = None
         self._battery_level = None
 
-    def update_characteristics(self, characteristics):
-        """Synchronise the Alarm Control Panel state with Home Assistant."""
+    def get_characteristic_types(self):
+        """Define the homekit characteristics the entity cares about."""
         # pylint: disable=import-error
         from homekit.model.characteristics import CharacteristicsTypes
+        return [
+            CharacteristicsTypes.SECURITY_SYSTEM_STATE_CURRENT,
+            CharacteristicsTypes.SECURITY_SYSTEM_STATE_TARGET,
+            CharacteristicsTypes.BATTERY_LEVEL,
+        ]
 
-        for characteristic in characteristics:
-            ctype = characteristic['type']
-            ctype = CharacteristicsTypes.get_short(ctype)
-            if ctype == "security-system-state.current":
-                self._chars['security-system-state.current'] = \
-                    characteristic['iid']
-                self._state = CURRENT_STATE_MAP[characteristic['value']]
-            elif ctype == "security-system-state.target":
-                self._chars['security-system-state.target'] = \
-                    characteristic['iid']
-            elif ctype == "battery-level":
-                self._chars['battery-level'] = characteristic['iid']
-                self._battery_level = characteristic['value']
+    def _update_security_system_state_current(self, value):
+        self._state = CURRENT_STATE_MAP[value]
+
+    def _update_battery_level(self, value):
+        self._battery_level = value
 
     @property
     def icon(self):

--- a/homeassistant/components/homekit_controller/climate.py
+++ b/homeassistant/components/homekit_controller/climate.py
@@ -49,46 +49,55 @@ class HomeKitClimateDevice(HomeKitEntity, ClimateDevice):
         self._current_temp = None
         self._target_temp = None
 
-    def update_characteristics(self, characteristics):
-        """Synchronise device state with Home Assistant."""
+    def get_characteristic_types(self):
+        """Define the homekit characteristics the entity cares about."""
         # pylint: disable=import-error
         from homekit.model.characteristics import CharacteristicsTypes
 
-        for characteristic in characteristics:
-            ctype = CharacteristicsTypes.get_short_uuid(characteristic['type'])
-            if ctype == CharacteristicsTypes.HEATING_COOLING_CURRENT:
-                self._state = MODE_HOMEKIT_TO_HASS.get(
-                    characteristic['value'])
-            if ctype == CharacteristicsTypes.HEATING_COOLING_TARGET:
-                self._chars['target_mode'] = characteristic['iid']
-                self._features |= SUPPORT_OPERATION_MODE
-                self._current_mode = MODE_HOMEKIT_TO_HASS.get(
-                    characteristic['value'])
+        return [
+            CharacteristicsTypes.HEATING_COOLING_CURRENT,
+            CharacteristicsTypes.HEATING_COOLING_TARGET,
+            CharacteristicsTypes.TEMPERATURE_CURRENT,
+            CharacteristicsTypes.TEMPERATURE_TARGET,
+        ]
 
-                valid_values = characteristic.get(
-                    'valid-values', DEFAULT_VALID_MODES)
-                self._valid_modes = [MODE_HOMEKIT_TO_HASS.get(
-                    mode) for mode in valid_values]
-            elif ctype == CharacteristicsTypes.TEMPERATURE_CURRENT:
-                self._current_temp = characteristic['value']
-            elif ctype == CharacteristicsTypes.TEMPERATURE_TARGET:
-                self._chars['target_temp'] = characteristic['iid']
-                self._features |= SUPPORT_TARGET_TEMPERATURE
-                self._target_temp = characteristic['value']
+    def _setup_heating_cooling_target(self, characteristic):
+        self._features |= SUPPORT_OPERATION_MODE
+
+        valid_values = characteristic.get(
+            'valid-values', DEFAULT_VALID_MODES)
+        self._valid_modes = [
+            MODE_HOMEKIT_TO_HASS.get(mode) for mode in valid_values
+        ]
+
+    def _setup_temperature_target(self, characteristic):
+        self._features |= SUPPORT_TARGET_TEMPERATURE
+
+    def _update_heating_cooling_current(self, value):
+        self._state = MODE_HOMEKIT_TO_HASS.get(value)
+
+    def _update_heating_cooling_target(self, value):
+        self._current_mode = MODE_HOMEKIT_TO_HASS.get(value)
+
+    def _update_temperature_current(self, value):
+        self._current_temp = value
+
+    def _update_temperature_target(self, value):
+        self._target_temp = value
 
     def set_temperature(self, **kwargs):
         """Set new target temperature."""
         temp = kwargs.get(ATTR_TEMPERATURE)
 
         characteristics = [{'aid': self._aid,
-                            'iid': self._chars['target_temp'],
+                            'iid': self._chars['temperature.target'],
                             'value': temp}]
         self.put_characteristics(characteristics)
 
     def set_operation_mode(self, operation_mode):
         """Set new target operation mode."""
         characteristics = [{'aid': self._aid,
-                            'iid': self._chars['target_mode'],
+                            'iid': self._chars['heating-cooling.target'],
                             'value': MODE_HASS_TO_HOMEKIT[operation_mode]}]
         self.put_characteristics(characteristics)
 

--- a/homeassistant/components/homekit_controller/cover.py
+++ b/homeassistant/components/homekit_controller/cover.py
@@ -206,7 +206,7 @@ class HomeKitWindowCover(HomeKitEntity, CoverDevice):
                 self._chars['vertical-tilt.target'] = \
                     characteristic['iid']
             elif ctype == "horizontal-tilt.target":
-                self._chars['vertical-tilt.target'] = \
+                self._chars['horizontal-tilt.target'] = \
                     characteristic['iid']
             elif ctype == "obstruction-detected":
                 self._chars['obstruction-detected'] = characteristic['iid']

--- a/homeassistant/components/homekit_controller/cover.py
+++ b/homeassistant/components/homekit_controller/cover.py
@@ -72,27 +72,25 @@ class HomeKitGarageDoorCover(HomeKitEntity, CoverDevice):
         """Define this cover as a garage door."""
         return 'garage'
 
-    def update_characteristics(self, characteristics):
-        """Synchronise the Cover state with Home Assistant."""
+    def get_characteristic_types(self):
+        """Define the homekit characteristics the entity cares about."""
         # pylint: disable=import-error
         from homekit.model.characteristics import CharacteristicsTypes
+        return [
+            CharacteristicsTypes.DOOR_STATE_CURRENT,
+            CharacteristicsTypes.DOOR_STATE_TARGET,
+            CharacteristicsTypes.OBSTRUCTION_DETECTED,
+            CharacteristicsTypes.NAME,
+        ]
 
-        for characteristic in characteristics:
-            ctype = characteristic['type']
-            ctype = CharacteristicsTypes.get_short(ctype)
-            if ctype == "door-state.current":
-                self._chars['door-state.current'] = \
-                    characteristic['iid']
-                self._state = CURRENT_GARAGE_STATE_MAP[characteristic['value']]
-            elif ctype == "door-state.target":
-                self._chars['door-state.target'] = \
-                    characteristic['iid']
-            elif ctype == "obstruction-detected":
-                self._chars['obstruction-detected'] = characteristic['iid']
-                self._obstruction_detected = characteristic['value']
-            elif ctype == "name":
-                self._chars['name'] = characteristic['iid']
-                self._name = characteristic['value']
+    def _update_door_state_current(self, value):
+        self._state = CURRENT_GARAGE_STATE_MAP[value]
+
+    def _update_obstruction_detected(self, value):
+        self._obstruction_detected = value
+
+    def _update_name(self, value):
+        self._name = value
 
     @property
     def name(self):
@@ -169,52 +167,44 @@ class HomeKitWindowCover(HomeKitEntity, CoverDevice):
         """Return True if entity is available."""
         return self._state is not None
 
-    def update_characteristics(self, characteristics):
-        """Synchronise the Cover state with Home Assistant."""
+    def get_characteristic_types(self):
+        """Define the homekit characteristics the entity cares about."""
         # pylint: disable=import-error
         from homekit.model.characteristics import CharacteristicsTypes
 
-        for characteristic in characteristics:
-            ctype = characteristic['type']
-            ctype = CharacteristicsTypes.get_short(ctype)
-            if ctype == "position.state":
-                self._chars['position.state'] = \
-                    characteristic['iid']
-                if 'value' in characteristic:
-                    self._state = \
-                        CURRENT_WINDOW_STATE_MAP[characteristic['value']]
-            elif ctype == "position.current":
-                self._chars['position.current'] = \
-                    characteristic['iid']
-                self._position = characteristic['value']
-            elif ctype == "position.target":
-                self._chars['position.target'] = \
-                    characteristic['iid']
-            elif ctype == "position.hold":
-                self._chars['position.hold'] = characteristic['iid']
-                if 'value' in characteristic:
-                    self._hold = characteristic['value']
-            elif ctype == "vertical-tilt.current":
-                self._chars['vertical-tilt.current'] = characteristic['iid']
-                if characteristic['value'] is not None:
-                    self._tilt_position = characteristic['value']
-            elif ctype == "horizontal-tilt.current":
-                self._chars['horizontal-tilt.current'] = characteristic['iid']
-                if characteristic['value'] is not None:
-                    self._tilt_position = characteristic['value']
-            elif ctype == "vertical-tilt.target":
-                self._chars['vertical-tilt.target'] = \
-                    characteristic['iid']
-            elif ctype == "horizontal-tilt.target":
-                self._chars['horizontal-tilt.target'] = \
-                    characteristic['iid']
-            elif ctype == "obstruction-detected":
-                self._chars['obstruction-detected'] = characteristic['iid']
-                self._obstruction_detected = characteristic['value']
-            elif ctype == "name":
-                self._chars['name'] = characteristic['iid']
-                if 'value' in characteristic:
-                    self._name = characteristic['value']
+        return [
+            CharacteristicsTypes.POSITION_STATE,
+            CharacteristicsTypes.POSITION_CURRENT,
+            CharacteristicsTypes.POSITION_TARGET,
+            CharacteristicsTypes.POSITION_HOLD,
+            CharacteristicsTypes.VERTICAL_TILT_CURRENT,
+            CharacteristicsTypes.VERTICAL_TILT_TARGET,
+            CharacteristicsTypes.HORIZONTAL_TILT_CURRENT,
+            CharacteristicsTypes.HORIZONTAL_TILT_TARGET,
+            CharacteristicsTypes.OBSTRUCTION_DETECTED,
+            CharacteristicsTypes.NAME,
+        ]
+
+    def _update_position_state(self, value):
+        self._state = CURRENT_WINDOW_STATE_MAP[value]
+
+    def _update_position_current(self, value):
+        self._position = value
+
+    def _update_position_hold(self, value):
+        self._hold = value
+
+    def _update_vertical_tilt_current(self, value):
+        self._tilt_position = value
+
+    def _update_horizontal_tilt_current(self, value):
+        self._tilt_position = value
+
+    def _update_obstruction_detected(self, value):
+        self._obstruction_detected = value
+
+    def _update_name(self, value):
+        self._hold = value
 
     @property
     def name(self):

--- a/homeassistant/components/homekit_controller/light.py
+++ b/homeassistant/components/homekit_controller/light.py
@@ -52,7 +52,7 @@ class HomeKitLight(HomeKitEntity, Light):
                 self._features |= SUPPORT_BRIGHTNESS
                 self._brightness = characteristic['value']
             elif ctype == 'color-temperature':
-                self._chars['color_temperature'] = characteristic['iid']
+                self._chars['color-temperature'] = characteristic['iid']
                 self._features |= SUPPORT_COLOR_TEMP
                 self._color_temperature = characteristic['value']
             elif ctype == "hue":

--- a/homeassistant/components/homekit_controller/light.py
+++ b/homeassistant/components/homekit_controller/light.py
@@ -36,33 +36,44 @@ class HomeKitLight(HomeKitEntity, Light):
         self._hue = None
         self._saturation = None
 
-    def update_characteristics(self, characteristics):
-        """Synchronise light state with Home Assistant."""
+    def get_characteristic_types(self):
+        """Define the homekit characteristics the entity cares about."""
         # pylint: disable=import-error
         from homekit.model.characteristics import CharacteristicsTypes
+        return [
+            CharacteristicsTypes.ON,
+            CharacteristicsTypes.BRIGHTNESS,
+            CharacteristicsTypes.COLOR_TEMPERATURE,
+            CharacteristicsTypes.HUE,
+            CharacteristicsTypes.SATURATION,
+        ]
 
-        for characteristic in characteristics:
-            ctype = characteristic['type']
-            ctype = CharacteristicsTypes.get_short(ctype)
-            if ctype == "on":
-                self._chars['on'] = characteristic['iid']
-                self._on = characteristic['value']
-            elif ctype == 'brightness':
-                self._chars['brightness'] = characteristic['iid']
-                self._features |= SUPPORT_BRIGHTNESS
-                self._brightness = characteristic['value']
-            elif ctype == 'color-temperature':
-                self._chars['color-temperature'] = characteristic['iid']
-                self._features |= SUPPORT_COLOR_TEMP
-                self._color_temperature = characteristic['value']
-            elif ctype == "hue":
-                self._chars['hue'] = characteristic['iid']
-                self._features |= SUPPORT_COLOR
-                self._hue = characteristic['value']
-            elif ctype == "saturation":
-                self._chars['saturation'] = characteristic['iid']
-                self._features |= SUPPORT_COLOR
-                self._saturation = characteristic['value']
+    def _setup_brightness(self, characteristic):
+        self._features |= SUPPORT_BRIGHTNESS
+
+    def _setup_color_temperature(self, characteristic):
+        self._features |= SUPPORT_COLOR_TEMP
+
+    def _setup_hue(self, characteristic):
+        self._features |= SUPPORT_COLOR
+
+    def _setup_saturation(self, characteristic):
+        self._features |= SUPPORT_COLOR
+
+    def _update_on(self, value):
+        self._on = value
+
+    def _update_brightness(self, value):
+        self._brightness = value
+
+    def _update_color_temperature(self, value):
+        self._color_temperature = value
+
+    def _update_hue(self, value):
+        self._hue = value
+
+    def _update_saturation(self, value):
+        self._saturation = value
 
     @property
     def is_on(self):

--- a/homeassistant/components/homekit_controller/lock.py
+++ b/homeassistant/components/homekit_controller/lock.py
@@ -51,24 +51,21 @@ class HomeKitLock(HomeKitEntity, LockDevice):
         self._name = discovery_info['model']
         self._battery_level = None
 
-    def update_characteristics(self, characteristics):
-        """Synchronise the Lock state with Home Assistant."""
+    def get_characteristic_types(self):
+        """Define the homekit characteristics the entity cares about."""
         # pylint: disable=import-error
         from homekit.model.characteristics import CharacteristicsTypes
+        return [
+            CharacteristicsTypes.LOCK_MECHANISM_CURRENT_STATE,
+            CharacteristicsTypes.LOCK_MECHANISM_TARGET_STATE,
+            CharacteristicsTypes.BATTERY_LEVEL,
+        ]
 
-        for characteristic in characteristics:
-            ctype = characteristic['type']
-            ctype = CharacteristicsTypes.get_short(ctype)
-            if ctype == "lock-mechanism.current-state":
-                self._chars['lock-mechanism.current-state'] = \
-                    characteristic['iid']
-                self._state = CURRENT_STATE_MAP[characteristic['value']]
-            elif ctype == "lock-mechanism.target-state":
-                self._chars['lock-mechanism.target-state'] = \
-                    characteristic['iid']
-            elif ctype == "battery-level":
-                self._chars['battery-level'] = characteristic['iid']
-                self._battery_level = characteristic['value']
+    def _update_lock_mechanism_current_state(self, value):
+        self._state = CURRENT_STATE_MAP[value]
+
+    def _update_battery_level(self, value):
+        self._battery_level = value
 
     @property
     def name(self):

--- a/homeassistant/components/homekit_controller/switch.py
+++ b/homeassistant/components/homekit_controller/switch.py
@@ -33,20 +33,20 @@ class HomeKitSwitch(HomeKitEntity, SwitchDevice):
         self._on = None
         self._outlet_in_use = None
 
-    def update_characteristics(self, characteristics):
-        """Synchronise the switch state with Home Assistant."""
+    def get_characteristic_types(self):
+        """Define the homekit characteristics the entity cares about."""
         # pylint: disable=import-error
         from homekit.model.characteristics import CharacteristicsTypes
+        return [
+            CharacteristicsTypes.ON,
+            CharacteristicsTypes.OUTLET_IN_USE,
+        ]
 
-        for characteristic in characteristics:
-            ctype = characteristic['type']
-            ctype = CharacteristicsTypes.get_short(ctype)
-            if ctype == "on":
-                self._chars['on'] = characteristic['iid']
-                self._on = characteristic['value']
-            elif ctype == "outlet-in-use":
-                self._chars['outlet-in-use'] = characteristic['iid']
-                self._outlet_in_use = characteristic['value']
+    def _update_on(self, value):
+        self._on = value
+
+    def _update_outlet_in_use(self, value):
+        self._outlet_in_use = value
 
     @property
     def is_on(self):

--- a/tests/components/homekit_controller/common.py
+++ b/tests/components/homekit_controller/common.py
@@ -73,13 +73,14 @@ class FakeController:
 class Helper:
     """Helper methods for interacting with HomeKit fakes."""
 
-    def __init__(self, hass, entity_id, pairing, accessory):
+    def __init__(self, hass, entity, pairing, accessory):
         """Create a helper for a given accessory/entity."""
         from homekit.model.services import ServicesTypes
         from homekit.model.characteristics import CharacteristicsTypes
 
         self.hass = hass
-        self.entity_id = entity_id
+        self.entity = entity
+        self.entity_id = entity.entity_id
         self.pairing = pairing
         self.accessory = accessory
 
@@ -141,4 +142,16 @@ async def setup_test_component(hass, services):
     fire_service_discovered(hass, SERVICE_HOMEKIT, discovery_info)
     await hass.async_block_till_done()
 
-    return Helper(hass, '.'.join((domain, 'testdevice')), pairing, accessory)
+    # We can't guarantee what our entity_id will be so we have to find it
+    # in hass after its been created. (The cover entity in particular unsets
+    # its name, meaning its unique_id is used and that isn't stable enough to
+    # rely on)
+    entities = list(hass.data[domain].entities)
+
+    # Right now we only support testing a single entity at a time
+    # This will need extending to find the new entity in the list if more
+    # entities are needed at once
+    assert len(entities) == 1
+    entity = entities[0]
+
+    return Helper(hass, entity, pairing, accessory)

--- a/tests/components/homekit_controller/common.py
+++ b/tests/components/homekit_controller/common.py
@@ -102,6 +102,41 @@ class Helper:
         return state
 
 
+def create_generic_service(service_name):
+    """Create a test HomeKit service model."""
+    from homekit.model.services import AbstractService, ServicesTypes
+    from homekit.model.characteristics import (
+        AbstractCharacteristic, CharacteristicPermissions)
+    from homekit.model import get_id
+
+    class Characteristic(AbstractCharacteristic):
+        """
+        A model of a generic HomeKit characteristic.
+
+        Base is abstract and can't be instanced directly so this subclass is
+        needed even though it doesn't add any methods.
+        """
+
+        pass
+
+    class Service(AbstractService):
+        """A model of a generic HomeKit service."""
+
+        def add_characteristic(self, name):
+            """Add a characteristic to this service by name."""
+            full_name = 'public.hap.characteristic.' + name
+            char = Characteristic(get_id(), full_name, None)
+            char.perms = [
+                CharacteristicPermissions.paired_read,
+                CharacteristicPermissions.paired_write
+            ]
+            self.characteristics.append(char)
+            return char
+
+    char_type = ServicesTypes.get_uuid(service_name)
+    return Service(char_type, get_id())
+
+
 async def setup_test_component(hass, services):
     """Load a fake homekit accessory based on a homekit accessory model."""
     from homekit.model import Accessory

--- a/tests/components/homekit_controller/test_alarm_control_panel.py
+++ b/tests/components/homekit_controller/test_alarm_control_panel.py
@@ -1,0 +1,79 @@
+"""Basic checks for HomeKitalarm_control_panel."""
+from tests.components.homekit_controller.common import (
+    create_generic_service, setup_test_component)
+
+CURRENT_STATE = ('security-system', 'security-system-state.current')
+TARGET_STATE = ('security-system', 'security-system-state.target')
+
+
+def create_security_system_service():
+    """Define a security-system characteristics as per page 219 of HAP spec."""
+    service = create_generic_service('public.hap.service.security-system')
+
+    cur_state = service.add_characteristic('security-system-state.current')
+    cur_state.value = 0
+
+    targ_state = service.add_characteristic('security-system-state.target')
+    targ_state.value = 0
+
+    # According to the spec, a battery-level characteristic is normally
+    # part of a seperate service. However as the code was written (which
+    # predates this test) the battery level would have to be part of the lock
+    # service as it is here.
+    targ_state = service.add_characteristic('battery-level')
+    targ_state.value = 50
+
+    return service
+
+
+async def test_switch_change_alarm_state(hass, utcnow):
+    """Test that we can turn a HomeKit alarm on and off again."""
+    alarm_control_panel = create_security_system_service()
+    helper = await setup_test_component(hass, [alarm_control_panel])
+
+    await hass.services.async_call('alarm_control_panel', 'alarm_arm_home', {
+        'entity_id': 'alarm_control_panel.testdevice',
+    }, blocking=True)
+    assert helper.characteristics[TARGET_STATE].value == 0
+
+    await hass.services.async_call('alarm_control_panel', 'alarm_arm_away', {
+        'entity_id': 'alarm_control_panel.testdevice',
+    }, blocking=True)
+    assert helper.characteristics[TARGET_STATE].value == 1
+
+    await hass.services.async_call('alarm_control_panel', 'alarm_arm_night', {
+        'entity_id': 'alarm_control_panel.testdevice',
+    }, blocking=True)
+    assert helper.characteristics[TARGET_STATE].value == 2
+
+    await hass.services.async_call('alarm_control_panel', 'alarm_disarm', {
+        'entity_id': 'alarm_control_panel.testdevice',
+    }, blocking=True)
+    assert helper.characteristics[TARGET_STATE].value == 3
+
+
+async def test_switch_read_alarm_state(hass, utcnow):
+    """Test that we can read the state of a HomeKit alarm accessory."""
+    alarm_control_panel = create_security_system_service()
+    helper = await setup_test_component(hass, [alarm_control_panel])
+
+    helper.characteristics[CURRENT_STATE].value = 0
+    state = await helper.poll_and_get_state()
+    assert state.state == 'armed_home'
+    assert state.attributes['battery_level'] == 50
+
+    helper.characteristics[CURRENT_STATE].value = 1
+    state = await helper.poll_and_get_state()
+    assert state.state == 'armed_away'
+
+    helper.characteristics[CURRENT_STATE].value = 2
+    state = await helper.poll_and_get_state()
+    assert state.state == 'armed_night'
+
+    helper.characteristics[CURRENT_STATE].value = 3
+    state = await helper.poll_and_get_state()
+    assert state.state == 'disarmed'
+
+    helper.characteristics[CURRENT_STATE].value = 4
+    state = await helper.poll_and_get_state()
+    assert state.state == 'triggered'

--- a/tests/components/homekit_controller/test_cover.py
+++ b/tests/components/homekit_controller/test_cover.py
@@ -1,0 +1,213 @@
+"""Basic checks for HomeKitalarm_control_panel."""
+from tests.components.homekit_controller.common import (
+    create_generic_service, setup_test_component)
+
+POSITION_STATE = ('window-covering', 'position.state')
+POSITION_CURRENT = ('window-covering', 'position.current')
+POSITION_TARGET = ('window-covering', 'position.target')
+
+H_TILT_CURRENT = ('window-covering', 'horizontal-tilt.current')
+H_TILT_TARGET = ('window-covering', 'horizontal-tilt.target')
+
+V_TILT_CURRENT = ('window-covering', 'vertical-tilt.current')
+V_TILT_TARGET = ('window-covering', 'vertical-tilt.target')
+
+WINDOW_OBSTRUCTION = ('window-covering', 'obstruction-detected')
+
+DOOR_CURRENT = ('garage-door-opener', 'door-state.current')
+DOOR_TARGET = ('garage-door-opener', 'door-state.target')
+DOOR_OBSTRUCTION = ('garage-door-opener', 'obstruction-detected')
+
+
+def create_window_covering_service():
+    """Define a window-covering characteristics as per page 219 of HAP spec."""
+    service = create_generic_service('public.hap.service.window-covering')
+
+    cur_state = service.add_characteristic('position.current')
+    cur_state.value = 0
+
+    targ_state = service.add_characteristic('position.target')
+    targ_state.value = 0
+
+    position_state = service.add_characteristic('position.state')
+    position_state.value = 0
+
+    position_hold = service.add_characteristic('position.hold')
+    position_hold.value = 0
+
+    obstruction = service.add_characteristic('obstruction-detected')
+    obstruction.value = False
+
+    name = service.add_characteristic('name')
+    name.value = "Window Cover 1"
+
+    return service
+
+
+def create_window_covering_service_with_h_tilt():
+    """Define a window-covering characteristics as per page 219 of HAP spec."""
+    service = create_window_covering_service()
+
+    tilt_current = service.add_characteristic('horizontal-tilt.current')
+    tilt_current.value = 0
+
+    tilt_target = service.add_characteristic('horizontal-tilt.target')
+    tilt_target.value = 0
+
+    return service
+
+
+def create_window_covering_service_with_v_tilt():
+    """Define a window-covering characteristics as per page 219 of HAP spec."""
+    service = create_window_covering_service()
+
+    tilt_current = service.add_characteristic('vertical-tilt.current')
+    tilt_current.value = 0
+
+    tilt_target = service.add_characteristic('vertical-tilt.target')
+    tilt_target.value = 0
+
+    return service
+
+
+async def test_change_window_cover_state(hass, utcnow):
+    """Test that we can turn a HomeKit alarm on and off again."""
+    window_cover = create_window_covering_service()
+    helper = await setup_test_component(hass, [window_cover])
+
+    await hass.services.async_call('cover', 'open_cover', {
+        'entity_id': helper.entity_id,
+    }, blocking=True)
+    assert helper.characteristics[POSITION_TARGET].value == 100
+
+    await hass.services.async_call('cover', 'close_cover', {
+        'entity_id': helper.entity_id,
+    }, blocking=True)
+    assert helper.characteristics[POSITION_TARGET].value == 0
+
+
+async def test_read_window_cover_state(hass, utcnow):
+    """Test that we can read the state of a HomeKit alarm accessory."""
+    window_cover = create_window_covering_service()
+    helper = await setup_test_component(hass, [window_cover])
+
+    helper.characteristics[POSITION_STATE].value = 0
+    state = await helper.poll_and_get_state()
+    assert state.state == 'opening'
+
+    helper.characteristics[POSITION_STATE].value = 1
+    state = await helper.poll_and_get_state()
+    assert state.state == 'closing'
+
+    helper.characteristics[POSITION_STATE].value = 2
+    state = await helper.poll_and_get_state()
+    assert state.state == 'closed'
+
+    helper.characteristics[WINDOW_OBSTRUCTION].value = True
+    state = await helper.poll_and_get_state()
+    assert state.attributes['obstruction-detected'] is True
+
+
+async def test_read_window_cover_tilt_horizontal(hass, utcnow):
+    """Test that horizontal tilt is handled correctly."""
+    window_cover = create_window_covering_service_with_h_tilt()
+    helper = await setup_test_component(hass, [window_cover])
+
+    helper.characteristics[H_TILT_CURRENT].value = 75
+    state = await helper.poll_and_get_state()
+    assert state.attributes['current_tilt_position'] == 75
+
+
+async def test_read_window_cover_tilt_vertical(hass, utcnow):
+    """Test that vertical tilt is handled correctly."""
+    window_cover = create_window_covering_service_with_v_tilt()
+    helper = await setup_test_component(hass, [window_cover])
+
+    helper.characteristics[V_TILT_CURRENT].value = 75
+    state = await helper.poll_and_get_state()
+    assert state.attributes['current_tilt_position'] == 75
+
+
+async def test_write_window_cover_tilt_horizontal(hass, utcnow):
+    """Test that horizontal tilt is written correctly."""
+    window_cover = create_window_covering_service_with_h_tilt()
+    helper = await setup_test_component(hass, [window_cover])
+
+    await hass.services.async_call('cover', 'set_cover_tilt_position', {
+        'entity_id': helper.entity_id,
+        'tilt_position': 90
+    }, blocking=True)
+    assert helper.characteristics[H_TILT_TARGET].value == 90
+
+
+async def test_write_window_cover_tilt_vertical(hass, utcnow):
+    """Test that vertical tilt is written correctly."""
+    window_cover = create_window_covering_service_with_v_tilt()
+    helper = await setup_test_component(hass, [window_cover])
+
+    await hass.services.async_call('cover', 'set_cover_tilt_position', {
+        'entity_id': helper.entity_id,
+        'tilt_position': 90
+    }, blocking=True)
+    assert helper.characteristics[V_TILT_TARGET].value == 90
+
+
+def create_garage_door_opener_service():
+    """Define a garage-door-opener chars as per page 217 of HAP spec."""
+    service = create_generic_service('public.hap.service.garage-door-opener')
+
+    cur_state = service.add_characteristic('door-state.current')
+    cur_state.value = 0
+
+    targ_state = service.add_characteristic('door-state.target')
+    targ_state.value = 0
+
+    obstruction = service.add_characteristic('obstruction-detected')
+    obstruction.value = False
+
+    name = service.add_characteristic('name')
+    name.value = "Garage Door Opener 1"
+
+    return service
+
+
+async def test_change_door_state(hass, utcnow):
+    """Test that we can turn open and close a HomeKit garage door."""
+    door = create_garage_door_opener_service()
+    helper = await setup_test_component(hass, [door])
+
+    await hass.services.async_call('cover', 'open_cover', {
+        'entity_id': helper.entity_id,
+    }, blocking=True)
+    assert helper.characteristics[DOOR_TARGET].value == 0
+
+    await hass.services.async_call('cover', 'close_cover', {
+        'entity_id': helper.entity_id,
+    }, blocking=True)
+    assert helper.characteristics[DOOR_TARGET].value == 1
+
+
+async def test_read_door_state(hass, utcnow):
+    """Test that we can read the state of a HomeKit garage door."""
+    door = create_garage_door_opener_service()
+    helper = await setup_test_component(hass, [door])
+
+    helper.characteristics[DOOR_CURRENT].value = 0
+    state = await helper.poll_and_get_state()
+    assert state.state == 'open'
+
+    helper.characteristics[DOOR_CURRENT].value = 1
+    state = await helper.poll_and_get_state()
+    assert state.state == 'closed'
+
+    helper.characteristics[DOOR_CURRENT].value = 2
+    state = await helper.poll_and_get_state()
+    assert state.state == 'opening'
+
+    helper.characteristics[DOOR_CURRENT].value = 3
+    state = await helper.poll_and_get_state()
+    assert state.state == 'closing'
+
+    helper.characteristics[DOOR_OBSTRUCTION].value = True
+    state = await helper.poll_and_get_state()
+    assert state.attributes['obstruction-detected'] is True

--- a/tests/components/homekit_controller/test_light.py
+++ b/tests/components/homekit_controller/test_light.py
@@ -1,46 +1,128 @@
 """Basic checks for HomeKitSwitch."""
 from tests.components.homekit_controller.common import (
-    setup_test_component)
+    create_generic_service, setup_test_component)
+
+
+LIGHT_ON = ('lightbulb', 'on')
+LIGHT_BRIGHTNESS = ('lightbulb', 'brightness')
+LIGHT_HUE = ('lightbulb', 'hue')
+LIGHT_SATURATION = ('lightbulb', 'saturation')
+LIGHT_COLOR_TEMP = ('lightbulb', 'color-temperature')
+
+
+def create_lightbulb_service():
+    """Define lightbulb characteristics."""
+    service = create_generic_service('public.hap.service.lightbulb')
+
+    on_char = service.add_characteristic('on')
+    on_char.value = 0
+
+    brightness = service.add_characteristic('brightness')
+    brightness.value = 0
+
+    return service
+
+
+def create_lightbulb_service_with_hs():
+    """Define a lightbulb service with hue + saturation."""
+    service = create_lightbulb_service()
+
+    hue = service.add_characteristic('hue')
+    hue.value = 0
+
+    saturation = service.add_characteristic('saturation')
+    saturation.value = 0
+
+    return service
+
+
+def create_lightbulb_service_with_color_temp():
+    """Define a lightbulb service with color temp."""
+    service = create_lightbulb_service()
+
+    color_temp = service.add_characteristic('color-temperature')
+    color_temp.value = 0
+
+    return service
 
 
 async def test_switch_change_light_state(hass, utcnow):
     """Test that we can turn a HomeKit light on and off again."""
-    from homekit.model.services import BHSLightBulbService
-
-    helper = await setup_test_component(hass, [BHSLightBulbService()])
+    bulb = create_lightbulb_service_with_hs()
+    helper = await setup_test_component(hass, [bulb])
 
     await hass.services.async_call('light', 'turn_on', {
         'entity_id': 'light.testdevice',
         'brightness': 255,
         'hs_color': [4, 5],
     }, blocking=True)
-    assert helper.characteristics[('lightbulb', 'on')].value == 1
-    assert helper.characteristics[('lightbulb', 'brightness')].value == 100
-    assert helper.characteristics[('lightbulb', 'hue')].value == 4
-    assert helper.characteristics[('lightbulb', 'saturation')].value == 5
+
+    assert helper.characteristics[LIGHT_ON].value == 1
+    assert helper.characteristics[LIGHT_BRIGHTNESS].value == 100
+    assert helper.characteristics[LIGHT_HUE].value == 4
+    assert helper.characteristics[LIGHT_SATURATION].value == 5
 
     await hass.services.async_call('light', 'turn_off', {
         'entity_id': 'light.testdevice',
     }, blocking=True)
-    assert helper.characteristics[('lightbulb', 'on')].value == 0
+    assert helper.characteristics[LIGHT_ON].value == 0
+
+
+async def test_switch_change_light_state_color_temp(hass, utcnow):
+    """Test that we can turn change color_temp."""
+    bulb = create_lightbulb_service_with_color_temp()
+    helper = await setup_test_component(hass, [bulb])
+
+    await hass.services.async_call('light', 'turn_on', {
+        'entity_id': 'light.testdevice',
+        'brightness': 255,
+        'color_temp': 400,
+    }, blocking=True)
+    assert helper.characteristics[LIGHT_ON].value == 1
+    assert helper.characteristics[LIGHT_BRIGHTNESS].value == 100
+    assert helper.characteristics[LIGHT_COLOR_TEMP].value == 400
 
 
 async def test_switch_read_light_state(hass, utcnow):
     """Test that we can read the state of a HomeKit light accessory."""
-    from homekit.model.services import BHSLightBulbService
-
-    helper = await setup_test_component(hass, [BHSLightBulbService()])
+    bulb = create_lightbulb_service_with_hs()
+    helper = await setup_test_component(hass, [bulb])
 
     # Initial state is that the light is off
     state = await helper.poll_and_get_state()
     assert state.state == 'off'
 
     # Simulate that someone switched on the device in the real world not via HA
-    helper.characteristics[('lightbulb', 'on')].set_value(True)
+    helper.characteristics[LIGHT_ON].set_value(True)
+    helper.characteristics[LIGHT_BRIGHTNESS].value = 100
+    helper.characteristics[LIGHT_HUE].value = 4
+    helper.characteristics[LIGHT_SATURATION].value = 5
     state = await helper.poll_and_get_state()
     assert state.state == 'on'
+    assert state.attributes['brightness'] == 255
+    assert state.attributes['hs_color'] == (4, 5)
 
     # Simulate that device switched off in the real world not via HA
-    helper.characteristics[('lightbulb', 'on')].set_value(False)
+    helper.characteristics[LIGHT_ON].set_value(False)
     state = await helper.poll_and_get_state()
     assert state.state == 'off'
+
+
+async def test_switch_read_light_state_color_temp(hass, utcnow):
+    """Test that we can read the color_temp of a  light accessory."""
+    bulb = create_lightbulb_service_with_color_temp()
+    helper = await setup_test_component(hass, [bulb])
+
+    # Initial state is that the light is off
+    state = await helper.poll_and_get_state()
+    assert state.state == 'off'
+
+    # Simulate that someone switched on the device in the real world not via HA
+    helper.characteristics[LIGHT_ON].set_value(True)
+    helper.characteristics[LIGHT_BRIGHTNESS].value = 100
+    helper.characteristics[LIGHT_COLOR_TEMP].value = 400
+
+    state = await helper.poll_and_get_state()
+    assert state.state == 'on'
+    assert state.attributes['brightness'] == 255
+    assert state.attributes['color_temp'] == 400

--- a/tests/components/homekit_controller/test_lock.py
+++ b/tests/components/homekit_controller/test_lock.py
@@ -1,0 +1,59 @@
+"""Basic checks for HomeKitLock."""
+from tests.components.homekit_controller.common import (
+    create_generic_service, setup_test_component)
+
+LOCK_CURRENT_STATE = ('lock-mechanism', 'lock-mechanism.current-state')
+LOCK_TARGET_STATE = ('lock-mechanism', 'lock-mechanism.target-state')
+
+
+def create_lock_service():
+    """Define a lock characteristics as per page 219 of HAP spec."""
+    service = create_generic_service('public.hap.service.lock-mechanism')
+
+    cur_state = service.add_characteristic('lock-mechanism.current-state')
+    cur_state.value = 0
+
+    targ_state = service.add_characteristic('lock-mechanism.target-state')
+    targ_state.value = 0
+
+    # According to the spec, a battery-level characteristic is normally
+    # part of a seperate service. However as the code was written (which
+    # predates this test) the battery level would have to be part of the lock
+    # service as it is here.
+    targ_state = service.add_characteristic('battery-level')
+    targ_state.value = 50
+
+    return service
+
+
+async def test_switch_change_lock_state(hass, utcnow):
+    """Test that we can turn a HomeKit lock on and off again."""
+    lock = create_lock_service()
+    helper = await setup_test_component(hass, [lock])
+
+    await hass.services.async_call('lock', 'lock', {
+        'entity_id': 'lock.testdevice',
+    }, blocking=True)
+    assert helper.characteristics[LOCK_TARGET_STATE].value == 1
+
+    await hass.services.async_call('lock', 'unlock', {
+        'entity_id': 'lock.testdevice',
+    }, blocking=True)
+    assert helper.characteristics[LOCK_TARGET_STATE].value == 0
+
+
+async def test_switch_read_lock_state(hass, utcnow):
+    """Test that we can read the state of a HomeKit lock accessory."""
+    lock = create_lock_service()
+    helper = await setup_test_component(hass, [lock])
+
+    helper.characteristics[LOCK_CURRENT_STATE].value = 0
+    helper.characteristics[LOCK_TARGET_STATE].value = 0
+    state = await helper.poll_and_get_state()
+    assert state.state == 'unlocked'
+    assert state.attributes['battery_level'] == 50
+
+    helper.characteristics[LOCK_CURRENT_STATE].value = 1
+    helper.characteristics[LOCK_TARGET_STATE].value = 1
+    state = await helper.poll_and_get_state()
+    assert state.state == 'locked'


### PR DESCRIPTION
## Description:

Note: This PR builds on #20325 which is a bug fix change. I'm opening this PR in parallel as anticipate some discussion around the changes.

This pull request lays down some foundational work for supporting HomeKit BLE devices. There will be more of this when the homekit library ships BLE support (branch [here](https://github.com/jlusiardi/homekit_python/tree/add_bluetooth), but I want to keep the delta i'm running small in the meantime (easier to work on BLE AND support HA users if the delta is small).

There are a couple of issues with the current component that become a problem with BLE:

 * BLE doesn't have an equivalent to the `list_accessories_and_characteristics()` endpoint so we have to emulate it. It's slooooow. A normal homekit controller uses the `get_characteristics()` API and only polls the characteristics its tracking.

 * BLE devices are often battery powered and optimized for low interaction with the controller (e.g. favouring events). To save batteries (and polar bears) we want to interact with devices less (and eventually switch to events rather than polling).

Put another way its silly to waste time and battery asking a battery powered Eve Motion what its serial number is once a minute. We should stop doing that.

As a first step to support these goals this branch i've switched to calling `get_characteristics` for only the characteristic types we are interested in. Additionally, theres now a distinct `setup` and `update` phase. The setup phase runs at start up and configures supported features based on the discovery data. There is no need to wait for the first successful `update` to know that a light supports brightness control (which is what happens now).

There is now a per characteristic callback for decoding a value from the API into entity state. Ultimately this will be called directly by an event from the HomeKit API.

The best part of this change is of course that is accompanied by the first set of tests for homekit_controller.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
