### PR TITLE
Change connection test method of InfluxDB

### DIFF
--- a/homeassistant/components/sensor/influxdb.py
+++ b/homeassistant/components/sensor/influxdb.py
@@ -111,7 +111,7 @@ class InfluxSensor(Entity):
             database=database, ssl=influx_conf['ssl'],
             verify_ssl=influx_conf['verify_ssl'])
         try:
-            influx.query("SHOW DIAGNOSTICS;")
+            influx.query("SHOW SERIES LIMIT 1;")
             self.connected = True
             self.data = InfluxSensorData(
                 influx, query.get(CONF_GROUP_FUNCTION), query.get(CONF_FIELD),


### PR DESCRIPTION
## Description:
SHOW DIAGNOSTICS always needs admin privileges on influxdb. For the purposes of home-assistant this is too much.
Use 'SHOW SERIES' to have a relatively lightweight query which only needs READ privileges.

**Related issue (if applicable):** fixes #20378

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
