### PR TITLE
Avoid unnecessary commands in Vizio update function

### DIFF
--- a/homeassistant/components/media_player/vizio.py
+++ b/homeassistant/components/media_player/vizio.py
@@ -91,25 +91,31 @@ class VizioDevice(MediaPlayerDevice):
     def update(self):
         """Retrieve latest state of the TV."""
         is_on = self._device.get_power_state()
-        if is_on is None:
-            self._state = None
-            return
-        if is_on is False:
-            self._state = STATE_OFF
-        else:
+
+        if is_on:
             self._state = STATE_ON
 
-        volume = self._device.get_current_volume()
-        if volume is not None:
-            self._volume_level = float(volume) / 100.
-        input_ = self._device.get_current_input()
-        if input_ is not None:
-            self._current_input = input_.meta_name
-        inputs = self._device.get_inputs()
-        if inputs is not None:
-            self._available_inputs = []
-            for input_ in inputs:
-                self._available_inputs.append(input_.name)
+            volume = self._device.get_current_volume()
+            if volume is not None:
+                self._volume_level = float(volume) / 100.
+
+            input_ = self._device.get_current_input()
+            if input_ is not None:
+                self._current_input = input_.meta_name
+
+            inputs = self._device.get_inputs()
+            if inputs is not None:
+                self._available_inputs = [input_.name for input_ in inputs]
+
+        else:
+            if is_on is None:
+                self._state = None
+            else:
+                self._state = STATE_OFF
+
+            self._volume_level = None
+            self._current_input = None
+            self._available_inputs = None
 
     @property
     def state(self):


### PR DESCRIPTION
## Description:

If the power is off, we don't need to check the `_volume_level`, `_current_input`, and `_available_inputs` attributes; we can just set them to `None`.  

I'm hopeful that this can help me avoid errors of the form (this occurs in pyvizio when trying to get the volume level):

```
[pyvizio.vizio] Failed to execute command: int() argument must be a string, a bytes-like object or a number, not 'NoneType'
```


**Related issue (if applicable):** 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** 

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
