### PR TITLE
add fan support for spider thermostats

### DIFF
--- a/homeassistant/components/spider/__init__.py
+++ b/homeassistant/components/spider/__init__.py
@@ -14,7 +14,7 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.discovery import load_platform
 
-REQUIREMENTS = ['spiderpy==1.2.0']
+REQUIREMENTS = ['spiderpy==1.3.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/spider/climate.py
+++ b/homeassistant/components/spider/climate.py
@@ -42,14 +42,14 @@ SPIDER_STATE_TO_HA = {value: key for key, value in HA_STATE_TO_SPIDER.items()}
 _LOGGER = logging.getLogger(__name__)
 
 
-def setup_platform(hass, config, add_devices, discovery_info=None):
+def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Spider thermostat."""
     if discovery_info is None:
         return
 
     devices = [SpiderThermostat(hass.data[SPIDER_DOMAIN]['controller'], device)
                for device in hass.data[SPIDER_DOMAIN]['thermostats']]
-    add_devices(devices, True)
+    add_entities(devices, True)
 
 
 class SpiderThermostat(ClimateDevice):
@@ -66,10 +66,10 @@ class SpiderThermostat(ClimateDevice):
         supports = SUPPORT_TARGET_TEMPERATURE
 
         if self.thermostat.has_operation_mode:
-            supports = supports | SUPPORT_OPERATION_MODE
+            supports |= SUPPORT_OPERATION_MODE
 
         if self.thermostat.has_fan_mode:
-            supports = supports | SUPPORT_FAN_MODE
+            supports |= SUPPORT_FAN_MODE
 
         return supports
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1573,7 +1573,7 @@ somecomfort==0.5.2
 speedtest-cli==2.0.2
 
 # homeassistant.components.spider
-spiderpy==1.2.0
+spiderpy==1.3.1
 
 # homeassistant.components.sensor.spotcrime
 spotcrime==1.0.3


### PR DESCRIPTION
## Description:
This change add fan support to the spider thermostats. It also resolves a caching issue with the power plugs.

Initial discussion happened here in the library itself:
https://github.com/peternijssen/spiderpy/issues/3

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** https://github.com/home-assistant/home-assistant.io/pull/8456

## Example entry for `configuration.yaml` (if applicable):
```yaml
spider:
  username: username
  password: password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.



[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
