### PR TITLE
Add SmartThings button support via events

### DIFF
--- a/homeassistant/components/smartthings/__init__.py
+++ b/homeassistant/components/smartthings/__init__.py
@@ -19,7 +19,7 @@ from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 from .config_flow import SmartThingsFlowHandler  # noqa
 from .const import (
     CONF_APP_ID, CONF_INSTALLED_APP_ID, DATA_BROKERS, DATA_MANAGER, DOMAIN,
-    SIGNAL_SMARTTHINGS_UPDATE, SUPPORTED_PLATFORMS)
+    EVENT_BUTTON, SIGNAL_SMARTTHINGS_UPDATE, SUPPORTED_PLATFORMS)
 from .smartapp import (
     setup_smartapp, setup_smartapp_endpoint, validate_installed_app)
 
@@ -154,6 +154,19 @@ class DeviceBroker:
                 continue
             device.status.apply_attribute_update(
                 evt.component_id, evt.capability, evt.attribute, evt.value)
+
+            # Fire events for buttons
+            if evt.capability == 'button' and evt.attribute == 'button':
+                data = {
+                    'component_id': evt.component_id,
+                    'device_id': evt.device_id,
+                    'location_id': evt.location_id,
+                    'value': evt.value,
+                    'name': device.label
+                }
+                self._hass.bus.async_fire(EVENT_BUTTON, data)
+                _LOGGER.debug("Fired button event: %s", data)
+
             updated_devices.add(device.device_id)
         _LOGGER.debug("Update received with %s events and updated %s devices",
                       len(req.events), len(updated_devices))

--- a/homeassistant/components/smartthings/const.py
+++ b/homeassistant/components/smartthings/const.py
@@ -12,6 +12,7 @@ CONF_LOCATION_ID = 'location_id'
 DATA_MANAGER = 'manager'
 DATA_BROKERS = 'brokers'
 DOMAIN = 'smartthings'
+EVENT_BUTTON = "smartthings.button"
 SIGNAL_SMARTTHINGS_UPDATE = 'smartthings_update'
 SIGNAL_SMARTAPP_PREFIX = 'smartthings_smartap_'
 SETTINGS_INSTANCE_ID = "hassInstanceId"
@@ -25,6 +26,7 @@ SUPPORTED_PLATFORMS = [
 ]
 SUPPORTED_CAPABILITIES = [
     'accelerationSensor',
+    'button',
     'colorControl',
     'colorTemperature',
     'contactSensor',

--- a/tests/components/smartthings/conftest.py
+++ b/tests/components/smartthings/conftest.py
@@ -254,14 +254,16 @@ def device_factory_fixture():
 @pytest.fixture(name="event_factory")
 def event_factory_fixture():
     """Fixture for creating mock devices."""
-    def _factory(device_id, event_type="DEVICE_EVENT"):
+    def _factory(device_id, event_type="DEVICE_EVENT", capability='',
+                 attribute='Updated', value='Value'):
         event = Mock()
         event.event_type = event_type
         event.device_id = device_id
         event.component_id = 'main'
-        event.capability = ''
-        event.attribute = 'Updated'
-        event.value = 'Value'
+        event.capability = capability
+        event.attribute = attribute
+        event.value = value
+        event.location_id = str(uuid4())
         return event
     return _factory
 
@@ -269,11 +271,15 @@ def event_factory_fixture():
 @pytest.fixture(name="event_request_factory")
 def event_request_factory_fixture(event_factory):
     """Fixture for creating mock smartapp event requests."""
-    def _factory(device_ids):
+    def _factory(device_ids=None, events=None):
         request = Mock()
         request.installed_app_id = uuid4()
-        request.events = [event_factory(id) for id in device_ids]
-        request.events.append(event_factory(uuid4()))
-        request.events.append(event_factory(device_ids[0], event_type="OTHER"))
+        if events is None:
+            events = []
+        if device_ids:
+            events.extend([event_factory(id) for id in device_ids])
+            events.append(event_factory(uuid4()))
+            events.append(event_factory(device_ids[0], event_type="OTHER"))
+        request.events = events
         return request
     return _factory


### PR DESCRIPTION
## Description:
Adds support for SmartThings devices with the `button` capability:
- Fires event `smartthings.button` with the data describing the event
- Users will need to remove and reinstall the Home Assistant SmartApp/Automation in the SmartThings Classic mobile app if they have previously used this component.

This PR also addresses some binary_sensor unit tests comments by @MartinHjelmare from PR #20699.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation:** home-assistant/home-assistant.io#8392

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54