### PR TITLE
Fix missing sensor values for Point

### DIFF
--- a/homeassistant/components/point/__init__.py
+++ b/homeassistant/components/point/__init__.py
@@ -26,7 +26,7 @@ from .const import (
     CONF_WEBHOOK_URL, DOMAIN, EVENT_RECEIVED, POINT_DISCOVERY_NEW,
     SCAN_INTERVAL, SIGNAL_UPDATE_ENTITY, SIGNAL_WEBHOOK)
 
-REQUIREMENTS = ['pypoint==1.0.6']
+REQUIREMENTS = ['pypoint==1.0.7']
 DEPENDENCIES = ['webhook']
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/point/sensor.py
+++ b/homeassistant/components/point/sensor.py
@@ -67,6 +67,8 @@ class MinutPointSensor(MinutPointEntity):
     @property
     def state(self):
         """Return the state of the sensor."""
+        if self.value is None:
+            return None
         return round(self.value, self._device_prop[1])
 
     @property

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1186,7 +1186,7 @@ pypck==0.5.9
 pypjlink2==1.2.0
 
 # homeassistant.components.point
-pypoint==1.0.6
+pypoint==1.0.7
 
 # homeassistant.components.sensor.pollen
 pypollencom==2.2.2


### PR DESCRIPTION
## Description:

Sometimes the API returns empty sensor readings, this fixes that case.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
