### PR TITLE
Keep cloud tokens always valid

### DIFF
--- a/homeassistant/components/cloud/__init__.py
+++ b/homeassistant/components/cloud/__init__.py
@@ -106,6 +106,7 @@ async def async_setup(hass, config):
     )
 
     cloud = hass.data[DOMAIN] = Cloud(hass, **kwargs)
+    await auth_api.async_setup(hass, cloud)
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, cloud.async_start)
     await http_api.async_setup(hass)
     return True
@@ -263,7 +264,7 @@ class Cloud:
         self.access_token = info['access_token']
         self.refresh_token = info['refresh_token']
 
-        self.hass.add_job(self.iot.connect())
+        self.hass.async_create_task(self.iot.connect())
 
     def _decode_claims(self, token):  # pylint: disable=no-self-use
         """Decode the claims in a token."""

--- a/homeassistant/components/cloud/auth_api.py
+++ b/homeassistant/components/cloud/auth_api.py
@@ -87,7 +87,7 @@ def _map_aws_exception(err):
 
 def register(cloud, email, password):
     """Register a new account."""
-    from botocore.exceptions import ClientError
+    from botocore.exceptions import ClientError, EndpointConnectionError
 
     cognito = _cognito(cloud)
     # Workaround for bug in Warrant. PR with fix:
@@ -95,13 +95,16 @@ def register(cloud, email, password):
     cognito.add_base_attributes()
     try:
         cognito.register(email, password)
+
     except ClientError as err:
         raise _map_aws_exception(err)
+    except EndpointConnectionError:
+        raise UnknownError()
 
 
 def resend_email_confirm(cloud, email):
     """Resend email confirmation."""
-    from botocore.exceptions import ClientError
+    from botocore.exceptions import ClientError, EndpointConnectionError
 
     cognito = _cognito(cloud, username=email)
 
@@ -112,18 +115,23 @@ def resend_email_confirm(cloud, email):
         )
     except ClientError as err:
         raise _map_aws_exception(err)
+    except EndpointConnectionError:
+        raise UnknownError()
 
 
 def forgot_password(cloud, email):
     """Initialize forgotten password flow."""
-    from botocore.exceptions import ClientError
+    from botocore.exceptions import ClientError, EndpointConnectionError
 
     cognito = _cognito(cloud, username=email)
 
     try:
         cognito.initiate_forgot_password()
+
     except ClientError as err:
         raise _map_aws_exception(err)
+    except EndpointConnectionError:
+        raise UnknownError()
 
 
 def login(cloud, email, password):
@@ -137,7 +145,7 @@ def login(cloud, email, password):
 
 def check_token(cloud):
     """Check that the token is valid and verify if needed."""
-    from botocore.exceptions import ClientError
+    from botocore.exceptions import ClientError, EndpointConnectionError
 
     cognito = _cognito(
         cloud,
@@ -149,13 +157,17 @@ def check_token(cloud):
             cloud.id_token = cognito.id_token
             cloud.access_token = cognito.access_token
             cloud.write_user_info()
+
     except ClientError as err:
         raise _map_aws_exception(err)
+
+    except EndpointConnectionError:
+        raise UnknownError()
 
 
 def renew_access_token(cloud):
     """Renew access token."""
-    from botocore.exceptions import ClientError
+    from botocore.exceptions import ClientError, EndpointConnectionError
 
     cognito = _cognito(
         cloud,
@@ -167,13 +179,17 @@ def renew_access_token(cloud):
         cloud.id_token = cognito.id_token
         cloud.access_token = cognito.access_token
         cloud.write_user_info()
+
     except ClientError as err:
         raise _map_aws_exception(err)
+
+    except EndpointConnectionError:
+        raise UnknownError()
 
 
 def _authenticate(cloud, email, password):
     """Log in and return an authenticated Cognito instance."""
-    from botocore.exceptions import ClientError
+    from botocore.exceptions import ClientError, EndpointConnectionError
     from warrant.exceptions import ForceChangePasswordException
 
     assert not cloud.is_logged_in, 'Cannot login if already logged in.'
@@ -185,10 +201,13 @@ def _authenticate(cloud, email, password):
         return cognito
 
     except ForceChangePasswordException:
-        raise PasswordChangeRequired
+        raise PasswordChangeRequired()
 
     except ClientError as err:
         raise _map_aws_exception(err)
+
+    except EndpointConnectionError:
+        raise UnknownError()
 
 
 def _cognito(cloud, **kwargs):

--- a/homeassistant/components/cloud/iot.py
+++ b/homeassistant/components/cloud/iot.py
@@ -349,11 +349,6 @@ async def async_handle_cloud(hass, cloud, payload):
         await cloud.logout()
         _LOGGER.error("You have been logged out from Home Assistant cloud: %s",
                       payload['reason'])
-    elif action == 'refresh_auth':
-        # Refresh the auth token between now and payload['seconds']
-        hass.helpers.event.async_call_later(
-            random.randint(0, payload['seconds']),
-            lambda now: auth_api.check_token(cloud))
     else:
         _LOGGER.warning("Received unknown cloud action: %s", action)
 

--- a/tests/components/cloud/test_iot.py
+++ b/tests/components/cloud/test_iot.py
@@ -158,26 +158,6 @@ async def test_handling_core_messages_logout(hass, mock_cloud):
     assert len(mock_cloud.logout.mock_calls) == 1
 
 
-async def test_handling_core_messages_refresh_auth(hass, mock_cloud):
-    """Test handling core messages."""
-    mock_cloud.hass = hass
-    with patch('random.randint', return_value=0) as mock_rand, patch(
-        'homeassistant.components.cloud.auth_api.check_token'
-    ) as mock_check:
-        await iot.async_handle_cloud(hass, mock_cloud, {
-            'action': 'refresh_auth',
-            'seconds': 230,
-        })
-        async_fire_time_changed(hass, dt_util.utcnow())
-        await hass.async_block_till_done()
-
-    assert len(mock_rand.mock_calls) == 1
-    assert mock_rand.mock_calls[0][1] == (0, 230)
-
-    assert len(mock_check.mock_calls) == 1
-    assert mock_check.mock_calls[0][1][0] is mock_cloud
-
-
 @asyncio.coroutine
 def test_cloud_getting_disconnected_by_server(mock_client, caplog, mock_cloud):
     """Test server disconnecting instance."""

--- a/tests/components/cloud/test_iot.py
+++ b/tests/components/cloud/test_iot.py
@@ -10,9 +10,8 @@ from homeassistant.components.cloud import (
     Cloud, iot, auth_api, MODE_DEV)
 from homeassistant.components.cloud.const import (
     PREF_ENABLE_ALEXA, PREF_ENABLE_GOOGLE)
-from homeassistant.util import dt as dt_util
 from tests.components.alexa import test_smart_home as test_alexa
-from tests.common import mock_coro, async_fire_time_changed
+from tests.common import mock_coro
 
 from . import mock_cloud_prefs
 


### PR DESCRIPTION
## Description:

 - Keep cloud tokens always valid when connected to the cloud
 - Catch an extra exception when refreshing auth
 - Remove unused refresh_auth message

Replaces #20754

## Example entry for `configuration.yaml` (if applicable):
```yaml
cloud:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
