### PR TITLE
Add missing switch for motion_detect

### DIFF
--- a/homeassistant/components/android_ip_webcam.py
+++ b/homeassistant/components/android_ip_webcam.py
@@ -123,8 +123,9 @@ ICON_MAP = {
     'whitebalance_lock': 'mdi:white-balance-auto'
 }
 
-SWITCHES = ['exposure_lock', 'ffc', 'focus', 'gps_active', 'night_vision',
-            'overlay', 'torch', 'whitebalance_lock', 'video_recording']
+SWITCHES = ['exposure_lock', 'ffc', 'focus', 'gps_active',
+            'motion_detect', 'night_vision', 'overlay',
+            'torch', 'whitebalance_lock', 'video_recording']
 
 SENSORS = ['audio_connections', 'battery_level', 'battery_temp',
            'battery_voltage', 'light', 'motion', 'pressure', 'proximity',


### PR DESCRIPTION
## Description:
Add switch for motion_detect.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>
https://github.com/home-assistant/home-assistant/issues/20539

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)
