### PR TITLE
Fix for blink initialization failure. Fixes #20335

### DIFF
--- a/homeassistant/components/blink/__init__.py
+++ b/homeassistant/components/blink/__init__.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
     CONF_BINARY_SENSORS, CONF_SENSORS, CONF_FILENAME,
     CONF_MONITORED_CONDITIONS, TEMP_FAHRENHEIT)
 
-REQUIREMENTS = ['blinkpy==0.11.1']
+REQUIREMENTS = ['blinkpy==0.11.2']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -196,7 +196,7 @@ bellows==0.7.0
 bimmer_connected==0.5.3
 
 # homeassistant.components.blink
-blinkpy==0.11.1
+blinkpy==0.11.2
 
 # homeassistant.components.light.blinksticklight
 blinkstick==1.1.8


### PR DESCRIPTION
## Description:
Due to upstream API endpoint changes for Blink, the current integration fails to load.  I have a fix in the `blinkpy` library to handle this error until a long term fix is in (ie. finding the new endpoint).  This fix allows for everything in the Blink home-assistant component to continue working **except** for motion detection.

**Breaking Change:**
Blink motion detection temporarily broken due to API change.

`blinkpy` change log: https://github.com/fronzbot/blinkpy/releases/tag/v0.11.2

**Related issue (if applicable):** fixes #20335 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

@dgomes 