### PR TITLE
Teleinfo

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -552,6 +552,7 @@ omit =
     homeassistant/components/sensor/tank_utility.py
     homeassistant/components/sensor/tautulli.py
     homeassistant/components/sensor/ted5000.py
+    homeassistant/components/sensor/teleinfo.py
     homeassistant/components/sensor/temper.py
     homeassistant/components/sensor/thermoworks_smoke.py
     homeassistant/components/sensor/time_date.py

--- a/homeassistant/components/august/binary_sensor.py
+++ b/homeassistant/components/august/binary_sensor.py
@@ -181,4 +181,4 @@ class AugustDoorbellBinarySensor(BinarySensorDevice):
         """Get the latest state of the sensor."""
         state_provider = SENSOR_TYPES_DOORBELL[self._sensor_type][2]
         self._state = state_provider(self._data, self._doorbell)
-        self._available = self._state is not None
+        self._available = self._doorbell.is_online

--- a/homeassistant/components/homematic/__init__.py
+++ b/homeassistant/components/homematic/__init__.py
@@ -90,7 +90,7 @@ HM_DEVICE_TYPES = {
         'IPShutterContact', 'HMWIOSwitch', 'MaxShutterContact', 'Rain',
         'WiredSensor', 'PresenceIP', 'IPWeatherSensor', 'IPPassageSensor',
         'SmartwareMotion', 'IPWeatherSensorPlus', 'MotionIPV2', 'WaterIP',
-        'IPMultiIO'],
+        'IPMultiIO', 'TiltIP'],
     DISCOVER_COVER: ['Blind', 'KeyBlind', 'IPKeyBlind', 'IPKeyBlindTilt'],
     DISCOVER_LOCKS: ['KeyMatic']
 }

--- a/homeassistant/components/light/rflink.py
+++ b/homeassistant/components/light/rflink.py
@@ -186,6 +186,14 @@ class DimmableRflinkLight(SwitchableRflinkDevice, Light):
         return self._brightness
 
     @property
+    def device_state_attributes(self):
+        """Return the device state attributes."""
+        attr = {}
+        if self._brightness is not None:
+            attr[ATTR_BRIGHTNESS] = self._brightness
+        return attr
+
+    @property
     def supported_features(self):
         """Flag supported features."""
         return SUPPORT_BRIGHTNESS
@@ -238,6 +246,14 @@ class HybridRflinkLight(SwitchableRflinkDevice, Light):
     def brightness(self):
         """Return the brightness of this light between 0..255."""
         return self._brightness
+
+    @property
+    def device_state_attributes(self):
+        """Return the device state attributes."""
+        attr = {}
+        if self._brightness is not None:
+            attr[ATTR_BRIGHTNESS] = self._brightness
+        return attr
 
     @property
     def supported_features(self):

--- a/homeassistant/components/mqtt/camera.py
+++ b/homeassistant/components/mqtt/camera.py
@@ -110,7 +110,8 @@ class MqttCamera(MqttDiscoveryUpdate, Camera):
             self.hass, self._sub_state,
             {'state_topic': {'topic': self._config.get(CONF_TOPIC),
                              'msg_callback': message_received,
-                             'qos': self._qos}})
+                             'qos': self._qos,
+                             'encoding': None}})
 
     async def async_will_remove_from_hass(self):
         """Unsubscribe when removed."""

--- a/homeassistant/components/person/__init__.py
+++ b/homeassistant/components/person/__init__.py
@@ -4,26 +4,37 @@ Support for tracking people.
 For more details about this component, please refer to the documentation.
 https://home-assistant.io/components/person/
 """
+from collections import OrderedDict
 import logging
+import uuid
 
 import voluptuous as vol
 
 from homeassistant.components.device_tracker import (
     DOMAIN as DEVICE_TRACKER_DOMAIN)
 from homeassistant.const import (
-    ATTR_ID, ATTR_LATITUDE, ATTR_LONGITUDE, CONF_ID, CONF_NAME)
+    ATTR_ID, ATTR_LATITUDE, ATTR_LONGITUDE, CONF_ID, CONF_NAME,
+    EVENT_HOMEASSISTANT_START)
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.storage import Store
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.event import async_track_state_change
 from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.components import websocket_api
+from homeassistant.helpers.typing import HomeAssistantType, ConfigType
+from homeassistant.util import dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
+ATTR_EDITABLE = 'editable'
 ATTR_SOURCE = 'source'
 ATTR_USER_ID = 'user_id'
 CONF_DEVICE_TRACKERS = 'device_trackers'
 CONF_USER_ID = 'user_id'
 DOMAIN = 'person'
+STORAGE_KEY = DOMAIN
+STORAGE_VERSION = 1
+SAVE_DELAY = 10
 
 PERSON_SCHEMA = vol.Schema({
     vol.Required(CONF_ID): cv.string,
@@ -34,30 +45,161 @@ PERSON_SCHEMA = vol.Schema({
 })
 
 CONFIG_SCHEMA = vol.Schema({
-    DOMAIN: vol.All(cv.ensure_list, [PERSON_SCHEMA])
+    vol.Optional(DOMAIN): vol.Any(vol.All(cv.ensure_list, [PERSON_SCHEMA]), {})
 }, extra=vol.ALLOW_EXTRA)
 
+_UNDEF = object()
 
-async def async_setup(hass, config):
+
+class PersonManager:
+    """Manage person data."""
+
+    def __init__(self, hass: HomeAssistantType, component: EntityComponent,
+                 config_persons):
+        """Initialize person storage."""
+        self.hass = hass
+        self.component = component
+        self.store = Store(hass, STORAGE_VERSION, STORAGE_KEY)
+        self.storage_data = None
+
+        config_data = self.config_data = OrderedDict()
+        for conf in config_persons:
+            person_id = conf[CONF_ID]
+
+            if person_id in config_data:
+                _LOGGER.error("Found config user with duplicate ID: %s",
+                              person_id)
+                continue
+
+            config_data[person_id] = conf
+
+    @property
+    def storage_persons(self):
+        """Iterate over persons stored in storage."""
+        return list(self.storage_data.values())
+
+    @property
+    def config_persons(self):
+        """Iterate over persons stored in config."""
+        return list(self.config_data.values())
+
+    async def async_initialize(self):
+        """Get the person data."""
+        raw_storage = await self.store.async_load()
+
+        if raw_storage is None:
+            raw_storage = {
+                'persons': []
+            }
+
+        storage_data = self.storage_data = OrderedDict()
+
+        for person in raw_storage['persons']:
+            storage_data[person[CONF_ID]] = person
+
+        entities = []
+
+        for person_conf in self.config_data.values():
+            person_id = person_conf[CONF_ID]
+            user_id = person_conf.get(CONF_USER_ID)
+
+            if (user_id is not None
+                    and await self.hass.auth.async_get_user(user_id) is None):
+                _LOGGER.error(
+                    "Invalid user_id detected for person %s", person_id)
+                continue
+
+            entities.append(Person(person_conf, False))
+
+        for person_conf in storage_data.values():
+            if person_conf[CONF_ID] in self.config_data:
+                _LOGGER.error(
+                    "Skipping adding person from storage with same ID as"
+                    " configuration.yaml entry: %s", person_id)
+                continue
+
+            entities.append(Person(person_conf, True))
+
+        if entities:
+            await self.component.async_add_entities(entities)
+
+    async def async_create_person(self, *, name, device_trackers=None,
+                                  user_id=None):
+        """Create a new person."""
+        person = {
+            CONF_ID: uuid.uuid4().hex,
+            CONF_NAME: name,
+            CONF_USER_ID: user_id,
+            CONF_DEVICE_TRACKERS: device_trackers,
+        }
+        self.storage_data[person[CONF_ID]] = person
+        self._async_schedule_save()
+        await self.component.async_add_entities([Person(person, True)])
+        return person
+
+    async def async_update_person(self, person_id, *, name=_UNDEF,
+                                  device_trackers=_UNDEF, user_id=_UNDEF):
+        """Update person."""
+        if person_id not in self.storage_data:
+            raise ValueError("Invalid person specified.")
+
+        changes = {
+            key: value for key, value in (
+                ('name', name),
+                ('device_trackers', device_trackers),
+                ('user_id', user_id)
+            ) if value is not _UNDEF
+        }
+
+        self.storage_data[person_id].update(changes)
+        self._async_schedule_save()
+
+        for entity in self.component.entities:
+            if entity.unique_id == person_id:
+                entity.person_updated()
+                break
+
+        return self.storage_data[person_id]
+
+    async def async_delete_person(self, person_id):
+        """Delete person."""
+        if person_id not in self.storage_data:
+            raise ValueError("Invalid person specified.")
+
+        self.storage_data.pop(person_id)
+        self._async_schedule_save()
+        ent_reg = await self.hass.helpers.entity_registry.async_get_registry()
+
+        for entity in self.component.entities:
+            if entity.unique_id == person_id:
+                await entity.async_remove()
+                ent_reg.async_remove(entity.entity_id)
+                break
+
+    @callback
+    def _async_schedule_save(self) -> None:
+        """Schedule saving the area registry."""
+        self.store.async_delay_save(self._data_to_save, SAVE_DELAY)
+
+    @callback
+    def _data_to_save(self) -> dict:
+        """Return data of area registry to store in a file."""
+        return {
+            'persons': list(self.storage_data.values())
+        }
+
+
+async def async_setup(hass: HomeAssistantType, config: ConfigType):
     """Set up the person component."""
     component = EntityComponent(_LOGGER, DOMAIN, hass)
-    conf = config[DOMAIN]
-    entities = []
-    for person_conf in conf:
-        user_id = person_conf.get(CONF_USER_ID)
-        if (user_id is not None
-                and await hass.auth.async_get_user(user_id) is None):
-            _LOGGER.error(
-                "Invalid user_id detected for person %s",
-                person_conf[CONF_NAME])
-            continue
-        entities.append(Person(person_conf, user_id))
+    conf_persons = config.get(DOMAIN, [])
+    manager = hass.data[DOMAIN] = PersonManager(hass, component, conf_persons)
+    await manager.async_initialize()
 
-    if not entities:
-        _LOGGER.error("No persons could be set up")
-        return False
-
-    await component.async_add_entities(entities)
+    websocket_api.async_register_command(hass, ws_list_person)
+    websocket_api.async_register_command(hass, ws_create_person)
+    websocket_api.async_register_command(hass, ws_update_person)
+    websocket_api.async_register_command(hass, ws_delete_person)
 
     return True
 
@@ -65,21 +207,20 @@ async def async_setup(hass, config):
 class Person(RestoreEntity):
     """Represent a tracked person."""
 
-    def __init__(self, config, user_id):
+    def __init__(self, config, editable):
         """Set up person."""
-        self._id = config[CONF_ID]
+        self._config = config
+        self._editable = editable
         self._latitude = None
         self._longitude = None
-        self._name = config[CONF_NAME]
         self._source = None
         self._state = None
-        self._trackers = config.get(CONF_DEVICE_TRACKERS)
-        self._user_id = user_id
+        self._unsub_track_device = None
 
     @property
     def name(self):
         """Return the name of the entity."""
-        return self._name
+        return self._config[CONF_NAME]
 
     @property
     def should_poll(self):
@@ -97,22 +238,25 @@ class Person(RestoreEntity):
     @property
     def state_attributes(self):
         """Return the state attributes of the person."""
-        data = {}
-        data[ATTR_ID] = self._id
+        data = {
+            ATTR_EDITABLE: self._editable,
+            ATTR_ID: self.unique_id,
+        }
         if self._latitude is not None:
             data[ATTR_LATITUDE] = round(self._latitude, 5)
         if self._longitude is not None:
             data[ATTR_LONGITUDE] = round(self._longitude, 5)
         if self._source is not None:
             data[ATTR_SOURCE] = self._source
-        if self._user_id is not None:
-            data[ATTR_USER_ID] = self._user_id
+        user_id = self._config.get(CONF_USER_ID)
+        if user_id is not None:
+            data[ATTR_USER_ID] = user_id
         return data
 
     @property
     def unique_id(self):
         """Return a unique ID for the person."""
-        return self._id
+        return self._config[CONF_ID]
 
     async def async_added_to_hass(self):
         """Register device trackers."""
@@ -121,25 +265,137 @@ class Person(RestoreEntity):
         if state:
             self._parse_source_state(state)
 
-        if not self._trackers:
-            return
-
         @callback
-        def async_handle_tracker_update(entity, old_state, new_state):
-            """Handle the device tracker state changes."""
-            self._parse_source_state(new_state)
-            self.async_schedule_update_ha_state()
+        def person_start_hass(now):
+            self.person_updated()
 
-        _LOGGER.debug(
-            "Subscribe to device trackers for %s", self.entity_id)
+        self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START,
+                                        person_start_hass)
 
-        for tracker in self._trackers:
-            async_track_state_change(
-                self.hass, tracker, async_handle_tracker_update)
+    @callback
+    def person_updated(self):
+        """Handle when the config is updated."""
+        if self._unsub_track_device is not None:
+            self._unsub_track_device()
+            self._unsub_track_device = None
 
+        trackers = self._config.get(CONF_DEVICE_TRACKERS)
+
+        if trackers:
+            def sort_key(state):
+                if state:
+                    return state.last_updated
+                return dt_util.utc_from_timestamp(0)
+
+            latest = max(
+                [self.hass.states.get(entity_id) for entity_id in trackers],
+                key=sort_key
+            )
+
+            @callback
+            def async_handle_tracker_update(entity, old_state, new_state):
+                """Handle the device tracker state changes."""
+                self._parse_source_state(new_state)
+                self.async_schedule_update_ha_state()
+
+            _LOGGER.debug(
+                "Subscribe to device trackers for %s", self.entity_id)
+
+            self._unsub_track_device = async_track_state_change(
+                self.hass, trackers, async_handle_tracker_update)
+
+        else:
+            latest = None
+
+        if latest:
+            self._parse_source_state(latest)
+        else:
+            self._state = None
+            self._source = None
+            self._latitude = None
+            self._longitude = None
+
+        self.async_schedule_update_ha_state()
+
+    @callback
     def _parse_source_state(self, state):
-        """Parse source state and set person attributes."""
+        """Parse source state and set person attributes.
+
+        This is a device tracker state or the restored person state.
+        """
         self._state = state.state
         self._source = state.entity_id
         self._latitude = state.attributes.get(ATTR_LATITUDE)
         self._longitude = state.attributes.get(ATTR_LONGITUDE)
+
+
+@websocket_api.websocket_command({
+    vol.Required('type'): 'person/list',
+})
+def ws_list_person(hass: HomeAssistantType,
+                   connection: websocket_api.ActiveConnection, msg):
+    """List persons."""
+    manager = hass.data[DOMAIN]  # type: PersonManager
+    connection.send_result(msg['id'], {
+        'storage': manager.storage_persons,
+        'config': manager.config_persons,
+    })
+
+
+@websocket_api.websocket_command({
+    vol.Required('type'): 'person/create',
+    vol.Required('name'): str,
+    vol.Optional('user_id'): vol.Any(str, None),
+    vol.Optional('device_trackers', default=[]): vol.All(
+        cv.ensure_list, cv.entities_domain(DEVICE_TRACKER_DOMAIN)),
+})
+@websocket_api.require_admin
+@websocket_api.async_response
+async def ws_create_person(hass: HomeAssistantType,
+                           connection: websocket_api.ActiveConnection, msg):
+    """Create a person."""
+    manager = hass.data[DOMAIN]  # type: PersonManager
+    person = await manager.async_create_person(
+        name=msg['name'],
+        user_id=msg.get('user_id'),
+        device_trackers=msg['device_trackers']
+    )
+    connection.send_result(msg['id'], person)
+
+
+@websocket_api.websocket_command({
+    vol.Required('type'): 'person/update',
+    vol.Required('person_id'): str,
+    vol.Optional('name'): str,
+    vol.Optional('user_id'): vol.Any(str, None),
+    vol.Optional(CONF_DEVICE_TRACKERS, default=[]): vol.All(
+        cv.ensure_list, cv.entities_domain(DEVICE_TRACKER_DOMAIN)),
+})
+@websocket_api.require_admin
+@websocket_api.async_response
+async def ws_update_person(hass: HomeAssistantType,
+                           connection: websocket_api.ActiveConnection, msg):
+    """Update a person."""
+    manager = hass.data[DOMAIN]  # type: PersonManager
+    changes = {}
+    for key in ('name', 'user_id', 'device_trackers'):
+        if key in msg:
+            changes[key] = msg[key]
+
+    person = await manager.async_update_person(msg['person_id'], **changes)
+    connection.send_result(msg['id'], person)
+
+
+@websocket_api.websocket_command({
+    vol.Required('type'): 'person/delete',
+    vol.Required('person_id'): str,
+})
+@websocket_api.require_admin
+@websocket_api.async_response
+async def ws_delete_person(hass: HomeAssistantType,
+                           connection: websocket_api.ActiveConnection,
+                           msg):
+    """Delete a person."""
+    manager = hass.data[DOMAIN]  # type: PersonManager
+    await manager.async_delete_person(msg['person_id'])
+    connection.send_result(msg['id'])

--- a/homeassistant/components/rflink/__init__.py
+++ b/homeassistant/components/rflink/__init__.py
@@ -345,6 +345,7 @@ class RflinkDevice(Entity):
 
     async def async_added_to_hass(self):
         """Register update callback."""
+        await super().async_added_to_hass()
         # Remove temporary bogus entity_id if added
         tmp_entity = TMP_ENTITY.format(self._device_id)
         if tmp_entity in self.hass.data[DATA_ENTITY_LOOKUP][

--- a/homeassistant/components/sensor/darksky.py
+++ b/homeassistant/components/sensor/darksky.py
@@ -162,9 +162,9 @@ CONDITION_PICTURES = {
 # Language Supported Codes
 LANGUAGE_CODES = [
     'ar', 'az', 'be', 'bg', 'bs', 'ca', 'cs', 'da', 'de', 'el', 'en', 'es',
-    'et', 'fi', 'fr', 'hr', 'hu', 'id', 'is', 'it', 'ja', 'ka', 'kw', 'nb',
-    'nl', 'pl', 'pt', 'ro', 'ru', 'sk', 'sl', 'sr', 'sv', 'tet', 'tr', 'uk',
-    'x-pig-latin', 'zh', 'zh-tw',
+    'et', 'fi', 'fr', 'he', 'hr', 'hu', 'id', 'is', 'it', 'ja', 'ka', 'ko',
+    'kw', 'lv', 'nb', 'nl', 'pl', 'pt', 'ro', 'ru', 'sk', 'sl', 'sr', 'sv',
+    'tet', 'tr', 'uk', 'x-pig-latin', 'zh', 'zh-tw',
 ]
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({

--- a/homeassistant/components/sensor/teleinfo.py
+++ b/homeassistant/components/sensor/teleinfo.py
@@ -88,7 +88,7 @@ class SerialTeleinfoSensor(Entity):
                              parity='E', stopbits=1, rtscts=1))
 
     async def serial_read(self, device, **kwargs):
-        """ Process the serial data """
+        """Process the serial data."""
         import serial_asyncio
         _LOGGER.debug(u"Initializing Teleinfo")
         reader, _ = await serial_asyncio.open_serial_connection(url=device,

--- a/homeassistant/components/sensor/teleinfo.py
+++ b/homeassistant/components/sensor/teleinfo.py
@@ -114,7 +114,7 @@ class SerialTeleinfoSensor(Entity):
                     # The checksum char is ' '.
                     name, value = line.split()
                 else:
-                    name, value, checksum = line.split()
+                    name, value = line.split()[0:2]
 
                 _LOGGER.debug(" Got : [%s] =  (%s)", name, value)
                 self._attributes[name] = value

--- a/homeassistant/components/sensor/teleinfo.py
+++ b/homeassistant/components/sensor/teleinfo.py
@@ -1,0 +1,139 @@
+"""
+Support for reading Teleinfo data from a serial port.
+
+Teleinfo is a French specific protocol used in electricity smart meters.
+It provides real time information on power consumption, rates and current on
+a user accessible serial port.
+
+For more details about this platform, please refer to the documentation at
+https://www.enedis.fr/sites/default/files/Enedis-NOI-CPT_02E.pdf
+
+Sample configuration.yaml
+
+    sensor:
+    - platform: teleinfo2
+        name: "EDF teleinfo"
+        serial_port: "/dev/ttyAMA0"
+
+"""
+import logging
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import (
+    CONF_NAME, EVENT_HOMEASSISTANT_STOP, ATTR_ATTRIBUTION)
+from homeassistant.helpers.entity import Entity
+
+REQUIREMENTS = ['pyserial-asyncio==0.4']
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_SERIAL_PORT = 'serial_port'
+
+CONF_ATTRIBUTION = "Provided by EDF Teleinfo."
+
+DEFAULT_NAME = "Serial Teleinfo Sensor"
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_SERIAL_PORT): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string
+})
+
+
+async def async_setup_platform(hass, config, async_add_entities,
+                               discovery_info=None):
+    """Set up the Serial sensor platform."""
+    name = config.get(CONF_NAME)
+    port = config.get(CONF_SERIAL_PORT)
+    sensor = SerialTeleinfoSensor(name, port)
+
+    hass.bus.async_listen_once(
+        EVENT_HOMEASSISTANT_STOP, sensor.stop_serial_read())
+    async_add_entities([sensor], True)
+
+
+class SerialTeleinfoSensor(Entity):
+    """Representation of a Serial sensor."""
+
+    def __init__(self, name, port):
+        """Initialize the Serial sensor."""
+        self._name = name
+        self._port = port
+        self._serial_loop_task = None
+        self._state = None
+        self._attributes = {}
+
+    async def async_added_to_hass(self):
+        """Handle when an entity is about to be added to Home Assistant."""
+        self._serial_loop_task = self.hass.loop.create_task(
+            self.serial_read(self._port, baudrate=1200, bytesize=7,\
+                             parity='E', stopbits=1, rtscts=1))
+
+    async def serial_read(self, device, **kwargs):
+        """ Process the serial data """
+        import serial_asyncio
+        _LOGGER.debug(u"Initializing Teleinfo")
+        reader, _ = await serial_asyncio.open_serial_connection(url=device, **kwargs)
+
+        is_over = True
+
+        # First read need to clear the grimlins.
+        line = await reader.readline()
+
+        while True:
+            line = await reader.readline()
+            line = line.decode('ascii').replace('\r', '').replace('\n', '')
+
+            if is_over and ('\x02' in line):
+                is_over = False
+                _LOGGER.debug(" Start Frame")
+                continue
+
+            if (not is_over) and ('\x03' not in line):
+                # Don't use strip() here because the checksum can be ' '.
+                if len(line.split()) == 2:
+                    # The checksum char is ' '.
+                    name, value = line.split()
+                else:
+                    name, value, checksum = line.split()
+
+                _LOGGER.debug(" Got : [%s] =  (%s)", name, value)
+                self._attributes[name] = value
+
+                if name == 'PAPP':
+                    self._state = int(value)
+                continue
+
+            if (not is_over) and ('\x03' in line):
+                is_over = True
+                self.async_schedule_update_ha_state()
+                _LOGGER.debug(" End Frame")
+                continue
+
+    async def stop_serial_read(self):
+        """Close resources."""
+        if self._serial_loop_task:
+            self._serial_loop_task.cancel()
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def should_poll(self):
+        """No polling needed."""
+        return False
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        self._attributes[ATTR_ATTRIBUTION] = CONF_ATTRIBUTION
+        return self._attributes
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state

--- a/homeassistant/components/sensor/teleinfo.py
+++ b/homeassistant/components/sensor/teleinfo.py
@@ -19,13 +19,15 @@ Sample configuration.yaml
     - platform: template
         sensors:
         teleinfo_base:
-            value_template: '{{ (states.sensor.edf_teleinfo.attributes["BASE"] | float / 1000) | round(0) }}'
+            value_template: '{{ (states.sensor.edf_teleinfo.
+                attributes["BASE"] | float / 1000) | round(0) }}'
             unit_of_measurement: 'kWh'
             icon_template: mdi:flash
     - platform: template
         sensors:
         teleinfo_iinst1:
-            value_template: '{{ states.sensor.edf_teleinfo.attributes["IINST1"] | int }}'
+            value_template: '{{ states.sensor.edf_teleinfo.
+                attributes["IINST1"] | int }}'
             unit_of_measurement: 'A'
             icon_template: mdi:flash
 
@@ -90,7 +92,7 @@ class SerialTeleinfoSensor(Entity):
         import serial_asyncio
         _LOGGER.debug(u"Initializing Teleinfo")
         reader, _ = await serial_asyncio.open_serial_connection(url=device,
-                          **kwargs)
+                                                                **kwargs)
 
         is_over = True
 

--- a/homeassistant/components/spider/__init__.py
+++ b/homeassistant/components/spider/__init__.py
@@ -14,7 +14,7 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.discovery import load_platform
 
-REQUIREMENTS = ['spiderpy==1.2.0']
+REQUIREMENTS = ['spiderpy==1.3.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/spider/climate.py
+++ b/homeassistant/components/spider/climate.py
@@ -9,11 +9,22 @@ import logging
 
 from homeassistant.components.climate import (
     ATTR_TEMPERATURE, STATE_COOL, STATE_HEAT, STATE_IDLE,
-    SUPPORT_OPERATION_MODE, SUPPORT_TARGET_TEMPERATURE, ClimateDevice)
+    SUPPORT_OPERATION_MODE, SUPPORT_TARGET_TEMPERATURE,
+    SUPPORT_FAN_MODE, ClimateDevice)
 from homeassistant.components.spider import DOMAIN as SPIDER_DOMAIN
 from homeassistant.const import TEMP_CELSIUS
 
 DEPENDENCIES = ['spider']
+
+FAN_LIST = [
+    'Auto',
+    'Low',
+    'Medium',
+    'High',
+    'Boost 10',
+    'Boost 20',
+    'Boost 30'
+]
 
 OPERATION_LIST = [
     STATE_HEAT,
@@ -55,7 +66,10 @@ class SpiderThermostat(ClimateDevice):
         supports = SUPPORT_TARGET_TEMPERATURE
 
         if self.thermostat.has_operation_mode:
-            supports = supports | SUPPORT_OPERATION_MODE
+            supports |= SUPPORT_OPERATION_MODE
+
+        if self.thermostat.has_fan_mode:
+            supports |= SUPPORT_FAN_MODE
 
         return supports
 
@@ -121,6 +135,20 @@ class SpiderThermostat(ClimateDevice):
         """Set new target operation mode."""
         self.thermostat.set_operation_mode(
             HA_STATE_TO_SPIDER.get(operation_mode))
+
+    @property
+    def current_fan_mode(self):
+        """Return the fan setting."""
+        return self.thermostat.current_fan_speed
+
+    def set_fan_mode(self, fan_mode):
+        """Set fan mode."""
+        self.thermostat.set_fan_speed(fan_mode)
+
+    @property
+    def fan_list(self):
+        """List of available fan modes."""
+        return FAN_LIST
 
     def update(self):
         """Get the latest data."""

--- a/homeassistant/components/websocket_api/connection.py
+++ b/homeassistant/components/websocket_api/connection.py
@@ -32,6 +32,16 @@ class ActiveConnection:
         return Context(user_id=user.id)
 
     @callback
+    def send_result(self, msg_id, result=None):
+        """Send a result message."""
+        self.send_message(messages.result_message(msg_id, result))
+
+    @callback
+    def send_error(self, msg_id, code, message):
+        """Send a error message."""
+        self.send_message(messages.error_message(msg_id, code, message))
+
+    @callback
     def async_handle(self, msg):
         """Handle a single incoming message."""
         handlers = self.hass.data[const.DOMAIN]

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -319,7 +319,7 @@ class Entity:
     @callback
     def async_schedule_update_ha_state(self, force_refresh=False):
         """Schedule an update ha state change task."""
-        self.hass.async_add_job(self.async_update_ha_state(force_refresh))
+        self.hass.async_create_task(self.async_update_ha_state(force_refresh))
 
     async def async_device_update(self, warning=True):
         """Process 'update' or 'async_update' from entity.

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1573,7 +1573,7 @@ somecomfort==0.5.2
 speedtest-cli==2.0.2
 
 # homeassistant.components.spider
-spiderpy==1.2.0
+spiderpy==1.3.1
 
 # homeassistant.components.sensor.spotcrime
 spotcrime==1.0.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1213,6 +1213,7 @@ pysabnzbd==1.1.0
 pysensibo==1.0.3
 
 # homeassistant.components.sensor.serial
+# homeassistant.components.sensor.teleinfo
 pyserial-asyncio==0.4
 
 # homeassistant.components.switch.acer_projector

--- a/tests/components/light/test_rflink.py
+++ b/tests/components/light/test_rflink.py
@@ -632,7 +632,7 @@ async def test_restore_state(hass, monkeypatch):
     state = hass.states.get(DOMAIN + '.l4')
     assert state
     assert state.state == STATE_OFF
-    assert not state.attributes.get(ATTR_BRIGHTNESS)
+    assert state.attributes[ATTR_BRIGHTNESS] == 255
     assert state.attributes['assumed_state']
 
     # test coverage for dimmable light

--- a/tests/components/mqtt/test_camera.py
+++ b/tests/components/mqtt/test_camera.py
@@ -168,7 +168,7 @@ async def test_entity_id_update(hass, mqtt_mock):
     state = hass.states.get('camera.beer')
     assert state is not None
     assert mock_mqtt.async_subscribe.call_count == 1
-    mock_mqtt.async_subscribe.assert_any_call('test-topic', ANY, 0, 'utf-8')
+    mock_mqtt.async_subscribe.assert_any_call('test-topic', ANY, 0, None)
     mock_mqtt.async_subscribe.reset_mock()
 
     registry.async_update_entity('camera.beer', new_entity_id='camera.milk')
@@ -181,4 +181,4 @@ async def test_entity_id_update(hass, mqtt_mock):
     state = hass.states.get('camera.milk')
     assert state is not None
     assert mock_mqtt.async_subscribe.call_count == 1
-    mock_mqtt.async_subscribe.assert_any_call('test-topic', ANY, 0, 'utf-8')
+    mock_mqtt.async_subscribe.assert_any_call('test-topic', ANY, 0, None)

--- a/tests/components/person/test_init.py
+++ b/tests/components/person/test_init.py
@@ -1,14 +1,39 @@
 """The tests for the person component."""
 from homeassistant.components.person import ATTR_SOURCE, ATTR_USER_ID, DOMAIN
 from homeassistant.const import (
-    ATTR_ID, ATTR_LATITUDE, ATTR_LONGITUDE, STATE_UNKNOWN)
+    ATTR_ID, ATTR_LATITUDE, ATTR_LONGITUDE, STATE_UNKNOWN,
+    EVENT_HOMEASSISTANT_START)
 from homeassistant.core import CoreState, State
 from homeassistant.setup import async_setup_component
+
+import pytest
 
 from tests.common import mock_component, mock_restore_cache
 
 DEVICE_TRACKER = 'device_tracker.test_tracker'
 DEVICE_TRACKER_2 = 'device_tracker.test_tracker_2'
+
+
+@pytest.fixture
+def storage_setup(hass, hass_storage, hass_admin_user):
+    """Storage setup."""
+    hass_storage[DOMAIN] = {
+        'key': DOMAIN,
+        'version': 1,
+        'data': {
+            'persons': [
+                {
+                    'id': '1234',
+                    'name': 'tracked person',
+                    'user_id': hass_admin_user.id,
+                    'device_trackers': DEVICE_TRACKER
+                }
+            ]
+        }
+    }
+    assert hass.loop.run_until_complete(
+        async_setup_component(hass, DOMAIN, {})
+    )
 
 
 async def test_minimal_setup(hass):
@@ -36,9 +61,9 @@ async def test_setup_no_name(hass):
     assert not await async_setup_component(hass, DOMAIN, config)
 
 
-async def test_setup_user_id(hass, hass_owner_user):
+async def test_setup_user_id(hass, hass_admin_user):
     """Test config with user id."""
-    user_id = hass_owner_user.id
+    user_id = hass_admin_user.id
     config = {
         DOMAIN: {'id': '1234', 'name': 'test person', 'user_id': user_id}}
     assert await async_setup_component(hass, DOMAIN, config)
@@ -52,17 +77,9 @@ async def test_setup_user_id(hass, hass_owner_user):
     assert state.attributes.get(ATTR_USER_ID) == user_id
 
 
-async def test_setup_invalid_user_id(hass):
-    """Test config with invalid user id."""
-    config = {
-        DOMAIN: {
-            'id': '1234', 'name': 'test bad user', 'user_id': 'bad_user_id'}}
-    assert not await async_setup_component(hass, DOMAIN, config)
-
-
-async def test_valid_invalid_user_ids(hass, hass_owner_user):
+async def test_valid_invalid_user_ids(hass, hass_admin_user):
     """Test a person with valid user id and a person with invalid user id ."""
-    user_id = hass_owner_user.id
+    user_id = hass_admin_user.id
     config = {DOMAIN: [
         {'id': '1234', 'name': 'test valid user', 'user_id': user_id},
         {'id': '5678', 'name': 'test bad user', 'user_id': 'bad_user_id'}]}
@@ -79,9 +96,9 @@ async def test_valid_invalid_user_ids(hass, hass_owner_user):
     assert state is None
 
 
-async def test_setup_tracker(hass, hass_owner_user):
+async def test_setup_tracker(hass, hass_admin_user):
     """Test set up person with one device tracker."""
-    user_id = hass_owner_user.id
+    user_id = hass_admin_user.id
     config = {DOMAIN: {
         'id': '1234', 'name': 'tracked person', 'user_id': user_id,
         'device_trackers': DEVICE_TRACKER}}
@@ -96,6 +113,12 @@ async def test_setup_tracker(hass, hass_owner_user):
     assert state.attributes.get(ATTR_USER_ID) == user_id
 
     hass.states.async_set(DEVICE_TRACKER, 'home')
+    await hass.async_block_till_done()
+
+    state = hass.states.get('person.tracked_person')
+    assert state.state == STATE_UNKNOWN
+
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
     await hass.async_block_till_done()
 
     state = hass.states.get('person.tracked_person')
@@ -120,9 +143,9 @@ async def test_setup_tracker(hass, hass_owner_user):
     assert state.attributes.get(ATTR_USER_ID) == user_id
 
 
-async def test_setup_two_trackers(hass, hass_owner_user):
+async def test_setup_two_trackers(hass, hass_admin_user):
     """Test set up person with two device trackers."""
-    user_id = hass_owner_user.id
+    user_id = hass_admin_user.id
     config = {DOMAIN: {
         'id': '1234', 'name': 'tracked person', 'user_id': user_id,
         'device_trackers': [DEVICE_TRACKER, DEVICE_TRACKER_2]}}
@@ -136,6 +159,8 @@ async def test_setup_two_trackers(hass, hass_owner_user):
     assert state.attributes.get(ATTR_SOURCE) is None
     assert state.attributes.get(ATTR_USER_ID) == user_id
 
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    await hass.async_block_till_done()
     hass.states.async_set(DEVICE_TRACKER, 'home')
     await hass.async_block_till_done()
 
@@ -161,9 +186,9 @@ async def test_setup_two_trackers(hass, hass_owner_user):
     assert state.attributes.get(ATTR_USER_ID) == user_id
 
 
-async def test_restore_home_state(hass, hass_owner_user):
+async def test_restore_home_state(hass, hass_admin_user):
     """Test that the state is restored for a person on startup."""
-    user_id = hass_owner_user.id
+    user_id = hass_admin_user.id
     attrs = {
         ATTR_ID: '1234', ATTR_LATITUDE: 10.12346, ATTR_LONGITUDE: 11.12346,
         ATTR_SOURCE: DEVICE_TRACKER, ATTR_USER_ID: user_id}
@@ -184,3 +209,203 @@ async def test_restore_home_state(hass, hass_owner_user):
     # When restoring state the entity_id of the person will be used as source.
     assert state.attributes.get(ATTR_SOURCE) == 'person.tracked_person'
     assert state.attributes.get(ATTR_USER_ID) == user_id
+
+
+async def test_duplicate_ids(hass, hass_admin_user):
+    """Test we don't allow duplicate IDs."""
+    config = {DOMAIN: [
+        {'id': '1234', 'name': 'test user 1'},
+        {'id': '1234', 'name': 'test user 2'}]}
+    assert await async_setup_component(hass, DOMAIN, config)
+
+    assert len(hass.states.async_entity_ids('person')) == 1
+    assert hass.states.get('person.test_user_1') is not None
+    assert hass.states.get('person.test_user_2') is None
+
+
+async def test_load_person_storage(hass, hass_admin_user, storage_setup):
+    """Test set up person from storage."""
+    state = hass.states.get('person.tracked_person')
+    assert state.state == STATE_UNKNOWN
+    assert state.attributes.get(ATTR_ID) == '1234'
+    assert state.attributes.get(ATTR_LATITUDE) is None
+    assert state.attributes.get(ATTR_LONGITUDE) is None
+    assert state.attributes.get(ATTR_SOURCE) is None
+    assert state.attributes.get(ATTR_USER_ID) == hass_admin_user.id
+
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    await hass.async_block_till_done()
+    hass.states.async_set(DEVICE_TRACKER, 'home')
+    await hass.async_block_till_done()
+
+    state = hass.states.get('person.tracked_person')
+    assert state.state == 'home'
+    assert state.attributes.get(ATTR_ID) == '1234'
+    assert state.attributes.get(ATTR_LATITUDE) is None
+    assert state.attributes.get(ATTR_LONGITUDE) is None
+    assert state.attributes.get(ATTR_SOURCE) == DEVICE_TRACKER
+    assert state.attributes.get(ATTR_USER_ID) == hass_admin_user.id
+
+
+async def test_ws_list(hass, hass_ws_client, storage_setup):
+    """Test listing via WS."""
+    manager = hass.data[DOMAIN]
+
+    client = await hass_ws_client(hass)
+
+    resp = await client.send_json({
+        'id': 6,
+        'type': 'person/list',
+    })
+    resp = await client.receive_json()
+    assert resp['success']
+    assert resp['result']['storage'] == manager.storage_persons
+    assert len(resp['result']['storage']) == 1
+    assert len(resp['result']['config']) == 0
+
+
+async def test_ws_create(hass, hass_ws_client, storage_setup,
+                         hass_read_only_user):
+    """Test creating via WS."""
+    manager = hass.data[DOMAIN]
+
+    client = await hass_ws_client(hass)
+
+    resp = await client.send_json({
+        'id': 6,
+        'type': 'person/create',
+        'name': 'Hello',
+        'device_trackers': [DEVICE_TRACKER],
+        'user_id': hass_read_only_user.id,
+    })
+    resp = await client.receive_json()
+
+    persons = manager.storage_persons
+    assert len(persons) == 2
+
+    assert resp['success']
+    assert resp['result'] == persons[1]
+
+
+async def test_ws_create_requires_admin(hass, hass_ws_client, storage_setup,
+                                        hass_admin_user, hass_read_only_user):
+    """Test creating via WS requires admin."""
+    hass_admin_user.groups = []
+    manager = hass.data[DOMAIN]
+
+    client = await hass_ws_client(hass)
+
+    resp = await client.send_json({
+        'id': 6,
+        'type': 'person/create',
+        'name': 'Hello',
+        'device_trackers': [DEVICE_TRACKER],
+        'user_id': hass_read_only_user.id,
+    })
+    resp = await client.receive_json()
+
+    persons = manager.storage_persons
+    assert len(persons) == 1
+
+    assert not resp['success']
+
+
+async def test_ws_update(hass, hass_ws_client, storage_setup):
+    """Test updating via WS."""
+    manager = hass.data[DOMAIN]
+
+    client = await hass_ws_client(hass)
+    persons = manager.storage_persons
+
+    resp = await client.send_json({
+        'id': 6,
+        'type': 'person/update',
+        'person_id': persons[0]['id'],
+        'name': 'Updated Name',
+        'device_trackers': [DEVICE_TRACKER_2],
+        'user_id': None,
+    })
+    resp = await client.receive_json()
+
+    persons = manager.storage_persons
+    assert len(persons) == 1
+
+    assert resp['success']
+    assert resp['result'] == persons[0]
+    assert persons[0]['name'] == 'Updated Name'
+    assert persons[0]['name'] == 'Updated Name'
+    assert persons[0]['device_trackers'] == [DEVICE_TRACKER_2]
+    assert persons[0]['user_id'] is None
+
+    state = hass.states.get('person.tracked_person')
+    assert state.name == 'Updated Name'
+
+
+async def test_ws_update_require_admin(hass, hass_ws_client, storage_setup,
+                                       hass_admin_user):
+    """Test updating via WS requires admin."""
+    hass_admin_user.groups = []
+    manager = hass.data[DOMAIN]
+
+    client = await hass_ws_client(hass)
+    original = dict(manager.storage_persons[0])
+
+    resp = await client.send_json({
+        'id': 6,
+        'type': 'person/update',
+        'person_id': original['id'],
+        'name': 'Updated Name',
+        'device_trackers': [DEVICE_TRACKER_2],
+        'user_id': None,
+    })
+    resp = await client.receive_json()
+    assert not resp['success']
+
+    not_updated = dict(manager.storage_persons[0])
+    assert original == not_updated
+
+
+async def test_ws_delete(hass, hass_ws_client, storage_setup):
+    """Test deleting via WS."""
+    manager = hass.data[DOMAIN]
+
+    client = await hass_ws_client(hass)
+    persons = manager.storage_persons
+
+    resp = await client.send_json({
+        'id': 6,
+        'type': 'person/delete',
+        'person_id': persons[0]['id'],
+    })
+    resp = await client.receive_json()
+
+    persons = manager.storage_persons
+    assert len(persons) == 0
+
+    assert resp['success']
+    assert len(hass.states.async_entity_ids('person')) == 0
+    ent_reg = await hass.helpers.entity_registry.async_get_registry()
+    assert not ent_reg.async_is_registered('person.tracked_person')
+
+
+async def test_ws_delete_require_admin(hass, hass_ws_client, storage_setup,
+                                       hass_admin_user):
+    """Test deleting via WS requires admin."""
+    hass_admin_user.groups = []
+    manager = hass.data[DOMAIN]
+
+    client = await hass_ws_client(hass)
+
+    resp = await client.send_json({
+        'id': 6,
+        'type': 'person/delete',
+        'person_id': manager.storage_persons[0]['id'],
+        'name': 'Updated Name',
+        'device_trackers': [DEVICE_TRACKER_2],
+        'user_id': None,
+    })
+    resp = await client.receive_json()
+    assert not resp['success']
+
+    persons = manager.storage_persons
+    assert len(persons) == 1

--- a/tests/components/sensor/test_teleinfo.py
+++ b/tests/components/sensor/test_teleinfo.py
@@ -1,0 +1,26 @@
+"""The tests for the teleinfo platform."""
+
+import json
+import unittest
+# from unittest import mock
+from unittest.mock import patch
+
+from homeassistant.setup import setup_component
+
+from tests.common import (get_test_home_assistant, load_fixture)
+
+
+VALID_CONFIG_MINIMAL = {
+    'sensor': {
+        'platform': 'teleinfo',
+        'device': '/dev/ttyACM0',
+    }
+}
+
+VALID_CONFIG_NAME = {
+    'sensor': {
+        'platform': 'teleinfo',
+        'name': 'edf',
+        'device': '/dev/ttyUSB0',
+    }
+}

--- a/tests/components/sensor/test_teleinfo.py
+++ b/tests/components/sensor/test_teleinfo.py
@@ -1,15 +1,5 @@
 """The tests for the teleinfo platform."""
 
-import json
-import unittest
-# from unittest import mock
-from unittest.mock import patch
-
-from homeassistant.setup import setup_component
-
-from tests.common import (get_test_home_assistant, load_fixture)
-
-
 VALID_CONFIG_MINIMAL = {
     'sensor': {
         'platform': 'teleinfo',

--- a/tests/components/zha/test_api.py
+++ b/tests/components/zha/test_api.py
@@ -1,0 +1,111 @@
+"""Test ZHA API."""
+from unittest.mock import Mock
+import pytest
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.components.switch import DOMAIN
+from homeassistant.components.zha.api import (
+    async_load_api, WS_ENTITIES_BY_IEEE, WS_ENTITY_CLUSTERS, ATTR_IEEE, TYPE,
+    ID, NAME, WS_ENTITY_CLUSTER_ATTRIBUTES, WS_ENTITY_CLUSTER_COMMANDS
+)
+from homeassistant.components.zha.core.const import (
+    ATTR_CLUSTER_ID, ATTR_CLUSTER_TYPE, IN
+)
+from .common import async_init_zigpy_device
+
+
+@pytest.fixture
+async def zha_client(hass, config_entry, zha_gateway, hass_ws_client):
+    """Test zha switch platform."""
+    from zigpy.zcl.clusters.general import OnOff
+
+    # load the ZHA API
+    async_load_api(hass, Mock(), zha_gateway)
+
+    # create zigpy device
+    await async_init_zigpy_device(
+        hass, [OnOff.cluster_id], [], None, zha_gateway)
+
+    # load up switch domain
+    await hass.config_entries.async_forward_entry_setup(
+        config_entry, DOMAIN)
+    await hass.async_block_till_done()
+
+    return await hass_ws_client(hass)
+
+
+async def test_entities_by_ieee(hass, config_entry, zha_gateway, zha_client):
+    """Test getting entity refs by ieee address."""
+    await zha_client.send_json({
+        ID: 5,
+        TYPE: WS_ENTITIES_BY_IEEE,
+    })
+
+    msg = await zha_client.receive_json()
+
+    assert '00:0d:6f:00:0a:90:69:e7' in msg['result']
+    assert len(msg['result']['00:0d:6f:00:0a:90:69:e7']) == 2
+
+
+async def test_entity_clusters(hass, config_entry, zha_gateway, zha_client):
+    """Test getting entity cluster info."""
+    await zha_client.send_json({
+        ID: 5,
+        TYPE: WS_ENTITY_CLUSTERS,
+        ATTR_ENTITY_ID: 'switch.fakemanufacturer_fakemodel_0a9069e7_1_6',
+        ATTR_IEEE: '00:0d:6f:00:0a:90:69:e7'
+    })
+
+    msg = await zha_client.receive_json()
+
+    assert len(msg['result']) == 1
+
+    cluster_info = msg['result'][0]
+
+    assert cluster_info[TYPE] == IN
+    assert cluster_info[ID] == 6
+    assert cluster_info[NAME] == 'OnOff'
+
+
+async def test_entity_cluster_attributes(
+        hass, config_entry, zha_gateway, zha_client):
+    """Test getting entity cluster attributes."""
+    await zha_client.send_json({
+        ID: 5,
+        TYPE: WS_ENTITY_CLUSTER_ATTRIBUTES,
+        ATTR_ENTITY_ID: 'switch.fakemanufacturer_fakemodel_0a9069e7_1_6',
+        ATTR_IEEE: '00:0d:6f:00:0a:90:69:e7',
+        ATTR_CLUSTER_ID: 6,
+        ATTR_CLUSTER_TYPE: IN
+    })
+
+    msg = await zha_client.receive_json()
+
+    attributes = msg['result']
+    assert len(attributes) == 4
+
+    for attribute in attributes:
+        assert attribute[ID] is not None
+        assert attribute[NAME] is not None
+
+
+async def test_entity_cluster_commands(
+        hass, config_entry, zha_gateway, zha_client):
+    """Test getting entity cluster commands."""
+    await zha_client.send_json({
+        ID: 5,
+        TYPE: WS_ENTITY_CLUSTER_COMMANDS,
+        ATTR_ENTITY_ID: 'switch.fakemanufacturer_fakemodel_0a9069e7_1_6',
+        ATTR_IEEE: '00:0d:6f:00:0a:90:69:e7',
+        ATTR_CLUSTER_ID: 6,
+        ATTR_CLUSTER_TYPE: IN
+    })
+
+    msg = await zha_client.receive_json()
+
+    commands = msg['result']
+    assert len(commands) == 6
+
+    for command in commands:
+        assert command[ID] is not None
+        assert command[NAME] is not None
+        assert command[TYPE] is not None

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -58,9 +58,9 @@ def test_async_add_job_schedule_partial_callback():
     assert len(hass.add_job.mock_calls) == 0
 
 
-def test_async_add_job_schedule_coroutinefunction():
+def test_async_add_job_schedule_coroutinefunction(loop):
     """Test that we schedule coroutines and add jobs to the job pool."""
-    hass = MagicMock()
+    hass = MagicMock(loop=MagicMock(wraps=loop))
 
     async def job():
         pass
@@ -71,9 +71,9 @@ def test_async_add_job_schedule_coroutinefunction():
     assert len(hass.add_job.mock_calls) == 0
 
 
-def test_async_add_job_schedule_partial_coroutinefunction():
+def test_async_add_job_schedule_partial_coroutinefunction(loop):
     """Test that we schedule partial coros and add jobs to the job pool."""
-    hass = MagicMock()
+    hass = MagicMock(loop=MagicMock(wraps=loop))
 
     async def job():
         pass
@@ -98,9 +98,9 @@ def test_async_add_job_add_threaded_job_to_pool():
     assert len(hass.loop.run_in_executor.mock_calls) == 1
 
 
-def test_async_create_task_schedule_coroutine():
+def test_async_create_task_schedule_coroutine(loop):
     """Test that we schedule coroutines and add jobs to the job pool."""
-    hass = MagicMock()
+    hass = MagicMock(loop=MagicMock(wraps=loop))
 
     async def job():
         pass


### PR DESCRIPTION
## Description:

Add support for Teleinfo Serial Sensor.

Teleinfo is a French specific protocol used in electricity smart meters.
It provides real time information on power consumption, rates and current on
a user accessible serial port.

- Full asyncio version
- Only one deps (pyserial)

## Example entry for `configuration.yaml` (if applicable):
```yaml
 sensor:
   - platform: teleinfo
        name: "EDF teleinfo"
        serial_port: "/dev/ttyAMA0"
  - platform: template
    sensors:
      teleinfo_base:
        value_template: '{{ (states.sensor.edf_teleinfo.attributes["BASE"] | float / 1000) | round(0) }}'
        unit_of_measurement: 'kWh'
        icon_template: mdi:flash
  - platform: template
    sensors:
      teleinfo_iinst1:
        value_template: '{{ states.sensor.edf_teleinfo.attributes["IINST1"] | int }}'
        unit_of_measurement: 'A'
        icon_template: mdi:flash
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)
  -  [home-assistant/home-assistant.io#4382](https://github.com/home-assistant/home-assistant.io/pull/4382)

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

Linked PR (thanks to @nlamirault ): 
Add EDF Teleinfo sensor #14200
[WIP] Add: Teleinfo sensor #10603
