### PR TITLE
Separate embedded mqtt broker status from client_config

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -354,10 +354,7 @@ async def _async_setup_server(hass: HomeAssistantType, config: ConfigType):
         await server.async_start(
             hass, conf.get(CONF_PASSWORD), conf.get(CONF_EMBEDDED))
 
-    if not success:
-        return None
-
-    return broker_config
+    return success, broker_config
 
 
 async def _async_setup_discovery(hass: HomeAssistantType, conf: ConfigType,
@@ -407,23 +404,24 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
                 "mqtt/broker#embedded-broker for details")
             return False
 
-        broker_config = await _async_setup_server(hass, config)
+        success, broker_config = await _async_setup_server(hass, config)
 
-        if broker_config is None:
+        if not success:
             _LOGGER.error("Unable to start embedded MQTT broker")
             return False
 
-        conf.update({
-            CONF_BROKER: broker_config[0],
-            CONF_PORT: broker_config[1],
-            CONF_USERNAME: broker_config[2],
-            CONF_PASSWORD: broker_config[3],
-            CONF_CERTIFICATE: broker_config[4],
-            CONF_PROTOCOL: broker_config[5],
-            CONF_CLIENT_KEY: None,
-            CONF_CLIENT_CERT: None,
-            CONF_TLS_INSECURE: None,
-        })
+        if broker_config:
+            conf.update({
+                CONF_BROKER: broker_config[0],
+                CONF_PORT: broker_config[1],
+                CONF_USERNAME: broker_config[2],
+                CONF_PASSWORD: broker_config[3],
+                CONF_CERTIFICATE: broker_config[4],
+                CONF_PROTOCOL: broker_config[5],
+                CONF_CLIENT_KEY: None,
+                CONF_CLIENT_CERT: None,
+                CONF_TLS_INSECURE: None,
+            })
 
     hass.data[DATA_MQTT_CONFIG] = conf
 


### PR DESCRIPTION
## Description:
To have the embedded mqtt broker work with a custom config, we need to
separate the client config bit from the broker status bits.

In lower layers they where already separate but in higher layers they
where merged, but in a faulty way. That caused HA to think the broker
setup failed, when it didn't generate a client_config.

When running a embedded mqtt broker with some custom config, one needs
also to provide a client config which works with that broker setup.

## Example entry for `configuration.yaml` (if applicable):
```yaml
mqtt:
  broker: 1.2.3.4
  password: !secret mqtt_pw
  client_id: homeassistant
  discovery: True
  embedded:
    auth:
      #plugins: ['auth_anonymous']
      plugins: []
      allow-anonymous: false
      password-file:  !secret mqtt_pw_file
    topic-check:
      enabled: False
    listeners:
      default:
        type: tcp
        max-connections: 1024
        bind: 1.2.3.4:1883
```