### PR TITLE
0.86.2

### DIFF
--- a/homeassistant/components/hue/light.py
+++ b/homeassistant/components/hue/light.py
@@ -228,9 +228,6 @@ class HueLight(Light):
             self.is_philips = light.manufacturername == 'Philips'
             self.gamut_typ = self.light.colorgamuttype
             self.gamut = self.light.colorgamut
-            if not self.gamut:
-                err_msg = 'Can not get color gamut of light "%s"'
-                _LOGGER.warning(err_msg, self.name)
 
     @property
     def unique_id(self):

--- a/homeassistant/components/recorder/models.py
+++ b/homeassistant/components/recorder/models.py
@@ -131,6 +131,9 @@ class States(Base):   # type: ignore
                 _process_timestamp(self.last_changed),
                 _process_timestamp(self.last_updated),
                 context=context,
+                # Temp, because database can still store invalid entity IDs
+                # Remove with 1.0 or in 2020.
+                temp_invalid_id_bypass=True
             )
         except ValueError:
             # When json.loads fails

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -2,7 +2,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 86
-PATCH_VERSION = '1'
+PATCH_VERSION = '2'
 __short_version__ = '{}.{}'.format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = '{}.{}'.format(__short_version__, PATCH_VERSION)
 REQUIRED_PYTHON_VER = (3, 5, 3)

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -663,11 +663,14 @@ class State:
                  attributes: Optional[Dict] = None,
                  last_changed: Optional[datetime.datetime] = None,
                  last_updated: Optional[datetime.datetime] = None,
-                 context: Optional[Context] = None) -> None:
+                 context: Optional[Context] = None,
+                 # Temp, because database can still store invalid entity IDs
+                 # Remove with 1.0 or in 2020.
+                 temp_invalid_id_bypass: Optional[bool] = False) -> None:
         """Initialize a new state."""
         state = str(state)
 
-        if not valid_entity_id(entity_id):
+        if not valid_entity_id(entity_id) and not temp_invalid_id_bypass:
             raise InvalidEntityFormatError((
                 "Invalid entity id encountered: {}. "
                 "Format should be <domain>.<object_id>").format(entity_id))

--- a/tests/components/recorder/test_models.py
+++ b/tests/components/recorder/test_models.py
@@ -142,3 +142,12 @@ class TestRecorderRuns(unittest.TestCase):
 
         assert sorted(run.entity_ids()) == ['sensor.humidity', 'sensor.lux']
         assert run.entity_ids(in_run2) == ['sensor.humidity']
+
+
+def test_states_from_native_invalid_entity_id():
+    """Test loading a state from an invalid entity ID."""
+    event = States()
+    event.entity_id = "test.invalid__id"
+    event.attributes = "{}"
+    state = event.to_native()
+    assert state.entity_id == 'test.invalid__id'


### PR DESCRIPTION
- Philips Hue - Remove unnessesary warning ([@starkillerOG] - [#20394]) ([hue docs])
- history allowed to load states with invalid entity IDs ([@balloob] - [#20399])

[#20394]: https://github.com/home-assistant/home-assistant/pull/20394
[#20399]: https://github.com/home-assistant/home-assistant/pull/20399
[@balloob]: https://github.com/balloob
[@starkillerOG]: https://github.com/starkillerOG
[hue docs]: https://www.home-assistant.io/components/hue/