### PR TITLE
Don't expose services in Utility_Meter unless tariffs are available

### DIFF
--- a/homeassistant/components/utility_meter/__init__.py
+++ b/homeassistant/components/utility_meter/__init__.py
@@ -57,6 +57,7 @@ async def async_setup(hass, config):
     """Set up an Utility Meter."""
     component = EntityComponent(_LOGGER, DOMAIN, hass)
     hass.data[DATA_UTILITY] = {}
+    register_services = False
 
     for meter, conf in config.get(DOMAIN).items():
         _LOGGER.debug("Setup %s.%s", DOMAIN, meter)
@@ -86,21 +87,23 @@ async def async_setup(hass, config):
                     })
             hass.async_create_task(discovery.async_load_platform(
                 hass, SENSOR_DOMAIN, DOMAIN, tariff_confs, config))
+            register_services = True
 
-            component.async_register_entity_service(
-                SERVICE_RESET, SERVICE_METER_SCHEMA,
-                'async_reset_meters'
-            )
+    if register_services:
+        component.async_register_entity_service(
+            SERVICE_RESET, SERVICE_METER_SCHEMA,
+            'async_reset_meters'
+        )
 
-            component.async_register_entity_service(
-                SERVICE_SELECT_TARIFF, SERVICE_SELECT_TARIFF_SCHEMA,
-                'async_select_tariff'
-            )
+        component.async_register_entity_service(
+            SERVICE_SELECT_TARIFF, SERVICE_SELECT_TARIFF_SCHEMA,
+            'async_select_tariff'
+        )
 
-            component.async_register_entity_service(
-                SERVICE_SELECT_NEXT_TARIFF, SERVICE_METER_SCHEMA,
-                'async_next_tariff'
-            )
+        component.async_register_entity_service(
+            SERVICE_SELECT_NEXT_TARIFF, SERVICE_METER_SCHEMA,
+            'async_next_tariff'
+        )
 
     return True
 

--- a/homeassistant/components/utility_meter/__init__.py
+++ b/homeassistant/components/utility_meter/__init__.py
@@ -87,20 +87,20 @@ async def async_setup(hass, config):
             hass.async_create_task(discovery.async_load_platform(
                 hass, SENSOR_DOMAIN, DOMAIN, tariff_confs, config))
 
-    component.async_register_entity_service(
-        SERVICE_RESET, SERVICE_METER_SCHEMA,
-        'async_reset_meters'
-    )
+            component.async_register_entity_service(
+                SERVICE_RESET, SERVICE_METER_SCHEMA,
+                'async_reset_meters'
+            )
 
-    component.async_register_entity_service(
-        SERVICE_SELECT_TARIFF, SERVICE_SELECT_TARIFF_SCHEMA,
-        'async_select_tariff'
-    )
+            component.async_register_entity_service(
+                SERVICE_SELECT_TARIFF, SERVICE_SELECT_TARIFF_SCHEMA,
+                'async_select_tariff'
+            )
 
-    component.async_register_entity_service(
-        SERVICE_SELECT_NEXT_TARIFF, SERVICE_METER_SCHEMA,
-        'async_next_tariff'
-    )
+            component.async_register_entity_service(
+                SERVICE_SELECT_NEXT_TARIFF, SERVICE_METER_SCHEMA,
+                'async_next_tariff'
+            )
 
     return True
 
@@ -156,6 +156,7 @@ class TariffSelect(RestoreEntity):
 
     async def async_reset_meters(self):
         """Reset all sensors of this meter."""
+        _LOGGER.debug("reset meter %s", self.entity_id)
         async_dispatcher_send(self.hass, SIGNAL_RESET_METER,
                               self.entity_id)
 

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -196,6 +196,7 @@ class UtilityMeterSensor(RestoreEntity):
                 if self._tariff != tariff_entity_state.state:
                     return
 
+            _LOGGER.debug("tracking source: %s", self._sensor_source_id)
             self._collecting = async_track_state_change(
                 self.hass, self._sensor_source_id, self.async_reading)
 


### PR DESCRIPTION
## Description:

The utility_meter component provides services to change tariffs. When there are no tariffs the services fill no purpose. This PR setup's services ONLY when tariffs are defined.

**Related issue (if applicable):** fixes #20982 and https://community.home-assistant.io/t/utility-meter-reset-service-seems-not-be-working/98271

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
utility_meter:
  hourly_energy:
    source: sensor.total_energy_spent
    cycle: hourly
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54