### PR TITLE
Update device registry of MQTT cover

### DIFF
--- a/homeassistant/components/mqtt/cover.py
+++ b/homeassistant/components/mqtt/cover.py
@@ -140,7 +140,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         try:
             discovery_hash = discovery_payload[ATTR_DISCOVERY_HASH]
             config = PLATFORM_SCHEMA(discovery_payload)
-            await _async_setup_entity(config, async_add_entities,
+            await _async_setup_entity(config, async_add_entities, config_entry,
                                       discovery_hash)
         except Exception:
             if discovery_hash:
@@ -152,16 +152,17 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         async_discover)
 
 
-async def _async_setup_entity(config, async_add_entities, discovery_hash=None):
+async def _async_setup_entity(config, async_add_entities, config_entry=None,
+                              discovery_hash=None):
     """Set up the MQTT Cover."""
-    async_add_entities([MqttCover(config, discovery_hash)])
+    async_add_entities([MqttCover(config, config_entry, discovery_hash)])
 
 
 class MqttCover(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
                 MqttEntityDeviceInfo, CoverDevice):
     """Representation of a cover that can be controlled using MQTT."""
 
-    def __init__(self, config, discovery_hash):
+    def __init__(self, config, config_entry, discovery_hash):
         """Initialize the cover."""
         self._unique_id = config.get(CONF_UNIQUE_ID)
         self._position = None
@@ -181,7 +182,7 @@ class MqttCover(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
         MqttAvailability.__init__(self, config)
         MqttDiscoveryUpdate.__init__(self, discovery_hash,
                                      self.discovery_update)
-        MqttEntityDeviceInfo.__init__(self, device_config)
+        MqttEntityDeviceInfo.__init__(self, device_config, config_entry)
 
     async def async_added_to_hass(self):
         """Subscribe MQTT events."""
@@ -194,6 +195,7 @@ class MqttCover(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
         self._setup_from_config(config)
         await self.attributes_discovery_update(config)
         await self.availability_discovery_update(config)
+        await self.device_info_discovery_update(config)
         await self._subscribe_topics()
         self.async_schedule_update_ha_state()
 

--- a/tests/components/mqtt/test_cover.py
+++ b/tests/components/mqtt/test_cover.py
@@ -1293,6 +1293,53 @@ async def test_entity_device_info_with_identifier(hass, mqtt_mock):
     assert device.sw_version == '0.1-beta'
 
 
+async def test_entity_device_info_update(hass, mqtt_mock):
+    """Test device registry update."""
+    entry = MockConfigEntry(domain=mqtt.DOMAIN)
+    entry.add_to_hass(hass)
+    await async_start(hass, 'homeassistant', {}, entry)
+    registry = await hass.helpers.device_registry.async_get_registry()
+
+    config = {
+        'platform': 'mqtt',
+        'name': 'Test 1',
+        'state_topic': 'test-topic',
+        'command_topic': 'test-command-topic',
+        'device': {
+            'identifiers': ['helloworld'],
+            'connections': [
+                ["mac", "02:5b:26:a8:dc:12"],
+            ],
+            'manufacturer': 'Whatever',
+            'name': 'Beer',
+            'model': 'Glass',
+            'sw_version': '0.1-beta',
+        },
+        'unique_id': 'veryunique'
+    }
+
+    data = json.dumps(config)
+    async_fire_mqtt_message(hass, 'homeassistant/cover/bla/config',
+                            data)
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+
+    device = registry.async_get_device({('mqtt', 'helloworld')}, set())
+    assert device is not None
+    assert device.name == 'Beer'
+
+    config['device']['name'] = 'Milk'
+    data = json.dumps(config)
+    async_fire_mqtt_message(hass, 'homeassistant/cover/bla/config',
+                            data)
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+
+    device = registry.async_get_device({('mqtt', 'helloworld')}, set())
+    assert device is not None
+    assert device.name == 'Milk'
+
+
 async def test_entity_id_update(hass, mqtt_mock):
     """Test MQTT subscriptions are managed when entity_id is updated."""
     registry = mock_registry(hass, {})

--- a/tests/components/mqtt/test_cover.py
+++ b/tests/components/mqtt/test_cover.py
@@ -758,6 +758,7 @@ class TestCoverMQTT(unittest.TestCase):
                 'set_position_topic': None, 'set_position_template': None,
                 'unique_id': None, 'device_config': None,
             },
+            None,
             None)
 
         assert 44 == mqtt_cover.find_percentage_in_range(44)
@@ -788,6 +789,7 @@ class TestCoverMQTT(unittest.TestCase):
                 'set_position_topic': None, 'set_position_template': None,
                 'unique_id': None, 'device_config': None,
             },
+            None,
             None)
 
         assert 40 == mqtt_cover.find_percentage_in_range(120)
@@ -818,6 +820,7 @@ class TestCoverMQTT(unittest.TestCase):
                 'set_position_topic': None, 'set_position_template': None,
                 'unique_id': None, 'device_config': None,
             },
+            None,
             None)
 
         assert 56 == mqtt_cover.find_percentage_in_range(44)
@@ -848,6 +851,7 @@ class TestCoverMQTT(unittest.TestCase):
                 'set_position_topic': None, 'set_position_template': None,
                 'unique_id': None, 'device_config': None,
             },
+            None,
             None)
 
         assert 60 == mqtt_cover.find_percentage_in_range(120)
@@ -878,6 +882,7 @@ class TestCoverMQTT(unittest.TestCase):
                 'set_position_topic': None, 'set_position_template': None,
                 'unique_id': None, 'device_config': None,
             },
+            None,
             None)
 
         assert 44 == mqtt_cover.find_in_range_from_percent(44)
@@ -908,6 +913,7 @@ class TestCoverMQTT(unittest.TestCase):
                 'set_position_topic': None, 'set_position_template': None,
                 'unique_id': None, 'device_config': None,
             },
+            None,
             None)
 
         assert 120 == mqtt_cover.find_in_range_from_percent(40)
@@ -938,6 +944,7 @@ class TestCoverMQTT(unittest.TestCase):
                 'set_position_topic': None, 'set_position_template': None,
                 'unique_id': None, 'device_config': None,
             },
+            None,
             None)
 
         assert 44 == mqtt_cover.find_in_range_from_percent(56)
@@ -968,6 +975,7 @@ class TestCoverMQTT(unittest.TestCase):
                 'set_position_topic': None, 'set_position_template': None,
                 'unique_id': None, 'device_config': None,
             },
+            None,
             None)
 
         assert 120 == mqtt_cover.find_in_range_from_percent(60)


### PR DESCRIPTION
## Description:
Support update of device registry so Hass doesn't need to be restarted to, for example, show updated firmware version of the device.
(Based on #19540 and same as #19697 which can't be reopened after rebase)

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.