### PR TITLE
Update platform loading path

### DIFF
--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -7,8 +7,8 @@ __short_version__ = '{}.{}'.format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = '{}.{}'.format(__short_version__, PATCH_VERSION)
 REQUIRED_PYTHON_VER = (3, 5, 3)
 
-# Format for platforms
-PLATFORM_FORMAT = '{domain}.{platform}'
+# Format for platform files
+PLATFORM_FORMAT = '{platform}.{domain}'
 
 # Can be used to specify a catch all when registering state or event listeners.
 MATCH_ALL = '*'

--- a/tests/common.py
+++ b/tests/common.py
@@ -486,6 +486,8 @@ class MockModule:
 class MockPlatform:
     """Provide a fake platform."""
 
+    __name__ = "homeassistant.components.light.bla"
+
     # pylint: disable=invalid-name
     def __init__(self, setup_platform=None, dependencies=None,
                  platform_schema=None, async_setup_platform=None,

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -132,3 +132,17 @@ async def test_log_warning_custom_component(hass, caplog):
 
     loader.get_component(hass, 'light.test')
     assert 'You are using a custom component for light.test' in caplog.text
+
+
+async def test_get_platform(hass, caplog):
+    """Test get_platform."""
+    # Test we prefer embedded over normal platforms."""
+    embedded_platform = loader.get_platform(hass, 'switch', 'test_embedded')
+    assert embedded_platform.__name__ == \
+        'custom_components.test_embedded.switch'
+
+    caplog.clear()
+
+    legacy_platform = loader.get_platform(hass, 'switch', 'test')
+    assert legacy_platform.__name__ == 'custom_components.switch.test'
+    assert 'Integrations need to be in their own folder.' in caplog.text

--- a/tests/testing_config/custom_components/switch/test_embedded.py
+++ b/tests/testing_config/custom_components/switch/test_embedded.py
@@ -1,0 +1,1 @@
+"""Test switch platform for test_embedded component."""


### PR DESCRIPTION
## Description:
Change the platform loading path to first check `hue/light.py` instead of `light/hue.py`. Also print a warning if we find a custom component platform that is in the format of `light/hue.py`.

**Breaking change**: We are moving to a new integration structure. Platforms now live embedded in components. Custom platforms will have to be updated to follow this pattern. This is only a breaking change in case your custom platform overrides a built-in platform. Rename your custom platform from, ie `light/hue.py` to `hue/light.py`.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
