### PR TITLE
Update to the newest python-wink and fix push updates!

### DIFF
--- a/homeassistant/components/wink/__init__.py
+++ b/homeassistant/components/wink/__init__.py
@@ -358,10 +358,9 @@ def setup(hass, config):
         time.sleep(1)
         pywink.set_user_agent(USER_AGENT)
         _temp_response = pywink.wink_api_fetch()
-        _LOGGER.debug(str(json.dumps(_temp_response)))
+        _LOGGER.debug("%s", _temp_response)
         _temp_response = pywink.post_session()
-        _LOGGER.debug(str(json.dumps(_temp_response)))
-
+        _LOGGER.debug("%s", _temp_response)
 
     # Call the Wink API every hour to keep PubNub updates flowing
     track_time_interval(hass, keep_alive_call, timedelta(minutes=60))

--- a/homeassistant/components/wink/__init__.py
+++ b/homeassistant/components/wink/__init__.py
@@ -25,7 +25,7 @@ from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.event import track_time_interval
 from homeassistant.util.json import load_json, save_json
 
-REQUIREMENTS = ['python-wink==1.10.1', 'pubnubsub-handler==1.0.3']
+REQUIREMENTS = ['python-wink==1.10.3', 'pubnubsub-handler==1.0.3']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -359,6 +359,9 @@ def setup(hass, config):
         pywink.set_user_agent(USER_AGENT)
         _temp_response = pywink.wink_api_fetch()
         _LOGGER.debug(str(json.dumps(_temp_response)))
+        _temp_response = pywink.post_session()
+        _LOGGER.debug(str(json.dumps(_temp_response)))
+
 
     # Call the Wink API every hour to keep PubNub updates flowing
     track_time_interval(hass, keep_alive_call, timedelta(minutes=60))

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1354,7 +1354,7 @@ python-velbus==2.0.21
 python-vlc==1.1.2
 
 # homeassistant.components.wink
-python-wink==1.10.1
+python-wink==1.10.3
 
 # homeassistant.components.sensor.awair
 python_awair==0.0.3


### PR DESCRIPTION
## Description:
Bump python-wink version and add additional call during the pubnub keep alive call to fix push updates for some users.

Thanks to @juched78 for all the hard work testing and diagnosing this, wouldn't have been able to figure this issue out without the assistance.


**Related issue (if applicable):** fixes #17962 

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
