### PR TITLE
Add ClickSend "caller" option

### DIFF
--- a/homeassistant/components/notify/clicksend_tts.py
+++ b/homeassistant/components/notify/clicksend_tts.py
@@ -31,7 +31,6 @@ CONF_CALLER = 'caller'
 
 DEFAULT_LANGUAGE = 'en-us'
 DEFAULT_VOICE = 'female'
-DEFAULT_CALLER = ''
 TIMEOUT = 5
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -40,7 +39,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_RECIPIENT): cv.string,
     vol.Optional(CONF_LANGUAGE, default=DEFAULT_LANGUAGE): cv.string,
     vol.Optional(CONF_VOICE, default=DEFAULT_VOICE): cv.string,
-    vol.Optional(CONF_CALLER, default=DEFAULT_CALLER): cv.string,
+    vol.Optional(CONF_CALLER): cv.string,
 })
 
 
@@ -64,7 +63,7 @@ class ClicksendNotificationService(BaseNotificationService):
         self.language = config.get(CONF_LANGUAGE)
         self.voice = config.get(CONF_VOICE)
         self.caller = config.get(CONF_CALLER)
-        if self.caller == '':
+        if self.caller is None:
             self.caller = self.recipient
 
     def send_message(self, message="", **kwargs):

--- a/homeassistant/components/notify/clicksend_tts.py
+++ b/homeassistant/components/notify/clicksend_tts.py
@@ -63,7 +63,8 @@ class ClicksendNotificationService(BaseNotificationService):
 
     def send_message(self, message="", **kwargs):
         """Send a voice call to a user."""
-        data = ({'messages': [{'source': 'hass.notify', 'to': self.recipient, 'body': message,
+        data = ({'messages': [{'source': 'hass.notify', 
+                               'to': self.recipient, 'body': message,
                                'lang': self.language, 'voice': self.voice}]})
         api_url = "{}/voice/send".format(BASE_API_URL)
         resp = requests.post(api_url,

--- a/homeassistant/components/notify/clicksend_tts.py
+++ b/homeassistant/components/notify/clicksend_tts.py
@@ -63,8 +63,7 @@ class ClicksendNotificationService(BaseNotificationService):
 
     def send_message(self, message="", **kwargs):
         """Send a voice call to a user."""
-        data = ({'messages': [{'source': 'hass.notify', 'from': self.recipient,
-                               'to': self.recipient, 'body': message,
+        data = ({'messages': [{'source': 'hass.notify', 'to': self.recipient, 'body': message,
                                'lang': self.language, 'voice': self.voice}]})
         api_url = "{}/voice/send".format(BASE_API_URL)
         resp = requests.post(api_url,

--- a/homeassistant/components/notify/clicksend_tts.py
+++ b/homeassistant/components/notify/clicksend_tts.py
@@ -27,9 +27,11 @@ HEADERS = {CONTENT_TYPE: CONTENT_TYPE_JSON}
 
 CONF_LANGUAGE = 'language'
 CONF_VOICE = 'voice'
+CONF_CALLER = 'caller'
 
 DEFAULT_LANGUAGE = 'en-us'
 DEFAULT_VOICE = 'female'
+DEFAULT_CALLER = ''
 TIMEOUT = 5
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
@@ -38,6 +40,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_RECIPIENT): cv.string,
     vol.Optional(CONF_LANGUAGE, default=DEFAULT_LANGUAGE): cv.string,
     vol.Optional(CONF_VOICE, default=DEFAULT_VOICE): cv.string,
+    vol.Optional(CONF_CALLER, default=DEFAULT_CALLER): cv.string,
 })
 
 
@@ -60,10 +63,13 @@ class ClicksendNotificationService(BaseNotificationService):
         self.recipient = config.get(CONF_RECIPIENT)
         self.language = config.get(CONF_LANGUAGE)
         self.voice = config.get(CONF_VOICE)
+        self.caller = config.get(CONF_CALLER)
+        if self.caller == '':
+            self.caller = self.recipient
 
     def send_message(self, message="", **kwargs):
         """Send a voice call to a user."""
-        data = ({'messages': [{'source': 'hass.notify', 
+        data = ({'messages': [{'source': 'hass.notify', 'from': self.caller,
                                'to': self.recipient, 'body': message,
                                'lang': self.language, 'voice': self.voice}]})
         api_url = "{}/voice/send".format(BASE_API_URL)


### PR DESCRIPTION
Added optional "caller" parameter to let ClickSend API call be more compliant with some cellular networks that do not allow incoming calls from the same recipient number.
If "caller" is not defined, then the recipient parameter value is used.

**Doc PR**
https://github.com/home-assistant/home-assistant.io/pull/8831