### PR TITLE
Set August doorbell availability state from online state

### DIFF
--- a/homeassistant/components/august/binary_sensor.py
+++ b/homeassistant/components/august/binary_sensor.py
@@ -181,4 +181,4 @@ class AugustDoorbellBinarySensor(BinarySensorDevice):
         """Get the latest state of the sensor."""
         state_provider = SENSOR_TYPES_DOORBELL[self._sensor_type][2]
         self._state = state_provider(self._data, self._doorbell)
-        self._available = self._state is not None
+        self._available = self._doorbell.is_online


### PR DESCRIPTION
## Description:

The available state for the August Doorbell is currently set based on the state of the binary ding sensor.  This means that if there is no door bell rings in a while on startup the doorbell is shown as Unavailable . This ties the availability of the doorbell to the  actual online state thats in the device information retrieved from august so that even if there has not been a doorbell ring activity on a while the device shows as online when it is.

**Related issue (if applicable):** fixes #20421


**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml
august:
  login_method: email
  username: <some email>
  password: <some password>
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.