### PR TITLE
Add lagging hdate for sensors that should lag to update

### DIFF
--- a/homeassistant/components/sensor/jewish_calendar.py
+++ b/homeassistant/components/sensor/jewish_calendar.py
@@ -160,10 +160,10 @@ class JewishCalSensor(Entity):
         # Not all sensors should advance immediately when the Hebrew date
         # officially changes (i.e. after sunset), hence lagging_date.
         if now > sunset:
-          date = date.next_day
+            date = date.next_day
         today_times = make_zmanim(today)
         if today_times.havdalah and now > today_times.havdalah:
-          lagging_date = lagging_date.next_day
+            lagging_date = lagging_date.next_day
 
         # Terminology note: by convention in py-libhdate library, "upcoming"
         # refers to "current" or "upcoming" dates.

--- a/homeassistant/components/sensor/jewish_calendar.py
+++ b/homeassistant/components/sensor/jewish_calendar.py
@@ -4,7 +4,6 @@ Platform to retrieve Jewish calendar information for Home Assistant.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.jewish_calendar/
 """
-from datetime import timedelta
 import logging
 
 import voluptuous as vol

--- a/homeassistant/components/sensor/jewish_calendar.py
+++ b/homeassistant/components/sensor/jewish_calendar.py
@@ -140,12 +140,6 @@ class JewishCalSensor(Entity):
 
         _LOGGER.debug("Now: %s Sunset: %s", now, sunset)
 
-        if now > sunset:
-            today += timedelta(1)
-
-        date = hdate.HDate(
-            today, diaspora=self.diaspora, hebrew=self._hebrew)
-
         location = hdate.Location(latitude=self.latitude,
                                   longitude=self.longitude,
                                   timezone=self.timezone,
@@ -158,27 +152,43 @@ class JewishCalSensor(Entity):
                 candle_lighting_offset=self.candle_lighting_offset,
                 havdalah_offset=self.havdalah_offset, hebrew=self._hebrew)
 
+        date = hdate.HDate(
+            today, diaspora=self.diaspora, hebrew=self._hebrew)
+        lagging_date = date
+
+        # Advance Hebrew date if sunset has passed.
+        # Not all sensors should advance immediately when the Hebrew date
+        # officially changes (i.e. after sunset), hence lagging_date.
+        if now > sunset:
+          date = date.next_day
+        today_times = make_zmanim(today)
+        if today_times.havdalah and now > today_times.havdalah:
+          lagging_date = lagging_date.next_day
+
+        # Terminology note: by convention in py-libhdate library, "upcoming"
+        # refers to "current" or "upcoming" dates.
         if self.type == 'date':
             self._state = date.hebrew_date
         elif self.type == 'weekly_portion':
             # Compute the weekly portion based on the upcoming shabbat.
-            self._state = date.upcoming_shabbat.parasha
+            self._state = lagging_date.upcoming_shabbat.parasha
         elif self.type == 'holiday_name':
             self._state = date.holiday_description
         elif self.type == 'holyness':
             self._state = date.holiday_type
         elif self.type == 'upcoming_shabbat_candle_lighting':
-            times = make_zmanim(date.upcoming_shabbat.previous_day.gdate)
-            self._state = times.candle_lighting
-        elif self.type == 'upcoming_candle_lighting':
-            times = make_zmanim(date.upcoming_shabbat_or_yom_tov.first_day
+            times = make_zmanim(lagging_date.upcoming_shabbat
                                 .previous_day.gdate)
             self._state = times.candle_lighting
+        elif self.type == 'upcoming_candle_lighting':
+            times = make_zmanim(lagging_date.upcoming_shabbat_or_yom_tov
+                                .first_day.previous_day.gdate)
+            self._state = times.candle_lighting
         elif self.type == 'upcoming_shabbat_havdalah':
-            times = make_zmanim(date.upcoming_shabbat.gdate)
+            times = make_zmanim(lagging_date.upcoming_shabbat.gdate)
             self._state = times.havdalah
         elif self.type == 'upcoming_havdalah':
-            times = make_zmanim(date.upcoming_shabbat_or_yom_tov
+            times = make_zmanim(lagging_date.upcoming_shabbat_or_yom_tov
                                 .last_day.gdate)
             self._state = times.havdalah
         elif self.type == 'issur_melacha_in_effect':

--- a/tests/components/sensor/test_jewish_calendar.py
+++ b/tests/components/sensor/test_jewish_calendar.py
@@ -159,6 +159,14 @@ class TestJewishCalenderSensor():
              'hebrew_weekly_portion': 'כי תבוא'},
             havdalah_offset=50),
         make_nyc_test_params(
+            dt(2018, 9, 1, 20, 0),
+            {'upcoming_shabbat_candle_lighting': dt(2018, 8, 31, 19, 15),
+             'upcoming_shabbat_havdalah': dt(2018, 9, 1, 20, 14),
+             'upcoming_candle_lighting': dt(2018, 8, 31, 19, 15),
+             'upcoming_havdalah': dt(2018, 9, 1, 20, 14),
+             'weekly_portion': 'Ki Tavo',
+             'hebrew_weekly_portion': 'כי תבוא'}),
+        make_nyc_test_params(
             dt(2018, 9, 1, 20, 21),
             {'upcoming_shabbat_candle_lighting': dt(2018, 9, 7, 19, 4),
              'upcoming_shabbat_havdalah': dt(2018, 9, 8, 20, 2),
@@ -317,6 +325,7 @@ class TestJewishCalenderSensor():
     shabbat_test_ids = [
         "currently_first_shabbat",
         "currently_first_shabbat_with_havdalah_offset",
+        "currently_first_shabbat_bein_hashmashot_lagging_date",
         "after_first_shabbat",
         "friday_upcoming_shabbat",
         "upcoming_rosh_hashana",


### PR DESCRIPTION
## Description:
Since some new jewish_calendar sensors should not update immediately when the Hebrew date officially changes (i.e. after sunset), this PR introduces a "lagging" Hebrew date for these sensors.

**Related issue (if applicable):** fixes #20492 

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
