### PR TITLE
Fix cloud webhook body

### DIFF
--- a/homeassistant/components/cloud/iot.py
+++ b/homeassistant/components/cloud/iot.py
@@ -12,9 +12,10 @@ from homeassistant.components.alexa import smart_home as alexa
 from homeassistant.components.google_assistant import smart_home as ga
 from homeassistant.core import callback
 from homeassistant.util.decorator import Registry
-from homeassistant.util.aiohttp import MockRequest, serialize_response
+from homeassistant.util.aiohttp import MockRequest
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from . import auth_api
+from . import utils
 from .const import MESSAGE_EXPIRATION, MESSAGE_AUTH_FAIL
 
 HANDLERS = Registry()
@@ -360,7 +361,7 @@ async def async_handle_webhook(hass, cloud, payload):
     response = await hass.components.webhook.async_handle_webhook(
         found['webhook_id'], request)
 
-    response_dict = serialize_response(response)
+    response_dict = utils.aiohttp_serialize_response(response)
     body = response_dict.get('body')
 
     return {

--- a/homeassistant/components/cloud/iot.py
+++ b/homeassistant/components/cloud/iot.py
@@ -362,8 +362,6 @@ async def async_handle_webhook(hass, cloud, payload):
 
     response_dict = serialize_response(response)
     body = response_dict.get('body')
-    if body:
-        body = body.decode('utf-8')
 
     return {
         'body': body,

--- a/homeassistant/components/cloud/utils.py
+++ b/homeassistant/components/cloud/utils.py
@@ -1,0 +1,13 @@
+"""Helper functions for cloud components."""
+from typing import Any, Dict
+
+from aiohttp import web
+
+
+def aiohttp_serialize_response(response: web.Response) -> Dict[str, Any]:
+    """Serialize an aiohttp response to a dictionary."""
+    return {
+        'status': response.status,
+        'body': response.text,
+        'headers': dict(response.headers),
+    }

--- a/homeassistant/util/aiohttp.py
+++ b/homeassistant/util/aiohttp.py
@@ -3,7 +3,6 @@ import json
 from urllib.parse import parse_qsl
 from typing import Any, Dict, Optional
 
-from aiohttp import web
 from multidict import CIMultiDict, MultiDict
 
 
@@ -42,12 +41,3 @@ class MockRequest:
     async def text(self) -> str:
         """Return the body as text."""
         return self._text
-
-
-def serialize_response(response: web.Response) -> Dict[str, Any]:
-    """Serialize an aiohttp response to a dictionary."""
-    return {
-        'status': response.status,
-        'body': response.text,
-        'headers': dict(response.headers),
-    }

--- a/homeassistant/util/aiohttp.py
+++ b/homeassistant/util/aiohttp.py
@@ -48,6 +48,6 @@ def serialize_response(response: web.Response) -> Dict[str, Any]:
     """Serialize an aiohttp response to a dictionary."""
     return {
         'status': response.status,
-        'body': response.body,
+        'body': response.text,
         'headers': dict(response.headers),
     }

--- a/tests/components/cloud/test_utils.py
+++ b/tests/components/cloud/test_utils.py
@@ -1,0 +1,24 @@
+"""Test aiohttp request helper."""
+from aiohttp import web
+
+from homeassistant.components.cloud import utils
+
+
+def test_serialize_text():
+    """Test serializing a text response."""
+    response = web.Response(status=201, text='Hello')
+    assert utils.aiohttp_serialize_response(response) == {
+        'status': 201,
+        'body': 'Hello',
+        'headers': {'Content-Type': 'text/plain; charset=utf-8'},
+    }
+
+
+def test_serialize_json():
+    """Test serializing a JSON response."""
+    response = web.json_response({"how": "what"})
+    assert utils.aiohttp_serialize_response(response) == {
+        'status': 200,
+        'body': '{"how": "what"}',
+        'headers': {'Content-Type': 'application/json; charset=utf-8'},
+    }

--- a/tests/util/test_aiohttp.py
+++ b/tests/util/test_aiohttp.py
@@ -1,5 +1,4 @@
 """Test aiohttp request helper."""
-from aiohttp import web
 
 from homeassistant.util import aiohttp
 

--- a/tests/util/test_aiohttp.py
+++ b/tests/util/test_aiohttp.py
@@ -32,23 +32,3 @@ async def test_request_post_query():
     assert request.query == {
         'get': 'true'
     }
-
-
-def test_serialize_text():
-    """Test serializing a text response."""
-    response = web.Response(status=201, text='Hello')
-    assert aiohttp.serialize_response(response) == {
-        'status': 201,
-        'body': 'Hello',
-        'headers': {'Content-Type': 'text/plain; charset=utf-8'},
-    }
-
-
-def test_serialize_json():
-    """Test serializing a JSON response."""
-    response = web.json_response({"how": "what"})
-    assert aiohttp.serialize_response(response) == {
-        'status': 200,
-        'body': '{"how": "what"}',
-        'headers': {'Content-Type': 'application/json; charset=utf-8'},
-    }

--- a/tests/util/test_aiohttp.py
+++ b/tests/util/test_aiohttp.py
@@ -39,7 +39,7 @@ def test_serialize_text():
     response = web.Response(status=201, text='Hello')
     assert aiohttp.serialize_response(response) == {
         'status': 201,
-        'body': b'Hello',
+        'body': 'Hello',
         'headers': {'Content-Type': 'text/plain; charset=utf-8'},
     }
 
@@ -49,6 +49,6 @@ def test_serialize_json():
     response = web.json_response({"how": "what"})
     assert aiohttp.serialize_response(response) == {
         'status': 200,
-        'body': b'{"how": "what"}',
+        'body': '{"how": "what"}',
         'headers': {'Content-Type': 'application/json; charset=utf-8'},
     }


### PR DESCRIPTION
## Description:

I change it to `text` because we only support text as response and aioHttp perform the correct charset that not need to be `utf-8` like we set now static.

Fix:

```
Error handling message
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/homeassistant/components/cloud/iot.py", line 237, in _handle_connection
    hass, self.cloud, msg['handler'], msg['payload'])
  File "/usr/local/lib/python3.6/site-packages/homeassistant/components/cloud/iot.py", line 293, in async_handle_message
    return (yield from handler(hass, cloud, payload))
  File "/usr/local/lib/python3.6/site-packages/homeassistant/components/cloud/iot.py", line 366, in async_handle_webhook
    body = body.decode('utf-8')
AttributeError: 'StringPayload' object has no attribute 'decode'
```