### PR TITLE
Expose effect_list attribute for turned off lights

### DIFF
--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -439,6 +439,9 @@ class Light(ToggleEntity):
             data[ATTR_MIN_MIREDS] = self.min_mireds
             data[ATTR_MAX_MIREDS] = self.max_mireds
 
+        if supported_features & SUPPORT_EFFECT:
+            data[ATTR_EFFECT_LIST] = self.effect_list
+
         if self.is_on:
             if supported_features & SUPPORT_BRIGHTNESS:
                 data[ATTR_BRIGHTNESS] = self.brightness
@@ -460,7 +463,6 @@ class Light(ToggleEntity):
                 data[ATTR_WHITE_VALUE] = self.white_value
 
             if supported_features & SUPPORT_EFFECT:
-                data[ATTR_EFFECT_LIST] = self.effect_list
                 data[ATTR_EFFECT] = self.effect
 
         return {key: val for key, val in data.items() if val is not None}


### PR DESCRIPTION
## Description:

**Related issue:** fixes #20583

Expose `effect_list` attribute for all lights regardless of state (not only for turned on lights).

Another PR into `home-assistant-polymer` repo will follow right now.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
