### PR TITLE
Bump pymodbus to 1.5.2

### DIFF
--- a/homeassistant/components/modbus.py
+++ b/homeassistant/components/modbus.py
@@ -16,7 +16,7 @@ from homeassistant.const import (
 
 DOMAIN = 'modbus'
 
-REQUIREMENTS = ['pymodbus==1.3.1']
+REQUIREMENTS = ['pymodbus==1.5.2']
 
 # Type of network
 CONF_BAUDRATE = 'baudrate'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1122,7 +1122,7 @@ pymitv==1.4.3
 pymochad==0.2.0
 
 # homeassistant.components.modbus
-pymodbus==1.3.1
+pymodbus==1.5.2
 
 # homeassistant.components.media_player.monoprice
 pymonoprice==0.3


### PR DESCRIPTION
## Description:
Bumps pymodbus to 1.5.2
It is running for more than 1 month on my Home Assistant setup, and solves pymodbus crash problems when unexpected input is received on ModBusTCP. Unfortunately I can not test if it fixes timing issues observed by others.

**Related issue (if applicable):** fixes #<18128>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

