### PR TITLE
Bump aioesphomeapi to 1.5.0

### DIFF
--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
         ServiceCall
 
 DOMAIN = 'esphome'
-REQUIREMENTS = ['aioesphomeapi==1.4.2']
+REQUIREMENTS = ['aioesphomeapi==1.5.0']
 
 
 DISPATCHER_UPDATE_ENTITY = 'esphome_{entry_id}_update_{component_key}_{key}'

--- a/homeassistant/components/esphome/config_flow.py
+++ b/homeassistant/components/esphome/config_flow.py
@@ -55,7 +55,8 @@ class EsphomeFlowHandler(config_entries.ConfigFlow):
 
     async def async_step_discovery(self, user_input: ConfigType):
         """Handle discovery."""
-        address = user_input['properties'].get('address', user_input['hostname'][:-1])
+        address = user_input['properties'].get(
+            'address', user_input['hostname'][:-1])
         for entry in self._async_current_entries():
             if entry.data['host'] == address:
                 return self.async_abort(

--- a/homeassistant/components/esphome/config_flow.py
+++ b/homeassistant/components/esphome/config_flow.py
@@ -55,11 +55,9 @@ class EsphomeFlowHandler(config_entries.ConfigFlow):
 
     async def async_step_discovery(self, user_input: ConfigType):
         """Handle discovery."""
-        # mDNS hostname has additional '.' at end
-        hostname = user_input['hostname'][:-1]
-        hosts = (hostname, user_input['host'])
+        address = user_input['properties'].get('address', user_input['hostname'][:-1])
         for entry in self._async_current_entries():
-            if entry.data['host'] in hosts:
+            if entry.data['host'] == address:
                 return self.async_abort(
                     reason='already_configured'
                 )
@@ -67,7 +65,7 @@ class EsphomeFlowHandler(config_entries.ConfigFlow):
         # Prefer .local addresses (mDNS is available after all, otherwise
         # we wouldn't have received the discovery message)
         return await self.async_step_user(user_input={
-            'host': hostname,
+            'host': address,
             'port': user_input['port'],
         })
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -102,7 +102,7 @@ aioautomatic==0.6.5
 aiodns==1.1.1
 
 # homeassistant.components.esphome
-aioesphomeapi==1.4.2
+aioesphomeapi==1.5.0
 
 # homeassistant.components.freebox
 aiofreepybox==0.0.6

--- a/tests/components/esphome/test_config_flow.py
+++ b/tests/components/esphome/test_config_flow.py
@@ -242,7 +242,9 @@ async def test_discovery_already_configured_ip(hass, mock_client):
         'host': '192.168.43.183',
         'port': 6053,
         'hostname': 'test8266.local.',
-        'properties': {}
+        'properties': {
+            "address": "192.168.43.183"
+        }
     }
     result = await flow.async_step_discovery(user_input=service_info)
     assert result['type'] == 'abort'


### PR DESCRIPTION
## Description:

Bump aioesphomeapi to 1.5.0 - Contains some fixes and one new feature:
- aioesphomeapi now includes its own mDNS client so that `.local` addresses can be resolved with zeroconf.

Also the mDNS payload in discovery now contains an `address` TXT record which tells Home Assistant which address the ESP would like to be reached as.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

