### PR TITLE
Fix area registry config being loaded

### DIFF
--- a/homeassistant/components/config/__init__.py
+++ b/homeassistant/components/config/__init__.py
@@ -14,6 +14,7 @@ from homeassistant.util.yaml import load_yaml, dump
 DOMAIN = 'config'
 DEPENDENCIES = ['http']
 SECTIONS = (
+    'area_registry',
     'auth',
     'auth_provider_homeassistant',
     'automation',

--- a/homeassistant/components/config/device_registry.py
+++ b/homeassistant/components/config/device_registry.py
@@ -18,7 +18,7 @@ WS_TYPE_UPDATE = 'config/device_registry/update'
 SCHEMA_WS_UPDATE = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend({
     vol.Required('type'): WS_TYPE_UPDATE,
     vol.Required('device_id'): str,
-    vol.Optional('area_id'): str,
+    vol.Optional('area_id'): vol.Any(str, None),
 })
 
 


### PR DESCRIPTION
## Description:
Fix area registry config commands being loaded as part of the config component setup. 

Fix not accepting `None` as area_id value when updating a device. Needed to set area to "No Area".

CC @Kane610 

## Example entry for `configuration.yaml` (if applicable):
```yaml
config:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.


[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
