### PR TITLE
Show ted5000 MTU as unavailable

### DIFF
--- a/homeassistant/components/sensor/ted5000.py
+++ b/homeassistant/components/sensor/ted5000.py
@@ -29,7 +29,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
     vol.Optional(CONF_PORT, default=80): cv.port,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional('show_unavailable', default=True): cv.boolean,
 })
 
 
@@ -38,10 +37,9 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     host = config.get(CONF_HOST)
     port = config.get(CONF_PORT)
     name = config.get(CONF_NAME)
-    availability = config.get('show_unavailable')
     url = 'http://{}:{}/api/LiveData.xml'.format(host, port)
 
-    gateway = Ted5000Gateway(url, availability)
+    gateway = Ted5000Gateway(url)
 
     # Get MTU information to create the sensors.
     gateway.update()
@@ -94,10 +92,7 @@ class Ted5000Sensor(Entity):
     def available(self):
         """Return the availability state."""
         try:
-            if self._gateway.availability:
-                return self._gateway.data[self._mtu]['A']
-            else:
-                return True
+            return self._gateway.data[self._mtu]['A']
         except KeyError:
             pass
 
@@ -105,11 +100,10 @@ class Ted5000Sensor(Entity):
 class Ted5000Gateway:
     """The class for handling the data retrieval."""
 
-    def __init__(self, url, availability):
+    def __init__(self, url):
         """Initialize the data object."""
         self.url = url
         self.data = dict()
-        self.availability = availability
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):

--- a/homeassistant/components/sensor/ted5000.py
+++ b/homeassistant/components/sensor/ted5000.py
@@ -130,8 +130,8 @@ class Ted5000Gateway:
                               ["VoltageNow"])
 
                 if power == 0 and voltage == 0:
-                    self.data[mtu] = {'W': power, 'V': voltage / 10, 
+                    self.data[mtu] = {'W': power, 'V': voltage / 10,
                                       'A': False}
                 else:
-                    self.data[mtu] = {'W': power, 'V': voltage / 10, 
+                    self.data[mtu] = {'W': power, 'V': voltage / 10,
                                       'A': True}

--- a/homeassistant/components/sensor/ted5000.py
+++ b/homeassistant/components/sensor/ted5000.py
@@ -89,7 +89,7 @@ class Ted5000Sensor(Entity):
     def update(self):
         """Get the latest data from REST API."""
         self._gateway.update()
-        
+
     @property
     def available(self):
         """Return the availability state."""
@@ -130,6 +130,8 @@ class Ted5000Gateway:
                               ["VoltageNow"])
 
                 if power == 0 and voltage == 0:
-                    self.data[mtu] = {'W': power, 'V': voltage / 10, 'A': False}
+                    self.data[mtu] = {'W': power, 'V': voltage / 10, 
+                                      'A': False}
                 else:
-                    self.data[mtu] = {'W': power, 'V': voltage / 10, 'A': True}
+                    self.data[mtu] = {'W': power, 'V': voltage / 10, 
+                                      'A': True}


### PR DESCRIPTION
## Description:
As requested in previous [commit](https://github.com/home-assistant/home-assistant/pull/20654) (already pushed to dev), it would be great to show the MTU as unavailable whenever it is off. Even though this is a good idea for everyone, I don't want this for me. Therefor, I added the feature as an optional user exposed functionality. 
If `show_unavailable: false` disable the `unavailable` display and it will show 0W and/or 0V whenever it's off. Default value is true and will display `unavailable`.

I also modified the `MIN_TIME_BETWEEN_UPDATES`. The TED5000 is refreshing every 3 seconds and it would be great to get this refresh rate as well. Of course, if user wants a slower refresh rate, user can use `scan_interval` to setup a preferred delay between calls.

## Example entry for `configuration.yaml` :
```
- platform: ted5000
    host: 192.168.x.x
    scan_interval: 10
    show_unavailable: false
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)
