### PR TITLE
CoolMasterNet Climate platform

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -67,6 +67,7 @@ omit =
     homeassistant/components/camera/xiaomi.py
     homeassistant/components/camera/yi.py
     homeassistant/components/cast/*
+    homeassistant/components/climate/coolmaster.py
     homeassistant/components/climate/ephember.py
     homeassistant/components/climate/eq3btsmart.py
     homeassistant/components/climate/flexit.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -53,6 +53,7 @@ homeassistant/components/binary_sensor/hikvision.py @mezz64
 homeassistant/components/binary_sensor/threshold.py @fabaff
 homeassistant/components/binary_sensor/uptimerobot.py @ludeeus
 homeassistant/components/camera/yi.py @bachya
+homeassistant/components/climate/coolmaster.py @OnFreund
 homeassistant/components/climate/ephember.py @ttroy50
 homeassistant/components/climate/eq3btsmart.py @rytilahti
 homeassistant/components/climate/mill.py @danielhiversen

--- a/homeassistant/components/climate/coolmaster.py
+++ b/homeassistant/components/climate/coolmaster.py
@@ -1,0 +1,207 @@
+"""
+CoolMasterNet platform that offers control of CoolMasteNet Climate Devices.
+
+For more details about this platform, please refer to the documentation
+https://www.home-assistant.io/components/climate.coolmaster/
+"""
+
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components.climate import (
+    PLATFORM_SCHEMA, STATE_AUTO, STATE_COOL, STATE_DRY, STATE_FAN_ONLY,
+    STATE_HEAT, SUPPORT_FAN_MODE, SUPPORT_ON_OFF, SUPPORT_OPERATION_MODE,
+    SUPPORT_TARGET_TEMPERATURE, ClimateDevice)
+from homeassistant.const import (
+    ATTR_TEMPERATURE, CONF_HOST, CONF_PORT, TEMP_CELSIUS, TEMP_FAHRENHEIT)
+import homeassistant.helpers.config_validation as cv
+
+REQUIREMENTS = ['pycoolmasternet==0.0.4']
+
+SUPPORT_FLAGS = (SUPPORT_TARGET_TEMPERATURE | SUPPORT_FAN_MODE |
+                 SUPPORT_OPERATION_MODE | SUPPORT_ON_OFF)
+
+FAN_ONLY_OVERRIDE = 'fan'
+
+DEFAULT_PORT = 10102
+
+DOMAIN = 'coolmaster'
+
+AVAILABLE_MODES = [STATE_HEAT, STATE_COOL, STATE_AUTO, STATE_DRY,
+                   STATE_FAN_ONLY]
+
+CONF_SUPPORTED_MODES = 'supported_modes'
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_HOST): cv.string,
+    vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+    vol.Optional(CONF_SUPPORTED_MODES, default=AVAILABLE_MODES):
+        vol.All(cv.ensure_list, [vol.In(AVAILABLE_MODES)]),
+})
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_platform(hass, config, async_add_entities,
+                               discovery_info=None):
+    """Set up the CoolMasterNet climate platform."""
+    from pycoolmasternet import CoolMasterNet
+
+    supported_modes = config.get(CONF_SUPPORTED_MODES)
+    host = config.get(CONF_HOST)
+    port = config.get(CONF_PORT)
+    cool = CoolMasterNet(host, port=port)
+
+    default_unit = hass.config.units.temperature_unit
+
+    all_devices = [CoolmasterClimate(device, supported_modes, default_unit)
+                   for device in cool.devices()]
+
+    async_add_entities(all_devices, True)
+
+
+class CoolmasterClimate(ClimateDevice):
+    """Representation of a coolmaster climate device."""
+
+    def __init__(self, device, supported_modes, default_unit):
+        """Initialize the climate device."""
+        _LOGGER.debug("Adding device %s", device.uid)
+        self._device = device
+        self._uid = device.uid
+        self._operation_list = supported_modes
+        self._support_flags = SUPPORT_FLAGS
+        self._fan_list = ['low', 'med', 'high', 'auto']
+        self._target_temperature = 0
+        self._current_temperature = 0
+        self._current_fan_mode = ''
+        self._current_operation = ''
+        self._on = False
+        self._unit = default_unit
+
+    def update(self):
+        """Pull state from CoolMasterNet."""
+        status = self._device.status
+        self._target_temperature = status['thermostat']
+        self._current_temperature = status['temperature']
+        self._current_fan_mode = status['fan_speed']
+        self._on = status['is_on']
+
+        device_mode = status['mode']
+        if device_mode == FAN_ONLY_OVERRIDE:
+            self._current_operation = STATE_FAN_ONLY
+        else:
+            self._current_operation = device_mode
+
+        if status['unit'] == 'celsius':
+            self._unit = TEMP_CELSIUS
+        else:
+            self._unit = TEMP_FAHRENHEIT
+
+    @property
+    def unique_id(self):
+        """Return unique ID for this device."""
+        return self._uid
+
+    @property
+    def device_info(self):
+        """Return information about the device."""
+        return {
+            'identifiers': {
+                (DOMAIN, self.unique_id),
+            },
+            'name': self.name,
+            'manufacturer': 'CoolMasterNet',
+        }
+
+    @property
+    def supported_features(self):
+        """Return the list of supported features."""
+        return self._support_flags
+
+    @property
+    def should_poll(self):
+        """Return the polling state."""
+        return True
+
+    @property
+    def name(self):
+        """Return the name of the climate device."""
+        return self.unique_id
+
+    @property
+    def temperature_unit(self):
+        """Return the unit of measurement."""
+        return self._unit
+
+    @property
+    def current_temperature(self):
+        """Return the current temperature."""
+        return self._current_temperature
+
+    @property
+    def target_temperature(self):
+        """Return the temperature we try to reach."""
+        return self._target_temperature
+
+    @property
+    def current_operation(self):
+        """Return current operation ie. heat, cool, idle."""
+        return self._current_operation
+
+    @property
+    def operation_list(self):
+        """Return the list of available operation modes."""
+        return self._operation_list
+
+    @property
+    def is_on(self):
+        """Return true if the device is on."""
+        return self._on
+
+    @property
+    def current_fan_mode(self):
+        """Return the fan setting."""
+        return self._current_fan_mode
+
+    @property
+    def fan_list(self):
+        """Return the list of available fan modes."""
+        return self._fan_list
+
+    def set_temperature(self, **kwargs):
+        """Set new target temperatures."""
+        temp = kwargs.get(ATTR_TEMPERATURE)
+        if temp is not None:
+            _LOGGER.debug("Setting temp of %s to %s", self.unique_id,
+                          str(temp))
+            self._device.set_thermostat(str(temp))
+            self.schedule_update_ha_state()
+
+    def set_fan_mode(self, fan_mode):
+        """Set new target temperature."""
+        _LOGGER.debug("Setting fan mode of %s to %s", self.unique_id,
+                      fan_mode)
+        self._device.set_fan_speed(fan_mode)
+        self.schedule_update_ha_state()
+
+    def set_operation_mode(self, operation_mode):
+        """Set new target temperature."""
+        if operation_mode == STATE_FAN_ONLY:
+            operation_mode = FAN_ONLY_OVERRIDE
+
+        _LOGGER.debug("Setting operation mode of %s to %s", self.unique_id,
+                      operation_mode)
+        self._device.set_mode(operation_mode)
+        self.schedule_update_ha_state()
+
+    def turn_on(self):
+        """Turn on."""
+        _LOGGER.debug("Turning %s on", self.unique_id)
+        self._device.turn_on()
+        self.schedule_update_ha_state()
+
+    def turn_off(self):
+        """Turn off."""
+        _LOGGER.debug("Turning %s off", self.unique_id)
+        self._device.turn_off()
+        self.schedule_update_ha_state()

--- a/homeassistant/components/climate/demo.py
+++ b/homeassistant/components/climate/demo.py
@@ -186,22 +186,22 @@ class DemoClimate(ClimateDevice):
         self.schedule_update_ha_state()
 
     def set_humidity(self, humidity):
-        """Set new target temperature."""
+        """Set new humidity level."""
         self._target_humidity = humidity
         self.schedule_update_ha_state()
 
     def set_swing_mode(self, swing_mode):
-        """Set new target temperature."""
+        """Set new swing mode."""
         self._current_swing_mode = swing_mode
         self.schedule_update_ha_state()
 
     def set_fan_mode(self, fan_mode):
-        """Set new target temperature."""
+        """Set new fan mode."""
         self._current_fan_mode = fan_mode
         self.schedule_update_ha_state()
 
     def set_operation_mode(self, operation_mode):
-        """Set new target temperature."""
+        """Set new operation mode."""
         self._current_operation = operation_mode
         self.schedule_update_ha_state()
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -957,6 +957,9 @@ pycmus==0.1.1
 # homeassistant.components.comfoconnect
 pycomfoconnect==0.3
 
+# homeassistant.components.climate.coolmaster
+pycoolmasternet==0.0.4
+
 # homeassistant.components.tts.microsoft
 pycsspeechtts==1.0.2
 


### PR DESCRIPTION
## Description:

[CoolMasterNet](https://coolautomation.com/products/coolmasternet/) as a Climate platform. This allows you to controller multiple HVAC instances connected to a single CoolMasterNet controller.
The integration is based on [pycoolmaster](https://github.com/koreth/pycoolmasternet).

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8422

## Example entry for `configuration.yaml` (if applicable):
```yaml
climate:
  - platform: coolmaster
    host: YOUR_COOLMASTER_HOST
    port: YOUR_COOLMASTER_PORT
    supported_modes:
      - heat
      - cool
      - dry
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
