### PR TITLE
Fix Tellduslive device info

### DIFF
--- a/homeassistant/components/tellduslive/entry.py
+++ b/homeassistant/components/tellduslive/entry.py
@@ -116,10 +116,17 @@ class TelldusLiveEntity(Entity):
     def device_info(self):
         """Return device info."""
         device = self._client.device_info(self.device.device_id)
-        return {
+        device_info = {
             'identifiers': {('tellduslive', self.device.device_id)},
             'name': self.device.name,
-            'model': device['model'].title(),
-            'manufacturer': device['protocol'].title(),
-            'via_hub': ('tellduslive', device.get('client')),
         }
+        model = device.get('model')
+        if model is not None:
+            device_info['model'] = model.title()
+        protocol = device.get('protocol')
+        if protocol is not None:
+            device_info['manufacturer'] = protocol.title()
+        client = device.get('client')
+        if client is not None:
+            device_info['via_hub'] = ('tellduslive', client)
+        return device_info


### PR DESCRIPTION
## Description:

Fixes issue when the API does not report **model** and/or **protocol**, which causes `device_info` to crash.

**Related issue (if applicable):** fixes #20387 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
