### PR TITLE
Enable the available property for ZHA entities

### DIFF
--- a/homeassistant/components/zha/entity.py
+++ b/homeassistant/components/zha/entity.py
@@ -62,9 +62,7 @@ class ZhaEntity(entity.Entity):
         self._device_state_attributes = {}
         self._zha_device = zha_device
         self.cluster_listeners = {}
-        # this will get flipped to false once we enable the feature after the
-        # reorg is merged
-        self._available = True
+        self._available = False
         self._component = kwargs['component']
         self._unsubs = []
         for listener in listeners:

--- a/tests/components/zha/common.py
+++ b/tests/components/zha/common.py
@@ -1,7 +1,7 @@
 """Common test objects."""
 import time
 from unittest.mock import patch, Mock
-from homeassistant.const import STATE_UNKNOWN
+from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.components.zha.core.helpers import convert_ieee
 from homeassistant.components.zha.core.const import (
     DATA_ZHA, DATA_ZHA_CONFIG, DATA_ZHA_DISPATCHERS, DATA_ZHA_BRIDGE_ID
@@ -168,8 +168,7 @@ async def async_enable_traffic(hass, zha_gateway, zha_devices):
 
 
 async def async_test_device_join(
-        hass, zha_gateway, cluster_id, domain, device_type=None,
-        expected_state=STATE_UNKNOWN):
+        hass, zha_gateway, cluster_id, domain, device_type=None):
     """Test a newly joining device.
 
     This creates a new fake device and adds it to the network. It is meant to
@@ -193,4 +192,4 @@ async def async_test_device_join(
             cluster = zigpy_device.endpoints.get(1).in_clusters[cluster_id]
             entity_id = make_entity_id(
                 domain, zigpy_device, cluster, use_suffix=device_type is None)
-            assert hass.states.get(entity_id).state == expected_state
+            assert hass.states.get(entity_id).state == STATE_UNAVAILABLE

--- a/tests/components/zha/test_binary_sensor.py
+++ b/tests/components/zha/test_binary_sensor.py
@@ -1,9 +1,9 @@
 """Test zha binary sensor."""
 from homeassistant.components.binary_sensor import DOMAIN
-from homeassistant.const import STATE_ON, STATE_OFF
+from homeassistant.const import STATE_ON, STATE_OFF, STATE_UNAVAILABLE
 from .common import (
     async_init_zigpy_device, make_attribute, make_entity_id,
-    async_test_device_join
+    async_test_device_join, async_enable_traffic
 )
 
 
@@ -48,19 +48,21 @@ async def test_binary_sensor(hass, config_entry, zha_gateway):
     # load up binary_sensor domain
     await hass.config_entries.async_forward_entry_setup(
         config_entry, DOMAIN)
-    await zha_gateway.accept_zigbee_messages({})
     await hass.async_block_till_done()
 
     # on off binary_sensor
     zone_cluster = zigpy_device_zone.endpoints.get(
         1).ias_zone
     zone_entity_id = make_entity_id(DOMAIN, zigpy_device_zone, zone_cluster)
+    zone_zha_device = zha_gateway.get_device(str(zigpy_device_zone.ieee))
 
     # occupancy binary_sensor
     occupancy_cluster = zigpy_device_occupancy.endpoints.get(
         1).occupancy
     occupancy_entity_id = make_entity_id(
         DOMAIN, zigpy_device_occupancy, occupancy_cluster)
+    occupancy_zha_device = zha_gateway.get_device(
+        str(zigpy_device_occupancy.ieee))
 
     # dimmable binary_sensor
     remote_on_off_cluster = zigpy_device_remote.endpoints.get(
@@ -70,6 +72,16 @@ async def test_binary_sensor(hass, config_entry, zha_gateway):
     remote_entity_id = make_entity_id(DOMAIN, zigpy_device_remote,
                                       remote_on_off_cluster,
                                       use_suffix=False)
+    remote_zha_device = zha_gateway.get_device(str(zigpy_device_remote.ieee))
+
+    # test that the sensors exist and are in the unavailable state
+    assert hass.states.get(zone_entity_id).state == STATE_UNAVAILABLE
+    assert hass.states.get(remote_entity_id).state == STATE_UNAVAILABLE
+    assert hass.states.get(occupancy_entity_id).state == STATE_UNAVAILABLE
+
+    await async_enable_traffic(hass, zha_gateway,
+                               [zone_zha_device, remote_zha_device,
+                                occupancy_zha_device])
 
     # test that the sensors exist and are in the off state
     assert hass.states.get(zone_entity_id).state == STATE_OFF
@@ -98,8 +110,7 @@ async def test_binary_sensor(hass, config_entry, zha_gateway):
 
     # test new sensor join
     await async_test_device_join(
-        hass, zha_gateway, OccupancySensing.cluster_id, DOMAIN,
-        expected_state=STATE_OFF)
+        hass, zha_gateway, OccupancySensing.cluster_id, DOMAIN)
 
 
 async def async_test_binary_sensor_on_off(hass, cluster, entity_id):

--- a/tests/components/zha/test_fan.py
+++ b/tests/components/zha/test_fan.py
@@ -1,7 +1,7 @@
 """Test zha fan."""
 from unittest.mock import call, patch
 from homeassistant.components import fan
-from homeassistant.const import STATE_ON, STATE_OFF
+from homeassistant.const import STATE_ON, STATE_OFF, STATE_UNAVAILABLE
 from homeassistant.components.fan import (
     ATTR_SPEED, DOMAIN, SERVICE_SET_SPEED
 )
@@ -10,7 +10,7 @@ from homeassistant.const import (
 from tests.common import mock_coro
 from .common import (
     async_init_zigpy_device, make_attribute, make_entity_id,
-    async_test_device_join
+    async_test_device_join, async_enable_traffic
 )
 
 
@@ -31,8 +31,15 @@ async def test_fan(hass, config_entry, zha_gateway):
 
     cluster = zigpy_device.endpoints.get(1).fan
     entity_id = make_entity_id(DOMAIN, zigpy_device, cluster)
+    zha_device = zha_gateway.get_device(str(zigpy_device.ieee))
 
-    # test that the fan was created and that it is off
+    # test that the fan was created and that it is unavailable
+    assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
+
+    # allow traffic to flow through the gateway and device
+    await async_enable_traffic(hass, zha_gateway, [zha_device])
+
+    # test that the state has changed from unavailable to off
     assert hass.states.get(entity_id).state == STATE_OFF
 
     # turn on at fan
@@ -78,8 +85,7 @@ async def test_fan(hass, config_entry, zha_gateway):
             {'fan_mode': 3})
 
     # test adding new fan to the network and HA
-    await async_test_device_join(hass, zha_gateway, Fan.cluster_id, DOMAIN,
-                                 expected_state=STATE_OFF)
+    await async_test_device_join(hass, zha_gateway, Fan.cluster_id, DOMAIN)
 
 
 async def async_turn_on(hass, entity_id, speed=None):

--- a/tests/components/zha/test_light.py
+++ b/tests/components/zha/test_light.py
@@ -1,11 +1,11 @@
 """Test zha light."""
 from unittest.mock import call, patch
 from homeassistant.components.light import DOMAIN
-from homeassistant.const import STATE_ON, STATE_OFF
+from homeassistant.const import STATE_ON, STATE_OFF, STATE_UNAVAILABLE
 from tests.common import mock_coro
 from .common import (
     async_init_zigpy_device, make_attribute, make_entity_id,
-    async_test_device_join
+    async_test_device_join, async_enable_traffic
 )
 
 ON = 1
@@ -48,6 +48,7 @@ async def test_light(hass, config_entry, zha_gateway):
     on_off_entity_id = make_entity_id(DOMAIN, zigpy_device_on_off,
                                       on_off_device_on_off_cluster,
                                       use_suffix=False)
+    on_off_zha_device = zha_gateway.get_device(str(zigpy_device_on_off.ieee))
 
     # dimmable light
     level_device_on_off_cluster = zigpy_device_level.endpoints.get(1).on_off
@@ -55,6 +56,15 @@ async def test_light(hass, config_entry, zha_gateway):
     level_entity_id = make_entity_id(DOMAIN, zigpy_device_level,
                                      level_device_on_off_cluster,
                                      use_suffix=False)
+    level_zha_device = zha_gateway.get_device(str(zigpy_device_level.ieee))
+
+    # test that the lights were created and that they are unavailable
+    assert hass.states.get(on_off_entity_id).state == STATE_UNAVAILABLE
+    assert hass.states.get(level_entity_id).state == STATE_UNAVAILABLE
+
+    # allow traffic to flow through the gateway and device
+    await async_enable_traffic(hass, zha_gateway,
+                               [on_off_zha_device, level_zha_device])
 
     # test that the lights were created and are off
     assert hass.states.get(on_off_entity_id).state == STATE_OFF
@@ -85,7 +95,7 @@ async def test_light(hass, config_entry, zha_gateway):
     # test adding a new light to the network and HA
     await async_test_device_join(
         hass, zha_gateway, OnOff.cluster_id,
-        DOMAIN, device_type=DeviceType.ON_OFF_LIGHT, expected_state=STATE_OFF)
+        DOMAIN, device_type=DeviceType.ON_OFF_LIGHT)
 
 
 async def async_test_on_off_from_light(hass, cluster, entity_id):

--- a/tests/components/zha/test_sensor.py
+++ b/tests/components/zha/test_sensor.py
@@ -1,9 +1,9 @@
 """Test zha sensor."""
 from homeassistant.components.sensor import DOMAIN
-from homeassistant.const import STATE_UNKNOWN
+from homeassistant.const import STATE_UNKNOWN, STATE_UNAVAILABLE
 from .common import (
     async_init_zigpy_device, make_attribute, make_entity_id,
-    async_test_device_join
+    async_test_device_join, async_enable_traffic
 )
 
 
@@ -31,6 +31,17 @@ async def test_sensor(hass, config_entry, zha_gateway):
         hass, zha_gateway, config_entry, cluster_ids)
 
     # ensure the sensor entity was created for each id in cluster_ids
+    for cluster_id in cluster_ids:
+        zigpy_device_info = zigpy_device_infos[cluster_id]
+        entity_id = zigpy_device_info["entity_id"]
+        assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
+
+    # allow traffic to flow through the gateway and devices
+    await async_enable_traffic(hass, zha_gateway, [
+        zigpy_device_info["zha_device"] for zigpy_device_info in
+        zigpy_device_infos.values()])
+
+    # test that the sensors now have a state of unknown
     for cluster_id in cluster_ids:
         zigpy_device_info = zigpy_device_infos[cluster_id]
         entity_id = zigpy_device_info["entity_id"]
@@ -103,6 +114,8 @@ async def async_build_devices(hass, zha_gateway, config_entry, cluster_ids):
             1).in_clusters[cluster_id]
         device_info["entity_id"] = make_entity_id(
             DOMAIN, zigpy_device, device_info["cluster"])
+        device_info["zha_device"] = zha_gateway.get_device(
+            str(zigpy_device.ieee))
     return device_infos
 
 

--- a/tests/components/zha/test_switch.py
+++ b/tests/components/zha/test_switch.py
@@ -1,11 +1,11 @@
 """Test zha switch."""
 from unittest.mock import call, patch
 from homeassistant.components.switch import DOMAIN
-from homeassistant.const import STATE_ON, STATE_OFF
+from homeassistant.const import STATE_ON, STATE_OFF, STATE_UNAVAILABLE
 from tests.common import mock_coro
 from .common import (
     async_init_zigpy_device, make_attribute, make_entity_id,
-    async_test_device_join
+    async_test_device_join, async_enable_traffic
 )
 
 ON = 1
@@ -29,6 +29,13 @@ async def test_switch(hass, config_entry, zha_gateway):
 
     cluster = zigpy_device.endpoints.get(1).on_off
     entity_id = make_entity_id(DOMAIN, zigpy_device, cluster)
+    zha_device = zha_gateway.get_device(str(zigpy_device.ieee))
+
+    # test that the switch was created and that its state is unavailable
+    assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
+
+    # allow traffic to flow through the gateway and device
+    await async_enable_traffic(hass, zha_gateway, [zha_device])
 
     # test that the state has changed from unavailable to off
     assert hass.states.get(entity_id).state == STATE_OFF
@@ -71,4 +78,4 @@ async def test_switch(hass, config_entry, zha_gateway):
 
     # test joining a new switch to the network and HA
     await async_test_device_join(
-        hass, zha_gateway, OnOff.cluster_id, DOMAIN, expected_state=STATE_OFF)
+        hass, zha_gateway, OnOff.cluster_id, DOMAIN)


### PR DESCRIPTION
**BREAKING CHANGE**

* Implement the available property on all entities for ZHA. Entities for devices that are not connected to the zigbee network will now show as unavailable instead of conveying stale state. 

Motivations:

- There are lots of defects referencing stale states in the UI when the devices aren't available
- It is a requirement for the integration scale silver level: https://developers.home-assistant.io/docs/en/integration_quality_scale_index.html#silver And we want platinum!!
- Only show accurate state in the UI
