### PR TITLE
Bump feedparser version to py3.7 compat

### DIFF
--- a/homeassistant/components/feedreader/__init__.py
+++ b/homeassistant/components/feedreader/__init__.py
@@ -16,7 +16,7 @@ from homeassistant.const import EVENT_HOMEASSISTANT_START, CONF_SCAN_INTERVAL
 from homeassistant.helpers.event import track_time_interval
 import homeassistant.helpers.config_validation as cv
 
-REQUIREMENTS = ['feedparser==5.2.1']
+REQUIREMENTS = ['feedparser-homeassistant==5.2.2.dev1']
 
 _LOGGER = getLogger(__name__)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -408,7 +408,7 @@ fastdotcom==0.0.3
 fedexdeliverymanager==1.0.6
 
 # homeassistant.components.feedreader
-feedparser==5.2.1
+feedparser-homeassistant==5.2.2.dev1
 
 # homeassistant.components.fibaro
 fiblary3==0.1.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -83,9 +83,6 @@ ephem==3.7.6.0
 # homeassistant.components.climate.honeywell
 evohomeclient==0.2.8
 
-# homeassistant.components.feedreader
-feedparser==5.2.1
-
 # homeassistant.components.sensor.foobot
 foobot_async==0.3.1
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -83,6 +83,9 @@ ephem==3.7.6.0
 # homeassistant.components.climate.honeywell
 evohomeclient==0.2.8
 
+# homeassistant.components.feedreader
+feedparser-homeassistant==5.2.2.dev1
+
 # homeassistant.components.sensor.foobot
 foobot_async==0.3.1
 

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -51,7 +51,7 @@ TEST_REQUIREMENTS = (
     'enturclient',
     'ephem',
     'evohomeclient',
-    'feedparser',
+    'feedparser-homeassistant',
     'foobot_async',
     'geojson_client',
     'georss_client',


### PR DESCRIPTION
## Description:
PR was merged for feedparser but no new release was done. So I created a fork and released it under `feedparser-homeassistant`. Now we can start using Python 3.7 🎉 

Fork here: https://github.com/home-assistant/feedparser

**Related issue (if applicable):** fixes #15479
