### PR TITLE
Fix timeout issue on Unifi controller

### DIFF
--- a/homeassistant/components/unifi/controller.py
+++ b/homeassistant/components/unifi/controller.py
@@ -114,7 +114,7 @@ async def get_controller(
     )
 
     try:
-        with async_timeout.timeout(5):
+        with async_timeout.timeout(10):
             await controller.login()
         return controller
 


### PR DESCRIPTION
The Unifi controller currently times out after 5 seconds. The component works, but always results in an error on HA restart:
```bash
2019-01-30 12:14:23 ERROR (MainThread) [homeassistant.components.unifi] Error connecting to the UniFi controller at 192.168.2.163
2019-01-30 12:14:23 ERROR (MainThread) [homeassistant.components.unifi] Error connecting to the UniFi controller. Retrying in 2 seconds
```
Given the range of things that need to be carried on a restart, 5 seconds seems too low to time out. This PR changes it to 10 seconds, which is also consistent with other components. 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
