### PR TITLE
Fix error when API doesn't return a forecast.

### DIFF
--- a/homeassistant/components/weather/ipma.py
+++ b/homeassistant/components/weather/ipma.py
@@ -116,6 +116,9 @@ class IPMAWeather(WeatherEntity):
     @property
     def condition(self):
         """Return the current condition."""
+        if self._forecast:
+            return
+
         return next((k for k, v in CONDITION_CLASSES.items()
                      if self._forecast[0].idWeatherType in v), None)
 

--- a/homeassistant/components/weather/ipma.py
+++ b/homeassistant/components/weather/ipma.py
@@ -116,7 +116,7 @@ class IPMAWeather(WeatherEntity):
     @property
     def condition(self):
         """Return the current condition."""
-        if self._forecast:
+        if not self._forecast:
             return
 
         return next((k for k, v in CONDITION_CLASSES.items()


### PR DESCRIPTION
## Description:

Seldomly the API will not return a forecast, this makes sure we don't throw an error.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
weather:
  - platform: ipma
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
