### PR TITLE
Revert "Expose more information about shipments by PostNL (#18334)"

### DIFF
--- a/homeassistant/components/sensor/postnl.py
+++ b/homeassistant/components/sensor/postnl.py
@@ -59,9 +59,7 @@ class PostNLSensor(Entity):
     def __init__(self, api, name):
         """Initialize the PostNL sensor."""
         self._name = name
-        self._attributes = {
-            ATTR_ATTRIBUTION: ATTRIBUTION,
-        }
+        self._attributes = None
         self._state = None
         self._api = api
 
@@ -94,5 +92,18 @@ class PostNLSensor(Entity):
     def update(self):
         """Update device state."""
         shipments = self._api.get_relevant_shipments()
-        self._attributes['shipments'] = shipments
-        self._state = len(shipments)
+        status_counts = {}
+
+        for shipment in shipments:
+            status = shipment['status']['formatted']['short']
+            status = self._api.parse_datetime(status, '%d-%m-%Y', '%H:%M')
+
+            name = shipment['settings']['title']
+            status_counts[name] = status
+
+        self._attributes = {
+            ATTR_ATTRIBUTION: ATTRIBUTION,
+            **status_counts
+        }
+
+        self._state = len(status_counts)


### PR DESCRIPTION
This reverts commit 8c27bf8c7c20973c105ff94c96b4a90c24991c41.

## Description:

This undoes a regression causing the postNL sensor to no longer give useful info:
![image](https://user-images.githubusercontent.com/1885159/51764436-7f74e180-20d5-11e9-93ff-d6078eee15b1.png)

Relevant pull request: #18334 