### PR TITLE
Fix STATE_UNLOCKED for verisure

### DIFF
--- a/homeassistant/components/verisure/lock.py
+++ b/homeassistant/components/verisure/lock.py
@@ -80,7 +80,7 @@ class VerisureDoorlock(LockDevice):
             "$.doorLockStatusList[?(@.deviceLabel=='%s')].lockedState",
             self._device_label)
         if status == 'UNLOCKED':
-            self._state = None
+            self._state = STATE_UNLOCKED
         elif status == 'LOCKED':
             self._state = STATE_LOCKED
         elif status != 'PENDING':


### PR DESCRIPTION
## Description:

FIx bug from https://github.com/home-assistant/home-assistant/pull/20337


## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
