### PR TITLE
Update synology-srm dependency to 0.0.4

### DIFF
--- a/homeassistant/components/device_tracker/synology_srm.py
+++ b/homeassistant/components/device_tracker/synology_srm.py
@@ -13,7 +13,7 @@ from homeassistant.const import (
     CONF_HOST, CONF_USERNAME, CONF_PASSWORD,
     CONF_PORT, CONF_SSL, CONF_VERIFY_SSL)
 
-REQUIREMENTS = ['synology-srm==0.0.3']
+REQUIREMENTS = ['synology-srm==0.0.4']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1610,7 +1610,7 @@ suds-py3==1.3.3.0
 swisshydrodata==0.0.3
 
 # homeassistant.components.device_tracker.synology_srm
-synology-srm==0.0.3
+synology-srm==0.0.4
 
 # homeassistant.components.tahoma
 tahoma-api==0.0.14


### PR DESCRIPTION
## Description

This PR fixes error 119 with the Synology SRM API. When the API token starts with a digit, it can not be used with a GET parameter. The token is now put in a cookie. 

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
