### PR TITLE
Allow pausing xiaomi vacuum in all states

### DIFF
--- a/homeassistant/components/xiaomi_miio/vacuum.py
+++ b/homeassistant/components/xiaomi_miio/vacuum.py
@@ -227,31 +227,27 @@ class MiroboVacuum(StateVacuumDevice):
                 ATTR_DO_NOT_DISTURB_END: str(self.dnd_state.end),
                 # Not working --> 'Cleaning mode':
                 #    STATE_ON if self.vacuum_state.in_cleaning else STATE_OFF,
-                ATTR_CLEANING_TIME: (int(
+                ATTR_CLEANING_TIME: int(
                     self.vacuum_state.clean_time.total_seconds()
-                    / 60) if self.vacuum_state.clean_time else 0),
-                ATTR_CLEANED_AREA: (int(self.vacuum_state.clean_area) if
-                                    self.vacuum_state.clean_area else 0),
-                ATTR_CLEANING_COUNT: (int(self.clean_history.count) if
-                                      self.clean_history.count else 0),
-                ATTR_CLEANED_TOTAL_AREA: (int(self.clean_history.total_area) if
-                                          self.clean_history.total_area
-                                          else 0),
-                ATTR_CLEANING_TOTAL_TIME: (int(
+                    / 60),
+                ATTR_CLEANED_AREA: int(self.vacuum_state.clean_area),
+                ATTR_CLEANING_COUNT: int(self.clean_history.count),
+                ATTR_CLEANED_TOTAL_AREA: int(self.clean_history.total_area),
+                ATTR_CLEANING_TOTAL_TIME: int(
                     self.clean_history.total_duration.total_seconds()
-                    / 60) if self.clean_history.total_duration else 0),
-                ATTR_MAIN_BRUSH_LEFT: (int(
+                    / 60),
+                ATTR_MAIN_BRUSH_LEFT: int(
                     self.consumable_state.main_brush_left.total_seconds()
-                    / 3600) if self.consumable_state.main_brush_left else 0),
-                ATTR_SIDE_BRUSH_LEFT: (int(
+                    / 3600),
+                ATTR_SIDE_BRUSH_LEFT: int(
                     self.consumable_state.side_brush_left.total_seconds()
-                    / 3600) if self.consumable_state.side_brush_left else 0),
-                ATTR_FILTER_LEFT: (int(
+                    / 3600),
+                ATTR_FILTER_LEFT: int(
                     self.consumable_state.filter_left.total_seconds()
-                    / 3600) if self.consumable_state.filter_left else 0),
-                ATTR_SENSOR_DIRTY_LEFT: (int(
+                    / 3600),
+                ATTR_SENSOR_DIRTY_LEFT: int(
                     self.consumable_state.sensor_dirty_left.total_seconds()
-                    / 3600) if self.consumable_state.sensor_dirty_left else 0),
+                    / 3600),
                 ATTR_STATUS: str(self.vacuum_state.state)
                 })
 

--- a/homeassistant/components/xiaomi_miio/vacuum.py
+++ b/homeassistant/components/xiaomi_miio/vacuum.py
@@ -287,9 +287,8 @@ class MiroboVacuum(StateVacuumDevice):
 
     async def async_pause(self):
         """Pause the cleaning task."""
-        if self.state == STATE_CLEANING or self.state == STATE_RETURNING:
-            await self._try_command(
-                "Unable to set start/pause: %s", self._vacuum.pause)
+        await self._try_command(
+            "Unable to set start/pause: %s", self._vacuum.pause)
 
     async def async_stop(self, **kwargs):
         """Stop the vacuum cleaner."""

--- a/homeassistant/components/xiaomi_miio/vacuum.py
+++ b/homeassistant/components/xiaomi_miio/vacuum.py
@@ -227,27 +227,31 @@ class MiroboVacuum(StateVacuumDevice):
                 ATTR_DO_NOT_DISTURB_END: str(self.dnd_state.end),
                 # Not working --> 'Cleaning mode':
                 #    STATE_ON if self.vacuum_state.in_cleaning else STATE_OFF,
-                ATTR_CLEANING_TIME: int(
+                ATTR_CLEANING_TIME: (int(
                     self.vacuum_state.clean_time.total_seconds()
-                    / 60),
-                ATTR_CLEANED_AREA: int(self.vacuum_state.clean_area),
-                ATTR_CLEANING_COUNT: int(self.clean_history.count),
-                ATTR_CLEANED_TOTAL_AREA: int(self.clean_history.total_area),
-                ATTR_CLEANING_TOTAL_TIME: int(
+                    / 60) if self.vacuum_state.clean_time else 0),
+                ATTR_CLEANED_AREA: (int(self.vacuum_state.clean_area) if
+                                    self.vacuum_state.clean_area else 0),
+                ATTR_CLEANING_COUNT: (int(self.clean_history.count) if
+                                      self.clean_history.count else 0),
+                ATTR_CLEANED_TOTAL_AREA: (int(self.clean_history.total_area) if
+                                          self.clean_history.total_area
+                                          else 0),
+                ATTR_CLEANING_TOTAL_TIME: (int(
                     self.clean_history.total_duration.total_seconds()
-                    / 60),
-                ATTR_MAIN_BRUSH_LEFT: int(
+                    / 60) if self.clean_history.total_duration else 0),
+                ATTR_MAIN_BRUSH_LEFT: (int(
                     self.consumable_state.main_brush_left.total_seconds()
-                    / 3600),
-                ATTR_SIDE_BRUSH_LEFT: int(
+                    / 3600) if self.consumable_state.main_brush_left else 0),
+                ATTR_SIDE_BRUSH_LEFT: (int(
                     self.consumable_state.side_brush_left.total_seconds()
-                    / 3600),
-                ATTR_FILTER_LEFT: int(
+                    / 3600) if self.consumable_state.side_brush_left else 0),
+                ATTR_FILTER_LEFT: (int(
                     self.consumable_state.filter_left.total_seconds()
-                    / 3600),
-                ATTR_SENSOR_DIRTY_LEFT: int(
+                    / 3600) if self.consumable_state.filter_left else 0),
+                ATTR_SENSOR_DIRTY_LEFT: (int(
                     self.consumable_state.sensor_dirty_left.total_seconds()
-                    / 3600),
+                    / 3600) if self.consumable_state.sensor_dirty_left else 0),
                 ATTR_STATUS: str(self.vacuum_state.state)
                 })
 
@@ -287,7 +291,7 @@ class MiroboVacuum(StateVacuumDevice):
 
     async def async_pause(self):
         """Pause the cleaning task."""
-        if self.state == STATE_CLEANING:
+        if self.state == STATE_CLEANING or self.state == STATE_RETURNING:
             await self._try_command(
                 "Unable to set start/pause: %s", self._vacuum.pause)
 


### PR DESCRIPTION
I bought Xiaomii vacuum for my parents and found one bug and also reason for one annoying problem.
So two fixes in this PR.

1. 

For now user can only pause vacuum while cleaning. I thought that it was some limitation of python miio module, but no. It was component designed that way.
```
if self.state == STATE_CLEANING:
            await self._try_command(
                "Unable to set start/pause: %s", self._vacuum.pause)
```

so added STATE_RETURNING to this if.

2.  When new vacuum is connected and no cleaning was performed xiaomi component is crashing.
Don't know if checking should be added to every attribute update. Waiting for your opinions on it.
For sure it was crashing on:
```
self.vacuum_state.clean_time
self.clean_history.count
self.clean_history.total_duration
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
