### PR TITLE
Point alarm control

### DIFF
--- a/homeassistant/components/point/__init__.py
+++ b/homeassistant/components/point/__init__.py
@@ -20,7 +20,7 @@ from .const import (
     CONF_WEBHOOK_URL, DOMAIN, EVENT_RECEIVED, POINT_DISCOVERY_NEW,
     SCAN_INTERVAL, SIGNAL_UPDATE_ENTITY, SIGNAL_WEBHOOK)
 
-REQUIREMENTS = ['pypoint==1.0.8']
+REQUIREMENTS = ['pypoint==1.1.0']
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -225,11 +225,11 @@ class MinutPointClient():
 
     def alarm_disarm(self, home_id):
         """Send alarm disarm command."""
-        self._client.alarm_disarm(home_id)
+        return self._client.alarm_disarm(home_id)
 
     def alarm_arm(self, home_id):
         """Send alarm arm command."""
-        self._client.alarm_arm(home_id)
+        return self._client.alarm_arm(home_id)
 
 
 class MinutPointEntity(Entity):
@@ -304,7 +304,7 @@ class MinutPointEntity(Entity):
             'model': 'Point v{}'.format(device['hardware_version']),
             'name': device['description'],
             'sw_version': device['firmware']['installed'],
-            'via_hub': device['home'],
+            'via_hub': (DOMAIN, device['home']),
         }
 
     @property

--- a/homeassistant/components/point/__init__.py
+++ b/homeassistant/components/point/__init__.py
@@ -20,7 +20,7 @@ from .const import (
     CONF_WEBHOOK_URL, DOMAIN, EVENT_RECEIVED, POINT_DISCOVERY_NEW,
     SCAN_INTERVAL, SIGNAL_UPDATE_ENTITY, SIGNAL_WEBHOOK)
 
-REQUIREMENTS = ['pypoint==1.1.0']
+REQUIREMENTS = ['pypoint==1.1.1']
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/point/__init__.py
+++ b/homeassistant/components/point/__init__.py
@@ -195,15 +195,15 @@ class MinutPointClient():
                 device_id)
 
         self._is_available = True
+        for home_id in self._client.homes:
+            if home_id not in self._known_homes:
+                await new_device(home_id, 'alarm_control_panel')
+                self._known_homes.add(home_id)
         for device in self._client.devices:
             if device.device_id not in self._known_devices:
                 for component in ('sensor', 'binary_sensor'):
                     await new_device(device.device_id, component)
                 self._known_devices.add(device.device_id)
-        for home_id in self._client.homes:
-            if home_id not in self._known_homes:
-                await new_device(home_id, 'alarm_control_panel')
-                self._known_homes.add(home_id)
         async_dispatcher_send(self._hass, SIGNAL_UPDATE_ENTITY)
 
     def device(self, device_id):
@@ -304,6 +304,7 @@ class MinutPointEntity(Entity):
             'model': 'Point v{}'.format(device['hardware_version']),
             'name': device['description'],
             'sw_version': device['firmware']['installed'],
+            'via_hub': device['home'],
         }
 
     @property

--- a/homeassistant/components/point/__init__.py
+++ b/homeassistant/components/point/__init__.py
@@ -159,6 +159,7 @@ class MinutPointClient():
                  session):
         """Initialize the Minut data object."""
         self._known_devices = set()
+        self._known_homes = set()
         self._hass = hass
         self._config_entry = config_entry
         self._is_available = True
@@ -199,6 +200,10 @@ class MinutPointClient():
                 for component in ('sensor', 'binary_sensor'):
                     await new_device(device.device_id, component)
                 self._known_devices.add(device.device_id)
+        for home_id in self._client.homes:
+            if home_id not in self._known_homes:
+                await new_device(home_id, 'alarm_control_panel')
+                self._known_homes.add(home_id)
         async_dispatcher_send(self._hass, SIGNAL_UPDATE_ENTITY)
 
     def device(self, device_id):
@@ -212,6 +217,19 @@ class MinutPointClient():
     def remove_webhook(self):
         """Remove the session webhook."""
         return self._client.remove_webhook()
+
+    @property
+    def homes(self):
+        """Return known homes."""
+        return self._client.homes
+
+    def alarm_disarm(self, home_id):
+        """Send alarm disarm command."""
+        self._client.alarm_disarm(home_id)
+
+    def alarm_arm(self, home_id):
+        """Send alarm arm command."""
+        self._client.alarm_arm(home_id)
 
 
 class MinutPointEntity(Entity):

--- a/homeassistant/components/point/alarm_control_panel.py
+++ b/homeassistant/components/point/alarm_control_panel.py
@@ -2,7 +2,7 @@
 Support for Minut Point.
 
 For more details about this platform, please refer to the documentation at
-https://home-assistant.io/components/alarm_control_panel.point/
+https://home-assistant.io/components/point/
 """
 
 import logging

--- a/homeassistant/components/point/alarm_control_panel.py
+++ b/homeassistant/components/point/alarm_control_panel.py
@@ -64,6 +64,10 @@ class MinutPointAlarmControl(AlarmControlPanel):
         """Send arm away command."""
         self._client.alarm_arm(self._home_id)
 
+    def alarm_arm_home(self, code=None):
+        """Send arm home command."""
+        self.alarm_arm_away()
+
     @property
     def unique_id(self):
         """Return the unique id of the sensor."""

--- a/homeassistant/components/point/alarm_control_panel.py
+++ b/homeassistant/components/point/alarm_control_panel.py
@@ -1,10 +1,4 @@
-"""
-Support for Minut Point.
-
-For more details about this platform, please refer to the documentation at
-https://home-assistant.io/components/point/
-"""
-
+"""Support for Minut Point."""
 import logging
 
 from homeassistant.components.alarm_control_panel import (DOMAIN,
@@ -65,14 +59,10 @@ class MinutPointAlarmControl(AlarmControlPanel):
         if status:
             self._home['alarm_status'] = 'on'
 
-    def alarm_arm_home(self, code=None):
-        """Send arm home command."""
-        self.alarm_arm_away()
-
     @property
     def unique_id(self):
         """Return the unique id of the sensor."""
-        return 'point.{}-{}'.format(DOMAIN, self._home_id)
+        return 'point.{}'.format(self._home_id)
 
     @property
     def device_info(self):

--- a/homeassistant/components/point/alarm_control_panel.py
+++ b/homeassistant/components/point/alarm_control_panel.py
@@ -1,0 +1,81 @@
+"""
+Support for Minut Point.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/alarm_control_panel.point/
+"""
+
+import logging
+
+from homeassistant.components.alarm_control_panel import (DOMAIN,
+                                                          AlarmControlPanel)
+from homeassistant.const import (STATE_ALARM_ARMED_AWAY, STATE_ALARM_DISARMED)
+from homeassistant.components.point.const import (
+    DOMAIN as POINT_DOMAIN, POINT_DISCOVERY_NEW)
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up a Point's alarm_control_panel based on a config entry."""
+    async def async_discover_home(device_id):
+        """Discover and add a discovered home."""
+        client = hass.data[POINT_DOMAIN][config_entry.entry_id]
+        homes = client.homes
+        async_add_entities(
+            (MinutPointAlarmControl(client, home)
+             for home in homes), True)
+
+    async_dispatcher_connect(
+        hass, POINT_DISCOVERY_NEW.format(DOMAIN, POINT_DOMAIN),
+        async_discover_home)
+
+
+class MinutPointAlarmControl(AlarmControlPanel):
+    """The platform class required by Home Assistant."""
+
+    def __init__(self, point_client, home_id):
+        """Initialize the entity."""
+        self._client = point_client
+        self._home_id = home_id
+
+    @property
+    def _home(self):
+        """Return the home object."""
+        return self._client.homes[self._home_id]
+
+    @property
+    def name(self):
+        """Return name of the device."""
+        return self._home['name']
+
+    @property
+    def state(self):
+        """Return state of the device."""
+        return STATE_ALARM_DISARMED if self._home[
+            'alarm_status'] == 'off' else STATE_ALARM_ARMED_AWAY
+
+    def alarm_disarm(self, code=None):
+        """Send disarm command."""
+        self._client.alarm_disarm(self._home_id)
+
+    def alarm_arm_away(self, code=None):
+        """Send arm away command."""
+        self._client.alarm_arm(self._home_id)
+
+    @property
+    def unique_id(self):
+        """Return the unique id of the sensor."""
+        return 'point.{}-{}'.format(DOMAIN, self._home_id)
+
+    @property
+    def device_info(self):
+        """Return a device description for device registry."""
+        return {
+            'connections': {(POINT_DOMAIN, d['device_id'])
+                            for d in self._home['devices']},
+            'identifieres': self._home_id,
+            'manufacturer': 'Minut',
+            'name': self.name,
+        }

--- a/homeassistant/components/point/alarm_control_panel.py
+++ b/homeassistant/components/point/alarm_control_panel.py
@@ -73,8 +73,6 @@ class MinutPointAlarmControl(AlarmControlPanel):
     def device_info(self):
         """Return a device description for device registry."""
         return {
-            'connections': {(POINT_DOMAIN, d['device_id'])
-                            for d in self._home['devices']},
             'identifieres': self._home_id,
             'manufacturer': 'Minut',
             'name': self.name,

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1196,7 +1196,7 @@ pypck==0.5.9
 pypjlink2==1.2.0
 
 # homeassistant.components.point
-pypoint==1.0.8
+pypoint==1.1.0
 
 # homeassistant.components.sensor.pollen
 pypollencom==2.2.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1196,7 +1196,7 @@ pypck==0.5.9
 pypjlink2==1.2.0
 
 # homeassistant.components.point
-pypoint==1.1.0
+pypoint==1.1.1
 
 # homeassistant.components.sensor.pollen
 pypollencom==2.2.2


### PR DESCRIPTION
## Description:

Adds support for toggling the alarm part of the Minut Point.

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8477


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

## Wip:
- [x] Community tests.
- [x] Version bump github.com/fredrike/pypoint.
- [x] (Supported features of **alarm_control_panel**), apparently doesn't the **alarm_control_panel** implement supported features like the **climate** platform does.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
