### PR TITLE
Fix binary sensor in Ambient PWS

### DIFF
--- a/homeassistant/components/ambient_station/__init__.py
+++ b/homeassistant/components/ambient_station/__init__.py
@@ -129,8 +129,9 @@ async def async_unload_entry(hass, config_entry):
     ambient = hass.data[DOMAIN][DATA_CLIENT].pop(config_entry.entry_id)
     hass.async_create_task(ambient.ws_disconnect())
 
-    await hass.config_entries.async_forward_entry_unload(
-        config_entry, 'sensor')
+    for component in ('binary_sensor', 'sensor'):
+        await hass.config_entries.async_forward_entry_unload(
+            config_entry, component)
 
     return True
 
@@ -181,9 +182,10 @@ class AmbientStation:
                     ATTR_NAME: station['info']['name'],
                 }
 
+            for component in ('binary_sensor', 'sensor'):
                 self._hass.async_create_task(
                     self._hass.config_entries.async_forward_entry_setup(
-                        self._config_entry, 'sensor'))
+                        self._config_entry, component))
 
                 self._ws_reconnect_delay = DEFAULT_SOCKET_MIN_RETRY
 

--- a/homeassistant/components/ambient_station/__init__.py
+++ b/homeassistant/components/ambient_station/__init__.py
@@ -30,37 +30,67 @@ _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_SOCKET_MIN_RETRY = 15
 
+TYPE_24HOURRAININ = '24hourrainin'
+TYPE_BAROMABSIN = 'baromabsin'
+TYPE_BAROMRELIN = 'baromrelin'
+TYPE_BATTOUT = 'battout'
+TYPE_CO2 = 'co2'
+TYPE_DAILYRAININ = 'dailyrainin'
+TYPE_DEWPOINT = 'dewPoint'
+TYPE_EVENTRAININ = 'eventrainin'
+TYPE_FEELSLIKE = 'feelsLike'
+TYPE_HOURLYRAININ = 'hourlyrainin'
+TYPE_HUMIDITY = 'humidity'
+TYPE_HUMIDITYIN = 'humidityin'
+TYPE_LASTRAIN = 'lastRain'
+TYPE_MAXDAILYGUST = 'maxdailygust'
+TYPE_MONTHLYRAININ = 'monthlyrainin'
+TYPE_SOLARRADIATION = 'solarradiation'
+TYPE_TEMPF = 'tempf'
+TYPE_TEMPINF = 'tempinf'
+TYPE_TOTALRAININ = 'totalrainin'
+TYPE_UV = 'uv'
+TYPE_WEEKLYRAININ = 'weeklyrainin'
+TYPE_WINDDIR = 'winddir'
+TYPE_WINDDIR_AVG10M = 'winddir_avg10m'
+TYPE_WINDDIR_AVG2M = 'winddir_avg2m'
+TYPE_WINDGUSTDIR = 'windgustdir'
+TYPE_WINDGUSTMPH = 'windgustmph'
+TYPE_WINDSPDMPH_AVG10M = 'windspdmph_avg10m'
+TYPE_WINDSPDMPH_AVG2M = 'windspdmph_avg2m'
+TYPE_WINDSPEEDMPH = 'windspeedmph'
+TYPE_YEARLYRAININ = 'yearlyrainin'
 SENSOR_TYPES = {
-    '24hourrainin': ('24 Hr Rain', 'in', TYPE_SENSOR, None),
-    'baromabsin': ('Abs Pressure', 'inHg', TYPE_SENSOR, None),
-    'baromrelin': ('Rel Pressure', 'inHg', TYPE_SENSOR, None),
-    'battout': ('Battery', None, TYPE_BINARY_SENSOR, 'battery'),
-    'co2': ('co2', 'ppm', TYPE_SENSOR, None),
-    'dailyrainin': ('Daily Rain', 'in', TYPE_SENSOR, None),
-    'dewPoint': ('Dew Point', '°F', TYPE_SENSOR, None),
-    'eventrainin': ('Event Rain', 'in', TYPE_SENSOR, None),
-    'feelsLike': ('Feels Like', '°F', TYPE_SENSOR, None),
-    'hourlyrainin': ('Hourly Rain Rate', 'in/hr', TYPE_SENSOR, None),
-    'humidity': ('Humidity', '%', TYPE_SENSOR, None),
-    'humidityin': ('Humidity In', '%', TYPE_SENSOR, None),
-    'lastRain': ('Last Rain', None, TYPE_SENSOR, None),
-    'maxdailygust': ('Max Gust', 'mph', TYPE_SENSOR, None),
-    'monthlyrainin': ('Monthly Rain', 'in', TYPE_SENSOR, None),
-    'solarradiation': ('Solar Rad', 'W/m^2', TYPE_SENSOR, None),
-    'tempf': ('Temp', '°F', TYPE_SENSOR, None),
-    'tempinf': ('Inside Temp', '°F', TYPE_SENSOR, None),
-    'totalrainin': ('Lifetime Rain', 'in', TYPE_SENSOR, None),
-    'uv': ('uv', 'Index', TYPE_SENSOR, None),
-    'weeklyrainin': ('Weekly Rain', 'in', TYPE_SENSOR, None),
-    'winddir': ('Wind Dir', '°', TYPE_SENSOR, None),
-    'winddir_avg10m': ('Wind Dir Avg 10m', '°', TYPE_SENSOR, None),
-    'winddir_avg2m': ('Wind Dir Avg 2m', 'mph', TYPE_SENSOR, None),
-    'windgustdir': ('Gust Dir', '°', TYPE_SENSOR, None),
-    'windgustmph': ('Wind Gust', 'mph', TYPE_SENSOR, None),
-    'windspdmph_avg10m': ('Wind Avg 10m', 'mph', TYPE_SENSOR, None),
-    'windspdmph_avg2m': ('Wind Avg 2m', 'mph', TYPE_SENSOR, None),
-    'windspeedmph': ('Wind Speed', 'mph', TYPE_SENSOR, None),
-    'yearlyrainin': ('Yearly Rain', 'in', TYPE_SENSOR, None),
+    TYPE_24HOURRAININ: ('24 Hr Rain', 'in', TYPE_SENSOR, None),
+    TYPE_BAROMABSIN: ('Abs Pressure', 'inHg', TYPE_SENSOR, None),
+    TYPE_BAROMRELIN: ('Rel Pressure', 'inHg', TYPE_SENSOR, None),
+    TYPE_BATTOUT: ('Battery', None, TYPE_BINARY_SENSOR, 'battery'),
+    TYPE_CO2: ('co2', 'ppm', TYPE_SENSOR, None),
+    TYPE_DAILYRAININ: ('Daily Rain', 'in', TYPE_SENSOR, None),
+    TYPE_DEWPOINT: ('Dew Point', '°F', TYPE_SENSOR, None),
+    TYPE_EVENTRAININ: ('Event Rain', 'in', TYPE_SENSOR, None),
+    TYPE_FEELSLIKE: ('Feels Like', '°F', TYPE_SENSOR, None),
+    TYPE_HOURLYRAININ: ('Hourly Rain Rate', 'in/hr', TYPE_SENSOR, None),
+    TYPE_HUMIDITY: ('Humidity', '%', TYPE_SENSOR, None),
+    TYPE_HUMIDITYIN: ('Humidity In', '%', TYPE_SENSOR, None),
+    TYPE_LASTRAIN: ('Last Rain', None, TYPE_SENSOR, None),
+    TYPE_MAXDAILYGUST: ('Max Gust', 'mph', TYPE_SENSOR, None),
+    TYPE_MONTHLYRAININ: ('Monthly Rain', 'in', TYPE_SENSOR, None),
+    TYPE_SOLARRADIATION: ('Solar Rad', 'W/m^2', TYPE_SENSOR, None),
+    TYPE_TEMPF: ('Temp', '°F', TYPE_SENSOR, None),
+    TYPE_TEMPINF: ('Inside Temp', '°F', TYPE_SENSOR, None),
+    TYPE_TOTALRAININ: ('Lifetime Rain', 'in', TYPE_SENSOR, None),
+    TYPE_UV: ('uv', 'Index', TYPE_SENSOR, None),
+    TYPE_WEEKLYRAININ: ('Weekly Rain', 'in', TYPE_SENSOR, None),
+    TYPE_WINDDIR: ('Wind Dir', '°', TYPE_SENSOR, None),
+    TYPE_WINDDIR_AVG10M: ('Wind Dir Avg 10m', '°', TYPE_SENSOR, None),
+    TYPE_WINDDIR_AVG2M: ('Wind Dir Avg 2m', 'mph', TYPE_SENSOR, None),
+    TYPE_WINDGUSTDIR: ('Gust Dir', '°', TYPE_SENSOR, None),
+    TYPE_WINDGUSTMPH: ('Wind Gust', 'mph', TYPE_SENSOR, None),
+    TYPE_WINDSPDMPH_AVG10M: ('Wind Avg 10m', 'mph', TYPE_SENSOR, None),
+    TYPE_WINDSPDMPH_AVG2M: ('Wind Avg 2m', 'mph', TYPE_SENSOR, None),
+    TYPE_WINDSPEEDMPH: ('Wind Speed', 'mph', TYPE_SENSOR, None),
+    TYPE_YEARLYRAININ: ('Yearly Rain', 'in', TYPE_SENSOR, None),
 }
 
 CONFIG_SCHEMA = vol.Schema({

--- a/homeassistant/components/ambient_station/__init__.py
+++ b/homeassistant/components/ambient_station/__init__.py
@@ -265,18 +265,12 @@ class AmbientWeatherEntity(Entity):
         return False
 
     @property
-    def state(self):
-        """Return the state of the sensor."""
-        return self._state
-
-    @property
     def unique_id(self):
         """Return a unique, unchanging string that represents this sensor."""
         return '{0}_{1}'.format(self._mac_address, self._sensor_name)
 
     async def async_added_to_hass(self):
         """Register callbacks."""
-
         @callback
         def update():
             """Update the state."""

--- a/homeassistant/components/ambient_station/binary_sensor.py
+++ b/homeassistant/components/ambient_station/binary_sensor.py
@@ -65,11 +65,6 @@ class AmbientWeatherBinarySensor(AmbientWeatherEntity, BinarySensorDevice):
 
         return self._state == 1
 
-    @property
-    def state(self):
-        """Return the state of the sensor."""
-        return self._state
-
     async def async_update(self):
         """Fetch new state data for the entity."""
         self._state = self._ambient.stations[

--- a/homeassistant/components/ambient_station/binary_sensor.py
+++ b/homeassistant/components/ambient_station/binary_sensor.py
@@ -7,7 +7,7 @@ https://home-assistant.io/components/binary_sensor.ambient_station/
 import logging
 
 from homeassistant.components.ambient_station import (
-    SENSOR_TYPES, AmbientWeatherEntity)
+    SENSOR_TYPES, TYPE_BATTOUT, AmbientWeatherEntity)
 from homeassistant.components.binary_sensor import BinarySensorDevice
 from homeassistant.const import ATTR_NAME
 
@@ -56,6 +56,14 @@ class AmbientWeatherBinarySensor(AmbientWeatherEntity, BinarySensorDevice):
     def device_class(self):
         """Return the device class."""
         return self._device_class
+
+    @property
+    def is_on(self):
+        """Return the status of the sensor."""
+        if self._sensor_type == TYPE_BATTOUT:
+            return self._state == 0
+
+        return self._state
 
     async def async_update(self):
         """Fetch new state data for the entity."""

--- a/homeassistant/components/ambient_station/binary_sensor.py
+++ b/homeassistant/components/ambient_station/binary_sensor.py
@@ -1,16 +1,17 @@
 """
-Support for Ambient Weather Station sensors.
+Support for Ambient Weather Station binary sensors.
 
 For more details about this platform, please refer to the documentation at
-https://home-assistant.io/components/sensor.ambient_station/
+https://home-assistant.io/components/binary_sensor.ambient_station/
 """
 import logging
 
 from homeassistant.components.ambient_station import (
     SENSOR_TYPES, AmbientWeatherEntity)
+from homeassistant.components.binary_sensor import BinarySensorDevice
 from homeassistant.const import ATTR_NAME
 
-from .const import ATTR_LAST_DATA, DATA_CLIENT, DOMAIN, TYPE_SENSOR
+from .const import ATTR_LAST_DATA, DATA_CLIENT, DOMAIN, TYPE_BINARY_SENSOR
 
 DEPENDENCIES = ['ambient_station']
 _LOGGER = logging.getLogger(__name__)
@@ -18,45 +19,45 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_platform(
         hass, config, async_add_entities, discovery_info=None):
-    """Set up Ambient PWS sensors based on existing config."""
+    """Set up Ambient PWS binary sensors based on the old way."""
     pass
 
 
 async def async_setup_entry(hass, entry, async_add_entities):
-    """Set up Ambient PWS sensors based on a config entry."""
+    """Set up Ambient PWS binary sensors based on a config entry."""
     ambient = hass.data[DOMAIN][DATA_CLIENT][entry.entry_id]
 
-    sensor_list = []
+    binary_sensor_list = []
     for mac_address, station in ambient.stations.items():
         for condition in ambient.monitored_conditions:
-            name, unit, kind, _ = SENSOR_TYPES[condition]
-            if kind == TYPE_SENSOR:
-                sensor_list.append(
-                    AmbientWeatherSensor(
+            name, _, kind, device_class = SENSOR_TYPES[condition]
+            if kind == TYPE_BINARY_SENSOR:
+                binary_sensor_list.append(
+                    AmbientWeatherBinarySensor(
                         ambient, mac_address, station[ATTR_NAME], condition,
-                        name, unit))
+                        name, device_class))
 
-    async_add_entities(sensor_list, True)
+    async_add_entities(binary_sensor_list, True)
 
 
-class AmbientWeatherSensor(AmbientWeatherEntity):
-    """Define an Ambient sensor."""
+class AmbientWeatherBinarySensor(AmbientWeatherEntity, BinarySensorDevice):
+    """Define an Ambient binary sensor."""
 
     def __init__(
             self, ambient, mac_address, station_name, sensor_type, sensor_name,
-            unit):
+            device_class):
         """Initialize the sensor."""
         super().__init__(
             ambient, mac_address, station_name, sensor_type, sensor_name)
 
-        self._unit = unit
+        self._device_class = device_class
 
     @property
-    def unit_of_measurement(self):
-        """Return the unit of measurement."""
-        return self._unit
+    def device_class(self):
+        """Return the device class."""
+        return self._device_class
 
     async def async_update(self):
-        """Fetch new state data for the sensor."""
+        """Fetch new state data for the entity."""
         self._state = self._ambient.stations[
             self._mac_address][ATTR_LAST_DATA].get(self._sensor_type)

--- a/homeassistant/components/ambient_station/binary_sensor.py
+++ b/homeassistant/components/ambient_station/binary_sensor.py
@@ -63,7 +63,7 @@ class AmbientWeatherBinarySensor(AmbientWeatherEntity, BinarySensorDevice):
         if self._sensor_type == TYPE_BATTOUT:
             return self._state == 0
 
-        return self._state
+        return self._state == 1
 
     async def async_update(self):
         """Fetch new state data for the entity."""

--- a/homeassistant/components/ambient_station/binary_sensor.py
+++ b/homeassistant/components/ambient_station/binary_sensor.py
@@ -65,6 +65,11 @@ class AmbientWeatherBinarySensor(AmbientWeatherEntity, BinarySensorDevice):
 
         return self._state == 1
 
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
     async def async_update(self):
         """Fetch new state data for the entity."""
         self._state = self._ambient.stations[

--- a/homeassistant/components/ambient_station/const.py
+++ b/homeassistant/components/ambient_station/const.py
@@ -8,3 +8,6 @@ CONF_APP_KEY = 'app_key'
 DATA_CLIENT = 'data_client'
 
 TOPIC_UPDATE = 'update'
+
+TYPE_BINARY_SENSOR = 'binary_sensor'
+TYPE_SENSOR = 'sensor'

--- a/homeassistant/components/ambient_station/sensor.py
+++ b/homeassistant/components/ambient_station/sensor.py
@@ -52,6 +52,11 @@ class AmbientWeatherSensor(AmbientWeatherEntity):
         self._unit = unit
 
     @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
     def unit_of_measurement(self):
         """Return the unit of measurement."""
         return self._unit


### PR DESCRIPTION
## Description:

Some Ambient stations return a battery sensor, which was not properly "casted" to a binary sensor. This PR fixes that.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
ambient_station:
  api_key: !secret ambient_pws_api_key
  app_key: !secret ambient_pws_app_key
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
