### PR TITLE
Fix sensor.cpuspeed inside docker container (#20614)

### DIFF
--- a/homeassistant/components/sensor/cpuspeed.py
+++ b/homeassistant/components/sensor/cpuspeed.py
@@ -21,6 +21,9 @@ ATTR_BRAND = 'Brand'
 ATTR_HZ = 'GHz Advertised'
 ATTR_ARCH = 'arch'
 
+HZ_ACTUAL_RAW = 'hz_actual_raw'
+HZ_ADVERTISED_RAW = 'hz_advertised_raw'
+
 DEFAULT_NAME = 'CPU speed'
 
 ICON = 'mdi:pulse'
@@ -66,11 +69,16 @@ class CpuSpeedSensor(Entity):
     def device_state_attributes(self):
         """Return the state attributes."""
         if self.info is not None:
-            return {
+            attrs = {
                 ATTR_ARCH: self.info['arch'],
                 ATTR_BRAND: self.info['brand'],
-                ATTR_HZ: round(self.info['hz_advertised_raw'][0]/10**9, 2)
             }
+
+            if HZ_ADVERTISED_RAW in self.info:
+                attrs[ATTR_HZ] = round(
+                    self.info[HZ_ADVERTISED_RAW][0] / 10 ** 9, 2
+                )
+            return attrs
 
     @property
     def icon(self):
@@ -82,4 +90,9 @@ class CpuSpeedSensor(Entity):
         from cpuinfo import cpuinfo
 
         self.info = cpuinfo.get_cpu_info()
-        self._state = round(float(self.info['hz_actual_raw'][0])/10**9, 2)
+        if HZ_ACTUAL_RAW in self.info:
+            self._state = round(
+                float(self.info[HZ_ACTUAL_RAW][0]) / 10 ** 9, 2
+            )
+        else:
+            self._state = None


### PR DESCRIPTION
## Description:
Check for missing attributes in docker container before using them in CPU Speed sensor.

**Related issue (if applicable):** fixes #20614

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
