### PR TITLE
0.87.1

### DIFF
--- a/homeassistant/components/geofency/__init__.py
+++ b/homeassistant/components/geofency/__init__.py
@@ -123,7 +123,7 @@ def _set_location(hass, data, location_name):
     )
 
     return web.Response(
-        body="Setting location for {}".format(device),
+        text="Setting location for {}".format(device),
         status=HTTP_OK
     )
 

--- a/homeassistant/components/gpslogger/__init__.py
+++ b/homeassistant/components/gpslogger/__init__.py
@@ -66,7 +66,7 @@ async def handle_webhook(hass, webhook_id, request):
         data = WEBHOOK_SCHEMA(dict(await request.post()))
     except vol.MultipleInvalid as error:
         return web.Response(
-            body=error.error_message,
+            text=error.error_message,
             status=HTTP_UNPROCESSABLE_ENTITY
         )
 
@@ -91,7 +91,7 @@ async def handle_webhook(hass, webhook_id, request):
     )
 
     return web.Response(
-        body='Setting location for {}'.format(device),
+        text='Setting location for {}'.format(device),
         status=HTTP_OK
     )
 

--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -224,7 +224,12 @@ class HomeKitEntity(Entity):
                 if service['iid'] != self._iid:
                     continue
                 for char in service['characteristics']:
-                    uuid = CharacteristicsTypes.get_uuid(char['type'])
+                    try:
+                        uuid = CharacteristicsTypes.get_uuid(char['type'])
+                    except KeyError:
+                        # If a KeyError is raised its a non-standard
+                        # characteristic. We must ignore it in this case.
+                        continue
                     if uuid not in characteristic_types:
                         continue
                     self._setup_characteristic(char)

--- a/homeassistant/components/locative/__init__.py
+++ b/homeassistant/components/locative/__init__.py
@@ -101,7 +101,7 @@ async def handle_webhook(hass, webhook_id, request):
                 location_name
             )
             return web.Response(
-                body='Setting location to not home',
+                text='Setting location to not home',
                 status=HTTP_OK
             )
 
@@ -110,7 +110,7 @@ async def handle_webhook(hass, webhook_id, request):
         # before the previous zone was exited. The enter message will
         # be sent first, then the exit message will be sent second.
         return web.Response(
-            body='Ignoring exit from {} (already in {})'.format(
+            text='Ignoring exit from {} (already in {})'.format(
                 location_name, current_state
             ),
             status=HTTP_OK
@@ -120,14 +120,14 @@ async def handle_webhook(hass, webhook_id, request):
         # In the app, a test message can be sent. Just return something to
         # the user to let them know that it works.
         return web.Response(
-            body='Received test message.',
+            text='Received test message.',
             status=HTTP_OK
         )
 
     _LOGGER.error('Received unidentified message from Locative: %s',
                   direction)
     return web.Response(
-        body='Received unidentified message: {}'.format(direction),
+        text='Received unidentified message: {}'.format(direction),
         status=HTTP_UNPROCESSABLE_ENTITY
     )
 

--- a/homeassistant/components/lock/verisure.py
+++ b/homeassistant/components/lock/verisure.py
@@ -80,7 +80,7 @@ class VerisureDoorlock(LockDevice):
             "$.doorLockStatusList[?(@.deviceLabel=='%s')].lockedState",
             self._device_label)
         if status == 'UNLOCKED':
-            self._state = None
+            self._state = STATE_UNLOCKED
         elif status == 'LOCKED':
             self._state = STATE_LOCKED
         elif status != 'PENDING':

--- a/homeassistant/components/sensor/transmission.py
+++ b/homeassistant/components/sensor/transmission.py
@@ -4,10 +4,12 @@ Support for monitoring the Transmission BitTorrent client API.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/sensor.transmission/
 """
+from datetime import timedelta
+
 import logging
 
 from homeassistant.components.transmission import (
-    DATA_TRANSMISSION, SENSOR_TYPES, SCAN_INTERVAL)
+    DATA_TRANSMISSION, SENSOR_TYPES)
 from homeassistant.const import STATE_IDLE
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
@@ -17,6 +19,8 @@ DEPENDENCIES = ['transmission']
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_NAME = 'Transmission'
+
+SCAN_INTERVAL = timedelta(seconds=120)
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):

--- a/homeassistant/components/sensor/waze_travel_time.py
+++ b/homeassistant/components/sensor/waze_travel_time.py
@@ -16,6 +16,7 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers import location
 from homeassistant.helpers.entity import Entity
+from homeassistant.util import Throttle
 
 REQUIREMENTS = ['WazeRouteCalculator==0.6']
 
@@ -40,6 +41,7 @@ ICON = 'mdi:car'
 REGIONS = ['US', 'NA', 'EU', 'IL', 'AU']
 
 SCAN_INTERVAL = timedelta(minutes=5)
+MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=5)
 
 TRACKABLE_DOMAINS = ['device_tracker', 'sensor', 'zone']
 
@@ -67,7 +69,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     sensor = WazeTravelTime(name, origin, destination, region,
                             incl_filter, excl_filter, realtime)
 
-    add_entities([sensor])
+    add_entities([sensor], True)
 
     # Wait until start event is sent to load this component.
     hass.bus.listen_once(
@@ -182,6 +184,7 @@ class WazeTravelTime(Entity):
 
         return friendly_name
 
+    @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
         """Fetch new state data for the sensor."""
         import WazeRouteCalculator

--- a/homeassistant/components/switch/transmission.py
+++ b/homeassistant/components/switch/transmission.py
@@ -4,10 +4,12 @@ Support for setting the Transmission BitTorrent client Turtle Mode.
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/switch.transmission/
 """
+from datetime import timedelta
+
 import logging
 
 from homeassistant.components.transmission import (
-    DATA_TRANSMISSION, SCAN_INTERVAL)
+    DATA_TRANSMISSION)
 from homeassistant.const import (
     STATE_OFF, STATE_ON)
 from homeassistant.helpers.entity import ToggleEntity
@@ -18,6 +20,8 @@ DEPENDENCIES = ['transmission']
 _LOGGING = logging.getLogger(__name__)
 
 DEFAULT_NAME = 'Transmission Turtle Mode'
+
+SCAN_INTERVAL = timedelta(seconds=120)
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):

--- a/homeassistant/components/zoneminder/__init__.py
+++ b/homeassistant/components/zoneminder/__init__.py
@@ -16,7 +16,7 @@ from homeassistant.helpers.discovery import async_load_platform
 
 _LOGGER = logging.getLogger(__name__)
 
-REQUIREMENTS = ['zm-py==0.3.1']
+REQUIREMENTS = ['zm-py==0.3.3']
 
 CONF_PATH_ZMS = 'path_zms'
 

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -2,7 +2,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 0
 MINOR_VERSION = 87
-PATCH_VERSION = '0'
+PATCH_VERSION = '1'
 __short_version__ = '{}.{}'.format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = '{}.{}'.format(__short_version__, PATCH_VERSION)
 REQUIRED_PYTHON_VER = (3, 5, 3)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1792,4 +1792,4 @@ zigpy-xbee==0.1.1
 zigpy==0.2.0
 
 # homeassistant.components.zoneminder
-zm-py==0.3.1
+zm-py==0.3.3


### PR DESCRIPTION
- Fix waze_travel_time component ERROR on startup ([@VirtualL] - [#20316]) ([sensor.waze_travel_time docs])
- Add Transmission component 'scan_interval' option ([@jonudewux] - [#20575]) ([transmission docs])
- Fix homekit_controller non-standard hk characteristics ([@Jc2k] - [#20824]) ([homekit_controller docs])
- Fix STATE_UNLOCKED for verisure ([@Danielhiversen] - [#20858]) ([verisure docs])
- Use text= instead of body= for creating web responses ([@balloob] - [#20879])
- Upgrade zm-py to 0.3.3 ([@mnoorenberghe] - [#20886]) ([zoneminder docs])

[#20316]: https://github.com/home-assistant/home-assistant/pull/20316
[#20575]: https://github.com/home-assistant/home-assistant/pull/20575
[#20824]: https://github.com/home-assistant/home-assistant/pull/20824
[#20858]: https://github.com/home-assistant/home-assistant/pull/20858
[#20879]: https://github.com/home-assistant/home-assistant/pull/20879
[#20886]: https://github.com/home-assistant/home-assistant/pull/20886
[@Danielhiversen]: https://github.com/Danielhiversen
[@Jc2k]: https://github.com/Jc2k
[@VirtualL]: https://github.com/VirtualL
[@balloob]: https://github.com/balloob
[@jonudewux]: https://github.com/jonudewux
[@mnoorenberghe]: https://github.com/mnoorenberghe
[homekit_controller docs]: https://www.home-assistant.io/components/homekit_controller/
[sensor.waze_travel_time docs]: https://www.home-assistant.io/components/sensor.waze_travel_time/
[transmission docs]: https://www.home-assistant.io/components/transmission/
[verisure docs]: https://www.home-assistant.io/components/verisure/
[zoneminder docs]: https://www.home-assistant.io/components/zoneminder/