### PR TITLE
Fix bad request for some IP ONVIF cameras

### DIFF
--- a/homeassistant/components/camera/onvif.py
+++ b/homeassistant/components/camera/onvif.py
@@ -154,8 +154,8 @@ class ONVIFHassCamera(Camera):
         
         if dt_diff_seconds > 5:
             _LOGGER.warning("The date/time on the camera is '%s', which is different from the system '%s', this could lead to authentication issues", 
-                cam_date,
-                system_date)
+                            cam_date,
+                            system_date)
 
         _LOGGER.debug("Setting up the ONVIF media service")
 
@@ -175,11 +175,11 @@ class ONVIFHassCamera(Camera):
 
         try:
             _LOGGER.debug("Retrieving profiles")
-        
+
             profiles = self._media_service.GetProfiles()
 
             _LOGGER.debug("Retrieved '%d' profiles", 
-                len(profiles))
+                          len(profiles))
             
             if self._profile_index >= len(profiles):
                 _LOGGER.warning("ONVIF Camera '%s' doesn't provide profile %d."
@@ -189,24 +189,25 @@ class ONVIFHassCamera(Camera):
 
             _LOGGER.debug("Using profile index '%d'", 
                 self._profile_index)
-                
+
             _LOGGER.debug("Retrieving stream uri")
                 
             req = self._media_service.create_type('GetStreamUri')
             req.ProfileToken = profiles[self._profile_index].token
-            req.StreamSetup = {'Stream': 'RTP-Unicast', 'Transport': {'Protocol': 'RTSP'}}
-            
+            req.StreamSetup = {'Stream': 'RTP-Unicast', 
+                               'Transport': {'Protocol': 'RTSP'}}
+
             uri_no_auth = self._media_service.GetStreamUri(req).Uri
             uri_for_log = uri_no_auth.replace(
                 'rtsp://', 'rtsp://<user>:<password>@', 1)
             self._input = uri_no_auth.replace(
                 'rtsp://', 'rtsp://{}:{}@'.format(self._username,
                                                   self._password), 1)
-                                                  
+
             _LOGGER.debug(
                 "ONVIF Camera Using the following URL for %s: %s",
                 self._name, uri_for_log)
-                
+
             # we won't need the media service anymore
             self._media_service = None
         except exceptions.ONVIFError as err:

--- a/homeassistant/components/camera/onvif.py
+++ b/homeassistant/components/camera/onvif.py
@@ -136,24 +136,26 @@ class ONVIFHassCamera(Camera):
         _LOGGER.debug("Setting up the ONVIF device management service")
 
         self._devicemgmt = self._camera.create_devicemgmt_service()
-        
+
         _LOGGER.debug("Retrieving current camera date/time")
-        
+
         system_date = dt.datetime.utcnow()
         cdate = self._devicemgmt.GetSystemDateAndTime().UTCDateTime
         cam_date = dt.datetime(cdate.Date.Year, cdate.Date.Month, cdate.Date.Day, cdate.Time.Hour, cdate.Time.Minute, cdate.Time.Second)
-        
+
         _LOGGER.debug("Camera date/time: %s",
             cam_date)
 
         _LOGGER.debug("System date/time: %s",
             system_date)
-        
+
         dt_diff = cam_date - system_date
         dt_diff_seconds = dt_diff.total_seconds()
-        
+
         if dt_diff_seconds > 5:
-            _LOGGER.warning("The date/time on the camera is '%s', which is different from the system '%s', this could lead to authentication issues", 
+            _LOGGER.warning("The date/time on the camera is '%s', "
+                            "which is different from the system '%s', "
+                            "this could lead to authentication issues",
                             cam_date,
                             system_date)
 
@@ -191,7 +193,7 @@ class ONVIFHassCamera(Camera):
                 self._profile_index)
 
             _LOGGER.debug("Retrieving stream uri")
-                
+
             req = self._media_service.create_type('GetStreamUri')
             req.ProfileToken = profiles[self._profile_index].token
             req.StreamSetup = {'Stream': 'RTP-Unicast', 

--- a/homeassistant/components/camera/onvif.py
+++ b/homeassistant/components/camera/onvif.py
@@ -143,7 +143,8 @@ class ONVIFHassCamera(Camera):
 
         system_date = dt.datetime.utcnow()
         cdate = self._devicemgmt.GetSystemDateAndTime().UTCDateTime
-        cam_date = dt.datetime(cdate.Date.Year, cdate.Date.Month, cdate.Date.Day, cdate.Time.Hour, cdate.Time.Minute, cdate.Time.Second)
+        cam_date = dt.datetime(cdate.Date.Year, cdate.Date.Month, cdate.Date.Day,
+                               cdate.Time.Hour, cdate.Time.Minute, cdate.Time.Second)
 
         _LOGGER.debug("Camera date/time: %s",
                       cam_date)
@@ -182,17 +183,17 @@ class ONVIFHassCamera(Camera):
 
             profiles = self._media_service.GetProfiles()
 
-            _LOGGER.debug("Retrieved '%d' profiles", 
+            _LOGGER.debug("Retrieved '%d' profiles",
                           len(profiles))
-            
+
             if self._profile_index >= len(profiles):
                 _LOGGER.warning("ONVIF Camera '%s' doesn't provide profile %d."
                                 " Using the last profile.",
                                 self._name, self._profile_index)
                 self._profile_index = -1
 
-            _LOGGER.debug("Using profile index '%d'", 
-                self._profile_index)
+            _LOGGER.debug("Using profile index '%d'",
+                          self._profile_index)
 
             _LOGGER.debug("Retrieving stream uri")
 

--- a/homeassistant/components/camera/onvif.py
+++ b/homeassistant/components/camera/onvif.py
@@ -193,10 +193,8 @@ class ONVIFHassCamera(Camera):
                                 self._name, self._profile_index)
                 self._profile_index = -1
 
-            _LOGGER.debug("Using profile index '%d'",
+            _LOGGER.debug("Retrieving stream uri using profile index '%d'",
                           self._profile_index)
-
-            _LOGGER.debug("Retrieving stream uri")
 
             req = self._media_service.create_type('GetStreamUri')
             req.ProfileToken = profiles[self._profile_index].token

--- a/homeassistant/components/camera/onvif.py
+++ b/homeassistant/components/camera/onvif.py
@@ -122,16 +122,15 @@ class ONVIFHassCamera(Camera):
         self._profile_index = config.get(CONF_PROFILE)
         self._input = None
 
-        _LOGGER.debug("Setting up the ONVIF camera device @ '%s:%s'", 
-            self._host, 
-            self._port)
+        _LOGGER.debug("Setting up the ONVIF camera device @ '%s:%s'",
+                      self._host,
+                      self._port)
 
         self._camera = ONVIFCamera(self._host, 
-            self._port, 
-            self._username, 
-            self._password,
-            '{}/wsdl/'.format(os.path.dirname(onvif.__file__)),
-            )
+                                   self._port, 
+                                   self._username, 
+                                   self._password,
+                                   '{}/wsdl/'.format(os.path.dirname(onvif.__file__)))
 
         _LOGGER.debug("Setting up the ONVIF device management service")
 
@@ -144,10 +143,10 @@ class ONVIFHassCamera(Camera):
         cam_date = dt.datetime(cdate.Date.Year, cdate.Date.Month, cdate.Date.Day, cdate.Time.Hour, cdate.Time.Minute, cdate.Time.Second)
 
         _LOGGER.debug("Camera date/time: %s",
-            cam_date)
+                      cam_date)
 
         _LOGGER.debug("System date/time: %s",
-            system_date)
+                      system_date)
 
         dt_diff = cam_date - system_date
         dt_diff_seconds = dt_diff.total_seconds()
@@ -196,7 +195,7 @@ class ONVIFHassCamera(Camera):
 
             req = self._media_service.create_type('GetStreamUri')
             req.ProfileToken = profiles[self._profile_index].token
-            req.StreamSetup = {'Stream': 'RTP-Unicast', 
+            req.StreamSetup = {'Stream': 'RTP-Unicast',
                                'Transport': {'Protocol': 'RTSP'}}
 
             uri_no_auth = self._media_service.GetStreamUri(req).Uri

--- a/homeassistant/components/camera/onvif.py
+++ b/homeassistant/components/camera/onvif.py
@@ -25,6 +25,7 @@ from onvif import ONVIFCamera
 
 import zeep
 
+
 def zeep_pythonvalue(self, xmlvalue):
     return xmlvalue
 

--- a/homeassistant/components/camera/onvif.py
+++ b/homeassistant/components/camera/onvif.py
@@ -28,6 +28,7 @@ import zeep
 def zeep_pythonvalue(self, xmlvalue):
     return xmlvalue
 
+
 zeep.xsd.simple.AnySimpleType.pythonvalue = zeep_pythonvalue
 
 _LOGGER = logging.getLogger(__name__)
@@ -126,11 +127,12 @@ class ONVIFHassCamera(Camera):
                       self._host,
                       self._port)
 
-        self._camera = ONVIFCamera(self._host, 
-                                   self._port, 
-                                   self._username, 
+        self._camera = ONVIFCamera(self._host,
+                                   self._port,
+                                   self._username,
                                    self._password,
-                                   '{}/wsdl/'.format(os.path.dirname(onvif.__file__)))
+                                   '{}/wsdl/'
+                                   .format(os.path.dirname(onvif.__file__)))
 
         _LOGGER.debug("Setting up the ONVIF device management service")
 

--- a/homeassistant/components/camera/onvif.py
+++ b/homeassistant/components/camera/onvif.py
@@ -143,8 +143,9 @@ class ONVIFHassCamera(Camera):
 
         system_date = dt.datetime.utcnow()
         cdate = self._devicemgmt.GetSystemDateAndTime().UTCDateTime
-        cam_date = dt.datetime(cdate.Date.Year, cdate.Date.Month, cdate.Date.Day,
-                               cdate.Time.Hour, cdate.Time.Minute, cdate.Time.Second)
+        cam_date = dt.datetime(cdate.Date.Year, cdate.Date.Month,
+                               cdate.Date.Day, cdate.Time.Hour,
+                               cdate.Time.Minute, cdate.Time.Second)
 
         _LOGGER.debug("Camera date/time: %s",
                       cam_date)

--- a/homeassistant/components/camera/onvif.py
+++ b/homeassistant/components/camera/onvif.py
@@ -8,9 +8,11 @@ import asyncio
 import logging
 import os
 
-import voluptuous as vol
 import datetime as dt
+import voluptuous as vol
+import zeep
 
+from onvif import ONVIFCamera
 from homeassistant.const import (
     CONF_NAME, CONF_HOST, CONF_USERNAME, CONF_PASSWORD, CONF_PORT,
     ATTR_ENTITY_ID)
@@ -21,9 +23,6 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.aiohttp_client import (
     async_aiohttp_proxy_stream)
 from homeassistant.helpers.service import extract_entity_ids
-from onvif import ONVIFCamera
-
-import zeep
 
 
 def zeep_pythonvalue(self, xmlvalue):


### PR DESCRIPTION
This PR contains the following changes:

1. Replace the onvif component with onvif-zeep v0.2.12 (seems more actively maintained, but better yet, ensures correct authentication headers)
2. Add warning in case the date/time of the camera and system are not the same, this could potentially lead to authentication issues
3. Added extra logging to be able to find the cause of mismatch easier in the future

Fixes #20668