### PR TITLE
RFC: Add system health component

### DIFF
--- a/homeassistant/components/system_health/__init__.py
+++ b/homeassistant/components/system_health/__init__.py
@@ -1,6 +1,7 @@
 """System health component."""
 import asyncio
 from collections import OrderedDict
+import logging
 from typing import Callable, Dict
 
 import async_timeout
@@ -14,6 +15,7 @@ from homeassistant.components import websocket_api
 DEPENDENCIES = ['http']
 DOMAIN = 'system_health'
 INFO_CALLBACK_TIMEOUT = 5
+_LOGGER = logging.getLogger(__name__)
 
 
 @bind_hass
@@ -40,6 +42,11 @@ async def _info_wrapper(hass, info_callback):
     except asyncio.TimeoutError:
         return {
             'error': 'Fetching info timed out'
+        }
+    except Exception as err:  # pylint: disable=W0703
+        _LOGGER.exception("Error fetching info")
+        return {
+            'error': str(err)
         }
 
 

--- a/homeassistant/components/system_health/__init__.py
+++ b/homeassistant/components/system_health/__init__.py
@@ -1,0 +1,47 @@
+"""System health component."""
+from collections import OrderedDict
+from typing import Callable, Dict
+from aiohttp.web import Request, Response, json_response
+
+from homeassistant.core import callback
+from homeassistant.loader import bind_hass
+from homeassistant.helpers.typing import HomeAssistantType, ConfigType
+from homeassistant.components.http.view import HomeAssistantView
+
+DEPENDENCIES = ['http']
+DOMAIN = 'system_health'
+
+
+@bind_hass
+@callback
+def async_register_info(hass: HomeAssistantType, domain: str,
+                        info_callback: Callable[[HomeAssistantType], Dict]):
+    """Register an info callback."""
+    data = hass.data.setdefault(
+        DOMAIN, OrderedDict()).setdefault('info', OrderedDict())
+    data[domain] = info_callback
+
+
+async def async_setup(hass: HomeAssistantType, config: ConfigType):
+    """Set up the System Health component."""
+    hass.http.register_view(InfoView)
+    return True
+
+
+class InfoView(HomeAssistantView):
+    """HTTP endpoint to offer health info."""
+
+    url = "/api/system_health/info"
+    name = "api:system_health:info"
+
+    async def get(self, request: Request) -> Response:
+        """Handle GET request."""
+        hass = request.app['hass']  # type: HomeAssistantType
+        info_callbacks = hass.data.get(DOMAIN, {}).get('info', {}).items()
+        data = OrderedDict()
+        data['homeassistant'] = await hass.components.updater.get_system_info()
+
+        for domain, info_callback in info_callbacks:
+            data[domain] = info_callback(hass)
+
+        return json_response(data)

--- a/homeassistant/components/system_health/__init__.py
+++ b/homeassistant/components/system_health/__init__.py
@@ -56,10 +56,11 @@ async def handle_info(hass: HomeAssistantType,
     data['homeassistant'] = \
         await hass.helpers.system_info.async_get_system_info()
 
-    for domain, domain_data in zip(info_callbacks, await asyncio.gather(*[
-            _info_wrapper(hass, info_callback) for info_callback
-            in info_callbacks.values()
-    ])):
-        data[domain] = domain_data
+    if info_callbacks:
+        for domain, domain_data in zip(info_callbacks, await asyncio.gather(*[
+                _info_wrapper(hass, info_callback) for info_callback
+                in info_callbacks.values()
+        ])):
+            data[domain] = domain_data
 
     connection.send_message(websocket_api.result_message(msg['id'], data))

--- a/homeassistant/components/system_health/__init__.py
+++ b/homeassistant/components/system_health/__init__.py
@@ -39,10 +39,10 @@ class InfoView(HomeAssistantView):
         hass = request.app['hass']  # type: HomeAssistantType
         info_callbacks = hass.data.get(DOMAIN, {}).get('info', {})
         data = OrderedDict()
-        data['homeassistant'] = await hass.components.updater.get_system_info()
+        data['homeassistant'] = \
+            await hass.helpers.system_info.async_get_system_info(hass)
 
         for domain, info_callback in info_callbacks.items():
-            print(domain, info_callback)
             data[domain] = info_callback(hass)
 
         return json_response(data)

--- a/homeassistant/components/system_health/__init__.py
+++ b/homeassistant/components/system_health/__init__.py
@@ -37,11 +37,12 @@ class InfoView(HomeAssistantView):
     async def get(self, request: Request) -> Response:
         """Handle GET request."""
         hass = request.app['hass']  # type: HomeAssistantType
-        info_callbacks = hass.data.get(DOMAIN, {}).get('info', {}).items()
+        info_callbacks = hass.data.get(DOMAIN, {}).get('info', {})
         data = OrderedDict()
         data['homeassistant'] = await hass.components.updater.get_system_info()
 
-        for domain, info_callback in info_callbacks:
+        for domain, info_callback in info_callbacks.items():
+            print(domain, info_callback)
             data[domain] = info_callback(hass)
 
         return json_response(data)

--- a/homeassistant/components/updater.py
+++ b/homeassistant/components/updater.py
@@ -18,8 +18,9 @@ import aiohttp
 import async_timeout
 import voluptuous as vol
 
-from homeassistant.const import ATTR_FRIENDLY_NAME
-from homeassistant.const import __version__ as current_version
+from homeassistant.const import (
+    ATTR_FRIENDLY_NAME, __version__ as current_version)
+from homeassistant.loader import bind_hass
 from homeassistant.helpers import event
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
@@ -124,7 +125,8 @@ async def async_setup(hass, config):
     return True
 
 
-async def get_system_info(hass, include_components):
+@bind_hass
+async def get_system_info(hass, include_components=False):
     """Return info about the system."""
     info_object = {
         'arch': platform.machine(),

--- a/homeassistant/components/updater.py
+++ b/homeassistant/components/updater.py
@@ -125,7 +125,7 @@ async def get_newest_version(hass, huuid, include_components):
     """Get the newest Home Assistant version."""
     if huuid:
         info_object = \
-            await hass.helpers.system_info.async_get_system_info(hass)
+            await hass.helpers.system_info.async_get_system_info()
 
         if include_components:
             info_object['components'] = list(hass.config.components)

--- a/homeassistant/components/updater.py
+++ b/homeassistant/components/updater.py
@@ -10,8 +10,6 @@ from datetime import timedelta
 from distutils.version import StrictVersion
 import json
 import logging
-import os
-import platform
 import uuid
 
 import aiohttp
@@ -20,12 +18,10 @@ import voluptuous as vol
 
 from homeassistant.const import (
     ATTR_FRIENDLY_NAME, __version__ as current_version)
-from homeassistant.loader import bind_hass
 from homeassistant.helpers import event
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.dt as dt_util
-from homeassistant.util.package import is_virtual_env
 
 REQUIREMENTS = ['distro==1.3.0']
 
@@ -125,45 +121,14 @@ async def async_setup(hass, config):
     return True
 
 
-@bind_hass
-async def get_system_info(hass, include_components=False):
-    """Return info about the system."""
-    info_object = {
-        'arch': platform.machine(),
-        'dev': 'dev' in current_version,
-        'docker': False,
-        'os_name': platform.system(),
-        'python_version': platform.python_version(),
-        'timezone': dt_util.DEFAULT_TIME_ZONE.zone,
-        'version': current_version,
-        'virtualenv': is_virtual_env(),
-        'hassio': hass.components.hassio.is_hassio(),
-    }
-
-    if include_components:
-        info_object['components'] = list(hass.config.components)
-
-    if platform.system() == 'Windows':
-        info_object['os_version'] = platform.win32_ver()[0]
-    elif platform.system() == 'Darwin':
-        info_object['os_version'] = platform.mac_ver()[0]
-    elif platform.system() == 'FreeBSD':
-        info_object['os_version'] = platform.release()
-    elif platform.system() == 'Linux':
-        import distro
-        linux_dist = await hass.async_add_job(
-            distro.linux_distribution, False)
-        info_object['distribution'] = linux_dist[0]
-        info_object['os_version'] = linux_dist[1]
-        info_object['docker'] = os.path.isfile('/.dockerenv')
-
-    return info_object
-
-
 async def get_newest_version(hass, huuid, include_components):
     """Get the newest Home Assistant version."""
     if huuid:
-        info_object = await get_system_info(hass, include_components)
+        info_object = \
+            await hass.helpers.system_info.async_get_system_info(hass)
+        if include_components:
+            info_object['components'] = list(hass.config.components)
+
         info_object['huuid'] = huuid
     else:
         info_object = {}

--- a/homeassistant/components/updater.py
+++ b/homeassistant/components/updater.py
@@ -126,8 +126,16 @@ async def get_newest_version(hass, huuid, include_components):
     if huuid:
         info_object = \
             await hass.helpers.system_info.async_get_system_info(hass)
+
         if include_components:
             info_object['components'] = list(hass.config.components)
+
+        import distro
+
+        linux_dist = await hass.async_add_executor_job(
+            distro.linux_distribution, False)
+        info_object['distribution'] = linux_dist[0]
+        info_object['os_version'] = linux_dist[1]
 
         info_object['huuid'] = huuid
     else:

--- a/homeassistant/components/websocket_api/__init__.py
+++ b/homeassistant/components/websocket_api/__init__.py
@@ -22,13 +22,22 @@ result_message = messages.result_message
 async_response = decorators.async_response
 require_admin = decorators.require_admin
 ws_require_user = decorators.ws_require_user
+websocket_command = decorators.websocket_command
 # pylint: enable=invalid-name
 
 
 @bind_hass
 @callback
-def async_register_command(hass, command, handler, schema):
+def async_register_command(hass, command_or_handler, handler=None,
+                           schema=None):
     """Register a websocket command."""
+    # pylint: disable=protected-access
+    if handler is None:
+        handler = command_or_handler
+        command = handler._ws_command
+        schema = handler._ws_schema
+    else:
+        command = command_or_handler
     handlers = hass.data.get(DOMAIN)
     if handlers is None:
         handlers = hass.data[DOMAIN] = {}

--- a/homeassistant/components/websocket_api/decorators.py
+++ b/homeassistant/components/websocket_api/decorators.py
@@ -98,3 +98,17 @@ def ws_require_user(
         return check_current_user
 
     return validator
+
+
+def websocket_command(schema):
+    """Tag a function as a websocket command."""
+    command = schema['type']
+
+    def decorate(func):
+        """Decorate ws command function."""
+        # pylint: disable=protected-access
+        func._ws_schema = messages.BASE_COMMAND_MESSAGE_SCHEMA.extend(schema)
+        func._ws_command = command
+        return func
+
+    return decorate

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -105,6 +105,9 @@ map:
 # Track the sun
 sun:
 
+# Allow diagnosing system problems
+system_health:
+
 # Sensors
 sensor:
   # Weather prediction

--- a/homeassistant/helpers/system_info.py
+++ b/homeassistant/helpers/system_info.py
@@ -20,7 +20,7 @@ async def async_get_system_info(hass: HomeAssistantType) -> Dict:
         'python_version': platform.python_version(),
         'docker': False,
         'arch': platform.machine(),
-        'timezone': hass.config.time_zone,
+        'timezone': str(hass.config.time_zone),
         'os_name': platform.system(),
     }
 

--- a/homeassistant/helpers/system_info.py
+++ b/homeassistant/helpers/system_info.py
@@ -31,11 +31,6 @@ async def async_get_system_info(hass: HomeAssistantType) -> Dict:
     elif platform.system() == 'FreeBSD':
         info_object['os_version'] = platform.release()
     elif platform.system() == 'Linux':
-        import distro
-        linux_dist = await hass.async_add_executor_job(
-            distro.linux_distribution, False)
-        info_object['distribution'] = linux_dist[0]
-        info_object['os_version'] = linux_dist[1]
         info_object['docker'] = os.path.isfile('/.dockerenv')
 
     return info_object

--- a/homeassistant/helpers/system_info.py
+++ b/homeassistant/helpers/system_info.py
@@ -1,0 +1,42 @@
+"""Helper to gather system info."""
+import os
+import platform
+from typing import Dict
+
+from homeassistant.const import __version__ as current_version
+from homeassistant.loader import bind_hass
+import homeassistant.util.dt as dt_util
+from homeassistant.util.package import is_virtual_env
+from .typing import HomeAssistantType
+
+
+@bind_hass
+async def async_get_system_info(hass: HomeAssistantType) -> Dict:
+    """Return info about the system."""
+    info_object = {
+        'version': current_version,
+        'dev': 'dev' in current_version,
+        'hassio': hass.components.hassio.is_hassio(),
+        'virtualenv': is_virtual_env(),
+        'python_version': platform.python_version(),
+        'docker': False,
+        'arch': platform.machine(),
+        'timezone': hass.config.time_zone,
+        'os_name': platform.system(),
+    }
+
+    if platform.system() == 'Windows':
+        info_object['os_version'] = platform.win32_ver()[0]
+    elif platform.system() == 'Darwin':
+        info_object['os_version'] = platform.mac_ver()[0]
+    elif platform.system() == 'FreeBSD':
+        info_object['os_version'] = platform.release()
+    elif platform.system() == 'Linux':
+        import distro
+        linux_dist = await hass.async_add_executor_job(
+            distro.linux_distribution, False)
+        info_object['distribution'] = linux_dist[0]
+        info_object['os_version'] = linux_dist[1]
+        info_object['docker'] = os.path.isfile('/.dockerenv')
+
+    return info_object

--- a/homeassistant/helpers/system_info.py
+++ b/homeassistant/helpers/system_info.py
@@ -5,7 +5,6 @@ from typing import Dict
 
 from homeassistant.const import __version__ as current_version
 from homeassistant.loader import bind_hass
-import homeassistant.util.dt as dt_util
 from homeassistant.util.package import is_virtual_env
 from .typing import HomeAssistantType
 

--- a/tests/components/system_health/__init__.py
+++ b/tests/components/system_health/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the system health component."""

--- a/tests/components/system_health/test_init.py
+++ b/tests/components/system_health/test_init.py
@@ -11,7 +11,7 @@ from tests.common import mock_coro
 @pytest.fixture
 def mock_system_info():
     """Mock system info."""
-    with patch('homeassistant.components.updater.get_system_info',
+    with patch('homeassistant.helpers.system_info.async_get_system_info',
                return_value=mock_coro({'hello': True})):
         yield
 

--- a/tests/components/system_health/test_init.py
+++ b/tests/components/system_health/test_init.py
@@ -4,7 +4,6 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant.setup import async_setup_component
-# from homeassistant.components import system_health
 
 from tests.common import mock_coro
 

--- a/tests/components/system_health/test_init.py
+++ b/tests/components/system_health/test_init.py
@@ -1,6 +1,6 @@
 """Tests for the system health component init."""
 import asyncio
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -13,7 +13,7 @@ from tests.common import mock_coro
 def mock_system_info():
     """Mock system info."""
     with patch('homeassistant.helpers.system_info.async_get_system_info',
-               return_value=mock_coro({'hello': True})):
+               Mock(return_value=mock_coro({'hello': True}))):
         yield
 
 

--- a/tests/components/system_health/test_init.py
+++ b/tests/components/system_health/test_init.py
@@ -1,0 +1,57 @@
+"""Tests for the system health component init."""
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.setup import async_setup_component
+# from homeassistant.components import system_health
+
+from tests.common import mock_coro
+
+
+@pytest.fixture
+def mock_system_info():
+    """Mock system info."""
+    with patch('homeassistant.components.updater.get_system_info',
+               return_value=mock_coro({'hello': True})):
+        yield
+
+
+async def test_info_endpoint_requires_auth(hass, aiohttp_client):
+    """Test that the info endpoint requires auth."""
+    assert await async_setup_component(hass, 'system_health', {})
+    client = await aiohttp_client(hass.http.app)
+    resp = await client.get('/api/system_health/info')
+    assert resp.status == 401
+
+
+async def test_info_endpoint_return_info(hass, hass_client,
+                                         mock_system_info):
+    """Test that the info endpoint requires auth."""
+    assert await async_setup_component(hass, 'system_health', {})
+    client = await hass_client()
+
+    resp = await client.get('/api/system_health/info')
+    assert resp.status == 200
+    data = await resp.json()
+
+    assert len(data) == 1
+    data = data['homeassistant']
+    assert data == {'hello': True}
+
+
+async def test_info_endpoint_register_callback(hass, hass_client,
+                                               mock_system_info):
+    """Test that the info endpoint requires auth."""
+    hass.components.system_health.async_register_info(
+        'lovelace', lambda hass: {'storage': 'YAML'})
+    assert await async_setup_component(hass, 'system_health', {})
+    client = await hass_client()
+
+    resp = await client.get('/api/system_health/info')
+    assert resp.status == 200
+    data = await resp.json()
+
+    assert len(data) == 2
+    data = data['lovelace']
+    assert data == {'storage': 'YAML'}

--- a/tests/components/system_health/test_init.py
+++ b/tests/components/system_health/test_init.py
@@ -54,3 +54,4 @@ async def test_info_endpoint_register_callback(hass, hass_client,
     assert len(data) == 2
     data = data['lovelace']
     assert data == {'storage': 'YAML'}
+    assert False, data

--- a/tests/components/system_health/test_init.py
+++ b/tests/components/system_health/test_init.py
@@ -10,11 +10,11 @@ from tests.common import mock_coro
 
 
 @pytest.fixture
-def mock_system_info():
+def mock_system_info(hass):
     """Mock system info."""
-    with patch('homeassistant.helpers.system_info.async_get_system_info',
-               Mock(return_value=mock_coro({'hello': True}))):
-        yield
+    hass.helpers.system_info.async_get_system_info = Mock(
+        return_value=mock_coro({'hello': True})
+    )
 
 
 async def test_info_endpoint_return_info(hass, hass_ws_client,

--- a/tests/components/system_health/test_init.py
+++ b/tests/components/system_health/test_init.py
@@ -1,6 +1,6 @@
 """Tests for the system health component init."""
 import asyncio
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pytest
 

--- a/tests/components/system_health/test_init.py
+++ b/tests/components/system_health/test_init.py
@@ -16,40 +16,40 @@ def mock_system_info():
         yield
 
 
-async def test_info_endpoint_requires_auth(hass, aiohttp_client):
-    """Test that the info endpoint requires auth."""
-    assert await async_setup_component(hass, 'system_health', {})
-    client = await aiohttp_client(hass.http.app)
-    resp = await client.get('/api/system_health/info')
-    assert resp.status == 401
-
-
-async def test_info_endpoint_return_info(hass, hass_client,
+async def test_info_endpoint_return_info(hass, hass_ws_client,
                                          mock_system_info):
     """Test that the info endpoint requires auth."""
     assert await async_setup_component(hass, 'system_health', {})
-    client = await hass_client()
+    client = await hass_ws_client(hass)
 
-    resp = await client.get('/api/system_health/info')
-    assert resp.status == 200
-    data = await resp.json()
+    resp = await client.send_json({
+        'id': 6,
+        'type': 'system_health/info',
+    })
+    resp = await client.receive_json()
+    assert resp['success']
+    data = resp['result']
 
     assert len(data) == 1
     data = data['homeassistant']
     assert data == {'hello': True}
 
 
-async def test_info_endpoint_register_callback(hass, hass_client,
+async def test_info_endpoint_register_callback(hass, hass_ws_client,
                                                mock_system_info):
     """Test that the info endpoint requires auth."""
     hass.components.system_health.async_register_info(
         'lovelace', lambda hass: {'storage': 'YAML'})
     assert await async_setup_component(hass, 'system_health', {})
-    client = await hass_client()
+    client = await hass_ws_client(hass)
 
-    resp = await client.get('/api/system_health/info')
-    assert resp.status == 200
-    data = await resp.json()
+    resp = await client.send_json({
+        'id': 6,
+        'type': 'system_health/info',
+    })
+    resp = await client.receive_json()
+    assert resp['success']
+    data = resp['result']
 
     assert len(data) == 2
     data = data['lovelace']

--- a/tests/components/system_health/test_init.py
+++ b/tests/components/system_health/test_init.py
@@ -54,4 +54,3 @@ async def test_info_endpoint_register_callback(hass, hass_client,
     assert len(data) == 2
     data = data['lovelace']
     assert data == {'storage': 'YAML'}
-    assert False, data

--- a/tests/components/test_updater.py
+++ b/tests/components/test_updater.py
@@ -8,7 +8,8 @@ import pytest
 from homeassistant.setup import async_setup_component
 from homeassistant.components import updater
 import homeassistant.util.dt as dt_util
-from tests.common import async_fire_time_changed, mock_coro, mock_component
+from tests.common import (
+    async_fire_time_changed, mock_coro, mock_component, MockDependency)
 
 NEW_VERSION = '10000.0'
 MOCK_VERSION = '10.0'
@@ -21,6 +22,13 @@ MOCK_RESPONSE = {
 MOCK_CONFIG = {updater.DOMAIN: {
     'reporting': True
 }}
+
+@pytest.fixture(autouse=True)
+def mock_distro():
+    """Mock distro dep."""
+    with MockDependency('distro'):
+        yield
+
 
 
 @pytest.fixture

--- a/tests/components/test_updater.py
+++ b/tests/components/test_updater.py
@@ -100,29 +100,11 @@ def test_disable_reporting(hass, mock_get_uuid, mock_get_newest_version):
 
 
 @asyncio.coroutine
-def test_enabled_component_info(hass, mock_get_uuid):
-    """Test if new entity is created if new version is available."""
-    with patch('homeassistant.components.updater.platform.system',
-               Mock(return_value="junk")):
-        res = yield from updater.get_system_info(hass, True)
-        assert 'components' in res, 'Updater failed to generate component list'
-
-
-@asyncio.coroutine
-def test_disable_component_info(hass, mock_get_uuid):
-    """Test if new entity is created if new version is available."""
-    with patch('homeassistant.components.updater.platform.system',
-               Mock(return_value="junk")):
-        res = yield from updater.get_system_info(hass, False)
-        assert 'components' not in res, 'Updater failed, components generate'
-
-
-@asyncio.coroutine
 def test_get_newest_version_no_analytics_when_no_huuid(hass, aioclient_mock):
     """Test we do not gather analytics when no huuid is passed in."""
     aioclient_mock.post(updater.UPDATER_URL, json=MOCK_RESPONSE)
 
-    with patch('homeassistant.components.updater.get_system_info',
+    with patch('homeassistant.helpers.system_info.async_get_system_info',
                side_effect=Exception):
         res = yield from updater.get_newest_version(hass, None, False)
         assert res == (MOCK_RESPONSE['version'],
@@ -134,7 +116,7 @@ def test_get_newest_version_analytics_when_huuid(hass, aioclient_mock):
     """Test we do not gather analytics when no huuid is passed in."""
     aioclient_mock.post(updater.UPDATER_URL, json=MOCK_RESPONSE)
 
-    with patch('homeassistant.components.updater.get_system_info',
+    with patch('homeassistant.helpers.system_info.async_get_system_info',
                Mock(return_value=mock_coro({'fake': 'bla'}))):
         res = yield from updater.get_newest_version(hass, MOCK_HUUID, False)
         assert res == (MOCK_RESPONSE['version'],
@@ -144,7 +126,7 @@ def test_get_newest_version_analytics_when_huuid(hass, aioclient_mock):
 @asyncio.coroutine
 def test_error_fetching_new_version_timeout(hass):
     """Test we do not gather analytics when no huuid is passed in."""
-    with patch('homeassistant.components.updater.get_system_info',
+    with patch('homeassistant.helpers.system_info.async_get_system_info',
                Mock(return_value=mock_coro({'fake': 'bla'}))), \
             patch('async_timeout.timeout', side_effect=asyncio.TimeoutError):
         res = yield from updater.get_newest_version(hass, MOCK_HUUID, False)
@@ -156,7 +138,7 @@ def test_error_fetching_new_version_bad_json(hass, aioclient_mock):
     """Test we do not gather analytics when no huuid is passed in."""
     aioclient_mock.post(updater.UPDATER_URL, text='not json')
 
-    with patch('homeassistant.components.updater.get_system_info',
+    with patch('homeassistant.helpers.system_info.async_get_system_info',
                Mock(return_value=mock_coro({'fake': 'bla'}))):
         res = yield from updater.get_newest_version(hass, MOCK_HUUID, False)
         assert res is None
@@ -170,7 +152,7 @@ def test_error_fetching_new_version_invalid_response(hass, aioclient_mock):
         # 'release-notes' is missing
     })
 
-    with patch('homeassistant.components.updater.get_system_info',
+    with patch('homeassistant.helpers.system_info.async_get_system_info',
                Mock(return_value=mock_coro({'fake': 'bla'}))):
         res = yield from updater.get_newest_version(hass, MOCK_HUUID, False)
         assert res is None

--- a/tests/components/test_updater.py
+++ b/tests/components/test_updater.py
@@ -23,12 +23,12 @@ MOCK_CONFIG = {updater.DOMAIN: {
     'reporting': True
 }}
 
+
 @pytest.fixture(autouse=True)
 def mock_distro():
     """Mock distro dep."""
     with MockDependency('distro'):
         yield
-
 
 
 @pytest.fixture

--- a/tests/helpers/test_system_info.py
+++ b/tests/helpers/test_system_info.py
@@ -1,0 +1,9 @@
+"""Tests for the system info helper."""
+from homeassistant.const import __version__ as current_version
+
+
+async def test_get_system_info(hass):
+    """Test the get system info."""
+    info = await hass.helpers.system_info.async_get_system_info()
+    assert isinstance(info, dict)
+    assert info['version'] == current_version

--- a/tests/helpers/test_system_info.py
+++ b/tests/helpers/test_system_info.py
@@ -1,4 +1,6 @@
 """Tests for the system info helper."""
+import json
+
 from homeassistant.const import __version__ as current_version
 
 
@@ -7,3 +9,4 @@ async def test_get_system_info(hass):
     info = await hass.helpers.system_info.async_get_system_info()
     assert isinstance(info, dict)
     assert info['version'] == current_version
+    assert json.dumps(info) is not None


### PR DESCRIPTION
## Description:
Was talking with Tinkerer, and we came to the conclusion that we should prioritize adding this component as it will help with helping (how meta).

Goal is to get a place in the UI to show the info on the machine. This will help people with diagnosing problems. 

Some RFC about this implementation:
 - Right now info is just a callback function (not awaitable) to get some static info. 
 - Idea is to add a diagnostics view that allows components to actually run some tests (like is network connected, can I reach the internet, is HA Cloud reachable etc). I am not sure if this is something that we should make part of the same info registration method or add a new one.

UI will look something like this:

 - System
   - OS: HassOS
   - Version: 2.6
 - Lovelace
   - Storage: YAML


**Related issue (if applicable):** fixes https://github.com/home-assistant/architecture/issues/114

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** TODO home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
system_health:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
