### PR TITLE
Use CONF_RECIPIENT for default recipient in config

### DIFF
--- a/homeassistant/components/tplink_lte/__init__.py
+++ b/homeassistant/components/tplink_lte/__init__.py
@@ -13,7 +13,8 @@ import voluptuous as vol
 
 from homeassistant.components.notify import ATTR_TARGET
 from homeassistant.const import (
-    CONF_HOST, CONF_NAME, CONF_PASSWORD, EVENT_HOMEASSISTANT_STOP)
+    CONF_HOST, CONF_NAME, CONF_PASSWORD, EVENT_HOMEASSISTANT_STOP,
+    CONF_RECIPIENT)
 from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv, discovery
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
@@ -27,10 +28,22 @@ DATA_KEY = 'tplink_lte'
 
 CONF_NOTIFY = "notify"
 
-_NOTIFY_SCHEMA = vol.All(vol.Schema({
-    vol.Optional(CONF_NAME): cv.string,
-    vol.Required(ATTR_TARGET): vol.All(cv.ensure_list, [cv.string]),
-}))
+# Deprecated in 0.88.0, invalidated in 0.91.0, remove in 0.92.0
+ATTR_TARGET_INVALIDATION_VERSION = '0.81.0'
+
+_NOTIFY_SCHEMA = vol.All(
+    vol.Schema({
+        vol.Optional(CONF_NAME): cv.string,
+        vol.Optional(ATTR_TARGET): vol.All(cv.ensure_list, [cv.string]),
+        vol.Optional(CONF_RECIPIENT): vol.All(cv.ensure_list, [cv.string])
+    }),
+    cv.deprecated(
+        ATTR_TARGET,
+        replacement_key=CONF_RECIPIENT,
+        invalidation_version=ATTR_TARGET_INVALIDATION_VERSION
+    ),
+    cv.has_at_least_one_key(CONF_RECIPIENT),
+)
 
 CONFIG_SCHEMA = vol.Schema({
     DOMAIN: vol.All(cv.ensure_list, [vol.Schema({

--- a/homeassistant/components/tplink_lte/__init__.py
+++ b/homeassistant/components/tplink_lte/__init__.py
@@ -29,7 +29,7 @@ DATA_KEY = 'tplink_lte'
 CONF_NOTIFY = "notify"
 
 # Deprecated in 0.88.0, invalidated in 0.91.0, remove in 0.92.0
-ATTR_TARGET_INVALIDATION_VERSION = '0.81.0'
+ATTR_TARGET_INVALIDATION_VERSION = '0.91.0'
 
 _NOTIFY_SCHEMA = vol.All(
     vol.Schema({

--- a/homeassistant/components/tplink_lte/notify.py
+++ b/homeassistant/components/tplink_lte/notify.py
@@ -10,6 +10,7 @@ import attr
 
 from homeassistant.components.notify import (
     ATTR_TARGET, BaseNotificationService)
+from homeassistant.const import CONF_RECIPIENT
 
 from ..tplink_lte import DATA_KEY
 
@@ -40,7 +41,7 @@ class TplinkNotifyService(BaseNotificationService):
             _LOGGER.error("No modem available")
             return
 
-        phone = self.config[ATTR_TARGET]
+        phone = self.config[CONF_RECIPIENT]
         targets = kwargs.get(ATTR_TARGET, phone)
         if targets and message:
             for target in targets:


### PR DESCRIPTION
## Description:
Use the new deprecated vol validator to replace `ATTR_TARGET` with `CONF_RECIPIENT` in tpklink_lte.

**Breaking Change:** `target` has been deprecated and replaced with `recipient` in the `tplink_lte` configuration. This is a soft deprecation in this release and will automatically become a hard breaking change in Home Assistant version 0.91.0.

**Related issue (if applicable):** fixes #20671

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8460

## Example entry for `configuration.yaml` (if applicable):
```yaml
tplink_lte:
  - host: IP_ADDRESS
    password: SECRET
    notify:
      - name: sms1
        recipient: "+15105550123"
      - name: sms2
        recipient: "+55520525252"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
