### PR TITLE
Fix encoding for MQTT camera

### DIFF
--- a/homeassistant/components/mqtt/camera.py
+++ b/homeassistant/components/mqtt/camera.py
@@ -110,7 +110,8 @@ class MqttCamera(MqttDiscoveryUpdate, Camera):
             self.hass, self._sub_state,
             {'state_topic': {'topic': self._config.get(CONF_TOPIC),
                              'msg_callback': message_received,
-                             'qos': self._qos}})
+                             'qos': self._qos,
+                             'encoding': None}})
 
     async def async_will_remove_from_hass(self):
         """Unsubscribe when removed."""

--- a/tests/components/mqtt/test_camera.py
+++ b/tests/components/mqtt/test_camera.py
@@ -168,7 +168,7 @@ async def test_entity_id_update(hass, mqtt_mock):
     state = hass.states.get('camera.beer')
     assert state is not None
     assert mock_mqtt.async_subscribe.call_count == 1
-    mock_mqtt.async_subscribe.assert_any_call('test-topic', ANY, 0, 'utf-8')
+    mock_mqtt.async_subscribe.assert_any_call('test-topic', ANY, 0, None)
     mock_mqtt.async_subscribe.reset_mock()
 
     registry.async_update_entity('camera.beer', new_entity_id='camera.milk')
@@ -181,4 +181,4 @@ async def test_entity_id_update(hass, mqtt_mock):
     state = hass.states.get('camera.milk')
     assert state is not None
     assert mock_mqtt.async_subscribe.call_count == 1
-    mock_mqtt.async_subscribe.assert_any_call('test-topic', ANY, 0, 'utf-8')
+    mock_mqtt.async_subscribe.assert_any_call('test-topic', ANY, 0, None)


### PR DESCRIPTION
## Description:
Fix encoding for MQTT camera, which was incorrectly changed to UTF-8 by PR #20529

**Related issue (if applicable):** fixes #20855

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
