### PR TITLE
Fix error handling in switch.broadlink module

### DIFF
--- a/homeassistant/components/switch/broadlink.py
+++ b/homeassistant/components/switch/broadlink.py
@@ -235,7 +235,7 @@ class BroadlinkRMSwitch(SwitchDevice):
             self._device.send_data(packet)
         except (socket.timeout, ValueError) as error:
             if retry < 1:
-                _LOGGER.error(error)
+                _LOGGER.error("Error during sending a packet: %s", error)
                 return False
             if not self._auth():
                 return False
@@ -245,10 +245,10 @@ class BroadlinkRMSwitch(SwitchDevice):
     def _auth(self, retry=2):
         try:
             auth = self._device.auth()
-        except socket.timeout as error:
+        except socket.timeout:
             auth = False
             if retry < 1:
-                _LOGGER.error(error)
+                _LOGGER.error("Timeout during authorization")
         if not auth and retry > 0:
             return self._auth(retry-1)
         return auth
@@ -270,7 +270,7 @@ class BroadlinkSP1Switch(BroadlinkRMSwitch):
             self._device.set_power(packet)
         except (socket.timeout, ValueError) as error:
             if retry < 1:
-                _LOGGER.error(error)
+                _LOGGER.error("Error during sending a packet: %s", error)
                 return False
             if not self._auth():
                 return False
@@ -310,7 +310,7 @@ class BroadlinkSP2Switch(BroadlinkSP1Switch):
             load_power = self._device.get_energy()
         except (socket.timeout, ValueError) as error:
             if retry < 1:
-                _LOGGER.error(error)
+                _LOGGER.error("Error during updating the state: %s", error)
                 return
             if not self._auth():
                 return
@@ -343,7 +343,7 @@ class BroadlinkMP1Slot(BroadlinkRMSwitch):
             self._device.set_power(self._slot, packet)
         except (socket.timeout, ValueError) as error:
             if retry < 1:
-                _LOGGER.error(error)
+                _LOGGER.error("Error during sending a packet: %s", error)
                 return False
             if not self._auth():
                 return False
@@ -384,7 +384,7 @@ class BroadlinkMP1Switch:
             states = self._device.check_power()
         except (socket.timeout, ValueError) as error:
             if retry < 1:
-                _LOGGER.error(error)
+                _LOGGER.error("Error during updating the state: %s", error)
                 return
             if not self._auth():
                 return

--- a/homeassistant/components/switch/broadlink.py
+++ b/homeassistant/components/switch/broadlink.py
@@ -245,8 +245,10 @@ class BroadlinkRMSwitch(SwitchDevice):
     def _auth(self, retry=2):
         try:
             auth = self._device.auth()
-        except socket.timeout:
+        except socket.timeout as error:
             auth = False
+            if retry < 1:
+                _LOGGER.error(error)
         if not auth and retry > 0:
             return self._auth(retry-1)
         return auth


### PR DESCRIPTION
## Description:

Add missing log message in case of a connection error.

**Related issue:** fixes #20770

## Example entry for `configuration.yaml`:
```yaml
  - platform: broadlink
    friendly_name: rmpro
    host: 192.168.1.190
    mac: '***'
    switches:
      ...
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
