### PR TITLE
html5 notifications add VAPID support

### DIFF
--- a/homeassistant/components/notify/html5.py
+++ b/homeassistant/components/notify/html5.py
@@ -158,17 +158,18 @@ def _load_config(filename):
 
 
 class HTML5ApplicationServerKeyView(HomeAssistantView):
-    """To fetch applicationServerKey from a browser."""
+    """To fetch application_server_key from a browser."""
 
     url = '/api/notify.html5/applicationServerKey'
     name = 'api:notify.html5:applicationServerKey'
 
-    def __init__(self, applicationServerKey):
+    def __init__(self, application_server_key):
         """Init HTMLApplicationServerKeyView."""
-        self.applicationServerKey = applicationServerKey
+        self.application_server_key = application_server_key
 
     async def get(self, request):
-        return self.json_message(self.applicationServerKey)
+        """Accept the GET request for application_server_key."""
+        return self.json_message(self.application_server_key)
 
 
 class HTML5PushRegistrationView(HomeAssistantView):

--- a/homeassistant/components/notify/html5.py
+++ b/homeassistant/components/notify/html5.py
@@ -136,8 +136,7 @@ def get_service(hass, config, discovery_info=None):
     vapid_prv_key = config.get(ATTR_VAPID_PRV_KEY)
     vapid_email = config.get(ATTR_VAPID_EMAIL)
 
-    @websocket_api.async_response
-    async def websocket_appkey(hass, connection, msg):
+    def websocket_appkey(hass, connection, msg):
         connection.send_message(
             websocket_api.result_message(msg['id'], vapid_pub_key))
 

--- a/homeassistant/components/notify/html5.py
+++ b/homeassistant/components/notify/html5.py
@@ -39,10 +39,16 @@ SERVICE_DISMISS = 'html5_dismiss'
 
 ATTR_GCM_SENDER_ID = 'gcm_sender_id'
 ATTR_GCM_API_KEY = 'gcm_api_key'
+ATTR_VAPID_PUB_KEY = 'vapid_pub_key'
+ATTR_VAPID_PRV_KEY = 'vapid_prv_key'
+ATTR_VAPID_EMAIL = 'vapid_email'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(ATTR_GCM_SENDER_ID): cv.string,
     vol.Optional(ATTR_GCM_API_KEY): cv.string,
+    vol.Optional(ATTR_VAPID_PUB_KEY): cv.string,
+    vol.Optional(ATTR_VAPID_PRV_KEY): cv.string,
+    vol.Optional(ATTR_VAPID_EMAIL): cv.string,
 })
 
 ATTR_SUBSCRIPTION = 'subscription'
@@ -120,6 +126,12 @@ def get_service(hass, config, discovery_info=None):
     if registrations is None:
         return None
 
+    vapid_pub_key = config.get(ATTR_VAPID_PUB_KEY)
+    vapid_prv_key = config.get(ATTR_VAPID_PRV_KEY)
+    vapid_email = config.get(ATTR_VAPID_EMAIL)
+
+    hass.http.register_view(HTML5ApplicationServerKeyView(vapid_pub_key))
+
     hass.http.register_view(
         HTML5PushRegistrationView(registrations, json_path))
     hass.http.register_view(HTML5PushCallbackView(registrations))
@@ -132,7 +144,8 @@ def get_service(hass, config, discovery_info=None):
             ATTR_GCM_SENDER_ID, config.get(ATTR_GCM_SENDER_ID))
 
     return HTML5NotificationService(
-        hass, gcm_api_key, registrations, json_path)
+        hass, gcm_api_key, vapid_prv_key, vapid_email, registrations,
+        json_path)
 
 
 def _load_config(filename):
@@ -142,6 +155,20 @@ def _load_config(filename):
     except HomeAssistantError:
         pass
     return {}
+
+
+class HTML5ApplicationServerKeyView(HomeAssistantView):
+    """To fetch applicationServerKey from a browser."""
+
+    url = '/api/notify.html5/applicationServerKey'
+    name = 'api:notify.html5:applicationServerKey'
+
+    def __init__(self, applicationServerKey):
+        """Init HTMLApplicationServerKeyView."""
+        self.applicationServerKey = applicationServerKey
+
+    async def get(self, request):
+        return self.json_message(self.applicationServerKey)
 
 
 class HTML5PushRegistrationView(HomeAssistantView):
@@ -336,9 +363,12 @@ class HTML5PushCallbackView(HomeAssistantView):
 class HTML5NotificationService(BaseNotificationService):
     """Implement the notification service for HTML5."""
 
-    def __init__(self, hass, gcm_key, registrations, json_path):
+    def __init__(self, hass, gcm_key, vapid_prv, vapid_email, registrations,
+                 json_path):
         """Initialize the service."""
         self._gcm_key = gcm_key
+        self._vapid_prv = vapid_prv
+        self._vapid_claims = {"sub": "mailto:{}".format(vapid_email)}
         self.registrations = registrations
         self.registrations_json_path = json_path
 
@@ -425,7 +455,7 @@ class HTML5NotificationService(BaseNotificationService):
     def _push_message(self, payload, **kwargs):
         """Send the message."""
         import jwt
-        from pywebpush import WebPusher
+        from pywebpush import WebPusher, webpush
 
         timestamp = int(time.time())
 
@@ -452,14 +482,23 @@ class HTML5NotificationService(BaseNotificationService):
             jwt_token = jwt.encode(jwt_claims, jwt_secret).decode('utf-8')
             payload[ATTR_DATA][ATTR_JWT] = jwt_token
 
-            # Only pass the gcm key if we're actually using GCM
-            # If we don't, notifications break on FireFox
-            gcm_key = self._gcm_key \
-                if 'googleapis.com' in info[ATTR_SUBSCRIPTION][ATTR_ENDPOINT] \
-                else None
-            response = WebPusher(info[ATTR_SUBSCRIPTION]).send(
-                json.dumps(payload), gcm_key=gcm_key, ttl='86400'
-            )
+            if self._vapid_prv and self._vapid_claims:
+                response = webpush(
+                    info[ATTR_SUBSCRIPTION],
+                    json.dumps(payload),
+                    vapid_private_key=self._vapid_prv,
+                    vapid_claims=self._vapid_claims
+                )
+            else:
+                # Only pass the gcm key if we're actually using GCM
+                # If we don't, notifications break on FireFox
+                gcm_key = self._gcm_key \
+                    if 'googleapis.com' \
+                    in info[ATTR_SUBSCRIPTION][ATTR_ENDPOINT] \
+                    else None
+                response = WebPusher(info[ATTR_SUBSCRIPTION]).send(
+                    json.dumps(payload), gcm_key=gcm_key, ttl='86400'
+                )
 
             if response.status_code == 410:
                 _LOGGER.info("Notification channel has expired")


### PR DESCRIPTION
## Description:
> As of April 10, 2018, Google has deprecated GCM. The GCM server and client APIs are deprecated and will be removed as soon as April 11, 2019. Migrate GCM apps to Firebase Cloud Messaging (FCM), which inherits the reliable and scalable GCM infrastructure, plus many new features. See the migration guide to learn more.

> How will this affect Web APIs (Webpush protocol and chrome.gcm API)?
For Chrome extensions, keep an eye on chrome.gcm API deprecation plans.
For Webpush protocol, start using Voluntary Application Identification when subscribing to PushManager.

Add support for VAPID.

**Pull request in [home-assistant-polymer](https://github.com/home-assistant/home-assistant-polymer) with documentation (if applicable):** home-assistant/home-assistant-polymer#2560
**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8279

## Example entry for `configuration.yaml` (if applicable):
```yaml
notify:
  - platform: html5
    vapid_pub_key: <public key>
    vapid_prv_key: <private key>
    vapid_email: <email>
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
