### PR TITLE
Allow light toggle service to accept all turn on params

### DIFF
--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -123,10 +123,7 @@ LIGHT_TURN_OFF_SCHEMA = vol.Schema({
     ATTR_FLASH: vol.In([FLASH_SHORT, FLASH_LONG]),
 })
 
-LIGHT_TOGGLE_SCHEMA = vol.Schema({
-    ATTR_ENTITY_ID: cv.comp_entity_ids,
-    ATTR_TRANSITION: VALID_TRANSITION,
-})
+LIGHT_TOGGLE_SCHEMA = LIGHT_TURN_ON_SCHEMA
 
 PROFILE_SCHEMA = vol.Schema(
     vol.ExactSequence((str, cv.small_float, cv.small_float, cv.byte))

--- a/homeassistant/components/light/services.yaml
+++ b/homeassistant/components/light/services.yaml
@@ -68,12 +68,8 @@ turn_off:
 toggle:
   description: Toggles a light.
   fields:
-    entity_id:
-      description: Name(s) of entities to toggle.
-      example: 'light.kitchen'
-    transition:
-      description: Duration in seconds it takes to get to next state.
-      example: 60
+    '...':
+      description: All turn_on parameters can be used.
 
 hue_activate_scene:
   description: Activate a hue scene stored in the hue hub.


### PR DESCRIPTION
## Description:
Looks like toggle service now accepts [kwargs](https://github.com/home-assistant/home-assistant/blob/5c3a4e3d10c5b0bfc0d5a10bfb64a4bfcc7aa62f/homeassistant/helpers/entity.py#L457). Wanted to retry this [PR](https://github.com/home-assistant/home-assistant/pull/4745/files). Ability to use service light.toggle to turn on light with specified brightness / color etc. It allow for easier scripting, than writing own toggle method, to toggle with specific settings.

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with https://github.com/home-assistant/home-assistant.io/pull/8612

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.