### PR TITLE
Allow chaining contexts

### DIFF
--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -220,6 +220,15 @@ def _apply_update(engine, new_version, old_version):
         _create_index(engine, "states", "ix_states_context_user_id")
     elif new_version == 7:
         _create_index(engine, "states", "ix_states_entity_id")
+    elif new_version == 8:
+        # Pending migration, want to group a few.
+        pass
+        # _add_columns(engine, "events", [
+        #     'context_parent_id CHARACTER(36)',
+        # ])
+        # _add_columns(engine, "states", [
+        #     'context_parent_id CHARACTER(36)',
+        # ])
     else:
         raise ValueError("No schema migration defined for version {}"
                          .format(new_version))

--- a/homeassistant/components/recorder/models.py
+++ b/homeassistant/components/recorder/models.py
@@ -34,16 +34,20 @@ class Events(Base):  # type: ignore
     created = Column(DateTime(timezone=True), default=datetime.utcnow)
     context_id = Column(String(36), index=True)
     context_user_id = Column(String(36), index=True)
+    # context_parent_id = Column(String(36), index=True)
 
     @staticmethod
     def from_event(event):
         """Create an event database object from a native event."""
-        return Events(event_type=event.event_type,
-                      event_data=json.dumps(event.data, cls=JSONEncoder),
-                      origin=str(event.origin),
-                      time_fired=event.time_fired,
-                      context_id=event.context.id,
-                      context_user_id=event.context.user_id)
+        return Events(
+            event_type=event.event_type,
+            event_data=json.dumps(event.data, cls=JSONEncoder),
+            origin=str(event.origin),
+            time_fired=event.time_fired,
+            context_id=event.context.id,
+            context_user_id=event.context.user_id,
+            # context_parent_id=event.context.parent_id,
+        )
 
     def to_native(self):
         """Convert to a natve HA Event."""
@@ -81,6 +85,7 @@ class States(Base):   # type: ignore
     created = Column(DateTime(timezone=True), default=datetime.utcnow)
     context_id = Column(String(36), index=True)
     context_user_id = Column(String(36), index=True)
+    # context_parent_id = Column(String(36), index=True)
 
     __table_args__ = (
         # Used for fetching the state of entities at a specific time
@@ -99,6 +104,7 @@ class States(Base):   # type: ignore
             entity_id=entity_id,
             context_id=event.context.id,
             context_user_id=event.context.user_id,
+            # context_parent_id=event.context.parent_id,
         )
 
         # State got deleted

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -409,6 +409,10 @@ class Context:
         type=str,
         default=None,
     )
+    parent_id = attr.ib(
+        type=Optional[str],
+        default=None
+    )
     id = attr.ib(
         type=str,
         default=attr.Factory(lambda: uuid.uuid4().hex),
@@ -418,6 +422,7 @@ class Context:
         """Return a dictionary representation of the context."""
         return {
             'id': self.id,
+            'parent_id': self.parent_id,
             'user_id': self.user_id,
         }
 

--- a/tests/components/automation/test_event.py
+++ b/tests/components/automation/test_event.py
@@ -41,7 +41,7 @@ async def test_if_fires_on_event(hass, calls):
     hass.bus.async_fire('test_event', context=context)
     await hass.async_block_till_done()
     assert 1 == len(calls)
-    assert calls[0].context is context
+    assert calls[0].context.parent_id == context.id
 
     await common.async_turn_off(hass)
     await hass.async_block_till_done()

--- a/tests/components/automation/test_geo_location.py
+++ b/tests/components/automation/test_geo_location.py
@@ -68,7 +68,7 @@ async def test_if_fires_on_zone_enter(hass, calls):
     await hass.async_block_till_done()
 
     assert 1 == len(calls)
-    assert calls[0].context is context
+    assert calls[0].context.parent_id == context.id
     assert 'geo_location - geo_location.entity - hello - hello - test' == \
         calls[0].data['some']
 
@@ -221,7 +221,7 @@ async def test_if_fires_on_zone_appear(hass, calls):
     await hass.async_block_till_done()
 
     assert 1 == len(calls)
-    assert calls[0].context is context
+    assert calls[0].context.parent_id == context.id
     assert 'geo_location - geo_location.entity -  - hello - test' == \
         calls[0].data['some']
 

--- a/tests/components/automation/test_numeric_state.py
+++ b/tests/components/automation/test_numeric_state.py
@@ -45,7 +45,7 @@ async def test_if_fires_on_entity_change_below(hass, calls):
     hass.states.async_set('test.entity', 9, context=context)
     await hass.async_block_till_done()
     assert 1 == len(calls)
-    assert calls[0].context is context
+    assert calls[0].context.parent_id == context.id
 
     # Set above 12 so the automation will fire again
     hass.states.async_set('test.entity', 12)
@@ -134,7 +134,7 @@ async def test_if_not_fires_on_entity_change_below_to_below(hass, calls):
     hass.states.async_set('test.entity', 9, context=context)
     await hass.async_block_till_done()
     assert 1 == len(calls)
-    assert calls[0].context is context
+    assert calls[0].context.parent_id == context.id
 
     # already below so should not fire again
     hass.states.async_set('test.entity', 5)

--- a/tests/components/automation/test_state.py
+++ b/tests/components/automation/test_state.py
@@ -55,7 +55,7 @@ async def test_if_fires_on_entity_change(hass, calls):
     hass.states.async_set('test.entity', 'world', context=context)
     await hass.async_block_till_done()
     assert 1 == len(calls)
-    assert calls[0].context is context
+    assert calls[0].context.parent_id == context.id
     assert 'state - test.entity - hello - world - None' == \
         calls[0].data['some']
 

--- a/tests/components/automation/test_template.py
+++ b/tests/components/automation/test_template.py
@@ -257,7 +257,7 @@ async def test_if_fires_on_change_with_template_advanced(hass, calls):
     hass.states.async_set('test.entity', 'world', context=context)
     await hass.async_block_till_done()
     assert 1 == len(calls)
-    assert calls[0].context is context
+    assert calls[0].context.parent_id == context.id
     assert 'template - test.entity - hello - world' == \
         calls[0].data['some']
 

--- a/tests/components/automation/test_zone.py
+++ b/tests/components/automation/test_zone.py
@@ -66,7 +66,7 @@ async def test_if_fires_on_zone_enter(hass, calls):
     await hass.async_block_till_done()
 
     assert 1 == len(calls)
-    assert calls[0].context is context
+    assert calls[0].context.parent_id == context.id
     assert 'zone - test.entity - hello - hello - test' == \
         calls[0].data['some']
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -310,6 +310,7 @@ class TestEvent(unittest.TestCase):
             'time_fired': now,
             'context': {
                 'id': event.context.id,
+                'parent_id': None,
                 'user_id': event.context.user_id,
             },
         }
@@ -1061,3 +1062,16 @@ async def test_service_call_event_contains_original_data(hass):
     assert len(calls) == 1
     assert calls[0].data['number'] == 23
     assert calls[0].context is context
+
+
+def test_context():
+    """Test context init."""
+    c = ha.Context()
+    assert c.user_id is None
+    assert c.parent_id is None
+    assert c.id is not None
+
+    c = ha.Context(23, 100)
+    assert c.user_id == 23
+    assert c.parent_id == 100
+    assert c.id is not None


### PR DESCRIPTION
## Description:
When an automation is triggered, we were re-using the context from the event that triggered the automation. However, this has the unintended side effect that the automation will run with the permissions of the user triggering the automation.

It also would have caused issues in the future when doing machine learning, because although the result of an automation should be linked to the triggering event, it should not be _fully_ attributed. It is the automation that is doing things now.

So to cover this partial relationship I'm introducing a `parent_id` for `Context`. This will allow a context to optionally point at a previous context that caused this context to start, without conflating the concerns that the actions of the automation get attributed to the triggering event.

The first thing being done with the context is firing an `automation_triggered` event, so that it's clear that it's an automation.

We need to store the context parent ID in the database. I want to do that, but I want to group a couple of more migration changes together (like increasing event type size), so have commented it out for now.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
