### PR TITLE
Update default Blink scan interval to 5 minutes.

### DIFF
--- a/homeassistant/components/blink/__init__.py
+++ b/homeassistant/components/blink/__init__.py
@@ -29,7 +29,7 @@ DEFAULT_BRAND = 'Blink'
 DEFAULT_ATTRIBUTION = "Data provided by immedia-semi.com"
 SIGNAL_UPDATE_BLINK = "blink_update"
 
-DEFAULT_SCAN_INTERVAL = timedelta(seconds=60)
+DEFAULT_SCAN_INTERVAL = timedelta(seconds=300)
 
 TYPE_CAMERA_ARMED = 'motion_enabled'
 TYPE_MOTION_DETECTED = 'motion_detected'


### PR DESCRIPTION
## Description:
Some users are getting locked out of their blink account due to too many api-calls.  This is likely due to the aggressive default scan interval of this component.  By default, I think having a relaxed scan interval is more appropriate as a default since most use cases don't need to be polling their cameras every 60s.  Any edge cases that require fast polling can easily override the default _at their own risk_.

[Reference](https://community.home-assistant.io/t/blink-camera-authentication-issue-unauthorised-access/98660/12)

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8549

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
