### PR TITLE
Added egg age to the eggminder sensor

### DIFF
--- a/homeassistant/components/wink/sensor.py
+++ b/homeassistant/components/wink/sensor.py
@@ -8,7 +8,6 @@ import logging
 
 from homeassistant.components.wink import DOMAIN, WinkDevice
 from homeassistant.const import TEMP_CELSIUS
-from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/wink/sensor.py
+++ b/homeassistant/components/wink/sensor.py
@@ -47,7 +47,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                 _LOGGER.info("Device is not a sensor")
 
 
-class WinkSensorDevice(WinkDevice, Entity):
+class WinkSensorDevice(WinkDevice):
     """Representation of a Wink sensor."""
 
     def __init__(self, wink, hass):
@@ -87,3 +87,15 @@ class WinkSensorDevice(WinkDevice, Entity):
     def unit_of_measurement(self):
         """Return the unit of measurement of this entity, if any."""
         return self._unit_of_measurement
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        super_attrs = super().device_state_attributes
+        _LOGGER.debug("Adding in eggs if egg minder")
+        try:
+            super_attrs['egg_times'] = self.wink.eggs()
+            _LOGGER.debug("Its an egg minder")
+        except AttributeError:
+            _LOGGER.debug("Not an eggtray")
+        return super_attrs


### PR DESCRIPTION
## Description:
Feature requested over here https://community.home-assistant.io/t/quirky-egg-minder-via-wink/47829/14

This adds a new attribute on each eggminder sensor that is a list of unix timestamps that each egg was added to the eggminder. The list is in order from egg 1-14


## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
