### PR TITLE
Teleinfo

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -552,6 +552,7 @@ omit =
     homeassistant/components/sensor/tank_utility.py
     homeassistant/components/sensor/tautulli.py
     homeassistant/components/sensor/ted5000.py
+    homeassistant/components/sensor/teleinfo.py
     homeassistant/components/sensor/temper.py
     homeassistant/components/sensor/thermoworks_smoke.py
     homeassistant/components/sensor/time_date.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -134,6 +134,7 @@ homeassistant/components/sensor/statistics.py @fabaff
 homeassistant/components/sensor/swiss*.py @fabaff
 homeassistant/components/sensor/sytadin.py @gautric
 homeassistant/components/sensor/tautulli.py @ludeeus
+homeassistant/components/sensor/teleinfo.py @guiguid
 homeassistant/components/sensor/time_data.py @fabaff
 homeassistant/components/sensor/version.py @fabaff
 homeassistant/components/sensor/waqi.py @andrey-git

--- a/homeassistant/components/sensor/teleinfo.py
+++ b/homeassistant/components/sensor/teleinfo.py
@@ -1,0 +1,156 @@
+"""
+Support for reading Teleinfo data from a serial port.
+
+Teleinfo is a French specific protocol used in electricity smart meters.
+It provides real time information on power consumption, rates and current on
+a user accessible serial port.
+
+For more details about this platform, please refer to the documentation at
+https://www.enedis.fr/sites/default/files/Enedis-NOI-CPT_02E.pdf
+
+Work based on https://github.com/nlamirault
+
+Sample configuration.yaml
+
+    sensor:
+    - platform: teleinfo
+        name: "EDF teleinfo"
+        serial_port: "/dev/ttyAMA0"
+    - platform: template
+        sensors:
+        teleinfo_base:
+            value_template: '{{ (states.sensor.edf_teleinfo.
+                attributes["BASE"] | float / 1000) | round(0) }}'
+            unit_of_measurement: 'kWh'
+            icon_template: mdi:flash
+    - platform: template
+        sensors:
+        teleinfo_iinst1:
+            value_template: '{{ states.sensor.edf_teleinfo.
+                attributes["IINST1"] | int }}'
+            unit_of_measurement: 'A'
+            icon_template: mdi:flash
+
+"""
+import logging
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import (
+    CONF_NAME, EVENT_HOMEASSISTANT_STOP, ATTR_ATTRIBUTION)
+from homeassistant.helpers.entity import Entity
+
+REQUIREMENTS = ['pyserial-asyncio==0.4']
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_SERIAL_PORT = 'serial_port'
+
+CONF_ATTRIBUTION = "Provided by EDF Teleinfo."
+
+DEFAULT_NAME = "Serial Teleinfo Sensor"
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_SERIAL_PORT): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string
+})
+
+
+async def async_setup_platform(hass, config, async_add_entities,
+                               discovery_info=None):
+    """Set up the Serial sensor platform."""
+    name = config.get(CONF_NAME)
+    port = config.get(CONF_SERIAL_PORT)
+    sensor = SerialTeleinfoSensor(name, port)
+
+    hass.bus.async_listen_once(
+        EVENT_HOMEASSISTANT_STOP, sensor.stop_serial_read())
+    async_add_entities([sensor], True)
+
+
+class SerialTeleinfoSensor(Entity):
+    """Representation of a Serial sensor."""
+
+    def __init__(self, name, port):
+        """Initialize the Serial sensor."""
+        self._name = name
+        self._port = port
+        self._serial_loop_task = None
+        self._state = None
+        self._attributes = {}
+
+    async def async_added_to_hass(self):
+        """Handle when an entity is about to be added to Home Assistant."""
+        self._serial_loop_task = self.hass.loop.create_task(
+            self.serial_read(self._port, baudrate=1200, bytesize=7,
+                             parity='E', stopbits=1, rtscts=1))
+
+    async def serial_read(self, device, **kwargs):
+        """Process the serial data."""
+        import serial_asyncio
+        _LOGGER.debug(u"Initializing Teleinfo")
+        reader, _ = await serial_asyncio.open_serial_connection(url=device,
+                                                                **kwargs)
+
+        is_over = True
+
+        # First read need to clear the grimlins.
+        line = await reader.readline()
+
+        while True:
+            line = await reader.readline()
+            line = line.decode('ascii').replace('\r', '').replace('\n', '')
+
+            if is_over and ('\x02' in line):
+                is_over = False
+                _LOGGER.debug(" Start Frame")
+                continue
+
+            if (not is_over) and ('\x03' not in line):
+                # Don't use strip() here because the checksum can be ' '.
+                if len(line.split()) == 2:
+                    # The checksum char is ' '.
+                    name, value = line.split()
+                else:
+                    name, value = line.split()[0:2]
+
+                _LOGGER.debug(" Got : [%s] =  (%s)", name, value)
+                self._attributes[name] = value
+
+                if name == 'PAPP':
+                    self._state = int(value)
+                continue
+
+            if (not is_over) and ('\x03' in line):
+                is_over = True
+                self.async_schedule_update_ha_state()
+                _LOGGER.debug(" End Frame")
+                continue
+
+    async def stop_serial_read(self):
+        """Close resources."""
+        if self._serial_loop_task:
+            self._serial_loop_task.cancel()
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def should_poll(self):
+        """No polling needed."""
+        return False
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        self._attributes[ATTR_ATTRIBUTION] = CONF_ATTRIBUTION
+        return self._attributes
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state

--- a/homeassistant/components/sensor/teleinfo.py
+++ b/homeassistant/components/sensor/teleinfo.py
@@ -5,10 +5,10 @@ Teleinfo is a French specific protocol used in electricity smart meters.
 It provides real time information on power consumption, rates and current on
 a user accessible serial port.
 
-For more details about this platform, please refer to the documentation at
-https://www.enedis.fr/sites/default/files/Enedis-NOI-CPT_02E.pdf
-
 Work based on https://github.com/nlamirault
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/sensor.teleinfo/
 
 Sample configuration.yaml
 
@@ -67,7 +67,7 @@ async def async_setup_platform(hass, config, async_add_entities,
 
     hass.bus.async_listen_once(
         EVENT_HOMEASSISTANT_STOP, sensor.stop_serial_read())
-    async_add_entities([sensor], True)
+    async_add_entities([sensor])
 
 
 class SerialTeleinfoSensor(Entity):
@@ -109,13 +109,7 @@ class SerialTeleinfoSensor(Entity):
                 continue
 
             if (not is_over) and ('\x03' not in line):
-                # Don't use strip() here because the checksum can be ' '.
-                if len(line.split()) == 2:
-                    # The checksum char is ' '.
-                    name, value = line.split()
-                else:
-                    name, value = line.split()[0:2]
-
+                name, value = line.split()[0:2]
                 _LOGGER.debug(" Got : [%s] =  (%s)", name, value)
                 self._attributes[name] = value
 
@@ -147,7 +141,6 @@ class SerialTeleinfoSensor(Entity):
     @property
     def device_state_attributes(self):
         """Return the state attributes."""
-        self._attributes[ATTR_ATTRIBUTION] = CONF_ATTRIBUTION
         return self._attributes
 
     @property

--- a/homeassistant/components/sensor/teleinfo.py
+++ b/homeassistant/components/sensor/teleinfo.py
@@ -39,7 +39,7 @@ import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import (
-    CONF_NAME, EVENT_HOMEASSISTANT_STOP, ATTR_ATTRIBUTION)
+    CONF_NAME, EVENT_HOMEASSISTANT_STOP)
 from homeassistant.helpers.entity import Entity
 
 REQUIREMENTS = ['pyserial-asyncio==0.4']

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1213,6 +1213,7 @@ pysabnzbd==1.1.0
 pysensibo==1.0.3
 
 # homeassistant.components.sensor.serial
+# homeassistant.components.sensor.teleinfo
 pyserial-asyncio==0.4
 
 # homeassistant.components.switch.acer_projector

--- a/tests/components/sensor/test_teleinfo.py
+++ b/tests/components/sensor/test_teleinfo.py
@@ -1,0 +1,16 @@
+"""The tests for the teleinfo platform."""
+
+VALID_CONFIG_MINIMAL = {
+    'sensor': {
+        'platform': 'teleinfo',
+        'device': '/dev/ttyACM0',
+    }
+}
+
+VALID_CONFIG_NAME = {
+    'sensor': {
+        'platform': 'teleinfo',
+        'name': 'edf',
+        'device': '/dev/ttyUSB0',
+    }
+}


### PR DESCRIPTION
## Description:

Add support for Teleinfo Serial Sensor.

Teleinfo is a French specific protocol used in electricity smart meters.
It provides real time information on power consumption, rates and current on
a user accessible serial port.

- Full asyncio version
- Only one deps (pyserial)
- Based on : https://www.home-assistant.io/components/sensor.serial/
https://github.com/home-assistant/home-assistant/blob/master/homeassistant/components/sensor/serial.py
with minimal changes. Only serial initialization and protocol decoder added.
All information as Attributes has the information available depends on power subscription, number of lanes, billing hours.... 

## Example entry for `configuration.yaml` (if applicable):
```yaml
 sensor:
   - platform: teleinfo
        name: "EDF teleinfo"
        serial_port: "/dev/ttyAMA0"
  - platform: template
    sensors:
      teleinfo_base:
        value_template: '{{ (states.sensor.edf_teleinfo.attributes["BASE"] | float / 1000) | round(0) }}'
        unit_of_measurement: 'kWh'
        icon_template: mdi:flash
  - platform: template
    sensors:
      teleinfo_iinst1:
        value_template: '{{ states.sensor.edf_teleinfo.attributes["IINST1"] | int }}'
        unit_of_measurement: 'A'
        icon_template: mdi:flash
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)
  -  [home-assistant/home-assistant.io##8517](https://github.com/home-assistant/home-assistant.io/pull/#8517)

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [X] New files were added to `.coveragerc`.

Linked PR (thanks to @nlamirault ): 
Add EDF Teleinfo sensor #14200
[WIP] Add: Teleinfo sensor #10603
