### PR TITLE
Add SmartThings Sensor platform

### DIFF
--- a/homeassistant/components/smartthings/__init__.py
+++ b/homeassistant/components/smartthings/__init__.py
@@ -23,7 +23,7 @@ from .const import (
 from .smartapp import (
     setup_smartapp, setup_smartapp_endpoint, validate_installed_app)
 
-REQUIREMENTS = ['pysmartapp==0.3.0', 'pysmartthings==0.5.0']
+REQUIREMENTS = ['pysmartapp==0.3.0', 'pysmartthings==0.6.0']
 DEPENDENCIES = ['webhook']
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/smartthings/const.py
+++ b/homeassistant/components/smartthings/const.py
@@ -25,23 +25,6 @@ SUPPORTED_PLATFORMS = [
     'sensor',
     'switch'
 ]
-SUPPORTED_CAPABILITIES = [
-    'accelerationSensor',
-    'button',
-    'colorControl',
-    'colorTemperature',
-    'contactSensor',
-    'fanSpeed',
-    'filterStatus',
-    'motionSensor',
-    'presenceSensor',
-    'soundSensor',
-    'switch',
-    'switchLevel',
-    'tamperAlert',
-    'valve',
-    'waterSensor'
-]
 VAL_UID = "^(?:([0-9a-fA-F]{32})|([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]" \
           "{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}))$"
 VAL_UID_MATCHER = re.compile(VAL_UID)

--- a/homeassistant/components/smartthings/const.py
+++ b/homeassistant/components/smartthings/const.py
@@ -22,6 +22,7 @@ SUPPORTED_PLATFORMS = [
     'binary_sensor',
     'fan',
     'light',
+    'sensor',
     'switch'
 ]
 SUPPORTED_CAPABILITIES = [

--- a/homeassistant/components/smartthings/sensor.py
+++ b/homeassistant/components/smartthings/sensor.py
@@ -1,0 +1,220 @@
+"""
+Support for sensors through the SmartThings cloud API.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/smartthings.sensor/
+"""
+from collections import namedtuple
+
+from homeassistant.const import (
+    DEVICE_CLASS_BATTERY, DEVICE_CLASS_HUMIDITY, DEVICE_CLASS_ILLUMINANCE,
+    DEVICE_CLASS_TEMPERATURE, DEVICE_CLASS_TIMESTAMP, MASS_KILOGRAMS,
+    STATE_UNKNOWN, TEMP_CELSIUS, TEMP_FAHRENHEIT)
+from homeassistant.helpers.entity import Entity
+
+from . import SmartThingsEntity
+from .const import DATA_BROKERS, DOMAIN
+
+DEPENDENCIES = ['smartthings']
+
+Map = namedtuple("map", "attribute name default_unit device_class")
+
+CAPABILITY_TO_SENSORS = {
+    'activityLightingMode': [
+        Map('lightingMode', "Activity Lighting Mode", None, None)],
+    'airConditionerMode': [
+        Map('airConditionerMode', "Air Conditioner Mode", None, None)],
+    'airQualitySensor': [
+        Map('airQuality', "Air Quality", 'CAQI', None)],
+    'alarm': [
+        Map('alarm', "Alarm", None, None)],
+    'audioVolume': [
+        Map('volume', "Volume", "%", None)],
+    'battery': [
+        Map('battery', "Battery", "%", DEVICE_CLASS_BATTERY)],
+    'bodyMassIndexMeasurement': [
+        Map('bmiMeasurement', "Body Mass Index", "kg/m^2", None)],
+    'bodyWeightMeasurement': [
+        Map('bodyWeightMeasurement', "Body Weight", MASS_KILOGRAMS, None)],
+    'carbonDioxideMeasurement': [
+        Map('carbonDioxide', "Carbon Dioxide Measurement", "ppm", None)],
+    'carbonMonoxideDetector': [
+        Map('carbonMonoxide', "Carbon Monoxide Detector", None, None)],
+    'carbonMonoxideMeasurement': [
+        Map('carbonMonoxideLevel', "Carbon Monoxide Measurement", "ppm",
+            None)],
+    'dishwasherOperatingState': [
+        Map('machineState', "Dishwasher Machine State", None, None),
+        Map('dishwasherJobState', "Dishwasher Job State", None, None),
+        Map('completionTime', "Dishwasher Completion Time", None,
+            DEVICE_CLASS_TIMESTAMP)],
+    'doorControl': [
+        Map('door', "Door", None, None)],
+    'dryerMode': [
+        Map('dryerMode', "Dryer Mode", None, None)],
+    'dryerOperatingState': [
+        Map('machineState', "Dryer Machine State", None, None),
+        Map('dryerJobState', "Dryer Job State", None, None),
+        Map('completionTime', "Dryer Completion Time", None,
+            DEVICE_CLASS_TIMESTAMP)],
+    'dustSensor': [
+        Map('fineDustLevel', "Fine Dust Level", None, None),
+        Map('dustLevel', "Dust Level", None, None)],
+    'energyMeter': [
+        Map('energy', "Energy Meter", 'kWh', None)],
+    'equivalentCarbonDioxideMeasurement': [
+        Map('equivalentCarbonDioxideMeasurement',
+            'Equivalent Carbon Dioxide Measurement', 'ppm', None)],
+    'formaldehydeMeasurement': [
+        Map('formaldehydeLevel', 'Formaldehyde Measurement', 'ppm', None)],
+    'garageDoorControl': [
+        Map('door', 'Garage Door', None, None)],
+    'illuminanceMeasurement': [
+        Map('illuminance', "Illuminance", 'lux', DEVICE_CLASS_ILLUMINANCE)],
+    'infraredLevel': [
+        Map('infraredLevel', "Infrared Level", '%', None)],
+    'lock': [
+        Map('lock', "Lock", None, None)],
+    'mediaInputSource': [
+        Map('inputSource', "Media Input Source", None, None)],
+    'mediaPlaybackRepeat': [
+        Map('playbackRepeatMode', "Media Playback Repeat", None, None)],
+    'mediaPlaybackShuffle': [
+        Map('playbackShuffle', "Media Playback Shuffle", None, None)],
+    'mediaPlayback': [
+        Map('playbackStatus', "Media Playback Status", None, None)],
+    'odorSensor': [
+        Map('odorLevel', "Odor Sensor", None, None)],
+    'ovenMode': [
+        Map('ovenMode', "Oven Mode", None, None)],
+    'ovenOperatingState': [
+        Map('machineState', "Oven Machine State", None, None),
+        Map('ovenJobState', "Oven Job State", None, None),
+        Map('completionTime', "Oven Completion Time", None, None)],
+    'ovenSetpoint': [
+        Map('ovenSetpoint', "Oven Set Point", None, None)],
+    'powerMeter': [
+        Map('power', "Power Meter", 'W', None)],
+    'powerSource': [
+        Map('powerSource', "Power Source", None, None)],
+    'refrigerationSetpoint': [
+        Map('refrigerationSetpoint', "Refrigeration Setpoint", TEMP_CELSIUS,
+            DEVICE_CLASS_TEMPERATURE)],
+    'relativeHumidityMeasurement': [
+        Map('humidity', "Relative Humidity Measurement", '%',
+            DEVICE_CLASS_HUMIDITY)],
+    'robotCleanerCleaningMode': [
+        Map('robotCleanerCleaningMode', "Robot Cleaner Cleaning Mode",
+            None, None)],
+    'robotCleanerMovement': [
+        Map('robotCleanerMovement', "Robot Cleaner Movement", None, None)],
+    'robotCleanerTurboMode': [
+        Map('robotCleanerTurboMode', "Robot Cleaner Turbo Mode", None, None)],
+    'signalStrength': [
+        Map('lqi', "LQI Signal Strength", None, None),
+        Map('rssi', "RSSI Signal Strength", None, None)],
+    'smokeDetector': [
+        Map('smoke', "Smoke Detector", None, None)],
+    'temperatureMeasurement': [
+        Map('temperature', "Temperature Measurement", TEMP_CELSIUS,
+            DEVICE_CLASS_TEMPERATURE)],
+    'thermostatCoolingSetpoint': [
+        Map('coolingSetpoint', "Thermostat Cooling Setpoint", TEMP_CELSIUS,
+            DEVICE_CLASS_TEMPERATURE)],
+    'thermostatFanMode': [
+        Map('thermostatFanMode', "Thermostat Fan Mode", None, None)],
+    'thermostatHeatingSetpoint': [
+        Map('heatingSetpoint', "Thermostat Heating Setpoint", TEMP_CELSIUS,
+            DEVICE_CLASS_TEMPERATURE)],
+    'thermostatMode': [
+        Map('thermostatMode', "Thermostat Mode", None, None)],
+    'thermostatOperatingState': [
+        Map('thermostatOperatingState', "Thermostat Operating State",
+            None, None)],
+    'thermostatSetpoint': [
+        Map('thermostatSetpoint', "Thermostat Setpoint", TEMP_CELSIUS,
+            DEVICE_CLASS_TEMPERATURE)],
+    'tvChannel': [
+        Map('tvChannel', "Tv Channel", None, None)],
+    'tvocMeasurement': [
+        Map('tvocLevel', "Tvoc Measurement", 'ppm', None)],
+    'ultravioletIndex': [
+        Map('ultravioletIndex', "Ultraviolet Index", None, None)],
+    'voltageMeasurement': [
+        Map('voltage', "Voltage Measurement", 'V', None)],
+    'washerMode': [
+        Map('washerMode', "Washer Mode", None, None)],
+    'washerOperatingState': [
+        Map('machineState', "Washer Machine State", None, None),
+        Map('washerJobState', "Washer Job State", None, None),
+        Map('completionTime', "Washer Completion Time", None,
+            DEVICE_CLASS_TIMESTAMP)],
+    'windowShade': [
+        Map('windowShade', 'Window Shade', None, None)]
+}
+
+UNITS = {
+    'C': TEMP_CELSIUS,
+    'F': TEMP_FAHRENHEIT
+}
+
+
+async def async_setup_platform(
+        hass, config, async_add_entities, discovery_info=None):
+    """Platform uses config entry setup."""
+    pass
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Add binary sensors for a config entry."""
+    broker = hass.data[DOMAIN][DATA_BROKERS][config_entry.entry_id]
+    sensors = []
+    for device in broker.devices.values():
+        for capability, maps in CAPABILITY_TO_SENSORS.items():
+            if capability in device.capabilities:
+                sensors.extend([
+                    SmartThingsSensor(
+                        device, m.attribute, m.name, m.default_unit,
+                        m.device_class)
+                    for m in maps])
+    async_add_entities(sensors)
+
+
+class SmartThingsSensor(SmartThingsEntity, Entity):
+    """Define a SmartThings Binary Sensor."""
+
+    def __init__(self, device, attribute: str, name: str,
+                 default_unit: str, device_class: str):
+        """Init the class."""
+        super().__init__(device)
+        self._attribute = attribute
+        self._name = name
+        self._device_class = device_class
+        self._default_unit = default_unit
+
+    @property
+    def name(self) -> str:
+        """Return the name of the binary sensor."""
+        return '{} {}'.format(self._device.label, self._name)
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique ID."""
+        return '{}.{}'.format(self._device.device_id, self._attribute)
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._device.status.attributes[self._attribute].value \
+            or STATE_UNKNOWN
+
+    @property
+    def device_class(self):
+        """Return the device class of the sensor."""
+        return self._device_class
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit this state is expressed in."""
+        unit = self._device.status.attributes[self._attribute].unit
+        return UNITS.get(unit, unit) if unit else self._default_unit

--- a/homeassistant/components/smartthings/sensor.py
+++ b/homeassistant/components/smartthings/sensor.py
@@ -9,7 +9,7 @@ from collections import namedtuple
 from homeassistant.const import (
     DEVICE_CLASS_BATTERY, DEVICE_CLASS_HUMIDITY, DEVICE_CLASS_ILLUMINANCE,
     DEVICE_CLASS_TEMPERATURE, DEVICE_CLASS_TIMESTAMP, MASS_KILOGRAMS,
-    STATE_UNKNOWN, TEMP_CELSIUS, TEMP_FAHRENHEIT)
+    TEMP_CELSIUS, TEMP_FAHRENHEIT)
 
 from . import SmartThingsEntity
 from .const import DATA_BROKERS, DOMAIN
@@ -204,8 +204,7 @@ class SmartThingsSensor(SmartThingsEntity):
     @property
     def state(self):
         """Return the state of the sensor."""
-        return self._device.status.attributes[self._attribute].value \
-            or STATE_UNKNOWN
+        return self._device.status.attributes[self._attribute].value
 
     @property
     def device_class(self):

--- a/homeassistant/components/smartthings/sensor.py
+++ b/homeassistant/components/smartthings/sensor.py
@@ -10,7 +10,6 @@ from homeassistant.const import (
     DEVICE_CLASS_BATTERY, DEVICE_CLASS_HUMIDITY, DEVICE_CLASS_ILLUMINANCE,
     DEVICE_CLASS_TEMPERATURE, DEVICE_CLASS_TIMESTAMP, MASS_KILOGRAMS,
     STATE_UNKNOWN, TEMP_CELSIUS, TEMP_FAHRENHEIT)
-from homeassistant.helpers.entity import Entity
 
 from . import SmartThingsEntity
 from .const import DATA_BROKERS, DOMAIN
@@ -180,7 +179,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     async_add_entities(sensors)
 
 
-class SmartThingsSensor(SmartThingsEntity, Entity):
+class SmartThingsSensor(SmartThingsEntity):
     """Define a SmartThings Binary Sensor."""
 
     def __init__(self, device, attribute: str, name: str,

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1231,7 +1231,7 @@ pysma==0.3.1
 pysmartapp==0.3.0
 
 # homeassistant.components.smartthings
-pysmartthings==0.5.0
+pysmartthings==0.6.0
 
 # homeassistant.components.device_tracker.snmp
 # homeassistant.components.sensor.snmp

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -217,7 +217,7 @@ pyqwikswitch==0.8
 pysmartapp==0.3.0
 
 # homeassistant.components.smartthings
-pysmartthings==0.5.0
+pysmartthings==0.6.0
 
 # homeassistant.components.sonos
 pysonos==0.0.6

--- a/tests/components/smartthings/conftest.py
+++ b/tests/components/smartthings/conftest.py
@@ -13,8 +13,8 @@ from homeassistant.components import webhook
 from homeassistant.components.smartthings import DeviceBroker
 from homeassistant.components.smartthings.const import (
     APP_NAME_PREFIX, CONF_APP_ID, CONF_INSTALLED_APP_ID, CONF_INSTANCE_ID,
-    CONF_LOCATION_ID, DOMAIN, SETTINGS_INSTANCE_ID, STORAGE_KEY,
-    STORAGE_VERSION, DATA_BROKERS)
+    CONF_LOCATION_ID, DATA_BROKERS, DOMAIN, SETTINGS_INSTANCE_ID, STORAGE_KEY,
+    STORAGE_VERSION)
 from homeassistant.config_entries import (
     CONN_CLASS_CLOUD_PUSH, SOURCE_USER, ConfigEntry)
 from homeassistant.const import CONF_ACCESS_TOKEN, CONF_WEBHOOK_ID

--- a/tests/components/smartthings/conftest.py
+++ b/tests/components/smartthings/conftest.py
@@ -10,16 +10,34 @@ from pysmartthings.api import Api
 import pytest
 
 from homeassistant.components import webhook
+from homeassistant.components.smartthings import DeviceBroker
 from homeassistant.components.smartthings.const import (
     APP_NAME_PREFIX, CONF_APP_ID, CONF_INSTALLED_APP_ID, CONF_INSTANCE_ID,
     CONF_LOCATION_ID, DOMAIN, SETTINGS_INSTANCE_ID, STORAGE_KEY,
-    STORAGE_VERSION)
+    STORAGE_VERSION, DATA_BROKERS)
 from homeassistant.config_entries import (
     CONN_CLASS_CLOUD_PUSH, SOURCE_USER, ConfigEntry)
 from homeassistant.const import CONF_ACCESS_TOKEN, CONF_WEBHOOK_ID
 from homeassistant.setup import async_setup_component
 
 from tests.common import mock_coro
+
+
+async def setup_platform(hass, platform: str, *devices):
+    """Set up the SmartThings platform and prerequisites."""
+    hass.config.components.add(DOMAIN)
+    broker = DeviceBroker(hass, devices, '')
+    config_entry = ConfigEntry("1", DOMAIN, "Test", {},
+                               SOURCE_USER, CONN_CLASS_CLOUD_PUSH)
+    hass.data[DOMAIN] = {
+        DATA_BROKERS: {
+            config_entry.entry_id: broker
+        }
+    }
+    await hass.config_entries.async_forward_entry_setup(
+        config_entry, platform)
+    await hass.async_block_till_done()
+    return config_entry
 
 
 @pytest.fixture(autouse=True)

--- a/tests/components/smartthings/test_binary_sensor.py
+++ b/tests/components/smartthings/test_binary_sensor.py
@@ -4,12 +4,12 @@ Test for the SmartThings binary_sensor platform.
 The only mocking required is of the underlying SmartThings API object so
 real HTTP calls are not initiated during testing.
 """
-from pysmartthings import Attribute, Capability
+from pysmartthings import ATTRIBUTES, CAPABILITIES, Attribute, Capability
 
 from homeassistant.components.binary_sensor import DEVICE_CLASSES
 from homeassistant.components.smartthings import DeviceBroker, binary_sensor
 from homeassistant.components.smartthings.const import (
-    DATA_BROKERS, DOMAIN, SIGNAL_SMARTTHINGS_UPDATE, SUPPORTED_CAPABILITIES)
+    DATA_BROKERS, DOMAIN, SIGNAL_SMARTTHINGS_UPDATE)
 from homeassistant.config_entries import (
     CONN_CLASS_CLOUD_PUSH, SOURCE_USER, ConfigEntry)
 from homeassistant.const import ATTR_FRIENDLY_NAME
@@ -35,14 +35,16 @@ async def _setup_platform(hass, *devices):
 
 async def test_mapping_integrity():
     """Test ensures the map dicts have proper integrity."""
-    # Ensure every CAPABILITY_TO_ATTRIB key is in SUPPORTED_CAPABILITIES
+    # Ensure every CAPABILITY_TO_ATTRIB key is in CAPABILITIES
     # Ensure every CAPABILITY_TO_ATTRIB value is in ATTRIB_TO_CLASS keys
     for capability, attrib in binary_sensor.CAPABILITY_TO_ATTRIB.items():
-        assert capability in SUPPORTED_CAPABILITIES, capability
+        assert capability in CAPABILITIES, capability
+        assert attrib in ATTRIBUTES, attrib
         assert attrib in binary_sensor.ATTRIB_TO_CLASS.keys(), attrib
     # Ensure every ATTRIB_TO_CLASS value is in DEVICE_CLASSES
-    for device_class in binary_sensor.ATTRIB_TO_CLASS.values():
-        assert device_class in DEVICE_CLASSES
+    for attrib, device_class in binary_sensor.ATTRIB_TO_CLASS.items():
+        assert attrib in ATTRIBUTES, attrib
+        assert device_class in DEVICE_CLASSES, device_class
 
 
 async def test_async_setup_platform():

--- a/tests/components/smartthings/test_init.py
+++ b/tests/components/smartthings/test_init.py
@@ -162,7 +162,7 @@ async def test_event_handler_dispatches_updated_devices(
 
     assert called
     for device in devices:
-        assert device.status.attributes['Updated'] == 'Value'
+        assert device.status.values['Updated'] == 'Value'
 
 
 async def test_event_handler_ignores_other_installed_app(

--- a/tests/components/smartthings/test_sensor.py
+++ b/tests/components/smartthings/test_sensor.py
@@ -1,0 +1,95 @@
+"""
+Test for the SmartThings sensors platform.
+
+The only mocking required is of the underlying SmartThings API object so
+real HTTP calls are not initiated during testing.
+"""
+from pysmartthings import Attribute, Capability, CAPABILITIES, ATTRIBUTES
+
+from homeassistant.components.sensor import DEVICE_CLASSES, DOMAIN as SENSOR_DOMAIN
+from homeassistant.components.smartthings import sensor
+from homeassistant.components.smartthings.const import (
+    DOMAIN, SIGNAL_SMARTTHINGS_UPDATE)
+from homeassistant.const import ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+
+from .conftest import setup_platform
+
+
+async def test_mapping_integrity():
+    """Test ensures the map dicts have proper integrity."""
+    for capability, maps in sensor.CAPABILITY_TO_SENSORS.items():
+        assert capability in CAPABILITIES, capability
+        for map in maps:
+            assert map.attribute in ATTRIBUTES, map.attribute
+            if map.device_class:
+                assert map.device_class in DEVICE_CLASSES, map.device_class
+
+
+async def test_async_setup_platform():
+    """Test setup platform does nothing (it uses config entries)."""
+    await sensor.async_setup_platform(None, None, None)
+
+
+async def test_entity_state(hass, device_factory):
+    """Tests the state attributes properly match the light types."""
+    device = device_factory('Sensor 1', [Capability.battery],
+                            {Attribute.battery: 100})
+    await setup_platform(hass, SENSOR_DOMAIN, device)
+    state = hass.states.get('sensor.sensor_1_battery')
+    assert state.state == '100'
+    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == '%'
+    assert state.attributes[ATTR_FRIENDLY_NAME] ==\
+        device.label + " Battery"
+
+
+async def test_entity_and_device_attributes(hass, device_factory):
+    """Test the attributes of the entity are correct."""
+    # Arrange
+    device = device_factory('Sensor 1', [Capability.battery],
+                            {Attribute.battery: 100})
+    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    device_registry = await hass.helpers.device_registry.async_get_registry()
+    # Act
+    await setup_platform(hass, SENSOR_DOMAIN, device)
+    # Assert
+    entry = entity_registry.async_get('sensor.sensor_1_battery')
+    assert entry
+    assert entry.unique_id == device.device_id + '.' + Attribute.battery
+    entry = device_registry.async_get_device(
+        {(DOMAIN, device.device_id)}, [])
+    assert entry
+    assert entry.name == device.label
+    assert entry.model == device.device_type_name
+    assert entry.manufacturer == 'Unavailable'
+
+
+async def test_update_from_signal(hass, device_factory):
+    """Test the binary_sensor updates when receiving a signal."""
+    # Arrange
+    device = device_factory('Sensor 1', [Capability.battery],
+                            {Attribute.battery: 100})
+    await setup_platform(hass, SENSOR_DOMAIN, device)
+    device.status.apply_attribute_update(
+        'main', Capability.battery, Attribute.battery, 75)
+    # Act
+    async_dispatcher_send(hass, SIGNAL_SMARTTHINGS_UPDATE,
+                          [device.device_id])
+    # Assert
+    await hass.async_block_till_done()
+    state = hass.states.get('sensor.sensor_1_battery')
+    assert state is not None
+    assert state.state == '75'
+
+
+async def test_unload_config_entry(hass, device_factory):
+    """Test the binary_sensor is removed when the config entry is unloaded."""
+    # Arrange
+    device = device_factory('Sensor 1', [Capability.battery],
+                            {Attribute.battery: 100})
+    config_entry = await setup_platform(hass, SENSOR_DOMAIN, device)
+    # Act
+    await hass.config_entries.async_forward_entry_unload(
+        config_entry, 'sensor')
+    # Assert
+    assert not hass.states.get('sensor.sensor_1_battery')

--- a/tests/components/smartthings/test_sensor.py
+++ b/tests/components/smartthings/test_sensor.py
@@ -4,9 +4,10 @@ Test for the SmartThings sensors platform.
 The only mocking required is of the underlying SmartThings API object so
 real HTTP calls are not initiated during testing.
 """
-from pysmartthings import Attribute, Capability, CAPABILITIES, ATTRIBUTES
+from pysmartthings import ATTRIBUTES, CAPABILITIES, Attribute, Capability
 
-from homeassistant.components.sensor import DEVICE_CLASSES, DOMAIN as SENSOR_DOMAIN
+from homeassistant.components.sensor import (
+    DEVICE_CLASSES, DOMAIN as SENSOR_DOMAIN)
 from homeassistant.components.smartthings import sensor
 from homeassistant.components.smartthings.const import (
     DOMAIN, SIGNAL_SMARTTHINGS_UPDATE)
@@ -20,10 +21,11 @@ async def test_mapping_integrity():
     """Test ensures the map dicts have proper integrity."""
     for capability, maps in sensor.CAPABILITY_TO_SENSORS.items():
         assert capability in CAPABILITIES, capability
-        for map in maps:
-            assert map.attribute in ATTRIBUTES, map.attribute
-            if map.device_class:
-                assert map.device_class in DEVICE_CLASSES, map.device_class
+        for sensor_map in maps:
+            assert sensor_map.attribute in ATTRIBUTES, sensor_map.attribute
+            if sensor_map.device_class:
+                assert sensor_map.device_class in DEVICE_CLASSES, \
+                    sensor_map.device_class
 
 
 async def test_async_setup_platform():


### PR DESCRIPTION
## Description:
Adds SmartThings Sensor platform that represents SmartThings devices that have sensor-related capabilities and updates capability subscription logic to optimally only subscribe to capabilities held by the devices in the given location.

 Highlights:
* Supports 57 different types of sensors (see code/docs for list)
* Sensor entities are automatically created for each capability supported by the device.
* Users will need to re-authorize the Home Assistant Automation in the SmartThings Classic mobile app if they have previously used this component to begin receiving push updates for the new sensors.  This is completed by navigating to Automations -> Home Assistant -> Done -> Allow

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8443

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
