### PR TITLE
Xfinity Gateway device_tracker platform

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -138,6 +138,7 @@ omit =
     homeassistant/components/device_tracker/trackr.py
     homeassistant/components/device_tracker/ubee.py
     homeassistant/components/device_tracker/ubus.py
+    homeassistant/components/device_tracker/xfinity.py
     homeassistant/components/digital_ocean/*
     homeassistant/components/dominos/*
     homeassistant/components/doorbird/*

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -63,12 +63,13 @@ homeassistant/components/cover/group.py @cdce8p
 homeassistant/components/cover/template.py @PhracturedBlue
 homeassistant/components/device_tracker/asuswrt.py @kennedyshead
 homeassistant/components/device_tracker/automatic.py @armills
+homeassistant/components/device_tracker/bt_smarthub.py @jxwolstenholme
 homeassistant/components/device_tracker/huawei_router.py @abmantis
 homeassistant/components/device_tracker/quantum_gateway.py @cisasteelersfan
 homeassistant/components/device_tracker/tile.py @bachya
 homeassistant/components/device_tracker/traccar.py @ludeeus
-homeassistant/components/device_tracker/bt_smarthub.py @jxwolstenholme
 homeassistant/components/device_tracker/synology_srm.py @aerialls
+homeassistant/components/device_tracker/xfinity.py @cisasteelersfan
 homeassistant/components/light/lifx_legacy.py @amelchio
 homeassistant/components/light/yeelight.py @rytilahti
 homeassistant/components/light/yeelightsunflower.py @lindsaymarkward

--- a/homeassistant/components/device_tracker/xfinity.py
+++ b/homeassistant/components/device_tracker/xfinity.py
@@ -1,9 +1,4 @@
-"""
-Support for Xfinity Gateways.
-
-For more details about this platform, please refer to the documentation at
-https://home-assistant.io/components/device_tracker.xfinity/
-"""
+"""Support for device tracking via Xfinity Gateways."""
 import logging
 
 from requests.exceptions import RequestException
@@ -27,10 +22,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 def get_scanner(hass, config):
     """Validate the configuration and return an Xfinity Gateway scanner."""
-    info = config[DOMAIN]
-    host = info.get(CONF_HOST)
-
-    scanner = XfinityDeviceScanner(host)
+    scanner = XfinityDeviceScanner(config[DOMAIN][CONF_HOST])
 
     return scanner if scanner.success_init else None
 

--- a/homeassistant/components/device_tracker/xfinity.py
+++ b/homeassistant/components/device_tracker/xfinity.py
@@ -43,7 +43,8 @@ class XfinityDeviceScanner(DeviceScanner):
             self.success_init = True
         except (RequestException, ValueError):
             self.success_init = False
-            _LOGGER.error("Unable to connect to gateway. Check host: " + self.gateway.host)
+            _LOGGER.error("Unable to connect to gateway. Check host: %s",\
+                           self.gateway.host)
 
     def scan_devices(self):
         """Scan for new devices and return a list of found MACs."""
@@ -51,7 +52,8 @@ class XfinityDeviceScanner(DeviceScanner):
         try:
             connected_devices = self.gateway.scan_devices()
         except (RequestException, ValueError):
-            _LOGGER.error("Unable to scan devices. Check connection to gateway")
+            _LOGGER.error("Unable to scan devices. "
+                          "Check connection to gateway")
         return connected_devices
 
     def get_device_name(self, device):

--- a/homeassistant/components/device_tracker/xfinity.py
+++ b/homeassistant/components/device_tracker/xfinity.py
@@ -39,9 +39,9 @@ def get_scanner(hass, config):
 class XfinityDeviceScanner(DeviceScanner):
     """This class queries an Xfinity Gateway."""
 
-    def __init__(self, xfinityGateway):
+    def __init__(self, gateway):
         """Initialize the scanner."""
-        self.gateway = xfinityGateway
+        self.gateway = gateway
 
     def scan_devices(self):
         """Scan for new devices and return a list of found MACs."""

--- a/homeassistant/components/device_tracker/xfinity.py
+++ b/homeassistant/components/device_tracker/xfinity.py
@@ -1,0 +1,59 @@
+import logging
+
+from requests.exceptions import RequestException
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.device_tracker import (
+    DOMAIN, PLATFORM_SCHEMA, DeviceScanner)
+from homeassistant.const import CONF_HOST
+
+REQUIREMENTS = ['xfinity-gateway==0.0.3']
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_HOST = '10.0.0.1'
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Optional(CONF_HOST, default=DEFAULT_HOST): cv.string
+})
+
+
+def get_scanner(hass, config):
+    """Validate the configuration and return an Xfinity Gateway scanner."""
+    info = config[DOMAIN]
+    host = info.get(CONF_HOST)
+
+    scanner = XfinityDeviceScanner(host)
+
+    return scanner if scanner.success_init else None
+
+
+class XfinityDeviceScanner(DeviceScanner):
+    """This class queries an Xfinity Gateway."""
+
+    def __init__(self, address):
+        """Initialize the scanner."""
+        from xfinity_gateway import XfinityGateway
+
+        try:
+            _LOGGER.debug('Initializing')
+            self.gateway = XfinityGateway(address)
+            self.gateway.scan_devices()
+            self.success_init = True
+        except (RequestException, ValueError):
+            self.success_init = False
+            _LOGGER.error("Unable to connect to gateway. Check host: " + self.gateway.host)
+
+    def scan_devices(self):
+        """Scan for new devices and return a list of found MACs."""
+        connected_devices = []
+        try:
+            connected_devices = self.gateway.scan_devices()
+        except (RequestException, ValueError):
+            _LOGGER.error("Unable to scan devices. Check connection to gateway")
+        return connected_devices
+
+    def get_device_name(self, device):
+        """Return the name of the given device or None if we don't know."""
+        return self.gateway.get_device_name(device)

--- a/homeassistant/components/device_tracker/xfinity.py
+++ b/homeassistant/components/device_tracker/xfinity.py
@@ -1,3 +1,9 @@
+"""
+Support for Xfinity Gateways.
+
+For more details about this platform, please refer to the documentation at
+https://home-assistant.io/components/device_tracker.xfinity/
+"""
 import logging
 
 from requests.exceptions import RequestException
@@ -43,8 +49,8 @@ class XfinityDeviceScanner(DeviceScanner):
             self.success_init = True
         except (RequestException, ValueError):
             self.success_init = False
-            _LOGGER.error("Unable to connect to gateway. Check host: %s",\
-                           self.gateway.host)
+            _LOGGER.error("Unable to connect to gateway. Check host: %s",
+                          self.gateway.host)
 
     def scan_devices(self):
         """Scan for new devices and return a list of found MACs."""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1779,7 +1779,7 @@ xbee-helper==0.0.7
 xboxapi==0.1.1
 
 # homeassistant.components.device_tracker.xfinity
-xfinity-gateway==0.0.3
+xfinity-gateway==0.0.4
 
 # homeassistant.components.knx
 xknx==0.9.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1778,6 +1778,9 @@ xbee-helper==0.0.7
 # homeassistant.components.sensor.xbox_live
 xboxapi==0.1.1
 
+# homeassistant.components.device_tracker.xfinity
+xfinity-gateway==0.0.3
+
 # homeassistant.components.knx
 xknx==0.9.4
 


### PR DESCRIPTION
## Description:

Xfinity Gateway device_tracker platform. On the login page of the gateway, a list of connected devices with MAC address & hostname is displayed. My Pypi package scrapes this page using BeautifulSoup. 


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8535

## Example entry for `configuration.yaml` (if applicable):
```yaml
device_tracker:
  platform: xfinity
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
