### PR TITLE
WIP: .pre-commit hooks with isort, black, mypy, flake8 and pylint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,27 @@
+repos:
+-   repo: https://github.com/ambv/black
+    rev: 18.9b0
+    hooks:
+    - id: black
+      language_version: python3.7
+-   repo: https://github.com/pre-commit/mirrors-isort
+    rev: v4.3.4  # Use the revision sha / tag you want to point at
+    hooks:
+    -   id: isort
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.1.0
+    hooks:
+    - id: flake8
+-   repo: local
+    hooks:
+      - id: pylint
+        name: pylint
+        entry: python3 -m pylint.__main__
+        language: system
+        types: [python]
+-   repo: git://github.com/luismayta/pre-commit-mypy
+    rev: 0.1.1  # Use the sha you want to point at
+    hooks:
+    -   id: mypy
+        args:
+        - --ignore-missing-imports

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.black]
+line-length = 79
+skip-string-normalization = true

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -15,3 +15,4 @@ pytest-sugar==0.9.2
 pytest-timeout==1.3.3
 pytest==4.1.1
 requests_mock==1.5.2
+black==18.9b0;python_version>'3.6'


### PR DESCRIPTION
This is what I've been running on home-assistant-cli the last few months and 
seem to work pretty great. Might need to tweak the flake8 and pylint run
to be more true to what travis run finds.

But wanted to submit the PR to get feedback.


## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54