### PR TITLE
Fix minor homematicip cloud binary sensor issues

### DIFF
--- a/homeassistant/components/binary_sensor/homematicip_cloud.py
+++ b/homeassistant/components/binary_sensor/homematicip_cloud.py
@@ -93,8 +93,8 @@ class HomematicipSmokeDetector(HomematicipGenericDevice, BinarySensorDevice):
     def is_on(self):
         """Return true if smoke is detected."""
         from homematicip.base.enums import SmokeDetectorAlarmType
-        return self._device.smokeDetectorAlarmType 
-            != SmokeDetectorAlarmType.IDLE_OFF
+        return (self._device.smokeDetectorAlarmType 
+            != SmokeDetectorAlarmType.IDLE_OFF)
 
 
 class HomematicipWaterDetector(HomematicipGenericDevice, BinarySensorDevice):

--- a/homeassistant/components/binary_sensor/homematicip_cloud.py
+++ b/homeassistant/components/binary_sensor/homematicip_cloud.py
@@ -94,7 +94,7 @@ class HomematicipSmokeDetector(HomematicipGenericDevice, BinarySensorDevice):
         """Return true if smoke is detected."""
         from homematicip.base.enums import SmokeDetectorAlarmType
         return (self._device.smokeDetectorAlarmType 
-            != SmokeDetectorAlarmType.IDLE_OFF)
+                != SmokeDetectorAlarmType.IDLE_OFF)
 
 
 class HomematicipWaterDetector(HomematicipGenericDevice, BinarySensorDevice):

--- a/homeassistant/components/binary_sensor/homematicip_cloud.py
+++ b/homeassistant/components/binary_sensor/homematicip_cloud.py
@@ -95,7 +95,7 @@ class HomematicipSmokeDetector(HomematicipGenericDevice, BinarySensorDevice):
     @property
     def is_on(self):
         """Return true if smoke is detected."""
-        return self._device.smokeDetectorAlarmType != STATE_SMOKE_OFF
+        return str(self._device.smokeDetectorAlarmType) != STATE_SMOKE_OFF
 
 
 class HomematicipWaterDetector(HomematicipGenericDevice, BinarySensorDevice):

--- a/homeassistant/components/binary_sensor/homematicip_cloud.py
+++ b/homeassistant/components/binary_sensor/homematicip_cloud.py
@@ -15,6 +15,7 @@ DEPENDENCIES = ['homematicip_cloud']
 
 _LOGGER = logging.getLogger(__name__)
 
+
 async def async_setup_platform(
         hass, config, async_add_entities, discovery_info=None):
     """Set up the HomematicIP Cloud binary sensor devices."""
@@ -93,7 +94,7 @@ class HomematicipSmokeDetector(HomematicipGenericDevice, BinarySensorDevice):
     def is_on(self):
         """Return true if smoke is detected."""
         from homematicip.base.enums import SmokeDetectorAlarmType
-        return (self._device.smokeDetectorAlarmType 
+        return (self._device.smokeDetectorAlarmType
                 != SmokeDetectorAlarmType.IDLE_OFF)
 
 

--- a/homeassistant/components/binary_sensor/homematicip_cloud.py
+++ b/homeassistant/components/binary_sensor/homematicip_cloud.py
@@ -65,7 +65,7 @@ class HomematicipShutterContact(HomematicipGenericDevice, BinarySensorDevice):
             return True
         if self._device.windowState is None:
             return None
-        return self._device.windowState == WindowState.OPEN
+        return self._device.windowState != WindowState.CLOSED
 
 
 class HomematicipMotionDetector(HomematicipGenericDevice, BinarySensorDevice):

--- a/homeassistant/components/binary_sensor/homematicip_cloud.py
+++ b/homeassistant/components/binary_sensor/homematicip_cloud.py
@@ -93,7 +93,8 @@ class HomematicipSmokeDetector(HomematicipGenericDevice, BinarySensorDevice):
     def is_on(self):
         """Return true if smoke is detected."""
         from homematicip.base.enums import SmokeDetectorAlarmType
-        return self._device.smokeDetectorAlarmType != SmokeDetectorAlarmType.IDLE_OFF
+        return self._device.smokeDetectorAlarmType 
+            != SmokeDetectorAlarmType.IDLE_OFF
 
 
 class HomematicipWaterDetector(HomematicipGenericDevice, BinarySensorDevice):

--- a/homeassistant/components/binary_sensor/homematicip_cloud.py
+++ b/homeassistant/components/binary_sensor/homematicip_cloud.py
@@ -15,9 +15,6 @@ DEPENDENCIES = ['homematicip_cloud']
 
 _LOGGER = logging.getLogger(__name__)
 
-STATE_SMOKE_OFF = 'IDLE_OFF'
-
-
 async def async_setup_platform(
         hass, config, async_add_entities, discovery_info=None):
     """Set up the HomematicIP Cloud binary sensor devices."""
@@ -95,7 +92,8 @@ class HomematicipSmokeDetector(HomematicipGenericDevice, BinarySensorDevice):
     @property
     def is_on(self):
         """Return true if smoke is detected."""
-        return str(self._device.smokeDetectorAlarmType) != STATE_SMOKE_OFF
+        from homematicip.base.enums import SmokeDetectorAlarmType
+        return self._device.smokeDetectorAlarmType != SmokeDetectorAlarmType.IDLE_OFF
 
 
 class HomematicipWaterDetector(HomematicipGenericDevice, BinarySensorDevice):

--- a/homeassistant/components/homematicip_cloud/__init__.py
+++ b/homeassistant/components/homematicip_cloud/__init__.py
@@ -19,7 +19,7 @@ from .const import (
 from .device import HomematicipGenericDevice  # noqa: F401
 from .hap import HomematicipAuth, HomematicipHAP  # noqa: F401
 
-REQUIREMENTS = ['homematicip==0.10.3']
+REQUIREMENTS = ['homematicip==0.10.4']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -529,7 +529,7 @@ homeassistant-pyozw==0.1.2
 # homekit==0.12.2
 
 # homeassistant.components.homematicip_cloud
-homematicip==0.10.3
+homematicip==0.10.4
 
 # homeassistant.components.google
 # homeassistant.components.remember_the_milk

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -113,7 +113,7 @@ holidays==0.9.9
 home-assistant-frontend==20190121.1
 
 # homeassistant.components.homematicip_cloud
-homematicip==0.10.3
+homematicip==0.10.4
 
 # homeassistant.components.influxdb
 # homeassistant.components.sensor.influxdb


### PR DESCRIPTION
## Description:
the current version will think, that there is a smoke detected due an EnumValue != String comparison which will result to be always true -> smoke detected

additionally a tilted window will now be considered as open

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.