### PR TITLE
Don't directly update config entries

### DIFF
--- a/homeassistant/components/deconz/gateway.py
+++ b/homeassistant/components/deconz/gateway.py
@@ -44,8 +44,9 @@ class DeconzGateway:
             async def retry_setup(_now):
                 """Retry setup."""
                 if await self.async_setup(tries + 1):
-                    # This feels hacky, we should find a better way to do this
-                    self.config_entry.state = config_entries.ENTRY_STATE_LOADED
+                    hass.config_entries.async_update_entry(
+                        entry=self.config_entry,
+                        state=config_entries.ENTRY_STATE_LOADED)
 
             self._cancel_retry_setup = hass.helpers.event.async_call_later(
                 retry_delay, retry_setup)

--- a/homeassistant/components/deconz/gateway.py
+++ b/homeassistant/components/deconz/gateway.py
@@ -1,5 +1,5 @@
 """Representation of a deCONZ gateway."""
-from homeassistant import config_entries
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.const import CONF_EVENT, CONF_ID
 from homeassistant.core import EventOrigin, callback
 from homeassistant.helpers import aiohttp_client
@@ -8,7 +8,7 @@ from homeassistant.helpers.dispatcher import (
 from homeassistant.util import slugify
 
 from .const import (
-    _LOGGER, DECONZ_REACHABLE, CONF_ALLOW_CLIP_SENSOR, SUPPORTED_PLATFORMS)
+    DECONZ_REACHABLE, CONF_ALLOW_CLIP_SENSOR, SUPPORTED_PLATFORMS)
 
 
 class DeconzGateway:
@@ -20,7 +20,6 @@ class DeconzGateway:
         self.config_entry = config_entry
         self.available = True
         self.api = None
-        self._cancel_retry_setup = None
 
         self.deconz_ids = {}
         self.events = []
@@ -35,23 +34,8 @@ class DeconzGateway:
             self.async_connection_status_callback
         )
 
-        if self.api is False:
-            retry_delay = 2 ** (tries + 1)
-            _LOGGER.error(
-                "Error connecting to deCONZ gateway. Retrying in %d seconds",
-                retry_delay)
-
-            async def retry_setup(_now):
-                """Retry setup."""
-                if await self.async_setup(tries + 1):
-                    hass.config_entries.async_update_entry(
-                        entry=self.config_entry,
-                        state=config_entries.ENTRY_STATE_LOADED)
-
-            self._cancel_retry_setup = hass.helpers.event.async_call_later(
-                retry_delay, retry_setup)
-
-            return False
+        if not self.api:
+            raise ConfigEntryNotReady
 
         for component in SUPPORTED_PLATFORMS:
             hass.async_create_task(
@@ -108,12 +92,6 @@ class DeconzGateway:
         Will cancel any scheduled setup retry and will unload
         the config entry.
         """
-        # If we have a retry scheduled, we were never setup.
-        if self._cancel_retry_setup is not None:
-            self._cancel_retry_setup()
-            self._cancel_retry_setup = None
-            return True
-
         self.api.close()
 
         for component in SUPPORTED_PLATFORMS:

--- a/homeassistant/components/homematicip_cloud/hap.py
+++ b/homeassistant/components/homematicip_cloud/hap.py
@@ -104,7 +104,9 @@ class HomematicipHAP:
             async def retry_setup(_now):
                 """Retry setup."""
                 if await self.async_setup(tries + 1):
-                    self.config_entry.state = config_entries.ENTRY_STATE_LOADED
+                    self.hass.config_entries.async_update_entry(
+                        entry=self.config_entry,
+                        state=config_entries.ENTRY_STATE_LOADED)
 
             self._retry_setup = self.hass.helpers.event.async_call_later(
                 retry_delay, retry_setup)

--- a/homeassistant/components/homematicip_cloud/hap.py
+++ b/homeassistant/components/homematicip_cloud/hap.py
@@ -2,7 +2,7 @@
 import asyncio
 import logging
 
-from homeassistant import config_entries
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.core import callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
@@ -84,7 +84,6 @@ class HomematicipHAP:
         self._retry_task = None
         self._tries = 0
         self._accesspoint_connected = True
-        self._retry_setup = None
 
     async def async_setup(self, tries=0):
         """Initialize connection."""
@@ -96,22 +95,7 @@ class HomematicipHAP:
                 self.config_entry.data.get(HMIPC_NAME)
             )
         except HmipcConnectionError:
-            retry_delay = 2 ** min(tries, 8)
-            _LOGGER.error("Error connecting to HomematicIP with HAP %s. "
-                          "Retrying in %d seconds",
-                          self.config_entry.data.get(HMIPC_HAPID), retry_delay)
-
-            async def retry_setup(_now):
-                """Retry setup."""
-                if await self.async_setup(tries + 1):
-                    self.hass.config_entries.async_update_entry(
-                        entry=self.config_entry,
-                        state=config_entries.ENTRY_STATE_LOADED)
-
-            self._retry_setup = self.hass.helpers.event.async_call_later(
-                retry_delay, retry_setup)
-
-            return False
+            raise ConfigEntryNotReady
 
         _LOGGER.info("Connected to HomematicIP with HAP %s",
                      self.config_entry.data.get(HMIPC_HAPID))
@@ -211,8 +195,6 @@ class HomematicipHAP:
     async def async_reset(self):
         """Close the websocket connection."""
         self._ws_close_requested = True
-        if self._retry_setup is not None:
-            self._retry_setup.cancel()
         if self._retry_task is not None:
             self._retry_task.cancel()
         await self.home.disable_events()

--- a/homeassistant/components/hue/bridge.py
+++ b/homeassistant/components/hue/bridge.py
@@ -66,8 +66,9 @@ class HueBridge:
             async def retry_setup(_now):
                 """Retry setup."""
                 if await self.async_setup(tries + 1):
-                    # This feels hacky, we should find a better way to do this
-                    self.config_entry.state = config_entries.ENTRY_STATE_LOADED
+                    hass.config_entries.async_update_entry(
+                        entry=self.config_entry,
+                        state=config_entries.ENTRY_STATE_LOADED)
 
             self._cancel_retry_setup = hass.helpers.event.async_call_later(
                 retry_delay, retry_setup)

--- a/homeassistant/components/hue/bridge.py
+++ b/homeassistant/components/hue/bridge.py
@@ -5,6 +5,7 @@ import async_timeout
 import voluptuous as vol
 
 from homeassistant import config_entries
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import aiohttp_client, config_validation as cv
 
 from .const import DOMAIN, LOGGER
@@ -30,7 +31,6 @@ class HueBridge:
         self.allow_groups = allow_groups
         self.available = True
         self.api = None
-        self._cancel_retry_setup = None
 
     @property
     def host(self):
@@ -59,21 +59,7 @@ class HueBridge:
             return False
 
         except CannotConnect:
-            retry_delay = 2 ** (tries + 1)
-            LOGGER.error("Error connecting to the Hue bridge at %s. Retrying "
-                         "in %d seconds", host, retry_delay)
-
-            async def retry_setup(_now):
-                """Retry setup."""
-                if await self.async_setup(tries + 1):
-                    hass.config_entries.async_update_entry(
-                        entry=self.config_entry,
-                        state=config_entries.ENTRY_STATE_LOADED)
-
-            self._cancel_retry_setup = hass.helpers.event.async_call_later(
-                retry_delay, retry_setup)
-
-            return False
+            raise ConfigEntryNotReady
 
         except Exception:  # pylint: disable=broad-except
             LOGGER.exception('Unknown error connecting with Hue bridge at %s',
@@ -98,13 +84,6 @@ class HueBridge:
         # The bridge can be in 3 states:
         #  - Setup was successful, self.api is not None
         #  - Authentication was wrong, self.api is None, not retrying setup.
-        #  - Host was down. self.api is None, we're retrying setup
-
-        # If we have a retry scheduled, we were never setup.
-        if self._cancel_retry_setup is not None:
-            self._cancel_retry_setup()
-            self._cancel_retry_setup = None
-            return True
 
         # If the authentication was wrong.
         if self.api is None:

--- a/homeassistant/components/unifi/controller.py
+++ b/homeassistant/components/unifi/controller.py
@@ -55,8 +55,9 @@ class UniFiController:
             async def retry_setup(_now):
                 """Retry setup."""
                 if await self.async_setup(tries + 1):
-                    # This feels hacky, we should find a better way to do this
-                    self.config_entry.state = config_entries.ENTRY_STATE_LOADED
+                    hass.config_entries.async_update_entry(
+                        entry=self.config_entry,
+                        state=config_entries.ENTRY_STATE_LOADED)
 
             self._cancel_retry_setup = hass.helpers.event.async_call_later(
                 retry_delay, retry_setup)

--- a/homeassistant/components/unifi/controller.py
+++ b/homeassistant/components/unifi/controller.py
@@ -5,7 +5,6 @@ import async_timeout
 
 from aiohttp import CookieJar
 
-from homeassistant import config_entries
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.const import CONF_HOST
 from homeassistant.helpers import aiohttp_client

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -127,6 +127,7 @@ from homeassistant.util.decorator import Registry
 
 
 _LOGGER = logging.getLogger(__name__)
+_UNDEF = object()
 
 SOURCE_USER = 'user'
 SOURCE_DISCOVERY = 'discovery'
@@ -441,9 +442,12 @@ class ConfigEntries:
             for entry in config['entries']]
 
     @callback
-    def async_update_entry(self, entry, *, data):
+    def async_update_entry(self, entry, *, data=_UNDEF, state=_UNDEF):
         """Update a config entry."""
-        entry.data = data
+        if data is not _UNDEF:
+            entry.data = data
+        if state is not _UNDEF:
+            entry.state = state
         self._async_schedule_save()
 
     async def async_forward_entry_setup(self, entry, component):

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -442,12 +442,10 @@ class ConfigEntries:
             for entry in config['entries']]
 
     @callback
-    def async_update_entry(self, entry, *, data=_UNDEF, state=_UNDEF):
+    def async_update_entry(self, entry, *, data=_UNDEF):
         """Update a config entry."""
         if data is not _UNDEF:
             entry.data = data
-        if state is not _UNDEF:
-            entry.state = state
         self._async_schedule_save()
 
     async def async_forward_entry_setup(self, entry, component):

--- a/tests/components/deconz/test_init.py
+++ b/tests/components/deconz/test_init.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock, patch
 import pytest
 import voluptuous as vol
 
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.setup import async_setup_component
 from homeassistant.components import deconz
 
@@ -79,9 +80,11 @@ async def test_setup_entry_no_available_bridge(hass):
     """Test setup entry fails if deCONZ is not available."""
     entry = Mock()
     entry.data = {'host': '1.2.3.4', 'port': 80, 'api_key': '1234567890ABCDEF'}
-    with patch('pydeconz.DeconzSession.async_load_parameters',
-               return_value=mock_coro(False)):
-        assert await deconz.async_setup_entry(hass, entry) is False
+    with patch(
+        'pydeconz.DeconzSession.async_load_parameters',
+        return_value=mock_coro(False)
+    ), pytest.raises(ConfigEntryNotReady):
+        await deconz.async_setup_entry(hass, entry)
 
 
 async def test_setup_entry_successful(hass):

--- a/tests/components/homematicip_cloud/test_hap.py
+++ b/tests/components/homematicip_cloud/test_hap.py
@@ -1,6 +1,9 @@
 """Test HomematicIP Cloud accesspoint."""
 from unittest.mock import Mock, patch
 
+import pytest
+
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.components.homematicip_cloud import hap as hmipc
 from homeassistant.components.homematicip_cloud import const, errors
 from tests.common import mock_coro, mock_coro_func
@@ -82,9 +85,10 @@ async def test_hap_setup_connection_error():
         hmipc.HMIPC_NAME: 'hmip',
     }
     hap = hmipc.HomematicipHAP(hass, entry)
-    with patch.object(hap, 'get_hap',
-                      side_effect=errors.HmipcConnectionError):
-        assert await hap.async_setup() is False
+    with patch.object(
+            hap, 'get_hap', side_effect=errors.HmipcConnectionError
+    ), pytest.raises(ConfigEntryNotReady):
+        await hap.async_setup()
 
     assert len(hass.async_add_job.mock_calls) == 0
     assert len(hass.config_entries.flow.async_init.mock_calls) == 0

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -411,13 +411,20 @@ async def test_updating_entry_data(manager):
     entry = MockConfigEntry(
         domain='test',
         data={'first': True},
+        state=config_entries.ENTRY_STATE_SETUP_ERROR,
     )
     entry.add_to_manager(manager)
+
+    manager.async_update_entry(entry, state=config_entries.ENTRY_STATE_LOADED)
+    assert entry.state == config_entries.ENTRY_STATE_LOADED
+    assert entry.data == {
+        'first': True
+    }
 
     manager.async_update_entry(entry, data={
         'second': True
     })
-
+    assert entry.state == config_entries.ENTRY_STATE_LOADED
     assert entry.data == {
         'second': True
     }

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -415,8 +415,7 @@ async def test_updating_entry_data(manager):
     )
     entry.add_to_manager(manager)
 
-    manager.async_update_entry(entry, state=config_entries.ENTRY_STATE_LOADED)
-    assert entry.state == config_entries.ENTRY_STATE_LOADED
+    manager.async_update_entry(entry)
     assert entry.data == {
         'first': True
     }
@@ -424,7 +423,6 @@ async def test_updating_entry_data(manager):
     manager.async_update_entry(entry, data={
         'second': True
     })
-    assert entry.state == config_entries.ENTRY_STATE_LOADED
     assert entry.data == {
         'second': True
     }


### PR DESCRIPTION
## Description:
We should not update config entries directly, but instead always go via the Config Entry manager.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
