### PR TITLE
Remove fingerprint middleware

### DIFF
--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -25,8 +25,7 @@ from .auth import setup_auth
 from .ban import setup_bans
 from .cors import setup_cors
 from .real_ip import setup_real_ip
-from .static import (
-    CachingFileResponse, CachingStaticResource, staticresource_middleware)
+from .static import CachingFileResponse, CachingStaticResource
 
 # Import as alias
 from .const import KEY_AUTHENTICATED, KEY_REAL_IP  # noqa
@@ -192,8 +191,7 @@ class HomeAssistantHTTP:
                  use_x_forwarded_for, trusted_proxies, trusted_networks,
                  login_threshold, is_ban_enabled, ssl_profile):
         """Initialize the HTTP Home Assistant server."""
-        app = self.app = web.Application(
-            middlewares=[staticresource_middleware])
+        app = self.app = web.Application(middlewares=[])
 
         # This order matters
         setup_real_ip(app, use_x_forwarded_for, trusted_proxies)

--- a/homeassistant/components/http/static.py
+++ b/homeassistant/components/http/static.py
@@ -8,8 +8,6 @@ from aiohttp.web_exceptions import HTTPNotFound
 from aiohttp.web_urldispatcher import StaticResource
 from yarl import URL
 
-_FINGERPRINT = re.compile(r'^(.+)-[a-z0-9]{32}\.(\w+)$', re.IGNORECASE)
-
 
 class CachingStaticResource(StaticResource):
     """Static Resource handler that will add cache headers."""
@@ -56,19 +54,3 @@ class CachingFileResponse(FileResponse):
 
         # Overwriting like this because __init__ can change implementation.
         self._sendfile = sendfile
-
-
-@middleware
-async def staticresource_middleware(request, handler):
-    """Middleware to strip out fingerprint from fingerprinted assets."""
-    path = request.path
-    if not path.startswith('/static/') and not path.startswith('/frontend'):
-        return await handler(request)
-
-    fingerprinted = _FINGERPRINT.match(request.match_info['filename'])
-
-    if fingerprinted:
-        request.match_info['filename'] = \
-            '{}.{}'.format(*fingerprinted.groups())
-
-    return await handler(request)

--- a/homeassistant/components/http/static.py
+++ b/homeassistant/components/http/static.py
@@ -1,9 +1,6 @@
 """Static file handling for HTTP component."""
-
-import re
-
 from aiohttp import hdrs
-from aiohttp.web import FileResponse, middleware
+from aiohttp.web import FileResponse
 from aiohttp.web_exceptions import HTTPNotFound
 from aiohttp.web_urldispatcher import StaticResource
 from yarl import URL


### PR DESCRIPTION
## Description:
We used to be able to add a 32 char hash to each filename to bust cache. This was dangerous and often ended up with files not being served correctly (older firmware etc, messing up with service workers).

After https://github.com/home-assistant/home-assistant-polymer/pull/2652 is merged and the frontend is updated in the backend, we will no longer need it.

