### PR TITLE
Prevent template changing options

### DIFF
--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -436,13 +436,15 @@ def template(value):
 def template_complex(value):
     """Validate a complex jinja2 template."""
     if isinstance(value, list):
-        for idx, element in enumerate(value):
-            value[idx] = template_complex(element)
-        return value
+        return_value = value.copy()
+        for idx, element in enumerate(return_value):
+            return_value[idx] = template_complex(element)
+        return return_value
     if isinstance(value, dict):
-        for key, element in value.items():
-            value[key] = template_complex(element)
-        return value
+        return_value = value.copy()
+        for key, element in return_value.items():
+            return_value[key] = template_complex(element)
+        return return_value
 
     return template(value)
 

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -402,8 +402,7 @@ def test_template():
     schema = vol.Schema(cv.template)
 
     for value in (None, '{{ partial_print }', '{% if True %}Hello', ['test']):
-        with pytest.raises(vol.Invalid,
-                           message='{} not considered invalid'.format(value)):
+        with pytest.raises(vol.Invalid):
             schema(value)
 
     options = (

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -433,6 +433,15 @@ def test_template_complex():
     for value in options:
         schema(value)
 
+    # ensure the validator didn't mutate the input
+    assert options == (
+        1, 'Hello',
+        '{{ beer }}',
+        '{% if 1 == 1 %}Hello{% else %}World{% endif %}',
+        {'test': 1, 'test2': '{{ beer }}'},
+        ['{{ beer }}', 1]
+    )
+
 
 def test_time_zone():
     """Test time zone validation."""


### PR DESCRIPTION
## Description:
- Prevent the complex template config validation changing the original value.
- Fix deprecation warnings when running test file. Message has been [deprecated](https://github.com/pytest-dev/pytest/pull/4539) without an alternative, as it was little used.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
