### PR TITLE
Fixing the openssl issue in Asuswrt

### DIFF
--- a/homeassistant/components/asuswrt.py
+++ b/homeassistant/components/asuswrt.py
@@ -14,7 +14,7 @@ from homeassistant.const import (
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.discovery import async_load_platform
 
-REQUIREMENTS = ['aioasuswrt==1.1.18']
+REQUIREMENTS = ['aioasuswrt==1.1.20']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sensor/asuswrt.py
+++ b/homeassistant/components/sensor/asuswrt.py
@@ -60,7 +60,7 @@ class AsuswrtSensor(Entity):
 
     async def async_update(self):
         """Fetch status from asuswrt."""
-        self._rates = await self._api.async_get_packets_total()
+        self._rates = await self._api.async_get_bytes_total()
         self._speed = await self._api.async_get_current_transfer_rates()
 
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -90,7 +90,7 @@ afsapi==0.0.4
 aioambient==0.1.0
 
 # homeassistant.components.asuswrt
-aioasuswrt==1.1.18
+aioasuswrt==1.1.20
 
 # homeassistant.components.device_tracker.automatic
 aioautomatic==0.6.5


### PR DESCRIPTION
## Description:
This freezes asyncssh to 1.15.0

**Related issue (if applicable):** fixes #20556

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running 