### PR TITLE
Added more language options

### DIFF
--- a/homeassistant/components/sensor/darksky.py
+++ b/homeassistant/components/sensor/darksky.py
@@ -162,9 +162,9 @@ CONDITION_PICTURES = {
 # Language Supported Codes
 LANGUAGE_CODES = [
     'ar', 'az', 'be', 'bg', 'bs', 'ca', 'cs', 'da', 'de', 'el', 'en', 'es',
-    'et', 'fi', 'fr', 'hr', 'hu', 'id', 'is', 'it', 'ja', 'ka', 'kw', 'nb',
-    'nl', 'pl', 'pt', 'ro', 'ru', 'sk', 'sl', 'sr', 'sv', 'tet', 'tr', 'uk',
-    'x-pig-latin', 'zh', 'zh-tw',
+    'et', 'fi', 'fr', 'he', 'hr', 'hu', 'id', 'is', 'it', 'ja', 'ka', 'ko',
+    'kw', 'lv', 'nb', 'nl', 'pl', 'pt', 'ro', 'ru', 'sk', 'sl', 'sr', 'sv',
+    'tet', 'tr', 'uk', 'x-pig-latin', 'zh', 'zh-tw',
 ]
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({


### PR DESCRIPTION
## Description:
This is a Small PR, Just added 3 more languages that have added to [Dark Sky API](https://darksky.net/dev/docs) : 
* he: Hebrew
* ko: Korean
* lv: Latvian
To be used in the Dark Sky sensor (at sensor.dark_sky_summary_X ,  sensor.dark_sky_daily_summary )
 I am using this new language in a custom-UI card 
<img width="516" alt="screen shot 2019-02-09 at 11 17 28" src="https://user-images.githubusercontent.com/10164935/52519508-db5a7100-2c64-11e9-812c-7f0896901404.png">
language: he
<img width="605" alt="screen shot 2019-02-09 at 11 43 44" src="https://user-images.githubusercontent.com/10164935/52519505-d72e5380-2c64-11e9-93da-21f37f7ce4d0.png">
language: ko 
<img width="605" alt="screen shot 2019-02-09 at 11 45 02" src="https://user-images.githubusercontent.com/10164935/52519528-fb8a3000-2c64-11e9-8c4d-f6280488a875.png">
language: lv 
<img width="658" alt="screen shot 2019-02-09 at 11 46 31" src="https://user-images.githubusercontent.com/10164935/52519530-00e77a80-2c65-11e9-9167-410c41033ec1.png">


**Related issue (if applicable):** It's not a bug, it's a feature :)

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8455
## Example entry for `configuration.yaml` (if applicable):
```yaml
sensor:
  - platform: darksky
    api_key: YOUR_API_KEY
    language: he #New Added- he: Hebrew / ko: Korean / lv: Latvian
    forecast:
      - 0
    monitored_conditions:
      - summary
      - icon
      - temperature
```

## Checklist:
  - [x] The code change is tested and works locally -all 3 languages working great!
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

~~If the code communicates with devices, web services, or third-party tools:~~
  ~~-  New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).~~
  ~~-  New dependencies are only imported inside functions that use them ([example][ex-import]).~~
  ~~-  New or updated dependencies have been added to `requirements_all.txt` by running`script/gen_requirements_all.py`.~~
  ~~-  New files were added to `.coveragerc`.~~

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
