### PR TITLE
Fix LIFX for single-zone strip extensions

### DIFF
--- a/homeassistant/components/light/lifx.py
+++ b/homeassistant/components/light/lifx.py
@@ -714,3 +714,7 @@ class LIFXStrip(LIFXColor):
             if resp:
                 zone += 8
                 top = resp.count
+
+                # We only await multizone responses so don't ask for just one
+                if zone == top-1:
+                    zone -= 1


### PR DESCRIPTION
## Description:

This works around a hang when a LIFX strip extension is cut to have just a single zone. The GetColorZones message returns a different response in this case.

Rather than adding code to handle this additional response, just ask for an extra zone so the response is as expected.

CC @merc1031

**Related issue (if applicable):** fixes #20528

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`.
  - [X] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54