### PR TITLE
SMHI component: Bugfix - calc precipitation

### DIFF
--- a/homeassistant/components/smhi/__init__.py
+++ b/homeassistant/components/smhi/__init__.py
@@ -11,7 +11,7 @@ from homeassistant.core import Config, HomeAssistant
 from .config_flow import smhi_locations  # noqa: F401
 from .const import DOMAIN  # noqa: F401
 
-REQUIREMENTS = ['smhi-pkg==1.0.5']
+REQUIREMENTS = ['smhi-pkg==1.0.8']
 
 DEFAULT_NAME = 'smhi'
 

--- a/homeassistant/components/smhi/weather.py
+++ b/homeassistant/components/smhi/weather.py
@@ -22,7 +22,7 @@ from homeassistant.const import (
     CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME, TEMP_CELSIUS)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import aiohttp_client
-from homeassistant.util import Throttle, dt, slugify
+from homeassistant.util import Throttle, slugify
 
 DEPENDENCIES = ['smhi']
 
@@ -212,21 +212,24 @@ class SmhiWeather(WeatherEntity):
             return None
 
         data = []
+        first_cast = True
+
         for forecast in self._forecasts:
             condition = next((
                 k for k, v in CONDITION_CLASSES.items()
                 if forecast.symbol in v), None)
 
-            #  Only get mid day forecasts
-            if forecast.valid_time.hour == 12:
+            if not first_cast:
                 data.append({
-                    ATTR_FORECAST_TIME: dt.as_local(forecast.valid_time),
+                    ATTR_FORECAST_TIME: forecast.valid_time.isoformat(),
                     ATTR_FORECAST_TEMP: forecast.temperature_max,
                     ATTR_FORECAST_TEMP_LOW: forecast.temperature_min,
                     ATTR_FORECAST_PRECIPITATION:
-                        round(forecast.mean_precipitation*24),
+                        round(forecast.total_precipitation),
                     ATTR_FORECAST_CONDITION: condition,
                 })
+            else:
+                first_cast = False
 
         return data
 

--- a/homeassistant/components/smhi/weather.py
+++ b/homeassistant/components/smhi/weather.py
@@ -212,14 +212,13 @@ class SmhiWeather(WeatherEntity):
             return None
 
         data = []
-        first_cast = True
 
-        for forecast in self._forecasts:
-            condition = next((
-                k for k, v in CONDITION_CLASSES.items()
-                if forecast.symbol in v), None)
+        if len(self._forecasts) > 1:
+            for forecast in self._forecasts[1:]:
+                condition = next((
+                    k for k, v in CONDITION_CLASSES.items()
+                    if forecast.symbol in v), None)
 
-            if not first_cast:
                 data.append({
                     ATTR_FORECAST_TIME: forecast.valid_time.isoformat(),
                     ATTR_FORECAST_TEMP: forecast.temperature_max,
@@ -228,8 +227,6 @@ class SmhiWeather(WeatherEntity):
                         round(forecast.total_precipitation),
                     ATTR_FORECAST_CONDITION: condition,
                 })
-            else:
-                first_cast = False
 
         return data
 

--- a/homeassistant/components/smhi/weather.py
+++ b/homeassistant/components/smhi/weather.py
@@ -208,25 +208,24 @@ class SmhiWeather(WeatherEntity):
     @property
     def forecast(self) -> List:
         """Return the forecast."""
-        if self._forecasts is None:
+        if self._forecasts is None or len(self._forecasts) < 2:
             return None
 
         data = []
 
-        if len(self._forecasts) > 1:
-            for forecast in self._forecasts[1:]:
-                condition = next((
-                    k for k, v in CONDITION_CLASSES.items()
-                    if forecast.symbol in v), None)
+        for forecast in self._forecasts[1:]:
+            condition = next((
+                k for k, v in CONDITION_CLASSES.items()
+                if forecast.symbol in v), None)
 
-                data.append({
-                    ATTR_FORECAST_TIME: forecast.valid_time.isoformat(),
-                    ATTR_FORECAST_TEMP: forecast.temperature_max,
-                    ATTR_FORECAST_TEMP_LOW: forecast.temperature_min,
-                    ATTR_FORECAST_PRECIPITATION:
-                        round(forecast.total_precipitation),
-                    ATTR_FORECAST_CONDITION: condition,
-                })
+            data.append({
+                ATTR_FORECAST_TIME: forecast.valid_time.isoformat(),
+                ATTR_FORECAST_TEMP: forecast.temperature_max,
+                ATTR_FORECAST_TEMP_LOW: forecast.temperature_min,
+                ATTR_FORECAST_PRECIPITATION:
+                    round(forecast.total_precipitation),
+                ATTR_FORECAST_CONDITION: condition,
+            })
 
         return data
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1552,7 +1552,7 @@ smappy==0.2.16
 # smbus-cffi==0.5.1
 
 # homeassistant.components.smhi
-smhi-pkg==1.0.5
+smhi-pkg==1.0.8
 
 # homeassistant.components.media_player.snapcast
 snapcast==2.0.9

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -269,7 +269,7 @@ simplisafe-python==3.1.14
 sleepyq==0.6
 
 # homeassistant.components.smhi
-smhi-pkg==1.0.5
+smhi-pkg==1.0.8
 
 # homeassistant.components.climate.honeywell
 somecomfort==0.5.2

--- a/tests/components/smhi/test_weather.py
+++ b/tests/components/smhi/test_weather.py
@@ -1,7 +1,7 @@
 """Test for the smhi weather entity."""
 import asyncio
 import logging
-from datetime import datetime, timezone
+from datetime import datetime
 from unittest.mock import Mock, patch
 
 from homeassistant.components.weather import (

--- a/tests/components/smhi/test_weather.py
+++ b/tests/components/smhi/test_weather.py
@@ -61,12 +61,11 @@ async def test_setup_hass(hass: HomeAssistant, aioclient_mock) -> None:
     assert state.attributes[ATTR_WEATHER_WIND_SPEED] == 7
     assert state.attributes[ATTR_WEATHER_WIND_BEARING] == 134
     _LOGGER.error(state.attributes)
-    assert len(state.attributes['forecast']) == 1
+    assert len(state.attributes['forecast']) == 4
 
-    forecast = state.attributes['forecast'][0]
-    assert forecast[ATTR_FORECAST_TIME] == datetime(2018, 9, 2, 12, 0,
-                                                    tzinfo=timezone.utc)
-    assert forecast[ATTR_FORECAST_TEMP] == 20
+    forecast = state.attributes['forecast'][1]
+    assert forecast[ATTR_FORECAST_TIME] == '2018-09-02T12:00:00'
+    assert forecast[ATTR_FORECAST_TEMP] == 21
     assert forecast[ATTR_FORECAST_TEMP_LOW] == 6
     assert forecast[ATTR_FORECAST_PRECIPITATION] == 0
     assert forecast[ATTR_FORECAST_CONDITION] == 'partlycloudy'
@@ -102,7 +101,8 @@ def test_properties_unknown_symbol() -> None:
     hass = Mock()
     data = Mock()
     data.temperature = 5
-    data.mean_precipitation = 1
+    data.mean_precipitation = 0.5
+    data.total_precipitation = 1
     data.humidity = 5
     data.wind_speed = 10
     data.wind_direction = 180
@@ -114,7 +114,8 @@ def test_properties_unknown_symbol() -> None:
 
     data2 = Mock()
     data2.temperature = 5
-    data2.mean_precipitation = 1
+    data2.mean_precipitation = 0.5
+    data2.total_precipitation = 1
     data2.humidity = 5
     data2.wind_speed = 10
     data2.wind_direction = 180
@@ -126,7 +127,8 @@ def test_properties_unknown_symbol() -> None:
 
     data3 = Mock()
     data3.temperature = 5
-    data3.mean_precipitation = 1
+    data3.mean_precipitation = 0.5
+    data3.total_precipitation = 1
     data3.humidity = 5
     data3.wind_speed = 10
     data3.wind_direction = 180


### PR DESCRIPTION
BUGFIX:

- Precipitation (total daily) was calculated in a wrong way. Uppgraded the smhi package and
changed to use the new total_precipitation property.

- Fixed the bug where it could report same day twice during noon UTC. Now just skipping first forecast as supposed to.

No doc changes.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

