### PR TITLE
Fix WeMo device discovery issues

### DIFF
--- a/homeassistant/components/wemo.py
+++ b/homeassistant/components/wemo.py
@@ -20,8 +20,8 @@ REQUIREMENTS = ['pywemo==0.4.34']
 
 DOMAIN = 'wemo'
 
-# Mapping from Wemo device type to Home Assistant component type.
-WEMO_DEVICE_TYPE_DISPATCH = {
+# Mapping from Wemo model_name to component.
+WEMO_MODEL_DISPATCH = {
     'Bridge':  'light',
     'CoffeeMaker': 'switch',
     'Dimmer': 'light',
@@ -30,7 +30,8 @@ WEMO_DEVICE_TYPE_DISPATCH = {
     'LightSwitch': 'switch',
     'Maker':   'switch',
     'Motion': 'binary_sensor',
-    'Switch':  'switch'
+    'Sensor':  'binary_sensor',
+    'Socket':  'switch'
 }
 
 SUBSCRIPTION_REGISTRY = None
@@ -109,7 +110,7 @@ def setup(hass, config):
     def discovery_dispatch(service, discovery_info):
         """Dispatcher for incoming WeMo discovery events."""
         # name, model, location, mac
-        device_type = discovery_info.get('device_type')
+        model_name = discovery_info.get('model_name')
         serial = discovery_info.get('serial')
 
         # Only register a device once
@@ -121,7 +122,7 @@ def setup(hass, config):
         _LOGGER.debug('Discovered unique WeMo device: %s', serial)
         KNOWN_DEVICES.append(serial)
 
-        component = WEMO_DEVICE_TYPE_DISPATCH.get(device_type, 'switch')
+        component = WEMO_MODEL_DISPATCH.get(model_name, 'switch')
 
         discovery.load_platform(hass, component, DOMAIN,
                                 discovery_info, config)
@@ -165,7 +166,7 @@ def setup(hass, config):
                           device.host, device.port)
 
             discovery_info = {
-                'device_type': device.__class__.__name__,
+                'model_name': device.model_name,
                 'serial': device.serialnumber,
                 'mac_address': device.mac,
                 'ssdp_description': url,


### PR DESCRIPTION
## Description:
Revert changes made in PR #19691, which introduced the issues in #19808 and #20006.

**Related issue (if applicable):**
fixes #19808
fixes #20006

## Example entry for `configuration.yaml` (if applicable):
```yaml
wemo:
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.