### PR TITLE
Fix cast platform album name property

### DIFF
--- a/homeassistant/components/media_player/cast.py
+++ b/homeassistant/components/media_player/cast.py
@@ -613,7 +613,7 @@ class CastDevice(MediaPlayerDevice):
         return self.media_status.artist if self.media_status else None
 
     @property
-    def media_album(self):
+    def media_album_name(self):
         """Album of current playing media (Music track only)."""
         return self.media_status.album_name if self.media_status else None
 


### PR DESCRIPTION
## Description:
Fixed album name property. It was named wrong, correct name taken from: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/media_player/__init__.py#L72

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**