### PR TITLE
Nuki lock improvements

### DIFF
--- a/homeassistant/components/lock/nuki.py
+++ b/homeassistant/components/lock/nuki.py
@@ -11,15 +11,16 @@ import voluptuous as vol
 
 from homeassistant.components.lock import DOMAIN, PLATFORM_SCHEMA, LockDevice
 from homeassistant.const import (
-    ATTR_ENTITY_ID, CONF_HOST, CONF_PORT, CONF_TOKEN)
+    ATTR_ENTITY_ID, CONF_HOST, CONF_PORT, CONF_TOKEN, CONF_TIMEOUT)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.service import extract_entity_ids
 
-REQUIREMENTS = ['pynuki==1.3.2']
+REQUIREMENTS = ['pynuki==1.3.3']
 
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_PORT = 8080
+DEFAULT_TIMEOUT = 5
 
 ATTR_BATTERY_CRITICAL = 'battery_critical'
 ATTR_NUKI_ID = 'nuki_id'
@@ -36,7 +37,8 @@ SERVICE_UNLATCH = 'nuki_unlatch'
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
     vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
-    vol.Required(CONF_TOKEN): cv.string
+    vol.Required(CONF_TOKEN): cv.string,
+    vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int
 })
 
 LOCK_N_GO_SERVICE_SCHEMA = vol.Schema({
@@ -52,7 +54,8 @@ UNLATCH_SERVICE_SCHEMA = vol.Schema({
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Nuki lock platform."""
     from pynuki import NukiBridge
-    bridge = NukiBridge(config.get(CONF_HOST), config.get(CONF_TOKEN))
+    bridge = NukiBridge(config.get(CONF_HOST), config.get(CONF_TOKEN),
+    config.get(CONF_PORT), config.get(CONF_TIMEOUT))
     add_entities([NukiLock(lock) for lock in bridge.locks])
 
     def service_handler(service):

--- a/homeassistant/components/lock/nuki.py
+++ b/homeassistant/components/lock/nuki.py
@@ -6,6 +6,7 @@ https://home-assistant.io/components/lock.nuki/
 """
 from datetime import timedelta
 import logging
+import requests
 
 import voluptuous as vol
 
@@ -141,8 +142,8 @@ class NukiLock(LockDevice):
         """Update the nuki lock properties."""
         try:
             self._nuki_lock.update(aggressive=False)
-        except requests.exceptions.ConnectionError:
-            self._lock_reachable = false
+        except requests.exceptions.RequestException:
+            self._lock_reachable = False
         else:
             self._name = self._nuki_lock.name
             self._locked = self._nuki_lock.is_locked
@@ -175,7 +176,7 @@ class NukiLock(LockDevice):
         """Update the nuki lock properties."""
         try:
             self._nuki_lock.update(aggressive=True)
-        except requests.exceptions.ConnectionError:
-            self._lock_reachable = false
+        except requests.exceptions.RequestException:
+            self._lock_reachable = False
         else:
             self._lock_reachable = self._nuki_lock.state != 255

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1149,7 +1149,7 @@ pynetgear==0.5.2
 pynetio==0.1.9.1
 
 # homeassistant.components.lock.nuki
-pynuki==1.3.2
+pynuki==1.3.3
 
 # homeassistant.components.sensor.nut
 pynut2==2.1.2


### PR DESCRIPTION
## Description:
Nuki lock component improvements:
 - Bride port: The port parameter was not forwarded on bridge component initialization. 
 - timeout configuration parameter (optional): The user can establish the timeout in the component configuration. Default is 5s
 - lock_reachable attribute: New boolean attribute to check if the communication HA <-> brigde and bridge <-> lock is fine.
 - Check connection service: If, by any reason, the connection between the bridge and the lock was lost, there was no way to detect it. There is now a new service to force the communication between the bridge and the lock, instead of retrieving the last know state. If that communication fails, the attribute lock_reachable will become true. 
- unlatch_to_unlock configuration parameter (optional): If set to true, when calling the service unlock, the lock will unlatch. Default is false.

## Example entry for `configuration.yaml` (if applicable):
```yaml
lock:
  - platform: nuki
    host: 192.168.0.85
    port: 8080
    token: [token]
    timeout: 25
    unlatch_to_unlock: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
