### PR TITLE
Run tasks when ZHA devices become available 

### DIFF
--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -152,10 +152,12 @@ async def async_setup_entry(hass, config_entry):
     def handle_message(sender, is_reply, profile, cluster,
                        src_ep, dst_ep, tsn, command_id, args):
         """Handle message from a device."""
-        if sender.last_seen is None and not sender.initializing:
-            if sender.ieee in zha_gateway.devices:
-                device = zha_gateway.devices[sender.ieee]
-                device.update_available(True)
+        hass.async_create_task(
+            zha_gateway.async_handle_zigbee_message(
+                sender, is_reply, profile, cluster, src_ep, dst_ep, tsn,
+                command_id, args
+            )
+        )
         return sender.handle_message(
             is_reply, profile, cluster, src_ep, dst_ep, tsn, command_id, args)
 

--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -152,12 +152,15 @@ async def async_setup_entry(hass, config_entry):
     def handle_message(sender, is_reply, profile, cluster,
                        src_ep, dst_ep, tsn, command_id, args):
         """Handle message from a device."""
-        hass.async_create_task(
-            zha_gateway.async_handle_zigbee_message(
-                sender, is_reply, profile, cluster, src_ep, dst_ep, tsn,
-                command_id, args
+        if (sender.last_seen is None and not sender.initializing) or \
+                (sender.ieee in zha_gateway.devices and not
+                 zha_gateway.devices[sender.ieee].available):
+            hass.async_create_task(
+                zha_gateway.async_device_became_available(
+                    sender, is_reply, profile, cluster, src_ep, dst_ep, tsn,
+                    command_id, args
+                )
             )
-        )
         return sender.handle_message(
             is_reply, profile, cluster, src_ep, dst_ep, tsn, command_id, args)
 

--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -152,9 +152,8 @@ async def async_setup_entry(hass, config_entry):
     def handle_message(sender, is_reply, profile, cluster,
                        src_ep, dst_ep, tsn, command_id, args):
         """Handle message from a device."""
-        if (sender.last_seen is None and not sender.initializing) or \
-                (sender.ieee in zha_gateway.devices and not
-                 zha_gateway.devices[sender.ieee].available):
+        if not sender.initializing and sender.ieee in zha_gateway.devices and \
+                not zha_gateway.devices[sender.ieee].available:
             hass.async_create_task(
                 zha_gateway.async_device_became_available(
                     sender, is_reply, profile, cluster, src_ep, dst_ep, tsn,

--- a/homeassistant/components/zha/core/gateway.py
+++ b/homeassistant/components/zha/core/gateway.py
@@ -130,9 +130,9 @@ class ZHAGateway:
             self, sender, is_reply, profile, cluster, src_ep, dst_ep, tsn,
             command_id, args):
         """Handle tasks when a device becomes available."""
-        await self.async_update_device(sender)
+        self.async_update_device(sender)
 
-    async def async_update_device(self, sender):
+    def async_update_device(self, sender):
         """Update device that has just become available."""
         if sender.ieee in self.devices:
             device = self.devices[sender.ieee]

--- a/homeassistant/components/zha/core/gateway.py
+++ b/homeassistant/components/zha/core/gateway.py
@@ -133,7 +133,7 @@ class ZHAGateway:
         await self.async_update_device(sender)
 
     async def async_update_device(self, sender):
-        """Update device that has just became available."""
+        """Update device that has just become available."""
         if sender.ieee in self.devices:
             device = self.devices[sender.ieee]
             device.update_available(True)

--- a/homeassistant/components/zha/core/gateway.py
+++ b/homeassistant/components/zha/core/gateway.py
@@ -126,18 +126,17 @@ class ZHAGateway:
             self._devices[zigpy_device.ieee] = zha_device
         return zha_device
 
-    async def async_handle_zigbee_message(
+    async def async_device_became_available(
             self, sender, is_reply, profile, cluster, src_ep, dst_ep, tsn,
             command_id, args):
-        """Intercept messages from a zigbee devices and create tasks."""
-        self._hass.async_create_task(self.async_maybe_update_device(sender))
+        """Handle tasks when a device becomes available."""
+        await self.async_update_device(sender)
 
-    async def async_maybe_update_device(self, sender):
-        """Update device if it just became available."""
-        if sender.last_seen is None and not sender.initializing:
-            if sender.ieee in self.devices:
-                device = self.devices[sender.ieee]
-                device.update_available(True)
+    async def async_update_device(self, sender):
+        """Update device that has just became available."""
+        if sender.ieee in self.devices:
+            device = self.devices[sender.ieee]
+            device.update_available(True)
 
     async def async_device_initialized(self, device, is_new_join):
         """Handle device joined and basic information discovered (async)."""


### PR DESCRIPTION
This uses tasks to update devices if the need to be updated and adds the foundation for a "reconfigure all devices" type function in the future.