### PR TITLE
Add error-attribute to HomeMatic

### DIFF
--- a/homeassistant/components/homematic/__init__.py
+++ b/homeassistant/components/homematic/__init__.py
@@ -106,10 +106,14 @@ HM_IGNORE_DISCOVERY_NODE_EXCEPTIONS = {
         'IPWeatherSensorPlus', 'IPWeatherSensorBasic'],
 }
 
+# pylint: disable=duplicate-key
 HM_ATTRIBUTE_SUPPORT = {
     'LOWBAT': ['battery', {0: 'High', 1: 'Low'}],
     'LOW_BAT': ['battery', {0: 'High', 1: 'Low'}],
-    'ERROR': ['error', {0: 'No'}],
+    'ERROR': ['error', {0: 'No'}], # noqa
+    # The following line is depricated and will be replaced by the line 
+    # above ("error")
+    'ERROR': ['sabotage', {0: 'No', 1: 'Yes'}], # noqa
     'ERROR_SABOTAGE': ['sabotage', {0: 'No', 1: 'Yes'}],
     'SABOTAGE': ['sabotage', {0: 'No', 1: 'Yes'}],
     'RSSI_PEER': ['rssi', {}],

--- a/homeassistant/components/homematic/__init__.py
+++ b/homeassistant/components/homematic/__init__.py
@@ -111,7 +111,7 @@ HM_ATTRIBUTE_SUPPORT = {
     'LOWBAT': ['battery', {0: 'High', 1: 'Low'}],
     'LOW_BAT': ['battery', {0: 'High', 1: 'Low'}],
     'ERROR': ['error', {0: 'No'}], # noqa
-    # The following line is depricated and will be replaced by the line 
+    # The following line is depricated and will be replaced by the line
     # above ("error")
     'ERROR': ['sabotage', {0: 'No', 1: 'Yes'}], # noqa
     'ERROR_SABOTAGE': ['sabotage', {0: 'No', 1: 'Yes'}],

--- a/homeassistant/components/homematic/__init__.py
+++ b/homeassistant/components/homematic/__init__.py
@@ -106,14 +106,10 @@ HM_IGNORE_DISCOVERY_NODE_EXCEPTIONS = {
         'IPWeatherSensorPlus', 'IPWeatherSensorBasic'],
 }
 
-# pylint: disable=duplicate-key
 HM_ATTRIBUTE_SUPPORT = {
     'LOWBAT': ['battery', {0: 'High', 1: 'Low'}],
     'LOW_BAT': ['battery', {0: 'High', 1: 'Low'}],
-    'ERROR': ['error', {0: 'No'}], # noqa
-    # The following line is depricated and will be replaced by the line
-    # above ("error")
-    'ERROR': ['sabotage', {0: 'No', 1: 'Yes'}], # noqa
+    'ERROR': ['error', {0: 'No'}],
     'ERROR_SABOTAGE': ['sabotage', {0: 'No', 1: 'Yes'}],
     'SABOTAGE': ['sabotage', {0: 'No', 1: 'Yes'}],
     'RSSI_PEER': ['rssi', {}],

--- a/homeassistant/components/homematic/__init__.py
+++ b/homeassistant/components/homematic/__init__.py
@@ -109,7 +109,7 @@ HM_IGNORE_DISCOVERY_NODE_EXCEPTIONS = {
 HM_ATTRIBUTE_SUPPORT = {
     'LOWBAT': ['battery', {0: 'High', 1: 'Low'}],
     'LOW_BAT': ['battery', {0: 'High', 1: 'Low'}],
-    'ERROR': ['sabotage', {0: 'No', 1: 'Yes'}],
+    'ERROR': ['error', {0: 'No'}],
     'ERROR_SABOTAGE': ['sabotage', {0: 'No', 1: 'Yes'}],
     'SABOTAGE': ['sabotage', {0: 'No', 1: 'Yes'}],
     'RSSI_PEER': ['rssi', {}],


### PR DESCRIPTION
## Description:
ERROR has different meanings depending on the device. It is not only for sabotage errors but also for eg. LOWBAT on some devices. The numeric value will indicate the error details.

This change has no implication on the documentation because no attributes are detailed there.

### Breaking change
For some [HomeMatic](https://www.home-assistant.io/components/homematic/) devices the `sabotage` attribute is replaced by `error`. The value (if not 0) is a device specific error code.

## Checklist:
- [x] The code change is tested and works locally.
- [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.

