### PR TITLE
flake8 and pylint import marker and related cleanups

### DIFF
--- a/homeassistant/__main__.py
+++ b/homeassistant/__main__.py
@@ -7,7 +7,8 @@ import platform
 import subprocess
 import sys
 import threading
-from typing import List, Dict, Any  # noqa pylint: disable=unused-import
+from typing import Any, List
+from typing import Dict  # pylint: disable=unused-import
 
 
 from homeassistant import monkey_patch

--- a/homeassistant/auth/auth_store.py
+++ b/homeassistant/auth/auth_store.py
@@ -4,7 +4,7 @@ from collections import OrderedDict
 from datetime import timedelta
 import hmac
 from logging import getLogger
-from typing import Any, Dict, List, Optional  # noqa: F401
+from typing import Any, Dict, List, Optional
 
 from homeassistant.auth.const import ACCESS_TOKEN_EXPIRATION
 from homeassistant.core import HomeAssistant, callback
@@ -13,7 +13,7 @@ from homeassistant.util import dt as dt_util
 from . import models
 from .const import GROUP_ID_ADMIN, GROUP_ID_READ_ONLY
 from .permissions import PermissionLookup, system_policies
-from .permissions.types import PolicyType  # noqa: F401
+from .permissions.types import PolicyType
 
 STORAGE_VERSION = 1
 STORAGE_KEY = 'auth'

--- a/homeassistant/auth/mfa_modules/totp.py
+++ b/homeassistant/auth/mfa_modules/totp.py
@@ -1,7 +1,7 @@
 """Time-based One Time Password auth module."""
 import logging
 from io import BytesIO
-from typing import Any, Dict, Optional, Tuple  # noqa: F401
+from typing import Any, Dict, Optional, Tuple
 
 import voluptuous as vol
 

--- a/homeassistant/auth/models.py
+++ b/homeassistant/auth/models.py
@@ -1,6 +1,6 @@
 """Auth models."""
 from datetime import datetime, timedelta
-from typing import Dict, List, NamedTuple, Optional  # noqa: F401
+from typing import Dict, List, NamedTuple, Optional
 import uuid
 
 import attr

--- a/homeassistant/auth/permissions/__init__.py
+++ b/homeassistant/auth/permissions/__init__.py
@@ -1,8 +1,6 @@
 """Permissions for Home Assistant."""
 import logging
-from typing import (  # noqa: F401
-    cast, Any, Callable, Dict, List, Mapping, Set, Tuple, Union,
-    TYPE_CHECKING)
+from typing import Any, Callable
 
 import voluptuous as vol
 

--- a/homeassistant/auth/permissions/entities.py
+++ b/homeassistant/auth/permissions/entities.py
@@ -1,6 +1,6 @@
 """Entity permissions."""
 from functools import wraps
-from typing import Callable, List, Union  # noqa: F401
+from typing import Callable, List, Union
 
 import voluptuous as vol
 

--- a/homeassistant/auth/permissions/merge.py
+++ b/homeassistant/auth/permissions/merge.py
@@ -1,6 +1,5 @@
 """Merging of policies."""
-from typing import (  # noqa: F401
-    cast, Dict, List, Set)
+from typing import cast, Dict, List, Set
 
 from .types import PolicyType, CategoryType
 

--- a/homeassistant/auth/providers/__init__.py
+++ b/homeassistant/auth/providers/__init__.py
@@ -16,7 +16,7 @@ from homeassistant.util.decorator import Registry
 
 from ..auth_store import AuthStore
 from ..const import MFA_SESSION_EXPIRATION
-from ..models import Credentials, User, UserMeta  # noqa: F401
+from ..models import Credentials, User, UserMeta
 
 _LOGGER = logging.getLogger(__name__)
 DATA_REQS = 'auth_prov_reqs_processed'

--- a/homeassistant/auth/providers/homeassistant.py
+++ b/homeassistant/auth/providers/homeassistant.py
@@ -3,7 +3,7 @@ import base64
 from collections import OrderedDict
 import logging
 
-from typing import Any, Dict, List, Optional, Set, cast  # noqa: F401
+from typing import Any, Dict, List, Optional, Set, cast
 
 import bcrypt
 import voluptuous as vol

--- a/homeassistant/auth/providers/legacy_api_password.py
+++ b/homeassistant/auth/providers/legacy_api_password.py
@@ -16,7 +16,7 @@ from .. import AuthManager
 from ..models import Credentials, UserMeta, User
 
 if TYPE_CHECKING:
-    from homeassistant.components.http import HomeAssistantHTTP  # noqa: F401
+    from homeassistant.components.http import HomeAssistantHTTP
 
 
 USER_SCHEMA = vol.Schema({

--- a/homeassistant/auth/providers/trusted_networks.py
+++ b/homeassistant/auth/providers/trusted_networks.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, Optional, cast
 
 import voluptuous as vol
 
-from homeassistant.components.http import HomeAssistantHTTP  # noqa: F401
+from homeassistant.components.http import HomeAssistantHTTP
 from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
 

--- a/homeassistant/components/cast/media_player.py
+++ b/homeassistant/components/cast/media_player.py
@@ -325,7 +325,7 @@ class CastDevice(MediaPlayerDevice):
 
     def __init__(self, cast_info):
         """Initialize the cast device."""
-        import pychromecast  # noqa: pylint: disable=unused-import
+        import pychromecast  # pylint: disable=unused-import
         self._cast_info = cast_info  # type: ChromecastInfo
         self._chromecast = None  # type: Optional[pychromecast.Chromecast]
         self.cast_status = None

--- a/homeassistant/components/daikin/__init__.py
+++ b/homeassistant/components/daikin/__init__.py
@@ -19,7 +19,7 @@ from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.util import Throttle
 
-from . import config_flow  # noqa  pylint_disable=unused-import
+from . import config_flow  # noqa
 from .const import KEY_HOST
 
 REQUIREMENTS = ['pydaikin==0.9']

--- a/homeassistant/components/device_tracker/bbox.py
+++ b/homeassistant/components/device_tracker/bbox.py
@@ -45,7 +45,7 @@ class BboxDeviceScanner(DeviceScanner):
 
     def __init__(self, config):
         """Get host from config."""
-        from typing import List  # noqa: pylint: disable=unused-import
+        from typing import List  # pylint: disable=unused-import
 
         self.host = config[CONF_HOST]
 

--- a/homeassistant/components/elkm1/__init__.py
+++ b/homeassistant/components/elkm1/__init__.py
@@ -12,11 +12,11 @@ import voluptuous as vol
 from homeassistant.const import (
     CONF_EXCLUDE, CONF_HOST, CONF_INCLUDE, CONF_PASSWORD,
     CONF_TEMPERATURE_UNIT, CONF_USERNAME)
-from homeassistant.core import HomeAssistant, callback  # noqa
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import discovery
 from homeassistant.helpers.entity import Entity
-from homeassistant.helpers.typing import ConfigType  # noqa
+from homeassistant.helpers.typing import ConfigType
 
 DOMAIN = "elkm1"
 

--- a/homeassistant/components/image_processing/tensorflow.py
+++ b/homeassistant/components/image_processing/tensorflow.py
@@ -100,8 +100,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         # Verify that the TensorFlow Object Detection API is pre-installed
         # pylint: disable=unused-import,unused-variable
         os.environ['TF_CPP_MIN_LOG_LEVEL'] = '2'
-        import tensorflow as tf # noqa
-        from object_detection.utils import label_map_util # noqa
+        import tensorflow as tf
+        from object_detection.utils import label_map_util
     except ImportError:
         # pylint: disable=line-too-long
         _LOGGER.error(

--- a/homeassistant/components/media_player/onkyo.py
+++ b/homeassistant/components/media_player/onkyo.py
@@ -6,8 +6,7 @@ https://home-assistant.io/components/media_player.onkyo/
 """
 import logging
 
-# pylint: disable=unused-import
-from typing import List  # noqa: F401
+from typing import List  # pylint: disable=unused-import
 
 import voluptuous as vol
 

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -13,7 +13,7 @@ import os
 import socket
 import ssl
 import time
-from typing import Any, Callable, List, Optional, Union, cast  # noqa: F401
+from typing import Any, Callable, List, Optional, Union  # noqa: F401
 
 import attr
 import requests.certs

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -13,7 +13,7 @@ import os
 import socket
 import ssl
 import time
-from typing import Any, Callable, List, Optional, Union  # noqa: F401
+from typing import Any, Callable, List, Optional, Union
 
 import attr
 import requests.certs

--- a/homeassistant/components/point/__init__.py
+++ b/homeassistant/components/point/__init__.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.util.dt import as_local, parse_datetime, utc_from_timestamp
 
-from . import config_flow  # noqa  pylint_disable=unused-import
+from . import config_flow
 from .const import (
     CONF_WEBHOOK_URL, DOMAIN, EVENT_RECEIVED, POINT_DISCOVERY_NEW,
     SCAN_INTERVAL, SIGNAL_UPDATE_ENTITY, SIGNAL_WEBHOOK)

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -15,7 +15,7 @@ import logging
 import queue
 import threading
 import time
-from typing import Any, Dict, Optional  # noqa: F401
+from typing import Any, Dict, Optional
 
 import voluptuous as vol
 

--- a/homeassistant/components/tellduslive/__init__.py
+++ b/homeassistant/components/tellduslive/__init__.py
@@ -16,7 +16,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.event import async_call_later
 
-from . import config_flow  # noqa  pylint_disable=unused-import
+from . import config_flow  # noqa
 from .const import (
     CONF_HOST, DOMAIN, KEY_HOST, KEY_SCAN_INTERVAL, KEY_SESSION,
     MIN_UPDATE_INTERVAL, NOT_SO_PRIVATE_KEY, PUBLIC_KEY, SCAN_INTERVAL,

--- a/homeassistant/components/tradfri/__init__.py
+++ b/homeassistant/components/tradfri/__init__.py
@@ -16,7 +16,7 @@ from homeassistant.util.json import load_json
 from .const import (
     CONF_IMPORT_GROUPS, CONF_IDENTITY, CONF_HOST, CONF_KEY, CONF_GATEWAY_ID)
 
-from . import config_flow  # noqa  pylint_disable=unused-import
+from . import config_flow  # noqa
 
 REQUIREMENTS = ['pytradfri[async]==6.0.1']
 

--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -8,7 +8,7 @@ import asyncio
 from datetime import timedelta
 import logging
 from urllib.parse import urlparse
-from typing import Dict  # noqa: F401 pylint: disable=unused-import
+from typing import Dict  # pylint: disable=unused-import
 
 import voluptuous as vol
 

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -6,8 +6,9 @@ import logging
 import os
 import re
 import shutil
-from typing import (  # noqa: F401 pylint: disable=unused-import
-    Any, Tuple, Optional, Dict, List, Union, Callable, Sequence, Set)
+from typing import (
+    Any, Callable, Dict, Optional, Sequence, Tuple, Union)
+from typing import List, Set  # pylint: disable=unused-import
 from types import ModuleType
 import voluptuous as vol
 from voluptuous.humanize import humanize_error

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -117,7 +117,7 @@ the flow from the config panel.
 """
 import logging
 import uuid
-from typing import Set, Optional, List  # noqa pylint: disable=unused-import
+from typing import Set, Optional, List  # pylint: disable=unused-import
 
 from homeassistant import data_entry_flow
 from homeassistant.core import callback, HomeAssistant

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -117,7 +117,7 @@ the flow from the config panel.
 """
 import logging
 import uuid
-from typing import Set, Optional, List, Dict  # noqa pylint: disable=unused-import
+from typing import Set, Optional, List  # noqa pylint: disable=unused-import
 
 from homeassistant import data_entry_flow
 from homeassistant.core import callback, HomeAssistant

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -20,7 +20,7 @@ import uuid
 from types import MappingProxyType
 from typing import (  # noqa: F401 pylint: disable=unused-import
     Optional, Any, Callable, List, TypeVar, Dict, Coroutine, Set,
-    TYPE_CHECKING, Awaitable, Iterator)
+    TYPE_CHECKING, Awaitable)
 
 from async_timeout import timeout
 import attr

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -43,12 +43,12 @@ from homeassistant.util.async_ import (
 from homeassistant import util
 import homeassistant.util.dt as dt_util
 from homeassistant.util import location, slugify
-from homeassistant.util.unit_system import UnitSystem, METRIC_SYSTEM  # NOQA
+from homeassistant.util.unit_system import UnitSystem, METRIC_SYSTEM
 
 # Typing imports that create a circular dependency
 # pylint: disable=using-constant-test
 if TYPE_CHECKING:
-    from homeassistant.config_entries import ConfigEntries  # noqa
+    from homeassistant.config_entries import ConfigEntries
 
 # pylint: disable=invalid-name
 T = TypeVar('T')

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -18,7 +18,7 @@ from time import monotonic
 import uuid
 
 from types import MappingProxyType
-from typing import (  # noqa: F401 pylint: disable=unused-import
+from typing import (  # pylint: disable=unused-import
     Optional, Any, Callable, List, TypeVar, Dict, Coroutine, Set,
     TYPE_CHECKING, Awaitable)
 

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -1,6 +1,6 @@
 """Classes to help gather user submissions."""
 import logging
-from typing import Dict, Any, Callable, Hashable, List, Optional  # noqa pylint: disable=unused-import
+from typing import Dict, Any, Callable, Hashable, List, Optional
 import uuid
 import voluptuous as vol
 from .core import callback, HomeAssistant

--- a/homeassistant/helpers/aiohttp_client.py
+++ b/homeassistant/helpers/aiohttp_client.py
@@ -1,9 +1,8 @@
 """Helper for aiohttp webclient stuff."""
 import asyncio
 import sys
-from ssl import SSLContext  # noqa: F401
-from typing import Any, Awaitable, Optional, cast
-from typing import Union  # noqa: F401
+from ssl import SSLContext
+from typing import Any, Awaitable, Optional, Union, cast
 
 import aiohttp
 from aiohttp.hdrs import USER_AGENT, CONTENT_TYPE

--- a/homeassistant/helpers/area_registry.py
+++ b/homeassistant/helpers/area_registry.py
@@ -2,8 +2,7 @@
 import logging
 import uuid
 from collections import OrderedDict
-from typing import MutableMapping  # noqa: F401
-from typing import Iterable, Optional, cast
+from typing import Iterable, MutableMapping, Optional, cast
 
 import attr
 

--- a/homeassistant/helpers/entity_values.py
+++ b/homeassistant/helpers/entity_values.py
@@ -2,7 +2,7 @@
 from collections import OrderedDict
 import fnmatch
 import re
-from typing import Any, Dict, Optional, Pattern  # noqa: F401
+from typing import Any, Dict, Optional, Pattern
 
 from homeassistant.core import split_entity_id
 

--- a/homeassistant/helpers/restore_state.py
+++ b/homeassistant/helpers/restore_state.py
@@ -2,7 +2,7 @@
 import asyncio
 import logging
 from datetime import timedelta, datetime
-from typing import Any, Dict, List, Set, Optional  # noqa  pylint_disable=unused-import
+from typing import Any, Dict, List, Set, Optional
 
 from homeassistant.core import (
     HomeAssistant, callback, State, CoreState, valid_entity_id)
@@ -13,7 +13,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.json import JSONEncoder
-from homeassistant.helpers.storage import Store  # noqa  pylint_disable=unused-import
+from homeassistant.helpers.storage import Store
 
 DATA_RESTORE_STATE_TASK = 'restore_state_task'
 

--- a/homeassistant/helpers/state.py
+++ b/homeassistant/helpers/state.py
@@ -5,8 +5,8 @@ import json
 import logging
 from collections import defaultdict
 from types import TracebackType
-from typing import (  # noqa: F401 pylint: disable=unused-import
-    Awaitable, Dict, Iterable, List, Optional, Tuple, Type, Union)
+from typing import Iterable, List, Optional, Type, Union
+from typing import Awaitable, Dict, Tuple  # pylint: disable=unused-import
 
 from homeassistant.loader import bind_hass
 import homeassistant.util.dt as dt_util

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -15,14 +15,14 @@ import importlib
 import logging
 import sys
 from types import ModuleType
-from typing import Optional, Set, TYPE_CHECKING, Callable, Any, TypeVar  # noqa pylint: disable=unused-import
+from typing import Optional, Set, TYPE_CHECKING, Callable, Any, TypeVar
 
 from homeassistant.const import PLATFORM_FORMAT
 
 # Typing imports that create a circular dependency
 # pylint: disable=using-constant-test,unused-import
 if TYPE_CHECKING:
-    from homeassistant.core import HomeAssistant  # NOQA
+    from homeassistant.core import HomeAssistant
 
 CALLABLE_T = TypeVar('CALLABLE_T', bound=Callable)  # noqa pylint: disable=invalid-name
 

--- a/homeassistant/util/__init__.py
+++ b/homeassistant/util/__init__.py
@@ -10,7 +10,7 @@ import string
 from functools import wraps
 from types import MappingProxyType
 from typing import (Any, Optional, TypeVar, Callable, KeysView, Union,  # noqa
-                    Iterable, List, Dict, Iterator, Coroutine, MutableSet)
+                    Iterable, Coroutine)
 
 import slugify as unicode_slug
 

--- a/homeassistant/util/__init__.py
+++ b/homeassistant/util/__init__.py
@@ -9,7 +9,7 @@ import random
 import string
 from functools import wraps
 from types import MappingProxyType
-from typing import (Any, Optional, TypeVar, Callable, KeysView, Union,  # noqa
+from typing import (Any, Optional, TypeVar, Callable, KeysView, Union,
                     Iterable, Coroutine)
 
 import slugify as unicode_slug

--- a/homeassistant/util/dt.py
+++ b/homeassistant/util/dt.py
@@ -1,12 +1,12 @@
 """Helper methods to handle the time in Home Assistant."""
 import datetime as dt
 import re
-from typing import (Any, Union, Optional,  # noqa pylint: disable=unused-import
-                    Tuple, List, cast, Dict)
+from typing import Any, List, Optional, Tuple, Union, cast
+from typing import Dict  # pylint: disable=unused-import
 
 import pytz
 import pytz.exceptions as pytzexceptions
-import pytz.tzinfo as pytzinfo  # noqa pylint: disable=unused-import
+import pytz.tzinfo as pytzinfo  # pylint: disable=unused-import
 
 from homeassistant.const import MATCH_ALL
 


### PR DESCRIPTION
## Description:

Cleanups related to flake and pylint markers on imports. More to follow later. 

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
