### PR TITLE
Add opencv-python to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ COPY requirements_all.txt requirements_all.txt
 # Uninstall enum34 because some dependencies install it but breaks Python 3.4+.
 # See PR #8103 for more info.
 RUN pip3 install --no-cache-dir -r requirements_all.txt && \
-    pip3 install --no-cache-dir mysqlclient psycopg2 uvloop cchardet cython tensorflow
+    pip3 install --no-cache-dir mysqlclient psycopg2 uvloop cchardet cython tensorflow opencv-python
 
 # Copy source
 COPY . .


### PR DESCRIPTION
## Description:
Both Tensorflow and OpenCV components require this module:
ERROR (SyncWorker_5) [homeassistant.components.image_processing.opencv] No OpenCV library found! Install or compile for your system following instructions here: http://opencv.org/releases.html
WARNING (SyncWorker_0) [homeassistant.components.image_processing.tensorflow] No OpenCV library found. TensorFlow will process image with PIL at reduced resolution

## Example entry for `configuration.yaml` (if applicable):
```yaml
image_processing:
  - platform: opencv
    name: Front Door Faces
    source:
      - entity_id: camera.local
  - platform: tensorflow
    source:
      - entity_id: camera.local
    model:
      graph: /config/tensorflow/frozen_inference_graph.pb
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
