### PR TITLE
Fix temperature unit conversion in Ambient PWS

### DIFF
--- a/homeassistant/components/ambient_station/const.py
+++ b/homeassistant/components/ambient_station/const.py
@@ -8,6 +8,3 @@ CONF_APP_KEY = 'app_key'
 DATA_CLIENT = 'data_client'
 
 TOPIC_UPDATE = 'update'
-
-UNITS_SI = 'si'
-UNITS_US = 'us'

--- a/homeassistant/components/ambient_station/sensor.py
+++ b/homeassistant/components/ambient_station/sensor.py
@@ -12,13 +12,10 @@ from homeassistant.const import ATTR_NAME
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
-from .const import (
-    ATTR_LAST_DATA, DATA_CLIENT, DOMAIN, TOPIC_UPDATE, UNITS_SI, UNITS_US)
+from .const import ATTR_LAST_DATA, DATA_CLIENT, DOMAIN, TOPIC_UPDATE
 
 DEPENDENCIES = ['ambient_station']
 _LOGGER = logging.getLogger(__name__)
-
-UNIT_SYSTEM = {UNITS_US: 0, UNITS_SI: 1}
 
 
 async def async_setup_platform(
@@ -31,20 +28,10 @@ async def async_setup_entry(hass, entry, async_add_entities):
     """Set up an Ambient PWS sensor based on a config entry."""
     ambient = hass.data[DOMAIN][DATA_CLIENT][entry.entry_id]
 
-    if ambient.unit_system:
-        sys_units = ambient.unit_system
-    elif hass.config.units.is_metric:
-        sys_units = UNITS_SI
-    else:
-        sys_units = UNITS_US
-
     sensor_list = []
     for mac_address, station in ambient.stations.items():
         for condition in ambient.monitored_conditions:
             name, unit = SENSOR_TYPES[condition]
-            if isinstance(unit, list):
-                unit = unit[UNIT_SYSTEM[sys_units]]
-
             sensor_list.append(
                 AmbientWeatherSensor(
                     ambient, mac_address, station[ATTR_NAME], condition, name,
@@ -58,7 +45,7 @@ class AmbientWeatherSensor(Entity):
 
     def __init__(
             self, ambient, mac_address, station_name, sensor_type, sensor_name,
-            units):
+            unit):
         """Initialize the sensor."""
         self._ambient = ambient
         self._async_unsub_dispatcher_connect = None
@@ -67,7 +54,7 @@ class AmbientWeatherSensor(Entity):
         self._sensor_type = sensor_type
         self._state = None
         self._station_name = station_name
-        self._units = units
+        self._unit = unit
 
     @property
     def name(self):
@@ -87,7 +74,7 @@ class AmbientWeatherSensor(Entity):
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement."""
-        return self._units
+        return self._unit
 
     @property
     def unique_id(self):


### PR DESCRIPTION
## Description:

The previous Ambient PWS sensor platform and the forthcoming PWS component introduced a bug where temperature unit conversion was not handled properly. This PR fixes that by allowing HASS to control any needed conversion.

While I was editing the sensor attributes, I change some lists to tuples, as well, for "mutability correctness." 😆 

Since the re-architecture completed in #20332 is slated to go live in 0.87, tagging this for inclusion in 0.87, as well.

**Related issue (if applicable):** fixes #20665

## Example entry for `configuration.yaml` (if applicable):
```yaml
ambient_station:
  api_key: !secret ambient_api_key
  app_key: !secret ambient_app_key
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
