### PR TITLE
Add support to register/de-register from Lightwave WiFi Link Hub

### DIFF
--- a/homeassistant/components/lightwave/__init__.py
+++ b/homeassistant/components/lightwave/__init__.py
@@ -13,6 +13,8 @@ from homeassistant.helpers.discovery import async_load_platform
 REQUIREMENTS = ['lightwave==0.17']
 LIGHTWAVE_LINK = 'lightwave_link'
 DOMAIN = 'lightwave'
+SERVICE_REGISTER = 'lightwave_registration'
+SERVICE_DEREGISTER = 'lightwave_deregistration'
 
 
 CONFIG_SCHEMA = vol.Schema({
@@ -28,6 +30,10 @@ CONFIG_SCHEMA = vol.Schema({
         })
 }, extra=vol.ALLOW_EXTRA)
 
+# Currently no attributes but it might change later
+LIGHTWAVE_REGISTRATION_SCHEMA = vol.Schema({})
+LIGHTWAVE_DEREGISTRATION_SCHEMA = vol.Schema({})
+
 
 async def async_setup(hass, config):
     """Try to start embedded Lightwave broker."""
@@ -35,6 +41,16 @@ async def async_setup(hass, config):
 
     host = config[DOMAIN][CONF_HOST]
     hass.data[LIGHTWAVE_LINK] = LWLink(host)
+
+    """Provide service to register with Lightwave Wifi Link"""
+    async def async_registration_service_handler(service):
+        lwlink = hass.data[LIGHTWAVE_LINK]
+        lwlink.register()
+
+    """Provide service to deregister with Lightwave Wifi Link"""
+    async def async_deregistration_service_handler(service):
+        lwlink = hass.data[LIGHTWAVE_LINK]
+        lwlink.deregister_all()
 
     lights = config[DOMAIN][CONF_LIGHTS]
     if lights:
@@ -45,5 +61,13 @@ async def async_setup(hass, config):
     if switches:
         hass.async_create_task(async_load_platform(
             hass, 'switch', DOMAIN, switches, config))
+
+    hass.services.async_register(
+        DOMAIN, SERVICE_REGISTER, async_registration_service_handler,
+        schema=LIGHTWAVE_REGISTRATION_SCHEMA)
+
+    hass.services.async_register(
+        DOMAIN, SERVICE_DEREGISTER, async_deregistration_service_handler,
+        schema=LIGHTWAVE_DEREGISTRATION_SCHEMA)
 
     return True

--- a/homeassistant/components/lightwave/__init__.py
+++ b/homeassistant/components/lightwave/__init__.py
@@ -10,7 +10,7 @@ from homeassistant.const import (CONF_HOST, CONF_LIGHTS, CONF_NAME,
                                  CONF_SWITCHES)
 from homeassistant.helpers.discovery import async_load_platform
 
-REQUIREMENTS = ['lightwave==0.15']
+REQUIREMENTS = ['lightwave==0.17']
 LIGHTWAVE_LINK = 'lightwave_link'
 DOMAIN = 'lightwave'
 

--- a/homeassistant/components/lightwave/services.yaml
+++ b/homeassistant/components/lightwave/services.yaml
@@ -1,0 +1,4 @@
+lightwave_registration:
+  description: Register home assistant with Lightwave WiFi Link hub.
+lightwave_deregistration:
+  description: De-register all devices from Lightwave WiFi Link hub.

--- a/homeassistant/components/lightwave/switch.py
+++ b/homeassistant/components/lightwave/switch.py
@@ -55,11 +55,17 @@ class LWRFSwitch(SwitchDevice):
     async def async_turn_on(self, **kwargs):
         """Turn the LightWave switch on."""
         self._state = True
-        self._lwlink.turn_on_switch(self._device_id, self._name)
+        if self._device_id == "registration":
+            self._lwlink.register()
+        else:
+            self._lwlink.turn_on_switch(self._device_id, self._name)
         self.async_schedule_update_ha_state()
 
     async def async_turn_off(self, **kwargs):
         """Turn the LightWave switch off."""
         self._state = False
-        self._lwlink.turn_off(self._device_id, self._name)
+        if self._device_id == "registration":
+            self._lwlink.deregister_all()
+        else:
+            self._lwlink.turn_off(self._device_id, self._name)
         self.async_schedule_update_ha_state()

--- a/homeassistant/components/lightwave/switch.py
+++ b/homeassistant/components/lightwave/switch.py
@@ -55,17 +55,11 @@ class LWRFSwitch(SwitchDevice):
     async def async_turn_on(self, **kwargs):
         """Turn the LightWave switch on."""
         self._state = True
-        if self._device_id == "registration":
-            self._lwlink.register()
-        else:
-            self._lwlink.turn_on_switch(self._device_id, self._name)
+        self._lwlink.turn_on_switch(self._device_id, self._name)
         self.async_schedule_update_ha_state()
 
     async def async_turn_off(self, **kwargs):
         """Turn the LightWave switch off."""
         self._state = False
-        if self._device_id == "registration":
-            self._lwlink.deregister_all()
-        else:
-            self._lwlink.turn_off(self._device_id, self._name)
+        self._lwlink.turn_off(self._device_id, self._name)
         self.async_schedule_update_ha_state()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -630,7 +630,7 @@ liffylights==0.9.4
 lightify==1.0.6.1
 
 # homeassistant.components.lightwave
-lightwave==0.15
+lightwave==0.17
 
 # homeassistant.components.light.limitlessled
 limitlessled==1.1.3


### PR DESCRIPTION
## Description:
Add support to manually register/de-register Lightwave WiFi Link Hub. Some users have reported issues and this is an attempt to address the issues.

Please note: This is my second attempt as submitting the same code. As I am new to GitHub and how I created the PR previously apparently caused a problem. I hope I have got it right this time. If not please let me know and I can try again.

## Example entry for `configuration.yaml` (if applicable):
```yaml
lightwave:
  host: 192.168.1.2
  switches:
    registration:
      name: Registration
```

### `registration`
The `id` of `registration` is a reserved switch for registering and de-registering Home Assistant from your Lightwave WiFi link. Switching this on will register with your Ligthwave Wifi link hub. You then have 12 seconds to push the button on your hub to accept this registration. Switching this off will deregister **all devices** that have been registered. Use this wisely.