### PR TITLE
Upgrade cryptography to 2.5

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -6,7 +6,7 @@ bcrypt==3.1.5
 certifi>=2018.04.16
 jinja2>=2.10
 PyJWT==1.6.4
-cryptography==2.3.1
+cryptography==2.5
 pip>=8.0.3
 python-slugify==1.2.6
 pytz>=2018.07

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -7,7 +7,7 @@ bcrypt==3.1.5
 certifi>=2018.04.16
 jinja2>=2.10
 PyJWT==1.6.4
-cryptography==2.3.1
+cryptography==2.5
 pip>=8.0.3
 python-slugify==1.2.6
 pytz>=2018.07

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ REQUIRES = [
     'jinja2>=2.10',
     'PyJWT==1.6.4',
     # PyJWT has loose dependency. We want the latest one.
-    'cryptography==2.3.1',
+    'cryptography==2.5',
     'pip>=8.0.3',
     'python-slugify==1.2.6',
     'pytz>=2018.07',


### PR DESCRIPTION
## Description:

https://github.com/pyca/cryptography/blob/master/CHANGELOG.rst#25---2019-01-22

**Related issue (if applicable):** fixes #21001

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

