### PR TITLE
Add support for HomeKit motion sensor devices

### DIFF
--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -28,7 +28,8 @@ HOMEKIT_ACCESSORY_DISPATCH = {
     'garage-door-opener': 'cover',
     'window': 'cover',
     'window-covering': 'cover',
-    'lock-mechanism': 'lock'
+    'lock-mechanism': 'lock',
+    'motion': 'binary_sensor',
 }
 
 HOMEKIT_IGNORE = [

--- a/homeassistant/components/homekit_controller/binary_sensor.py
+++ b/homeassistant/components/homekit_controller/binary_sensor.py
@@ -1,0 +1,55 @@
+"""
+Support for Homekit motion sensors.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/binary_sensor.homekit_controller/
+"""
+import logging
+
+from homeassistant.components.homekit_controller import (HomeKitEntity,
+                                                         KNOWN_ACCESSORIES)
+from homeassistant.components.binary_sensor import BinarySensorDevice
+
+DEPENDENCIES = ['homekit_controller']
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    """Set up Homekit motion sensor support."""
+    if discovery_info is not None:
+        accessory = hass.data[KNOWN_ACCESSORIES][discovery_info['serial']]
+        add_entities([HomeKitMotionSensor(accessory, discovery_info)], True)
+
+
+class HomeKitMotionSensor(HomeKitEntity, BinarySensorDevice):
+    """Representation of a Homekit sensor."""
+
+    def __init__(self, *args):
+        """Initialise the entity."""
+        super().__init__(*args)
+        self._on = False
+
+    def get_characteristic_types(self):
+        """Define the homekit characteristics the entity is tracking."""
+        # pylint: disable=import-error
+        from homekit.model.characteristics import CharacteristicsTypes
+
+        return [
+            CharacteristicsTypes.MOTION_DETECTED,
+        ]
+
+    def _update_motion_detected(self, value):
+        self._on = value
+
+    @property
+    def device_class(self):
+        """Define this binary_sensor as a motion sensor."""
+        return 'motion'
+
+    @property
+    def is_on(self):
+        """Has motion been detected."""
+        if not self.available:
+            return False
+        return self._on

--- a/tests/components/homekit_controller/test_binary_sensor.py
+++ b/tests/components/homekit_controller/test_binary_sensor.py
@@ -1,0 +1,29 @@
+"""Basic checks for HomeKitLock."""
+from tests.components.homekit_controller.common import (
+    FakeService, setup_test_component)
+
+MOTION_DETECTED = ('motion', 'motion-detected')
+
+
+def create_sensor_motion_service():
+    """Define motion characteristics as per page 225 of HAP spec."""
+    service = FakeService('public.hap.service.sensor.motion')
+
+    cur_state = service.add_characteristic('motion-detected')
+    cur_state.value = 0
+
+    return service
+
+
+async def test_sensor_read_state(hass, utcnow):
+    """Test that we can read the state of a HomeKit motion sensor accessory."""
+    sensor = create_sensor_motion_service()
+    helper = await setup_test_component(hass, [sensor])
+
+    helper.characteristics[MOTION_DETECTED].value = False
+    state = await helper.poll_and_get_state()
+    assert state.state == 'off'
+
+    helper.characteristics[MOTION_DETECTED].value = True
+    state = await helper.poll_and_get_state()
+    assert state.state == 'on'


### PR DESCRIPTION
## Description:

Add support for polling HomeKit motion sensors.

I'm testing with an [Eve Motion](https://www.evehome.com/en/eve-motion) (on my bluetooth branch) and a homekit_python demoserver accessory based on the HAP spec (page 225). A HomeKit motion sensor will have a service of type `public.hap.service.sensor.motion` with a single required characteristic of `public.hap.characteristic.motion-detected` which is a bool. The characteristic will be set to true after motion is detected and will return to false after a minute or so with no motion detected. (In the case of the Eve Motion you can tweak this duration in the app).

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8332

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
