### PR TITLE
Bump aioambient to 0.1.1

### DIFF
--- a/homeassistant/components/ambient_station/__init__.py
+++ b/homeassistant/components/ambient_station/__init__.py
@@ -25,7 +25,7 @@ from .const import (
     ATTR_LAST_DATA, CONF_APP_KEY, DATA_CLIENT, DOMAIN, TOPIC_UPDATE,
     TYPE_BINARY_SENSOR, TYPE_SENSOR)
 
-REQUIREMENTS = ['aioambient==0.1.0']
+REQUIREMENTS = ['aioambient==0.1.1']
 _LOGGER = logging.getLogger(__name__)
 
 DATA_CONFIG = 'config'
@@ -257,7 +257,7 @@ async def async_setup(hass, config):
 async def async_setup_entry(hass, config_entry):
     """Set up the Ambient PWS as config entry."""
     from aioambient import Client
-    from aioambient.errors import WebsocketConnectionError
+    from aioambient.errors import WebsocketError
 
     session = aiohttp_client.async_get_clientsession(hass)
 
@@ -270,7 +270,7 @@ async def async_setup_entry(hass, config_entry):
             hass.data[DOMAIN][DATA_CONFIG].get(CONF_MONITORED_CONDITIONS, []))
         hass.loop.create_task(ambient.ws_connect())
         hass.data[DOMAIN][DATA_CLIENT][config_entry.entry_id] = ambient
-    except WebsocketConnectionError as err:
+    except WebsocketError as err:
         _LOGGER.error('Config entry failed: %s', err)
         raise ConfigEntryNotReady
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -90,7 +90,7 @@ abodepy==0.15.0
 afsapi==0.0.4
 
 # homeassistant.components.ambient_station
-aioambient==0.1.0
+aioambient==0.1.1
 
 # homeassistant.components.asuswrt
 aioasuswrt==1.1.20

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -31,7 +31,7 @@ PyTransportNSW==0.1.1
 YesssSMS==0.2.3
 
 # homeassistant.components.ambient_station
-aioambient==0.1.0
+aioambient==0.1.1
 
 # homeassistant.components.device_tracker.automatic
 aioautomatic==0.6.5


### PR DESCRIPTION
## Description:

This PR bumps `aioambient` to 0.1.1. Changelog: https://github.com/bachya/aioambient/releases/tag/0.1.1

**Related issue (if applicable):** fixes #20849

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** N/A

## Example entry for `configuration.yaml` (if applicable):
```yaml
ambient_station:
  api_key: !secret ambient_pws_api_key
  app_key: !secret ambient_pws_app_key
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
