### PR TITLE
Unique Ids for August entities to allow renames

### DIFF
--- a/homeassistant/components/august/binary_sensor.py
+++ b/homeassistant/components/august/binary_sensor.py
@@ -143,6 +143,14 @@ class AugustDoorBinarySensor(BinarySensorDevice):
 
         from august.lock import LockDoorStatus
         self._state = self._state == LockDoorStatus.OPEN
+    
+    @property
+    def unique_id(self) -> str:
+        """Get the unique of the door open binary sensor."""
+        return '{:s}_{:s}'.format(self._door.device_id,
+                                  SENSOR_TYPES_DOOR[self._sensor_type][0]
+                                  .lower())
+
 
 
 class AugustDoorbellBinarySensor(BinarySensorDevice):
@@ -182,3 +190,11 @@ class AugustDoorbellBinarySensor(BinarySensorDevice):
         state_provider = SENSOR_TYPES_DOORBELL[self._sensor_type][2]
         self._state = state_provider(self._data, self._doorbell)
         self._available = self._state is not None
+
+    @property
+    def unique_id(self) -> str:
+        """Get the unique id of the doorbell sensor."""
+        return '{:s}_{:s}'.format(self._doorbell.device_id,
+                                  SENSOR_TYPES_DOORBELL[self._sensor_type][0]
+                                  .lower())
+    

--- a/homeassistant/components/august/binary_sensor.py
+++ b/homeassistant/components/august/binary_sensor.py
@@ -197,4 +197,4 @@ class AugustDoorbellBinarySensor(BinarySensorDevice):
         return '{:s}_{:s}'.format(self._doorbell.device_id,
                                   SENSOR_TYPES_DOORBELL[self._sensor_type][0]
                                   .lower())
-    
+

--- a/homeassistant/components/august/binary_sensor.py
+++ b/homeassistant/components/august/binary_sensor.py
@@ -189,7 +189,7 @@ class AugustDoorbellBinarySensor(BinarySensorDevice):
         """Get the latest state of the sensor."""
         state_provider = SENSOR_TYPES_DOORBELL[self._sensor_type][2]
         self._state = state_provider(self._data, self._doorbell)
-        self._available = self._state is not None
+        self._available = self._doorbell.is_online
 
     @property
     def unique_id(self) -> str:

--- a/homeassistant/components/august/binary_sensor.py
+++ b/homeassistant/components/august/binary_sensor.py
@@ -143,7 +143,7 @@ class AugustDoorBinarySensor(BinarySensorDevice):
 
         from august.lock import LockDoorStatus
         self._state = self._state == LockDoorStatus.OPEN
-    
+
     @property
     def unique_id(self) -> str:
         """Get the unique of the door open binary sensor."""

--- a/homeassistant/components/august/binary_sensor.py
+++ b/homeassistant/components/august/binary_sensor.py
@@ -143,7 +143,7 @@ class AugustDoorBinarySensor(BinarySensorDevice):
 
         from august.lock import LockDoorStatus
         self._state = self._state == LockDoorStatus.OPEN
-
+    
     @property
     def unique_id(self) -> str:
         """Get the unique of the door open binary sensor."""
@@ -197,3 +197,4 @@ class AugustDoorbellBinarySensor(BinarySensorDevice):
         return '{:s}_{:s}'.format(self._doorbell.device_id,
                                   SENSOR_TYPES_DOORBELL[self._sensor_type][0]
                                   .lower())
+

--- a/homeassistant/components/august/binary_sensor.py
+++ b/homeassistant/components/august/binary_sensor.py
@@ -190,6 +190,7 @@ class AugustDoorbellBinarySensor(BinarySensorDevice):
         state_provider = SENSOR_TYPES_DOORBELL[self._sensor_type][2]
         self._state = state_provider(self._data, self._doorbell)
         self._available = self._doorbell.is_online
+
     @property
     def unique_id(self) -> str:
         """Get the unique id of the doorbell sensor."""

--- a/homeassistant/components/august/binary_sensor.py
+++ b/homeassistant/components/august/binary_sensor.py
@@ -197,4 +197,3 @@ class AugustDoorbellBinarySensor(BinarySensorDevice):
         return '{:s}_{:s}'.format(self._doorbell.device_id,
                                   SENSOR_TYPES_DOORBELL[self._sensor_type][0]
                                   .lower())
-

--- a/homeassistant/components/august/binary_sensor.py
+++ b/homeassistant/components/august/binary_sensor.py
@@ -152,7 +152,6 @@ class AugustDoorBinarySensor(BinarySensorDevice):
                                   .lower())
 
 
-
 class AugustDoorbellBinarySensor(BinarySensorDevice):
     """Representation of an August binary sensor."""
 

--- a/homeassistant/components/august/camera.py
+++ b/homeassistant/components/august/camera.py
@@ -74,3 +74,8 @@ class AugustCamera(Camera):
                                                timeout=self._timeout).content
 
         return self._image_content
+
+    @property
+    def unique_id(self) -> str:
+        """Get the unique id of the camera."""
+        return '{:s}_camera'.format(self._doorbell.device_id)

--- a/homeassistant/components/august/lock.py
+++ b/homeassistant/components/august/lock.py
@@ -100,4 +100,3 @@ class AugustLock(LockDevice):
     def unique_id(self) -> str:
         """Get the unique id of the lock."""
         return '{:s}_lock'.format(self._lock.device_id)
-

--- a/homeassistant/components/august/lock.py
+++ b/homeassistant/components/august/lock.py
@@ -95,3 +95,9 @@ class AugustLock(LockDevice):
         return {
             ATTR_BATTERY_LEVEL: self._lock_detail.battery_level,
         }
+
+    @property
+    def unique_id(self) -> str:
+        """Get the unique id of the lock."""
+        return '{:s}_lock'.format(self._lock.device_id)
+


### PR DESCRIPTION
## Description:
This sets up unique ids on the august devices to allow for the devices to be used in the registry and support renames of them.  This should be backwards compatible and does not effect the entity_id and name.

## Example entry for `configuration.yaml` (if applicable):
```yaml
august:
  login_method: email
  username: !secret august_user
  password: !secret august_password
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
