### PR TITLE
HomematicIP fix cover direction

### DIFF
--- a/homeassistant/components/homematicip_cloud/cover.py
+++ b/homeassistant/components/homematicip_cloud/cover.py
@@ -15,6 +15,8 @@ DEPENDENCIES = ['homematicip_cloud']
 
 _LOGGER = logging.getLogger(__name__)
 
+HMIP_COVER_OPEN = 0
+HMIP_COVER_CLOSED = 1
 
 async def async_setup_platform(
         hass, config, async_add_entities, discovery_info=None):
@@ -47,23 +49,24 @@ class HomematicipCoverShutter(HomematicipGenericDevice, CoverDevice):
     async def async_set_cover_position(self, **kwargs):
         """Move the cover to a specific position."""
         position = kwargs[ATTR_POSITION]
-        level = position / 100.0
-        await self._device.set_shutter_level(1-level)
+        # HmIP cover is closed:1 -> open:0
+        level = 1 - position / 100.0
+        await self._device.set_shutter_level(level)
 
     @property
     def is_closed(self):
         """Return if the cover is closed."""
         if self._device.shutterLevel is not None:
-            return self._device.shutterLevel == 1
+            return self._device.shutterLevel == HMIP_COVER_CLOSED
         return None
 
     async def async_open_cover(self, **kwargs):
         """Open the cover."""
-        await self._device.set_shutter_level(0)
+        await self._device.set_shutter_level(HMIP_COVER_OPEN)
 
     async def async_close_cover(self, **kwargs):
         """Close the cover."""
-        await self._device.set_shutter_level(1)
+        await self._device.set_shutter_level(HMIP_COVER_CLOSED)
 
     async def async_stop_cover(self, **kwargs):
         """Stop the device if in motion."""

--- a/homeassistant/components/homematicip_cloud/cover.py
+++ b/homeassistant/components/homematicip_cloud/cover.py
@@ -18,6 +18,7 @@ _LOGGER = logging.getLogger(__name__)
 HMIP_COVER_OPEN = 0
 HMIP_COVER_CLOSED = 1
 
+
 async def async_setup_platform(
         hass, config, async_add_entities, discovery_info=None):
     """Set up the HomematicIP Cloud cover devices."""

--- a/homeassistant/components/homematicip_cloud/cover.py
+++ b/homeassistant/components/homematicip_cloud/cover.py
@@ -48,22 +48,22 @@ class HomematicipCoverShutter(HomematicipGenericDevice, CoverDevice):
         """Move the cover to a specific position."""
         position = kwargs[ATTR_POSITION]
         level = position / 100.0
-        await self._device.set_shutter_level(level)
+        await self._device.set_shutter_level(1-level)
 
     @property
     def is_closed(self):
         """Return if the cover is closed."""
         if self._device.shutterLevel is not None:
-            return self._device.shutterLevel == 0
+            return self._device.shutterLevel == 1
         return None
 
     async def async_open_cover(self, **kwargs):
         """Open the cover."""
-        await self._device.set_shutter_level(1)
+        await self._device.set_shutter_level(0)
 
     async def async_close_cover(self, **kwargs):
         """Close the cover."""
-        await self._device.set_shutter_level(0)
+        await self._device.set_shutter_level(1)
 
     async def async_stop_cover(self, **kwargs):
         """Stop the device if in motion."""


### PR DESCRIPTION
## Description:
Fix for the inverted cover direction.

**Related issue (if applicable): see comments: https://github.com/home-assistant/home-assistant/pull/19794#issuecomment-461784744

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
