### PR TITLE
Downgrade MQTT Payload warning to info

### DIFF
--- a/homeassistant/components/mqtt/binary_sensor.py
+++ b/homeassistant/components/mqtt/binary_sensor.py
@@ -145,9 +145,9 @@ class MqttBinarySensor(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
                 self._state = False
             else:  # Payload is not for this entity
                 _LOGGER.info('No matching payload found'
-                                ' for entity: %s with state_topic: %s',
-                                self._config.get(CONF_NAME),
-                                self._config.get(CONF_STATE_TOPIC))
+                             ' for entity: %s with state_topic: %s',
+                             self._config.get(CONF_NAME),
+                             self._config.get(CONF_STATE_TOPIC))
                 return
 
             if self._delay_listener is not None:

--- a/homeassistant/components/mqtt/binary_sensor.py
+++ b/homeassistant/components/mqtt/binary_sensor.py
@@ -30,7 +30,6 @@ _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_NAME = 'MQTT Binary sensor'
 CONF_OFF_DELAY = 'off_delay'
-CONF_DISABLE_PAYLOAD_WARNING = 'disable_payload_warning'
 DEFAULT_PAYLOAD_OFF = 'OFF'
 DEFAULT_PAYLOAD_ON = 'ON'
 DEFAULT_FORCE_UPDATE = False
@@ -50,8 +49,7 @@ PLATFORM_SCHEMA = mqtt.MQTT_RO_PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_UNIQUE_ID): cv.string,
     vol.Optional(CONF_DEVICE): mqtt.MQTT_ENTITY_DEVICE_INFO_SCHEMA,
 }).extend(mqtt.MQTT_AVAILABILITY_SCHEMA.schema).extend(
-    mqtt.MQTT_JSON_ATTRS_SCHEMA.schema),
-    vol.Optional(CONF_DISABLE_PAYLOAD_WARNING): cv.bool
+    mqtt.MQTT_JSON_ATTRS_SCHEMA.schema)
 
 async def async_setup_platform(hass: HomeAssistantType, config: ConfigType,
                                async_add_entities, discovery_info=None):
@@ -96,7 +94,6 @@ class MqttBinarySensor(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
         self._state = None
         self._sub_state = None
         self._delay_listener = None
-        self._disable_payload_warning = config.get(CONF_DISABLE_PAYLOAD_WARNING)
 
         device_config = config.get(CONF_DEVICE)
 
@@ -146,11 +143,10 @@ class MqttBinarySensor(MqttAttributes, MqttAvailability, MqttDiscoveryUpdate,
             elif payload == self._config.get(CONF_PAYLOAD_OFF):
                 self._state = False
             else:  # Payload is not for this entity
-                if not self._disable_payload_warning:
-                    _LOGGER.warning('No matching payload found'
-                                    ' for entity: %s with state_topic: %s',
-                                    self._config.get(CONF_NAME),
-                                    self._config.get(CONF_STATE_TOPIC))
+                _LOGGER.info('No matching payload found'
+                                ' for entity: %s with state_topic: %s',
+                                self._config.get(CONF_NAME),
+                                self._config.get(CONF_STATE_TOPIC))
                 return
 
             if self._delay_listener is not None:

--- a/homeassistant/components/mqtt/binary_sensor.py
+++ b/homeassistant/components/mqtt/binary_sensor.py
@@ -51,6 +51,7 @@ PLATFORM_SCHEMA = mqtt.MQTT_RO_PLATFORM_SCHEMA.extend({
 }).extend(mqtt.MQTT_AVAILABILITY_SCHEMA.schema).extend(
     mqtt.MQTT_JSON_ATTRS_SCHEMA.schema)
 
+
 async def async_setup_platform(hass: HomeAssistantType, config: ConfigType,
                                async_add_entities, discovery_info=None):
     """Set up MQTT binary sensor through configuration.yaml."""


### PR DESCRIPTION
## Description:

Downgrades warning to info to stop the mass of logs when using a `value_template`.

## Example JSON

```
binary_sensor:
  - platform: mqtt
    name: 'Front Door'
    state_topic: 'tele/sonoff-rf/RESULT'
    value_template: '{{ value_json.RfReceived.Data }}'
    payload_on: '0EE10A'
    payload_off: '0EE10E'
    availability_topic: 'tele/sonoff-rf/LWT'
    payload_available: 'Online'
    payload_not_available: 'Offline'
    device_class: door
```

## Additional

See below for the problem I face with this type of `binary_sensor`:

![image](https://user-images.githubusercontent.com/28114703/52595955-043a5c00-2e47-11e9-81f2-23685fba97de.png)

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
