### PR TITLE
Add Ambient PWS to device registry

### DIFF
--- a/homeassistant/components/ambient_station/__init__.py
+++ b/homeassistant/components/ambient_station/__init__.py
@@ -255,6 +255,17 @@ class AmbientWeatherEntity(Entity):
         self._station_name = station_name
 
     @property
+    def device_info(self):
+        """Return device registry information for this entity."""
+        return {
+            'identifiers': {
+                (DOMAIN, self._mac_address)
+            },
+            'name': self._station_name,
+            'manufacturer': 'Ambient Weather',
+        }
+
+    @property
     def name(self):
         """Return the name of the sensor."""
         return '{0}_{1}'.format(self._station_name, self._sensor_name)


### PR DESCRIPTION
## Description:

This PR adds Ambient PWS to the device registry.

**Related issue (if applicable):** N/A

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
ambient_station:
  api_key: !secret ambient_pws_api_key
  app_key: !secret ambient_pws_app_key
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54