### PR TITLE
Update ZHA helpers

### DIFF
--- a/homeassistant/components/zha/core/helpers.py
+++ b/homeassistant/components/zha/core/helpers.py
@@ -6,7 +6,6 @@ https://home-assistant.io/components/zha/
 """
 import asyncio
 import logging
-from concurrent.futures._base import TimeoutError as Timeout
 
 from .const import (
     DEFAULT_BAUDRATE, REPORT_CONFIG_MAX_INT, REPORT_CONFIG_MIN_INT,
@@ -49,7 +48,7 @@ async def bind_cluster(entity_id, cluster):
         _LOGGER.debug(
             "%s: bound  '%s' cluster: %s", entity_id, cluster_name, res[0]
         )
-    except (DeliveryError, Timeout) as ex:
+    except (DeliveryError, TimeoutError) as ex:
         _LOGGER.debug(
             "%s: Failed to bind '%s' cluster: %s",
             entity_id, cluster_name, str(ex)
@@ -69,8 +68,10 @@ async def configure_reporting(entity_id, cluster, attr,
     from zigpy.exceptions import DeliveryError
 
     attr_name = cluster.attributes.get(attr, [attr])[0]
-    attr_id = (attr, get_attr_id_by_name(cluster, attr_name))[
-        isinstance(attr, str)]
+    attr_id = (
+        attr,
+        get_attr_id_by_name(cluster, attr_name)
+        )[isinstance(attr, str)]
     cluster_name = cluster.ep_attribute
     kwargs = {}
     if manufacturer:
@@ -84,7 +85,7 @@ async def configure_reporting(entity_id, cluster, attr,
             entity_id, attr_name, cluster_name, min_report, max_report,
             reportable_change, res
         )
-    except (DeliveryError, Timeout) as ex:
+    except (DeliveryError, TimeoutError) as ex:
         _LOGGER.debug(
             "%s: failed to set reporting for '%s' attr on '%s' cluster: %s",
             entity_id, attr_name, cluster_name, str(ex)

--- a/homeassistant/components/zha/core/helpers.py
+++ b/homeassistant/components/zha/core/helpers.py
@@ -6,7 +6,7 @@ https://home-assistant.io/components/zha/
 """
 import asyncio
 import logging
-
+from concurrent.futures import TimeoutError as Timeout
 from .const import (
     DEFAULT_BAUDRATE, REPORT_CONFIG_MAX_INT, REPORT_CONFIG_MIN_INT,
     REPORT_CONFIG_RPT_CHANGE, RadioType)
@@ -48,7 +48,7 @@ async def bind_cluster(entity_id, cluster):
         _LOGGER.debug(
             "%s: bound  '%s' cluster: %s", entity_id, cluster_name, res[0]
         )
-    except (DeliveryError, TimeoutError) as ex:
+    except (DeliveryError, Timeout) as ex:
         _LOGGER.debug(
             "%s: Failed to bind '%s' cluster: %s",
             entity_id, cluster_name, str(ex)
@@ -87,7 +87,7 @@ async def configure_reporting(entity_id, cluster, attr,
             entity_id, attr_name, cluster_name, min_report, max_report,
             reportable_change, res
         )
-    except (DeliveryError, TimeoutError) as ex:
+    except (DeliveryError, Timeout) as ex:
         _LOGGER.debug(
             "%s: failed to set reporting for '%s' attr on '%s' cluster: %s",
             entity_id, attr_name, cluster_name, str(ex)

--- a/homeassistant/components/zha/core/helpers.py
+++ b/homeassistant/components/zha/core/helpers.py
@@ -68,10 +68,12 @@ async def configure_reporting(entity_id, cluster, attr,
     from zigpy.exceptions import DeliveryError
 
     attr_name = cluster.attributes.get(attr, [attr])[0]
-    attr_id = (
-        attr,
-        get_attr_id_by_name(cluster, attr_name)
-        )[isinstance(attr, str)]
+
+    if isinstance(attr, str):
+        attr_id = get_attr_id_by_name(cluster, attr_name)
+    else:
+        attr_id = attr
+
     cluster_name = cluster.ep_attribute
     kwargs = {}
     if manufacturer:

--- a/homeassistant/components/zha/core/listeners.py
+++ b/homeassistant/components/zha/core/listeners.py
@@ -15,7 +15,7 @@ from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from .helpers import (
     bind_configure_reporting, construct_unique_id,
-    safe_read, get_attr_id_by_name)
+    safe_read, get_attr_id_by_name, bind_cluster)
 from .const import (
     CLUSTER_REPORT_CONFIGS, REPORT_CONFIG_DEFAULT, SIGNAL_ATTR_UPDATED,
     SIGNAL_MOVE_LEVEL, SIGNAL_SET_LEVEL, SIGNAL_STATE_ATTR, ATTR_LEVEL
@@ -373,18 +373,8 @@ class IASZoneListener(ClusterListener):
         from zigpy.exceptions import DeliveryError
         _LOGGER.debug("%s: started IASZoneListener configuration",
                       self._unique_id)
-        try:
-            res = await self._cluster.bind()
-            _LOGGER.debug(
-                "%s: bound  '%s' cluster: %s",
-                self.unique_id, self._cluster.ep_attribute, res[0]
-            )
-        except DeliveryError as ex:
-            _LOGGER.debug(
-                "%s: Failed to bind '%s' cluster: %s",
-                self.unique_id, self._cluster.ep_attribute, str(ex)
-            )
 
+        await bind_cluster(self.unique_id, self._cluster)
         ieee = self._cluster.endpoint.device.application.ieee
 
         try:


### PR DESCRIPTION
This PR catches an additional exception type during bind and configure reporting operations and it also allows attribute ids to be used in addition to attr names during configure reporting.