### PR TITLE
Use HASS latitude/longitude as defaults for Lyft

### DIFF
--- a/homeassistant/components/sensor/lyft.py
+++ b/homeassistant/components/sensor/lyft.py
@@ -33,8 +33,8 @@ MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=60)
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_CLIENT_ID): cv.string,
     vol.Required(CONF_CLIENT_SECRET): cv.string,
-    vol.Required(CONF_START_LATITUDE): cv.latitude,
-    vol.Required(CONF_START_LONGITUDE): cv.longitude,
+    vol.Optional(CONF_START_LATITUDE): cv.latitude,
+    vol.Optional(CONF_START_LONGITUDE): cv.longitude,
     vol.Optional(CONF_END_LATITUDE): cv.latitude,
     vol.Optional(CONF_END_LONGITUDE): cv.longitude,
     vol.Optional(CONF_PRODUCT_IDS):
@@ -56,7 +56,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         session = auth_flow.get_session()
 
         timeandpriceest = LyftEstimate(
-            session, config[CONF_START_LATITUDE], config[CONF_START_LONGITUDE],
+            session, config.get(CONF_START_LATITUDE, hass.config.latitude),
+            config.get(CONF_START_LONGITUDE, hass.config.longitude),
             config.get(CONF_END_LATITUDE), config.get(CONF_END_LONGITUDE))
         timeandpriceest.fetch_data()
     except APIError as exc:


### PR DESCRIPTION
## Description:

The Lyft sensor currently requires starting latitude and longitude as config parameters; this PR adjusts the platform the use the HASS latitude and longitude if no starting coordinates are provided.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** https://github.com/home-assistant/home-assistant.io/pull/8297

## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: lyft
    client_id: CLIENT_ID
    client_secret: CLIENT_SECRET
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
