### PR TITLE
Add Lock capability to SmartThings platform

### DIFF
--- a/homeassistant/components/smartthings/__init__.py
+++ b/homeassistant/components/smartthings/__init__.py
@@ -23,7 +23,7 @@ from .const import (
 from .smartapp import (
     setup_smartapp, setup_smartapp_endpoint, validate_installed_app)
 
-REQUIREMENTS = ['pysmartapp==0.3.0', 'pysmartthings==0.6.0']
+REQUIREMENTS = ['pysmartapp==0.3.0', 'pysmartthings==0.6.1']
 DEPENDENCIES = ['webhook']
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/smartthings/const.py
+++ b/homeassistant/components/smartthings/const.py
@@ -22,6 +22,7 @@ SUPPORTED_PLATFORMS = [
     'binary_sensor',
     'fan',
     'light',
+    'lock',
     'sensor',
     'switch'
 ]

--- a/homeassistant/components/smartthings/lock.py
+++ b/homeassistant/components/smartthings/lock.py
@@ -68,6 +68,6 @@ class SmartThingsLock(SmartThingsEntity, LockDevice):
         if isinstance(status.data, dict):
             for st_attr, ha_attr in ST_LOCK_ATTR_MAP.items():
                 data_val = status.data.get(st_attr)
-                if data_val:
+                if data_val is not None:
                     state_attrs[ha_attr] = data_val
         return state_attrs

--- a/homeassistant/components/smartthings/lock.py
+++ b/homeassistant/components/smartthings/lock.py
@@ -55,7 +55,7 @@ class SmartThingsLock(SmartThingsEntity, LockDevice):
     def device_state_attributes(self):
         """Return device specific state attributes."""
         from pysmartthings import Attribute
-        attrs = self._device.status.attributes[Attribute.lock] or Object()
+        attrs = self._device.status.attributes[Attribute.lock] or object()
         lock_data = attrs.data or {}
         raw_lock_state = attrs.value or None
         return {

--- a/homeassistant/components/smartthings/lock.py
+++ b/homeassistant/components/smartthings/lock.py
@@ -5,7 +5,7 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/smartthings.lock/
 """
 from homeassistant.components.lock import LockDevice
-from homeassistant.const import (STATE_LOCKED, STATE_UNLOCKED)
+from homeassistant.const import STATE_LOCKED
 
 from . import SmartThingsEntity
 from .const import DATA_BROKERS, DOMAIN

--- a/homeassistant/components/smartthings/lock.py
+++ b/homeassistant/components/smartthings/lock.py
@@ -30,9 +30,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 def is_lock(device):
     """Determine if the device supports the lock capability."""
     from pysmartthings import Capability
-    if Capability.lock in device.capabilities:
-        return True
-    return False
+    return Capability.lock in device.capabilities
 
 
 class SmartThingsLock(SmartThingsEntity, LockDevice):

--- a/homeassistant/components/smartthings/lock.py
+++ b/homeassistant/components/smartthings/lock.py
@@ -65,7 +65,7 @@ class SmartThingsLock(SmartThingsEntity, LockDevice):
         status = self._device.status.attributes[Attribute.lock]
         if status.value:
             state_attrs['lock_state'] = status.value
-        if type(status.data) is dict:
+        if isinstance(status.data, dict):
             for st_attr, ha_attr in ST_LOCK_ATTR_MAP.items():
                 data_val = status.data.get(st_attr)
                 if data_val:

--- a/homeassistant/components/smartthings/lock.py
+++ b/homeassistant/components/smartthings/lock.py
@@ -1,0 +1,55 @@
+"""
+Support for locks through the SmartThings cloud API.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/smartthings.lock/
+"""
+from homeassistant.components.lock import LockDevice
+from homeassistant.const import (STATE_LOCKED, STATE_UNLOCKED)
+
+from . import SmartThingsEntity
+from .const import DATA_BROKERS, DOMAIN
+
+DEPENDENCIES = ['smartthings']
+
+
+async def async_setup_platform(hass, config, async_add_entities,
+                               discovery_info=None):
+    """Platform uses config entry setup."""
+    pass
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Add locks for a config entry."""
+    broker = hass.data[DOMAIN][DATA_BROKERS][config_entry.entry_id]
+    async_add_entities(
+        [SmartThingsLock(device) for device in broker.devices.values()
+         if is_lock(device)])
+
+
+def is_lock(device):
+    """Determine if the device supports the lock capability."""
+    from pysmartthings import Capability
+    # Must be able to be turned on/off.
+    if Capability.lock in device.capabilities:
+        return True
+    return False
+
+
+class SmartThingsLock(SmartThingsEntity, LockDevice):
+    """Define a SmartThings lock."""
+
+    async def async_lock(self, **kwargs):
+        """Lock the device."""
+        await self._device.lock()
+        self.async_schedule_update_ha_state()
+
+    async def async_unlock(self, **kwargs):
+        """Unlock the device."""
+        await self._device.unlock()
+        self.async_schedule_update_ha_state()
+
+    @property
+    def is_locked(self):
+        """Return true if lock is locked."""
+        return self._device.status.lock == STATE_LOCKED

--- a/homeassistant/components/smartthings/lock.py
+++ b/homeassistant/components/smartthings/lock.py
@@ -53,14 +53,14 @@ class SmartThingsLock(SmartThingsEntity, LockDevice):
 
     @property
     def device_state_attributes(self):
-        """Return all state attributes provided by SmartThings."""
+        """Return device specific state attributes."""
         from pysmartthings import Attribute
-        state_attrs = {}
-        for attr, status in self._device.status.attributes.items():
-            if not status.value:
-                continue
-            # Convert camelCase to snake_case
-            new_attr = ''.join('_' + char.lower() if char.isupper() else char
-              for char in attr).lstrip('_')
-            state_attrs[new_attr] = status.value
-        return state_attrs
+        attrs = self._device.status.attributes[Attribute.lock] or Object()
+        lock_data = attrs.data or {}
+        raw_lock_state = attrs.value or None
+        return {
+            'method': lock_data.get('method'),
+            'code_id': lock_data.get('codeId'),
+            'timeout': lock_data.get('timeout'),
+            'lock_state': raw_lock_state
+        }

--- a/homeassistant/components/smartthings/lock.py
+++ b/homeassistant/components/smartthings/lock.py
@@ -30,7 +30,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 def is_lock(device):
     """Determine if the device supports the lock capability."""
     from pysmartthings import Capability
-    # Must be able to be turned on/off.
     if Capability.lock in device.capabilities:
         return True
     return False

--- a/homeassistant/components/smartthings/lock.py
+++ b/homeassistant/components/smartthings/lock.py
@@ -5,12 +5,13 @@ For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/smartthings.lock/
 """
 from homeassistant.components.lock import LockDevice
-from homeassistant.const import STATE_LOCKED
 
 from . import SmartThingsEntity
 from .const import DATA_BROKERS, DOMAIN
 
 DEPENDENCIES = ['smartthings']
+
+ST_STATE_LOCKED = 'locked'
 
 
 async def async_setup_platform(hass, config, async_add_entities,
@@ -49,7 +50,7 @@ class SmartThingsLock(SmartThingsEntity, LockDevice):
     @property
     def is_locked(self):
         """Return true if lock is locked."""
-        return self._device.status.lock == STATE_LOCKED
+        return self._device.status.lock == ST_STATE_LOCKED
 
     @property
     def device_state_attributes(self):

--- a/homeassistant/components/smartthings/lock.py
+++ b/homeassistant/components/smartthings/lock.py
@@ -52,3 +52,17 @@ class SmartThingsLock(SmartThingsEntity, LockDevice):
     def is_locked(self):
         """Return true if lock is locked."""
         return self._device.status.lock == STATE_LOCKED
+
+    @property
+    def device_state_attributes(self):
+        """Return all state attributes provided by SmartThings."""
+        from pysmartthings import Attribute
+        state_attrs = {}
+        for attr, status in self._device.status.attributes.items():
+            if not status.value:
+                continue
+            # Convert camelCase to snake_case
+            new_attr = ''.join('_' + char.lower() if char.isupper() else char
+              for char in attr).lstrip('_')
+            state_attrs[new_attr] = status.value
+        return state_attrs

--- a/homeassistant/components/smartthings/lock.py
+++ b/homeassistant/components/smartthings/lock.py
@@ -64,12 +64,9 @@ class SmartThingsLock(SmartThingsEntity, LockDevice):
         status = self._device.status.attributes[Attribute.lock]
         if status.value:
             state_attrs['lock_state'] = status.value
-        if status.data:
-            for attr, data_val in status.data.items():
-                if not data_val:
-                    continue
-                # Convert camelCase to snake_case
-                new_attr = ''.join('_' + ch.lower() if ch.isupper() else ch
-                                   for ch in attr).lstrip('_')
-                state_attrs[new_attr] = data_val
+        if type(status.data) is dict:
+            for st_attr, ha_attr in ST_LOCK_ATTR_MAP.items():
+                data_val = status.data.get(st_attr)
+                if data_val:
+                    state_attrs[ha_attr] = data_val
         return state_attrs

--- a/homeassistant/components/smartthings/lock.py
+++ b/homeassistant/components/smartthings/lock.py
@@ -41,12 +41,12 @@ class SmartThingsLock(SmartThingsEntity, LockDevice):
 
     async def async_lock(self, **kwargs):
         """Lock the device."""
-        await self._device.lock()
+        await self._device.lock(set_status=True)
         self.async_schedule_update_ha_state()
 
     async def async_unlock(self, **kwargs):
         """Unlock the device."""
-        await self._device.unlock()
+        await self._device.unlock(set_status=True)
         self.async_schedule_update_ha_state()
 
     @property

--- a/homeassistant/components/smartthings/lock.py
+++ b/homeassistant/components/smartthings/lock.py
@@ -18,6 +18,7 @@ ST_LOCK_ATTR_MAP = {
     'timeout': 'timeout'
 }
 
+
 async def async_setup_platform(hass, config, async_add_entities,
                                discovery_info=None):
     """Platform uses config entry setup."""

--- a/homeassistant/components/smartthings/lock.py
+++ b/homeassistant/components/smartthings/lock.py
@@ -55,12 +55,11 @@ class SmartThingsLock(SmartThingsEntity, LockDevice):
     def device_state_attributes(self):
         """Return device specific state attributes."""
         from pysmartthings import Attribute
-        attrs = self._device.status.attributes[Attribute.lock] or object()
-        lock_data = attrs.data or {}
-        raw_lock_state = attrs.value or None
+        status = self._device.status.attributes[Attribute.lock]
+        status_data = status.data or {}
         return {
-            'method': lock_data.get('method'),
-            'code_id': lock_data.get('codeId'),
-            'timeout': lock_data.get('timeout'),
-            'lock_state': raw_lock_state
+            'method': status_data.get('method'),
+            'code_id': status_data.get('codeId'),
+            'timeout': status_data.get('timeout'),
+            'lock_state': status.value
         }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1240,7 +1240,7 @@ pysma==0.3.1
 pysmartapp==0.3.0
 
 # homeassistant.components.smartthings
-pysmartthings==0.6.0
+pysmartthings==0.6.1
 
 # homeassistant.components.device_tracker.snmp
 # homeassistant.components.sensor.snmp

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -217,7 +217,7 @@ pyqwikswitch==0.8
 pysmartapp==0.3.0
 
 # homeassistant.components.smartthings
-pysmartthings==0.6.0
+pysmartthings==0.6.1
 
 # homeassistant.components.sonos
 pysonos==0.0.6

--- a/tests/components/smartthings/test_lock.py
+++ b/tests/components/smartthings/test_lock.py
@@ -95,3 +95,16 @@ async def test_update_from_signal(hass, device_factory):
     state = hass.states.get('lock.lock_1')
     assert state is not None
     assert state.state == 'locked'
+
+
+async def test_unload_config_entry(hass, device_factory):
+    """Test the lock is removed when the config entry is unloaded."""
+    # Arrange
+    device = device_factory('Lock_1', [Capability.lock],
+                            {Attribute.lock: 'locked'})
+    config_entry = await setup_platform(hass, LOCK_DOMAIN, device)
+    # Act
+    await hass.config_entries.async_forward_entry_unload(
+        config_entry, 'lock')
+    # Assert
+    assert not hass.states.get('lock.lock_1')

--- a/tests/components/smartthings/test_lock.py
+++ b/tests/components/smartthings/test_lock.py
@@ -1,0 +1,125 @@
+"""
+Test for the SmartThings lock platform.
+
+The only mocking required is of the underlying SmartThings API object so
+real HTTP calls are not initiated during testing.
+"""
+from pysmartthings import Attribute, Capability
+
+from homeassistant.components.smartthings import DeviceBroker, lock
+from homeassistant.components.smartthings.const import (
+    DATA_BROKERS, DOMAIN, SIGNAL_SMARTTHINGS_UPDATE)
+from homeassistant.config_entries import (
+    CONN_CLASS_CLOUD_PUSH, SOURCE_USER, ConfigEntry)
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+
+
+async def _setup_platform(hass, *devices):
+    """Set up the SmartThings lock platform and prerequisites."""
+    hass.config.components.add(DOMAIN)
+    broker = DeviceBroker(hass, devices, '')
+    config_entry = ConfigEntry("1", DOMAIN, "Test", {},
+                               SOURCE_USER, CONN_CLASS_CLOUD_PUSH)
+    hass.data[DOMAIN] = {
+        DATA_BROKERS: {
+            config_entry.entry_id: broker
+        }
+    }
+    await hass.config_entries.async_forward_entry_setup(config_entry, 'lock')
+    await hass.async_block_till_done()
+    return config_entry
+
+
+async def test_async_setup_platform():
+    """Test setup platform does nothing (it uses config entries)."""
+    await lock.async_setup_platform(None, None, None)
+
+
+def test_is_lock(device_factory):
+    """Test lockes are correctly identified."""
+    lock_device = device_factory('Lock', [Capability.lock])
+    assert lock.is_lock(lock_device)
+
+
+async def test_entity_and_device_attributes(hass, device_factory):
+    """Test the attributes of the entity are correct."""
+    # Arrange
+    device = device_factory('Lock_1', [Capability.lock],
+                            {Attribute.lock: 'on'})
+    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    device_registry = await hass.helpers.device_registry.async_get_registry()
+    # Act
+    await _setup_platform(hass, device)
+    # Assert
+    entry = entity_registry.async_get('lock.lock_1')
+    assert entry
+    assert entry.unique_id == device.device_id
+
+    entry = device_registry.async_get_device(
+        {(DOMAIN, device.device_id)}, [])
+    assert entry
+    assert entry.name == device.label
+    assert entry.model == device.device_type_name
+    assert entry.manufacturer == 'Unavailable'
+
+
+async def test_lock(hass, device_factory):
+    """Test the lock locks successfully."""
+    # Arrange
+    device = device_factory('Lock_1', [Capability.lock],
+                            {Attribute.lock: 'unlocked'})
+    await _setup_platform(hass, device)
+    # Act
+    await hass.services.async_call(
+        'lock', 'lock', {'entity_id': 'lock.lock_1'},
+        blocking=True)
+    # Assert
+    state = hass.states.get('lock.lock_1')
+    assert state is not None
+    assert state.state == 'locked'
+
+
+async def test_unlock(hass, device_factory):
+    """Test the lock unlocks successfully."""
+    # Arrange
+    device = device_factory('Lock_1', [Capability.lock],
+                            {Attribute.lock: 'locked'})
+    await _setup_platform(hass, device)
+    # Act
+    await hass.services.async_call(
+        'lock', 'unlock', {'entity_id': 'lock.lock_1'},
+        blocking=True)
+    # Assert
+    state = hass.states.get('lock.lock_1')
+    assert state is not None
+    assert state.state == 'unlocked'
+
+
+async def test_update_from_signal(hass, device_factory):
+    """Test the lock updates when receiving a signal."""
+    # Arrange
+    device = device_factory('Lock_1', [Capability.lock],
+                            {Attribute.lock: 'unlocked'})
+    await _setup_platform(hass, device)
+    await device.lock(True)
+    # Act
+    async_dispatcher_send(hass, SIGNAL_SMARTTHINGS_UPDATE,
+                          [device.device_id])
+    # Assert
+    await hass.async_block_till_done()
+    state = hass.states.get('lock.lock_1')
+    assert state is not None
+    assert state.state == 'locked'
+
+
+async def test_unload_config_entry(hass, device_factory):
+    """Test the lock is removed when the config entry is unloaded."""
+    # Arrange
+    device = device_factory('Lock', [Capability.lock],
+                            {Attribute.lock: 'locked'})
+    config_entry = await _setup_platform(hass, device)
+    # Act
+    await hass.config_entries.async_forward_entry_unload(
+        config_entry, 'lock')
+    # Assert
+    assert not hass.states.get('lock.lock_1')

--- a/tests/components/smartthings/test_lock.py
+++ b/tests/components/smartthings/test_lock.py
@@ -30,7 +30,7 @@ async def test_entity_and_device_attributes(hass, device_factory):
     """Test the attributes of the entity are correct."""
     # Arrange
     device = device_factory('Lock_1', [Capability.lock],
-                            {Attribute.lock: 'on'})
+                            {Attribute.lock: 'unlocked'})
     entity_registry = await hass.helpers.entity_registry.async_get_registry()
     device_registry = await hass.helpers.device_registry.async_get_registry()
     # Act
@@ -56,7 +56,7 @@ async def test_lock(hass, device_factory):
     await setup_platform(hass, LOCK_DOMAIN, device)
     # Act
     await hass.services.async_call(
-        'lock', 'lock', {'entity_id': 'lock.lock_1'},
+        LOCK_DOMAIN, 'lock', {'entity_id': 'lock.lock_1'},
         blocking=True)
     # Assert
     state = hass.states.get('lock.lock_1')
@@ -72,7 +72,7 @@ async def test_unlock(hass, device_factory):
     await setup_platform(hass, LOCK_DOMAIN, device)
     # Act
     await hass.services.async_call(
-        'lock', 'unlock', {'entity_id': 'lock.lock_1'},
+        LOCK_DOMAIN, 'unlock', {'entity_id': 'lock.lock_1'},
         blocking=True)
     # Assert
     state = hass.states.get('lock.lock_1')

--- a/tests/components/smartthings/test_lock.py
+++ b/tests/components/smartthings/test_lock.py
@@ -6,28 +6,13 @@ real HTTP calls are not initiated during testing.
 """
 from pysmartthings import Attribute, Capability
 
-from homeassistant.components.smartthings import DeviceBroker, lock
+from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN
+from homeassistant.components.smartthings import lock
 from homeassistant.components.smartthings.const import (
-    DATA_BROKERS, DOMAIN, SIGNAL_SMARTTHINGS_UPDATE)
-from homeassistant.config_entries import (
-    CONN_CLASS_CLOUD_PUSH, SOURCE_USER, ConfigEntry)
+    DOMAIN, SIGNAL_SMARTTHINGS_UPDATE)
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
-
-async def _setup_platform(hass, *devices):
-    """Set up the SmartThings lock platform and prerequisites."""
-    hass.config.components.add(DOMAIN)
-    broker = DeviceBroker(hass, devices, '')
-    config_entry = ConfigEntry("1", DOMAIN, "Test", {},
-                               SOURCE_USER, CONN_CLASS_CLOUD_PUSH)
-    hass.data[DOMAIN] = {
-        DATA_BROKERS: {
-            config_entry.entry_id: broker
-        }
-    }
-    await hass.config_entries.async_forward_entry_setup(config_entry, 'lock')
-    await hass.async_block_till_done()
-    return config_entry
+from .conftest import setup_platform
 
 
 async def test_async_setup_platform():
@@ -36,7 +21,7 @@ async def test_async_setup_platform():
 
 
 def test_is_lock(device_factory):
-    """Test lockes are correctly identified."""
+    """Test locks are correctly identified."""
     lock_device = device_factory('Lock', [Capability.lock])
     assert lock.is_lock(lock_device)
 
@@ -49,7 +34,7 @@ async def test_entity_and_device_attributes(hass, device_factory):
     entity_registry = await hass.helpers.entity_registry.async_get_registry()
     device_registry = await hass.helpers.device_registry.async_get_registry()
     # Act
-    await _setup_platform(hass, device)
+    await setup_platform(hass, LOCK_DOMAIN, device)
     # Assert
     entry = entity_registry.async_get('lock.lock_1')
     assert entry
@@ -68,7 +53,7 @@ async def test_lock(hass, device_factory):
     # Arrange
     device = device_factory('Lock_1', [Capability.lock],
                             {Attribute.lock: 'unlocked'})
-    await _setup_platform(hass, device)
+    await setup_platform(hass, LOCK_DOMAIN, device)
     # Act
     await hass.services.async_call(
         'lock', 'lock', {'entity_id': 'lock.lock_1'},
@@ -84,7 +69,7 @@ async def test_unlock(hass, device_factory):
     # Arrange
     device = device_factory('Lock_1', [Capability.lock],
                             {Attribute.lock: 'locked'})
-    await _setup_platform(hass, device)
+    await setup_platform(hass, LOCK_DOMAIN, device)
     # Act
     await hass.services.async_call(
         'lock', 'unlock', {'entity_id': 'lock.lock_1'},
@@ -100,7 +85,7 @@ async def test_update_from_signal(hass, device_factory):
     # Arrange
     device = device_factory('Lock_1', [Capability.lock],
                             {Attribute.lock: 'unlocked'})
-    await _setup_platform(hass, device)
+    await setup_platform(hass, LOCK_DOMAIN, device)
     await device.lock(True)
     # Act
     async_dispatcher_send(hass, SIGNAL_SMARTTHINGS_UPDATE,
@@ -110,16 +95,3 @@ async def test_update_from_signal(hass, device_factory):
     state = hass.states.get('lock.lock_1')
     assert state is not None
     assert state.state == 'locked'
-
-
-async def test_unload_config_entry(hass, device_factory):
-    """Test the lock is removed when the config entry is unloaded."""
-    # Arrange
-    device = device_factory('Lock', [Capability.lock],
-                            {Attribute.lock: 'locked'})
-    config_entry = await _setup_platform(hass, device)
-    # Act
-    await hass.config_entries.async_forward_entry_unload(
-        config_entry, 'lock')
-    # Assert
-    assert not hass.states.get('lock.lock_1')

--- a/tests/components/smartthings/test_switch.py
+++ b/tests/components/smartthings/test_switch.py
@@ -126,7 +126,7 @@ async def test_update_from_signal(hass, device_factory):
 async def test_unload_config_entry(hass, device_factory):
     """Test the switch is removed when the config entry is unloaded."""
     # Arrange
-    device = device_factory('Switch', [Capability.switch],
+    device = device_factory('Switch 1', [Capability.switch],
                             {Attribute.switch: 'on'})
     config_entry = await _setup_platform(hass, device)
     # Act


### PR DESCRIPTION
## Description:

This PR adds functionality for Locks expressed through the SmartThings platform.

Locking/Unlocking is working great, however I'm not sure whether we should update the state straight away (faster UI feedback) or wait for the confirmation from SmartThings (removes false positives).

Also as mentioned in the referenced issue, there are some other attributes that could possibly be added to the entity. @andrewsayre any chance you could expand on those here? 😄 

**Related issue (if applicable):** fixes #20889 

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8493

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [X] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [X] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [X] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [X] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

If the code does not interact with devices:
  - [X] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
