### PR TITLE
Fix googlehome alarm sensor platform

### DIFF
--- a/homeassistant/components/googlehome/sensor.py
+++ b/homeassistant/components/googlehome/sensor.py
@@ -36,9 +36,10 @@ async def async_setup_platform(hass, config,
             "To use this you need to configure the 'googlehome' component")
         return
 
+    await hass.data[CLIENT].update_info(discovery_info['host'])
+
     devices = []
     for condition in SENSOR_TYPES:
-        await hass.data[CLIENT].update_info(discovery_info['host'])
         data = hass.data[GOOGLEHOME_DOMAIN][discovery_info['host']]
         info = data.get('info', {})
         device = GoogleHomeAlarm(hass.data[CLIENT], condition,
@@ -59,7 +60,6 @@ class GoogleHomeAlarm(Entity):
         self._name = None
         self._state = None
         self._available = True
-        self._info = None
         self._name = "{} {}".format(name, SENSOR_TYPES[self._condition])
 
     async def async_update(self):

--- a/homeassistant/components/googlehome/sensor.py
+++ b/homeassistant/components/googlehome/sensor.py
@@ -37,11 +37,11 @@ async def async_setup_platform(hass, config,
         return
 
     await hass.data[CLIENT].update_info(discovery_info['host'])
+    data = hass.data[GOOGLEHOME_DOMAIN][discovery_info['host']]
+    info = data.get('info', {})
 
     devices = []
     for condition in SENSOR_TYPES:
-        data = hass.data[GOOGLEHOME_DOMAIN][discovery_info['host']]
-        info = data.get('info', {})
         device = GoogleHomeAlarm(hass.data[CLIENT], condition,
                                  discovery_info, info.get('name', NAME))
         devices.append(device)


### PR DESCRIPTION
## Description:
Fixed the Google Home Alarm sensor platform to return in case of missing discovery_info and changed the name attribution mechanism as pointed out by @MartinHjelmare here: https://github.com/home-assistant/home-assistant/pull/20709#discussion_r253538735

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.