### PR TITLE
Alexa-support for climate-devices in manual-mode

### DIFF
--- a/homeassistant/components/alexa/smart_home.py
+++ b/homeassistant/components/alexa/smart_home.py
@@ -63,6 +63,7 @@ API_THERMOSTAT_MODES = OrderedDict([
     (climate.STATE_COOL, 'COOL'),
     (climate.STATE_AUTO, 'AUTO'),
     (climate.STATE_ECO, 'ECO'),
+    (climate.STATE_MANUAL, 'AUTO'),
     (climate.STATE_OFF, 'OFF'),
     (climate.STATE_IDLE, 'OFF'),
     (climate.STATE_FAN_ONLY, 'OFF'),


### PR DESCRIPTION
## Description:

**Related issue (if applicable):** fixes #19990

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

Open for discussions, if a thermostat in manual mode should be considered AUTO or HEATING towards Alexa. But since a climate component that is set to manual might actually also just be cooling, I think AUTO is a fair compromise. Not that it would change anything on the Alexa-side except for a little badge displayed next to the entity.
