### PR TITLE
Use strict timeout when polling Aquos TV

### DIFF
--- a/homeassistant/components/media_player/aquostv.py
+++ b/homeassistant/components/media_player/aquostv.py
@@ -82,7 +82,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     host = config.get(CONF_HOST)
     remote = sharp_aquos_rc.TV(host, port, username, password, 15, 1)
 
-    add_entities([SharpAquosTVDevice(name, host, port, 
+    add_entities([SharpAquosTVDevice(name, host, port,
                   timeout, remote, power_on_enabled)])
     return True
 
@@ -109,8 +109,8 @@ def _retry(func):
 class SharpAquosTVDevice(MediaPlayerDevice):
     """Representation of a Aquos TV."""
 
-    def __init__(self, name, host, port, timeout, 
-                remote, power_on_enabled=False):
+    def __init__(self, name, host, port, timeout,
+                 remote, power_on_enabled=False):
         """Initialize the aquos device."""
         global SUPPORT_SHARPTV
         self._power_on_enabled = power_on_enabled

--- a/homeassistant/components/media_player/aquostv.py
+++ b/homeassistant/components/media_player/aquostv.py
@@ -15,7 +15,7 @@ from homeassistant.components.media_player import (
     SUPPORT_TURN_ON, SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_SET,
     SUPPORT_VOLUME_STEP, MediaPlayerDevice)
 from homeassistant.const import (
-    CONF_HOST, CONF_NAME, CONF_PASSWORD, CONF_PORT, CONF_TIMEOUT,
+    CONF_HOST, CONF_NAME, CONF_PASSWORD, CONF_PORT,
     CONF_USERNAME, STATE_OFF, STATE_ON)
 import homeassistant.helpers.config_validation as cv
 
@@ -41,8 +41,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
     vol.Optional(CONF_USERNAME, default=DEFAULT_USERNAME): cv.string,
     vol.Optional(CONF_PASSWORD, default=DEFAULT_PASSWORD): cv.string,
-    vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int,
-    vol.Optional('retries', default=DEFAULT_RETRIES): cv.string,
     vol.Optional('power_on_enabled', default=False): cv.boolean,
 })
 
@@ -63,7 +61,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     name = config.get(CONF_NAME)
     port = config.get(CONF_PORT)
-    timeout = config.get(CONF_TIMEOUT)
+    timeout = DEFAULT_TIMEOUT
     username = config.get(CONF_USERNAME)
     password = config.get(CONF_PASSWORD)
     power_on_enabled = config.get('power_on_enabled')
@@ -76,14 +74,14 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
         host = vals[0]
         remote = sharp_aquos_rc.TV(host, port, username, password, timeout=20)
-        add_entities([SharpAquosTVDevice(name, remote, power_on_enabled)])
+        add_entities([SharpAquosTVDevice(name, remote, timeout, power_on_enabled)])
         return True
 
     host = config.get(CONF_HOST)
     remote = sharp_aquos_rc.TV(host, port, username, password, 15, 1)
 
     add_entities([SharpAquosTVDevice(name, host, port,
-                  timeout, remote, power_on_enabled)])
+                                     timeout, remote, power_on_enabled)])
     return True
 
 

--- a/homeassistant/components/media_player/aquostv.py
+++ b/homeassistant/components/media_player/aquostv.py
@@ -82,7 +82,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     host = config.get(CONF_HOST)
     remote = sharp_aquos_rc.TV(host, port, username, password, 15, 1)
 
-    add_entities([SharpAquosTVDevice(name, host, port, timeout, remote, power_on_enabled)])
+    add_entities([SharpAquosTVDevice(name, host, port, 
+                  timeout, remote, power_on_enabled)])
     return True
 
 
@@ -91,24 +92,25 @@ def _retry(func):
     def wrapper(obj, *args, **kwargs):
         """Wrap all query functions."""
         if obj.test_connection():
-          update_retries = 5
-          while update_retries > 0:
-              try:
-                  func(obj, *args, **kwargs)
-                  break
-              except (OSError, TypeError, ValueError):
-                  update_retries -= 1
-                  if update_retries == 0:
-                      obj.set_state(STATE_OFF)
+            update_retries = 5
+            while update_retries > 0:
+                try:
+                    func(obj, *args, **kwargs)
+                    break
+                except (OSError, TypeError, ValueError):
+                    update_retries -= 1
+                    if update_retries == 0:
+                        obj.set_state(STATE_OFF)
         else:
-          obj.set_state(STATE_OFF)
+            obj.set_state(STATE_OFF)
     return wrapper
 
 
 class SharpAquosTVDevice(MediaPlayerDevice):
     """Representation of a Aquos TV."""
 
-    def __init__(self, name, host, port, timeout, remote, power_on_enabled=False):
+    def __init__(self, name, host, port, timeout, 
+                remote, power_on_enabled=False):
         """Initialize the aquos device."""
         global SUPPORT_SHARPTV
         self._power_on_enabled = power_on_enabled
@@ -130,7 +132,7 @@ class SharpAquosTVDevice(MediaPlayerDevice):
     def set_state(self, state):
         """Set TV state."""
         self._state = state
-    
+
     def test_connection(self):
         try:
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/homeassistant/components/media_player/aquostv.py
+++ b/homeassistant/components/media_player/aquostv.py
@@ -74,7 +74,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
         host = vals[0]
         remote = sharp_aquos_rc.TV(host, port, username, password, timeout=20)
-        add_entities([SharpAquosTVDevice(name, remote, timeout, power_on_enabled)])
+        add_entities([SharpAquosTVDevice(name, remote, timeout,
+                                         power_on_enabled)])
         return True
 
     host = config.get(CONF_HOST)


### PR DESCRIPTION
## Description:
Issue: Updating aquostv media_player took longer than the scheduled update interval 0:00:10
Im a python beginner and new to github but i hope I submitted this right. The code works for me with my aquostv.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.