### PR TITLE
Remove wink sensor log calls

### DIFF
--- a/homeassistant/components/wink/sensor.py
+++ b/homeassistant/components/wink/sensor.py
@@ -95,4 +95,5 @@ class WinkSensorDevice(WinkDevice):
             super_attrs['egg_times'] = self.wink.eggs()
         except AttributeError:
             # Ignore error, this sensor isn't an eggminder
+            pass
         return super_attrs

--- a/homeassistant/components/wink/sensor.py
+++ b/homeassistant/components/wink/sensor.py
@@ -91,10 +91,8 @@ class WinkSensorDevice(WinkDevice):
     def device_state_attributes(self):
         """Return the state attributes."""
         super_attrs = super().device_state_attributes
-        _LOGGER.debug("Adding in eggs if egg minder")
         try:
             super_attrs['egg_times'] = self.wink.eggs()
-            _LOGGER.debug("Its an egg minder")
         except AttributeError:
-            _LOGGER.debug("Not an eggtray")
+            # Ignore error, this sensor isn't an eggminder
         return super_attrs


### PR DESCRIPTION
## Description:

@MartinHjelmare requested that the logging calls be removed in the attributes over here https://github.com/home-assistant/home-assistant/pull/20758


## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
