### PR TITLE
Philips Hue: add prompt to update bridge/bulb

### DIFF
--- a/homeassistant/components/hue/__init__.py
+++ b/homeassistant/components/hue/__init__.py
@@ -19,7 +19,7 @@ from .bridge import HueBridge
 # Loading the config flow file will register the flow
 from .config_flow import configured_hosts
 
-REQUIREMENTS = ['aiohue==1.8.0']
+REQUIREMENTS = ['aiohue==1.9.0']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/hue/light.py
+++ b/homeassistant/components/hue/light.py
@@ -230,12 +230,18 @@ class HueLight(Light):
             self.gamut_typ = self.light.colorgamuttype
             self.gamut = self.light.colorgamut
             _LOGGER.debug("Color gamut of %s: %s", self.name, str(self.gamut))
+            if self.light.swupdatestate == "readytoinstall":
+                err = (
+                    "Please check for software updates of the bridge "
+                    "and/or the bulb: %s, in the Philips Hue App."
+                )
+                _LOGGER.warning(err, self.name)
             if self.gamut:
                 if not color.check_valid_gamut(self.gamut):
-                    err = "Please check for software updates of the bridge " \
-                          "and/or bulb in the Philips Hue App, " \
-                          "Color gamut of %s: %s, not valid, " \
-                          "setting gamut to None."
+                    err = (
+                        "Color gamut of %s: %s, not valid, "
+                        "setting gamut to None."
+                    )
                     _LOGGER.warning(err, self.name, str(self.gamut))
                     self.gamut_typ = GAMUT_TYPE_UNAVAILABLE
                     self.gamut = None

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -115,7 +115,7 @@ aioharmony==0.1.5
 aiohttp_cors==0.7.0
 
 # homeassistant.components.hue
-aiohue==1.8.0
+aiohue==1.9.0
 
 # homeassistant.components.sensor.iliad_italy
 aioiliad==0.1.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -41,7 +41,7 @@ aioautomatic==0.6.5
 aiohttp_cors==0.7.0
 
 # homeassistant.components.hue
-aiohue==1.8.0
+aiohue==1.9.0
 
 # homeassistant.components.unifi
 aiounifi==4


### PR DESCRIPTION
## Description:
add a check to check if their is an update available for the lights used in HomeAssistant.
If an update is available, issue a warning in the log to promt users to update their Philips Hue Bridge/bulbs through the Hue App.

**Related issue (if applicable):** this is related to issue: #20447
Actually that issue is already fixed in HomeAssistant 0.86.4. This will just make the warning messages a bit nicer.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
