### PR TITLE
Check if a script requirement is available before install

### DIFF
--- a/homeassistant/scripts/__init__.py
+++ b/homeassistant/scripts/__init__.py
@@ -11,7 +11,8 @@ from pkg_resources import Requirement
 
 from homeassistant.bootstrap import async_mount_local_lib_path
 from homeassistant.config import get_default_config_dir
-from homeassistant import requirements
+from homeassistant.core import HomeAssistant
+from homeassistant.requirements import pip_kwargs, PackageLoadable
 from homeassistant.util.package import install_package, is_virtual_env
 
 
@@ -41,24 +42,25 @@ def run(args: List) -> int:
 
     config_dir = extract_config_dir()
 
-    if not is_virtual_env():
-        asyncio.get_event_loop().run_until_complete(
-            async_mount_local_lib_path(config_dir))
+    loop = asyncio.get_event_loop()
 
-    pip_kwargs = requirements.pip_kwargs(config_dir)
+    if not is_virtual_env():
+        loop.run_until_complete(async_mount_local_lib_path(config_dir))
+
+    _pip_kwargs = pip_kwargs(config_dir)
 
     logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 
+    hass = HomeAssistant(loop)
+    pkgload = PackageLoadable(hass)
     for req in getattr(script, 'REQUIREMENTS', []):
         try:
-            # Only use the requirement's project_name to verify it exists
-            project_name = Requirement.parse(req).project_name
-            importlib.import_module(project_name)
+            loop.run_until_complete(pkgload.loadable(req))
             continue
         except ImportError:
             pass
 
-        returncode = install_package(req, **pip_kwargs)
+        returncode = install_package(req, **_pip_kwargs)
 
         if not returncode:
             print('Aborting script, could not install dependency', req)

--- a/homeassistant/scripts/__init__.py
+++ b/homeassistant/scripts/__init__.py
@@ -7,8 +7,6 @@ import os
 import sys
 from typing import List
 
-from pkg_resources import Requirement
-
 from homeassistant.bootstrap import async_mount_local_lib_path
 from homeassistant.config import get_default_config_dir
 from homeassistant.core import HomeAssistant

--- a/homeassistant/scripts/__init__.py
+++ b/homeassistant/scripts/__init__.py
@@ -7,6 +7,8 @@ import os
 import sys
 from typing import List
 
+from pkg_resources import Requirement
+
 from homeassistant.bootstrap import async_mount_local_lib_path
 from homeassistant.config import get_default_config_dir
 from homeassistant import requirements
@@ -48,6 +50,14 @@ def run(args: List) -> int:
     logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 
     for req in getattr(script, 'REQUIREMENTS', []):
+        try:
+            # Only use the requirement's project_name to verify it exists
+            project_name = Requirement.parse(req).project_name
+            importlib.import_module(project_name)
+            continue
+        except ImportError:
+            pass
+
         returncode = install_package(req, **pip_kwargs)
 
         if not returncode:

--- a/homeassistant/scripts/check_config.py
+++ b/homeassistant/scripts/check_config.py
@@ -22,8 +22,6 @@ from homeassistant.util import yaml
 from homeassistant.exceptions import HomeAssistantError
 
 REQUIREMENTS = ('colorlog==4.0.2',)
-if system() == 'Windows':  # Ensure colorama installed for colorlog on Windows
-    REQUIREMENTS += ('colorama<=1',)
 
 _LOGGER = logging.getLogger(__name__)
 # pylint: disable=protected-access

--- a/homeassistant/scripts/check_config.py
+++ b/homeassistant/scripts/check_config.py
@@ -5,7 +5,6 @@ import logging
 import os
 from collections import OrderedDict, namedtuple
 from glob import glob
-from platform import system
 from typing import Dict, List, Sequence
 from unittest.mock import patch
 


### PR DESCRIPTION
## Description:
Retry of #20272

- Current behaviour always installs a script's requirement


- ~~This checks if a requirement's project name is available (by import) before it forces install~~

~~There is full (including version) requirement handling available in `requirements.py`, but this requires a full hass instance and seems like an overkill for scripts~~


**Related issue (if applicable):** fixes #18651 

```bash
hass --script check_config
INFO:homeassistant.util.package:Attempting install of colorlog==4.0.2
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
