### PR TITLE
Fix bug with monitored_conditions in Ambient PWS

### DIFF
--- a/homeassistant/components/ambient_station/__init__.py
+++ b/homeassistant/components/ambient_station/__init__.py
@@ -28,8 +28,6 @@ from .const import (
 REQUIREMENTS = ['aioambient==0.1.0']
 _LOGGER = logging.getLogger(__name__)
 
-DATA_CONFIG = 'config'
-
 DEFAULT_SOCKET_MIN_RETRY = 15
 
 TYPE_24HOURRAININ = '24hourrainin'
@@ -123,9 +121,6 @@ async def async_setup(hass, config):
         hass.config_entries.flow.async_init(
             DOMAIN, context={'source': SOURCE_IMPORT}, data=conf))
 
-    # Store config for entry setup:
-    hass.data[DOMAIN][DATA_CONFIG] = conf.get(CONF_MONITORED_CONDITIONS)
-
     return True
 
 
@@ -142,7 +137,8 @@ async def async_setup_entry(hass, config_entry):
             Client(
                 config_entry.data[CONF_API_KEY],
                 config_entry.data[CONF_APP_KEY], session),
-            hass.data[DOMAIN].get(DATA_CONFIG, []))
+            config_entry.data.get(
+                CONF_MONITORED_CONDITIONS, list(SENSOR_TYPES)))
         hass.loop.create_task(ambient.ws_connect())
         hass.data[DOMAIN][DATA_CLIENT][config_entry.entry_id] = ambient
     except WebsocketConnectionError as err:

--- a/homeassistant/components/ambient_station/__init__.py
+++ b/homeassistant/components/ambient_station/__init__.py
@@ -28,6 +28,8 @@ from .const import (
 REQUIREMENTS = ['aioambient==0.1.0']
 _LOGGER = logging.getLogger(__name__)
 
+DATA_CONFIG = 'config'
+
 DEFAULT_SOCKET_MIN_RETRY = 15
 
 TYPE_24HOURRAININ = '24hourrainin'
@@ -114,12 +116,20 @@ async def async_setup(hass, config):
 
     conf = config[DOMAIN]
 
+    # Store config for use during entry setup:
+    hass.data[DOMAIN][DATA_CONFIG] = conf
+
     if conf[CONF_APP_KEY] in configured_instances(hass):
         return True
 
     hass.async_create_task(
         hass.config_entries.flow.async_init(
-            DOMAIN, context={'source': SOURCE_IMPORT}, data=conf))
+            DOMAIN,
+            context={'source': SOURCE_IMPORT},
+            data={
+                CONF_API_KEY: conf[CONF_API_KEY],
+                CONF_APP_KEY: conf[CONF_APP_KEY]
+            }))
 
     return True
 
@@ -137,7 +147,7 @@ async def async_setup_entry(hass, config_entry):
             Client(
                 config_entry.data[CONF_API_KEY],
                 config_entry.data[CONF_APP_KEY], session),
-            config_entry.data.get(CONF_MONITORED_CONDITIONS, []))
+            hass.data[DOMAIN][DATA_CONFIG].get(CONF_MONITORED_CONDITIONS, []))
         hass.loop.create_task(ambient.ws_connect())
         hass.data[DOMAIN][DATA_CLIENT][config_entry.entry_id] = ambient
     except WebsocketConnectionError as err:

--- a/homeassistant/components/ambient_station/__init__.py
+++ b/homeassistant/components/ambient_station/__init__.py
@@ -28,6 +28,8 @@ from .const import (
 REQUIREMENTS = ['aioambient==0.1.0']
 _LOGGER = logging.getLogger(__name__)
 
+DATA_CONFIG = 'config'
+
 DEFAULT_SOCKET_MIN_RETRY = 15
 
 TYPE_24HOURRAININ = '24hourrainin'
@@ -121,6 +123,9 @@ async def async_setup(hass, config):
         hass.config_entries.flow.async_init(
             DOMAIN, context={'source': SOURCE_IMPORT}, data=conf))
 
+    # Store config for entry setup:
+    hass.data[DOMAIN][DATA_CONFIG] = conf.get(CONF_MONITORED_CONDITIONS)
+
     return True
 
 
@@ -137,7 +142,7 @@ async def async_setup_entry(hass, config_entry):
             Client(
                 config_entry.data[CONF_API_KEY],
                 config_entry.data[CONF_APP_KEY], session),
-            config_entry.data.get(CONF_MONITORED_CONDITIONS, []))
+            hass.data[DOMAIN].get(DATA_CONFIG, []))
         hass.loop.create_task(ambient.ws_connect())
         hass.data[DOMAIN][DATA_CLIENT][config_entry.entry_id] = ambient
     except WebsocketConnectionError as err:

--- a/homeassistant/components/ambient_station/__init__.py
+++ b/homeassistant/components/ambient_station/__init__.py
@@ -137,8 +137,7 @@ async def async_setup_entry(hass, config_entry):
             Client(
                 config_entry.data[CONF_API_KEY],
                 config_entry.data[CONF_APP_KEY], session),
-            config_entry.data.get(
-                CONF_MONITORED_CONDITIONS, list(SENSOR_TYPES)))
+            config_entry.data.get(CONF_MONITORED_CONDITIONS, []))
         hass.loop.create_task(ambient.ws_connect())
         hass.data[DOMAIN][DATA_CLIENT][config_entry.entry_id] = ambient
     except WebsocketConnectionError as err:

--- a/homeassistant/components/ambient_station/config_flow.py
+++ b/homeassistant/components/ambient_station/config_flow.py
@@ -69,4 +69,8 @@ class AmbientStationFlowHandler(config_entries.ConfigFlow):
         # to show nicely in the UI, so we take the first 12 characters (similar
         # to how GitHub does it):
         return self.async_create_entry(
-            title=user_input[CONF_APP_KEY][:12], data=user_input)
+            title=user_input[CONF_APP_KEY][:12],
+            data={
+                CONF_API_KEY: user_input[CONF_API_KEY],
+                CONF_APP_KEY: user_input[CONF_APP_KEY],
+            })

--- a/homeassistant/components/ambient_station/config_flow.py
+++ b/homeassistant/components/ambient_station/config_flow.py
@@ -69,8 +69,4 @@ class AmbientStationFlowHandler(config_entries.ConfigFlow):
         # to show nicely in the UI, so we take the first 12 characters (similar
         # to how GitHub does it):
         return self.async_create_entry(
-            title=user_input[CONF_APP_KEY][:12],
-            data={
-                CONF_API_KEY: user_input[CONF_API_KEY],
-                CONF_APP_KEY: user_input[CONF_APP_KEY],
-            })
+            title=user_input[CONF_APP_KEY][:12], data=user_input)


### PR DESCRIPTION
## Description:

A bug existed in the Ambient PWS component where `monitored_conditions` would be stored in the config entry. Those values would then be used on every load, regardless of any value changes in `configuration.yaml`. This PR fixes that.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
ambient_station:
  api_key: !secret ambient_pws_api_key
  app_key: !secret ambient_pws_app_key
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
