### PR TITLE
Fix pjlink issue

### DIFF
--- a/homeassistant/components/media_player/pjlink.py
+++ b/homeassistant/components/media_player/pjlink.py
@@ -103,10 +103,20 @@ class PjLinkDevice(MediaPlayerDevice):
                 self._muted = projector.get_mute()[1]
                 self._current_source = \
                     format_input_source(*projector.get_input())
-            except:
-                self._pwstate = STATE_OFF
-                self._muted = False
-                self._current_source = None
+            except KeyError as err:
+                if str(err) == "'OK'":
+                    self._pwstate = STATE_OFF
+                    self._muted = False
+                    self._current_source = None
+                else:
+                    raise
+            except Exception as err:
+                if type(err).__name__ == 'ProjectorError' and str(err) == 'unavailable time':
+                    self._pwstate = STATE_OFF
+                    self._muted = False
+                    self._current_source = None
+                else:
+                    raise
 
     @property
     def name(self):

--- a/homeassistant/components/media_player/pjlink.py
+++ b/homeassistant/components/media_player/pjlink.py
@@ -93,6 +93,7 @@ class PjLinkDevice(MediaPlayerDevice):
 
     def update(self):
         """Get the latest state from the device."""
+        from pypjlink.projector import ProjectorError
         with self.projector() as projector:
             try:
                 pwstate = projector.get_power()
@@ -110,8 +111,8 @@ class PjLinkDevice(MediaPlayerDevice):
                     self._current_source = None
                 else:
                     raise
-            except Exception as err:
-                if type(err).__name__ == 'ProjectorError' and str(err) == 'unavailable time':
+            except ProjectorError as err:
+                if str(err) == 'unavailable time':
                     self._pwstate = STATE_OFF
                     self._muted = False
                     self._current_source = None

--- a/homeassistant/components/media_player/pjlink.py
+++ b/homeassistant/components/media_player/pjlink.py
@@ -94,14 +94,19 @@ class PjLinkDevice(MediaPlayerDevice):
     def update(self):
         """Get the latest state from the device."""
         with self.projector() as projector:
-            pwstate = projector.get_power()
-            if pwstate == 'off':
+            try:
+                pwstate = projector.get_power()
+                if pwstate == 'on' or pwstate == 'warm-up':
+                    self._pwstate = STATE_ON
+                else:
+                    self._pwstate = STATE_OFF
+                self._muted = projector.get_mute()[1]
+                self._current_source = \
+                    format_input_source(*projector.get_input())
+            except:
                 self._pwstate = STATE_OFF
-            else:
-                self._pwstate = STATE_ON
-            self._muted = projector.get_mute()[1]
-            self._current_source = \
-                format_input_source(*projector.get_input())
+                self._muted = False
+                self._current_source = None
 
     @property
     def name(self):

--- a/homeassistant/components/media_player/pjlink.py
+++ b/homeassistant/components/media_player/pjlink.py
@@ -97,7 +97,7 @@ class PjLinkDevice(MediaPlayerDevice):
         with self.projector() as projector:
             try:
                 pwstate = projector.get_power()
-                if pwstate == 'on' or pwstate == 'warm-up':
+                if pwstate in ('on', 'warm-up'):
                     self._pwstate = STATE_ON
                 else:
                     self._pwstate = STATE_OFF


### PR DESCRIPTION
## Description:
Some projectors do not respond to pjlink requests during a short period after the status changes or when its in standby, resulting in pypjlink2 throwing an error. This fix catches these errors. Furthermore, only the status 'on' and 'warm-up' is interpreted as switched on, because 'cooling' is actually a switched off status.

**Related issue (if applicable):** fixes #16606 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.