### PR TITLE
Homekit controller BLE groundwork (part 2)

### DIFF
--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -272,6 +272,13 @@ class HomeKitEntity(Entity):
                 'type': ctype,
                 'value': result['value'],
             }])
+            # Callback to update the entity with this characteristic value
+            char_name = escape_characteristic_name(self._char_names[iid])
+            update_fn = getattr(self, '_update_{}'.format(char_name), None)
+            if not update_fn:
+                continue
+            # pylint: disable=E1102
+            update_fn(result['value'])
 
     @property
     def unique_id(self):
@@ -294,7 +301,7 @@ class HomeKitEntity(Entity):
 
     def update_characteristics(self, characteristics):
         """Synchronise a HomeKit device state with Home Assistant."""
-        raise NotImplementedError
+        pass
 
     def put_characteristics(self, characteristics):
         """Control a HomeKit device state from Home Assistant."""

--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -247,7 +247,7 @@ class HomeKitEntity(Entity):
         setup_fn = getattr(self, '_setup_{}'.format(setup_fn_name), None)
         if not setup_fn:
             return
-        # pylint: disable=E1102
+        # pylint: disable=not-callable
         setup_fn(char)
 
     def update(self):
@@ -270,7 +270,7 @@ class HomeKitEntity(Entity):
             update_fn = getattr(self, '_update_{}'.format(char_name), None)
             if not update_fn:
                 continue
-            # pylint: disable=E1102
+            # pylint: disable=not-callable
             update_fn(result['value'])
 
     @property

--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -254,7 +254,6 @@ class HomeKitEntity(Entity):
         """Obtain a HomeKit device's state."""
         # pylint: disable=import-error
         from homekit.exceptions import AccessoryDisconnectedError
-        from homekit.model.characteristics import CharacteristicsTypes
 
         pairing = self._accessory.pairing
 
@@ -266,12 +265,6 @@ class HomeKitEntity(Entity):
         for (_, iid), result in new_values_dict.items():
             if 'value' not in result:
                 continue
-            ctype = CharacteristicsTypes.get_uuid(
-                'public.hap.characteristic.' + self._char_names[iid])
-            self.update_characteristics([{
-                'type': ctype,
-                'value': result['value'],
-            }])
             # Callback to update the entity with this characteristic value
             char_name = escape_characteristic_name(self._char_names[iid])
             update_fn = getattr(self, '_update_{}'.format(char_name), None)

--- a/homeassistant/components/homekit_controller/alarm_control_panel.py
+++ b/homeassistant/components/homekit_controller/alarm_control_panel.py
@@ -64,18 +64,11 @@ class HomeKitAlarmControlPanel(HomeKitEntity, AlarmControlPanel):
             CharacteristicsTypes.BATTERY_LEVEL,
         ]
 
-    def update_characteristics(self, characteristics):
-        """Synchronise the Alarm Control Panel state with Home Assistant."""
-        # pylint: disable=import-error
-        from homekit.model.characteristics import CharacteristicsTypes
+    def _update_security_system_state_current(self, value):
+        self._state = CURRENT_STATE_MAP[value]
 
-        for characteristic in characteristics:
-            ctype = characteristic['type']
-            ctype = CharacteristicsTypes.get_short(ctype)
-            if ctype == "security-system-state.current":
-                self._state = CURRENT_STATE_MAP[characteristic['value']]
-            elif ctype == "battery-level":
-                self._battery_level = characteristic['value']
+    def _update_battery_level(self, value):
+        self._battery_level = value
 
     @property
     def icon(self):

--- a/homeassistant/components/homekit_controller/climate.py
+++ b/homeassistant/components/homekit_controller/climate.py
@@ -72,23 +72,17 @@ class HomeKitClimateDevice(HomeKitEntity, ClimateDevice):
     def _setup_temperature_target(self, characteristic):
         self._features |= SUPPORT_TARGET_TEMPERATURE
 
-    def update_characteristics(self, characteristics):
-        """Synchronise device state with Home Assistant."""
-        # pylint: disable=import-error
-        from homekit.model.characteristics import CharacteristicsTypes
+    def _update_heating_cooling_current(self, value):
+        self._state = MODE_HOMEKIT_TO_HASS.get(value)
 
-        for characteristic in characteristics:
-            ctype = CharacteristicsTypes.get_short_uuid(characteristic['type'])
-            if ctype == CharacteristicsTypes.HEATING_COOLING_CURRENT:
-                self._state = MODE_HOMEKIT_TO_HASS.get(
-                    characteristic['value'])
-            if ctype == CharacteristicsTypes.HEATING_COOLING_TARGET:
-                self._current_mode = MODE_HOMEKIT_TO_HASS.get(
-                    characteristic['value'])
-            elif ctype == CharacteristicsTypes.TEMPERATURE_CURRENT:
-                self._current_temp = characteristic['value']
-            elif ctype == CharacteristicsTypes.TEMPERATURE_TARGET:
-                self._target_temp = characteristic['value']
+    def _update_heating_cooling_target(self, value):
+        self._current_mode = MODE_HOMEKIT_TO_HASS.get(value)
+
+    def _update_temperature_current(self, value):
+        self._current_temp = value
+
+    def _update_temperature_target(self, value):
+        self._target_temp = value
 
     def set_temperature(self, **kwargs):
         """Set new target temperature."""

--- a/homeassistant/components/homekit_controller/cover.py
+++ b/homeassistant/components/homekit_controller/cover.py
@@ -85,18 +85,14 @@ class HomeKitGarageDoorCover(HomeKitEntity, CoverDevice):
     def _setup_name(self, char):
         self._name = char['value']
 
-    def update_characteristics(self, characteristics):
-        """Synchronise the Cover state with Home Assistant."""
-        # pylint: disable=import-error
-        from homekit.model.characteristics import CharacteristicsTypes
+    def _update_door_state_current(self, value):
+        self._state = CURRENT_GARAGE_STATE_MAP[value]
 
-        for characteristic in characteristics:
-            ctype = characteristic['type']
-            ctype = CharacteristicsTypes.get_short(ctype)
-            if ctype == "door-state.current":
-                self._state = CURRENT_GARAGE_STATE_MAP[characteristic['value']]
-            elif ctype == "obstruction-detected":
-                self._obstruction_detected = characteristic['value']
+    def _update_obstruction_detected(self, value):
+        self._obstruction_detected = value
+
+    def _update_name(self, value):
+        self._name = value
 
     @property
     def available(self):
@@ -187,31 +183,26 @@ class HomeKitWindowCover(HomeKitEntity, CoverDevice):
     def _setup_name(self, char):
         self._name = char['value']
 
-    def update_characteristics(self, characteristics):
-        """Synchronise the Cover state with Home Assistant."""
-        # pylint: disable=import-error
-        from homekit.model.characteristics import CharacteristicsTypes
+    def _update_position_state(self, value):
+        self._state = CURRENT_WINDOW_STATE_MAP[value]
 
-        for characteristic in characteristics:
-            ctype = characteristic['type']
-            ctype = CharacteristicsTypes.get_short(ctype)
-            if ctype == "position.state":
-                if 'value' in characteristic:
-                    self._state = \
-                        CURRENT_WINDOW_STATE_MAP[characteristic['value']]
-            elif ctype == "position.current":
-                self._position = characteristic['value']
-            elif ctype == "position.hold":
-                if 'value' in characteristic:
-                    self._hold = characteristic['value']
-            elif ctype == "vertical-tilt.current":
-                if characteristic['value'] is not None:
-                    self._tilt_position = characteristic['value']
-            elif ctype == "horizontal-tilt.current":
-                if characteristic['value'] is not None:
-                    self._tilt_position = characteristic['value']
-            elif ctype == "obstruction-detected":
-                self._obstruction_detected = characteristic['value']
+    def _update_position_current(self, value):
+        self._position = value
+
+    def _update_position_hold(self, value):
+        self._hold = value
+
+    def _update_vertical_tilt_current(self, value):
+        self._tilt_position = value
+
+    def _update_horizontal_tilt_current(self, value):
+        self._tilt_position = value
+
+    def _update_obstruction_detected(self, value):
+        self._obstruction_detected = value
+
+    def _update_name(self, value):
+        self._hold = value
 
     @property
     def supported_features(self):

--- a/homeassistant/components/homekit_controller/light.py
+++ b/homeassistant/components/homekit_controller/light.py
@@ -60,24 +60,20 @@ class HomeKitLight(HomeKitEntity, Light):
     def _setup_saturation(self, char):
         self._features |= SUPPORT_COLOR
 
-    def update_characteristics(self, characteristics):
-        """Synchronise light state with Home Assistant."""
-        # pylint: disable=import-error
-        from homekit.model.characteristics import CharacteristicsTypes
+    def _update_on(self, value):
+        self._on = value
 
-        for characteristic in characteristics:
-            ctype = characteristic['type']
-            ctype = CharacteristicsTypes.get_short(ctype)
-            if ctype == "on":
-                self._on = characteristic['value']
-            elif ctype == 'brightness':
-                self._brightness = characteristic['value']
-            elif ctype == 'color-temperature':
-                self._color_temperature = characteristic['value']
-            elif ctype == "hue":
-                self._hue = characteristic['value']
-            elif ctype == "saturation":
-                self._saturation = characteristic['value']
+    def _update_brightness(self, value):
+        self._brightness = value
+
+    def _update_color_temperature(self, value):
+        self._color_temperature = value
+
+    def _update_hue(self, value):
+        self._hue = value
+
+    def _update_saturation(self, value):
+        self._saturation = value
 
     @property
     def is_on(self):

--- a/homeassistant/components/homekit_controller/lock.py
+++ b/homeassistant/components/homekit_controller/lock.py
@@ -61,18 +61,11 @@ class HomeKitLock(HomeKitEntity, LockDevice):
             CharacteristicsTypes.BATTERY_LEVEL,
         ]
 
-    def update_characteristics(self, characteristics):
-        """Synchronise the Lock state with Home Assistant."""
-        # pylint: disable=import-error
-        from homekit.model.characteristics import CharacteristicsTypes
+    def _update_lock_mechanism_current_state(self, value):
+        self._state = CURRENT_STATE_MAP[value]
 
-        for characteristic in characteristics:
-            ctype = characteristic['type']
-            ctype = CharacteristicsTypes.get_short(ctype)
-            if ctype == "lock-mechanism.current-state":
-                self._state = CURRENT_STATE_MAP[characteristic['value']]
-            elif ctype == "battery-level":
-                self._battery_level = characteristic['value']
+    def _update_battery_level(self, value):
+        self._battery_level = value
 
     @property
     def name(self):

--- a/homeassistant/components/homekit_controller/switch.py
+++ b/homeassistant/components/homekit_controller/switch.py
@@ -42,18 +42,11 @@ class HomeKitSwitch(HomeKitEntity, SwitchDevice):
             CharacteristicsTypes.OUTLET_IN_USE,
         ]
 
-    def update_characteristics(self, characteristics):
-        """Synchronise the switch state with Home Assistant."""
-        # pylint: disable=import-error
-        from homekit.model.characteristics import CharacteristicsTypes
+    def _update_on(self, value):
+        self._on = value
 
-        for characteristic in characteristics:
-            ctype = characteristic['type']
-            ctype = CharacteristicsTypes.get_short(ctype)
-            if ctype == "on":
-                self._on = characteristic['value']
-            elif ctype == "outlet-in-use":
-                self._outlet_in_use = characteristic['value']
+    def _update_outlet_in_use(self, value):
+        self._outlet_in_use = value
 
     @property
     def is_on(self):


### PR DESCRIPTION
## Description:

This is a follow up to #20538, and the last piece to get upstream from my #20345 PR. It's primary intention is to switch to `get_characteristics` for entity polling. This is the API an iPhone uses when it is polling a device. It's lighter weight - we don't need to poll the serial number of an accessory once a minute - and is an important first step towards supporting BLE HomeKit devices which are slow and often battery powered.

It also switches from looping over characteristics and comparing their short names to using callbacks, freeing up 8 characters of indentation, making the code easier to understand (IMO) and paving the way for event callbacks too.

The test fakes already support the new API introduced in this PR so work transparently without any changes.

As per the previous PR, I have split this up into seperate commits to make it easier to review. This was not how it was implemented, the first commit is entirely artificial. Regardless, the tests pass after every commit.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
