### PR TITLE
Add missing data fields to Ambient PWS

### DIFF
--- a/homeassistant/components/ambient_station/__init__.py
+++ b/homeassistant/components/ambient_station/__init__.py
@@ -33,6 +33,16 @@ DEFAULT_SOCKET_MIN_RETRY = 15
 TYPE_24HOURRAININ = '24hourrainin'
 TYPE_BAROMABSIN = 'baromabsin'
 TYPE_BAROMRELIN = 'baromrelin'
+TYPE_BATT1 = 'batt1'
+TYPE_BATT10 = 'batt10'
+TYPE_BATT2 = 'batt2'
+TYPE_BATT3 = 'batt3'
+TYPE_BATT4 = 'batt4'
+TYPE_BATT5 = 'batt5'
+TYPE_BATT6 = 'batt6'
+TYPE_BATT7 = 'batt7'
+TYPE_BATT8 = 'batt8'
+TYPE_BATT9 = 'batt9'
 TYPE_BATTOUT = 'battout'
 TYPE_CO2 = 'co2'
 TYPE_DAILYRAININ = 'dailyrainin'
@@ -41,11 +51,61 @@ TYPE_EVENTRAININ = 'eventrainin'
 TYPE_FEELSLIKE = 'feelsLike'
 TYPE_HOURLYRAININ = 'hourlyrainin'
 TYPE_HUMIDITY = 'humidity'
+TYPE_HUMIDITY1 = 'humidity1'
+TYPE_HUMIDITY10 = 'humidity10'
+TYPE_HUMIDITY2 = 'humidity2'
+TYPE_HUMIDITY3 = 'humidity3'
+TYPE_HUMIDITY4 = 'humidity4'
+TYPE_HUMIDITY5 = 'humidity5'
+TYPE_HUMIDITY6 = 'humidity6'
+TYPE_HUMIDITY7 = 'humidity7'
+TYPE_HUMIDITY8 = 'humidity8'
+TYPE_HUMIDITY9 = 'humidity9'
 TYPE_HUMIDITYIN = 'humidityin'
 TYPE_LASTRAIN = 'lastRain'
 TYPE_MAXDAILYGUST = 'maxdailygust'
 TYPE_MONTHLYRAININ = 'monthlyrainin'
+TYPE_RELAY1 = 'relay1'
+TYPE_RELAY10 = 'relay10'
+TYPE_RELAY2 = 'relay2'
+TYPE_RELAY3 = 'relay3'
+TYPE_RELAY4 = 'relay4'
+TYPE_RELAY5 = 'relay5'
+TYPE_RELAY6 = 'relay6'
+TYPE_RELAY7 = 'relay7'
+TYPE_RELAY8 = 'relay8'
+TYPE_RELAY9 = 'relay9'
+TYPE_SOILHUM1 = 'soilhum1'
+TYPE_SOILHUM10 = 'soilhum10'
+TYPE_SOILHUM2 = 'soilhum2'
+TYPE_SOILHUM3 = 'soilhum3'
+TYPE_SOILHUM4 = 'soilhum4'
+TYPE_SOILHUM5 = 'soilhum5'
+TYPE_SOILHUM6 = 'soilhum6'
+TYPE_SOILHUM7 = 'soilhum7'
+TYPE_SOILHUM8 = 'soilhum8'
+TYPE_SOILHUM9 = 'soilhum9'
+TYPE_SOILTEMP1F = 'soiltemp1f'
+TYPE_SOILTEMP10F = 'soiltemp10f'
+TYPE_SOILTEMP2F = 'soiltemp2f'
+TYPE_SOILTEMP3F = 'soiltemp3f'
+TYPE_SOILTEMP4F = 'soiltemp4f'
+TYPE_SOILTEMP5F = 'soiltemp5f'
+TYPE_SOILTEMP6F = 'soiltemp6f'
+TYPE_SOILTEMP7F = 'soiltemp7f'
+TYPE_SOILTEMP8F = 'soiltemp8f'
+TYPE_SOILTEMP9F = 'soiltemp9f'
 TYPE_SOLARRADIATION = 'solarradiation'
+TYPE_TEMP10F = 'temp10f'
+TYPE_TEMP1F = 'temp1f'
+TYPE_TEMP2F = 'temp2f'
+TYPE_TEMP3F = 'temp3f'
+TYPE_TEMP4F = 'temp4f'
+TYPE_TEMP5F = 'temp5f'
+TYPE_TEMP6F = 'temp6f'
+TYPE_TEMP7F = 'temp7f'
+TYPE_TEMP8F = 'temp8f'
+TYPE_TEMP9F = 'temp9f'
 TYPE_TEMPF = 'tempf'
 TYPE_TEMPINF = 'tempinf'
 TYPE_TOTALRAININ = 'totalrainin'
@@ -64,6 +124,16 @@ SENSOR_TYPES = {
     TYPE_24HOURRAININ: ('24 Hr Rain', 'in', TYPE_SENSOR, None),
     TYPE_BAROMABSIN: ('Abs Pressure', 'inHg', TYPE_SENSOR, None),
     TYPE_BAROMRELIN: ('Rel Pressure', 'inHg', TYPE_SENSOR, None),
+    TYPE_BATT10: ('Battery 10', None, TYPE_BINARY_SENSOR, 'battery'),
+    TYPE_BATT1: ('Battery 1', None, TYPE_BINARY_SENSOR, 'battery'),
+    TYPE_BATT2: ('Battery 2', None, TYPE_BINARY_SENSOR, 'battery'),
+    TYPE_BATT3: ('Battery 3', None, TYPE_BINARY_SENSOR, 'battery'),
+    TYPE_BATT4: ('Battery 4', None, TYPE_BINARY_SENSOR, 'battery'),
+    TYPE_BATT5: ('Battery 5', None, TYPE_BINARY_SENSOR, 'battery'),
+    TYPE_BATT6: ('Battery 6', None, TYPE_BINARY_SENSOR, 'battery'),
+    TYPE_BATT7: ('Battery 7', None, TYPE_BINARY_SENSOR, 'battery'),
+    TYPE_BATT8: ('Battery 8', None, TYPE_BINARY_SENSOR, 'battery'),
+    TYPE_BATT9: ('Battery 9', None, TYPE_BINARY_SENSOR, 'battery'),
     TYPE_BATTOUT: ('Battery', None, TYPE_BINARY_SENSOR, 'battery'),
     TYPE_CO2: ('co2', 'ppm', TYPE_SENSOR, None),
     TYPE_DAILYRAININ: ('Daily Rain', 'in', TYPE_SENSOR, None),
@@ -71,12 +141,62 @@ SENSOR_TYPES = {
     TYPE_EVENTRAININ: ('Event Rain', 'in', TYPE_SENSOR, None),
     TYPE_FEELSLIKE: ('Feels Like', '°F', TYPE_SENSOR, None),
     TYPE_HOURLYRAININ: ('Hourly Rain Rate', 'in/hr', TYPE_SENSOR, None),
+    TYPE_HUMIDITY10: ('Humidity 10', '%', TYPE_SENSOR, None),
+    TYPE_HUMIDITY1: ('Humidity 1', '%', TYPE_SENSOR, None),
+    TYPE_HUMIDITY2: ('Humidity 2', '%', TYPE_SENSOR, None),
+    TYPE_HUMIDITY3: ('Humidity 3', '%', TYPE_SENSOR, None),
+    TYPE_HUMIDITY4: ('Humidity 4', '%', TYPE_SENSOR, None),
+    TYPE_HUMIDITY5: ('Humidity 5', '%', TYPE_SENSOR, None),
+    TYPE_HUMIDITY6: ('Humidity 6', '%', TYPE_SENSOR, None),
+    TYPE_HUMIDITY7: ('Humidity 7', '%', TYPE_SENSOR, None),
+    TYPE_HUMIDITY8: ('Humidity 8', '%', TYPE_SENSOR, None),
+    TYPE_HUMIDITY9: ('Humidity 9', '%', TYPE_SENSOR, None),
     TYPE_HUMIDITY: ('Humidity', '%', TYPE_SENSOR, None),
     TYPE_HUMIDITYIN: ('Humidity In', '%', TYPE_SENSOR, None),
     TYPE_LASTRAIN: ('Last Rain', None, TYPE_SENSOR, None),
     TYPE_MAXDAILYGUST: ('Max Gust', 'mph', TYPE_SENSOR, None),
     TYPE_MONTHLYRAININ: ('Monthly Rain', 'in', TYPE_SENSOR, None),
+    TYPE_RELAY10: ('Relay 10', None, TYPE_BINARY_SENSOR, 'connectivity'),
+    TYPE_RELAY1: ('Relay 1', None, TYPE_BINARY_SENSOR, 'connectivity'),
+    TYPE_RELAY2: ('Relay 2', None, TYPE_BINARY_SENSOR, 'connectivity'),
+    TYPE_RELAY3: ('Relay 3', None, TYPE_BINARY_SENSOR, 'connectivity'),
+    TYPE_RELAY4: ('Relay 4', None, TYPE_BINARY_SENSOR, 'connectivity'),
+    TYPE_RELAY5: ('Relay 5', None, TYPE_BINARY_SENSOR, 'connectivity'),
+    TYPE_RELAY6: ('Relay 6', None, TYPE_BINARY_SENSOR, 'connectivity'),
+    TYPE_RELAY7: ('Relay 7', None, TYPE_BINARY_SENSOR, 'connectivity'),
+    TYPE_RELAY8: ('Relay 8', None, TYPE_BINARY_SENSOR, 'connectivity'),
+    TYPE_RELAY9: ('Relay 9', None, TYPE_BINARY_SENSOR, 'connectivity'),
+    TYPE_SOILHUM10: ('Soil Humidity 10', '%', TYPE_SENSOR, None),
+    TYPE_SOILHUM1: ('Soil Humidity 1', '%', TYPE_SENSOR, None),
+    TYPE_SOILHUM2: ('Soil Humidity 2', '%', TYPE_SENSOR, None),
+    TYPE_SOILHUM3: ('Soil Humidity 3', '%', TYPE_SENSOR, None),
+    TYPE_SOILHUM4: ('Soil Humidity 4', '%', TYPE_SENSOR, None),
+    TYPE_SOILHUM5: ('Soil Humidity 5', '%', TYPE_SENSOR, None),
+    TYPE_SOILHUM6: ('Soil Humidity 6', '%', TYPE_SENSOR, None),
+    TYPE_SOILHUM7: ('Soil Humidity 7', '%', TYPE_SENSOR, None),
+    TYPE_SOILHUM8: ('Soil Humidity 8', '%', TYPE_SENSOR, None),
+    TYPE_SOILHUM9: ('Soil Humidity 9', '%', TYPE_SENSOR, None),
+    TYPE_SOILTEMP10F: ('Soil Temp 10', '°F', TYPE_SENSOR, None),
+    TYPE_SOILTEMP1F: ('Soil Temp 1', '°F', TYPE_SENSOR, None),
+    TYPE_SOILTEMP2F: ('Soil Temp 2', '°F', TYPE_SENSOR, None),
+    TYPE_SOILTEMP3F: ('Soil Temp 3', '°F', TYPE_SENSOR, None),
+    TYPE_SOILTEMP4F: ('Soil Temp 4', '°F', TYPE_SENSOR, None),
+    TYPE_SOILTEMP5F: ('Soil Temp 5', '°F', TYPE_SENSOR, None),
+    TYPE_SOILTEMP6F: ('Soil Temp 6', '°F', TYPE_SENSOR, None),
+    TYPE_SOILTEMP7F: ('Soil Temp 7', '°F', TYPE_SENSOR, None),
+    TYPE_SOILTEMP8F: ('Soil Temp 8', '°F', TYPE_SENSOR, None),
+    TYPE_SOILTEMP9F: ('Soil Temp 9', '°F', TYPE_SENSOR, None),
     TYPE_SOLARRADIATION: ('Solar Rad', 'W/m^2', TYPE_SENSOR, None),
+    TYPE_TEMP10F: ('Temp 10', '°F', TYPE_SENSOR, None),
+    TYPE_TEMP1F: ('Temp 1', '°F', TYPE_SENSOR, None),
+    TYPE_TEMP2F: ('Temp 2', '°F', TYPE_SENSOR, None),
+    TYPE_TEMP3F: ('Temp 3', '°F', TYPE_SENSOR, None),
+    TYPE_TEMP4F: ('Temp 4', '°F', TYPE_SENSOR, None),
+    TYPE_TEMP5F: ('Temp 5', '°F', TYPE_SENSOR, None),
+    TYPE_TEMP6F: ('Temp 6', '°F', TYPE_SENSOR, None),
+    TYPE_TEMP7F: ('Temp 7', '°F', TYPE_SENSOR, None),
+    TYPE_TEMP8F: ('Temp 8', '°F', TYPE_SENSOR, None),
+    TYPE_TEMP9F: ('Temp 9', '°F', TYPE_SENSOR, None),
     TYPE_TEMPF: ('Temp', '°F', TYPE_SENSOR, None),
     TYPE_TEMPINF: ('Inside Temp', '°F', TYPE_SENSOR, None),
     TYPE_TOTALRAININ: ('Lifetime Rain', 'in', TYPE_SENSOR, None),

--- a/homeassistant/components/ambient_station/binary_sensor.py
+++ b/homeassistant/components/ambient_station/binary_sensor.py
@@ -65,11 +65,6 @@ class AmbientWeatherBinarySensor(AmbientWeatherEntity, BinarySensorDevice):
 
         return self._state == 1
 
-    @property
-    def state(self):
-        """Return the state of the sensor."""
-        return self._state
-
     async def async_update(self):
         """Fetch new state data for the entity."""
         self._state = self._ambient.stations[

--- a/homeassistant/components/ambient_station/binary_sensor.py
+++ b/homeassistant/components/ambient_station/binary_sensor.py
@@ -7,7 +7,9 @@ https://home-assistant.io/components/binary_sensor.ambient_station/
 import logging
 
 from homeassistant.components.ambient_station import (
-    SENSOR_TYPES, TYPE_BATTOUT, AmbientWeatherEntity)
+    SENSOR_TYPES, TYPE_BATT1, TYPE_BATT10, TYPE_BATT2, TYPE_BATT3, TYPE_BATT4,
+    TYPE_BATT5, TYPE_BATT6, TYPE_BATT7, TYPE_BATT8, TYPE_BATT9, TYPE_BATTOUT,
+    AmbientWeatherEntity)
 from homeassistant.components.binary_sensor import BinarySensorDevice
 from homeassistant.const import ATTR_NAME
 
@@ -60,7 +62,10 @@ class AmbientWeatherBinarySensor(AmbientWeatherEntity, BinarySensorDevice):
     @property
     def is_on(self):
         """Return the status of the sensor."""
-        if self._sensor_type == TYPE_BATTOUT:
+        if self._sensor_type in (TYPE_BATT1, TYPE_BATT10, TYPE_BATT2,
+                                 TYPE_BATT3, TYPE_BATT4, TYPE_BATT5,
+                                 TYPE_BATT6, TYPE_BATT7, TYPE_BATT8,
+                                 TYPE_BATT9, TYPE_BATTOUT):
             return self._state == 0
 
         return self._state == 1

--- a/homeassistant/components/ambient_station/binary_sensor.py
+++ b/homeassistant/components/ambient_station/binary_sensor.py
@@ -65,6 +65,11 @@ class AmbientWeatherBinarySensor(AmbientWeatherEntity, BinarySensorDevice):
 
         return self._state == 1
 
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
     async def async_update(self):
         """Fetch new state data for the entity."""
         self._state = self._ambient.stations[

--- a/homeassistant/components/ambient_station/sensor.py
+++ b/homeassistant/components/ambient_station/sensor.py
@@ -52,11 +52,6 @@ class AmbientWeatherSensor(AmbientWeatherEntity):
         self._unit = unit
 
     @property
-    def state(self):
-        """Return the state of the sensor."""
-        return self._state
-
-    @property
     def unit_of_measurement(self):
         """Return the unit of measurement."""
         return self._unit

--- a/homeassistant/components/ambient_station/sensor.py
+++ b/homeassistant/components/ambient_station/sensor.py
@@ -52,6 +52,11 @@ class AmbientWeatherSensor(AmbientWeatherEntity):
         self._unit = unit
 
     @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
     def unit_of_measurement(self):
         """Return the unit of measurement."""
         return self._unit


### PR DESCRIPTION
## Description:

This PR adds various possible data fields that were previously missing. **This is branched off of https://github.com/home-assistant/home-assistant/pull/20801 and should not be merged until that one is merged.**

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** https://github.com/home-assistant/home-assistant.io/pull/8432

## Example entry for `configuration.yaml` (if applicable):
```yaml
ambient_station:
  api_key: !secret ambient_pws_api_key
  app_key: !secret ambient_pws_app_key
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
