### PR TITLE
Person component: add storage and WS commands

### DIFF
--- a/homeassistant/components/person/__init__.py
+++ b/homeassistant/components/person/__init__.py
@@ -4,7 +4,9 @@ Support for tracking people.
 For more details about this component, please refer to the documentation.
 https://home-assistant.io/components/person/
 """
+from collections import OrderedDict
 import logging
+import uuid
 
 import voluptuous as vol
 
@@ -18,6 +20,8 @@ from homeassistant.helpers.storage import Store
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.event import async_track_state_change
 from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.components import websocket_api
+from homeassistant.helpers.typing import HomeAssistantType, ConfigType
 
 _LOGGER = logging.getLogger(__name__)
 ATTR_SOURCE = 'source'
@@ -27,6 +31,7 @@ CONF_USER_ID = 'user_id'
 DOMAIN = 'person'
 STORAGE_KEY = DOMAIN
 STORAGE_VERSION = 1
+SAVE_DELAY = 10
 
 PERSON_SCHEMA = vol.Schema({
     vol.Required(CONF_ID): cv.string,
@@ -40,56 +45,136 @@ CONFIG_SCHEMA = vol.Schema({
     vol.Optional(DOMAIN): vol.All(cv.ensure_list, [PERSON_SCHEMA])
 }, extra=vol.ALLOW_EXTRA)
 
+_UNDEF = object()
 
-async def async_setup(hass, config):
-    """Set up the person component."""
-    component = EntityComponent(_LOGGER, DOMAIN, hass)
-    conf = config.get(DOMAIN, [])
-    entities = []
-    seen_ids = set()
 
-    for person_conf in conf:
-        person_id = person_conf[CONF_ID]
+class PersonManager:
+    """Manage person data."""
 
-        if person_id in seen_ids:
-            _LOGGER.error("Found user with duplicate ID.")
-            continue
+    def __init__(self, hass: HomeAssistantType, component: EntityComponent,
+                 config_persons):
+        """Initialize person storage."""
+        self.hass = hass
+        self.component = component
+        self.store = Store(hass, STORAGE_VERSION, STORAGE_KEY)
+        self.storage_data = None
 
-        # We are going to track the ID as seen, even if they might be skipped
-        # because of an invalid user id. That way we have predictable behavior
-        # if users are added/removed.
-        seen_ids.add(person_id)
+        config_data = self.config_data = OrderedDict()
+        for conf in config_persons:
+            person_id = conf[CONF_ID]
 
-        user_id = person_conf.get(CONF_USER_ID)
-
-        if (user_id is not None
-                and await hass.auth.async_get_user(user_id) is None):
-            _LOGGER.error(
-                "Invalid user_id detected for person %s",
-                person_conf[CONF_NAME])
-            continue
-
-        entities.append(Person(person_conf, False))
-
-    store = Store(hass, STORAGE_VERSION, STORAGE_KEY)
-
-    data = await store.async_load()
-
-    if data is not None:
-        for person_conf in data['persons']:
-            person_id = person_conf[CONF_ID]
-
-            if person_id in seen_ids:
-                _LOGGER.error("Found storage user with duplicate ID.")
+            if person_id in config_data:
+                _LOGGER.error("Found config user with duplicate ID.")
                 continue
 
-            seen_ids.add(person_id)
+            config_data[person_id] = conf
+
+    @callback
+    def list_persons(self):
+        """Iterate the person manager."""
+        yield from self.config_data.values()
+        yield from self.storage_data.values()
+
+    async def async_initialize(self):
+        """Get the person data."""
+        raw_storage = await self.store.async_load()
+
+        if raw_storage is None:
+            raw_storage = {
+                'persons': []
+            }
+
+        storage_data = self.storage_data = OrderedDict()
+
+        for person in raw_storage['persons']:
+            storage_data[person[CONF_ID]] = person
+
+        entities = []
+
+        for person_conf in self.config_data.values():
+            person_id = person_conf[CONF_ID]
+            user_id = person_conf.get(CONF_USER_ID)
+
+            if (user_id is not None
+                    and await self.hass.auth.async_get_user(user_id) is None):
+                _LOGGER.error(
+                    "Invalid user_id detected for person %s", person_id)
+                continue
+
+            entities.append(Person(person_conf, False))
+
+        for person_conf in storage_data.values():
+            if person_conf[CONF_ID] in self.config_data:
+                _LOGGER.error(
+                    "Skipping adding person from storage with same ID as"
+                    " configuration.yaml entry: %s.", person_id)
+                continue
 
             entities.append(Person(person_conf, True))
 
-    if entities:
-        await component.async_add_entities(entities)
+        if entities:
+            await self.component.async_add_entities(entities)
 
+    async def async_create_person(self, *, name, device_trackers=None,
+                                  user_id=None):
+        """Create a new person."""
+        person = {
+            CONF_ID: uuid.uuid4().hex,
+            CONF_NAME: name,
+            CONF_USER_ID: user_id,
+            CONF_DEVICE_TRACKERS: device_trackers,
+        }
+        self.storage_data[person[CONF_ID]] = person
+        self._async_schedule_save()
+        await self.component.async_add_entities([Person(person, True)])
+        return person
+
+    async def async_update_person(self, person_id, *, name=_UNDEF,
+                                  device_trackers=_UNDEF, user_id=_UNDEF):
+        """Update person."""
+        if person_id not in self.storage_data:
+            raise ValueError("Invalid person specified.")
+
+        changes = {
+            key: value for key, value in (
+                ('name', name),
+                ('device_trackers', device_trackers),
+                ('user_id', user_id)
+            ) if value is not _UNDEF
+        }
+
+        self.storage_data[person_id].update(changes)
+        self._async_schedule_save()
+        return self.storage_data[person_id]
+
+    async def async_delete_person(self, person_id):
+        """Delete person."""
+        if person_id not in self.storage_data:
+            raise ValueError("Invalid person specified.")
+
+        self.storage_data.pop(person_id)
+        self._async_schedule_save()
+
+    @callback
+    def _async_schedule_save(self) -> None:
+        """Schedule saving the area registry."""
+        self.store.async_delay_save(self._data_to_save, SAVE_DELAY)
+
+    @callback
+    def _data_to_save(self) -> dict:
+        """Return data of area registry to store in a file."""
+        return {
+            'persons': list(self.storage_data.values())
+        }
+
+
+async def async_setup(hass: HomeAssistantType, config: ConfigType):
+    """Set up the person component."""
+    component = EntityComponent(_LOGGER, DOMAIN, hass)
+    conf_persons = config.get(DOMAIN, [])
+    manager = hass.data[DOMAIN] = PersonManager(hass, component, conf_persons)
+    await manager.async_initialize()
+    websocket_api.async_register_command(hass, ws_create_person)
     return True
 
 
@@ -176,3 +261,69 @@ class Person(RestoreEntity):
         self._source = state.entity_id
         self._latitude = state.attributes.get(ATTR_LATITUDE)
         self._longitude = state.attributes.get(ATTR_LONGITUDE)
+
+
+@websocket_api.websocket_command({
+    vol.Required('type'): 'person/list',
+})
+def ws_list_person(hass: HomeAssistantType,
+                   connection: websocket_api.ActiveConnection, msg):
+    """List persons."""
+    manager = hass.data[DOMAIN]  # type: PersonManager
+    connection.send_result(msg['id'], list(manager.list_persons))
+
+
+@websocket_api.websocket_command({
+    vol.Required('type'): 'person/create',
+    vol.Required('name'): str,
+    vol.Optional('user_id'): str,
+    vol.Optional('device_trackers', default=[]): vol.All(
+        cv.ensure_list, cv.entities_domain(DEVICE_TRACKER_DOMAIN)),
+})
+@websocket_api.async_response
+async def ws_create_person(hass: HomeAssistantType,
+                           connection: websocket_api.ActiveConnection, msg):
+    """Create a new person."""
+    manager = hass.data[DOMAIN]  # type: PersonManager
+    person = await manager.async_create_person(
+        name=msg['name'],
+        user_id=msg.get('user_id'),
+        device_trackers=msg['device_trackers']
+    )
+    connection.send_result(msg['id'], person)
+
+
+@websocket_api.websocket_command({
+    vol.Required('type'): 'person/update',
+    vol.Required('person_id'): str,
+    vol.Optional('name'): str,
+    vol.Optional('user_id'): str,
+    vol.Optional(CONF_DEVICE_TRACKERS, default=[]): vol.All(
+        cv.ensure_list, cv.entities_domain(DEVICE_TRACKER_DOMAIN)),
+})
+@websocket_api.async_response
+async def ws_update_person(hass: HomeAssistantType,
+                           connection: websocket_api.ActiveConnection, msg):
+    """Update a new person."""
+    manager = hass.data[DOMAIN]  # type: PersonManager
+    changes = {}
+    for key in ('name', 'user_id', 'device_trackers'):
+        if key in msg:
+            changes[key] = msg[key]
+
+    person = await manager.async_update_person(msg['person_id'], **changes)
+    connection.send_result(msg['id'], person)
+
+
+@websocket_api.websocket_command({
+    vol.Required('type'): 'person/delete',
+    vol.Required('person_id'): str,
+})
+@websocket_api.async_response
+async def ws_delete_person(hass: HomeAssistantType,
+                           connection: websocket_api.ActiveConnection,
+                           msg):
+    """Delete a new person."""
+    manager = hass.data[DOMAIN]  # type: PersonManager
+    await manager.async_delete_person(msg['person_id'])
+    connection.send_result(msg['id'])

--- a/homeassistant/components/person/__init__.py
+++ b/homeassistant/components/person/__init__.py
@@ -43,7 +43,7 @@ PERSON_SCHEMA = vol.Schema({
 })
 
 CONFIG_SCHEMA = vol.Schema({
-    vol.Optional(DOMAIN): vol.All(cv.ensure_list, [PERSON_SCHEMA])
+    vol.Optional(DOMAIN): vol.Any({}, vol.All(cv.ensure_list, [PERSON_SCHEMA]))
 }, extra=vol.ALLOW_EXTRA)
 
 _UNDEF = object()

--- a/homeassistant/components/person/__init__.py
+++ b/homeassistant/components/person/__init__.py
@@ -65,7 +65,8 @@ class PersonManager:
             person_id = conf[CONF_ID]
 
             if person_id in config_data:
-                _LOGGER.error("Found config user with duplicate ID.")
+                _LOGGER.error("Found config user with duplicate ID: %s",
+                              person_id)
                 continue
 
             config_data[person_id] = conf
@@ -112,7 +113,7 @@ class PersonManager:
             if person_conf[CONF_ID] in self.config_data:
                 _LOGGER.error(
                     "Skipping adding person from storage with same ID as"
-                    " configuration.yaml entry: %s.", person_id)
+                    " configuration.yaml entry: %s", person_id)
                 continue
 
             entities.append(Person(person_conf, True))
@@ -266,7 +267,6 @@ class Person(RestoreEntity):
     @callback
     def person_updated(self):
         """Handle when the config is updated."""
-        print("PERSON UDPATED")
         self._update_state_tracking()
 
         trackers = self._config.get(CONF_DEVICE_TRACKERS)

--- a/homeassistant/components/websocket_api/connection.py
+++ b/homeassistant/components/websocket_api/connection.py
@@ -32,6 +32,16 @@ class ActiveConnection:
         return Context(user_id=user.id)
 
     @callback
+    def send_result(self, msg_id, result=None):
+        """Send a result message."""
+        self.send_message(messages.result_message(msg_id, result))
+
+    @callback
+    def send_error(self, msg_id, code, message):
+        """Send a error message."""
+        self.send_message(messages.error_message(msg_id, code, message))
+
+    @callback
     def async_handle(self, msg):
         """Handle a single incoming message."""
         handlers = self.hass.data[const.DOMAIN]

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -319,7 +319,6 @@ class Entity:
     @callback
     def async_schedule_update_ha_state(self, force_refresh=False):
         """Schedule an update ha state change task."""
-        print("schedule")
         self.hass.async_create_task(self.async_update_ha_state(force_refresh))
 
     async def async_device_update(self, warning=True):

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -319,7 +319,8 @@ class Entity:
     @callback
     def async_schedule_update_ha_state(self, force_refresh=False):
         """Schedule an update ha state change task."""
-        self.hass.async_add_job(self.async_update_ha_state(force_refresh))
+        print("schedule")
+        self.hass.async_create_task(self.async_update_ha_state(force_refresh))
 
     async def async_device_update(self, warning=True):
         """Process 'update' or 'async_update' from entity.

--- a/tests/components/person/test_init.py
+++ b/tests/components/person/test_init.py
@@ -248,8 +248,9 @@ async def test_ws_list(hass, hass_ws_client, storage_setup):
     })
     resp = await client.receive_json()
     assert resp['success']
-    assert resp['result'] == list(manager.list_persons())
-    assert len(resp['result']) == 1
+    assert resp['result']['storage'] == manager.storage_persons
+    assert len(resp['result']['storage']) == 1
+    assert len(resp['result']['config']) == 0
 
 
 async def test_ws_create(hass, hass_ws_client, storage_setup,
@@ -268,7 +269,7 @@ async def test_ws_create(hass, hass_ws_client, storage_setup,
     })
     resp = await client.receive_json()
 
-    persons = list(manager.list_persons())
+    persons = manager.storage_persons
     assert len(persons) == 2
 
     assert resp['success']
@@ -292,7 +293,7 @@ async def test_ws_create_requires_admin(hass, hass_ws_client, storage_setup,
     })
     resp = await client.receive_json()
 
-    persons = list(manager.list_persons())
+    persons = manager.storage_persons
     assert len(persons) == 1
 
     assert not resp['success']
@@ -303,7 +304,7 @@ async def test_ws_update(hass, hass_ws_client, storage_setup):
     manager = hass.data[DOMAIN]
 
     client = await hass_ws_client(hass)
-    persons = list(manager.list_persons())
+    persons = manager.storage_persons
 
     resp = await client.send_json({
         'id': 6,
@@ -315,7 +316,7 @@ async def test_ws_update(hass, hass_ws_client, storage_setup):
     })
     resp = await client.receive_json()
 
-    persons = list(manager.list_persons())
+    persons = manager.storage_persons
     assert len(persons) == 1
 
     assert resp['success']
@@ -333,7 +334,7 @@ async def test_ws_update_require_admin(hass, hass_ws_client, storage_setup,
     manager = hass.data[DOMAIN]
 
     client = await hass_ws_client(hass)
-    original = dict(list(manager.list_persons())[0])
+    original = dict(manager.storage_persons[0])
 
     resp = await client.send_json({
         'id': 6,
@@ -346,7 +347,7 @@ async def test_ws_update_require_admin(hass, hass_ws_client, storage_setup,
     resp = await client.receive_json()
     assert not resp['success']
 
-    not_updated = dict(list(manager.list_persons())[0])
+    not_updated = dict(manager.storage_persons[0])
     assert original == not_updated
 
 
@@ -355,7 +356,7 @@ async def test_ws_delete(hass, hass_ws_client, storage_setup):
     manager = hass.data[DOMAIN]
 
     client = await hass_ws_client(hass)
-    persons = list(manager.list_persons())
+    persons = manager.storage_persons
 
     resp = await client.send_json({
         'id': 6,
@@ -364,7 +365,7 @@ async def test_ws_delete(hass, hass_ws_client, storage_setup):
     })
     resp = await client.receive_json()
 
-    persons = list(manager.list_persons())
+    persons = manager.storage_persons
     assert len(persons) == 0
 
     assert resp['success']
@@ -381,7 +382,7 @@ async def test_ws_delete_require_admin(hass, hass_ws_client, storage_setup,
     resp = await client.send_json({
         'id': 6,
         'type': 'person/delete',
-        'person_id': list(manager.list_persons())[0]['id'],
+        'person_id': manager.storage_persons[0]['id'],
         'name': 'Updated Name',
         'device_trackers': [DEVICE_TRACKER_2],
         'user_id': None,
@@ -389,5 +390,5 @@ async def test_ws_delete_require_admin(hass, hass_ws_client, storage_setup,
     resp = await client.receive_json()
     assert not resp['success']
 
-    persons = list(manager.list_persons())
+    persons = manager.storage_persons
     assert len(persons) == 1

--- a/tests/components/person/test_init.py
+++ b/tests/components/person/test_init.py
@@ -5,10 +5,34 @@ from homeassistant.const import (
 from homeassistant.core import CoreState, State
 from homeassistant.setup import async_setup_component
 
+import pytest
+
 from tests.common import mock_component, mock_restore_cache
 
 DEVICE_TRACKER = 'device_tracker.test_tracker'
 DEVICE_TRACKER_2 = 'device_tracker.test_tracker_2'
+
+
+@pytest.fixture
+def storage_setup(hass, hass_storage, hass_admin_user):
+    """Storage setup."""
+    hass_storage[DOMAIN] = {
+        'key': DOMAIN,
+        'version': 1,
+        'data': {
+            'persons': [
+                {
+                    'id': '1234',
+                    'name': 'tracked person',
+                    'user_id': hass_admin_user.id,
+                    'device_trackers': DEVICE_TRACKER
+                }
+            ]
+        }
+    }
+    assert hass.loop.run_until_complete(
+        async_setup_component(hass, DOMAIN, {})
+    )
 
 
 async def test_minimal_setup(hass):
@@ -36,9 +60,9 @@ async def test_setup_no_name(hass):
     assert not await async_setup_component(hass, DOMAIN, config)
 
 
-async def test_setup_user_id(hass, hass_owner_user):
+async def test_setup_user_id(hass, hass_admin_user):
     """Test config with user id."""
-    user_id = hass_owner_user.id
+    user_id = hass_admin_user.id
     config = {
         DOMAIN: {'id': '1234', 'name': 'test person', 'user_id': user_id}}
     assert await async_setup_component(hass, DOMAIN, config)
@@ -52,9 +76,9 @@ async def test_setup_user_id(hass, hass_owner_user):
     assert state.attributes.get(ATTR_USER_ID) == user_id
 
 
-async def test_valid_invalid_user_ids(hass, hass_owner_user):
+async def test_valid_invalid_user_ids(hass, hass_admin_user):
     """Test a person with valid user id and a person with invalid user id ."""
-    user_id = hass_owner_user.id
+    user_id = hass_admin_user.id
     config = {DOMAIN: [
         {'id': '1234', 'name': 'test valid user', 'user_id': user_id},
         {'id': '5678', 'name': 'test bad user', 'user_id': 'bad_user_id'}]}
@@ -71,9 +95,9 @@ async def test_valid_invalid_user_ids(hass, hass_owner_user):
     assert state is None
 
 
-async def test_setup_tracker(hass, hass_owner_user):
+async def test_setup_tracker(hass, hass_admin_user):
     """Test set up person with one device tracker."""
-    user_id = hass_owner_user.id
+    user_id = hass_admin_user.id
     config = {DOMAIN: {
         'id': '1234', 'name': 'tracked person', 'user_id': user_id,
         'device_trackers': DEVICE_TRACKER}}
@@ -112,9 +136,9 @@ async def test_setup_tracker(hass, hass_owner_user):
     assert state.attributes.get(ATTR_USER_ID) == user_id
 
 
-async def test_setup_two_trackers(hass, hass_owner_user):
+async def test_setup_two_trackers(hass, hass_admin_user):
     """Test set up person with two device trackers."""
-    user_id = hass_owner_user.id
+    user_id = hass_admin_user.id
     config = {DOMAIN: {
         'id': '1234', 'name': 'tracked person', 'user_id': user_id,
         'device_trackers': [DEVICE_TRACKER, DEVICE_TRACKER_2]}}
@@ -153,9 +177,9 @@ async def test_setup_two_trackers(hass, hass_owner_user):
     assert state.attributes.get(ATTR_USER_ID) == user_id
 
 
-async def test_restore_home_state(hass, hass_owner_user):
+async def test_restore_home_state(hass, hass_admin_user):
     """Test that the state is restored for a person on startup."""
-    user_id = hass_owner_user.id
+    user_id = hass_admin_user.id
     attrs = {
         ATTR_ID: '1234', ATTR_LATITUDE: 10.12346, ATTR_LONGITUDE: 11.12346,
         ATTR_SOURCE: DEVICE_TRACKER, ATTR_USER_ID: user_id}
@@ -178,7 +202,7 @@ async def test_restore_home_state(hass, hass_owner_user):
     assert state.attributes.get(ATTR_USER_ID) == user_id
 
 
-async def test_duplicate_ids(hass, hass_owner_user):
+async def test_duplicate_ids(hass, hass_admin_user):
     """Test we don't allow duplicate IDs."""
     config = {DOMAIN: [
         {'id': '1234', 'name': 'test user 1'},
@@ -190,32 +214,15 @@ async def test_duplicate_ids(hass, hass_owner_user):
     assert hass.states.get('person.test_user_2') is None
 
 
-async def test_load_person_stoarge(hass, hass_owner_user, hass_storage):
+async def test_load_person_stoarge(hass, hass_admin_user, storage_setup):
     """Test set up person with one device tracker."""
-    user_id = hass_owner_user.id
-    hass_storage[DOMAIN] = {
-        'key': DOMAIN,
-        'version': 1,
-        'data': {
-            'persons': [
-                {
-                    'id': '1234',
-                    'name': 'tracked person',
-                    'user_id': user_id,
-                    'device_trackers': DEVICE_TRACKER
-                }
-            ]
-        }
-    }
-    assert await async_setup_component(hass, DOMAIN, {})
-
     state = hass.states.get('person.tracked_person')
     assert state.state == STATE_UNKNOWN
     assert state.attributes.get(ATTR_ID) == '1234'
     assert state.attributes.get(ATTR_LATITUDE) is None
     assert state.attributes.get(ATTR_LONGITUDE) is None
     assert state.attributes.get(ATTR_SOURCE) is None
-    assert state.attributes.get(ATTR_USER_ID) == user_id
+    assert state.attributes.get(ATTR_USER_ID) == hass_admin_user.id
 
     hass.states.async_set(DEVICE_TRACKER, 'home')
     await hass.async_block_till_done()
@@ -226,4 +233,161 @@ async def test_load_person_stoarge(hass, hass_owner_user, hass_storage):
     assert state.attributes.get(ATTR_LATITUDE) is None
     assert state.attributes.get(ATTR_LONGITUDE) is None
     assert state.attributes.get(ATTR_SOURCE) == DEVICE_TRACKER
-    assert state.attributes.get(ATTR_USER_ID) == user_id
+    assert state.attributes.get(ATTR_USER_ID) == hass_admin_user.id
+
+
+async def test_ws_list(hass, hass_ws_client, storage_setup):
+    """Test listing via WS."""
+    manager = hass.data[DOMAIN]
+
+    client = await hass_ws_client(hass)
+
+    resp = await client.send_json({
+        'id': 6,
+        'type': 'person/list',
+    })
+    resp = await client.receive_json()
+    assert resp['success']
+    assert resp['result'] == list(manager.list_persons())
+    assert len(resp['result']) == 1
+
+
+async def test_ws_create(hass, hass_ws_client, storage_setup,
+                         hass_read_only_user):
+    """Test creating via WS."""
+    manager = hass.data[DOMAIN]
+
+    client = await hass_ws_client(hass)
+
+    resp = await client.send_json({
+        'id': 6,
+        'type': 'person/create',
+        'name': 'Hello',
+        'device_trackers': [DEVICE_TRACKER],
+        'user_id': hass_read_only_user.id,
+    })
+    resp = await client.receive_json()
+
+    persons = list(manager.list_persons())
+    assert len(persons) == 2
+
+    assert resp['success']
+    assert resp['result'] == persons[1]
+
+
+async def test_ws_create_requires_admin(hass, hass_ws_client, storage_setup,
+                                        hass_admin_user, hass_read_only_user):
+    """Test creating via WS requires admin."""
+    hass_admin_user.groups = []
+    manager = hass.data[DOMAIN]
+
+    client = await hass_ws_client(hass)
+
+    resp = await client.send_json({
+        'id': 6,
+        'type': 'person/create',
+        'name': 'Hello',
+        'device_trackers': [DEVICE_TRACKER],
+        'user_id': hass_read_only_user.id,
+    })
+    resp = await client.receive_json()
+
+    persons = list(manager.list_persons())
+    assert len(persons) == 1
+
+    assert not resp['success']
+
+
+async def test_ws_update(hass, hass_ws_client, storage_setup):
+    """Test updating via WS."""
+    manager = hass.data[DOMAIN]
+
+    client = await hass_ws_client(hass)
+    persons = list(manager.list_persons())
+
+    resp = await client.send_json({
+        'id': 6,
+        'type': 'person/update',
+        'person_id': persons[0]['id'],
+        'name': 'Updated Name',
+        'device_trackers': [DEVICE_TRACKER_2],
+        'user_id': None,
+    })
+    resp = await client.receive_json()
+
+    persons = list(manager.list_persons())
+    assert len(persons) == 1
+
+    assert resp['success']
+    assert resp['result'] == persons[0]
+    assert persons[0]['name'] == 'Updated Name'
+    assert persons[0]['name'] == 'Updated Name'
+    assert persons[0]['device_trackers'] == [DEVICE_TRACKER_2]
+    assert persons[0]['user_id'] is None
+
+
+async def test_ws_update_require_admin(hass, hass_ws_client, storage_setup,
+                                       hass_admin_user):
+    """Test updating via WS requires admin."""
+    hass_admin_user.groups = []
+    manager = hass.data[DOMAIN]
+
+    client = await hass_ws_client(hass)
+    original = dict(list(manager.list_persons())[0])
+
+    resp = await client.send_json({
+        'id': 6,
+        'type': 'person/update',
+        'person_id': original['id'],
+        'name': 'Updated Name',
+        'device_trackers': [DEVICE_TRACKER_2],
+        'user_id': None,
+    })
+    resp = await client.receive_json()
+    assert not resp['success']
+
+    not_updated = dict(list(manager.list_persons())[0])
+    assert original == not_updated
+
+
+async def test_ws_delete(hass, hass_ws_client, storage_setup):
+    """Test deleting via WS."""
+    manager = hass.data[DOMAIN]
+
+    client = await hass_ws_client(hass)
+    persons = list(manager.list_persons())
+
+    resp = await client.send_json({
+        'id': 6,
+        'type': 'person/delete',
+        'person_id': persons[0]['id'],
+    })
+    resp = await client.receive_json()
+
+    persons = list(manager.list_persons())
+    assert len(persons) == 0
+
+    assert resp['success']
+
+
+async def test_ws_delete_require_admin(hass, hass_ws_client, storage_setup,
+                                       hass_admin_user):
+    """Test deleting via WS requires admin."""
+    hass_admin_user.groups = []
+    manager = hass.data[DOMAIN]
+
+    client = await hass_ws_client(hass)
+
+    resp = await client.send_json({
+        'id': 6,
+        'type': 'person/delete',
+        'person_id': list(manager.list_persons())[0]['id'],
+        'name': 'Updated Name',
+        'device_trackers': [DEVICE_TRACKER_2],
+        'user_id': None,
+    })
+    resp = await client.receive_json()
+    assert not resp['success']
+
+    persons = list(manager.list_persons())
+    assert len(persons) == 1

--- a/tests/components/person/test_init.py
+++ b/tests/components/person/test_init.py
@@ -184,3 +184,15 @@ async def test_restore_home_state(hass, hass_owner_user):
     # When restoring state the entity_id of the person will be used as source.
     assert state.attributes.get(ATTR_SOURCE) == 'person.tracked_person'
     assert state.attributes.get(ATTR_USER_ID) == user_id
+
+
+async def test_duplicate_ids(hass, hass_owner_user):
+    """Test we don't allow duplicate IDs."""
+    config = {DOMAIN: [
+        {'id': '1234', 'name': 'test user 1'},
+        {'id': '1234', 'name': 'test user 2'}]}
+    assert await async_setup_component(hass, DOMAIN, config)
+
+    assert len(hass.states.async_entity_ids('person')) == 1
+    assert hass.states.get('person.test_user_1') is not None
+    assert hass.states.get('person.test_user_2') is None

--- a/tests/components/person/test_init.py
+++ b/tests/components/person/test_init.py
@@ -1,7 +1,8 @@
 """The tests for the person component."""
 from homeassistant.components.person import ATTR_SOURCE, ATTR_USER_ID, DOMAIN
 from homeassistant.const import (
-    ATTR_ID, ATTR_LATITUDE, ATTR_LONGITUDE, STATE_UNKNOWN)
+    ATTR_ID, ATTR_LATITUDE, ATTR_LONGITUDE, STATE_UNKNOWN,
+    EVENT_HOMEASSISTANT_START)
 from homeassistant.core import CoreState, State
 from homeassistant.setup import async_setup_component
 
@@ -115,6 +116,12 @@ async def test_setup_tracker(hass, hass_admin_user):
     await hass.async_block_till_done()
 
     state = hass.states.get('person.tracked_person')
+    assert state.state == STATE_UNKNOWN
+
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    await hass.async_block_till_done()
+
+    state = hass.states.get('person.tracked_person')
     assert state.state == 'home'
     assert state.attributes.get(ATTR_ID) == '1234'
     assert state.attributes.get(ATTR_LATITUDE) is None
@@ -152,6 +159,8 @@ async def test_setup_two_trackers(hass, hass_admin_user):
     assert state.attributes.get(ATTR_SOURCE) is None
     assert state.attributes.get(ATTR_USER_ID) == user_id
 
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    await hass.async_block_till_done()
     hass.states.async_set(DEVICE_TRACKER, 'home')
     await hass.async_block_till_done()
 
@@ -224,6 +233,8 @@ async def test_load_person_storage(hass, hass_admin_user, storage_setup):
     assert state.attributes.get(ATTR_SOURCE) is None
     assert state.attributes.get(ATTR_USER_ID) == hass_admin_user.id
 
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    await hass.async_block_till_done()
     hass.states.async_set(DEVICE_TRACKER, 'home')
     await hass.async_block_till_done()
 

--- a/tests/components/person/test_init.py
+++ b/tests/components/person/test_init.py
@@ -214,8 +214,8 @@ async def test_duplicate_ids(hass, hass_admin_user):
     assert hass.states.get('person.test_user_2') is None
 
 
-async def test_load_person_stoarge(hass, hass_admin_user, storage_setup):
-    """Test set up person with one device tracker."""
+async def test_load_person_storage(hass, hass_admin_user, storage_setup):
+    """Test set up person from storage."""
     state = hass.states.get('person.tracked_person')
     assert state.state == STATE_UNKNOWN
     assert state.attributes.get(ATTR_ID) == '1234'

--- a/tests/components/person/test_init.py
+++ b/tests/components/person/test_init.py
@@ -326,6 +326,9 @@ async def test_ws_update(hass, hass_ws_client, storage_setup):
     assert persons[0]['device_trackers'] == [DEVICE_TRACKER_2]
     assert persons[0]['user_id'] is None
 
+    state = hass.states.get('person.tracked_person')
+    assert state.name == 'Updated Name'
+
 
 async def test_ws_update_require_admin(hass, hass_ws_client, storage_setup,
                                        hass_admin_user):
@@ -369,6 +372,9 @@ async def test_ws_delete(hass, hass_ws_client, storage_setup):
     assert len(persons) == 0
 
     assert resp['success']
+    assert len(hass.states.async_entity_ids('person')) == 0
+    ent_reg = await hass.helpers.entity_registry.async_get_registry()
+    assert not ent_reg.async_is_registered('person.tracked_person')
 
 
 async def test_ws_delete_require_admin(hass, hass_ws_client, storage_setup,


### PR DESCRIPTION
## Description:
Add support for storing persons in storage. Also adds WS commands.

To do:
 - [x] On update, update the entity in state machine
 - [x] on Delete, remove entity from state machine

## Example entry for `configuration.yaml` (if applicable):
```yaml
person:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
