### PR TITLE
Error handling for recorder purge

### DIFF
--- a/homeassistant/components/recorder/purge.py
+++ b/homeassistant/components/recorder/purge.py
@@ -12,28 +12,27 @@ _LOGGER = logging.getLogger(__name__)
 def purge_old_data(instance, purge_days, repack):
     """Purge events and states older than purge_days ago."""
     from .models import States, Events
+    from sqlalchemy.exc import SQLAlchemyError
 
     purge_before = dt_util.utcnow() - timedelta(days=purge_days)
     _LOGGER.debug("Purging events before %s", purge_before)
 
-    with session_scope(session=instance.get_session()) as session:
-        deleted_rows = session.query(States) \
-            .filter((States.last_updated < purge_before)) \
-            .delete(synchronize_session=False)
-        _LOGGER.debug("Deleted %s states", deleted_rows)
+    try:
+        with session_scope(session=instance.get_session()) as session:
+            deleted_rows = session.query(States) \
+                .filter((States.last_updated < purge_before)) \
+                .delete(synchronize_session=False)
+            _LOGGER.debug("Deleted %s states", deleted_rows)
 
-        deleted_rows = session.query(Events) \
-            .filter((Events.time_fired < purge_before)) \
-            .delete(synchronize_session=False)
-        _LOGGER.debug("Deleted %s events", deleted_rows)
+            deleted_rows = session.query(Events) \
+                .filter((Events.time_fired < purge_before)) \
+                .delete(synchronize_session=False)
+            _LOGGER.debug("Deleted %s events", deleted_rows)
 
-    # Execute sqlite vacuum command to free up space on disk
-    _LOGGER.debug("DB engine driver: %s", instance.engine.driver)
-    if repack and instance.engine.driver == 'pysqlite':
-        from sqlalchemy import exc
-
-        _LOGGER.debug("Vacuuming SQLite to free space")
-        try:
+        # Execute sqlite vacuum command to free up space on disk
+        if repack and instance.engine.driver == 'pysqlite':
+            _LOGGER.debug("Vacuuming SQLite to free space")
             instance.engine.execute("VACUUM")
-        except exc.OperationalError as err:
-            _LOGGER.error("Error vacuuming SQLite: %s.", err)
+
+    except SQLAlchemyError as err:
+        _LOGGER.warning("Error purging history: %s.", err)

--- a/tests/components/recorder/test_purge.py
+++ b/tests/components/recorder/test_purge.py
@@ -170,5 +170,5 @@ class TestRecorderPurge(unittest.TestCase):
                                         service_data=service_data)
                 self.hass.block_till_done()
                 self.hass.data[DATA_INSTANCE].block_till_done()
-                assert mock_logger.debug.mock_calls[4][1][0] == \
+                assert mock_logger.debug.mock_calls[3][1][0] == \
                     "Vacuuming SQLite to free space"


### PR DESCRIPTION
## Description:

A database error during recorder purge could result in an uncaught exception that would kill the recorder thread.

We already had exception handling for the vacuum operation so I extended that to cover the entire purge.

**Related issue (if applicable):** fixes #14271 (or at least sweetens it)

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.
  - [X] There is no commented out code in this PR.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.
