### PR TITLE
Add Transmission component 'scan_interval' option

### DIFF
--- a/homeassistant/components/transmission/__init__.py
+++ b/homeassistant/components/transmission/__init__.py
@@ -64,8 +64,8 @@ CONFIG_SCHEMA = vol.Schema({
 def setup(hass, config):
     """Set up the Transmission Component."""
     host = config[DOMAIN][CONF_HOST]
-    username = config[DOMAIN][CONF_USERNAME]
-    password = config[DOMAIN][CONF_PASSWORD]
+    username = config[DOMAIN].get(CONF_USERNAME)
+    password = config[DOMAIN].get(CONF_PASSWORD)
     port = config[DOMAIN][CONF_PORT]
     scan_interval = config[DOMAIN][CONF_SCAN_INTERVAL]
 

--- a/homeassistant/components/transmission/__init__.py
+++ b/homeassistant/components/transmission/__init__.py
@@ -63,12 +63,11 @@ CONFIG_SCHEMA = vol.Schema({
 
 def setup(hass, config):
     """Set up the Transmission Component."""
-    conf = config[DOMAIN]
-    host = conf.get(CONF_HOST)
-    username = conf.get(CONF_USERNAME)
-    password = conf.get(CONF_PASSWORD)
-    port = conf.get(CONF_PORT)
-    scan_interval = conf.get(CONF_SCAN_INTERVAL)
+    host = config[DOMAIN][CONF_HOST]
+    username = config[DOMAIN][CONF_USERNAME]
+    password = config[DOMAIN][CONF_PASSWORD]
+    port = config[DOMAIN][CONF_PORT]
+    scan_interval = config[DOMAIN][CONF_SCAN_INTERVAL]
 
     import transmissionrpc
     from transmissionrpc.error import TransmissionError

--- a/homeassistant/components/transmission/__init__.py
+++ b/homeassistant/components/transmission/__init__.py
@@ -15,7 +15,8 @@ from homeassistant.const import (
     CONF_NAME,
     CONF_PASSWORD,
     CONF_PORT,
-    CONF_USERNAME
+    CONF_USERNAME,
+    CONF_SCAN_INTERVAL
 )
 from homeassistant.helpers import discovery, config_validation as cv
 from homeassistant.helpers.event import track_time_interval
@@ -42,6 +43,8 @@ SENSOR_TYPES = {
     'started_torrents': ['Started Torrents', None],
 }
 
+DEFAULT_SCAN_INTERVAL = timedelta(seconds=120)
+
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
         vol.Required(CONF_HOST): cv.string,
@@ -50,20 +53,22 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
         vol.Optional(TURTLE_MODE, default=False): cv.boolean,
+        vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL):
+            cv.time_period,
         vol.Optional(CONF_MONITORED_CONDITIONS, default=['current_status']):
         vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
     })
 }, extra=vol.ALLOW_EXTRA)
 
-SCAN_INTERVAL = timedelta(minutes=2)
-
 
 def setup(hass, config):
     """Set up the Transmission Component."""
-    host = config[DOMAIN][CONF_HOST]
-    username = config[DOMAIN][CONF_USERNAME]
-    password = config[DOMAIN][CONF_PASSWORD]
-    port = config[DOMAIN][CONF_PORT]
+    conf = config[DOMAIN]
+    host = conf.get(CONF_HOST)
+    username = conf.get(CONF_USERNAME)
+    password = conf.get(CONF_PASSWORD)
+    port = conf.get(CONF_PORT)
+    scan_interval = conf.get(CONF_SCAN_INTERVAL)
 
     import transmissionrpc
     from transmissionrpc.error import TransmissionError
@@ -85,7 +90,7 @@ def setup(hass, config):
         """Get the latest data from Transmission."""
         tm_data.update()
 
-    track_time_interval(hass, refresh, SCAN_INTERVAL)
+    track_time_interval(hass, refresh, scan_interval)
 
     sensorconfig = {
         'sensors': config[DOMAIN][CONF_MONITORED_CONDITIONS],

--- a/homeassistant/components/transmission/sensor.py
+++ b/homeassistant/components/transmission/sensor.py
@@ -4,10 +4,12 @@ Support for monitoring the Transmission BitTorrent client API.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.transmission/
 """
+from datetime import timedelta
+
 import logging
 
 from homeassistant.components.transmission import (
-    DATA_TRANSMISSION, SENSOR_TYPES, SCAN_INTERVAL)
+    DATA_TRANSMISSION, SENSOR_TYPES)
 from homeassistant.const import STATE_IDLE
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
@@ -17,6 +19,8 @@ DEPENDENCIES = ['transmission']
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_NAME = 'Transmission'
+
+SCAN_INTERVAL = timedelta(seconds=120)
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):

--- a/homeassistant/components/transmission/switch.py
+++ b/homeassistant/components/transmission/switch.py
@@ -4,10 +4,12 @@ Support for setting the Transmission BitTorrent client Turtle Mode.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/switch.transmission/
 """
+from datetime import timedelta
+
 import logging
 
 from homeassistant.components.transmission import (
-    DATA_TRANSMISSION, SCAN_INTERVAL)
+    DATA_TRANSMISSION)
 from homeassistant.const import (
     STATE_OFF, STATE_ON)
 from homeassistant.helpers.entity import ToggleEntity
@@ -18,6 +20,8 @@ DEPENDENCIES = ['transmission']
 _LOGGING = logging.getLogger(__name__)
 
 DEFAULT_NAME = 'Transmission Turtle Mode'
+
+SCAN_INTERVAL = timedelta(seconds=120)
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes #20574

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8344

## Example entry for `configuration.yaml` (if applicable):
```yaml
  host: !secret trans_host
  port: !secret trans_port
  username: !secret trans_user
  password: !secret trans_pass
  name: trans
  scan_interval: 300
  monitored_conditions:
    - 'current_status'

```

## Checklist:
  - [x] The code change is tested and works locally.
Locally tested as custom component.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
