### PR TITLE
Use more up-to-date version of pyfoscam library

### DIFF
--- a/homeassistant/components/camera/foscam.py
+++ b/homeassistant/components/camera/foscam.py
@@ -15,7 +15,7 @@ from homeassistant.helpers import config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['libpyfoscam==1.0']
+REQUIREMENTS = ['pyfoscam==1.2']
 
 CONF_IP = 'ip'
 
@@ -43,7 +43,7 @@ class FoscamCam(Camera):
 
     def __init__(self, device_info):
         """Initialize a Foscam camera."""
-        from libpyfoscam import FoscamCamera
+        from foscam import FoscamCamera
 
         super(FoscamCam, self).__init__()
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -599,9 +599,6 @@ libnacl==1.6.1
 # homeassistant.components.dyson
 libpurecoollink==0.4.2
 
-# homeassistant.components.camera.foscam
-pyfoscam==1.2
-
 # homeassistant.components.device_tracker.mikrotik
 librouteros==2.2.0
 
@@ -1007,6 +1004,9 @@ pyflunearyou==1.0.1
 
 # homeassistant.components.light.futurenow
 pyfnip==0.2
+
+# homeassistant.components.camera.foscam
+pyfoscam==1.2
 
 # homeassistant.components.fritzbox
 pyfritzhome==0.4.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -600,7 +600,7 @@ libnacl==1.6.1
 libpurecoollink==0.4.2
 
 # homeassistant.components.camera.foscam
-libpyfoscam==1.0
+pyfoscam==1.2
 
 # homeassistant.components.device_tracker.mikrotik
 librouteros==2.2.0


### PR DESCRIPTION
## Description:
There are several differnent foscam libraries, all pretty similar.  It seems that an old, un-maintained version is currently being used.  Just redirecting this to one that is more actively maintained and has some newer bug fixes that I have already tested and confirmed work on my local installation.  Should not break any existing installations.


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
