### PR TITLE
Return None if no GTFS departures found

### DIFF
--- a/homeassistant/components/sensor/gtfs.py
+++ b/homeassistant/components/sensor/gtfs.py
@@ -205,7 +205,7 @@ class GTFSDepartureSensor(Entity):
         self._icon = ICON
         self._name = ''
         self._unit_of_measurement = 'min'
-        self._state = 0
+        self._state = None
         self._attributes = {}
         self.lock = threading.Lock()
         self.update()
@@ -241,7 +241,7 @@ class GTFSDepartureSensor(Entity):
             self._departure = get_next_departure(
                 self._pygtfs, self.origin, self.destination, self._offset)
             if not self._departure:
-                self._state = 0
+                self._state = None
                 self._attributes = {'Info': 'No more departures today'}
                 if self._name == '':
                     self._name = (self._custom_name or DEFAULT_NAME)


### PR DESCRIPTION
## Description:
Currently, if a bus timetable query returns nothing because no more departures are scheduled for today, then the resulting state is `0`, as in "0 minutes until departure", which is wrong as it blurs the lines with the real state of `0` when a bus really is less than a minute until departure. This PR changes the resulting state when no results are found to `None`, which is more accurate.

Since a default result changes, this PR should be labelled breaking change.

**Breaking Change:**
The GTFS sensor will now return unknown state instead of `0` if no next departures are found.

**Related issue (if applicable):** relates to #7956, but does not fix the issue.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
