### PR TITLE
Added missing Binary Sensor TiltIP in discover list

### DIFF
--- a/homeassistant/components/homematic/__init__.py
+++ b/homeassistant/components/homematic/__init__.py
@@ -90,7 +90,7 @@ HM_DEVICE_TYPES = {
         'IPShutterContact', 'HMWIOSwitch', 'MaxShutterContact', 'Rain',
         'WiredSensor', 'PresenceIP', 'IPWeatherSensor', 'IPPassageSensor',
         'SmartwareMotion', 'IPWeatherSensorPlus', 'MotionIPV2', 'WaterIP',
-        'IPMultiIO'],
+        'IPMultiIO', 'TiltIP'],
     DISCOVER_COVER: ['Blind', 'KeyBlind', 'IPKeyBlind', 'IPKeyBlindTilt'],
     DISCOVER_LOCKS: ['KeyMatic']
 }


### PR DESCRIPTION
TiltIP Binary Sensor is missing in the discover list. This sensor is already implemented in pyhomematic.

## Checklist:
  - [x ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ x] There is no commented out code in this PR.