### PR TITLE
Update instruction text for PWA

### DIFF
--- a/homeassistant/components/deconz/strings.json
+++ b/homeassistant/components/deconz/strings.json
@@ -11,7 +11,7 @@
             },
             "link": {
                 "title": "Link with deCONZ",
-                "description": "Unlock your deCONZ gateway to register with Home Assistant.\n\n1. Go to deCONZ system settings\n2. Press \"Unlock Gateway\" button"
+                "description": "Unlock your deCONZ gateway to register with Home Assistant.\n\n1. Go to deCONZ advanced system settings\n2. Press \"Authenticate app\" button"
             },
             "options": {
                 "title": "Extra configuration options for deCONZ",


### PR DESCRIPTION
## Description:

The integration text in deCONZ integration was written for outdated deconz app. Now deCONZ uses PWA app as default app and I updated text for new app.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>
None

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.





[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
