### PR TITLE
Prevent OverflowError in ESPHome integration

### DIFF
--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -325,6 +325,7 @@ async def _setup_auto_reconnect_logic(hass: HomeAssistantType,
             # In the future another API will be set up so that the ESP can
             # notify HA of connectivity directly, but for new we'll use a
             # really short reconnect interval.
+            tries = min(tries, 10)  # prevent OverflowError
             wait_time = int(round(min(1.8**tries, 60.0)))
             _LOGGER.info("Trying to reconnect in %s seconds", wait_time)
             await asyncio.sleep(wait_time)


### PR DESCRIPTION
## Description:

This is a fun error :D

When `tries` exceeds 1208, the expression `1.8**tries` results in an OverflowError. This occurs after around 1208/60 = 20 hours of the device not being connectable.

**Related issue (if applicable):** https://github.com/home-assistant/home-assistant/issues/21005#issuecomment-462883835

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
