### PR TITLE
Improve cloud error handling

### DIFF
--- a/homeassistant/components/cloud/http_api.py
+++ b/homeassistant/components/cloud/http_api.py
@@ -107,7 +107,7 @@ def _handle_cloud_errors(handler):
             result = await handler(view, request, *args, **kwargs)
             return result
 
-        except Exception as err:  # pylint: disable=bare-except
+        except Exception as err:  # pylint: disable=broad-except
             err_info = _CLOUD_ERRORS.get(err.__class__)
             if err_info is None:
                 _LOGGER.exception(

--- a/homeassistant/components/cloud/http_api.py
+++ b/homeassistant/components/cloud/http_api.py
@@ -107,13 +107,16 @@ def _handle_cloud_errors(handler):
             result = await handler(view, request, *args, **kwargs)
             return result
 
-        except (auth_api.CloudError, asyncio.TimeoutError) as err:
+        except Exception as err:  # pylint: disable=bare-except
             err_info = _CLOUD_ERRORS.get(err.__class__)
             if err_info is None:
+                _LOGGER.exception(
+                    "Unexpected error processing request for %s", request.path)
                 err_info = (502, 'Unexpected error: {}'.format(err))
             status, msg = err_info
-            return view.json_message(msg, status_code=status,
-                                     message_code=err.__class__.__name__)
+            return view.json_message(
+                msg, status_code=status,
+                message_code=err.__class__.__name__.lower())
 
     return error_handler
 

--- a/tests/components/cloud/test_http_api.py
+++ b/tests/components/cloud/test_http_api.py
@@ -111,6 +111,18 @@ def test_login_view(hass, cloud_client, mock_cognito):
     assert result_pass == 'my_password'
 
 
+async def test_login_view_random_exception(cloud_client):
+    """Try logging in with invalid JSON."""
+    with patch('async_timeout.timeout', side_effect=ValueError('Boom')):
+        req = await cloud_client.post('/api/cloud/login', json={
+            'email': 'my_username',
+            'password': 'my_password'
+        })
+    assert req.status == 502
+    resp = await req.json()
+    assert resp == {'code': 'valueerror', 'message': 'Unexpected error: Boom'}
+
+
 @asyncio.coroutine
 def test_login_view_invalid_json(cloud_client):
     """Try logging in with invalid JSON."""


### PR DESCRIPTION
## Description:
Catch any exception when dealing with the cloud code and handle properly. This will make  the UI give better feedback instead of "Unknown error".

## Example entry for `configuration.yaml` (if applicable):
```yaml
cloud:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
