### PR TITLE
Allow to set icons for Broadlink RM mini switches

### DIFF
--- a/homeassistant/components/switch/broadlink.py
+++ b/homeassistant/components/switch/broadlink.py
@@ -17,7 +17,7 @@ from homeassistant.components.switch import (
     DOMAIN, PLATFORM_SCHEMA, SwitchDevice, ENTITY_ID_FORMAT)
 from homeassistant.const import (
     CONF_COMMAND_OFF, CONF_COMMAND_ON, CONF_FRIENDLY_NAME, CONF_HOST, CONF_MAC,
-    CONF_SWITCHES, CONF_TIMEOUT, CONF_TYPE)
+    CONF_SWITCHES, CONF_TIMEOUT, CONF_TYPE, CONF_ICON)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import Throttle, slugify
 from homeassistant.util.dt import utcnow
@@ -48,6 +48,7 @@ SWITCH_SCHEMA = vol.Schema({
     vol.Optional(CONF_COMMAND_OFF): cv.string,
     vol.Optional(CONF_COMMAND_ON): cv.string,
     vol.Optional(CONF_FRIENDLY_NAME): cv.string,
+    vol.Optional(CONF_ICON): cv.string,
 })
 
 MP1_SWITCH_SLOT_SCHEMA = vol.Schema({
@@ -154,7 +155,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                     device_config.get(CONF_FRIENDLY_NAME, object_id),
                     broadlink_device,
                     device_config.get(CONF_COMMAND_ON),
-                    device_config.get(CONF_COMMAND_OFF)
+                    device_config.get(CONF_COMMAND_OFF),
+                    device_config.get(CONF_ICON)
                 )
             )
     elif switch_type in SP1_TYPES:
@@ -185,7 +187,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class BroadlinkRMSwitch(SwitchDevice):
     """Representation of an Broadlink switch."""
 
-    def __init__(self, name, friendly_name, device, command_on, command_off):
+    def __init__(self, name, friendly_name, device, command_on, command_off,
+                 icon=None):
         """Initialize the switch."""
         self.entity_id = ENTITY_ID_FORMAT.format(slugify(name))
         self._name = friendly_name
@@ -193,11 +196,17 @@ class BroadlinkRMSwitch(SwitchDevice):
         self._command_on = b64decode(command_on) if command_on else None
         self._command_off = b64decode(command_off) if command_off else None
         self._device = device
+        self._icon = icon
 
     @property
     def name(self):
         """Return the name of the switch."""
         return self._name
+
+    @property
+    def icon(self):
+        """Return the icon associated with the switch."""
+        return self._icon
 
     @property
     def assumed_state(self):


### PR DESCRIPTION
## Description:

This adds optional 'icon' configuration option for Broadlink switches 
 
**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** https://github.com/home-assistant/home-assistant.io/pull/8384

## Example entry for `configuration.yaml` (if applicable):
```yaml
switch:
  - platform: broadlink
    host: <RM Mini IP address>
    mac: <RM Mini MAC>
    type: rm_mini
    switches:
      tv:
        icon: mdi:television
        command_on: <command_on_code>
        command_off: <command_off_code>
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
