### PR TITLE
Fix allow extra in locative webhook schema validation

### DIFF
--- a/homeassistant/components/locative/__init__.py
+++ b/homeassistant/components/locative/__init__.py
@@ -28,6 +28,7 @@ TRACKER_UPDATE = '{}_tracker_update'.format(DOMAIN)
 
 ATTR_DEVICE_ID = 'device'
 ATTR_TRIGGER = 'trigger'
+ATTR_DEVICE_TYPE = 'device_type'
 
 
 def _id(value: str) -> str:
@@ -48,8 +49,8 @@ WEBHOOK_SCHEMA = vol.All(
         vol.Required(ATTR_LONGITUDE): cv.longitude,
         vol.Required(ATTR_DEVICE_ID): cv.string,
         vol.Required(ATTR_TRIGGER): cv.string,
-        vol.Optional(ATTR_ID): vol.All(cv.string, _id)
-    }),
+        vol.Optional(ATTR_ID): vol.All(cv.string, _id),
+    }, extra=vol.ALLOW_EXTRA),
     _validate_test_mode
 )
 

--- a/homeassistant/components/locative/__init__.py
+++ b/homeassistant/components/locative/__init__.py
@@ -28,7 +28,6 @@ TRACKER_UPDATE = '{}_tracker_update'.format(DOMAIN)
 
 ATTR_DEVICE_ID = 'device'
 ATTR_TRIGGER = 'trigger'
-ATTR_DEVICE_TYPE = 'device_type'
 
 
 def _id(value: str) -> str:


### PR DESCRIPTION
## Description:
Locative sends several extra keys that we don't care about when it sends the webhook request. Since we hadn't set `extra=vol.ALLOW_EXTRA` or defined those keys in the schema, it was getting rejected. Since we don't care about the values in those keys, we should just allow the extra keys to be sent.

**Related issue (if applicable):** fixes #20566
 
## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
