### PR TITLE
Add cover support for EnOcean

### DIFF
--- a/homeassistant/components/enocean/__init__.py
+++ b/homeassistant/components/enocean/__init__.py
@@ -124,13 +124,15 @@ class EnOceanDongle:
                     if temp.sender_int == self._combine_hex(device.dev_id):
                         device.value_changed(value)
         elif isinstance(temp, Packet):
-            # case of base_id packet which not identied as RadioPacket but simple Packet
-            from enocean.protocol.constants import PARSE_RESULT, RETURN_CODE
+            # case of base_id packet which not identied as
+            # RadioPacket but simple Packet
+            from enocean.protocol.constants import RETURN_CODE
             packet = temp
             if (packet.packet_type == PACKET.RESPONSE
                     and packet.response == RETURN_CODE.OK
                     and len(packet.response_data) == 4):
                 self.__communicator.base_id = packet.response_data
+
 
 class EnOceanDevice():
     """Parent class for all devices associated with the EnOcean component."""
@@ -150,4 +152,5 @@ class EnOceanDevice():
         ENOCEAN_DONGLE.send_command(packet)
 
     def send_packet(self, packet):
+        """Send a packet via the EnOcean dongle."""
         ENOCEAN_DONGLE.send_command(packet)

--- a/homeassistant/components/enocean/cover.py
+++ b/homeassistant/components/enocean/cover.py
@@ -1,5 +1,5 @@
 """
-Support for EnOcean cover sources
+Support for EnOcean cover sources.
 
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/cover.enocean/
@@ -36,11 +36,13 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 })
 
+
 def setup_platform(hass, config, add_devices, discovery_infom=None):
     """Set up the EnOcean Cover platform."""
     devname = config.get(CONF_NAME)
     dev_id = config.get(CONF_ID)
     add_devices([EnOceanCover(devname, dev_id)])
+
 
 class EnOceanCover(enocean.EnOceanDevice, CoverDevice):
     """Representation of an EnOcean cover source."""
@@ -80,9 +82,12 @@ class EnOceanCover(enocean.EnOceanDevice, CoverDevice):
         return 100 - self.percent_closed
 
     def value_changed(self, value):
-        """Update the current cover position and adjust all status of cover entity"""
-        def on_done(a):
-            """Called when timer throttle or percent determine close or opened"""
+        """Update the current cover position.
+
+        And adjust all status of cover entity
+        """
+        def on_done(time):
+            """Reset opening/closing status."""
             self._is_closing = False
             self._is_opening = False
             self.schedule_update_ha_state()

--- a/homeassistant/components/enocean/cover.py
+++ b/homeassistant/components/enocean/cover.py
@@ -1,0 +1,177 @@
+"""
+Support for EnOcean cover sources
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/cover.enocean/
+"""
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components.cover import (
+    CoverDevice,
+    SUPPORT_OPEN,
+    SUPPORT_SET_POSITION,
+    SUPPORT_CLOSE,
+    ATTR_POSITION,
+    PLATFORM_SCHEMA
+)
+from homeassistant.const import (CONF_NAME, CONF_ID)
+from homeassistant.components import enocean
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.event import async_call_later
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_SENDER_ID = 'sender_id'
+
+DEFAULT_NAME = 'EnOcean Cover'
+DEPENDENCIES = ['enocean']
+
+SUPPORT_ENOCEAN = SUPPORT_OPEN | SUPPORT_CLOSE | SUPPORT_SET_POSITION
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_ID, default=[]):
+        vol.All(cv.ensure_list, [vol.Coerce(int)]),
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+})
+
+def setup_platform(hass, config, add_devices, discovery_infom=None):
+    """Set up the EnOcean Cover platform."""
+    devname = config.get(CONF_NAME)
+    dev_id = config.get(CONF_ID)
+    add_devices([EnOceanCover(devname, dev_id)])
+
+class EnOceanCover(enocean.EnOceanDevice, CoverDevice):
+    """Representation of an EnOcean cover source."""
+
+    def __init__(self, devname, dev_id):
+        """Initialize the EnOcean cover source."""
+        from enocean.protocol.packet import Packet
+        from enocean.protocol.constants import PACKET, RORG
+
+        enocean.EnOceanDevice.__init__(self)
+        # self._sender_id = sender_id
+        self.dev_id = dev_id
+        self._devname = devname
+        self.stype = "cover"
+        self.percent_closed = 100
+        self._is_opening = False
+        self._is_closing = False
+
+        self._async_on_done_timer = None
+
+        self.send_packet(Packet.create(
+            packet_type=PACKET.RADIO,
+            rorg=RORG.VLD,
+            rorg_func=0x05,
+            rorg_type=0x00,
+            destination=self.dev_id,
+            sender=self.base_id,
+            command=3
+        ))
+
+    @property
+    def current_cover_position(self):
+        """Return current position of cover.
+
+        None is unknown, 0 is closed, 100 is fully open.
+        """
+        return 100 - self.percent_closed
+
+    def value_changed(self, value):
+        """Update the current cover position and adjust all status of cover entity"""
+        def on_done(a):
+            """Called when timer throttle or percent determine close or opened"""
+            self._is_closing = False
+            self._is_opening = False
+            self.schedule_update_ha_state()
+
+        self.percent_closed = value
+        if self._async_on_done_timer:
+            self._async_on_done_timer()
+        if self.percent_closed <= 0 or self.percent_closed >= 100:
+            on_done(None)
+        else:
+            self._async_on_done_timer = async_call_later(self.hass, 3, on_done)
+        self.schedule_update_ha_state()
+
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+        return SUPPORT_ENOCEAN
+
+    def open_cover(self, **kwargs):
+        """Open the cover."""
+        from enocean.protocol.packet import Packet
+        from enocean.protocol.constants import PACKET, RORG
+        self._is_opening = True
+        self._is_closing = False
+
+        self.send_packet(Packet.create(
+            packet_type=PACKET.RADIO,
+            rorg=RORG.VLD,
+            rorg_func=0x05,
+            rorg_type=0x00,
+            destination=self.dev_id,
+            sender=self.base_id,
+            command=1,
+            POS=0
+        ))
+
+    def close_cover(self, **kwargs):
+        """Close cover."""
+        from enocean.protocol.packet import Packet
+        from enocean.protocol.constants import PACKET, RORG
+        self._is_opening = False
+        self._is_closing = True
+        self.send_packet(Packet.create(
+            packet_type=PACKET.RADIO,
+            rorg=RORG.VLD,
+            rorg_func=0x05,
+            rorg_type=0x00,
+            destination=self.dev_id,
+            sender=self.base_id,
+            command=1,
+            POS=100
+        ))
+
+    def set_cover_position(self, **kwargs):
+        """Move the cover to a specific position."""
+        from enocean.protocol.packet import Packet
+        from enocean.protocol.constants import PACKET, RORG
+        position = kwargs.get(ATTR_POSITION)
+        position = 100 - position
+
+        if position < self.percent_closed:
+            self._is_closing = False
+            self._is_opening = True
+        else:
+            self._is_closing = True
+            self._is_opening = False
+
+        self.send_packet(Packet.create(
+            packet_type=PACKET.RADIO,
+            rorg=RORG.VLD,
+            rorg_func=0x05,
+            rorg_type=0x00,
+            destination=self.dev_id,
+            sender=self.base_id,
+            command=1,
+            POS=position
+        ))
+
+    @property
+    def is_opening(self):
+        """Return if the cover is opening or not."""
+        return self._is_opening
+
+    @property
+    def is_closing(self):
+        """Return if the cover is closing or not."""
+        return self._is_closing
+
+    @property
+    def is_closed(self):
+        """Return if the cover is closed or not."""
+        return self.percent_closed == 100

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -367,7 +367,7 @@ elkm1-lib==0.7.13
 emulated_roku==0.1.8
 
 # homeassistant.components.enocean
-enocean==0.40
+enocean-lib==1.0.0
 
 # homeassistant.components.sensor.entur_public_transport
 enturclient==0.1.3


### PR DESCRIPTION
## Description:

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8428

## Example entry for `configuration.yaml` (if applicable):
```yaml
cover:
  - platform: enocean
    id: [0x01,0x90,0x84,0x3C]
    name: "The cover name"
```

## Checklist:
  - [ * ] The code change is tested and works locally.
  - [ * ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ * ] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ * ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ * ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ * ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ * ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ * ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54