### PR TITLE
Fix homekit_controller non-standard hk characteristics

### DIFF
--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -224,7 +224,12 @@ class HomeKitEntity(Entity):
                 if service['iid'] != self._iid:
                     continue
                 for char in service['characteristics']:
-                    uuid = CharacteristicsTypes.get_uuid(char['type'])
+                    try:
+                        uuid = CharacteristicsTypes.get_uuid(char['type'])
+                    except KeyError:
+                        # If a KeyError is raised its a non-standard
+                        # characteristic. We must ignore it in this case.
+                        continue
                     if uuid not in characteristic_types:
                         continue
                     self._setup_characteristic(char)


### PR DESCRIPTION
## Description:

In the latest HA I normalize the `type` field of a given characteristic (as annoyingly some present the short form and some present the long form). Unfortunately this breaks for non-Apple characteristics that aren't in the HAP spec.

This fixes the regression by ignoring characteristics that aren't known.

**Related issue (if applicable):** fixes #20800

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
