### PR TITLE
Fix the line reference in config error message

### DIFF
--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -446,7 +446,11 @@ def _format_config_error(ex: vol.Invalid, domain: str, config: Dict) -> str:
     else:
         message += '{}.'.format(humanize_error(config, ex))
 
-    domain_config = config.get(domain, config)
+    try:
+        domain_config = config.get(domain, config)
+    except AttributeError:
+        domain_config = config
+
     message += " (See {}, line {}). ".format(
         getattr(domain_config, '__config_file__', '?'),
         getattr(domain_config, '__line__', '?'))

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -759,7 +759,7 @@ def async_process_component_config(
                     p_validated = component.PLATFORM_SCHEMA(  # type: ignore
                         p_config)
             except vol.Invalid as ex:
-                async_log_exception(ex, domain, config, hass)
+                async_log_exception(ex, domain, p_config, hass)
                 continue
 
             # Not all platform components follow same pattern for platforms
@@ -782,7 +782,7 @@ def async_process_component_config(
                         p_validated)
                 except vol.Invalid as ex:
                     async_log_exception(ex, '{}.{}'.format(domain, p_name),
-                                        p_validated, hass)
+                                        p_config, hass)
                     continue
 
             platforms.append(p_validated)

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -779,7 +779,7 @@ def async_process_component_config(
                 # pylint: disable=no-member
                 try:
                     p_validated = platform.PLATFORM_SCHEMA(  # type: ignore
-                        p_validated)
+                        p_config)
                 except vol.Invalid as ex:
                     async_log_exception(ex, '{}.{}'.format(domain, p_name),
                                         p_config, hass)

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -555,7 +555,7 @@ async def test_reload_config_when_invalid_config(hass, calls):
     assert calls[0].data.get('event') == 'test_event'
 
     with patch('homeassistant.config.load_yaml_config_file', autospec=True,
-               return_value={automation.DOMAIN: {'not valid': {}}}):
+               return_value={automation.DOMAIN: 'not valid'}):
         with patch('homeassistant.config.find_config_file',
                    return_value=''):
             await common.async_reload(hass)

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -555,7 +555,7 @@ async def test_reload_config_when_invalid_config(hass, calls):
     assert calls[0].data.get('event') == 'test_event'
 
     with patch('homeassistant.config.load_yaml_config_file', autospec=True,
-               return_value={automation.DOMAIN: 'not valid'}):
+               return_value={automation.DOMAIN: {'not valid': {}}}):
         with patch('homeassistant.config.find_config_file',
                    return_value=''):
             await common.async_reload(hass)


### PR DESCRIPTION
## Description:

The platform configuration will go through double validation, first on component level then platform level.
The error handling in the latter validation was passing the result of first validation which already lost meta information about the configuration file and line number. 

**Related issue (if applicable):** fixes #20738 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
camera:
  - platform: generic
    xstill_image_url: 'someurl'
  - xplatform: generic
    ystill_image_url: 'otherurl'
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.


