### PR TITLE
Warn for old slugs/entity ids

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -166,7 +166,8 @@ async def async_from_config_dict(config: Dict[str, Any],
                 "This will become a breaking change."
             )
             msg.append('\n'.join('- {} -> {}'.format(*item)
-                                 for item in cv.INVALID_ENTITY_IDS_FOUND.items()))
+                                 for item
+                                 in cv.INVALID_ENTITY_IDS_FOUND.items()))
 
         if cv.INVALID_SLUGS_FOUND:
             msg.append(

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -14,10 +14,12 @@ from homeassistant import (
 from homeassistant.components import persistent_notification
 from homeassistant.const import EVENT_HOMEASSISTANT_CLOSE
 from homeassistant.setup import async_setup_component
+from homeassistant.util import slugify
 from homeassistant.util.logging import AsyncHandler
 from homeassistant.util.package import async_get_user_site, is_virtual_env
 from homeassistant.util.yaml import clear_secret_cache
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -152,6 +154,32 @@ async def async_from_config_dict(config: Dict[str, Any],
 
     stop = time()
     _LOGGER.info("Home Assistant initialized in %.2fs", stop-start)
+
+    # TEMP: warn users for invalid slugs
+    if cv.INVALID_SLUGS_FOUND or cv.INVALID_ENTITY_IDS_FOUND:
+        msg = []
+
+        if cv.INVALID_ENTITY_IDS_FOUND:
+            msg.append(
+                "Your configuration contains invalid entity ID references. "
+                "Please find and update the following. "
+                "This will become a breaking change."
+            )
+            msg.append('\n'.join('- {} -> {}'.format(*item)
+                       for item in cv.INVALID_ENTITY_IDS_FOUND.items()))
+
+        if cv.INVALID_SLUGS_FOUND:
+            msg.append(
+                "Your configuration contains invalid slugs. "
+                "Please find and update the following. "
+                "This will become a breaking change."
+            )
+            msg.append('\n'.join('- {} -> {}'.format(*item)
+                       for item in cv.INVALID_SLUGS_FOUND.items()))
+
+        hass.components.persistent_notification.async_create(
+            '\n\n'.join(msg), "Config Warning", "config_warning"
+        )
 
     return hass
 

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -166,7 +166,7 @@ async def async_from_config_dict(config: Dict[str, Any],
                 "This will become a breaking change."
             )
             msg.append('\n'.join('- {} -> {}'.format(*item)
-                       for item in cv.INVALID_ENTITY_IDS_FOUND.items()))
+                                 for item in cv.INVALID_ENTITY_IDS_FOUND.items()))
 
         if cv.INVALID_SLUGS_FOUND:
             msg.append(
@@ -175,7 +175,7 @@ async def async_from_config_dict(config: Dict[str, Any],
                 "This will become a breaking change."
             )
             msg.append('\n'.join('- {} -> {}'.format(*item)
-                       for item in cv.INVALID_SLUGS_FOUND.items()))
+                                 for item in cv.INVALID_SLUGS_FOUND.items()))
 
         hass.components.persistent_notification.async_create(
             '\n\n'.join(msg), "Config Warning", "config_warning"

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -14,7 +14,6 @@ from homeassistant import (
 from homeassistant.components import persistent_notification
 from homeassistant.const import EVENT_HOMEASSISTANT_CLOSE
 from homeassistant.setup import async_setup_component
-from homeassistant.util import slugify
 from homeassistant.util.logging import AsyncHandler
 from homeassistant.util.package import async_get_user_site, is_virtual_env
 from homeassistant.util.yaml import clear_secret_cache

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -156,6 +156,7 @@ async def async_from_config_dict(config: Dict[str, Any],
     _LOGGER.info("Home Assistant initialized in %.2fs", stop-start)
 
     # TEMP: warn users for invalid slugs
+    # Remove after 0.94 or 1.0
     if cv.INVALID_SLUGS_FOUND or cv.INVALID_ENTITY_IDS_FOUND:
         msg = []
 

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -1,5 +1,4 @@
 """Helpers for config validation using voluptuous."""
-from collections import OrderedDict
 from datetime import (timedelta, datetime as datetime_sys,
                       time as time_sys, date as date_sys)
 import os

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -26,7 +26,7 @@ from homeassistant.helpers import template as template_helper
 # pylint: disable=invalid-name
 
 TIME_PERIOD_ERROR = "offset {} should be format 'HH:MM' or 'HH:MM:SS'"
-OLD_SLUG_VALIDATION = r'[a-z0-9_]+'
+OLD_SLUG_VALIDATION = r'^[a-z0-9_]+$'
 OLD_ENTITY_ID_VALIDATION = r"^(\w+)\.(\w+)$"
 # Keep track of invalid slugs and entity ids found so we can create a
 # persistent notification. Rare temporary exception to use a global.
@@ -357,12 +357,11 @@ def schema_with_slug_keys(value_schema: Union[T, Callable]) -> Callable:
             except vol.Invalid:
                 # To ease the breaking change, we allow old slugs for now
                 # Remove after 0.94 or 1.0
-                if re.match(OLD_SLUG_VALIDATION,
-                            key.lower().replace(" ", "_")):
+                if re.match(OLD_SLUG_VALIDATION, key):
                     fixed = util_slugify(key)
                     INVALID_SLUGS_FOUND[key] = fixed
                     logging.getLogger(__name__).warning(
-                        "Found invalid slug %s, please update with %s. This"
+                        "Found invalid slug %s, please update with %s. This "
                         "will be come a breaking change.",
                         key, fixed
                     )

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -158,6 +158,8 @@ def entity_id(value: Any) -> str:
     if valid_entity_id(value):
         return value
     elif re.match(OLD_ENTITY_ID_VALIDATION, value):
+        # To ease the breaking change, we allow old slugs for now
+        # Remove after 0.94 or 1.0
         fixed = '.'.join(util_slugify(part) for part in value.split('.', 1))
         INVALID_ENTITY_IDS_FOUND[value] = fixed
         logging.getLogger(__name__).warning(
@@ -356,7 +358,8 @@ def schema_with_slug_keys(value_schema: Union[T, Callable]) -> Callable:
             except vol.Invalid:
                 # To ease the breaking change, we allow old slugs for now
                 # Remove after 0.94 or 1.0
-                if re.match(OLD_SLUG_VALIDATION, key.lower().replace(" ", "_")):
+                if re.match(OLD_SLUG_VALIDATION,
+                            key.lower().replace(" ", "_")):
                     fixed = util_slugify(key)
                     INVALID_SLUGS_FOUND[key] = fixed
                     logging.getLogger(__name__).warning(

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -609,13 +609,13 @@ def test_schema_with_slug_keys_allows_old_slugs(caplog):
     schema = cv.schema_with_slug_keys(str)
 
     with patch.dict(cv.INVALID_SLUGS_FOUND, clear=True):
-        for value in ('_world', 'World', 'wow__yeah'):
+        for value in ('_world', 'wow__yeah'):
             caplog.clear()
             # Will raise if not allowing old slugs
             schema({value: 'yo'})
             assert "Found invalid slug {}".format(value) in caplog.text
 
-        assert len(cv.INVALID_SLUGS_FOUND) == 3
+        assert len(cv.INVALID_SLUGS_FOUND) == 2
 
 
 def test_entity_id_allow_old_validation(caplog):

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -602,3 +602,31 @@ def test_comp_entity_ids():
     for invalid in (['light.kitchen', 'not-entity-id'], '*', ''):
         with pytest.raises(vol.Invalid):
             schema(invalid)
+
+
+def test_schema_with_slug_keys_allows_old_slugs(caplog):
+    """Test schema with slug keys allowing old slugs."""
+    schema = cv.schema_with_slug_keys(str)
+
+    with patch.dict(cv.INVALID_SLUGS_FOUND, clear=True):
+        for value in ('_world', 'World', 'wow__yeah'):
+            caplog.clear()
+            # Will raise if not allowing old slugs
+            schema({value: 'yo'})
+            assert "Found invalid slug {}".format(value) in caplog.text
+
+        assert len(cv.INVALID_SLUGS_FOUND) == 3
+
+
+def test_entity_id_allow_old_validation(caplog):
+    """Test schema allowing old entity_ids."""
+    schema = vol.Schema(cv.entity_id)
+
+    with patch.dict(cv.INVALID_ENTITY_IDS_FOUND, clear=True):
+        for value in ('hello.__world', 'great.wow__yeah'):
+            caplog.clear()
+            # Will raise if not allowing old entity ID
+            schema(value)
+            assert "Found invalid entity_id {}".format(value) in caplog.text
+
+        assert len(cv.INVALID_ENTITY_IDS_FOUND) == 2


### PR DESCRIPTION
## Description:
Undo the breaking changes of 0.86. No more core breaking changes like that.

This will warn users that have invalid Entity IDs or slugs and creates a notification.

Log messages:
 - 2019-01-26 10:13:40 WARNING (MainThread) [homeassistant.helpers.config_validation] Found invalid entity_id yolo.beer__beer, please update with yolo.beer_beer. This will become a breaking change.
 - 2019-01-26 10:13:40 WARNING (MainThread) [homeassistant.helpers.config_validation] Found invalid slug incorrect__, please update with incorrect. Thiswill be come a breaking change.

Notification:
![image](https://user-images.githubusercontent.com/1444314/51791125-2ba8dd80-2153-11e9-8fc0-eff8d5c0370f.png)

CC @pvizeli @kellerza 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
