### PR TITLE
Deprecate conf_update_interval

### DIFF
--- a/homeassistant/components/fastdotcom/__init__.py
+++ b/homeassistant/components/fastdotcom/__init__.py
@@ -5,7 +5,8 @@ from datetime import timedelta
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
-from homeassistant.const import CONF_UPDATE_INTERVAL
+from homeassistant.const import CONF_UPDATE_INTERVAL, CONF_SCAN_INTERVAL, \
+    CONF_UPDATE_INTERVAL_INVALIDATION_VERSION
 from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.dispatcher import dispatcher_send
 from homeassistant.helpers.event import async_track_time_interval
@@ -22,13 +23,21 @@ CONF_MANUAL = 'manual'
 DEFAULT_INTERVAL = timedelta(hours=1)
 
 CONFIG_SCHEMA = vol.Schema({
-    DOMAIN: vol.Schema({
-        vol.Optional(CONF_UPDATE_INTERVAL, default=DEFAULT_INTERVAL):
-            vol.All(
-                cv.time_period, cv.positive_timedelta
-            ),
-        vol.Optional(CONF_MANUAL, default=False): cv.boolean,
-    })
+    DOMAIN: vol.All(
+        vol.Schema({
+            vol.Optional(CONF_UPDATE_INTERVAL):
+                vol.All(cv.time_period, cv.positive_timedelta),
+            vol.Optional(CONF_SCAN_INTERVAL):
+                vol.All(cv.time_period, cv.positive_timedelta),
+            vol.Optional(CONF_MANUAL, default=False): cv.boolean,
+        }),
+        cv.deprecated(
+            CONF_UPDATE_INTERVAL,
+            replacement_key=CONF_SCAN_INTERVAL,
+            invalidation_version=CONF_UPDATE_INTERVAL_INVALIDATION_VERSION,
+            default=DEFAULT_INTERVAL
+        )
+    )
 }, extra=vol.ALLOW_EXTRA)
 
 
@@ -39,7 +48,7 @@ async def async_setup(hass, config):
 
     if not conf[CONF_MANUAL]:
         async_track_time_interval(
-            hass, data.update, conf[CONF_UPDATE_INTERVAL]
+            hass, data.update, conf[CONF_SCAN_INTERVAL]
         )
 
     def update(call=None):

--- a/homeassistant/components/fastdotcom/__init__.py
+++ b/homeassistant/components/fastdotcom/__init__.py
@@ -27,7 +27,7 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Schema({
             vol.Optional(CONF_UPDATE_INTERVAL):
                 vol.All(cv.time_period, cv.positive_timedelta),
-            vol.Optional(CONF_SCAN_INTERVAL):
+            vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_INTERVAL):
                 vol.All(cv.time_period, cv.positive_timedelta),
             vol.Optional(CONF_MANUAL, default=False): cv.boolean,
         }),

--- a/homeassistant/components/freedns/__init__.py
+++ b/homeassistant/components/freedns/__init__.py
@@ -13,7 +13,8 @@ import async_timeout
 import voluptuous as vol
 
 from homeassistant.const import (CONF_URL, CONF_ACCESS_TOKEN,
-                                 CONF_UPDATE_INTERVAL, CONF_SCAN_INTERVAL)
+                                 CONF_UPDATE_INTERVAL, CONF_SCAN_INTERVAL,
+                                 CONF_UPDATE_INTERVAL_INVALIDATION_VERSION)
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
@@ -38,7 +39,7 @@ CONFIG_SCHEMA = vol.Schema({
         cv.deprecated(
             CONF_UPDATE_INTERVAL,
             replacement_key=CONF_SCAN_INTERVAL,
-            invalidation_version='1.0.0',
+            invalidation_version=CONF_UPDATE_INTERVAL_INVALIDATION_VERSION,
             default=DEFAULT_INTERVAL
         )
     )

--- a/homeassistant/components/freedns/__init__.py
+++ b/homeassistant/components/freedns/__init__.py
@@ -33,7 +33,7 @@ CONFIG_SCHEMA = vol.Schema({
             vol.Exclusive(CONF_ACCESS_TOKEN, DOMAIN): cv.string,
             vol.Optional(CONF_UPDATE_INTERVAL):
                 vol.All(cv.time_period, cv.positive_timedelta),
-            vol.Optional(CONF_SCAN_INTERVAL):
+            vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_INTERVAL):
                 vol.All(cv.time_period, cv.positive_timedelta),
         }),
         cv.deprecated(

--- a/homeassistant/components/mythicbeastsdns/__init__.py
+++ b/homeassistant/components/mythicbeastsdns/__init__.py
@@ -5,7 +5,9 @@ import logging
 import voluptuous as vol
 
 from homeassistant.const import (
-    CONF_DOMAIN, CONF_HOST, CONF_PASSWORD, CONF_UPDATE_INTERVAL)
+    CONF_HOST, CONF_DOMAIN, CONF_PASSWORD, CONF_UPDATE_INTERVAL,
+    CONF_SCAN_INTERVAL, CONF_UPDATE_INTERVAL_INVALIDATION_VERSION
+)
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import async_track_time_interval
@@ -19,13 +21,23 @@ DOMAIN = 'mythicbeastsdns'
 DEFAULT_INTERVAL = timedelta(minutes=10)
 
 CONFIG_SCHEMA = vol.Schema({
-    DOMAIN: vol.Schema({
-        vol.Required(CONF_DOMAIN): cv.string,
-        vol.Required(CONF_HOST): cv.string,
-        vol.Required(CONF_PASSWORD): cv.string,
-        vol.Optional(CONF_UPDATE_INTERVAL, default=DEFAULT_INTERVAL): vol.All(
-            cv.time_period, cv.positive_timedelta),
-    })
+    DOMAIN: vol.All(
+        vol.Schema({
+            vol.Required(CONF_DOMAIN): cv.string,
+            vol.Required(CONF_HOST): cv.string,
+            vol.Required(CONF_PASSWORD): cv.string,
+            vol.Optional(CONF_UPDATE_INTERVAL):
+                vol.All(cv.time_period, cv.positive_timedelta),
+            vol.Optional(CONF_SCAN_INTERVAL):
+                vol.All(cv.time_period, cv.positive_timedelta),
+        }),
+        cv.deprecated(
+            CONF_UPDATE_INTERVAL,
+            replacement_key=CONF_SCAN_INTERVAL,
+            invalidation_version=CONF_UPDATE_INTERVAL_INVALIDATION_VERSION,
+            default=DEFAULT_INTERVAL
+        )
+    )
 }, extra=vol.ALLOW_EXTRA)
 
 
@@ -36,7 +48,7 @@ async def async_setup(hass, config):
     domain = config[DOMAIN][CONF_DOMAIN]
     password = config[DOMAIN][CONF_PASSWORD]
     host = config[DOMAIN][CONF_HOST]
-    update_interval = config[DOMAIN][CONF_UPDATE_INTERVAL]
+    update_interval = config[DOMAIN][CONF_SCAN_INTERVAL]
 
     session = async_get_clientsession(hass)
 

--- a/homeassistant/components/mythicbeastsdns/__init__.py
+++ b/homeassistant/components/mythicbeastsdns/__init__.py
@@ -28,7 +28,7 @@ CONFIG_SCHEMA = vol.Schema({
             vol.Required(CONF_PASSWORD): cv.string,
             vol.Optional(CONF_UPDATE_INTERVAL):
                 vol.All(cv.time_period, cv.positive_timedelta),
-            vol.Optional(CONF_SCAN_INTERVAL):
+            vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_INTERVAL):
                 vol.All(cv.time_period, cv.positive_timedelta),
         }),
         cv.deprecated(

--- a/homeassistant/components/sensor/broadlink.py
+++ b/homeassistant/components/sensor/broadlink.py
@@ -26,7 +26,7 @@ _LOGGER = logging.getLogger(__name__)
 
 DEVICE_DEFAULT_NAME = 'Broadlink sensor'
 DEFAULT_TIMEOUT = 10
-DEFAULT_INTERVAL = timedelta(seconds=300)
+SCAN_INTERVAL = timedelta(seconds=300)
 
 SENSOR_TYPES = {
     'temperature': ['Temperature', TEMP_CELSIUS],
@@ -43,8 +43,6 @@ PLATFORM_SCHEMA = vol.All(
             vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
         vol.Optional(CONF_UPDATE_INTERVAL):
             vol.All(cv.time_period, cv.positive_timedelta),
-        vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_INTERVAL):
-            vol.All(cv.time_period, cv.positive_timedelta),
         vol.Required(CONF_HOST): cv.string,
         vol.Required(CONF_MAC): cv.string,
         vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int
@@ -53,7 +51,7 @@ PLATFORM_SCHEMA = vol.All(
         CONF_UPDATE_INTERVAL,
         replacement_key=CONF_SCAN_INTERVAL,
         invalidation_version=CONF_UPDATE_INTERVAL_INVALIDATION_VERSION,
-        default=DEFAULT_INTERVAL
+        default=SCAN_INTERVAL
     )
 )
 
@@ -65,7 +63,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     mac_addr = binascii.unhexlify(mac)
     name = config.get(CONF_NAME)
     timeout = config.get(CONF_TIMEOUT)
-    update_interval = config[CONF_SCAN_INTERVAL]
+    update_interval = config.get(CONF_SCAN_INTERVAL, SCAN_INTERVAL)
     broadlink_data = BroadlinkData(update_interval, host, mac_addr, timeout)
     dev = []
     for variable in config[CONF_MONITORED_CONDITIONS]:

--- a/homeassistant/components/sensor/broadlink.py
+++ b/homeassistant/components/sensor/broadlink.py
@@ -14,7 +14,8 @@ import voluptuous as vol
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
     CONF_HOST, CONF_MAC, CONF_MONITORED_CONDITIONS, CONF_NAME, TEMP_CELSIUS,
-    CONF_TIMEOUT, CONF_UPDATE_INTERVAL)
+    CONF_TIMEOUT, CONF_UPDATE_INTERVAL, CONF_SCAN_INTERVAL,
+    CONF_UPDATE_INTERVAL_INVALIDATION_VERSION)
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
 import homeassistant.helpers.config_validation as cv
@@ -25,6 +26,7 @@ _LOGGER = logging.getLogger(__name__)
 
 DEVICE_DEFAULT_NAME = 'Broadlink sensor'
 DEFAULT_TIMEOUT = 10
+DEFAULT_INTERVAL = timedelta(seconds=300)
 
 SENSOR_TYPES = {
     'temperature': ['Temperature', TEMP_CELSIUS],
@@ -34,16 +36,26 @@ SENSOR_TYPES = {
     'noise': ['Noise', ' '],
 }
 
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Optional(CONF_NAME, default=DEVICE_DEFAULT_NAME): vol.Coerce(str),
-    vol.Optional(CONF_MONITORED_CONDITIONS, default=[]):
-        vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
-    vol.Optional(CONF_UPDATE_INTERVAL, default=timedelta(seconds=300)): (
-        vol.All(cv.time_period, cv.positive_timedelta)),
-    vol.Required(CONF_HOST): cv.string,
-    vol.Required(CONF_MAC): cv.string,
-    vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int
-})
+PLATFORM_SCHEMA = vol.All(
+    PLATFORM_SCHEMA.extend({
+        vol.Optional(CONF_NAME, default=DEVICE_DEFAULT_NAME): vol.Coerce(str),
+        vol.Optional(CONF_MONITORED_CONDITIONS, default=[]):
+            vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
+        vol.Optional(CONF_UPDATE_INTERVAL):
+            vol.All(cv.time_period, cv.positive_timedelta),
+        vol.Optional(CONF_SCAN_INTERVAL):
+            vol.All(cv.time_period, cv.positive_timedelta),
+        vol.Required(CONF_HOST): cv.string,
+        vol.Required(CONF_MAC): cv.string,
+        vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int
+    }),
+    cv.deprecated(
+        CONF_UPDATE_INTERVAL,
+        replacement_key=CONF_SCAN_INTERVAL,
+        invalidation_version=CONF_UPDATE_INTERVAL_INVALIDATION_VERSION,
+        default=DEFAULT_INTERVAL
+    )
+)
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
@@ -53,7 +65,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     mac_addr = binascii.unhexlify(mac)
     name = config.get(CONF_NAME)
     timeout = config.get(CONF_TIMEOUT)
-    update_interval = config.get(CONF_UPDATE_INTERVAL)
+    update_interval = config[CONF_SCAN_INTERVAL]
     broadlink_data = BroadlinkData(update_interval, host, mac_addr, timeout)
     dev = []
     for variable in config[CONF_MONITORED_CONDITIONS]:

--- a/homeassistant/components/sensor/broadlink.py
+++ b/homeassistant/components/sensor/broadlink.py
@@ -43,7 +43,7 @@ PLATFORM_SCHEMA = vol.All(
             vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
         vol.Optional(CONF_UPDATE_INTERVAL):
             vol.All(cv.time_period, cv.positive_timedelta),
-        vol.Optional(CONF_SCAN_INTERVAL):
+        vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_INTERVAL):
             vol.All(cv.time_period, cv.positive_timedelta),
         vol.Required(CONF_HOST): cv.string,
         vol.Required(CONF_MAC): cv.string,

--- a/homeassistant/components/sensor/darksky.py
+++ b/homeassistant/components/sensor/darksky.py
@@ -14,7 +14,8 @@ import voluptuous as vol
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
     ATTR_ATTRIBUTION, CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE,
-    CONF_MONITORED_CONDITIONS, CONF_NAME, UNIT_UV_INDEX, CONF_UPDATE_INTERVAL)
+    CONF_MONITORED_CONDITIONS, CONF_NAME, UNIT_UV_INDEX, CONF_UPDATE_INTERVAL,
+    CONF_SCAN_INTERVAL, CONF_UPDATE_INTERVAL_INVALIDATION_VERSION)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
@@ -30,8 +31,8 @@ CONF_LANGUAGE = 'language'
 CONF_UNITS = 'units'
 
 DEFAULT_LANGUAGE = 'en'
-
 DEFAULT_NAME = 'Dark Sky'
+DEFAULT_INTERVAL = timedelta(seconds=300)
 
 DEPRECATED_SENSOR_TYPES = {
     'apparent_temperature_max',
@@ -167,23 +168,41 @@ LANGUAGE_CODES = [
     'tet', 'tr', 'uk', 'x-pig-latin', 'zh', 'zh-tw',
 ]
 
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_MONITORED_CONDITIONS):
-        vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
-    vol.Required(CONF_API_KEY): cv.string,
-    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional(CONF_UNITS): vol.In(['auto', 'si', 'us', 'ca', 'uk', 'uk2']),
-    vol.Optional(CONF_LANGUAGE,
-                 default=DEFAULT_LANGUAGE): vol.In(LANGUAGE_CODES),
-    vol.Inclusive(CONF_LATITUDE, 'coordinates',
-                  'Latitude and longitude must exist together'): cv.latitude,
-    vol.Inclusive(CONF_LONGITUDE, 'coordinates',
-                  'Latitude and longitude must exist together'): cv.longitude,
-    vol.Optional(CONF_UPDATE_INTERVAL, default=timedelta(seconds=300)): (
-        vol.All(cv.time_period, cv.positive_timedelta)),
-    vol.Optional(CONF_FORECAST):
-        vol.All(cv.ensure_list, [vol.Range(min=0, max=7)]),
-})
+ALLOWED_UNITS = ['auto', 'si', 'us', 'ca', 'uk', 'uk2']
+
+PLATFORM_SCHEMA = vol.All(
+    PLATFORM_SCHEMA.extend({
+        vol.Required(CONF_MONITORED_CONDITIONS):
+            vol.All(cv.ensure_list, [vol.In(SENSOR_TYPES)]),
+        vol.Required(CONF_API_KEY): cv.string,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+        vol.Optional(CONF_UNITS): vol.In(ALLOWED_UNITS),
+        vol.Optional(CONF_LANGUAGE,
+                     default=DEFAULT_LANGUAGE): vol.In(LANGUAGE_CODES),
+        vol.Inclusive(
+            CONF_LATITUDE,
+            'coordinates',
+            'Latitude and longitude must exist together'
+        ): cv.latitude,
+        vol.Inclusive(
+            CONF_LONGITUDE,
+            'coordinates',
+            'Latitude and longitude must exist together'
+        ): cv.longitude,
+        vol.Optional(CONF_UPDATE_INTERVAL):
+            vol.All(cv.time_period, cv.positive_timedelta),
+        vol.Optional(CONF_SCAN_INTERVAL):
+            vol.All(cv.time_period, cv.positive_timedelta),
+        vol.Optional(CONF_FORECAST):
+            vol.All(cv.ensure_list, [vol.Range(min=0, max=7)]),
+    }),
+    cv.deprecated(
+        CONF_UPDATE_INTERVAL,
+        replacement_key=CONF_SCAN_INTERVAL,
+        invalidation_version=CONF_UPDATE_INTERVAL_INVALIDATION_VERSION,
+        default=DEFAULT_INTERVAL
+    )
+)
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
@@ -191,7 +210,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     latitude = config.get(CONF_LATITUDE, hass.config.latitude)
     longitude = config.get(CONF_LONGITUDE, hass.config.longitude)
     language = config.get(CONF_LANGUAGE)
-    interval = config.get(CONF_UPDATE_INTERVAL)
+    interval = config[CONF_SCAN_INTERVAL]
 
     if CONF_UNITS in config:
         units = config[CONF_UNITS]

--- a/homeassistant/components/sensor/darksky.py
+++ b/homeassistant/components/sensor/darksky.py
@@ -209,7 +209,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Dark Sky sensor."""
     latitude = config.get(CONF_LATITUDE, hass.config.latitude)
     longitude = config.get(CONF_LONGITUDE, hass.config.longitude)
-    language = config.get(CONF_LANGUAGE)
+    language = config[CONF_LANGUAGE]
     interval = config[CONF_SCAN_INTERVAL]
 
     if CONF_UNITS in config:

--- a/homeassistant/components/sensor/darksky.py
+++ b/homeassistant/components/sensor/darksky.py
@@ -191,7 +191,7 @@ PLATFORM_SCHEMA = vol.All(
         ): cv.longitude,
         vol.Optional(CONF_UPDATE_INTERVAL):
             vol.All(cv.time_period, cv.positive_timedelta),
-        vol.Optional(CONF_SCAN_INTERVAL):
+        vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_INTERVAL):
             vol.All(cv.time_period, cv.positive_timedelta),
         vol.Optional(CONF_FORECAST):
             vol.All(cv.ensure_list, [vol.Range(min=0, max=7)]),

--- a/homeassistant/components/sensor/darksky.py
+++ b/homeassistant/components/sensor/darksky.py
@@ -32,7 +32,7 @@ CONF_UNITS = 'units'
 
 DEFAULT_LANGUAGE = 'en'
 DEFAULT_NAME = 'Dark Sky'
-DEFAULT_INTERVAL = timedelta(seconds=300)
+SCAN_INTERVAL = timedelta(seconds=300)
 
 DEPRECATED_SENSOR_TYPES = {
     'apparent_temperature_max',
@@ -191,8 +191,6 @@ PLATFORM_SCHEMA = vol.All(
         ): cv.longitude,
         vol.Optional(CONF_UPDATE_INTERVAL):
             vol.All(cv.time_period, cv.positive_timedelta),
-        vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_INTERVAL):
-            vol.All(cv.time_period, cv.positive_timedelta),
         vol.Optional(CONF_FORECAST):
             vol.All(cv.ensure_list, [vol.Range(min=0, max=7)]),
     }),
@@ -200,7 +198,7 @@ PLATFORM_SCHEMA = vol.All(
         CONF_UPDATE_INTERVAL,
         replacement_key=CONF_SCAN_INTERVAL,
         invalidation_version=CONF_UPDATE_INTERVAL_INVALIDATION_VERSION,
-        default=DEFAULT_INTERVAL
+        default=SCAN_INTERVAL
     )
 )
 
@@ -210,7 +208,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     latitude = config.get(CONF_LATITUDE, hass.config.latitude)
     longitude = config.get(CONF_LONGITUDE, hass.config.longitude)
     language = config.get(CONF_LANGUAGE)
-    interval = config[CONF_SCAN_INTERVAL]
+    interval = config.get(CONF_SCAN_INTERVAL, SCAN_INTERVAL)
 
     if CONF_UNITS in config:
         units = config[CONF_UNITS]

--- a/homeassistant/components/sensor/darksky.py
+++ b/homeassistant/components/sensor/darksky.py
@@ -209,7 +209,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Dark Sky sensor."""
     latitude = config.get(CONF_LATITUDE, hass.config.latitude)
     longitude = config.get(CONF_LONGITUDE, hass.config.longitude)
-    language = config[CONF_LANGUAGE]
+    language = config.get(CONF_LANGUAGE)
     interval = config[CONF_SCAN_INTERVAL]
 
     if CONF_UNITS in config:

--- a/homeassistant/components/sensor/fedex.py
+++ b/homeassistant/components/sensor/fedex.py
@@ -33,7 +33,7 @@ ICON = 'mdi:package-variant-closed'
 
 STATUS_DELIVERED = 'delivered'
 
-DEFAULT_INTERVAL = timedelta(seconds=1800)
+SCAN_INTERVAL = timedelta(seconds=1800)
 
 PLATFORM_SCHEMA = vol.All(
     PLATFORM_SCHEMA.extend({
@@ -42,14 +42,12 @@ PLATFORM_SCHEMA = vol.All(
         vol.Optional(CONF_NAME): cv.string,
         vol.Optional(CONF_UPDATE_INTERVAL):
             vol.All(cv.time_period, cv.positive_timedelta),
-        vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_INTERVAL):
-            vol.All(cv.time_period, cv.positive_timedelta),
     }),
     cv.deprecated(
         CONF_UPDATE_INTERVAL,
         replacement_key=CONF_SCAN_INTERVAL,
         invalidation_version=CONF_UPDATE_INTERVAL_INVALIDATION_VERSION,
-        default=DEFAULT_INTERVAL
+        default=SCAN_INTERVAL
     )
 )
 
@@ -59,7 +57,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     import fedexdeliverymanager
 
     name = config.get(CONF_NAME)
-    update_interval = config[CONF_SCAN_INTERVAL]
+    update_interval = config.get(CONF_SCAN_INTERVAL, SCAN_INTERVAL)
 
     try:
         cookie = hass.config.path(COOKIE)

--- a/homeassistant/components/sensor/fedex.py
+++ b/homeassistant/components/sensor/fedex.py
@@ -12,7 +12,9 @@ import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (CONF_NAME, CONF_USERNAME, CONF_PASSWORD,
-                                 ATTR_ATTRIBUTION, CONF_UPDATE_INTERVAL)
+                                 ATTR_ATTRIBUTION, CONF_UPDATE_INTERVAL,
+                                 CONF_SCAN_INTERVAL,
+                                 CONF_UPDATE_INTERVAL_INVALIDATION_VERSION)
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import slugify
 from homeassistant.util import Throttle
@@ -31,13 +33,25 @@ ICON = 'mdi:package-variant-closed'
 
 STATUS_DELIVERED = 'delivered'
 
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_USERNAME): cv.string,
-    vol.Required(CONF_PASSWORD): cv.string,
-    vol.Optional(CONF_NAME): cv.string,
-    vol.Optional(CONF_UPDATE_INTERVAL, default=timedelta(seconds=1800)):
-        vol.All(cv.time_period, cv.positive_timedelta),
-})
+DEFAULT_INTERVAL = timedelta(seconds=1800)
+
+PLATFORM_SCHEMA = vol.All(
+    PLATFORM_SCHEMA.extend({
+        vol.Required(CONF_USERNAME): cv.string,
+        vol.Required(CONF_PASSWORD): cv.string,
+        vol.Optional(CONF_NAME): cv.string,
+        vol.Optional(CONF_UPDATE_INTERVAL):
+            vol.All(cv.time_period, cv.positive_timedelta),
+        vol.Optional(CONF_SCAN_INTERVAL):
+            vol.All(cv.time_period, cv.positive_timedelta),
+    }),
+    cv.deprecated(
+        CONF_UPDATE_INTERVAL,
+        replacement_key=CONF_SCAN_INTERVAL,
+        invalidation_version=CONF_UPDATE_INTERVAL_INVALIDATION_VERSION,
+        default=DEFAULT_INTERVAL
+    )
+)
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
@@ -45,7 +59,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     import fedexdeliverymanager
 
     name = config.get(CONF_NAME)
-    update_interval = config.get(CONF_UPDATE_INTERVAL)
+    update_interval = config[CONF_SCAN_INTERVAL]
 
     try:
         cookie = hass.config.path(COOKIE)

--- a/homeassistant/components/sensor/fedex.py
+++ b/homeassistant/components/sensor/fedex.py
@@ -42,7 +42,7 @@ PLATFORM_SCHEMA = vol.All(
         vol.Optional(CONF_NAME): cv.string,
         vol.Optional(CONF_UPDATE_INTERVAL):
             vol.All(cv.time_period, cv.positive_timedelta),
-        vol.Optional(CONF_SCAN_INTERVAL):
+        vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_INTERVAL):
             vol.All(cv.time_period, cv.positive_timedelta),
     }),
     cv.deprecated(

--- a/homeassistant/components/sensor/ups.py
+++ b/homeassistant/components/sensor/ups.py
@@ -39,7 +39,7 @@ PLATFORM_SCHEMA = vol.All(
         vol.Optional(CONF_NAME): cv.string,
         vol.Optional(CONF_UPDATE_INTERVAL): (
             vol.All(cv.time_period, cv.positive_timedelta)),
-        vol.Optional(CONF_SCAN_INTERVAL): (
+        vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_INTERVAL): (
             vol.All(cv.time_period, cv.positive_timedelta)),
     }),
     cv.deprecated(

--- a/homeassistant/components/sensor/ups.py
+++ b/homeassistant/components/sensor/ups.py
@@ -12,7 +12,9 @@ import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (CONF_NAME, CONF_USERNAME, CONF_PASSWORD,
-                                 ATTR_ATTRIBUTION, CONF_UPDATE_INTERVAL)
+                                 ATTR_ATTRIBUTION, CONF_UPDATE_INTERVAL,
+                                 CONF_SCAN_INTERVAL,
+                                 CONF_UPDATE_INTERVAL_INVALIDATION_VERSION)
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import slugify
 from homeassistant.util import Throttle
@@ -28,13 +30,25 @@ COOKIE = 'upsmychoice_cookies.pickle'
 ICON = 'mdi:package-variant-closed'
 STATUS_DELIVERED = 'delivered'
 
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_USERNAME): cv.string,
-    vol.Required(CONF_PASSWORD): cv.string,
-    vol.Optional(CONF_NAME): cv.string,
-    vol.Optional(CONF_UPDATE_INTERVAL, default=timedelta(seconds=1800)): (
-        vol.All(cv.time_period, cv.positive_timedelta)),
-})
+DEFAULT_INTERVAL = timedelta(seconds=1800)
+
+PLATFORM_SCHEMA = vol.All(
+    PLATFORM_SCHEMA.extend({
+        vol.Required(CONF_USERNAME): cv.string,
+        vol.Required(CONF_PASSWORD): cv.string,
+        vol.Optional(CONF_NAME): cv.string,
+        vol.Optional(CONF_UPDATE_INTERVAL): (
+            vol.All(cv.time_period, cv.positive_timedelta)),
+        vol.Optional(CONF_SCAN_INTERVAL): (
+            vol.All(cv.time_period, cv.positive_timedelta)),
+    }),
+    cv.deprecated(
+        CONF_UPDATE_INTERVAL,
+        replacement_key=CONF_SCAN_INTERVAL,
+        invalidation_version=CONF_UPDATE_INTERVAL_INVALIDATION_VERSION,
+        default=DEFAULT_INTERVAL
+    )
+)
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
@@ -50,7 +64,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         return False
 
     add_entities([UPSSensor(session, config.get(CONF_NAME),
-                            config.get(CONF_UPDATE_INTERVAL))], True)
+                            config[CONF_SCAN_INTERVAL])], True)
 
 
 class UPSSensor(Entity):

--- a/homeassistant/components/sensor/ups.py
+++ b/homeassistant/components/sensor/ups.py
@@ -30,7 +30,7 @@ COOKIE = 'upsmychoice_cookies.pickle'
 ICON = 'mdi:package-variant-closed'
 STATUS_DELIVERED = 'delivered'
 
-DEFAULT_INTERVAL = timedelta(seconds=1800)
+SCAN_INTERVAL = timedelta(seconds=1800)
 
 PLATFORM_SCHEMA = vol.All(
     PLATFORM_SCHEMA.extend({
@@ -39,14 +39,12 @@ PLATFORM_SCHEMA = vol.All(
         vol.Optional(CONF_NAME): cv.string,
         vol.Optional(CONF_UPDATE_INTERVAL): (
             vol.All(cv.time_period, cv.positive_timedelta)),
-        vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_INTERVAL): (
-            vol.All(cv.time_period, cv.positive_timedelta)),
     }),
     cv.deprecated(
         CONF_UPDATE_INTERVAL,
         replacement_key=CONF_SCAN_INTERVAL,
         invalidation_version=CONF_UPDATE_INTERVAL_INVALIDATION_VERSION,
-        default=DEFAULT_INTERVAL
+        default=SCAN_INTERVAL
     )
 )
 
@@ -63,8 +61,11 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         _LOGGER.exception("Could not connect to UPS My Choice")
         return False
 
-    add_entities([UPSSensor(session, config.get(CONF_NAME),
-                            config[CONF_SCAN_INTERVAL])], True)
+    add_entities([UPSSensor(
+        session,
+        config.get(CONF_NAME),
+        config.get(CONF_SCAN_INTERVAL, SCAN_INTERVAL)
+    )], True)
 
 
 class UPSSensor(Entity):

--- a/homeassistant/components/speedtestdotnet/__init__.py
+++ b/homeassistant/components/speedtestdotnet/__init__.py
@@ -8,7 +8,8 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.components.speedtestdotnet.const import DOMAIN, \
     DATA_UPDATED, SENSOR_TYPES
 from homeassistant.const import CONF_MONITORED_CONDITIONS, \
-    CONF_UPDATE_INTERVAL
+    CONF_UPDATE_INTERVAL, CONF_SCAN_INTERVAL, \
+    CONF_UPDATE_INTERVAL_INVALIDATION_VERSION
 from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.dispatcher import dispatcher_send
 from homeassistant.helpers.event import async_track_time_interval
@@ -24,16 +25,26 @@ CONF_MANUAL = 'manual'
 DEFAULT_INTERVAL = timedelta(hours=1)
 
 CONFIG_SCHEMA = vol.Schema({
-    DOMAIN: vol.Schema({
-        vol.Optional(CONF_SERVER_ID): cv.positive_int,
-        vol.Optional(CONF_UPDATE_INTERVAL, default=DEFAULT_INTERVAL):
-            vol.All(
-                cv.time_period, cv.positive_timedelta
-            ),
-        vol.Optional(CONF_MANUAL, default=False): cv.boolean,
-        vol.Optional(CONF_MONITORED_CONDITIONS, default=list(SENSOR_TYPES)):
-            vol.All(cv.ensure_list, [vol.In(list(SENSOR_TYPES))])
-    })
+    DOMAIN: vol.All(
+        vol.Schema({
+            vol.Optional(CONF_SERVER_ID): cv.positive_int,
+            vol.Optional(CONF_UPDATE_INTERVAL):
+                vol.All(cv.time_period, cv.positive_timedelta),
+            vol.Optional(CONF_SCAN_INTERVAL):
+                vol.All(cv.time_period, cv.positive_timedelta),
+            vol.Optional(CONF_MANUAL, default=False): cv.boolean,
+            vol.Optional(
+                CONF_MONITORED_CONDITIONS,
+                default=list(SENSOR_TYPES)
+            ): vol.All(cv.ensure_list, [vol.In(list(SENSOR_TYPES))])
+        }),
+        cv.deprecated(
+            CONF_UPDATE_INTERVAL,
+            replacement_key=CONF_SCAN_INTERVAL,
+            invalidation_version=CONF_UPDATE_INTERVAL_INVALIDATION_VERSION,
+            default=DEFAULT_INTERVAL
+        )
+    )
 }, extra=vol.ALLOW_EXTRA)
 
 
@@ -44,7 +55,7 @@ async def async_setup(hass, config):
 
     if not conf[CONF_MANUAL]:
         async_track_time_interval(
-            hass, data.update, conf[CONF_UPDATE_INTERVAL]
+            hass, data.update, conf[CONF_SCAN_INTERVAL]
         )
 
     def update(call=None):

--- a/homeassistant/components/speedtestdotnet/__init__.py
+++ b/homeassistant/components/speedtestdotnet/__init__.py
@@ -30,7 +30,7 @@ CONFIG_SCHEMA = vol.Schema({
             vol.Optional(CONF_SERVER_ID): cv.positive_int,
             vol.Optional(CONF_UPDATE_INTERVAL):
                 vol.All(cv.time_period, cv.positive_timedelta),
-            vol.Optional(CONF_SCAN_INTERVAL):
+            vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_INTERVAL):
                 vol.All(cv.time_period, cv.positive_timedelta),
             vol.Optional(CONF_MANUAL, default=False): cv.boolean,
             vol.Optional(

--- a/homeassistant/components/tellduslive/__init__.py
+++ b/homeassistant/components/tellduslive/__init__.py
@@ -6,7 +6,8 @@ import logging
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.const import CONF_UPDATE_INTERVAL
+from homeassistant.const import CONF_UPDATE_INTERVAL, CONF_SCAN_INTERVAL, \
+    CONF_UPDATE_INTERVAL_INVALIDATION_VERSION
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.event import async_call_later
@@ -23,17 +24,23 @@ REQUIREMENTS = ['tellduslive==0.10.10']
 
 _LOGGER = logging.getLogger(__name__)
 
-CONFIG_SCHEMA = vol.Schema(
-    {
-        DOMAIN:
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.All(
         vol.Schema({
             vol.Optional(CONF_HOST, default=DOMAIN): cv.string,
-            vol.Optional(CONF_UPDATE_INTERVAL, default=SCAN_INTERVAL):
-            (vol.All(cv.time_period, vol.Clamp(min=MIN_UPDATE_INTERVAL)))
+            vol.Optional(CONF_UPDATE_INTERVAL):
+                vol.All(cv.time_period, vol.Clamp(min=MIN_UPDATE_INTERVAL)),
+            vol.Optional(CONF_SCAN_INTERVAL, default=SCAN_INTERVAL):
+                vol.All(cv.time_period, vol.Clamp(min=MIN_UPDATE_INTERVAL)),
         }),
-    },
-    extra=vol.ALLOW_EXTRA,
-)
+        cv.deprecated(
+            CONF_UPDATE_INTERVAL,
+            replacement_key=CONF_SCAN_INTERVAL,
+            invalidation_version=CONF_UPDATE_INTERVAL_INVALIDATION_VERSION,
+            default=SCAN_INTERVAL
+        )
+    )
+}, extra=vol.ALLOW_EXTRA)
 
 DATA_CONFIG_ENTRY_LOCK = 'tellduslive_config_entry_lock'
 CONFIG_ENTRY_IS_SETUP = 'telldus_config_entry_is_setup'
@@ -102,7 +109,7 @@ async def async_setup(hass, config):
             context={'source': config_entries.SOURCE_IMPORT},
             data={
                 KEY_HOST: config[DOMAIN].get(CONF_HOST),
-                KEY_SCAN_INTERVAL: config[DOMAIN].get(CONF_UPDATE_INTERVAL),
+                KEY_SCAN_INTERVAL: config[DOMAIN][CONF_SCAN_INTERVAL],
             }))
     return True
 

--- a/homeassistant/components/volvooncall/__init__.py
+++ b/homeassistant/components/volvooncall/__init__.py
@@ -90,7 +90,7 @@ CONFIG_SCHEMA = vol.Schema({
             vol.Required(CONF_PASSWORD): cv.string,
             vol.Optional(CONF_UPDATE_INTERVAL):
                 vol.All(cv.time_period, vol.Clamp(min=MIN_UPDATE_INTERVAL)),
-            vol.Optional(CONF_SCAN_INTERVAL):
+            vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_UPDATE_INTERVAL):
                 vol.All(cv.time_period, vol.Clamp(min=MIN_UPDATE_INTERVAL)),
             vol.Optional(CONF_NAME, default={}):
                 cv.schema_with_slug_keys(cv.string),

--- a/homeassistant/components/volvooncall/__init__.py
+++ b/homeassistant/components/volvooncall/__init__.py
@@ -6,7 +6,8 @@ import voluptuous as vol
 
 from homeassistant.const import (CONF_USERNAME, CONF_PASSWORD,
                                  CONF_NAME, CONF_RESOURCES,
-                                 CONF_UPDATE_INTERVAL)
+                                 CONF_UPDATE_INTERVAL, CONF_SCAN_INTERVAL,
+                                 CONF_UPDATE_INTERVAL_INVALIDATION_VERSION)
 from homeassistant.helpers import discovery
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
@@ -83,20 +84,30 @@ RESOURCES = [
 ]
 
 CONFIG_SCHEMA = vol.Schema({
-    DOMAIN: vol.Schema({
-        vol.Required(CONF_USERNAME): cv.string,
-        vol.Required(CONF_PASSWORD): cv.string,
-        vol.Optional(CONF_UPDATE_INTERVAL, default=DEFAULT_UPDATE_INTERVAL): (
-            vol.All(cv.time_period, vol.Clamp(min=MIN_UPDATE_INTERVAL))),
-        vol.Optional(CONF_NAME, default={}):
-            cv.schema_with_slug_keys(cv.string),
-        vol.Optional(CONF_RESOURCES): vol.All(
-            cv.ensure_list, [vol.In(RESOURCES)]),
-        vol.Optional(CONF_REGION): cv.string,
-        vol.Optional(CONF_SERVICE_URL): cv.string,
-        vol.Optional(CONF_MUTABLE, default=True): cv.boolean,
-        vol.Optional(CONF_SCANDINAVIAN_MILES, default=False): cv.boolean,
-    }),
+    DOMAIN: vol.All(
+        vol.Schema({
+            vol.Required(CONF_USERNAME): cv.string,
+            vol.Required(CONF_PASSWORD): cv.string,
+            vol.Optional(CONF_UPDATE_INTERVAL):
+                vol.All(cv.time_period, vol.Clamp(min=MIN_UPDATE_INTERVAL)),
+            vol.Optional(CONF_SCAN_INTERVAL):
+                vol.All(cv.time_period, vol.Clamp(min=MIN_UPDATE_INTERVAL)),
+            vol.Optional(CONF_NAME, default={}):
+                cv.schema_with_slug_keys(cv.string),
+            vol.Optional(CONF_RESOURCES): vol.All(
+                cv.ensure_list, [vol.In(RESOURCES)]),
+            vol.Optional(CONF_REGION): cv.string,
+            vol.Optional(CONF_SERVICE_URL): cv.string,
+            vol.Optional(CONF_MUTABLE, default=True): cv.boolean,
+            vol.Optional(CONF_SCANDINAVIAN_MILES, default=False): cv.boolean,
+        }),
+        cv.deprecated(
+            CONF_UPDATE_INTERVAL,
+            replacement_key=CONF_SCAN_INTERVAL,
+            invalidation_version=CONF_UPDATE_INTERVAL_INVALIDATION_VERSION,
+            default=DEFAULT_UPDATE_INTERVAL
+        )
+    )
 }, extra=vol.ALLOW_EXTRA)
 
 
@@ -112,7 +123,7 @@ async def async_setup(hass, config):
         service_url=config[DOMAIN].get(CONF_SERVICE_URL),
         region=config[DOMAIN].get(CONF_REGION))
 
-    interval = config[DOMAIN].get(CONF_UPDATE_INTERVAL)
+    interval = config[DOMAIN][CONF_SCAN_INTERVAL]
 
     data = hass.data[DATA_KEY] = VolvoData(config)
 

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -147,7 +147,11 @@ CONF_TTL = 'ttl'
 CONF_TYPE = 'type'
 CONF_UNIT_OF_MEASUREMENT = 'unit_of_measurement'
 CONF_UNIT_SYSTEM = 'unit_system'
+
+# Deprecated in 0.88.0, invalidated in 0.91.0, remove in 0.92.0
 CONF_UPDATE_INTERVAL = 'update_interval'
+CONF_UPDATE_INTERVAL_INVALIDATION_VERSION = '0.91.0'
+
 CONF_URL = 'url'
 CONF_USERNAME = 'username'
 CONF_VALUE_TEMPLATE = 'value_template'

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -606,7 +606,8 @@ def deprecated(key: str,
         else:
             value = default
         if (replacement_key
-                and replacement_key not in config
+                and (replacement_key not in config
+                     or default == config.get(replacement_key))
                 and value is not None):
             config[replacement_key] = value
 

--- a/tests/components/freedns/test_init.py
+++ b/tests/components/freedns/test_init.py
@@ -24,7 +24,7 @@ def setup_freedns(hass, aioclient_mock):
     hass.loop.run_until_complete(async_setup_component(hass, freedns.DOMAIN, {
             freedns.DOMAIN: {
                 'access_token': ACCESS_TOKEN,
-                'update_interval': UPDATE_INTERVAL,
+                'scan_interval': UPDATE_INTERVAL,
             }
         }))
 
@@ -62,7 +62,7 @@ def test_setup_fails_if_wrong_token(hass, aioclient_mock):
     result = yield from async_setup_component(hass, freedns.DOMAIN, {
         freedns.DOMAIN: {
             'access_token': ACCESS_TOKEN,
-            'update_interval': UPDATE_INTERVAL,
+            'scan_interval': UPDATE_INTERVAL,
         }
     })
     assert not result

--- a/tests/components/sensor/test_darksky.py
+++ b/tests/components/sensor/test_darksky.py
@@ -1,7 +1,7 @@
 """The tests for the Dark Sky platform."""
 import re
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 from datetime import timedelta
 
 from requests.exceptions import HTTPError
@@ -9,7 +9,6 @@ import requests_mock
 
 import forecastio
 
-from homeassistant.components.sensor import darksky
 from homeassistant.setup import setup_component
 
 from tests.common import (load_fixture, get_test_home_assistant,
@@ -138,9 +137,7 @@ class TestDarkSkySetup(unittest.TestCase):
         msg = '400 Client Error: Bad Request for url: {}'.format(url)
         mock_get_forecast.side_effect = HTTPError(msg,)
 
-        response = darksky.setup_platform(self.hass, VALID_CONFIG_MINIMAL,
-                                          MagicMock())
-        assert not response
+        assert setup_component(self.hass, 'sensor', VALID_CONFIG_MINIMAL)
 
     @requests_mock.Mocker()
     @patch('forecastio.api.get_forecast', wraps=forecastio.api.get_forecast)

--- a/tests/components/sensor/test_darksky.py
+++ b/tests/components/sensor/test_darksky.py
@@ -1,7 +1,7 @@
 """The tests for the Dark Sky platform."""
 import re
 import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 from datetime import timedelta
 
 from requests.exceptions import HTTPError
@@ -9,6 +9,7 @@ import requests_mock
 
 import forecastio
 
+from homeassistant.components.sensor import darksky
 from homeassistant.setup import setup_component
 
 from tests.common import (load_fixture, get_test_home_assistant,
@@ -137,7 +138,12 @@ class TestDarkSkySetup(unittest.TestCase):
         msg = '400 Client Error: Bad Request for url: {}'.format(url)
         mock_get_forecast.side_effect = HTTPError(msg,)
 
-        assert setup_component(self.hass, 'sensor', VALID_CONFIG_MINIMAL)
+        response = darksky.setup_platform(
+            self.hass,
+            VALID_CONFIG_MINIMAL['sensor'],
+            MagicMock()
+        )
+        assert not response
 
     @requests_mock.Mocker()
     @patch('forecastio.api.get_forecast', wraps=forecastio.api.get_forecast)

--- a/tests/components/sensor/test_darksky.py
+++ b/tests/components/sensor/test_darksky.py
@@ -21,7 +21,7 @@ VALID_CONFIG_MINIMAL = {
         'api_key': 'foo',
         'forecast': [1, 2],
         'monitored_conditions': ['summary', 'icon', 'temperature_high'],
-        'update_interval': timedelta(seconds=120),
+        'scan_interval': timedelta(seconds=120),
     }
 }
 
@@ -31,7 +31,7 @@ INVALID_CONFIG_MINIMAL = {
         'api_key': 'foo',
         'forecast': [1, 2],
         'monitored_conditions': ['sumary', 'iocn', 'temperature_high'],
-        'update_interval': timedelta(seconds=120),
+        'scan_interval': timedelta(seconds=120),
     }
 }
 
@@ -45,7 +45,7 @@ VALID_CONFIG_LANG_DE = {
         'monitored_conditions': ['summary', 'icon', 'temperature_high',
                                  'minutely_summary', 'hourly_summary',
                                  'daily_summary', 'humidity', ],
-        'update_interval': timedelta(seconds=120),
+        'scan_interval': timedelta(seconds=120),
     }
 }
 
@@ -56,7 +56,7 @@ INVALID_CONFIG_LANG = {
         'forecast': [1, 2],
         'language': 'yz',
         'monitored_conditions': ['summary', 'icon', 'temperature_high'],
-        'update_interval': timedelta(seconds=120),
+        'scan_interval': timedelta(seconds=120),
     }
 }
 

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -713,7 +713,7 @@ def test_deprecated_with_default(caplog, schema):
 
 def test_deprecated_with_replacement_key_and_default(caplog, schema):
     """
-    Test deprecation behaves correctly when only a replacement key is provided.
+    Test deprecation with a replacement key and default.
 
     Expected behavior:
         - Outputs the appropriate deprecation warning if key is detected
@@ -747,6 +747,22 @@ def test_deprecated_with_replacement_key_and_default(caplog, schema):
     output = deprecated_schema(test_data.copy())
     assert len(caplog.records) == 0
     assert {'venus': True, 'jupiter': False} == output
+
+    deprecated_schema_with_default = vol.All(
+        vol.Schema({
+            'venus': cv.boolean,
+            vol.Optional('mars', default=False): cv.boolean,
+            vol.Optional('jupiter', default=False): cv.boolean
+        }),
+        cv.deprecated('mars', replacement_key='jupiter', default=False)
+    )
+
+    test_data = {'mars': True}
+    output = deprecated_schema_with_default(test_data.copy())
+    assert len(caplog.records) == 1
+    assert ("The 'mars' option (with value 'True') is deprecated, "
+            "please replace it with 'jupiter'") in caplog.text
+    assert {'jupiter': True} == output
 
 
 def test_deprecated_with_replacement_key_invalidation_version_default(


### PR DESCRIPTION
## Description:

As noticed in #20526 , `CONF_UPDATE_INTERVAL` and `CONF_SCAN_INTERVAL` serve identical purposes and `CONF_SCAN_INTERVAL` is used a lot more.

Now that we have a clean way to deprecate configs without causing breaking changes, (#20565) we can clean this up.

`CONF_UPDATE_INTERVAL` has been deprecated in 0.88 and is set to become invalid in 0.91 (three versions out). In 0.92, we can go ahead and do a final cleanup since all users should have migrated over by then.

**Breaking Change:** `update_interval` has been deprecated and replaced with `scan_interval` in all components and platforms. This is a soft deprecation in this release and will automatically become a hard breaking change in Home Assistant version 0.91.0.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8603

~~I need to go through all of these components/platforms and update the documentation.~~

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
