### PR TITLE
Cleanup ZHA listener life cycle

### DIFF
--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -147,8 +147,6 @@ async def async_setup_entry(hass, config_entry):
     )
 
     zha_gateway = ZHAGateway(hass, config)
-    hass.bus.async_listen_once(
-        ha_const.EVENT_HOMEASSISTANT_START, zha_gateway.accept_zigbee_messages)
 
     # Patch handle_message until zigpy can provide an event here
     def handle_message(sender, is_reply, profile, cluster,

--- a/homeassistant/components/zha/core/device.py
+++ b/homeassistant/components/zha/core/device.py
@@ -170,10 +170,6 @@ class ZHADevice:
         await self._execute_listener_tasks('async_initialize', from_cache)
         _LOGGER.debug('%s: completed initialization', self.name)
 
-    async def async_accept_messages(self):
-        """Start accepting messages from the zigbee network."""
-        await self._execute_listener_tasks('accept_messages')
-
     async def _execute_listener_tasks(self, task_name, *args):
         """Gather and execute a set of listener tasks."""
         listener_tasks = []

--- a/homeassistant/components/zha/core/gateway.py
+++ b/homeassistant/components/zha/core/gateway.py
@@ -126,13 +126,6 @@ class ZHAGateway:
             self._devices[zigpy_device.ieee] = zha_device
         return zha_device
 
-    async def accept_zigbee_messages(self, _service_or_event):
-        """Allow devices to accept zigbee messages."""
-        accept_messages_calls = []
-        for device in self.devices.values():
-            accept_messages_calls.append(device.async_accept_messages())
-        await asyncio.gather(*accept_messages_calls)
-
     async def async_device_initialized(self, device, is_new_join):
         """Handle device joined and basic information discovered (async)."""
         zha_device = await self._get_or_create_device(device)

--- a/tests/components/zha/common.py
+++ b/tests/components/zha/common.py
@@ -161,7 +161,6 @@ def make_entity_id(domain, device, cluster, use_suffix=True):
 
 async def async_enable_traffic(hass, zha_gateway, zha_devices):
     """Allow traffic to flow through the gateway and the zha device."""
-    await zha_gateway.accept_zigbee_messages({})
     for zha_device in zha_devices:
         zha_device.update_available(True)
     await hass.async_block_till_done()

--- a/tests/components/zha/test_binary_sensor.py
+++ b/tests/components/zha/test_binary_sensor.py
@@ -48,7 +48,6 @@ async def test_binary_sensor(hass, config_entry, zha_gateway):
     # load up binary_sensor domain
     await hass.config_entries.async_forward_entry_setup(
         config_entry, DOMAIN)
-    await zha_gateway.accept_zigbee_messages({})
     await hass.async_block_till_done()
 
     # on off binary_sensor

--- a/tests/components/zha/test_fan.py
+++ b/tests/components/zha/test_fan.py
@@ -26,7 +26,6 @@ async def test_fan(hass, config_entry, zha_gateway):
     # load up fan domain
     await hass.config_entries.async_forward_entry_setup(
         config_entry, DOMAIN)
-    await zha_gateway.accept_zigbee_messages({})
     await hass.async_block_till_done()
 
     cluster = zigpy_device.endpoints.get(1).fan

--- a/tests/components/zha/test_light.py
+++ b/tests/components/zha/test_light.py
@@ -40,7 +40,6 @@ async def test_light(hass, config_entry, zha_gateway):
     # load up light domain
     await hass.config_entries.async_forward_entry_setup(
         config_entry, DOMAIN)
-    await zha_gateway.accept_zigbee_messages({})
     await hass.async_block_till_done()
 
     # on off light

--- a/tests/components/zha/test_sensor.py
+++ b/tests/components/zha/test_sensor.py
@@ -92,7 +92,6 @@ async def async_build_devices(hass, zha_gateway, config_entry, cluster_ids):
     # load up sensor domain
     await hass.config_entries.async_forward_entry_setup(
         config_entry, DOMAIN)
-    await zha_gateway.accept_zigbee_messages({})
     await hass.async_block_till_done()
 
     # put the other relevant info in the device info dict

--- a/tests/components/zha/test_switch.py
+++ b/tests/components/zha/test_switch.py
@@ -24,7 +24,6 @@ async def test_switch(hass, config_entry, zha_gateway):
     # load up switch domain
     await hass.config_entries.async_forward_entry_setup(
         config_entry, DOMAIN)
-    await zha_gateway.accept_zigbee_messages({})
     await hass.async_block_till_done()
 
     cluster = zigpy_device.endpoints.get(1).on_off


### PR DESCRIPTION
This PR removes the need for the listening stage from the listener life cycle. It is an artifact left over from before we were using the dispatcher helper and it is no longer needed. Listeners can now listen to the zigbee network as soon as they are created without adversely affecting anything in HA. 