### PR TITLE
history allowed to load states with invalid entity IDs

### DIFF
--- a/homeassistant/components/recorder/models.py
+++ b/homeassistant/components/recorder/models.py
@@ -131,6 +131,9 @@ class States(Base):   # type: ignore
                 _process_timestamp(self.last_changed),
                 _process_timestamp(self.last_updated),
                 context=context,
+                # Temp, because database can still store invalid entity IDs
+                # Remove with 1.0 or in 2020.
+                temp_invalid_id_bypass=True
             )
         except ValueError:
             # When json.loads fails

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -664,11 +664,14 @@ class State:
                  attributes: Optional[Dict] = None,
                  last_changed: Optional[datetime.datetime] = None,
                  last_updated: Optional[datetime.datetime] = None,
-                 context: Optional[Context] = None) -> None:
+                 context: Optional[Context] = None,
+                 # Temp, because database can still store invalid entity IDs
+                 # Remove with 1.0 or in 2020.
+                 temp_invalid_id_bypass: Optional[bool] = False) -> None:
         """Initialize a new state."""
         state = str(state)
 
-        if not valid_entity_id(entity_id):
+        if not valid_entity_id(entity_id) and not temp_invalid_id_bypass:
             raise InvalidEntityFormatError((
                 "Invalid entity id encountered: {}. "
                 "Format should be <domain>.<object_id>").format(entity_id))

--- a/tests/components/recorder/test_models.py
+++ b/tests/components/recorder/test_models.py
@@ -142,3 +142,12 @@ class TestRecorderRuns(unittest.TestCase):
 
         assert sorted(run.entity_ids()) == ['sensor.humidity', 'sensor.lux']
         assert run.entity_ids(in_run2) == ['sensor.humidity']
+
+
+def test_states_from_native_invalid_entity_id():
+    """Test loading a state from an invalid entity ID."""
+    event = States()
+    event.entity_id = "test.invalid__id"
+    event.attributes = "{}"
+    state = event.to_native()
+    assert state.entity_id == 'test.invalid__id'


### PR DESCRIPTION
## Description:
Yet another slugify fallout… history would contain invalid IDs, which are convered to HA States before being rendered as JSON (yes, that's very inefficient and we should fix that, but not in this PR).

Exception would occur when converting to native, as it blew up on the invalid entity ID. Solution is to temporarily allow history to disable the slugify validation when restoring states.

**Related issue (if applicable):** fixes #20371

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
