### PR TITLE
Expose detailed Ecobee equipment status

### DIFF
--- a/homeassistant/components/ecobee/climate.py
+++ b/homeassistant/components/ecobee/climate.py
@@ -283,6 +283,7 @@ class Thermostat(ClimateDevice):
             "fan": self.fan,
             "climate_mode": self.mode,
             "operation": operation,
+            "equipment_running": status,
             "climate_list": self.climate_list,
             "fan_min_on_time": self.fan_min_on_time
         }

--- a/homeassistant/components/ecobee/climate.py
+++ b/homeassistant/components/ecobee/climate.py
@@ -238,7 +238,7 @@ class Thermostat(ClimateDevice):
         - STATE_IDLE: thermostat is on, but not actively heating or cooling
         - STATE_HEAT: actively heating
         - STATE_COOL: actively cooling
-        - None: unknown state"""
+        """
         status = self.thermostat['equipmentStatus']
         if self.operation_mode == STATE_OFF:
             operation = STATE_OFF
@@ -402,8 +402,8 @@ class Thermostat(ClimateDevice):
         heatCoolMinDelta property.
         https://www.ecobee.com/home/developer/api/examples/ex5.shtml
         """
-        if self.current_operation_mode == STATE_HEAT or self.current_operation_mode == \
-                STATE_COOL:
+        if self.current_operation_mode == STATE_HEAT or \
+                self.current_operation_mode == STATE_COOL:
             heat_temp = temp
             cool_temp = temp
         else:

--- a/homeassistant/components/ecobee/climate.py
+++ b/homeassistant/components/ecobee/climate.py
@@ -238,7 +238,7 @@ class Thermostat(ClimateDevice):
         - STATE_IDLE: thermostat is on, but not actively heating or cooling
         - STATE_HEAT: actively heating
         - STATE_COOL: actively cooling
-        """
+        - None: unknown state"""
         status = self.thermostat['equipmentStatus']
         if self.operation_mode == STATE_OFF:
             operation = STATE_OFF
@@ -402,8 +402,8 @@ class Thermostat(ClimateDevice):
         heatCoolMinDelta property.
         https://www.ecobee.com/home/developer/api/examples/ex5.shtml
         """
-        if self.current_operation_mode == STATE_HEAT or \
-                self.current_operation_mode == STATE_COOL:
+        if self.current_operation_mode == STATE_HEAT or self.current_operation_mode == \
+                STATE_COOL:
             heat_temp = temp
             cool_temp = temp
         else:

--- a/homeassistant/components/ecobee/climate.py
+++ b/homeassistant/components/ecobee/climate.py
@@ -159,25 +159,25 @@ class Thermostat(ClimateDevice):
     @property
     def target_temperature_low(self):
         """Return the lower bound temperature we try to reach."""
-        if self.current_operation_mode == STATE_AUTO:
+        if self.current_operation == STATE_AUTO:
             return self.thermostat['runtime']['desiredHeat'] / 10.0
         return None
 
     @property
     def target_temperature_high(self):
         """Return the upper bound temperature we try to reach."""
-        if self.current_operation_mode == STATE_AUTO:
+        if self.current_operation == STATE_AUTO:
             return self.thermostat['runtime']['desiredCool'] / 10.0
         return None
 
     @property
     def target_temperature(self):
         """Return the temperature we try to reach."""
-        if self.current_operation_mode == STATE_AUTO:
+        if self.current_operation == STATE_AUTO:
             return None
-        if self.current_operation_mode == STATE_HEAT:
+        if self.current_operation == STATE_HEAT:
             return self.thermostat['runtime']['desiredHeat'] / 10.0
-        if self.current_operation_mode == STATE_COOL:
+        if self.current_operation == STATE_COOL:
             return self.thermostat['runtime']['desiredCool'] / 10.0
         return None
 
@@ -232,29 +232,7 @@ class Thermostat(ClimateDevice):
 
     @property
     def current_operation(self):
-        """Return current operation the thermostat is calling for.
-
-        - STATE_OFF : thermostat is off
-        - STATE_IDLE: thermostat is on, but not actively heating or cooling
-        - STATE_HEAT: actively heating
-        - STATE_COOL: actively cooling
-        - None: unknown state"""
-        status = self.thermostat['equipmentStatus']
-        if self.operation_mode == STATE_OFF:
-            operation = STATE_OFF
-        elif 'Cool' in status:
-            operation = STATE_COOL
-        elif 'auxHeat' in status:
-            operation = STATE_HEAT
-        elif 'heatPump' in status:
-            operation = STATE_HEAT
-        else:
-            operation = STATE_IDLE
-        return operation
-
-    @property
-    def current_operation_mode(self):
-        """Return current mode mapped to states."""
+        """Return current operation."""
         if self.operation_mode == 'auxHeatOnly' or \
                 self.operation_mode == 'heatPump':
             return STATE_HEAT
@@ -286,7 +264,9 @@ class Thermostat(ClimateDevice):
     @property
     def device_state_attributes(self):
         """Return device specific state attributes."""
+        # Move these to Thermostat Device and make them global
         status = self.thermostat['equipmentStatus']
+        operation = None
         if status == '':
             operation = STATE_IDLE
         elif 'Cool' in status:
@@ -402,7 +382,7 @@ class Thermostat(ClimateDevice):
         heatCoolMinDelta property.
         https://www.ecobee.com/home/developer/api/examples/ex5.shtml
         """
-        if self.current_operation_mode == STATE_HEAT or self.current_operation_mode == \
+        if self.current_operation == STATE_HEAT or self.current_operation == \
                 STATE_COOL:
             heat_temp = temp
             cool_temp = temp
@@ -418,7 +398,7 @@ class Thermostat(ClimateDevice):
         high_temp = kwargs.get(ATTR_TARGET_TEMP_HIGH)
         temp = kwargs.get(ATTR_TEMPERATURE)
 
-        if self.current_operation_mode == STATE_AUTO and \
+        if self.current_operation == STATE_AUTO and \
                 (low_temp is not None or high_temp is not None):
             self.set_auto_temp_hold(low_temp, high_temp)
         elif temp is not None:

--- a/tests/components/ecobee/test_climate.py
+++ b/tests/components/ecobee/test_climate.py
@@ -183,7 +183,8 @@ class TestEcobee(unittest.TestCase):
                 'fan': 'off',
                 'fan_min_on_time': 10,
                 'climate_mode': 'Climate1',
-                'operation': 'heat'} == \
+                'operation': 'heat',
+                'equipment_running': 'heatPump2'} == \
             self.thermostat.device_state_attributes
 
         self.ecobee['equipmentStatus'] = 'auxHeat2'
@@ -192,7 +193,8 @@ class TestEcobee(unittest.TestCase):
                 'fan': 'off',
                 'fan_min_on_time': 10,
                 'climate_mode': 'Climate1',
-                'operation': 'heat'} == \
+                'operation': 'heat',
+                'equipment_running': 'auxHeat2'} == \
             self.thermostat.device_state_attributes
         self.ecobee['equipmentStatus'] = 'compCool1'
         assert {'actual_humidity': 15,
@@ -200,7 +202,8 @@ class TestEcobee(unittest.TestCase):
                 'fan': 'off',
                 'fan_min_on_time': 10,
                 'climate_mode': 'Climate1',
-                'operation': 'cool'} == \
+                'operation': 'cool',
+                'equipment_running': 'compCool1'} == \
             self.thermostat.device_state_attributes
         self.ecobee['equipmentStatus'] = ''
         assert {'actual_humidity': 15,
@@ -208,7 +211,8 @@ class TestEcobee(unittest.TestCase):
                 'fan': 'off',
                 'fan_min_on_time': 10,
                 'climate_mode': 'Climate1',
-                'operation': 'idle'} == \
+                'operation': 'idle',
+                'equipment_running': ''} == \
             self.thermostat.device_state_attributes
 
         self.ecobee['equipmentStatus'] = 'Unknown'
@@ -217,7 +221,8 @@ class TestEcobee(unittest.TestCase):
                 'fan': 'off',
                 'fan_min_on_time': 10,
                 'climate_mode': 'Climate1',
-                'operation': 'Unknown'} == \
+                'operation': 'Unknown',
+                'equipment_running': 'Unknown'} == \
             self.thermostat.device_state_attributes
 
     def test_is_away_mode_on(self):

--- a/tests/components/ecobee/test_climate.py
+++ b/tests/components/ecobee/test_climate.py
@@ -142,30 +142,15 @@ class TestEcobee(unittest.TestCase):
 
     def test_current_operation(self):
         """Test current operation property."""
-        self.ecobee['settings']['hvacMode'] = 'auto'
-        self.ecobee['equipmentStatus'] = ''
-        assert 'idle' == self.thermostat.current_operation
-        self.ecobee['equipmentStatus'] = 'fan,heatPump1'
+        assert 'auto' == self.thermostat.current_operation
+        self.ecobee['settings']['hvacMode'] = 'heat'
         assert 'heat' == self.thermostat.current_operation
-        self.ecobee['equipmentStatus'] = 'fan,compCool1'
+        self.ecobee['settings']['hvacMode'] = 'cool'
         assert 'cool' == self.thermostat.current_operation
-        self.ecobee['equipmentStatus'] = 'fan,auxHeat1'
+        self.ecobee['settings']['hvacMode'] = 'auxHeatOnly'
         assert 'heat' == self.thermostat.current_operation
         self.ecobee['settings']['hvacMode'] = 'off'
         assert 'off' == self.thermostat.current_operation
-
-    def test_current_operation_mode(self):
-        """Test current operation mode property."""
-        self.ecobee['settings']['hvacMode'] = 'auto'
-        assert 'auto' == self.thermostat.current_operation_mode
-        self.ecobee['settings']['hvacMode'] = 'heat'
-        assert 'heat' == self.thermostat.current_operation_mode
-        self.ecobee['settings']['hvacMode'] = 'cool'
-        assert 'cool' == self.thermostat.current_operation_mode
-        self.ecobee['settings']['hvacMode'] = 'auxHeatOnly'
-        assert 'heat' == self.thermostat.current_operation_mode
-        self.ecobee['settings']['hvacMode'] = 'off'
-        assert 'off' == self.thermostat.current_operation_mode
 
     def test_operation_list(self):
         """Test operation list property."""

--- a/tests/components/ecobee/test_climate.py
+++ b/tests/components/ecobee/test_climate.py
@@ -142,15 +142,30 @@ class TestEcobee(unittest.TestCase):
 
     def test_current_operation(self):
         """Test current operation property."""
-        assert 'auto' == self.thermostat.current_operation
-        self.ecobee['settings']['hvacMode'] = 'heat'
+        self.ecobee['settings']['hvacMode'] = 'auto'
+        self.ecobee['equipmentStatus'] = ''
+        assert 'idle' == self.thermostat.current_operation
+        self.ecobee['equipmentStatus'] = 'fan,heatPump1'
         assert 'heat' == self.thermostat.current_operation
-        self.ecobee['settings']['hvacMode'] = 'cool'
+        self.ecobee['equipmentStatus'] = 'fan,compCool1'
         assert 'cool' == self.thermostat.current_operation
-        self.ecobee['settings']['hvacMode'] = 'auxHeatOnly'
+        self.ecobee['equipmentStatus'] = 'fan,auxHeat1'
         assert 'heat' == self.thermostat.current_operation
         self.ecobee['settings']['hvacMode'] = 'off'
         assert 'off' == self.thermostat.current_operation
+
+    def test_current_operation_mode(self):
+        """Test current operation mode property."""
+        self.ecobee['settings']['hvacMode'] = 'auto'
+        assert 'auto' == self.thermostat.current_operation_mode
+        self.ecobee['settings']['hvacMode'] = 'heat'
+        assert 'heat' == self.thermostat.current_operation_mode
+        self.ecobee['settings']['hvacMode'] = 'cool'
+        assert 'cool' == self.thermostat.current_operation_mode
+        self.ecobee['settings']['hvacMode'] = 'auxHeatOnly'
+        assert 'heat' == self.thermostat.current_operation_mode
+        self.ecobee['settings']['hvacMode'] = 'off'
+        assert 'off' == self.thermostat.current_operation_mode
 
     def test_operation_list(self):
         """Test operation list property."""


### PR DESCRIPTION
## Description:
Expose the running equipment status as an attribute. Currently, equipment status is parsed to a generic heat/cool/idle operation mode. I want to be able to get the detailed list of running equipment to differentiate between compressor stages. For example it will now have attributes:
```
...
fan: on
operation: heat
equipment_running: fan,heatPump2
...
```

**Related issue (if applicable):** n/a

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8414

## Example entry for `configuration.yaml` (if applicable):
```yaml
n/a
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
