### PR TITLE
Add missing abbreviations

### DIFF
--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -11,7 +11,7 @@ import re
 
 from homeassistant.components import mqtt
 from homeassistant.components.mqtt import ATTR_DISCOVERY_HASH, CONF_STATE_TOPIC
-from homeassistant.const import CONF_PLATFORM
+from homeassistant.const import CONF_DEVICE, CONF_PLATFORM
 from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.typing import HomeAssistantType
@@ -81,6 +81,7 @@ ABBREVIATIONS = {
     'cln_tpl': 'cleaning_template',
     'cmd_t': 'command_topic',
     'curr_temp_t': 'current_temperature_topic',
+    'dev': 'device',
     'dev_cla': 'device_class',
     'dock_t': 'docked_topic',
     'dock_tpl': 'docked_template',
@@ -104,6 +105,7 @@ ABBREVIATIONS = {
     'ic': 'icon',
     'init': 'initial',
     'json_attr': 'json_attributes',
+    'json_attr_t': 'json_attributes_topic',
     'max_temp': 'max_temp',
     'min_temp': 'min_temp',
     'mode_cmd_t': 'mode_command_topic',
@@ -172,11 +174,21 @@ ABBREVIATIONS = {
     'unit_of_meas': 'unit_of_measurement',
     'val_tpl': 'value_template',
     'whit_val_cmd_t': 'white_value_command_topic',
+    'whit_val_scl': 'white_value_scale',
     'whit_val_stat_t': 'white_value_state_topic',
     'whit_val_tpl': 'white_value_template',
     'xy_cmd_t': 'xy_command_topic',
     'xy_stat_t': 'xy_state_topic',
     'xy_val_tpl': 'xy_value_template',
+}
+
+DEVICE_ABBREVIATIONS = {
+    'cns': 'connections',
+    'ids': 'identifiers',
+    'name': 'name',
+    'mf': 'manufacturer',
+    'mdl': 'model',
+    'sw': 'sw_version',
 }
 
 
@@ -215,6 +227,13 @@ async def async_start(hass: HomeAssistantType, discovery_topic, hass_config,
             abbreviated_key = key
             key = ABBREVIATIONS.get(key, key)
             payload[key] = payload.pop(abbreviated_key)
+
+        if CONF_DEVICE in payload:
+            device = payload[CONF_DEVICE]
+            for key in list(device.keys()):
+                abbreviated_key = key
+                key = DEVICE_ABBREVIATIONS.get(key, key)
+                device[key] = device.pop(abbreviated_key)
 
         base = payload.pop(TOPIC_BASE, None)
         if base:

--- a/tests/components/mqtt/test_discovery.py
+++ b/tests/components/mqtt/test_discovery.py
@@ -222,7 +222,15 @@ def test_discovery_expansion(hass, mqtt_mock, caplog):
         '{ "~": "some/base/topic",'
         '  "name": "DiscoveryExpansionTest1",'
         '  "stat_t": "test_topic/~",'
-        '  "cmd_t": "~/test_topic" }'
+        '  "cmd_t": "~/test_topic",'
+        '  "dev":{'
+        '    "ids":["5706DF"],'
+        '    "name":"DiscoveryExpansionTest1 Device",'
+        '    "mdl":"Generic",'
+        '    "sw":"1.2.3.4",'
+        '    "mf":"Noone"'
+        '  }'
+        '}'
     )
 
     async_fire_mqtt_message(


### PR DESCRIPTION
## Description:
Add missing abbreviations for MQTT discovery.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8793

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.
