### PR TITLE
Expose device_tracker config in asuswrt

### DIFF
--- a/homeassistant/components/asuswrt.py
+++ b/homeassistant/components/asuswrt.py
@@ -11,6 +11,7 @@ import voluptuous as vol
 from homeassistant.const import (
     CONF_HOST, CONF_PASSWORD, CONF_USERNAME, CONF_PORT, CONF_MODE,
     CONF_PROTOCOL)
+from homeassistant.components import device_tracker
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.discovery import async_load_platform
 
@@ -28,6 +29,7 @@ DEFAULT_SSH_PORT = 22
 SECRET_GROUP = 'Password or SSH Key'
 CONF_SENSORS = 'sensors'
 SENSOR_TYPES = ['upload_speed', 'download_speed', 'download', 'upload']
+CONF_DEVICE_TRACKER = 'device_tracker'
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema({
@@ -42,6 +44,8 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Exclusive(CONF_PUB_KEY, SECRET_GROUP): cv.isfile,
         vol.Optional(CONF_SENSORS): vol.All(
             cv.ensure_list, [vol.In(SENSOR_TYPES)]),
+        vol.Optional(CONF_DEVICE_TRACKER):
+            device_tracker.DEVICE_TRACKER_SCHEMA,
     }),
 }, extra=vol.ALLOW_EXTRA)
 
@@ -67,7 +71,11 @@ async def async_setup(hass, config):
 
     hass.async_create_task(async_load_platform(
         hass, 'sensor', DOMAIN, config[DOMAIN].get(CONF_SENSORS), config))
+    disc_info = {}
+    device_tracker_config = config[DOMAIN].get(CONF_DEVICE_TRACKER)
+    if device_tracker_config:
+        disc_info = {CONF_DEVICE_TRACKER: device_tracker_config}
     hass.async_create_task(async_load_platform(
-        hass, 'device_tracker', DOMAIN, {}, config))
+        hass, 'device_tracker', DOMAIN, disc_info, config))
 
     return True

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -87,7 +87,7 @@ NEW_DEVICE_DEFAULTS_SCHEMA = vol.Any(None, vol.Schema({
     vol.Optional(CONF_TRACK_NEW, default=DEFAULT_TRACK_NEW): cv.boolean,
     vol.Optional(CONF_AWAY_HIDE, default=DEFAULT_AWAY_HIDE): cv.boolean,
 }))
-PLATFORM_SCHEMA = cv.PLATFORM_SCHEMA.extend({
+DEVICE_TRACKER_SCHEMA = vol.Schema({
     vol.Optional(CONF_SCAN_INTERVAL): cv.time_period,
     vol.Optional(CONF_TRACK_NEW): cv.boolean,
     vol.Optional(CONF_CONSIDER_HOME,
@@ -96,6 +96,7 @@ PLATFORM_SCHEMA = cv.PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NEW_DEVICE_DEFAULTS,
                  default={}): NEW_DEVICE_DEFAULTS_SCHEMA
 })
+PLATFORM_SCHEMA = cv.PLATFORM_SCHEMA.extend(DEVICE_TRACKER_SCHEMA.schema)
 SERVICE_SEE_PAYLOAD_SCHEMA = vol.Schema(vol.All(
     cv.has_at_least_one_key(ATTR_MAC, ATTR_DEV_ID), {
         ATTR_MAC: cv.string,
@@ -163,6 +164,9 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType):
             hass, config, DOMAIN, p_type)
         if platform is None:
             return
+
+        if disc_info:
+            p_config.update(disc_info.get(DOMAIN, {}))
 
         _LOGGER.info("Setting up %s.%s", DOMAIN, p_type)
         try:


### PR DESCRIPTION
## Description:


**Related issue (if applicable):** fixes #19848

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** 

TBD if accepted home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

asuswrt:
  host: 192.168.1.254
  username: admin
  ssh_key: key 
  device_tracker:
    interval_seconds: 90
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)