### PR TITLE
[FIX] Time reporting incorrect in sensor.gtt

### DIFF
--- a/homeassistant/components/sensor/gtt.py
+++ b/homeassistant/components/sensor/gtt.py
@@ -112,7 +112,9 @@ class GttData:
             if bus['bus_name'] == self._bus_name:
                 return bus
 
+
 def get_datetime(bus):
+    """Get the datetime from a bus."""
     bustime = datetime.strptime(bus['time'][0]['run'], "%H:%M")
     now = datetime.now()
     bustime = bustime.replace(year=now.year, month=now.month, day=now.day)

--- a/homeassistant/components/sensor/gtt.py
+++ b/homeassistant/components/sensor/gtt.py
@@ -98,7 +98,7 @@ class GttData:
     def get_data(self):
         """Get the data from the api."""
         self.bus_list = self._pygtt.get_by_stop(self._stop)
-        self.bus_list.sort(key=lambda b: get_datetime(b)) #pylint: disable=unnecessary-lambda
+        self.bus_list.sort(key=get_datetime)
 
         if self._bus_name is not None:
             self.state_bus = self.get_bus_by_name()

--- a/homeassistant/components/sensor/gtt.py
+++ b/homeassistant/components/sensor/gtt.py
@@ -79,8 +79,7 @@ class GttSensor(Entity):
     def update(self):
         """Update device state."""
         self.data.get_data()
-        next_time = datetime.strptime(
-            self.data.state_bus['time'][0]['run'], "%H:%M")
+        next_time = get_datetime(self.data.state_bus)
         self._state = next_time.isoformat()
 
 
@@ -99,8 +98,7 @@ class GttData:
     def get_data(self):
         """Get the data from the api."""
         self.bus_list = self._pygtt.get_by_stop(self._stop)
-        self.bus_list.sort(key=lambda b:
-                           datetime.strptime(b['time'][0]['run'], "%H:%M"))
+        self.bus_list.sort(key=lambda b: get_datetime(b))
 
         if self._bus_name is not None:
             self.state_bus = self.get_bus_by_name()
@@ -113,3 +111,12 @@ class GttData:
         for bus in self.bus_list:
             if bus['bus_name'] == self._bus_name:
                 return bus
+
+def get_datetime(bus):
+    bustime = datetime.strptime(bus['time'][0]['run'], "%H:%M")
+    now = datetime.now()
+    bustime = bustime.replace(year=now.year, month=now.month, day=now.day)
+    if bustime < now:
+        bustime = bustime + timedelta(days=1)
+    print(bustime)
+    return bustime

--- a/homeassistant/components/sensor/gtt.py
+++ b/homeassistant/components/sensor/gtt.py
@@ -118,5 +118,4 @@ def get_datetime(bus):
     bustime = bustime.replace(year=now.year, month=now.month, day=now.day)
     if bustime < now:
         bustime = bustime + timedelta(days=1)
-    print(bustime)
     return bustime

--- a/homeassistant/components/sensor/gtt.py
+++ b/homeassistant/components/sensor/gtt.py
@@ -98,7 +98,7 @@ class GttData:
     def get_data(self):
         """Get the data from the api."""
         self.bus_list = self._pygtt.get_by_stop(self._stop)
-        self.bus_list.sort(key=lambda b: get_datetime(b))
+        self.bus_list.sort(get_datetime(b))
 
         if self._bus_name is not None:
             self.state_bus = self.get_bus_by_name()

--- a/homeassistant/components/sensor/gtt.py
+++ b/homeassistant/components/sensor/gtt.py
@@ -98,7 +98,7 @@ class GttData:
     def get_data(self):
         """Get the data from the api."""
         self.bus_list = self._pygtt.get_by_stop(self._stop)
-        self.bus_list.sort(get_datetime(b))
+        self.bus_list.sort(key=lambda b: get_datetime(b)) #pylint: disable=unnecessary-lambda
 
         if self._bus_name is not None:
             self.state_bus = self.get_bus_by_name()


### PR DESCRIPTION
## Description:
Fix time reporting incorrect on sensor.gtt. 

There was a problem that slipped though testing: 
datetime years were displayed as year 1900.

I've added a method to set the current day, month and year so it's possible to use the sensor.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.