### PR TITLE
Add a human-friendly "last_tripped" attribute to envisialink binary sensors

### DIFF
--- a/homeassistant/components/binary_sensor/envisalink.py
+++ b/homeassistant/components/binary_sensor/envisalink.py
@@ -13,17 +13,19 @@ from homeassistant.components.binary_sensor import BinarySensorDevice
 from homeassistant.components.envisalink import (
     DATA_EVL, ZONE_SCHEMA, CONF_ZONENAME, CONF_ZONETYPE, EnvisalinkDevice,
     SIGNAL_ZONE_UPDATE)
-from homeassistant.const import ATTR_LAST_TRIP_TIME
+from homeassistant.const import ATTR_LAST_TRIP_TIME, ATTR_LAST_TRIPPED
 from homeassistant.util import dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = ['envisalink']
-
+REQUIREMENTS = ['humanize==0.5.1']
 
 async def async_setup_platform(hass, config, async_add_entities,
                                discovery_info=None):
     """Set up the Envisalink binary sensor devices."""
+    import humanize
+
     configured_zones = discovery_info['zones']
 
     devices = []
@@ -78,10 +80,13 @@ class EnvisalinkBinarySensor(EnvisalinkDevice, BinarySensorDevice):
             now = dt_util.now().replace(microsecond=0)
             delta = datetime.timedelta(seconds=seconds_ago)
             last_trip_time = (now - delta).isoformat()
+            last_tripped = humanize.naturaltime(delta)
         else:
             last_trip_time = None
+            last_tripped = None
 
         attr[ATTR_LAST_TRIP_TIME] = last_trip_time
+        attr[ATTR_LAST_TRIPPED] = last_tripped
         return attr
 
     @property

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -288,6 +288,10 @@ ATTR_TRIPPED = 'device_tripped'
 # time the device was tripped
 ATTR_LAST_TRIP_TIME = 'last_tripped_time'
 
+# For sensors that support 'tripping' this holds a friendly
+# version of the time since the device was tripped, eg. "12 seconds ago"
+ATTR_LAST_TRIPPED = 'last_tripped'
+
 # For all entity's, this hold whether or not it should be hidden
 ATTR_HIDDEN = 'hidden'
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -538,6 +538,9 @@ httplib2==0.10.3
 # homeassistant.components.huawei_lte
 huawei-lte-api==1.1.3
 
+# homeassistant.components.binary_sensor.envisalink
+humanize==0.5.1
+
 # homeassistant.components.hydrawise
 hydrawiser==0.1.1
 


### PR DESCRIPTION
## Description:

Adds a simple human friendly attribute showing the time since the sensor was last tripped. I thought it would look good in Lovelace.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
