### PR TITLE
Upgrade to async-upnp-client==0.14.3

### DIFF
--- a/homeassistant/components/media_player/dlna_dmr.py
+++ b/homeassistant/components/media_player/dlna_dmr.py
@@ -26,7 +26,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import get_local_ip
 
-REQUIREMENTS = ['async-upnp-client==0.14.2']
+REQUIREMENTS = ['async-upnp-client==0.14.3']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/upnp/__init__.py
+++ b/homeassistant/components/upnp/__init__.py
@@ -29,7 +29,7 @@ from .const import LOGGER as _LOGGER
 from .device import Device
 
 
-REQUIREMENTS = ['async-upnp-client==0.14.2']
+REQUIREMENTS = ['async-upnp-client==0.14.3']
 
 NOTIFICATION_ID = 'upnp_notification'
 NOTIFICATION_TITLE = 'UPnP/IGD Setup'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -164,7 +164,7 @@ asterisk_mbox==0.5.0
 
 # homeassistant.components.upnp
 # homeassistant.components.media_player.dlna_dmr
-async-upnp-client==0.14.2
+async-upnp-client==0.14.3
 
 # homeassistant.components.light.avion
 # avion==0.10


### PR DESCRIPTION
## Description:

Fix to `async_upnp_client` to support HEOS-1 speakers.

**Related issue (if applicable):** fixes https://github.com/StevenLooman/async_upnp_client/issues/31

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
