### PR TITLE
Update pyhomematic to 0.1.55

### DIFF
--- a/homeassistant/components/homematic/__init__.py
+++ b/homeassistant/components/homematic/__init__.py
@@ -19,7 +19,7 @@ from homeassistant.helpers import discovery
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 
-REQUIREMENTS = ['pyhomematic==0.1.54']
+REQUIREMENTS = ['pyhomematic==0.1.55']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -65,7 +65,7 @@ HM_DEVICE_TYPES = {
     DISCOVER_SWITCHES: [
         'Switch', 'SwitchPowermeter', 'IOSwitch', 'IPSwitch', 'RFSiren',
         'IPSwitchPowermeter', 'HMWIOSwitch', 'Rain', 'EcoLogic',
-        'IPKeySwitchPowermeter', 'IPGarage'],
+        'IPKeySwitchPowermeter', 'IPGarage', 'IPKeySwitch', 'IPMultiIO'],
     DISCOVER_LIGHTS: ['Dimmer', 'KeyDimmer', 'IPKeyDimmer', 'IPDimmer',
                       'ColorEffectLight'],
     DISCOVER_SENSORS: [
@@ -79,7 +79,7 @@ HM_DEVICE_TYPES = {
         'IPWeatherSensor', 'RotaryHandleSensorIP', 'IPPassageSensor',
         'IPKeySwitchPowermeter', 'IPThermostatWall230V', 'IPWeatherSensorPlus',
         'IPWeatherSensorBasic', 'IPBrightnessSensor', 'IPGarage',
-        'UniversalSensor', 'MotionIPV2'],
+        'UniversalSensor', 'MotionIPV2', 'IPMultiIO'],
     DISCOVER_CLIMATE: [
         'Thermostat', 'ThermostatWall', 'MAXThermostat', 'ThermostatWall2',
         'MAXWallThermostat', 'IPThermostat', 'IPThermostatWall',
@@ -89,7 +89,8 @@ HM_DEVICE_TYPES = {
         'MotionIP', 'RemoteMotion', 'WeatherSensor', 'TiltSensor',
         'IPShutterContact', 'HMWIOSwitch', 'MaxShutterContact', 'Rain',
         'WiredSensor', 'PresenceIP', 'IPWeatherSensor', 'IPPassageSensor',
-        'SmartwareMotion', 'IPWeatherSensorPlus', 'MotionIPV2'],
+        'SmartwareMotion', 'IPWeatherSensorPlus', 'MotionIPV2', 'WaterIP',
+        'IPMultiIO'],
     DISCOVER_COVER: ['Blind', 'KeyBlind', 'IPKeyBlind', 'IPKeyBlindTilt'],
     DISCOVER_LOCKS: ['KeyMatic']
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1037,7 +1037,7 @@ pyhik==0.1.9
 pyhiveapi==0.2.17
 
 # homeassistant.components.homematic
-pyhomematic==0.1.54
+pyhomematic==0.1.55
 
 # homeassistant.components.homeworks
 pyhomeworks==0.0.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -181,7 +181,7 @@ pydeconz==47
 pydispatcher==2.0.5
 
 # homeassistant.components.homematic
-pyhomematic==0.1.54
+pyhomematic==0.1.55
 
 # homeassistant.components.litejet
 pylitejet==0.1


### PR DESCRIPTION
## Description:
Update pyhomematic to 0.1.55. Changes in pyhomematic:
Adds support for HomeMatic devices: HmIP-SWDM-B2, HmIP-KRC4, HmIP-BRC2, HmIP-SWD, HmIP-BSL, HmIP-MIOB and regional variants of devices that have already been implemented previously

@pvizeli 
I have thought about removing support for resolving names by using the XML-API addon. It was obsolete from the beginning, since the CCU always supported doing this with JSON-RPC. Would you agree if we add a warning for people using `xml` that support will be dropped in a future version? That way I could some day remove that code from pyhomematic, saving us a bit of memory because we don't need the XML-parsing libraries.
I would do that in a separate PR. Just wanted your statement about this beforehand.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
