### PR TITLE
Upgrade blinkpy to re-enable motion detection (Fixes #20380)

### DIFF
--- a/homeassistant/components/blink/__init__.py
+++ b/homeassistant/components/blink/__init__.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
     CONF_BINARY_SENSORS, CONF_SENSORS, CONF_FILENAME,
     CONF_MONITORED_CONDITIONS, TEMP_FAHRENHEIT)
 
-REQUIREMENTS = ['blinkpy==0.11.2']
+REQUIREMENTS = ['blinkpy==0.12.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -199,7 +199,7 @@ bellows==0.7.0
 bimmer_connected==0.5.3
 
 # homeassistant.components.blink
-blinkpy==0.11.2
+blinkpy==0.12.1
 
 # homeassistant.components.light.blinksticklight
 blinkstick==1.1.8


### PR DESCRIPTION
## Description:
Motion detection now works again, and the pesky warning in the logs about requiring an app update have been eliminated.

In addition, I fixed the logging problems so now logs can be filtered according to [the logger component](https://www.home-assistant.io/components/logger/).  Ex: you can add `blinkpy.api: error` to show only errors from that module in the library, which is how everything should have worked from the beginning.

**Related issue (if applicable):** fixes #20380 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

@dgomes 