### PR TITLE
Add switch platform for Danfoss Air and additional sensors.

### DIFF
--- a/homeassistant/components/danfoss_air/__init__.py
+++ b/homeassistant/components/danfoss_air/__init__.py
@@ -1,9 +1,4 @@
-"""
-Support for Danfoss Air HRV.
-
-For more details about this component, please refer to the documentation at
-https://home-assistant.io/components/danfoss_air/
-"""
+"""Support for Danfoss Air HRV."""
 from datetime import timedelta
 import logging
 

--- a/homeassistant/components/danfoss_air/__init__.py
+++ b/homeassistant/components/danfoss_air/__init__.py
@@ -14,11 +14,11 @@ from homeassistant.helpers import discovery
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import Throttle
 
-REQUIREMENTS = ['pydanfossair==0.0.6']
+REQUIREMENTS = ['pydanfossair==0.0.7']
 
 _LOGGER = logging.getLogger(__name__)
 
-DANFOSS_AIR_PLATFORMS = ['sensor', 'binary_sensor']
+DANFOSS_AIR_PLATFORMS = ['sensor', 'binary_sensor', 'switch']
 DOMAIN = 'danfoss_air'
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=60)
@@ -57,6 +57,10 @@ class DanfossAir:
         """Get value for sensor."""
         return self._data.get(item)
 
+    def update_state(self, command, state_command):
+        """Send update command to Danfoss Air CCM."""
+        self._data[state_command] = self._client.command(command)
+
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
         """Use the data from Danfoss Air API."""
@@ -76,5 +80,17 @@ class DanfossAir:
             = round(self._client.command(ReadCommand.filterPercent), 2)
         self._data[ReadCommand.bypass] \
             = self._client.command(ReadCommand.bypass)
+        self._data[ReadCommand.fan_step] \
+            = self._client.command(ReadCommand.fan_step)
+        self._data[ReadCommand.supply_fan_speed] \
+            = self._client.command(ReadCommand.supply_fan_speed)
+        self._data[ReadCommand.exhaust_fan_speed] \
+            = self._client.command(ReadCommand.exhaust_fan_speed)
+        self._data[ReadCommand.away_mode] \
+            = self._client.command(ReadCommand.away_mode)
+        self._data[ReadCommand.boost] \
+            = self._client.command(ReadCommand.boost)
+        self._data[ReadCommand.battery_percent] \
+            = self._client.command(ReadCommand.battery_percent)
 
         _LOGGER.debug("Done fetching data from Danfoss Air CCM module")

--- a/homeassistant/components/danfoss_air/binary_sensor.py
+++ b/homeassistant/components/danfoss_air/binary_sensor.py
@@ -22,7 +22,10 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     dev = []
 
     for sensor in sensors:
-        dev.append(DanfossAirBinarySensor(data, sensor[0], sensor[1], sensor[2]))
+        dev.append(DanfossAirBinarySensor(data,
+                                          sensor[0],
+                                          sensor[1],
+                                          sensor[2]))
 
     add_entities(dev, True)
 

--- a/homeassistant/components/danfoss_air/binary_sensor.py
+++ b/homeassistant/components/danfoss_air/binary_sensor.py
@@ -1,9 +1,4 @@
-"""
-Support for the for Danfoss Air HRV binary sensor platform.
-
-For more details about this component, please refer to the documentation at
-https://home-assistant.io/components/binary_sensor.danfoss_air/
-"""
+"""Support for the for Danfoss Air HRV binary sensors."""
 from homeassistant.components.binary_sensor import BinarySensorDevice
 from homeassistant.components.danfoss_air import DOMAIN \
      as DANFOSS_AIR_DOMAIN
@@ -16,16 +11,14 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     sensors = [
         ["Danfoss Air Bypass Active", ReadCommand.bypass, "opening"],
-        ["Danfoss Air Away Mode Active", ReadCommand.away_mode, None]
+        ["Danfoss Air Away Mode Active", ReadCommand.away_mode, None],
     ]
 
     dev = []
 
     for sensor in sensors:
-        dev.append(DanfossAirBinarySensor(data,
-                                          sensor[0],
-                                          sensor[1],
-                                          sensor[2]))
+        dev.append(DanfossAirBinarySensor(
+             data, sensor[0], sensor[1], sensor[2]))
 
     add_entities(dev, True)
 

--- a/homeassistant/components/danfoss_air/binary_sensor.py
+++ b/homeassistant/components/danfoss_air/binary_sensor.py
@@ -18,7 +18,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     for sensor in sensors:
         dev.append(DanfossAirBinarySensor(
-             data, sensor[0], sensor[1], sensor[2]))
+            data, sensor[0], sensor[1], sensor[2]))
 
     add_entities(dev, True)
 

--- a/homeassistant/components/danfoss_air/binary_sensor.py
+++ b/homeassistant/components/danfoss_air/binary_sensor.py
@@ -14,12 +14,15 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     from pydanfossair.commands import ReadCommand
     data = hass.data[DANFOSS_AIR_DOMAIN]
 
-    sensors = [["Danfoss Air Bypass Active", ReadCommand.bypass]]
+    sensors = [
+        ["Danfoss Air Bypass Active", ReadCommand.bypass, "opening"],
+        ["Danfoss Air Away Mode Active", ReadCommand.away_mode, None]
+    ]
 
     dev = []
 
     for sensor in sensors:
-        dev.append(DanfossAirBinarySensor(data, sensor[0], sensor[1]))
+        dev.append(DanfossAirBinarySensor(data, sensor[0], sensor[1], sensor[2]))
 
     add_entities(dev, True)
 
@@ -27,12 +30,13 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class DanfossAirBinarySensor(BinarySensorDevice):
     """Representation of a Danfoss Air binary sensor."""
 
-    def __init__(self, data, name, sensor_type):
+    def __init__(self, data, name, sensor_type, device_class):
         """Initialize the Danfoss Air binary sensor."""
         self._data = data
         self._name = name
         self._state = None
         self._type = sensor_type
+        self._device_class = device_class
 
     @property
     def name(self):
@@ -47,7 +51,7 @@ class DanfossAirBinarySensor(BinarySensorDevice):
     @property
     def device_class(self):
         """Type of device class."""
-        return "opening"
+        return self._device_class
 
     def update(self):
         """Fetch new state data for the sensor."""

--- a/homeassistant/components/danfoss_air/sensor.py
+++ b/homeassistant/components/danfoss_air/sensor.py
@@ -1,10 +1,6 @@
-"""
-Support for the for Danfoss Air HRV sensor platform.
-
-For more details about this component, please refer to the documentation at
-https://home-assistant.io/components/sensor.danfoss_air/
-"""
+"""Support for the for Danfoss Air HRV sensors."""
 import logging
+
 from homeassistant.components.danfoss_air import DOMAIN \
      as DANFOSS_AIR_DOMAIN
 from homeassistant.const import (
@@ -47,11 +43,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     dev = []
 
     for sensor in sensors:
-        dev.append(DanfossAir(data,
-                              sensor[0],
-                              sensor[1],
-                              sensor[2],
-                              sensor[3]))
+        dev.append(DanfossAir(
+             data, sensor[0], sensor[1], sensor[2], sensor[3]))
 
     add_entities(dev, True)
 

--- a/homeassistant/components/danfoss_air/sensor.py
+++ b/homeassistant/components/danfoss_air/sensor.py
@@ -4,11 +4,15 @@ Support for the for Danfoss Air HRV sensor platform.
 For more details about this component, please refer to the documentation at
 https://home-assistant.io/components/sensor.danfoss_air/
 """
+import logging
 from homeassistant.components.danfoss_air import DOMAIN \
      as DANFOSS_AIR_DOMAIN
-from homeassistant.const import TEMP_CELSIUS
+from homeassistant.const import (
+    TEMP_CELSIUS, DEVICE_CLASS_BATTERY,
+    DEVICE_CLASS_TEMPERATURE, DEVICE_CLASS_HUMIDITY)
 from homeassistant.helpers.entity import Entity
 
+_LOGGER = logging.getLogger(__name__)
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the available Danfoss Air sensors etc."""
@@ -18,23 +22,35 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     sensors = [
         ["Danfoss Air Exhaust Temperature", TEMP_CELSIUS,
-         ReadCommand.exhaustTemperature],
+         ReadCommand.exhaustTemperature, DEVICE_CLASS_TEMPERATURE],
         ["Danfoss Air Outdoor Temperature", TEMP_CELSIUS,
-         ReadCommand.outdoorTemperature],
+         ReadCommand.outdoorTemperature, DEVICE_CLASS_TEMPERATURE],
         ["Danfoss Air Supply Temperature", TEMP_CELSIUS,
-         ReadCommand.supplyTemperature],
+         ReadCommand.supplyTemperature, DEVICE_CLASS_TEMPERATURE],
         ["Danfoss Air Extract Temperature", TEMP_CELSIUS,
-         ReadCommand.extractTemperature],
+         ReadCommand.extractTemperature, DEVICE_CLASS_TEMPERATURE],
         ["Danfoss Air Remaining Filter", '%',
-         ReadCommand.filterPercent],
+         ReadCommand.filterPercent, None],
         ["Danfoss Air Humidity", '%',
-         ReadCommand.humidity]
+         ReadCommand.humidity, DEVICE_CLASS_HUMIDITY],
+        ["Danfoss Air Fan Step", '%',
+         ReadCommand.fan_step, None],
+        ["Dandoss Air Exhaust Fan Speed", 'RPM',
+         ReadCommand.exhaust_fan_speed, None],
+        ["Dandoss Air Supply Fan Speed", 'RPM',
+         ReadCommand.supply_fan_speed, None],
+        ["Dandoss Air Dial Battery", '%',
+         ReadCommand.battery_percent, DEVICE_CLASS_BATTERY]
         ]
 
     dev = []
 
     for sensor in sensors:
-        dev.append(DanfossAir(data, sensor[0], sensor[1], sensor[2]))
+        dev.append(DanfossAir(data,
+                              sensor[0],
+                              sensor[1],
+                              sensor[2],
+                              sensor[3]))
 
     add_entities(dev, True)
 
@@ -42,18 +58,24 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class DanfossAir(Entity):
     """Representation of a Sensor."""
 
-    def __init__(self, data, name, sensor_unit, sensor_type):
+    def __init__(self, data, name, sensor_unit, sensor_type, device_class):
         """Initialize the sensor."""
         self._data = data
         self._name = name
         self._state = None
         self._type = sensor_type
         self._unit = sensor_unit
+        self._device_class = device_class
 
     @property
     def name(self):
         """Return the name of the sensor."""
         return self._name
+
+    @property
+    def device_class(self):
+        """Return the device class of the sensor."""
+        return self._device_class
 
     @property
     def state(self):
@@ -74,3 +96,5 @@ class DanfossAir(Entity):
         self._data.update()
 
         self._state = self._data.get_value(self._type)
+        if self._state is None:
+            _LOGGER.debug("Could not get data for %s", self._type)

--- a/homeassistant/components/danfoss_air/sensor.py
+++ b/homeassistant/components/danfoss_air/sensor.py
@@ -44,7 +44,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     for sensor in sensors:
         dev.append(DanfossAir(
-             data, sensor[0], sensor[1], sensor[2], sensor[3]))
+            data, sensor[0], sensor[1], sensor[2], sensor[3]))
 
     add_entities(dev, True)
 

--- a/homeassistant/components/danfoss_air/sensor.py
+++ b/homeassistant/components/danfoss_air/sensor.py
@@ -14,6 +14,7 @@ from homeassistant.helpers.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)
 
+
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the available Danfoss Air sensors etc."""
     from pydanfossair.commands import ReadCommand

--- a/homeassistant/components/danfoss_air/switch.py
+++ b/homeassistant/components/danfoss_air/switch.py
@@ -73,7 +73,6 @@ class DanfossAir(SwitchDevice):
 
     def update(self):
         """Update the switch's state."""
-
         self._data.update()
 
         self._state = self._data.get_value(self._state_command)

--- a/homeassistant/components/danfoss_air/switch.py
+++ b/homeassistant/components/danfoss_air/switch.py
@@ -1,9 +1,4 @@
-"""
-Support for the for Danfoss Air HRV sswitch platform.
-
-For more details about this component, please refer to the documentation at
-https://home-assistant.io/components/switch.danfoss_air/
-"""
+"""Support for the for Danfoss Air HRV sswitches."""
 import logging
 
 from homeassistant.components.switch import (
@@ -24,17 +19,14 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         ["Danfoss Air Boost",
          ReadCommand.boost,
          UpdateCommand.boost_activate,
-         UpdateCommand.boost_deactivate]
+         UpdateCommand.boost_deactivate],
     ]
 
     dev = []
 
     for switch in switches:
-        dev.append(DanfossAir(data,
-                              switch[0],
-                              switch[1],
-                              switch[2],
-                              switch[3]))
+        dev.append(DanfossAir(
+            data, switch[0], switch[1], switch[2], switch[3]))
 
     add_entities(dev)
 
@@ -63,7 +55,7 @@ class DanfossAir(SwitchDevice):
 
     def turn_on(self, **kwargs):
         """Turn the switch on."""
-        _LOGGER.debug("Turning on switch with command %s.", self._on_command)
+        _LOGGER.debug("Turning on switch with command %s", self._on_command)
         self._data.update_state(self._on_command, self._state_command)
 
     def turn_off(self, **kwargs):
@@ -77,4 +69,4 @@ class DanfossAir(SwitchDevice):
 
         self._state = self._data.get_value(self._state_command)
         if self._state is None:
-            _LOGGER.debug("Could not get data for %s.", self._state_command)
+            _LOGGER.debug("Could not get data for %s", self._state_command)

--- a/homeassistant/components/danfoss_air/switch.py
+++ b/homeassistant/components/danfoss_air/switch.py
@@ -1,0 +1,76 @@
+"""
+Support for the for Danfoss Air HRV sswitch platform.
+
+For more details about this component, please refer to the documentation at
+https://home-assistant.io/components/switch.danfoss_air/
+"""
+import logging
+
+from homeassistant.components.switch import (
+    SwitchDevice)
+from homeassistant.components.danfoss_air import DOMAIN \
+     as DANFOSS_AIR_DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    """Set up the Danfoss Air HRV switch platform."""
+    from pydanfossair.commands import ReadCommand, UpdateCommand
+
+    data = hass.data[DANFOSS_AIR_DOMAIN]
+
+    switches = [
+        ["Danfoss Air Boost",
+         ReadCommand.boost,
+         UpdateCommand.boost_activate,
+         UpdateCommand.boost_deactivate]
+    ]
+
+    dev = []
+
+    for switch in switches:
+        dev.append(DanfossAir(data, switch[0], switch[1], switch[2], switch[3]))
+
+    add_entities(dev)
+
+
+class DanfossAir(SwitchDevice):
+    """Representation of a Danfoss Air HRV Switch."""
+
+    def __init__(self, data, name, state_command, on_command, off_command):
+        """Initialize the switch."""
+        self._data = data
+        self._name = name
+        self._state_command = state_command
+        self._on_command = on_command
+        self._off_command = off_command
+        self._state = None
+
+    @property
+    def name(self):
+        """Return the name of the switch."""
+        return self._name
+
+    @property
+    def is_on(self):
+        """Return true if switch is on."""
+        return self._state
+
+    def turn_on(self, **kwargs):
+        """Turn the switch on."""
+        _LOGGER.debug("Turning on switch with command %s.", self._on_command)
+        self._data.update_state(self._on_command, self._state_command)
+
+    def turn_off(self, **kwargs):
+        """Turn the switch off."""
+        _LOGGER.debug("Turning of switch with command %s", self._off_command)
+        self._data.update_state(self._off_command, self._state_command)
+
+    def update(self):
+        """Update the switch's state."""
+
+        self._data.update()
+
+        self._state = self._data.get_value(self._state_command)
+        if self._state is None:
+            _LOGGER.debug("Could not get data for %s.", self._state_command)

--- a/homeassistant/components/danfoss_air/switch.py
+++ b/homeassistant/components/danfoss_air/switch.py
@@ -13,6 +13,7 @@ from homeassistant.components.danfoss_air import DOMAIN \
 
 _LOGGER = logging.getLogger(__name__)
 
+
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the Danfoss Air HRV switch platform."""
     from pydanfossair.commands import ReadCommand, UpdateCommand
@@ -29,7 +30,11 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     dev = []
 
     for switch in switches:
-        dev.append(DanfossAir(data, switch[0], switch[1], switch[2], switch[3]))
+        dev.append(DanfossAir(data,
+                              switch[0],
+                              switch[1],
+                              switch[2],
+                              switch[3]))
 
     add_entities(dev)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -977,7 +977,7 @@ pycsspeechtts==1.0.2
 pydaikin==0.9
 
 # homeassistant.components.danfoss_air
-pydanfossair==0.0.6
+pydanfossair==0.0.7
 
 # homeassistant.components.deconz
 pydeconz==47


### PR DESCRIPTION
## Description:
Add additional sensors and binary sensor for Danfoss Air HRV. Add switch platform as well. 

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#8554

## Example entry for `configuration.yaml` (if applicable):
```yaml
danfoss_air:
        host: X.X.X.X

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [x] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [x] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [x] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
