### PR TITLE
Enable auth providers to update user info upon authentication

### DIFF
--- a/homeassistant/auth/models.py
+++ b/homeassistant/auth/models.py
@@ -1,6 +1,6 @@
 """Auth models."""
 from datetime import datetime, timedelta
-from typing import Dict, List, NamedTuple, Optional  # noqa: F401
+from typing import Dict, List, Optional  # noqa: F401
 import uuid
 
 import attr
@@ -124,5 +124,9 @@ class Credentials:
     is_new = attr.ib(type=bool, default=True)
 
 
-UserMeta = NamedTuple("UserMeta",
-                      [('name', Optional[str]), ('is_active', bool)])
+@attr.s(slots=True)
+class UserMeta:
+    """Used to pass attributes to be changed on a User object."""
+
+    name = attr.ib(type=Optional[str], default=None)
+    is_active = attr.ib(type=Optional[bool], default=None)

--- a/homeassistant/auth/providers/__init__.py
+++ b/homeassistant/auth/providers/__init__.py
@@ -104,9 +104,16 @@ class AuthProvider:
             self, credentials: Credentials) -> UserMeta:
         """Return extra user metadata for credentials.
 
-        Will be used to populate info when creating a new user.
+        Will be used to populate info when creating a new user or after
+        authenticating an existing one.
+        Returning an empty UserMeta() will cause default values to be
+        used for new users and not update existing users, which also is
+        the default implementation.
+        If values should only be set for new users, check for
+        credentials.is_new and only set fields in the returned UserMeta
+        object when that's True.
         """
-        raise NotImplementedError
+        return UserMeta()
 
 
 async def auth_provider_from_config(

--- a/homeassistant/auth/providers/command_line.py
+++ b/homeassistant/auth/providers/command_line.py
@@ -126,7 +126,6 @@ class CommandLineAuthProvider(AuthProvider):
         meta = self._user_meta.get(credentials.data["username"], {})
         return UserMeta(
             name=meta.get("name"),
-            is_active=True,
         )
 
 

--- a/homeassistant/auth/providers/homeassistant.py
+++ b/homeassistant/auth/providers/homeassistant.py
@@ -257,7 +257,7 @@ class HassAuthProvider(AuthProvider):
     async def async_user_meta_for_credentials(
             self, credentials: Credentials) -> UserMeta:
         """Get extra info for this credential."""
-        return UserMeta(name=credentials.data['username'], is_active=True)
+        return UserMeta(name=credentials.data['username'])
 
     async def async_will_remove_credentials(
             self, credentials: Credentials) -> None:

--- a/homeassistant/auth/providers/insecure_example.py
+++ b/homeassistant/auth/providers/insecure_example.py
@@ -73,19 +73,16 @@ class ExampleAuthProvider(AuthProvider):
 
     async def async_user_meta_for_credentials(
             self, credentials: Credentials) -> UserMeta:
-        """Return extra user metadata for credentials.
-
-        Will be used to populate info when creating a new user.
-        """
+        """Return extra user metadata for credentials."""
         username = credentials.data['username']
         name = None
 
         for user in self.config['users']:
             if user['username'] == username:
-                name = user.get('name')
+                name = cast(Optional[str], user.get('name'))
                 break
 
-        return UserMeta(name=name, is_active=True)
+        return UserMeta(name=name)
 
 
 class ExampleLoginFlow(LoginFlow):

--- a/homeassistant/auth/providers/legacy_api_password.py
+++ b/homeassistant/auth/providers/legacy_api_password.py
@@ -82,12 +82,8 @@ class LegacyApiPasswordAuthProvider(AuthProvider):
 
     async def async_user_meta_for_credentials(
             self, credentials: Credentials) -> UserMeta:
-        """
-        Return info for the user.
-
-        Will be used to populate info when creating a new user.
-        """
-        return UserMeta(name=LEGACY_USER_NAME, is_active=True)
+        """Return info for the user."""
+        return UserMeta(name=LEGACY_USER_NAME)
 
 
 class LegacyLoginFlow(LoginFlow):

--- a/homeassistant/auth/providers/trusted_networks.py
+++ b/homeassistant/auth/providers/trusted_networks.py
@@ -85,9 +85,9 @@ class TrustedNetworksAuthProvider(AuthProvider):
             self, credentials: Credentials) -> UserMeta:
         """Return extra user metadata for credentials.
 
-        Trusted network auth provider should never create new user.
+        Trusted network auth provider doesn't update user info.
         """
-        raise NotImplementedError
+        return UserMeta()
 
     @callback
     def async_validate_access(self, ip_addr: IPAddress) -> None:

--- a/tests/auth/test_init.py
+++ b/tests/auth/test_init.py
@@ -207,7 +207,7 @@ async def test_login_as_existing_user(mock_hass):
         id='mock-user',
         is_owner=False,
         is_active=False,
-        name='Paulus',
+        name='Obsolete Name',
     ).add_to_auth_manager(manager)
     user.credentials.append(auth_models.Credentials(
         id='mock-id',
@@ -231,7 +231,7 @@ async def test_login_as_existing_user(mock_hass):
     assert user.id == 'mock-user'
     assert user.is_owner is False
     assert user.is_active is False
-    assert user.name == 'Paulus'
+    assert user.name == 'Test Name'
 
 
 async def test_linking_user_to_two_auth_providers(hass, hass_storage):


### PR DESCRIPTION
## Description:

Enable auth providers to update user info upon authentication. Can be used for common single sign on scenarios where the auth provider knows all user info (such as real name) and keeps this info in sync with systems that need it. This is particularly useful with the upcoming command_line auth provider (#19985) and e.g. LDAP.

This PR is the counterpart to an ongoing discussion in an issue in the architecture repo and serves as a proof of concept for now.

**Related issue (if applicable):** fixes https://github.com/home-assistant/architecture/issues/138

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>


## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.
