### PR TITLE
Correctly detect devices, which went offline during HA restart

### DIFF
--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -579,8 +579,7 @@ class Device(RestoreEntity):
             return
         self._state = state.state
         self.last_update_home = (state.state == STATE_HOME)
-        if self.last_update_home:
-            self.last_seen = dt_util.utcnow()
+        self.last_seen = dt_util.utcnow()
 
         for attr, var in (
                 (ATTR_SOURCE_TYPE, 'source_type'),

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -579,6 +579,8 @@ class Device(RestoreEntity):
             return
         self._state = state.state
         self.last_update_home = (state.state == STATE_HOME)
+        if self.last_update_home:
+            self.last_seen = dt_util.utcnow()
 
         for attr, var in (
                 (ATTR_SOURCE_TYPE, 'source_type'),


### PR DESCRIPTION
## Description:

**Related issue:** fixes #18698

This fix addresses the following scenario:

1. Device is online (`home`)
2. Stop Home Assistant
3. Power off device
4. Start Home Assistant
5. Home Assistant thinks that the device is `home` forever

So, what happens?

1. `Device` object is created with `state` = `not home` and `last seen` = None.
2. `async_added_to_hass` loads the previous state of the entity and updates `state` = `home`.  `last_seen` is still None.
3. Sooner or later `async_update_stale` correctly detects that the device is stale and triggers `async_update_ha_state`.
4. It calls `async_update` and we expect that the following code will run:
    ```
        elif self.stale():
            self.mark_stale()
    ```
    Nope.  Nothing happens because:
    ```
        if not self.last_seen:
            return
    ```

The cause of the problem is a situation when `state` = `home` and `last seen` = None: a device was never seen, but is treated online.

The idea of the fix is to set *some* `last_seen` when we loaded the previous state and it's `home`.  That allows to correctly handle the scenario above and shouldn't break any other scenarios.

## Example entry for `configuration.yaml`:
```yaml
device_tracker:
  - platform: ping
    consider_home: 120
    hosts:
      slinex: 192.168.1.83
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
