### PR TITLE
WIP: RFC: Don't allow device tracker platforms to submit invalid device ids

### DIFF
--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -297,7 +297,7 @@ class DeviceTracker:
             if not device:
                 dev_id = util.slugify(host_name or '') or util.slugify(mac)
         else:
-            dev_id = cv.slug(str(dev_id).lower())
+            dev_id = util.slugify(dev_id)
             device = self.devices.get(dev_id)
 
         if device:


### PR DESCRIPTION
## Description:
Device tracker platforms can pass device IDs that are not valid slugs to `async_see`, causing the call to fail.

This PR will slugify incoming device IDs instead of failing the call.

I am not sure if this is better fixed here or inside locative.

**Changed this to WIP because I am not sure if this warrants a breaking change.**

**Related issue (if applicable):** fixes #20781
