### PR TITLE
Fix restore state crashing invalid entity ID

### DIFF
--- a/homeassistant/helpers/restore_state.py
+++ b/homeassistant/helpers/restore_state.py
@@ -4,7 +4,8 @@ import logging
 from datetime import timedelta, datetime
 from typing import Any, Dict, List, Set, Optional  # noqa  pylint_disable=unused-import
 
-from homeassistant.core import HomeAssistant, callback, State, CoreState
+from homeassistant.core import (
+    HomeAssistant, callback, State, CoreState, valid_entity_id)
 from homeassistant.const import (
     EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP)
 import homeassistant.util.dt as dt_util
@@ -80,7 +81,8 @@ class RestoreStateData():
                 else:
                     data.last_states = {
                         item['state']['entity_id']: StoredState.from_dict(item)
-                        for item in stored_states}
+                        for item in stored_states
+                        if valid_entity_id(item['state']['entity_id'])}
                     _LOGGER.debug(
                         'Created cache with %s', list(data.last_states))
 


### PR DESCRIPTION
## Description:
Restore state would crash when loading when the stored states contained invalid entity IDs.


**Related issue (if applicable):** fixes #20366


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
