### PR TITLE
Revert #20611: code in Abode alarm panel 

### DIFF
--- a/homeassistant/components/alarm_control_panel/abode.py
+++ b/homeassistant/components/alarm_control_panel/abode.py
@@ -57,11 +57,6 @@ class AbodeAlarm(AbodeDevice, alarm.AlarmControlPanel):
             state = None
         return state
 
-    @property
-    def code_format(self):
-        """Return one or more digits/characters."""
-        return alarm.FORMAT_NUMBER
-
     def alarm_disarm(self, code=None):
         """Send disarm command."""
         self._device.set_standby()


### PR DESCRIPTION
Looks like Abode does not have code support and the change introduced in #20611 does not work. Reverting it. 


## Checklist:
  - [X] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
