### PR TITLE
sensor.history_stats was working in the future (fixes #20571)

### DIFF
--- a/homeassistant/components/sensor/history_stats.py
+++ b/homeassistant/components/sensor/history_stats.py
@@ -282,6 +282,13 @@ class HistoryStatsSensor(Entity):
         if end is None:
             end = start + self._duration
 
+        if start > dt_util.now():
+            # History hasn't been written yet for this period
+            return
+        if dt_util.now() < end:
+            # No point in making stats of the future
+            end = dt_util.now()
+
         self._period = start, end
 
 


### PR DESCRIPTION
## Description:
The sensor.history_stats platform was calculating future statistics which resulted in negative values

**Related issue (if applicable):** fixes #20571 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
  - platform: history_stats
    name: History Stats test
    entity_id: sensor.test
    state: 'whatever''
    type: time
    end: '{{now().replace(hour=23).replace(minute=0).replace(second=0)}}'
    duration:
      hours: 1
```
(this only fails before 22h00)

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54