### PR TITLE
Fix netatmo sensor home-coach error

### DIFF
--- a/homeassistant/components/sensor/netatmo.py
+++ b/homeassistant/components/sensor/netatmo.py
@@ -334,7 +334,7 @@ class NetAtmoData:
                 station_data = data_class(self.auth)
                 _LOGGER.debug("%s detected!", str(data_class.__name__))
                 return station_data
-            except TypeError:
+            except Exception:
                 continue
 
     def update(self):


### PR DESCRIPTION
## Description:
I do not have weather station device.
i have only home coach.
WeatherStationData throw http error("Device not found")
so it can not get 'resp["body"]["devices"]'

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
