### PR TITLE
Make monitored_conditions more specific in Ambient PWS

### DIFF
--- a/homeassistant/components/ambient_station/__init__.py
+++ b/homeassistant/components/ambient_station/__init__.py
@@ -24,8 +24,6 @@ from .const import (
 REQUIREMENTS = ['aioambient==0.1.0']
 _LOGGER = logging.getLogger(__name__)
 
-DATA_CONFIG = 'config'
-
 DEFAULT_SOCKET_MIN_RETRY = 15
 
 SENSOR_TYPES = {
@@ -89,9 +87,6 @@ async def async_setup(hass, config):
         hass.config_entries.flow.async_init(
             DOMAIN, context={'source': SOURCE_IMPORT}, data=conf))
 
-    # Store config for entry setup:
-    hass.data[DOMAIN][DATA_CONFIG] = conf.get(CONF_MONITORED_CONDITIONS)
-
     return True
 
 
@@ -109,7 +104,8 @@ async def async_setup_entry(hass, config_entry):
             Client(
                 config_entry.data[CONF_API_KEY],
                 config_entry.data[CONF_APP_KEY], session),
-            hass.data[DOMAIN].get(DATA_CONFIG, []))
+            config_entry.data.get(
+                CONF_MONITORED_CONDITIONS, list(SENSOR_TYPES)))
         hass.loop.create_task(ambient.ws_connect())
         hass.data[DOMAIN][DATA_CLIENT][config_entry.entry_id] = ambient
     except WebsocketConnectionError as err:

--- a/homeassistant/components/ambient_station/__init__.py
+++ b/homeassistant/components/ambient_station/__init__.py
@@ -24,6 +24,8 @@ from .const import (
 REQUIREMENTS = ['aioambient==0.1.0']
 _LOGGER = logging.getLogger(__name__)
 
+DATA_CONFIG = 'config'
+
 DEFAULT_SOCKET_MIN_RETRY = 15
 
 SENSOR_TYPES = {
@@ -62,12 +64,9 @@ SENSOR_TYPES = {
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN:
         vol.Schema({
-            vol.Required(CONF_APP_KEY):
-                cv.string,
-            vol.Required(CONF_API_KEY):
-                cv.string,
-            vol.Optional(
-                CONF_MONITORED_CONDITIONS, default=list(SENSOR_TYPES)):
+            vol.Required(CONF_APP_KEY): cv.string,
+            vol.Required(CONF_API_KEY): cv.string,
+            vol.Optional(CONF_MONITORED_CONDITIONS):
                 vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
         })
 }, extra=vol.ALLOW_EXTRA)
@@ -90,6 +89,9 @@ async def async_setup(hass, config):
         hass.config_entries.flow.async_init(
             DOMAIN, context={'source': SOURCE_IMPORT}, data=conf))
 
+    # Store config for entry setup:
+    hass.data[DOMAIN][DATA_CONFIG] = conf.get(CONF_MONITORED_CONDITIONS)
+
     return True
 
 
@@ -107,8 +109,7 @@ async def async_setup_entry(hass, config_entry):
             Client(
                 config_entry.data[CONF_API_KEY],
                 config_entry.data[CONF_APP_KEY], session),
-            config_entry.data.get(
-                CONF_MONITORED_CONDITIONS, list(SENSOR_TYPES)))
+            hass.data[DOMAIN].get(DATA_CONFIG, []))
         hass.loop.create_task(ambient.ws_connect())
         hass.data[DOMAIN][DATA_CLIENT][config_entry.entry_id] = ambient
     except WebsocketConnectionError as err:
@@ -171,6 +172,15 @@ class AmbientStation:
                     continue
 
                 _LOGGER.debug('New station subscription: %s', data)
+
+                # If the user hasn't specified monitored conditions, use only
+                # those that their station supports (and which are defined
+                # here):
+                if not self.monitored_conditions:
+                    self.monitored_conditions = [
+                        k for k in station['lastData'].keys()
+                        if k in SENSOR_TYPES
+                    ]
 
                 self.stations[station['macAddress']] = {
                     ATTR_LAST_DATA: station['lastData'],

--- a/homeassistant/components/ambient_station/__init__.py
+++ b/homeassistant/components/ambient_station/__init__.py
@@ -104,8 +104,7 @@ async def async_setup_entry(hass, config_entry):
             Client(
                 config_entry.data[CONF_API_KEY],
                 config_entry.data[CONF_APP_KEY], session),
-            config_entry.data.get(
-                CONF_MONITORED_CONDITIONS, list(SENSOR_TYPES)))
+            config_entry.data.get(CONF_MONITORED_CONDITIONS, []))
         hass.loop.create_task(ambient.ws_connect())
         hass.data[DOMAIN][DATA_CLIENT][config_entry.entry_id] = ambient
     except WebsocketConnectionError as err:

--- a/homeassistant/components/ambient_station/config_flow.py
+++ b/homeassistant/components/ambient_station/config_flow.py
@@ -69,4 +69,8 @@ class AmbientStationFlowHandler(config_entries.ConfigFlow):
         # to show nicely in the UI, so we take the first 12 characters (similar
         # to how GitHub does it):
         return self.async_create_entry(
-            title=user_input[CONF_APP_KEY][:12], data=user_input)
+            title=user_input[CONF_APP_KEY][:12],
+            data={
+                CONF_API_KEY: user_input[CONF_API_KEY],
+                CONF_APP_KEY: user_input[CONF_APP_KEY],
+            })

--- a/homeassistant/components/ambient_station/config_flow.py
+++ b/homeassistant/components/ambient_station/config_flow.py
@@ -69,8 +69,4 @@ class AmbientStationFlowHandler(config_entries.ConfigFlow):
         # to show nicely in the UI, so we take the first 12 characters (similar
         # to how GitHub does it):
         return self.async_create_entry(
-            title=user_input[CONF_APP_KEY][:12],
-            data={
-                CONF_API_KEY: user_input[CONF_API_KEY],
-                CONF_APP_KEY: user_input[CONF_APP_KEY],
-            })
+            title=user_input[CONF_APP_KEY][:12], data=user_input)


### PR DESCRIPTION
## Description:

This PR adjusts the Ambient PWS component's use of `monitored_conditions` within `configuration.yaml`. Before, an empty `monitored_conditions` would add _all_ sensor types, regardless of whether a user's station supported them; now, an empty `monitored_conditions` will only create sensors that are actually supported by the station.

Incidentally, this also means that Ambient integrations added via config entry will get the same benefit.

I'm torn on whether this is a breaking change; yes, the behavior changed, but the old behavior – wherein a user would see empty/unknown sensors – wasn't terribly useful. Thoughts?

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
ambient_station:
  api_key: !secret ambient_pws_api_key
  app_key: !secret ambient_pws_app_key
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
