### PR TITLE
Upgrade zm-py to 0.3.3 to fix event counts

### DIFF
--- a/homeassistant/components/zoneminder/__init__.py
+++ b/homeassistant/components/zoneminder/__init__.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.discovery import async_load_platform
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['zm-py==0.3.1']
+REQUIREMENTS = ['zm-py==0.3.3']
 
 CONF_PATH_ZMS = 'path_zms'
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1798,4 +1798,4 @@ zigpy-xbee==0.1.1
 zigpy==0.2.0
 
 # homeassistant.components.zoneminder
-zm-py==0.3.1
+zm-py==0.3.3


### PR DESCRIPTION
@rohankapoorcom I assume you're fine with this.

## Description:
Handles an empty array being returned from the array when an object is normally expected. This is a quirk in the ZM API.

**Related issue (if applicable):** fixes #20833
