### PR TITLE
Calling save before load would crash Lovelace storage

### DIFF
--- a/homeassistant/components/lovelace/__init__.py
+++ b/homeassistant/components/lovelace/__init__.py
@@ -101,6 +101,8 @@ class LovelaceStorage:
 
     async def async_save(self, config):
         """Save config."""
+        if self._data is None:
+            self._data = {'config': None}
         self._data['config'] = config
         await self._store.async_save(self._data)
 

--- a/tests/components/lovelace/test_init.py
+++ b/tests/components/lovelace/test_init.py
@@ -50,6 +50,27 @@ async def test_lovelace_from_storage(hass, hass_ws_client, hass_storage):
     }
 
 
+async def test_lovelace_from_storage_save_before_load(hass, hass_ws_client,
+                                                      hass_storage):
+    """Test we can load lovelace config from storage."""
+    assert await async_setup_component(hass, 'lovelace', {})
+    client = await hass_ws_client(hass)
+
+    # Store new config
+    await client.send_json({
+        'id': 6,
+        'type': 'lovelace/config/save',
+        'config': {
+            'yo': 'hello'
+        }
+    })
+    response = await client.receive_json()
+    assert response['success']
+    assert hass_storage[lovelace.STORAGE_KEY]['data'] == {
+        'config': {'yo': 'hello'}
+    }
+
+
 async def test_lovelace_from_yaml(hass, hass_ws_client):
     """Test we load lovelace config from yaml."""
     assert await async_setup_component(hass, 'lovelace', {


### PR DESCRIPTION
## Description:
In storage mode, Lovelace would crash if we call "save" before calling "load".

~~I am not sure how this can happen, but someone reported it  🤷‍♂️~~

STR:
 - Have no local Lovelace config
 - Open browser and browse to Lovelace panel
 - Restart Home Assistant
 - Take control of UI




**Related issue (if applicable):** https://community.home-assistant.io/t/0-86-new-lovelace-ui-and-zigbee-management-panel/93897/39?u=balloob

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
