### PR TITLE
Remove unnecessary warning from Philips Hue

### DIFF
--- a/homeassistant/components/hue/light.py
+++ b/homeassistant/components/hue/light.py
@@ -228,9 +228,6 @@ class HueLight(Light):
             self.is_philips = light.manufacturername == 'Philips'
             self.gamut_typ = self.light.colorgamuttype
             self.gamut = self.light.colorgamut
-            if not self.gamut:
-                err_msg = 'Can not get color gamut of light "%s"'
-                _LOGGER.warning(err_msg, self.name)
 
     @property
     def unique_id(self):


### PR DESCRIPTION
## Description:
for white hue bulbs and bulbs from other brands like Ikea and Innr, this warning will be issued while this is not really a problem.
So just remove the warning.
If the color gamut cannot be retrieved the gamut will be set to "None" and theirefore the color util will just ignore the whole gamut in the conversion and work just like it used to work before this upgrade.
Theirfore this warning is anoying and unnesesarry.
sorry my bad.


**Related issue (if applicable):** fixes #20379


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
