### PR TITLE
Add additional devices and features to Homematic IP

### DIFF
--- a/homeassistant/components/homematicip_cloud/__init__.py
+++ b/homeassistant/components/homematicip_cloud/__init__.py
@@ -19,7 +19,7 @@ from .const import (
 from .device import HomematicipGenericDevice  # noqa: F401
 from .hap import HomematicipAuth, HomematicipHAP  # noqa: F401
 
-REQUIREMENTS = ['homematicip==0.10.4']
+REQUIREMENTS = ['homematicip==0.10.5']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/homematicip_cloud/sensor.py
+++ b/homeassistant/components/homematicip_cloud/sensor.py
@@ -9,7 +9,7 @@ import logging
 from homeassistant.components.homematicip_cloud import (
     DOMAIN as HMIPC_DOMAIN, HMIPC_HAPID, HomematicipGenericDevice)
 from homeassistant.const import (
-    DEVICE_CLASS_HUMIDITY, DEVICE_CLASS_ILLUMINANCE, DEVICE_CLASS_POWER,
+    DEVICE_CLASS_HUMIDITY, DEVICE_CLASS_ILLUMINANCE,
     DEVICE_CLASS_TEMPERATURE, TEMP_CELSIUS)
 
 _LOGGER = logging.getLogger(__name__)
@@ -212,7 +212,7 @@ class HomematicipPowerSensor(HomematicipGenericDevice):
     @property
     def device_class(self):
         """Return the device class of the sensor."""
-        return DEVICE_CLASS_POWER
+        return 'power'
 
     @property
     def state(self):

--- a/homeassistant/components/homematicip_cloud/sensor.py
+++ b/homeassistant/components/homematicip_cloud/sensor.py
@@ -210,11 +210,6 @@ class HomematicipPowerSensor(HomematicipGenericDevice):
         super().__init__(home, device, 'Power')
 
     @property
-    def device_class(self):
-        """Return the device class of the sensor."""
-        return 'power'
-
-    @property
     def state(self):
         """Return the state."""
         return self._device.currentPowerConsumption

--- a/homeassistant/components/homematicip_cloud/sensor.py
+++ b/homeassistant/components/homematicip_cloud/sensor.py
@@ -7,11 +7,10 @@ https://home-assistant.io/components/sensor.homematicip_cloud/
 import logging
 
 from homeassistant.components.homematicip_cloud import (
-    HMIPC_HAPID, HomematicipGenericDevice)
-from homeassistant.components.homematicip_cloud import DOMAIN as HMIPC_DOMAIN
+    DOMAIN as HMIPC_DOMAIN, HMIPC_HAPID, HomematicipGenericDevice)
 from homeassistant.const import (
-    DEVICE_CLASS_HUMIDITY, DEVICE_CLASS_ILLUMINANCE, DEVICE_CLASS_TEMPERATURE,
-    TEMP_CELSIUS)
+    DEVICE_CLASS_HUMIDITY, DEVICE_CLASS_ILLUMINANCE,
+    DEVICE_CLASS_TEMPERATURE, TEMP_CELSIUS)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -36,7 +35,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         AsyncHeatingThermostat, AsyncTemperatureHumiditySensorWithoutDisplay,
         AsyncTemperatureHumiditySensorDisplay, AsyncMotionDetectorIndoor,
         AsyncTemperatureHumiditySensorOutdoor,
-        AsyncMotionDetectorPushButton)
+        AsyncMotionDetectorPushButton, AsyncLightSensor)
 
     home = hass.data[HMIPC_DOMAIN][config_entry.data[HMIPC_HAPID]].home
     devices = [HomematicipAccesspointStatus(home)]
@@ -51,6 +50,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         if isinstance(device, (AsyncMotionDetectorIndoor,
                                AsyncMotionDetectorPushButton)):
             devices.append(HomematicipIlluminanceSensor(home, device))
+        if isinstance(device, AsyncLightSensor):
+            devices.append(HomematicipLightSensor(home, device))
 
     if devices:
         async_add_entities(devices)
@@ -184,3 +185,12 @@ class HomematicipIlluminanceSensor(HomematicipGenericDevice):
     def unit_of_measurement(self):
         """Return the unit this state is expressed in."""
         return 'lx'
+
+
+class HomematicipLightSensor(HomematicipIlluminanceSensor):
+    """Represenation of a HomematicIP Illuminance device."""
+
+    @property
+    def state(self):
+        """Return the state."""
+        return self._device.averageIllumination

--- a/homeassistant/components/homematicip_cloud/sensor.py
+++ b/homeassistant/components/homematicip_cloud/sensor.py
@@ -211,7 +211,7 @@ class HomematicipPowerSensor(HomematicipGenericDevice):
 
     @property
     def state(self):
-        """Return the state."""
+        """Returns the current power consumption of the device"""
         return self._device.currentPowerConsumption
 
     @property

--- a/homeassistant/components/homematicip_cloud/sensor.py
+++ b/homeassistant/components/homematicip_cloud/sensor.py
@@ -211,7 +211,7 @@ class HomematicipPowerSensor(HomematicipGenericDevice):
 
     @property
     def state(self):
-        """Returns the current power consumption of the device"""
+        """Represenation of the HomematicIP power comsumption value."""
         return self._device.currentPowerConsumption
 
     @property

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -181,9 +181,10 @@ EVENT_SCRIPT_STARTED = 'script_started'
 DEVICE_CLASS_BATTERY = 'battery'
 DEVICE_CLASS_HUMIDITY = 'humidity'
 DEVICE_CLASS_ILLUMINANCE = 'illuminance'
+DEVICE_CLASS_POWER = 'power'
+DEVICE_CLASS_PRESSURE = 'pressure'
 DEVICE_CLASS_TEMPERATURE = 'temperature'
 DEVICE_CLASS_TIMESTAMP = 'timestamp'
-DEVICE_CLASS_PRESSURE = 'pressure'
 
 # #### STATES ####
 STATE_ON = 'on'

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -181,10 +181,9 @@ EVENT_SCRIPT_STARTED = 'script_started'
 DEVICE_CLASS_BATTERY = 'battery'
 DEVICE_CLASS_HUMIDITY = 'humidity'
 DEVICE_CLASS_ILLUMINANCE = 'illuminance'
-DEVICE_CLASS_POWER = 'power'
-DEVICE_CLASS_PRESSURE = 'pressure'
 DEVICE_CLASS_TEMPERATURE = 'temperature'
 DEVICE_CLASS_TIMESTAMP = 'timestamp'
+DEVICE_CLASS_PRESSURE = 'pressure'
 
 # #### STATES ####
 STATE_ON = 'on'

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -487,7 +487,7 @@ greenwavereality==0.5.1
 gstreamer-player==1.1.2
 
 # homeassistant.components.ffmpeg
-ha-ffmpeg==1.11
+ha-ffmpeg==1.9
 
 # homeassistant.components.media_player.philips_js
 ha-philipsjs==0.0.5
@@ -535,7 +535,7 @@ homeassistant-pyozw==0.1.2
 homekit==0.12.2
 
 # homeassistant.components.homematicip_cloud
-homematicip==0.10.4
+homematicip==0.10.5
 
 # homeassistant.components.google
 # homeassistant.components.remember_the_milk

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -487,7 +487,7 @@ greenwavereality==0.5.1
 gstreamer-player==1.1.2
 
 # homeassistant.components.ffmpeg
-ha-ffmpeg==1.9
+ha-ffmpeg==1.11
 
 # homeassistant.components.media_player.philips_js
 ha-philipsjs==0.0.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -101,7 +101,7 @@ geojson_client==0.3
 georss_client==0.5
 
 # homeassistant.components.ffmpeg
-ha-ffmpeg==1.11
+ha-ffmpeg==1.9
 
 # homeassistant.components.hangouts
 hangups==0.4.6
@@ -122,7 +122,7 @@ home-assistant-frontend==20190203.0
 homekit==0.12.2
 
 # homeassistant.components.homematicip_cloud
-homematicip==0.10.4
+homematicip==0.10.5
 
 # homeassistant.components.influxdb
 # homeassistant.components.sensor.influxdb

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -101,7 +101,7 @@ geojson_client==0.3
 georss_client==0.5
 
 # homeassistant.components.ffmpeg
-ha-ffmpeg==1.9
+ha-ffmpeg==1.11
 
 # homeassistant.components.hangouts
 hangups==0.4.6


### PR DESCRIPTION
## Description:
- updated depency for homematicip to 0.10.5 (required for HmIP-SLO)
- Added support for HmIP-SLO Lightsensor
- Added power measure for HmIP-BSM, HmIP-FSM, HmIP-PSM

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.