### PR TITLE
Fix init of TransmissionData

### DIFF
--- a/homeassistant/components/transmission/__init__.py
+++ b/homeassistant/components/transmission/__init__.py
@@ -106,9 +106,9 @@ def setup(hass, config):
 
     return True
 
+
 class TransmissionData:
     """Get the latest data and update the states."""
-
 
     def __init__(self, hass, config, api):
         """Initialize the Transmission RPC API."""

--- a/homeassistant/components/transmission/__init__.py
+++ b/homeassistant/components/transmission/__init__.py
@@ -28,7 +28,7 @@ REQUIREMENTS = ['transmissionrpc==0.11']
 _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = 'transmission'
-DATA_UPDATED = '{}_data_updated'.format(DOMAIN)
+DATA_UPDATED = 'transmission_data_updated' 
 DATA_TRANSMISSION = 'data_transmission'
 
 DEFAULT_NAME = 'Transmission'
@@ -64,7 +64,7 @@ CONFIG_SCHEMA = vol.Schema({
 }, extra=vol.ALLOW_EXTRA)
 
 
-async def async_setup(hass, config):
+def setup(hass, config):
     """Set up the Transmission Component."""
     host = config[DOMAIN][CONF_HOST]
     username = config[DOMAIN].get(CONF_USERNAME)
@@ -86,6 +86,8 @@ async def async_setup(hass, config):
 
     tm_data = hass.data[DATA_TRANSMISSION] = TransmissionData(
         hass, config, api)
+        
+    tm_data.update()
     tm_data.init_torrent_list()
 
     def refresh(call=None):
@@ -102,27 +104,26 @@ async def async_setup(hass, config):
         
     hass.async_create_task(
         async_load_platform(
-            hass, 
-            'sensor', 
-            DOMAIN, 
-            sensorconfig, 
+            hass,
+            'sensor',
+            DOMAIN,
+            sensorconfig,
             config
         )
     )
 
     if config[DOMAIN][TURTLE_MODE]:
         hass.async_create_task(
-            async_load_platform( 
-                    hass, 
-                    'switch', 
-                    DOMAIN, 
-                    sensorconfig, 
+            async_load_platform(
+                    hass,
+                    'switch',
+                    DOMAIN,
+                    sensorconfig,
                     config
             )
-        )   
+        )
 
     return True
-
 
 class TransmissionData:
     """Get the latest data and update the states."""
@@ -151,7 +152,7 @@ class TransmissionData:
             self.check_started_torrent()
 
             dispatcher_send(self.hass, DATA_UPDATED)
-            
+
             _LOGGER.debug("Torrent Data updated")
             self.available = True
         except TransmissionError:

--- a/homeassistant/components/transmission/__init__.py
+++ b/homeassistant/components/transmission/__init__.py
@@ -21,7 +21,7 @@ from homeassistant.const import (
 from homeassistant.helpers import discovery, config_validation as cv
 from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.dispatcher import dispatcher_send
-from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.helpers.event import track_time_interval
 
 
 REQUIREMENTS = ['transmissionrpc==0.11']
@@ -94,7 +94,7 @@ def setup(hass, config):
         """Service call to update the data."""
         tm_data.update()
 
-    async_track_time_interval(hass, refresh, scan_interval)
+    track_time_interval(hass, refresh, scan_interval)
 
     hass.services.async_register(DOMAIN, 'transmission', refresh)
 
@@ -102,26 +102,10 @@ def setup(hass, config):
         'sensors': config[DOMAIN][CONF_MONITORED_CONDITIONS],
         'client_name': config[DOMAIN][CONF_NAME]}
 
-    hass.async_create_task(
-        async_load_platform(
-            hass,
-            'sensor',
-            DOMAIN,
-            sensorconfig,
-            config
-        )
-    )
+    discovery.load_platform(hass, 'sensor', DOMAIN, sensorconfig, config)
 
     if config[DOMAIN][TURTLE_MODE]:
-        hass.async_create_task(
-            async_load_platform(
-                    hass,
-                    'switch',
-                    DOMAIN,
-                    sensorconfig,
-                    config
-            )
-        )
+        discovery.load_platform(hass, 'switch', DOMAIN, sensorconfig, config)
 
     return True
 

--- a/homeassistant/components/transmission/__init__.py
+++ b/homeassistant/components/transmission/__init__.py
@@ -28,7 +28,7 @@ REQUIREMENTS = ['transmissionrpc==0.11']
 _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = 'transmission'
-DATA_UPDATED = 'transmission_data_updated' 
+DATA_UPDATED = 'transmission_data_updated'
 DATA_TRANSMISSION = 'data_transmission'
 
 DEFAULT_NAME = 'Transmission'
@@ -86,7 +86,7 @@ def setup(hass, config):
 
     tm_data = hass.data[DATA_TRANSMISSION] = TransmissionData(
         hass, config, api)
-        
+
     tm_data.update()
     tm_data.init_torrent_list()
 
@@ -95,13 +95,13 @@ def setup(hass, config):
         tm_data.update()
 
     async_track_time_interval(hass, refresh, scan_interval)
-    
+
     hass.services.async_register(DOMAIN, 'transmission', refresh)
 
     sensorconfig = {
         'sensors': config[DOMAIN][CONF_MONITORED_CONDITIONS],
         'client_name': config[DOMAIN][CONF_NAME]}
-        
+
     hass.async_create_task(
         async_load_platform(
             hass,

--- a/homeassistant/components/transmission/__init__.py
+++ b/homeassistant/components/transmission/__init__.py
@@ -90,7 +90,7 @@ def setup(hass, config):
     tm_data.init_torrent_list()
 
     def refresh(event_time):
-        """Service call to update the data."""
+        """Get the latest data from Transmission."""
         tm_data.update()
 
     track_time_interval(hass, refresh, scan_interval)
@@ -109,7 +109,7 @@ def setup(hass, config):
 class TransmissionData:
     """Get the latest data and update the states."""
 
-    
+
     def __init__(self, hass, config, api):
         """Initialize the Transmission RPC API."""
         self.data = None

--- a/homeassistant/components/transmission/__init__.py
+++ b/homeassistant/components/transmission/__init__.py
@@ -19,7 +19,6 @@ from homeassistant.const import (
     CONF_SCAN_INTERVAL
 )
 from homeassistant.helpers import discovery, config_validation as cv
-from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.dispatcher import dispatcher_send
 from homeassistant.helpers.event import track_time_interval
 
@@ -90,13 +89,11 @@ def setup(hass, config):
     tm_data.update()
     tm_data.init_torrent_list()
 
-    def refresh(call=None):
+    def refresh(event_time):
         """Service call to update the data."""
         tm_data.update()
 
     track_time_interval(hass, refresh, scan_interval)
-
-    hass.services.async_register(DOMAIN, 'transmission', refresh)
 
     sensorconfig = {
         'sensors': config[DOMAIN][CONF_MONITORED_CONDITIONS],
@@ -112,6 +109,7 @@ def setup(hass, config):
 class TransmissionData:
     """Get the latest data and update the states."""
 
+    
     def __init__(self, hass, config, api):
         """Initialize the Transmission RPC API."""
         self.data = None
@@ -200,6 +198,6 @@ class TransmissionData:
     def get_alt_speed_enabled(self):
         """Get the alternative speed flag."""
         if self.session is None:
-            return 
+            return None
 
         return self.session.alt_speed_enabled

--- a/homeassistant/components/transmission/__init__.py
+++ b/homeassistant/components/transmission/__init__.py
@@ -115,6 +115,8 @@ class TransmissionData:
         self.started_torrents = []
         self.hass = hass
 
+        self.update()
+
     def update(self):
         """Get the latest data from Transmission instance."""
         from transmissionrpc.error import TransmissionError

--- a/homeassistant/components/transmission/sensor.py
+++ b/homeassistant/components/transmission/sensor.py
@@ -51,7 +51,7 @@ async def async_setup_platform(
 class TransmissionSensor(Entity):
     """Representation of a Transmission sensor."""
 
-    
+
     def __init__(
             self,
             sensor_type,

--- a/homeassistant/components/transmission/sensor.py
+++ b/homeassistant/components/transmission/sensor.py
@@ -9,11 +9,11 @@ from datetime import timedelta
 import logging
 
 from homeassistant.components.transmission import (
-    DATA_TRANSMISSION, SENSOR_TYPES)
+    DATA_TRANSMISSION, SENSOR_TYPES, DATA_UPDATED)
 from homeassistant.const import STATE_IDLE
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.entity import Entity 
 from homeassistant.util import Throttle
 
 DEPENDENCIES = ['transmission']
@@ -21,7 +21,6 @@ DEPENDENCIES = ['transmission']
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_NAME = 'Transmission'
-DATA_UPDATED = 'transmission_data_updated'
 
 SCAN_INTERVAL = timedelta(seconds=120)
 
@@ -29,7 +28,7 @@ SCAN_INTERVAL = timedelta(seconds=120)
 async def async_setup_platform(
         hass,
         config,
-        add_entities,
+        async_add_entities,
         discovery_info=None):
     """Set up the Transmission sensors."""
     if discovery_info is None:
@@ -48,7 +47,7 @@ async def async_setup_platform(
             SENSOR_TYPES[sensor_type][0],
             SENSOR_TYPES[sensor_type][1]))
 
-    add_entities(dev, True)
+    async_add_entities(dev, True)
 
 class TransmissionSensor(Entity):
     """Representation of a Transmission sensor."""

--- a/homeassistant/components/transmission/sensor.py
+++ b/homeassistant/components/transmission/sensor.py
@@ -21,16 +21,16 @@ DEPENDENCIES = ['transmission']
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_NAME = 'Transmission'
-DATA_UPDATED = 'transmission_data_updated' 
+DATA_UPDATED = 'transmission_data_updated'
 
 SCAN_INTERVAL = timedelta(seconds=120)
 
 
 async def async_setup_platform(
-    hass,
-    config,
-    add_entities,
-    discovery_info=None):
+        hass,
+        config,
+        add_entities,
+        discovery_info=None):
     """Set up the Transmission sensors."""
     if discovery_info is None:
         return

--- a/homeassistant/components/transmission/sensor.py
+++ b/homeassistant/components/transmission/sensor.py
@@ -48,9 +48,9 @@ async def async_setup_platform(
 
     async_add_entities(dev, True)
 
+
 class TransmissionSensor(Entity):
     """Representation of a Transmission sensor."""
-
 
     def __init__(
             self,

--- a/homeassistant/components/transmission/sensor.py
+++ b/homeassistant/components/transmission/sensor.py
@@ -13,8 +13,7 @@ from homeassistant.components.transmission import (
 from homeassistant.const import STATE_IDLE
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers.entity import Entity 
-from homeassistant.util import Throttle
+from homeassistant.helpers.entity import Entity
 
 DEPENDENCIES = ['transmission']
 
@@ -52,6 +51,7 @@ async def async_setup_platform(
 class TransmissionSensor(Entity):
     """Representation of a Transmission sensor."""
 
+    
     def __init__(
             self,
             sensor_type,

--- a/homeassistant/components/transmission/switch.py
+++ b/homeassistant/components/transmission/switch.py
@@ -4,8 +4,6 @@ Support for setting the Transmission BitTorrent client Turtle Mode.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/switch.transmission/
 """
-from datetime import timedelta
-
 import logging
 
 from homeassistant.components.transmission import (
@@ -14,8 +12,7 @@ from homeassistant.const import (
     STATE_OFF, STATE_ON)
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers.entity import ToggleEntity 
-from homeassistant.util import Throttle
+from homeassistant.helpers.entity import ToggleEntity
 
 DEPENDENCIES = ['transmission']
 
@@ -42,6 +39,7 @@ async def async_setup_platform(
 class TransmissionSwitch(ToggleEntity):
     """Representation of a Transmission switch."""
 
+    
     def __init__(self, transmission_client, name):
         """Initialize the Transmission switch."""
         self._name = name

--- a/homeassistant/components/transmission/switch.py
+++ b/homeassistant/components/transmission/switch.py
@@ -24,11 +24,12 @@ _LOGGING = logging.getLogger(__name__)
 DEFAULT_NAME = 'Transmission Turtle Mode'
 DATA_UPDATED = 'transmission_data_updated'
 
+
 async def async_setup_platform(
-    hass,
-    config,
-    add_entities,
-    discovery_info=None):
+        hass,
+        config,
+        add_entities,
+        discovery_info=None):
     """Set up the Transmission switch."""
     if discovery_info is None:
         return

--- a/homeassistant/components/transmission/switch.py
+++ b/homeassistant/components/transmission/switch.py
@@ -39,7 +39,7 @@ async def async_setup_platform(
 class TransmissionSwitch(ToggleEntity):
     """Representation of a Transmission switch."""
 
-    
+
     def __init__(self, transmission_client, name):
         """Initialize the Transmission switch."""
         self._name = name

--- a/homeassistant/components/transmission/switch.py
+++ b/homeassistant/components/transmission/switch.py
@@ -36,9 +36,9 @@ async def async_setup_platform(
 
     async_add_entities([TransmissionSwitch(transmission_api, name)], True)
 
+
 class TransmissionSwitch(ToggleEntity):
     """Representation of a Transmission switch."""
-
 
     def __init__(self, transmission_client, name):
         """Initialize the Transmission switch."""

--- a/homeassistant/components/transmission/switch.py
+++ b/homeassistant/components/transmission/switch.py
@@ -9,12 +9,12 @@ from datetime import timedelta
 import logging
 
 from homeassistant.components.transmission import (
-    DATA_TRANSMISSION)
+    DATA_TRANSMISSION, DATA_UPDATED)
 from homeassistant.const import (
     STATE_OFF, STATE_ON)
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers.entity import ToggleEntity
+from homeassistant.helpers.entity import ToggleEntity 
 from homeassistant.util import Throttle
 
 DEPENDENCIES = ['transmission']
@@ -22,13 +22,12 @@ DEPENDENCIES = ['transmission']
 _LOGGING = logging.getLogger(__name__)
 
 DEFAULT_NAME = 'Transmission Turtle Mode'
-DATA_UPDATED = 'transmission_data_updated'
 
 
 async def async_setup_platform(
         hass,
         config,
-        add_entities,
+        async_add_entities,
         discovery_info=None):
     """Set up the Transmission switch."""
     if discovery_info is None:
@@ -38,7 +37,7 @@ async def async_setup_platform(
     transmission_api = hass.data[component_name]
     name = discovery_info['client_name']
 
-    add_entities([TransmissionSwitch(transmission_api, name)], True)
+    async_add_entities([TransmissionSwitch(transmission_api, name)], True)
 
 class TransmissionSwitch(ToggleEntity):
     """Representation of a Transmission switch."""
@@ -69,12 +68,12 @@ class TransmissionSwitch(ToggleEntity):
         """Return true if device is on."""
         return self._state == STATE_ON
 
-    async def async_turn_on(self, **kwargs):
+    def turn_on(self, **kwargs):
         """Turn the device on."""
         _LOGGING.debug("Turning Turtle Mode of Transmission on")
         self.transmission_client.set_alt_speed_enabled(True)
 
-    async def async_turn_off(self, **kwargs):
+    def turn_off(self, **kwargs):
         """Turn the device off."""
         _LOGGING.debug("Turning Turtle Mode of Transmission off")
         self.transmission_client.set_alt_speed_enabled(False)


### PR DESCRIPTION
## Description:
Quick fix in order to avoid a null object reference at startup when having configured a switch for Turtle Mode.

Error shown in log

```
 transmission: Error on device update!
Traceback (most recent call last):
  File "/srv/homeassistant/lib/python3.6/site-packages/homeassistant/helpers/entity_platform.py", line 248, in _async_add_entity
    await entity.async_device_update(warning=False)
  File "/srv/homeassistant/lib/python3.6/site-packages/homeassistant/helpers/entity.py", line 349, in async_device_update
    await self.hass.async_add_executor_job(self.update)
  File "/usr/local/lib/python3.6/concurrent/futures/thread.py", line 56, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/srv/homeassistant/lib/python3.6/site-packages/homeassistant/util/__init__.py", line 315, in wrapper
    result = method(*args, **kwargs)
  File "/srv/homeassistant/lib/python3.6/site-packages/homeassistant/components/switch/transmission.py", line 77, in update
    active = self.transmission_client.get_alt_speed_enabled()
  File "/home/homeassistant/.homeassistant/custom_components/transmission.py", line 194, in get_alt_speed_enabled
    return self.session.alt_speed_enabled
AttributeError: 'NoneType' object has no attribute 'alt_speed_enabled'
```
   
 
[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
