### PR TITLE
Added climate scheduler

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -84,6 +84,7 @@ omit =
     homeassistant/components/climate/touchline.py
     homeassistant/components/climate/venstar.py
     homeassistant/components/climate/zhong_hong.py
+    homeassistant/components/climate_scheduler.py
     homeassistant/components/cloudflare/*
     homeassistant/components/coinbase/*
     homeassistant/components/comfoconnect/*

--- a/homeassistant/components/climate_scheduler/__init__.py
+++ b/homeassistant/components/climate_scheduler/__init__.py
@@ -108,10 +108,14 @@ class ClimateScheduler(Entity):
             temp = self.rules[rule_id]['temp']
             days = self.rules[rule_id]['days']
             if days[dt.as_local(now).weekday()]:
-                self.hass.services.async_call('climate', 'set_temperature', {
-                    "entity_id": self.climate,
-                    "temperature": temp
-                })
+                self.hass.loop.create_task(
+                    self.hass.services.async_call(
+                        'climate',
+                        'set_temperature',
+                        {
+                            "entity_id": self.climate,
+                            "temperature": temp
+                        }))
         return run_id
 
     @callback

--- a/homeassistant/components/climate_scheduler/__init__.py
+++ b/homeassistant/components/climate_scheduler/__init__.py
@@ -12,9 +12,10 @@ Example component configuration:
 climate_scheduler:
   target_climate: climate.home
 """
-import logging
-import voluptuous as vol
 import json
+import logging
+
+import voluptuous as vol
 
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import dt
@@ -92,12 +93,12 @@ class ClimateScheduler(Entity):
             unsub()
         self.unsubs = []
 
-        for x in range(len(self.rules)):
-            rule = self.rules[x]
+        for rule_pos in range(len(self.rules)):
+            rule = self.rules[rule_pos]
             r_time = tuple(map(int, rule['time'].split(':')))
             self.unsubs.append(
                 async_track_time_change(self.hass,
-                                        self.run_schecule(x),
+                                        self.run_schecule(rule_pos),
                                         hour=r_time[0],
                                         minute=r_time[1],
                                         second=0))

--- a/homeassistant/components/climate_scheduler/__init__.py
+++ b/homeassistant/components/climate_scheduler/__init__.py
@@ -15,7 +15,6 @@ climate_scheduler:
 import logging
 import voluptuous as vol
 import json
-import os
 
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import dt

--- a/homeassistant/components/climate_scheduler/__init__.py
+++ b/homeassistant/components/climate_scheduler/__init__.py
@@ -1,0 +1,142 @@
+"""
+Schedules temperature updates to the climate component.
+
+Schedule is read from 'schedule_persistance.json' in the
+configuration directory.
+
+Lovelace card to control it (WIP, in spanish):
+https://gist.github.com/alex-torregrosa/482f62fec60d892b60b9dfe73289cd6f
+
+Example component configuration:
+
+climate_scheduler:
+  target_climate: climate.home
+"""
+import logging
+import voluptuous as vol
+import json
+import os
+
+from homeassistant.helpers.entity import Entity
+from homeassistant.util import dt
+from homeassistant.helpers.event import (
+    async_track_time_change)
+import homeassistant.helpers.config_validation as cv
+from homeassistant.const import STATE_ON
+from homeassistant.core import callback
+
+
+_LOGGER = logging.getLogger(__name__)
+
+# The domain of your component. Equal to the filename of your component.
+DOMAIN = "climate_scheduler"
+ENTITY_ID = "climate_scheduler.main"
+CONF_CLIMATE = 'target_climate'
+ATTR_TIMES = "timetable"
+DEFAULT_TIMES = "[]"
+PERISSTENCE_FILE = 'schedule_persistance.json'
+
+CONFIG_SCHEMA = vol.Schema({
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_CLIMATE): cv.entity_id,
+    })
+}, extra=vol.ALLOW_EXTRA)
+
+
+async def async_setup(hass, config):
+    """Setups the climate scheduler component."""
+    climate = config[DOMAIN].get(CONF_CLIMATE, None)
+    if climate is None:
+        _LOGGER.error("No climate provided.")
+    ClimateScheduler(hass, climate)
+    # Return boolean to indicate that initialization was successfully.
+    return True
+
+
+class ClimateScheduler(Entity):
+    """Representation of a climate scheduler entity."""
+
+    entity_id = ENTITY_ID
+
+    def __init__(self, hass, climate):
+        """Initialize the scheduler."""
+        self.hass = hass
+        self._state = STATE_ON
+        self.climate = climate
+        self.rules = []
+        self.unsubs = []
+        self.persistence_file = hass.config.path(PERISSTENCE_FILE)
+
+        try:
+            with open(self.persistence_file, 'r') as file_handle:
+                self.rules = json.load(file_handle)
+        except FileNotFoundError:
+            self.saveRules()
+
+        self.update_rules()
+
+        hass.services.async_register(DOMAIN, 'update', self.handle_update)
+        self.async_schedule_update_ha_state()
+
+    def saveRules(self):
+        """Save rules to persistence file."""
+        with open(self.persistence_file, 'w') as file_handle:
+            json.dump(self.rules, file_handle, indent=4)
+            file_handle.flush()
+            os.fsync(file_handle.fileno())
+
+    def update_rules(self):
+        """Update the trackers for all rules."""
+        for unsub in self.unsubs:
+            unsub()
+        self.unsubs = []
+
+        for x in range(len(self.rules)):
+            rule = self.rules[x]
+            r_time = tuple(map(int, rule['time'].split(':')))
+            self.unsubs.append(
+                async_track_time_change(self.hass,
+                                        self.run_schecule(x),
+                                        hour=r_time[0],
+                                        minute=r_time[1],
+                                        second=0))
+
+    def run_schecule(self, rule_id):
+        """Generate a callback function for the given rule."""
+        @callback
+        def run_id(now):
+            temp = self.rules[rule_id]['temp']
+            days = self.rules[rule_id]['days']
+            if days[dt.as_local(now).weekday()]:
+                self.hass.services.async_call('climate', 'set_temperature', {
+                    "entity_id": self.climate,
+                    "temperature": temp
+                })
+        return run_id
+
+    @callback
+    def handle_update(self, call):
+        """Update the rule list."""
+        new_rules = call.data.get(ATTR_TIMES, DEFAULT_TIMES)
+        self.rules = json.loads(new_rules)
+        self.saveRules()
+        self.update_rules()
+        self.async_schedule_update_ha_state()
+
+    @property
+    def name(self):
+        """Name of the device."""
+        return 'Climate Scheduler'
+
+    @property
+    def state(self):
+        """State of the device."""
+        return self._state
+
+    @property
+    def device_state_attributes(self):
+        """Return the optional state attributes."""
+        return {
+            "rules_count": len(self.rules),
+            "rules_json": json.dumps(self.rules)
+        }

--- a/homeassistant/components/climate_scheduler/__init__.py
+++ b/homeassistant/components/climate_scheduler/__init__.py
@@ -73,10 +73,11 @@ class ClimateScheduler(Entity):
         hass.services.async_register(DOMAIN, 'update', self.handle_update)
 
     async def async_save_rules(self):
-        """Save rules to persistence file."""
+        """Save rules to storage."""
         await self.store.async_save(self.rules)
 
     async def async_load_rules(self):
+        """Load rules from storage."""
         loaded_rules = await self.store.async_load()
         if loaded_rules is None:
             await self.async_save_rules()


### PR DESCRIPTION
## Description:
Adds a basic scheduler for the climate platform. Right now it allows to set the temperature automatically at certain hours and days.

WIP frontend (custom lovelace card):
https://gist.github.com/alex-torregrosa/482f62fec60d892b60b9dfe73289cd6f


**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml`:
```yaml
climate_scheduler:
  target_climate: climate.home
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
