### PR TITLE
Improve deprecation warnings

### DIFF
--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -169,7 +169,8 @@ class EntityComponent:
                 self.logger.warning(
                     'Not passing an entity ID to a service to target all '
                     'entities is deprecated. Update your call to %s.%s to be '
-                    'instead: entity_id: "*"', service.domain, service.service)
+                    'instead: entity_id: %s', service.domain, service.service,
+                    ENTITY_MATCH_ALL)
 
             return [entity for entity in self.entities if entity.available]
 
@@ -182,8 +183,9 @@ class EntityComponent:
         """Register an entity service."""
         async def handle_service(call):
             """Handle the service."""
+            service_name = "{}.{}".format(self.domain, name)
             await self.hass.helpers.service.entity_service_call(
-                self._platforms.values(), func, call
+                self._platforms.values(), func, call, service_name
             )
 
         self.hass.services.async_register(

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -187,7 +187,7 @@ async def async_get_all_descriptions(hass):
 
 
 @bind_hass
-async def entity_service_call(hass, platforms, func, call):
+async def entity_service_call(hass, platforms, func, call, service_name=''):
     """Handle an entity service call.
 
     Calls all platforms simultaneously.
@@ -204,9 +204,11 @@ async def entity_service_call(hass, platforms, func, call):
     if ATTR_ENTITY_ID in call.data:
         target_all_entities = call.data[ATTR_ENTITY_ID] == ENTITY_MATCH_ALL
     else:
+        # Remove the service_name parameter along with this warning
         _LOGGER.warning(
-            'Not passing an entity ID to a service to target all entities is '
-            'deprecated. Use instead: entity_id: "%s"', ENTITY_MATCH_ALL)
+            'Not passing an entity ID to a service to target all '
+            'entities is deprecated. Update your call to %s to be '
+            'instead: entity_id: %s', service_name, ENTITY_MATCH_ALL)
         target_all_entities = True
 
     if not target_all_entities:


### PR DESCRIPTION
## Description:

* One more `*` ➡ `all` conversion
* Remove quotes from the recommended change
* Log the name of the service call

I think the last one is fairly important, it is hard to debug the warning without the service name.

**Related issue (if applicable):** [seen in forum](https://community.home-assistant.io/t/not-passing-an-entity-id-to-a-service-to-target-all-entities-is-deprecated-use-instead-entity-id-all/94105)

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.
  - [X] There is no commented out code in this PR.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
