### PR TITLE
Nuki lock improvements

### DIFF
--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1149,7 +1149,7 @@ pynetgear==0.5.2
 pynetio==0.1.9.1
 
 # homeassistant.components.lock.nuki
-pynuki==1.3.2
+pynuki==1.3.3
 
 # homeassistant.components.sensor.nut
 pynut2==2.1.2


### PR DESCRIPTION
## Description:
Nuki lock component improvements:
 - Bride port: The port parameter was not forwarded on bridge component initialization. 
 - timeout configuration parameter (optional): The user can establish the timeout in the component configuration. Default is 5s
 - lock_reachable attribute: New boolean attribute to check if the communication HA <-> brigde and bridge <-> lock is fine.
 - Check connection service: If, by any reason, the connection between the bridge and the lock was lost, there was no way to detect it. There is now a new service to force the communication between the bridge and the lock, instead of retrieving the last know state. If that communication fails, the attribute lock_reachable will become true. 
- unlatch_to_unlock configuration parameter (optional): If set to true, when calling the service unlock, the lock will unlatch. Default is false.

## Example entry for `configuration.yaml` (if applicable):
```yaml
lock:
  - platform: nuki
    host: 192.168.0.85
    port: 8080
    token: [token]
    timeout: 25
    unlatch_to_unlock: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
